### PR TITLE
FRESH-286 jenkins envInject plugin overwrites BUILD_URL value

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -16,6 +16,9 @@ The actual release notes
 
 ## Features
  - FRESH-265 Procurement Candidates: Packvorschrift overwrite
+ - FRESH-286 jenkins envInject plugin overwrites BUILD_URL value
+	* introducing a new environment variable ROLLOUT_BUILD_URL to be set by the caller. Falback to BUILD_URL if the new var is not set
+	
 ## Fixes
 
 # metasfresh 4.16.15

--- a/de.metas.scripts.rollout/src/main/bash/tools.sh
+++ b/de.metas.scripts.rollout/src/main/bash/tools.sh
@@ -44,6 +44,9 @@ check_file_readable(){
 	exit 1
 }
 
+#
+# If the given variable is not set (value being either "" or "NOT_SET"), then this method fails the script (exit 1)
+#
 check_var()
 {
 	local varName=$1
@@ -59,7 +62,10 @@ check_var()
 	return 0
 }
 
-# if the given var is not set, then it 
+# 
+# If the first given variable is not set (value being either "" or "NOT_SET"), then it falls back to the second given variable 
+# and sets the first var to the second var's value. If the second variabe is not set either then this method fails the script (exit 1).
+#
 check_var_fallback()
 {
 	local varName=$1


### PR DESCRIPTION
introducing a new environment variable ROLLOUT_BUILD_URL to be set by
the caller. Fallback to BUILD_URL if the new var is not set