### PR TITLE
FRESH-314 Foreign BPartner reference included in sales order C_Order.C_BPartner_ID

### DIFF
--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/session/impl/SessionDAO.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/session/impl/SessionDAO.java
@@ -135,8 +135,8 @@ public class SessionDAO implements ISessionDAO
 						, record.getAD_Column_ID() //
 						, record.getRecord_ID() //
 						//
-						, record.getAD_Session_ID()
-						, record.getAD_PInstance_ID() // FRESH-314
+						, record.getAD_Session_ID() <= 0 ? null : record.getAD_Session_ID() // FRESH-314
+						, record.getAD_PInstance_ID() <= 0 ? null : record.getAD_PInstance_ID() // FRESH-314
 						, record.getEventType() // EventChangeLog (type)
 						, oldValue == null ? CHANGELOG_NullValue : oldValue.toString() //
 						, newValue == null ? CHANGELOG_NullValue : newValue.toString() //

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5446140_sys_FRESH-314_ad_changelog_no_FKs_requried.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5446140_sys_FRESH-314_ad_changelog_no_FKs_requried.sql
@@ -1,0 +1,24 @@
+--
+-- expecting no FK for AD_Table, AD_Session and AD_PInstance, because we want to be able to "clean up" theses hables without getting trouble because of some ancient AD_ChangeLogs
+--
+
+-- 25.05.2016 13:18
+-- URL zum Konzept
+UPDATE AD_Column SET DDL_NoForeignKey='Y',Updated=TO_TIMESTAMP('2016-05-25 13:18:28','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=554396
+;
+
+-- 25.05.2016 13:18
+-- URL zum Konzept
+UPDATE AD_Column SET DDL_NoForeignKey='Y', IsUpdateable='N',Updated=TO_TIMESTAMP('2016-05-25 13:18:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=8813
+;
+
+-- 25.05.2016 13:18
+-- URL zum Konzept
+UPDATE AD_Column SET DDL_NoForeignKey='Y',Updated=TO_TIMESTAMP('2016-05-25 13:18:44','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=8804
+;
+
+-- 25.05.2016 13:18
+-- URL zum Konzept
+UPDATE AD_Column SET AD_Reference_ID=30,Updated=TO_TIMESTAMP('2016-05-25 13:18:50','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=8804
+;
+


### PR DESCRIPTION
*making it clear in the AD that we don't need FKs for AD_Session,
AD_PInstance and AD_Table
* inserting new AD_ChangeLog records with NULL references instead of 0