### PR TITLE
#139 FRESH-475 Check for java8 in the rollout-scripts

### DIFF
--- a/de.metas.scripts.rollout/src/main/bash/minor_remote.sh
+++ b/de.metas.scripts.rollout/src/main/bash/minor_remote.sh
@@ -51,6 +51,8 @@ prepare()
 
 	check_dir_exists $JAVA_HOME
 	
+	check_java_version
+	
 	export JAVA_HOME=$JAVA_HOME
 	
 	check_file_exists ~/local_settings.properties
@@ -60,8 +62,9 @@ prepare()
 	if [ "$LOCAL_SETTINGS_PERMS" != "-rw-------" ]; then
 		trace prepare "file ~/local_settings.properties has permissions '$LOCAL_SETTINGS_PERMS'. It should have '-rw-------'. Use 'chmod 0600 ~/local_settings.properties' to fix "
 	fi
-
-	trace prepare END
+        
+        trace prepare END
+        
 }
 
 install_metasfresh()

--- a/de.metas.scripts.rollout/src/main/bash/sql_remote.sh
+++ b/de.metas.scripts.rollout/src/main/bash/sql_remote.sh
@@ -15,6 +15,8 @@ fi
 #DEBUG_OPTS="-Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=4000,suspend=y"
 DEBUG_OPTS=""
 
+check_java_version
+
 trace $(basename $0) "BEGIN"
 
 check_std_tool java

--- a/de.metas.scripts.rollout/src/main/bash/tools.sh
+++ b/de.metas.scripts.rollout/src/main/bash/tools.sh
@@ -120,6 +120,23 @@ check_vars_server()
 	trace check_vars_server END
 }
 
+check_java_version()
+{
+        trace check_java_version BEGIN
+    
+        if [[ -f "/usr/bin/java" ]]; then
+            local JAVA_VERSION="$(/usr/bin/java -version 2>&1 | awk -F '"' '/version/ {print $2}' | cut -d "." -f2)"
+            if [[ ! $JAVA_VERSION == "8" ]]; then
+                trace check_java_version "[ERROR] JAVA-Version does not match supported version (found Java 1.${JAVA_VERSION})! Only Java 1.8 JDK supported! Check ' http://docs.metasfresh.org/howto_collection/Wie_aktualisiere_ich_die_Java_Version_auf_meinem_server.html ' for more infos and make sure 'java -version' is 1.8.x !"
+                exit 1
+            fi
+        else
+            trace check_java_version "could not find valid /usr/bin/java. assuming Java 1.8 JDK is installed."
+        fi
+        
+        trace check_java_version END
+}
+
 check_rollout_user()
 {
 	trace check_rollout_user BEGIN


### PR DESCRIPTION
Added additional function to check for java 1.8.x in tools.sh to be used
by sql_remote.sh and minor_remote.sh