### PR TITLE
#139 FRESH-475 Check for java8 in the rollout-scripts

### DIFF
--- a/de.metas.scripts.rollout/src/main/bash/minor_remote.sh
+++ b/de.metas.scripts.rollout/src/main/bash/minor_remote.sh
@@ -49,11 +49,7 @@ prepare()
 	check_vars_server
 	check_rollout_user
 
-	check_dir_exists $JAVA_HOME
-	
 	check_java_version
-	
-	export JAVA_HOME=$JAVA_HOME
 	
 	check_file_exists ~/local_settings.properties
 	

--- a/de.metas.scripts.rollout/src/main/bash/tools.sh
+++ b/de.metas.scripts.rollout/src/main/bash/tools.sh
@@ -115,8 +115,7 @@ check_vars_server()
 	trace check_vars_server BEGIN
 
 	check_var_fallback "METASFRESH_HOME" ${METASFRESH_HOME:-NOT_SET} "ADEMPIERE_HOME" ${ADEMPIERE_HOME:-NOT_SET}
-	check_var "JAVA_HOME" $JAVA_HOME
-		
+			
 	trace check_vars_server END
 }
 
@@ -184,7 +183,6 @@ check_vars_minor()
 	trace check_vars_minor BEGIN
 
 	check_var_fallback "METASFRESH_HOME" ${METASFRESH_HOME:-NOT_SET} "ADEMPIERE_HOME" ${ADEMPIERE_HOME:-NOT_SET}
-	check_var "JAVA_HOME" $JAVA_HOME
 	check_var "PATH" $PATH
 
 	trace check_vars_minor END


### PR DESCRIPTION
Removed obsolete checks for JAVA_HOME. Not needed anymore, since
springboot uses /usr/bin/java