### PR TITLE
FRESH-588 #288

### DIFF
--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/ModelValidator.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/ModelValidator.java
@@ -115,7 +115,7 @@ public interface ModelValidator
 	public static final int TIMING_AFTER_REVERSECORRECT = DOCTIMING_Offset + 13;
 	/** Called after document is reverse-accrual */
 	public static final int TIMING_AFTER_REVERSEACCRUAL = DOCTIMING_Offset + 14;
-	
+
 	/** Called after document is un-posted */
 	public static final int TIMING_AFTER_UNPOST = DOCTIMING_Offset + 16;
 

--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/ILoggerCustomizer.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/ILoggerCustomizer.java
@@ -12,12 +12,12 @@ import org.slf4j.Logger;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -27,11 +27,18 @@ import org.slf4j.Logger;
 
 /**
  * Implementations of this interface are used to customize {@link Logger} when they are returned to callers.
- * 
+ *
  * @author tsa
  *
  */
 public interface ILoggerCustomizer
 {
 	void customize(Logger logger);
+
+	/**
+	 *
+	 * @return information that is useful to understand the customizer's behavior
+	 * @task https://github.com/metasfresh/metasfresh/issues/288
+	 */
+	String dumpConfig();
 }

--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/LogManager.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/LogManager.java
@@ -46,6 +46,17 @@ public final class LogManager
 	private static final ILoggerCustomizer loggerCustomizer = SysConfigLoggerCustomizer.instance;
 
 	/**
+	 * See {@link ILoggerCustomizer#dumpConfig()}.
+	 *
+	 * @return
+	 * @task https://github.com/metasfresh/metasfresh/issues/288
+	 */
+	public static String dumpCustomizerConfig()
+	{
+		return loggerCustomizer.dumpConfig();
+	}
+
+	/**
 	 * Initialize Logging
 	 *
 	 * @param isClient client

--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/NullLoggerCustomizer.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/NullLoggerCustomizer.java
@@ -12,22 +12,21 @@ import org.slf4j.Logger;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 
-
 /**
  * Do nothing {@link ILoggerCustomizer} implementation.
- * 
+ *
  * @author tsa
  *
  */
@@ -44,6 +43,12 @@ public final class NullLoggerCustomizer implements ILoggerCustomizer
 	public void customize(final Logger logger)
 	{
 		// do nothing
+	}
+
+	@Override
+	public String dumpConfig()
+	{
+		return getClass().getName() + " has no config to dump";
 	}
 
 }

--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/SysConfigLoggerCustomizer.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/SysConfigLoggerCustomizer.java
@@ -134,11 +134,6 @@ class SysConfigLoggerCustomizer implements ILoggerCustomizer
 		}
 	}
 
-	/**
-	 * This method is public because we want to see from outside which hostname the customizer works with.
-	 *
-	 * @return
-	 */
 	private final String getHostNameWithDot()
 	{
 		if (Check.isEmpty(_hostNameWithDot, true))

--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/SysConfigLoggerCustomizer.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/SysConfigLoggerCustomizer.java
@@ -10,14 +10,14 @@ package de.metas.logging;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
@@ -37,7 +37,7 @@ import ch.qos.logback.classic.Level;
 
 /**
  * Sets log level which is configured in {@link ISysConfigBL}.
- * 
+ *
  * @author tsa
  *
  */
@@ -46,6 +46,10 @@ class SysConfigLoggerCustomizer implements ILoggerCustomizer
 	public static final transient SysConfigLoggerCustomizer instance = new SysConfigLoggerCustomizer();
 
 	private static final String CFG_C_LOGGER_LEVEL_PREFIX = "CLogger.Level.";
+
+	/**
+	 * Thread-local boolean to make sure that only one thread is within the {@link #customize(Logger)} method at a time
+	 */
 	private static final ThreadLocal<Boolean> withinCustomizeLogLevel = new ThreadLocal<Boolean>();
 
 	/**
@@ -70,7 +74,7 @@ class SysConfigLoggerCustomizer implements ILoggerCustomizer
 
 		if (withinCustomizeLogLevel.get() != null && withinCustomizeLogLevel.get())
 		{
-			return;
+			return; // was already handled
 		}
 		withinCustomizeLogLevel.set(true);
 		try
@@ -119,7 +123,6 @@ class SysConfigLoggerCustomizer implements ILoggerCustomizer
 			}
 
 			final Level level = LogManager.asLogbackLevel(logLevelStr);
-			// logger.setMaxLevel(level); // we want to make sure nobody is highering the log level (e.g. change from INFO to WARNING)
 			if (!LogManager.setLoggerLevel(logger, level))
 			{
 				logger.warn("SysConfig with name {} contained unparsable loglevel {} for logger {}", sysConfigName, logLevelStr, logger.getName());
@@ -131,6 +134,11 @@ class SysConfigLoggerCustomizer implements ILoggerCustomizer
 		}
 	}
 
+	/**
+	 * This method is public because we want to see from outside which hostname the customizer works with.
+	 *
+	 * @return
+	 */
 	private final String getHostNameWithDot()
 	{
 		if (Check.isEmpty(_hostNameWithDot, true))
@@ -143,7 +151,7 @@ class SysConfigLoggerCustomizer implements ILoggerCustomizer
 	private final String getSysConfigValue(final String sysConfigName)
 	{
 		final Map<String, String> properties = getPropertiesMap();
-		if (properties == null)  // shall not happen
+		if (properties == null)            // shall not happen
 		{
 			return null;
 		}
@@ -162,6 +170,24 @@ class SysConfigLoggerCustomizer implements ILoggerCustomizer
 		// Load the properties map from underlying database
 		// NOTE: we assume it's cached on that level
 		return Services.get(ISysConfigBL.class).getValuesForPrefix(CFG_C_LOGGER_LEVEL_PREFIX, removePrefix, adClientId, adOrgId);
+	}
+
+	@Override
+	public String dumpConfig()
+	{
+		final Map<String, String> propertiesMap = getPropertiesMap();
+
+		final StringBuilder out = new StringBuilder();
+		out.append("Customizer class: " + getClass().getName() + "\n");
+		out.append("Hostname (with dot): " + getHostNameWithDot() + "\n");
+		out.append("Logger settings from SysConfig (count=" + propertiesMap.size() + "):" + "\n");
+
+		for (final String key : propertiesMap.keySet())
+		{
+			out.append("\t" + key + " = " + propertiesMap.get(key) + "\n");
+		}
+
+		return out.toString();
 	}
 
 }

--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/model/interceptor/LoggingModuleInterceptor.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/model/interceptor/LoggingModuleInterceptor.java
@@ -1,0 +1,87 @@
+package de.metas.logging.model.interceptor;
+
+import org.adempiere.ad.modelvalidator.AbstractModuleInterceptor;
+import org.adempiere.util.Check;
+import org.slf4j.Logger;
+
+import ch.qos.logback.classic.Level;
+import de.metas.logging.ILoggerCustomizer;
+import de.metas.logging.LogManager;
+
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2016 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ *
+ * @author metas-dev <dev@metasfresh.com>
+ *
+ */
+public class LoggingModuleInterceptor extends AbstractModuleInterceptor
+{
+	private final static transient Logger logger = LogManager.getLogger(LoggingModuleInterceptor.class);
+
+	public static final LoggingModuleInterceptor INSTANCE = new LoggingModuleInterceptor();
+
+	private LoggingModuleInterceptor()
+	{
+	}
+
+	/**
+	 * Logs the output of {@link ILoggerCustomizer#dumpConfig()}.
+	 *
+	 * @task https://github.com/metasfresh/metasfresh/issues/288
+	 */
+	@Override
+	public void onUserLogin(final int AD_Org_ID_IGNORED, final int AD_Role_ID_IGNORED, final int AD_User_ID_IGNORED)
+	{
+		logCustomizerConfig();
+	}
+
+	private void logCustomizerConfig()
+	{
+		final String customizerConfig = LogManager.dumpCustomizerConfig();
+
+		// try to get the current log level for this interceptor's logger
+		final String logLevelBkp = LogManager.getLoggerLevelName(logger);
+
+		if (Check.isEmpty(logLevelBkp))
+		{
+			System.err.println("Unable to log the customizer config to logger=" + logger);
+			System.err.println("Writing the customizer config to std-err instead");
+
+			// there is a problem, but still try to output the information.
+			System.err.println(customizerConfig);
+			return;
+		}
+
+		// this is the normal case. Make sure that we are loglevel info, log the information and set the logger back to its former level.
+		try
+		{
+			LogManager.setLoggerLevel(logger, Level.INFO);
+			logger.info(customizerConfig);
+		}
+		finally
+		{
+			LogManager.setLoggerLevel(logger, logLevelBkp);
+		}
+	}
+}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/service/impl/SysConfigDAO.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/service/impl/SysConfigDAO.java
@@ -78,7 +78,7 @@ public class SysConfigDAO extends AbstractSysConfigDAO
 	@Cached(cacheName = I_AD_SysConfig.Table_Name + "#NamesForPrefix", expireMinutes = Cached.EXPIREMINUTES_Never)
 	public List<String> retrieveNamesForPrefix(final String prefix, final int adClientId, final int adOrgId)
 	{
-		Check.assume(!Check.isEmpty(prefix, true), "prefix is empty");
+		Check.errorUnless(!Check.isEmpty(prefix, true), "prefix is empty");
 
 		final String whereClause = I_AD_SysConfig.COLUMNNAME_Name + " LIKE ?"
 				+ " AND " + I_AD_SysConfig.COLUMNNAME_AD_Client_ID + " IN (0,?)"

--- a/de.metas.business/src/main/java/org/adempiere/model/validator/AdempiereBaseValidator.java
+++ b/de.metas.business/src/main/java/org/adempiere/model/validator/AdempiereBaseValidator.java
@@ -128,6 +128,9 @@ public final class AdempiereBaseValidator extends AbstractModuleInterceptor
 		engine.addModelValidator(de.metas.inout.model.validator.M_InOutLine.INSTANCE, client);
 
 		engine.addModelValidator(de.metas.order.model.validator.OrderModuleInterceptor.INSTANCE, client);
+
+		// gh-issue #288
+		engine.addModelValidator(de.metas.logging.model.interceptor.LoggingModuleInterceptor.INSTANCE, client);
 	}
 
 	@Override

--- a/de.metas.util/src/main/java/org/adempiere/util/net/NetUtils.java
+++ b/de.metas.util/src/main/java/org/adempiere/util/net/NetUtils.java
@@ -10,12 +10,12 @@ package org.adempiere.util.net;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -34,7 +34,7 @@ public final class NetUtils
 	}
 
 	/**
-	 * 
+	 *
 	 * @return never returns <code>null</code>
 	 */
 	public static IHostIdentifier getLocalHost()


### PR DESCRIPTION
After user login, the client now logs the logger customizer config. 
It can be used to check if a host's name (as retrieved by the client) matches any SysConfig values.