### PR TITLE
FRESH-608 #315 ReceiptSchedule.QtyToMove not properly updated on reopen

### DIFF
--- a/de.metas.business/src/main/java/de/metas/adempiere/service/IOrderBL.java
+++ b/de.metas.business/src/main/java/de/metas/adempiere/service/IOrderBL.java
@@ -36,6 +36,8 @@ import org.compiere.model.I_C_Tax;
 import org.compiere.model.I_M_PriceList_Version;
 import org.compiere.model.I_M_Product;
 
+import de.metas.order.IOrderPA;
+
 public interface IOrderBL extends ISingletonService
 {
 
@@ -109,9 +111,9 @@ public interface IOrderBL extends ISingletonService
 
 	/**
 	 * Check if there is a price list for the given location and pricing system.
-	 * 
+	 *
 	 * In case there is any error, this method will throw an exception.
-	 * 
+	 *
 	 * NOTE: in case the bpartner location or the pricing system is not set, this method will skip the validation and no exception will be thrown.
 	 *
 	 * @param order
@@ -230,7 +232,8 @@ public interface IOrderBL extends ISingletonService
 	boolean isTaxIncluded(I_C_Order order, I_C_Tax tax);
 
 	/**
-	 * Close given order line (i.e. set QtyOrdered=QtyDelivered) and update reservations.
+	 * Close given order line by setting the line's <code>QtyOrdered</code> to the current <code>QtyDelviered</code>.
+	 * Also update the order line's reservation via {@link IOrderPA#reserveStock(I_C_Order, I_C_OrderLine...)}.
 	 *
 	 * This method is saving the order line.
 	 *

--- a/de.metas.handlingunits.client/src/main/java/de/metas/handlingunits/client/terminal/receipt/model/ReceiptScheduleCUKey.java
+++ b/de.metas.handlingunits.client/src/main/java/de/metas/handlingunits/client/terminal/receipt/model/ReceiptScheduleCUKey.java
@@ -50,7 +50,7 @@ import de.metas.handlingunits.exceptions.HUException;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_ReceiptSchedule;
 import de.metas.handlingunits.receiptschedule.IHUReceiptScheduleBL;
-import de.metas.inoutcandidate.api.IReceiptScheduleQtysHandler;
+import de.metas.inoutcandidate.api.IReceiptScheduleQtysBL;
 
 /**
  * CU Key based on a given receipt schedule.
@@ -75,7 +75,7 @@ public class ReceiptScheduleCUKey extends CUKey
 		receiptScheduleRow = row;
 		receiptSchedule = row.getM_ReceiptSchedule();
 
-		final BigDecimal qtyToMove = Services.get(IReceiptScheduleQtysHandler.class).getQtyToMove(receiptSchedule);
+		final BigDecimal qtyToMove = Services.get(IReceiptScheduleQtysBL.class).getQtyToMove(receiptSchedule);
 		setSuggestedQty(qtyToMove.signum() >= 0 ? qtyToMove : BigDecimal.ZERO);
 
 		uom = receiptSchedule.getC_UOM();

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/adempiere/service/impl/OrderBL.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/adempiere/service/impl/OrderBL.java
@@ -27,8 +27,6 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import org.slf4j.Logger;
-import de.metas.logging.LogManager;
 
 import org.adempiere.ad.dao.IQueryAggregateBuilder;
 import org.adempiere.ad.dao.IQueryBL;
@@ -65,6 +63,7 @@ import org.compiere.model.PO;
 import org.compiere.model.Query;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
+import org.slf4j.Logger;
 
 import de.metas.adempiere.model.I_C_BPartner_Location;
 import de.metas.adempiere.service.IOrderBL;
@@ -73,6 +72,7 @@ import de.metas.currency.ICurrencyDAO;
 import de.metas.freighcost.api.IFreightCostBL;
 import de.metas.interfaces.I_C_BPartner;
 import de.metas.interfaces.I_C_OrderLine;
+import de.metas.logging.LogManager;
 import de.metas.order.IOrderPA;
 import de.metas.product.IProductPA;
 
@@ -900,7 +900,8 @@ public class OrderBL implements IOrderBL
 		//
 		// Update qty reservation
 		final I_C_Order order = orderLine.getC_Order();
-		Services.get(IOrderPA.class).reserveStock(order, orderLine); // FIXME: move reserveStock method to an orderBL service
+		final IOrderPA orderPA = Services.get(IOrderPA.class);
+		orderPA.reserveStock(order, orderLine);
 
 	}
 

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IReceiptScheduleBL.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IReceiptScheduleBL.java
@@ -10,18 +10,17 @@ package de.metas.inoutcandidate.api;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
-
 
 import java.math.BigDecimal;
 import java.util.Iterator;
@@ -39,6 +38,7 @@ import de.metas.adempiere.model.I_C_BPartner_Location;
 import de.metas.inout.model.I_M_InOutLine;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule_Alloc;
+import de.metas.inoutcandidate.modelvalidator.C_OrderLine_ReceiptSchedule;
 import de.metas.inoutcandidate.spi.IReceiptScheduleListener;
 import de.metas.interfaces.I_C_BPartner;
 
@@ -48,7 +48,7 @@ public interface IReceiptScheduleBL extends ISingletonService
 
 	/**
 	 * Create {@link IInOutProducer} instance for given initial result
-	 * 
+	 *
 	 * @param resultInitial
 	 * @param complete true if generated documents shall be completed
 	 * @return producer
@@ -56,9 +56,9 @@ public interface IReceiptScheduleBL extends ISingletonService
 	IInOutProducer createInOutProducer(InOutGenerateResult resultInitial, boolean complete);
 
 	/**
-	 * 
+	 *
 	 * NOTE: this method assumes that <code>receiptSchedules</code> are already ordered by aggregation keys.
-	 * 
+	 *
 	 * @param ctx
 	 * @param receiptSchedules
 	 * @param result results collector
@@ -70,16 +70,16 @@ public interface IReceiptScheduleBL extends ISingletonService
 
 	/**
 	 * Gets Target Qty (i.e. how much shall we receive in the end).
-	 * 
+	 *
 	 * NOTE: {@link I_M_ReceiptSchedule#COLUMNNAME_QtyToMove_Override} is checked first and if is not set then {@link I_M_ReceiptSchedule#COLUMNNAME_QtyOrdered} is considered.
-	 * 
+	 *
 	 * @param rs
 	 * @return target qty
 	 */
 	BigDecimal getQtyOrdered(I_M_ReceiptSchedule rs);
 
 	/**
-	 * 
+	 *
 	 * @param rs
 	 * @return qty moved
 	 */
@@ -88,14 +88,14 @@ public interface IReceiptScheduleBL extends ISingletonService
 	BigDecimal getQtyMovedWithIssues(I_M_ReceiptSchedule rs);
 
 	/**
-	 * 
+	 *
 	 * @param rs
 	 * @return override-qty or the qty (if no override set) of the given {@code rs}.
 	 */
 	BigDecimal getQtyToMove(final I_M_ReceiptSchedule rs);
 
 	/**
-	 * 
+	 *
 	 * @param rs
 	 * @return M_Warehouse_Override_ID and falls back to M_Warehouse_ID if no override value is set
 	 */
@@ -109,14 +109,14 @@ public interface IReceiptScheduleBL extends ISingletonService
 
 	/**
 	 * Gets effective locator to be used when receiving materials with this receipt schedule.
-	 * 
+	 *
 	 * @param rs
 	 * @return default locator for {@link #getM_Warehouse_Effective(I_M_ReceiptSchedule)}.
 	 */
 	I_M_Locator getM_Locator_Effective(I_M_ReceiptSchedule rs);
 
 	/**
-	 * 
+	 *
 	 * @param rs
 	 * @return C_BP_Location_Override_ID and falls back to C_BPartner_Location_ID if no override value is set
 	 */
@@ -154,14 +154,14 @@ public interface IReceiptScheduleBL extends ISingletonService
 	I_AD_User getAD_User_Effective(I_M_ReceiptSchedule rs);
 
 	/**
-	 * 
+	 *
 	 * @param rs
 	 * @return M_AttributeSetInstance_ID to use
 	 */
 	int getM_AttributeSetInstance_Effective_ID(I_M_ReceiptSchedule rs);
 
 	/**
-	 * 
+	 *
 	 * @param rs
 	 * @return {@link I_M_AttributeSetInstance} to use
 	 */
@@ -169,7 +169,7 @@ public interface IReceiptScheduleBL extends ISingletonService
 
 	/**
 	 * Sets the effective attribute set instance (i.e. M_AttributeSetInstance_Override_ID)
-	 * 
+	 *
 	 * @param rs
 	 * @param asi
 	 */
@@ -179,23 +179,23 @@ public interface IReceiptScheduleBL extends ISingletonService
 
 	/**
 	 * Updates {@link I_M_ReceiptSchedule#COLUMNNAME_BPartnerAddress}
-	 * 
+	 *
 	 * @param receiptSchedule
 	 */
 	void updateBPartnerAddress(I_M_ReceiptSchedule receiptSchedule);
 
 	/**
 	 * Updates {@link I_M_ReceiptSchedule#COLUMNNAME_BPartnerAddress_Override}
-	 * 
+	 *
 	 * @param receiptSchedule
 	 */
 	void updateBPartnerAddressOverride(I_M_ReceiptSchedule receiptSchedule);
 
 	/**
 	 * Gets {@link I_M_ReceiptSchedule_Alloc} from {@link I_M_ReceiptSchedule} to {@link I_M_InOutLine}.
-	 * 
+	 *
 	 * If allocation does not exist, it will be created. If allocation exists, it will be returned untouched.
-	 * 
+	 *
 	 * @param receiptSchedule
 	 * @param receipt
 	 * @return
@@ -204,9 +204,9 @@ public interface IReceiptScheduleBL extends ISingletonService
 
 	/**
 	 * Allocate given receipt line to the list of of provided receipt schedules.
-	 * 
+	 *
 	 * NOTE: if all receipt schedules were linked to the same Order Line, that order line will be set to given receipt.
-	 * 
+	 *
 	 * @param receiptSchedules
 	 * @param receiptLine
 	 * @return receipt schedule allocations that were created
@@ -217,38 +217,46 @@ public interface IReceiptScheduleBL extends ISingletonService
 
 	/**
 	 * updates preparation time
-	 * 
+	 *
 	 * @param receiptSchedule
 	 */
 	void updatePreparationTime(I_M_ReceiptSchedule receiptSchedule);
 
 	/**
 	 * Reverse given allocation by creating a new allocation which is canceling the effect.
-	 * 
+	 *
 	 * NOTE: reversal allocation will not be saved because user may want to change some fields before saving
-	 * 
+	 *
 	 * @param rsa
 	 * @return reversal allocation (not saved)
 	 */
 	I_M_ReceiptSchedule_Alloc reverseAllocation(I_M_ReceiptSchedule_Alloc rsa);
 
 	/**
-	 * Close receipt schedule line and mark it as processed. Also saves the given <code>rs</code>.
-	 * 
+	 * Close receipt schedule line and mark it as processed.
+	 *
+	 * Call the {@link IReceiptScheduleListener}s' beforeClose method, then set the schedule to <code>Processed=Y</code>, then saves the given <code>receiptSchedule</code>, then calls the listeners' afterClose() methods and finally saves the record again.
+	 * <p>
+	 * The saving prior to <code>afterClose()</code> is done because the listeners might also retrieve the same <code>receiptSchedule</code> data record from the DB and might also change and save it.
+	 * See {@link C_OrderLine_ReceiptSchedule} for an example.
+	 * <p>
+	 * The saving after <code>afterClose()</code> is done to acomodate for listeners that only alter the given <code>receiptSchedule</code> without saving it (which is actually the nice thing to do).
+	 *
+	 *
 	 * @param rs
 	 */
-	void close(I_M_ReceiptSchedule rs);
+	void close(I_M_ReceiptSchedule receiptSchedule);
 
 	/**
-	 * Re-open a closed receipt schedule line.
-	 * 
+	 * Re-open a closed receipt schedule line. Similar to {@link #close(I_M_ReceiptSchedule)}. Also, we save the given <code>receiptSchedule</code> twice for similar reasons.
+	 *
 	 * @param receiptSchedule
 	 */
 	void reopen(I_M_ReceiptSchedule receiptSchedule);
 
 	/**
 	 * Checks if given receipt schedule is closed (i.e. {@link I_M_ReceiptSchedule#isProcessed()}).
-	 * 
+	 *
 	 * @param receiptSchedule
 	 * @return true if receipt schedule is closed
 	 */

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IReceiptScheduleQtysBL.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IReceiptScheduleQtysBL.java
@@ -10,12 +10,12 @@ package de.metas.inoutcandidate.api;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -35,18 +35,22 @@ import de.metas.inoutcandidate.model.I_M_ReceiptSchedule_Alloc;
  * <ul>
  * <li> {@link I_M_ReceiptSchedule#COLUMNNAME_QtyMoved}
  * <li> {@link I_M_ReceiptSchedule#COLUMNNAME_QtyToMove}
+ * <li> {@link I_M_ReceiptSchedule#COLUMNNAME_QtyOrderedOverUnder}
+ * <li> {@link I_M_ReceiptSchedule#COLUMNNAME_QtyMovedWithIssues}
+ * <li> {@link I_M_ReceiptSchedule#COLUMNNAME_QualityDiscountPercent}
+ * <li> {@link I_M_ReceiptSchedule#COLUMNNAME_QualityNote}
  * </ul>
- * 
+ *
  * @author tsa
- * 
+ *
  */
-public interface IReceiptScheduleQtysHandler extends ISingletonService
+public interface IReceiptScheduleQtysBL extends ISingletonService
 {
 	/**
 	 * Gets Target Qty (i.e. how much shall we receive in the end).
-	 * 
+	 *
 	 * NOTE: {@link I_M_ReceiptSchedule#COLUMNNAME_QtyToMove_Override} is checked first and if is not set then {@link I_M_ReceiptSchedule#COLUMNNAME_QtyOrdered} is considered.
-	 * 
+	 *
 	 * @param rs
 	 * @return target qty
 	 */
@@ -54,9 +58,9 @@ public interface IReceiptScheduleQtysHandler extends ISingletonService
 
 	/**
 	 * Gets QtyToMove.
-	 * 
+	 *
 	 * NOTE: QtyToMove_Override is not considered
-	 * 
+	 *
 	 * @param rs
 	 * @return qty to move
 	 */
@@ -64,7 +68,7 @@ public interface IReceiptScheduleQtysHandler extends ISingletonService
 
 	/**
 	 * Gets QtyMoved
-	 * 
+	 *
 	 * @param rs
 	 * @return qty moved
 	 */
@@ -80,31 +84,33 @@ public interface IReceiptScheduleQtysHandler extends ISingletonService
 	BigDecimal getQtyOverUnderDelivery(I_M_ReceiptSchedule rs);
 
 	/**
-	 * Called when receipt schedule was created/updated and quantities needs to be set
-	 * 
+	 * Called by model interceptor {@link de.metas.inoutcandidate.modelvalidator.M_ReceiptSchedule} when the given <code>receiptSchedule</code> was created/updated and quantities needs to be set.
+	 * Since it's called by the MI, there is no need to call it manually throughout the code.
+	 * Please keep that MI in sync when you change those methods to use more/less/different properties of the given <code>receiptSchedule</code>.
+	 *
 	 * NOTE: implementor of this method shall not save the receiptSchedule. API is handling this.
-	 * 
+	 *
 	 * @param receiptSchedule
 	 */
 	void onReceiptScheduleChanged(I_M_ReceiptSchedule receiptSchedule);
 
 	/**
 	 * Called when an {@link I_M_ReceiptSchedule_Alloc} was created
-	 * 
+	 *
 	 * @param receiptScheduleAlloc
 	 */
 	void onReceiptScheduleAdded(final I_M_ReceiptSchedule_Alloc receiptScheduleAlloc);
 
 	/**
 	 * Called when an {@link I_M_ReceiptSchedule_Alloc} was changed
-	 * 
+	 *
 	 * @param receiptScheduleAlloc
 	 */
 	void onReceiptScheduleUpdated(final I_M_ReceiptSchedule_Alloc receiptScheduleAlloc);
 
 	/**
 	 * Called when an {@link I_M_ReceiptSchedule_Alloc} was deleted
-	 * 
+	 *
 	 * @param receiptScheduleAlloc
 	 */
 	void onReceiptScheduleDeleted(final I_M_ReceiptSchedule_Alloc receiptScheduleAlloc);

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleQtysBL.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleQtysBL.java
@@ -10,25 +10,24 @@ package de.metas.inoutcandidate.api.impl;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
-
 
 import java.math.BigDecimal;
 
 import org.adempiere.model.InterfaceWrapperHelper;
 
 import de.metas.inout.model.I_M_InOutLine;
-import de.metas.inoutcandidate.api.IReceiptScheduleQtysHandler;
+import de.metas.inoutcandidate.api.IReceiptScheduleQtysBL;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule_Alloc;
 import de.metas.inoutcandidate.spi.impl.IQtyAndQuality;
@@ -36,12 +35,11 @@ import de.metas.inoutcandidate.spi.impl.MutableQtyAndQuality;
 import de.metas.inoutcandidate.spi.impl.QualityNoticesCollection;
 
 /**
- * Implementation of this class is updating QtyMoved and QtyToMove columns when a {@link I_M_ReceiptSchedule_Alloc} is created, change or deleted.
- * 
- * @author tsa
- * 
+ *
+ * @author metas-dev <dev@metasfresh.com>
+ *
  */
-public class ReceiptScheduleQtysHandler implements IReceiptScheduleQtysHandler
+public class ReceiptScheduleQtysBL implements IReceiptScheduleQtysBL
 {
 	@Override
 	public BigDecimal getQtyOrdered(final I_M_ReceiptSchedule rs)
@@ -104,9 +102,9 @@ public class ReceiptScheduleQtysHandler implements IReceiptScheduleQtysHandler
 
 	/**
 	 * Gets current receipt schedule quantities.
-	 * 
+	 *
 	 * NOTE: we are taking the values directly from receipt schedule and not from getters (e.g. {@link #getQtyMoved(I_M_ReceiptSchedule)}) because we are about to update them.
-	 * 
+	 *
 	 * @param rs
 	 * @return receipt schedule quantities
 	 */
@@ -187,7 +185,8 @@ public class ReceiptScheduleQtysHandler implements IReceiptScheduleQtysHandler
 
 		// QtyToMove shall be updated in "onReceiptScheduleChanged"
 		// NOTE: make sure it is called right away (see 6185, G01T010)
-		onReceiptScheduleChanged(receiptSchedule);
+		// note: it's called via model interceptor on save.
+		// onReceiptScheduleChanged(receiptSchedule);
 
 		InterfaceWrapperHelper.save(receiptSchedule);
 	}
@@ -216,7 +215,7 @@ public class ReceiptScheduleQtysHandler implements IReceiptScheduleQtysHandler
 
 		//
 		// Case: receipt schedule was marked as processed.
-		// Now we preciselly know which is the actual Over/Under Delivery.
+		// Now we precisely know which is the actual Over/Under Delivery.
 		// i.e. if qtyOverUnder < 0 it means it's an under delivery (we delivered less)
 		// but we know this for sure ONLY when receipt schedule line is closed.
 		// Else we can consider that more receipts will come after.

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/async/GenerateReceiptScheduleWorkpackageProcessor.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/async/GenerateReceiptScheduleWorkpackageProcessor.java
@@ -10,12 +10,12 @@ package de.metas.inoutcandidate.async;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -40,13 +40,13 @@ import de.metas.inoutcandidate.spi.IReceiptScheduleProducer;
 
 /**
  * Process given models and creates {@link I_M_ReceiptSchedule} records.
- * 
+ *
  * Input: models (e.g. I_C_Order etc)
- * 
+ *
  * Output: {@link I_M_ReceiptSchedule}s
- * 
+ *
  * @author lc
- * 
+ *
  */
 public class GenerateReceiptScheduleWorkpackageProcessor implements IWorkpackageProcessor
 {
@@ -57,7 +57,7 @@ public class GenerateReceiptScheduleWorkpackageProcessor implements IWorkpackage
 		final IQueueDAO queueDAO = Services.get(IQueueDAO.class);
 		final ILoggable loggable = Services.get(IWorkPackageBL.class).createLoggable(workpackage);
 
-		// maybe the underyling order line was deleted meanwhile, after the order was reactivated. Using retrieveItemsSkipMissing() because we don't need to make a fuss about that.
+		// maybe the underlying order line was deleted meanwhile, after the order was reactivated. Using retrieveItemsSkipMissing() because we don't need to make a fuss about that.
 		final List<Object> models = queueDAO.retrieveItemsSkipMissing(workpackage, Object.class, localTrxName);
 		loggable.addLog("Retrieved " + models.size() + " items for this work package");
 
@@ -65,7 +65,9 @@ public class GenerateReceiptScheduleWorkpackageProcessor implements IWorkpackage
 		{
 			final String tableName = InterfaceWrapperHelper.getModelTableName(model);
 
-			final IReceiptScheduleProducer producer = Services.get(IReceiptScheduleProducerFactory.class).createProducer(tableName, false);
+			final IReceiptScheduleProducerFactory receiptScheduleProducerFactory = Services.get(IReceiptScheduleProducerFactory.class);
+			final boolean async = false;
+			final IReceiptScheduleProducer producer = receiptScheduleProducerFactory.createProducer(tableName, async);
 			final List<I_M_ReceiptSchedule> previousSchedules = Collections.emptyList();
 			producer.createOrUpdateReceiptSchedules(model, previousSchedules);
 		}

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_OrderLine_ReceiptSchedule.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_OrderLine_ReceiptSchedule.java
@@ -10,18 +10,17 @@ package de.metas.inoutcandidate.modelvalidator;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
-
 
 import java.util.Collections;
 import java.util.List;
@@ -39,7 +38,13 @@ import de.metas.inoutcandidate.spi.IReceiptScheduleProducer;
 @Validator(I_C_OrderLine.class)
 public class C_OrderLine_ReceiptSchedule
 {
-	@ModelChange(timings = { ModelValidator.TYPE_AFTER_CHANGE }, ifColumnsChanged = { I_C_OrderLine.COLUMNNAME_QtyOrderedOverUnder })
+	/**
+	 * Invokes {@link IReceiptScheduleProducer#createOrUpdateReceiptSchedules(Object, List)} (synchronously!)
+	 * @param orderLine
+	 */
+	@ModelChange(timings = { ModelValidator.TYPE_AFTER_CHANGE }, ifColumnsChanged = {
+			// I_C_OrderLine.COLUMNNAME_QtyOrderedOverUnder, this column is *only* set from the receipt schedule, so there is no point in creating/updating the rs if QtyOrderedOverUnder was changed from the rs.
+			I_C_OrderLine.COLUMNNAME_QtyOrdered })
 	public void createReceiptSchedules(final I_C_OrderLine orderLine)
 	{
 		if (!C_Order_ReceiptSchedule.isEligibleForReceiptSchedule(orderLine.getC_Order()))
@@ -47,8 +52,9 @@ public class C_OrderLine_ReceiptSchedule
 			return;
 		}
 
-		final IReceiptScheduleProducer producer = Services.get(IReceiptScheduleProducerFactory.class)
-				.createProducer(I_C_OrderLine.Table_Name, false);
+		final IReceiptScheduleProducerFactory receiptScheduleProducerFactory = Services.get(IReceiptScheduleProducerFactory.class);
+		final boolean async = false;
+		final IReceiptScheduleProducer producer = receiptScheduleProducerFactory.createProducer(I_C_OrderLine.Table_Name, async);
 
 		final List<I_M_ReceiptSchedule> previousSchedules = Collections.emptyList();
 		producer.createOrUpdateReceiptSchedules(orderLine, previousSchedules);

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ReceiptSchedule_Alloc.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ReceiptSchedule_Alloc.java
@@ -28,7 +28,7 @@ import org.adempiere.ad.modelvalidator.annotations.Validator;
 import org.adempiere.util.Services;
 import org.compiere.model.ModelValidator;
 
-import de.metas.inoutcandidate.api.IReceiptScheduleQtysHandler;
+import de.metas.inoutcandidate.api.IReceiptScheduleQtysBL;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule_Alloc;
 
 @Validator(I_M_ReceiptSchedule_Alloc.class)
@@ -37,18 +37,18 @@ public class M_ReceiptSchedule_Alloc
 	@ModelChange(timings = { ModelValidator.TYPE_AFTER_NEW })
 	public void updateQtyMovedAdd(final I_M_ReceiptSchedule_Alloc receiptScheduleAlloc)
 	{
-		Services.get(IReceiptScheduleQtysHandler.class).onReceiptScheduleAdded(receiptScheduleAlloc);
+		Services.get(IReceiptScheduleQtysBL.class).onReceiptScheduleAdded(receiptScheduleAlloc);
 	}
 
 	@ModelChange(timings = { ModelValidator.TYPE_AFTER_CHANGE })
 	public void updateQtyMovedChange(final I_M_ReceiptSchedule_Alloc receiptScheduleAlloc)
 	{
-		Services.get(IReceiptScheduleQtysHandler.class).onReceiptScheduleUpdated(receiptScheduleAlloc);
+		Services.get(IReceiptScheduleQtysBL.class).onReceiptScheduleUpdated(receiptScheduleAlloc);
 	}
 
 	@ModelChange(timings = { ModelValidator.TYPE_AFTER_DELETE })
 	public void updateQtyMovedSubtract(final I_M_ReceiptSchedule_Alloc receiptScheduleAlloc)
 	{
-		Services.get(IReceiptScheduleQtysHandler.class).onReceiptScheduleDeleted(receiptScheduleAlloc);
+		Services.get(IReceiptScheduleQtysBL.class).onReceiptScheduleDeleted(receiptScheduleAlloc);
 	}
 }

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ReceiptSchedule_Close.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ReceiptSchedule_Close.java
@@ -10,12 +10,12 @@ package de.metas.inoutcandidate.process;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -34,12 +34,12 @@ import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
 
 /**
  * Close receipt schedule line.
- * 
+ *
  * This is counter-part of {@link M_ReceiptSchedule_ReOpen}.
- * 
+ *
  * @author tsa
  * @task http://dewiki908/mediawiki/index.php/08480_Korrekturm%C3%B6glichkeit_Wareneingang_-_Menge%2C_Packvorschrift%2C_Merkmal_%28109195602347%29
- * 
+ *
  */
 public class M_ReceiptSchedule_Close extends SvrProcess implements ISvrProcessPrecondition
 {
@@ -57,12 +57,6 @@ public class M_ReceiptSchedule_Close extends SvrProcess implements ISvrProcessPr
 		}
 
 		return true;
-	}
-
-	@Override
-	protected void prepare()
-	{
-		// nothing
 	}
 
 	@Override

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ReceiptSchedule_ReOpen.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ReceiptSchedule_ReOpen.java
@@ -10,12 +10,12 @@ package de.metas.inoutcandidate.process;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -34,9 +34,9 @@ import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
 
 /**
  * Re-open closed receipt schedule.
- * 
+ *
  * This is counter-part of {@link M_ReceiptSchedule_Close}.
- * 
+ *
  * @author tsa
  * @task http://dewiki908/mediawiki/index.php/08480_Korrekturm%C3%B6glichkeit_Wareneingang_-_Menge%2C_Packvorschrift%2C_Merkmal_%28109195602347%29
  */
@@ -56,12 +56,6 @@ public class M_ReceiptSchedule_ReOpen extends SvrProcess implements ISvrProcessP
 		}
 
 		return true;
-	}
-
-	@Override
-	protected void prepare()
-	{
-		// nothing
 	}
 
 	@Override

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/AsyncReceiptScheduleProducer.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/AsyncReceiptScheduleProducer.java
@@ -46,7 +46,8 @@ public class AsyncReceiptScheduleProducer extends AbstractReceiptScheduleProduce
 
 		final Properties ctx = InterfaceWrapperHelper.getCtx(model);
 
-		final IWorkPackageQueue queue = Services.get(IWorkPackageQueueFactory.class).getQueueForEnqueuing(ctx, GenerateReceiptScheduleWorkpackageProcessor.class);
+		final IWorkPackageQueueFactory workPackageQueueFactory = Services.get(IWorkPackageQueueFactory.class);
+		final IWorkPackageQueue queue = workPackageQueueFactory.getQueueForEnqueuing(ctx, GenerateReceiptScheduleWorkpackageProcessor.class);
 
 		queue.enqueueElement(model);
 

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/CompositeReceiptScheduleListener.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/CompositeReceiptScheduleListener.java
@@ -10,12 +10,12 @@ package de.metas.inoutcandidate.spi.impl;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -84,6 +84,12 @@ public class CompositeReceiptScheduleListener implements IReceiptScheduleListene
 		{
 			listener.onAfterReopen(receiptSchedule);
 		}
+	}
+
+	@Override
+	public String toString()
+	{
+		return "CompositeReceiptScheduleListener [listeners=" + listeners + "]";
 	}
 
 }

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleListener.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleListener.java
@@ -10,27 +10,25 @@ package de.metas.inoutcandidate.spi.impl;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 
-
 import org.adempiere.util.Services;
-import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_OrderLine;
 
 import de.metas.adempiere.service.IOrderBL;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
+import de.metas.inoutcandidate.spi.IReceiptScheduleProducer;
 import de.metas.inoutcandidate.spi.ReceiptScheduleListenerAdapter;
-import de.metas.order.IOrderPA;
 
 public class OrderLineReceiptScheduleListener extends ReceiptScheduleListenerAdapter
 {
@@ -41,9 +39,8 @@ public class OrderLineReceiptScheduleListener extends ReceiptScheduleListenerAda
 	}
 
 	/**
-	 * If a receipt schedule is closed then this method retrieves its order line and sets the line's <code>QtyOrdered</code> to the current <code>QtyDelviered</code>, thus effectively "closing" the
-	 * line. Is also updates the order line's reservation via {@link IOrderPA#reserveStock(I_C_Order, I_C_OrderLine...)}.
-	 * 
+	 * If a receipt schedule is closed then this method retrieves its <code>orderLine</code> and invokes {@link IOrderBL#closeLine(I_C_OrderLine)} on it.
+	 *
 	 * @task 08452
 	 */
 	@Override
@@ -55,9 +52,19 @@ public class OrderLineReceiptScheduleListener extends ReceiptScheduleListenerAda
 			return; // shall not happen
 		}
 
-		Services.get(IOrderBL.class).closeLine(orderLine);
+		final IOrderBL orderBL = Services.get(IOrderBL.class);
+		orderBL.closeLine(orderLine);
 	}
 
+	/**
+	 * If a receipt schedule is reopened then this method retrieves its <code>orderLine</code> and invokes {@link IOrderBL#reopenLine(I_C_OrderLine)} on it.
+	 * <p>
+	 * Note: we open the order line <b>after</b> the reopen,
+	 * because this reopening will cause a synchronous updating of the receipt schedule via the {@link IReceiptScheduleProducer} framework
+	 * and the <code>receiptSchedule</code> that is to be reopened uses the order line's <code>QtyOrdered</code> value.
+	 *
+	 * @task <a href="https://github.com/metasfresh/metasfresh/issues/315">issue #315</a>
+	 */
 	@Override
 	public void onAfterReopen(final I_M_ReceiptSchedule receiptSchedule)
 	{
@@ -67,6 +74,7 @@ public class OrderLineReceiptScheduleListener extends ReceiptScheduleListenerAda
 			return; // shall not happen
 		}
 
-		Services.get(IOrderBL.class).reopenLine(orderLine);
+		final IOrderBL orderBL = Services.get(IOrderBL.class);
+		orderBL.reopenLine(orderLine);
 	}
 }

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleProducer.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleProducer.java
@@ -10,12 +10,12 @@ package de.metas.inoutcandidate.spi.impl;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -50,7 +50,7 @@ import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
 import de.metas.inoutcandidate.spi.AbstractReceiptScheduleProducer;
 
 /**
- * 
+ *
  */
 public class OrderLineReceiptScheduleProducer extends AbstractReceiptScheduleProducer
 {
@@ -107,15 +107,16 @@ public class OrderLineReceiptScheduleProducer extends AbstractReceiptSchedulePro
 		// BPartner & Location
 		receiptSchedule.setC_BPartner_ID(line.getC_BPartner_ID());
 		receiptSchedule.setC_BPartner_Location_ID(line.getC_BPartner_Location_ID());
-		receiptSchedule.setAD_User_ID(line.getC_Order().getAD_User_ID());
+		final I_C_Order order = line.getC_Order();
+		receiptSchedule.setAD_User_ID(order.getAD_User_ID());
 
 		//
 		// Delivery rule, Priority rule
 		{
-			receiptSchedule.setDeliveryRule(line.getC_Order().getDeliveryRule());
-			receiptSchedule.setDeliveryViaRule(line.getC_Order().getDeliveryViaRule());
+			receiptSchedule.setDeliveryRule(order.getDeliveryRule());
+			receiptSchedule.setDeliveryViaRule(order.getDeliveryViaRule());
 
-			receiptSchedule.setPriorityRule(line.getC_Order().getPriorityRule());
+			receiptSchedule.setPriorityRule(order.getPriorityRule());
 		}
 
 		//
@@ -158,7 +159,7 @@ public class OrderLineReceiptScheduleProducer extends AbstractReceiptSchedulePro
 			receiptSchedule.setM_Product_ID(line.getM_Product_ID());
 
 			Services.get(IAttributeSetInstanceBL.class).cloneASI(receiptSchedule, line);
-			
+
 			receiptSchedule.setC_UOM_ID(line.getC_UOM_ID());
 		}
 
@@ -172,7 +173,7 @@ public class OrderLineReceiptScheduleProducer extends AbstractReceiptSchedulePro
 			receiptSchedule.setQtyMoved(line.getQtyDelivered());
 		}
 		receiptSchedule.setQtyOrdered(line.getQtyOrdered());
-		// receiptSchedule.setQtyToMove(line.getQtyOrdered()); // QtyToMove will be computed
+		// receiptSchedule.setQtyToMove(line.getQtyOrdered()); // QtyToMove will be computed in IReceiptScheduleQtysBL
 
 		//
 		// Update aggregation key
@@ -282,13 +283,13 @@ public class OrderLineReceiptScheduleProducer extends AbstractReceiptSchedulePro
 
 	/**
 	 * Suggests the C_DocType_ID to be used for the future Material Receipt.
-	 * 
+	 *
 	 * Basically, it checks:
 	 * <ul>
 	 * <li>order's C_DocType.C_DocType_Shipment_ID if set
 	 * <li>standard Material Receipt document type
 	 * </ul>
-	 * 
+	 *
 	 * @param orderLine
 	 * @return
 	 */


### PR DESCRIPTION
* fix ifColumnschanged of C_OrderLine_ReceiptSchedule MI.
* fix saving of the receipt schedule during close and reopen.
* add a bunch of comments and javadocs.
* rename IReceiptScheduleQtysHandler to IReceiptScheduleQtysBL, because 
when it sais "handler", i generally think "SPI" (hoping not to confuse 
others with this rename).
* do minor stuff like fixing typos and removing obsolete prepareIt() 
implementation.