### PR TITLE
FRESH-1070 #742 R_Request column c_order_id autocomplete too slow

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5454810_sys_FRESH-1070_switch-off_autocomplete_c_order_id.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5454810_sys_FRESH-1070_switch-off_autocomplete_c_order_id.sql
@@ -1,0 +1,5 @@
+-- 20.12.2016 16:04
+-- URL zum Konzept
+UPDATE AD_Column SET IsAutocomplete='N',Updated=TO_TIMESTAMP('2016-12-20 16:04:30','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=5436
+;
+


### PR DESCRIPTION
Switch off autocomplete for field c_order_id (seq scan takes too long
for large datasets)