### PR TITLE
FRESH-1257 #886 GrandTotal missing in Purchase Order Grid view

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5455672_sys_FRESH-1257-GrandTotal-missingPurchaseOrder.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5455672_sys_FRESH-1257-GrandTotal-missingPurchaseOrder.sql
@@ -1,0 +1,5 @@
+-- 30.01.2017 13:57
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsAdvancedField='N',Updated=TO_TIMESTAMP('2017-01-30 13:57:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=541253
+;
+


### PR DESCRIPTION
Add GrandTotal Field into Purchase Order Grid View (workaround: disabled
Advanced Edit).