### PR TITLE
#781 ESR scan processing returns improper bpartner

### DIFF
--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/model/InterfaceWrapperHelper.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/model/InterfaceWrapperHelper.java
@@ -22,13 +22,13 @@ package org.adempiere.model;
  * #L%
  */
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -326,28 +326,24 @@ public class InterfaceWrapperHelper
 			return null;
 		}
 
-		final List<T> result = new ArrayList<>(list.size());
-		for (final S model : list)
-		{
-			final T modelConv = create(model, clazz);
-			result.add(modelConv);
-		}
+		final List<T> result = list.stream()
+				.map(item -> create(item, clazz))
+				.collect(Collectors.toList());
 
 		return result;
 	}
-	
+
 	public static <T, S> List<T> wrapToImmutableList(final List<S> list, final Class<T> clazz)
 	{
 		if (list == null || list.isEmpty())
 		{
 			return ImmutableList.of();
 		}
-		
+
 		return list.stream()
 				.map(model -> create(model, clazz))
 				.collect(GuavaCollectors.toImmutableList());
 	}
-
 
 	public static void refresh(final Object model)
 	{
@@ -707,12 +703,12 @@ public class InterfaceWrapperHelper
 		{
 			return new MissingTableNameException("@NotFound@ @TableName@ (class=" + modelClass + ")");
 		}
-		
+
 		private static final MissingTableNameException notFound(final Class<?> modelClass, final String fallbackTableName)
 		{
 			return new MissingTableNameException("@NotFound@ @TableName@ (class=" + modelClass + ", fallbackTableName=" + fallbackTableName + ")");
 		}
-		
+
 		private static final MissingTableNameException notMatching(final Class<?> modelClass, final String modelClassTableName, final String expectedTableName)
 		{
 			return new MissingTableNameException("modelClass's table name is not matching the expected table name:"
@@ -783,13 +779,13 @@ public class InterfaceWrapperHelper
 
 		// Case: there is no expected/default table name
 		// => fail if modelClass has no table name either.
-		if(expectedTableName == null)
+		if (expectedTableName == null)
 		{
 			if (modelClassTableName == null)
 			{
 				throw MissingTableNameException.notFound(modelClass, expectedTableName);
 			}
-			
+
 			return modelClassTableName;
 		}
 		// Case: there is an expected/default table name

--- a/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/IPaymentStringDataProvider.java
+++ b/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/IPaymentStringDataProvider.java
@@ -1,5 +1,10 @@
 package de.metas.banking.payment;
 
+import java.util.List;
+
+import org.adempiere.model.IContextAware;
+import org.compiere.model.I_C_BP_BankAccount;
+
 /*
  * #%L
  * de.metas.banking.base
@@ -23,9 +28,7 @@ package de.metas.banking.payment;
  */
 
 
-import org.adempiere.model.IContextAware;
 
-import de.metas.interfaces.I_C_BP_BankAccount;
 
 /**
  * Interface used to retrieve information from an {@link IPaymentString}.
@@ -36,7 +39,10 @@ public interface IPaymentStringDataProvider
 {
 	IPaymentString getPaymentString();
 
-	I_C_BP_BankAccount getC_BP_BankAccountOrNull();
+	/**
+	 * @return bank accounts that match this instance.
+	 */
+	List<I_C_BP_BankAccount> getC_BP_BankAccounts();
 
 	/**
 	 * Create and save a new C_BP_BankAccount based on the data contained in this provider.

--- a/de.metas.banking/de.metas.banking.swingui/src/main/java/de/metas/banking/payment/paymentallocation/form/ReadPaymentDialogWindowAdapter.java
+++ b/de.metas.banking/de.metas.banking.swingui/src/main/java/de/metas/banking/payment/paymentallocation/form/ReadPaymentDialogWindowAdapter.java
@@ -69,7 +69,7 @@ public abstract class ReadPaymentDialogWindowAdapter extends WindowAdapter
 
 		//
 		// Update information
-		final ReadPaymentPanelResult result = readPaymentPanel.getResultIfValid().orNull();
+		final ReadPaymentPanelResult result = readPaymentPanel.getResultIfValid().orElse(null);
 		if (result == null)
 		{
 			return;

--- a/de.metas.banking/de.metas.banking.swingui/src/main/java/de/metas/banking/payment/paymentallocation/form/ReadPaymentDocumentForm.java
+++ b/de.metas.banking/de.metas.banking.swingui/src/main/java/de/metas/banking/payment/paymentallocation/form/ReadPaymentDocumentForm.java
@@ -106,7 +106,9 @@ public class ReadPaymentDocumentForm implements FormPanel, IProcessPrecondition
 	private ReadPaymentDocumentPanel createAndBindPanel(final int windowNo, final Frame frame, final int adOrgId)
 	{
 		final ReadPaymentDocumentPanel readPaymentPanel = new ReadPaymentDocumentPanel(windowNo, frame, adOrgId);
-		readPaymentPanel.setContextBPartner(invoice==null?null:invoice.getC_BPartner());
+		
+		// gh #897: provide the invoice's bPartner so the panel can filter matching accounts by relevance
+		readPaymentPanel.setContextBPartner(invoice == null ? null : invoice.getC_BPartner());
 		
 		frame.addWindowListener(new ReadPaymentDialogWindowAdapter(readPaymentPanel)
 		{

--- a/de.metas.banking/de.metas.banking.swingui/src/main/java/de/metas/banking/payment/paymentallocation/form/ReadPaymentDocumentForm.java
+++ b/de.metas.banking/de.metas.banking.swingui/src/main/java/de/metas/banking/payment/paymentallocation/form/ReadPaymentDocumentForm.java
@@ -106,6 +106,8 @@ public class ReadPaymentDocumentForm implements FormPanel, IProcessPrecondition
 	private ReadPaymentDocumentPanel createAndBindPanel(final int windowNo, final Frame frame, final int adOrgId)
 	{
 		final ReadPaymentDocumentPanel readPaymentPanel = new ReadPaymentDocumentPanel(windowNo, frame, adOrgId);
+		readPaymentPanel.setContextBPartner(invoice==null?null:invoice.getC_BPartner());
+		
 		frame.addWindowListener(new ReadPaymentDialogWindowAdapter(readPaymentPanel)
 		{
 			@Override

--- a/de.metas.banking/de.metas.banking.swingui/src/main/java/de/metas/banking/payment/paymentallocation/form/ReadPaymentDocumentPanel.java
+++ b/de.metas.banking/de.metas.banking.swingui/src/main/java/de/metas/banking/payment/paymentallocation/form/ReadPaymentDocumentPanel.java
@@ -13,15 +13,14 @@ package de.metas.banking.payment.paymentallocation.form;
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
-
 
 import java.awt.BorderLayout;
 import java.awt.Component;
@@ -33,6 +32,8 @@ import java.awt.event.FocusEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.VetoableChangeListener;
 import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.Optional;
 import java.util.Properties;
 
 import javax.swing.AbstractAction;
@@ -42,6 +43,7 @@ import javax.swing.JLabel;
 import javax.swing.KeyStroke;
 import javax.swing.SwingConstants;
 
+import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
@@ -51,6 +53,8 @@ import org.adempiere.model.PlainContextAware;
 import org.adempiere.util.Check;
 import org.adempiere.util.Services;
 import org.adempiere.util.api.IMsgBL;
+import org.adempiere.util.lang.IPair;
+import org.adempiere.util.lang.ImmutablePair;
 import org.compiere.apps.ConfirmPanel;
 import org.compiere.grid.ed.VLookup;
 import org.compiere.grid.ed.VNumber;
@@ -65,9 +69,6 @@ import org.compiere.swing.CTextField;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
 import org.slf4j.Logger;
-import org.slf4j.Logger;
-
-import com.google.common.base.Optional;
 
 import de.metas.adempiere.form.IClientUI;
 import de.metas.banking.payment.IPaymentString;
@@ -75,7 +76,7 @@ import de.metas.banking.payment.IPaymentStringBL;
 import de.metas.banking.payment.IPaymentStringDataProvider;
 import de.metas.banking.payment.spi.IPaymentStringParser;
 import de.metas.banking.payment.spi.exception.PaymentStringParseException;
-import de.metas.logging.LogManager;
+import de.metas.interfaces.I_C_BP_Relation;
 import de.metas.logging.LogManager;
 import de.metas.payment.model.I_C_Payment_Request;
 import net.miginfocom.swing.MigLayout;
@@ -142,6 +143,8 @@ class ReadPaymentDocumentPanel
 	private final JLabel amountLabel = new JLabel();
 	private final VNumber amountField;
 
+	private I_C_BPartner contextBPartner;
+
 	/**
 	 * @param window
 	 * @param AD_Org_ID
@@ -186,8 +189,7 @@ class ReadPaymentDocumentPanel
 				I_C_BPartner.COLUMNNAME_C_BPartner_ID,
 				138, // C_BPartner (trx)
 				false,
-				validationCode
-				);
+				validationCode);
 
 		bpartnerField = new VLookup(I_C_BPartner.COLUMNNAME_C_BPartner_ID,
 				true, // mandatory
@@ -215,6 +217,20 @@ class ReadPaymentDocumentPanel
 				msgBL.translate(ctx, I_C_Payment_Request.COLUMNNAME_Amount));
 
 		init();
+	}
+
+	/**
+	 * Optionally set a bPartner that needs to have a relation to the payment document which we are reading.<br>
+	 * If set, and the system finds an existing {@link I_C_BP_BankAccount}, then that bank account is only used
+	 * if it belongs to the given {@code contextBPartner} or to a second bPartner who has a {@code RemitTo} {@link I_C_BP_Relation} with the given {@code contextPartner}.
+	 * 
+	 * @param contextBPartner
+	 * 
+	 * @task https://github.com/metasfresh/metasfresh/issues/781
+	 */
+	public void setContextBPartner(I_C_BPartner contextBPartner)
+	{
+		this.contextBPartner = contextBPartner;
 	}
 
 	public Component getComponent()
@@ -366,6 +382,7 @@ class ReadPaymentDocumentPanel
 	private final void parsePaymentString(final Properties ctx)
 	{
 		updateCurrentPaymentString();
+
 		if (Check.isEmpty(currentPaymentString, true))
 		{
 			return; // do nothing if it's empty
@@ -385,7 +402,7 @@ class ReadPaymentDocumentPanel
 
 		final IPaymentString paymentString = dataProvider.getPaymentString();
 
-		final I_C_BP_BankAccount bpBankAccountExisting = dataProvider.getC_BP_BankAccountOrNull();
+		final I_C_BP_BankAccount bpBankAccountExisting = getAndVerifyBPartnerAccount(dataProvider);
 		if (bpBankAccountExisting != null)
 		{
 			setC_BPartner_ID(bpBankAccountExisting.getC_BPartner_ID());
@@ -408,7 +425,7 @@ class ReadPaymentDocumentPanel
 			}
 			else
 			{
-				final IContextAware contextProvider = new PlainContextAware(ctx);
+				final IContextAware contextProvider = PlainContextAware.newOutOfTrx(ctx);
 
 				//
 				// Let the user edit for now
@@ -423,6 +440,66 @@ class ReadPaymentDocumentPanel
 		setAmount(amount);
 
 		currentParsedPaymentString = paymentString;
+	}
+
+	/**
+	 * Calls {@link IPaymentStringDataProvider#getC_BP_BankAccounts()} and
+	 * <li>filters out accounts where {@link #validateAgainstContextBPartner(I_C_BP_BankAccount)} returned a {@code 3}
+	 * <li>orders by the result of {@link #validateAgainstContextBPartner(I_C_BP_BankAccount)}, i.e. prefers 1s order 2s
+	 * <li>returns the first match.
+	 * 
+	 * @param dataProvider
+	 * @return
+	 */
+	private I_C_BP_BankAccount getAndVerifyBPartnerAccount(final IPaymentStringDataProvider dataProvider)
+	{
+		final Optional<I_C_BP_BankAccount> firstBankAccount = dataProvider.getC_BP_BankAccounts().stream()
+				.map(bankAccount -> ImmutablePair.of(bankAccount, validateAgainstContextBPartner(bankAccount)))
+				.filter(pair -> pair.getRight() < 3)
+				.sorted(Comparator.comparing(IPair::getRight))
+				.map(pair -> pair.getLeft())
+				.findFirst();
+
+		return firstBankAccount.orElseGet(null);
+	}
+
+	/**
+	 * Checks the given {@code bpBankAccount} against the partner that was set via {@link #setContextBPartner(I_C_BPartner)} (if any) and returns:
+	 * <li>{@code 1} if no {@link #setContextBPartner(I_C_BPartner)} was set, or if the given {@code bpBankAccount}'s bPartner is the one that was set
+	 * <li>{@code 2} else, if the given {@code bpBankAccount}'s bPartner is a {@code RemitTo} partner of the {@link #setContextBPartner(I_C_BPartner)} partner
+	 * <li>{@code 3} else
+	 * 
+	 * @param bpBankAccount
+	 * @return
+	 */
+	private int validateAgainstContextBPartner(final I_C_BP_BankAccount bpBankAccount)
+	{
+		final int ctxBPartnerID = contextBPartner != null ? contextBPartner.getC_BPartner_ID() : 0;
+		if (ctxBPartnerID <= 0)
+		{
+			// we have no BPartner-Context-Info, so we can't verify the bank account.
+			return 1;
+		}
+
+		if (ctxBPartnerID == bpBankAccount.getC_BPartner_ID())
+		{
+			// the BPartner from the account we looked up is thae one from context
+			return 1;
+		}
+
+		final IQueryBL queryBL = Services.get(IQueryBL.class);
+		final boolean existsRelation = queryBL.createQueryBuilder(I_C_BP_Relation.class, bpBankAccount)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_C_BP_Relation.COLUMNNAME_IsRemitTo, true)
+				.addEqualsFilter(I_C_BP_Relation.COLUMNNAME_C_BPartner_ID, ctxBPartnerID)
+				.addEqualsFilter(I_C_BP_Relation.COLUMNNAME_C_BPartnerRelation_ID, bpBankAccount.getC_BPartner_ID())
+				.create()
+				.match();
+		if (existsRelation)
+		{
+			return 2;
+		}
+		return 3;
 	}
 
 	public IPaymentString getParsedPaymentStringOrNull()
@@ -495,7 +572,7 @@ class ReadPaymentDocumentPanel
 	 */
 	private void onDialogOk()
 	{
-		final IContextAware contextProvider = new PlainContextAware(Env.getCtx(), ITrx.TRXNAME_None);
+		final IContextAware contextProvider = PlainContextAware.newOutOfTrx(Env.getCtx());
 
 		//
 		// Create it, but do not save it!
@@ -638,7 +715,7 @@ class ReadPaymentDocumentPanel
 		if (paymentRequestTemplate == null)
 		{
 			// dialog was cancelled => nothing to do
-			return Optional.absent();
+			return Optional.empty();
 		}
 
 		final ReadPaymentPanelResult.Builder resultBuilder = ReadPaymentPanelResult.builder();
@@ -668,7 +745,7 @@ class ReadPaymentDocumentPanel
 		final IPaymentString parsedPaymentString = getParsedPaymentStringOrNull();
 		if (parsedPaymentString == null)
 		{
-			return Optional.absent();
+			return Optional.empty();
 		}
 		final String reference = parsedPaymentString.getReferenceNoComplete();
 		paymentRequestTemplate.setReference(reference);

--- a/de.metas.payment.esr/src/main/java/de/metas/payment/api/impl/ESRPaymentStringDataProvider.java
+++ b/de.metas.payment.esr/src/main/java/de/metas/payment/api/impl/ESRPaymentStringDataProvider.java
@@ -13,16 +13,16 @@ package de.metas.payment.api.impl;
  * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  * 
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 
-
+import java.util.List;
 import org.adempiere.bpartner.service.IBPartnerDAO;
 import org.adempiere.model.IContextAware;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -47,15 +47,20 @@ public class ESRPaymentStringDataProvider extends AbstractPaymentStringDataProvi
 	}
 
 	@Override
-	public I_C_BP_BankAccount getC_BP_BankAccountOrNull()
+	public List<org.compiere.model.I_C_BP_BankAccount> getC_BP_BankAccounts()
 	{
 		final IPaymentString paymentString = getPaymentString();
 
 		final String postAccountNo = paymentString.getPostAccountNo();
 		final String innerAccountNo = paymentString.getInnerAccountNo();
 
-		final I_C_BP_BankAccount bankAccount = Services.get(IESRBPBankAccountDAO.class).retrieveESRBPBankAccountOrNull(postAccountNo, innerAccountNo);
-		return bankAccount;
+		final IESRBPBankAccountDAO esrbpBankAccountDAO = Services.get(IESRBPBankAccountDAO.class);
+
+		final List<org.compiere.model.I_C_BP_BankAccount> bankAccounts = InterfaceWrapperHelper.createList(
+				esrbpBankAccountDAO.retrieveESRBPBankAccounts(postAccountNo, innerAccountNo),
+				org.compiere.model.I_C_BP_BankAccount.class);
+
+		return bankAccounts;
 	}
 
 	@Override
@@ -76,7 +81,7 @@ public class ESRPaymentStringDataProvider extends AbstractPaymentStringDataProvi
 		// bpBankAccount.setC_Bank_ID(C_Bank_ID); // introduce a standard ESR-Dummy-Bank, or leave it empty
 
 		final I_C_Currency currency = Services.get(ICurrencyDAO.class).retrieveCurrencyByISOCode(contextProvider.getCtx(), "CHF"); // CHF, because it's ESR
-		bpBankAccount.setC_Currency(currency); 
+		bpBankAccount.setC_Currency(currency);
 		bpBankAccount.setIsEsrAccount(true); // ..because we are creating this from an ESR string
 		bpBankAccount.setIsACH(true);
 		bpBankAccount.setA_Name(bpBankAccount.getC_BPartner().getName());

--- a/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/IESRBPBankAccountDAO.java
+++ b/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/IESRBPBankAccountDAO.java
@@ -13,20 +13,20 @@ package de.metas.payment.esr.api;
  * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  * 
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
-
 
 import java.util.List;
 
 import org.adempiere.util.ISingletonService;
 import org.compiere.model.I_AD_Org;
+import org.compiere.model.I_C_BPartner;
 
 import de.metas.payment.esr.model.I_C_BP_BankAccount;
 
@@ -39,11 +39,15 @@ public interface IESRBPBankAccountDAO extends ISingletonService
 	 * @return account(s) if exist, throw exception otherwise. If there is more than one ESR account, then the one with IsDefaultESR='Y' is returned first.
 	 */
 	public List<I_C_BP_BankAccount> fetchOrgEsrAccounts(I_AD_Org org);
-	
+
 	/**
+	 * Retrieve matching ESR bank accounts. Note that the given {@code postAccountNo} and {@code innerAccountNo} are <b>not</b> guaranteed to be unique.<br>
+	 * A simple example of non-unique parameters would be two {@link I_C_BPartner}s that are tightly coupled in the real world and have the same bank account.
+	 * 
+	 * 
 	 * @param postAccountNo
 	 * @param innerAccountNo
-	 * @return {@link I_C_BP_BankAccount} (unique) corresponding to the ESR accountNo and inner-bank accountNo or <code>null</code> if none was found
+	 * @return {@link I_C_BP_BankAccount}s corresponding to the ESR accountNo and inner-bank accountNo or an empty list if none was found.
 	 */
-	I_C_BP_BankAccount retrieveESRBPBankAccountOrNull(String postAccountNo, String innerAccountNo);
+	List<I_C_BP_BankAccount> retrieveESRBPBankAccounts(String postAccountNo, String innerAccountNo);
 }

--- a/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/AbstractBPBankAccountDAO.java
+++ b/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/AbstractBPBankAccountDAO.java
@@ -1,5 +1,7 @@
 package de.metas.payment.esr.api.impl;
 
+import java.util.List;
+
 /*
  * #%L
  * de.metas.payment.esr
@@ -13,15 +15,14 @@ package de.metas.payment.esr.api.impl;
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
-
 
 import java.util.Properties;
 
@@ -38,7 +39,7 @@ import de.metas.payment.esr.model.I_C_BP_BankAccount;
 public abstract class AbstractBPBankAccountDAO implements IESRBPBankAccountDAO
 {
 	@Override
-	public I_C_BP_BankAccount retrieveESRBPBankAccountOrNull(final String postAccountNo, final String innerAccountNo)
+	public List<I_C_BP_BankAccount> retrieveESRBPBankAccounts(final String postAccountNo, final String innerAccountNo)
 	{
 		Check.assumeNotEmpty(postAccountNo, "postAccountNo not null");
 		Check.assumeNotEmpty(innerAccountNo, "innerAccountNo not null");
@@ -46,7 +47,9 @@ public abstract class AbstractBPBankAccountDAO implements IESRBPBankAccountDAO
 		final Properties ctx = Env.getCtx();
 		final String trxName = ITrx.TRXNAME_None;
 
-		final IQueryBuilder<I_C_BP_BankAccount> qb = Services.get(IQueryBL.class).createQueryBuilder(I_C_BP_BankAccount.class, ctx, trxName)
+		final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+		final IQueryBuilder<I_C_BP_BankAccount> qb = queryBL.createQueryBuilder(I_C_BP_BankAccount.class, ctx, trxName)
 				.addEqualsFilter(I_C_BP_BankAccount.COLUMNNAME_ESR_RenderedAccountNo, postAccountNo)
 				.addEqualsFilter(I_C_BP_BankAccount.COLUMNNAME_IsEsrAccount, true);
 
@@ -58,8 +61,10 @@ public abstract class AbstractBPBankAccountDAO implements IESRBPBankAccountDAO
 		qb
 				.addOnlyActiveRecordsFilter()
 				.addOnlyContextClient();
-		return qb.create()
-				.firstOnly(I_C_BP_BankAccount.class);
+
+		return qb
+				.create()
+				.list();
 	}
 
 }

--- a/de.metas.payment.esr/src/main/sql/postgresql/system/5455800_sys_gh781_ESR_C_BP_BankAccount_UC.sql
+++ b/de.metas.payment.esr/src/main/sql/postgresql/system/5455800_sys_gh781_ESR_C_BP_BankAccount_UC.sql
@@ -1,0 +1,41 @@
+
+-- 31.01.2017 17:03
+-- URL zum Konzept
+INSERT INTO AD_Index_Table (AD_Client_ID,AD_Index_Table_ID,AD_Org_ID,AD_Table_ID,Created,CreatedBy,EntityType,IsActive,IsUnique,Name,Processing,Updated,UpdatedBy,WhereClause) VALUES (0,540394,0,298,TO_TIMESTAMP('2017-01-31 17:03:25','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr','Y','N','C_BP_BankAccount_IsEsrAccount_UC','N',TO_TIMESTAMP('2017-01-31 17:03:25','YYYY-MM-DD HH24:MI:SS'),100,'IsActive=''Y'' AND IsEsrAccount=''Y''')
+;
+
+-- 31.01.2017 17:03
+-- URL zum Konzept
+INSERT INTO AD_Index_Table_Trl (AD_Language,AD_Index_Table_ID, ErrorMsg, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Index_Table_ID, t.ErrorMsg, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Index_Table t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Index_Table_ID=540394 AND NOT EXISTS (SELECT * FROM AD_Index_Table_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Index_Table_ID=t.AD_Index_Table_ID)
+;
+
+-- 31.01.2017 17:03
+-- URL zum Konzept
+INSERT INTO AD_Index_Column (AD_Client_ID,AD_Column_ID,AD_Index_Column_ID,AD_Index_Table_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,SeqNo,Updated,UpdatedBy) VALUES (0,3102,540787,540394,0,TO_TIMESTAMP('2017-01-31 17:03:40','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr','Y',10,TO_TIMESTAMP('2017-01-31 17:03:40','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 31.01.2017 17:04
+-- URL zum Konzept
+INSERT INTO AD_Index_Column (AD_Client_ID,AD_Column_ID,AD_Index_Column_ID,AD_Index_Table_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,SeqNo,Updated,UpdatedBy) VALUES (0,548019,540788,540394,0,TO_TIMESTAMP('2017-01-31 17:04:05','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr','Y',20,TO_TIMESTAMP('2017-01-31 17:04:05','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 31.01.2017 17:05
+-- URL zum Konzept
+INSERT INTO AD_Index_Column (AD_Client_ID,AD_Column_ID,AD_Index_Column_ID,AD_Index_Table_ID,AD_Org_ID,ColumnSQL,Created,CreatedBy,EntityType,IsActive,SeqNo,Updated,UpdatedBy) VALUES (0,3105,540789,540394,0,'COALESCE(AccountNo, ''0000000'')',TO_TIMESTAMP('2017-01-31 17:05:20','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr','Y',30,TO_TIMESTAMP('2017-01-31 17:05:20','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 31.01.2017 17:06
+-- URL zum Konzept
+UPDATE AD_Index_Table SET ErrorMsg='Bei ESR-Konten müssen Teilnehmernummer und Kontonummer pro Geschäftspartner eindeutig sein.', IsUnique='Y',Updated=TO_TIMESTAMP('2017-01-31 17:06:22','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Index_Table_ID=540394
+;
+
+-- 31.01.2017 17:06
+-- URL zum Konzept
+UPDATE AD_Index_Table_Trl SET IsTranslated='N' WHERE AD_Index_Table_ID=540394
+;
+
+-- 31.01.2017 17:09
+-- URL zum Konzept
+CREATE UNIQUE INDEX IF NOT EXISTS C_BP_BankAccount_IsEsrAccount_UC ON C_BP_BankAccount (C_BPartner_ID,ESR_RenderedAccountNo,COALESCE(AccountNo, '0000000')) WHERE IsActive='Y' AND IsEsrAccount='Y'
+;
+

--- a/de.metas.payment.esr/src/test/java/de/metas/payment/spi/impl/ESRCreaLogixStringParserTests.java
+++ b/de.metas.payment.esr/src/test/java/de/metas/payment/spi/impl/ESRCreaLogixStringParserTests.java
@@ -1,0 +1,40 @@
+package de.metas.payment.spi.impl;
+
+import org.compiere.util.Env;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+
+import de.metas.banking.payment.IPaymentString;
+
+/*
+ * #%L
+ * de.metas.payment.esr
+ * %%
+ * Copyright (C) 2017 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+public class ESRCreaLogixStringParserTests
+{
+	@Test
+	public void parse()
+	{
+		final IPaymentString result = ESRCreaLogixStringParser.instance.parse(Env.getCtx(), "042>000000162591872680005352198+ 012000007>");
+		assertThat(result.getPostAccountNo(), is("012000007"));
+	}
+}


### PR DESCRIPTION
filter and order C_BP_BankAccounts according to ctx-BPartner

* until now it was assumed that there can be only one ESR account per
ESR_RenderedAccountNo and AccountNo, but that's not true.
* as of now, we allow multiple such accounts and make sure that only the
relevant ones are taken into account when an ESR string is scanned.
* by relevant, we mean that the ESR account either belongs to the
BPartner in question or (with lesser priority) to a C_BPArtner which has
a remetTo relation to the BPArtner in question.
* at the same time, we establish a UC (there was none so far) to make
sure that there are no duplicate ESR accounts per bPartner.

FRESH-1113 #781 ESR scan processing returns improper bpartner