### PR TITLE
Release 2017 06+patch4

### DIFF
--- a/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/RUN_metasfresh.bat
+++ b/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/RUN_metasfresh.bat
@@ -78,24 +78,16 @@ SET METASFRESH_HOME=%~dp0
 REM @goto MULTI_INSTALL
 
 :METASFRESH_HOME_OK
-SET MAIN_CLASSNAME=org.springframework.boot.loader.JarLauncher
+SET MAIN_CLASSNAME=org.springframework.boot.loader.PropertiesLauncher
 
 @REM finding our jar file
 @REM thx to http://stackoverflow.com/questions/13876771/find-file-and-return-full-path-using-a-batch-file
 for /f "delims=" %%F in ('dir /b /s "%METASFRESH_HOME%\lib\de.metas.endcustomer.*.swingui-*.jar" 2^>nul') do set JAR=%%F
 
-SET USERJARS=
-for /R "%METASFRESH_HOME%/userlib" %%a in (*.jar) do call :ADDTO_USERJARS "%%a"
-goto :ADDTO_USERJARS_END
+SET CLASSPATH=%JAR%
 
-:ADDTO_USERJARS
-@Echo userjar added to CLASSPATH %~1
-set USERJARS=%~1;%USERJARS%
-GOTO :EOF
-:ADDTO_USERJARS_END
-
-@REM Multiple path entries are separated by semicolons with no spaces , see https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html
-SET CLASSPATH=%USERJARS%;%JAR%
+@REM Comma-separated Classpath, e.g. lib,${HOME}/app/lib. see https://docs.spring.io/spring-boot/docs/current/reference/html/executable-jar.html#executable-jar-property-launcher-features
+SET LOADER_PATH=%METASFRESH_HOME%\userlib
 
 SET PATH=%PATH%;%METASFRESH_HOME%\userlib-x64
 
@@ -121,6 +113,7 @@ SET PATH=%PATH%;%METASFRESH_HOME%\userlib-x64
 @Echo JMX_REMOTE_DEBUG_OPTS=%JMX_REMOTE_DEBUG_OPTS%
 @Echo SECURE=%SECURE%
 @Echo CLASSPATH=%CLASSPATH%
+@Echo LOADER_PATH=%LOADER_PATH%
 @Echo MAIN_CLASSNAME=%MAIN_CLASSNAME%
 
 :START
@@ -129,5 +122,3 @@ SET JAVA_OPTS=-Xms32m -Xmx1024m -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryE
 
 @Rem @sleep 15
 @CHOICE /C YN /T 15 /D N > NUL
-
-:EOF

--- a/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/RUN_metasfresh.bat
+++ b/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/RUN_metasfresh.bat
@@ -89,7 +89,7 @@ for /R "%METASFRESH_HOME%/userlib" %%a in (*.jar) do call :ADDTO_USERJARS "%%a"
 goto :ADDTO_USERJARS_END
 
 :ADDTO_USERJARS
-@Echo userjar is %~1
+@Echo userjar added to CLASSPATH %~1
 set USERJARS=%~1;%USERJARS%
 GOTO :EOF
 :ADDTO_USERJARS_END

--- a/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/RUN_metasfresh.bat
+++ b/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/RUN_metasfresh.bat
@@ -5,7 +5,7 @@
 @Rem explicitly here for different versions, etc. e.g.
 @Rem
 @Rem SET METASFRESH_HOME=C:\metasfresh
-@Rem SET JAVA_HOME=c:\Program Files\Java\jdk1.8.0_40
+@Rem SET JAVA_HOME=c:\Program Files\Java\jdk1.8.0_112
 
 @Rem Variables: 
 @Rem DBG_PORT                   ->  Start-Port the script will scan (min. port)
@@ -84,7 +84,20 @@ SET MAIN_CLASSNAME=org.springframework.boot.loader.JarLauncher
 @REM thx to http://stackoverflow.com/questions/13876771/find-file-and-return-full-path-using-a-batch-file
 for /f "delims=" %%F in ('dir /b /s "%METASFRESH_HOME%\lib\de.metas.endcustomer.*.swingui-*.jar" 2^>nul') do set JAR=%%F
 
-SET CLASSPATH=%JAR%
+SET USERJARS=
+for /R "%METASFRESH_HOME%/userlib" %%a in (*.jar) do call :ADDTO_USERJARS "%%a"
+goto :ADDTO_USERJARS_END
+
+:ADDTO_USERJARS
+@Echo userjar is %~1
+set USERJARS=%~1;%USERJARS%
+GOTO :EOF
+:ADDTO_USERJARS_END
+
+@REM Multiple path entries are separated by semicolons with no spaces , see https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html
+SET CLASSPATH=%USERJARS%;%JAR%
+
+SET PATH=%PATH%;%METASFRESH_HOME%\userlib-x64
 
 :MULTI_INSTALL
 @REM  To switch between multiple installs, copy the created metasfresh.properties file
@@ -116,3 +129,5 @@ SET JAVA_OPTS=-Xms32m -Xmx1024m -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryE
 
 @Rem @sleep 15
 @CHOICE /C YN /T 15 /D N > NUL
+
+:EOF

--- a/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/log/README.txt
+++ b/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/log/README.txt
@@ -1,0 +1,2 @@
+
+This folder holds log-files ex. metasfresh.JJJJ-MM-DD_HHMMSS.log 

--- a/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/userlib-x64/README.txt
+++ b/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/userlib-x64/README.txt
@@ -1,3 +1,5 @@
 
 This folder is empty per default,
 copy ms-x64 dlls here if you want to expand the path
+ 
+see https://forum.metasfresh.org/t/schnittstelle-zu-ms-com-excel-outlook-via-groovy/98/8

--- a/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/userlib-x64/README.txt
+++ b/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/userlib-x64/README.txt
@@ -1,0 +1,3 @@
+
+This folder is empty per default,
+copy ms-x64 dlls here if you want to expand the path

--- a/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/userlib/README.txt
+++ b/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/userlib/README.txt
@@ -2,3 +2,4 @@
 This folder is empty per default,
 copy jars here if you want to expand the CLASSPATH
 
+see https://forum.metasfresh.org/t/schnittstelle-zu-ms-com-excel-outlook-via-groovy/98/8

--- a/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/userlib/README.txt
+++ b/de.metas.endcustomer.mf15/de.metas.endcustomer.mf15.swingui/src/main/resources/userlib/README.txt
@@ -1,0 +1,4 @@
+
+This folder is empty per default,
+copy jars here if you want to expand the CLASSPATH
+


### PR DESCRIPTION
Hi @metas-ts ,
this is an implementation for #695 

In my opinion there is no need for any interceptor, because the jars are not loaded at startup.
I tested it with the simple helloworld example from 
https://forum.metasfresh.org/t/schnittstelle-zu-ms-com-excel-outlook-via-groovy/98/10
and with an excel ActiveXObject : 

just copy the needed jar in userlib, the dll in userllib-x64