### PR TITLE
#1014 Add window layout for Purchase Order Field Receipt Warehouse

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5456960_sys_gh164_migration-missing-menu-entries.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5456960_sys_gh164_migration-missing-menu-entries.sql
@@ -931,11 +931,3 @@ from get_AD_TreeNodeMM_Paths(10, 1000007) t
 where not IsCycle
 order by path
 ;
-
-
---
--- Check results:
--- select * from AD_TreeNodeMM where AD_Tree_ID=1000039 order by Node_ID
-select * from get_AD_TreeNodeMM_Paths(1000039, null) t
--- where IsCycle
-order by path;

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5457000_gh1014_window-layout-purchase-order-warehouse.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5457000_gh1014_window-layout-purchase-order-warehouse.sql
@@ -1,0 +1,20 @@
+-- 22.02.2017 07:30
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,3451,0,294,540072,541802,TO_TIMESTAMP('2017-02-22 07:30:56','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','N','N','Warenannahme',20,0,0,TO_TIMESTAMP('2017-02-22 07:30:56','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 22.02.2017 07:31
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET SeqNo=30,Updated=TO_TIMESTAMP('2017-02-22 07:31:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=541280
+;
+
+-- 22.02.2017 07:32
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=541287
+;
+
+-- 22.02.2017 07:32
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsAdvancedField='Y',Updated=TO_TIMESTAMP('2017-02-22 07:32:28','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=541253
+;
+


### PR DESCRIPTION
Moved the field Receipt Warehouse from second column to first and
primary column to be able to record this often adjusted field in a more
efficient way.

FRESH-1481 https://github.com/metasfresh/metasfresh/issues/1014