### PR TITLE
#1102 Add Field PriceListVersion as search Field

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5458410_sys_gh1102Field-PriceListVersion-search-Field.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5458410_sys_gh1102Field-PriceListVersion-search-Field.sql
@@ -1,0 +1,5 @@
+-- 14.03.2017 16:29
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET AD_Reference_ID=30, IsAutocomplete='Y', IsUpdateable='N',Updated=TO_TIMESTAMP('2017-03-14 16:29:45','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=2760
+;
+


### PR DESCRIPTION
Changing the FieldType for PriceListVersion from tableDirect to search
an autocomplete in Window Product Prices.

FRESH-1645 https://github.com/metasfresh/metasfresh/issues/1102