### PR TITLE
#1260 Add C_DocTypeTarget_ID to window in WebUI

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5459550_sys_gh1260-invoice-documentno-auto.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5459550_sys_gh1260-invoice-documentno-auto.sql
@@ -1,0 +1,5 @@
+-- 2017-04-03T14:00:48.310
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_Field_ID=2954,Updated=TO_TIMESTAMP('2017-04-03 14:00:48','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=540789
+;
+


### PR DESCRIPTION
Adding C_DocTypeTarget_ID to Invoice Window in WebUI tio allow recording
of DocuemtnType which is a mandatory field.

FRESH-1878 https://github.com/metasfresh/metasfresh/issues/1260