### PR TITLE
#1382 Make Packing Item editable in Manufacturing Order Header

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5460650_sys_gh1382-packing-item-editable-pp-order.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5460650_sys_gh1382-packing-item-editable-pp-order.sql
@@ -1,0 +1,5 @@
+-- 2017-04-25T10:28:00.695
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET IsReadOnly='N',Updated=TO_TIMESTAMP('2017-04-25 10:28:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=554547
+;
+


### PR DESCRIPTION
Adjusting the field Packing Item in pp_order, making it editable.

FRESH-2063 https://github.com/metasfresh/metasfresh/issues/1382