### PR TITLE
#1399 DocumentNo not generated for PP_Orders in WebUI

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5461030_cli_gh1399-documentno-for-PP-orders.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5461030_cli_gh1399-documentno-for-PP-orders.sql
@@ -26,3 +26,31 @@ WHERE C_DocType_ID=540938
 AND AD_Client_ID=1000000 AND 'metasfresh' = (select name from AD_Client where AD_Client_ID=1000000)
 ;
 
+-- 2017-04-29T15:19:46.069
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE C_DocType SET DocNoSequence_ID=545473,Updated=TO_TIMESTAMP('2017-04-29 15:19:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 
+WHERE C_DocType_ID=1000038 
+AND AD_Client_ID=1000000 AND 'metasfresh' = (select name from AD_Client where AD_Client_ID=1000000)
+;
+
+-- 2017-04-29T15:19:55.746
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE C_DocType SET DocNoSequence_ID=545473,Updated=TO_TIMESTAMP('2017-04-29 15:19:55','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 
+WHERE C_DocType_ID=540938 
+AND AD_Client_ID=1000000 AND 'metasfresh' = (select name from AD_Client where AD_Client_ID=1000000)
+;
+
+-- 2017-04-29T15:20:04.953
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE C_DocType SET DocNoSequence_ID=545473,Updated=TO_TIMESTAMP('2017-04-29 15:20:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 
+WHERE C_DocType_ID=1000036 
+AND AD_Client_ID=1000000 AND 'metasfresh' = (select name from AD_Client where AD_Client_ID=1000000)
+;
+
+-- 2017-04-29T15:20:12.929
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE C_DocType SET DocNoSequence_ID=545473,Updated=TO_TIMESTAMP('2017-04-29 15:20:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 
+WHERE C_DocType_ID=1000037 
+AND AD_Client_ID=1000000 AND 'metasfresh' = (select name from AD_Client where AD_Client_ID=1000000)
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5461030_cli_gh1399-documentno-for-PP-orders.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5461030_cli_gh1399-documentno-for-PP-orders.sql
@@ -1,0 +1,28 @@
+-- 2017-04-29T15:09:40.737
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE C_DocType SET IsDocNoControlled='Y',Updated=TO_TIMESTAMP('2017-04-29 15:09:40','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 
+WHERE C_DocType_ID=1000036 
+AND AD_Client_ID=1000000 AND 'metasfresh' = (select name from AD_Client where AD_Client_ID=1000000)
+;
+
+-- 2017-04-29T15:09:50.967
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE C_DocType SET IsDocNoControlled='Y',Updated=TO_TIMESTAMP('2017-04-29 15:09:50','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 
+WHERE C_DocType_ID=1000037 
+AND AD_Client_ID=1000000 AND 'metasfresh' = (select name from AD_Client where AD_Client_ID=1000000)
+;
+
+-- 2017-04-29T15:09:59.431
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE C_DocType SET IsDocNoControlled='Y',Updated=TO_TIMESTAMP('2017-04-29 15:09:59','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 
+WHERE C_DocType_ID=1000038 
+AND AD_Client_ID=1000000 AND 'metasfresh' = (select name from AD_Client where AD_Client_ID=1000000)
+;
+
+-- 2017-04-29T15:10:09.821
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE C_DocType SET IsDocNoControlled='Y',Updated=TO_TIMESTAMP('2017-04-29 15:10:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 
+WHERE C_DocType_ID=540938 
+AND AD_Client_ID=1000000 AND 'metasfresh' = (select name from AD_Client where AD_Client_ID=1000000)
+;
+


### PR DESCRIPTION
Adjusting the manufacturing Order Documenttypes to allow automatic document No control.

FRESH-2039 https://github.com/metasfresh/metasfresh/issues/1399