### PR TITLE
#1657 Removing 2 Dates Fields from Manufacturing Order default Filter

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5463535_sys_gh1657-search-column-date-manufacturing-order.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5463535_sys_gh1657-search-column-date-manufacturing-order.sql
@@ -1,0 +1,10 @@
+-- 2017-05-26T15:17:53.803
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='N',Updated=TO_TIMESTAMP('2017-05-26 15:17:53','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=53641
+;
+
+-- 2017-05-26T15:17:57.305
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='N',Updated=TO_TIMESTAMP('2017-05-26 15:17:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=53643
+;
+


### PR DESCRIPTION
Removing 2 Dates Fields from Manufacturing Order default Filter

FRESH-2399 https://github.com/metasfresh/metasfresh/issues/1657