### PR TITLE
#1754 Rearranging the UI Group w/ Org Information

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5465130_sys_gh1754-adjustment-transport-dispo-window-webui.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5465130_sys_gh1754-adjustment-transport-dispo-window-webui.sql
@@ -1,0 +1,70 @@
+-- 2017-06-13T15:32:15.818
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_UI_Section (AD_Client_ID,AD_Org_ID,AD_Tab_ID,AD_UI_Section_ID,Created,CreatedBy,IsActive,SeqNo,Updated,UpdatedBy,Value) VALUES (0,0,540609,540292,TO_TIMESTAMP('2017-06-13 15:32:15','YYYY-MM-DD HH24:MI:SS'),100,'Y',30,TO_TIMESTAMP('2017-06-13 15:32:15','YYYY-MM-DD HH24:MI:SS'),100,'org')
+;
+
+-- 2017-06-13T15:32:15.841
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_UI_Section_Trl (AD_Language,AD_UI_Section_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_UI_Section_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_UI_Section t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_UI_Section_ID=540292 AND NOT EXISTS (SELECT * FROM AD_UI_Section_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_UI_Section_ID=t.AD_UI_Section_ID)
+;
+
+-- 2017-06-13T15:32:41.671
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_UI_Column (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_Section_ID,Created,CreatedBy,IsActive,SeqNo,Updated,UpdatedBy) VALUES (0,0,540396,540292,TO_TIMESTAMP('2017-06-13 15:32:41','YYYY-MM-DD HH24:MI:SS'),100,'Y',10,TO_TIMESTAMP('2017-06-13 15:32:41','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2017-06-13T15:32:43.080
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_UI_Column (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_Section_ID,Created,CreatedBy,IsActive,SeqNo,Updated,UpdatedBy) VALUES (0,0,540397,540292,TO_TIMESTAMP('2017-06-13 15:32:43','YYYY-MM-DD HH24:MI:SS'),100,'Y',20,TO_TIMESTAMP('2017-06-13 15:32:43','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2017-06-13T15:33:10.283
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_UI_ElementGroup (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_ElementGroup_ID,Created,CreatedBy,IsActive,Name,SeqNo,Updated,UpdatedBy) VALUES (0,0,540396,540676,TO_TIMESTAMP('2017-06-13 15:33:10','YYYY-MM-DD HH24:MI:SS'),100,'Y','transport order',10,TO_TIMESTAMP('2017-06-13 15:33:10','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2017-06-13T15:33:27.716
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,554619,0,540609,540676,545733,TO_TIMESTAMP('2017-06-13 15:33:27','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','N','N','Transport Auftrag',10,0,0,TO_TIMESTAMP('2017-06-13 15:33:27','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2017-06-13T15:33:40.349
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_UI_ElementGroup (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_ElementGroup_ID,Created,CreatedBy,IsActive,Name,SeqNo,Updated,UpdatedBy) VALUES (0,0,540397,540677,TO_TIMESTAMP('2017-06-13 15:33:40','YYYY-MM-DD HH24:MI:SS'),100,'Y','org',10,TO_TIMESTAMP('2017-06-13 15:33:40','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2017-06-13T15:33:49.044
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,554614,0,540609,540677,545734,TO_TIMESTAMP('2017-06-13 15:33:49','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','N','N','Sektion',10,0,0,TO_TIMESTAMP('2017-06-13 15:33:49','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2017-06-13T15:33:56.679
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,554613,0,540609,540677,545735,TO_TIMESTAMP('2017-06-13 15:33:56','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','N','N','Mandant',20,0,0,TO_TIMESTAMP('2017-06-13 15:33:56','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2017-06-13T15:34:18.645
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=545526
+;
+
+-- 2017-06-13T15:34:22.650
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_ElementGroup WHERE AD_UI_ElementGroup_ID=540624
+;
+
+-- 2017-06-13T15:34:32.135
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=545530
+;
+
+-- 2017-06-13T15:34:34.538
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=545529
+;
+
+-- 2017-06-13T15:34:39.262
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_ElementGroup WHERE AD_UI_ElementGroup_ID=540626
+;
+


### PR DESCRIPTION
Rearranging the UI Group w/ Org Information. Creating an own UI Section
instead, so the Org/ Client is shown at the bottom of the main view as
usual.

FRESH-2526 https://github.com/metasfresh/metasfresh/issues/1754