### PR TITLE
Now setting the Hostkey updates both the respective ctx and AD_Session

### DIFF
--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/session/MFSession.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/session/MFSession.java
@@ -193,13 +193,32 @@ public class MFSession
 		InterfaceWrapperHelper.save(sessionPO);
 	}
 
-	public void setHostKey(final String hostKey)
+	/**
+	 * Stores the given {@code hostKey} in the {@link I_AD_Session} this instance encapsulates and also updates the given {@code ctxToUpdate} (unless the given context is {@code null}!).
+	 * 
+	 * @param hostKey the key to store
+	 * @param ctxToUpdate may be {@code null}; the context to update.
+	 */
+	public void setHostKey(final String hostKey, final Properties ctxToUpdate)
 	{
 		sessionPO.setHostKey(hostKey);
 		InterfaceWrapperHelper.save(sessionPO);
+
+		if (ctxToUpdate != null)
+		{
+			Env.setContext(ctxToUpdate, CTX_Prefix + I_AD_Session.COLUMNNAME_HostKey, hostKey); // now this should also solve gh #1314
+		}
 	}
 
-	public String getHostKey()
+	/**
+	 * Gets or creates a hostkey for this session. If the hostkey was already determined it is just returned.<br>
+	 * If the hostkey is created (via {@link IHostKeyBL}), it is not only returned, but also {@link #setHostKey(String, Properties)} is called.
+	 * 
+	 * @param ctxToUpdate; maybe be {@code null}; will be passed to {@link #setHostKey(String, Properties)} in case that method is called.
+	 * 
+	 * @return the hostkey which is currently mostly used for printing.
+	 */
+	public String getHostKey(final Properties ctxToUpdate)
 	{
 		final String hostKey = sessionPO.getHostKey();
 
@@ -213,8 +232,7 @@ public class MFSession
 		final String newHostKey = hostKeyBL.getCreateHostKey();
 		log.info("Setting AD_Session.HostKey={} for sessionPO={}", hostKey, sessionPO);
 
-		sessionPO.setHostKey(newHostKey);
-		InterfaceWrapperHelper.save(sessionPO);
+		setHostKey(newHostKey, ctxToUpdate);
 		return newHostKey;
 	}
 

--- a/de.metas.printing.ait/src/test/java/de/metas/printing/test/integration/TestFromPrintingQueueToClient.java
+++ b/de.metas.printing.ait/src/test/java/de/metas/printing/test/integration/TestFromPrintingQueueToClient.java
@@ -27,8 +27,10 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.UUID;
 
+import org.adempiere.ad.session.ISessionBL;
 import org.adempiere.ad.session.MFSession;
 import org.adempiere.util.Check;
+import org.adempiere.util.Services;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -80,7 +82,7 @@ public class TestFromPrintingQueueToClient extends de.metas.esb.printing.test.Ab
 
 	public void setupPrintingClient()
 	{
-		final MFSession session = printingCoreHelper.getDAO().retrieveCurrentSession(adempiere.getCtx());
+		final MFSession session = Services.get(ISessionBL.class).getCurrentSession(adempiere.getCtx());
 
 		final Context ctx = Context.getContext();
 		ctx.setProperty(Context.CTX_SessionId, Integer.toString(session.getAD_Session_ID()));

--- a/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/api/IPrintingDAO.java
+++ b/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/api/IPrintingDAO.java
@@ -86,8 +86,6 @@ public interface IPrintingDAO extends ISingletonService
 	 */
 	void runWithTrxName(String trxName, Runnable runnable);
 
-	MFSession retrieveCurrentSession(final Properties ctx);
-
 	/**
 	 * 
 	 * @param job

--- a/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/api/impl/PlainPrintingDAO.java
+++ b/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/api/impl/PlainPrintingDAO.java
@@ -33,8 +33,6 @@ import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryFilter;
 import org.adempiere.ad.dao.IQueryOrderBy;
 import org.adempiere.ad.dao.impl.POJOQuery;
-import org.adempiere.ad.session.ISessionBL;
-import org.adempiere.ad.session.MFSession;
 import org.adempiere.ad.wrapper.POJOLookupMap;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -431,20 +429,6 @@ public class PlainPrintingDAO extends AbstractPrintingDAO
 				return pojo.getC_Print_Job_ID() == printJob.getC_Print_Job_ID();
 			}
 		});
-	}
-
-	@Override
-	public MFSession retrieveCurrentSession(final Properties ctx)
-	{
-		return Services.get(ISessionBL.class).getCurrentSession(ctx);
-//		final int sessionId = Env.getContextAsInt(ctx, Env.CTXNAME_AD_Session_ID);
-//		Check.assume(sessionId > 0, "No session found in context");
-//		final I_AD_Session sessionPO = lookupMap.lookup(I_AD_Session.class, sessionId);
-//		if(sessionPO == null)
-//		{
-//			return null;
-//		}
-//		return new MFSession(sessionPO);
 	}
 
 	@Override

--- a/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/api/impl/PrintPackageBL.java
+++ b/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/api/impl/PrintPackageBL.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.Properties;
 
+import org.adempiere.ad.session.ISessionBL;
 import org.adempiere.ad.session.MFSession;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
@@ -164,14 +165,14 @@ public class PrintPackageBL implements IPrintPackageBL
 	{
 		final PrintPackageCtx printCtx = new PrintPackageCtx();
 
-		final MFSession session = Services.get(IPrintingDAO.class).retrieveCurrentSession(ctx);
+		final MFSession session = Services.get(ISessionBL.class).getCurrentSession(ctx);
 		if (session == null)
 		{
 			throw new AdempiereException("@NotFound@ @AD_Session_ID@");
 		}
 		logger.debug("Session: {}", session);
 
-		final String hostKey = session.getHostKey();
+		final String hostKey = session.getHostKey(ctx);
 		Check.assumeNotEmpty(hostKey, "{} has a hostKey", session);
 
 		printCtx.setHostKey(hostKey);
@@ -184,10 +185,10 @@ public class PrintPackageBL implements IPrintPackageBL
 	public String getHostKeyOrNull(final Properties ctx)
 	{
 		// Check session
-		final MFSession session = Services.get(IPrintingDAO.class).retrieveCurrentSession(ctx);
+		final MFSession session = Services.get(ISessionBL.class).getCurrentSession(ctx);
 		if (session != null)
 		{
-			return session.getHostKey();
+			return session.getHostKey(ctx);
 		}
 
 		return null;

--- a/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/api/impl/PrintingDAO.java
+++ b/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/api/impl/PrintingDAO.java
@@ -461,12 +461,6 @@ public class PrintingDAO extends AbstractPrintingDAO
 	}
 
 	@Override
-	public MFSession retrieveCurrentSession(final Properties ctx)
-	{
-		return Services.get(ISessionBL.class).getCurrentSession(ctx);
-	}
-
-	@Override
 	public List<I_AD_Printer> retrievePrinters(final Properties ctx, final int adOrgId)
 	{
 		final int adClientId = Env.getAD_Client_ID(ctx);

--- a/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/model/validator/AD_User_Login.java
+++ b/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/model/validator/AD_User_Login.java
@@ -170,7 +170,7 @@ public class AD_User_Login
 		// Update newly create AD_Session
 		final MFSession session = Services.get(ISessionBL.class).getSessionById(ctx, adSessionId);
 		Check.assumeNotNull(session, "session not null");
-		session.setHostKey(hostKey);
+		session.setHostKey(hostKey, loginCtx);
 		session.updateContext(loginCtx);
 
 		//

--- a/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/model/validator/SwingPrintingClientValidator.java
+++ b/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/model/validator/SwingPrintingClientValidator.java
@@ -83,7 +83,7 @@ public class SwingPrintingClientValidator extends AbstractModuleInterceptor
 			// Get HostKey
 			final Properties ctx = Env.getCtx();
 			final MFSession session = Services.get(ISessionBL.class).getCurrentSession(ctx);
-			final String hostKey = session.getHostKey();
+			final String hostKey = session.getHostKey(ctx);
 
 			//
 			// Create/Start the printing client thread *if* we do not use another client's config

--- a/de.metas.printing/de.metas.printing.base/src/test/java/de/metas/printing/api/impl/Helper.java
+++ b/de.metas.printing/de.metas.printing.base/src/test/java/de/metas/printing/api/impl/Helper.java
@@ -13,15 +13,14 @@ package de.metas.printing.api.impl;
  * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  * 
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
-
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -36,6 +35,7 @@ import java.util.UUID;
 import javax.print.attribute.standard.MediaSize;
 
 import org.adempiere.ad.dao.IQueryFilter;
+import org.adempiere.ad.session.ISessionBL;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.trx.api.ITrxManager;
@@ -99,7 +99,7 @@ import de.metas.printing.model.validator.AD_Archive;
 import de.metas.printing.rpl.requesthandler.CreatePrintPackageRequestHandler;
 import de.metas.printing.spi.IPrintJobMonitor;
 
-//there is high amount of methods because it's a helper...
+// there is high amount of methods because it's a helper...
 @SuppressWarnings("PMD.CouplingBetweenObjects")
 public class Helper
 {
@@ -211,7 +211,7 @@ public class Helper
 
 	public String getSessionHostKey()
 	{
-		return printingDAO.retrieveCurrentSession(ctx).getHostKey();
+		return Services.get(ISessionBL.class).getCurrentSession(ctx).getHostKey(ctx);
 	}
 
 	public POJOLookupMap getDB()


### PR DESCRIPTION
also removed superfluous method IPrintingDAO.retrieveCurrentSession()

lazy-assigned Hostkey is not shown in swing-client's settings #1314

1771: add legacy features
Task-Url: https://github.com/metasfresh/metasfresh/issues/1771
(cherry picked from commit 51a6fd13f62c87cb10fb0128d0df6903342d7ebf)