### PR TITLE
#1861 Performance degradation in HUKey.isReadonly()

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5465830_sys_gh1861_M_HU_PI_Version_Fix_ValueName.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5465830_sys_gh1861_M_HU_PI_Version_Fix_ValueName.sql
@@ -1,0 +1,15 @@
+-- 2017-06-20T17:53:46.183
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Ref_List SET ValueName='VirtualPI',Updated=TO_TIMESTAMP('2017-06-20 17:53:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Ref_List_ID=540817
+;
+
+-- 2017-06-20T17:53:54.948
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Ref_List SET ValueName='LoadLogistiqueUnit',Updated=TO_TIMESTAMP('2017-06-20 17:53:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Ref_List_ID=540735
+;
+
+-- 2017-06-20T17:53:58.070
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Ref_List SET ValueName='TransportUnit',Updated=TO_TIMESTAMP('2017-06-20 17:53:58','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Ref_List_ID=540734
+;
+

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/I_M_HU.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/I_M_HU.java
@@ -127,6 +127,29 @@ public interface I_M_HU
     public static final String COLUMNNAME_C_BPartner_Location_ID = "C_BPartner_Location_ID";
 
 	/**
+	 * Set TUs Count.
+	 *
+	 * <br>Type: Integer
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	public void setCompressed_TUsCount (int Compressed_TUsCount);
+
+	/**
+	 * Get TUs Count.
+	 *
+	 * <br>Type: Integer
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	public int getCompressed_TUsCount();
+
+    /** Column definition for Compressed_TUsCount */
+    public static final org.adempiere.model.ModelColumn<I_M_HU, Object> COLUMN_Compressed_TUsCount = new org.adempiere.model.ModelColumn<I_M_HU, Object>(I_M_HU.class, "Compressed_TUsCount", null);
+    /** Column name Compressed_TUsCount */
+    public static final String COLUMNNAME_Compressed_TUsCount = "Compressed_TUsCount";
+
+	/**
 	 * Get Erstellt.
 	 * Datum, an dem dieser Eintrag erstellt wurde
 	 *
@@ -257,20 +280,45 @@ public interface I_M_HU
     public static final String COLUMNNAME_IsChildHU = "IsChildHU";
 
 	/**
-	 * Set Gesperrt.
+	 * Set Compressed VHU.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
+	public void setIsCompressedVHU (boolean IsCompressedVHU);
+
+	/**
+	 * Get Compressed VHU.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	public boolean isCompressedVHU();
+
+    /** Column definition for IsCompressedVHU */
+    public static final org.adempiere.model.ModelColumn<I_M_HU, Object> COLUMN_IsCompressedVHU = new org.adempiere.model.ModelColumn<I_M_HU, Object>(I_M_HU.class, "IsCompressedVHU", null);
+    /** Column name IsCompressedVHU */
+    public static final String COLUMNNAME_IsCompressedVHU = "IsCompressedVHU";
+
+	/**
+	 * Set Gesperrt.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true
+	 * @deprecated Please don't use it because this is a virtual column
+	 */
+	@Deprecated
 	public void setLocked (boolean Locked);
 
 	/**
 	 * Get Gesperrt.
 	 *
 	 * <br>Type: YesNo
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true
 	 */
 	public boolean isLocked();
 

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/I_M_HU_PI_Attribute.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/I_M_HU_PI_Attribute.java
@@ -234,7 +234,7 @@ public interface I_M_HU_PI_Attribute
     public static final String COLUMNNAME_IsDisplayed = "IsDisplayed";
 
 	/**
-	 * Set Instanz-Attribut.
+	 * Set Instanz Merkmal.
 	 * The product attribute is specific to the instance (like Serial No, Lot or Guarantee Date)
 	 *
 	 * <br>Type: YesNo
@@ -244,7 +244,7 @@ public interface I_M_HU_PI_Attribute
 	public void setIsInstanceAttribute (boolean IsInstanceAttribute);
 
 	/**
-	 * Get Instanz-Attribut.
+	 * Get Instanz Merkmal.
 	 * The product attribute is specific to the instance (like Serial No, Lot or Guarantee Date)
 	 *
 	 * <br>Type: YesNo

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU.java
@@ -14,7 +14,7 @@ public class X_M_HU extends org.compiere.model.PO implements I_M_HU, org.compier
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = -170404471L;
+	private static final long serialVersionUID = -379321177L;
 
     /** Standard Constructor */
     public X_M_HU (Properties ctx, int M_HU_ID, String trxName)
@@ -22,10 +22,8 @@ public class X_M_HU extends org.compiere.model.PO implements I_M_HU, org.compier
       super (ctx, M_HU_ID, trxName);
       /** if (M_HU_ID == 0)
         {
-			setHUStatus (null);
-// 'P'
-			setLocked (false);
-// N
+			setHUStatus (null); // 'P'
+			setIsCompressedVHU (false); // N
 			setM_HU_ID (0);
 			setM_HU_PI_Version_ID (0);
 			setValue (null);
@@ -121,6 +119,25 @@ public class X_M_HU extends org.compiere.model.PO implements I_M_HU, org.compier
 		return ii.intValue();
 	}
 
+	/** Set TUs Count.
+		@param Compressed_TUsCount TUs Count	  */
+	@Override
+	public void setCompressed_TUsCount (int Compressed_TUsCount)
+	{
+		set_Value (COLUMNNAME_Compressed_TUsCount, Integer.valueOf(Compressed_TUsCount));
+	}
+
+	/** Get TUs Count.
+		@return TUs Count	  */
+	@Override
+	public int getCompressed_TUsCount () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_Compressed_TUsCount);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
 	/** Set eigene Gebinde.
 		@param HUPlanningReceiptOwnerPM 
 		If true, then the packing material's owner is "us" (the guys who ordered it). If false, then the packing material's owner is the PO's partner.
@@ -204,13 +221,35 @@ public class X_M_HU extends org.compiere.model.PO implements I_M_HU, org.compier
 		return false;
 	}
 
+	/** Set Compressed VHU.
+		@param IsCompressedVHU Compressed VHU	  */
+	@Override
+	public void setIsCompressedVHU (boolean IsCompressedVHU)
+	{
+		set_Value (COLUMNNAME_IsCompressedVHU, Boolean.valueOf(IsCompressedVHU));
+	}
+
+	/** Get Compressed VHU.
+		@return Compressed VHU	  */
+	@Override
+	public boolean isCompressedVHU () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsCompressedVHU);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
 	/** Set Gesperrt.
 		@param Locked Gesperrt	  */
 	@Override
 	public void setLocked (boolean Locked)
 	{
-		set_Value (COLUMNNAME_Locked, Boolean.valueOf(Locked));
-	}
+		throw new IllegalArgumentException ("Locked is virtual column");	}
 
 	/** Get Gesperrt.
 		@return Gesperrt	  */

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Assignment.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Assignment.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_Assignment
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_Assignment extends org.compiere.model.PO implements I_M_HU_A
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = -197246446L;
+	private static final long serialVersionUID = 1104235555L;
 
     /** Standard Constructor */
     public X_M_HU_Assignment (Properties ctx, int M_HU_Assignment_ID, String trxName)
@@ -25,8 +24,7 @@ public class X_M_HU_Assignment extends org.compiere.model.PO implements I_M_HU_A
       /** if (M_HU_Assignment_ID == 0)
         {
 			setAD_Table_ID (0);
-			setIsTransferPackingMaterials (true);
-// Y
+			setIsTransferPackingMaterials (true); // Y
 			setM_HU_Assignment_ID (0);
 			setM_HU_ID (0);
 			setRecord_ID (0);

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Attribute.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Attribute.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_Attribute
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_Attribute extends org.compiere.model.PO implements I_M_HU_At
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 567598441L;
+	private static final long serialVersionUID = 1660606286L;
 
     /** Standard Constructor */
     public X_M_HU_Attribute (Properties ctx, int M_HU_Attribute_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Attribute_Snapshot.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Attribute_Snapshot.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_Attribute_Snapshot
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_Attribute_Snapshot extends org.compiere.model.PO implements 
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 1886956406L;
+	private static final long serialVersionUID = 1213728625L;
 
     /** Standard Constructor */
     public X_M_HU_Attribute_Snapshot (Properties ctx, int M_HU_Attribute_Snapshot_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Instance_Properties_v.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Instance_Properties_v.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_Instance_Properties_v
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_Instance_Properties_v extends org.compiere.model.PO implemen
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 1798624295L;
+	private static final long serialVersionUID = 1851984908L;
 
     /** Standard Constructor */
     public X_M_HU_Instance_Properties_v (Properties ctx, int M_HU_Instance_Properties_v_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Item.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Item.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_Item
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_Item extends org.compiere.model.PO implements I_M_HU_Item, o
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 477090733L;
+	private static final long serialVersionUID = -4216088L;
 
     /** Standard Constructor */
     public X_M_HU_Item (Properties ctx, int M_HU_Item_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Item_Snapshot.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Item_Snapshot.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_Item_Snapshot
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_Item_Snapshot extends org.compiere.model.PO implements I_M_H
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 317893535L;
+	private static final long serialVersionUID = -1874399100L;
 
     /** Standard Constructor */
     public X_M_HU_Item_Snapshot (Properties ctx, int M_HU_Item_Snapshot_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Item_Storage.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Item_Storage.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_Item_Storage
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_Item_Storage extends org.compiere.model.PO implements I_M_HU
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 790935216L;
+	private static final long serialVersionUID = 1557154859L;
 
     /** Standard Constructor */
     public X_M_HU_Item_Storage (Properties ctx, int M_HU_Item_Storage_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Item_Storage_Snapshot.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Item_Storage_Snapshot.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_Item_Storage_Snapshot
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_Item_Storage_Snapshot extends org.compiere.model.PO implemen
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 157516636L;
+	private static final long serialVersionUID = 81324673L;
 
     /** Standard Constructor */
     public X_M_HU_Item_Storage_Snapshot (Properties ctx, int M_HU_Item_Storage_Snapshot_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_LUTU_Configuration.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_LUTU_Configuration.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_LUTU_Configuration
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_LUTU_Configuration extends org.compiere.model.PO implements 
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 196512502L;
+	private static final long serialVersionUID = 1426073199L;
 
     /** Standard Constructor */
     public X_M_HU_LUTU_Configuration (Properties ctx, int M_HU_LUTU_Configuration_ID, String trxName)
@@ -25,12 +24,9 @@ public class X_M_HU_LUTU_Configuration extends org.compiere.model.PO implements 
       /** if (M_HU_LUTU_Configuration_ID == 0)
         {
 			setC_UOM_ID (0);
-			setIsInfiniteQtyCU (false);
-// N
-			setIsInfiniteQtyLU (false);
-// N
-			setIsInfiniteQtyTU (false);
-// N
+			setIsInfiniteQtyCU (false); // N
+			setIsInfiniteQtyLU (false); // N
+			setIsInfiniteQtyTU (false); // N
 			setM_HU_LUTU_Configuration_ID (0);
 			setM_Product_ID (0);
 			setM_TU_HU_PI_ID (0);

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PI.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PI.java
@@ -14,7 +14,7 @@ public class X_M_HU_PI extends org.compiere.model.PO implements I_M_HU_PI, org.c
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 2145252053L;
+	private static final long serialVersionUID = 287280127L;
 
     /** Standard Constructor */
     public X_M_HU_PI (Properties ctx, int M_HU_PI_ID, String trxName)
@@ -22,8 +22,7 @@ public class X_M_HU_PI extends org.compiere.model.PO implements I_M_HU_PI, org.c
       super (ctx, M_HU_PI_ID, trxName);
       /** if (M_HU_PI_ID == 0)
         {
-			setIsDefaultLU (false);
-// N
+			setIsDefaultLU (false); // N
 			setM_HU_PI_ID (0);
 			setName (null);
         } */

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PI_Attribute.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PI_Attribute.java
@@ -14,7 +14,7 @@ public class X_M_HU_PI_Attribute extends org.compiere.model.PO implements I_M_HU
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = -1224383560L;
+	private static final long serialVersionUID = -488667486L;
 
     /** Standard Constructor */
     public X_M_HU_PI_Attribute (Properties ctx, int M_HU_PI_Attribute_ID, String trxName)
@@ -23,17 +23,13 @@ public class X_M_HU_PI_Attribute extends org.compiere.model.PO implements I_M_HU
       /** if (M_HU_PI_Attribute_ID == 0)
         {
 			setHU_TansferStrategy_JavaClass_ID (0);
-			setIsDisplayed (true);
-// Y
-			setIsReadOnly (false);
-// N
+			setIsDisplayed (true); // Y
+			setIsReadOnly (false); // N
 			setM_Attribute_ID (0);
 			setM_HU_PI_Attribute_ID (0);
 			setM_HU_PI_Version_ID (0);
-			setPropagationType (null);
-// NONE
-			setUseInASI (true);
-// Y
+			setPropagationType (null); // NONE
+			setUseInASI (true); // Y
         } */
     }
 
@@ -186,7 +182,7 @@ public class X_M_HU_PI_Attribute extends org.compiere.model.PO implements I_M_HU
 		return false;
 	}
 
-	/** Set Instanz-Attribut.
+	/** Set Instanz Merkmal.
 		@param IsInstanceAttribute 
 		The product attribute is specific to the instance (like Serial No, Lot or Guarantee Date)
 	  */
@@ -196,7 +192,7 @@ public class X_M_HU_PI_Attribute extends org.compiere.model.PO implements I_M_HU
 		set_Value (COLUMNNAME_IsInstanceAttribute, Boolean.valueOf(IsInstanceAttribute));
 	}
 
-	/** Get Instanz-Attribut.
+	/** Get Instanz Merkmal.
 		@return The product attribute is specific to the instance (like Serial No, Lot or Guarantee Date)
 	  */
 	@Override

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PI_Item.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PI_Item.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_PI_Item
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_PI_Item extends org.compiere.model.PO implements I_M_HU_PI_I
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = -1402725139L;
+	private static final long serialVersionUID = -825836056L;
 
     /** Standard Constructor */
     public X_M_HU_PI_Item (Properties ctx, int M_HU_PI_Item_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PI_Item_Product.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PI_Item_Product.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_PI_Item_Product
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_PI_Item_Product extends org.compiere.model.PO implements I_M
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = -1276359644L;
+	private static final long serialVersionUID = 883893087L;
 
     /** Standard Constructor */
     public X_M_HU_PI_Item_Product (Properties ctx, int M_HU_PI_Item_Product_ID, String trxName)
@@ -24,10 +23,8 @@ public class X_M_HU_PI_Item_Product extends org.compiere.model.PO implements I_M
       super (ctx, M_HU_PI_Item_Product_ID, trxName);
       /** if (M_HU_PI_Item_Product_ID == 0)
         {
-			setIsAllowAnyProduct (false);
-// N
-			setIsInfiniteCapacity (false);
-// N
+			setIsAllowAnyProduct (false); // N
+			setIsInfiniteCapacity (false); // N
 			setM_HU_PI_Item_ID (0);
 			setM_HU_PI_Item_Product_ID (0);
 			setQty (BigDecimal.ZERO);

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PI_Version.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PI_Version.java
@@ -14,7 +14,7 @@ public class X_M_HU_PI_Version extends org.compiere.model.PO implements I_M_HU_P
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 759839647L;
+	private static final long serialVersionUID = -59133326L;
 
     /** Standard Constructor */
     public X_M_HU_PI_Version (Properties ctx, int M_HU_PI_Version_ID, String trxName)
@@ -22,8 +22,7 @@ public class X_M_HU_PI_Version extends org.compiere.model.PO implements I_M_HU_P
       super (ctx, M_HU_PI_Version_ID, trxName);
       /** if (M_HU_PI_Version_ID == 0)
         {
-			setIsCurrent (false);
-// N
+			setIsCurrent (false); // N
 			setM_HU_PI_ID (0);
 			setM_HU_PI_Version_ID (0);
 			setName (null);
@@ -66,11 +65,11 @@ public class X_M_HU_PI_Version extends org.compiere.model.PO implements I_M_HU_P
 	 * Reference name: HU_UnitType
 	 */
 	public static final int HU_UNITTYPE_AD_Reference_ID=540472;
-	/** Transport Unit = TU */
+	/** TransportUnit = TU */
 	public static final String HU_UNITTYPE_TransportUnit = "TU";
-	/** Load/Logistique Unit = LU */
+	/** LoadLogistiqueUnit = LU */
 	public static final String HU_UNITTYPE_LoadLogistiqueUnit = "LU";
-	/** Virtual PI = V */
+	/** VirtualPI = V */
 	public static final String HU_UNITTYPE_VirtualPI = "V";
 	/** Set Handling Unit Typ.
 		@param HU_UnitType Handling Unit Typ	  */

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PackingMaterial.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PackingMaterial.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_PackingMaterial
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_PackingMaterial extends org.compiere.model.PO implements I_M
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = -1971954628L;
+	private static final long serialVersionUID = 1569342263L;
 
     /** Standard Constructor */
     public X_M_HU_PackingMaterial (Properties ctx, int M_HU_PackingMaterial_ID, String trxName)
@@ -24,8 +23,7 @@ public class X_M_HU_PackingMaterial extends org.compiere.model.PO implements I_M
       super (ctx, M_HU_PackingMaterial_ID, trxName);
       /** if (M_HU_PackingMaterial_ID == 0)
         {
-			setIsClosed (false);
-// N
+			setIsClosed (false); // N
 			setM_HU_PackingMaterial_ID (0);
 			setName (null);
         } */

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Process.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Process.java
@@ -14,7 +14,7 @@ public class X_M_HU_Process extends org.compiere.model.PO implements I_M_HU_Proc
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 431111907L;
+	private static final long serialVersionUID = -1772676787L;
 
     /** Standard Constructor */
     public X_M_HU_Process (Properties ctx, int M_HU_Process_ID, String trxName)
@@ -23,12 +23,9 @@ public class X_M_HU_Process extends org.compiere.model.PO implements I_M_HU_Proc
       /** if (M_HU_Process_ID == 0)
         {
 			setAD_Process_ID (0);
-			setIsApplyLU (false);
-// N
-			setIsApplyTU (false);
-// N
-			setIsApplyVirtualPI (false);
-// N
+			setIsApplyLU (false); // N
+			setIsApplyTU (false); // N
+			setIsApplyVirtualPI (false); // N
 			setM_HU_Process_ID (0);
         } */
     }

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Snapshot.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Snapshot.java
@@ -14,7 +14,7 @@ public class X_M_HU_Snapshot extends org.compiere.model.PO implements I_M_HU_Sna
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = -129873402L;
+	private static final long serialVersionUID = -16809402L;
 
     /** Standard Constructor */
     public X_M_HU_Snapshot (Properties ctx, int M_HU_Snapshot_ID, String trxName)
@@ -22,10 +22,8 @@ public class X_M_HU_Snapshot extends org.compiere.model.PO implements I_M_HU_Sna
       super (ctx, M_HU_Snapshot_ID, trxName);
       /** if (M_HU_Snapshot_ID == 0)
         {
-			setHUStatus (null);
-// 'P'
-			setLocked (false);
-// N
+			setHUStatus (null); // 'P'
+			setLocked (false); // N
 			setM_HU_ID (0);
 			setM_HU_PI_Item_Product_ID (0);
 			setM_HU_PI_Version_ID (0);

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Status.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Status.java
@@ -14,7 +14,7 @@ public class X_M_HU_Status extends org.compiere.model.PO implements I_M_HU_Statu
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = -1382994553L;
+	private static final long serialVersionUID = -543718351L;
 
     /** Standard Constructor */
     public X_M_HU_Status (Properties ctx, int M_HU_Status_ID, String trxName)
@@ -22,8 +22,7 @@ public class X_M_HU_Status extends org.compiere.model.PO implements I_M_HU_Statu
       super (ctx, M_HU_Status_ID, trxName);
       /** if (M_HU_Status_ID == 0)
         {
-			setExchangeGebindelagerWhenEmpty (false);
-// N
+			setExchangeGebindelagerWhenEmpty (false); // N
 			setHUStatus (null);
 			setM_HU_Status_ID (0);
 			setName (null);

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Storage.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Storage.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_Storage
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_Storage extends org.compiere.model.PO implements I_M_HU_Stor
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 1994716708L;
+	private static final long serialVersionUID = 642334623L;
 
     /** Standard Constructor */
     public X_M_HU_Storage (Properties ctx, int M_HU_Storage_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Storage_Snapshot.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Storage_Snapshot.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_Storage_Snapshot
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_Storage_Snapshot extends org.compiere.model.PO implements I_
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 1857829944L;
+	private static final long serialVersionUID = 134855987L;
 
     /** Standard Constructor */
     public X_M_HU_Storage_Snapshot (Properties ctx, int M_HU_Storage_Snapshot_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Trx_Attribute.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Trx_Attribute.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_Trx_Attribute
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_Trx_Attribute extends org.compiere.model.PO implements I_M_H
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = -1543538405L;
+	private static final long serialVersionUID = -1466964180L;
 
     /** Standard Constructor */
     public X_M_HU_Trx_Attribute (Properties ctx, int M_HU_Trx_Attribute_ID, String trxName)
@@ -28,8 +27,7 @@ public class X_M_HU_Trx_Attribute extends org.compiere.model.PO implements I_M_H
 			setM_HU_Trx_Attribute_ID (0);
 			setM_HU_Trx_Hdr_ID (0);
 			setOperation (null);
-			setProcessed (false);
-// N
+			setProcessed (false); // N
         } */
     }
 

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Trx_Line.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_Trx_Line.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for M_HU_Trx_Line
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_M_HU_Trx_Line extends org.compiere.model.PO implements I_M_HU_Trx
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 1523124742L;
+	private static final long serialVersionUID = -1907765589L;
 
     /** Standard Constructor */
     public X_M_HU_Trx_Line (Properties ctx, int M_HU_Trx_Line_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_PickingSlot_Trx.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_PickingSlot_Trx.java
@@ -14,7 +14,7 @@ public class X_M_PickingSlot_Trx extends org.compiere.model.PO implements I_M_Pi
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 19069508L;
+	private static final long serialVersionUID = -463548198L;
 
     /** Standard Constructor */
     public X_M_PickingSlot_Trx (Properties ctx, int M_PickingSlot_Trx_ID, String trxName)
@@ -22,8 +22,7 @@ public class X_M_PickingSlot_Trx extends org.compiere.model.PO implements I_M_Pi
       super (ctx, M_PickingSlot_Trx_ID, trxName);
       /** if (M_PickingSlot_Trx_ID == 0)
         {
-			setIsUserAction (false);
-// N
+			setIsUserAction (false); // N
 			setM_HU_ID (0);
 			setM_PickingSlot_ID (0);
 			setM_PickingSlot_Trx_ID (0);

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_PP_Order_Qty.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_PP_Order_Qty.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for PP_Order_Qty
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_PP_Order_Qty extends org.compiere.model.PO implements I_PP_Order_
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = -1376727325L;
+	private static final long serialVersionUID = -360386190L;
 
     /** Standard Constructor */
     public X_PP_Order_Qty (Properties ctx, int PP_Order_Qty_ID, String trxName)
@@ -31,10 +30,8 @@ public class X_PP_Order_Qty extends org.compiere.model.PO implements I_PP_Order_
 			setMovementDate (new Timestamp( System.currentTimeMillis() ));
 			setPP_Order_ID (0);
 			setPP_Order_Qty_ID (0);
-			setProcessed (false);
-// N
-			setQty (BigDecimal.ZERO);
-// 0
+			setProcessed (false); // N
+			setQty (BigDecimal.ZERO); // 0
         } */
     }
 

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_RV_HU_Quantities.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_RV_HU_Quantities.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for RV_HU_Quantities
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_RV_HU_Quantities extends org.compiere.model.PO implements I_RV_HU
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = -299796698L;
+	private static final long serialVersionUID = -443016053L;
 
     /** Standard Constructor */
     public X_RV_HU_Quantities (Properties ctx, int RV_HU_Quantities_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_RV_HU_Quantities_Summary.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_RV_HU_Quantities_Summary.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for RV_HU_Quantities_Summary
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_RV_HU_Quantities_Summary extends org.compiere.model.PO implements
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 969057434L;
+	private static final long serialVersionUID = -1018620139L;
 
     /** Standard Constructor */
     public X_RV_HU_Quantities_Summary (Properties ctx, int RV_HU_Quantities_Summary_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_RV_M_HU_Storage_InvoiceHistory.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_RV_M_HU_Storage_InvoiceHistory.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for RV_M_HU_Storage_InvoiceHistory
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_RV_M_HU_Storage_InvoiceHistory extends org.compiere.model.PO impl
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 854822395L;
+	private static final long serialVersionUID = 818468064L;
 
     /** Standard Constructor */
     public X_RV_M_HU_Storage_InvoiceHistory (Properties ctx, int RV_M_HU_Storage_InvoiceHistory_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_RV_M_Material_Tracking_HU_Details.java
+++ b/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_RV_M_Material_Tracking_HU_Details.java
@@ -4,7 +4,6 @@ package de.metas.handlingunits.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
-import org.compiere.util.Env;
 
 /** Generated Model for RV_M_Material_Tracking_HU_Details
  *  @author Adempiere (generated) 
@@ -16,7 +15,7 @@ public class X_RV_M_Material_Tracking_HU_Details extends org.compiere.model.PO i
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = -250732721L;
+	private static final long serialVersionUID = 990798666L;
 
     /** Standard Constructor */
     public X_RV_M_Material_Tracking_HU_Details (Properties ctx, int RV_M_Material_Tracking_HU_Details_ID, String trxName)

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -536,13 +536,13 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 	private IPair<BigDecimal, BigDecimal> calculateQtyDeliveredFromInOutLines(final Collection<I_M_ShipmentSchedule_QtyPicked> allocations)
 	{
 		// set of the linked inouts that have status Complete. It will be needed to determine the number of LUs
-		final Set<Integer> seenIOIds = new HashSet<Integer>();
+		final Set<Integer> seenIOIds = new HashSet<>();
 
 		// task 08298: fallback and use the actual lines' TU-Qty
 		BigDecimal iolTuQtySum = BigDecimal.ZERO;
 
 		// not sure if each line is always allocated just once..using this set to make sure we don't count a line twice
-		final Set<Integer> seenIolIds = new HashSet<Integer>();
+		final Set<Integer> seenIolIds = new HashSet<>();
 
 		for (final I_M_ShipmentSchedule_QtyPicked alloc : allocations)
 		{

--- a/de.metas.handlingunits.base/src/main/sql/postgresql/system/5465820_sys_gh1861_M_HU_Locked_VirtualColumn.sql
+++ b/de.metas.handlingunits.base/src/main/sql/postgresql/system/5465820_sys_gh1861_M_HU_Locked_VirtualColumn.sql
@@ -1,0 +1,20 @@
+-- 2017-06-20T17:39:29.650
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET ColumnSQL='(CASE WHEN EXISTS ( select 1 from T_Lock l where l.AD_Table_ID=540516 and l.Record_ID=M_HU_ID ) THEN ''Y'' ELSE ''N'' END)', IsMandatory='N', IsUpdateable='N',Updated=TO_TIMESTAMP('2017-06-20 17:39:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=550691
+;
+
+
+-- 2017-06-20T18:03:13.609
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541151,'S',TO_TIMESTAMP('2017-06-20 18:03:13','YYYY-MM-DD HH24:MI:SS'),100,'Determines if the system uses the virtual column M_HU.Locked. This boosts performance if running "not-near" the DB, but can introduce problems with stale M_HUs.
+Values: A = "Always"; N = "Never"; C = "if run from swing-client"  (also lower-case is posssible).
+The default if not set, or for any other value is "Never"','de.metas.handlingunits','Y','de.metas.handlingunits.HULockBL.UseVirtualColumn',TO_TIMESTAMP('2017-06-20 18:03:13','YYYY-MM-DD HH24:MI:SS'),100,'C')
+;
+
+-- 2017-06-20T18:06:06.567
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_SysConfig SET Description='Determines if the system uses the virtual column M_HU.Locked. This boosts performance if running "not-near" the DB, but can introduce problems with stale M_HUs.
+Values: A = "Always"; N = "Never"; C = "if run from swing-client"  (also lower-case is posssible).
+The default if not set, or for any other value is "Never"; see https://github.com/metasfresh/metasfresh/issues/1861',Updated=TO_TIMESTAMP('2017-06-20 18:06:06','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_SysConfig_ID=541151
+;
+

--- a/de.metas.handlingunits.base/src/main/sql/postgresql/system/5465830_sys_gh1861_AD_RefList_not_updatable.sql
+++ b/de.metas.handlingunits.base/src/main/sql/postgresql/system/5465830_sys_gh1861_AD_RefList_not_updatable.sql
@@ -1,0 +1,5 @@
+
+-- 2017-06-20T18:03:59.565
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsUpdateable='N',Updated=TO_TIMESTAMP('2017-06-20 18:03:59','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=63682
+;


### PR DESCRIPTION
reintroduce M_HU_Locked as virtual column of T_Lock
..but only use it if configured that way
also fix a AD_RefList valueName and make the column not updatable from now on

1861: Performance degradation in HUKey.isReadonly()

Task-Url: https://github.com/metasfresh/metasfresh/issues/1861