### PR TITLE
#1893 Adding a default Doctype to shipment Window

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5466140_sys_gh1893-shipment-default-doctype.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5466140_sys_gh1893-shipment-default-doctype.sql
@@ -1,0 +1,5 @@
+-- 2017-06-25T15:39:35.033
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET DefaultValue='1000011',Updated=TO_TIMESTAMP('2017-06-25 15:39:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2931
+;
+


### PR DESCRIPTION
Adding the default Doctype for SHipment Window. This is only needed for
manually created Shipments, and reduced the fields that have to be
filled initially.

FRESH-2727 https://github.com/metasfresh/metasfresh/issues/1893