### PR TITLE
#1933 Menu Translations for Language en_US

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5466670_sys_gh1933-menu-trl-en-us-webui.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5466670_sys_gh1933-menu-trl-en-us-webui.sql
@@ -298,3 +298,103 @@ UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:36:46',
 UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:37:51','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Resource Type',Description='Create and Maintain Resource Types',WEBUI_NameBrowse='Resource Type' WHERE AD_Menu_ID=540819 AND AD_Language='en_US'
 ;
 
+-- 2017-07-02T12:47:24.368
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:47:24','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Storage Conference Terms',WEBUI_NameBrowse='Storage Conference Terms' WHERE AD_Menu_ID=540889 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:47:37.887
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:47:37','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Storage Conference Terms' WHERE AD_Window_ID=540230 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:47:45.337
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:47:45','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Storage Conference Terms' WHERE AD_Tab_ID=540616 AND AD_Language='it_CH'
+;
+
+-- 2017-07-02T12:47:59.600
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:47:59','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Storage Conference Terms Version' WHERE AD_Tab_ID=540617 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:49:06.887
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:49:06','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Invoice Schedule',Description='Create and Maintain Invoicing Schedules',WEBUI_NameBrowse='Invoice Schedule' WHERE AD_Menu_ID=540825 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:49:37.562
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:49:37','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Window_ID=540322 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:50:11.934
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:50:11','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Empty Return',Description='Empty Return to Vendors' WHERE AD_Tab_ID=540778 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:50:52.476
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:50:52','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Empties Return',WEBUI_NameBrowse='Empties Return' WHERE AD_Menu_ID=540783 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:51:12.323
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:51:12','YYYY-MM-DD HH24:MI:SS'),Name='Empties Return' WHERE AD_Window_ID=540322 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:51:23.843
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:51:23','YYYY-MM-DD HH24:MI:SS'),Name='Empties Return' WHERE AD_Tab_ID=540778 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:52:02.294
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET EntityType='D',Updated=TO_TIMESTAMP('2017-07-02 12:52:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=540841
+;
+
+-- 2017-07-02T12:52:46.294
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:52:46','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Customer Return',Description='Customer Return',WEBUI_NameBrowse='Customer Return' WHERE AD_Menu_ID=540841 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:53:17.345
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET Name='Kommissionier Terminal',Updated=TO_TIMESTAMP('2017-07-02 12:53:17','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=540868
+;
+
+-- 2017-07-02T12:53:27.523
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window SET Name='Kommissionier Terminal',Updated=TO_TIMESTAMP('2017-07-02 12:53:27','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Window_ID=540345
+;
+
+-- 2017-07-02T12:54:06.799
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:54:06','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Picking Terminal (Prototype)',Description='New Picking Terminal (Prototype)' WHERE AD_Window_ID=540345 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:54:18.160
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:54:18','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Tab_ID=540830 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:54:40.769
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET Name='Kommissionier Terminal (Prototyp)', WEBUI_NameBrowse='Kommissionier Terminal (Prototyp)',Updated=TO_TIMESTAMP('2017-07-02 12:54:40','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=540868
+;
+
+-- 2017-07-02T12:55:53.667
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:55:53','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Client',Description='Maintain Clients',WEBUI_NameBrowse='Client' WHERE AD_Menu_ID=540838 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T13:19:38.125
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:19:38','YYYY-MM-DD HH24:MI:SS'),Name='Organization Type' WHERE AD_Tab_ID=588 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T13:19:55.836
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:19:55','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Organization Type',Description='Maintain Organization Types',WEBUI_NameBrowse='Organization Type' WHERE AD_Menu_ID=540832 AND AD_Language='en_US'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5466670_sys_gh1933-menu-trl-en-us-webui.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5466670_sys_gh1933-menu-trl-en-us-webui.sql
@@ -448,3 +448,13 @@ UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:31:37
 UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:31:54','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='KPI Field Translations' WHERE AD_Tab_ID=540837 AND AD_Language='en_US'
 ;
 
+-- 2017-07-02T13:40:16.526
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:40:16','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Business Partner Revenue',WEBUI_NameBrowse='Business Partner Revenue' WHERE AD_Menu_ID=540738 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T13:40:31.919
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:40:31','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Business Partner Revenue' WHERE AD_Process_ID=540561 AND AD_Language='it_CH'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5466670_sys_gh1933-menu-trl-en-us-webui.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5466670_sys_gh1933-menu-trl-en-us-webui.sql
@@ -398,3 +398,53 @@ UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:19:38','
 UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:19:55','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Organization Type',Description='Maintain Organization Types',WEBUI_NameBrowse='Organization Type' WHERE AD_Menu_ID=540832 AND AD_Language='en_US'
 ;
 
+-- 2017-07-02T13:23:48.660
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:23:48','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Picking Terminal (Prototype)',WEBUI_NameBrowse='Picking Terminal (Prototype)' WHERE AD_Menu_ID=540868 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T13:27:35.245
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:27:35','YYYY-MM-DD HH24:MI:SS'),Name='Organisation Type',Description='Maintain Organisation Types',WEBUI_NameBrowse='Organisation Type' WHERE AD_Menu_ID=540832 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T13:28:14.781
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:28:14','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Document Type',Description='Maintain Document Types',WEBUI_NameBrowse='Document Type' WHERE AD_Menu_ID=540826 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T13:28:52.222
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:28:52','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Print Format',Description='Maintain Print Format',WEBUI_NameBrowse='Print Format' WHERE AD_Menu_ID=540827 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T13:29:35.119
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:29:35','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Document Sequence',Description='Maintain System and Document Sequences',WEBUI_NameBrowse='Document Sequence' WHERE AD_Menu_ID=540828 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T13:30:04.993
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:30:04','YYYY-MM-DD HH24:MI:SS'),Name='Country, Region and City' WHERE AD_Window_ID=122 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T13:30:45.624
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:30:45','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Country, Region and City',Description='Maintain Countries, Regions and Cities',WEBUI_NameBrowse='Country, Region and City' WHERE AD_Menu_ID=540845 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T13:31:25.673
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:31:25','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='KPI Field Translations',WEBUI_NameBrowse='KPI Field Translations' WHERE AD_Menu_ID=540865 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T13:31:37.647
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:31:37','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='KPI Field Translations' WHERE AD_Window_ID=540348 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T13:31:54.587
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 13:31:54','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='KPI Field Translations' WHERE AD_Tab_ID=540837 AND AD_Language='en_US'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5466670_sys_gh1933-menu-trl-en-us-webui.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5466670_sys_gh1933-menu-trl-en-us-webui.sql
@@ -1,0 +1,205 @@
+-- 2017-07-02T11:44:08.126
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:44:08','YYYY-MM-DD HH24:MI:SS'),Name='Request for Proposal Topic',Description='Maintain Request for Proposal Topics and invite Partners',WEBUI_NameBrowse='Request for Proposal Topic' WHERE AD_Menu_ID=540878 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:44:11.068
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:44:11','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Menu_ID=540878 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:45:16.067
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:45:16','YYYY-MM-DD HH24:MI:SS'),Name='Request for Proposal Topic',Description='Maintain Request for Proposal Topic and Subscribers',Help='A Request for Proposal Topic allows you to maintain a subscriber list of potential Vendors to respond to RfPs' WHERE AD_Window_ID=314 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:45:46.380
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:45:46','YYYY-MM-DD HH24:MI:SS'),Description='Request for Proposal Topic',Help='A Request for Proposal Topic allows you to maintain a subscriber list of potential Vendors to respond to RfPs' WHERE AD_Tab_ID=619 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:46:36.024
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:46:36','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Procurement Notifications',WEBUI_NameBrowse='Procurement Notifications' WHERE AD_Menu_ID=540876 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:47:01.728
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:47:01','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Procurement Notifications' WHERE AD_Window_ID=540293 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:47:16.861
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:47:16','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Notifications' WHERE AD_Tab_ID=540735 AND AD_Language='de_CH'
+;
+
+-- 2017-07-02T11:47:57.244
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:47:57','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Deliveryplanning Record',WEBUI_NameBrowse='Deliveryplanning Record' WHERE AD_Menu_ID=540873 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:48:29.230
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:48:29','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Deliveryplanning Record' WHERE AD_Window_ID=540286 AND AD_Language='de_CH'
+;
+
+-- 2017-07-02T11:48:42.612
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:48:42','YYYY-MM-DD HH24:MI:SS'),IsTranslated='N',Name='Lieferplanungsdatensatz',Help='Deliveryplanning Record' WHERE AD_Window_ID=540286 AND AD_Language='de_CH'
+;
+
+-- 2017-07-02T11:48:45.539
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:48:45','YYYY-MM-DD HH24:MI:SS'),Help='' WHERE AD_Window_ID=540286 AND AD_Language='de_CH'
+;
+
+-- 2017-07-02T11:48:52.840
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:48:52','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Deliveryplanning Record' WHERE AD_Window_ID=540286 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:49:07.816
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:49:07','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Deliveryplanning Record' WHERE AD_Tab_ID=540727 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:49:52.064
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:49:52','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',WEBUI_NameBrowse='Availabity Trend Record' WHERE AD_Menu_ID=540874 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:50:01.946
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:50:01','YYYY-MM-DD HH24:MI:SS'),Name='Availabity Trend Record' WHERE AD_Menu_ID=540874 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:50:16.640
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:50:16','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Availabity Trend Record' WHERE AD_Window_ID=540290 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:50:34.674
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:50:34','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Availabity Trends' WHERE AD_Tab_ID=540733 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:52:09.187
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:52:09','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Menu_ID=540756 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:52:32.480
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:52:32','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Price System' WHERE AD_Window_ID=540320 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:52:49.004
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:52:49','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Preis System' WHERE AD_Tab_ID=540775 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:52:55.780
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:52:55','YYYY-MM-DD HH24:MI:SS'),Name='Price System' WHERE AD_Tab_ID=540775 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:53:22.180
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:53:22','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Price List',WEBUI_NameBrowse='Price List',WEBUI_NameNew='New Price List' WHERE AD_Menu_ID=540775 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:53:47.435
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:53:47','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='New Price List' WHERE AD_Window_ID=540321 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:54:00.243
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:54:00','YYYY-MM-DD HH24:MI:SS'),Name='Price List' WHERE AD_Window_ID=540321 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:54:16.310
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:54:16','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Price List' WHERE AD_Tab_ID=540776 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:54:42.270
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:54:42','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Product Prices',WEBUI_NameBrowse='Product Prices' WHERE AD_Menu_ID=540776 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:54:48.832
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET EntityType='D',Updated=TO_TIMESTAMP('2017-07-02 11:54:48','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=540776
+;
+
+-- 2017-07-02T11:55:02.844
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:55:02','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Product Prices' WHERE AD_Window_ID=540325 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T11:55:16.249
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 11:55:16','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Product Prices' WHERE AD_Tab_ID=540787 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:12:06.911
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET EntityType='D',Updated=TO_TIMESTAMP('2017-07-02 12:12:06','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=540777
+;
+
+-- 2017-07-02T12:12:26.100
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:12:26','YYYY-MM-DD HH24:MI:SS'),Name='Price Schema',Description='Maintain Price Schemas',WEBUI_NameBrowse='Price Schema' WHERE AD_Menu_ID=540777 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:12:28.601
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:12:28','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Menu_ID=540777 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:13:22.499
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:13:22','YYYY-MM-DD HH24:MI:SS'),Name='Price List Schema',Description='Maintain Price List Schemas',WEBUI_NameBrowse='Price List Schema' WHERE AD_Menu_ID=540777 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:14:00.595
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:14:00','YYYY-MM-DD HH24:MI:SS'),Name='Pricing Rule',WEBUI_NameBrowse='Pricing Rule' WHERE AD_Menu_ID=540778 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:14:15.071
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window SET Name='Preisberechnung',Updated=TO_TIMESTAMP('2017-07-02 12:14:15','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Window_ID=53189
+;
+
+-- 2017-07-02T12:14:15.078
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET Description='Defines a list of pricing and discount rules that need to be invoked when product price is calculated.', IsActive='Y', Name='Preisberechnung',Updated=TO_TIMESTAMP('2017-07-02 12:14:15','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=53432
+;
+
+-- 2017-07-02T12:14:25.762
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:14:25','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Window_ID=53189 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:14:33.975
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab SET Name='Regel',Updated=TO_TIMESTAMP('2017-07-02 12:14:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Tab_ID=53540
+;
+
+-- 2017-07-02T12:14:42.148
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:14:42','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Tab_ID=53540 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:15:12.128
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET EntityType='D',Updated=TO_TIMESTAMP('2017-07-02 12:15:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=540791
+;
+
+-- 2017-07-02T12:21:56.678
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:21:56','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Inventory Move',Description='Inventory Move',WEBUI_NameBrowse='Inventory Move' WHERE AD_Menu_ID=540791 AND AD_Language='en_US'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5466670_sys_gh1933-menu-trl-en-us-webui.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5466670_sys_gh1933-menu-trl-en-us-webui.sql
@@ -203,3 +203,98 @@ UPDATE AD_Menu SET EntityType='D',Updated=TO_TIMESTAMP('2017-07-02 12:15:12','YY
 UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:21:56','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Inventory Move',Description='Inventory Move',WEBUI_NameBrowse='Inventory Move' WHERE AD_Menu_ID=540791 AND AD_Language='en_US'
 ;
 
+-- 2017-07-02T12:26:44.331
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:26:44','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Menu_ID=1000080 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:27:30.635
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:27:30','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Contract Terms',Description='Maintain Contract Terms',WEBUI_NameBrowse='Contract Terms' WHERE AD_Menu_ID=540883 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:28:00.192
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:28:00','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Contract Terms',Description='Maintain Contract Terms',Help='' WHERE AD_Window_ID=540113 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:28:19.411
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:28:19','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Terms',Description='Terms',Help='' WHERE AD_Tab_ID=540331 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:29:49.532
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:29:49','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Contract Period',WEBUI_NameBrowse='Contract Period' WHERE AD_Menu_ID=540884 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:30:02.978
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:30:02','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Contract Period' WHERE AD_Window_ID=540120 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:30:23.181
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:30:23','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Period' WHERE AD_Tab_ID=540353 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:31:10.311
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:31:10','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Forecast',Description='Maintain Material Forecasts',WEBUI_NameBrowse='Forecast' WHERE AD_Menu_ID=540800 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:32:20.616
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:32:20','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Material Schedule',WEBUI_NameBrowse='Material Schedule' WHERE AD_Menu_ID=540805 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:32:38.358
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:32:38','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Material Schedule' WHERE AD_Window_ID=540334 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:32:49.329
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:32:49','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Material Schedule' WHERE AD_Tab_ID=540802 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:33:22.031
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:33:22','YYYY-MM-DD HH24:MI:SS'),Name='Product Planning' WHERE AD_Window_ID=53007 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:34:00.923
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:34:00','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Product Planning',Description='Create and Maintain Product Planning Data',WEBUI_NameBrowse='Product Planning' WHERE AD_Menu_ID=540820 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:35:10.235
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:35:10','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Manufacturing Workflows',Description='Record and Maintain Manufacturing Workflows',WEBUI_NameBrowse='Manufacturing Workflows' WHERE AD_Menu_ID=540822 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:35:32.733
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:35:32','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Manufacturing Workflow Transitions',WEBUI_NameBrowse='Manufacturing Workflow Transitions' WHERE AD_Menu_ID=540823 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:35:44.744
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:35:44','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Manufacturing Workflow Transitions' WHERE AD_Window_ID=540339 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:35:51.955
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:35:51','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Manufacturing Workflow Transitions' WHERE AD_Tab_ID=540818 AND AD_Language='de_CH'
+;
+
+-- 2017-07-02T12:36:46.532
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:36:46','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Manufacturing Resource',Description='Create and Maintain Manufacturing Resources',WEBUI_NameBrowse='Manufacturing Resource' WHERE AD_Menu_ID=540818 AND AD_Language='en_US'
+;
+
+-- 2017-07-02T12:37:51.745
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-07-02 12:37:51','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Resource Type',Description='Create and Maintain Resource Types',WEBUI_NameBrowse='Resource Type' WHERE AD_Menu_ID=540819 AND AD_Language='en_US'
+;
+


### PR DESCRIPTION
Establishing the Translations of en_US in metasfresh WebUI menu. Added missing Translations for Menu entries and Window and Tab Names.

FRESH-2788 https://github.com/metasfresh/metasfresh/issues/1933