### PR TITLE
#1995 Language Names too Long

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -16,6 +16,8 @@ Here come the actual release notes:
 
 ## Features
 * metasfresh-app
+  * [#1993](https://github.com/metasfresh/metasfresh/issues/1993) Set default Widget width for certain Columns
+    * Refining and Harmonizing the Widget width of columns in GridView for those, where generic width according to their widget type does not match to the user requirement or field content. 
 
 * metasfresh-webui-api
 

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5467760_sys_gh1995-shorten-language-name.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5467760_sys_gh1995-shorten-language-name.sql
@@ -1,0 +1,475 @@
+-- 2017-07-16T12:56:37.050
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Deutsch (DE)',Updated=TO_TIMESTAMP('2017-07-16 12:56:37','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=191
+;
+
+-- 2017-07-16T12:57:12.088
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Deutsch (CH)',Updated=TO_TIMESTAMP('2017-07-16 12:57:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=123
+;
+
+-- 2017-07-16T12:59:14.140
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Albanian (AL)',Updated=TO_TIMESTAMP('2017-07-16 12:59:14','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=181
+;
+
+-- 2017-07-16T12:59:39.455
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (DZ)',Updated=TO_TIMESTAMP('2017-07-16 12:59:39','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=102
+;
+
+-- 2017-07-16T12:59:44.942
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (BH)',Updated=TO_TIMESTAMP('2017-07-16 12:59:44','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=101
+;
+
+-- 2017-07-16T12:59:48.386
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (EG)',Updated=TO_TIMESTAMP('2017-07-16 12:59:48','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=103
+;
+
+-- 2017-07-16T12:59:53.371
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (IQ)',Updated=TO_TIMESTAMP('2017-07-16 12:59:53','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=104
+;
+
+-- 2017-07-16T12:59:57.677
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (JO)',Updated=TO_TIMESTAMP('2017-07-16 12:59:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=105
+;
+
+-- 2017-07-16T13:00:02.317
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (KW)',Updated=TO_TIMESTAMP('2017-07-16 13:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=106
+;
+
+-- 2017-07-16T13:00:07.836
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (LB)',Updated=TO_TIMESTAMP('2017-07-16 13:00:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=107
+;
+
+-- 2017-07-16T13:00:12.101
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (LY)',Updated=TO_TIMESTAMP('2017-07-16 13:00:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=108
+;
+
+-- 2017-07-16T13:00:15.477
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (MA)',Updated=TO_TIMESTAMP('2017-07-16 13:00:15','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=109
+;
+
+-- 2017-07-16T13:00:19.972
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (OM)',Updated=TO_TIMESTAMP('2017-07-16 13:00:19','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=110
+;
+
+-- 2017-07-16T13:00:23.227
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (QA)',Updated=TO_TIMESTAMP('2017-07-16 13:00:23','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=111
+;
+
+-- 2017-07-16T13:00:28.351
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (SA)',Updated=TO_TIMESTAMP('2017-07-16 13:00:28','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=112
+;
+
+-- 2017-07-16T13:00:33.382
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (SD)',Updated=TO_TIMESTAMP('2017-07-16 13:00:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=113
+;
+
+-- 2017-07-16T13:00:36.932
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (SY)',Updated=TO_TIMESTAMP('2017-07-16 13:00:36','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=114
+;
+
+-- 2017-07-16T13:00:42.812
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (TN)',Updated=TO_TIMESTAMP('2017-07-16 13:00:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=115
+;
+
+-- 2017-07-16T13:00:48.541
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (AE)',Updated=TO_TIMESTAMP('2017-07-16 13:00:48','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=100
+;
+
+-- 2017-07-16T13:00:52.390
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Arabic (YE)',Updated=TO_TIMESTAMP('2017-07-16 13:00:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=116
+;
+
+-- 2017-07-16T13:01:30.189
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Bulgarian (BG)',Updated=TO_TIMESTAMP('2017-07-16 13:01:30','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=118
+;
+
+-- 2017-07-16T13:01:34.682
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Byelorussian (BY)',Updated=TO_TIMESTAMP('2017-07-16 13:01:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=117
+;
+
+-- 2017-07-16T13:01:40.428
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Catalan (ES)',Updated=TO_TIMESTAMP('2017-07-16 13:01:40','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=119
+;
+
+-- 2017-07-16T13:01:44.835
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Chinese (CH)',Updated=TO_TIMESTAMP('2017-07-16 13:01:44','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=187
+;
+
+-- 2017-07-16T13:01:50.013
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Chinese (HK)',Updated=TO_TIMESTAMP('2017-07-16 13:01:50','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=188
+;
+
+-- 2017-07-16T13:01:54.804
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Chinese (TW)',Updated=TO_TIMESTAMP('2017-07-16 13:01:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=189
+;
+
+-- 2017-07-16T13:02:03.421
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Croatian (HR)',Updated=TO_TIMESTAMP('2017-07-16 13:02:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=159
+;
+
+-- 2017-07-16T13:02:09.389
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Czech (CZ)',Updated=TO_TIMESTAMP('2017-07-16 13:02:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=120
+;
+
+-- 2017-07-16T13:02:14.373
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Danish (DK)',Updated=TO_TIMESTAMP('2017-07-16 13:02:14','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=121
+;
+
+-- 2017-07-16T13:02:24.158
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Dutch (BE)',Updated=TO_TIMESTAMP('2017-07-16 13:02:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=170
+;
+
+-- 2017-07-16T13:02:28.569
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Dutch (NL)',Updated=TO_TIMESTAMP('2017-07-16 13:02:28','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=171
+;
+
+-- 2017-07-16T13:02:35.305
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='English (AU)',Updated=TO_TIMESTAMP('2017-07-16 13:02:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=126
+;
+
+-- 2017-07-16T13:02:38.982
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='English (CA)',Updated=TO_TIMESTAMP('2017-07-16 13:02:38','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=127
+;
+
+-- 2017-07-16T13:02:43.984
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='English (IN)',Updated=TO_TIMESTAMP('2017-07-16 13:02:43','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=130
+;
+
+-- 2017-07-16T13:02:48.254
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='English (IE)',Updated=TO_TIMESTAMP('2017-07-16 13:02:48','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=129
+;
+
+-- 2017-07-16T13:02:54.079
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='English (NZ)',Updated=TO_TIMESTAMP('2017-07-16 13:02:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=131
+;
+
+-- 2017-07-16T13:03:01.049
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='English (ZA)',Updated=TO_TIMESTAMP('2017-07-16 13:03:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=132
+;
+
+-- 2017-07-16T13:03:06.391
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='English (GB)',Updated=TO_TIMESTAMP('2017-07-16 13:03:06','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=128
+;
+
+-- 2017-07-16T13:03:10.566
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='English (US)',Updated=TO_TIMESTAMP('2017-07-16 13:03:10','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=192
+;
+
+-- 2017-07-16T13:03:16.906
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Estonian (EE)',Updated=TO_TIMESTAMP('2017-07-16 13:03:16','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=152
+;
+
+-- 2017-07-16T13:03:33.190
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Farsi (IR)',Updated=TO_TIMESTAMP('2017-07-16 13:03:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=193
+;
+
+-- 2017-07-16T13:03:41.266
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Finnish (FI)',Updated=TO_TIMESTAMP('2017-07-16 13:03:41','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=153
+;
+
+-- 2017-07-16T13:04:28.474
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Französisch (FR)',Updated=TO_TIMESTAMP('2017-07-16 13:04:28','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=190
+;
+
+-- 2017-07-16T13:04:37.614
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='French (BE)',Updated=TO_TIMESTAMP('2017-07-16 13:04:37','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=154
+;
+
+-- 2017-07-16T13:04:42.371
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='French (CE)',Updated=TO_TIMESTAMP('2017-07-16 13:04:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=155
+;
+
+-- 2017-07-16T13:04:47.855
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='French (LU)',Updated=TO_TIMESTAMP('2017-07-16 13:04:47','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=157
+;
+
+-- 2017-07-16T13:04:52.770
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='French (CH)',Updated=TO_TIMESTAMP('2017-07-16 13:04:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=156
+;
+
+-- 2017-07-16T13:04:57.417
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='German (AU)',Updated=TO_TIMESTAMP('2017-07-16 13:04:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=122
+;
+
+-- 2017-07-16T13:05:03.209
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='German (LU)',Updated=TO_TIMESTAMP('2017-07-16 13:05:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=124
+;
+
+-- 2017-07-16T13:05:07.842
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Greek (GR)',Updated=TO_TIMESTAMP('2017-07-16 13:05:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=125
+;
+
+-- 2017-07-16T13:05:13.536
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Hebrew (IL)',Updated=TO_TIMESTAMP('2017-07-16 13:05:13','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=164
+;
+
+-- 2017-07-16T13:05:17.499
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Hindi (IN)',Updated=TO_TIMESTAMP('2017-07-16 13:05:17','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=158
+;
+
+-- 2017-07-16T13:05:22.849
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Hungarian (HU)',Updated=TO_TIMESTAMP('2017-07-16 13:05:22','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=160
+;
+
+-- 2017-07-16T13:05:26.979
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Icelandic (IS)',Updated=TO_TIMESTAMP('2017-07-16 13:05:26','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=161
+;
+
+-- 2017-07-16T13:05:32.113
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Italian (IT)',Updated=TO_TIMESTAMP('2017-07-16 13:05:32','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=163
+;
+
+-- 2017-07-16T13:05:38.510
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Italienisch (CH)',Updated=TO_TIMESTAMP('2017-07-16 13:05:38','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=162
+;
+
+-- 2017-07-16T13:05:43.858
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Japanese (JP)',Updated=TO_TIMESTAMP('2017-07-16 13:05:43','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=165
+;
+
+-- 2017-07-16T13:05:48.912
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Korean (KR)',Updated=TO_TIMESTAMP('2017-07-16 13:05:48','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=166
+;
+
+-- 2017-07-16T13:05:56.401
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Latvian (LV)',Updated=TO_TIMESTAMP('2017-07-16 13:05:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=168
+;
+
+-- 2017-07-16T13:06:04.465
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Lithuanian (LT)',Updated=TO_TIMESTAMP('2017-07-16 13:06:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=167
+;
+
+-- 2017-07-16T13:06:09.353
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Macedonian (MK)',Updated=TO_TIMESTAMP('2017-07-16 13:06:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=169
+;
+
+-- 2017-07-16T13:06:14.019
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Norwegian (NO)',Updated=TO_TIMESTAMP('2017-07-16 13:06:14','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=172
+;
+
+-- 2017-07-16T13:06:19.618
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Polish (PL)',Updated=TO_TIMESTAMP('2017-07-16 13:06:19','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=173
+;
+
+-- 2017-07-16T13:06:23.645
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Portuguese (BR)',Updated=TO_TIMESTAMP('2017-07-16 13:06:23','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=174
+;
+
+-- 2017-07-16T13:06:31.451
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Portuguese (PO)',Updated=TO_TIMESTAMP('2017-07-16 13:06:31','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=175
+;
+
+-- 2017-07-16T13:06:36.570
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Romanian (RO)',Updated=TO_TIMESTAMP('2017-07-16 13:06:36','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=176
+;
+
+-- 2017-07-16T13:06:49.060
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Russian (RU)',Updated=TO_TIMESTAMP('2017-07-16 13:06:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=177
+;
+
+-- 2017-07-16T13:06:55.933
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Serbian (YU)',Updated=TO_TIMESTAMP('2017-07-16 13:06:55','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=182
+;
+
+-- 2017-07-16T13:07:03.023
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Serbo-Croatian (YU)',Updated=TO_TIMESTAMP('2017-07-16 13:07:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=178
+;
+
+-- 2017-07-16T13:07:09.462
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Slovak (SL)',Updated=TO_TIMESTAMP('2017-07-16 13:07:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=179
+;
+
+-- 2017-07-16T13:07:20.021
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Slovenian (SL)',Updated=TO_TIMESTAMP('2017-07-16 13:07:20','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=180
+;
+
+-- 2017-07-16T13:07:24.837
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (AR)',Updated=TO_TIMESTAMP('2017-07-16 13:07:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=133
+;
+
+-- 2017-07-16T13:07:30.091
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (BO)',Updated=TO_TIMESTAMP('2017-07-16 13:07:30','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=134
+;
+
+-- 2017-07-16T13:07:34.349
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (CH)',Updated=TO_TIMESTAMP('2017-07-16 13:07:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=135
+;
+
+-- 2017-07-16T13:07:38.988
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (CO)',Updated=TO_TIMESTAMP('2017-07-16 13:07:38','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=136
+;
+
+-- 2017-07-16T13:07:43.276
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (CR)',Updated=TO_TIMESTAMP('2017-07-16 13:07:43','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=137
+;
+
+-- 2017-07-16T13:07:48.709
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (DO)',Updated=TO_TIMESTAMP('2017-07-16 13:07:48','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=138
+;
+
+-- 2017-07-16T13:07:52.751
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (EC)',Updated=TO_TIMESTAMP('2017-07-16 13:07:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=139
+;
+
+-- 2017-07-16T13:08:00.547
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (SV)',Updated=TO_TIMESTAMP('2017-07-16 13:08:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=149
+;
+
+-- 2017-07-16T13:08:04.980
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (GT)',Updated=TO_TIMESTAMP('2017-07-16 13:08:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=141
+;
+
+-- 2017-07-16T13:08:09.427
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (HN)',Updated=TO_TIMESTAMP('2017-07-16 13:08:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=142
+;
+
+-- 2017-07-16T13:08:13.363
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (MX)',Updated=TO_TIMESTAMP('2017-07-16 13:08:13','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=143
+;
+
+-- 2017-07-16T13:08:17.960
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (NI)',Updated=TO_TIMESTAMP('2017-07-16 13:08:17','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=144
+;
+
+-- 2017-07-16T13:08:21.608
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (PA)',Updated=TO_TIMESTAMP('2017-07-16 13:08:21','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=145
+;
+
+-- 2017-07-16T13:08:26.852
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (PY)',Updated=TO_TIMESTAMP('2017-07-16 13:08:26','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=148
+;
+
+-- 2017-07-16T13:08:30.607
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (PE)',Updated=TO_TIMESTAMP('2017-07-16 13:08:30','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=146
+;
+
+-- 2017-07-16T13:08:35.132
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (PR)',Updated=TO_TIMESTAMP('2017-07-16 13:08:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=147
+;
+
+-- 2017-07-16T13:08:39.980
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (ES)',Updated=TO_TIMESTAMP('2017-07-16 13:08:39','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=140
+;
+
+-- 2017-07-16T13:08:44.219
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (UY)',Updated=TO_TIMESTAMP('2017-07-16 13:08:44','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=150
+;
+
+-- 2017-07-16T13:08:48.580
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Spanish (VE)',Updated=TO_TIMESTAMP('2017-07-16 13:08:48','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=151
+;
+
+-- 2017-07-16T13:08:52.228
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Swedish (SE)',Updated=TO_TIMESTAMP('2017-07-16 13:08:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=183
+;
+
+-- 2017-07-16T13:08:56.996
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Thai (TH)',Updated=TO_TIMESTAMP('2017-07-16 13:08:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=184
+;
+
+-- 2017-07-16T13:09:00.879
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Turkish (TR)',Updated=TO_TIMESTAMP('2017-07-16 13:09:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=185
+;
+
+-- 2017-07-16T13:09:51.990
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Ukrainian (UA)',Updated=TO_TIMESTAMP('2017-07-16 13:09:51','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=186
+;
+
+-- 2017-07-16T13:09:58.830
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Language SET Name='Vietnamese (VN)',Updated=TO_TIMESTAMP('2017-07-16 13:09:58','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language_ID=194
+;
+


### PR DESCRIPTION
Shortening the Language Names setting them to 2-digit Country Code

FRESH-2901 https://github.com/metasfresh/metasfresh/issues/1995
