### PR TITLE
#2058 Changing the Identifier of AD_Table to name

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -18,6 +18,8 @@ Here come the actual release notes:
 * metasfresh-app
   * [#1994](https://github.com/metasfresh/metasfresh/issues/1994) Adjust Sales Invoice Window
     * Finetuning for the Sales Invoice Window to adjust the Layout to meet our current Look And Feel concept.
+  * [#2032](https://github.com/metasfresh/metasfresh/issues/2032) Layout for Handling Unit Editor Window in WebUI
+    * Refined Layout for the Detail Views in Handling Unit Editor Window of WebUI.
 
 * metasfresh-webui-api
 

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5468580_sys_gh2058-table-identifier-work.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5468580_sys_gh2058-table-identifier-work.sql
@@ -1,0 +1,25 @@
+-- 2017-07-24T19:06:42.208
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', IsUpdateable='N',Updated=TO_TIMESTAMP('2017-07-24 19:06:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=100
+;
+
+-- 2017-07-24T19:06:44.693
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='N',Updated=TO_TIMESTAMP('2017-07-24 19:06:44','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=356
+;
+
+-- 2017-07-24T19:07:13.610
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y',Updated=TO_TIMESTAMP('2017-07-24 19:07:13','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=105
+;
+
+-- 2017-07-24T19:07:42.439
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsIdentifier='N',Updated=TO_TIMESTAMP('2017-07-24 19:07:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=107
+;
+
+-- 2017-07-24T19:07:47.144
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET SeqNo=1,Updated=TO_TIMESTAMP('2017-07-24 19:07:47','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=102
+;
+


### PR DESCRIPTION
Changing the Identifier of AD_Table to name instead of Name and
Tablename. Now the denifier looks more User friendly in Table +
Record_ID combinations.

FRESH-2981 https://github.com/metasfresh/metasfresh/issues/2058