### PR TITLE
2106 & 2107: Problems on CAMT 54 Import

### DIFF
--- a/de.metas.payment.esr/pom.xml
+++ b/de.metas.payment.esr/pom.xml
@@ -68,6 +68,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 		<!--
 			Lombok
 			See https://github.com/metasfresh/metasfresh/issues/1125
@@ -144,7 +150,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.2</version>
 				<executions>
 					<execution>
 						<goals>

--- a/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/impl/camt54/ESRDataImporterCamt54.java
+++ b/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/impl/camt54/ESRDataImporterCamt54.java
@@ -168,15 +168,16 @@ public class ESRDataImporterCamt54 implements IESRDataImporter
 	 */
 	private BigDecimal iterateEntryDetails(
 			@NonNull final ESRStatementBuilder stmtBuilder,
-			@Nullable BigDecimal ctrlQty,
+			@Nullable final BigDecimal ctrlQty,
 			@NonNull final ReportEntry8 ntry)
 	{
+		BigDecimal newCtrlQty = ctrlQty;
 		for (final EntryDetails7 ntryDtl : ntry.getNtryDtls())
 		{
 			if (ntryDtl.getBtch() != null && ntryDtl.getBtch().getNbOfTxs() != null)
 			{
 				final BigDecimal augend = new BigDecimal(ntryDtl.getBtch().getNbOfTxs());
-				ctrlQty = (ctrlQty == null) ? augend : ctrlQty.add(augend);
+				newCtrlQty = (newCtrlQty == null) ? augend : newCtrlQty.add(augend);
 			}
 
 			final List<ESRTransaction> transactions = iterateTransactionDetails(ntry, ntryDtl);
@@ -184,7 +185,7 @@ public class ESRDataImporterCamt54 implements IESRDataImporter
 
 		} // ntryDtl
 
-		return ctrlQty;
+		return newCtrlQty;
 	}
 
 	private List<ESRTransaction> iterateTransactionDetails(

--- a/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/impl/camt54/ESRDataImporterCamt54.java
+++ b/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/impl/camt54/ESRDataImporterCamt54.java
@@ -19,8 +19,8 @@ import javax.xml.stream.util.StreamReaderDelegate;
 
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
-import org.adempiere.util.Check;
 import org.adempiere.util.Loggables;
+import org.adempiere.util.Services;
 import org.adempiere.util.lang.IAutoCloseable;
 import org.compiere.util.Env;
 import org.slf4j.Logger;
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import com.google.common.base.Objects;
 
 import ch.qos.logback.classic.Level;
+import de.metas.i18n.IMsgBL;
 import de.metas.logging.LogManager;
 import de.metas.payment.camt054_001_06.AccountNotification12;
 import de.metas.payment.camt054_001_06.ActiveOrHistoricCurrencyAndAmount;
@@ -89,6 +90,12 @@ import lombok.NonNull;
 public class ESRDataImporterCamt54 implements IESRDataImporter
 {
 
+	private static final String MSG_UNSUPPORTED_CREDIT_DEBIT_CODE_1P = "ESR_CAMT54_UnsupportedCreditDebitCode";
+
+	private static final String MSG_MISSING_ESR_REFERENCE = "ESR_CAMT54_Missing_ESR_Reference";
+
+	private static final String MSG_BANK_ACCOUNT_MISMATCH_2P = "ESR_CAMT54_BankAccountMismatch";
+
 	/**
 	 * This constant is used as value in {@code /BkToCstmrDbtCdtNtfctn/Ntfctn/Ntry/NtryDtls/TxDtls/RmtInf/Strd/CdtrRefInf/Tp/CdOrPrtry/Prtry} to indicate that the references given in {@code CdtrRefInf} is an ESR number.
 	 */
@@ -107,6 +114,122 @@ public class ESRDataImporterCamt54 implements IESRDataImporter
 
 	@Override
 	public ESRStatement importData()
+	{
+		final BankToCustomerDebitCreditNotificationV06 bkToCstmrDbtCdtNtfctn = loadXML();
+
+		if (bkToCstmrDbtCdtNtfctn.getGrpHdr() != null && bkToCstmrDbtCdtNtfctn.getGrpHdr().getAddtlInf() != null)
+		{
+			Loggables.get().withLogger(logger, Level.INFO).addLog("The given input is a test file: bkToCstmrDbtCdtNtfctn/grpHdr/addtlInf={}", bkToCstmrDbtCdtNtfctn.getGrpHdr().getAddtlInf());
+		}
+
+		try (final IAutoCloseable switchContext = Env.switchContext(InterfaceWrapperHelper.getCtx(header, true)))
+		{
+			return createESRStatement(bkToCstmrDbtCdtNtfctn);
+		}
+	}
+
+	private ESRStatement createESRStatement(final BankToCustomerDebitCreditNotificationV06 bkToCstmrDbtCdtNtfctn)
+	{
+		final IMsgBL msgBL = Services.get(IMsgBL.class);
+		final ESRStatementBuilder stmtBuilder = ESRStatement.builder();
+
+		BigDecimal ctrAmount = BigDecimal.ZERO;
+		BigDecimal ctrlQty = null; // start with null (not zero) because in the camt.54 file there just might be no information provided at all
+
+		for (final AccountNotification12 ntfctn : bkToCstmrDbtCdtNtfctn.getNtfctn())
+		{
+			for (final ReportEntry8 ntry : ntfctn.getNtry()) // gh #1947: there can be many ntry records
+			{
+				ctrAmount = ctrAmount.add(ntry.getAmt().getValue());
+
+				for (final EntryDetails7 ntryDtl : ntry.getNtryDtls())
+				{
+					if (ntryDtl.getBtch() != null && ntryDtl.getBtch().getNbOfTxs() != null)
+					{
+						final BigDecimal augend = new BigDecimal(ntryDtl.getBtch().getNbOfTxs());
+						if (ctrlQty == null)
+						{
+							ctrlQty = augend;
+						}
+						ctrlQty = ctrlQty.add(augend);
+					}
+
+					for (final EntryTransaction8 txDtls : ntryDtl.getTxDtls())
+					{
+						// get the esr reference string out of the XML tree
+						final Optional<String> esrReferenceNumberString = txDtls.getRmtInf().getStrd().stream()
+								.map(strd -> strd.getCdtrRefInf())
+
+								// it's stored in the cdtrRefInf records whose cdtrRefInf/tp/cdOrPrtry/prtr equals to ISR_REFERENCE
+								.filter(cdtrRefInf -> cdtrRefInf != null
+										&& cdtrRefInf.getTp() != null
+										&& cdtrRefInf.getTp().getCdOrPrtry() != null
+										&& cdtrRefInf.getTp().getCdOrPrtry().getPrtry().equals(ISR_REFERENCE))
+
+								.map(cdtrRefInf -> cdtrRefInf.getRef())
+								.findFirst();
+
+						stmtBuilder.errorMsg(msgBL.getMsg(Env.getCtx(), MSG_MISSING_ESR_REFERENCE));
+
+						final ActiveOrHistoricCurrencyAndAmount transactionDetailAmt = txDtls.getAmt();
+						final BigDecimal amountValue;
+
+						// verify that the currency is consistent
+						// TODO: this does not really belong into the loader! move it to the matcher code.
+						if (header.getC_BP_BankAccount_ID() > 0)
+						{
+							final String headerCurrencyISO = header.getC_BP_BankAccount().getC_Currency().getISO_Code();
+							if (!headerCurrencyISO.equalsIgnoreCase(transactionDetailAmt.getCcy()))
+							{
+								stmtBuilder.errorMsg(msgBL.getMsg(Env.getCtx(), MSG_BANK_ACCOUNT_MISMATCH_2P, 
+										new Object[] { headerCurrencyISO, transactionDetailAmt.getCcy() }));
+							}
+						}
+
+						// credit-or-debit indicator
+						final String trxType;
+						if (txDtls.getCdtDbtInd() == CreditDebitCode.CRDT)
+						{
+							if (ntry.isRvslInd() != null && ntry.isRvslInd())
+							{
+								trxType = ESRConstants.ESRTRXTYPE_ReverseBooking;
+								amountValue = transactionDetailAmt.getValue().negate();
+							}
+							else
+							{
+								trxType = ESRConstants.ESRTRXTYPE_CreditMemo;
+								amountValue = transactionDetailAmt.getValue();
+							}
+						}
+						else
+						{
+							// we get charged; currently not supported
+							stmtBuilder.errorMsg(msgBL.getMsg(Env.getCtx(), MSG_UNSUPPORTED_CREDIT_DEBIT_CODE_1P, new Object[]
+								{ ntry.getCdtDbtInd() }));
+							trxType = "???";
+							amountValue = null;
+						}
+
+						stmtBuilder.transaction(ESRTransaction.builder()
+								.trxType(trxType)
+								.amount(amountValue)
+								.accountingDate(asTimestamp(ntry.getBookgDt()))
+								.paymentDate(asTimestamp(ntry.getValDt()))
+								.esrParticipantNo(ntry.getNtryRef())
+								.esrReferenceNumber(esrReferenceNumberString.orElse(null))
+								.transactionKey(mkTrxKey(txDtls))
+								.build());
+					}
+				} // ntryDtl
+			} // for ntry
+		} // ntfctn
+		return stmtBuilder
+				.ctrlAmount(ctrAmount)
+				.ctrlQty(ctrlQty)
+				.build();
+	}
+
+	private BankToCustomerDebitCreditNotificationV06 loadXML()
 	{
 		final Document document;
 		try
@@ -130,109 +253,7 @@ public class ESRDataImporterCamt54 implements IESRDataImporter
 		}
 
 		final BankToCustomerDebitCreditNotificationV06 bkToCstmrDbtCdtNtfctn = document.getBkToCstmrDbtCdtNtfctn();
-		if (bkToCstmrDbtCdtNtfctn.getGrpHdr() != null && bkToCstmrDbtCdtNtfctn.getGrpHdr().getAddtlInf() != null)
-		{
-			Loggables.get().withLogger(logger, Level.INFO).addLog("The given input is a test file: bkToCstmrDbtCdtNtfctn/grpHdr/addtlInf={}", bkToCstmrDbtCdtNtfctn.getGrpHdr().getAddtlInf());
-		}
-
-		try (final IAutoCloseable switchContext = Env.switchContext(InterfaceWrapperHelper.getCtx(header, true)))
-		{
-			final ESRStatementBuilder stmtBuilder = ESRStatement.builder();
-
-			if (bkToCstmrDbtCdtNtfctn.getNtfctn().isEmpty())
-			{
-				return stmtBuilder.ctrlAmount(BigDecimal.ZERO).ctrlQty(BigDecimal.ZERO).build();
-			}
-			final AccountNotification12 ntfctn = bkToCstmrDbtCdtNtfctn.getNtfctn().get(0);
-
-			if (ntfctn.getNtry().isEmpty())
-			{
-				return stmtBuilder.ctrlAmount(BigDecimal.ZERO).ctrlQty(BigDecimal.ZERO).build();
-			}
-
-			BigDecimal ctrAmount = BigDecimal.ZERO;
-			BigDecimal ctrlQty = BigDecimal.ZERO;
-
-			for (final ReportEntry8 ntry : ntfctn.getNtry()) // gh #1947: there can be many ntry records
-			{
-				ctrAmount = ctrAmount.add(ntry.getAmt().getValue());
-
-				if (ntry.getNtryDtls().isEmpty())
-				{
-					return stmtBuilder.ctrlAmount(ctrAmount).ctrlQty(BigDecimal.ZERO).build();
-				}
-				final EntryDetails7 ntryDtl = ntry.getNtryDtls().get(0);
-
-				ctrlQty = ctrlQty.add(new BigDecimal(ntryDtl.getBtch().getNbOfTxs()));
-
-				for (final EntryTransaction8 txDtls : ntryDtl.getTxDtls())
-				{
-					// get the esr reference string out of the XML tree
-					final Optional<String> esrReferenceNumberString = txDtls.getRmtInf().getStrd().stream()
-							.map(strd -> strd.getCdtrRefInf())
-
-							// it's stored in the cdtrRefInf records whose cdtrRefInf/tp/cdOrPrtry/prtr equals to ISR_REFERENCE
-							.filter(cdtrRefInf -> cdtrRefInf != null
-									&& cdtrRefInf.getTp() != null
-									&& cdtrRefInf.getTp().getCdOrPrtry() != null
-									&& cdtrRefInf.getTp().getCdOrPrtry().getPrtry().equals(ISR_REFERENCE))
-
-							.map(cdtrRefInf -> cdtrRefInf.getRef())
-							.findFirst();
-					Check.errorUnless(esrReferenceNumberString.isPresent(), "Missing ESR creditor reference");
-
-					final ActiveOrHistoricCurrencyAndAmount transactionDetailAmt = txDtls.getAmt();
-					final BigDecimal amountValue;
-
-					// verify that the currency is consistent
-					// TODO: this does not really belong into the loader! move it to the matcher code.
-					if (header.getC_BP_BankAccount_ID() > 0)
-					{
-						final String headerCurrencyISO = header.getC_BP_BankAccount().getC_Currency().getISO_Code();
-						Check.errorUnless(headerCurrencyISO.equalsIgnoreCase(transactionDetailAmt.getCcy()),
-								"Currency {} of C_BP_BankAccount does not match the currency {} of the current xml ntry; C_BP_BankAccount={}",
-								headerCurrencyISO, transactionDetailAmt.getCcy(), header.getC_BP_BankAccount());
-					}
-					// credit-or-debit indicator
-					final String trxType;
-					if (txDtls.getCdtDbtInd() == CreditDebitCode.CRDT)
-					{
-						if (ntry.isRvslInd() != null && ntry.isRvslInd())
-						{
-							trxType = ESRConstants.ESRTRXTYPE_ReverseBooking;
-							amountValue = transactionDetailAmt.getValue().negate();
-						}
-						else
-						{
-							trxType = ESRConstants.ESRTRXTYPE_CreditMemo;
-							amountValue = transactionDetailAmt.getValue();
-						}
-					}
-					else
-					{
-						// we get charged; currently not supported
-						Check.errorIf(true, "Unsupported cdtDbtInd={}", ntry.getCdtDbtInd());
-						trxType = "???";
-						amountValue = null;
-					}
-
-					stmtBuilder.transaction(ESRTransaction.builder()
-							.trxType(trxType)
-							.transactionKey(mkTrxKey(txDtls))
-							.amount(amountValue)
-							.accountingDate(asTimestamp(ntry.getBookgDt()))
-							.paymentDate(asTimestamp(ntry.getValDt()))
-							.esrParticipantNo(ntry.getNtryRef())
-							.esrReferenceNumber(esrReferenceNumberString.get())
-							.build());
-				}
-			} // for ntry
-			return stmtBuilder
-					.ctrlAmount(ctrAmount)
-					.ctrlQty(ctrlQty)
-					.build();
-		}
-
+		return bkToCstmrDbtCdtNtfctn;
 	}
 
 	/**

--- a/de.metas.payment.esr/src/main/sql/postgresql/system/5469020_gh2106_gh_2107_add_AD_Messages.sql
+++ b/de.metas.payment.esr/src/main/sql/postgresql/system/5469020_gh2106_gh_2107_add_AD_Messages.sql
@@ -38,3 +38,18 @@ INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,E
 INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Message t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=544469 AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
 ;
 
+-- 2017-08-03T09:23:25.780
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Message SET MsgText='Die Transaktion enthält keine Referenznummer',Updated=TO_TIMESTAMP('2017-08-03 09:23:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Message_ID=544467
+;
+
+-- 2017-08-03T09:24:52.801
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,544470,0,TO_TIMESTAMP('2017-08-03 09:24:52','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr','Y','Die Referenznummer der Transaktion ist nicht explizit as ESR-Nummer gekennzeichnet.','E',TO_TIMESTAMP('2017-08-03 09:24:52','YYYY-MM-DD HH24:MI:SS'),100,'ESR_CAMT54_Ambigous_Reference')
+;
+
+-- 2017-08-03T09:24:52.803
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Message t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=544470 AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+

--- a/de.metas.payment.esr/src/main/sql/postgresql/system/5469020_gh2106_gh_2107_add_AD_Messages.sql
+++ b/de.metas.payment.esr/src/main/sql/postgresql/system/5469020_gh2106_gh_2107_add_AD_Messages.sql
@@ -1,0 +1,40 @@
+-- 2017-08-02T21:05:06.080
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,544467,0,TO_TIMESTAMP('2017-08-02 21:05:05','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr','Y','Die TRansaction enthält keine ESR Referenznummer','E',TO_TIMESTAMP('2017-08-02 21:05:05','YYYY-MM-DD HH24:MI:SS'),100,'CAMT54_Missing_ESR_Reference')
+;
+
+-- 2017-08-02T21:05:06.091
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Message t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=544467 AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- 2017-08-02T21:05:13.370
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Message SET MsgText='Die Transaktion enthält keine ESR Referenznummer',Updated=TO_TIMESTAMP('2017-08-02 21:05:13','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Message_ID=544467
+;
+
+-- 2017-08-02T21:05:26.708
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Message SET Value='ESR_CAMT54_Missing_ESR_Reference',Updated=TO_TIMESTAMP('2017-08-02 21:05:26','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Message_ID=544467
+;
+
+-- 2017-08-02T21:10:43.179
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,544468,0,TO_TIMESTAMP('2017-08-02 21:10:43','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr','Y','Die Transaktion is keine Gutschrift (CreditDebitCode={0})','E',TO_TIMESTAMP('2017-08-02 21:10:43','YYYY-MM-DD HH24:MI:SS'),100,'ESR_CAMT54_UnsupportedCreditDebitCode')
+;
+
+-- 2017-08-02T21:10:43.181
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Message t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=544468 AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- 2017-08-02T21:17:40.989
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,544469,0,TO_TIMESTAMP('2017-08-02 21:17:40','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr','Y','Die Währung {0} der Kopfdatensatzes unterscheidet sich von der Währung {1} der Transaktion.','E',TO_TIMESTAMP('2017-08-02 21:17:40','YYYY-MM-DD HH24:MI:SS'),100,'ESR_CAMT54_BankAccountMismatch')
+;
+
+-- 2017-08-02T21:17:40.990
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Message t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=544469 AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+

--- a/de.metas.payment.esr/src/test/java/de/metas/payment/esr/dataimporter/impl/camt54/ESRDataImporterCamt54Tests.java
+++ b/de.metas.payment.esr/src/test/java/de/metas/payment/esr/dataimporter/impl/camt54/ESRDataImporterCamt54Tests.java
@@ -1,19 +1,18 @@
 package de.metas.payment.esr.dataimporter.impl.camt54;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
-import static org.hamcrest.Matchers.comparesEqualTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.InputStream;
 import java.math.BigDecimal;
 
 import org.adempiere.test.AdempiereTestHelper;
+import org.assertj.core.api.Condition;
 import org.junit.Before;
 import org.junit.Test;
 
 import de.metas.payment.esr.dataimporter.ESRStatement;
+import de.metas.payment.esr.dataimporter.ESRTransaction;
 import de.metas.payment.esr.model.I_ESR_Import;
 
 /*
@@ -40,6 +39,10 @@ import de.metas.payment.esr.model.I_ESR_Import;
 
 public class ESRDataImporterCamt54Tests
 {
+	private final Condition<? super ESRTransaction> trxHasNoErrors = new Condition<>(
+			t -> t.getErrorMsgs().isEmpty(),
+			"ESRTransaction has no error messages");
+
 	@Before
 	public void init()
 	{
@@ -47,26 +50,129 @@ public class ESRDataImporterCamt54Tests
 	}
 
 	@Test
-	public void test()
+	public void testWithSampleFile()
 	{
-		final InputStream inputStream = getClass().getResourceAsStream("/camt.054-ESR-ASR_P_CH0309000000250090342_38000000_0_2016052723010603.xml");
-		assertThat(inputStream, notNullValue());
+		final InputStream inputStream = getClass().getResourceAsStream("/camt054.xml");
+		assertThat(inputStream).isNotNull();
 
 		final ESRStatement importData = new ESRDataImporterCamt54(newInstance(I_ESR_Import.class), inputStream).importData();
-		assertThat(importData.getCtrlAmount(), comparesEqualTo(new BigDecimal("1000")));
-		assertThat(importData.getCtrlQty(), comparesEqualTo(new BigDecimal("10")));
-		assertThat(importData.getTransactions().size(), is(10));
+
+		// no errors
+		assertThat(importData.getErrorMsgs()).isEmpty();
+		assertThat(importData.getTransactions())
+				.allMatch(t -> t.getErrorMsgs().isEmpty());
+
+		assertThat(importData.getCtrlAmount())
+				.isEqualByComparingTo("1000");
+
+		assertThat(importData.getCtrlQty()).as("CtrlQty")
+				.isEqualByComparingTo("10");
+	}
+
+	@Test
+	public void testMissingCtrlQty()
+	{
+		final InputStream inputStream = getClass().getResourceAsStream("/camt54_no_Btch.xml");
+		assertThat(inputStream).isNotNull();
+
+		final ESRStatement importData = new ESRDataImporterCamt54(newInstance(I_ESR_Import.class), inputStream).importData();
+
+		assertThat(importData.getTransactions()).hasSize(10);
+
+		// no errors
+		assertThat(importData.getErrorMsgs()).isEmpty();
+
+		assertThat(importData.getTransactions())
+				.as("MissingCtrlQty is no error")
+				.are(trxHasNoErrors);
+
+		assertThat(importData.getCtrlAmount()).isEqualByComparingTo("1000");
+		assertThat(importData.getCtrlQty()).isNull();
+
+	}
+
+	@Test
+	public void testAmbigousEsrReference()
+	{
+		final ESRStatement importData = performWithMissingOrAmbigousEsrReference("/camt54_one_ESR_reference_ambigous.xml");
+
+		// all have a reference set
+		assertThat(importData.getTransactions())
+				.as("All ten transactions have a  non-empty reference set")
+				.allSatisfy(t -> {
+					assertThat(t.getEsrReferenceNumber()).isNotEmpty();
+				});
+
+		assertThat(importData.getTransactions())
+				.filteredOn(t -> t.getEsrReferenceNumber().equals("000000000002016030001593614"))
+				.hasSize(1) // guard
+				.allSatisfy(t -> {
+					assertThat(t.getErrorMsgs()).hasSize(1);
+					assertThat(t.getErrorMsgs().get(0)).isEqualTo(ESRDataImporterCamt54.MSG_AMBIGOUS_REFERENCE);
+				});
+
+		assertThat(importData.getCtrlAmount()).isEqualByComparingTo("1000");
+	}
+
+	@Test
+	public void testMissingEsrReference()
+	{
+		final ESRStatement importData = performWithMissingOrAmbigousEsrReference("/camt54_one_ESR_reference_missing.xml");
+
+		assertThat(importData.getTransactions())
+				.as("those nine transactions that have a reference set, also have a non-empty string")
+				.filteredOn(t -> t.getEsrReferenceNumber() != null)
+				.hasSize(9)
+				.allSatisfy(t -> {
+					assertThat(t.getEsrReferenceNumber()).isNotEmpty();
+				});
+
+		assertThat(importData.getTransactions())
+				.filteredOn(t -> t.getEsrReferenceNumber() == null)
+				.hasSize(1) // guard
+				.allSatisfy(t -> {
+					assertThat(t.getErrorMsgs()).hasSize(1);
+					assertThat(t.getErrorMsgs().get(0)).isEqualTo(ESRDataImporterCamt54.MSG_MISSING_ESR_REFERENCE);
+				});
+
+		assertThat(importData.getCtrlAmount()).isEqualByComparingTo("1000");
+	}
+
+	private ESRStatement performWithMissingOrAmbigousEsrReference(final String xmlResourceName)
+	{
+		final InputStream inputStream = getClass().getResourceAsStream(xmlResourceName);
+		assertThat(inputStream).as("Unable to load %s", xmlResourceName).isNotNull();
+
+		final ESRStatement importData = new ESRDataImporterCamt54(newInstance(I_ESR_Import.class), inputStream).importData();
+
+		assertThat(importData.getCtrlQty()).isEqualByComparingTo("10");
+		assertThat(importData.getTransactions()).hasSize(10);
+
+		// no errors on "header" level
+		assertThat(importData.getErrorMsgs()).isEmpty();
+
+		// only one transaction has that little problem
+		assertThat(importData.getTransactions())
+				.areExactly(9, trxHasNoErrors);
+
+		return importData;
 	}
 
 	// @Test
 	public void otherTest()
 	{
-		final InputStream inputStream = getClass().getResourceAsStream("some-temporary-file-you-are-not-allowed-to-share");
-		assertThat(inputStream, notNullValue());
+		final InputStream inputStream = getClass().getResourceAsStream("/adempiere_7924089069896117994_017-Binningen_1707_camt.054-ESR-ASR_P_CH3909000000400099806_303041189_0_2017072823282302.xml");
+		assertThat(inputStream).isNotNull();
 
 		final ESRStatement importData = new ESRDataImporterCamt54(newInstance(I_ESR_Import.class), inputStream).importData();
-		assertThat(importData.getTransactions().size(), is(9));
-		assertThat(importData.getCtrlQty(), comparesEqualTo(BigDecimal.valueOf(9)));
-		assertThat(importData.getCtrlAmount(), comparesEqualTo(BigDecimal.valueOf(540)));
+		assertThat(importData.getTransactions().size())
+				.isEqualTo(13);
+
+		assertThat(importData.getCtrlQty())
+				.isEqualByComparingTo(new BigDecimal("13"));
+
+		assertThat(importData.getCtrlAmount())
+				.isEqualByComparingTo(new BigDecimal("540"));
+
 	}
 }

--- a/de.metas.payment.esr/src/test/resources/camt054.xml
+++ b/de.metas.payment.esr/src/test/resources/camt054.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+	We received this file as camt.054-ESR-ASR_P_CH0309000000250090342_38000000_0_2016052723010603.xml
+	but renamed it for convenience
+ -->
 <Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.054.001.04" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.054.001.04 camt.054.001.04.xsd">
 	<BkToCstmrDbtCdtNtfctn>
 		<GrpHdr>

--- a/de.metas.payment.esr/src/test/resources/camt54_no_Btch.xml
+++ b/de.metas.payment.esr/src/test/resources/camt54_no_Btch.xml
@@ -1,0 +1,749 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+	We received this file as camt.054-ESR-ASR_P_CH0309000000250090342_38000000_0_2016052723010603.xml
+	but renamed it for convenience
+ -->
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.054.001.04" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.054.001.04 camt.054.001.04.xsd">
+	<BkToCstmrDbtCdtNtfctn>
+		<GrpHdr>
+			<MsgId>20160527375204000015681</MsgId>
+			<CreDtTm>2016-05-27T23:00:57</CreDtTm>
+			<MsgPgntn>
+				<PgNb>1</PgNb>
+				<LastPgInd>true</LastPgInd>
+			</MsgPgntn>
+			<AddtlInf>Productive</AddtlInf>
+		</GrpHdr>
+		<Ntfctn>
+			<Id>20160527375204000015680</Id>
+			<CreDtTm>2016-05-27T23:00:57</CreDtTm>
+			<FrToDt>
+				<FrDtTm>2016-05-27T00:00:00</FrDtTm>
+				<ToDtTm>2016-05-27T23:59:59</ToDtTm>
+			</FrToDt>
+			<Acct>
+				<Id>
+					<IBAN>CH0309000000250090342</IBAN>
+				</Id>
+				<Ownr>
+					<Nm>Robert Schneider SA Grands magasins Biel/Bienne</Nm>
+				</Ownr>
+			</Acct>
+			<Ntry>
+				<NtryRef>010000004</NtryRef>
+				<Amt Ccy="CHF">1000.00</Amt>
+				<CdtDbtInd>CRDT</CdtDbtInd>
+				<RvslInd>false</RvslInd>
+				<Sts>BOOK</Sts>
+				<BookgDt>
+					<Dt>2016-05-27</Dt>
+				</BookgDt>
+				<ValDt>
+					<Dt>2016-05-30</Dt>
+				</ValDt>
+				<AcctSvcrRef>20160530007602769939022000000012</AcctSvcrRef>
+				<BkTxCd>
+					<Domn>
+						<Cd>PMNT</Cd>
+						<Fmly>
+							<Cd>RCDT</Cd>
+							<SubFmlyCd>VCOM</SubFmlyCd>
+						</Fmly>
+					</Domn>
+				</BkTxCd>
+				<Chrgs>
+					<TtlChrgsAndTaxAmt Ccy="CHF">5.60</TtlChrgsAndTaxAmt>
+					<Rcrd>
+						<Amt Ccy="CHF">5.40</Amt>
+						<CdtDbtInd>DBIT</CdtDbtInd>
+						<ChrgInclInd>false</ChrgInclInd>
+						<Tp>
+							<Prtry>
+								<Id>2</Id>
+							</Prtry>
+						</Tp>
+					</Rcrd>
+					<Rcrd>
+						<Amt Ccy="CHF">0.20</Amt>
+						<CdtDbtInd>DBIT</CdtDbtInd>
+						<ChrgInclInd>false</ChrgInclInd>
+						<Tp>
+							<Prtry>
+								<Id>4</Id>
+							</Prtry>
+						</Tp>
+					</Rcrd>
+				</Chrgs>
+				<NtryDtls>
+				<!-- commenting out this optional field 
+					<Btch>
+						<NbOfTxs>10</NbOfTxs>
+					</Btch>
+				 -->
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3L0GE</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526531801000100274</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">100.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">1.24</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">1.20</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002015110002913192</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3KWWA</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T3KWWA</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">50.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>AUTT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdPties>
+							<Dbtr>
+								<Nm>Rutschmann Pia</Nm>
+								<PstlAdr>
+									<StrtNm>Marktgasse</StrtNm>
+									<BldgNb>28</BldgNb>
+									<PstCd>9400</PstCd>
+									<TwnNm>Rorschach</TwnNm>
+									<Ctry>CH</Ctry>
+								</PstlAdr>
+							</Dbtr>
+						</RltdPties>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030002820804</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T2H28C</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T2H28C</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">200.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>ATXN</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<ClrSysMmbId>
+										<MmbId>000048358</MmbId>
+									</ClrSysMmbId>
+									<Nm>Credit Suisse AG</Nm>
+									<PstlAdr>
+										<AdrLine>Paradeplatz 8</AdrLine>
+										<AdrLine>8070 Zürich</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030001581632</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3L0W5</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526838805000100263</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">50.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">0.94</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">0.90</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002015110003015939</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3L0NC</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526017105000100040</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">100.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">1.24</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">1.20</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030000535990</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3KXDV</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T3KXDV</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">200.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>AUTT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdPties>
+							<Dbtr>
+								<Nm>Bernasconi Maria</Nm>
+								<PstlAdr>
+									<StrtNm>Place de la Gare</StrtNm>
+									<BldgNb>12</BldgNb>
+									<PstCd>2502</PstCd>
+									<TwnNm>Biel/Bienne</TwnNm>
+									<Ctry>CH</Ctry>
+								</PstlAdr>
+							</Dbtr>
+							<DbtrAcct>
+								<Id>
+									<IBAN>CH4444444444444444444</IBAN>
+								</Id>
+							</DbtrAcct>
+						</RltdPties>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030002463591</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3KZO9</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526252501000100033</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">50.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">0.94</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">0.90</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030002780613</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3L0V2</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526832003000100047</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">100.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">1.24</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">1.20</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030001554373</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T99DU7</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T99DU7</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">50.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>AUTT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdPties>
+							<Dbtr>
+								<Nm>Zürcher Kantonalbank</Nm>
+								<PstlAdr>
+									<StrtNm>Bahnhofstrasse</StrtNm>
+									<BldgNb>9</BldgNb>
+									<PstCd>8001</PstCd>
+									<TwnNm>Zürich</TwnNm>
+									<Ctry>CH</Ctry>
+								</PstlAdr>
+							</Dbtr>
+							<DbtrAcct>
+								<Id>
+									<IBAN>CH0000000000000000000</IBAN>
+								</Id>
+							</DbtrAcct>
+						</RltdPties>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030000985620</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T99EBW</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T99EBW</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">100.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>AUTT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdPties>
+							<Dbtr>
+								<Nm>UBS Switzerland AG</Nm>
+								<PstlAdr>
+									<StrtNm>Bahnhofstrasse</StrtNm>
+									<BldgNb>45</BldgNb>
+									<PstCd>8001</PstCd>
+									<TwnNm>Zürich</TwnNm>
+									<Ctry>CH</Ctry>
+								</PstlAdr>
+							</Dbtr>
+							<DbtrAcct>
+								<Id>
+									<IBAN>CH0000000000000000000</IBAN>
+								</Id>
+							</DbtrAcct>
+						</RltdPties>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030001593614</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+				</NtryDtls>
+				<AddtlNtryInf>SAMMELGUTSCHRIFT ESR VERARBEITUNG VOM 27.05.2016 KUNDENNUMMER 01-000000-4 PAKET ID: 160527CH000000RU</AddtlNtryInf>
+			</Ntry>
+		</Ntfctn>
+	</BkToCstmrDbtCdtNtfctn>
+</Document>

--- a/de.metas.payment.esr/src/test/resources/camt54_one_ESR_reference_ambigous.xml
+++ b/de.metas.payment.esr/src/test/resources/camt54_one_ESR_reference_ambigous.xml
@@ -1,0 +1,751 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+	We received this file as camt.054-ESR-ASR_P_CH0309000000250090342_38000000_0_2016052723010603.xml
+	but renamed it for convenience.
+	In this copy, the last transaction's one ESR reference is thre, but not flagged as such
+ -->
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.054.001.04" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.054.001.04 camt.054.001.04.xsd">
+	<BkToCstmrDbtCdtNtfctn>
+		<GrpHdr>
+			<MsgId>20160527375204000015681</MsgId>
+			<CreDtTm>2016-05-27T23:00:57</CreDtTm>
+			<MsgPgntn>
+				<PgNb>1</PgNb>
+				<LastPgInd>true</LastPgInd>
+			</MsgPgntn>
+			<AddtlInf>Productive</AddtlInf>
+		</GrpHdr>
+		<Ntfctn>
+			<Id>20160527375204000015680</Id>
+			<CreDtTm>2016-05-27T23:00:57</CreDtTm>
+			<FrToDt>
+				<FrDtTm>2016-05-27T00:00:00</FrDtTm>
+				<ToDtTm>2016-05-27T23:59:59</ToDtTm>
+			</FrToDt>
+			<Acct>
+				<Id>
+					<IBAN>CH0309000000250090342</IBAN>
+				</Id>
+				<Ownr>
+					<Nm>Robert Schneider SA Grands magasins Biel/Bienne</Nm>
+				</Ownr>
+			</Acct>
+			<Ntry>
+				<NtryRef>010000004</NtryRef>
+				<Amt Ccy="CHF">1000.00</Amt>
+				<CdtDbtInd>CRDT</CdtDbtInd>
+				<RvslInd>false</RvslInd>
+				<Sts>BOOK</Sts>
+				<BookgDt>
+					<Dt>2016-05-27</Dt>
+				</BookgDt>
+				<ValDt>
+					<Dt>2016-05-30</Dt>
+				</ValDt>
+				<AcctSvcrRef>20160530007602769939022000000012</AcctSvcrRef>
+				<BkTxCd>
+					<Domn>
+						<Cd>PMNT</Cd>
+						<Fmly>
+							<Cd>RCDT</Cd>
+							<SubFmlyCd>VCOM</SubFmlyCd>
+						</Fmly>
+					</Domn>
+				</BkTxCd>
+				<Chrgs>
+					<TtlChrgsAndTaxAmt Ccy="CHF">5.60</TtlChrgsAndTaxAmt>
+					<Rcrd>
+						<Amt Ccy="CHF">5.40</Amt>
+						<CdtDbtInd>DBIT</CdtDbtInd>
+						<ChrgInclInd>false</ChrgInclInd>
+						<Tp>
+							<Prtry>
+								<Id>2</Id>
+							</Prtry>
+						</Tp>
+					</Rcrd>
+					<Rcrd>
+						<Amt Ccy="CHF">0.20</Amt>
+						<CdtDbtInd>DBIT</CdtDbtInd>
+						<ChrgInclInd>false</ChrgInclInd>
+						<Tp>
+							<Prtry>
+								<Id>4</Id>
+							</Prtry>
+						</Tp>
+					</Rcrd>
+				</Chrgs>
+				<NtryDtls>
+					<Btch>
+						<NbOfTxs>10</NbOfTxs>
+					</Btch>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3L0GE</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526531801000100274</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">100.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">1.24</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">1.20</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002015110002913192</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3KWWA</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T3KWWA</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">50.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>AUTT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdPties>
+							<Dbtr>
+								<Nm>Rutschmann Pia</Nm>
+								<PstlAdr>
+									<StrtNm>Marktgasse</StrtNm>
+									<BldgNb>28</BldgNb>
+									<PstCd>9400</PstCd>
+									<TwnNm>Rorschach</TwnNm>
+									<Ctry>CH</Ctry>
+								</PstlAdr>
+							</Dbtr>
+						</RltdPties>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030002820804</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T2H28C</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T2H28C</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">200.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>ATXN</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<ClrSysMmbId>
+										<MmbId>000048358</MmbId>
+									</ClrSysMmbId>
+									<Nm>Credit Suisse AG</Nm>
+									<PstlAdr>
+										<AdrLine>Paradeplatz 8</AdrLine>
+										<AdrLine>8070 Zürich</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030001581632</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3L0W5</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526838805000100263</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">50.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">0.94</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">0.90</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002015110003015939</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3L0NC</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526017105000100040</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">100.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">1.24</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">1.20</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030000535990</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3KXDV</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T3KXDV</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">200.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>AUTT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdPties>
+							<Dbtr>
+								<Nm>Bernasconi Maria</Nm>
+								<PstlAdr>
+									<StrtNm>Place de la Gare</StrtNm>
+									<BldgNb>12</BldgNb>
+									<PstCd>2502</PstCd>
+									<TwnNm>Biel/Bienne</TwnNm>
+									<Ctry>CH</Ctry>
+								</PstlAdr>
+							</Dbtr>
+							<DbtrAcct>
+								<Id>
+									<IBAN>CH4444444444444444444</IBAN>
+								</Id>
+							</DbtrAcct>
+						</RltdPties>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030002463591</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3KZO9</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526252501000100033</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">50.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">0.94</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">0.90</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030002780613</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3L0V2</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526832003000100047</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">100.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">1.24</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">1.20</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030001554373</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T99DU7</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T99DU7</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">50.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>AUTT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdPties>
+							<Dbtr>
+								<Nm>Zürcher Kantonalbank</Nm>
+								<PstlAdr>
+									<StrtNm>Bahnhofstrasse</StrtNm>
+									<BldgNb>9</BldgNb>
+									<PstCd>8001</PstCd>
+									<TwnNm>Zürich</TwnNm>
+									<Ctry>CH</Ctry>
+								</PstlAdr>
+							</Dbtr>
+							<DbtrAcct>
+								<Id>
+									<IBAN>CH0000000000000000000</IBAN>
+								</Id>
+							</DbtrAcct>
+						</RltdPties>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030000985620</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T99EBW</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T99EBW</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">100.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>AUTT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdPties>
+							<Dbtr>
+								<Nm>UBS Switzerland AG</Nm>
+								<PstlAdr>
+									<StrtNm>Bahnhofstrasse</StrtNm>
+									<BldgNb>45</BldgNb>
+									<PstCd>8001</PstCd>
+									<TwnNm>Zürich</TwnNm>
+									<Ctry>CH</Ctry>
+								</PstlAdr>
+							</Dbtr>
+							<DbtrAcct>
+								<Id>
+									<IBAN>CH0000000000000000000</IBAN>
+								</Id>
+							</DbtrAcct>
+						</RltdPties>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+									<!--
+									comment out the marker that tells us we are dealing with an ESR Reference
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									-->
+									</Tp>
+									<Ref>000000000002016030001593614</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+				</NtryDtls>
+				<AddtlNtryInf>SAMMELGUTSCHRIFT ESR VERARBEITUNG VOM 27.05.2016 KUNDENNUMMER 01-000000-4 PAKET ID: 160527CH000000RU</AddtlNtryInf>
+			</Ntry>
+		</Ntfctn>
+	</BkToCstmrDbtCdtNtfctn>
+</Document>

--- a/de.metas.payment.esr/src/test/resources/camt54_one_ESR_reference_missing.xml
+++ b/de.metas.payment.esr/src/test/resources/camt54_one_ESR_reference_missing.xml
@@ -1,0 +1,750 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+	We received this file as camt.054-ESR-ASR_P_CH0309000000250090342_38000000_0_2016052723010603.xml
+	but renamed it for convenience.
+	In this copy, the last transaction's one ESR reference is "broken" 
+ -->
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.054.001.04" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.054.001.04 camt.054.001.04.xsd">
+	<BkToCstmrDbtCdtNtfctn>
+		<GrpHdr>
+			<MsgId>20160527375204000015681</MsgId>
+			<CreDtTm>2016-05-27T23:00:57</CreDtTm>
+			<MsgPgntn>
+				<PgNb>1</PgNb>
+				<LastPgInd>true</LastPgInd>
+			</MsgPgntn>
+			<AddtlInf>Productive</AddtlInf>
+		</GrpHdr>
+		<Ntfctn>
+			<Id>20160527375204000015680</Id>
+			<CreDtTm>2016-05-27T23:00:57</CreDtTm>
+			<FrToDt>
+				<FrDtTm>2016-05-27T00:00:00</FrDtTm>
+				<ToDtTm>2016-05-27T23:59:59</ToDtTm>
+			</FrToDt>
+			<Acct>
+				<Id>
+					<IBAN>CH0309000000250090342</IBAN>
+				</Id>
+				<Ownr>
+					<Nm>Robert Schneider SA Grands magasins Biel/Bienne</Nm>
+				</Ownr>
+			</Acct>
+			<Ntry>
+				<NtryRef>010000004</NtryRef>
+				<Amt Ccy="CHF">1000.00</Amt>
+				<CdtDbtInd>CRDT</CdtDbtInd>
+				<RvslInd>false</RvslInd>
+				<Sts>BOOK</Sts>
+				<BookgDt>
+					<Dt>2016-05-27</Dt>
+				</BookgDt>
+				<ValDt>
+					<Dt>2016-05-30</Dt>
+				</ValDt>
+				<AcctSvcrRef>20160530007602769939022000000012</AcctSvcrRef>
+				<BkTxCd>
+					<Domn>
+						<Cd>PMNT</Cd>
+						<Fmly>
+							<Cd>RCDT</Cd>
+							<SubFmlyCd>VCOM</SubFmlyCd>
+						</Fmly>
+					</Domn>
+				</BkTxCd>
+				<Chrgs>
+					<TtlChrgsAndTaxAmt Ccy="CHF">5.60</TtlChrgsAndTaxAmt>
+					<Rcrd>
+						<Amt Ccy="CHF">5.40</Amt>
+						<CdtDbtInd>DBIT</CdtDbtInd>
+						<ChrgInclInd>false</ChrgInclInd>
+						<Tp>
+							<Prtry>
+								<Id>2</Id>
+							</Prtry>
+						</Tp>
+					</Rcrd>
+					<Rcrd>
+						<Amt Ccy="CHF">0.20</Amt>
+						<CdtDbtInd>DBIT</CdtDbtInd>
+						<ChrgInclInd>false</ChrgInclInd>
+						<Tp>
+							<Prtry>
+								<Id>4</Id>
+							</Prtry>
+						</Tp>
+					</Rcrd>
+				</Chrgs>
+				<NtryDtls>
+					<Btch>
+						<NbOfTxs>10</NbOfTxs>
+					</Btch>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3L0GE</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526531801000100274</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">100.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">1.24</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">1.20</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002015110002913192</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3KWWA</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T3KWWA</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">50.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>AUTT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdPties>
+							<Dbtr>
+								<Nm>Rutschmann Pia</Nm>
+								<PstlAdr>
+									<StrtNm>Marktgasse</StrtNm>
+									<BldgNb>28</BldgNb>
+									<PstCd>9400</PstCd>
+									<TwnNm>Rorschach</TwnNm>
+									<Ctry>CH</Ctry>
+								</PstlAdr>
+							</Dbtr>
+						</RltdPties>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030002820804</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T2H28C</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T2H28C</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">200.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>ATXN</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<ClrSysMmbId>
+										<MmbId>000048358</MmbId>
+									</ClrSysMmbId>
+									<Nm>Credit Suisse AG</Nm>
+									<PstlAdr>
+										<AdrLine>Paradeplatz 8</AdrLine>
+										<AdrLine>8070 Zürich</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030001581632</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3L0W5</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526838805000100263</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">50.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">0.94</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">0.90</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002015110003015939</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3L0NC</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526017105000100040</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">100.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">1.24</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">1.20</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030000535990</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3KXDV</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T3KXDV</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">200.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>AUTT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdPties>
+							<Dbtr>
+								<Nm>Bernasconi Maria</Nm>
+								<PstlAdr>
+									<StrtNm>Place de la Gare</StrtNm>
+									<BldgNb>12</BldgNb>
+									<PstCd>2502</PstCd>
+									<TwnNm>Biel/Bienne</TwnNm>
+									<Ctry>CH</Ctry>
+								</PstlAdr>
+							</Dbtr>
+							<DbtrAcct>
+								<Id>
+									<IBAN>CH4444444444444444444</IBAN>
+								</Id>
+							</DbtrAcct>
+						</RltdPties>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030002463591</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3KZO9</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526252501000100033</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">50.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">0.94</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">0.90</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030002780613</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T3L0V2</AcctSvcrRef>
+							<Prtry>
+								<Tp>04</Tp>
+								<Ref>20160526832003000100047</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">100.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>CNTR</Cd>
+									<SubFmlyCd>CDPT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<Chrgs>
+							<TtlChrgsAndTaxAmt Ccy="CHF">1.24</TtlChrgsAndTaxAmt>
+							<Rcrd>
+								<Amt Ccy="CHF">1.20</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>2</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+							<Rcrd>
+								<Amt Ccy="CHF">0.04</Amt>
+								<CdtDbtInd>DBIT</CdtDbtInd>
+								<ChrgInclInd>false</ChrgInclInd>
+								<Tp>
+									<Prtry>
+										<Id>4</Id>
+									</Prtry>
+								</Tp>
+							</Rcrd>
+						</Chrgs>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030001554373</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-26T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T99DU7</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T99DU7</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">50.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>AUTT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdPties>
+							<Dbtr>
+								<Nm>Zürcher Kantonalbank</Nm>
+								<PstlAdr>
+									<StrtNm>Bahnhofstrasse</StrtNm>
+									<BldgNb>9</BldgNb>
+									<PstCd>8001</PstCd>
+									<TwnNm>Zürich</TwnNm>
+									<Ctry>CH</Ctry>
+								</PstlAdr>
+							</Dbtr>
+							<DbtrAcct>
+								<Id>
+									<IBAN>CH0000000000000000000</IBAN>
+								</Id>
+							</DbtrAcct>
+						</RltdPties>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030000985620</Ref>
+								</CdtrRefInf>
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>160527CH00T99EBW</AcctSvcrRef>
+							<Prtry>
+								<Tp>01</Tp>
+								<Ref>160527CH00T99EBW</Ref>
+							</Prtry>
+						</Refs>
+						<Amt Ccy="CHF">100.00</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<BkTxCd>
+							<Domn>
+								<Cd>PMNT</Cd>
+								<Fmly>
+									<Cd>RCDT</Cd>
+									<SubFmlyCd>AUTT</SubFmlyCd>
+								</Fmly>
+							</Domn>
+						</BkTxCd>
+						<RltdPties>
+							<Dbtr>
+								<Nm>UBS Switzerland AG</Nm>
+								<PstlAdr>
+									<StrtNm>Bahnhofstrasse</StrtNm>
+									<BldgNb>45</BldgNb>
+									<PstCd>8001</PstCd>
+									<TwnNm>Zürich</TwnNm>
+									<Ctry>CH</Ctry>
+								</PstlAdr>
+							</Dbtr>
+							<DbtrAcct>
+								<Id>
+									<IBAN>CH0000000000000000000</IBAN>
+								</Id>
+							</DbtrAcct>
+						</RltdPties>
+						<RltdAgts>
+							<DbtrAgt>
+								<FinInstnId>
+									<BICFI>POFICHBEXXX</BICFI>
+									<Nm>POSTFINANCE AG</Nm>
+									<PstlAdr>
+										<AdrLine>MINGERSTRASSE 20</AdrLine>
+										<AdrLine>3030 BERNE</AdrLine>
+									</PstlAdr>
+								</FinInstnId>
+							</DbtrAgt>
+						</RltdAgts>
+						<RmtInf>
+							<Strd>
+								<!-- comment out the the whole reference
+								<CdtrRefInf>
+									<Tp>
+										<CdOrPrtry>
+											<Prtry>ISR Reference</Prtry>
+										</CdOrPrtry>
+									</Tp>
+									<Ref>000000000002016030001593614</Ref>
+								</CdtrRefInf>
+								-->
+								<AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+							</Strd>
+						</RmtInf>
+						<RltdDts>
+							<AccptncDtTm>2016-05-27T20:00:00</AccptncDtTm>
+						</RltdDts>
+					</TxDtls>
+				</NtryDtls>
+				<AddtlNtryInf>SAMMELGUTSCHRIFT ESR VERARBEITUNG VOM 27.05.2016 KUNDENNUMMER 01-000000-4 PAKET ID: 160527CH000000RU</AddtlNtryInf>
+			</Ntry>
+		</Ntfctn>
+	</BkToCstmrDbtCdtNtfctn>
+</Document>


### PR DESCRIPTION
* drop assumptions about the number of some XML elements
* allow ctrlQty to remain null
* if the ESR reference is missing and/or if there is an unexpected
transaction type, then don't fail the import, but record an error
* Add AD_Messages for the new non-fatal errors

Task-Urls: 
https://github.com/metasfresh/metasfresh/issues/2106
https://github.com/metasfresh/metasfresh/issues/2107