### PR TITLE
#2184 Removing processed from Advanced edit

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5469660_sys_gh2184-order-candidates-window-webui.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5469660_sys_gh2184-order-candidates-window-webui.sql
@@ -1,0 +1,5 @@
+-- 2017-08-20T15:59:10.725
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=547197
+;
+


### PR DESCRIPTION
Removing the processed Flag from Advanced edit mode.

FRESH-3135 https://github.com/metasfresh/metasfresh/issues/2184