### PR TITLE
#2086 Sales Order Advanced Edit Window in main View

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5470550_sys_gh2086-sales-order-window-refining-webui.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5470550_sys_gh2086-sales-order-window-refining-webui.sql
@@ -1,0 +1,235 @@
+-- 2017-09-03T12:31:45.223
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_ElementGroup SET AD_UI_Column_ID=540301, SeqNo=60,Updated=TO_TIMESTAMP('2017-09-03 12:31:45','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_ElementGroup_ID=540504
+;
+
+-- 2017-09-03T12:31:49.010
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Column WHERE AD_UI_Column_ID=540302
+;
+
+-- 2017-09-03T12:31:54.078
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM  AD_UI_Section_Trl WHERE AD_UI_Section_ID=540217
+;
+
+-- 2017-09-03T12:31:54.088
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Section WHERE AD_UI_Section_ID=540217
+;
+
+-- 2017-09-03T12:32:05.225
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Section SET Value='advanced edit',Updated=TO_TIMESTAMP('2017-09-03 12:32:05','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Section_ID=540216
+;
+
+-- 2017-09-03T12:33:13.530
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=80,Updated=TO_TIMESTAMP('2017-09-03 12:33:13','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544787
+;
+
+-- 2017-09-03T12:33:18.626
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=90,Updated=TO_TIMESTAMP('2017-09-03 12:33:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544788
+;
+
+-- 2017-09-03T12:33:24.088
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=100,Updated=TO_TIMESTAMP('2017-09-03 12:33:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544802
+;
+
+-- 2017-09-03T12:33:29.932
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=110,Updated=TO_TIMESTAMP('2017-09-03 12:33:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544803
+;
+
+-- 2017-09-03T12:33:34.500
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_ElementGroup WHERE AD_UI_ElementGroup_ID=540501
+;
+
+-- 2017-09-03T12:33:41.321
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=120,Updated=TO_TIMESTAMP('2017-09-03 12:33:41','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544769
+;
+
+-- 2017-09-03T12:33:45.785
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=130,Updated=TO_TIMESTAMP('2017-09-03 12:33:45','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544770
+;
+
+-- 2017-09-03T12:33:50.160
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=140,Updated=TO_TIMESTAMP('2017-09-03 12:33:50','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544771
+;
+
+-- 2017-09-03T12:33:54.985
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=150,Updated=TO_TIMESTAMP('2017-09-03 12:33:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544772
+;
+
+-- 2017-09-03T12:33:59.380
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=160,Updated=TO_TIMESTAMP('2017-09-03 12:33:59','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544773
+;
+
+-- 2017-09-03T12:34:03.933
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=170,Updated=TO_TIMESTAMP('2017-09-03 12:34:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544774
+;
+
+-- 2017-09-03T12:34:08.054
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=180,Updated=TO_TIMESTAMP('2017-09-03 12:34:08','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544775
+;
+
+-- 2017-09-03T12:34:12.402
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_ElementGroup WHERE AD_UI_ElementGroup_ID=540498
+;
+
+-- 2017-09-03T12:34:20.759
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=190,Updated=TO_TIMESTAMP('2017-09-03 12:34:20','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544783
+;
+
+-- 2017-09-03T12:34:25.630
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=200,Updated=TO_TIMESTAMP('2017-09-03 12:34:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544784
+;
+
+-- 2017-09-03T12:34:30.018
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=210,Updated=TO_TIMESTAMP('2017-09-03 12:34:30','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544785
+;
+
+-- 2017-09-03T12:34:34.750
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=220,Updated=TO_TIMESTAMP('2017-09-03 12:34:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544786
+;
+
+-- 2017-09-03T12:34:39.051
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=230,Updated=TO_TIMESTAMP('2017-09-03 12:34:39','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544800
+;
+
+-- 2017-09-03T12:34:43.266
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=240,Updated=TO_TIMESTAMP('2017-09-03 12:34:43','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544801
+;
+
+-- 2017-09-03T12:34:47.488
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_ElementGroup WHERE AD_UI_ElementGroup_ID=540500
+;
+
+-- 2017-09-03T12:34:54.930
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=250,Updated=TO_TIMESTAMP('2017-09-03 12:34:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544805
+;
+
+-- 2017-09-03T12:34:59.310
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=260,Updated=TO_TIMESTAMP('2017-09-03 12:34:59','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544806
+;
+
+-- 2017-09-03T12:35:03.841
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=270,Updated=TO_TIMESTAMP('2017-09-03 12:35:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544807
+;
+
+-- 2017-09-03T12:35:08.845
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=280,Updated=TO_TIMESTAMP('2017-09-03 12:35:08','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544808
+;
+
+-- 2017-09-03T12:35:13.480
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_ElementGroup WHERE AD_UI_ElementGroup_ID=540503
+;
+
+-- 2017-09-03T12:35:22.495
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=290,Updated=TO_TIMESTAMP('2017-09-03 12:35:22','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544813
+;
+
+-- 2017-09-03T12:35:27.497
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=300,Updated=TO_TIMESTAMP('2017-09-03 12:35:27','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544814
+;
+
+-- 2017-09-03T12:35:32.108
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=310,Updated=TO_TIMESTAMP('2017-09-03 12:35:32','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544815
+;
+
+-- 2017-09-03T12:35:36.297
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=320,Updated=TO_TIMESTAMP('2017-09-03 12:35:36','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544816
+;
+
+-- 2017-09-03T12:35:40.951
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=330,Updated=TO_TIMESTAMP('2017-09-03 12:35:40','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544817
+;
+
+-- 2017-09-03T12:35:45.651
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=340,Updated=TO_TIMESTAMP('2017-09-03 12:35:45','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544818
+;
+
+-- 2017-09-03T12:35:50.307
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=350,Updated=TO_TIMESTAMP('2017-09-03 12:35:50','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544824
+;
+
+-- 2017-09-03T12:35:54.775
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=360,Updated=TO_TIMESTAMP('2017-09-03 12:35:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544825
+;
+
+-- 2017-09-03T12:36:00.818
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=370,Updated=TO_TIMESTAMP('2017-09-03 12:36:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544826
+;
+
+-- 2017-09-03T12:36:05.540
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=380,Updated=TO_TIMESTAMP('2017-09-03 12:36:05','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544827
+;
+
+-- 2017-09-03T12:36:10.111
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=540499, SeqNo=390,Updated=TO_TIMESTAMP('2017-09-03 12:36:10','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=544828
+;
+
+-- 2017-09-03T12:36:14.277
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_ElementGroup WHERE AD_UI_ElementGroup_ID=540504
+;
+
+-- 2017-09-03T12:36:29.760
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_ElementGroup SET Name='advanced edit',Updated=TO_TIMESTAMP('2017-09-03 12:36:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_ElementGroup_ID=540499
+;
+
+-- 2017-09-03T12:37:50.517
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-09-03 12:37:50','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Lines' WHERE AD_Field_ID=545267 AND AD_Language='en_US'
+;
+
+-- 2017-09-03T12:38:06.933
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-09-03 12:38:06','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Net Sum' WHERE AD_Field_ID=546256 AND AD_Language='en_US'
+;
+
+-- 2017-09-03T12:38:27.574
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-09-03 12:38:27','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Tax Sum' WHERE AD_Field_ID=545269 AND AD_Language='en_US'
+;
+
+-- 2017-09-03T12:38:57.280
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-09-03 12:38:57','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Bankaccount' WHERE AD_Field_ID=502200 AND AD_Language='en_US'
+;
+


### PR DESCRIPTION
Fixes for failed IT added. Further improvements in Advanced edit (only 1 section/ group now), added Translations for en_US.

FRESH-3008 https://github.com/metasfresh/metasfresh/issues/2086