### PR TITLE
#2306 Period mass actions missing in WebUI

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5470580_sys_gh2306-period-action-open-close.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5470580_sys_gh2306-period-action-open-close.sql
@@ -1,0 +1,20 @@
+-- 2017-09-04T07:27:33.578
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Table_Process (AD_Client_ID,AD_Org_ID,AD_Process_ID,AD_Table_ID,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy,WEBUI_QuickAction,WEBUI_QuickAction_Default) VALUES (0,0,167,145,TO_TIMESTAMP('2017-09-04 07:27:33','YYYY-MM-DD HH24:MI:SS'),100,'D','Y',TO_TIMESTAMP('2017-09-04 07:27:33','YYYY-MM-DD HH24:MI:SS'),100,'N','N')
+;
+
+-- 2017-09-04T07:38:58.278
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y',Updated=TO_TIMESTAMP('2017-09-04 07:38:58','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=5943
+;
+
+-- 2017-09-04T07:39:07.868
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='N',Updated=TO_TIMESTAMP('2017-09-04 07:39:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=5943
+;
+
+-- 2017-09-04T07:39:19.059
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', IsUpdateable='N',Updated=TO_TIMESTAMP('2017-09-04 07:39:19','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=846
+;
+


### PR DESCRIPTION
Added the action for period open/ close to Perdiod Window/ Table.

FRESH-3261 https://github.com/metasfresh/metasfresh/issues/2306