### PR TITLE
Lookup validation rule shall support @CtxName/Default@ annotation #585

### DIFF
--- a/de.metas.adempiere.adempiere/base/pom.xml
+++ b/de.metas.adempiere.adempiere/base/pom.xml
@@ -303,6 +303,12 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/GridField.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/GridField.java
@@ -310,11 +310,11 @@ public class GridField
 	{
 		final List<String> list = new ArrayList<String>();
 		// Display
-		list.addAll(m_vo.getDisplayLogic().getParametersAsPlainStrings());
-		list.addAll(m_vo.getDisplayLogic().getParametersAsPlainStrings()); // metas: 03093
-		list.addAll(m_vo.getReadOnlyLogic().getParametersAsPlainStrings()); // metas: 03093
-		list.addAll(m_vo.getMandatoryLogic().getParametersAsPlainStrings()); // metas: 03093
-		list.addAll(m_vo.getColorLogic().getParametersAsPlainStrings()); // metas-2009_0021_AP1_CR045
+		list.addAll(m_vo.getDisplayLogic().getParameterNames());
+		list.addAll(m_vo.getDisplayLogic().getParameterNames()); // metas: 03093
+		list.addAll(m_vo.getReadOnlyLogic().getParameterNames()); // metas: 03093
+		list.addAll(m_vo.getMandatoryLogic().getParameterNames()); // metas: 03093
+		list.addAll(m_vo.getColorLogic().getParameterNames()); // metas-2009_0021_AP1_CR045
 		// Lookup
 		final Lookup lookup = getLookup();
 		if (lookup != null)

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/GridField.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/GridField.java
@@ -310,11 +310,11 @@ public class GridField
 	{
 		final List<String> list = new ArrayList<String>();
 		// Display
-		list.addAll(m_vo.getDisplayLogic().getParameters());
-		list.addAll(m_vo.getDisplayLogic().getParameters()); // metas: 03093
-		list.addAll(m_vo.getReadOnlyLogic().getParameters()); // metas: 03093
-		list.addAll(m_vo.getMandatoryLogic().getParameters()); // metas: 03093
-		list.addAll(m_vo.getColorLogic().getParameters()); // metas-2009_0021_AP1_CR045
+		list.addAll(m_vo.getDisplayLogic().getParametersAsPlainStrings());
+		list.addAll(m_vo.getDisplayLogic().getParametersAsPlainStrings()); // metas: 03093
+		list.addAll(m_vo.getReadOnlyLogic().getParametersAsPlainStrings()); // metas: 03093
+		list.addAll(m_vo.getMandatoryLogic().getParametersAsPlainStrings()); // metas: 03093
+		list.addAll(m_vo.getColorLogic().getParametersAsPlainStrings()); // metas-2009_0021_AP1_CR045
 		// Lookup
 		final Lookup lookup = getLookup();
 		if (lookup != null)

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MColumn.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MColumn.java
@@ -32,7 +32,7 @@ import org.adempiere.util.Check;
 import org.adempiere.util.Services;
 import org.compiere.dbPort.Convert;
 import org.compiere.util.CCache;
-import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 import org.compiere.util.DB;
 import org.compiere.util.DisplayType;
 import org.slf4j.Logger;
@@ -255,7 +255,7 @@ public class MColumn extends X_AD_Column
 		{
 			// Make sure there are no context variables in ColumnSQL
 			final String columnSql = getColumnSQL();
-			if (columnSql != null && columnSql.indexOf(CtxName.NAME_Marker) >= 0)
+			if (columnSql != null && columnSql.indexOf(CtxNames.NAME_Marker) >= 0)
 			{
 				throw new AdempiereException("Context variables are not allowed in ColumnSQL: " + columnSql);
 			}

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MLookupInfo.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MLookupInfo.java
@@ -31,6 +31,7 @@ import org.adempiere.util.Check;
 import org.adempiere.util.Services;
 import org.compiere.model.MLookupFactory.LanguageInfo;
 import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 import org.compiere.util.Env;
 import org.slf4j.Logger;
 
@@ -85,7 +86,7 @@ public final class MLookupInfo implements Serializable, Cloneable
 
 	static final long serialVersionUID = -7958664359250070233L;
 
-	/* package */static final CtxName CTXNAME_AD_Language = CtxName.parse(Env.CTXNAME_AD_Language);
+	/* package */static final CtxName CTXNAME_AD_Language = CtxNames.parse(Env.CTXNAME_AD_Language);
 
 	/** SQL Query */
 	private final TranslatableParameterizedString sqlQuery;

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/Env.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/Env.java
@@ -2129,7 +2129,7 @@ public final class Env
 	{
 		Check.assumeNotNull(ctx, "ctx not null");
 
-		final CtxName name = CtxName.parse(context);
+		final CtxName name = CtxNames.parse(context);
 		Check.assumeNotNull(name, "name not null");
 
 		boolean isExplicitGlobal = name.isExplicitGlobal();

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/Evaluator.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/Evaluator.java
@@ -175,6 +175,6 @@ public class Evaluator
 			return;
 		}
 		
-		list.addAll(expr.getParametersAsPlainStrings());
+		list.addAll(expr.getParameterNames());
 	}
 }	//	Evaluator

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/Evaluator.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/Evaluator.java
@@ -25,6 +25,7 @@ import org.adempiere.ad.expression.api.IStringExpression;
 import org.adempiere.util.Check;
 import org.adempiere.util.Services;
 import org.slf4j.Logger;
+
 import de.metas.logging.LogManager;
 
 
@@ -103,10 +104,6 @@ public class Evaluator
 		return expression.evaluate(source, ignoreUnparsable);
 	}   //  evaluateLogic
 
-	// private static boolean evaluateLogicTuple (Evaluatee source, String logic) // metas: removed
-	
-	// private static boolean evaluateLogicTuple (String value1, String operand, String value2) // metas: removed
-	
 	/**
 	 *  Parse String and add variables with @ to the list.
 	 *  @param list list to be added to
@@ -123,7 +120,7 @@ public class Evaluator
 	// metas:
 	private static String getValue(Evaluatee source, String variable)
 	{
-		return CtxName.parse(variable).getValueAsString(source);
+		return CtxNames.parse(variable).getValueAsString(source);
 	}
 	
 	public static String parseContext(Evaluatee source, String expression)
@@ -178,6 +175,6 @@ public class Evaluator
 			return;
 		}
 		
-		list.addAll(expr.getParameters());
+		list.addAll(expr.getParametersAsPlainStrings());
 	}
 }	//	Evaluator

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ConstantLogicExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ConstantLogicExpression.java
@@ -7,6 +7,7 @@ import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.exceptions.ExpressionCompileException;
 import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
 import org.adempiere.ad.expression.json.JsonLogicExpressionSerializer;
+import org.compiere.util.CtxName;
 import org.compiere.util.Evaluatee;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -94,7 +95,13 @@ public final class ConstantLogicExpression implements ILogicExpression
 	}
 
 	@Override
-	public Set<String> getParameters()
+	public Set<String> getParametersAsPlainStrings()
+	{
+		return ImmutableSet.of();
+	}
+	
+	@Override
+	public Set<CtxName> getParameters()
 	{
 		return ImmutableSet.of();
 	}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ConstantLogicExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ConstantLogicExpression.java
@@ -95,7 +95,7 @@ public final class ConstantLogicExpression implements ILogicExpression
 	}
 
 	@Override
-	public Set<String> getParametersAsPlainStrings()
+	public Set<String> getParameterNames()
 	{
 		return ImmutableSet.of();
 	}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ConstantLogicExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ConstantLogicExpression.java
@@ -93,12 +93,6 @@ public final class ConstantLogicExpression implements ILogicExpression
 	{
 		return expressionString;
 	}
-
-	@Override
-	public Set<String> getParameterNames()
-	{
-		return ImmutableSet.of();
-	}
 	
 	@Override
 	public Set<CtxName> getParameters()

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ICachedStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ICachedStringExpression.java
@@ -30,4 +30,5 @@ package org.adempiere.ad.expression.api;
  */
 public interface ICachedStringExpression extends IStringExpression
 {
+		
 }

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/IExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/IExpression.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
+import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 import org.compiere.util.Evaluatee;
 
 /**
@@ -38,11 +40,20 @@ public interface IExpression<V>
 	}
 
 	/**
-	 * Gets the list of parameter names
+	 * Gets the list of parameter names.<br>
+	 * In most implementations this should be the result of {@link #getParameters()} that was "dumbed down" via {@link CtxNames#asNames(java.util.Collection)}.
 	 * 
-	 * @return list of parameter names or empty list; never return NULL
+	 * @return list of parameter names or empty list; never return {@code null}
 	 */
-	Set<String> getParameters();
+	Set<String> getParametersAsPlainStrings();
+
+	/**
+	 * Return the parameters as {@link CtxName}s.<br>
+	 * If you really, really have only strings in your implementation, you can use {@link CtxNames#parseStringsWithoutMarkers(java.util.Collection)} to implement the method.
+	 * 
+	 * @return
+	 */
+	Set<CtxName> getParameters();
 
 	/**
 	 * Consider using {@link #evaluate(Evaluatee, OnVariableNotFound)}. This method will be deprecated in future.

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/IExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/IExpression.java
@@ -41,11 +41,15 @@ public interface IExpression<V>
 
 	/**
 	 * Gets the list of parameter names.<br>
-	 * In most implementations this should be the result of {@link #getParameters()} that was "dumbed down" via {@link CtxNames#toNames(java.util.Collection)}.
+	 * In most implementations this can be the result of a {@link #getParameters()} that was "dumbed down" via {@link CtxNames#toNames(java.util.Collection)}.<br>
+	 * However, if your implementation wraps around and delegates to an internal {@link IExpression} instance, then I recommend to explicitly delegate also this method.
 	 * 
 	 * @return list of parameter names or empty list; never return {@code null}
 	 */
-	Set<String> getParameterNames();
+	default Set<String> getParameterNames()
+	{
+		return CtxNames.toNames(getParameters());
+	}
 
 	/**
 	 * Return the parameters as {@link CtxName}s.<br>

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/IExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/IExpression.java
@@ -41,15 +41,15 @@ public interface IExpression<V>
 
 	/**
 	 * Gets the list of parameter names.<br>
-	 * In most implementations this should be the result of {@link #getParameters()} that was "dumbed down" via {@link CtxNames#asNames(java.util.Collection)}.
+	 * In most implementations this should be the result of {@link #getParameters()} that was "dumbed down" via {@link CtxNames#toNames(java.util.Collection)}.
 	 * 
 	 * @return list of parameter names or empty list; never return {@code null}
 	 */
-	Set<String> getParametersAsPlainStrings();
+	Set<String> getParameterNames();
 
 	/**
 	 * Return the parameters as {@link CtxName}s.<br>
-	 * If you really, really have only strings in your implementation, you can use {@link CtxNames#parseStrings(java.util.Collection)} to implement the method.
+	 * If you really, really have only strings in your implementation, you can use {@link CtxNames#parseAll(java.util.Collection)} to implement the method.
 	 * 
 	 * @return
 	 */

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/IExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/IExpression.java
@@ -49,7 +49,7 @@ public interface IExpression<V>
 
 	/**
 	 * Return the parameters as {@link CtxName}s.<br>
-	 * If you really, really have only strings in your implementation, you can use {@link CtxNames#parseStringsWithoutMarkers(java.util.Collection)} to implement the method.
+	 * If you really, really have only strings in your implementation, you can use {@link CtxNames#parseStrings(java.util.Collection)} to implement the method.
 	 * 
 	 * @return
 	 */

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ILogicExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ILogicExpression.java
@@ -66,7 +66,7 @@ public interface ILogicExpression extends IExpression<Boolean>
 	String getFormatedExpressionString();
 
 	@Override
-	Set<String> getParametersAsPlainStrings();
+	Set<String> getParameterNames();
 
 	@Override
 	default Boolean evaluate(final Evaluatee ctx, final boolean ignoreUnparsable)

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ILogicExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ILogicExpression.java
@@ -66,7 +66,7 @@ public interface ILogicExpression extends IExpression<Boolean>
 	String getFormatedExpressionString();
 
 	@Override
-	Set<String> getParameters();
+	Set<String> getParametersAsPlainStrings();
 
 	@Override
 	default Boolean evaluate(final Evaluatee ctx, final boolean ignoreUnparsable)

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ILogicExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ILogicExpression.java
@@ -23,7 +23,6 @@ package org.adempiere.ad.expression.api;
  */
 
 import java.util.List;
-import java.util.Set;
 
 import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.api.impl.LogicExpressionBuilder;
@@ -64,9 +63,6 @@ public interface ILogicExpression extends IExpression<Boolean>
 
 	@Override
 	String getFormatedExpressionString();
-
-	@Override
-	Set<String> getParameterNames();
 
 	@Override
 	default Boolean evaluate(final Evaluatee ctx, final boolean ignoreUnparsable)

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/IStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/IStringExpression.java
@@ -99,7 +99,7 @@ public interface IStringExpression extends IExpression<String>
 		
 	default boolean requiresParameter(final String parameterName)
 	{
-		return getParametersAsPlainStrings().contains(parameterName);
+		return getParameterNames().contains(parameterName);
 	}
 
 	@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/IStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/IStringExpression.java
@@ -2,7 +2,6 @@ package org.adempiere.ad.expression.api;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
@@ -58,7 +57,6 @@ public interface IStringExpression extends IExpression<String>
 		return StringExpressionCompiler.instance.compileOrDefault(expressionStr, defaultExpression);
 	}
 
-
 	/**
 	 * Gets a new composite string expression builder.
 	 * 
@@ -98,13 +96,10 @@ public interface IStringExpression extends IExpression<String>
 	{
 		return String.class;
 	}
-
-	@Override
-	Set<String> getParameters();
-	
+		
 	default boolean requiresParameter(final String parameterName)
 	{
-		return getParameters().contains(parameterName);
+		return getParametersAsPlainStrings().contains(parameterName);
 	}
 
 	@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/NullStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/NullStringExpression.java
@@ -39,12 +39,6 @@ public final class NullStringExpression implements ICachedStringExpression
 	}
 
 	@Override
-	public Set<String> getParameterNames()
-	{
-		return ImmutableSet.of();
-	}
-
-	@Override
 	public Set<CtxName> getParameters()
 	{
 		return ImmutableSet.of();

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/NullStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/NullStringExpression.java
@@ -39,7 +39,7 @@ public final class NullStringExpression implements ICachedStringExpression
 	}
 
 	@Override
-	public Set<String> getParametersAsPlainStrings()
+	public Set<String> getParameterNames()
 	{
 		return ImmutableSet.of();
 	}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/NullStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/NullStringExpression.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.json.JsonStringExpressionSerializer;
+import org.compiere.util.CtxName;
 import org.compiere.util.Evaluatee;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -38,7 +39,13 @@ public final class NullStringExpression implements ICachedStringExpression
 	}
 
 	@Override
-	public Set<String> getParameters()
+	public Set<String> getParametersAsPlainStrings()
+	{
+		return ImmutableSet.of();
+	}
+
+	@Override
+	public Set<CtxName> getParameters()
 	{
 		return ImmutableSet.of();
 	}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/TranslatableParameterizedStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/TranslatableParameterizedStringExpression.java
@@ -8,8 +8,8 @@ import org.adempiere.ad.expression.api.impl.ConstantStringExpression;
 import org.adempiere.ad.expression.api.impl.StringExpressionCompiler;
 import org.adempiere.ad.expression.api.impl.StringExpressionsHelper;
 import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
-import org.adempiere.util.Check;
 import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 import org.compiere.util.Evaluatee;
 import org.compiere.util.Evaluatees;
 
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableSet;
 
 import de.metas.i18n.Language;
 import de.metas.i18n.TranslatableParameterizedString;
+import lombok.NonNull;
 
 /*
  * #%L
@@ -32,11 +33,11 @@ import de.metas.i18n.TranslatableParameterizedString;
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
@@ -54,7 +55,7 @@ public final class TranslatableParameterizedStringExpression implements IStringE
 {
 	public static final TranslatableParameterizedStringExpression of(final String adLanguageParamName, final IStringExpression expressionBaseLang, final IStringExpression expressionTrl)
 	{
-		final CtxName adLanguageParam = CtxName.parse(adLanguageParamName);
+		final CtxName adLanguageParam = CtxNames.parse(adLanguageParamName);
 		return new TranslatableParameterizedStringExpression(adLanguageParam, expressionBaseLang, expressionTrl);
 	}
 
@@ -65,7 +66,7 @@ public final class TranslatableParameterizedStringExpression implements IStringE
 			return NullStringExpression.instance;
 		}
 
-		final CtxName adLanguageParam = CtxName.parseWithMarkers(translatableString.getAD_LanguageParamName());
+		final CtxName adLanguageParam = CtxNames.parseWithMarkers(translatableString.getAD_LanguageParamName());
 		return of(adLanguageParam, translatableString.getStringBaseLanguage(), translatableString.getStringTrlPattern());
 	}
 
@@ -123,27 +124,23 @@ public final class TranslatableParameterizedStringExpression implements IStringE
 	private final IStringExpression expressionBaseLang;
 	private final IStringExpression expressionTrl;
 	private final CtxName adLanguageParam;
-	private final Set<String> parameters;
+	private final Set<CtxName> parameters;
 
-	private TranslatableParameterizedStringExpression(final CtxName adLanguageParam, final IStringExpression expressionBaseLang, final IStringExpression expressionTrl)
+	private TranslatableParameterizedStringExpression(
+			@NonNull final CtxName adLanguageParam,
+			@NonNull final IStringExpression expressionBaseLang,
+			@NonNull final IStringExpression expressionTrl)
 	{
-		super();
-
-		Check.assumeNotNull(adLanguageParam, "Parameter adLanguageParam is not null");
 		this.adLanguageParam = adLanguageParam;
-
-		Check.assumeNotNull(expressionBaseLang, "Parameter expressionBaseLang is not null");
 		this.expressionBaseLang = expressionBaseLang;
-
-		Check.assumeNotNull(expressionTrl, "Parameter expressionTrl is not null");
 		this.expressionTrl = expressionTrl;
 
 		//
 		// Expression parameters: all parameters from both expressions, plus the AD_Language parameter
-		this.parameters = ImmutableSet.<String>builder()
+		this.parameters = ImmutableSet.<CtxName> builder()
 				.addAll(expressionBaseLang.getParameters())
 				.addAll(expressionTrl.getParameters())
-				.add(adLanguageParam.getName())
+				.add(adLanguageParam)
 				.build();
 	}
 
@@ -213,7 +210,13 @@ public final class TranslatableParameterizedStringExpression implements IStringE
 	}
 
 	@Override
-	public Set<String> getParameters()
+	public Set<String> getParametersAsPlainStrings()
+	{
+		return CtxNames.asNames(parameters);
+	}
+
+	@Override
+	public Set<CtxName> getParameters()
 	{
 		return parameters;
 	}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/TranslatableParameterizedStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/TranslatableParameterizedStringExpression.java
@@ -210,12 +210,6 @@ public final class TranslatableParameterizedStringExpression implements IStringE
 	}
 
 	@Override
-	public Set<String> getParameterNames()
-	{
-		return CtxNames.toNames(parameters);
-	}
-
-	@Override
 	public Set<CtxName> getParameters()
 	{
 		return parameters;

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/TranslatableParameterizedStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/TranslatableParameterizedStringExpression.java
@@ -210,9 +210,9 @@ public final class TranslatableParameterizedStringExpression implements IStringE
 	}
 
 	@Override
-	public Set<String> getParametersAsPlainStrings()
+	public Set<String> getParameterNames()
 	{
-		return CtxNames.asNames(parameters);
+		return CtxNames.toNames(parameters);
 	}
 
 	@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/AbstractChunkBasedExpressionCompiler.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/AbstractChunkBasedExpressionCompiler.java
@@ -8,6 +8,7 @@ import org.adempiere.ad.expression.api.IExpression;
 import org.adempiere.ad.expression.api.IExpressionCompiler;
 import org.adempiere.ad.expression.exceptions.ExpressionCompileException;
 import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 
 /*
  * #%L
@@ -42,8 +43,8 @@ import org.compiere.util.CtxName;
  */
 public abstract class AbstractChunkBasedExpressionCompiler<V, ET extends IExpression<V>> implements IExpressionCompiler<V, ET>
 {
-	protected static final String PARAMETER_TAG = CtxName.NAME_Marker;
-	private static final int PARAMETER_TAG_LENGTH = CtxName.NAME_Marker.length();
+	protected static final String PARAMETER_TAG = CtxNames.NAME_Marker;
+	private static final int PARAMETER_TAG_LENGTH = CtxNames.NAME_Marker.length();
 	protected static final String PARAMETER_DOUBLE_TAG = PARAMETER_TAG + PARAMETER_TAG;
 
 	// NOTE to developer: make sure there are no variables here since we are using a shared instance
@@ -110,7 +111,7 @@ public abstract class AbstractChunkBasedExpressionCompiler<V, ET extends IExpres
 			{
 				// Parameter
 				final String token = inStr.substring(0, j);
-				final CtxName parameter = CtxName.parse(token);
+				final CtxName parameter = CtxNames.parse(token);
 				chunks.add(parameter);
 			}
 

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/CachedStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/CachedStringExpression.java
@@ -14,6 +14,7 @@ import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.api.IStringExpression;
 import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
 import org.adempiere.util.Check;
+import org.compiere.util.CtxName;
 import org.compiere.util.Env;
 import org.compiere.util.Evaluatee;
 import org.compiere.util.Evaluatee2;
@@ -124,7 +125,13 @@ public final class CachedStringExpression implements ICachedStringExpression
 	}
 
 	@Override
-	public Set<String> getParameters()
+	public Set<String> getParametersAsPlainStrings()
+	{
+		return expression.getParametersAsPlainStrings();
+	}
+	
+	@Override
+	public Set<CtxName> getParameters()
 	{
 		return expression.getParameters();
 	}
@@ -142,7 +149,7 @@ public final class CachedStringExpression implements ICachedStringExpression
 		{
 			// Build the effective context
 			final boolean failIfNotFound = onVariableNotFound == OnVariableNotFound.Fail;
-			final EffectiveValuesEvaluatee ctxEffective = EffectiveValuesEvaluatee.extractFrom(expression.getParameters(), ctx, failIfNotFound);
+			final EffectiveValuesEvaluatee ctxEffective = EffectiveValuesEvaluatee.extractFrom(expression.getParametersAsPlainStrings(), ctx, failIfNotFound);
 
 			// Caching key: the effective context and the OnVariableNotFound
 			final ArrayKey key = mkCachingKey(ctxEffective, onVariableNotFound);
@@ -165,7 +172,7 @@ public final class CachedStringExpression implements ICachedStringExpression
 		{
 			// Build the effective context
 			final boolean failIfNotFound = false;
-			final EffectiveValuesEvaluatee ctxEffective = EffectiveValuesEvaluatee.extractFrom(expression.getParameters(), ctx, failIfNotFound);
+			final EffectiveValuesEvaluatee ctxEffective = EffectiveValuesEvaluatee.extractFrom(expression.getParametersAsPlainStrings(), ctx, failIfNotFound);
 
 			// Caching key: the effective context and the OnVariableNotFound
 			final OnVariableNotFound onVariableNotFound = null; // not relevant

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/CachedStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/CachedStringExpression.java
@@ -125,9 +125,9 @@ public final class CachedStringExpression implements ICachedStringExpression
 	}
 
 	@Override
-	public Set<String> getParametersAsPlainStrings()
+	public Set<String> getParameterNames()
 	{
-		return expression.getParametersAsPlainStrings();
+		return expression.getParameterNames();
 	}
 	
 	@Override
@@ -149,7 +149,7 @@ public final class CachedStringExpression implements ICachedStringExpression
 		{
 			// Build the effective context
 			final boolean failIfNotFound = onVariableNotFound == OnVariableNotFound.Fail;
-			final EffectiveValuesEvaluatee ctxEffective = EffectiveValuesEvaluatee.extractFrom(expression.getParametersAsPlainStrings(), ctx, failIfNotFound);
+			final EffectiveValuesEvaluatee ctxEffective = EffectiveValuesEvaluatee.extractFrom(expression.getParameterNames(), ctx, failIfNotFound);
 
 			// Caching key: the effective context and the OnVariableNotFound
 			final ArrayKey key = mkCachingKey(ctxEffective, onVariableNotFound);
@@ -172,7 +172,7 @@ public final class CachedStringExpression implements ICachedStringExpression
 		{
 			// Build the effective context
 			final boolean failIfNotFound = false;
-			final EffectiveValuesEvaluatee ctxEffective = EffectiveValuesEvaluatee.extractFrom(expression.getParametersAsPlainStrings(), ctx, failIfNotFound);
+			final EffectiveValuesEvaluatee ctxEffective = EffectiveValuesEvaluatee.extractFrom(expression.getParameterNames(), ctx, failIfNotFound);
 
 			// Caching key: the effective context and the OnVariableNotFound
 			final OnVariableNotFound onVariableNotFound = null; // not relevant

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/CompositeStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/CompositeStringExpression.java
@@ -210,12 +210,12 @@ public final class CompositeStringExpression implements IStringExpression
 	}
 
 	@Override
-	public Set<String> getParametersAsPlainStrings()
+	public Set<String> getParameterNames()
 	{
 		if (_parameters == null)
 		{
 			_parameters = expressions.stream()
-					.flatMap(expression -> expression.getParametersAsPlainStrings().stream())
+					.flatMap(expression -> expression.getParameterNames().stream())
 					.collect(GuavaCollectors.toImmutableSet());
 		}
 		return _parameters;

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/CompositeStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/CompositeStringExpression.java
@@ -85,13 +85,15 @@ public final class CompositeStringExpression implements IStringExpression
 
 	private transient String _expressionStr;
 	private transient String _formatedExpressionString;
+	
 	private transient Set<String> _parameters;
+	private transient Set<CtxName> _parametersAsCtxNames;
 
 	private Integer _hashCode;
 
+
 	private CompositeStringExpression(final Collection<IStringExpression> expressions)
 	{
-		super();
 		this.expressions = ImmutableList.copyOf(expressions);
 	}
 
@@ -208,16 +210,30 @@ public final class CompositeStringExpression implements IStringExpression
 	}
 
 	@Override
-	public Set<String> getParameters()
+	public Set<String> getParametersAsPlainStrings()
 	{
 		if (_parameters == null)
 		{
 			_parameters = expressions.stream()
-					.flatMap(expression -> expression.getParameters().stream())
+					.flatMap(expression -> expression.getParametersAsPlainStrings().stream())
 					.collect(GuavaCollectors.toImmutableSet());
 		}
 		return _parameters;
 	}
+	
+
+	@Override
+	public Set<CtxName> getParameters()
+	{if (_parametersAsCtxNames == null)
+	{
+		_parametersAsCtxNames = expressions.stream()
+				.flatMap(expression -> expression.getParameters().stream())
+				.collect(GuavaCollectors.toImmutableSet());
+	}
+	return _parametersAsCtxNames;
+	}
+
+
 
 	public static final class Builder
 	{

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/CompositeStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/CompositeStringExpression.java
@@ -86,11 +86,9 @@ public final class CompositeStringExpression implements IStringExpression
 	private transient String _expressionStr;
 	private transient String _formatedExpressionString;
 	
-	private transient Set<String> _parameters;
 	private transient Set<CtxName> _parametersAsCtxNames;
 
 	private Integer _hashCode;
-
 
 	private CompositeStringExpression(final Collection<IStringExpression> expressions)
 	{
@@ -208,19 +206,6 @@ public final class CompositeStringExpression implements IStringExpression
 					.addExpression(this);
 		}
 	}
-
-	@Override
-	public Set<String> getParameterNames()
-	{
-		if (_parameters == null)
-		{
-			_parameters = expressions.stream()
-					.flatMap(expression -> expression.getParameterNames().stream())
-					.collect(GuavaCollectors.toImmutableSet());
-		}
-		return _parameters;
-	}
-	
 
 	@Override
 	public Set<CtxName> getParameters()

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/ConstantStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/ConstantStringExpression.java
@@ -119,7 +119,7 @@ public final class ConstantStringExpression implements IStringExpression, ICache
 	}
 
 	@Override
-	public Set<String> getParametersAsPlainStrings()
+	public Set<String> getParameterNames()
 	{
 		return ImmutableSet.of();
 	}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/ConstantStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/ConstantStringExpression.java
@@ -117,12 +117,6 @@ public final class ConstantStringExpression implements IStringExpression, ICache
 	{
 		return expressionStr;
 	}
-
-	@Override
-	public Set<String> getParameterNames()
-	{
-		return ImmutableSet.of();
-	}
 	
 	@Override
 	public Set<CtxName> getParameters()

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/ConstantStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/ConstantStringExpression.java
@@ -8,6 +8,7 @@ import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.api.IStringExpression;
 import org.adempiere.ad.expression.json.JsonStringExpressionSerializer;
 import org.adempiere.util.Check;
+import org.compiere.util.CtxName;
 import org.compiere.util.Evaluatee;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -70,7 +71,6 @@ public final class ConstantStringExpression implements IStringExpression, ICache
 
 	private ConstantStringExpression(final String expressionStr)
 	{
-		super();
 		Check.assumeNotNull(expressionStr, "Parameter expressionStr is not null");
 		this.expressionStr = expressionStr;
 	}
@@ -119,7 +119,13 @@ public final class ConstantStringExpression implements IStringExpression, ICache
 	}
 
 	@Override
-	public Set<String> getParameters()
+	public Set<String> getParametersAsPlainStrings()
+	{
+		return ImmutableSet.of();
+	}
+	
+	@Override
+	public Set<CtxName> getParameters()
 	{
 		return ImmutableSet.of();
 	}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicExpression.java
@@ -8,9 +8,13 @@ import org.adempiere.ad.expression.api.ILogicExpression;
 import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
 import org.adempiere.ad.expression.json.JsonLogicExpressionSerializer;
 import org.adempiere.util.Check;
+import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableSet;
+
+import lombok.NonNull;
 
 @JsonSerialize(using = JsonLogicExpressionSerializer.class)
 /* package */final class LogicExpression extends AbstractLogicExpression
@@ -20,19 +24,19 @@ import com.google.common.collect.ImmutableSet;
 	private final String operator;
 	private final Boolean constantValue;
 
-	private ImmutableSet<String> _parameters;
+	private ImmutableSet<CtxName> _parameters;
 
 	private Integer _hashcode; // lazy
 	private String _expressionString; // lazy
 	private String _formatedExpressionString; // lazy
 
-	/* package */ LogicExpression(final Boolean constantValue, final ILogicExpression left, final String operator, final ILogicExpression right)
+	/* package */ LogicExpression(
+			final Boolean constantValue,
+			@NonNull final ILogicExpression left,
+			@NonNull final String operator,
+			@NonNull final ILogicExpression right)
 	{
-		super();
-
-		Check.assumeNotNull(left, "left expression not null");
 		Check.assumeNotEmpty(operator, "operator not empty");
-		Check.assumeNotNull(right, "right expression not null");
 
 		this.left = left;
 		this.operator = operator;
@@ -43,7 +47,6 @@ import com.google.common.collect.ImmutableSet;
 	/** Constant LogicExpression constructor */
 	private LogicExpression(final Boolean constantValue, final LogicExpression from)
 	{
-		super();
 		left = from.left;
 		right = from.right;
 		operator = from.operator;
@@ -207,7 +210,13 @@ import com.google.common.collect.ImmutableSet;
 	}
 
 	@Override
-	public Set<String> getParameters()
+	public Set<String> getParametersAsPlainStrings()
+	{
+		return CtxNames.asNames(getParameters());
+	}
+
+	@Override
+	public Set<CtxName> getParameters()
 	{
 		if (_parameters == null)
 		{
@@ -217,7 +226,7 @@ import com.google.common.collect.ImmutableSet;
 			}
 			else
 			{
-				final Set<String> result = new LinkedHashSet<>(left.getParameters());
+				final Set<CtxName> result = new LinkedHashSet<>(left.getParameters());
 				result.addAll(right.getParameters());
 				_parameters = ImmutableSet.copyOf(result);
 			}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicExpression.java
@@ -210,9 +210,9 @@ import lombok.NonNull;
 	}
 
 	@Override
-	public Set<String> getParametersAsPlainStrings()
+	public Set<String> getParameterNames()
 	{
-		return CtxNames.asNames(getParameters());
+		return CtxNames.toNames(getParameters());
 	}
 
 	@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicExpression.java
@@ -9,7 +9,6 @@ import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
 import org.adempiere.ad.expression.json.JsonLogicExpressionSerializer;
 import org.adempiere.util.Check;
 import org.compiere.util.CtxName;
-import org.compiere.util.CtxNames;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableSet;
@@ -207,12 +206,6 @@ import lombok.NonNull;
 			// unknown operator
 			throw new ExpressionEvaluationException("Unknown operator: " + operator);
 		}
-	}
-
-	@Override
-	public Set<String> getParameterNames()
-	{
-		return CtxNames.toNames(getParameters());
 	}
 
 	@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicExpressionBuilder.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicExpressionBuilder.java
@@ -128,7 +128,7 @@ public final class LogicExpressionBuilder
 			}
 
 			// If the expression depends on external parameters, there is nothing we can do.
-			if (!expr.getParametersAsPlainStrings().isEmpty())
+			if (!expr.getParameterNames().isEmpty())
 			{
 				return expr;
 			}
@@ -177,7 +177,7 @@ public final class LogicExpressionBuilder
 				return expr.constantValue();
 			}
 
-			if (!expr.getParametersAsPlainStrings().isEmpty())
+			if (!expr.getParameterNames().isEmpty())
 			{
 				return null;
 			}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicExpressionBuilder.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicExpressionBuilder.java
@@ -128,7 +128,7 @@ public final class LogicExpressionBuilder
 			}
 
 			// If the expression depends on external parameters, there is nothing we can do.
-			if (!expr.getParameters().isEmpty())
+			if (!expr.getParametersAsPlainStrings().isEmpty())
 			{
 				return expr;
 			}
@@ -177,7 +177,7 @@ public final class LogicExpressionBuilder
 				return expr.constantValue();
 			}
 
-			if (!expr.getParameters().isEmpty())
+			if (!expr.getParametersAsPlainStrings().isEmpty())
 			{
 				return null;
 			}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicTuple.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicTuple.java
@@ -172,9 +172,9 @@ import com.google.common.collect.ImmutableSet;
 	}
 
 	@Override
-	public Set<String> getParametersAsPlainStrings()
+	public Set<String> getParameterNames()
 	{
-		return CtxNames.asNames(getParameters());
+		return CtxNames.toNames(getParameters());
 	}
 
 	@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicTuple.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicTuple.java
@@ -10,6 +10,7 @@ import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
 import org.adempiere.ad.expression.json.JsonLogicExpressionSerializer;
 import org.adempiere.util.Check;
 import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableList;
@@ -34,7 +35,7 @@ import com.google.common.collect.ImmutableSet;
 
 	private final Boolean constantValue;
 
-	private ImmutableSet<String> _parameters;
+	private ImmutableSet<CtxName> _parameters;
 
 	private final String expressionStr;
 	private Integer _hashcode; // lazy
@@ -51,9 +52,9 @@ import com.google.common.collect.ImmutableSet;
 
 		this.operator = operator;
 
-		if (operand1.indexOf(CtxName.NAME_Marker) != -1)
+		if (operand1.indexOf(CtxNames.NAME_Marker) != -1)
 		{
-			this.operand1 = CtxName.parseWithMarkers(operand1);
+			this.operand1 = CtxNames.parseWithMarkers(operand1);
 			isParameter1 = true;
 		}
 		else
@@ -62,9 +63,9 @@ import com.google.common.collect.ImmutableSet;
 			isParameter1 = false;
 		}
 
-		if (operand2.indexOf(CtxName.NAME_Marker) != -1)
+		if (operand2.indexOf(CtxNames.NAME_Marker) != -1)
 		{
-			this.operand2 = CtxName.parseWithMarkers(operand2);
+			this.operand2 = CtxNames.parseWithMarkers(operand2);
 			isParameter2 = true;
 		}
 		else
@@ -171,7 +172,13 @@ import com.google.common.collect.ImmutableSet;
 	}
 
 	@Override
-	public Set<String> getParameters()
+	public Set<String> getParametersAsPlainStrings()
+	{
+		return CtxNames.asNames(getParameters());
+	}
+
+	@Override
+	public Set<CtxName> getParameters()
 	{
 		if (_parameters == null)
 		{
@@ -181,14 +188,14 @@ import com.google.common.collect.ImmutableSet;
 			}
 			else
 			{
-				final Set<String> result = new LinkedHashSet<String>();
+				final Set<CtxName> result = new LinkedHashSet<>();
 				if (operand1 instanceof CtxName)
 				{
-					result.add(((CtxName)operand1).getName());
+					result.add((CtxName)operand1);
 				}
 				if (operand2 instanceof CtxName)
 				{
-					result.add(((CtxName)operand2).getName());
+					result.add((CtxName)operand2);
 				}
 				_parameters = ImmutableSet.copyOf(result);
 			}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicTuple.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/LogicTuple.java
@@ -172,12 +172,6 @@ import com.google.common.collect.ImmutableSet;
 	}
 
 	@Override
-	public Set<String> getParameterNames()
-	{
-		return CtxNames.toNames(getParameters());
-	}
-
-	@Override
 	public Set<CtxName> getParameters()
 	{
 		if (_parameters == null)

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/SingleParamStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/SingleParamStringExpression.java
@@ -49,6 +49,7 @@ import com.google.common.collect.ImmutableSet;
 	private final CtxName parameter;
 
 	private final Set<String> parameters;
+	private final Set<CtxName> parametersAsCtxName;
 
 	/* package */ SingleParameterStringExpression(final String expressionStr, final CtxName parameter)
 	{
@@ -61,6 +62,7 @@ import com.google.common.collect.ImmutableSet;
 		this.parameter = parameter;
 
 		parameters = ImmutableSet.of(parameter.getName()); // NOTE: we need only the parameter name (and not all modifiers)
+		parametersAsCtxName = ImmutableSet.of(parameter);
 	}
 
 	@Override
@@ -107,9 +109,16 @@ import com.google.common.collect.ImmutableSet;
 	}
 
 	@Override
-	public Set<String> getParameters()
+	public Set<String> getParametersAsPlainStrings()
 	{
 		return parameters;
+	}
+
+	
+	@Override
+	public Set<CtxName> getParameters()
+	{
+		return parametersAsCtxName;
 	}
 
 	@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/SingleParamStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/SingleParamStringExpression.java
@@ -109,7 +109,7 @@ import com.google.common.collect.ImmutableSet;
 	}
 
 	@Override
-	public Set<String> getParametersAsPlainStrings()
+	public Set<String> getParameterNames()
 	{
 		return parameters;
 	}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/SingleParamStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/SingleParamStringExpression.java
@@ -48,7 +48,6 @@ import com.google.common.collect.ImmutableSet;
 	private final String expressionStr;
 	private final CtxName parameter;
 
-	private final Set<String> parameters;
 	private final Set<CtxName> parametersAsCtxName;
 
 	/* package */ SingleParameterStringExpression(final String expressionStr, final CtxName parameter)
@@ -61,7 +60,6 @@ import com.google.common.collect.ImmutableSet;
 		Check.assumeNotNull(parameter, "Parameter parameter is not null");
 		this.parameter = parameter;
 
-		parameters = ImmutableSet.of(parameter.getName()); // NOTE: we need only the parameter name (and not all modifiers)
 		parametersAsCtxName = ImmutableSet.of(parameter);
 	}
 
@@ -107,13 +105,6 @@ import com.google.common.collect.ImmutableSet;
 	{
 		return parameter.toStringWithMarkers();
 	}
-
-	@Override
-	public Set<String> getParameterNames()
-	{
-		return parameters;
-	}
-
 	
 	@Override
 	public Set<CtxName> getParameters()

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/StringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/StringExpression.java
@@ -13,6 +13,7 @@ import org.adempiere.ad.expression.api.IStringExpression;
 import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
 import org.adempiere.ad.expression.json.JsonStringExpressionSerializer;
 import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 import org.compiere.util.Evaluatee;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -30,7 +31,7 @@ import com.google.common.collect.ImmutableSet;
 /* package */final class StringExpression implements IStringExpression
 {
 	private final List<Object> expressionChunks;
-	private final Set<String> parametersAsStringList;
+	private final Set<CtxName> parametersAsCtxName;
 
 	// Precomputed values
 	private String _expressionStr;
@@ -38,23 +39,20 @@ import com.google.common.collect.ImmutableSet;
 
 	/* package */ StringExpression(@Nullable final String expressionStr, final List<Object> expressionChunks)
 	{
-		super();
 		_expressionStr = expressionStr;
 		this.expressionChunks = ImmutableList.copyOf(expressionChunks);
 
 		//
 		// Initialize stringParams list
-		final Set<String> stringParams = new LinkedHashSet<>(); // NOTE: preserve parameters order because at least some tests are relying on this
+		final Set<CtxName> ctxNameParams = new LinkedHashSet<>(); // NOTE: preserve parameters order because at least some tests are relying on this
 		for (final Object chunk : expressionChunks)
 		{
 			if (chunk instanceof CtxName)
 			{
-				// NOTE: we need only the parameter name (and not all modifiers)
-				final String parameterName = ((CtxName)chunk).getName();
-				stringParams.add(parameterName);
+				ctxNameParams.add((CtxName)chunk);
 			}
 		}
-		parametersAsStringList = ImmutableSet.copyOf(stringParams);
+		parametersAsCtxName = ImmutableSet.copyOf(ctxNameParams);
 	}
 
 	@Override
@@ -129,9 +127,15 @@ import com.google.common.collect.ImmutableSet;
 	}
 
 	@Override
-	public Set<String> getParameters()
+	public Set<String> getParametersAsPlainStrings()
 	{
-		return parametersAsStringList;
+		return CtxNames.asNames(parametersAsCtxName);
+	}
+
+	@Override
+	public Set<CtxName> getParameters()
+	{
+		return parametersAsCtxName;
 	}
 
 	@VisibleForTesting

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/StringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/StringExpression.java
@@ -127,9 +127,9 @@ import com.google.common.collect.ImmutableSet;
 	}
 
 	@Override
-	public Set<String> getParametersAsPlainStrings()
+	public Set<String> getParameterNames()
 	{
-		return CtxNames.asNames(parametersAsCtxName);
+		return CtxNames.toNames(parametersAsCtxName);
 	}
 
 	@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/StringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/StringExpression.java
@@ -13,7 +13,6 @@ import org.adempiere.ad.expression.api.IStringExpression;
 import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
 import org.adempiere.ad.expression.json.JsonStringExpressionSerializer;
 import org.compiere.util.CtxName;
-import org.compiere.util.CtxNames;
 import org.compiere.util.Evaluatee;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -124,12 +123,6 @@ import com.google.common.collect.ImmutableSet;
 		}
 
 		return sb.toString();
-	}
-
-	@Override
-	public Set<String> getParameterNames()
-	{
-		return CtxNames.toNames(parametersAsCtxName);
 	}
 
 	@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/StringExpressionSupportTemplate.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/StringExpressionSupportTemplate.java
@@ -171,7 +171,7 @@ public abstract class StringExpressionSupportTemplate<V, ET extends IExpression<
 		}
 
 		@Override
-		public Set<String> getParametersAsPlainStrings()
+		public Set<String> getParameterNames()
 		{
 			return ImmutableSet.of();
 		}
@@ -261,7 +261,7 @@ public abstract class StringExpressionSupportTemplate<V, ET extends IExpression<
 		}
 
 		@Override
-		public Set<String> getParametersAsPlainStrings()
+		public Set<String> getParameterNames()
 		{
 			return ImmutableSet.of();
 		}
@@ -351,9 +351,9 @@ public abstract class StringExpressionSupportTemplate<V, ET extends IExpression<
 		}
 
 		@Override
-		public Set<String> getParametersAsPlainStrings()
+		public Set<String> getParameterNames()
 		{
-			return CtxNames.asNames(_parametersList);
+			return CtxNames.toNames(_parametersList);
 		}
 
 		@Override
@@ -422,9 +422,9 @@ public abstract class StringExpressionSupportTemplate<V, ET extends IExpression<
 		}
 
 		@Override
-		public Set<String> getParametersAsPlainStrings()
+		public Set<String> getParameterNames()
 		{
-			return stringExpression.getParametersAsPlainStrings();
+			return stringExpression.getParameterNames();
 		}
 
 		@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/StringExpressionSupportTemplate.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/StringExpressionSupportTemplate.java
@@ -171,12 +171,6 @@ public abstract class StringExpressionSupportTemplate<V, ET extends IExpression<
 		}
 
 		@Override
-		public Set<String> getParameterNames()
-		{
-			return ImmutableSet.of();
-		}
-
-		@Override
 		public Set<CtxName> getParameters()
 		{
 			return ImmutableSet.of();
@@ -261,12 +255,6 @@ public abstract class StringExpressionSupportTemplate<V, ET extends IExpression<
 		}
 
 		@Override
-		public Set<String> getParameterNames()
-		{
-			return ImmutableSet.of();
-		}
-
-		@Override
 		public Set<CtxName> getParameters()
 		{
 			return ImmutableSet.of();
@@ -348,12 +336,6 @@ public abstract class StringExpressionSupportTemplate<V, ET extends IExpression<
 		public String getFormatedExpressionString()
 		{
 			return expressionStr; // expressionStr is good enough in this case
-		}
-
-		@Override
-		public Set<String> getParameterNames()
-		{
-			return CtxNames.toNames(_parametersList);
 		}
 
 		@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/StringExpressionSupportTemplate.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/StringExpressionSupportTemplate.java
@@ -11,9 +11,12 @@ import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
 import org.adempiere.util.Check;
 import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 import org.compiere.util.Evaluatee;
 
 import com.google.common.collect.ImmutableSet;
+
+import lombok.NonNull;
 
 /*
  * #%L
@@ -28,11 +31,11 @@ import com.google.common.collect.ImmutableSet;
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
@@ -117,7 +120,6 @@ public abstract class StringExpressionSupportTemplate<V, ET extends IExpression<
 
 		private ExpressionTemplateBase(final ExpressionContext context, final Compiler<V, ET> compiler)
 		{
-			super();
 			this.valueClass = compiler.valueClass;
 			this.noResultValue = compiler.noResultValue;
 			this.valueConverter = compiler.valueConverter;
@@ -169,11 +171,17 @@ public abstract class StringExpressionSupportTemplate<V, ET extends IExpression<
 		}
 
 		@Override
-		public Set<String> getParameters()
+		public Set<String> getParametersAsPlainStrings()
 		{
 			return ImmutableSet.of();
 		}
 
+		@Override
+		public Set<CtxName> getParameters()
+		{
+			return ImmutableSet.of();
+		}
+		
 		@Override
 		public boolean isNullExpression()
 		{
@@ -253,7 +261,13 @@ public abstract class StringExpressionSupportTemplate<V, ET extends IExpression<
 		}
 
 		@Override
-		public Set<String> getParameters()
+		public Set<String> getParametersAsPlainStrings()
+		{
+			return ImmutableSet.of();
+		}
+
+		@Override
+		public Set<CtxName> getParameters()
 		{
 			return ImmutableSet.of();
 		}
@@ -276,18 +290,20 @@ public abstract class StringExpressionSupportTemplate<V, ET extends IExpression<
 		private final String expressionStr;
 
 		protected final CtxName parameter;
-		private final Set<String> _parametersList;
+		private final Set<CtxName> _parametersList;
 
-		/* package */ SingleParameterExpressionTemplate(final ExpressionContext context, final Compiler<V, ET> compiler, final String expressionStr, final CtxName parameter)
+		/* package */ SingleParameterExpressionTemplate(
+				final ExpressionContext context,
+				final Compiler<V, ET> compiler,
+				@NonNull final String expressionStr,
+				@NonNull final CtxName parameter)
 		{
 			super(context, compiler);
 
-			Check.assumeNotNull(expressionStr, "Parameter expressionStr is not null");
 			this.expressionStr = expressionStr;
 
-			Check.assumeNotNull(parameter, "Parameter parameter is not null");
 			this.parameter = parameter;
-			_parametersList = ImmutableSet.of(parameter.getName()); // NOTE: we need only the parameter name (and not all modifiers)
+			_parametersList = ImmutableSet.of(parameter); // NOTE: we need only the parameter name (and not all modifiers)
 		}
 
 		@Override
@@ -335,7 +351,13 @@ public abstract class StringExpressionSupportTemplate<V, ET extends IExpression<
 		}
 
 		@Override
-		public Set<String> getParameters()
+		public Set<String> getParametersAsPlainStrings()
+		{
+			return CtxNames.asNames(_parametersList);
+		}
+
+		@Override
+		public Set<CtxName> getParameters()
 		{
 			return _parametersList;
 		}
@@ -344,7 +366,7 @@ public abstract class StringExpressionSupportTemplate<V, ET extends IExpression<
 		{
 			final String valueStr = parameter.getValueAsString(ctx);
 
-			if (valueStr == null || valueStr == CtxName.VALUE_NULL)
+			if (valueStr == null || valueStr == CtxNames.VALUE_NULL)
 			{
 				return null;
 			}
@@ -400,7 +422,13 @@ public abstract class StringExpressionSupportTemplate<V, ET extends IExpression<
 		}
 
 		@Override
-		public Set<String> getParameters()
+		public Set<String> getParametersAsPlainStrings()
+		{
+			return stringExpression.getParametersAsPlainStrings();
+		}
+
+		@Override
+		public Set<CtxName> getParameters()
 		{
 			return stringExpression.getParameters();
 		}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/StringExpressionsHelper.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/StringExpressionsHelper.java
@@ -4,6 +4,7 @@ import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.api.IStringExpression;
 import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
 import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 import org.compiere.util.Evaluatee;
 
 /*
@@ -50,7 +51,7 @@ public final class StringExpressionsHelper
 	{
 		final String value = name.getValueAsString(ctx);
 
-		if (value != null && value != CtxName.VALUE_NULL)
+		if (value != null && value != CtxNames.VALUE_NULL)
 		{
 			return value;
 		}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/SysDateDateExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/SysDateDateExpression.java
@@ -71,12 +71,6 @@ public class SysDateDateExpression implements IExpression<java.util.Date>
 	}
 
 	@Override
-	public Set<String> getParameterNames()
-	{
-		return ImmutableSet.of();
-	}
-
-	@Override
 	public Set<CtxName> getParameters()
 	{
 		return ImmutableSet.of();

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/SysDateDateExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/SysDateDateExpression.java
@@ -8,6 +8,7 @@ import org.adempiere.ad.expression.api.IExpression;
 import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
 import org.adempiere.util.time.SystemTime;
+import org.compiere.util.CtxName;
 import org.compiere.util.Evaluatee;
 
 import com.google.common.collect.ImmutableSet;
@@ -25,11 +26,11 @@ import com.google.common.collect.ImmutableSet;
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
@@ -49,7 +50,6 @@ public class SysDateDateExpression implements IExpression<java.util.Date>
 
 	private SysDateDateExpression()
 	{
-		super();
 	}
 
 	@Override
@@ -71,7 +71,13 @@ public class SysDateDateExpression implements IExpression<java.util.Date>
 	}
 
 	@Override
-	public Set<String> getParameters()
+	public Set<String> getParametersAsPlainStrings()
+	{
+		return ImmutableSet.of();
+	}
+
+	@Override
+	public Set<CtxName> getParameters()
 	{
 		return ImmutableSet.of();
 	}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/SysDateDateExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/SysDateDateExpression.java
@@ -71,7 +71,7 @@ public class SysDateDateExpression implements IExpression<java.util.Date>
 	}
 
 	@Override
-	public Set<String> getParametersAsPlainStrings()
+	public Set<String> getParameterNames()
 	{
 		return ImmutableSet.of();
 	}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/security/impl/AccessSqlStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/security/impl/AccessSqlStringExpression.java
@@ -16,6 +16,7 @@ import org.adempiere.ad.security.IUserRolePermissions;
 import org.adempiere.ad.security.UserRolePermissionsKey;
 import org.adempiere.util.Check;
 import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 import org.compiere.util.Env;
 import org.compiere.util.Evaluatee;
 
@@ -77,18 +78,17 @@ public final class AccessSqlStringExpression implements IStringExpression
 	 *
 	 * @see UserRolePermissionsKey#toPermissionsKeyString()
 	 */
-	public static final CtxName PARAM_UserRolePermissionsKey = CtxName.parse("#PermissionsKey");
+	public static final CtxName PARAM_UserRolePermissionsKey = CtxNames.parse("#PermissionsKey");
 
 	private final IStringExpression sqlExpression;
 	private final String tableNameIn;
 	private final boolean fullyQualified;
 	private final boolean rw;
 
-	private final Set<String> parameters;
+	private final Set<CtxName> parametersAsCtxNames;
 
 	private AccessSqlStringExpression(final IStringExpression sqlExpression, final String tableNameIn, final boolean fullyQualified, final boolean rw)
 	{
-		super();
 		Check.assume(sqlExpression != null && !sqlExpression.isNullExpression(), "Parameter sqlExpression shall not be unll but it was {}", sqlExpression);
 		this.sqlExpression = sqlExpression;
 
@@ -98,10 +98,10 @@ public final class AccessSqlStringExpression implements IStringExpression
 		this.fullyQualified = fullyQualified;
 		this.rw = rw;
 
-		final LinkedHashSet<String> parameters = new LinkedHashSet<>();
-		parameters.add(PARAM_UserRolePermissionsKey.getName());
-		parameters.addAll(sqlExpression.getParameters());
-		this.parameters = ImmutableSet.copyOf(parameters);
+		final LinkedHashSet<CtxName> parametersAsCtxNames = new LinkedHashSet<>();
+		parametersAsCtxNames.add(PARAM_UserRolePermissionsKey);
+		parametersAsCtxNames.addAll(sqlExpression.getParameters());
+		this.parametersAsCtxNames = ImmutableSet.copyOf(parametersAsCtxNames);
 	}
 
 	@Override
@@ -158,9 +158,15 @@ public final class AccessSqlStringExpression implements IStringExpression
 	}
 
 	@Override
-	public Set<String> getParameters()
+	public Set<String> getParametersAsPlainStrings()
 	{
-		return parameters;
+		return parametersAsCtxNames.stream().map(CtxName::getName).collect(ImmutableSet.toImmutableSet());
+	}
+	
+	@Override
+	public Set<CtxName> getParameters()
+	{
+		return parametersAsCtxNames;
 	}
 
 	@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/security/impl/AccessSqlStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/security/impl/AccessSqlStringExpression.java
@@ -158,12 +158,6 @@ public final class AccessSqlStringExpression implements IStringExpression
 	}
 
 	@Override
-	public Set<String> getParameterNames()
-	{
-		return parametersAsCtxNames.stream().map(CtxName::getName).collect(ImmutableSet.toImmutableSet());
-	}
-	
-	@Override
 	public Set<CtxName> getParameters()
 	{
 		return parametersAsCtxNames;

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/security/impl/AccessSqlStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/security/impl/AccessSqlStringExpression.java
@@ -158,7 +158,7 @@ public final class AccessSqlStringExpression implements IStringExpression
 	}
 
 	@Override
-	public Set<String> getParametersAsPlainStrings()
+	public Set<String> getParameterNames()
 	{
 		return parametersAsCtxNames.stream().map(CtxName::getName).collect(ImmutableSet.toImmutableSet());
 	}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/IValidationRule.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/IValidationRule.java
@@ -25,7 +25,7 @@ public interface IValidationRule
 	 */
 	default boolean isImmutable()
 	{
-		return getPrefilterWhereClause().getParametersAsPlainStrings().isEmpty()
+		return getPrefilterWhereClause().getParameterNames().isEmpty()
 				&& getPostQueryFilter().getParameters().isEmpty();
 	}
 

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/IValidationRule.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/IValidationRule.java
@@ -25,7 +25,7 @@ public interface IValidationRule
 	 */
 	default boolean isImmutable()
 	{
-		return getPrefilterWhereClause().getParameters().isEmpty()
+		return getPrefilterWhereClause().getParametersAsPlainStrings().isEmpty()
 				&& getPostQueryFilter().getParameters().isEmpty();
 	}
 

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/impl/CompositeValidationRule.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/impl/CompositeValidationRule.java
@@ -98,7 +98,7 @@ public final class CompositeValidationRule implements IValidationRule
 		if(_allParameters == null)
 		{
 			_allParameters = ImmutableSet.<String>builder()
-					.addAll(prefilterWhereClause.getParameters())
+					.addAll(prefilterWhereClause.getParametersAsPlainStrings())
 					.addAll(postQueryPredicates.getParameters())
 					.build();
 		}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/impl/CompositeValidationRule.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/impl/CompositeValidationRule.java
@@ -98,7 +98,7 @@ public final class CompositeValidationRule implements IValidationRule
 		if(_allParameters == null)
 		{
 			_allParameters = ImmutableSet.<String>builder()
-					.addAll(prefilterWhereClause.getParametersAsPlainStrings())
+					.addAll(prefilterWhereClause.getParameterNames())
 					.addAll(postQueryPredicates.getParameters())
 					.build();
 		}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/impl/SQLValidationRule.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/impl/SQLValidationRule.java
@@ -69,13 +69,13 @@ import com.google.common.base.MoreObjects;
 	@Override
 	public Set<String> getAllParameters()
 	{
-		return whereClause.getParameters();
+		return whereClause.getParametersAsPlainStrings();
 	}
 
 	@Override
 	public boolean isImmutable()
 	{
-		return whereClause.getParameters().isEmpty();
+		return whereClause.getParametersAsPlainStrings().isEmpty();
 	}
 
 	@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/impl/SQLValidationRule.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/impl/SQLValidationRule.java
@@ -69,13 +69,13 @@ import com.google.common.base.MoreObjects;
 	@Override
 	public Set<String> getAllParameters()
 	{
-		return whereClause.getParametersAsPlainStrings();
+		return whereClause.getParameterNames();
 	}
 
 	@Override
 	public boolean isImmutable()
 	{
-		return whereClause.getParametersAsPlainStrings().isEmpty();
+		return whereClause.getParameterNames().isEmpty();
 	}
 
 	@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/compiere/util/CtxName.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/compiere/util/CtxName.java
@@ -1,168 +1,21 @@
 package org.compiere.util;
 
 import java.math.BigDecimal;
-
-/*
- * #%L
- * de.metas.adempiere.adempiere.base
- * %%
- * Copyright (C) 2015 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import org.adempiere.util.Check;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 
 /**
- * Immutable Context Name
- *
- * @author tsa
+ * Immutable Context Name. Use the methods for {@link CtxNames} to obtain instances.
+ * 
+ * @author metas-dev <dev@metasfresh.com>
  *
  */
 public final class CtxName
 {
-	public static final String NAME_Marker = "@";
-	public static final String MODIFIER_Old = "old";
-	private static final List<String> MODIFIERS = ImmutableList.<String> builder()
-			.add(MODIFIER_Old)
-			.build();
-
-	public static final String VALUE_NULL = null;
-	
-	private static final String SEPARATOR = "/";
-	private static final Splitter SEPARATOR_SPLITTER = Splitter.on(SEPARATOR)
-			//.omitEmptyStrings() // DO NOT omit empty strings because we want to support expressions like: @Description/@
-			;
-
-	public static CtxName parse(final String contextWithoutMarkers)
-	{
-		if (contextWithoutMarkers == null)
-		{
-			return null;
-		}
-
-		String name = null;
-
-		final List<String> modifiers = new ArrayList<>();
-		boolean firstToken = true;
-		for (String token : SEPARATOR_SPLITTER.splitToList(contextWithoutMarkers))
-		{
-			if (firstToken)
-			{
-				name = token.trim();
-			}
-			else
-			{
-				modifiers.add(token);
-			}
-			
-			firstToken = false;
-		}
-
-		final String defaultValue;
-		if (!modifiers.isEmpty() && !isModifier(modifiers.get(modifiers.size() - 1)))
-		{
-			defaultValue = modifiers.remove(modifiers.size() - 1);
-		}
-		else
-		{
-			defaultValue = VALUE_NULL;
-		}
-
-		return new CtxName(name, modifiers, defaultValue);
-	}
-
-	/** Parse a given name, surrounded by {@value #NAME_Marker} */
-	public static CtxName parseWithMarkers(final String contextWithMarkers)
-	{
-		if (contextWithMarkers == null)
-		{
-			return null;
-		}
-
-		String contextWithoutMarkers = contextWithMarkers.trim();
-		if (contextWithoutMarkers.startsWith(NAME_Marker))
-		{
-			contextWithoutMarkers = contextWithoutMarkers.substring(1);
-		}
-		if (contextWithoutMarkers.endsWith(NAME_Marker))
-		{
-			contextWithoutMarkers = contextWithoutMarkers.substring(0, contextWithoutMarkers.length() - 1);
-		}
-
-		return parse(contextWithoutMarkers);
-	}
-
-	/**
-	 *
-	 * @param name
-	 * @param expression expression with context variables (e.g. sql where clause)
-	 * @return true if expression contains given name
-	 */
-	static boolean containsName(final String name, final String expression)
-	{
-		// FIXME: replace it with StringExpression
-		if (name == null || name.isEmpty())
-		{
-			return false;
-		}
-
-		if (expression == null || expression.isEmpty())
-		{
-			return false;
-		}
-
-		final int idx = expression.indexOf(NAME_Marker + name);
-		if (idx < 0)
-		{
-			return false;
-		}
-
-		final int idx2 = expression.indexOf(NAME_Marker, idx + 1);
-		if (idx2 < 0)
-		{
-			return false;
-		}
-
-		final String nameStr = expression.substring(idx + 1, idx2);
-		return name.equals(parse(nameStr).getName());
-	}
-
-	/**
-	 *
-	 * @param modifier
-	 * @return true if given string is a registered modifier
-	 */
-	public static boolean isModifier(final String modifier)
-	{
-		if (Check.isEmpty(modifier))
-		{
-			return false;
-		}
-		return MODIFIERS.contains(modifier);
-	}
-
 	private final String name;
 	private final List<String> modifiers;
 	private final String defaultValue;
@@ -175,7 +28,6 @@ public final class CtxName
 
 	private Integer _hashcode; // lazy
 
-	@VisibleForTesting
 	/* package */ CtxName(final String name, final List<String> modifiers, final String defaultValue)
 	{
 		super();
@@ -223,7 +75,7 @@ public final class CtxName
 		}
 		return defaultValueBoolean.orElse(null);
 	}
-	
+
 	private BigDecimal getDefaultValueAsBigDecimal()
 	{
 		if (defaultValueBigDecimal == null)
@@ -242,10 +94,9 @@ public final class CtxName
 		return defaultValueDate.orElse(null);
 	}
 
-
 	public boolean isOld()
 	{
-		return modifiers != null && modifiers.contains(MODIFIER_Old);
+		return modifiers != null && modifiers.contains(CtxNames.MODIFIER_Old);
 	}
 
 	/**
@@ -326,7 +177,7 @@ public final class CtxName
 	public Integer getValueAsInteger(final Evaluatee source)
 	{
 		final Integer defaultValueAsInteger = getDefaultValueAsInteger();
-		
+
 		if (source == null)
 		{
 			return defaultValueAsInteger;
@@ -362,11 +213,11 @@ public final class CtxName
 		}
 		return defaultValueAsInteger;
 	}
-	
+
 	public Boolean getValueAsBoolean(final Evaluatee source)
 	{
 		final Boolean defaultValueAsBoolean = getDefaultValueAsBoolean();
-		
+
 		if (source == null)
 		{
 			return defaultValueAsBoolean;
@@ -402,11 +253,11 @@ public final class CtxName
 		}
 		return defaultValueAsBoolean;
 	}
-	
+
 	public BigDecimal getValueAsBigDecimal(final Evaluatee source)
 	{
 		final BigDecimal defaultValueAsBigDecimal = getDefaultValueAsBigDecimal();
-		
+
 		if (source == null)
 		{
 			return defaultValueAsBigDecimal;
@@ -445,7 +296,7 @@ public final class CtxName
 	public java.util.Date getValueAsDate(final Evaluatee source)
 	{
 		final java.util.Date defaultValueAsDate = getDefaultValueAsDate();
-		
+
 		if (source == null)
 		{
 			return defaultValueAsDate;
@@ -481,7 +332,6 @@ public final class CtxName
 		return defaultValueAsDate;
 	}
 
-
 	public String toString(final boolean includeTagMarkers)
 	{
 		return includeTagMarkers ? toStringWithMarkers() : toStringWithoutMarkers();
@@ -492,7 +342,7 @@ public final class CtxName
 		if (cachedToStringWithTagMarkers == null)
 		{
 			final StringBuilder sb = new StringBuilder();
-			sb.append(NAME_Marker).append(toStringWithoutMarkers()).append(NAME_Marker);
+			sb.append(CtxNames.NAME_Marker).append(toStringWithoutMarkers()).append(CtxNames.NAME_Marker);
 			cachedToStringWithTagMarkers = sb.toString();
 		}
 		return cachedToStringWithTagMarkers;
@@ -508,12 +358,12 @@ public final class CtxName
 			{
 				for (final String m : modifiers)
 				{
-					sb.append(SEPARATOR).append(m);
+					sb.append(CtxNames.SEPARATOR).append(m);
 				}
 			}
 			if (!Check.isEmpty(defaultValue))
 			{
-				sb.append(SEPARATOR).append(defaultValue);
+				sb.append(CtxNames.SEPARATOR).append(defaultValue);
 			}
 			cachedToStringWithoutTagMarkers = sb.toString();
 		}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/compiere/util/CtxNames.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/compiere/util/CtxNames.java
@@ -4,12 +4,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.adempiere.util.Check;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
@@ -27,11 +27,11 @@ import lombok.experimental.UtilityClass;
  * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  * 
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
@@ -48,32 +48,43 @@ public class CtxNames
 	public static final String NAME_Marker = "@";
 	public static final String MODIFIER_Old = "old";
 
-
 	public static final String VALUE_NULL = null;
-	
+
 	public static final String SEPARATOR = "/";
 	private static final Splitter SEPARATOR_SPLITTER = Splitter.on(SEPARATOR)
-			//.omitEmptyStrings() // DO NOT omit empty strings because we want to support expressions like: @Description/@
-			;
-	
+	// .omitEmptyStrings() // DO NOT omit empty strings because we want to support expressions like: @Description/@
+	;
+
 	private static final List<String> MODIFIERS = ImmutableList.<String> builder()
 			.add(MODIFIER_Old)
 			.build();
-	
-	public Set<CtxName> parseStringsWithoutMarkers(@NonNull final Collection<String> strings)
+
+	/**
+	 * Returns an immutable set of {@link CtxName}s that contains the results of {@link CtxNames#parse(String)}, applied to the strings of the given {@code stringsWithoutMarkers}.
+	 * 
+	 * @param stringsWithoutMarkers may not be {@code null}.
+	 * @return
+	 */
+	public Set<CtxName> parseStrings(@NonNull final Collection<String> stringsWithoutMarkers)
 	{
-		return strings.stream()
-				.map(s -> parse(s))
-				.collect(Collectors.toSet());
+		return stringsWithoutMarkers.stream()
+				.map(CtxNames::parse)
+				.collect(ImmutableSet.toImmutableSet());
 	}
-	
+
+	/**
+	 * Returns an immutable set of strings which contains the {@link CtxName#getName()}s of the give {@code ctxNames}.
+	 * 
+	 * @param ctxNames may not be {@code null}.
+	 * @return
+	 */
 	public Set<String> asNames(@NonNull final Collection<CtxName> ctxNames)
 	{
 		return ctxNames.stream()
 				.map(CtxName::getName)
-				.collect(Collectors.toSet());
+				.collect(ImmutableSet.toImmutableSet());
 	}
-	
+
 	public static CtxName parse(final String contextWithoutMarkers)
 	{
 		if (contextWithoutMarkers == null)
@@ -95,7 +106,7 @@ public class CtxNames
 			{
 				modifiers.add(token);
 			}
-			
+
 			firstToken = false;
 		}
 

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/compiere/util/CtxNames.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/compiere/util/CtxNames.java
@@ -1,0 +1,184 @@
+package org.compiere.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.adempiere.util.Check;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2017 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * This class contains the static methods and constants around {@link CtxName}.
+ * 
+ * @author metas-dev <dev@metasfresh.com>
+ *
+ */
+@UtilityClass
+public class CtxNames
+{
+	public static final String NAME_Marker = "@";
+	public static final String MODIFIER_Old = "old";
+
+
+	public static final String VALUE_NULL = null;
+	
+	public static final String SEPARATOR = "/";
+	private static final Splitter SEPARATOR_SPLITTER = Splitter.on(SEPARATOR)
+			//.omitEmptyStrings() // DO NOT omit empty strings because we want to support expressions like: @Description/@
+			;
+	
+	private static final List<String> MODIFIERS = ImmutableList.<String> builder()
+			.add(MODIFIER_Old)
+			.build();
+	
+	public Set<CtxName> parseStringsWithoutMarkers(@NonNull final Collection<String> strings)
+	{
+		return strings.stream()
+				.map(s -> parse(s))
+				.collect(Collectors.toSet());
+	}
+	
+	public Set<String> asNames(@NonNull final Collection<CtxName> ctxNames)
+	{
+		return ctxNames.stream()
+				.map(CtxName::getName)
+				.collect(Collectors.toSet());
+	}
+	
+	public static CtxName parse(final String contextWithoutMarkers)
+	{
+		if (contextWithoutMarkers == null)
+		{
+			return null;
+		}
+
+		String name = null;
+
+		final List<String> modifiers = new ArrayList<>();
+		boolean firstToken = true;
+		for (String token : SEPARATOR_SPLITTER.splitToList(contextWithoutMarkers))
+		{
+			if (firstToken)
+			{
+				name = token.trim();
+			}
+			else
+			{
+				modifiers.add(token);
+			}
+			
+			firstToken = false;
+		}
+
+		final String defaultValue;
+		if (!modifiers.isEmpty() && !isModifier(modifiers.get(modifiers.size() - 1)))
+		{
+			defaultValue = modifiers.remove(modifiers.size() - 1);
+		}
+		else
+		{
+			defaultValue = VALUE_NULL;
+		}
+
+		return new CtxName(name, modifiers, defaultValue);
+	}
+
+	/** Parse a given name, surrounded by {@value #NAME_Marker} */
+	public static CtxName parseWithMarkers(final String contextWithMarkers)
+	{
+		if (contextWithMarkers == null)
+		{
+			return null;
+		}
+
+		String contextWithoutMarkers = contextWithMarkers.trim();
+		if (contextWithoutMarkers.startsWith(NAME_Marker))
+		{
+			contextWithoutMarkers = contextWithoutMarkers.substring(1);
+		}
+		if (contextWithoutMarkers.endsWith(NAME_Marker))
+		{
+			contextWithoutMarkers = contextWithoutMarkers.substring(0, contextWithoutMarkers.length() - 1);
+		}
+
+		return parse(contextWithoutMarkers);
+	}
+
+	/**
+	 *
+	 * @param name
+	 * @param expression expression with context variables (e.g. sql where clause)
+	 * @return true if expression contains given name
+	 */
+	static boolean containsName(final String name, final String expression)
+	{
+		// FIXME: replace it with StringExpression
+		if (name == null || name.isEmpty())
+		{
+			return false;
+		}
+
+		if (expression == null || expression.isEmpty())
+		{
+			return false;
+		}
+
+		final int idx = expression.indexOf(NAME_Marker + name);
+		if (idx < 0)
+		{
+			return false;
+		}
+
+		final int idx2 = expression.indexOf(NAME_Marker, idx + 1);
+		if (idx2 < 0)
+		{
+			return false;
+		}
+
+		final String nameStr = expression.substring(idx + 1, idx2);
+		return name.equals(parse(nameStr).getName());
+	}
+
+	/**
+	 *
+	 * @param modifier
+	 * @return true if given string is a registered modifier
+	 */
+	public static boolean isModifier(final String modifier)
+	{
+		if (Check.isEmpty(modifier))
+		{
+			return false;
+		}
+		return MODIFIERS.contains(modifier);
+	}
+}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/compiere/util/CtxNames.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/compiere/util/CtxNames.java
@@ -65,7 +65,7 @@ public class CtxNames
 	 * @param stringsWithoutMarkers may not be {@code null}.
 	 * @return
 	 */
-	public Set<CtxName> parseStrings(@NonNull final Collection<String> stringsWithoutMarkers)
+	public Set<CtxName> parseAll(@NonNull final Collection<String> stringsWithoutMarkers)
 	{
 		return stringsWithoutMarkers.stream()
 				.map(CtxNames::parse)
@@ -78,7 +78,7 @@ public class CtxNames
 	 * @param ctxNames may not be {@code null}.
 	 * @return
 	 */
-	public Set<String> asNames(@NonNull final Collection<CtxName> ctxNames)
+	public Set<String> toNames(@NonNull final Collection<CtxName> ctxNames)
 	{
 		return ctxNames.stream()
 				.map(CtxName::getName)

--- a/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/expression/api/impl/StringExpressionCompilerTests.java
+++ b/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/expression/api/impl/StringExpressionCompilerTests.java
@@ -51,7 +51,7 @@ public class StringExpressionCompilerTests
 		{
 			final String sql = "C_BPartner_ID=@C_BPartner_Override_ID/-1@ AND C_BPartner_Location_ID=@C_BPartner_Location_Override_ID/-1@";
 			final IStringExpression expression = compiler.compile(sql);
-			final Set<String> dependsActual = expression.getParametersAsPlainStrings();
+			final Set<String> dependsActual = expression.getParameterNames();
 			final Set<String> dependsExpected = ImmutableSet.of("C_BPartner_Override_ID", "C_BPartner_Location_Override_ID");
 			assertEquals(dependsExpected, dependsActual);
 		}
@@ -59,7 +59,7 @@ public class StringExpressionCompilerTests
 			// test if is also works with strings and with nested '-signs
 			final String sql = "Type='@StringVar/'NONE'@' AND C_BPartner_Location_ID=@IntVar_ID/-1@ AND Type2='@NoDefaultStringVar@'";
 			final IStringExpression expression = compiler.compile(sql);
-			final Set<String> dependsActual = expression.getParametersAsPlainStrings();
+			final Set<String> dependsActual = expression.getParameterNames();
 			final Set<String> dependsExpected = ImmutableSet.of("StringVar", "IntVar_ID", "NoDefaultStringVar");
 			assertEquals(dependsExpected, dependsActual);
 		}
@@ -71,7 +71,7 @@ public class StringExpressionCompilerTests
 		final String expressionStr = "C_BPartner_ID=@C_BPartner_ID@ AND Text='@@'";
 		final IStringExpression expression = compiler.compile(expressionStr);
 		final Set<String> expectedParams = ImmutableSet.of("C_BPartner_ID");
-		assertEquals("Invalid params", expectedParams, expression.getParametersAsPlainStrings());
+		assertEquals("Invalid params", expectedParams, expression.getParameterNames());
 
 		assertEquals("Formated expression shall be equal to initial expression", expressionStr, expression.getFormatedExpressionString());
 

--- a/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/expression/api/impl/StringExpressionCompilerTests.java
+++ b/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/expression/api/impl/StringExpressionCompilerTests.java
@@ -51,7 +51,7 @@ public class StringExpressionCompilerTests
 		{
 			final String sql = "C_BPartner_ID=@C_BPartner_Override_ID/-1@ AND C_BPartner_Location_ID=@C_BPartner_Location_Override_ID/-1@";
 			final IStringExpression expression = compiler.compile(sql);
-			final Set<String> dependsActual = expression.getParameters();
+			final Set<String> dependsActual = expression.getParametersAsPlainStrings();
 			final Set<String> dependsExpected = ImmutableSet.of("C_BPartner_Override_ID", "C_BPartner_Location_Override_ID");
 			assertEquals(dependsExpected, dependsActual);
 		}
@@ -59,7 +59,7 @@ public class StringExpressionCompilerTests
 			// test if is also works with strings and with nested '-signs
 			final String sql = "Type='@StringVar/'NONE'@' AND C_BPartner_Location_ID=@IntVar_ID/-1@ AND Type2='@NoDefaultStringVar@'";
 			final IStringExpression expression = compiler.compile(sql);
-			final Set<String> dependsActual = expression.getParameters();
+			final Set<String> dependsActual = expression.getParametersAsPlainStrings();
 			final Set<String> dependsExpected = ImmutableSet.of("StringVar", "IntVar_ID", "NoDefaultStringVar");
 			assertEquals(dependsExpected, dependsActual);
 		}
@@ -71,7 +71,7 @@ public class StringExpressionCompilerTests
 		final String expressionStr = "C_BPartner_ID=@C_BPartner_ID@ AND Text='@@'";
 		final IStringExpression expression = compiler.compile(expressionStr);
 		final Set<String> expectedParams = ImmutableSet.of("C_BPartner_ID");
-		assertEquals("Invalid params", expectedParams, expression.getParameters());
+		assertEquals("Invalid params", expectedParams, expression.getParametersAsPlainStrings());
 
 		assertEquals("Formated expression shall be equal to initial expression", expressionStr, expression.getFormatedExpressionString());
 

--- a/de.metas.adempiere.adempiere/base/src/test/java/org/compiere/util/CtxNamesTests.java
+++ b/de.metas.adempiere.adempiere/base/src/test/java/org/compiere/util/CtxNamesTests.java
@@ -39,7 +39,7 @@ import org.junit.Test;
  * 
  * @author tsa
  */
-public class CtxNameTests
+public class CtxNamesTests
 {
 	private static final List<String> NO_MODIFIERS = null;
 
@@ -62,16 +62,16 @@ public class CtxNameTests
 				//
 				")";
 
-		assertTrue(CtxName.containsName("C_BPartner_ID", sql));
-		assertTrue(CtxName.containsName("IsSOTrx", sql));
-		assertTrue(CtxName.containsName("C_BPartner_Location_ID", sql));
-		assertFalse(CtxName.containsName("C_BPartner", sql));
-		assertFalse(CtxName.containsName("Bill_BPartner_ID", sql));
+		assertTrue(CtxNames.containsName("C_BPartner_ID", sql));
+		assertTrue(CtxNames.containsName("IsSOTrx", sql));
+		assertTrue(CtxNames.containsName("C_BPartner_Location_ID", sql));
+		assertFalse(CtxNames.containsName("C_BPartner", sql));
+		assertFalse(CtxNames.containsName("Bill_BPartner_ID", sql));
 
-		assertTrue(CtxName.containsName("C_BPartner_ID2", sql));
-		assertTrue(CtxName.containsName("My_BPartner_ID2", sql));
-		assertFalse(CtxName.containsName("My_BPartner_ID", sql));
-		assertTrue(CtxName.containsName("C_BPartner_ID3", sql));
+		assertTrue(CtxNames.containsName("C_BPartner_ID2", sql));
+		assertTrue(CtxNames.containsName("My_BPartner_ID2", sql));
+		assertFalse(CtxNames.containsName("My_BPartner_ID", sql));
+		assertTrue(CtxNames.containsName("C_BPartner_ID3", sql));
 	}
 
 	@Test
@@ -79,41 +79,41 @@ public class CtxNameTests
 	{
 		{
 			CtxName expected = new CtxName("Name", NO_MODIFIERS, null);
-			CtxName actual = CtxName.parse("Name");
+			CtxName actual = CtxNames.parse("Name");
 			assertEquals(expected, actual);
 		}
 		{
 			CtxName expected = new CtxName("Name", NO_MODIFIERS, "defaultValue");
-			CtxName actual = CtxName.parse("Name/defaultValue");
+			CtxName actual = CtxNames.parse("Name/defaultValue");
 			assertEquals(expected, actual);
 		}
 		{
 			// default value should be returned as-is (e.g. "@Name/'Tobi'@" should default to "'Tobi'", not "Tobi")
 			CtxName expected = new CtxName("Name", NO_MODIFIERS, "'defaultValue'");
-			CtxName actual = CtxName.parse("Name/'defaultValue'");
+			CtxName actual = CtxNames.parse("Name/'defaultValue'");
 			assertEquals(expected, actual);
 		}
 		{
-			CtxName expected = new CtxName("Name", Arrays.asList(CtxName.MODIFIER_Old), null);
-			CtxName actual = CtxName.parse("Name/" + CtxName.MODIFIER_Old);
+			CtxName expected = new CtxName("Name", Arrays.asList(CtxNames.MODIFIER_Old), null);
+			CtxName actual = CtxNames.parse("Name/" + CtxNames.MODIFIER_Old);
 			assertEquals(expected, actual);
 		}
 		{
 			// also make sure we did not changed the modifier name
 			CtxName expected = new CtxName("Name", Arrays.asList("old"), null);
-			CtxName actual = CtxName.parse("Name/old");
+			CtxName actual = CtxNames.parse("Name/old");
 			assertEquals(expected, actual);
 		}
 		{
 			// also make sure we did not changed the modifier name
 			CtxName expected = new CtxName("Name", Arrays.asList("old"), "def");
-			CtxName actual = CtxName.parse("Name/old/def");
+			CtxName actual = CtxNames.parse("Name/old/def");
 			assertEquals(expected, actual);
 		}
 		{
 			// also make sure we did not changed the modifier name
 			CtxName expected = new CtxName("Name", Arrays.asList("old", "upper", "lower"), "def2");
-			CtxName actual = CtxName.parse("Name/old/upper/lower/def2");
+			CtxName actual = CtxNames.parse("Name/old/upper/lower/def2");
 			assertEquals(expected, actual);
 		}
 	}
@@ -124,21 +124,21 @@ public class CtxNameTests
 		MockedEvaluatee ev = new MockedEvaluatee();
 		ev.put("name1", "value1");
 		ev.put("name2", "value2");
-		assertEquals("value1", CtxName.parse("name1").getValueAsString(ev));
-		assertEquals("value1", CtxName.parse("name1/old/default").getValueAsString(ev));
-		assertEquals("value1", CtxName.parse("name1/upper/old/default").getValueAsString(ev));
+		assertEquals("value1", CtxNames.parse("name1").getValueAsString(ev));
+		assertEquals("value1", CtxNames.parse("name1/old/default").getValueAsString(ev));
+		assertEquals("value1", CtxNames.parse("name1/upper/old/default").getValueAsString(ev));
 
 		MockedEvaluatee2 ev2 = new MockedEvaluatee2();
 		ev2.put("name1", "value1", "valueOld1");
 		ev2.put("name2", "value2", "valueOld2");
-		assertEquals("value1", CtxName.parse("name1").getValueAsString(ev2));
-		assertEquals("valueOld1", CtxName.parse("name1/old/default").getValueAsString(ev2));
-		assertEquals("valueOld1", CtxName.parse("name1/upper/old/default").getValueAsString(ev2));
+		assertEquals("value1", CtxNames.parse("name1").getValueAsString(ev2));
+		assertEquals("valueOld1", CtxNames.parse("name1/old/default").getValueAsString(ev2));
+		assertEquals("valueOld1", CtxNames.parse("name1/upper/old/default").getValueAsString(ev2));
 
-		assertNull(CtxName.parse("nameUnknown").getValueAsString(ev2));
-		assertEquals("default", CtxName.parse("nameUnknown/default").getValueAsString(ev2));
-		assertEquals("default", CtxName.parse("nameUnknown/old/default").getValueAsString(ev2));
-		assertEquals("default", CtxName.parse("nameUnknown/upper/old/default").getValueAsString(ev2));
+		assertNull(CtxNames.parse("nameUnknown").getValueAsString(ev2));
+		assertEquals("default", CtxNames.parse("nameUnknown/default").getValueAsString(ev2));
+		assertEquals("default", CtxNames.parse("nameUnknown/old/default").getValueAsString(ev2));
+		assertEquals("default", CtxNames.parse("nameUnknown/upper/old/default").getValueAsString(ev2));
 	}
 
 	@Test
@@ -147,7 +147,7 @@ public class CtxNameTests
 		final MockedEvaluatee evalCtx = new MockedEvaluatee();
 
 		// NOTE: variable name ends with "_ID"
-		final CtxName name = CtxName.parse("Test_ID/123");
+		final CtxName name = CtxNames.parse("Test_ID/123");
 
 		assertEquals("It shall return default value", "123", name.getValueAsString(evalCtx));
 	}
@@ -158,7 +158,7 @@ public class CtxNameTests
 		final MockedEvaluatee evalCtx = new MockedEvaluatee();
 
 		// NOTE: variable name DOES NOT end with "_ID"
-		final CtxName name = CtxName.parse("Test/123");
+		final CtxName name = CtxNames.parse("Test/123");
 
 		assertEquals("It shall return default value", "123", name.getValueAsString(evalCtx));
 	}
@@ -170,9 +170,9 @@ public class CtxNameTests
 		evalCtx.hasVariableReturn = false;
 
 		// NOTE: variable name ends with "_ID"
-		final CtxName name = CtxName.parse("Test_ID");
+		final CtxName name = CtxNames.parse("Test_ID");
 
-		assertEquals("It shall return null value", CtxName.VALUE_NULL, name.getValueAsString(evalCtx));
+		assertEquals("It shall return null value", CtxNames.VALUE_NULL, name.getValueAsString(evalCtx));
 	}
 
 	@Test
@@ -182,9 +182,9 @@ public class CtxNameTests
 		evalCtx.hasVariableReturn = false;
 
 		// NOTE: variable name DOES NOT end with "_ID"
-		final CtxName name = CtxName.parse("Test");
+		final CtxName name = CtxNames.parse("Test");
 
-		assertEquals("It shall return null value", CtxName.VALUE_NULL, name.getValueAsString(evalCtx));
+		assertEquals("It shall return null value", CtxNames.VALUE_NULL, name.getValueAsString(evalCtx));
 	}
 
 	@Test
@@ -193,7 +193,7 @@ public class CtxNameTests
 		final MockedEvaluatee2 evalCtx = new MockedEvaluatee2();
 		evalCtx.hasVariableReturn = false;
 
-		final CtxName name = CtxName.parse("Test/defaultValue");
+		final CtxName name = CtxNames.parse("Test/defaultValue");
 
 		assertEquals("It shall return default value", "defaultValue", name.getValueAsString(evalCtx));
 	}
@@ -204,9 +204,9 @@ public class CtxNameTests
 		final MockedEvaluatee2 evalCtx = new MockedEvaluatee2();
 		evalCtx.hasVariableReturn = false;
 
-		final CtxName name = CtxName.parse("Test");
+		final CtxName name = CtxNames.parse("Test");
 
-		assertEquals("It shall return null value", CtxName.VALUE_NULL, name.getValueAsString(evalCtx));
+		assertEquals("It shall return null value", CtxNames.VALUE_NULL, name.getValueAsString(evalCtx));
 	}
 
 	@Test
@@ -217,16 +217,16 @@ public class CtxNameTests
 		ev2.put("name2", "value2", "valueOld2");
 		ev2.hasVariableReturn = false;
 
-		assertEquals(CtxName.VALUE_NULL, CtxName.parse("nameUnknown").getValueAsString(ev2));
-		assertEquals(CtxName.VALUE_NULL, CtxName.parse("name1").getValueAsString(ev2));
-		assertEquals("default", CtxName.parse("name1/old/default").getValueAsString(ev2));
-		assertEquals("default", CtxName.parse("name1/upper/old/default").getValueAsString(ev2));
+		assertEquals(CtxNames.VALUE_NULL, CtxNames.parse("nameUnknown").getValueAsString(ev2));
+		assertEquals(CtxNames.VALUE_NULL, CtxNames.parse("name1").getValueAsString(ev2));
+		assertEquals("default", CtxNames.parse("name1/old/default").getValueAsString(ev2));
+		assertEquals("default", CtxNames.parse("name1/upper/old/default").getValueAsString(ev2));
 	}
 
 	@Test
 	public void test_EmptyDefault()
 	{
-		final CtxName ctxName = CtxName.parseWithMarkers("@Description/@");
+		final CtxName ctxName = CtxNames.parseWithMarkers("@Description/@");
 		assertEquals("Name", "Description", ctxName.getName());
 		assertEquals("DefaultValue", "", ctxName.getDefaultValue());
 	}

--- a/de.metas.adempiere.adempiere/base/src/test/java/org/compiere/util/EvaluatorTests.java
+++ b/de.metas.adempiere.adempiere/base/src/test/java/org/compiere/util/EvaluatorTests.java
@@ -1,5 +1,7 @@
 package org.compiere.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /*
  * #%L
  * de.metas.adempiere.adempiere.base
@@ -52,7 +54,7 @@ public class EvaluatorTests
 			List<String> dependsActual = new ArrayList<String>();
 			List<String> dependsExpected = Arrays.asList("C_BPartner_Override_ID", "C_BPartner_Location_Override_ID");
 			Evaluator.parseDepends(dependsActual, sql);
-			assertEquals(dependsExpected, dependsActual);
+			assertThat(dependsActual).containsAll(dependsExpected);
 		}
 		{
 			// test if is also works with strings and with nested '-signs
@@ -60,7 +62,7 @@ public class EvaluatorTests
 			List<String> dependsActual = new ArrayList<String>();
 			List<String> dependsExpected = Arrays.asList("StringVar", "IntVar_ID", "NoDefaultStringVar");
 			Evaluator.parseDepends(dependsActual, sql);
-			assertEquals(dependsExpected, dependsActual);
+			assertThat(dependsActual).containsAll(dependsExpected);
 		}
 	}
 

--- a/de.metas.handlingunits.base/de.metas.handlingunits_GenerateModels.launch
+++ b/de.metas.handlingunits.base/de.metas.handlingunits_GenerateModels.launch
@@ -17,5 +17,5 @@
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="./src/main/java-gen/de/metas/handlingunits/model/&#13;&#10;de.metas.handlingunits.model&#13;&#10;'de.metas.handlingunits'"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="de.metas.handlingunits.base"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-DPropertyFile=${project_loc:metasfresh-dist}/metasfresh.properties"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-DPropertyFile=${project_loc:metasfresh-sp80}/metasfresh.properties"/>
 </launchConfiguration>

--- a/de.metas.handlingunits.base/src/main/java/org/adempiere/mm/attributes/spi/impl/HUSubProducerBPartnerAttributeValuesProvider.java
+++ b/de.metas.handlingunits.base/src/main/java/org/adempiere/mm/attributes/spi/impl/HUSubProducerBPartnerAttributeValuesProvider.java
@@ -21,6 +21,7 @@ import org.compiere.model.X_M_Attribute;
 import org.compiere.util.CCache;
 import org.compiere.util.CCache.CCacheStats;
 import org.compiere.util.CtxName;
+import org.compiere.util.CtxNames;
 import org.compiere.util.Env;
 import org.compiere.util.Evaluatee;
 import org.compiere.util.Evaluatees;
@@ -78,9 +79,9 @@ class HUSubProducerBPartnerAttributeValuesProvider implements IAttributeValuesPr
 	private static final ITranslatableString DISPLAYNAME_None = Services.get(IMsgBL.class).translatable("NoneOrEmpty");
 	private static final ConcurrentHashMap<String, KeyNamePair> adLanguage2keyNamePairNone = new ConcurrentHashMap<>();
 
-	private static final CtxName CTXNAME_M_HU_ID = CtxName.parse("M_HU_ID/-1");
-	private static final CtxName CTXNAME_C_BPartner_ID = CtxName.parse("C_BPartner_ID/-1");
-	private static final CtxName CTXNAME_CurrentSubProducer_BPartner_ID = CtxName.parse("CurrentSubProducer_BPartner_ID/-1");
+	private static final CtxName CTXNAME_M_HU_ID = CtxNames.parse("M_HU_ID/-1");
+	private static final CtxName CTXNAME_C_BPartner_ID = CtxNames.parse("C_BPartner_ID/-1");
+	private static final CtxName CTXNAME_CurrentSubProducer_BPartner_ID = CtxNames.parse("CurrentSubProducer_BPartner_ID/-1");
 
 	//
 	//

--- a/de.metas.payment.esr/src/main/java/de/metas/payment/esr/process/ESR_Import_LoadFromAttachmentEntry.java
+++ b/de.metas.payment.esr/src/main/java/de/metas/payment/esr/process/ESR_Import_LoadFromAttachmentEntry.java
@@ -1,0 +1,81 @@
+package de.metas.payment.esr.process;
+
+import org.adempiere.util.Services;
+
+import de.metas.async.model.I_C_Async_Batch;
+import de.metas.attachments.AttachmentEntry;
+import de.metas.attachments.IAttachmentDAO;
+import de.metas.payment.esr.dataimporter.ESRImportEnqueuer;
+import de.metas.payment.esr.dataimporter.ESRImportEnqueuerDataSource;
+import de.metas.payment.esr.dataimporter.ESRImportEnqueuerDuplicateFilePolicy;
+import de.metas.payment.esr.model.I_ESR_Import;
+import de.metas.process.JavaProcess;
+import de.metas.process.Param;
+import de.metas.process.RunOutOfTrx;
+
+/*
+ * #%L
+ * de.metas.payment.esr
+ * %%
+ * Copyright (C) 2017 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+public class ESR_Import_LoadFromAttachmentEntry
+		extends JavaProcess
+{
+	// services
+	private final transient IAttachmentDAO attachmentDAO = Services.get(IAttachmentDAO.class);
+
+	// Parameters
+	@Param(mandatory = true, parameterName = "AD_AttachmentEntry_ID")
+	private int p_AD_AttachmentEntry_ID;
+
+	@Param(mandatory = true, parameterName = I_C_Async_Batch.COLUMNNAME_Name)
+	private final String p_AsyncBatchName = "ESR Import";
+
+	@Param(mandatory = true, parameterName = I_C_Async_Batch.COLUMNNAME_Description)
+	private final String p_AsyncBatchDesc = "ESR Import process";
+
+	@Override
+	@RunOutOfTrx
+	protected String doIt()
+	{
+		final AttachmentEntry fromAttachmentEntry = attachmentDAO.retrieveAttachmentEntryById(-1, p_AD_AttachmentEntry_ID); // attachmentId = -1
+
+		ESRImportEnqueuer.newInstance()
+				.esrImport(getRecord(I_ESR_Import.class))
+				.fromDataSource(ESRImportEnqueuerDataSource.builder()
+						.filename(fromAttachmentEntry.getFilename())
+						.content(attachmentDAO.retrieveData(fromAttachmentEntry))
+						.attachmentEntryId(fromAttachmentEntry.getId())
+						.build())
+				//
+				.asyncBatchName(p_AsyncBatchName)
+				.asyncBatchDesc(p_AsyncBatchDesc)
+				.adPInstanceId(getAD_PInstance_ID())
+				//
+				.loggable(this)
+				//
+				.duplicateFilePolicy(ESRImportEnqueuerDuplicateFilePolicy.NEVER)
+				//
+				.execute();
+
+		return MSG_OK;
+	}
+
+}

--- a/de.metas.payment.esr/src/main/sql/postgresql/system/5471660_sys_gh142webui_ESR_Import_LoadFromAttachmentEntry.sql
+++ b/de.metas.payment.esr/src/main/sql/postgresql/system/5471660_sys_gh142webui_ESR_Import_LoadFromAttachmentEntry.sql
@@ -1,0 +1,100 @@
+-- 2017-09-14T14:47:19.202
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Process (AccessLevel,AD_Client_ID,AD_Org_ID,AD_Process_ID,AllowProcessReRun,Classname,CopyFromProcess,Created,CreatedBy,EntityType,IsActive,IsApplySecuritySettings,IsBetaFunctionality,IsDirectPrint,IsOneInstanceOnly,IsReport,IsServerProcess,IsUseBPartnerLanguage,LockWaitTimeout,Name,RefreshAllAfterExecution,ShowHelp,Type,Updated,UpdatedBy,Value) VALUES ('3',0,0,540829,'N','de.metas.payment.esr.process.ESR_Import_LoadFromAttachmentEntry','N',TO_TIMESTAMP('2017-09-14 14:47:19','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr','Y','N','Y','N','N','N','N','Y',0,'1. V11-Datei importieren (attachment)','N','Y','Java',TO_TIMESTAMP('2017-09-14 14:47:19','YYYY-MM-DD HH24:MI:SS'),100,'ESR_Import_LoadFromAttachmentEntry')
+;
+
+-- 2017-09-14T14:47:19.210
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Process_Trl (AD_Language,AD_Process_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Process_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Process t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Process_ID=540829 AND NOT EXISTS (SELECT 1 FROM AD_Process_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_ID=t.AD_Process_ID)
+;
+
+-- 2017-09-14T14:47:29.911
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process SET IsBetaFunctionality='N',Updated=TO_TIMESTAMP('2017-09-14 14:47:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=540829
+;
+
+-- 2017-09-14T14:47:54.774
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process SET AccessLevel='3', AD_Client_ID=0, AD_Form_ID=NULL, AD_Org_ID=0, AD_PrintFormat_ID=NULL, AD_ReportView_ID=NULL, AD_Workflow_ID=NULL, AllowProcessReRun='N', Classname='de.metas.payment.esr.process.ESR_Import_LoadFromFile', CopyFromProcess='N', Description=NULL, EntityType='de.metas.payment.esr', Help=NULL, IsActive='Y', IsApplySecuritySettings='N', IsBetaFunctionality='Y', IsDirectPrint='N', IsOneInstanceOnly='N', IsReport='N', IsServerProcess='N', IsUseBPartnerLanguage='Y', JasperReport=NULL, JasperReport_Tabular=NULL, LockWaitTimeout=0, ProcedureName=NULL, RefreshAllAfterExecution='N', ShowHelp='Y', SQLStatement=NULL, Type='Java', WorkflowValue=NULL,Updated=TO_TIMESTAMP('2017-09-14 14:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=540829
+;
+
+-- 2017-09-14T14:47:54.946
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAutocomplete,IsCentrallyMaintained,IsMandatory,IsRange,Name,SeqNo,Updated,UpdatedBy) VALUES (0,2295,0,540829,541207,39,'FileName',TO_TIMESTAMP('2017-09-14 14:47:54','YYYY-MM-DD HH24:MI:SS'),100,'Name of the local file or URL','de.metas.payment.esr',0,'Name of a file in the local directory space - or URL (file://.., http://.., ftp://..)','Y','N','Y','Y','N','Datei öffnen',10,TO_TIMESTAMP('2017-09-14 14:47:54','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2017-09-14T14:47:54.956
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Process_Para_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Process_Para t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Process_Para_ID=541207 AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+-- 2017-09-14T14:47:54.965
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_Process_Para_Trl WHERE AD_Process_Para_ID = 541207
+;
+
+-- 2017-09-14T14:47:54.966
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Process_Para_Trl (AD_Process_Para_ID, AD_Language,  AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,  Name, Description, Help, IsTranslated)  SELECT AD_Process_Para_ID, AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy,  Updated, UpdatedBy, Name, Description, Help, IsTranslated  FROM AD_Process_Para_Trl WHERE AD_Process_Para_ID = 541207
+;
+
+-- 2017-09-14T14:47:55.033
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,ColumnName,Created,CreatedBy,DefaultValue,EntityType,FieldLength,IsActive,IsAutocomplete,IsCentrallyMaintained,IsMandatory,IsRange,Name,SeqNo,Updated,UpdatedBy) VALUES (0,0,540829,541208,10,'Name',TO_TIMESTAMP('2017-09-14 14:47:54','YYYY-MM-DD HH24:MI:SS'),100,'ESR Import','de.metas.payment.esr',60,'Y','N','Y','Y','N','Name',20,TO_TIMESTAMP('2017-09-14 14:47:54','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2017-09-14T14:47:55.035
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Process_Para_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Process_Para t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Process_Para_ID=541208 AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+-- 2017-09-14T14:47:55.037
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_Process_Para_Trl WHERE AD_Process_Para_ID = 541208
+;
+
+-- 2017-09-14T14:47:55.038
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Process_Para_Trl (AD_Process_Para_ID, AD_Language,  AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,  Name, Description, Help, IsTranslated)  SELECT AD_Process_Para_ID, AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy,  Updated, UpdatedBy, Name, Description, Help, IsTranslated  FROM AD_Process_Para_Trl WHERE AD_Process_Para_ID = 541208
+;
+
+-- 2017-09-14T14:47:55.102
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,ColumnName,Created,CreatedBy,DefaultValue,EntityType,FieldLength,IsActive,IsAutocomplete,IsCentrallyMaintained,IsMandatory,IsRange,Name,SeqNo,Updated,UpdatedBy) VALUES (0,275,0,540829,541209,10,'Description',TO_TIMESTAMP('2017-09-14 14:47:55','YYYY-MM-DD HH24:MI:SS'),100,'ESR Import Prozess','de.metas.payment.esr',100,'Y','N','Y','Y','N','Beschreibung',30,TO_TIMESTAMP('2017-09-14 14:47:55','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2017-09-14T14:47:55.103
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Process_Para_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Process_Para t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Process_Para_ID=541209 AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+-- 2017-09-14T14:47:55.104
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_Process_Para_Trl WHERE AD_Process_Para_ID = 541209
+;
+
+-- 2017-09-14T14:47:55.104
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Process_Para_Trl (AD_Process_Para_ID, AD_Language,  AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,  Name, Description, Help, IsTranslated)  SELECT AD_Process_Para_ID, AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy,  Updated, UpdatedBy, Name, Description, Help, IsTranslated  FROM AD_Process_Para_Trl WHERE AD_Process_Para_ID = 541209
+;
+
+-- 2017-09-14T14:48:10.457
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process SET Classname='de.metas.payment.esr.process.ESR_Import_LoadFromAttachmentEntry', IsBetaFunctionality='N',Updated=TO_TIMESTAMP('2017-09-14 14:48:10','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=540829
+;
+
+-- 2017-09-14T14:50:38.342
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Val_Rule (AD_Client_ID,AD_Org_ID,AD_Val_Rule_ID,Code,Created,CreatedBy,EntityType,IsActive,Name,Type,Updated,UpdatedBy) VALUES (0,0,540370,'AD_Table_ID=get_Table_ID(''ESR_Import'') and Record_ID=@ESR_Import_ID@',TO_TIMESTAMP('2017-09-14 14:50:38','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr','Y','ESR_Import_AD_AttachmentEntry','S',TO_TIMESTAMP('2017-09-14 14:50:38','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2017-09-14T14:51:00.949
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process_Para SET AD_Element_ID=543390, AD_Reference_ID=19, AD_Val_Rule_ID=540370, ColumnName='AD_AttachmentEntry_ID', Description=NULL, Help=NULL, Name='Attachment entry',Updated=TO_TIMESTAMP('2017-09-14 14:51:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_Para_ID=541207
+;
+
+-- 2017-09-14T14:51:21.241
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Table_Process (AD_Client_ID,AD_Org_ID,AD_Process_ID,AD_Table_ID,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy,WEBUI_QuickAction,WEBUI_QuickAction_Default) VALUES (0,0,540829,540409,TO_TIMESTAMP('2017-09-14 14:51:21','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr','Y',TO_TIMESTAMP('2017-09-14 14:51:21','YYYY-MM-DD HH24:MI:SS'),100,'N','N')
+;
+


### PR DESCRIPTION
Augment IExpression to return CtxNames instead of strings as parameters

* IExpression: rename getParameters() to getParamertsAsPlainStrings and
added a new method getParameters() that returns CtxNames.
CtxNames are more useful because they can contain a default value, but
they can also contain a "normal" string.
In our case, we need CtxNames so we can evaluate the @CtxVar/Default@
notation that is contained in many of the expressions we deal with.
* CtxNames: add new static utility class around CtxNames to separate the
static code from the actual instance code. 
* Implement the new CtxName returning getParameters() method wherever
needed; in most cases that means returning the CtxNames that are already
embedded in the respective implementations.

Lookup validation rule shall support @CtxName/Default@ annotation
https://github.com/metasfresh/metasfresh-webui-api/issues/585