### PR TITLE
#2934 Additional Locator Dimensions

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5477010_sys_gh2934-locator-trl-fix.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5477010_sys_gh2934-locator-trl-fix.sql
@@ -1,0 +1,15 @@
+-- 2017-11-14T05:44:50.135
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2017-11-14 05:44:50','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Rack' WHERE AD_Field_ID=560486 AND AD_Language='en_US'
+;
+
+-- 2017-11-14T05:45:02.209
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET EntityType='D',Updated=TO_TIMESTAMP('2017-11-14 05:45:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=560486
+;
+
+-- 2017-11-14T05:45:45.548
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsMandatory='Y',Updated=TO_TIMESTAMP('2017-11-14 05:45:45','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=557832
+;
+


### PR DESCRIPTION
Fixes a missing Translation for Locator Dimension and adding a mandatory Logic for (X1, Rack)

FRESH-3952 https://github.com/metasfresh/metasfresh/issues/2934