### PR TITLE
#3159 Translation Tab content missing for Product_Trl

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5479800_sys_gh3159-show-product-trl-again.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5479800_sys_gh3159-show-product-trl-again.sql
@@ -1,0 +1,33 @@
+--
+-- the following is about the tables C_BPartner_Product and C_BPartner_Product_Trl
+--
+-- 2017-12-07T08:01:48.537
+-- URL zum Konzept
+UPDATE AD_Column SET IsIdentifier='Y', SeqNo=10,Updated=TO_TIMESTAMP('2017-12-07 08:01:48','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=557915
+;
+
+-- 2017-12-07T08:02:55.151
+-- URL zum Konzept
+UPDATE AD_Column SET IsIdentifier='Y', IsUpdateable='N', SeqNo=20,Updated=TO_TIMESTAMP('2017-12-07 08:02:55','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=557940
+;
+
+-- 2017-12-07T08:04:39.293
+-- URL zum Konzept
+UPDATE AD_Table SET IsChangeLog='Y',Updated=TO_TIMESTAMP('2017-12-07 08:04:39','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Table_ID=540862
+;
+
+-- 2017-12-07T08:04:57.046
+-- URL zum Konzept
+UPDATE AD_Column SET IsIdentifier='Y', IsUpdateable='N', SeqNo=10,Updated=TO_TIMESTAMP('2017-12-07 08:04:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=10163
+;
+
+-- 2017-12-07T08:05:35.451
+-- URL zum Konzept
+UPDATE AD_Column SET IsIdentifier='Y', IsUpdateable='N', SeqNo=20,Updated=TO_TIMESTAMP('2017-12-07 08:05:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=10171
+;
+
+-- 2017-12-07T13:20:30.993
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab SET AD_Column_ID=3321,Updated=TO_TIMESTAMP('2017-12-07 13:20:30','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Tab_ID=235
+;
+


### PR DESCRIPTION
Fixing the Trabnslation Tab for Products. Now showing the Translation records again.

https://github.com/metasfresh/metasfresh/issues/3159