### PR TITLE
#3260 Undisplaying the Accounting Tab in Window Warehouse for WebUI

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5481410_sys_gh3260-warehouse-acct-tab-undisplay-webui.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5481410_sys_gh3260-warehouse-acct-tab-undisplay-webui.sql
@@ -1,0 +1,5 @@
+-- 2018-01-02T10:39:31.325
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab SET DisplayLogic='@#IsWebUI/N@=N',Updated=TO_TIMESTAMP('2018-01-02 10:39:31','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Tab_ID=209
+;
+


### PR DESCRIPTION
Undisplaying the Accounting Tab in Window Warehouse for WebUI

https://github.com/metasfresh/metasfresh/issues/3260