### PR TITLE
#3196 If there is no print format defined, throw an exception

### DIFF
--- a/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/spi/impl/DefaultModelArchiver.java
+++ b/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/spi/impl/DefaultModelArchiver.java
@@ -361,6 +361,10 @@ public class DefaultModelArchiver
 			{
 				printFormatId = getAD_PrintFormat_ID();
 			}
+			if (printFormatId < 0)
+			{
+				throw new AdempiereException("NoDocPrintFormat");
+			}
 			final MPrintFormat printFormat = MPrintFormat.get(ctx, printFormatId, readFromDisk);
 
 			final Language language = getLanguage();

--- a/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/spi/impl/DefaultModelArchiver.java
+++ b/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/spi/impl/DefaultModelArchiver.java
@@ -361,7 +361,7 @@ public class DefaultModelArchiver
 			{
 				printFormatId = getAD_PrintFormat_ID();
 			}
-			if (printFormatId < 0)
+			if (printFormatId <= 0)
 			{
 				throw new AdempiereException("NoDocPrintFormat");
 			}


### PR DESCRIPTION
#3196 dunning run: Exception on PDF generation