### PR TITLE
#3428 Removed Daterange Option in Filter Parm

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5484410_sys_gh3428-daterange-prepdate-filter-manufacturing-order.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5484410_sys_gh3428-daterange-prepdate-filter-manufacturing-order.sql
@@ -1,0 +1,5 @@
+-- 2018-02-01T09:01:32.078
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsRangeFilter='N',Updated=TO_TIMESTAMP('2018-02-01 09:01:32','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=550561
+;
+


### PR DESCRIPTION
Removed Daterange Option in Filter Parm o Preparation Date
https://github.com/metasfresh/metasfresh/issues/3428