### PR TITLE
#3439 Improvement of GO Delivery Order Window

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5484590_sys_gh3439-go-deliveryorder-improvements-webui.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5484590_sys_gh3439-go-deliveryorder-improvements-webui.sql
@@ -48,3 +48,13 @@ UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=541350, SeqNo=90,Updated=TO_TIMES
 UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=541350, SeqNo=100,Updated=TO_TIMESTAMP('2018-02-03 08:07:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550089
 ;
 
+-- 2018-02-03T08:12:37.416
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_ElementGroup WHERE AD_UI_ElementGroup_ID=541352
+;
+
+-- 2018-02-03T08:12:55.408
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_ElementGroup SET SeqNo=20,Updated=TO_TIMESTAMP('2018-02-03 08:12:55','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_ElementGroup_ID=541351
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5484590_sys_gh3439-go-deliveryorder-improvements-webui.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5484590_sys_gh3439-go-deliveryorder-improvements-webui.sql
@@ -1,0 +1,50 @@
+-- 2018-02-03T08:05:06.683
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=541354, SeqNo=130,Updated=TO_TIMESTAMP('2018-02-03 08:05:06','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550095
+;
+
+-- 2018-02-03T08:05:30.621
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=541350, SeqNo=50,Updated=TO_TIMESTAMP('2018-02-03 08:05:30','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550096
+;
+
+-- 2018-02-03T08:05:39.886
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=541350, SeqNo=60,Updated=TO_TIMESTAMP('2018-02-03 08:05:39','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550097
+;
+
+-- 2018-02-03T08:06:09.340
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsAdvancedField='Y',Updated=TO_TIMESTAMP('2018-02-03 08:06:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550095
+;
+
+-- 2018-02-03T08:06:17.446
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsAdvancedField='N',Updated=TO_TIMESTAMP('2018-02-03 08:06:17','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550096
+;
+
+-- 2018-02-03T08:06:18.405
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsAdvancedField='N',Updated=TO_TIMESTAMP('2018-02-03 08:06:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550097
+;
+
+-- 2018-02-03T08:07:36.078
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=541350, SeqNo=70,Updated=TO_TIMESTAMP('2018-02-03 08:07:36','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550098
+;
+
+-- 2018-02-03T08:07:40.088
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=541350, SeqNo=80,Updated=TO_TIMESTAMP('2018-02-03 08:07:40','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550099
+;
+
+-- 2018-02-03T08:07:44.823
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=541350, SeqNo=90,Updated=TO_TIMESTAMP('2018-02-03 08:07:44','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550088
+;
+
+-- 2018-02-03T08:07:52.287
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET AD_UI_ElementGroup_ID=541350, SeqNo=100,Updated=TO_TIMESTAMP('2018-02-03 08:07:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550089
+;
+


### PR DESCRIPTION
Removing UI Group from GO! Delivery Order WIndow. Rearranging important Fields moving them from advanced edit to the main view.

https://github.com/metasfresh/metasfresh/issues/3439