### PR TITLE
#3467 Adds Daterange config to preparation Date

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5485110_sys_gh3467-preparation-daterange-webui.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5485110_sys_gh3467-preparation-daterange-webui.sql
@@ -1,0 +1,5 @@
+-- 2018-02-10T08:14:42.040
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsRangeFilter='Y',Updated=TO_TIMESTAMP('2018-02-10 08:14:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=550561
+;
+


### PR DESCRIPTION
Adds the daterange config to the preparation date filter in
manufacturing order filter criteria.
https://github.com/metasfresh/metasfresh/issues/3467