### PR TITLE
#3609 Removes pharma specific fields from webui

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5487350_sys_gh3609-default-product-window-pharma-adjustments.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5487350_sys_gh3609-default-product-window-pharma-adjustments.sql
@@ -1,0 +1,40 @@
+-- 2018-03-03T13:50:30.951
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=549597
+;
+
+-- 2018-03-03T13:50:31.196
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=549598
+;
+
+-- 2018-03-03T13:50:31.216
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=549599
+;
+
+-- 2018-03-03T13:50:31.233
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=549600
+;
+
+-- 2018-03-03T13:50:31.249
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=549601
+;
+
+-- 2018-03-03T13:50:31.270
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=549602
+;
+
+-- 2018-03-03T13:50:31.287
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=549603
+;
+
+-- 2018-03-03T13:50:36.333
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_ElementGroup WHERE AD_UI_ElementGroup_ID=541294
+;
+


### PR DESCRIPTION
Removes pharma specific ui  elements from webui.
https://github.com/metasfresh/metasfresh/issues/3609