### PR TITLE
#3590-app - Make shipment line attribute set instance (ASI) configurable

### DIFF
--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/PO.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/PO.java
@@ -243,7 +243,7 @@ public abstract class PO
 			throw new IllegalArgumentException("Invalid PO Info - " + p_info);
 		m_KeyColumns = p_info.getKeyColumnNamesAsArray();
 		//
-		int size = p_info.getColumnCount();
+		final int size = p_info.getColumnCount();
 		m_oldValues = new Object[size];
 		m_newValues = new Object[size];
 		m_valueLoaded = new boolean[size]; // metas
@@ -473,10 +473,10 @@ public abstract class PO
 				index = get_ColumnIndex("Description");
 			if (index != -1)
 			{
-				PO po1 = (PO)o1;
-				Object comp1 = po1.get_Value(index);
-				PO po2 = (PO)o2;
-				Object comp2 = po2.get_Value(index);
+				final PO po1 = (PO)o1;
+				final Object comp1 = po1.get_Value(index);
+				final PO po2 = (PO)o2;
+				final Object comp2 = po2.get_Value(index);
 				if (comp1 == null)
 					return -1;
 				else if (comp2 == null)
@@ -531,7 +531,7 @@ public abstract class PO
 			return -1;
 		}
 
-		Object oo = m_IDs[0];
+		final Object oo = m_IDs[0];
 		if (oo != null && oo instanceof Integer)
 			return ((Integer)oo).intValue();
 		return 0;
@@ -617,7 +617,7 @@ public abstract class PO
 	 */
 	public final int get_ValueAsInt(final int index)
 	{
-		Object value = get_Value(index);
+		final Object value = get_Value(index);
 		if (value == null)
 			return 0;
 		if (value instanceof Integer)
@@ -626,7 +626,7 @@ public abstract class PO
 		{
 			return Integer.parseInt(value.toString());
 		}
-		catch (NumberFormatException ex)
+		catch (final NumberFormatException ex)
 		{
 			log.warn(p_info.getColumnName(index) + " - " + ex.getMessage());
 			return 0;
@@ -641,7 +641,7 @@ public abstract class PO
 	 */
 	public final Object get_Value(final String columnName)
 	{
-		int index = get_ColumnIndex(columnName);
+		final int index = get_ColumnIndex(columnName);
 		if (index < 0)
 		{
 			log.warn("Column {} not found in method PO.get_Value", columnName);
@@ -710,7 +710,7 @@ public abstract class PO
 	 */
 	public final Object get_ValueOfColumn(final int AD_Column_ID)
 	{
-		int index = p_info.getColumnIndex(AD_Column_ID);
+		final int index = p_info.getColumnIndex(AD_Column_ID);
 		if (index < 0)
 		{
 			log.warn("Column with AD_Column_ID={} not found in method PO.get_ValueOfColumn", AD_Column_ID);
@@ -744,7 +744,7 @@ public abstract class PO
 	 */
 	public final Object get_ValueOld(final String columnName)
 	{
-		int index = get_ColumnIndex(columnName);
+		final int index = get_ColumnIndex(columnName);
 		if (index < 0)
 		{
 			log.warn("Column {} not found in method PO.get_ValueOld", columnName);
@@ -761,7 +761,7 @@ public abstract class PO
 	 */
 	public final int get_ValueOldAsInt(final String columnName)
 	{
-		int index = get_ColumnIndex(columnName);
+		final int index = get_ColumnIndex(columnName);
 		if (index < 0)
 		{
 			log.warn("Column {} not found in method PO.get_ValueOldAsInt", columnName);
@@ -772,7 +772,7 @@ public abstract class PO
 
 	public final int get_ValueOldAsInt(final int index)
 	{
-		Object value = get_ValueOld(index);
+		final Object value = get_ValueOld(index);
 		if (value == null)
 			return 0;
 		if (value instanceof Integer)
@@ -781,7 +781,7 @@ public abstract class PO
 		{
 			return Integer.parseInt(value.toString());
 		}
-		catch (NumberFormatException ex)
+		catch (final NumberFormatException ex)
 		{
 			log.warn(get_ColumnName(index) + " - " + ex.getMessage());
 			return 0;
@@ -844,7 +844,7 @@ public abstract class PO
 	 */
 	public final boolean is_ValueChanged(final String columnName)
 	{
-		int index = get_ColumnIndex(columnName);
+		final int index = get_ColumnIndex(columnName);
 		if (index < 0)
 		{
 			log.warn("Column {} not found in method PO.is_ValueChanged", columnName);
@@ -889,7 +889,7 @@ public abstract class PO
 			return nValue;
 		if (nValue instanceof BigDecimal)
 		{
-			BigDecimal obd = (BigDecimal)oValue;
+			final BigDecimal obd = (BigDecimal)oValue;
 			return ((BigDecimal)nValue).subtract(obd);
 		}
 		else if (nValue instanceof Integer)
@@ -914,7 +914,7 @@ public abstract class PO
 	 */
 	public final Object get_ValueDifference(final String columnName)
 	{
-		int index = get_ColumnIndex(columnName);
+		final int index = get_ColumnIndex(columnName);
 		if (index < 0)
 		{
 			log.warn("Column {} not found in method PO.get_ValueDifference", columnName);
@@ -936,7 +936,7 @@ public abstract class PO
 				&& value.toString().toUpperCase().indexOf("=NULL") != -1)
 			log.warn("Invalid Null Value - " + ColumnName + "=" + value);
 
-		int index = get_ColumnIndex(ColumnName);
+		final int index = get_ColumnIndex(ColumnName);
 		if (index < 0)
 		{
 			log.warn("Column {} not found in method PO.set_Value", ColumnName);
@@ -945,7 +945,7 @@ public abstract class PO
 		if (ColumnName.endsWith("_ID") && value instanceof String)
 		{
 			// Convert to Integer only if info class is Integer - teo_sarca [ 2859125 ]
-			Class<?> clazz = p_info.getColumnClass(p_info.getColumnIndex(ColumnName));
+			final Class<?> clazz = p_info.getColumnClass(p_info.getColumnIndex(ColumnName));
 			if (Integer.class == clazz)
 			{
 				log.error("Invalid Data Type for " + ColumnName + "=" + value);
@@ -971,7 +971,7 @@ public abstract class PO
 			log.warn("Index invalid - " + index);
 			return false;
 		}
-		String ColumnName = p_info.getColumnName(index);
+		final String ColumnName = p_info.getColumnName(index);
 		//
 		if (p_info.isVirtualColumn(index))
 		{
@@ -1079,7 +1079,7 @@ public abstract class PO
 				{
 					m_newValues[index] = new Integer((String)value);
 				}
-				catch (NumberFormatException e)
+				catch (final NumberFormatException e)
 				{
 					log.error(ColumnName
 							+ " - Class invalid(1): " + value.getClass().toString()
@@ -1094,7 +1094,7 @@ public abstract class PO
 				return false;
 			}
 			// Validate (Min/Max)
-			String error = p_info.validate(index, value);
+			final String error = p_info.validate(index, value);
 			if (error != null)
 			{
 				log.warn(ColumnName + "=" + value + " - " + error);
@@ -1103,8 +1103,8 @@ public abstract class PO
 			// Length for String
 			if (p_info.getColumnClass(index) == String.class)
 			{
-				String stringValue = value.toString();
-				int length = p_info.getFieldLength(index);
+				final String stringValue = value.toString();
+				final int length = p_info.getFieldLength(index);
 				if (stringValue.length() > length && length > 0)
 				{
 					log.warn(ColumnName + " - Value too long - truncated to length=" + length
@@ -1121,7 +1121,7 @@ public abstract class PO
 				if (!hasListValue)
 				{
 					final StringBuilder validValues = new StringBuilder();
-					for (ValueNamePair vp : MRefList.getList(getCtx(), p_info.getColumn(index).AD_Reference_Value_ID, false))
+					for (final ValueNamePair vp : MRefList.getList(getCtx(), p_info.getColumn(index).AD_Reference_Value_ID, false))
 						validValues.append(" - ").append(vp.getValue());
 					throw new IllegalArgumentException(ColumnName + " Invalid value - "
 							+ value + " - Reference_ID=" + p_info.getColumn(index).AD_Reference_Value_ID + validValues.toString());
@@ -1146,7 +1146,7 @@ public abstract class PO
 	// metas: changed from protected to public
 	public final boolean set_ValueNoCheck(final String ColumnName, final Object value)
 	{
-		int index = get_ColumnIndex(ColumnName);
+		final int index = get_ColumnIndex(ColumnName);
 		if (index < 0)
 		{
 			log.warn("Column {} not found in method PO.set_ValueNoCheck", ColumnName);
@@ -1187,10 +1187,10 @@ public abstract class PO
 			{
 				try
 				{
-					int intValue = Integer.parseInt((String)value);
+					final int intValue = Integer.parseInt((String)value);
 					m_newValues[index] = Integer.valueOf(intValue);
 				}
-				catch (Exception e)
+				catch (final Exception e)
 				{
 					log.warn(get_ColumnName(index)
 							+ " - Class invalid(3): " + value.getClass().toString()
@@ -1208,14 +1208,14 @@ public abstract class PO
 
 			//
 			// Validate (Min/Max)
-			String error = p_info.validate(index, value);
+			final String error = p_info.validate(index, value);
 			if (error != null)
 				log.warn(get_ColumnName(index) + "=" + value + " - " + error);
 			// length for String
 			if (p_info.getColumnClass(index) == String.class)
 			{
-				String stringValue = value.toString();
-				int length = p_info.getFieldLength(index);
+				final String stringValue = value.toString();
+				final int length = p_info.getFieldLength(index);
 				if (stringValue.length() > length && length > 0)
 				{
 					log.warn(get_ColumnName(index) + " - Value too long - truncated to length=" + length);
@@ -1287,7 +1287,7 @@ public abstract class PO
 	{
 		// [ 1845793 ] PO.set_CustomColumn not updating correctly m_newValues
 		// this is for columns not in PO - verify and call proper method if exists
-		int poIndex = get_ColumnIndex(columnName);
+		final int poIndex = get_ColumnIndex(columnName);
 		// metas: tsa: correct, it should be greather OR EQUAL because else first column is skiped and we get duplicate column error on insert
 		if (poIndex >= 0)
 		{
@@ -1419,14 +1419,14 @@ public abstract class PO
 	 */
 	public final String get_DisplayValue(final String columnName, final boolean currentValue)
 	{
-		Object value = currentValue ? get_Value(columnName) : get_ValueOld(columnName);
+		final Object value = currentValue ? get_Value(columnName) : get_ValueOld(columnName);
 		if (value == null)
 			return "./.";
-		String retValue = value.toString();
-		int index = get_ColumnIndex(columnName);
+		final String retValue = value.toString();
+		final int index = get_ColumnIndex(columnName);
 		if (index < 0)
 			return retValue;
-		int dt = get_ColumnDisplayType(index);
+		final int dt = get_ColumnDisplayType(index);
 		if (DisplayType.isText(dt) || DisplayType.YesNo == dt)
 			return retValue;
 		// Lookup
@@ -1503,7 +1503,7 @@ public abstract class PO
 						{
 							if (to.getDynAttribute(PO.DYNATTR_CopyRecordSupport) != null)
 							{
-								CopyRecordSupport cps = (CopyRecordSupport)to.getDynAttribute(PO.DYNATTR_CopyRecordSupport);
+								final CopyRecordSupport cps = (CopyRecordSupport)to.getDynAttribute(PO.DYNATTR_CopyRecordSupport);
 								to.m_newValues[toColumnIndex] = cps.getValueToCopy(to, from, fromColumnName);
 							}
 							break;
@@ -1726,7 +1726,7 @@ public abstract class PO
 			// metas: 01537
 			m_stale = false;
 		}
-		catch (Exception e)
+		catch (final Exception e)
 		{
 			String msg = "";
 			if (m_trxName != null)
@@ -1762,7 +1762,7 @@ public abstract class PO
 	 */
 	protected final boolean load(final ResultSet rs)
 	{
-		int size = get_ColumnCount();
+		final int size = get_ColumnCount();
 		boolean success = true;
 		int index = 0;
 		log.trace("Loading from ResultSet");
@@ -1783,9 +1783,9 @@ public abstract class PO
 	private final boolean loadColumn(final int index, final ResultSet rs)
 	{
 		boolean success = true;
-		String columnName = p_info.getColumnName(index);
-		Class<?> clazz = p_info.getColumnClass(index);
-		int dt = p_info.getColumnDisplayType(index);
+		final String columnName = p_info.getColumnName(index);
+		final Class<?> clazz = p_info.getColumnClass(index);
+		final int dt = p_info.getColumnDisplayType(index);
 		try
 		{
 			if (clazz == Integer.class)
@@ -1817,7 +1817,7 @@ public abstract class PO
 			if (log.isTraceEnabled())
 				log.trace(String.valueOf(index) + ": " + p_info.getColumnName(index) + "(" + p_info.getColumnClass(index) + ") = " + m_oldValues[index]);
 		}
-		catch (SQLException e)
+		catch (final SQLException e)
 		{
 			if (p_info.isVirtualColumn(index)) 	// if rs constructor used
 			{
@@ -1857,7 +1857,7 @@ public abstract class PO
 				success = loadColumn(index, rs);
 			}
 		}
-		catch (SQLException e)
+		catch (final SQLException e)
 		{
 			throw new DBException(e);
 		}
@@ -1878,19 +1878,19 @@ public abstract class PO
 	 */
 	protected final boolean load(final HashMap<String, String> hmIn)
 	{
-		int size = get_ColumnCount();
+		final int size = get_ColumnCount();
 		boolean success = true;
 		int index = 0;
 		log.trace("Loading from HashMap");
 		// load column values
 		for (index = 0; index < size; index++)
 		{
-			String columnName = p_info.getColumnName(index);
-			String value = hmIn.get(columnName);
+			final String columnName = p_info.getColumnName(index);
+			final String value = hmIn.get(columnName);
 			if (value == null)
 				continue;
-			Class<?> clazz = p_info.getColumnClass(index);
-			int dt = p_info.getColumnDisplayType(index);
+			final Class<?> clazz = p_info.getColumnClass(index);
+			final int dt = p_info.getColumnDisplayType(index);
 			try
 			{
 				if (clazz == Integer.class)
@@ -1911,7 +1911,7 @@ public abstract class PO
 				if (log.isTraceEnabled())
 					log.trace(String.valueOf(index) + ": " + p_info.getColumnName(index) + "(" + p_info.getColumnClass(index) + ") = " + m_oldValues[index]);
 			}
-			catch (Exception e)
+			catch (final Exception e)
 			{
 				if (p_info.isVirtualColumn(index)) 	// if rs constructor used
 				{
@@ -2001,19 +2001,19 @@ public abstract class PO
 	 */
 	protected final HashMap<String, String> get_HashMap()
 	{
-		HashMap<String, String> hmOut = new HashMap<>();
-		int size = get_ColumnCount();
+		final HashMap<String, String> hmOut = new HashMap<>();
+		final int size = get_ColumnCount();
 		for (int i = 0; i < size; i++)
 		{
-			Object value = get_Value(i);
+			final Object value = get_Value(i);
 			// Don't insert NULL values (allows Database defaults)
 			if (value == null
 					|| p_info.isVirtualColumn(i))
 				continue;
 			// Display Type
-			int dt = p_info.getColumnDisplayType(i);
+			final int dt = p_info.getColumnDisplayType(i);
 			// Based on class of definition, not class of value
-			Class<?> c = p_info.getColumnClass(i);
+			final Class<?> c = p_info.getColumnClass(i);
 			String stringValue = null;
 			if (c == Object.class)
 				;	// saveNewSpecial (value, i));
@@ -2045,12 +2045,12 @@ public abstract class PO
 		// Custom Columns
 		if (m_custom != null)
 		{
-			Iterator<String> it = m_custom.keySet().iterator();
+			final Iterator<String> it = m_custom.keySet().iterator();
 			while (it.hasNext())
 			{
-				String column = it.next();
+				final String column = it.next();
 				// int index = p_info.getColumnIndex(column);
-				String value = m_custom.get(column);
+				final String value = m_custom.get(column);
 				if (value != null)
 					hmOut.put(column, value);
 			}
@@ -2128,7 +2128,7 @@ public abstract class PO
 		{
 			if (p_info.isVirtualColumn(i))
 				continue;
-			String colName = p_info.getColumnName(i);
+			final String colName = p_info.getColumnName(i);
 			// Set Standard Values
 			if (colName.endsWith("tedBy"))
 				m_newValues[i] = new Integer(Env.getAD_User_ID(ctx));
@@ -2160,7 +2160,7 @@ public abstract class PO
 		m_IDs = new Object[size];
 		for (int i = 0; i < size; i++)
 		{
-			String keyColumnName = m_KeyColumns[i];
+			final String keyColumnName = m_KeyColumns[i];
 			final Object valueObj = get_Value(keyColumnName);
 			if (keyColumnName.endsWith("_ID"))
 			{
@@ -2173,7 +2173,7 @@ public abstract class PO
 						valueInt = I_ZERO;
 					}
 				}
-				catch (Exception e)
+				catch (final Exception e)
 				{
 					log.error("Failed to cast ID column to Integer: " + keyColumnName + ", value=" + valueObj, e);
 					valueInt = null;
@@ -2196,7 +2196,7 @@ public abstract class PO
 	 */
 	protected final boolean isMandatoryOK()
 	{
-		int size = get_ColumnCount();
+		final int size = get_ColumnCount();
 		for (int i = 0; i < size; i++)
 		{
 			if (p_info.isColumnMandatory(i))
@@ -2231,7 +2231,7 @@ public abstract class PO
 	@Override
 	public final int getAD_Client_ID()
 	{
-		Integer ii = (Integer)get_Value("AD_Client_ID");
+		final Integer ii = (Integer)get_Value("AD_Client_ID");
 		if (ii == null)
 			return 0;
 		return ii.intValue();
@@ -2256,7 +2256,7 @@ public abstract class PO
 	@Override
 	public int getAD_Org_ID()
 	{
-		Integer ii = (Integer)get_Value("AD_Org_ID");
+		final Integer ii = (Integer)get_Value("AD_Org_ID");
 		if (ii == null)
 			return 0;
 		return ii.intValue();
@@ -2311,7 +2311,7 @@ public abstract class PO
 	 */
 	public final boolean isActive()
 	{
-		Boolean bb = (Boolean)get_Value("IsActive");
+		final Boolean bb = (Boolean)get_Value("IsActive");
 		if (bb != null)
 			return bb.booleanValue();
 		return false;
@@ -2344,7 +2344,7 @@ public abstract class PO
 	 */
 	final public int getCreatedBy()
 	{
-		Integer ii = (Integer)get_Value("CreatedBy");
+		final Integer ii = (Integer)get_Value("CreatedBy");
 		if (ii == null)
 			return 0;
 		return ii.intValue();
@@ -2357,7 +2357,7 @@ public abstract class PO
 	 */
 	final public int getUpdatedBy()
 	{
-		Integer ii = (Integer)get_Value("UpdatedBy");
+		final Integer ii = (Integer)get_Value("UpdatedBy");
 		if (ii == null)
 			return 0;
 		return ii.intValue();
@@ -2408,7 +2408,7 @@ public abstract class PO
 		// If no translation found or not translated, fallback to original:
 		if (retValue == null)
 		{
-			Object val = get_Value(columnName);
+			final Object val = get_Value(columnName);
 			retValue = (val != null ? val.toString() : null);
 		}
 		//
@@ -2668,7 +2668,7 @@ public abstract class PO
 			saveEx();
 			success = true;
 		}
-		catch (Exception e)
+		catch (final Exception e)
 		{
 			success = false;
 			log.error("Error while saving {}", this, e);
@@ -2961,7 +2961,7 @@ public abstract class PO
 			{
 				Class.forName("org.compiere.wf.DocWorkflowManager");
 			}
-			catch (Exception e)
+			catch (final Exception e)
 			{
 			}
 		}
@@ -3015,7 +3015,7 @@ public abstract class PO
 	 */
 	public final boolean is_Changed()
 	{
-		int size = get_ColumnCount();
+		final int size = get_ColumnCount();
 		for (int i = 0; i < size; i++)
 		{
 			// Test if the column has changed - teo_sarca [ 1704828 ]
@@ -3065,16 +3065,16 @@ public abstract class PO
 	 */
 	private final boolean saveUpdate() throws Exception
 	{
-		String where = get_WhereClause(true);
+		final String where = get_WhereClause(true);
 		//
 		boolean changes = false;
-		StringBuilder sql = new StringBuilder("UPDATE ");
+		final StringBuilder sql = new StringBuilder("UPDATE ");
 		sql.append(p_info.getTableName()).append(" SET ");
 		boolean updated = false;
 		boolean updatedBy = false;
 		lobReset();
 
-		int size = get_ColumnCount();
+		final int size = get_ColumnCount();
 		for (int i = 0; i < size; i++)
 		{
 			Object value = m_newValues[i];
@@ -3116,7 +3116,7 @@ public abstract class PO
 			// Update Document No
 			if (columnName.equals("DocumentNo"))
 			{
-				String documentNo = (String)value;
+				final String documentNo = (String)value;
 				if (IPreliminaryDocumentNoBuilder.hasPreliminaryMarkers(documentNo))
 				{
 					value = null;
@@ -3190,16 +3190,16 @@ public abstract class PO
 		// Custom Columns (cannot be logged as no column)
 		if (m_custom != null)
 		{
-			Iterator<String> it = m_custom.keySet().iterator();
+			final Iterator<String> it = m_custom.keySet().iterator();
 			while (it.hasNext())
 			{
 				if (changes)
 					sql.append(", ");
 				changes = true;
 				//
-				String column = it.next();
-				String value = m_custom.get(column);
-				int index = p_info.getColumnIndex(column);
+				final String column = it.next();
+				final String value = m_custom.get(column);
+				final int index = p_info.getColumnIndex(column);
 				sql.append(column).append("=").append(encrypt(index, value));
 			}
 			m_custom = null;
@@ -3213,7 +3213,7 @@ public abstract class PO
 
 			if (!updated) 	// Updated not explicitly set
 			{
-				Timestamp now = new Timestamp(System.currentTimeMillis());
+				final Timestamp now = new Timestamp(System.currentTimeMillis());
 				set_ValueNoCheck("Updated", now);
 				sql.append(",Updated=").append(DB.TO_DATE(now, false));
 			}
@@ -3569,7 +3569,7 @@ public abstract class PO
 					sqlValues.append(saveNewSpecial(value, i));
 				}
 			}
-			catch (Exception e)
+			catch (final Exception e)
 			{
 				String msg = "";
 				if (m_trxName != null)
@@ -3591,7 +3591,7 @@ public abstract class PO
 			{
 				final String column = it.next();
 				final int index = p_info.getColumnIndex(column);
-				String value = m_custom.get(column);
+				final String value = m_custom.get(column);
 				if (doComma)
 				{
 					sqlInsert.append(",");
@@ -3735,9 +3735,9 @@ public abstract class PO
 	 */
 	protected String saveNewSpecial(final Object value, final int index)
 	{
-		String colName = p_info.getColumnName(index);
-		String colClass = p_info.getColumnClass(index).toString();
-		String colValue = value == null ? "null" : value.getClass().toString();
+		final String colName = p_info.getColumnName(index);
+		final String colClass = p_info.getColumnClass(index).toString();
+		final String colValue = value == null ? "null" : value.getClass().toString();
 		// int dt = p_info.getColumnDisplayType(index);
 
 		log.error("Unknown class for column " + colName
@@ -3801,7 +3801,7 @@ public abstract class PO
 			deleteEx(force);
 			success = true;
 		}
-		catch (Exception e)
+		catch (final Exception e)
 		{
 			success = false;
 			log.error("Error while deleting " + this, e);
@@ -3873,7 +3873,7 @@ public abstract class PO
 		// Make sure record is not already processed (or we do "force" delete)
 		if (!force)
 		{
-			int iProcessed = get_ColumnIndex("Processed");
+			final int iProcessed = get_ColumnIndex("Processed");
 			if (iProcessed != -1)
 			{
 				final Boolean processed = (Boolean)get_Value(iProcessed);
@@ -4174,7 +4174,7 @@ public abstract class PO
 					s_acctColumns.add(rs.getString(1));
 				}
 			}
-			catch (Exception e)
+			catch (final Exception e)
 			{
 				log.error(acctTable, e);
 			}
@@ -4288,11 +4288,11 @@ public abstract class PO
 	 */
 	public final boolean lock()
 	{
-		int index = get_ProcessingIndex();
+		final int index = get_ProcessingIndex();
 		if (index != -1)
 		{
 			set_ValueNoCheck(index, true); // metas: 01537: replaced: m_newValues[index] = Boolean.TRUE; // direct
-			String sql = "UPDATE " + p_info.getTableName()
+			final String sql = "UPDATE " + p_info.getTableName()
 					+ " SET Processing='Y' WHERE (Processing='N' OR Processing IS NULL) AND "
 					+ get_WhereClause(true);
 			boolean success = false;
@@ -4328,11 +4328,11 @@ public abstract class PO
 	public final boolean unlock(final String trxName)
 	{
 		// log.warn(trxName);
-		int index = get_ProcessingIndex();
+		final int index = get_ProcessingIndex();
 		if (index != -1)
 		{
 			set_ValueNoCheck(index, false); // metas: 01537: replaced: m_newValues[index] = Boolean.FALSE; // direct
-			String sql = "UPDATE " + p_info.getTableName()
+			final String sql = "UPDATE " + p_info.getTableName()
 					+ " SET Processing='N' WHERE " + get_WhereClause(true);
 			boolean success = false;
 			if (isUseTimeoutForUpdate())
@@ -4391,7 +4391,7 @@ public abstract class PO
 	 */
 	public void dump(final int index)
 	{
-		StringBuilder sb = new StringBuilder(" ").append(index);
+		final StringBuilder sb = new StringBuilder(" ").append(index);
 		if (index < 0 || index >= get_ColumnCount())
 		{
 			log.trace(sb.append(": invalid").toString());
@@ -4422,8 +4422,8 @@ public abstract class PO
 	 */
 	public static int[] getAllIDs(final String TableName, final String WhereClause, final String trxName)
 	{
-		ArrayList<Integer> list = new ArrayList<>();
-		StringBuilder sql = new StringBuilder("SELECT ");
+		final ArrayList<Integer> list = new ArrayList<>();
+		final StringBuilder sql = new StringBuilder("SELECT ");
 		sql.append(TableName).append("_ID FROM ").append(TableName);
 		if (WhereClause != null && WhereClause.length() > 0)
 			sql.append(" WHERE ").append(WhereClause);
@@ -4436,7 +4436,7 @@ public abstract class PO
 			while (rs.next())
 				list.add(new Integer(rs.getInt(1)));
 		}
-		catch (SQLException e)
+		catch (final SQLException e)
 		{
 			s_log.error(sql.toString(), e);
 			return null;
@@ -4448,7 +4448,7 @@ public abstract class PO
 			pstmt = null;
 		}
 		// Convert to array
-		int[] retValue = new int[list.size()];
+		final int[] retValue = new int[list.size()];
 		for (int i = 0; i < retValue.length; i++)
 			retValue[i] = list.get(i).intValue();
 		return retValue;
@@ -4495,13 +4495,13 @@ public abstract class PO
 				retValue = value;
 			else if (value instanceof Clob) 		// returns String
 			{
-				Clob clob = (Clob)value;
+				final Clob clob = (Clob)value;
 				length = clob.length();
 				retValue = clob.getSubString(1, (int)length);
 			}
 			else if (value instanceof Blob) 	// returns byte[]
 			{
-				Blob blob = (Blob)value;
+				final Blob blob = (Blob)value;
 				length = blob.length();
 				int index = 1;	// correct
 				if (blob.getClass().getName().equals("oracle.jdbc.rowset.OracleSerialBlob"))
@@ -4512,7 +4512,7 @@ public abstract class PO
 			else
 				log.error("Unknown: " + value);
 		}
-		catch (Exception e)
+		catch (final Exception e)
 		{
 			log.error("Length=" + length, e);
 		}
@@ -4540,7 +4540,7 @@ public abstract class PO
 	private void lobAdd(final Object value, final int index, final int displayType)
 	{
 		log.trace("Adding LOB: Value={}", value);
-		PO_LOB lob = new PO_LOB(p_info.getTableName(), get_ColumnName(index),
+		final PO_LOB lob = new PO_LOB(p_info.getTableName(), get_ColumnName(index),
 				get_WhereClause(true), displayType, value);
 		if (m_lobInfo == null)
 			m_lobInfo = new ArrayList<>();
@@ -4589,18 +4589,18 @@ public abstract class PO
 		//
 		try
 		{
-			StringWriter writer = new StringWriter();
-			StreamResult result = new StreamResult(writer);
-			DOMSource source = new DOMSource(get_xmlDocument(xml.length() != 0));
-			TransformerFactory tFactory = TransformerFactory.newInstance();
-			Transformer transformer = tFactory.newTransformer();
+			final StringWriter writer = new StringWriter();
+			final StreamResult result = new StreamResult(writer);
+			final DOMSource source = new DOMSource(get_xmlDocument(xml.length() != 0));
+			final TransformerFactory tFactory = TransformerFactory.newInstance();
+			final Transformer transformer = tFactory.newTransformer();
 			transformer.setOutputProperty(javax.xml.transform.OutputKeys.INDENT, "yes");
 			transformer.transform(source, result);
-			StringBuffer newXML = writer.getBuffer();
+			final StringBuffer newXML = writer.getBuffer();
 			//
 			if (xml.length() != 0)
 			{	// // <?xml version="1.0" encoding="UTF-8"?>
-				int tagIndex = newXML.indexOf("?>");
+				final int tagIndex = newXML.indexOf("?>");
 				if (tagIndex != -1)
 					xml.append(newXML.substring(tagIndex + 2));
 				else
@@ -4609,7 +4609,7 @@ public abstract class PO
 			else
 				xml.append(newXML);
 		}
-		catch (Exception e)
+		catch (final Exception e)
 		{
 			log.error("", e);
 		}
@@ -4632,35 +4632,35 @@ public abstract class PO
 		Document document = null;
 		try
 		{
-			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-			DocumentBuilder builder = factory.newDocumentBuilder();
+			final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			final DocumentBuilder builder = factory.newDocumentBuilder();
 			document = builder.newDocument();
 			if (!noComment)
 				document.appendChild(document.createComment(Adempiere.getSummaryAscii()));
 		}
-		catch (Exception e)
+		catch (final Exception e)
 		{
 			log.error("", e);
 		}
 		// Root
-		Element root = document.createElement(get_TableName());
+		final Element root = document.createElement(get_TableName());
 		root.setAttribute(XML_ATTRIBUTE_AD_Table_ID, String.valueOf(get_Table_ID()));
 		root.setAttribute(XML_ATTRIBUTE_Record_ID, String.valueOf(get_ID()));
 		document.appendChild(root);
 		// Columns
-		int size = get_ColumnCount();
+		final int size = get_ColumnCount();
 		for (int i = 0; i < size; i++)
 		{
 			if (p_info.isVirtualColumn(i))
 				continue;
 
-			Element col = document.createElement(p_info.getColumnName(i));
+			final Element col = document.createElement(p_info.getColumnName(i));
 			//
-			Object value = get_Value(i);
+			final Object value = get_Value(i);
 			// Display Type
-			int dt = p_info.getColumnDisplayType(i);
+			final int dt = p_info.getColumnDisplayType(i);
 			// Based on class of definition, not class of value
-			Class<?> c = p_info.getColumnClass(i);
+			final Class<?> c = p_info.getColumnClass(i);
 			if (value == null || value.equals(Null.NULL))
 				;
 			else if (c == Object.class)
@@ -4690,14 +4690,14 @@ public abstract class PO
 		// Custom Columns
 		if (m_custom != null)
 		{
-			Iterator<String> it = m_custom.keySet().iterator();
+			final Iterator<String> it = m_custom.keySet().iterator();
 			while (it.hasNext())
 			{
-				String columnName = it.next();
+				final String columnName = it.next();
 				// int index = p_info.getColumnIndex(columnName);
-				String value = m_custom.get(columnName);
+				final String value = m_custom.get(columnName);
 				//
-				Element col = document.createElement(columnName);
+				final Element col = document.createElement(columnName);
 				if (value != null)
 					col.appendChild(document.createTextNode(value));
 				root.appendChild(col);
@@ -4723,7 +4723,7 @@ public abstract class PO
 	 */
 	public static void set_TrxName(final PO[] lines, final String trxName)
 	{
-		for (PO line : lines)
+		for (final PO line : lines)
 			line.set_TrxName(trxName);
 	}
 
@@ -4735,7 +4735,7 @@ public abstract class PO
 	 */
 	public final int get_ValueAsInt(final String columnName)
 	{
-		int idx = get_ColumnIndex(columnName);
+		final int idx = get_ColumnIndex(columnName);
 		if (idx < 0)
 		{
 			return 0;
@@ -4752,7 +4752,7 @@ public abstract class PO
 	// metas: tsa: changed and introduced get_ValueAsBoolean(int)
 	public final boolean get_ValueAsBoolean(final String columnName)
 	{
-		int idx = get_ColumnIndex(columnName);
+		final int idx = get_ColumnIndex(columnName);
 		if (idx < 0)
 		{
 			return false;
@@ -4762,7 +4762,7 @@ public abstract class PO
 
 	public final boolean get_ValueAsBoolean(final int index)
 	{
-		Object oo = get_Value(index);
+		final Object oo = get_Value(index);
 		if (oo != null)
 		{
 			if (oo instanceof Boolean)
@@ -4869,7 +4869,7 @@ public abstract class PO
 	@Override
 	public final String get_ValueOldAsString(final String columnName)
 	{
-		int index = get_ColumnIndex(columnName);
+		final int index = get_ColumnIndex(columnName);
 		if (index < 0)
 		{
 			log.warn("Column {} not found in method PO.get_ValueOldAsString", columnName);
@@ -4880,7 +4880,7 @@ public abstract class PO
 
 	public final String get_ValueOldAsString(final int index)
 	{
-		Object value = get_ValueOld(index);
+		final Object value = get_ValueOld(index);
 		if (value == null)
 			return "";
 		return value.toString();
@@ -5060,7 +5060,7 @@ public abstract class PO
 
 	public final Timestamp get_ValueAsTimestamp(final String columnName)
 	{
-		int idx = get_ColumnIndex(columnName);
+		final int idx = get_ColumnIndex(columnName);
 		if (idx < 0)
 		{
 			return null;
@@ -5144,7 +5144,7 @@ public abstract class PO
 			}
 			po = constructor.newInstance(getCtx(), ID_NewInstanceNoInit, m_trxName);
 		}
-		catch (Exception e)
+		catch (final Exception e)
 		{
 			throw new AdempiereException("Cannot create a new instance of " + this, e);
 		}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/impl/AbstractTrxManager.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/impl/AbstractTrxManager.java
@@ -162,7 +162,7 @@ public abstract class AbstractTrxManager implements ITrxManager
 				{
 					trxOld.close();
 				}
-				catch (Exception e)
+				catch (final Exception e)
 				{
 					throw new TrxException("Failed closing the old transaction: " + trxOld, e);
 				}
@@ -499,7 +499,7 @@ public abstract class AbstractTrxManager implements ITrxManager
 		final TrxCallable<Void> callable = TrxCallableWrappers.wrapIfNeeded(r);
 		call(trxName, callable);
 	}
-	
+
 	@Override
 	public void run(final String trxName, final Runnable runnable)
 	{
@@ -771,7 +771,7 @@ public abstract class AbstractTrxManager implements ITrxManager
 			callableResult = TrxCallableWrappers.wrapAsTrxCallableWithTrxNameIfNeeded(callable).call(trxName);
 
 			// Commit the transaction if we were asked to do it
-			OnRunnableSuccess onRunnableSuccess = cfg.getOnRunnableSuccess();
+			final OnRunnableSuccess onRunnableSuccess = cfg.getOnRunnableSuccess();
 			if (onRunnableSuccess == OnRunnableSuccess.COMMIT)
 			{
 				// if (trxPropagation != TrxPropagation.REQUIRES_NEW)
@@ -893,7 +893,7 @@ public abstract class AbstractTrxManager implements ITrxManager
 					{
 						trx.releaseSavepoint(savepoint);
 					}
-					catch (Exception e)
+					catch (final Exception e)
 					{
 						final String errmsg = "There was an exception while rolling back to savepoint. Going forward."
 								+ "\n Trx: " + trx
@@ -959,7 +959,7 @@ public abstract class AbstractTrxManager implements ITrxManager
 			{
 				runnable.doFinally();
 			}
-			catch (Throwable doFinallyException)
+			catch (final Throwable doFinallyException)
 			{
 				// Propagate the doFinallyException only if we are not currently throwing another exception.
 				// If we are currently throwing another exception, we suppress this one.

--- a/de.metas.business/src/main/java/org/adempiere/uom/api/IUOMConversionBL.java
+++ b/de.metas.business/src/main/java/org/adempiere/uom/api/IUOMConversionBL.java
@@ -32,6 +32,7 @@ import org.compiere.model.I_C_UOM_Conversion;
 import org.compiere.model.I_M_Product;
 
 import de.metas.quantity.Quantity;
+import lombok.NonNull;
 
 public interface IUOMConversionBL extends ISingletonService
 {
@@ -46,13 +47,26 @@ public interface IUOMConversionBL extends ISingletonService
 	/**
 	 * Convert quantity from <code>uomFrom</code> to <code>uomTo</code>
 	 *
-	 * @param product
-	 * @param qty
-	 * @param uomFrom
-	 * @param uomTo
+	 * @return converted quantity; never return NULL.
+	 * @deprecated please use {@link #convertQty(int, BigDecimal, I_C_UOM, I_C_UOM)}
+	 */
+	@Deprecated
+	default BigDecimal convertQty(
+			final I_M_Product product,
+			final BigDecimal qty,
+			@NonNull final I_C_UOM uomFrom,
+			@NonNull final I_C_UOM uomTo)
+	{
+		final int productId = product != null ? product.getM_Product_ID() : -1;
+		return convertQty(productId, qty, uomFrom, uomTo);
+	}
+
+	/**
+	 * Convert quantity from <code>uomFrom</code> to <code>uomTo</code>
+	 *
 	 * @return converted quantity; never return NULL.
 	 */
-	BigDecimal convertQty(I_M_Product product, BigDecimal qty, I_C_UOM uomFrom, I_C_UOM uomTo);
+	BigDecimal convertQty(int productId, BigDecimal qty, I_C_UOM uomFrom, I_C_UOM uomTo);
 
 	/**
 	 * Convert quantity from <code>uomFrom</code> to <code>uomTo</code>

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHandlingUnitsDAO.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHandlingUnitsDAO.java
@@ -85,9 +85,9 @@ public interface IHandlingUnitsDAO extends ISingletonService
 
 	void delete(I_M_HU hu);
 
-	I_M_HU_PI retrieveNoPI(Properties ctx);
+	I_M_HU_PI retrievePackingItemTemplatePI(Properties ctx);
 
-	I_M_HU_PI_Item retrieveNoPIItem(Properties ctx);
+	I_M_HU_PI_Item retrievePackingItemTemplatePIItem(Properties ctx);
 
 	/**
 	 * Gets Virtual PI
@@ -99,9 +99,9 @@ public interface IHandlingUnitsDAO extends ISingletonService
 
 	I_M_HU_PI_Item retrieveVirtualPIItem(Properties ctx);
 
-	int getNo_HU_PI_ID();
+	int getPackingItemTemplate_HU_PI_ID();
 
-	int getNo_HU_PI_Item_ID();
+	int getPackingItemTemplate_HU_PI_Item_ID();
 
 	int getVirtual_HU_PI_ID();
 

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/IHUSplitBuilder.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/IHUSplitBuilder.java
@@ -125,7 +125,7 @@ public interface IHUSplitBuilder
 	/**
 	 *
 	 *
-	 * @param splitOnNoPI not 100% sure but i think this needs to be <code>true</code> if we split individual CUs. See {@link IHandlingUnitsDAO#getNo_HU_PI_ID()}.
+	 * @param splitOnNoPI not 100% sure but i think this needs to be <code>true</code> if we split individual CUs. See {@link IHandlingUnitsDAO#getPackingItemTemplate_HU_PI_ID()}.
 	 * @return
 	 */
 	IHUSplitBuilder setSplitOnNoPI(boolean splitOnNoPI);

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/IHUPIAttributesDAO.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/IHUPIAttributesDAO.java
@@ -60,7 +60,7 @@ public interface IHUPIAttributesDAO extends ISingletonService
 	 * Mainly, returned list consists of
 	 * <ul>
 	 * <li>direct attributes - PI Attributes which are directly defined on given <code>version</code>
-	 * <li>attributes from template (i.e. NoPI) - PI attributes which are assigned to NoPI (see {@link IHandlingUnitsDAO#retrieveNoPI(java.util.Properties)})
+	 * <li>attributes from template (i.e. NoPI) - PI attributes which are assigned to NoPI (see {@link IHandlingUnitsDAO#retrievePackingItemTemplatePI(java.util.Properties)})
 	 * </ul>
 	 *
 	 * <br>

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/impl/AbstractAttributeValue.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/impl/AbstractAttributeValue.java
@@ -124,7 +124,7 @@ public abstract class AbstractAttributeValue implements IAttributeValue
 
 	protected final IHUAttributesDAO getHUAttributesDAO()
 	{
-		return getAttributeStorage().getHUAttributeStorageFactory().getHUAttributesDAO();
+		return getAttributeStorage().getAttributeStorageFactory().getHUAttributesDAO();
 	}
 
 	@Override

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/impl/AbstractHUAttributeValue.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/impl/AbstractHUAttributeValue.java
@@ -10,12 +10,12 @@ package de.metas.handlingunits.attribute.impl;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -43,14 +43,17 @@ public abstract class AbstractHUAttributeValue extends AbstractAttributeValue
 	// Services
 	private final IAttributeStrategyFactory attributeStrategyFactory = Services.get(IAttributeStrategyFactory.class);
 	private final I_M_HU_PI_Attribute huPIAttribute;
-	
+
 	private volatile Boolean _definedByTemplate; // lazy
 
-	public AbstractHUAttributeValue(final IAttributeStorage attributeStorage, final I_M_HU_PI_Attribute huPIAttribute, final Boolean isTemplateAttribute)
+	public AbstractHUAttributeValue(
+			final IAttributeStorage attributeStorage,
+			final I_M_HU_PI_Attribute huPIAttribute,
+			final Boolean isTemplateAttribute)
 	{
 		super(attributeStorage, huPIAttribute.getM_Attribute());
 		this.huPIAttribute = huPIAttribute;
-		
+
 		this._definedByTemplate = isTemplateAttribute; // null is OK
 	}
 
@@ -99,7 +102,7 @@ public abstract class AbstractHUAttributeValue extends AbstractAttributeValue
 	{
 		return huPIAttribute.isUseInASI();
 	}
-	
+
 	@Override
 	public boolean isDefinedByTemplate()
 	{
@@ -139,7 +142,7 @@ public abstract class AbstractHUAttributeValue extends AbstractAttributeValue
 	{
 		return huPIAttribute.isReadOnly();
 	}
-	
+
 	@Override
 	public boolean isDisplayedUI()
 	{

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/impl/HUPIAttributesDAO.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/impl/HUPIAttributesDAO.java
@@ -139,11 +139,11 @@ public class HUPIAttributesDAO implements IHUPIAttributesDAO
 		//
 		// Retrieve an add template attributes (from NoPI)
 		// only if given version is not of NoPI
-		if (M_HU_PI_Version_ID != HandlingUnitsDAO.NO_HU_PI_Version_ID)
+		if (M_HU_PI_Version_ID != HandlingUnitsDAO.PACKING_ITEM_TEMPLATE_HU_PI_Version_ID)
 		{
 			final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
 
-			final I_M_HU_PI noPI = handlingUnitsDAO.retrieveNoPI(ctx);
+			final I_M_HU_PI noPI = handlingUnitsDAO.retrievePackingItemTemplatePI(ctx);
 			final List<I_M_HU_PI_Attribute> noPIAttributes = retrieveDirectPIAttributes(noPI);
 
 			// Iterate template attributes and add only those who were not added yet
@@ -175,7 +175,7 @@ public class HUPIAttributesDAO implements IHUPIAttributesDAO
 		
 		//
 		// If the PI attribute is from template then it's a template attribute
-		if (huPIAttribute.getM_HU_PI_Version_ID() == HandlingUnitsDAO.NO_HU_PI_Version_ID)
+		if (huPIAttribute.getM_HU_PI_Version_ID() == HandlingUnitsDAO.PACKING_ITEM_TEMPLATE_HU_PI_Version_ID)
 		{
 			if(!huPIAttribute.isActive())
 			{
@@ -192,7 +192,7 @@ public class HUPIAttributesDAO implements IHUPIAttributesDAO
 		final int attributeId = huPIAttribute.getM_Attribute_ID();
 		final Properties ctx = InterfaceWrapperHelper.getCtx(huPIAttribute);
 		final String trxName = InterfaceWrapperHelper.getTrxName(huPIAttribute);
-		final List<I_M_HU_PI_Attribute> noPIAttributes = retrieveDirectPIAttributes(ctx, HandlingUnitsDAO.NO_HU_PI_Version_ID, trxName);
+		final List<I_M_HU_PI_Attribute> noPIAttributes = retrieveDirectPIAttributes(ctx, HandlingUnitsDAO.PACKING_ITEM_TEMPLATE_HU_PI_Version_ID, trxName);
 		for (final I_M_HU_PI_Attribute noPIAttribute : noPIAttributes)
 		{
 			if (noPIAttribute.getM_Attribute_ID() == attributeId && noPIAttribute.isActive())

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/AIAttributeValue.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/AIAttributeValue.java
@@ -1,0 +1,196 @@
+package de.metas.handlingunits.attribute.storage;
+
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2015 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_M_AttributeInstance;
+import org.compiere.util.TimeUtil;
+
+import de.metas.handlingunits.attribute.impl.AbstractAttributeValue;
+import de.metas.handlingunits.attribute.strategy.IAttributeAggregationStrategy;
+import de.metas.handlingunits.attribute.strategy.IAttributeSplitterStrategy;
+import de.metas.handlingunits.attribute.strategy.IHUAttributeTransferStrategy;
+import de.metas.handlingunits.attribute.strategy.impl.CopyHUAttributeTransferStrategy;
+import de.metas.handlingunits.attribute.strategy.impl.NullAggregationStrategy;
+import de.metas.handlingunits.attribute.strategy.impl.NullSplitterStrategy;
+import de.metas.handlingunits.model.X_M_HU_PI_Attribute;
+
+/**
+ * Wraps an {@link I_M_AttributeInstance}
+ *
+ * @author tsa
+ *
+ */
+/* package */class AIAttributeValue extends AbstractAttributeValue
+{
+	private final I_M_AttributeInstance attributeInstance;
+
+	public AIAttributeValue(
+			final IAttributeStorage attributeStorage,
+			final I_M_AttributeInstance attributeInstance)
+	{
+		super(
+				attributeStorage,
+				attributeInstance.getM_Attribute());
+
+		this.attributeInstance = attributeInstance;
+	}
+
+	@Override
+	protected void setInternalValueString(final String value)
+	{
+		attributeInstance.setValue(value);
+	}
+
+	@Override
+	protected void setInternalValueNumber(final BigDecimal value)
+	{
+		attributeInstance.setValueNumber(value);
+	}
+
+	@Override
+	protected String getInternalValueString()
+	{
+		return attributeInstance.getValue();
+	}
+
+	@Override
+	protected BigDecimal getInternalValueNumber()
+	{
+		return attributeInstance.getValueNumber();
+	}
+
+	@Override
+	protected String getInternalValueStringInitial()
+	{
+		return null;
+	}
+
+	/**
+	 * @return <code>null</code>.
+	 */
+	@Override
+	protected BigDecimal getInternalValueNumberInitial()
+	{
+		return null;
+	}
+
+	@Override
+	protected void setInternalValueStringInitial(final String value)
+	{
+		throw new UnsupportedOperationException("Setting initial value not supported");
+	}
+
+	@Override
+	protected void setInternalValueNumberInitial(final BigDecimal value)
+	{
+		throw new UnsupportedOperationException("Setting initial value not supported");
+	}
+
+	@Override
+	public boolean isNew()
+	{
+		return InterfaceWrapperHelper.isNew(attributeInstance);
+	}
+
+	@Override
+	protected void setInternalValueDate(Date value)
+	{
+		attributeInstance.setValueDate(TimeUtil.asTimestamp(value));
+	}
+
+	@Override
+	protected Date getInternalValueDate()
+	{
+		return attributeInstance.getValueDate();
+	}
+
+	@Override
+	protected void setInternalValueDateInitial(Date value)
+	{
+		throw new UnsupportedOperationException("Setting initial value not supported");
+	}
+
+	@Override
+	protected Date getInternalValueDateInitial()
+	{
+		return null;
+	}
+
+	@Override
+	public String getPropagationType()
+	{
+		return X_M_HU_PI_Attribute.PROPAGATIONTYPE_NoPropagation;
+	}
+
+	@Override
+	public IAttributeAggregationStrategy retrieveAggregationStrategy()
+	{
+		return NullAggregationStrategy.instance;
+	}
+
+	@Override
+	public IAttributeSplitterStrategy retrieveSplitterStrategy()
+	{
+		return NullSplitterStrategy.instance;
+	}
+
+	@Override
+	public IHUAttributeTransferStrategy retrieveTransferStrategy()
+	{
+		return CopyHUAttributeTransferStrategy.instance;
+	}
+
+	@Override
+	public boolean isReadonlyUI()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isDisplayedUI()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int getDisplaySeqNo()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isUseInASI()
+	{
+		return true;
+	}
+
+	@Override
+	public boolean isDefinedByTemplate()
+	{
+		throw new UnsupportedOperationException();
+	}
+}

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/ASIAttributeStorage.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/ASIAttributeStorage.java
@@ -1,0 +1,147 @@
+package de.metas.handlingunits.attribute.storage;
+
+import java.util.List;
+import java.util.Map;
+
+import org.adempiere.mm.attributes.api.IAttributeDAO;
+import org.adempiere.mm.attributes.spi.IAttributeValueContext;
+import org.adempiere.util.Services;
+import org.compiere.model.I_M_Attribute;
+import org.compiere.model.I_M_AttributeInstance;
+import org.compiere.model.I_M_AttributeSetInstance;
+
+import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.collect.ImmutableList;
+
+import de.metas.handlingunits.IMutableHUTransactionAttribute;
+import de.metas.handlingunits.attribute.IAttributeValue;
+import de.metas.handlingunits.attribute.storage.impl.AbstractAttributeStorage;
+import de.metas.handlingunits.attribute.storage.impl.NullAttributeStorage;
+import lombok.NonNull;
+
+/**
+ * Wraps an {@link I_M_AttributeSetInstance}.
+ */
+public class ASIAttributeStorage extends AbstractAttributeStorage
+{
+
+	public static IAttributeStorage createNew(
+			@NonNull final IAttributeStorageFactory attributeStorageFactory,
+			@NonNull final I_M_AttributeSetInstance attributeSetInstance)
+	{
+		return new ASIAttributeStorage(attributeStorageFactory, attributeSetInstance);
+	}
+
+	private final String id;
+	private final I_M_AttributeSetInstance asi;
+
+	private ASIAttributeStorage(
+			@NonNull final IAttributeStorageFactory storageFactory,
+			@NonNull final I_M_AttributeSetInstance asi)
+	{
+		super(storageFactory);
+
+		this.asi = asi;
+		this.id = I_M_AttributeSetInstance.COLUMNNAME_M_AttributeSetInstance_ID + "=" + asi.getM_AttributeSetInstance_ID();
+	}
+
+	@Override
+	public String getId()
+	{
+		return id;
+	}
+
+	@Override
+	public IAttributeStorage getParentAttributeStorage()
+	{
+		return NullAttributeStorage.instance;
+	}
+
+	/**
+	 * Always returns an empty collection.
+	 */
+	@Override
+	public final List<IAttributeStorage> getChildAttributeStorages(boolean loadIfNeeded_IGNORED)
+	{
+		return ImmutableList.of();
+	}
+
+	@Override
+	protected void toString(final ToStringHelper stringHelper)
+	{
+		stringHelper
+				.add("id", id)
+				.add("asi", asi)
+		// .add("huDisplayName", Services.get(IHandlingUnitsBL.class).getDisplayName(getM_HU())) // used only for debugging)
+		;
+	}
+
+	@Override
+	protected List<IAttributeValue> loadAttributeValues()
+	{
+		final IAttributeDAO attributesDAO = Services.get(IAttributeDAO.class);
+
+		final ImmutableList.Builder<IAttributeValue> result = ImmutableList.builder();
+
+		final List<I_M_AttributeInstance> attributeInstances = attributesDAO.retrieveAttributeInstances(asi);
+		for (final I_M_AttributeInstance attributeInstance : attributeInstances)
+		{
+			final IAttributeValue attributeValue = new AIAttributeValue(this, attributeInstance);
+			result.add(attributeValue);
+		}
+		return result.build();
+	}
+
+	@Override
+	protected List<IAttributeValue> generateAndGetInitialAttributes(final IAttributeValueContext attributesCtx, final Map<I_M_Attribute, Object> defaultAttributesValue)
+	{
+		throw new UnsupportedOperationException("Generating initial attributes not supported for " + this);
+	}
+
+	@Override
+	public void updateHUTrxAttribute(final IMutableHUTransactionAttribute huTrxAttribute, final IAttributeValue fromAttributeValue)
+	{
+		huTrxAttribute.setReferencedObject(asi);
+	}
+
+	/**
+	 * Method not supported.
+	 *
+	 * @throws UnsupportedOperationException
+	 */
+	@Override
+	protected void addChildAttributeStorage(final IAttributeStorage childAttributeStorage)
+	{
+		throw new UnsupportedOperationException("Child attribute storages are not supported for " + this);
+	}
+
+	/**
+	 * Method not supported.
+	 *
+	 * @throws UnsupportedOperationException
+	 */
+	@Override
+	protected IAttributeStorage removeChildAttributeStorage(final IAttributeStorage childAttributeStorage)
+	{
+		throw new UnsupportedOperationException("Child attribute storages are not supported for " + this);
+	}
+
+	@Override
+	public void saveChangesIfNeeded()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setSaveOnChange(boolean saveOnChange)
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getQtyUOMTypeOrNull()
+	{
+		// ASI attribute storages does not support Qty Storage
+		return null;
+	}
+}

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/IAttributeStorage.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/IAttributeStorage.java
@@ -327,7 +327,7 @@ public interface IAttributeStorage extends IAttributeSet
 	 */
 	void setSaveOnChange(final boolean saveOnChange);
 
-	IAttributeStorageFactory getHUAttributeStorageFactory();
+	IAttributeStorageFactory getAttributeStorageFactory();
 
 	/**
 	 * In case this attribute storage is attached to an {@link IHUStorageDAO} which supports product Qtys, it will return the UOM Type of that Qty Storage.

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/impl/AIWithHUPIAttributeValue.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/impl/AIWithHUPIAttributeValue.java
@@ -10,12 +10,12 @@ package de.metas.handlingunits.attribute.storage.impl;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -25,13 +25,13 @@ package de.metas.handlingunits.attribute.storage.impl;
 import java.math.BigDecimal;
 import java.util.Date;
 
-import org.adempiere.util.Check;
 import org.compiere.model.I_M_AttributeInstance;
 import org.compiere.util.TimeUtil;
 
 import de.metas.handlingunits.attribute.impl.AbstractHUAttributeValue;
 import de.metas.handlingunits.attribute.storage.IAttributeStorage;
 import de.metas.handlingunits.model.I_M_HU_PI_Attribute;
+import lombok.NonNull;
 
 /**
  * Wraps an {@link I_M_AttributeInstance} and uses definition from {@link I_M_HU_PI_Attribute}
@@ -39,13 +39,15 @@ import de.metas.handlingunits.model.I_M_HU_PI_Attribute;
  * @author tsa
  *
  */
-/* package */class AIAttributeValue extends AbstractHUAttributeValue
+/* package */class AIWithHUPIAttributeValue extends AbstractHUAttributeValue
 {
 	private final I_M_AttributeInstance attributeInstance;
 	private final boolean isGeneratedAttribute;
 
-	public AIAttributeValue(final IAttributeStorage attributeStorage, final I_M_AttributeInstance attributeInstance,
-			final I_M_HU_PI_Attribute piAttribute,
+	public AIWithHUPIAttributeValue(
+			final IAttributeStorage attributeStorage,
+			@NonNull final I_M_AttributeInstance attributeInstance,
+			@NonNull final I_M_HU_PI_Attribute piAttribute,
 			final boolean isGeneratedAttribute)
 	{
 		super(//
@@ -54,7 +56,6 @@ import de.metas.handlingunits.model.I_M_HU_PI_Attribute;
 				, Boolean.TRUE // ASI attributes are ALWAYS created from template attributes
 		);
 
-		Check.assumeNotNull(attributeInstance, "attributeInstance not null");
 		this.attributeInstance = attributeInstance;
 		this.isGeneratedAttribute = isGeneratedAttribute;
 	}
@@ -63,7 +64,6 @@ import de.metas.handlingunits.model.I_M_HU_PI_Attribute;
 	protected void setInternalValueString(final String value)
 	{
 		attributeInstance.setValue(value);
-
 	}
 
 	@Override

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/impl/ASIAttributeStorageFactory.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/impl/ASIAttributeStorageFactory.java
@@ -36,7 +36,7 @@ import de.metas.handlingunits.attribute.storage.IAttributeStorage;
  * @author tsa
  *
  */
-public class ASIAttributeStorageFactory extends AbstractModelAttributeStorageFactory<I_M_AttributeSetInstance, ASIAttributeStorage>
+public class ASIAttributeStorageFactory extends AbstractModelAttributeStorageFactory<I_M_AttributeSetInstance, ASIWithPackingItemTemplesAttributeStorage>
 {
 
 	@Override
@@ -63,8 +63,8 @@ public class ASIAttributeStorageFactory extends AbstractModelAttributeStorageFac
 	}
 
 	@Override
-	protected ASIAttributeStorage createAttributeStorage(final I_M_AttributeSetInstance model)
+	protected ASIWithPackingItemTemplesAttributeStorage createAttributeStorage(final I_M_AttributeSetInstance model)
 	{
-		return new ASIAttributeStorage(this, model);
+		return new ASIWithPackingItemTemplesAttributeStorage(this, model);
 	}
 }

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/impl/ASIAwareAttributeStorageFactory.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/impl/ASIAwareAttributeStorageFactory.java
@@ -38,7 +38,7 @@ import de.metas.handlingunits.attribute.storage.IAttributeStorage;
  * @author tsa
  *
  */
-public class ASIAwareAttributeStorageFactory extends AbstractModelAttributeStorageFactory<I_M_AttributeSetInstance, ASIAttributeStorage>
+public class ASIAwareAttributeStorageFactory extends AbstractModelAttributeStorageFactory<I_M_AttributeSetInstance, ASIWithPackingItemTemplesAttributeStorage>
 {
 	private final IAttributeSetInstanceAwareFactoryService asiAwareFactory = Services.get(IAttributeSetInstanceAwareFactoryService.class);
 
@@ -101,9 +101,9 @@ public class ASIAwareAttributeStorageFactory extends AbstractModelAttributeStora
 	}
 
 	@Override
-	protected ASIAttributeStorage createAttributeStorage(final I_M_AttributeSetInstance model)
+	protected ASIWithPackingItemTemplesAttributeStorage createAttributeStorage(final I_M_AttributeSetInstance model)
 	{
-		return new ASIAttributeStorage(this, model);
+		return new ASIWithPackingItemTemplesAttributeStorage(this, model);
 	}
 
 	@Override

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/impl/AbstractAttributeStorage.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/impl/AbstractAttributeStorage.java
@@ -130,32 +130,27 @@ public abstract class AbstractAttributeStorage implements IAttributeStorage
 	/**
 	 * Sort {@link IAttributeValue}s by DisplaySeqNo
 	 */
-	private static final Comparator<IAttributeValue> attributeValueSortBySeqNo = new Comparator<IAttributeValue>()
-	{
-		@Override
-		public int compare(final IAttributeValue o1, final IAttributeValue o2)
+	private static final Comparator<IAttributeValue> attributeValueSortBySeqNo = (o1, o2) -> {
+		// Sort by DisplaySeqNo
+		final int displaySeqNoCmp = o1.getDisplaySeqNo() - o2.getDisplaySeqNo();
+		if (displaySeqNoCmp != 0)
 		{
-			// Sort by DisplaySeqNo
-			final int displaySeqNoCmp = o1.getDisplaySeqNo() - o2.getDisplaySeqNo();
-			if (displaySeqNoCmp != 0)
-			{
-				return displaySeqNoCmp;
-			}
-
-			// Fallback: sort by M_Attribute_ID (just to have a predictible order)
-			final int attributeIdCmp = o1.getM_Attribute().getM_Attribute_ID() - o2.getM_Attribute().getM_Attribute_ID();
-			return attributeIdCmp;
+			return displaySeqNoCmp;
 		}
+
+		// Fallback: sort by M_Attribute_ID (just to have a predictible order)
+		final int attributeIdCmp = o1.getM_Attribute().getM_Attribute_ID() - o2.getM_Attribute().getM_Attribute_ID();
+		return attributeIdCmp;
 	};
 
 	public AbstractAttributeStorage(@NonNull final IAttributeStorageFactory storageFactory)
 	{
 		this.storageFactory = storageFactory;
-		huAttributesDAO = storageFactory.getHUAttributesDAO();
-		huStorageDAO = storageFactory.getHUStorageDAO();
+		this.huAttributesDAO = storageFactory.getHUAttributesDAO();
+		this.huStorageDAO = storageFactory.getHUStorageDAO();
 
-		calloutAttributeStorageListener = new CalloutAttributeStorageListener();
-		listeners.addAttributeStorageListener(calloutAttributeStorageListener);
+		this.calloutAttributeStorageListener = new CalloutAttributeStorageListener();
+		this.listeners.addAttributeStorageListener(calloutAttributeStorageListener);
 	}
 
 	@Override
@@ -179,7 +174,7 @@ public abstract class AbstractAttributeStorage implements IAttributeStorage
 	}
 
 	@Override
-	public final IAttributeStorageFactory getHUAttributeStorageFactory()
+	public final IAttributeStorageFactory getAttributeStorageFactory()
 	{
 		assertNotDisposed();
 
@@ -366,10 +361,10 @@ public abstract class AbstractAttributeStorage implements IAttributeStorage
 	}
 
 	@Override
-	public final boolean hasAttribute(final I_M_Attribute attribute)
+	public final boolean hasAttribute(@NonNull final I_M_Attribute attribute)
 	{
 		assertNotDisposed();
-		Check.assumeNotNull(attribute, "attribute not null");
+
 
 		final int attributeId = attribute.getM_Attribute_ID();
 		return getIndexedAttributeValues().hasAttribute(attributeId);
@@ -1258,11 +1253,11 @@ public abstract class AbstractAttributeStorage implements IAttributeStorage
 		private IndexedAttributeValues(final List<IAttributeValue> attributeValues)
 		{
 			super();
-			final List<IAttributeValue> attributeValuesList = new ArrayList<IAttributeValue>(attributeValues);
+			final List<IAttributeValue> attributeValuesList = new ArrayList<>(attributeValues);
 			Collections.sort(attributeValuesList, AbstractAttributeStorage.attributeValueSortBySeqNo);
 
-			final Map<Integer, I_M_Attribute> attributeId2attribute = new HashMap<Integer, I_M_Attribute>(attributeValuesList.size());
-			final Map<Integer, IAttributeValue> attributeId2attributeValue = new HashMap<Integer, IAttributeValue>(attributeValuesList.size());
+			final Map<Integer, I_M_Attribute> attributeId2attribute = new HashMap<>(attributeValuesList.size());
+			final Map<Integer, IAttributeValue> attributeId2attributeValue = new HashMap<>(attributeValuesList.size());
 			for (final IAttributeValue attributeValue : attributeValuesList)
 			{
 				final I_M_Attribute attribute = attributeValue.getM_Attribute();

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/impl/AbstractHUAttributeStorage.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/impl/AbstractHUAttributeStorage.java
@@ -377,7 +377,7 @@ public abstract class AbstractHUAttributeStorage extends AbstractAttributeStorag
 	@Override
 	public final BigDecimal getStorageQtyOrZERO()
 	{
-		final IHUStorageFactory huStorageFactory = getHUAttributeStorageFactory().getHUStorageFactory();
+		final IHUStorageFactory huStorageFactory = getAttributeStorageFactory().getHUStorageFactory();
 		final IHUStorage storage = huStorageFactory.getStorage(getM_HU());
 		final BigDecimal fullStorageQty = storage.getQtyForProductStorages();
 		return fullStorageQty;

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/impl/HUAttributeStorage.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/impl/HUAttributeStorage.java
@@ -115,7 +115,7 @@ import lombok.NonNull;
 		// Ensure that the parentItem is actually attached to an HU
 		Check.assumeNotNull(parentHU, "An M_HU_Item (parentHUItem) {} is linked to a handling unit for child HU={}", parentItem, hu);
 
-		final IAttributeStorageFactory storageFactory = getHUAttributeStorageFactory();
+		final IAttributeStorageFactory storageFactory = getAttributeStorageFactory();
 		final IAttributeStorage parentAttributeSetStorage = storageFactory.getAttributeStorage(parentHU);
 
 		return parentAttributeSetStorage;
@@ -144,7 +144,7 @@ import lombok.NonNull;
 
 	private final Map<String, IAttributeStorage> retrieveChildrenAttributeStorages()
 	{
-		final IAttributeStorageFactory storageFactory = getHUAttributeStorageFactory();
+		final IAttributeStorageFactory storageFactory = getAttributeStorageFactory();
 		final IHandlingUnitsDAO handlingUnitsDAO = getHandlingUnitsDAO();
 
 		final Map<String, IAttributeStorage> childrenAttributeSetStorages = new LinkedHashMap<String, IAttributeStorage>();

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/impl/NullAttributeStorage.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/impl/NullAttributeStorage.java
@@ -342,7 +342,7 @@ public final class NullAttributeStorage implements IAttributeStorage
 	 * @throws UnsupportedOperationException
 	 */
 	@Override
-	public IAttributeStorageFactory getHUAttributeStorageFactory()
+	public IAttributeStorageFactory getAttributeStorageFactory()
 	{
 		throw new UnsupportedOperationException();
 	}

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/strategy/impl/CopyHUAttributeTransferStrategy.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/strategy/impl/CopyHUAttributeTransferStrategy.java
@@ -10,12 +10,12 @@ package de.metas.handlingunits.attribute.strategy.impl;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -35,7 +35,6 @@ public final class CopyHUAttributeTransferStrategy implements IHUAttributeTransf
 
 	private CopyHUAttributeTransferStrategy()
 	{
-		super();
 	}
 
 	@Override

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HandlingUnitsBL.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HandlingUnitsBL.java
@@ -101,7 +101,7 @@ public class HandlingUnitsBL implements IHandlingUnitsBL
 			return false;
 		}
 		final IHandlingUnitsDAO dao = Services.get(IHandlingUnitsDAO.class);
-		if (piId == dao.getNo_HU_PI_ID())
+		if (piId == dao.getPackingItemTemplate_HU_PI_ID())
 		{
 			return false;
 		}
@@ -338,7 +338,7 @@ public class HandlingUnitsBL implements IHandlingUnitsBL
 		}
 
 		final int piItemId = piItem.getM_HU_PI_Item_ID();
-		if (piItemId == Services.get(IHandlingUnitsDAO.class).getNo_HU_PI_Item_ID())
+		if (piItemId == Services.get(IHandlingUnitsDAO.class).getPackingItemTemplate_HU_PI_Item_ID())
 		{
 			return true;
 		}

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HandlingUnitsDAO.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HandlingUnitsDAO.java
@@ -93,9 +93,10 @@ public class HandlingUnitsDAO implements IHandlingUnitsDAO
 	private final transient Logger logger = LogManager.getLogger(getClass());
 
 	// NOTE: it's public only for testing purposes
-	public static final int NO_HU_PI_ID = 100;
-	public static final int NO_HU_PI_Version_ID = 100;
-	public static final int NO_HU_PI_Item_ID = 540004;
+	public static final int PACKING_ITEM_TEMPLATE_HU_PI_ID = 100;
+	public static final int PACKING_ITEM_TEMPLATE_HU_PI_Version_ID = 100;
+	public static final int PACKING_ITEM_TEMPLATE_HU_PI_Item_ID = 540004;
+
 	public static final int VIRTUAL_HU_PI_ID = 101;
 	public static final int VIRTUAL_HU_PI_Version_ID = 101;
 	public static final int VIRTUAL_HU_PI_Item_ID = 101;
@@ -113,12 +114,12 @@ public class HandlingUnitsDAO implements IHandlingUnitsDAO
 	}
 
 	@Override
-	public I_M_HU_PI retrieveNoPI(final Properties ctx)
+	public I_M_HU_PI retrievePackingItemTemplatePI(final Properties ctx)
 	{
-		final I_M_HU_PI noPI = retrievePI(ctx, NO_HU_PI_ID);
+		final I_M_HU_PI noPI = retrievePI(ctx, PACKING_ITEM_TEMPLATE_HU_PI_ID);
 		if (noPI == null)
 		{
-			throw new AdempiereException("@NotFound@ @M_HU_PI_ID@ NoPI (ID=" + NO_HU_PI_ID + ")");
+			throw new AdempiereException("@NotFound@ @M_HU_PI_ID@ NoPI (ID=" + PACKING_ITEM_TEMPLATE_HU_PI_ID + ")");
 		}
 
 		return noPI;
@@ -126,12 +127,12 @@ public class HandlingUnitsDAO implements IHandlingUnitsDAO
 
 	@Override
 	@Cached
-	public I_M_HU_PI_Item retrieveNoPIItem(@CacheCtx final Properties ctx)
+	public I_M_HU_PI_Item retrievePackingItemTemplatePIItem(@CacheCtx final Properties ctx)
 	{
-		final I_M_HU_PI_Item noPIItem = InterfaceWrapperHelper.create(ctx, NO_HU_PI_Item_ID, I_M_HU_PI_Item.class, ITrx.TRXNAME_None);
+		final I_M_HU_PI_Item noPIItem = InterfaceWrapperHelper.create(ctx, PACKING_ITEM_TEMPLATE_HU_PI_Item_ID, I_M_HU_PI_Item.class, ITrx.TRXNAME_None);
 		if (noPIItem == null)
 		{
-			throw new AdempiereException("@NotFound@ @M_HU_PI_Item_ID@ NoPI (ID=" + NO_HU_PI_Item_ID + ")");
+			throw new AdempiereException("@NotFound@ @M_HU_PI_Item_ID@ NoPI (ID=" + PACKING_ITEM_TEMPLATE_HU_PI_Item_ID + ")");
 		}
 
 		return noPIItem;
@@ -175,15 +176,15 @@ public class HandlingUnitsDAO implements IHandlingUnitsDAO
 	}
 
 	@Override
-	public int getNo_HU_PI_ID()
+	public int getPackingItemTemplate_HU_PI_ID()
 	{
-		return NO_HU_PI_ID;
+		return PACKING_ITEM_TEMPLATE_HU_PI_ID;
 	}
 
 	@Override
-	public int getNo_HU_PI_Item_ID()
+	public int getPackingItemTemplate_HU_PI_Item_ID()
 	{
-		return NO_HU_PI_Item_ID;
+		return PACKING_ITEM_TEMPLATE_HU_PI_Item_ID;
 	}
 
 	@Override
@@ -652,7 +653,7 @@ public class HandlingUnitsDAO implements IHandlingUnitsDAO
 		//
 		// Fetch only those PI Items which have our given huPI included
 		// 08254: if No-PI, don't add included HU filter
-		if (huPIId != getNo_HU_PI_ID())
+		if (huPIId != getPackingItemTemplate_HU_PI_ID())
 		{
 			piItemsQueryBuilder.addEqualsFilter(I_M_HU_PI_Item.COLUMN_Included_HU_PI_ID, huPIId);
 		}

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/impl/HUShipmentAssignmentBL.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/impl/HUShipmentAssignmentBL.java
@@ -10,12 +10,12 @@ package de.metas.handlingunits.inout.impl;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -54,15 +54,16 @@ import de.metas.handlingunits.model.X_M_HU;
 import de.metas.handlingunits.util.HUTopLevel;
 import de.metas.inout.IInOutDAO;
 import de.metas.inoutcandidate.api.IShipmentScheduleAllocDAO;
+import lombok.NonNull;
 
 public class HUShipmentAssignmentBL implements IHUShipmentAssignmentBL
 {
 	@Override
-	public final void assignHU(final org.compiere.model.I_M_InOutLine shipmentLine, final HUTopLevel huToAssign, final boolean isTransferPackingMaterials)
+	public final void assignHU(
+			@NonNull final org.compiere.model.I_M_InOutLine shipmentLine,
+			@NonNull final HUTopLevel huToAssign,
+			final boolean isTransferPackingMaterials)
 	{
-		Check.assumeNotNull(shipmentLine, "shipmentLine not null");
-		Check.assumeNotNull(huToAssign, "huToAssign not null");
-
 		// services
 		final IHUAssignmentBL huAssignmentBL = Services.get(IHUAssignmentBL.class);
 

--- a/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/HUTestHelper.java
+++ b/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/HUTestHelper.java
@@ -660,13 +660,13 @@ public class HUTestHelper
 	{
 		final I_M_HU_PI huDefNone = InterfaceWrapperHelper.create(ctx, I_M_HU_PI.class, ITrx.TRXNAME_None);
 		huDefNone.setName("NoPI");
-		huDefNone.setM_HU_PI_ID(HandlingUnitsDAO.NO_HU_PI_ID);
+		huDefNone.setM_HU_PI_ID(HandlingUnitsDAO.PACKING_ITEM_TEMPLATE_HU_PI_ID);
 		InterfaceWrapperHelper.save(huDefNone);
 
 		final String huUnitType = null; // any
-		createVersion(huDefNone, true, huUnitType, HandlingUnitsDAO.NO_HU_PI_Version_ID);
+		createVersion(huDefNone, true, huUnitType, HandlingUnitsDAO.PACKING_ITEM_TEMPLATE_HU_PI_Version_ID);
 
-		huDefItemNone = createHU_PI_Item_Material(huDefNone, HandlingUnitsDAO.NO_HU_PI_Item_ID);
+		huDefItemNone = createHU_PI_Item_Material(huDefNone, HandlingUnitsDAO.PACKING_ITEM_TEMPLATE_HU_PI_Item_ID);
 		huDefItemProductNone = assignProductAny(huDefItemNone, HUPIItemProductDAO.NO_HU_PI_Item_Product_ID);
 
 		return huDefNone;
@@ -1772,7 +1772,7 @@ public class HUTestHelper
 
 	public boolean isNoPI(final I_M_HU_PI pi)
 	{
-		return pi.getM_HU_PI_ID() == Services.get(IHandlingUnitsDAO.class).getNo_HU_PI_ID();
+		return pi.getM_HU_PI_ID() == Services.get(IHandlingUnitsDAO.class).getPackingItemTemplate_HU_PI_ID();
 	}
 
 	public boolean isVirtualPI(final I_M_HU_PI pi)

--- a/de.metas.handlingunits.client/src/main/java/de/metas/handlingunits/client/terminal/editor/model/impl/HUAttributeSetPropertiesModel.java
+++ b/de.metas.handlingunits.client/src/main/java/de/metas/handlingunits/client/terminal/editor/model/impl/HUAttributeSetPropertiesModel.java
@@ -631,7 +631,7 @@ public class HUAttributeSetPropertiesModel extends AbstractPropertiesPanelModel
 
 		private final IHUAttributesDAO getHUAttributesDAO()
 		{
-			return attributeStorage.getHUAttributeStorageFactory().getHUAttributesDAO();
+			return attributeStorage.getAttributeStorageFactory().getHUAttributesDAO();
 		}
 
 		public final IAttributeValue getAttributeValue(final I_M_Attribute attribute)

--- a/de.metas.handlingunits.client/src/main/java/de/metas/handlingunits/client/terminal/lutuconfig/model/AbstractLUTUKey.java
+++ b/de.metas.handlingunits.client/src/main/java/de/metas/handlingunits/client/terminal/lutuconfig/model/AbstractLUTUKey.java
@@ -57,7 +57,7 @@ public class AbstractLUTUKey extends AbstractLUTUCUKey
 		final int huPIId = huPI.getM_HU_PI_ID();
 
 		final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
-		isNoPI = huPIId == handlingUnitsDAO.getNo_HU_PI_ID();
+		isNoPI = huPIId == handlingUnitsDAO.getPackingItemTemplate_HU_PI_ID();
 		isVirtualPI = huPIId == handlingUnitsDAO.getVirtual_HU_PI_ID();
 
 		value = new KeyNamePair(huPIId, huPI.getName());

--- a/de.metas.handlingunits.client/src/main/java/de/metas/handlingunits/client/terminal/lutuconfig/model/LUTUConfigurationEditorModel.java
+++ b/de.metas.handlingunits.client/src/main/java/de/metas/handlingunits/client/terminal/lutuconfig/model/LUTUConfigurationEditorModel.java
@@ -711,7 +711,7 @@ public class LUTUConfigurationEditorModel extends AbstractLTCUModel
 
 	private LUKey createNoPILUKey()
 	{
-		final I_M_HU_PI_Item noPIItem = handlingUnitsDAO.retrieveNoPIItem(getCtx());
+		final I_M_HU_PI_Item noPIItem = handlingUnitsDAO.retrievePackingItemTemplatePIItem(getCtx());
 		final I_M_HU_PI noPI = noPIItem.getM_HU_PI_Version().getM_HU_PI();
 
 		final LUKey luKey = new LUKey(getTerminalContext(), noPI, noPIItem);

--- a/de.metas.handlingunits.client/src/main/java/de/metas/handlingunits/client/terminal/mmovement/model/split/impl/HUSplitDefaultQtyHandler.java
+++ b/de.metas.handlingunits.client/src/main/java/de/metas/handlingunits/client/terminal/mmovement/model/split/impl/HUSplitDefaultQtyHandler.java
@@ -244,7 +244,7 @@ import de.metas.logging.LogManager;
 		}
 		Check.assumeNotNull(maxOccurrencePIId, "maxOccurrencePI not null");
 
-		final I_M_HU_PI noPI = handlingUnitsDAO.retrieveNoPI(InterfaceWrapperHelper.getCtx(luHU));
+		final I_M_HU_PI noPI = handlingUnitsDAO.retrievePackingItemTemplatePI(InterfaceWrapperHelper.getCtx(luHU));
 		final I_M_HU_PI virtualPI = handlingUnitsDAO.retrieveVirtualPI(InterfaceWrapperHelper.getCtx(luHU));
 
 		final IKeyLayout tuKeyLayout = model.getTUKeyLayout();
@@ -275,7 +275,7 @@ import de.metas.logging.LogManager;
 		final IKeyLayout luKeyLayout = model.getLUKeyLayout();
 		final List<ILUTUCUKey> lutuKeys = luKeyLayout.getKeys(ILUTUCUKey.class);
 
-		final int noHUPIId = handlingUnitsDAO.getNo_HU_PI_ID();
+		final int noHUPIId = handlingUnitsDAO.getPackingItemTemplate_HU_PI_ID();
 		final boolean isTopLevelHU = handlingUnitsBL.isTopLevel(tuHU);
 
 		final I_M_HU luHU = handlingUnitsDAO.retrieveParent(tuHU);

--- a/de.metas.handlingunits.client/src/main/java/de/metas/handlingunits/client/terminal/mmovement/model/split/impl/HUSplitModel.java
+++ b/de.metas.handlingunits.client/src/main/java/de/metas/handlingunits/client/terminal/mmovement/model/split/impl/HUSplitModel.java
@@ -316,7 +316,7 @@ public final class HUSplitModel extends AbstractLTCUModel
 		//
 		// Add the virtual PI
 		{
-			final I_M_HU_PI_Item noPIItem = handlingUnitsDAO.retrieveNoPIItem(ctx);
+			final I_M_HU_PI_Item noPIItem = handlingUnitsDAO.retrievePackingItemTemplatePIItem(ctx);
 			final I_M_HU_PI virtualPI = noPIItem.getM_HU_PI_Version().getM_HU_PI();
 
 			final LUSplitKey key = new LUSplitKey(getTerminalContext(), noPIItem, virtualPI, huUnitType);


### PR DESCRIPTION
Add dedicated *ASI-Only* attribute-storage ASIAttributeStorage

..and use it in ShipmentLineBuilder.
Background: for this issue we need to follow the iol-candidate's attribute config, no matter whether an attribute is among the HU default attributes or not.

Also
* refactor; "NoPIi" => "PackagingTemplatePI"
* rename the former ASIAttributeStorage to ASIWithPackingItemTemplesAttributeStorage, cause that's what it really is

https://github.com/metasfresh/metasfresh/issues/3590