### PR TITLE
#3897 Add Translations for Pharma Business Partner Window

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5491520_sys_gh3897-bpartner-pharma-details-trl.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5491520_sys_gh3897-bpartner-pharma-details-trl.sql
@@ -163,3 +163,28 @@ UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 16:55:31'
 UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 16:55:52','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Pharma Wholesale Permission' WHERE AD_Field_ID=563600 AND AD_Language='en_US'
 ;
 
+-- 2018-04-20T16:58:37.287
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 16:58:37','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Pharma Agent' WHERE AD_Field_ID=563605 AND AD_Language='en_US'
+;
+
+-- 2018-04-20T16:58:56.512
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 16:58:56','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Pharma Manufacturer' WHERE AD_Field_ID=563604 AND AD_Language='en_US'
+;
+
+-- 2018-04-20T16:59:09.841
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 16:59:09','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Pharma Wholesale' WHERE AD_Field_ID=563603 AND AD_Language='en_US'
+;
+
+-- 2018-04-20T17:00:15.771
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 17:00:15','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Date Permission Type A' WHERE AD_Field_ID=563610 AND AD_Language='en_US'
+;
+
+-- 2018-04-20T17:00:36.710
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 17:00:36','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Pharma Receipt Permission' WHERE AD_Field_ID=563615 AND AD_Language='en_US'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5491520_sys_gh3897-bpartner-pharma-details-trl.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5491520_sys_gh3897-bpartner-pharma-details-trl.sql
@@ -1,0 +1,135 @@
+-- 2018-04-20T16:22:01.762
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,559728,563614,0,541014,1,TO_TIMESTAMP('2018-04-20 16:22:01','YYYY-MM-DD HH24:MI:SS'),100,'',1,'de.metas.vertical.pharma',0,'Y','N','N','N','N','N','N','N','Lieferberechtigung',340,330,0,1,1,TO_TIMESTAMP('2018-04-20 16:22:01','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2018-04-20T16:22:01.768
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Field_ID=563614 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2018-04-20T16:22:40.126
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,559729,563615,0,541015,1,TO_TIMESTAMP('2018-04-20 16:22:40','YYYY-MM-DD HH24:MI:SS'),100,'',1,'de.metas.vertical.pharma',0,'Y','N','N','N','N','N','N','N','Bezugsberechtigung',210,190,0,1,1,TO_TIMESTAMP('2018-04-20 16:22:40','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2018-04-20T16:22:40.127
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Field_ID=563615 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2018-04-20T16:22:45.391
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-04-20 16:22:45','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=563615
+;
+
+-- 2018-04-20T16:23:05.330
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-04-20 16:23:05','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=563614
+;
+
+-- 2018-04-20T16:23:53.456
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,563614,0,541014,541547,551504,'F',TO_TIMESTAMP('2018-04-20 16:23:53','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','N','Y','N','N','Lieferberechtigung',60,0,0,TO_TIMESTAMP('2018-04-20 16:23:53','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2018-04-20T16:23:58.973
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET SeqNo=70,Updated=TO_TIMESTAMP('2018-04-20 16:23:58','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=551501
+;
+
+-- 2018-04-20T16:24:29.288
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=90,Updated=TO_TIMESTAMP('2018-04-20 16:24:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=551504
+;
+
+-- 2018-04-20T16:24:29.289
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=100,Updated=TO_TIMESTAMP('2018-04-20 16:24:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550651
+;
+
+-- 2018-04-20T16:24:29.294
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=110,Updated=TO_TIMESTAMP('2018-04-20 16:24:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550652
+;
+
+-- 2018-04-20T16:24:29.296
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=120,Updated=TO_TIMESTAMP('2018-04-20 16:24:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550650
+;
+
+-- 2018-04-20T16:24:29.298
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=130,Updated=TO_TIMESTAMP('2018-04-20 16:24:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550653
+;
+
+-- 2018-04-20T16:24:29.301
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=140,Updated=TO_TIMESTAMP('2018-04-20 16:24:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550656
+;
+
+-- 2018-04-20T16:24:29.302
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=150,Updated=TO_TIMESTAMP('2018-04-20 16:24:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550667
+;
+
+-- 2018-04-20T16:24:29.304
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=160,Updated=TO_TIMESTAMP('2018-04-20 16:24:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550642
+;
+
+-- 2018-04-20T16:24:58.543
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,563615,0,541015,541548,551505,'F',TO_TIMESTAMP('2018-04-20 16:24:58','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','N','Y','N','N','Bezugsberechtigung',50,0,0,TO_TIMESTAMP('2018-04-20 16:24:58','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2018-04-20T16:25:07.735
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=70,Updated=TO_TIMESTAMP('2018-04-20 16:25:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=551505
+;
+
+-- 2018-04-20T16:25:07.737
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=80,Updated=TO_TIMESTAMP('2018-04-20 16:25:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550673
+;
+
+-- 2018-04-20T16:25:07.739
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=90,Updated=TO_TIMESTAMP('2018-04-20 16:25:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550683
+;
+
+-- 2018-04-20T16:25:07.741
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=100,Updated=TO_TIMESTAMP('2018-04-20 16:25:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550681
+;
+
+-- 2018-04-20T16:25:07.743
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=110,Updated=TO_TIMESTAMP('2018-04-20 16:25:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=550674
+;
+
+-- 2018-04-20T16:25:30.041
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-04-20 16:25:30','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=563603
+;
+
+-- 2018-04-20T16:25:33.203
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-04-20 16:25:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=563604
+;
+
+-- 2018-04-20T16:25:36.755
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-04-20 16:25:36','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=563605
+;
+
+-- 2018-04-20T16:25:40.861
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-04-20 16:25:40','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=563610
+;
+
+-- 2018-04-20T16:26:09.943
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-04-20 16:26:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=563609
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5491520_sys_gh3897-bpartner-pharma-details-trl.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5491520_sys_gh3897-bpartner-pharma-details-trl.sql
@@ -143,3 +143,23 @@ UPDATE AD_Column SET DefaultValue='B',Updated=TO_TIMESTAMP('2018-04-20 16:30:31'
 UPDATE AD_Column SET DefaultValue='B',Updated=TO_TIMESTAMP('2018-04-20 16:30:50','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=559729
 ;
 
+-- 2018-04-20T16:54:58.042
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 16:54:58','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Pharma Agent Permission' WHERE AD_Field_ID=563601 AND AD_Language='en_US'
+;
+
+-- 2018-04-20T16:55:06.825
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 16:55:06','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Field_ID=563598 AND AD_Language='en_US'
+;
+
+-- 2018-04-20T16:55:31.261
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 16:55:31','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Pharma Manufacturer Permission' WHERE AD_Field_ID=563599 AND AD_Language='en_US'
+;
+
+-- 2018-04-20T16:55:52.704
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 16:55:52','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Pharma Wholesale Permission' WHERE AD_Field_ID=563600 AND AD_Language='en_US'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5491520_sys_gh3897-bpartner-pharma-details-trl.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5491520_sys_gh3897-bpartner-pharma-details-trl.sql
@@ -188,3 +188,33 @@ UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 17:00:15'
 UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 17:00:36','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Pharma Receipt Permission' WHERE AD_Field_ID=563615 AND AD_Language='en_US'
 ;
 
+-- 2018-04-20T17:04:45.068
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 17:04:45','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Veterinary Pharmacy Permission' WHERE AD_Field_ID=563602 AND AD_Language='en_US'
+;
+
+-- 2018-04-20T17:05:56.538
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 17:05:56','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Pharma Shipment Permission' WHERE AD_Field_ID=563609 AND AD_Language='en_US'
+;
+
+-- 2018-04-20T17:06:13.623
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET Name='Arzneimittelvermittler §52c Abs.1-3 AMG',Updated=TO_TIMESTAMP('2018-04-20 17:06:13','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=563601
+;
+
+-- 2018-04-20T17:06:22.889
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 17:06:22','YYYY-MM-DD HH24:MI:SS'),Name='Pharmacy Permission' WHERE AD_Field_ID=563598 AND AD_Language='en_US'
+;
+
+-- 2018-04-20T17:07:51.212
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 17:07:51','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Pharma Shipment Permission' WHERE AD_Field_ID=563614 AND AD_Language='en_US'
+;
+
+-- 2018-04-20T17:08:16.714
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-04-20 17:08:16','YYYY-MM-DD HH24:MI:SS'),Name='Date Permission Type A' WHERE AD_Field_ID=563609 AND AD_Language='en_US'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5491520_sys_gh3897-bpartner-pharma-details-trl.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5491520_sys_gh3897-bpartner-pharma-details-trl.sql
@@ -133,3 +133,13 @@ UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-04-20 16:25:40','Y
 UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-04-20 16:26:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=563609
 ;
 
+-- 2018-04-20T16:30:31.882
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET DefaultValue='B',Updated=TO_TIMESTAMP('2018-04-20 16:30:31','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=559728
+;
+
+-- 2018-04-20T16:30:50.748
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET DefaultValue='B',Updated=TO_TIMESTAMP('2018-04-20 16:30:50','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=559729
+;
+


### PR DESCRIPTION
Adds missing Translations for en_US for new Pharma Fields. Adds Default logic. Adds Readonly Logic.

https://github.com/metasfresh/metasfresh/issues/3897