### PR TITLE
#4149 add by default the AND operator to the segment, not to the entire code

### DIFF
--- a/de.metas.adempiere.adempiere/base/src/main/java/org/compiere/apps/search/UserQueryRepository.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/compiere/apps/search/UserQueryRepository.java
@@ -231,7 +231,7 @@ public class UserQueryRepository
 			if (!segmentStr.trim().startsWith(Join.AND.getCode())
 					&& !segmentStr.trim().startsWith(Join.OR.getCode()))
 			{
-				segmentStr = Join.AND.getCode() + FIELD_SEPARATOR + code;
+				segmentStr = Join.AND.getCode() + segmentStr;
 			}
 
 			final IUserQueryRestriction row = parseUserQuerySegment(segmentStr);


### PR DESCRIPTION
#4149 User query: IUserQueryRestriction is not built properly all the
time