### PR TITLE
#4158 WebUI Sitemap: Missing Translations en_US

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
@@ -228,3 +228,53 @@ UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:23:09
 UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:23:24','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Purchase Order' WHERE AD_Tab_ID=540996 AND AD_Language='en_US'
 ;
 
+-- 2018-06-01T13:07:43.937
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET Name='MSV3 Bestellung Antwort', WEBUI_NameBrowse='MSV3 Bestellung Antwort',Updated=TO_TIMESTAMP('2018-06-01 13:07:43','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=541025
+;
+
+-- 2018-06-01T13:08:00.918
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:08:00','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Purchase Order Response',WEBUI_NameBrowse='MSV3 Purchase Order Response' WHERE AD_Menu_ID=541025 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:08:14.806
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window SET Name='MSV3 Bestellung Antwort',Updated=TO_TIMESTAMP('2018-06-01 13:08:14','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Window_ID=540402
+;
+
+-- 2018-06-01T13:08:26.299
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:08:26','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Purchase Order Response' WHERE AD_Window_ID=540402 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:08:55.367
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:08:55','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Purchase Order Response' WHERE AD_Tab_ID=540999 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:09:55.734
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET Name='MSV3 Fehler Info', WEBUI_NameBrowse='MSV3 Fehler Info',Updated=TO_TIMESTAMP('2018-06-01 13:09:55','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=541029
+;
+
+-- 2018-06-01T13:10:04.398
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:10:04','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Fault Info' WHERE AD_Menu_ID=541029 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:10:16.462
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window SET Name='MSV3 Fehler Info',Updated=TO_TIMESTAMP('2018-06-01 13:10:16','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Window_ID=540403
+;
+
+-- 2018-06-01T13:10:27.885
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:10:27','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Fault Info' WHERE AD_Window_ID=540403 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:10:36.869
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:10:36','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Fault Info' WHERE AD_Tab_ID=541003 AND AD_Language='en_US'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
@@ -78,3 +78,38 @@ UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:52:31','
 UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:52:49','YYYY-MM-DD HH24:MI:SS'),Name='Picking Slot Trx',WEBUI_NameBrowse='Picking Slot Trx' WHERE AD_Menu_ID=540950 AND AD_Language='en_US'
 ;
 
+-- 2018-06-01T12:02:33.163
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:02:33','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Vendor Configuration' WHERE AD_Window_ID=540397 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T12:02:46.552
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:02:46','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Configuration' WHERE AD_Tab_ID=540990 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T12:02:57.246
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:02:57','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Vendor Configuration',WEBUI_NameBrowse='MSV3 Vendor Configuration' WHERE AD_Menu_ID=541013 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T12:04:33.818
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:04:33','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Availability Trx',WEBUI_NameBrowse='MSV3 Availability Trx' WHERE AD_Menu_ID=541026 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T12:05:08.613
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET Name='MSV3 Verfügbarkeit Transaktion', WEBUI_NameBrowse='MSV3 Verfügbarkeit Transaktion',Updated=TO_TIMESTAMP('2018-06-01 12:05:08','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=541026
+;
+
+-- 2018-06-01T12:05:32.582
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window SET Name='MSV3 Verfuegbarkeit Transaktion',Updated=TO_TIMESTAMP('2018-06-01 12:05:32','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Window_ID=540406
+;
+
+-- 2018-06-01T12:05:32.592
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET Description=NULL, IsActive='Y', Name='MSV3 Verfuegbarkeit Transaktion',Updated=TO_TIMESTAMP('2018-06-01 12:05:32','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=541026
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
@@ -168,3 +168,63 @@ UPDATE AD_Tab SET Name='Verfuegbarkeitsanfrage Einzelne Antwort',Updated=TO_TIME
 UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:13:01','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Single Availability Check Response' WHERE AD_Tab_ID=541009 AND AD_Language='en_US'
 ;
 
+-- 2018-06-01T12:20:46.919
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET Name='MSV3 Bestell Transaktion', WEBUI_NameBrowse='MSV3 Bestell Transaktion',Updated=TO_TIMESTAMP('2018-06-01 12:20:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=541023
+;
+
+-- 2018-06-01T12:21:01.928
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:21:01','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Purchase Trx',WEBUI_NameBrowse='MSV3 Purchase Trx' WHERE AD_Menu_ID=541023 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T12:21:19.691
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window SET Name='MSV3 Bestellung Transaktion',Updated=TO_TIMESTAMP('2018-06-01 12:21:19','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Window_ID=540400
+;
+
+-- 2018-06-01T12:21:19.692
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET Description=NULL, IsActive='Y', Name='MSV3 Bestellung Transaktion',Updated=TO_TIMESTAMP('2018-06-01 12:21:19','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=541023
+;
+
+-- 2018-06-01T12:21:30.992
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:21:30','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Purchase Trx' WHERE AD_Window_ID=540400 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T12:21:39.773
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:21:39','YYYY-MM-DD HH24:MI:SS') WHERE AD_Tab_ID=540995 AND AD_Language='de_CH'
+;
+
+-- 2018-06-01T12:21:48.117
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:21:48','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Purchase Transaction' WHERE AD_Tab_ID=540995 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T12:22:39.132
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET WEBUI_NameBrowse='MSV3 Bestellung',Updated=TO_TIMESTAMP('2018-06-01 12:22:39','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=541024
+;
+
+-- 2018-06-01T12:22:52.147
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:22:52','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Purchase Order',WEBUI_NameBrowse='MSV3 Purchase Order' WHERE AD_Menu_ID=541024 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T12:23:00.955
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window SET Name='MSV3 Bestellung',Updated=TO_TIMESTAMP('2018-06-01 12:23:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Window_ID=540401
+;
+
+-- 2018-06-01T12:23:09.453
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:23:09','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Purchase Order' WHERE AD_Window_ID=540401 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T12:23:24.913
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:23:24','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Purchase Order' WHERE AD_Tab_ID=540996 AND AD_Language='en_US'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
@@ -278,3 +278,68 @@ UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:10:27
 UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:10:36','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Fault Info' WHERE AD_Tab_ID=541003 AND AD_Language='en_US'
 ;
 
+-- 2018-06-01T13:49:28.624
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET WEBUI_NameBrowse='MSV3 Substitution',Updated=TO_TIMESTAMP('2018-06-01 13:49:28','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=541031
+;
+
+-- 2018-06-01T13:49:32.367
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:49:32','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Menu_ID=541031 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:49:40.363
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window SET Name='MSV3 Substitution',Updated=TO_TIMESTAMP('2018-06-01 13:49:40','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Window_ID=540404
+;
+
+-- 2018-06-01T13:49:48.188
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:49:48','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Substitution' WHERE AD_Window_ID=540404 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:49:53.999
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:49:53','YYYY-MM-DD HH24:MI:SS') WHERE AD_Tab_ID=541004 AND AD_Language='de_CH'
+;
+
+-- 2018-06-01T13:49:56.537
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:49:56','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Tab_ID=541004 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:50:07.729
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET WEBUI_NameBrowse='MSV3 Tour',Updated=TO_TIMESTAMP('2018-06-01 13:50:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=541032
+;
+
+-- 2018-06-01T13:50:12.623
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:50:12','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',WEBUI_NameBrowse='MSV3 Tour' WHERE AD_Menu_ID=541032 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:50:22.883
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:50:22','YYYY-MM-DD HH24:MI:SS'),WEBUI_NameBrowse='MSV3 Substitution' WHERE AD_Menu_ID=541031 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:50:31.832
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window SET Name='MSV3 Tour',Updated=TO_TIMESTAMP('2018-06-01 13:50:31','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Window_ID=540405
+;
+
+-- 2018-06-01T13:50:39.104
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:50:39','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Tour' WHERE AD_Window_ID=540405 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:50:47.822
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:50:47','YYYY-MM-DD HH24:MI:SS') WHERE AD_Tab_ID=541005 AND AD_Language='de_CH'
+;
+
+-- 2018-06-01T13:50:50.642
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:50:50','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Tab_ID=541005 AND AD_Language='en_US'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
@@ -1,0 +1,25 @@
+-- 2018-06-01T11:23:22.544
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET WEBUI_NameBrowse='Marketing Kontaktperson',Updated=TO_TIMESTAMP('2018-06-01 11:23:22','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=541090
+;
+
+-- 2018-06-01T11:23:47.722
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:23:47','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Marketing Contact' WHERE AD_Window_ID=540435 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T11:24:26.354
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:24:26','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Contact Person' WHERE AD_Tab_ID=541097 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T11:26:05.785
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:26:05','YYYY-MM-DD HH24:MI:SS'),Name='Marketing Contact Person' WHERE AD_Window_ID=540435 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T11:26:30.274
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:26:30','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Marketing Contact Person',WEBUI_NameBrowse='Marketing Contact Person' WHERE AD_Menu_ID=541090 AND AD_Language='en_US'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
@@ -438,3 +438,23 @@ UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:04:59
 UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:05:20','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Configuration' WHERE AD_Tab_ID=540652 AND AD_Language='en_US'
 ;
 
+-- 2018-06-01T14:07:56.032
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:07:56','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Import Business Partner',Description='Import Business Partner',WEBUI_NameBrowse='Import Business Partner' WHERE AD_Menu_ID=540983 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T14:09:07.451
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:09:07','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Board Settings',WEBUI_NameBrowse='Board Settings' WHERE AD_Menu_ID=540988 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T14:09:34.088
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:09:34','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Window_ID=540347 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T14:09:42.056
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:09:42','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Tab_ID=540832 AND AD_Language='en_US'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
@@ -43,3 +43,38 @@ UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:36:24
 UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:36:36','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Quality Note' WHERE AD_Tab_ID=540767 AND AD_Language='en_US'
 ;
 
+-- 2018-06-01T11:50:23.045
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:50:23','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Aggregation of Invoicecandidates',WEBUI_NameBrowse='Aggregation of Invoicecandidates' WHERE AD_Menu_ID=540998 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T11:50:32.429
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:50:32','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Aggregation of Invoicecandidates' WHERE AD_Window_ID=540117 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T11:51:00.631
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:51:00','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Aggregation Allocation' WHERE AD_Tab_ID=540345 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T11:52:12.189
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:52:12','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Picking Tray Trx',WEBUI_NameBrowse='Picking Tray Trx' WHERE AD_Menu_ID=540950 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T11:52:24.124
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:52:24','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Window_ID=540215 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T11:52:31.160
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:52:31','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Tab_ID=540589 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T11:52:49.491
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:52:49','YYYY-MM-DD HH24:MI:SS'),Name='Picking Slot Trx',WEBUI_NameBrowse='Picking Slot Trx' WHERE AD_Menu_ID=540950 AND AD_Language='en_US'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
@@ -343,3 +343,98 @@ UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:50:47','
 UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:50:50','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Tab_ID=541005 AND AD_Language='en_US'
 ;
 
+-- 2018-06-01T13:55:02.547
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:55:02','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Client/ Organisation',Description='',WEBUI_NameBrowse='Client/ Organisation' WHERE AD_Menu_ID=540833 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:55:11.649
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET EntityType='D',Updated=TO_TIMESTAMP('2018-06-01 13:55:11','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=540836
+;
+
+-- 2018-06-01T13:57:33.088
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:57:33','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Settings',WEBUI_NameBrowse='Settings' WHERE AD_Menu_ID=540836 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:58:54.801
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:58:54','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Workpackage Queue' WHERE AD_Window_ID=540163 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:59:01.255
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:59:01','YYYY-MM-DD HH24:MI:SS') WHERE AD_Tab_ID=540456 AND AD_Language='it_CH'
+;
+
+-- 2018-06-01T13:59:05.353
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:59:05','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Workpackage Queue' WHERE AD_Tab_ID=540456 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:59:17.580
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:59:17','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Workpackage Queue',WEBUI_NameBrowse='Workpackage Queue' WHERE AD_Menu_ID=540892 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T13:59:53.913
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 13:59:53','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Printing Queue',Description='Printing Queue',WEBUI_NameBrowse='Printing Queue' WHERE AD_Menu_ID=540911 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T14:00:08.826
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:00:08','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Printing Queue',Description='Printing Queue' WHERE AD_Window_ID=540165 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T14:00:14.466
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:00:14','YYYY-MM-DD HH24:MI:SS') WHERE AD_Tab_ID=540460 AND AD_Language='it_CH'
+;
+
+-- 2018-06-01T14:00:20.896
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:00:20','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Printing Queue' WHERE AD_Tab_ID=540460 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T14:00:41.321
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:00:41','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Printer',WEBUI_NameBrowse='Printer' WHERE AD_Menu_ID=540912 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T14:00:58.732
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:00:58','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Printer',Description='Printer' WHERE AD_Window_ID=540167 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T14:01:07.759
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:01:07','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Printer' WHERE AD_Tab_ID=540463 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T14:04:41.658
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:04:41','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Printer Allocation',Description='',WEBUI_NameBrowse='Printer Allocation' WHERE AD_Menu_ID=540913 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T14:04:50.536
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window SET Name='Drucker Zuordnung',Updated=TO_TIMESTAMP('2018-06-01 14:04:50','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Window_ID=540169
+;
+
+-- 2018-06-01T14:04:50.544
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET Description='Hostbasierte Zurodnung zwischen logischen Druckern und Hardware-Druckern', IsActive='Y', Name='Drucker Zuordnung',Updated=TO_TIMESTAMP('2018-06-01 14:04:50','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=540431
+;
+
+-- 2018-06-01T14:04:59.880
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:04:59','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Printer Allocation',Description='' WHERE AD_Window_ID=540169 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T14:05:20.138
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 14:05:20','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Configuration' WHERE AD_Tab_ID=540652 AND AD_Language='en_US'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
@@ -113,3 +113,58 @@ UPDATE AD_Window SET Name='MSV3 Verfuegbarkeit Transaktion',Updated=TO_TIMESTAMP
 UPDATE AD_Menu SET Description=NULL, IsActive='Y', Name='MSV3 Verfuegbarkeit Transaktion',Updated=TO_TIMESTAMP('2018-06-01 12:05:32','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=541026
 ;
 
+-- 2018-06-01T12:09:52.043
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET Name='MSV3 Verfuegbarkeitsanfrage Einzelne', WEBUI_NameBrowse='MSV3 Verfuegbarkeitsanfrage Einzelne',Updated=TO_TIMESTAMP('2018-06-01 12:09:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=541027
+;
+
+-- 2018-06-01T12:10:18.466
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:10:18','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Single Availability Check',WEBUI_NameBrowse='MSV3 Single Availability Check' WHERE AD_Menu_ID=541027 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T12:10:30.286
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window SET Name='MSV3 Verfuegbarkeitsanfrage Einzelne',Updated=TO_TIMESTAMP('2018-06-01 12:10:30','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Window_ID=540407
+;
+
+-- 2018-06-01T12:10:38.992
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:10:38','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Single Availability Check' WHERE AD_Window_ID=540407 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T12:10:50.066
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab SET Name='Verfuegbarkeitsanfrage Einzelne',Updated=TO_TIMESTAMP('2018-06-01 12:10:50','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Tab_ID=541007
+;
+
+-- 2018-06-01T12:10:57.888
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:10:57','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Single Availability Check' WHERE AD_Tab_ID=541007 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T12:11:52.803
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu SET Name='MSV3 Verfuegbarkeitsanfrage Einzelne Antwort', WEBUI_NameBrowse='MSV3 Verfuegbarkeitsanfrage Einzelne Antwort',Updated=TO_TIMESTAMP('2018-06-01 12:11:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Menu_ID=541028
+;
+
+-- 2018-06-01T12:12:22.259
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:12:22','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Single Availability Check Response',WEBUI_NameBrowse='MSV3 Single Availability Check Response' WHERE AD_Menu_ID=541028 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T12:12:36.995
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:12:36','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='MSV3 Single Availability Check Response' WHERE AD_Window_ID=540408 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T12:12:49.160
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab SET Name='Verfuegbarkeitsanfrage Einzelne Antwort',Updated=TO_TIMESTAMP('2018-06-01 12:12:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Tab_ID=541009
+;
+
+-- 2018-06-01T12:13:01.705
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 12:13:01','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Single Availability Check Response' WHERE AD_Tab_ID=541009 AND AD_Language='en_US'
+;
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5494940_sys_gh4158-webui-menu-missing-trl-en_US.sql
@@ -23,3 +23,23 @@ UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:26:05
 UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:26:30','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Marketing Contact Person',WEBUI_NameBrowse='Marketing Contact Person' WHERE AD_Menu_ID=541090 AND AD_Language='en_US'
 ;
 
+-- 2018-06-01T11:33:58.014
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:33:58','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Attribute Search',Description='',WEBUI_NameBrowse='Attribute Search' WHERE AD_Menu_ID=540990 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T11:36:06.938
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Menu_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:36:06','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Quality Note',WEBUI_NameBrowse='Quality Note' WHERE AD_Menu_ID=540978 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T11:36:24.860
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Window_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:36:24','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Window_ID=540316 AND AD_Language='en_US'
+;
+
+-- 2018-06-01T11:36:36.744
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-06-01 11:36:36','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Quality Note' WHERE AD_Tab_ID=540767 AND AD_Language='en_US'
+;
+


### PR DESCRIPTION
Adds en_US Translations for Sitemap entries, Window names, Tab Names.

https://github.com/metasfresh/metasfresh/issues/4158