### PR TITLE
#4233 Attributeset as Sysadmin cannot be created

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5495940_sys_gh4233-attributeset-client-validation.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5495940_sys_gh4233-attributeset-client-validation.sql
@@ -1,0 +1,10 @@
+-- 2018-06-16T12:44:52.874
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET AD_Val_Rule_ID=NULL,Updated=TO_TIMESTAMP('2018-06-16 12:44:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=8492
+;
+
+-- 2018-06-16T12:45:38.064
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET AD_Val_Rule_ID=NULL,Updated=TO_TIMESTAMP('2018-06-16 12:45:38','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=8530
+;
+


### PR DESCRIPTION
Removes dynamic validation from ad_client column 
https://github.com/metasfresh/metasfresh/issues/4233