### PR TITLE
#4271-app Reactivated and completed sales order is considered as new sales order in Material Dispo implement ShipmentScheduleDeletedHandler

### DIFF
--- a/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/candidate/CandidateId.java
+++ b/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/candidate/CandidateId.java
@@ -35,19 +35,15 @@ import lombok.Value;
 @ToString(doNotUseGetters = true)
 public class CandidateId implements RepoIdAware
 {
-	private static final int UNSPECIFIED_REPO_ID = Integer.MAX_VALUE - 10;
-
 	/**
 	 * Use this constant in a {@link CandidatesQuery} to indicate that the ID shall not be considered.
 	 */
-	public static final CandidateId UNSPECIFIED = CandidateId.ofRepoId(UNSPECIFIED_REPO_ID);
-
-	private static final int NULL_REPO_ID = Integer.MAX_VALUE - 20;
+	public static final CandidateId UNSPECIFIED = CandidateId.ofRepoId(IdConstants.UNSPECIFIED_REPO_ID);
 
 	/**
 	 * Use this constant in a {@link CandidatesQuery} to indicate that the ID be null (makes sense for parent-ID).
 	 */
-	public static final CandidateId NULL = CandidateId.ofRepoId(NULL_REPO_ID);
+	public static final CandidateId NULL = CandidateId.ofRepoId(IdConstants.NULL_REPO_ID);
 
 	int repoId;
 
@@ -83,11 +79,11 @@ public class CandidateId implements RepoIdAware
 
 	public boolean isNull()
 	{
-		return repoId == NULL_REPO_ID;
+		return repoId == IdConstants.NULL_REPO_ID;
 	}
 
 	public boolean isUnspecified()
 	{
-		return repoId == UNSPECIFIED_REPO_ID;
+		return repoId == IdConstants.UNSPECIFIED_REPO_ID;
 	}
 }

--- a/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/candidate/IdConstants.java
+++ b/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/candidate/IdConstants.java
@@ -1,0 +1,70 @@
+package de.metas.material.dispo.commons.candidate;
+
+import org.adempiere.util.Check;
+
+import lombok.NonNull;
+
+/*
+ * #%L
+ * metasfresh-material-dispo-commons
+ * %%
+ * Copyright (C) 2018 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * Class to help getting a grip on when an repoId <= 0 means "null" and when it means "not specified".
+ * The distinction is important when querying or storing stuff.
+ *
+ */
+public final class IdConstants
+{
+	public static final int UNSPECIFIED_REPO_ID = Integer.MAX_VALUE - 10;
+	public static final int NULL_REPO_ID = Integer.MAX_VALUE - 20;
+
+	private IdConstants()
+	{
+	}
+
+	public static int toRepoId(final int id)
+	{
+		if (id == UNSPECIFIED_REPO_ID)
+		{
+			return 0;
+		}
+		else if (id == NULL_REPO_ID)
+		{
+			return 0;
+		}
+		return id;
+	}
+
+	public static int toUnspecifiedIfZero(final int repoId)
+	{
+		if (repoId <= 0)
+		{
+			return UNSPECIFIED_REPO_ID;
+		}
+		return repoId;
+	}
+
+	public static void assertValidId(final int id, @NonNull final String name)
+	{
+		Check.errorUnless(id > 0 || id == UNSPECIFIED_REPO_ID || id == NULL_REPO_ID,
+				"{}={} needs to be >0 or ==IdConstants.UNSPECIFIED_REPO_ID or ==IdConstants.NULL_REPO_ID", name, id);
+	}
+}

--- a/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/candidate/businesscase/DemandDetail.java
+++ b/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/candidate/businesscase/DemandDetail.java
@@ -1,5 +1,8 @@
 package de.metas.material.dispo.commons.candidate.businesscase;
 
+import static de.metas.material.dispo.commons.candidate.IdConstants.UNSPECIFIED_REPO_ID;
+import static de.metas.material.dispo.commons.candidate.IdConstants.toUnspecifiedIfZero;
+
 import java.math.BigDecimal;
 
 import javax.annotation.Nullable;
@@ -40,7 +43,7 @@ import lombok.Value;
 @Builder(toBuilder = true)
 public class DemandDetail implements BusinessCaseDetail
 {
-	public static DemandDetail forDocumentDescriptor(
+	public static DemandDetail forDocumentLine(
 			final int shipmentScheduleId,
 			@NonNull final DocumentLineDescriptor documentDescriptor,
 			@NonNull final BigDecimal plannedQty)
@@ -48,17 +51,19 @@ public class DemandDetail implements BusinessCaseDetail
 		final int orderId;
 		final int orderLineId;
 		final int subscriptionProgressId;
+		final int forecastId = UNSPECIFIED_REPO_ID;
+		final int forecastLineId = UNSPECIFIED_REPO_ID;
 		if (documentDescriptor instanceof OrderLineDescriptor)
 		{
 			final OrderLineDescriptor orderLineDescriptor = (OrderLineDescriptor)documentDescriptor;
 			orderLineId = orderLineDescriptor.getOrderLineId();
 			orderId = orderLineDescriptor.getOrderId();
-			subscriptionProgressId = -1;
+			subscriptionProgressId = UNSPECIFIED_REPO_ID;
 		}
 		else if (documentDescriptor instanceof SubscriptionLineDescriptor)
 		{
-			orderLineId = 0;
-			orderId = 0;
+			orderLineId = UNSPECIFIED_REPO_ID;
+			orderId = UNSPECIFIED_REPO_ID;
 			subscriptionProgressId = ((SubscriptionLineDescriptor)documentDescriptor).getSubscriptionProgressId();
 		}
 		else
@@ -72,6 +77,8 @@ public class DemandDetail implements BusinessCaseDetail
 				.shipmentScheduleId(shipmentScheduleId)
 				.orderLineId(orderLineId)
 				.orderId(orderId)
+				.forecastLineId(forecastLineId)
+				.forecastId(forecastId)
 				.subscriptionProgressId(subscriptionProgressId)
 				.plannedQty(plannedQty).build();
 	}
@@ -84,13 +91,13 @@ public class DemandDetail implements BusinessCaseDetail
 			return null;
 		}
 		return DemandDetail.builder()
-				.demandCandidateId(supplyRequiredDescriptor.getDemandCandidateId())
-				.forecastId(supplyRequiredDescriptor.getForecastId())
-				.forecastLineId(supplyRequiredDescriptor.getForecastLineId())
-				.orderId(supplyRequiredDescriptor.getOrderId())
-				.orderLineId(supplyRequiredDescriptor.getOrderLineId())
-				.shipmentScheduleId(supplyRequiredDescriptor.getShipmentScheduleId())
-				.subscriptionProgressId(supplyRequiredDescriptor.getSubscriptionProgressId())
+				.demandCandidateId(toUnspecifiedIfZero(supplyRequiredDescriptor.getDemandCandidateId()))
+				.forecastId(toUnspecifiedIfZero(supplyRequiredDescriptor.getForecastId()))
+				.forecastLineId(toUnspecifiedIfZero(supplyRequiredDescriptor.getForecastLineId()))
+				.orderId(toUnspecifiedIfZero(supplyRequiredDescriptor.getOrderId()))
+				.orderLineId(toUnspecifiedIfZero(supplyRequiredDescriptor.getOrderLineId()))
+				.shipmentScheduleId(toUnspecifiedIfZero(supplyRequiredDescriptor.getShipmentScheduleId()))
+				.subscriptionProgressId(toUnspecifiedIfZero(supplyRequiredDescriptor.getSubscriptionProgressId()))
 				.plannedQty(supplyRequiredDescriptor.getMaterialDescriptor().getQuantity())
 				.build();
 	}

--- a/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/repository/query/CandidatesQuery.java
+++ b/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/repository/query/CandidatesQuery.java
@@ -76,10 +76,13 @@ public final class CandidatesQuery
 		final PurchaseDetailsQuery purchaseDetailsQuery = PurchaseDetailsQuery
 				.ofPurchaseDetailOrNull(PurchaseDetail.castOrNull(candidate.getBusinessCaseDetail()));
 
+		final DemandDetailsQuery demandDetailsQuery = DemandDetailsQuery
+				.ofDemandDetailOrNull(DemandDetail.castOrNull(candidate.getBusinessCaseDetail()));
+
 		final CandidatesQueryBuilder builder = CandidatesQuery.builder()
 				.materialDescriptorQuery(MaterialDescriptorQuery.forDescriptor(candidate.getMaterialDescriptor()))
 				.matchExactStorageAttributesKey(true)
-				.demandDetail(candidate.getDemandDetail())
+				.demandDetailsQuery(demandDetailsQuery)
 				.distributionDetailsQuery(distributionDetailsQuery)
 				.productionDetailsQuery(productionDetailsQuery)
 				.purchaseDetailsQuery(purchaseDetailsQuery)
@@ -114,7 +117,7 @@ public final class CandidatesQuery
 	 */
 	MaterialDescriptorQuery parentMaterialDescriptorQuery;
 
-	DemandDetail parentDemandDetail;
+	DemandDetailsQuery parentDemandDetailsQuery;
 
 	int orgId;
 
@@ -159,7 +162,7 @@ public final class CandidatesQuery
 	/**
 	 * Used for additional infos if this candidate relates to particular demand
 	 */
-	DemandDetail demandDetail;
+	DemandDetailsQuery demandDetailsQuery;
 
 	/**
 	 * If multiple transactionDetails are specified here, then a matching candidate needs to have matching transactionDetails for all of them.
@@ -169,7 +172,7 @@ public final class CandidatesQuery
 	@Builder
 	public CandidatesQuery(
 			final MaterialDescriptorQuery parentMaterialDescriptorQuery,
-			final DemandDetail parentDemandDetail,
+			final DemandDetailsQuery parentDemandDetailsQuery,
 			final int orgId,
 			final CandidateType type,
 			final CandidateBusinessCase businessCase,
@@ -182,11 +185,11 @@ public final class CandidatesQuery
 			final ProductionDetailsQuery productionDetailsQuery,
 			final DistributionDetailsQuery distributionDetailsQuery,
 			final PurchaseDetailsQuery purchaseDetailsQuery,
-			final DemandDetail demandDetail,
+			final DemandDetailsQuery demandDetailsQuery,
 			@Singular final List<TransactionDetail> transactionDetails)
 	{
 		this.parentMaterialDescriptorQuery = parentMaterialDescriptorQuery;
-		this.parentDemandDetail = parentDemandDetail;
+		this.parentDemandDetailsQuery = parentDemandDetailsQuery;
 
 		this.matchExactStorageAttributesKey = matchExactStorageAttributesKey;
 		this.orgId = orgId;
@@ -202,7 +205,7 @@ public final class CandidatesQuery
 		this.distributionDetailsQuery = distributionDetailsQuery;
 		this.purchaseDetailsQuery = purchaseDetailsQuery;
 
-		this.demandDetail = demandDetail;
+		this.demandDetailsQuery = demandDetailsQuery;
 		this.transactionDetails = transactionDetails;
 	}
 

--- a/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/repository/query/DemandDetailsQuery.java
+++ b/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/repository/query/DemandDetailsQuery.java
@@ -1,0 +1,127 @@
+package de.metas.material.dispo.commons.repository.query;
+
+import static de.metas.material.dispo.commons.candidate.IdConstants.UNSPECIFIED_REPO_ID;
+
+import javax.annotation.Nullable;
+
+import org.adempiere.util.Check;
+
+import de.metas.material.dispo.commons.candidate.IdConstants;
+import de.metas.material.dispo.commons.candidate.businesscase.DemandDetail;
+import de.metas.material.event.commons.DocumentLineDescriptor;
+import de.metas.material.event.commons.OrderLineDescriptor;
+import de.metas.material.event.commons.SubscriptionLineDescriptor;
+import lombok.NonNull;
+import lombok.Value;
+
+/*
+ * #%L
+ * metasfresh-material-dispo-commons
+ * %%
+ * Copyright (C) 2018 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+@Value
+public class DemandDetailsQuery
+{
+
+	public static DemandDetailsQuery ofShipmentScheduleId(final int shipmentScheduleId)
+	{
+		Check.assumeGreaterThanZero(shipmentScheduleId, "shipmentScheduleId");
+		return new DemandDetailsQuery(
+				shipmentScheduleId,
+				UNSPECIFIED_REPO_ID,
+				UNSPECIFIED_REPO_ID,
+				UNSPECIFIED_REPO_ID);
+	}
+
+	public static DemandDetailsQuery ofForecastLineId(final int forecastLineId)
+	{
+		return new DemandDetailsQuery(
+				UNSPECIFIED_REPO_ID,
+				UNSPECIFIED_REPO_ID,
+				UNSPECIFIED_REPO_ID,
+				forecastLineId);
+	}
+
+	public static DemandDetailsQuery ofDemandDetailOrNull(@Nullable final DemandDetail demandDetail)
+	{
+		if (demandDetail == null)
+		{
+			return null;
+		}
+		return new DemandDetailsQuery(
+				demandDetail.getShipmentScheduleId() == 0 ? UNSPECIFIED_REPO_ID : demandDetail.getShipmentScheduleId(),
+				demandDetail.getOrderLineId() == 0 ? UNSPECIFIED_REPO_ID : demandDetail.getOrderLineId(),
+				demandDetail.getSubscriptionProgressId() == 0 ? UNSPECIFIED_REPO_ID : demandDetail.getSubscriptionProgressId(),
+				demandDetail.getForecastLineId() == 0 ? UNSPECIFIED_REPO_ID : demandDetail.getForecastLineId());
+	}
+
+	public static DemandDetailsQuery forDocumentLine(
+			@NonNull final DocumentLineDescriptor documentLineDescriptor)
+	{
+		if (documentLineDescriptor instanceof OrderLineDescriptor)
+		{
+			final OrderLineDescriptor orderLineDescriptor = OrderLineDescriptor.cast(documentLineDescriptor);
+			return new DemandDetailsQuery(
+					UNSPECIFIED_REPO_ID,
+					orderLineDescriptor.getOrderLineId(),
+					UNSPECIFIED_REPO_ID,
+					UNSPECIFIED_REPO_ID);
+		}
+		else if (documentLineDescriptor instanceof SubscriptionLineDescriptor)
+		{
+			final SubscriptionLineDescriptor subscriptionLineDescriptor = SubscriptionLineDescriptor.cast(documentLineDescriptor);
+			return new DemandDetailsQuery(
+					UNSPECIFIED_REPO_ID,
+					UNSPECIFIED_REPO_ID,
+					subscriptionLineDescriptor.getSubscriptionProgressId(),
+					UNSPECIFIED_REPO_ID);
+		}
+		else
+		{
+			Check.fail("documentLineDescriptor has unsupported type={}; documentLineDescriptor={}", documentLineDescriptor.getClass(), documentLineDescriptor);
+		}
+
+		return null;
+	}
+
+	int shipmentScheduleId;
+
+	int orderLineId;
+	int subscriptionLineId;
+
+	int forecastLineId;
+
+	private DemandDetailsQuery(
+			final int shipmentScheduleId,
+			final int orderLineId,
+			final int subscriptionLineId,
+			final int forecastLineId)
+	{
+		this.shipmentScheduleId = shipmentScheduleId;
+		this.orderLineId = orderLineId;
+		this.subscriptionLineId = subscriptionLineId;
+		this.forecastLineId = forecastLineId;
+
+		IdConstants.assertValidId(shipmentScheduleId, "shipmentScheduleId");
+		IdConstants.assertValidId(orderLineId, "orderLineId");
+		IdConstants.assertValidId(subscriptionLineId, "subscriptionLineId");
+		IdConstants.assertValidId(forecastLineId, "forecastLineId");
+	}
+}

--- a/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/repository/repohelpers/RepositoryCommons.java
+++ b/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/repository/repohelpers/RepositoryCommons.java
@@ -1,5 +1,8 @@
 package de.metas.material.dispo.commons.repository.repohelpers;
 
+import static de.metas.material.dispo.commons.candidate.IdConstants.UNSPECIFIED_REPO_ID;
+import static de.metas.material.dispo.commons.candidate.IdConstants.toRepoId;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -18,9 +21,9 @@ import com.google.common.base.Preconditions;
 
 import de.metas.material.dispo.commons.candidate.CandidateId;
 import de.metas.material.dispo.commons.candidate.TransactionDetail;
-import de.metas.material.dispo.commons.candidate.businesscase.DemandDetail;
 import de.metas.material.dispo.commons.repository.AvailableToPromiseQuery;
 import de.metas.material.dispo.commons.repository.query.CandidatesQuery;
+import de.metas.material.dispo.commons.repository.query.DemandDetailsQuery;
 import de.metas.material.dispo.commons.repository.query.DistributionDetailsQuery;
 import de.metas.material.dispo.commons.repository.query.MaterialDescriptorQuery;
 import de.metas.material.dispo.commons.repository.query.MaterialDescriptorQuery.CustomerIdOperator;
@@ -117,17 +120,17 @@ public class RepositoryCommons
 			}
 		}
 
-		if (query.getParentDemandDetail() != null)
+		if (query.getParentDemandDetailsQuery() != null)
 		{
 			final IQueryBuilder<I_MD_Candidate> parentBuilder = queryBL.createQueryBuilder(I_MD_Candidate.class)
 					.addOnlyActiveRecordsFilter();
-			addDemandDetailToBuilder(query.getParentDemandDetail(), parentBuilder);
+			addDemandDetailToBuilder(query.getParentDemandDetailsQuery(), parentBuilder);
 			builder.addInSubQueryFilter(I_MD_Candidate.COLUMN_MD_Candidate_Parent_ID, I_MD_Candidate.COLUMN_MD_Candidate_ID, parentBuilder.create());
 		}
 
-		if (query.getDemandDetail() != null)
+		if (query.getDemandDetailsQuery() != null)
 		{
-			addDemandDetailToBuilder(query.getDemandDetail(), builder);
+			addDemandDetailToBuilder(query.getDemandDetailsQuery(), builder);
 		}
 
 		addProductionDetailToFilter(query, builder);
@@ -245,10 +248,10 @@ public class RepositoryCommons
 	 * @param builder
 	 */
 	private void addDemandDetailToBuilder(
-			@Nullable final DemandDetail demandDetail,
+			@Nullable final DemandDetailsQuery demandDetailsQuery,
 			@NonNull final IQueryBuilder<I_MD_Candidate> builder)
 	{
-		if (demandDetail == null)
+		if (demandDetailsQuery == null)
 		{
 			return;
 		}
@@ -257,25 +260,32 @@ public class RepositoryCommons
 				.createQueryBuilder(I_MD_Candidate_Demand_Detail.class)
 				.addOnlyActiveRecordsFilter();
 
-		final boolean hasOrderLine = demandDetail.getOrderLineId() > 0;
+		final boolean hasOrderLine = demandDetailsQuery.getOrderLineId() != UNSPECIFIED_REPO_ID;
 		if (hasOrderLine)
 		{
 			demandDetailsSubQueryBuilder
-					.addEqualsFilter(I_MD_Candidate_Demand_Detail.COLUMN_C_OrderLine_ID, demandDetail.getOrderLineId());
+					.addEqualsFilter(I_MD_Candidate_Demand_Detail.COLUMN_C_OrderLine_ID, toRepoId(demandDetailsQuery.getOrderLineId()));
 		}
 
-		final boolean hasShipmentschedule = demandDetail.getShipmentScheduleId() > 0;
+		final boolean hasSubscriptionLine = demandDetailsQuery.getSubscriptionLineId() != UNSPECIFIED_REPO_ID;
+		if (hasSubscriptionLine)
+		{
+			demandDetailsSubQueryBuilder
+					.addEqualsFilter(I_MD_Candidate_Demand_Detail.COLUMN_C_SubscriptionProgress_ID, toRepoId(demandDetailsQuery.getSubscriptionLineId()));
+		}
+
+		final boolean hasShipmentschedule = demandDetailsQuery.getShipmentScheduleId() != UNSPECIFIED_REPO_ID;
 		if (hasShipmentschedule)
 		{
 			demandDetailsSubQueryBuilder
-					.addEqualsFilter(I_MD_Candidate_Demand_Detail.COLUMNNAME_M_ShipmentSchedule_ID, demandDetail.getShipmentScheduleId());
+					.addEqualsFilter(I_MD_Candidate_Demand_Detail.COLUMNNAME_M_ShipmentSchedule_ID, toRepoId(demandDetailsQuery.getShipmentScheduleId()));
 		}
 
-		final boolean hasForecastLine = demandDetail.getForecastLineId() > 0;
+		final boolean hasForecastLine = demandDetailsQuery.getForecastLineId() != UNSPECIFIED_REPO_ID;
 		if (hasForecastLine)
 		{
 			demandDetailsSubQueryBuilder
-					.addEqualsFilter(I_MD_Candidate_Demand_Detail.COLUMN_M_ForecastLine_ID, demandDetail.getForecastLineId());
+					.addEqualsFilter(I_MD_Candidate_Demand_Detail.COLUMN_M_ForecastLine_ID, toRepoId(demandDetailsQuery.getForecastLineId()));
 		}
 
 		if (hasOrderLine || hasForecastLine || hasShipmentschedule)

--- a/de.metas.material/dispo-commons/src/test/java/de/metas/material/dispo/commons/candidate/DemandDetailTest.java
+++ b/de.metas.material/dispo-commons/src/test/java/de/metas/material/dispo/commons/candidate/DemandDetailTest.java
@@ -1,5 +1,6 @@
 package de.metas.material.dispo.commons.candidate;
 
+import static de.metas.material.dispo.commons.candidate.IdConstants.UNSPECIFIED_REPO_ID;
 import static de.metas.material.event.EventTestHelper.CLIENT_ID;
 import static de.metas.material.event.EventTestHelper.ORG_ID;
 import static de.metas.material.event.EventTestHelper.createMaterialDescriptor;
@@ -55,13 +56,13 @@ public class DemandDetailTest
 				.orderId(50)
 				.orderLineId(60)
 				.build();
-		final DemandDetail demandDetail = DemandDetail.forDocumentDescriptor(20, orderLineDescriptor, TEN);
+		final DemandDetail demandDetail = DemandDetail.forDocumentLine(20, orderLineDescriptor, TEN);
 		assertThat(demandDetail.getShipmentScheduleId()).isEqualTo(20);
 
-		assertThat(demandDetail.getForecastId()).isLessThanOrEqualTo(0);
-		assertThat(demandDetail.getForecastLineId()).isLessThanOrEqualTo(0);
+		assertThat(demandDetail.getForecastId()).isEqualTo(UNSPECIFIED_REPO_ID);
+		assertThat(demandDetail.getForecastLineId()).isEqualTo(UNSPECIFIED_REPO_ID);
 
-		assertThat(demandDetail.getSubscriptionProgressId()).isLessThanOrEqualTo(0);
+		assertThat(demandDetail.getSubscriptionProgressId()).isEqualTo(UNSPECIFIED_REPO_ID);
 
 		assertThat(demandDetail.getOrderId()).isEqualTo(50);
 		assertThat(demandDetail.getOrderLineId()).isEqualTo(60);
@@ -77,17 +78,17 @@ public class DemandDetailTest
 				.subscriptionProgressId(20)
 				.subscriptionBillBPartnerId(30).build();
 
-		final DemandDetail demandDetail = DemandDetail.forDocumentDescriptor(20, subscriptionLineDescriptor, TEN);
+		final DemandDetail demandDetail = DemandDetail.forDocumentLine(20, subscriptionLineDescriptor, TEN);
 
 		assertThat(demandDetail.getShipmentScheduleId()).isEqualTo(20);
 
-		assertThat(demandDetail.getForecastId()).isLessThanOrEqualTo(0);
-		assertThat(demandDetail.getForecastLineId()).isLessThanOrEqualTo(0);
+		assertThat(demandDetail.getForecastId()).isEqualTo(UNSPECIFIED_REPO_ID);
+		assertThat(demandDetail.getForecastLineId()).isEqualTo(UNSPECIFIED_REPO_ID);
 
-		assertThat(demandDetail.getSubscriptionProgressId()).isLessThanOrEqualTo(20);
+		assertThat(demandDetail.getSubscriptionProgressId()).isEqualTo(20);
 
-		assertThat(demandDetail.getOrderId()).isLessThanOrEqualTo(0);
-		assertThat(demandDetail.getOrderLineId()).isLessThanOrEqualTo(0);
+		assertThat(demandDetail.getOrderId()).isEqualTo(UNSPECIFIED_REPO_ID);
+		assertThat(demandDetail.getOrderLineId()).isEqualTo(UNSPECIFIED_REPO_ID);
 
 		assertThat(demandDetail.getPlannedQty()).isEqualByComparingTo(TEN);
 	}

--- a/de.metas.material/dispo-commons/src/test/java/de/metas/material/dispo/commons/repository/CandiateRepositoryRetrievalTests.java
+++ b/de.metas.material/dispo-commons/src/test/java/de/metas/material/dispo/commons/repository/CandiateRepositoryRetrievalTests.java
@@ -39,6 +39,7 @@ import de.metas.material.dispo.commons.candidate.businesscase.DistributionDetail
 import de.metas.material.dispo.commons.candidate.businesscase.ProductionDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.PurchaseDetail;
 import de.metas.material.dispo.commons.repository.query.CandidatesQuery;
+import de.metas.material.dispo.commons.repository.query.DemandDetailsQuery;
 import de.metas.material.dispo.commons.repository.query.DistributionDetailsQuery;
 import de.metas.material.dispo.commons.repository.query.MaterialDescriptorQuery;
 import de.metas.material.dispo.commons.repository.query.ProductionDetailsQuery;
@@ -588,7 +589,7 @@ public class CandiateRepositoryRetrievalTests
 		createCandiateRecordWithShipmentScheduleId(35);
 
 		final CandidatesQuery query = CandidatesQuery.builder()
-				.demandDetail(DemandDetail.forShipmentScheduleIdAndOrderLineId(25, -1, -1, TEN))
+				.demandDetailsQuery(DemandDetailsQuery.ofShipmentScheduleId(25))
 				.build();
 		final List<Candidate> result = candidateRepositoryRetrieval.retrieveOrderedByDateAndSeqNo(query);
 
@@ -613,10 +614,10 @@ public class CandiateRepositoryRetrievalTests
 	public void retrieveMatches_by_forecastLineId()
 	{
 		final I_MD_Candidate candidateRecord = createCandiateRecordWithForecastLineId(25, 26);
-		createCandiateRecordWithForecastLineId(35, 36);
+		createCandiateRecordWithForecastLineId(35, 36); // create another one
 
 		final CandidatesQuery query = CandidatesQuery.builder()
-				.demandDetail(DemandDetail.forForecastLineId(25, 35, TEN))
+				.demandDetailsQuery(DemandDetailsQuery.ofForecastLineId(25))
 				.build();
 		final List<Candidate> result = candidateRepositoryRetrieval.retrieveOrderedByDateAndSeqNo(query);
 

--- a/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/SupplyProposalEvaluator.java
+++ b/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/SupplyProposalEvaluator.java
@@ -8,6 +8,7 @@ import de.metas.material.dispo.commons.candidate.CandidateType;
 import de.metas.material.dispo.commons.candidate.businesscase.DemandDetail;
 import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
 import de.metas.material.dispo.commons.repository.query.CandidatesQuery;
+import de.metas.material.dispo.commons.repository.query.DemandDetailsQuery;
 import de.metas.material.dispo.commons.repository.query.MaterialDescriptorQuery;
 import lombok.Builder;
 import lombok.NonNull;
@@ -59,7 +60,7 @@ public class SupplyProposalEvaluator
 		final CandidatesQuery proposedDemandExistsQuery = CandidatesQuery
 				.builder()
 				.type(CandidateType.DEMAND)
-				.demandDetail(proposal.getDemandDetail())
+				.demandDetailsQuery(DemandDetailsQuery.ofDemandDetailOrNull(proposal.getDemandDetail()))
 				.materialDescriptorQuery(MaterialDescriptorQuery
 						.builder()
 						.warehouseId(proposal.getDemandWarehouseId())
@@ -74,7 +75,7 @@ public class SupplyProposalEvaluator
 		final CandidatesQuery proposedSupplyExistsQuery = CandidatesQuery
 				.builder()
 				.type(CandidateType.SUPPLY)
-				.demandDetail(proposal.getDemandDetail())
+				.demandDetailsQuery(DemandDetailsQuery.ofDemandDetailOrNull(proposal.getDemandDetail()))
 				.materialDescriptorQuery(MaterialDescriptorQuery
 						.builder()
 						.warehouseId(proposal.getSupplyWarehouseId())

--- a/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/ddorder/DDOrderAdvisedHandler.java
+++ b/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/ddorder/DDOrderAdvisedHandler.java
@@ -18,6 +18,7 @@ import de.metas.material.dispo.commons.candidate.businesscase.Flag;
 import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
 import de.metas.material.dispo.commons.repository.CandidateRepositoryWriteService;
 import de.metas.material.dispo.commons.repository.query.CandidatesQuery;
+import de.metas.material.dispo.commons.repository.query.DemandDetailsQuery;
 import de.metas.material.dispo.commons.repository.query.DistributionDetailsQuery;
 import de.metas.material.dispo.commons.repository.query.MaterialDescriptorQuery;
 import de.metas.material.dispo.service.candidatechange.CandidateChangeService;
@@ -133,11 +134,7 @@ public class DDOrderAdvisedHandler
 				DemandDetail.forSupplyRequiredDescriptorOrNull(ddOrderEvent.getSupplyRequiredDescriptor());
 		Check.errorIf(demandDetail == null, "Missing demandDetail for ppOrderAdvisedEvent={}", ddOrderAdvisedEvent);
 
-		final DDOrder ddOrder = ddOrderAdvisedEvent.getDdOrder();
-		final DistributionDetailsQuery distributionDetailsQuery = DistributionDetailsQuery.builder()
-				.productPlanningId(ddOrder.getProductPlanningId())
-				.networkDistributionLineId(ddOrderLine.getNetworkDistributionLineId())
-				.build();
+		final DemandDetailsQuery demandDetailsQuery = DemandDetailsQuery.ofDemandDetailOrNull(demandDetail);
 
 		final MaterialDescriptorQuery materialDescriptorQuery = MaterialDescriptorQuery.builder()
 				.productId(ddOrderLine.getProductDescriptor().getProductId())
@@ -146,10 +143,16 @@ public class DDOrderAdvisedHandler
 				.date(computeDate(ddOrderEvent, ddOrderLine, candidateType))
 				.build();
 
+		final DDOrder ddOrder = ddOrderAdvisedEvent.getDdOrder();
+		final DistributionDetailsQuery distributionDetailsQuery = DistributionDetailsQuery.builder()
+				.productPlanningId(ddOrder.getProductPlanningId())
+				.networkDistributionLineId(ddOrderLine.getNetworkDistributionLineId())
+				.build();
+
 		final CandidatesQuery query = CandidatesQuery.builder()
 				.type(candidateType)
 				.businessCase(CandidateBusinessCase.PRODUCTION)
-				.demandDetail(demandDetail)
+				.demandDetailsQuery(demandDetailsQuery)
 				.materialDescriptorQuery(materialDescriptorQuery)
 				.distributionDetailsQuery(distributionDetailsQuery)
 				.build();

--- a/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/pporder/PPOrderAdvisedHandler.java
+++ b/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/pporder/PPOrderAdvisedHandler.java
@@ -16,6 +16,7 @@ import de.metas.material.dispo.commons.candidate.businesscase.DemandDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.Flag;
 import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
 import de.metas.material.dispo.commons.repository.query.CandidatesQuery;
+import de.metas.material.dispo.commons.repository.query.DemandDetailsQuery;
 import de.metas.material.dispo.commons.repository.query.ProductionDetailsQuery;
 import de.metas.material.dispo.service.candidatechange.CandidateChangeService;
 import de.metas.material.event.pporder.AbstractPPOrderEvent;
@@ -102,6 +103,8 @@ public final class PPOrderAdvisedHandler
 				DemandDetail.forSupplyRequiredDescriptorOrNull(ppOrderEvent.getSupplyRequiredDescriptor());
 		Check.errorIf(demandDetail == null, "Missing demandDetail for ppOrderAdvisedEvent={}", ppOrderAdvisedEvent);
 
+		final DemandDetailsQuery demandDetailsQuery = DemandDetailsQuery.ofDemandDetailOrNull(demandDetail);
+
 		final PPOrder ppOrder = ppOrderAdvisedEvent.getPpOrder();
 		final ProductionDetailsQuery productionDetailsQuery = ProductionDetailsQuery.builder()
 				.productPlanningId(ppOrder.getProductPlanningId())
@@ -110,7 +113,7 @@ public final class PPOrderAdvisedHandler
 		final CandidatesQuery query = CandidatesQuery.builder()
 				.type(CandidateType.SUPPLY)
 				.businessCase(CandidateBusinessCase.PRODUCTION)
-				.demandDetail(demandDetail)
+				.demandDetailsQuery(demandDetailsQuery)
 				.productionDetailsQuery(productionDetailsQuery)
 				.build();
 
@@ -128,6 +131,8 @@ public final class PPOrderAdvisedHandler
 				DemandDetail.forSupplyRequiredDescriptorOrNull(ppOrderEvent.getSupplyRequiredDescriptor());
 		Check.errorIf(demandDetail == null, "Missing demandDetail for ppOrderAdvisedEvent={}", ppOrderAdvisedEvent);
 
+		final DemandDetailsQuery demandDetailsQuery = DemandDetailsQuery.ofDemandDetailOrNull(demandDetail);
+
 		final PPOrder ppOrder = ppOrderAdvisedEvent.getPpOrder();
 		final ProductionDetailsQuery productionDetailsQuery = ProductionDetailsQuery.builder()
 				.productPlanningId(ppOrder.getProductPlanningId())
@@ -137,7 +142,7 @@ public final class PPOrderAdvisedHandler
 		final CandidatesQuery query = CandidatesQuery.builder()
 				.type(extractCandidateType(ppOrderLine))
 				.businessCase(CandidateBusinessCase.PRODUCTION)
-				.demandDetail(demandDetail)
+				.demandDetailsQuery(demandDetailsQuery)
 				.productionDetailsQuery(productionDetailsQuery)
 				.build();
 

--- a/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/shipmentschedule/ShipmentScheduleDeletedHandler.java
+++ b/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/shipmentschedule/ShipmentScheduleDeletedHandler.java
@@ -1,0 +1,98 @@
+package de.metas.material.dispo.service.event.handler.shipmentschedule;
+
+import static java.math.BigDecimal.ZERO;
+
+import java.util.Collection;
+
+import org.adempiere.util.Loggables;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import com.google.common.collect.ImmutableList;
+
+import de.metas.Profiles;
+import de.metas.material.dispo.commons.candidate.Candidate;
+import de.metas.material.dispo.commons.candidate.CandidateBusinessCase;
+import de.metas.material.dispo.commons.candidate.CandidateType;
+import de.metas.material.dispo.commons.candidate.IdConstants;
+import de.metas.material.dispo.commons.candidate.businesscase.DemandDetail;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
+import de.metas.material.dispo.commons.repository.query.CandidatesQuery;
+import de.metas.material.dispo.commons.repository.query.DemandDetailsQuery;
+import de.metas.material.dispo.service.candidatechange.CandidateChangeService;
+import de.metas.material.event.MaterialEventHandler;
+import de.metas.material.event.shipmentschedule.ShipmentScheduleDeletedEvent;
+import lombok.NonNull;
+
+/*
+ * #%L
+ * metasfresh-material-dispo
+ * %%
+ * Copyright (C) 2017 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+@Service
+@Profile(Profiles.PROFILE_MaterialDispo)
+public class ShipmentScheduleDeletedHandler implements MaterialEventHandler<ShipmentScheduleDeletedEvent>
+{
+	private final CandidateChangeService candidateChangeHandler;
+	private final CandidateRepositoryRetrieval candidateRepository;
+
+	public ShipmentScheduleDeletedHandler(
+			@NonNull final CandidateChangeService candidateChangeHandler,
+			@NonNull final CandidateRepositoryRetrieval candidateRepository)
+	{
+		this.candidateChangeHandler = candidateChangeHandler;
+		this.candidateRepository = candidateRepository;
+	}
+
+	@Override
+	public Collection<Class<? extends ShipmentScheduleDeletedEvent>> getHandeledEventType()
+	{
+		return ImmutableList.of(ShipmentScheduleDeletedEvent.class);
+	}
+
+	@Override
+	public void handleEvent(@NonNull final ShipmentScheduleDeletedEvent event)
+	{
+		final DemandDetailsQuery demandDetailsQuery = DemandDetailsQuery.ofShipmentScheduleId(event.getShipmentScheduleId());
+		final CandidatesQuery candidatesQuery = CandidatesQuery
+				.builder()
+				.type(CandidateType.DEMAND)
+				.businessCase(CandidateBusinessCase.SHIPMENT)
+				.demandDetailsQuery(demandDetailsQuery)
+				.build();
+
+		final Candidate candidate = candidateRepository.retrieveLatestMatchOrNull(candidatesQuery);
+		if (candidate == null)
+		{
+			Loggables.get().addLog("Found no records to change for shipmentScheduleId={}", event.getShipmentScheduleId());
+			return;
+		}
+
+		final DemandDetail updatedDemandDetail = candidate
+				.getDemandDetail()
+				.toBuilder()
+				.shipmentScheduleId(IdConstants.NULL_REPO_ID)
+				.plannedQty(ZERO)
+				.build();
+		final Candidate updatedCandidate = candidate
+				.withQuantity(ZERO)
+				.withBusinessCaseDetail(updatedDemandDetail);
+		candidateChangeHandler.onCandidateNewOrChange(updatedCandidate);
+	}
+}

--- a/de.metas.material/dispo-service/src/test/java/de/metas/material/dispo/service/event/MaterialEventHandlerRegistryTests.java
+++ b/de.metas.material/dispo-service/src/test/java/de/metas/material/dispo/service/event/MaterialEventHandlerRegistryTests.java
@@ -38,11 +38,11 @@ import de.metas.material.dispo.service.candidatechange.StockCandidateService;
 import de.metas.material.dispo.service.candidatechange.handler.DemandCandiateHandler;
 import de.metas.material.dispo.service.candidatechange.handler.SupplyCandiateHandler;
 import de.metas.material.dispo.service.event.handler.ForecastCreatedHandler;
-import de.metas.material.dispo.service.event.handler.ShipmentScheduleCreatedHandler;
-import de.metas.material.dispo.service.event.handler.ShipmentScheduleCreatedHandlerTests;
 import de.metas.material.dispo.service.event.handler.TransactionEventHandler;
 import de.metas.material.dispo.service.event.handler.ddorder.DDOrderAdvisedHandler;
 import de.metas.material.dispo.service.event.handler.pporder.PPOrderAdvisedHandler;
+import de.metas.material.dispo.service.event.handler.shipmentschedule.ShipmentScheduleCreatedHandler;
+import de.metas.material.dispo.service.event.handler.shipmentschedule.ShipmentScheduleCreatedHandlerTests;
 import de.metas.material.event.MaterialEvent;
 import de.metas.material.event.MaterialEventHandler;
 import de.metas.material.event.MaterialEventHandlerRegistry;
@@ -159,7 +159,9 @@ public class MaterialEventHandlerRegistryTests
 				candidateRepositoryRetrieval,
 				postMaterialEventService);
 
-		final ShipmentScheduleCreatedHandler shipmentScheduleEventHandler = new ShipmentScheduleCreatedHandler(candidateChangeHandler);
+		final ShipmentScheduleCreatedHandler shipmentScheduleEventHandler = new ShipmentScheduleCreatedHandler(
+				candidateChangeHandler,
+				candidateRepositoryRetrieval);
 
 		@SuppressWarnings("rawtypes")
 		final Optional<Collection<MaterialEventHandler>> handlers = Optional.of(ImmutableList.of(

--- a/de.metas.material/dispo-service/src/test/java/de/metas/material/dispo/service/event/handler/TransactionCreatedHandlerTests.java
+++ b/de.metas.material/dispo-service/src/test/java/de/metas/material/dispo/service/event/handler/TransactionCreatedHandlerTests.java
@@ -299,7 +299,7 @@ public class TransactionCreatedHandlerTests
 	private static void assertDemandDetailQuery(final CandidatesQuery query)
 	{
 		assertThat(query).isNotNull();
-		assertThat(query.getDemandDetail().getShipmentScheduleId()).isEqualTo(SHIPMENT_SCHEDULE_ID);
+		assertThat(query.getDemandDetailsQuery().getShipmentScheduleId()).isEqualTo(SHIPMENT_SCHEDULE_ID);
 		assertThat(query.getMaterialDescriptorQuery())
 				.as("If we have a demand detail, then only query via that demand detail")
 				.isNull();

--- a/de.metas.material/dispo-service/src/test/java/de/metas/material/dispo/service/event/handler/shipmentschedule/ShipmentScheduleCreatedHandlerTests.java
+++ b/de.metas.material/dispo-service/src/test/java/de/metas/material/dispo/service/event/handler/shipmentschedule/ShipmentScheduleCreatedHandlerTests.java
@@ -1,0 +1,172 @@
+package de.metas.material.dispo.service.event.handler.shipmentschedule;
+
+import static de.metas.material.event.EventTestHelper.BPARTNER_ID;
+import static de.metas.material.event.EventTestHelper.CLIENT_ID;
+import static de.metas.material.event.EventTestHelper.NOW;
+import static de.metas.material.event.EventTestHelper.ORG_ID;
+import static de.metas.material.event.EventTestHelper.createProductDescriptor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.adempiere.ad.wrapper.POJOLookupMap;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+import com.google.common.collect.ImmutableList;
+
+import de.metas.material.dispo.commons.DispoTestUtils;
+import de.metas.material.dispo.commons.RepositoryTestHelper;
+import de.metas.material.dispo.commons.candidate.CandidateType;
+import de.metas.material.dispo.commons.repository.AvailableToPromiseRepository;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryWriteService;
+import de.metas.material.dispo.model.I_MD_Candidate;
+import de.metas.material.dispo.model.I_MD_Candidate_Demand_Detail;
+import de.metas.material.dispo.service.candidatechange.CandidateChangeService;
+import de.metas.material.dispo.service.candidatechange.StockCandidateService;
+import de.metas.material.dispo.service.candidatechange.handler.DemandCandiateHandler;
+import de.metas.material.event.PostMaterialEventService;
+import de.metas.material.event.commons.EventDescriptor;
+import de.metas.material.event.commons.MaterialDescriptor;
+import de.metas.material.event.commons.OrderLineDescriptor;
+import de.metas.material.event.shipmentschedule.ShipmentScheduleCreatedEvent;
+import lombok.NonNull;
+import mockit.Mocked;
+
+/*
+ * #%L
+ * metasfresh-material-dispo-service
+ * %%
+ * Copyright (C) 2017 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+public class ShipmentScheduleCreatedHandlerTests
+{
+	private static final int shipmentScheduleId = 76;
+
+	private static final int orderLineId = 86;
+
+	/** Watches the current tests and dumps the database to console in case of failure */
+	@Rule
+	public final TestWatcher testWatcher = new AdempiereTestWatcher();
+
+	private static final int toWarehouseId = 30;
+
+	@Mocked
+	private PostMaterialEventService postMaterialEventService;
+
+	private ShipmentScheduleCreatedHandler shipmentScheduleCreatedHandler;
+
+	private AvailableToPromiseRepository atpRepository;
+
+	@Before
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		final CandidateRepositoryRetrieval candidateRepositoryRetrieval = new CandidateRepositoryRetrieval();
+
+		final CandidateRepositoryWriteService candidateRepositoryCommands = new CandidateRepositoryWriteService();
+
+		atpRepository = new AvailableToPromiseRepository();
+
+		final CandidateChangeService candidateChangeHandler = new CandidateChangeService(ImmutableList.of(
+				new DemandCandiateHandler(
+						candidateRepositoryRetrieval,
+						candidateRepositoryCommands,
+						postMaterialEventService,
+						atpRepository,
+						new StockCandidateService(
+								candidateRepositoryRetrieval,
+								candidateRepositoryCommands))));
+
+		shipmentScheduleCreatedHandler = new ShipmentScheduleCreatedHandler(
+				candidateChangeHandler,
+				candidateRepositoryRetrieval);
+	}
+
+	@Test
+	public void handleEvent()
+	{
+		performTest(shipmentScheduleCreatedHandler, atpRepository);
+	}
+
+	public static int performTest(
+			@NonNull final ShipmentScheduleCreatedHandler shipmentScheduleEventHandler,
+			@NonNull final AvailableToPromiseRepository atpRepository)
+	{
+		final ShipmentScheduleCreatedEvent event = createShipmentScheduleTestEvent();
+
+		RepositoryTestHelper.setupMockedRetrieveAvailableToPromise(
+				atpRepository,
+				event.getMaterialDescriptor(),
+				"0"); // ATP-quantity = 0
+
+		shipmentScheduleEventHandler.handleEvent(event);
+
+		final List<I_MD_Candidate> allRecords = DispoTestUtils.retrieveAllRecords();
+		assertThat(allRecords).hasSize(2);
+
+		assertThat(DispoTestUtils.filter(CandidateType.DEMAND)).hasSize(1);
+		assertThat(DispoTestUtils.filter(CandidateType.STOCK)).hasSize(1);
+
+		final I_MD_Candidate demandRecord = DispoTestUtils.filter(CandidateType.DEMAND).get(0);
+		final I_MD_Candidate stockRecord = DispoTestUtils.filter(CandidateType.STOCK).get(0);
+
+		assertThat(demandRecord.getSeqNo()).isEqualTo(stockRecord.getSeqNo() - 1); // the demand record shall be displayed first
+		assertThat(stockRecord.getMD_Candidate_Parent_ID()).isEqualTo(demandRecord.getMD_Candidate_ID());
+
+		assertThat(demandRecord.getQty()).isEqualByComparingTo("10");
+		assertThat(stockRecord.getQty()).isEqualByComparingTo("-10"); // the stock is unbalanced, because there is no existing stock and no supply
+
+		assertThat(allRecords).allSatisfy(r -> assertThat(r.getC_BPartner_Customer_ID()).isEqualTo(BPARTNER_ID));
+
+		final List<I_MD_Candidate_Demand_Detail> demandDetailRecords = POJOLookupMap.get().getRecords(I_MD_Candidate_Demand_Detail.class);
+		assertThat(demandDetailRecords).hasSize(1);
+		assertThat(demandDetailRecords.get(0).getM_ShipmentSchedule_ID()).isEqualTo(event.getShipmentScheduleId());
+
+		return event.getShipmentScheduleId();
+	}
+
+	public static ShipmentScheduleCreatedEvent createShipmentScheduleTestEvent()
+	{
+		final ShipmentScheduleCreatedEvent event = ShipmentScheduleCreatedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientAndOrg(CLIENT_ID, ORG_ID))
+				.materialDescriptor(MaterialDescriptor.builder()
+						.date(NOW)
+						.productDescriptor(createProductDescriptor())
+						.customerId(BPARTNER_ID)
+						.quantity(BigDecimal.TEN)
+						.warehouseId(toWarehouseId)
+						.build())
+				.reservedQuantity(new BigDecimal("20"))
+				.shipmentScheduleId(shipmentScheduleId)
+				.documentLineDescriptor(OrderLineDescriptor.builder()
+						.orderLineId(orderLineId)
+						.orderId(30)
+						.build())
+				.build();
+		return event;
+	}
+}

--- a/de.metas.material/event/src/main/java/de/metas/material/event/commons/OrderLineDescriptor.java
+++ b/de.metas.material/event/src/main/java/de/metas/material/event/commons/OrderLineDescriptor.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Builder;
+import lombok.NonNull;
 import lombok.Value;
 
 /*
@@ -33,11 +34,15 @@ import lombok.Value;
 @Value
 public class OrderLineDescriptor implements DocumentLineDescriptor
 {
+	public static OrderLineDescriptor cast(@NonNull final DocumentLineDescriptor documentLineDescriptor)
+	{
+		return (OrderLineDescriptor)documentLineDescriptor;
+	}
+
 	int orderLineId;
 	int orderId;
 	int orderBPartnerId;
 	int docTypeId;
-
 
 	@Builder
 	@JsonCreator
@@ -61,4 +66,5 @@ public class OrderLineDescriptor implements DocumentLineDescriptor
 		checkIdGreaterThanZero("orderBPartnerId", orderBPartnerId);
 		checkIdGreaterThanZero("docTypeId", docTypeId);
 	}
+
 }

--- a/de.metas.material/event/src/main/java/de/metas/material/event/commons/SubscriptionLineDescriptor.java
+++ b/de.metas.material/event/src/main/java/de/metas/material/event/commons/SubscriptionLineDescriptor.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Builder;
+import lombok.NonNull;
 import lombok.Value;
 
 /*
@@ -34,9 +35,13 @@ import lombok.Value;
 @Builder
 public class SubscriptionLineDescriptor  implements DocumentLineDescriptor
 {
+	public static SubscriptionLineDescriptor cast(@NonNull final DocumentLineDescriptor documentLineDescriptor)
+	{
+		return (SubscriptionLineDescriptor)documentLineDescriptor;
+	}
+
 	int subscriptionProgressId;
 	int flatrateTermId;
-
 	int subscriptionBillBPartnerId;
 
 	@Builder


### PR DESCRIPTION
Also introduce DemandDetailsQuery because we need to look for possible existing candidates when handling both created and deleted-events
Reactivated and completed sales order is considered as new sales order in Material Dispo https://github.com/metasfresh/metasfresh/issues/4271