### PR TITLE
#4356-app - solve Sales Orderline error

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5497330_sys_gh4356-app_C_Payment_Term_fix_null_integer_columns.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5497330_sys_gh4356-app_C_Payment_Term_fix_null_integer_columns.sql
@@ -1,0 +1,13 @@
+
+ALTER TABLE public.c_paymentterm ALTER COLUMN fixmonthcutoff SET DEFAULT 0;
+UPDATE public.c_paymentterm SET fixmonthcutoff=0 WHERE fixmonthcutoff IS NULL;
+ALTER TABLE public.c_paymentterm ALTER COLUMN fixmonthcutoff SET NOT NULL;
+
+ALTER TABLE public.c_paymentterm ALTER COLUMN fixmonthday SET DEFAULT 0;
+UPDATE public.c_paymentterm SET fixmonthday=0 WHERE fixmonthday IS NULL;
+ALTER TABLE public.c_paymentterm ALTER COLUMN fixmonthday SET NOT NULL;
+
+ALTER TABLE public.c_paymentterm ALTER COLUMN fixmonthoffset SET DEFAULT 0;
+UPDATE public.c_paymentterm SET fixmonthoffset=0 WHERE fixmonthoffset IS NULL;
+ALTER TABLE public.c_paymentterm ALTER COLUMN fixmonthoffset SET NOT NULL;
+


### PR DESCRIPTION
solution: make sure that FixMonthOffset and others are zero in the DB. that way the C_PaymentTerm record will be found next time.
also for performance and stability: cache and select/create out of trx

Sales Orderline:ERROR: duplicate key value violates unique constraint "c_paymentterm_name" #4356