### PR TITLE
#4371-app - Sales Order VAT vs. Invoice Candidate VAT

### DIFF
--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/tax/api/ITaxBL.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/tax/api/ITaxBL.java
@@ -35,7 +35,7 @@ import org.compiere.model.I_M_Warehouse;
 public interface ITaxBL extends ISingletonService
 {
 	/**
-	 * Try to retrieve tax by {@link #retrieveTaxIdForCategory(Properties, int, int, org.compiere.model.I_C_BPartner_Location, Timestamp, int, boolean, String, boolean)} first.<br>
+	 * Try to retrieve tax by {@link #retrieveTaxIdForCategory(Properties, int, int, org.compiere.model.I_C_BPartner_Location, Timestamp, int, boolean, boolean)} first.<br>
 	 * If that doesn't work, try retrieving the German tax
 	 *
 	 * @param ctx
@@ -47,8 +47,7 @@ public interface ITaxBL extends ISingletonService
 	 * @param shipDate
 	 * @param adOrgId
 	 * @param warehouse
-	 * @param billC_BPartner_Location_ID
-	 * @param shipC_BPartner_Location_ID
+	 * @param shipC_BPartner_Location_ID place where the service is provided
 	 * @param isSOTrx
 	 * @param trxName
 	 * @return taxId
@@ -57,15 +56,12 @@ public interface ITaxBL extends ISingletonService
 			Object model,
 			int taxCategoryId,
 			int productId,
-			int chargeId,
 			Timestamp billDate,
 			Timestamp shipDate,
 			int adOrgId,
 			I_M_Warehouse warehouse,
-			int billC_BPartner_Location_ID,
 			int shipC_BPartner_Location_ID,
-			boolean isSOTrx,
-			String trxName);
+			boolean isSOTrx);
 
 	/**
 	 * Retrieve <code>taxId<code> from the given <code>taxCategoryId</code>
@@ -77,7 +73,6 @@ public interface ITaxBL extends ISingletonService
 	 * @param billDate
 	 * @param taxCategoryId
 	 * @param isSOTrx
-	 * @param trxName
 	 * @param throwEx if <code>true</code>, and no <code>C_Tax</code> record can be found, then throw an exception that contains the failed query. <br>
 	 * 			Otherwise, just log and return <code>-1</code>.
 	 * @return taxId
@@ -89,7 +84,6 @@ public interface ITaxBL extends ISingletonService
 			Timestamp billDate,
 			int taxCategoryId,
 			boolean isSOTrx,
-			String trxName,
 			boolean throwEx);
 
 	/**

--- a/de.metas.business/src/main/java-legacy/org/compiere/model/MInvoiceLine.java
+++ b/de.metas.business/src/main/java-legacy/org/compiere/model/MInvoiceLine.java
@@ -601,7 +601,6 @@ public class MInvoiceLine extends X_C_InvoiceLine
 				billDate,
 				taxCategoryId,
 				isSOTrx,
-				get_TrxName(),
 				true); // throwEx
 
 		if (taxId <= 0)

--- a/de.metas.business/src/main/java-legacy/org/compiere/model/MOrderLine.java
+++ b/de.metas.business/src/main/java-legacy/org/compiere/model/MOrderLine.java
@@ -302,7 +302,6 @@ public class MOrderLine extends X_C_OrderLine
 				getDateOrdered(),
 				taxCategoryId,
 				getParent().isSOTrx(),
-				get_TrxName(),
 				true); // throwEx
 
 		setC_Tax_ID(taxId);

--- a/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
@@ -69,6 +69,7 @@ import org.compiere.model.MRefList;
 import org.compiere.model.POInfo;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
+import org.compiere.util.Util;
 import org.slf4j.Logger;
 
 import ch.qos.logback.classic.Level;
@@ -428,20 +429,19 @@ public class FlatrateBL implements IFlatrateBL
 		final I_M_Warehouse warehouse = null;
 		final boolean isSOTrx = true;
 
+		final int shipToLocationId = Util.firstGreaterThanZero(term.getDropShip_Location_ID(), term.getBill_Location_ID());  // place of service performance
+
 		final int taxId = Services.get(ITaxBL.class).getTax(
 				ctx,
 				term,
 				taxCategoryId,
 				productId,
-				-1, // chargeId
 				dataEntry.getDate_Reported(),// billDate
 				dataEntry.getDate_Reported(),// shipDate
 				orgId,
 				warehouse,
-				billLocationID,
-				-1 // ship location id
-				, isSOTrx,
-				trxName);
+				shipToLocationId,
+				isSOTrx);
 
 		newCand.setC_Tax_ID(taxId);
 
@@ -476,7 +476,6 @@ public class FlatrateBL implements IFlatrateBL
 			final BigDecimal qtyToInvoice)
 	{
 		Check.assume(!dataEntry.isSimulation(), dataEntry + " has IsSimulation='N'");
-
 		final I_C_Flatrate_Conditions fc = term.getC_Flatrate_Conditions();
 
 		final Properties ctx = InterfaceWrapperHelper.getCtx(fc);
@@ -558,12 +557,18 @@ public class FlatrateBL implements IFlatrateBL
 		final I_M_Warehouse warehouse = null;
 		final boolean isSOTrx = true;
 
+		final int shipToLocationId = Util.firstGreaterThanZero(term.getDropShip_Location_ID(), term.getBill_Location_ID());  // place of service performance
 		final int taxId = Services.get(ITaxBL.class).getTax(
-				ctx, term, taxCategoryId, productIdForIc, -1 // chargeId
-				, dataEntry.getDate_Reported() // billDate
-				, dataEntry.getDate_Reported() // shipDate
-				, dataEntry.getAD_Org_ID(), warehouse, term.getBill_BPartner_ID(), -1 // ship location id
-				, isSOTrx, trxName);
+				ctx,
+				term,
+				taxCategoryId,
+				productIdForIc,
+				dataEntry.getDate_Reported(), // billDate
+				dataEntry.getDate_Reported(), // shipDate
+				dataEntry.getAD_Org_ID(),
+				warehouse,
+				shipToLocationId,
+				isSOTrx);
 
 		newCand.setC_Tax_ID(taxId);
 

--- a/de.metas.contracts/src/main/java/de/metas/contracts/subscription/invoicecandidatehandler/FlatrateTermSubscription_Handler.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/subscription/invoicecandidatehandler/FlatrateTermSubscription_Handler.java
@@ -27,12 +27,12 @@ import java.sql.Timestamp;
 import java.util.Iterator;
 import java.util.function.Consumer;
 
-import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.util.Check;
 import org.adempiere.util.Services;
 import org.compiere.model.I_M_Warehouse;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
+import org.compiere.util.Util;
 
 import de.metas.contracts.IContractsDAO;
 import de.metas.contracts.invoicecandidate.ConditionTypeSpecificInvoiceCandidateHandler;
@@ -83,15 +83,12 @@ public class FlatrateTermSubscription_Handler implements ConditionTypeSpecificIn
 				term,
 				taxCategoryId,
 				term.getM_Product_ID(),
-				-1, // chargeId
 				ic.getDateOrdered(), // billDate
 				ic.getDateOrdered(), // shipDate
 				term.getAD_Org_ID(),
 				warehouse,
-				term.getBill_Location_ID(),
-				-1, // ship location id
-				isSOTrx,
-				ITrx.TRXNAME_ThreadInherited);
+				Util.firstGreaterThanZero(term.getDropShip_Location_ID(), term.getBill_Location_ID()), // ship location id
+				isSOTrx);
 		ic.setC_Tax_ID(taxId);
 	}
 

--- a/de.metas.contracts/src/test/java/de/metas/contracts/impl/FlatrateBLTest.java
+++ b/de.metas.contracts/src/test/java/de/metas/contracts/impl/FlatrateBLTest.java
@@ -27,7 +27,6 @@ import static org.adempiere.model.InterfaceWrapperHelper.save;
 
 import java.util.Properties;
 
-import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.pricing.model.I_C_PricingRule;
 import org.adempiere.util.Services;
@@ -47,6 +46,7 @@ import org.compiere.model.I_M_PricingSystem;
 import org.compiere.model.I_M_Warehouse;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
+import org.compiere.util.Util;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -214,16 +214,22 @@ public class FlatrateBLTest extends ContractsTestBase
 				result = activity;
 
 				final Properties ctx = Env.getCtx();
-				final String trxName = ITrx.TRXNAME_None;
 
 				final int taxCategoryId = -1;
 				final I_M_Warehouse warehouse = null;
 				final boolean isSOTrx = true;
 
 				taxBL.getTax(
-						ctx, currentTerm, taxCategoryId, currentTerm.getM_Product_ID(), -1 // chargeId
-				, dataEntry.getDate_Reported(), dataEntry.getDate_Reported(), dataEntry.getAD_Org_ID(), warehouse, currentTerm.getBill_BPartner_ID(), -1 // ship location ID
-				, isSOTrx, trxName);
+						ctx,
+						currentTerm,
+						taxCategoryId,
+						currentTerm.getM_Product_ID(),
+						dataEntry.getDate_Reported(),
+						dataEntry.getDate_Reported(),
+						dataEntry.getAD_Org_ID(),
+						warehouse,
+						Util.firstGreaterThanZero(currentTerm.getDropShip_Location_ID(),currentTerm.getBill_Location_ID()),
+						isSOTrx);
 				minTimes = 0;
 				result = 3;
 			}

--- a/de.metas.contracts/src/test/java/de/metas/contracts/invoicecandidate/FlatrateTermHandlerTest.java
+++ b/de.metas.contracts/src/test/java/de/metas/contracts/invoicecandidate/FlatrateTermHandlerTest.java
@@ -7,7 +7,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.sql.Timestamp;
 import java.util.Properties;
 
-import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.wrapper.POJOWrapper;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -22,6 +21,7 @@ import org.compiere.model.I_M_Warehouse;
 import org.compiere.model.X_C_Order;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
+import org.compiere.util.Util;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -103,7 +103,6 @@ public class FlatrateTermHandlerTest extends ContractsTestBase
 				productAcctDAO.retrieveActivityForAcct((IContextAware)any, withNotEqual(org), withNotEqual(product1)); minTimes = 0; result = null;
 
 				final Properties ctx = Env.getCtx();
-				final String trxName = ITrx.TRXNAME_None;
 
 				final int taxCategoryId = -1;
 				final I_M_Warehouse warehouse = null;
@@ -114,15 +113,12 @@ public class FlatrateTermHandlerTest extends ContractsTestBase
 						, term1
 						, taxCategoryId
 						, term1.getM_Product_ID()
-						, -1 // chargeId
 						, term1.getStartDate()
 						, term1.getStartDate()
 						, term1.getAD_Org_ID()
 						, warehouse
-						, term1.getBill_BPartner_ID()
-						, -1 // ship location ID
-						, isSOTrx
-						, trxName);
+						, Util.firstGreaterThanZero(term1.getDropShip_Location_ID(), term1.getBill_Location_ID())
+						, isSOTrx);
 				minTimes = 0;
 				result = 3;
 		}};

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/ic/spi/impl/InvoiceCandidateWriter.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/ic/spi/impl/InvoiceCandidateWriter.java
@@ -602,8 +602,6 @@ public class InvoiceCandidateWriter
 		final IContextAware contextProvider = getContext();
 
 		final Properties ctx = contextProvider.getCtx();
-		final String trxName = contextProvider.getTrxName();
-
 		final int taxCategoryId = pricingResult.getC_TaxCategory_ID();
 		final I_M_Warehouse warehouse = null; // warehouse: N/A
 		final boolean isSOTrx = false;
@@ -613,14 +611,12 @@ public class InvoiceCandidateWriter
 				ic,
 				taxCategoryId,
 				ic.getM_Product_ID(),
-				-1 // C_Charge_ID
-				, date // bill date
-				, date // ship date
-				, ic.getAD_Org_ID(),
+				date, // bill date
+				date, // ship date
+				ic.getAD_Org_ID(),
 				warehouse,
-				ic.getBill_Location_ID(),
-				-1 // shipPartnerLocation
-				, isSOTrx, trxName);
+				ic.getBill_Location_ID(), // shipPartnerLocation TODO
+				isSOTrx);
 		ic.setC_Tax_ID(taxID);
 	}
 }

--- a/de.metas.salescandidate.base/src/main/java/de/metas/invoicecandidate/spi/impl/C_OLCand_Handler.java
+++ b/de.metas.salescandidate.base/src/main/java/de/metas/invoicecandidate/spi/impl/C_OLCand_Handler.java
@@ -209,16 +209,12 @@ public class C_OLCand_Handler extends AbstractInvoiceCandidateHandler
 				, ic
 				, taxCategoryId
 				, productId
-				, chargeId
 				, olc.getDatePromised()
 				, olc.getDatePromised()
 				, orgId
 				, warehouse
-				, billLocationId
-				, olCandEffectiveValuesBL.getC_BP_Location_Effective_ID(olc)
-				, isSOTrx
-				, trxName
-				);
+				, olCandEffectiveValuesBL.getDropShip_Location_Effective_ID(olc)
+				, isSOTrx);
 		ic.setC_Tax_ID(taxId);
 
 		return ic;

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/adempiere/service/impl/InvoiceLineBL.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/adempiere/service/impl/InvoiceLineBL.java
@@ -129,7 +129,6 @@ public class InvoiceLineBL implements IInvoiceLineBL
 				shipDate,
 				taxCategoryId,
 				il.getC_Invoice().isSOTrx(),
-				trxName,
 				false);
 
 		if (taxId <= 0)

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
@@ -361,9 +361,16 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 		final Timestamp billDate = inOut.getDateAcct();
 		final int locationId = inOut.getC_BPartner_Location_ID();
 		final int taxId = Services.get(ITaxBL.class).getTax(
-				ctx, ic, taxCategoryId, productId, chargeId, billDate, shipDate, adOrgId, inOut.getM_Warehouse(), locationId // billC_BPartner_Location_ID
-				, locationId // shipC_BPartner_Location_ID
-				, isSOTrx, trxName);
+				ctx,
+				ic,
+				taxCategoryId,
+				productId,
+				billDate,
+				shipDate,
+				adOrgId,
+				inOut.getM_Warehouse(),
+				locationId, // shipC_BPartner_Location_ID
+				isSOTrx);
 		ic.setC_Tax_ID(taxId);
 
 		//

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/form/CreateInvoiceCandidateDialog.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/form/CreateInvoiceCandidateDialog.java
@@ -331,7 +331,7 @@ public class CreateInvoiceCandidateDialog
 		{
 			missingCollector.add(I_C_Invoice_Candidate.COLUMNNAME_M_PricingSystem_ID);
 		}
-		pricingSystemField.setValue(pricingSystemId.getRepoId());
+		pricingSystemField.setValue(PricingSystemId.getRepoId(pricingSystemId));
 
 		// do not load UOMs; instead, they shall be loaded when the product is modified
 		// priceUOMField.loadFirstItem();
@@ -378,7 +378,7 @@ public class CreateInvoiceCandidateDialog
 		final Properties ctx = Env.getCtx();
 		final String trxName = ITrx.TRXNAME_None;
 
-		final IContextAware contextProvider = new PlainContextAware(ctx, trxName);
+		final IContextAware contextProvider = PlainContextAware.newWithTrxName(ctx, trxName);
 		final I_M_PricingSystem pricingSystem = InterfaceWrapperHelper.create(ctx, pricingSystemId, I_M_PricingSystem.class, trxName);
 		final I_M_Product product = InterfaceWrapperHelper.create(ctx, productId, I_M_Product.class, trxName);
 
@@ -440,22 +440,21 @@ public class CreateInvoiceCandidateDialog
 		try
 		{
 			final Properties ctx = contextProvider.getCtx();
-			final String trxName = contextProvider.getTrxName();
 
 			final int taxCategoryId = -1; // FIXME for accuracy, we will need the tax category
 			final I_M_Warehouse warehouse = null;
 
 			priceTaxId = Services.get(ITaxBL.class).getTax(
-					ctx, null // no model
-					, taxCategoryId, product.getM_Product_ID() // productId
-					, -1 // chargeId
-					, date // billDate
-					, date // shipDate
-					, product.getAD_Org_ID() // orgId
-					, warehouse, locationField.getValueAsInt() // billC_BPartner_Location_ID
-					, locationField.getValueAsInt() // shipC_BPartner_Location_ID
-					, soTrx.toBoolean() //
-					, trxName);
+					ctx,
+					null, // no model
+					taxCategoryId,
+					product.getM_Product_ID(), // productId
+					date, // billDate
+					date, // shipDate
+					product.getAD_Org_ID(), // orgId
+					warehouse,
+					locationField.getValueAsInt(), // shipC_BPartner_Location_ID
+					soTrx.toBoolean());
 		}
 		catch (final ProductPriceNotFoundException ppnfe)
 		{
@@ -552,7 +551,7 @@ public class CreateInvoiceCandidateDialog
 				throwExceptionIfNotFilled(columns2Ids);
 
 				final Properties ctx = Env.getCtx();
-				final IContextAware contextProvider = new PlainContextAware(ctx, localTrxName);
+				final IContextAware contextProvider = PlainContextAware.newWithTrxName(ctx, localTrxName);
 
 				final I_C_Invoice_Candidate ic = InterfaceWrapperHelper.newInstance(I_C_Invoice_Candidate.class, contextProvider);
 

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/M_InventoryLine_Handler.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/M_InventoryLine_Handler.java
@@ -195,10 +195,16 @@ public class M_InventoryLine_Handler extends AbstractInvoiceCandidateHandler
 		final Timestamp billDate = inOut.getDateAcct();
 		final int locationId = inOut.getC_BPartner_Location_ID();
 		final int taxId = Services.get(ITaxBL.class).getTax(
-				ctx, ic, taxCategoryId, productId, -1, billDate, shipDate, adOrgId, inOut.getM_Warehouse(), locationId // billC_BPartner_Location_ID
-				, locationId // shipC_BPartner_Location_ID
-				, false // isSOTrx same as in vendor return
-				, trxName);
+				ctx,
+				ic,
+				taxCategoryId,
+				productId,
+				billDate,
+				shipDate,
+				adOrgId,
+				inOut.getM_Warehouse(),
+				locationId, // shipC_BPartner_Location_ID
+				false); // isSOTrx same as in vendor return
 		ic.setC_Tax_ID(taxId);
 
 		//

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/invoicecandidate/C_OrderLine_Handler.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/invoicecandidate/C_OrderLine_Handler.java
@@ -41,6 +41,7 @@ import org.compiere.model.I_M_AttributeInstance;
 import org.compiere.model.I_M_AttributeSetInstance;
 import org.compiere.model.I_M_InOut;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
 
 import de.metas.adempiere.model.I_C_Order;
 import de.metas.document.engine.IDocumentBL;
@@ -196,15 +197,12 @@ public class C_OrderLine_Handler extends AbstractInvoiceCandidateHandler
 				ic,
 				orderLine.getC_TaxCategory_ID(),
 				orderLine.getM_Product_ID(),
-				orderLine.getC_Charge_ID(), // chargeId
 				order.getDatePromised(), // billDate
 				order.getDatePromised(), // shipDate
 				order.getAD_Org_ID(),
 				order.getM_Warehouse(),
-				order.getBill_Location_ID(), // bill location id
-				order.getC_BPartner_Location_ID(), // ship location id
-				order.isSOTrx(), // isSOTrx
-				trxName);
+				Util.firstGreaterThanZero(order.getDropShip_Location_ID(), order.getC_BPartner_Location_ID()), // ship location id
+				order.isSOTrx());
 		ic.setC_Tax_ID(taxId);
 
 		// set Quality Issue Percentage Override

--- a/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/AbstractDeliveryTest.java
+++ b/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/AbstractDeliveryTest.java
@@ -10,12 +10,12 @@ package de.metas.invoicecandidate.spi.impl;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -127,15 +127,12 @@ public abstract class AbstractDeliveryTest
 						, order
 						, -1 // taxCategoryId
 						, orderLine.getM_Product_ID()
-						, -1 // chargeId
 						, order.getDatePromised()
 						, order.getDatePromised()
 						, order.getAD_Org_ID()
 						, order.getM_Warehouse()
-						, order.getBill_BPartner_ID()
 						, order.getC_BPartner_Location_ID()
-						, order.isSOTrx()
-						, trxName);
+						, order.isSOTrx());
 				minTimes = 0;
 				result = 3;
 		}};

--- a/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/C_OrderLine_Handler_Test.java
+++ b/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/C_OrderLine_Handler_Test.java
@@ -167,21 +167,17 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 				result = null;
 
 				final Properties ctx = Env.getCtx();
-				final String trxName = ITrx.TRXNAME_None;
 				taxBL.getTax(
 						ctx
 						, order1
 						, -1 // taxCategoryId
 						, oL1.getM_Product_ID()
-						, -1 // chargeId
 						, order1.getDatePromised()
 						, order1.getDatePromised()
 						, order1.getAD_Org_ID()
 						, order1.getM_Warehouse()
-						, order1.getBill_BPartner_ID()
 						, order1.getC_BPartner_Location_ID()
-						, order1.isSOTrx()
-						, trxName);
+						, order1.isSOTrx());
 				minTimes = 0;
 				result = 3;
 		}};


### PR DESCRIPTION
TaxBL.getTax now uses the shipTo location instead of the billTo location. 
Because it matters where the service is performed, not where the bill is send to.
Also remove three (unused) parameters: chargeId, billC_BPartner_Location_ID and trxName
Sales Order VAT vs. Invoice Candidate VAT #4371