### PR TITLE
#4456-app Material Cockpit - attribute detail rows' dimenstion spec

### DIFF
--- a/de.metas.material/cockpit/src/main/sql/postgresql/system/75-material-cockpit/5498820_sys_gh4456-app_add_sysconfig.sql
+++ b/de.metas.material/cockpit/src/main/sql/postgresql/system/75-material-cockpit/5498820_sys_gh4456-app_add_sysconfig.sql
@@ -1,0 +1,6 @@
+-- 2018-08-03T14:46:49.781
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541228,'S',TO_TIMESTAMP('2018-08-03 14:46:49','YYYY-MM-DD HH24:MI:SS'),100,'DIM_Dimension_Spec.InternalName of the dimensions specification to use when displaying the dimension (attribute) related subrows in the material cockpit.
+The hard-coded default value is Material_Cockpit_Default_Spec.','de.metas.material.cockpit','Y','de.metas.ui.web.material.cockpit.DIM_Dimension_Spec.InternalName',TO_TIMESTAMP('2018-08-03 14:46:49','YYYY-MM-DD HH24:MI:SS'),100,'Material_Cockpit_Default_Spec')
+;
+


### PR DESCRIPTION
add AD_Sysconfig; preserve the previous behavior
https://github.com/metasfresh/metasfresh/issues/4456