### PR TITLE
#4624-app - invoice candidate not updated after shipment complete

### DIFF
--- a/de.metas.acct.base/src/main/java/org/adempiere/acct/api/impl/PostingRequestBuilder.java
+++ b/de.metas.acct.base/src/main/java/org/adempiere/acct/api/impl/PostingRequestBuilder.java
@@ -495,7 +495,7 @@ import lombok.NonNull;
 
 		//
 		// Case: we are running in a transaction.
-		if (!trxManager.isNull(trxName))
+		if (trxManager.isActive(trxName))
 		{
 			trxManager.getTrxListenerManager(trxName)
 					.newEventListener(TrxEventTiming.AFTER_COMMIT)

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/CacheMgt.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/CacheMgt.java
@@ -389,7 +389,7 @@ public final class CacheMgt
 	{
 		final ITrxManager trxManager = Services.get(ITrxManager.class);
 		final ITrx trx = trxManager.get(trxName, OnTrxMissingPolicy.ReturnTrxNone);
-		if (trxManager.isNull(trx))
+		if (!trxManager.isActive(trx))
 		{
 			reset(request, ResetMode.LOCAL_AND_BROADCAST);
 		}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/ITrxManager.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/ITrxManager.java
@@ -87,7 +87,7 @@ public interface ITrxManager extends ISingletonService
 
 		/**
 		 * The default is {@link TrxPropagation#REQUIRES_NEW}.
-		 * 
+		 *
 		 * @param trxPropagation
 		 * @return
 		 */
@@ -186,7 +186,7 @@ public interface ITrxManager extends ISingletonService
 	String createTrxName(String prefix, boolean createTrx);
 
 	<T> T call(Callable<T> callable);
-	
+
 	void run(Runnable runnable);
 
 	/**
@@ -214,9 +214,9 @@ public interface ITrxManager extends ISingletonService
 	 * @see #run(String, boolean, TrxRunnable)
 	 */
 	void run(String trxName, TrxRunnable r);
-	
+
 	void run(String trxName, Runnable runnable);
-	
+
 	default void runInThreadInheritedTrx(final Runnable runnable)
 	{
 		run(ITrx.TRXNAME_ThreadInherited, runnable);
@@ -361,6 +361,16 @@ public interface ITrxManager extends ISingletonService
 	default boolean isActive(final ITrx trx)
 	{
 		return !isNull(trx) && trx.isActive();
+	}
+
+	default boolean isActive(final String trxName)
+	{
+		if (isNull(trxName))
+		{
+			return false;
+		}
+		final ITrx trx = get(trxName, OnTrxMissingPolicy.ReturnTrxNone);
+		return isActive(trx);
 	}
 
 	/**

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/spi/TrxOnCommitCollectorFactory.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/spi/TrxOnCommitCollectorFactory.java
@@ -61,7 +61,7 @@ public abstract class TrxOnCommitCollectorFactory<CollectorType, ItemType>
 
 		final String trxName = extractTrxNameFromItem(item);
 		final ITrx trx = trxManager.getTrx(trxName);
-		if (trxManager.isNull(trx))
+		if (!trxManager.isActive(trx))
 		{
 			final CollectorType collector = newCollector(item);
 			collectItem(collector, item);

--- a/de.metas.async/src/main/java/de/metas/async/api/impl/WorkPackageQueue.java
+++ b/de.metas.async/src/main/java/de/metas/async/api/impl/WorkPackageQueue.java
@@ -751,13 +751,18 @@ public class WorkPackageQueue implements IWorkPackageQueue
 		}
 		finally
 		{
-			// Callback: if something went wrong we need to unregister the callback
-			if (!success)
+			try
 			{
-				queueProcessorEventDispatcher.unregisterListener(callback, workPackage.getC_Queue_WorkPackage_ID());
+				// Callback: if something went wrong we need to unregister the callback
+				if (!success)
+				{
+					queueProcessorEventDispatcher.unregisterListener(callback, workPackage.getC_Queue_WorkPackage_ID());
+				}
 			}
-
-			mainLock.unlock();
+			finally
+			{
+				mainLock.unlock(); // make sure we unlock, even if unregisterListener failed
+			}
 		}
 
 	}

--- a/de.metas.business/src/main/java/de/metas/inout/model/validator/M_InOutLine.java
+++ b/de.metas.business/src/main/java/de/metas/inout/model/validator/M_InOutLine.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_M_InOut;
 import org.compiere.model.ModelValidator;
+import org.springframework.stereotype.Component;
 
 import de.metas.inout.IInOutBL;
 import de.metas.inout.IInOutDAO;
@@ -39,14 +41,9 @@ import de.metas.util.Services;
  * @task http://dewiki908/mediawiki/index.php/09548_Avoid_FK-constraint_violation_when_a_packaging-iol-is_deleted_%28106784154474%29
  */
 @Interceptor(I_M_InOutLine.class)
+@Component("de.metas.inout.model.validator.M_InOutLine")
 public class M_InOutLine
 {
-	public static final M_InOutLine INSTANCE = new M_InOutLine();
-
-	private M_InOutLine()
-	{
-	}
-
 	/**
 	 * Sets <code>M_PackingMaterial_InOutLine_ID</code> to <code>null</code> for all inOutLines that reference the given <code>packingMaterialLine</code>.
 	 *
@@ -74,5 +71,35 @@ public class M_InOutLine
 	public void handleInOutLineDelete(final I_M_InOutLine iol)
 	{
 		Services.get(IInOutBL.class).deleteMatchInvsForInOutLine(iol); // task 08627
+	}
+
+	/**
+	 * If the <code>C_Order_ID</code> of the given line is at odds with the <code>C_Order_ID</code> of the line's <code>M_InOut</code>, then <code>M_InOut.C_Order</code> is set to <code>null</code>.
+	 *
+	 * @param inOutLine
+	 * @task 08451
+	 */
+	@ModelChange(timings = { ModelValidator.TYPE_AFTER_NEW, ModelValidator.TYPE_AFTER_CHANGE }, ifColumnsChanged = {
+			I_M_InOutLine.COLUMNNAME_M_InOut_ID, I_M_InOutLine.COLUMNNAME_C_OrderLine_ID })
+	public void unsetM_InOut_C_Order_ID(final I_M_InOutLine inOutLine)
+	{
+		if (inOutLine.getC_OrderLine_ID() <= 0)
+		{
+			return; // nothing to do
+		}
+		final I_M_InOut inOut = inOutLine.getM_InOut();
+		final int headerOrderId = inOut.getC_Order_ID();
+		if (headerOrderId <= 0)
+		{
+			return; // nothing to do
+		}
+
+		final int lineOrderId = inOutLine.getC_OrderLine().getC_Order_ID();
+		if (lineOrderId == headerOrderId)
+		{
+			return; // nothing to do
+		}
+
+		inOut.setC_Order_ID(0); // they are at odds. unset the reference
 	}
 }

--- a/de.metas.business/src/main/java/org/adempiere/model/validator/AdempiereBaseValidator.java
+++ b/de.metas.business/src/main/java/org/adempiere/model/validator/AdempiereBaseValidator.java
@@ -173,9 +173,6 @@ public final class AdempiereBaseValidator extends AbstractModuleInterceptor
 
 		engine.addModelValidator(de.metas.event.interceptor.Main.INSTANCE, client);
 
-		// Task 09548
-		engine.addModelValidator(de.metas.inout.model.validator.M_InOutLine.INSTANCE, client);
-
 		engine.addModelValidator(de.metas.order.model.interceptor.OrderModuleInterceptor.INSTANCE, client);
 
 		engine.addModelValidator(de.metas.invoice.model.interceptor.InvoiceModuleInterceptor.INSTANCE, client);

--- a/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/mrp_productinfo/IMRPProductInfoSelector.java
+++ b/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/mrp_productinfo/IMRPProductInfoSelector.java
@@ -2,9 +2,9 @@ package de.metas.fresh.mrp_productinfo;
 
 import java.sql.Timestamp;
 import java.util.Map;
+import java.util.Properties;
 
 import org.adempiere.model.InterfaceWrapperHelper;
-import org.adempiere.util.api.IParams;
 
 import de.metas.fresh.mrp_productinfo.impl.MRPProductInfoSelectorFactory;
 
@@ -46,13 +46,6 @@ public interface IMRPProductInfoSelector extends Comparable<IMRPProductInfoSelec
 	int getM_AttributeSetInstance_ID();
 
 	/**
-	 * Return the model this instance was created from or {@code null} if this instance was created from an {@link IParams}.
-	 *
-	 * @return
-	 */
-	Object getModelOrNull();
-
-	/**
 	 * Returns a string that looks like this:
 	 *
 	 * <pre>
@@ -86,12 +79,16 @@ public interface IMRPProductInfoSelector extends Comparable<IMRPProductInfoSelec
 	/**
 	 * If this instance was created from a model (using {@link MRPProductInfoSelectorFactory#createOrNullForModel(Object)}),
 	 * then return a string that starts with the model's table name as returned by {@link InterfaceWrapperHelper#getModelTableName(Object)}.
-	 * 
+	 *
 	 * If this instance was created using {@link MRPProductInfoSelectorFactory#createForParams(org.adempiere.util.api.IParams)},
 	 * then return the common prefix of the three parameter names whose parameter values were used to generate this instance.
-	 * 
-	 * 
+	 *
+	 *
 	 * @return never return {@code null}.
 	 */
 	String getParamPrefix();
+
+	Properties getCtx();
+
+	String getTrxName();
 }

--- a/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/mrp_productinfo/async/spi/impl/UpdateMRPProductInfoTableWorkPackageProcessor.java
+++ b/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/mrp_productinfo/async/spi/impl/UpdateMRPProductInfoTableWorkPackageProcessor.java
@@ -46,25 +46,34 @@ public class UpdateMRPProductInfoTableWorkPackageProcessor extends WorkpackagePr
 		@Override
 		protected Properties extractCtxFromItem(final IMRPProductInfoSelector item)
 		{
-			return InterfaceWrapperHelper.getCtx(item.getModelOrNull());
+			return item.getCtx();
 		}
 
 		@Override
 		protected String extractTrxNameFromItem(final IMRPProductInfoSelector item)
 		{
-			return InterfaceWrapperHelper.getTrxName(item.getModelOrNull());
+			return item.getTrxName();
 		}
 
+		/** @return null
+		 */
 		@Override
 		protected Object extractModelToEnqueueFromItem(final Collector collector, final IMRPProductInfoSelector item)
 		{
-			return item.getModelOrNull();
+			return null;
 		}
 
 		@Override
 		protected Map<String, Object> extractParametersFromItem(final IMRPProductInfoSelector item)
 		{
 			return item.asMap();
+		}
+
+		/** @return {@code true} because we don't enqueue elements, just parameters. */
+		@Override
+		protected boolean isEnqueueWorkpackageWhenNoModelsEnqueued()
+		{
+			return true;
 		}
 	};
 

--- a/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/mrp_productinfo/impl/MRPProductInfoBL.java
+++ b/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/mrp_productinfo/impl/MRPProductInfoBL.java
@@ -22,7 +22,6 @@ import org.compiere.model.I_AD_InfoWindow;
 import org.compiere.model.I_C_OrderLine;
 import org.compiere.model.I_M_Attribute;
 import org.compiere.model.I_M_AttributeSetInstance;
-import org.compiere.model.I_M_InOutLine;
 import org.compiere.model.I_M_Product;
 import org.compiere.util.DB;
 
@@ -31,7 +30,6 @@ import de.metas.fresh.model.I_X_MRP_ProductInfo_V;
 import de.metas.fresh.mrp_productinfo.IMRPProductInfoBL;
 import de.metas.fresh.mrp_productinfo.IMRPProductInfoSelector;
 import de.metas.fresh.mrp_productinfo.IMRPProductInfoSelectorFactory;
-import de.metas.inout.IInOutBL;
 import de.metas.storage.IStorageEngine;
 import de.metas.storage.IStorageEngineService;
 import de.metas.storage.IStorageQuery;
@@ -176,20 +174,6 @@ public class MRPProductInfoBL implements IMRPProductInfoBL
 				.create()
 				.list();
 
-		// check if any item still has a null QtyOnHand value.
-		// if yes, then we will use the storage engine to get the overall non-iterative QtyOnHand from the system.
-		boolean resetAllQtys = false;
-		for (I_X_MRP_ProductInfo_Detail_MV item : list)
-		{
-			if (selector.getModelOrNull() == null // if the model is null, then we already know that we need to reset all qtys, because there is no model to extract the delta from.
-					|| !selector.getParamPrefix().startsWith(I_M_InOutLine.Table_Name)
-					|| InterfaceWrapperHelper.isNull(item, I_X_MRP_ProductInfo_Detail_MV.COLUMNNAME_QtyOnHand))
-			{
-				resetAllQtys = true; // at least one item needs a full computation, so we can do it for all
-				break;
-			}
-		}
-
 		// if there are multiple I_X_MRP_ProductInfo_Detail_MV that share the same selector
 		// (i.e. one with IsFallBack='N' and following n with IsFallBack='Y')
 		// then use this set to only deal with the first one
@@ -219,23 +203,13 @@ public class MRPProductInfoBL implements IMRPProductInfoBL
 				itemToUse = item;
 			}
 
-			if (resetAllQtys)
+			// do the "full" computation. note that all item need the same qtyOnHand value
+			if (qtyOnHand == null)
 			{
-				// do the "full" computation. note that all item need the same qtyOnHand value
-				if (qtyOnHand == null)
-				{
-					qtyOnHand = retrieveQtyOnHand(ctx, selector);
-				}
-				itemToUse.setQtyOnHand(qtyOnHand);
+				qtyOnHand = retrieveQtyOnHand(ctx, selector);
 			}
-			else if (selector.getParamPrefix().startsWith(I_M_InOutLine.Table_Name))
-			{
-				// just increase or decrease by the inout line's qty
-				final IInOutBL inOutBL = Services.get(IInOutBL.class);
-				final I_M_InOutLine inOutLine = InterfaceWrapperHelper.create(selector.getModelOrNull(), I_M_InOutLine.class);
-				final BigDecimal delta = inOutBL.getEffectiveStorageChange(inOutLine);
-				itemToUse.setQtyOnHand(itemToUse.getQtyOnHand().add(delta));
-			}
+			itemToUse.setQtyOnHand(qtyOnHand);
+
 			InterfaceWrapperHelper.save(itemToUse);
 		}
 	}

--- a/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/mrp_productinfo/impl/MRPProductInfoSelectorFactory.java
+++ b/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/mrp_productinfo/impl/MRPProductInfoSelectorFactory.java
@@ -3,6 +3,7 @@ package de.metas.fresh.mrp_productinfo.impl;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 import org.adempiere.ad.trx.api.ITrx;
@@ -36,6 +37,8 @@ import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.procurement.base.model.I_PMM_PurchaseCandidate;
 import de.metas.util.Check;
 import de.metas.util.Services;
+import lombok.Getter;
+import lombok.NonNull;
 
 /*
  * #%L
@@ -234,15 +237,29 @@ public class MRPProductInfoSelectorFactory implements IMRPProductInfoSelectorFac
 	 */
 	static class MRPProductInfoSelector implements IMRPProductInfoSelector
 	{
+		@Getter
 		private final int M_Product_ID;
+
+		@Getter
 		private final int M_AttributeSetInstance_ID;
+
 		private String asiKey;
+
+		@Getter
 		private final Timestamp date;
-		private final Object model;
+
 		private final String paramPrefix;
 
+		private final Map<String, Object> parametersMap;
+
+		@Getter
+		private final Properties ctx;
+
+		@Getter
+		private final String trxName;
+
 		/**
-		 * 
+		 *
 		 * @param M_Product_ID
 		 * @param M_AttributeSetInstance_ID
 		 * @param date
@@ -252,7 +269,7 @@ public class MRPProductInfoSelectorFactory implements IMRPProductInfoSelectorFac
 		private MRPProductInfoSelector(
 				final int M_Product_ID,
 				final int M_AttributeSetInstance_ID,
-				final Timestamp date,
+				@NonNull final Timestamp date,
 				final Object model,
 				final String paramPrefix)
 		{
@@ -263,40 +280,23 @@ public class MRPProductInfoSelectorFactory implements IMRPProductInfoSelectorFac
 			this.M_Product_ID = M_Product_ID;
 			this.M_AttributeSetInstance_ID = M_AttributeSetInstance_ID;
 			this.date = date;
-			this.model = model;
 
 			if (model == null)
 			{
 				this.paramPrefix = paramPrefix;
+				this.ctx = null;
+				this.trxName = null;
 			}
 			else
 			{
 				this.paramPrefix = createParamPrefix(model);
+				this.ctx = InterfaceWrapperHelper.getCtx(model);
+				this.trxName = InterfaceWrapperHelper.getTrxName(model);
 			}
-		}
-
-		@Override
-		public int getM_Product_ID()
-		{
-			return M_Product_ID;
-		}
-
-		@Override
-		public int getM_AttributeSetInstance_ID()
-		{
-			return M_AttributeSetInstance_ID;
-		}
-
-		@Override
-		public Timestamp getDate()
-		{
-			return date;
-		}
-
-		@Override
-		public Object getModelOrNull()
-		{
-			return model;
+			this.parametersMap = ImmutableMap.<String, Object> of(
+					mkProductParamKey(this.paramPrefix), getM_Product_ID(),
+					mkAttributeSetInstanceParamKey(this.paramPrefix), getM_AttributeSetInstance_ID(),
+					mkDateParamKey(this.paramPrefix), getDate());
 		}
 
 		@Override
@@ -312,13 +312,10 @@ public class MRPProductInfoSelectorFactory implements IMRPProductInfoSelectorFac
 		@Override
 		public Map<String, Object> asMap()
 		{
-			return ImmutableMap.<String, Object> of(
-					mkProductParamKey(model), getM_Product_ID(),
-					mkAttributeSetInstanceParamKey(model), getM_AttributeSetInstance_ID(),
-					mkDateParamKey(model), getDate());
+			return parametersMap;
 		}
 
-		private static String createParamPrefix(final Object model)
+		private static String createParamPrefix(@NonNull final Object model)
 		{
 			final ITableRecordReference record = TableRecordReference.of(model);
 
@@ -326,22 +323,19 @@ public class MRPProductInfoSelectorFactory implements IMRPProductInfoSelectorFac
 			return prefix;
 		}
 
-		private static String mkProductParamKey(final Object model)
+		private static String mkProductParamKey(@NonNull final String paramPrefix)
 		{
-			final String prefix = createParamPrefix(model);
-			return prefix + PRODUCT_PARAM_SUFFIX;
+			return paramPrefix + PRODUCT_PARAM_SUFFIX;
 		}
 
-		private static String mkAttributeSetInstanceParamKey(final Object model)
+		private static String mkAttributeSetInstanceParamKey(@NonNull final String paramPrefix)
 		{
-			final String prefix = createParamPrefix(model);
-			return prefix + ASI_PARAM_SUFFIX;
+			return paramPrefix + ASI_PARAM_SUFFIX;
 		}
 
-		private static String mkDateParamKey(final Object model)
+		private static String mkDateParamKey(@NonNull final String paramPrefix)
 		{
-			final String prefix = createParamPrefix(model);
-			return prefix + DATE_PARAM_SUFFIX;
+			return paramPrefix + DATE_PARAM_SUFFIX;
 		}
 
 		@Override

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandUpdateSchedulerRequest.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandUpdateSchedulerRequest.java
@@ -2,8 +2,11 @@ package de.metas.invoicecandidate.api.impl;
 
 import java.util.Properties;
 
+import javax.annotation.Nullable;
+
 import de.metas.invoicecandidate.api.IInvoiceCandUpdateSchedulerRequest;
-import de.metas.util.Check;
+import lombok.NonNull;
+import lombok.Value;
 
 /*
  * #%L
@@ -15,47 +18,38 @@ import de.metas.util.Check;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 
+@Value
 public final class InvoiceCandUpdateSchedulerRequest implements IInvoiceCandUpdateSchedulerRequest
 {
-	public static final InvoiceCandUpdateSchedulerRequest of (final Properties ctx, final String trxName)
+	public static final InvoiceCandUpdateSchedulerRequest of (
+			@NonNull final Properties ctx,
+			@Nullable final String trxName)
 	{
 		return new InvoiceCandUpdateSchedulerRequest(ctx, trxName);
 	}
 
-	private final Properties ctx;
-	private final String trxName;
-	
-	private InvoiceCandUpdateSchedulerRequest(final Properties ctx, final String trxName)
+	String trxName;
+	Properties ctx;
+
+	private InvoiceCandUpdateSchedulerRequest(
+			@NonNull final Properties ctx,
+			@Nullable final String trxName)
 	{
-		super();
-		Check.assumeNotNull(ctx, "ctx not null");
 		this.ctx = ctx;
-		
+
 		// transaction name it's OK to be null
 		this.trxName = trxName;
-	}
-
-	@Override
-	public Properties getCtx()
-	{
-		return ctx;
-	}
-	
-	@Override
-	public String getTrxName()
-	{
-		return trxName;
 	}
 }

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
@@ -14,8 +14,7 @@ public class C_OrderLine
 {
 	@ModelChange(timings = ModelValidator.TYPE_AFTER_CHANGE
 			, ifColumnsChanged = {
-					I_C_OrderLine.COLUMNNAME_QtyDelivered // Using C_OrderLine.QtyDelivered to get notified of changes in the delivery status.
-					, I_C_OrderLine.COLUMNNAME_QtyOrdered // task 08452: make sure the IC gets invalidated when we sort of "close" a single line
+					I_C_OrderLine.COLUMNNAME_QtyOrdered // task 08452: make sure the IC gets invalidated when we sort of "close" a single line
 					, I_C_OrderLine.COLUMNNAME_QtyOrderedOverUnder
 					, I_C_OrderLine.COLUMNNAME_IsPackagingMaterial
 			})

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/M_InOut.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/M_InOut.java
@@ -13,15 +13,14 @@ package de.metas.invoicecandidate.modelvalidator;
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
-
 
 import org.adempiere.ad.modelvalidator.annotations.DocValidate;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
@@ -34,11 +33,13 @@ import de.metas.util.Services;
 @Interceptor(I_M_InOut.class)
 public class M_InOut
 {
+// Moved here from {@link de.metas.inout.model.validator.M_InOut}
+	@DocValidate(timings = { ModelValidator.TIMING_AFTER_REVERSECORRECT, //
+			ModelValidator.TIMING_AFTER_REVERSEACCRUAL, //
+			ModelValidator.TIMING_AFTER_REACTIVATE,
+			ModelValidator.TIMING_AFTER_COMPLETE // needed in case we complete an inout that was previously reactivated
+			})
 
-	// Moved here from {@link de.metas.inout.model.validator.M_InOut}
-	@DocValidate(timings = { ModelValidator.TIMING_AFTER_REVERSECORRECT
-			, ModelValidator.TIMING_AFTER_REVERSEACCRUAL
-			, ModelValidator.TIMING_AFTER_REACTIVATE })
 	public void invalidateInvoiceCandidatesOnReversal(final I_M_InOut inout)
 	{
 		final IInvoiceCandidateHandlerBL invoiceCandidateHandlerBL = Services.get(IInvoiceCandidateHandlerBL.class);

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/M_InOutLine.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/M_InOutLine.java
@@ -27,7 +27,6 @@ import java.util.List;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.ad.modelvalidator.annotations.Validator;
 import org.adempiere.model.InterfaceWrapperHelper;
-import org.compiere.model.I_M_InOut;
 import org.compiere.model.ModelValidator;
 
 import de.metas.inout.model.I_M_InOutLine;
@@ -118,35 +117,5 @@ public class M_InOutLine
 		// invalidate the candidates related to the inOutLine's order line..i'm not 100% if it's necessary, but we might need to e.g. update the
 		// QtyDelivered or QtyPicked or whatever...
 		Services.get(IInvoiceCandidateHandlerBL.class).invalidateCandidatesFor(orderLine);
-	}
-
-	/**
-	 * If the <code>C_Order_ID</code> of the given line is at odds with the <code>C_Order_ID</code> of the line's <code>M_InOut</code>, then <code>M_InOut.C_Order</code> is set to <code>null</code>.
-	 *
-	 * @param inOutLine
-	 * @task 08451
-	 */
-	@ModelChange(timings = { ModelValidator.TYPE_AFTER_NEW, ModelValidator.TYPE_AFTER_CHANGE }, ifColumnsChanged = {
-			I_M_InOutLine.COLUMNNAME_M_InOut_ID, I_M_InOutLine.COLUMNNAME_C_OrderLine_ID })
-	public void unsetM_InOut_C_Order_ID(final I_M_InOutLine inOutLine)
-	{
-		if (inOutLine.getC_OrderLine_ID() <= 0)
-		{
-			return; // nothing to do
-		}
-		final I_M_InOut inOut = inOutLine.getM_InOut();
-		final int headerOrderId = inOut.getC_Order_ID();
-		if (headerOrderId <= 0)
-		{
-			return; // nothing to do
-		}
-
-		final int lineOrderId = inOutLine.getC_OrderLine().getC_Order_ID();
-		if (lineOrderId == headerOrderId)
-		{
-			return; // nothing to do
-		}
-
-		inOut.setC_Order_ID(0); // they are at odds. unset the reference
 	}
 }


### PR DESCRIPTION
* invoice candidates are no longer invalidated when C_OrderLine.QtyDelivered changes; because this only catches ICs that have an order line
* instead they are invalidated on M_InOut completion (also reactivation, but we already had that before)

also
* IMRPProductInfoSelector et al: fix bug that no async prokpackage was created on M_Transaction delete (e.g. when a shipment was reactivated)
* ITrxManager add method isActive() also for String trxName
* CacheMgt, PostingRequestBuilder and TrxOnCommitCollectorFactory: use ITrxManager.isActive() instead of isNull(), to also handle the case of an already closed trx
* WorkPackageQueue.markReadyForProcessing() make *really* sure that the WP is unlocked at the end
* M_InOutLine move method that is not invoice-candidte-related to the general M_InOutLine interceptor
* InvoiceCandUpdateSchedulerRequest: cleanup

https://github.com/metasfresh/metasfresh/issues/4624