### PR TITLE
4652-app - AD Element Translations lead to wrong fieldname Translations

### DIFF
--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/column/callout/AD_Column.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/column/callout/AD_Column.java
@@ -3,11 +3,13 @@ package org.adempiere.ad.column.callout;
 import org.adempiere.ad.callout.annotations.Callout;
 import org.adempiere.ad.callout.annotations.CalloutMethod;
 import org.adempiere.ad.callout.api.ICalloutField;
+import org.adempiere.ad.callout.spi.IProgramaticCalloutProvider;
 import org.compiere.model.I_AD_Column;
 import org.compiere.model.I_AD_Element;
 import org.compiere.model.I_AD_Table;
 import org.compiere.model.MColumn;
 import org.compiere.util.DisplayType;
+import org.springframework.stereotype.Component;
 
 import de.metas.adempiere.service.IColumnBL;
 import de.metas.util.Check;
@@ -42,12 +44,16 @@ import de.metas.util.Services;
  *
  */
 @Callout(I_AD_Column.class)
+@Component("org.adempiere.ad.column.callout.AD_Column")
 public class AD_Column
 {
-
-	public static final AD_Column instance = new AD_Column();
-
 	public static final String ENTITYTYPE_Dictionary = "D";
+
+	public AD_Column()
+	{
+		final IProgramaticCalloutProvider programaticCalloutProvider = Services.get(IProgramaticCalloutProvider.class);
+		programaticCalloutProvider.registerAnnotatedCallout(this);
+	}
 
 	@CalloutMethod(columnNames = { I_AD_Column.COLUMNNAME_ColumnName })
 	public void onColumnName(final I_AD_Column column, final ICalloutField field)
@@ -75,14 +81,15 @@ public class AD_Column
 	{
 		if (column.getAD_Element_ID() <= 0)
 		{
-			// nothing to do
+			column.setColumnName(null);
+			column.setName(null);
 			return;
 		}
 
 		final I_AD_Element element = column.getAD_Element();
 
 		final String elementColumnName = element.getColumnName();
-		Check.assumeNotNull(elementColumnName, "The element {} does not have a column name set", element);
+		Check.assumeNotNull(elementColumnName, "The element {} needs to have a column name set", element);
 
 		column.setColumnName(elementColumnName);
 		column.setName(element.getName());

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502730_sys_gh4652-app_make_AD_Element_dependent_fields_readonly.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502730_sys_gh4652-app_make_AD_Element_dependent_fields_readonly.sql
@@ -95,16 +95,6 @@ UPDATE AD_Column SET ReadOnlyLogic='@AD_Element_ID\0@>0', TechnicalNote='This fi
 UPDATE AD_Column SET IsMandatory='N', TechnicalNote='This column''s value is maintained via AD_Element.',Updated=TO_TIMESTAMP('2018-10-05 11:05:08','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=111
 ;
 
--- 2018-10-05T11:05:10.812
--- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
-INSERT INTO t_alter_column values('ad_column','Name','VARCHAR(60)',null,null)
-;
-
--- 2018-10-05T11:05:10.820
--- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
-INSERT INTO t_alter_column values('ad_column','Name',null,'NULL',null)
-;
-
 -- 2018-10-05T11:06:29.945
 -- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
 UPDATE AD_Column SET TechnicalNote='This column''s value is maintained via AD_Element.',Updated=TO_TIMESTAMP('2018-10-05 11:06:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=116
@@ -114,8 +104,6 @@ UPDATE AD_Column SET TechnicalNote='This column''s value is maintained via AD_El
 -- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
 UPDATE AD_Column SET MandatoryLogic='@AD_Element_ID\0@>0',Updated=TO_TIMESTAMP('2018-10-05 11:07:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=116
 ;
-
-
 
 
 
@@ -129,11 +117,3 @@ UPDATE AD_Column SET MandatoryLogic='@AD_Element_ID\0@>0',Updated=TO_TIMESTAMP('
 -- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
 UPDATE AD_Column SET FieldLength=2000,Updated=TO_TIMESTAMP('2018-10-05 13:51:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=2604
 ;
-
--- 2018-10-05T13:51:12.231
--- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
-INSERT INTO t_alter_column values('ad_element','Description','VARCHAR(2000)',null,null)
-;
-
-select db_alter_table('ad_element_trl', 'ALTER TABLE public.ad_element_trl ALTER COLUMN description TYPE character varying (2000)');
-

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502730_sys_gh4652-app_make_AD_Element_dependent_fields_readonly.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502730_sys_gh4652-app_make_AD_Element_dependent_fields_readonly.sql
@@ -1,0 +1,139 @@
+
+-- AD_Field.Name
+-- 2018-10-05T10:40:52.607
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-10-05 10:40:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=127
+;
+
+-- AD_Field.Description
+-- 2018-10-05T10:41:38.569
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-10-05 10:41:38','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=128
+;
+
+-- AD_Field.Help
+-- 2018-10-05T10:42:09.336
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-10-05 10:42:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=129
+;
+
+-- AD_Tab of AD_Field_Trl
+-- 2018-10-05T10:43:44.747
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-10-05 10:43:44','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Tab_ID=115
+;
+
+-----------------
+--same for AD_Column
+
+-- 2018-10-05T10:45:29.902
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-10-05 10:45:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=152
+;
+
+-- 2018-10-05T10:45:35.551
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-10-05 10:45:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=153
+;
+
+-- 2018-10-05T10:45:48.421
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-10-05 10:45:48','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=154
+;
+
+-- 2018-10-05T10:46:01.482
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Tab SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2018-10-05 10:46:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Tab_ID=681
+;
+
+-----------------
+-- AD_Process_Para-- 2018-10-05T10:50:11.689
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET ReadOnlyLogic='@AD_Element_ID\0@>0', TechnicalNote='This field is only editable if no AD_Element_ID is referenced; Otherwise, the field''s terminology is maintained in the selected AD_Element',Updated=TO_TIMESTAMP('2018-10-05 10:50:11','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=2822
+;
+
+-- 2018-10-05T10:50:42.431
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET TechnicalNote='This field is only editable if no AD_Element_ID is referenced; Otherwise, the field''s terminology is maintained in the selected AD_Element.',Updated=TO_TIMESTAMP('2018-10-05 10:50:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=2823
+;
+
+-- 2018-10-05T10:50:52.383
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET TechnicalNote='This field is only editable if no AD_Element_ID is referenced; Otherwise, the field''s terminology is maintained in the selected AD_Element.',Updated=TO_TIMESTAMP('2018-10-05 10:50:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=2822
+;
+
+-- 2018-10-05T10:50:57.810
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET ReadOnlyLogic='@AD_Element_ID\0@>0',Updated=TO_TIMESTAMP('2018-10-05 10:50:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=2823
+;
+
+-- 2018-10-05T10:51:49.153
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET ReadOnlyLogic='@AD_Element_ID\0@>0', TechnicalNote='This field is only editable if no AD_Element_ID is referenced; Otherwise, the field''s terminology is maintained in the selected AD_Element.',Updated=TO_TIMESTAMP('2018-10-05 10:51:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=2824
+;
+
+-- 2018-10-05T10:52:48.753
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET ReadOnlyLogic='@AD_Element_ID\0@>0', TechnicalNote='This field is only editable if no AD_Element_ID is referenced; Otherwise, the field''s terminology is maintained in the selected AD_Element.',Updated=TO_TIMESTAMP('2018-10-05 10:52:48','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=2841
+;
+
+-- 2018-10-05T10:53:06.620
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET ReadOnlyLogic='@AD_Element_ID\0@>0', TechnicalNote='This field is only editable if no AD_Element_ID is referenced; Otherwise, the field''s terminology is maintained in the selected AD_Element.',Updated=TO_TIMESTAMP('2018-10-05 10:53:06','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=2840
+;
+
+-- 2018-10-05T10:53:36.564
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET ReadOnlyLogic='@AD_Element_ID\0@>0', TechnicalNote='This field is only editable if no AD_Element_ID is referenced; Otherwise, the field''s terminology is maintained in the selected AD_Element.',Updated=TO_TIMESTAMP('2018-10-05 10:53:36','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=3743
+;
+
+
+
+
+-- 2018-10-05T11:05:08.586
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsMandatory='N', TechnicalNote='This column''s value is maintained via AD_Element.',Updated=TO_TIMESTAMP('2018-10-05 11:05:08','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=111
+;
+
+-- 2018-10-05T11:05:10.812
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO t_alter_column values('ad_column','Name','VARCHAR(60)',null,null)
+;
+
+-- 2018-10-05T11:05:10.820
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO t_alter_column values('ad_column','Name',null,'NULL',null)
+;
+
+-- 2018-10-05T11:06:29.945
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET TechnicalNote='This column''s value is maintained via AD_Element.',Updated=TO_TIMESTAMP('2018-10-05 11:06:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=116
+;
+
+-- 2018-10-05T11:07:25.350
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET MandatoryLogic='@AD_Element_ID\0@>0',Updated=TO_TIMESTAMP('2018-10-05 11:07:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=116
+;
+
+
+
+
+
+-- 2018-10-05T11:24:12.995
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET MandatoryLogic='@AD_Element_ID\0@>0',Updated=TO_TIMESTAMP('2018-10-05 11:24:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=111
+;
+
+
+-- 2018-10-05T13:51:09.750
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET FieldLength=2000,Updated=TO_TIMESTAMP('2018-10-05 13:51:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=2604
+;
+
+-- 2018-10-05T13:51:12.231
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO t_alter_column values('ad_element','Description','VARCHAR(2000)',null,null)
+;
+
+select db_alter_table('ad_element_trl', 'ALTER TABLE public.ad_element_trl ALTER COLUMN description TYPE character varying (2000)');
+

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502731_sys_gh4652-app_make_AD_Element_dependent_fields_readonly_DDL.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502731_sys_gh4652-app_make_AD_Element_dependent_fields_readonly_DDL.sql
@@ -1,0 +1,20 @@
+
+
+-- 2018-10-05T13:51:12.231
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO t_alter_column values('ad_element','Description','VARCHAR(2000)',null,null)
+;
+
+select db_alter_table('ad_element_trl', 'ALTER TABLE public.ad_element_trl ALTER COLUMN description TYPE character varying (2000)');
+
+
+
+-- 2018-10-05T11:05:10.812
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO t_alter_column values('ad_column','Name','VARCHAR(60)',null,null)
+;
+
+-- 2018-10-05T11:05:10.820
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO t_alter_column values('ad_column','Name',null,'NULL',null)
+;

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502735_sys_gh4652-app_migrate_AD_Field_Trl_to_AD_Element_Trl.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502735_sys_gh4652-app_migrate_AD_Field_Trl_to_AD_Element_Trl.sql
@@ -248,6 +248,6 @@ FROM ad_element_migrate m
 
 --cleanup
 COMMIT;
+DROP VIEW AD_Field_Trl_to_save_V CASCADE;
 ALTER TABLE AD_Element_Trl DROP COLUMN AD_Field_Saved_ID;
 ALTER TABLE AD_Field_Trl DROP COLUMN IsSaved;
-DROP VIEW AD_Field_Trl_to_save_V CASCADE;

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502735_sys_gh4652-app_migrate_AD_Field_Trl_to_AD_Element_Trl.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502735_sys_gh4652-app_migrate_AD_Field_Trl_to_AD_Element_Trl.sql
@@ -1,6 +1,6 @@
 
 ALTER TABLE AD_Element_Trl ADD COLUMN AD_Field_Saved_ID numeric(10,0);
-ALTER TABLE AD_Field_Trl ADD COLUMN IsSaved character(1) DEFAULT 'N'
+ALTER TABLE AD_Field_Trl ADD COLUMN IsSaved character(1) DEFAULT 'N';
 
 DROP VIEW IF EXISTS AD_Field_Trl_to_save_V CASCADE;
 CREATE VIEW AD_Field_Trl_to_save_V AS

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502735_sys_gh4652-app_migrate_AD_Field_Trl_to_AD_Element_Trl.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502735_sys_gh4652-app_migrate_AD_Field_Trl_to_AD_Element_Trl.sql
@@ -247,6 +247,7 @@ FROM ad_element_migrate m
 --should return no results anymore
 
 --cleanup
+COMMIT;
 ALTER TABLE AD_Element_Trl DROP COLUMN AD_Field_Saved_ID;
 ALTER TABLE AD_Field_Trl DROP COLUMN IsSaved;
 DROP VIEW AD_Field_Trl_to_save_V CASCADE;

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502735_sys_gh4652-app_migrate_AD_Field_Trl_to_AD_Element_Trl.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502735_sys_gh4652-app_migrate_AD_Field_Trl_to_AD_Element_Trl.sql
@@ -52,7 +52,7 @@ WHERE ft_IsTranslated='Y'
 		(TRIM(COALESCE(ft_help,''))!='' AND ft_help!=ft_help OR et_IsTranslated != et_IsTranslated)
 	)
 ;
-	
+
 --select count(*) from AD_Field_Trl_to_save_V;
 --1406
 
@@ -240,12 +240,12 @@ SELECT
     ft.AD_Field_ID AS ad_field_saved_id -- numeric(10,0),
 FROM ad_element_migrate m
 	JOIN AD_Field_Trl ft ON ft.AD_Field_Id=m.AD_Field_ID AND ft.IsTranslated='Y'
-
--- with this,
-SELECT * FROM AD_Field_Trl_to_save_V
+;
+-- with this, insert done
+-- SELECT * FROM AD_Field_Trl_to_save_V
 --should return no results anymore
 
-
+--cleanup
 ALTER TABLE AD_Element_Trl DROP COLUMN AD_Field_Saved_ID;
 ALTER TABLE AD_Field_Trl DROP COLUMN IsSaved;
 DROP VIEW AD_Field_Trl_to_save_V CASCADE;

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502735_sys_gh4652-app_migrate_AD_Field_Trl_to_AD_Element_Trl.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502735_sys_gh4652-app_migrate_AD_Field_Trl_to_AD_Element_Trl.sql
@@ -133,9 +133,9 @@ $$ LANGUAGE plpgsql;
 select migrate();
 
 --
--- now deal with the cases where AD_Field_Trls with different name, description or help refer to the same AD_Element.
--- for these AD_Field_Trls, we create new AD_Element and AD_Element_Trl records and link them with AD_Field.AD_Name_ID.
---
+-- Now deal with the cases where AD_Field_Trls with different name, description or help refer to the same AD_Element.
+-- For these AD_Field_Trls, we create new AD_Element records and link them with AD_Field.AD_Name_ID.
+-- When that's done, we create AD_Element_Trl records for the respective preexisting AD_Field_Trls and newly added AD_Elements.
 
 --drop table ad_element_migrate;
 CREATE TEMP TABLE ad_element_migrate AS
@@ -148,6 +148,7 @@ SELECT
 	entitytype
 FROM AD_Field f
 WHERE EXISTS (select 1 from AD_Field_Trl_to_save_V v WHERE v.AD_Field_ID=f.AD_Field_ID)
+;
 
 INSERT INTO AD_Element (
 	ad_element_id, -- numeric(10,0) NOT NULL,

--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502735_sys_gh4652-app_migrate_AD_Field_Trl_to_AD_Element_Trl.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5502735_sys_gh4652-app_migrate_AD_Field_Trl_to_AD_Element_Trl.sql
@@ -1,0 +1,251 @@
+
+ALTER TABLE AD_Element_Trl ADD COLUMN AD_Field_Saved_ID numeric(10,0);
+ALTER TABLE AD_Field_Trl ADD COLUMN IsSaved character(1) DEFAULT 'N'
+
+DROP VIEW IF EXISTS AD_Field_Trl_to_save_V CASCADE;
+CREATE VIEW AD_Field_Trl_to_save_V AS
+SELECT * FROM
+(
+	-- collect element and field via AD_Field.AD_Name_ID
+	SELECT 
+		et.AD_Element_ID, 
+		ft.AD_Field_ID,
+		et.AD_Language,
+		'AD_Name_ID' AS IsLinkVia,
+		ft.IsSaved AS ft_IsSaved,
+		et.Name AS et_name, 
+		ft.Name AS ft_name,
+		et.Description AS et_Description,
+		ft.Description AS ft_Description,
+		et.help AS et_help,
+		ft.help AS ft_help,
+		et.IsTranslated AS et_IsTranslated, 
+		ft.IsTranslated AS ft_IsTranslated
+	FROM AD_Element_Trl et
+		JOIN AD_Field f ON et.AD_Element_ID = f.AD_Name_ID
+			JOIN AD_Field_Trl ft ON f.AD_Field_ID = ft.AD_Field_ID AND ft.AD_Language=et.AD_Language
+	UNION
+	-- collect element and field via AD_Column
+	SELECT 
+		et.AD_Element_ID, 
+		ft.AD_Field_ID,
+		et.AD_Language,
+		'AD_Column_ID' AS IsLinkVia,
+		ft.IsSaved AS ft_IsSaved,
+		et.Name AS et_name, 
+		ft.Name AS ft_name,
+		et.Description AS et_Description,
+		ft.Description AS ft_Description,
+		et.help AS et_help,
+		ft.help AS ft_help,
+		et.IsTranslated AS et_IsTranslated, 
+		ft.IsTranslated AS ft_IsTranslated
+	FROM AD_Element_Trl et
+		JOIN AD_Column c ON c.AD_Element_ID=et.AD_Element_ID
+			JOIN AD_Field f ON f.AD_Column_ID = c.AD_Column_ID AND /*important:*/f.AD_Name_ID IS NULL
+				JOIN AD_Field_Trl ft ON f.AD_Field_ID = ft.AD_Field_ID AND ft.AD_Language=et.AD_Language
+) data
+WHERE ft_IsTranslated='Y'
+	AND ( /*the columns are non-empty, and have a different value than the respective AD_Element's columns */
+		(TRIM(COALESCE(ft_Name,''))!='' AND ft_Name!=et_name) OR
+		(TRIM(COALESCE(ft_Description,''))!='' AND ft_Description!=et_Description) OR
+		(TRIM(COALESCE(ft_help,''))!='' AND ft_help!=ft_help OR et_IsTranslated != et_IsTranslated)
+	)
+;
+	
+--select count(*) from AD_Field_Trl_to_save_V;
+--1406
+
+--select count(distinct AD_Element_ID) from AD_Field_Trl_to_save_V
+--1014
+
+--- AD_Field_Trls to save where more than one AD_Field_Trls refer to the same AD_Element_Trl
+-- this view is more for diagnostics, we won't really use it
+DROP VIEW IF EXISTS AD_Field_Trl_with_missing_AD_Element_v;
+CREATE VIEW AD_Field_Trl_with_missing_AD_Element_v AS
+select 
+	AD_Element_ID, AD_Language, et_Name, et_IsTranslated, 
+	
+	array_agg(distinct AD_Field_ID) AS AD_Field_IDs,
+	Count(distinct AD_Field_ID) as AD_Field_ID_count,
+	
+	array_agg(distinct ft_name) AS ft_names, 
+	Count(distinct ft_name) as ft_name_count,
+	
+	array_agg(distinct ft_description) AS ft_descriptions, 
+	Count(distinct ft_description) as ft_description_count,
+	
+	array_agg(distinct ft_help) AS ft_helps, 
+	Count(distinct ft_help) as ft_help_count
+from AD_Field_Trl_to_save_V
+GROUP BY AD_Element_ID, AD_Language, et_IsTranslated, et_Name
+HAVING Count(distinct ft_name) > 1 OR Count(distinct ft_description) > 1 OR Count(distinct ft_help) > 1 OR Count(distinct AD_Field_ID) > 1
+ORDER BY Count(distinct ft_name) desc;
+--192 AD_Element_IDs are affected
+
+
+--UPDATE AD_Element_Trl SET AD_Field_Saved_ID = null;
+--UPDATE AD_Field_Trl SET IsSaved = 'N';
+
+-- create a function to copy the AD_Field_Trls to existing AD_Element_Trls
+-- The respecitve update also sets AD_Element_ID.AD_Field_Saved_ID
+CREATE OR REPLACE FUNCTION migrate() RETURNS VOID AS
+$$
+DECLARE
+    field_trl RECORD;
+	updated_element_trl RECORD;
+BEGIN
+	FOR field_trl IN SELECT * FROM AD_Field_Trl_to_save_V WHERE ft_IsSaved='N' /*AND AD_Element_ID=348 LIMIT 2*/ LOOP
+
+		RAISE NOTICE 'Processing field_trl with AD_Field_ID=% and lang=%', field_trl.AD_Field_ID, field_trl.AD_Language;
+		
+		UPDATE AD_Element_Trl et
+		SET 
+			Name = field_trl.ft_Name,
+			Description = field_trl.ft_Description,
+			Help = field_trl.ft_Help,
+			AD_Field_Saved_ID = field_trl.AD_Field_ID,
+			IsTranslated = field_trl.ft_IsTranslated,
+			Updated=now(),
+			UpdatedBy=99
+		WHERE et.AD_Element_ID = field_trl.AD_Element_ID 
+			AND et.AD_Language = field_trl.AD_Language 
+			AND et.AD_Field_Saved_ID IS NULL
+		RETURNING * INTO updated_element_trl;
+		
+		IF FOUND THEN
+							
+			UPDATE AD_Field_Trl ft 
+			SET IsSaved='Y' 
+			WHERE ft.AD_Field_ID=field_trl.AD_Field_ID AND ft.AD_Language = field_trl.AD_Language;
+			
+			RAISE NOTICE 'Successfully migrated field_trl=%', field_trl;
+		ELSE
+			-- Note: for many records this is not a problem; 
+			-- if their name, description and help are equal to the one that AD_Element_Trl was updated from, then they are also fine now.
+			RAISE NOTICE 'another AD_Field_Trl was already migrated to AD_Element_Trl; field_trl=%s', field_trl;
+		END IF;
+		
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+select migrate();
+
+--
+-- now deal with the cases where AD_Field_Trls with different name, description or help refer to the same AD_Element.
+-- for these AD_Field_Trls, we create new AD_Element and AD_Element_Trl records and link them with AD_Field.AD_Name_ID.
+--
+
+--drop table ad_element_migrate;
+CREATE TEMP TABLE ad_element_migrate AS
+SELECT 
+	nextval('ad_element_seq') AS AD_Element_new_ID,
+	ad_field_id,
+	name,
+	description,
+	help,
+	entitytype
+FROM AD_Field f
+WHERE EXISTS (select 1 from AD_Field_Trl_to_save_V v WHERE v.AD_Field_ID=f.AD_Field_ID)
+
+INSERT INTO AD_Element (
+	ad_element_id, -- numeric(10,0) NOT NULL,
+    ad_client_id, -- numeric(10,0) NOT NULL,
+    ad_org_id, -- numeric(10,0) NOT NULL,
+    isactive, -- character(1) COLLATE pg_catalog."default" NOT NULL DEFAULT 'Y'::bpchar,
+    created, -- timestamp with time zone NOT NULL,
+    createdby, -- numeric(10,0) NOT NULL,
+    updated, -- timestamp with time zone NOT NULL DEFAULT now(),
+    updatedby, -- numeric(10,0) NOT NULL,
+    columnname, -- character varying(60) COLLATE pg_catalog."default",
+    entitytype, -- character varying(512) COLLATE pg_catalog."default" NOT NULL DEFAULT 'D'::character varying,
+    name, -- character varying(60) COLLATE pg_catalog."default" NOT NULL,
+    printname, -- character varying(60) COLLATE pg_catalog."default" NOT NULL,
+    description, -- character varying(2000) COLLATE pg_catalog."default",
+    help, -- character varying(2000) COLLATE pg_catalog."default",
+    po_name, -- character varying(60) COLLATE pg_catalog."default",
+    po_printname, -- character varying(60) COLLATE pg_catalog."default",
+    po_description, -- character varying(255) COLLATE pg_catalog."default",
+    po_help, -- character varying(2000) COLLATE pg_catalog."default",
+    widgetsize -- character varying(50) COLLATE pg_catalog."default",
+)
+SELECT 
+	AD_Element_new_ID AS ad_element_id, -- numeric(10,0) NOT NULL,
+    0 AS ad_client_id, -- numeric(10,0) NOT NULL,
+    0 AS ad_org_id, -- numeric(10,0) NOT NULL,
+    'Y' AS isactive, -- character(1) COLLATE pg_catalog."default" NOT NULL DEFAULT 'Y'::bpchar,
+    now() AS created, -- timestamp with time zone NOT NULL,
+    99 AS createdby, -- numeric(10,0) NOT NULL,
+    now() AS updated, -- timestamp with time zone NOT NULL DEFAULT now(),
+    99 AS updatedby, -- numeric(10,0) NOT NULL,
+    NULL AS columnname, -- character varying(60) COLLATE pg_catalog."default",
+    f.entitytype, -- character varying(512) COLLATE pg_catalog."default" NOT NULL DEFAULT 'D'::character varying,
+    f.name, -- character varying(60) COLLATE pg_catalog."default" NOT NULL,
+    f.Name AS printname, -- character varying(60) COLLATE pg_catalog."default" NOT NULL,
+    f.description, -- character varying(2000) COLLATE pg_catalog."default",
+    f.help, -- character varying(2000) COLLATE pg_catalog."default",
+    NULL AS po_name, -- character varying(60) COLLATE pg_catalog."default",
+    NULL AS po_printname, -- character varying(60) COLLATE pg_catalog."default",
+    NULL AS po_description, -- character varying(255) COLLATE pg_catalog."default",
+    NULL AS po_help, -- character varying(2000) COLLATE pg_catalog."default",
+    NULL AS widgetsize -- character varying(50) COLLATE pg_catalog."default",
+FROM ad_element_migrate f;
+
+UPDATE AD_Field f
+SET AD_Name_ID=AD_Element_new_ID
+FROM ad_element_migrate m
+WHERE f.AD_Field_ID=m.AD_Field_ID;
+
+INSERT INTO AD_Element_Trl (
+	ad_element_id, -- numeric(10,0) NOT NULL,
+    ad_language, -- character varying(6) COLLATE pg_catalog."default" NOT NULL,
+    ad_client_id, -- numeric(10,0) NOT NULL,
+    ad_org_id, -- numeric(10,0) NOT NULL,
+    isactive, -- character(1) COLLATE pg_catalog."default" NOT NULL DEFAULT 'Y'::bpchar,
+    created, -- timestamp with time zone NOT NULL DEFAULT now(),
+    createdby, -- numeric(10,0) NOT NULL,
+    updated, -- timestamp with time zone NOT NULL DEFAULT now(),
+    updatedby, -- numeric(10,0) NOT NULL,
+    name, -- character varying(60) COLLATE pg_catalog."default" NOT NULL,
+    printname, -- character varying(60) COLLATE pg_catalog."default" NOT NULL,
+    description, -- character varying(2000) COLLATE pg_catalog."default",
+    help, -- character varying(2000) COLLATE pg_catalog."default",
+    po_name, -- character varying(60) COLLATE pg_catalog."default",
+    po_printname, -- character varying(60) COLLATE pg_catalog."default",
+    po_description, -- character varying(255) COLLATE pg_catalog."default",
+    po_help, -- character varying(2000) COLLATE pg_catalog."default",
+    istranslated, -- character(1) COLLATE pg_catalog."default" NOT NULL DEFAULT 'N'::bpchar,
+    ad_field_saved_id -- numeric(10,0),
+)
+SELECT
+	m.AD_Element_new_ID AS ad_element_id, -- numeric(10,0) NOT NULL,
+    ft.ad_language, -- character varying(6) COLLATE pg_catalog."default" NOT NULL,
+    0 AS ad_client_id, -- numeric(10,0) NOT NULL,
+    0 AS ad_org_id, -- numeric(10,0) NOT NULL,
+    ft.isactive, -- character(1) COLLATE pg_catalog."default" NOT NULL DEFAULT 'Y'::bpchar,
+    now() AS created, -- timestamp with time zone NOT NULL DEFAULT now(),
+    99 AS createdby, -- numeric(10,0) NOT NULL,
+    now() AS updated, -- timestamp with time zone NOT NULL DEFAULT now(),
+    99 AS updatedby, -- numeric(10,0) NOT NULL,
+    ft.name, -- character varying(60) COLLATE pg_catalog."default" NOT NULL,
+    ft.name AS printname, -- character varying(60) COLLATE pg_catalog."default" NOT NULL,
+    ft.description, -- character varying(2000) COLLATE pg_catalog."default",
+    ft.help, -- character varying(2000) COLLATE pg_catalog."default",
+    NULL AS po_name, -- character varying(60) COLLATE pg_catalog."default",
+    NULL AS po_printname, -- character varying(60) COLLATE pg_catalog."default",
+    NULL AS po_description, -- character varying(255) COLLATE pg_catalog."default",
+    NULL AS po_help, -- character varying(2000) COLLATE pg_catalog."default",
+    'Y' AS istranslated, -- character(1) COLLATE pg_catalog."default" NOT NULL DEFAULT 'N'::bpchar,
+    ft.AD_Field_ID AS ad_field_saved_id -- numeric(10,0),
+FROM ad_element_migrate m
+	JOIN AD_Field_Trl ft ON ft.AD_Field_Id=m.AD_Field_ID AND ft.IsTranslated='Y'
+
+-- with this,
+SELECT * FROM AD_Field_Trl_to_save_V
+--should return no results anymore
+
+
+ALTER TABLE AD_Element_Trl DROP COLUMN AD_Field_Saved_ID;
+ALTER TABLE AD_Field_Trl DROP COLUMN IsSaved;
+DROP VIEW AD_Field_Trl_to_save_V CASCADE;

--- a/de.metas.business/src/main/java/org/adempiere/model/validator/AdempiereBaseValidator.java
+++ b/de.metas.business/src/main/java/org/adempiere/model/validator/AdempiereBaseValidator.java
@@ -25,7 +25,6 @@ import java.util.List;
  */
 
 import org.adempiere.ad.callout.spi.IProgramaticCalloutProvider;
-import org.adempiere.ad.column.callout.AD_Column;
 import org.adempiere.ad.dao.cache.IModelCacheService;
 import org.adempiere.ad.dao.cache.ITableCacheConfig;
 import org.adempiere.ad.dao.cache.ITableCacheConfig.TrxLevel;
@@ -211,8 +210,6 @@ public final class AdempiereBaseValidator extends AbstractModuleInterceptor
 		calloutsRegistry.registerAnnotatedCallout(new de.metas.javaclasses.model.interceptor.AD_JavaClass_Type());
 
 		calloutsRegistry.registerAnnotatedCallout(new de.metas.process.callout.AD_Process_Para()); // FRESH-727
-
-		calloutsRegistry.registerAnnotatedCallout(AD_Column.instance);
 
 		calloutsRegistry.registerAnnotatedCallout(new C_BPartner_Product());
 	}


### PR DESCRIPTION
* make AD_Element controlled fields read-only (e.g. AD_Field.Name)
* migrate existing AD_Field_Trls into AD_Element_trl
AD Element Translations leads to wrong fieldname Translations https://github.com/metasfresh/metasfresh/issues/4652