### PR TITLE
#4700-app - Allow appending additional PDF-attachments to invoice-PDF

### DIFF
--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/attachments/AttachmentConstants.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/attachments/AttachmentConstants.java
@@ -26,6 +26,13 @@ public class AttachmentConstants
 {
 	public static final String TAGNAME_IS_DOCUMENT = "IsDocument";
 
+	/**
+	 * if set to {@code true}, it advises the system that
+	 * the respective attachment is a PDF
+	 * and when a PDF is created for the invoice to which it is attached, then this attachment's PDF shall be appended to that invoice's PDF.
+	 */
+	public static final String TAGNAME_CONCATENATE_PDF_TO_INVOICE_PDF = "Concatenate_Pdf_to_InvoicePdf";
+
 	public static final String TAGNAME_BPARTNER_RECIPIENT_ID = "C_BPartner_Recipient_ID";
 
 	public static final String TAGNAME_STORED_PREFIX = "Stored_";

--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/attachments/AttachmentEntry.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/attachments/AttachmentEntry.java
@@ -44,7 +44,7 @@ public final class AttachmentEntry
 	private final String name;
 	private final Type type;
 	private final String filename;
-	private final String contentType;
+	private final String mimeType;
 	private final URI url;
 
 	private final ImmutableMap<String, String> tags;
@@ -58,7 +58,7 @@ public final class AttachmentEntry
 			@Nullable final String name,
 			@NonNull final Type type,
 			@Nullable final String filename,
-			@Nullable final String contentType,
+			@Nullable final String mimeType,
 			@Nullable final URI url,
 			@Singular final Map<String, String> tags,
 			@Singular final Set<ITableRecordReference> linkedRecords)
@@ -74,12 +74,12 @@ public final class AttachmentEntry
 
 		if (type == Type.Data)
 		{
-			this.contentType = contentType != null ? contentType : MimeType.getMimeType(this.name);
+			this.mimeType = mimeType != null ? mimeType : MimeType.getMimeType(this.name);
 			this.url = null;
 		}
 		else if (type == Type.URL)
 		{
-			this.contentType = null;
+			this.mimeType = null;
 			this.url = Preconditions.checkNotNull(url, "url");
 		}
 		else
@@ -91,7 +91,7 @@ public final class AttachmentEntry
 	public String toStringX()
 	{
 		final StringBuilder sb = new StringBuilder(getName());
-		sb.append(" - ").append(getContentType());
+		sb.append(" - ").append(getMimeType());
 		return sb.toString();
 	}
 

--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/attachments/AttachmentEntryFactory.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/attachments/AttachmentEntryFactory.java
@@ -122,7 +122,7 @@ public class AttachmentEntryFactory
 				.name(entryRecord.getFileName())
 				.type(toAttachmentEntryTypeFromADRefListValue(entryRecord.getType()))
 				.filename(entryRecord.getFileName())
-				.contentType(entryRecord.getContentType())
+				.mimeType(entryRecord.getContentType())
 				.url(extractUriOrNull(entryRecord))
 				.tags(tags)
 				.build();

--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/attachments/AttachmentEntryService.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/attachments/AttachmentEntryService.java
@@ -8,10 +8,13 @@ import lombok.NonNull;
 import lombok.Singular;
 import lombok.Value;
 
+import javax.annotation.Nullable;
+
 import java.io.File;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.adempiere.exceptions.AdempiereException;
@@ -279,6 +282,7 @@ public class AttachmentEntryService
 				.stream()
 				.filter(e -> e.hasAllTagsSetToTrue(query.getTagsSetToTrue()))
 				.filter(e -> e.hasAllTagsSetToAnyValue(query.getTagsSetToAnyValue()))
+				.filter(e -> Check.isEmpty(query.getMimeType(), true) || Objects.equals(e.getMimeType(), query.getMimeType()))
 				.collect(ImmutableList.toImmutableList());
 	}
 
@@ -356,13 +360,18 @@ public class AttachmentEntryService
 
 		Object referencedRecord;
 
+		String mimeType;
+
 		@Builder
 		private AttachmentEntryQuery(
 				@Singular("tagSetToTrue") final List<String> tagsSetToTrue,
 				@Singular("tagSetToAnyValue") final List<String> tagsSetToAnyValue,
+				@Nullable final String mimeType,
 				@NonNull final Object referencedRecord)
 		{
 			this.referencedRecord = referencedRecord;
+
+			this.mimeType = mimeType;
 
 			this.tagsSetToTrue = tagsSetToTrue;
 			this.tagsSetToAnyValue = tagsSetToAnyValue;

--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/attachments/process/AD_AttachmentEntry_Download.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/attachments/process/AD_AttachmentEntry_Download.java
@@ -41,7 +41,7 @@ public class AD_AttachmentEntry_Download extends JavaProcess
 		final AttachmentEntry entry = attachmentEntryService.getById(entryId);
 		final byte[] data = attachmentEntryService.retrieveData(entry.getId());
 
-		getResult().setReportData(data, entry.getFilename(), entry.getContentType());
+		getResult().setReportData(data, entry.getFilename(), entry.getMimeType());
 
 		return MSG_OK;
 	}

--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/report/ExecuteReportStrategyUtil.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/report/ExecuteReportStrategyUtil.java
@@ -1,0 +1,137 @@
+package de.metas.report;
+
+import lombok.NonNull;
+import lombok.Value;
+import lombok.experimental.UtilityClass;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.print.ReportEngine;
+import org.compiere.util.Env;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.pdf.PdfCopy;
+import com.lowagie.text.pdf.PdfReader;
+
+import de.metas.adempiere.report.jasper.JasperConstants;
+import de.metas.print.IPrintService;
+import de.metas.process.ProcessExecutor;
+import de.metas.process.ProcessInfo;
+
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2018 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+@UtilityClass
+public class ExecuteReportStrategyUtil
+{
+	public byte[] executeJasperProcess(
+			final int jasperProcessId,
+			@NonNull final ProcessInfo processInfo)
+	{
+		final ProcessExecutor processExecutor = ProcessInfo.builder()
+				.setCtx(Env.getCtx())
+				.setAD_Process_ID(jasperProcessId)
+				.setRecord(processInfo.getTable_ID(), processInfo.getRecord_ID())
+				.addParameter(JasperConstants.REPORT_PARAM_BARCODE_URL, ReportEngine.getBarcodeServlet(Env.getCtx()))
+				.addParameter(IPrintService.PARAM_PrintCopies, 1)
+				.setPrintPreview(true) // don't archive it! just give us the PDF data
+				.buildAndPrepareExecution()
+				.onErrorThrowException(true)
+				.executeSync();
+
+		final byte[] processPdfData = processExecutor.getResult().getReportData();
+		return processPdfData;
+	}
+
+	public byte[] concatenate(
+			@NonNull final byte[] documentPdfData,
+			@NonNull final List<PdfDataProvider> additionalDataItemsToAttach)
+	{
+		final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+		print(out, documentPdfData, additionalDataItemsToAttach);
+
+		return out.toByteArray();
+	}
+
+	private void print(
+			@NonNull final OutputStream bos,
+			@NonNull final byte[] documentPdfData,
+			@NonNull final List<PdfDataProvider> additionalDataItemsToAttach)
+	{
+		final Document document = new Document();
+
+		try
+		{
+			final PdfCopy copy = new PdfCopy(document, bos);
+			document.open();
+
+			final PdfReader dunningDocDataReader = new PdfReader(documentPdfData);
+
+			for (int page = 0; page < dunningDocDataReader.getNumberOfPages();)
+			{
+				copy.addPage(copy.getImportedPage(dunningDocDataReader, ++page));
+			}
+			copy.freeReader(dunningDocDataReader);
+			dunningDocDataReader.close();
+
+			for (final PdfDataProvider additionalDataItemToAttach : additionalDataItemsToAttach)
+			{
+				final byte[] data = additionalDataItemToAttach.getPdfData();
+
+				final PdfReader invoiceDocDataReader = new PdfReader(data);
+
+				for (int page = 0; page < invoiceDocDataReader.getNumberOfPages();)
+				{
+					copy.addPage(copy.getImportedPage(invoiceDocDataReader, ++page));
+				}
+				copy.freeReader(invoiceDocDataReader);
+				invoiceDocDataReader.close();
+			}
+			document.close();
+
+		}
+		catch (Exception e)
+		{
+			throw AdempiereException.wrapIfNeeded(e);
+		}
+	}
+
+	@Value
+	public static class PdfDataProvider
+	{
+		public static PdfDataProvider forData(@NonNull final byte[] pdfData)
+		{
+			return new PdfDataProvider(pdfData);
+		}
+
+		byte[] pdfData;
+
+		private PdfDataProvider(@NonNull final byte[] pdfData)
+		{
+			this.pdfData = pdfData;
+		}
+	}
+}

--- a/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/test/AdempiereTestHelper.java
+++ b/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/test/AdempiereTestHelper.java
@@ -116,6 +116,9 @@ public class AdempiereTestHelper
 		// Make sure database is clean
 		POJOLookupMap.resetAll();
 
+		// we also don't want any model interceptors to interfere, unless we explicitly test them up to do so
+		POJOLookupMap.get().clear();
+
 		//
 		// POJOWrapper defaults
 		POJOWrapper.setAllowRefreshingChangedModels(false);

--- a/de.metas.business/src/main/java/de/metas/invoice/export/InvoiceToExportFactory.java
+++ b/de.metas.business/src/main/java/de/metas/invoice/export/InvoiceToExportFactory.java
@@ -199,7 +199,7 @@ public class InvoiceToExportFactory
 
 			final InvoiceAttachment invoiceAttachment = InvoiceAttachment.builder()
 					.fileName(attachment.getFilename())
-					.mimeType(attachment.getContentType())
+					.mimeType(attachment.getMimeType())
 					.data(attachmentData)
 					.invoiceExportProviderId(attachment.getTagValue(InvoiceExportClientFactory.ATTATCHMENT_TAGNAME_EXPORT_PROVIDER))
 					.primaryAttrachment(!isSecondaryAttachment)

--- a/de.metas.business/src/main/java/de/metas/invoice/process/C_Invoice_SalesInvoiceJasperWithAttachedDocuments.java
+++ b/de.metas.business/src/main/java/de/metas/invoice/process/C_Invoice_SalesInvoiceJasperWithAttachedDocuments.java
@@ -1,0 +1,52 @@
+package de.metas.invoice.process;
+
+import lombok.NonNull;
+
+import org.compiere.Adempiere;
+import org.compiere.model.I_C_Invoice;
+
+import de.metas.process.IProcessPrecondition;
+import de.metas.process.IProcessPreconditionsContext;
+import de.metas.process.ProcessPreconditionsResolution;
+import de.metas.report.ExecuteReportStrategy;
+import de.metas.report.ReportStarter;
+
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2018 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+public class C_Invoice_SalesInvoiceJasperWithAttachedDocuments extends ReportStarter implements IProcessPrecondition
+{
+	@Override
+	public ProcessPreconditionsResolution checkPreconditionsApplicable(
+			@NonNull final IProcessPreconditionsContext context)
+	{
+		return ProcessPreconditionsResolution
+				.acceptIf(I_C_Invoice.Table_Name.equals(context.getTableName()));
+	}
+
+	@Override
+	protected ExecuteReportStrategy getExecuteReportStrategy()
+	{
+		return Adempiere.getBean(C_Invoice_SalesInvoiceJasperWithAttachedDocumentsStrategy.class);
+	}
+
+}

--- a/de.metas.business/src/main/java/de/metas/invoice/process/C_Invoice_SalesInvoiceJasperWithAttachedDocumentsStrategy.java
+++ b/de.metas.business/src/main/java/de/metas/invoice/process/C_Invoice_SalesInvoiceJasperWithAttachedDocumentsStrategy.java
@@ -1,0 +1,98 @@
+package de.metas.invoice.process;
+
+import lombok.NonNull;
+
+import java.util.List;
+
+import org.adempiere.service.ISysConfigBL;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_C_Invoice;
+import org.compiere.util.Env;
+import org.compiere.util.MimeType;
+import org.springframework.stereotype.Component;
+
+import com.google.common.collect.ImmutableList;
+
+import de.metas.adempiere.report.jasper.OutputType;
+import de.metas.attachments.AttachmentConstants;
+import de.metas.attachments.AttachmentEntry;
+import de.metas.attachments.AttachmentEntryService;
+import de.metas.attachments.AttachmentEntryService.AttachmentEntryQuery;
+import de.metas.invoice.InvoiceId;
+import de.metas.process.ProcessInfo;
+import de.metas.report.ExecuteReportStrategy;
+import de.metas.report.ExecuteReportStrategyUtil;
+import de.metas.report.ExecuteReportStrategyUtil.PdfDataProvider;
+import de.metas.util.Check;
+import de.metas.util.Services;
+
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2018 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+@Component
+public class C_Invoice_SalesInvoiceJasperWithAttachedDocumentsStrategy implements ExecuteReportStrategy
+{
+	private static final String C_INVOICE_REPORT_AD_PROCESS_ID = "de.metas.invoice.C_Invoice.SalesInvoice.Report.AD_Process_ID";
+
+	private final AttachmentEntryService attachmentEntryService;
+
+	public C_Invoice_SalesInvoiceJasperWithAttachedDocumentsStrategy(@NonNull final AttachmentEntryService attachmentEntryService)
+	{
+		this.attachmentEntryService = attachmentEntryService;
+	}
+
+	@Override
+	public ExecuteReportResult executeReport(
+			@NonNull final ProcessInfo processInfo,
+			@NonNull final OutputType outputType)
+	{
+
+		final int dunningDocReportProcessId = Services.get(ISysConfigBL.class)
+				.getIntValue(
+						C_INVOICE_REPORT_AD_PROCESS_ID,
+						-1,
+						Env.getAD_Client_ID(),
+						Env.getAD_Org_ID(Env.getCtx()));
+		Check.assume(dunningDocReportProcessId > 0, "The sysconfig with name {} needs to have a value greater than 0; AD_Client_ID={}; AD_Org_ID={}", C_INVOICE_REPORT_AD_PROCESS_ID, Env.getAD_Client_ID(), Env.getAD_Org_ID(Env.getCtx()));
+		final byte[] invoicePdfData = ExecuteReportStrategyUtil.executeJasperProcess(dunningDocReportProcessId, processInfo);
+
+		final InvoiceId invoiceId = InvoiceId.ofRepoId(processInfo.getRecord_ID());
+
+		final AttachmentEntryQuery attachmentQuery = AttachmentEntryQuery.builder()
+				.referencedRecord(TableRecordReference.of(I_C_Invoice.Table_Name, invoiceId))
+				.tagSetToTrue(AttachmentConstants.TAGNAME_CONCATENATE_PDF_TO_INVOICE_PDF)
+				.mimeType(MimeType.TYPE_PDF)
+				.build();
+
+		final List<AttachmentEntry> attachments = attachmentEntryService.getByQuery(attachmentQuery);
+		final ImmutableList<PdfDataProvider> additionalPdfData = attachments.stream()
+				.map(AttachmentEntry::getId)
+				.map(attachmentEntryService::retrieveData)
+				.map(PdfDataProvider::forData)
+				.collect(ImmutableList.toImmutableList());
+
+		final byte[] result = ExecuteReportStrategyUtil.concatenate(invoicePdfData, additionalPdfData);
+
+		return new ExecuteReportResult(outputType, result);
+	}
+
+}

--- a/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5504710_sys_gh4700-app_add_process_update_printformats.sql
+++ b/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5504710_sys_gh4700-app_add_process_update_printformats.sql
@@ -1,0 +1,75 @@
+-- 2018-10-26T09:13:35.319
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process SET Classname='de.metas.report.jasper.client.process.JasperReportStarter', Type='JasperReports',Updated=TO_TIMESTAMP('2018-10-26 09:13:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=540944
+;
+
+-- 2018-10-26T09:24:07.108
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process SET Type='JasperReports',Updated=TO_TIMESTAMP('2018-10-26 09:24:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=500009
+;
+
+-- 2018-10-26T09:24:17.178
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process SET EntityType='de.metas.invoice',Updated=TO_TIMESTAMP('2018-10-26 09:24:17','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=500009
+;
+
+-- 2018-10-26T09:29:48.589
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Process (AD_Client_ID,IsActive,Created,CreatedBy,Updated,IsReport,IsDirectPrint,AccessLevel,ShowHelp,IsBetaFunctionality,IsServerProcess,CopyFromProcess,UpdatedBy,AD_Process_ID,Value,AllowProcessReRun,IsUseBPartnerLanguage,IsApplySecuritySettings,Description,RefreshAllAfterExecution,IsOneInstanceOnly,LockWaitTimeout,AD_Org_ID,Name,EntityType,TechnicalNote,Classname,Type) VALUES (0,'Y',TO_TIMESTAMP('2018-10-26 09:29:48','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2018-10-26 09:29:48','YYYY-MM-DD HH24:MI:SS'),'Y','N','3','Y','N','N','N',100,541030,'C_Invoice_JasperWithAttachedDocuments','Y','Y','N','Der Prozess erstellt ein Rechnungs-PDF, dass außerdem alle PDF-Anhänge der Rechnung enthält, die mit "Concatename_Pdf_to_InvoicePdf=true" getaggt sind.','N','N',0,0,'Rechnungsdruckstück mit ggf. angehängten PDF-Belegen','de.metas.invoice','This process first runs the Report (Jasper) process that is specified at SysConfig "de.metas.invoice.C_Invoice.SalesInvoice.Report.AD_Process_ID"
+and then appends all PDF attachments that is tagged with "Concatename_Pdf_to_InvoicePdf=true"','de.metas.invoice.process.C_Invoice_JasperWithAttachedDocuments','Java')
+;
+
+-- 2018-10-26T09:29:48.592
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Process_Trl (AD_Language,AD_Process_ID, Help,Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Process_ID, t.Help,t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Process t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Process_ID=541030 AND NOT EXISTS (SELECT 1 FROM AD_Process_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_ID=t.AD_Process_ID)
+;
+
+-- 2018-10-26T09:30:07.848
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-10-26 09:30:07','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y' WHERE AD_Process_ID=541030 AND AD_Language='de_CH'
+;
+
+-- 2018-10-26T09:38:05.135
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-10-26 09:38:05','YYYY-MM-DD HH24:MI:SS'),IsTranslated='Y',Name='Invoice-PDF with possible attached additional PDFs',Description='The process creates an invoice-PDF, then appends the PDF-data of attachments that are tagged with "Concatename_Pdf_to_InvoicePdf=true".' WHERE AD_Process_ID=541030 AND AD_Language='en_US'
+;
+
+-- 2018-10-26T09:38:24.204
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_SysConfig (AD_Client_ID,Created,CreatedBy,IsActive,ConfigurationLevel,Updated,UpdatedBy,AD_SysConfig_ID,Value,Description,AD_Org_ID,Name,EntityType) VALUES (0,TO_TIMESTAMP('2018-10-26 09:38:24','YYYY-MM-DD HH24:MI:SS'),100,'Y','O',TO_TIMESTAMP('2018-10-26 09:38:24','YYYY-MM-DD HH24:MI:SS'),100,541248,'500009','AD_Process_ID of the sale invoice jasper process.
+This config is used by the process C_Invoice_JasperWithAttachedDocuments',0,'de.metas.invoice.C_Invoice.SalesInvoice.Report.AD_Process_ID','de.metas.invoice')
+;
+
+-- 2018-10-26T09:39:09.398
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process SET Description='Der Prozess erstellt ein Rechnungs-PDF, dass außerdem alle PDF-Anhänge der Rechnung enthält, die mit "Concatenate_Pdf_to_InvoicePdf=true" getaggt sind.', TechnicalNote='This process first runs the Report (Jasper) process that is specified at SysConfig "de.metas.invoice.C_Invoice.SalesInvoice.Report.AD_Process_ID"
+and then appends all PDF attachments that is tagged with "Concatenate_Pdf_to_InvoicePdf=true"',Updated=TO_TIMESTAMP('2018-10-26 09:39:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=541030
+;
+
+-- 2018-10-26T09:39:13.772
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-10-26 09:39:13','YYYY-MM-DD HH24:MI:SS'),Description='The process creates an invoice-PDF, then appends the PDF-data of attachments that are tagged with "Concatenate_Pdf_to_InvoicePdf=true".' WHERE AD_Process_ID=541030 AND AD_Language='en_US'
+;
+
+-- 2018-10-26T09:39:18.401
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process_Trl SET UpdatedBy=100,Updated=TO_TIMESTAMP('2018-10-26 09:39:18','YYYY-MM-DD HH24:MI:SS'),Description='Der Prozess erstellt ein Rechnungs-PDF, dass außerdem alle PDF-Anhänge der Rechnung enthält, die mit "Concatenate_Pdf_to_InvoicePdf=true" getaggt sind.' WHERE AD_Process_ID=541030 AND AD_Language='de_CH'
+;
+
+-- 2018-10-26T09:40:39.791
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process SET Value='C_Invoice_SalesInvoiceJasperWithAttachedDocuments',Updated=TO_TIMESTAMP('2018-10-26 09:40:39','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=541030
+;
+
+-- 2018-10-26T09:40:44.989
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process SET Classname='de.metas.invoice.process.C_Invoice_SalesInvoiceJasperWithAttachedDocuments',Updated=TO_TIMESTAMP('2018-10-26 09:40:44','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=541030
+;
+
+-- 2018-10-26T09:40:51.522
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_SysConfig SET Description='AD_Process_ID of the sale invoice jasper process.
+This config is used by the process C_Invoice_SalesInvoiceJasperWithAttachedDocuments.',Updated=TO_TIMESTAMP('2018-10-26 09:40:51','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_SysConfig_ID=541248
+;
+
+UPDATE AD_PrintFormat SET JasperProcess_ID=541030, Updated=TO_TIMESTAMP('2018-10-26 09:40:51','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE JasperProcess_ID=500009;

--- a/de.metas.dunning/src/main/java/de/metas/dunning/modelvalidator/DunningValidator.java
+++ b/de.metas.dunning/src/main/java/de/metas/dunning/modelvalidator/DunningValidator.java
@@ -6,8 +6,8 @@ import org.compiere.model.ModelValidator;
 import org.compiere.model.PO;
 
 import de.metas.dunning.invoice.model.validator.InvoiceDunningValidator;
+import de.metas.dunning.printing.spi.impl.DunningPrintingQueueHandler;
 import de.metas.printing.api.IPrintingQueueBL;
-import de.metas.printing.spi.impl.DunningPrintingQueueHandler;
 import de.metas.util.Check;
 import de.metas.util.Services;
 

--- a/de.metas.dunning/src/main/java/de/metas/dunning/printing/spi/impl/DunningPrintingQueueHandler.java
+++ b/de.metas.dunning/src/main/java/de/metas/dunning/printing/spi/impl/DunningPrintingQueueHandler.java
@@ -1,4 +1,4 @@
-package de.metas.printing.spi.impl;
+package de.metas.dunning.printing.spi.impl;
 
 import org.adempiere.archive.api.IArchiveDAO;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -14,21 +14,20 @@ import de.metas.printing.spi.PrintingQueueHandlerAdapter;
 import de.metas.util.Services;
 
 /**
- * 
+ *
  * This handler adds <code>ItemName</code> specific info to a given queueItem
- * 
+ *
  */
 public class DunningPrintingQueueHandler extends PrintingQueueHandlerAdapter
 {
 	public static final transient DunningPrintingQueueHandler instance = new DunningPrintingQueueHandler();
-	
+
 	private static final Logger logger = LogManager.getLogger(DunningPrintingQueueHandler.class);
-	
+
 	private DunningPrintingQueueHandler()
 	{
-		super();
 	}
-	
+
 	@Override
 	public void afterEnqueueBeforeSave(final I_C_Printing_Queue queueItem, final I_AD_Archive archive)
 	{
@@ -39,7 +38,7 @@ public class DunningPrintingQueueHandler extends PrintingQueueHandlerAdapter
 			logger.debug("AD_Archive {} does not reference a PO; returning", archive);
 			return;
 		}
-		
+
 		if (InterfaceWrapperHelper.isInstanceOf(archiveRerencedModel, I_C_DunningDoc.class))
 		{
 			queueItem.setItemName(X_C_Printing_Queue.ITEMNAME_Mahnung);

--- a/de.metas.dunning/src/main/java/de/metas/dunning/process/C_DunningDoc_JasperWithInvoicePDFsStrategy.java
+++ b/de.metas.dunning/src/main/java/de/metas/dunning/process/C_DunningDoc_JasperWithInvoicePDFsStrategy.java
@@ -1,33 +1,27 @@
 package de.metas.dunning.process;
 
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
+import lombok.NonNull;
+
 import java.util.List;
 
 import org.adempiere.archive.api.IArchiveBL;
 import org.adempiere.archive.api.IArchiveDAO;
-import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.Adempiere;
 import org.compiere.model.I_AD_Archive;
 import org.compiere.model.I_C_Invoice;
-import org.compiere.print.ReportEngine;
 import org.compiere.util.Env;
 
-import com.lowagie.text.Document;
-import com.lowagie.text.pdf.PdfCopy;
-import com.lowagie.text.pdf.PdfReader;
+import com.google.common.collect.ImmutableList;
 
-import de.metas.adempiere.report.jasper.JasperConstants;
 import de.metas.adempiere.report.jasper.OutputType;
 import de.metas.dunning.DunningDocId;
 import de.metas.dunning.invoice.DunningService;
-import de.metas.print.IPrintService;
-import de.metas.process.ProcessExecutor;
 import de.metas.process.ProcessInfo;
 import de.metas.report.ExecuteReportStrategy;
+import de.metas.report.ExecuteReportStrategyUtil;
+import de.metas.report.ExecuteReportStrategyUtil.PdfDataProvider;
 import de.metas.util.Services;
-import lombok.NonNull;
 
 /*
  * #%L
@@ -42,19 +36,18 @@ import lombok.NonNull;
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 
-
 public class C_DunningDoc_JasperWithInvoicePDFsStrategy implements ExecuteReportStrategy
 {
-	private final transient  IArchiveBL archiveBL = Services.get(IArchiveBL.class);
+	private final transient IArchiveBL archiveBL = Services.get(IArchiveBL.class);
 	private final transient IArchiveDAO archiveDAO = Services.get(IArchiveDAO.class);
 	private final transient int dunningDocJasperProcessId;
 
@@ -70,81 +63,31 @@ public class C_DunningDoc_JasperWithInvoicePDFsStrategy implements ExecuteReport
 	{
 		final DunningDocId dunningDocId = DunningDocId.ofRepoId(processInfo.getRecord_ID());
 
-		final ProcessExecutor processExecutor = ProcessInfo.builder()
-				.setCtx(Env.getCtx())
-				.setAD_Process_ID(dunningDocJasperProcessId)
-				.setRecord(processInfo.getTable_ID(), processInfo.getRecord_ID())
-				.addParameter(JasperConstants.REPORT_PARAM_BARCODE_URL, ReportEngine.getBarcodeServlet(Env.getCtx()))
-				.addParameter(IPrintService.PARAM_PrintCopies, 1)
-				.setPrintPreview(true) // don't archive it! just give us the PDF data
-				.buildAndPrepareExecution()
-				.onErrorThrowException(true)
-				.executeSync();
-
-		final byte[] dunningDocPdfData = processExecutor.getResult().getReportData();
+		final byte[] dunningDocPdfData = ExecuteReportStrategyUtil.executeJasperProcess(dunningDocJasperProcessId, processInfo);
 
 		final DunningService dunningService = Adempiere.getBean(DunningService.class);
 		final List<I_C_Invoice> dunnedInvoices = dunningService.retrieveDunnedInvoices(dunningDocId);
-		final byte[] data = concatenate(dunningDocPdfData, dunnedInvoices);
+
+		final List<PdfDataProvider> additionalDataItemsToAttach = retrieveAdditionalDataItems(dunnedInvoices);
+		final byte[] data = ExecuteReportStrategyUtil.concatenate(dunningDocPdfData, additionalDataItemsToAttach);
 
 		return new ExecuteReportResult(outputType, data);
 	}
 
-	private byte[] concatenate(
-			@NonNull final byte[] dunningDocPdfData,
-			@NonNull final List<I_C_Invoice> dunnedInvoices)
+	private List<PdfDataProvider> retrieveAdditionalDataItems(@NonNull final List<I_C_Invoice> dunnedInvoices)
 	{
-		final ByteArrayOutputStream out = new ByteArrayOutputStream();
-		print(out, dunningDocPdfData, dunnedInvoices);
-		return out.toByteArray();
-	}
-
-	private void print(
-			@NonNull final OutputStream bos,
-			@NonNull final byte[] dunningDocPdfData,
-			@NonNull final List<I_C_Invoice> dunnedInvoices)
-	{
-		final Document document = new Document();
-
-		try
+		ImmutableList.Builder<PdfDataProvider> result = ImmutableList.builder();
+		for (final I_C_Invoice invoice : dunnedInvoices)
 		{
-			final PdfCopy copy = new PdfCopy(document, bos);
-			document.open();
-
-			final PdfReader dunningDocDataReader = new PdfReader(dunningDocPdfData);
-
-			for (int page = 0; page < dunningDocDataReader.getNumberOfPages();)
+			final List<I_AD_Archive> invoiceArchives = archiveDAO.retrieveLastArchives(Env.getCtx(), TableRecordReference.of(invoice), 1);
+			if (invoiceArchives.isEmpty())
 			{
-				copy.addPage(copy.getImportedPage(dunningDocDataReader, ++page));
+				continue;
 			}
-			copy.freeReader(dunningDocDataReader);
-			dunningDocDataReader.close();
 
-			for (final I_C_Invoice invoice : dunnedInvoices)
-			{
-				final List<I_AD_Archive> invoiceArchives = archiveDAO.retrieveLastArchives(Env.getCtx(), TableRecordReference.of(invoice), 1);
-				if (invoiceArchives.isEmpty())
-				{
-					continue;
-				}
-
-				final byte[] data = archiveBL.getBinaryData(invoiceArchives.get(0));
-
-				final PdfReader invoiceDocDataReader = new PdfReader(data);
-
-				for (int page = 0; page < invoiceDocDataReader.getNumberOfPages();)
-				{
-					copy.addPage(copy.getImportedPage(invoiceDocDataReader, ++page));
-				}
-				copy.freeReader(invoiceDocDataReader);
-				invoiceDocDataReader.close();
-			}
-			document.close();
-
+			final byte[] data = archiveBL.getBinaryData(invoiceArchives.get(0));
+			result.add(PdfDataProvider.forData(data));
 		}
-		catch (Exception e)
-		{
-			throw AdempiereException.wrapIfNeeded(e);
-		}
+		return result.build();
 	}
 }

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_HU.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_HU.java
@@ -1,9 +1,11 @@
 package de.metas.handlingunits.model.validator;
 
+import lombok.NonNull;
+
 import java.util.List;
 
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
-import org.adempiere.ad.modelvalidator.annotations.Validator;
 import org.adempiere.ad.service.IDeveloperModeBL;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.IContextAware;
@@ -20,12 +22,17 @@ import de.metas.logging.LogManager;
 import de.metas.storage.IStorageListeners;
 import de.metas.storage.spi.hu.impl.StorageSegmentFromHU;
 import de.metas.util.Services;
-import lombok.NonNull;
 
-@Validator(I_M_HU.class)
+@Interceptor(I_M_HU.class)
 public class M_HU
 {
+	public static final M_HU INSTANCE = new M_HU();
+
 	private final transient Logger logger = LogManager.getLogger(getClass());
+
+	private M_HU()
+	{
+	}
 
 	/**
 	 * Checks if HU is valid.

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/Main.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/Main.java
@@ -1,5 +1,7 @@
 package de.metas.handlingunits.model.validator;
 
+import lombok.NonNull;
+
 /*
  * #%L
  * de.metas.handlingunits.base
@@ -43,8 +45,8 @@ import de.metas.adempiere.callout.OrderFastInput;
 import de.metas.adempiere.gui.search.impl.HUOrderFastInputHandler;
 import de.metas.cache.CacheMgt;
 import de.metas.cache.model.IModelCacheService;
-import de.metas.cache.model.ITableCacheConfigBuilder;
 import de.metas.cache.model.ITableCacheConfig.TrxLevel;
+import de.metas.cache.model.ITableCacheConfigBuilder;
 import de.metas.handlingunits.IHUDocumentHandlerFactory;
 import de.metas.handlingunits.ddorder.spi.impl.DDOrderLineHUDocumentHandler;
 import de.metas.handlingunits.ddorder.spi.impl.ForecastLineHUDocumentHandler;
@@ -103,7 +105,6 @@ import de.metas.pricing.service.ProductPrices;
 import de.metas.storage.IStorageEngineService;
 import de.metas.tourplanning.api.IDeliveryDayBL;
 import de.metas.util.Services;
-import lombok.NonNull;
 
 public final class Main extends AbstractModuleInterceptor
 {
@@ -111,7 +112,7 @@ public final class Main extends AbstractModuleInterceptor
 	protected void onInit(final IModelValidationEngine engine, final I_AD_Client client)
 	{
 		super.onInit(engine, client);
-		
+
 		final IProgramaticCalloutProvider programaticCalloutProvider = Services.get(IProgramaticCalloutProvider.class);
 
 		registerFactories();
@@ -135,7 +136,7 @@ public final class Main extends AbstractModuleInterceptor
 		engine.addModelValidator(new de.metas.handlingunits.model.validator.C_Order(), client);
 		engine.addModelValidator(new de.metas.handlingunits.model.validator.C_Order_Line_Alloc(), client);
 		engine.addModelValidator(de.metas.handlingunits.model.validator.M_Movement.instance, client);
-		engine.addModelValidator(new de.metas.handlingunits.model.validator.M_HU(), client);
+		engine.addModelValidator(de.metas.handlingunits.model.validator.M_HU.INSTANCE, client);
 		engine.addModelValidator(new de.metas.handlingunits.model.validator.M_HU_Attribute(), client);
 		engine.addModelValidator(de.metas.handlingunits.model.validator.M_HU_Storage.INSTANCE, client);
 		engine.addModelValidator(new de.metas.handlingunits.model.validator.M_HU_Assignment(), client);

--- a/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/HUTransformTestsBase.java
+++ b/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/HUTransformTestsBase.java
@@ -110,7 +110,7 @@ public class HUTransformTestsBase
 			sourceTU = createdTUs.get(0);
 
 			huStatusBL.setHUStatus(data.helper.getHUContext(), sourceTU, X_M_HU.HUSTATUS_Active);
-			new M_HU().updateChildren(sourceTU);
+			M_HU.INSTANCE.updateChildren(sourceTU);
 			save(sourceTU);
 
 			testHUsBuilder.inititalParent(sourceTU);

--- a/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/impl/LUTUProducerDestinationTestSupport.java
+++ b/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/impl/LUTUProducerDestinationTestSupport.java
@@ -275,7 +275,7 @@ public class LUTUProducerDestinationTestSupport
 
 		final I_M_HU createdTU = createdTUs.get(0);
 		huStatusBL.setHUStatus(helper.getHUContext(), createdTU, X_M_HU.HUSTATUS_Active);
-		new M_HU().updateChildren(createdTU);
+		M_HU.INSTANCE.updateChildren(createdTU);
 		save(createdTU);
 
 		final List<I_M_HU> createdCUs = handlingUnitsDAO.retrieveIncludedHUs(createdTU);
@@ -342,7 +342,7 @@ public class LUTUProducerDestinationTestSupport
 		huStatusBL.setHUStatus(huContext, createdLU, X_M_HU.HUSTATUS_Active);
 		assertThat(createdLU.getHUStatus(), is(X_M_HU.HUSTATUS_Active));
 
-		new M_HU().updateChildren(createdLU);
+		M_HU.INSTANCE.updateChildren(createdLU);
 		save(createdLU);
 
 		final List<I_M_HU> createdAggregateHUs = handlingUnitsDAO.retrieveIncludedHUs(createdLUs.get(0));

--- a/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUPickingSlotTest.java
+++ b/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUPickingSlotTest.java
@@ -30,13 +30,11 @@ import static org.junit.Assert.assertThat;
 import java.util.Properties;
 
 import org.adempiere.ad.trx.api.ITrx;
-import org.adempiere.ad.wrapper.POJOWrapper;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.util.Env;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -55,19 +53,14 @@ import de.metas.handlingunits.picking.impl.HUPickingSlotBL;
 @SpringBootTest(classes = { StartupListener.class, PickingCandidateRepository.class, ShutdownListener.class })
 public class HUPickingSlotTest
 {
-	@BeforeClass
-	public final static void staticInit()
-	{
-		AdempiereTestHelper.get().staticInit();
-		POJOWrapper.setDefaultStrictValues(false);
-	}
-
 	/** Service under test */
 	private HUPickingSlotBL huPickingSlotBL;
 
 	@Before
 	public final void init()
 	{
+		AdempiereTestHelper.get().init();
+
 		huPickingSlotBL = new HUPickingSlotBL();
 	}
 

--- a/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/inventory/impl/HUInternalUseInventoryProducerTests.java
+++ b/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/inventory/impl/HUInternalUseInventoryProducerTests.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import lombok.NonNull;
+
 import java.math.BigDecimal;
 import java.util.List;
 
@@ -41,7 +43,6 @@ import de.metas.handlingunits.spi.IHUPackingMaterialCollectorSource;
 import de.metas.inventory.impl.InventoryBL;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
-import lombok.NonNull;
 import mockit.Mocked;
 
 /*
@@ -173,7 +174,7 @@ public class HUInternalUseInventoryProducerTests
 		assertThat(createdLU.getHUStatus()).isEqualTo(X_M_HU.HUSTATUS_Active);
 		createdLU.setM_Locator(locator);
 
-		new M_HU().updateChildren(createdLU);
+		M_HU.INSTANCE.updateChildren(createdLU);
 		save(createdLU);
 
 		final List<I_M_HU> createdAggregateHUs = handlingUnitsDAO.retrieveIncludedHUs(createdLUs.get(0));
@@ -232,7 +233,7 @@ public class HUInternalUseInventoryProducerTests
 		huStatusBL.setHUStatus(data.helper.getHUContext(), createdTU, X_M_HU.HUSTATUS_Active);
 		createdTU.setM_Locator(locator);
 
-		new M_HU().updateChildren(createdTU);
+		M_HU.INSTANCE.updateChildren(createdTU);
 		save(createdTU);
 
 		final List<I_M_HU> createdCUs = handlingUnitsDAO.retrieveIncludedHUs(createdTU);

--- a/de.metas.order.rest-api/src/main/java/de/metas/order/rest/controller/SalesOrderRestController.java
+++ b/de.metas.order.rest-api/src/main/java/de/metas/order/rest/controller/SalesOrderRestController.java
@@ -1,5 +1,7 @@
 package de.metas.order.rest.controller;
 
+import lombok.NonNull;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -43,7 +45,6 @@ import de.metas.quantity.Quantity;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import de.metas.util.web.MetasfreshRestAPIConstants;
-import lombok.NonNull;
 
 /*
  * #%L
@@ -180,7 +181,7 @@ public class SalesOrderRestController
 				.id(AttachmentEntryId.getRepoId(entry.getId()))
 				.type(entry.getType())
 				.filename(entry.getFilename())
-				.contentType(entry.getContentType())
+				.mimeType(entry.getMimeType())
 				.url(entry.getUrl() != null ? entry.getUrl().toString() : null)
 				.build();
 	}

--- a/de.metas.order.rest-api/src/main/java/de/metas/order/rest/model/JsonSalesOrderAttachment.java
+++ b/de.metas.order.rest-api/src/main/java/de/metas/order/rest/model/JsonSalesOrderAttachment.java
@@ -1,5 +1,8 @@
 package de.metas.order.rest.model;
 
+import lombok.Builder;
+import lombok.Value;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -7,8 +10,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import de.metas.attachments.AttachmentEntry;
-import lombok.Builder;
-import lombok.Value;
 
 /*
  * #%L
@@ -48,8 +49,8 @@ public class JsonSalesOrderAttachment
 	@JsonProperty("filename")
 	private final String filename;
 
-	@JsonProperty("contentType")
-	private final String contentType;
+	@JsonProperty("mimeType")
+	private final String mimeType;
 
 	@JsonProperty("url")
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -62,14 +63,14 @@ public class JsonSalesOrderAttachment
 			@JsonProperty("id") final int id,
 			@JsonProperty("type") final AttachmentEntry.Type type,
 			@JsonProperty("filename") final String filename,
-			@JsonProperty("contentType") final String contentType,
+			@JsonProperty("mimeType") final String mimeType,
 			@JsonProperty("url") final String url)
 	{
 		this.salesOrderId = salesOrderId;
 		this.id = id;
 		this.type = type;
 		this.filename = filename;
-		this.contentType = contentType;
+		this.mimeType = mimeType;
 		this.url = url;
 	}
 

--- a/de.metas.order.rest-api/src/test/java/de/metas/order/rest/model/JsonSerializationDeserializationTest.java
+++ b/de.metas.order.rest-api/src/test/java/de/metas/order/rest/model/JsonSerializationDeserializationTest.java
@@ -1,5 +1,7 @@
 package de.metas.order.rest.model;
 
+import lombok.NonNull;
+
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -11,7 +13,6 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.metas.attachments.AttachmentEntry;
-import lombok.NonNull;
 
 /*
  * #%L
@@ -86,7 +87,7 @@ public class JsonSerializationDeserializationTest
 				.id(444)
 				.type(AttachmentEntry.Type.Data)
 				.filename("file.pdf")
-				.contentType("application/pdf")
+				.mimeType("application/pdf")
 				.build());
 	}
 }

--- a/de.metas.ordercandidate.rest-api-impl/src/main/java/de/metas/ordercandidate/rest/OrderCandidatesRestControllerImpl.java
+++ b/de.metas.ordercandidate.rest-api-impl/src/main/java/de/metas/ordercandidate/rest/OrderCandidatesRestControllerImpl.java
@@ -159,7 +159,7 @@ public class OrderCandidatesRestControllerImpl implements OrderCandidatesRestEnd
 
 			@ApiParam(value = "List with an even number of items;\n"
 					+ "transformed to a map of key-value pairs and added to the new attachment as tags.\n"
-					+ "If the number of items is odd, the last item is discarded", allowEmptyValue = true) //
+					+ "If the number of items is odd, the last item is discarded.", allowEmptyValue = true) //
 			@RequestParam("tags") //
 			@Nullable final List<String> tagKeyValuePairs,
 
@@ -222,7 +222,7 @@ public class OrderCandidatesRestControllerImpl implements OrderCandidatesRestEnd
 				.attachmentId(attachmentId)
 				.type(entry.getType())
 				.filename(entry.getFilename())
-				.contentType(entry.getContentType())
+				.mimeType(entry.getMimeType())
 				.url(entry.getUrl() != null ? entry.getUrl().toString() : null)
 				.build();
 	}

--- a/de.metas.ordercandidate.rest-api/src/main/java/de/metas/ordercandidate/rest/JsonAttachment.java
+++ b/de.metas.ordercandidate.rest-api/src/main/java/de/metas/ordercandidate/rest/JsonAttachment.java
@@ -1,5 +1,9 @@
 package de.metas.ordercandidate.rest;
 
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -9,9 +13,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import de.metas.attachments.AttachmentEntry;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.Value;
 
 /*
  * #%L
@@ -61,7 +62,7 @@ public class JsonAttachment
 
 	String filename;
 
-	String contentType;
+	String mimeType;
 
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private final String url;
@@ -74,7 +75,7 @@ public class JsonAttachment
 			@JsonProperty("attachmentId") @NonNull final String attachmentId,
 			@JsonProperty("type") final @NonNull AttachmentEntry.Type type,
 			@JsonProperty("filename") @NonNull final String filename,
-			@JsonProperty("contentType") @NonNull final String contentType,
+			@JsonProperty("mimeType") @NonNull final String mimeType,
 			@JsonProperty("url") final String url)
 	{
 		this.externalReference = externalReference;
@@ -82,7 +83,7 @@ public class JsonAttachment
 		this.attachmentId = attachmentId;
 		this.type = type;
 		this.filename = filename;
-		this.contentType = contentType;
+		this.mimeType = mimeType;
 		this.url = url;
 	}
 

--- a/de.metas.shipper.gateway.dpd-legacy/src/main/java/de/metas/dpd/model/MDPDCountry.java
+++ b/de.metas.shipper.gateway.dpd-legacy/src/main/java/de/metas/dpd/model/MDPDCountry.java
@@ -10,12 +10,12 @@ package de.metas.dpd.model;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -29,10 +29,10 @@ import java.util.Properties;
 import org.adempiere.util.proxy.Cached;
 import org.compiere.model.Query;
 
-import de.metas.adempiere.util.CacheIgnore;
+import de.metas.cache.annotation.CacheIgnore;
 
 /**
- * 
+ *
  * @author ts
  * @see "<a href='http://dewiki908/mediawiki/index.php/Transportverpackung_%282009_0022_G61%29'>(2009_0022_G61)</a>"
  */
@@ -40,7 +40,7 @@ public class MDPDCountry extends X_DPD_Country
 {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 4704002032957293698L;
 

--- a/de.metas.shipper.gateway.dpd-legacy/src/main/java/de/metas/dpd/model/MDPDDepot.java
+++ b/de.metas.shipper.gateway.dpd-legacy/src/main/java/de/metas/dpd/model/MDPDDepot.java
@@ -10,12 +10,12 @@ package de.metas.dpd.model;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -29,10 +29,10 @@ import java.util.Properties;
 import org.adempiere.util.proxy.Cached;
 import org.compiere.model.Query;
 
-import de.metas.adempiere.util.CacheIgnore;
+import de.metas.cache.annotation.CacheIgnore;
 
 /**
- * 
+ *
  * @author ts
  * @see "<a href='http://dewiki908/mediawiki/index.php/Transportverpackung_%282009_0022_G61%29'>(2009_0022_G61)</a>"
  */
@@ -40,7 +40,7 @@ public class MDPDDepot extends X_DPD_Depot
 {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 7350231553001692690L;
 

--- a/de.metas.shipper.gateway.dpd-legacy/src/main/java/de/metas/dpd/model/MDPDFileInfo.java
+++ b/de.metas.shipper.gateway.dpd-legacy/src/main/java/de/metas/dpd/model/MDPDFileInfo.java
@@ -10,12 +10,12 @@ package de.metas.dpd.model;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -30,10 +30,10 @@ import java.util.Properties;
 import org.adempiere.util.proxy.Cached;
 import org.compiere.model.Query;
 
-import de.metas.adempiere.util.CacheIgnore;
+import de.metas.cache.annotation.CacheIgnore;
 
 /**
- * 
+ *
  * @author ts
  * @see "<a href='http://dewiki908/mediawiki/index.php/Transportverpackung_%282009_0022_G61%29'>(2009_0022_G61)</a>"
  */
@@ -41,7 +41,7 @@ public class MDPDFileInfo extends X_DPD_FileInfo
 {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = -3947007729609099418L;
 

--- a/de.metas.shipper.gateway.dpd-legacy/src/main/java/de/metas/dpd/model/MDPDScanCode.java
+++ b/de.metas.shipper.gateway.dpd-legacy/src/main/java/de/metas/dpd/model/MDPDScanCode.java
@@ -10,12 +10,12 @@ package de.metas.dpd.model;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -29,13 +29,13 @@ import java.util.Properties;
 import org.adempiere.util.proxy.Cached;
 import org.compiere.model.Query;
 
-import de.metas.adempiere.util.CacheIgnore;
+import de.metas.cache.annotation.CacheIgnore;
 
 public class MDPDScanCode extends X_DPD_ScanCode
 {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = -2396208024826917350L;
 

--- a/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_rest-api/src/main/java/de/metas/vertical/healthcare/forum_datenaustausch_ch/rest/HealthcareChPdfAttachmentController.java
+++ b/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_rest-api/src/main/java/de/metas/vertical/healthcare/forum_datenaustausch_ch/rest/HealthcareChPdfAttachmentController.java
@@ -1,5 +1,6 @@
 package de.metas.vertical.healthcare.forum_datenaustausch_ch.rest;
 
+import static de.metas.attachments.AttachmentConstants.TAGNAME_CONCATENATE_PDF_TO_INVOICE_PDF;
 import static de.metas.invoice_gateway.spi.InvoiceExportClientFactory.ATTATCHMENT_TAGNAME_BELONGS_TO_EXTERNAL_REFERENCE;
 import static de.metas.invoice_gateway.spi.InvoiceExportClientFactory.ATTATCHMENT_TAGNAME_EXPORT_PROVIDER;
 
@@ -63,9 +64,12 @@ public class HealthcareChPdfAttachmentController
 	}
 
 	@PostMapping("/attachedPdfFiles/{externalReference}")
-	@ApiOperation(value = "Attach a PDF document to an externalOrderId")
+	@ApiOperation(value = "Attach a PDF document to order line candidates with the given externalOrderId. The attachment is tagged with\n"
+			+ TAGNAME_CONCATENATE_PDF_TO_INVOICE_PDF + "=true, so the PDF will eventually be appended to the invoice's PDF\n"
+			+ ATTATCHMENT_TAGNAME_BELONGS_TO_EXTERNAL_REFERENCE + "=externalReference, so the base64-encoded PDF will eventually included in the invoice's forum-datenaustausch.ch-XML")
 	// TODO only allow PDF
 	public JsonAttachment attachPdfFile(
+
 			@ApiParam(value = "Reference string that was returned by the invoice-rest-controller", allowEmptyValue = false) //
 			@PathVariable("externalReference") final String externalReference,
 
@@ -74,7 +78,8 @@ public class HealthcareChPdfAttachmentController
 	{
 		final ImmutableList<String> tags = ImmutableList.of(
 				ATTATCHMENT_TAGNAME_EXPORT_PROVIDER/* name */, ForumDatenaustauschChConstants.INVOICE_EXPORT_PROVIDER_ID/* value */,
-				ATTATCHMENT_TAGNAME_BELONGS_TO_EXTERNAL_REFERENCE/* name */, externalReference/* value */);
+				ATTATCHMENT_TAGNAME_BELONGS_TO_EXTERNAL_REFERENCE/* name */, externalReference/* value */,
+				TAGNAME_CONCATENATE_PDF_TO_INVOICE_PDF/* name */, Boolean.TRUE.toString()/* value */);
 
 		return orderCandidatesRestEndpoint
 				.attachFile(


### PR DESCRIPTION
* Add new tag name to AttachmentConstants
* HealthcareChPdfAttachmentController attaches new attachments with the new tag
* Introduce process C_Invoice_SalesInvoiceJasperWithAttachedDocuments that invokes the "normal" jasper process (config via AD_SysConfig) and appends attachements.
* Extend AttachmentEntryQuery to filter by mimeType (contentType)
* Also:
  * extract common code into ExecuteReportStrategyUtil from C_DunningDoc_JasperWithInvoicePDFsStrategy
  * rename "contentType" to "mimeType", !!! also in the rest-API !!!
  * fix the package name of DunningPrintingQueueHandler
  * fix compile trivial issues in dpd-legacy
* minor

https://github.com/metasfresh/metasfresh/issues/4700