### PR TITLE
ITableRefInfo - rename "name" to "identifier" and make it more verbose

### DIFF
--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/adempiere/model/RelationTypeZoomProvider.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/adempiere/model/RelationTypeZoomProvider.java
@@ -530,7 +530,7 @@ public class RelationTypeZoomProvider implements IZoomProvider
 		}
 		if (windowId <= 0)
 		{
-			throw PORelationException.throwMissingWindowId(tableRefInfo.getName(), tableRefInfo.getTableName(), isSOTrx);
+			throw PORelationException.throwMissingWindowId(tableRefInfo.getIdentifier(), tableRefInfo.getTableName(), isSOTrx);
 		}
 
 		return windowId;

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MLookupFactory.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MLookupFactory.java
@@ -16,8 +16,6 @@
  *****************************************************************************/
 package org.compiere.model;
 
-import lombok.NonNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -45,6 +43,7 @@ import de.metas.i18n.TranslatableParameterizedString;
 import de.metas.logging.LogManager;
 import de.metas.util.Check;
 import de.metas.util.Services;
+import lombok.NonNull;
 
 /**
  * Create MLookups
@@ -611,7 +610,7 @@ public class MLookupFactory
 			{
 				if (whereClause.indexOf('.') == -1)
 				{
-					s_log.error("getLookupInfo: WHERE should be fully qualified: {} \n tableRefInfo={}", whereClause, tableRefInfo);
+					s_log.error("getLookupInfo: WHERE should be fully qualified whereClause={};\n tableRefInfo={}", whereClause, tableRefInfo);
 				}
 				sqlWhereClauseStatic = whereClause;
 				sqlWhereClauseDynamic = null;

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MLookupFactory.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MLookupFactory.java
@@ -512,7 +512,7 @@ public class MLookupFactory
 		// Do we have columns ?
 		if (displayColumns.isEmpty())
 		{
-			s_log.error("No Identifier records found for {}", tableRefInfo);
+			s_log.error("No Identifier records found for tableRefInfo={}", tableRefInfo);
 			return null;
 		}
 
@@ -610,7 +610,8 @@ public class MLookupFactory
 			{
 				if (whereClause.indexOf('.') == -1)
 				{
-					s_log.error("getLookupInfo: WHERE should be fully qualified whereClause={};\n tableRefInfo={}", whereClause, tableRefInfo);
+					s_log.error("getLookupInfo: whereClause of tableRefInfo {} should be fully qualified\n where={};\n tableRefInfo={}",
+							tableRefInfo.getIdentifier(), whereClause, tableRefInfo);
 				}
 				sqlWhereClauseStatic = whereClause;
 				sqlWhereClauseDynamic = null;

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MQuery.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MQuery.java
@@ -1,18 +1,18 @@
 /******************************************************************************
- * Product: Adempiere ERP & CRM Smart Business Solution                       *
- * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
- * This program is free software; you can redistribute it and/or modify it    *
- * under the terms version 2 of the GNU General Public License as published   *
- * by the Free Software Foundation. This program is distributed in the hope   *
+ * Product: Adempiere ERP & CRM Smart Business Solution *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved. *
+ * This program is free software; you can redistribute it and/or modify it *
+ * under the terms version 2 of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope *
  * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
- * See the GNU General Public License for more details.                       *
- * You should have received a copy of the GNU General Public License along    *
- * with this program; if not, write to the Free Software Foundation, Inc.,    *
- * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
- * For the text or an alternative of this public license, you may reach us    *
- * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
- * or via info@compiere.org or http://www.compiere.org/license.html           *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. *
+ * See the GNU General Public License for more details. *
+ * You should have received a copy of the GNU General Public License along *
+ * with this program; if not, write to the Free Software Foundation, Inc., *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA. *
+ * For the text or an alternative of this public license, you may reach us *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA *
+ * or via info@compiere.org or http://www.compiere.org/license.html *
  *****************************************************************************/
 package org.compiere.model;
 
@@ -51,14 +51,16 @@ import de.metas.process.PInstanceId;
 import de.metas.util.Check;
 import de.metas.util.GuavaCollectors;
 import de.metas.util.Services;
+import lombok.NonNull;
 
 /**
  * Query Descriptor. Maintains restrictions (WHERE clause)
  *
  * @author Jorg Janke
  * @version $Id: MQuery.java,v 1.4 2006/07/30 00:58:04 jjanke Exp $
- * 
- * @author Teo Sarca <li>BF [ 2860022 ] MQuery.get() is generating restictions for unexisting column https://sourceforge.net/tracker/?func=detail&aid=2860022&group_id=176962&atid=879332
+ *
+ * @author Teo Sarca
+ *         <li>BF [ 2860022 ] MQuery.get() is generating restictions for unexisting column https://sourceforge.net/tracker/?func=detail&aid=2860022&group_id=176962&atid=879332
  */
 @SuppressWarnings("serial")
 public final class MQuery implements Serializable
@@ -74,7 +76,7 @@ public final class MQuery implements Serializable
 	static public MQuery get(Properties ctx, PInstanceId pinstanceId, String TableName)
 	{
 		s_log.info("AD_PInstance_ID={}, TableName={}", pinstanceId, TableName);
-		
+
 		final MQuery query = new MQuery(TableName);
 		// Temporary Tables - add qualifier (not displayed)
 		boolean isTemporaryTable = false;
@@ -157,20 +159,20 @@ public final class MQuery implements Serializable
 				//
 				String Name = rs.getString(10);
 				boolean isRange = DisplayType.toBoolean(rs.getString(11));
-				
+
 				//
-				if(s_log.isDebugEnabled())
+				if (s_log.isDebugEnabled())
 				{
 					s_log.debug(ParameterName + " S=" + P_String + "-" + P_String_To
 							+ ", N=" + P_Number + "-" + P_Number_To + ", D=" + P_Date + "-" + P_Date_To
 							+ "; Name=" + Name + ", Info=" + Info + "-" + Info_To + ", Range=" + isRange);
 				}
-				
+
 				//
 				// Check if the parameter exists as column in our table.
 				// This condition applies only to temporary tables - teo_sarca [ 2860022 ]
 				final IADTableDAO tableDAO = Services.get(IADTableDAO.class);
-				if (isTemporaryTable && table != null 
+				if (isTemporaryTable && table != null
 						&& tableDAO.retrieveColumnOrNull(table.get_TableName(), ParameterName) == null)
 				{
 					s_log.info("Skip parameter " + ParameterName + " because there is no column in table " + TableName);
@@ -247,18 +249,18 @@ public final class MQuery implements Serializable
 			rs = null;
 			pstmt = null;
 		}
-		
+
 		s_log.info("query: {}", query);
 		return query;
 	}	// get
 
 	/**
-	 * Get Zoom Column Name. Converts Synonyms like SalesRep_ID to AD_User_ID
+	 * Get Zoom Column Name. Converts Synonyms like {@code SalesRep_ID} to {@code AD_User_ID}.
 	 *
-	 * @param columnName column name
-	 * @return column name
+	 * @param columnName
+	 * @return {@code null} only if {@code columnName} is {@code null}.
 	 */
-	public static String getZoomColumnName(String columnName)
+	public static String getZoomColumnName(@Nullable final String columnName)
 	{
 		if (columnName == null)
 			return null;
@@ -295,10 +297,9 @@ public final class MQuery implements Serializable
 	/**
 	 * Derive Zoom Table Name from column name. (e.g. drop _ID)
 	 *
-	 * @param columnName column name
 	 * @return table name
 	 */
-	public static String getZoomTableName(String columnName)
+	public static String getZoomTableName(@NonNull final String columnName)
 	{
 		String tableName = getZoomColumnName(columnName);
 		int index = tableName.lastIndexOf("_ID");
@@ -307,12 +308,8 @@ public final class MQuery implements Serializable
 		return tableName;
 	}	// getZoomTableName
 
-	/*************************************************************************
+	/**
 	 * Create simple Equal Query. Creates columnName=value or columnName='value'
-	 * 
-	 * @param columnName columnName
-	 * @param value value
-	 * @return quary
 	 */
 	public static MQuery getEqualQuery(String columnName, Object value)
 	{
@@ -324,7 +321,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Create simple Equal Query. Creates columnName=value
-	 * 
+	 *
 	 * @param columnName columnName
 	 * @param value value
 	 * @return quary
@@ -341,7 +338,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Create No Record query.
-	 * 
+	 *
 	 * @param tableName table name
 	 * @param newRecord new Record Indicator (2=3)
 	 * @return query
@@ -356,7 +353,7 @@ public final class MQuery implements Serializable
 		query.setRecordCount(0);
 		return query;
 	}	// getNoRecordQuery
-	
+
 	public static MQuery getNoRecordQuery(final String tableName)
 	{
 		final boolean newRecord = false;
@@ -369,7 +366,6 @@ public final class MQuery implements Serializable
 		final boolean newRecord = false;
 		return getNoRecordQuery(tableName, newRecord);
 	}
-
 
 	/** Static Logger */
 	private static final transient Logger s_log = LogManager.getLogger(MQuery.class);
@@ -384,7 +380,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param TableName Table Name
 	 */
 	public MQuery(final String TableName)
@@ -395,7 +391,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * NOTE: if possible, please use "TableName" constructor instead of this one!
-	 * 
+	 *
 	 * @param AD_Table_ID Table_ID
 	 */
 	public MQuery(final int AD_Table_ID)
@@ -433,7 +429,7 @@ public final class MQuery implements Serializable
 	{
 		return m_recordCount;
 	}	// getRecordCount
-	
+
 	@Nullable
 	public Duration getRecordCountDuration()
 	{
@@ -450,7 +446,7 @@ public final class MQuery implements Serializable
 		Duration duration = null; // N/A
 		setRecordCount(count, duration);
 	}
-	
+
 	public void setRecordCount(final int count, @Nullable final Duration countDuration)
 	{
 		m_recordCount = count;
@@ -477,7 +473,7 @@ public final class MQuery implements Serializable
 		LESS_EQUAL("<=", " <= "),  //
 		BETWEEN(" BETWEEN ", " >-< ") //
 		;
-		
+
 		private final String code;
 		private final String caption;
 
@@ -486,33 +482,33 @@ public final class MQuery implements Serializable
 			this.code = code;
 			this.caption = caption;
 		}
-		
+
 		@Override
 		public String toString()
 		{
 			return caption;
 		}
-		
+
 		public String getCode()
 		{
 			return code;
 		}
-		
+
 		public String getSql()
 		{
 			return code;
 		}
-		
+
 		public String getCaption()
 		{
 			return caption;
 		}
-		
+
 		public boolean isRangeOperator()
 		{
 			return this == BETWEEN;
 		}
-		
+
 		public static final Operator cast(final Object operatorObj)
 		{
 			return (Operator)operatorObj;
@@ -532,18 +528,18 @@ public final class MQuery implements Serializable
 			}
 			return op;
 		}
-		
+
 		private static final Map<String, Operator> operatorsByCode = Stream.of(values())
 				.collect(GuavaCollectors.toImmutableMapByKey(op -> op.getCode()));
-		
-		public static final List<Operator> operatorsForBooleans = ImmutableList.of(EQUAL); 
+
+		public static final List<Operator> operatorsForBooleans = ImmutableList.of(EQUAL);
 		public static final List<Operator> operatorsForLookups = ImmutableList.of(EQUAL, NOT_EQUAL);
 		public static final List<Operator> operators = ImmutableList.of(EQUAL, NOT_EQUAL, LIKE, LIKE_I, NOT_LIKE, GREATER, GREATER_EQUAL, LESS, LESS_EQUAL, BETWEEN); // note: does not include NOT_LIKE_I
 	}
 
 	/*************************************************************************
 	 * Add Restriction
-	 * 
+	 *
 	 * @param ColumnName ColumnName
 	 * @param Operator Operator, e.g. = != ..
 	 * @param Code Code, e.g 0, All%
@@ -564,7 +560,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Add Restriction
-	 * 
+	 *
 	 * @param ColumnName ColumnName
 	 * @param operator Operator, e.g. = != ..
 	 * @param Code Code, e.g 0, All%
@@ -585,7 +581,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Add Restriction
-	 * 
+	 *
 	 * @param ColumnName ColumnName
 	 * @param operator Operator, e.g. = != ..
 	 * @param Code Code, e.g 0
@@ -607,7 +603,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Add Range Restriction (BETWEEN)
-	 * 
+	 *
 	 * @param ColumnName ColumnName
 	 * @param Code Code, e.g 0, All%
 	 * @param Code_to Code, e.g 0, All%
@@ -634,7 +630,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Add Range Restriction (BETWEEN)
-	 * 
+	 *
 	 * @param ColumnName ColumnName
 	 * @param Code Code, e.g 0, All%
 	 * @param Code_to Code, e.g 0, All%
@@ -656,7 +652,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Add Restriction
-	 * 
+	 *
 	 * @param r Restriction
 	 */
 	private void addRestriction(final Restriction r)
@@ -666,7 +662,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Add Restriction
-	 * 
+	 *
 	 * @param whereClause SQL WHERE clause
 	 */
 	public void addRestriction(String whereClause)
@@ -677,11 +673,11 @@ public final class MQuery implements Serializable
 
 	public void addRestriction(String whereClause, boolean joinAnd)
 	{
-		if(Check.isEmpty(whereClause, true))
+		if (Check.isEmpty(whereClause, true))
 		{
 			return;
 		}
-		
+
 		final Restriction r = new Restriction(joinAnd, whereClause);
 		m_list.add(r);
 		m_newRecord = whereClause.equals(NEWRECORD);
@@ -699,7 +695,7 @@ public final class MQuery implements Serializable
 
 	/*************************************************************************
 	 * Create the resulting Query WHERE Clause
-	 * 
+	 *
 	 * @return Where Clause
 	 */
 	public String getWhereClause()
@@ -709,7 +705,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Create the resulting Query WHERE Clause
-	 * 
+	 *
 	 * @param fullyQualified fully qualified Table.ColumnName
 	 * @return Where Clause
 	 */
@@ -759,7 +755,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Create Query WHERE Clause. Not fully qualified
-	 * 
+	 *
 	 * @param index restriction index
 	 * @return Where Clause or "" if not valid
 	 */
@@ -776,7 +772,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Get Restriction Count
-	 * 
+	 *
 	 * @return number of restricctions
 	 */
 	public int getRestrictionCount()
@@ -786,7 +782,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Is Query Active
-	 * 
+	 *
 	 * @return true if number of restrictions > 0
 	 */
 	public boolean isActive()
@@ -796,7 +792,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Get Table Name
-	 * 
+	 *
 	 * @return Table Name
 	 */
 	public String getTableName()
@@ -806,21 +802,21 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Set Table Name
-	 * 
+	 *
 	 * @param TableName Table Name
 	 */
 	public void setTableName(String TableName)
 	{
 		m_TableName = TableName;
 	}	// setTableName
-	
+
 	public boolean isDirectWhereClause(final int index)
 	{
 		if (index < 0 || index >= m_list.size())
 			return false;
 		return m_list.get(index).isDirectWhereClause();
 	}
-	
+
 	public String getDirectWhereClause(final int index)
 	{
 		if (index < 0 || index >= m_list.size())
@@ -828,10 +824,9 @@ public final class MQuery implements Serializable
 		return m_list.get(index).getDirectWhereClause();
 	}
 
-
 	/*************************************************************************
 	 * Get ColumnName of index
-	 * 
+	 *
 	 * @param index index
 	 * @return ColumnName
 	 */
@@ -842,7 +837,7 @@ public final class MQuery implements Serializable
 		Restriction r = m_list.get(index);
 		return r.getColumnName();
 	}	// getColumnName
-	
+
 	public boolean isJoinAnd(final int index)
 	{
 		if (index < 0 || index >= m_list.size())
@@ -852,7 +847,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Set ColumnName of index
-	 * 
+	 *
 	 * @param index index
 	 * @param ColumnName new column name
 	 */
@@ -869,7 +864,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Get Operator of index
-	 * 
+	 *
 	 * @param index index
 	 * @return Operator
 	 */
@@ -883,7 +878,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Get Operator of index
-	 * 
+	 *
 	 * @param index index
 	 * @return Operator
 	 */
@@ -894,7 +889,7 @@ public final class MQuery implements Serializable
 		Restriction r = m_list.get(index);
 		return r.getCode();
 	}	// getCode
-	
+
 	public Object getCodeTo(int index)
 	{
 		if (index < 0 || index >= m_list.size())
@@ -908,7 +903,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Get Restriction Display of index
-	 * 
+	 *
 	 * @param index index
 	 * @return Restriction Display
 	 */
@@ -922,7 +917,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Get TO Restriction Display of index
-	 * 
+	 *
 	 * @param index index
 	 * @return Restriction Display
 	 */
@@ -936,7 +931,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Get Info Name
-	 * 
+	 *
 	 * @param index index
 	 * @return Info Name
 	 */
@@ -950,7 +945,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Get Info Operator
-	 * 
+	 *
 	 * @param index index
 	 * @return info Operator
 	 */
@@ -964,7 +959,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Get Display with optional To
-	 * 
+	 *
 	 * @param index index
 	 * @return info display
 	 */
@@ -978,7 +973,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Is AND Join
-	 * 
+	 *
 	 * @return true if it's AND Join
 	 */
 	// metas
@@ -989,7 +984,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * String representation
-	 * 
+	 *
 	 * @return info
 	 */
 	@Override
@@ -1028,7 +1023,7 @@ public final class MQuery implements Serializable
 	}
 
 	/**
-	 * 
+	 *
 	 * @param tableName
 	 */
 	public void setZoomTableName(String tableName)
@@ -1037,7 +1032,7 @@ public final class MQuery implements Serializable
 	}
 
 	/**
-	 * 
+	 *
 	 * @return zoom table name
 	 */
 	public String getZoomTableName()
@@ -1046,7 +1041,7 @@ public final class MQuery implements Serializable
 	}
 
 	/**
-	 * 
+	 *
 	 * @param column
 	 */
 	public void setZoomColumnName(String column)
@@ -1055,7 +1050,7 @@ public final class MQuery implements Serializable
 	}
 
 	/**
-	 * 
+	 *
 	 * @return zoom column name
 	 */
 	public String getZoomColumnName()
@@ -1064,7 +1059,7 @@ public final class MQuery implements Serializable
 	}
 
 	/**
-	 * 
+	 *
 	 * @param value
 	 */
 	public void setZoomValue(Object value)
@@ -1073,7 +1068,7 @@ public final class MQuery implements Serializable
 	}
 
 	/**
-	 * 
+	 *
 	 * @return zoom value, usually an integer
 	 */
 	public Object getZoomValue()
@@ -1116,7 +1111,7 @@ public final class MQuery implements Serializable
 		this.m_zoomTable = query.m_zoomTable;
 		this.m_zoomColumn = query.m_zoomColumn;
 		this.m_zoomValue = query.m_zoomValue;
-		
+
 		for (final Restriction restriction : query.m_list)
 		{
 			this.addRestriction(new Restriction(restriction));
@@ -1125,7 +1120,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Clone Query
-	 * 
+	 *
 	 * @return Query
 	 */
 	public MQuery deepCopy()
@@ -1134,7 +1129,7 @@ public final class MQuery implements Serializable
 	}	// clone
 
 	/**
-	 * 
+	 *
 	 * @param userQuery
 	 * @see #isUserQuery()
 	 */
@@ -1145,19 +1140,19 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Returns <code>true</code> if this query was issued by the user directly (i.e. NOT generated by system).
-	 * 
+	 *
 	 * Example of queries which are user queries:
 	 * <ul>
 	 * <li>the query which is created when user is searching in a window/tab
 	 * </ul>
-	 * 
+	 *
 	 * Example of queries which are NOT user queries:
 	 * <ul>
 	 * <li>the query which is generated because of Zoom/Zoom accross user action.
 	 * </ul>
-	 * 
+	 *
 	 * NOTE: if the flag was not set programatically, it's default is <code>false</code> (i.e. not a user query).
-	 * 
+	 *
 	 * @return <code>true</code> if this query was issued by the user directly
 	 */
 	public boolean isUserQuery()
@@ -1171,11 +1166,11 @@ public final class MQuery implements Serializable
  * Query Restriction
  */
 @SuppressWarnings("serial")
-/*package*/ final class Restriction implements Serializable
+/* package */ final class Restriction implements Serializable
 {
 	/**
 	 * Restriction constructor (without valueTo)
-	 * 
+	 *
 	 * @param columnName ColumnName
 	 * @param operator Operator, e.g. = != ..
 	 * @param code Code, e.g 0, All%
@@ -1198,7 +1193,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Restriction (full constructor)
-	 * 
+	 *
 	 * @param columnName ColumnName
 	 * @param code Code, e.g 0, All%
 	 * @param code_to Code, e.g 0, All%
@@ -1213,14 +1208,14 @@ public final class MQuery implements Serializable
 			, final Object code, final Object code_to //
 			, final String infoName //
 			, final String infoDisplay, final String infoDisplay_to //
-			)
+	)
 	{
 		super();
-		
+
 		//
 		// Join
 		this.joinAnd = joinAnd;
-		
+
 		//
 		// ColumnName and column's display name
 		this.columnName = columnName.trim();
@@ -1228,7 +1223,7 @@ public final class MQuery implements Serializable
 			this.infoName = infoName;
 		else
 			this.infoName = columnName;
-		
+
 		//
 		// Operator
 		this.operator = operator;
@@ -1237,7 +1232,7 @@ public final class MQuery implements Serializable
 		// Value
 		this.code = normalizeCode(code);
 		this.infoDisplay = buildInfoDisplay(infoDisplay, this.code);
-		
+
 		//
 		// ValueTo
 		this.codeTo = normalizeCode(code_to);
@@ -1251,45 +1246,45 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Create Restriction with direct WHERE clause
-	 * 
+	 *
 	 * @param whereClause SQL WHERE Clause
 	 */
 	Restriction(final boolean joinAnd, final String whereClause)
 	{
 		super();
-		
+
 		this.joinAnd = joinAnd;
-		
+
 		this.columnName = null;
 		this.infoName = null;
 		this.operator = null;
-		
+
 		this.code = null;
 		this.infoDisplay = null;
-		
+
 		this.codeTo = null;
 		this.infoDisplayTo = null;
-		
+
 		this.directWhereClause = whereClause;
 	}	// Restriction
-	
+
 	Restriction(final Restriction from)
 	{
 		super();
 		this.joinAnd = from.joinAnd;
-		
+
 		this.columnName = from.columnName;
 		this.infoName = from.infoName;
-		
+
 		this.operator = from.operator;
-		
+
 		this.code = from.code;
 		this.infoDisplay = from.infoDisplay;
-		
+
 		this.codeTo = from.codeTo;
 		this.infoDisplayTo = from.infoDisplayTo;
-		
-		this.directWhereClause= from.directWhereClause;
+
+		this.directWhereClause = from.directWhereClause;
 	}
 
 	/** And/Or Condition */
@@ -1310,7 +1305,7 @@ public final class MQuery implements Serializable
 	private final String infoDisplayTo;
 	/** Direct Where Clause */
 	private final String directWhereClause;
-	
+
 	private static final Object normalizeCode(final Object code)
 	{
 		Object codeNorm;
@@ -1322,7 +1317,7 @@ public final class MQuery implements Serializable
 			codeNorm = ((ValueNamePair)code).getValue();
 		else
 			codeNorm = code;
-		
+
 		// clean code
 		if (codeNorm instanceof String)
 		{
@@ -1331,13 +1326,13 @@ public final class MQuery implements Serializable
 				codeNormStr = codeNormStr.substring(1);
 			if (codeNormStr.endsWith("'"))
 				codeNormStr = codeNormStr.substring(0, codeNormStr.length() - 2);
-			
+
 			codeNorm = codeNormStr;
 		}
 
 		return codeNorm;
 	}
-	
+
 	private static final String buildInfoDisplay(final String infoDisplay, final Object code)
 	{
 		if (infoDisplay != null)
@@ -1347,12 +1342,12 @@ public final class MQuery implements Serializable
 		else
 			return null;
 	}
-	
+
 	public boolean isDirectWhereClause()
 	{
 		return directWhereClause != null;
 	}
-	
+
 	public String getDirectWhereClause()
 	{
 		return directWhereClause;
@@ -1360,7 +1355,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Return SQL construct for this restriction
-	 * 
+	 *
 	 * @param tableName optional table name
 	 * @return SQL WHERE construct
 	 */
@@ -1501,7 +1496,7 @@ public final class MQuery implements Serializable
 		if ((Operator.EQUAL == operatorToUse || Operator.NOT_EQUAL == operatorToUse)
 				&& (code_ToUse == null || "NULL".equalsIgnoreCase(code_ToUse.toString())))
 		{
-			if(Operator.EQUAL == operatorToUse)
+			if (Operator.EQUAL == operatorToUse)
 			{
 				sqlWhereClause.append(" IS NULL ");
 			}
@@ -1568,19 +1563,19 @@ public final class MQuery implements Serializable
 				}
 			}
 		}
-		
+
 		return sqlWhereClause.toString();
 	}	// getSQL
-	
+
 	private static final String toSqlValue(final Object value, final List<Object> sqlParams)
 	{
-		if(sqlParams != null)
+		if (sqlParams != null)
 		{
 			sqlParams.add(value);
 			return "?";
 		}
-		
-		if(value == null)
+
+		if (value == null)
 		{
 			return "NULL";
 		}
@@ -1588,7 +1583,7 @@ public final class MQuery implements Serializable
 		{
 			return DB.TO_STRING((String)value);
 		}
-		else if(value instanceof java.util.Date)
+		else if (value instanceof java.util.Date)
 		{
 			final java.util.Date date = (java.util.Date)value;
 			final String dateAsString = TimeUtil.asTimestamp(date).toString(); // date string (JDBC format)
@@ -1603,7 +1598,7 @@ public final class MQuery implements Serializable
 	/**
 	 * In case the given code is instanceof Timestamp, truncate it by the given truncValue.
 	 * In case the truncValue is null, leave it as it is
-	 * 
+	 *
 	 * @param code
 	 * @param truncValue optional truncate type
 	 * @return
@@ -1615,7 +1610,7 @@ public final class MQuery implements Serializable
 			// do not truncate
 			return date;
 		}
-		if(date == null)
+		if (date == null)
 		{
 			return null;
 		}
@@ -1625,7 +1620,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Get String Representation
-	 * 
+	 *
 	 * @return info
 	 */
 	@Override
@@ -1633,32 +1628,32 @@ public final class MQuery implements Serializable
 	{
 		return getSQL(null);
 	}
-	
+
 	public boolean isJoinAnd()
 	{
 		return joinAnd;
 	}
-	
+
 	public String getColumnName()
 	{
 		return columnName;
 	}
-	
-	/*package*/void setColumnName(final String columnName)
+
+	/* package */void setColumnName(final String columnName)
 	{
 		this.columnName = columnName;
 	}
 
 	/**
 	 * Get Info Name
-	 * 
+	 *
 	 * @return Info Name
 	 */
 	public String getInfoName()
 	{
 		return infoName;
 	}	// getInfoName
-	
+
 	public Operator getOperator()
 	{
 		return operator;
@@ -1666,7 +1661,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Get Info Operator
-	 * 
+	 *
 	 * @return info Operator
 	 */
 	public String getInfoOperator()
@@ -1676,7 +1671,7 @@ public final class MQuery implements Serializable
 
 	/**
 	 * Get Display with optional To
-	 * 
+	 *
 	 * @return info display
 	 */
 	public String getInfoDisplayAll()
@@ -1687,22 +1682,22 @@ public final class MQuery implements Serializable
 		sb.append(" - ").append(infoDisplayTo);
 		return sb.toString();
 	}	// getInfoDisplay
-	
+
 	public Object getCode()
 	{
 		return code;
 	}
-	
+
 	public String getInfoDisplay()
 	{
 		return infoDisplay;
 	}
-	
+
 	public Object getCodeTo()
 	{
 		return codeTo;
 	}
-	
+
 	public String getInfoDisplayTo()
 	{
 		return infoDisplayTo;

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/service/ILookupDAO.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/service/ILookupDAO.java
@@ -10,12 +10,12 @@ package org.adempiere.ad.service;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -37,9 +37,9 @@ import de.metas.util.collections.BlindIterator;
 
 /**
  * Field Lookup DAO methods
- * 
+ *
  * @author tsa
- * 
+ *
  */
 public interface ILookupDAO extends ISingletonService
 {
@@ -52,7 +52,7 @@ public interface ILookupDAO extends ISingletonService
 		int getAD_Reference_Value_ID();
 
 		String getColumnName();
-		
+
 		String getTableName();
 	}
 
@@ -61,20 +61,19 @@ public interface ILookupDAO extends ISingletonService
 	 */
 	interface ITableRefInfo
 	{
-		String getName();
-		
+		/** Tell the log reader what to fix when a problem regarding a sloppy table reference is logged. */
+		String getIdentifier();
+
 		String getTableName();
 
 		String getKeyColumn();
 
 		/**
-		 * 
 		 * @return actual ColumnName to be displayed or null
 		 */
 		String getDisplayColumn();
 
 		/**
-		 * 
 		 * @return actual ColumnName SQL to be displayed or null
 		 */
 		String getDisplayColumnSQL();
@@ -97,11 +96,8 @@ public interface ILookupDAO extends ISingletonService
 
 		/**
 		 * Check if the keyColumn ends with "_ID"
-		 * 
-		 * @return
 		 */
 		boolean isNumericKey();
-
 	}
 
 	interface ILookupDisplayInfo
@@ -117,21 +113,21 @@ public interface ILookupDAO extends ISingletonService
 
 	/**
 	 * Contains a set of {@link ValueNamePair} or {@link KeyNamePair} elements.
-	 * 
+	 *
 	 * @author tsa
-	 * 
+	 *
 	 */
 	public interface INamePairIterator extends BlindIterator<NamePair>, AutoCloseable
 	{
 		/**
-		 * 
+		 *
 		 * @return true if this iterator is valid
 		 */
 		boolean isValid();
 
 		/**
 		 * Gets validation key of data in loaded context.
-		 * 
+		 *
 		 * @return
 		 */
 		Object getValidationKey();
@@ -140,13 +136,13 @@ public interface ILookupDAO extends ISingletonService
 		public NamePair next();
 
 		/**
-		 * 
+		 *
 		 * @return true if last value was active
 		 */
 		boolean wasActive();
 
 		/**
-		 * 
+		 *
 		 * @return true if underlying elements are of type{@link KeyNamePair}; if false then elements are of type {@link ValueNamePair}
 		 */
 		boolean isNumericKey();
@@ -159,7 +155,7 @@ public interface ILookupDAO extends ISingletonService
 
 	/**
 	 * Same as {@link #retrieveTableRefInfoOrNull(int)} but in case the {@link ITableRefInfo} was not found, an warning is logged
-	 * 
+	 *
 	 * @param AD_Reference_Value_ID
 	 * @return table reference info or <code>null</code> if not found
 	 */
@@ -172,7 +168,7 @@ public interface ILookupDAO extends ISingletonService
 	boolean isTableReference(int AD_Reference_Value_ID);
 
 	ITableRefInfo retrieveTableDirectRefInfo(String columnName);
-	
+
 	ITableRefInfo retrieveAccountTableRefInfo();
 
 	ILookupDisplayInfo retrieveLookupDisplayInfo(ITableRefInfo tableRefInfo);
@@ -181,7 +177,7 @@ public interface ILookupDAO extends ISingletonService
 
 	/**
 	 * Retrieves all elements of <code>lookupInfo</code> in given <code>validationCtx</code> context
-	 * 
+	 *
 	 * @param validationCtx
 	 * @param lookupInfo
 	 */
@@ -189,7 +185,7 @@ public interface ILookupDAO extends ISingletonService
 
 	/**
 	 * Retrieves all elements of <code>lookupInfo</code> in given <code>validationCtx</code> context
-	 * 
+	 *
 	 * @param validationCtx
 	 * @param lookupInfo
 	 * @param additionalValidationRule optional additional validation rule to be applied on top of lookupInfo's validation rule
@@ -198,7 +194,7 @@ public interface ILookupDAO extends ISingletonService
 
 	/**
 	 * Directly retrieves a data element identified by <code>key</code>.
-	 * 
+	 *
 	 * @param validationCtx
 	 * @param lookupInfo
 	 * @param key
@@ -208,7 +204,7 @@ public interface ILookupDAO extends ISingletonService
 
 	/**
 	 * Creates a validation key to be used when checking if data is valid in a given context
-	 * 
+	 *
 	 * @param validationCtx
 	 * @param lookupInfo
 	 * @return
@@ -217,7 +213,7 @@ public interface ILookupDAO extends ISingletonService
 
 	/**
 	 * Retrieve TableRefInfo or null
-	 * 
+	 *
 	 * @param AD_Reference_ID
 	 * @return
 	 */

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/service/impl/LookupDAO.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/service/impl/LookupDAO.java
@@ -1,9 +1,5 @@
 package org.adempiere.ad.service.impl;
 
-import lombok.NonNull;
-
-import javax.annotation.concurrent.Immutable;
-
 /*
  * #%L
  * de.metas.adempiere.adempiere.base
@@ -49,8 +45,6 @@ import org.adempiere.ad.validationRule.impl.NullValidationRule;
 import org.adempiere.db.util.AbstractPreparedStatementBlindIterator;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.exceptions.DBException;
-import org.adempiere.util.lang.EqualsBuilder;
-import org.adempiere.util.lang.HashcodeBuilder;
 import org.adempiere.util.proxy.Cached;
 import org.compiere.model.ILookupDisplayColumn;
 import org.compiere.model.I_AD_Column;
@@ -71,13 +65,14 @@ import org.compiere.util.ValueNamePair;
 import org.slf4j.Logger;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
 import de.metas.adempiere.util.cache.annotations.CacheAllowMutable;
 import de.metas.logging.LogManager;
 import de.metas.util.Check;
 import de.metas.util.Services;
+import lombok.NonNull;
+import lombok.Value;
 
 public class LookupDAO implements ILookupDAO
 {
@@ -86,7 +81,7 @@ public class LookupDAO implements ILookupDAO
 	private final static String COLUMNNAME_Value = "Value";
 
 	private static final ITableRefInfo tableRefInfo_Account = TableRefInfo.builder()
-			.setName("Account")
+			.setIdentifier("Account - C_ValidCombination_ID")
 			.setTableName(I_C_ValidCombination.Table_Name)
 			.setKeyColumn(I_C_ValidCombination.COLUMNNAME_C_ValidCombination_ID)
 			.setAutoComplete(true)
@@ -141,7 +136,7 @@ public class LookupDAO implements ILookupDAO
 		}
 	}
 
-	@Immutable
+	@Value
 	@VisibleForTesting
 	public static final class TableRefInfo implements ITableRefInfo
 	{
@@ -150,11 +145,7 @@ public class LookupDAO implements ILookupDAO
 			return new TableRefInfoBuilder();
 		}
 
-		// NOTE to developer:
-		// * make sure all the fields are primitives or immutable.
-		// * when adding new fields, please change "equals" and "hashCode" methods too
-
-		private final String name; // used only for debugging
+		private final String identifier; // used only for debugging
 		private final String tableName;
 		private final String keyColumn;
 		private final String displayColumn;
@@ -170,13 +161,9 @@ public class LookupDAO implements ILookupDAO
 
 		private TableRefInfo(@NonNull final TableRefInfoBuilder builder)
 		{
-			name = builder.name;
-
-			Check.assumeNotEmpty(builder.tableName, "tableName not empty");
-			tableName = builder.tableName;
-
-			Check.assumeNotEmpty(builder.keyColumn, "keyColumn not empty");
-			keyColumn = builder.keyColumn;
+			identifier = builder.identifier;
+			tableName = Check.assumeNotEmpty(builder.tableName, "tableName not empty");
+			keyColumn = Check.assumeNotEmpty(builder.keyColumn, "keyColumn not empty");
 
 			if (!Check.isEmpty(builder.displayColumn, true))
 			{
@@ -222,157 +209,6 @@ public class LookupDAO implements ILookupDAO
 			zoomAD_Window_ID_Override = builder.zoomAD_Window_ID_Override <= 0 ? -1 : builder.zoomAD_Window_ID_Override;
 
 			autoComplete = builder.autoComplete;
-
-		}
-
-		@Override
-		public String toString()
-		{
-			return MoreObjects.toStringHelper(this)
-					.omitNullValues()
-					.add("name", name)
-					.add("tableName", tableName)
-					.add("keyColumn", keyColumn)
-					.add("displayColumn", displayColumn)
-					.add("displayColumnSQL", displayColumnSQL)
-					.add("valueDisplayed", valueDisplayed)
-					.add("whereClause", whereClause)
-					.add("orderByClause", orderByClause)
-					.add("translated", translated)
-					.add("zoomWindow", zoomSO_Window_ID)
-					.add("zoomWindowPO", zoomPO_Window_ID)
-					.add("overrideZoomWindow", zoomAD_Window_ID_Override)
-					.add("autoComplete", autoComplete)
-
-					.toString();
-		}
-
-		@Override
-		public int hashCode()
-		{
-			return new HashcodeBuilder()
-					.append(tableName)
-					.append(keyColumn)
-					.append(displayColumn)
-					.append(displayColumnSQL)
-					.append(valueDisplayed)
-					.append(whereClause)
-					.append(orderByClause)
-					.append(translated)
-					.append(zoomSO_Window_ID)
-					.append(zoomPO_Window_ID)
-					.append(zoomAD_Window_ID_Override)
-					.append(autoComplete)
-
-					.toHashcode();
-		}
-
-		@Override
-		public boolean equals(final Object obj)
-		{
-			if (this == obj)
-			{
-				return true;
-			}
-
-			final TableRefInfo other = EqualsBuilder.getOther(this, obj);
-			if (other == null)
-			{
-				return false;
-			}
-
-			return new EqualsBuilder()
-					.append(tableName, other.tableName)
-					.append(keyColumn, other.keyColumn)
-					.append(displayColumn, other.displayColumn)
-					.append(displayColumnSQL, other.displayColumnSQL)
-					.append(valueDisplayed, other.valueDisplayed)
-					.append(whereClause, other.whereClause)
-					.append(orderByClause, other.orderByClause)
-					.append(translated, other.translated)
-					.append(zoomSO_Window_ID, other.zoomSO_Window_ID)
-					.append(zoomPO_Window_ID, other.zoomPO_Window_ID)
-					.append(zoomAD_Window_ID_Override, other.zoomAD_Window_ID_Override)
-					.append(autoComplete, other.autoComplete)
-					.isEqual();
-		}
-
-		@Override
-		public String getName()
-		{
-			return name;
-		}
-
-		@Override
-		public String getTableName()
-		{
-			return tableName;
-		}
-
-		@Override
-		public String getKeyColumn()
-		{
-			return keyColumn;
-		}
-
-		@Override
-		public String getDisplayColumn()
-		{
-			return displayColumn;
-		}
-
-		@Override
-		public boolean isValueDisplayed()
-		{
-			return valueDisplayed;
-		}
-
-		@Override
-		public boolean isTranslated()
-		{
-			return translated;
-		}
-
-		@Override
-		public String getWhereClause()
-		{
-			return whereClause;
-		}
-
-		@Override
-		public String getOrderByClause()
-		{
-			return orderByClause;
-		}
-
-		@Override
-		public int getZoomSO_Window_ID()
-		{
-			return zoomSO_Window_ID;
-		}
-
-		@Override
-		public int getZoomPO_Window_ID()
-		{
-			return zoomPO_Window_ID;
-		}
-
-		@Override
-		public int getZoomAD_Window_ID_Override()
-		{
-			return zoomAD_Window_ID_Override;
-		}
-
-		@Override
-		public String getDisplayColumnSQL()
-		{
-			return displayColumnSQL;
-		}
-
-		@Override
-		public boolean isAutoComplete()
-		{
-			return autoComplete;
 		}
 
 		@Override
@@ -389,7 +225,7 @@ public class LookupDAO implements ILookupDAO
 	@VisibleForTesting
 	public static final class TableRefInfoBuilder
 	{
-		private String name; // used only for debugging
+		private String identifier; // used only for debugging
 		private String tableName;
 		private String keyColumn;
 		private String displayColumn = null;
@@ -405,7 +241,6 @@ public class LookupDAO implements ILookupDAO
 
 		private TableRefInfoBuilder()
 		{
-			super();
 		}
 
 		public TableRefInfo build()
@@ -413,9 +248,9 @@ public class LookupDAO implements ILookupDAO
 			return new TableRefInfo(this);
 		}
 
-		public TableRefInfoBuilder setName(final String name)
+		public TableRefInfoBuilder setIdentifier(final String identifier)
 		{
-			this.name = name;
+			this.identifier = identifier;
 			return this;
 		}
 
@@ -490,7 +325,6 @@ public class LookupDAO implements ILookupDAO
 			this.autoComplete = autoComplete;
 			return this;
 		}
-
 	}
 
 	/* package */class LookupDisplayInfo implements ILookupDisplayInfo
@@ -637,7 +471,7 @@ public class LookupDAO implements ILookupDAO
 				+ "t.AD_Table_ID, cd.ColumnSQL as DisplayColumnSQL, "					// 10..11
 				+ "rt.AD_Window_ID as RT_AD_Window_ID, " // 12
 				+ "t." + I_AD_Table.COLUMNNAME_IsAutocomplete // 13
-				+ ", r.Name as ReferenceName" // 14
+				+ ", r.Name as ReferenceName"
 				// #2340 Also collect information about the ref table being a reference target
 				+ " FROM AD_Ref_Table rt"
 				+ " INNER JOIN AD_Reference r on (r.AD_Reference_ID=rt.AD_Reference_ID)"
@@ -671,10 +505,10 @@ public class LookupDAO implements ILookupDAO
 				final String displayColumnSQL = rs.getString(11);
 				final int zoomAD_Window_ID_Override = rs.getInt(12);
 				final boolean autoComplete = "Y".equals(rs.getString(13));
-				final String referenceName = rs.getString(14);
+				final String referenceName = rs.getString("ReferenceName");
 
 				tableRefInfo = TableRefInfo.builder()
-						.setName(referenceName)
+						.setIdentifier("AD_Reference[ID=" + AD_Reference_ID + ",Name=" + referenceName + "]")
 						.setTableName(TableName)
 						.setKeyColumn(KeyColumn)
 						.setDisplayColumn(DisplayColumn)
@@ -744,7 +578,7 @@ public class LookupDAO implements ILookupDAO
 		}
 
 		final ITableRefInfo tableRefInfo = TableRefInfo.builder()
-				.setName("Direct_" + tableName)
+				.setIdentifier("Direct[FromColumn" + columnName + ",To=" + tableName + "." + columnName + "]")
 				.setTableName(tableName)
 				.setKeyColumn(keyColumn)
 				.setAutoComplete(autoComplete)

--- a/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/model/RelationTypeZoomProviderFactoryTest.java
+++ b/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/model/RelationTypeZoomProviderFactoryTest.java
@@ -33,12 +33,12 @@ import mockit.Mocked;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -80,7 +80,7 @@ public class RelationTypeZoomProviderFactoryTest
 		final I_AD_RelationType relationType = createRelationType(isTableRecordIdTarget, null, referenceTarget);
 
 		TableRefInfo build = LookupDAO.TableRefInfo.builder()
-				.setName(refTargetName)
+				.setIdentifier(refTargetName)
 				.setTableName(tableName)
 				.setKeyColumn(keyColumnName)
 				.setDisplayColumn(keyColumnName)
@@ -101,8 +101,8 @@ public class RelationTypeZoomProviderFactoryTest
 
 		assertThat(zoomProvider.isTableRecordIdTarget()).isTrue();
 	}
-	
-	
+
+
 
 	@Test
 	public void findZoomProvider_Is_Not_TableRecordIdTarget_WithSource()
@@ -111,7 +111,7 @@ public class RelationTypeZoomProviderFactoryTest
 		final String refTargetName = "RefTargetName1";
 		final String validationType = X_AD_Reference.VALIDATIONTYPE_TableValidation;
 		final I_AD_Reference referenceTarget = createReferenceSourceOrTarget(refTargetName, validationType);
-		
+
 		final String refSourceName = "RefSourceName1";
 		final I_AD_Reference referenceSource = createReferenceSourceOrTarget(refSourceName, validationType);
 
@@ -129,7 +129,7 @@ public class RelationTypeZoomProviderFactoryTest
 		final I_AD_RelationType relationType = createRelationType(isTableRecordIdTarget, referenceSource,  referenceTarget);
 
 		TableRefInfo build = LookupDAO.TableRefInfo.builder()
-				.setName(refTargetName)
+				.setIdentifier(refTargetName)
 				.setTableName(tableName)
 				.setKeyColumn(keyColumnName)
 				.setDisplayColumn(keyColumnName)


### PR DESCRIPTION
### What is the current behavior?

Example, from a log file:
```
2018-12-19 23:02:41.096 ERROR 100 --- [https-jsse-nio-8443-exec-6] org.compiere.model.MLookupFactory        : getLookupInfo: WHERE should be fully qualified: issystemuser='Y'
 tableRefInfo=TableRefInfo{name=AD_User, tableName=AD_User, keyColumn=AD_User_ID, displayColumn=Name, valueDisplayed=false, whereClause=issystemuser='Y', orderByClause=AD_User.Name, translated=false, zoomWindow=108, zoomWindowPO=123, overrideZoomWindow=-1, autoComplete=false}
```

Note: it seems that this particular where clause was already fixed in `master` in the meantime.

### What is the expected or desired behavior?

With my change, this message will be

```
2018-12-19 23:02:41.096 ERROR 100 --- [https-jsse-nio-8443-exec-6] org.compiere.model.MLookupFactory        : getLookupInfo: whereClause of tableRefInfo AD_Reference[ID=540401,Name=AD_User] should be fully qualified;
 where=issystemuser='Y';
 tableRefInfo=TableRefInfo{identifier=AD_Reference[ID=540401,Name=AD_User], tableName=AD_User, keyColumn=AD_User_ID, displayColumn=Name, valueDisplayed=false, whereClause=issystemuser='Y', orderByClause=AD_User.Name, translated=false, zoomWindow=108, zoomWindowPO=123, overrideZoomWindow=-1, autoComplete=false}
```

imho this make is much clearer where the problem is and there the reader can go to fix it