### PR TITLE
Refund contract - add further options

### DIFF
--- a/de.metas.business/src/main/java-legacy/org/adempiere/model/PromotionRule.java
+++ b/de.metas.business/src/main/java-legacy/org/adempiere/model/PromotionRule.java
@@ -207,7 +207,7 @@ public class PromotionRule {
 						} else if (pr.getRewardType().equals(MPromotionReward.REWARDTYPE_FlatDiscount)) {
 							discount = pr.getAmount();
 						} else if (pr.getRewardType().equals(MPromotionReward.REWARDTYPE_Percentage)) {
-							discount = pr.getAmount().divide(BigDecimal.valueOf(100.00)).multiply(totalPrice);
+							discount = pr.getAmount().divide(Env.ONEHUNDRED).multiply(totalPrice);
 						}
 						if (discount.signum() > 0) {
 							addDiscountLine(order, null, discount, BigDecimal.valueOf(1.00), pr.getC_Charge_ID(), pr.getM_Promotion());

--- a/de.metas.business/src/test/java/de/metas/money/MoneyServiceTest.java
+++ b/de.metas.business/src/test/java/de/metas/money/MoneyServiceTest.java
@@ -37,7 +37,7 @@ public class MoneyServiceTest
 {
 	private MoneyService moneyService;
 
-	private Currency currency;
+	// private Currency currency;
 
 	private Money zeroEuro;
 
@@ -46,6 +46,8 @@ public class MoneyServiceTest
 	private Money oneHundretEuro;
 
 	private Money twoHundredEuro;
+
+	private CurrencyId currencyId;
 
 	@Before
 	public void init()
@@ -56,10 +58,11 @@ public class MoneyServiceTest
 		moneyService = new MoneyService(currencyRepository);
 
 		final I_C_Currency currencyRecord = newInstance(I_C_Currency.class);
+		currencyRecord.setStdPrecision(2);
 		saveRecord(currencyRecord);
 
-		final CurrencyId currencyId = CurrencyId.ofRepoId(currencyRecord.getC_Currency_ID());
-		currency = currencyRepository.getById(currencyId);
+		currencyId = CurrencyId.ofRepoId(currencyRecord.getC_Currency_ID());
+		// Currency currency = currencyRepository.getById(currencyId);
 
 		zeroEuro = Money.of(0, currencyId);
 		seventyEuro = Money.of(70, currencyId);
@@ -72,7 +75,7 @@ public class MoneyServiceTest
 	{
 		final Money result = moneyService.percentage(Percent.of(80), twoHundredEuro);
 
-		assertThat(result.getCurrencyId()).isEqualTo(currency.getId());
+		assertThat(result.getCurrencyId()).isEqualTo(currencyId);
 		assertThat(result.getValue()).isEqualByComparingTo("160");
 	}
 
@@ -81,9 +84,19 @@ public class MoneyServiceTest
 	{
 		final Money result = moneyService.percentage(Percent.of(0), twoHundredEuro);
 
-		assertThat(result.getCurrencyId()).isEqualTo(currency.getId());
+		assertThat(result.getCurrencyId()).isEqualTo(currencyId);
 		assertThat(result).isEqualTo(zeroEuro);
 		assertThat(result.isZero()).isTrue();
+	}
+
+	/** This test shall work because we set the currency precision to >= 1. */
+	@Test
+	public void percentage_real_world_example()
+	{
+		final Money result = moneyService.percentage(Percent.of(10), Money.of(14, currencyId));
+
+		assertThat(result.getCurrencyId()).isEqualTo(currencyId);
+		assertThat(result.getValue()).isEqualByComparingTo("1.4");
 	}
 
 	@Test

--- a/de.metas.contracts/src/main/java/de/metas/contracts/invoicecandidate/ConditionTypeSpecificInvoiceCandidateHandler.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/invoicecandidate/ConditionTypeSpecificInvoiceCandidateHandler.java
@@ -45,7 +45,7 @@ public interface ConditionTypeSpecificInvoiceCandidateHandler
 
 	PriceAndTax calculatePriceAndTax(I_C_Invoice_Candidate invoiceCandidateRecord);
 
-	Consumer<I_C_Invoice_Candidate> getSetInvoiceScheduleImplementation(Consumer<I_C_Invoice_Candidate> defaultImplementation);
+	Consumer<I_C_Invoice_Candidate> getInvoiceScheduleSetterFunction(Consumer<I_C_Invoice_Candidate> defaultImplementation);
 
 	boolean isMissingInvoiceCandidate(I_C_Flatrate_Term flatrateTerm);
 }

--- a/de.metas.contracts/src/main/java/de/metas/contracts/invoicecandidate/FlatrateTerm_Handler.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/invoicecandidate/FlatrateTerm_Handler.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
@@ -203,13 +204,14 @@ public class FlatrateTerm_Handler extends AbstractInvoiceCandidateHandler
 	}
 
 	@Override
-	public void setInvoiceSchedule(@NonNull final I_C_Invoice_Candidate ic)
+	public void setInvoiceScheduleAndDateToInvoice(@NonNull final I_C_Invoice_Candidate ic)
 	{
 		final I_C_Flatrate_Term term = HandlerTools.retrieveTerm(ic);
 		final ConditionTypeSpecificInvoiceCandidateHandler handler = getSpecificHandler(term);
 
-		handler
-				.getSetInvoiceScheduleImplementation(super::setInvoiceSchedule)
+		final Consumer<I_C_Invoice_Candidate> defaultImplementation = super::setInvoiceScheduleAndDateToInvoice;
+
+		handler.getInvoiceScheduleSetterFunction(defaultImplementation)
 				.accept(ic);
 	}
 

--- a/de.metas.contracts/src/main/java/de/metas/contracts/refund/AssignableInvoiceCandidate.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/refund/AssignableInvoiceCandidate.java
@@ -40,7 +40,9 @@ import lombok.Value;
  * #L%
  */
 
-/** Represents an invoice candidate that matches a refund contract and can therefore be assigned to a {@link RefundInvoiceCandidate}. */
+/**
+ * Represents a "normal" invoice candidate (e.g. from a purchase order line) that matches a refund contract and can therefore be assigned to one or more {@link RefundInvoiceCandidate}(s).
+ */
 @Value
 public class AssignableInvoiceCandidate
 {

--- a/de.metas.contracts/src/main/java/de/metas/contracts/refund/AssignableInvoiceCandidateFactory.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/refund/AssignableInvoiceCandidateFactory.java
@@ -1,9 +1,11 @@
 package de.metas.contracts.refund;
 
+import static de.metas.util.NumberUtils.stripTrailingDecimalZeros;
 import static org.adempiere.model.InterfaceWrapperHelper.getValueOverrideOrValue;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -11,13 +13,17 @@ import org.compiere.model.I_C_Currency;
 import org.compiere.util.TimeUtil;
 import org.springframework.stereotype.Service;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import de.metas.bpartner.BPartnerId;
+import de.metas.invoice.InvoiceScheduleRepository;
 import de.metas.invoicecandidate.InvoiceCandidateId;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.money.CurrencyId;
 import de.metas.money.Money;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
+import lombok.NonNull;
 
 /*
  * #%L
@@ -44,6 +50,27 @@ import de.metas.quantity.Quantity;
 @Service
 public class AssignableInvoiceCandidateFactory
 {
+	private final AssignmentToRefundCandidateRepository assignmentToRefundCandidateRepository;
+
+	@VisibleForTesting
+	public static AssignableInvoiceCandidateFactory newForUnitTesting()
+	{
+		final InvoiceScheduleRepository invoiceScheduleRepository = new InvoiceScheduleRepository();
+		final RefundConfigRepository refundConfigRepository = new RefundConfigRepository(invoiceScheduleRepository);
+		final RefundContractRepository refundContractRepository = new RefundContractRepository(refundConfigRepository);
+		final AssignmentAggregateService assignmentAggregateService = new AssignmentAggregateService(refundConfigRepository);
+		final RefundInvoiceCandidateFactory refundInvoiceCandidateFactory = new RefundInvoiceCandidateFactory(refundContractRepository, assignmentAggregateService);
+		final RefundInvoiceCandidateRepository refundInvoiceCandidateRepository = new RefundInvoiceCandidateRepository(refundContractRepository, refundInvoiceCandidateFactory);
+		final AssignmentToRefundCandidateRepository assignmentToRefundCandidateRepository = new AssignmentToRefundCandidateRepository(refundInvoiceCandidateRepository);
+
+		return new AssignableInvoiceCandidateFactory(assignmentToRefundCandidateRepository);
+	}
+
+	public AssignableInvoiceCandidateFactory(@NonNull final AssignmentToRefundCandidateRepository assignmentToRefundCandidateRepository)
+	{
+		this.assignmentToRefundCandidateRepository = assignmentToRefundCandidateRepository;
+	}
+
 	/** Note: does not load&include {@link AssignmentToRefundCandidate}s; those need to be retrieved using {@link AssignmentToRefundCandidateRepository}. */
 	public AssignableInvoiceCandidate ofRecord(@Nullable final I_C_Invoice_Candidate assignableRecord)
 	{
@@ -58,11 +85,13 @@ public class AssignableInvoiceCandidateFactory
 		final CurrencyId currencyId = CurrencyId.ofRepoId(currencyRecord.getC_Currency_ID());
 		final int precision = currencyRecord.getStdPrecision();
 
-		final Money money = Money.of(moneyAmount, currencyId);
+		final Money money = Money.of(stripTrailingDecimalZeros(moneyAmount), currencyId);
 
 		final Quantity quantity = Quantity.of(
-				assignableRecord.getQtyToInvoice().add(assignableRecord.getQtyInvoiced()),
+				assignableRecord.getQtyToInvoice().add(stripTrailingDecimalZeros(assignableRecord.getQtyInvoiced())),
 				assignableRecord.getM_Product().getC_UOM());
+
+		final List<AssignmentToRefundCandidate> assignments = assignmentToRefundCandidateRepository.getAssignmentsByAssignableCandidateId(invoiceCandidateId);
 
 		final AssignableInvoiceCandidate invoiceCandidate = AssignableInvoiceCandidate.builder()
 				.repoId(invoiceCandidateId)
@@ -72,6 +101,7 @@ public class AssignableInvoiceCandidateFactory
 				.precision(precision)
 				.quantity(quantity)
 				.productId(ProductId.ofRepoId(assignableRecord.getM_Product_ID()))
+				.assignmentsToRefundCandidates(assignments)
 				.build();
 
 		return invoiceCandidate;

--- a/de.metas.contracts/src/main/java/de/metas/contracts/refund/AssignmentToRefundCandidate.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/refund/AssignmentToRefundCandidate.java
@@ -3,6 +3,7 @@ package de.metas.contracts.refund;
 import de.metas.invoicecandidate.InvoiceCandidateId;
 import de.metas.money.Money;
 import de.metas.quantity.Quantity;
+import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 
@@ -29,6 +30,7 @@ import lombok.Value;
  */
 
 @Value
+@Builder
 public class AssignmentToRefundCandidate
 {
 	@NonNull
@@ -52,6 +54,11 @@ public class AssignmentToRefundCandidate
 
 	boolean useAssignedQtyInSum;
 
+	/**
+	 *
+	 * @return an instance that has the currently assigned money and quantity subtracted;
+	 *         also from the new instance's {@link #getRefundInvoiceCandidate()}
+	 */
 	public AssignmentToRefundCandidate withSubtractedAssignedMoneyAndQuantity()
 	{
 		final Money moneySubtrahent = getMoneyAssignedToRefundCandidate();

--- a/de.metas.contracts/src/main/java/de/metas/contracts/refund/AssignmentToRefundCandidateRepository.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/refund/AssignmentToRefundCandidateRepository.java
@@ -64,13 +64,8 @@ public class AssignmentToRefundCandidateRepository
 		this.refundInvoiceCandidateRepository = refundInvoiceCandidateRepository;
 	}
 
-	public List<AssignmentToRefundCandidate> getAssignmentsToRefundCandidate(
-			@NonNull final AssignableInvoiceCandidate assignableInvoiceCandidate)
+	public List<AssignmentToRefundCandidate> getAssignmentsByAssignableCandidateId(@NonNull final InvoiceCandidateId invoiceCandidateId)
 	{
-		Check.assumeNotNull(assignableInvoiceCandidate.getRepoId(),
-				"The given assignableInvoiceCandidate needs to have a not-null Id; assignableInvoiceCandidate={}",
-				assignableInvoiceCandidate);
-
 		final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 		final List<I_C_Invoice_Candidate_Assignment> assignmentRecords = queryBL
@@ -78,7 +73,7 @@ public class AssignmentToRefundCandidateRepository
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(
 						I_C_Invoice_Candidate_Assignment.COLUMN_C_Invoice_Candidate_Assigned_ID,
-						assignableInvoiceCandidate.getRepoId().getRepoId())
+						invoiceCandidateId.getRepoId())
 				.create()
 				.list(I_C_Invoice_Candidate_Assignment.class); // we might have multiple records with different C_Flatrate_RefundConfig_ID
 

--- a/de.metas.contracts/src/main/java/de/metas/contracts/refund/RefundInvoiceCandidate.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/refund/RefundInvoiceCandidate.java
@@ -18,6 +18,7 @@ import de.metas.money.Money;
 import de.metas.quantity.Quantity;
 import lombok.Builder;
 import lombok.NonNull;
+import lombok.Singular;
 import lombok.Value;
 
 /*
@@ -43,7 +44,7 @@ import lombok.Value;
  */
 
 /**
- * Represents the invoice candidate that will end up as "refund" invoice line.
+ * Represents the invoice candidate that will end up as "refund" invoice line, based on a refund contract.
  * Also see {@link AssignableInvoiceCandidate}.
  */
 @Value
@@ -66,9 +67,8 @@ public class RefundInvoiceCandidate
 	/**
 	 * If {@link RefundMode} is {@link RefundMode#APPLY_TO_EXCEEDING_QTY}, then there is one config per candidate; if it is {@link RefundMode#APPLY_TO_ALL_QTIES}, then there is one or many.
 	 */
-	// @NonNull
-	// RefundConfig refundConfig;
 	@NonNull
+	@Singular
 	List<RefundConfig> refundConfigs;
 
 	@NonNull

--- a/de.metas.contracts/src/main/java/de/metas/contracts/refund/RefundInvoiceCandidateFactory.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/refund/RefundInvoiceCandidateFactory.java
@@ -7,10 +7,10 @@ import static org.adempiere.model.InterfaceWrapperHelper.getTableId;
 import static org.adempiere.model.InterfaceWrapperHelper.getValueOverrideOrValue;
 import static org.adempiere.model.InterfaceWrapperHelper.load;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.compiere.util.TimeUtil.asTimestamp;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -33,11 +33,11 @@ import de.metas.contracts.model.I_C_Flatrate_Term;
 import de.metas.contracts.model.X_C_Flatrate_Term;
 import de.metas.contracts.refund.RefundConfig.RefundInvoiceType;
 import de.metas.contracts.refund.RefundConfig.RefundMode;
+import de.metas.contracts.refund.RefundContract.NextInvoiceDate;
 import de.metas.document.DocTypeId;
 import de.metas.document.DocTypeQuery;
 import de.metas.document.DocTypeQuery.DocTypeQueryBuilder;
 import de.metas.document.IDocTypeDAO;
-import de.metas.invoice.InvoiceSchedule;
 import de.metas.invoicecandidate.InvoiceCandidateId;
 import de.metas.invoicecandidate.api.IInvoiceCandBL;
 import de.metas.invoicecandidate.api.IInvoiceCandDAO;
@@ -157,23 +157,12 @@ public class RefundInvoiceCandidateFactory
 		refundInvoiceCandidateRecord.setInvoiceRule_Override(null);
 		refundInvoiceCandidateRecord.setDateToInvoice_Override(null);
 
-		final InvoiceSchedule invoiceSchedule = extractSingleElement(refundConfigs, RefundConfig::getInvoiceSchedule);
-		refundInvoiceCandidateRecord.setC_InvoiceSchedule_ID(invoiceSchedule.getId().getRepoId());
+		final NextInvoiceDate nextRefundInvoiceDate = refundContract.computeNextInvoiceDate(assignableCandidate.getInvoiceableFrom());
+		refundInvoiceCandidateRecord.setC_InvoiceSchedule_ID(nextRefundInvoiceDate.getInvoiceSchedule().getId().getRepoId());
 
-		final LocalDate dateToInvoiceFromInvoiceSchedule = invoiceSchedule.calculateNextDateToInvoice(assignableCandidate.getInvoiceableFrom());
-		final Timestamp dateForRefundCandidate;
-		if (dateToInvoiceFromInvoiceSchedule.isAfter(refundContract.getEndDate()))
-		{
-			// make sure the refund candidate's dateToInvoice is not *after* the contract's actual ending.
-			// otherwise RefundInvoiceCandidateRepository.getRefundInvoiceCandidates() won't find the invoice candidate record later.
-			dateForRefundCandidate = TimeUtil.asTimestamp(refundContract.getEndDate());
-		}
-		else
-		{
-			dateForRefundCandidate = TimeUtil.asTimestamp(dateToInvoiceFromInvoiceSchedule);
-		}
-		refundInvoiceCandidateRecord.setDateOrdered(dateForRefundCandidate);
-		refundInvoiceCandidateRecord.setDeliveryDate(dateForRefundCandidate);
+		final Timestamp dateToInvoiceFromInvoiceSchedule = asTimestamp(nextRefundInvoiceDate.getDateToInvoice());
+		refundInvoiceCandidateRecord.setDateOrdered(dateToInvoiceFromInvoiceSchedule);
+		refundInvoiceCandidateRecord.setDeliveryDate(dateToInvoiceFromInvoiceSchedule);
 
 		final RefundInvoiceType refundInvoiceType = extractSingleElement(refundConfigs, RefundConfig::getRefundInvoiceType);
 		try
@@ -198,6 +187,7 @@ public class RefundInvoiceCandidateFactory
 
 		final RefundInvoiceCandidate resultCandidate = refundInvoiceCandidate
 				.toBuilder()
+				.clearRefundConfigs()
 				.refundConfigs(refundConfigs)
 				.build();
 		return resultCandidate;

--- a/de.metas.contracts/src/main/java/de/metas/contracts/refund/RefundInvoiceCandidateService.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/refund/RefundInvoiceCandidateService.java
@@ -28,7 +28,6 @@ import de.metas.money.MoneyService;
 import de.metas.quantity.Quantity;
 import de.metas.util.Check;
 import de.metas.util.lang.Percent;
-
 import lombok.NonNull;
 
 /*
@@ -262,5 +261,4 @@ public class RefundInvoiceCandidateService
 
 		return refundInvoiceCandidateRepository.save(candidateWithUpdatedMoney);
 	}
-
 }

--- a/de.metas.contracts/src/main/java/de/metas/contracts/refund/allqties/CandidateAssignServiceAllQties.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/refund/allqties/CandidateAssignServiceAllQties.java
@@ -14,12 +14,12 @@ import de.metas.contracts.refund.AssignmentToRefundCandidateRepository;
 import de.metas.contracts.refund.CandidateAssignmentService.UpdateAssignmentResult;
 import de.metas.contracts.refund.RefundConfig;
 import de.metas.contracts.refund.RefundConfig.RefundMode;
-import de.metas.contracts.refund.allqties.refundconfigchange.RefundConfigChangeService;
 import de.metas.contracts.refund.RefundConfigs;
 import de.metas.contracts.refund.RefundContract;
 import de.metas.contracts.refund.RefundInvoiceCandidate;
 import de.metas.contracts.refund.RefundInvoiceCandidateRepository;
 import de.metas.contracts.refund.RefundInvoiceCandidateService;
+import de.metas.contracts.refund.allqties.refundconfigchange.RefundConfigChangeService;
 import de.metas.quantity.Quantity;
 import de.metas.util.Check;
 import lombok.NonNull;
@@ -112,7 +112,7 @@ public class CandidateAssignServiceAllQties
 		final AssignableInvoiceCandidate resultCandidate = assignableCandidate
 				.toBuilder()
 				.clearAssignmentsToRefundCandidates() // need to reload the assignments
-				.assignmentsToRefundCandidates(assignmentToRefundCandidateRepository.getAssignmentsToRefundCandidate(assignableCandidate))
+				.assignmentsToRefundCandidates(assignmentToRefundCandidateRepository.getAssignmentsByAssignableCandidateId(assignableCandidate.getRepoId()))
 				.build();
 		return UpdateAssignmentResult.updateDone(resultCandidate, ImmutableList.of());
 	}

--- a/de.metas.contracts/src/main/java/de/metas/contracts/refund/allqties/refundconfigchange/AmountRefundConfigChangeHandler.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/refund/allqties/refundconfigchange/AmountRefundConfigChangeHandler.java
@@ -56,14 +56,15 @@ public class AmountRefundConfigChangeHandler extends RefundConfigChangeHandler
 
 		final Money moneyToAssign = amountToApply.multiply(quantityAssigendToRefundCandidate.getAsBigDecimal());
 
-		return new AssignmentToRefundCandidate(
-				getCurrentRefundConfig().getId(),
-				existingAssignment.getAssignableInvoiceCandidateId(),
-				existingAssignment.getRefundInvoiceCandidate(),
-				existingAssignment.getMoneyBase(),
-				moneyToAssign,
-				quantityAssigendToRefundCandidate,
-				getCurrentRefundConfig().isIncludeAssignmentsWithThisConfigInSum());
+		return AssignmentToRefundCandidate.builder()
+				.refundConfigId(getCurrentRefundConfig().getId())
+				.assignableInvoiceCandidateId(existingAssignment.getAssignableInvoiceCandidateId())
+				.refundInvoiceCandidate(existingAssignment.getRefundInvoiceCandidate())
+				.moneyBase(existingAssignment.getMoneyBase())
+				.moneyAssignedToRefundCandidate(moneyToAssign)
+				.quantityAssigendToRefundCandidate(quantityAssigendToRefundCandidate)
+				.useAssignedQtyInSum(getCurrentRefundConfig().isIncludeAssignmentsWithThisConfigInSum())
+				.build();
 	}
 
 	@Override

--- a/de.metas.contracts/src/main/java/de/metas/contracts/refund/allqties/refundconfigchange/PercentRefundConfigChangeHandler.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/refund/allqties/refundconfigchange/PercentRefundConfigChangeHandler.java
@@ -7,7 +7,6 @@ import de.metas.money.Money;
 import de.metas.money.MoneyService;
 import de.metas.util.Check;
 import de.metas.util.lang.Percent;
-
 import lombok.NonNull;
 
 /*
@@ -68,14 +67,15 @@ public class PercentRefundConfigChangeHandler extends RefundConfigChangeHandler
 
 		final Money moneyToAssign = moneyService.percentage(percentToApply, base);
 
-		return new AssignmentToRefundCandidate(
-				getCurrentRefundConfig().getId(),
-				existingAssignment.getAssignableInvoiceCandidateId(),
-				existingAssignment.getRefundInvoiceCandidate(),
-				existingAssignment.getMoneyBase(),
-				moneyToAssign,
-				existingAssignment.getQuantityAssigendToRefundCandidate(),
-				getCurrentRefundConfig().isIncludeAssignmentsWithThisConfigInSum());
+		return AssignmentToRefundCandidate.builder()
+				.refundConfigId(getCurrentRefundConfig().getId())
+				.assignableInvoiceCandidateId(existingAssignment.getAssignableInvoiceCandidateId())
+				.refundInvoiceCandidate(existingAssignment.getRefundInvoiceCandidate())
+				.moneyBase(existingAssignment.getMoneyBase())
+				.moneyAssignedToRefundCandidate(moneyToAssign)
+				.quantityAssigendToRefundCandidate(existingAssignment.getQuantityAssigendToRefundCandidate())
+				.useAssignedQtyInSum(getCurrentRefundConfig().isIncludeAssignmentsWithThisConfigInSum())
+				.build();
 	}
 
 	@Override

--- a/de.metas.contracts/src/main/java/de/metas/contracts/refund/interceptor/C_Invoice_Candidate_Manage_Refund_Candidates.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/refund/interceptor/C_Invoice_Candidate_Manage_Refund_Candidates.java
@@ -2,8 +2,6 @@ package de.metas.contracts.refund.interceptor;
 
 import static org.adempiere.model.InterfaceWrapperHelper.getValueOverrideOrValue;
 
-import lombok.NonNull;
-
 import java.sql.Timestamp;
 
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
@@ -26,6 +24,7 @@ import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.logging.LogManager;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
+import lombok.NonNull;
 
 /*
  * #%L
@@ -109,7 +108,7 @@ public class C_Invoice_Candidate_Manage_Refund_Candidates
 			invoiceCandidateAssignmentService.updateAssignment(assignableInvoiceCandidate);
 		}
 		catch (final RuntimeException e)
-		{
+		{e.printStackTrace();
 			// allow the "normal ICs" to be updated, even if something is wrong with the "refund-ICs"
 			final I_AD_Issue issue = Services.get(IErrorManager.class).createIssue(e);
 			Loggables.get()

--- a/de.metas.contracts/src/main/java/de/metas/contracts/refund/invoicecandidatehandler/FlatrateTermRefund_Handler.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/refund/invoicecandidatehandler/FlatrateTermRefund_Handler.java
@@ -1,29 +1,27 @@
 package de.metas.contracts.refund.invoicecandidatehandler;
 
 import static java.math.BigDecimal.ONE;
+import static org.compiere.util.TimeUtil.asLocalDate;
+import static org.compiere.util.TimeUtil.asTimestamp;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.Iterator;
-import java.util.List;
 import java.util.function.Consumer;
 
-import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.Adempiere;
 
 import com.google.common.collect.ImmutableList;
 
-import de.metas.contracts.ConditionsId;
+import de.metas.contracts.FlatrateTermId;
 import de.metas.contracts.invoicecandidate.ConditionTypeSpecificInvoiceCandidateHandler;
 import de.metas.contracts.model.I_C_Flatrate_Term;
 import de.metas.contracts.model.X_C_Flatrate_Term;
-import de.metas.contracts.refund.RefundConfig;
-import de.metas.contracts.refund.RefundConfigQuery;
-import de.metas.contracts.refund.RefundConfigRepository;
+import de.metas.contracts.refund.RefundContract;
+import de.metas.contracts.refund.RefundContract.NextInvoiceDate;
+import de.metas.contracts.refund.RefundContractRepository;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.invoicecandidate.spi.IInvoiceCandidateHandler.PriceAndTax;
-import de.metas.product.ProductId;
-import de.metas.util.collections.CollectionUtils;
 import lombok.NonNull;
 
 /*
@@ -104,29 +102,23 @@ public class FlatrateTermRefund_Handler
 	}
 
 	@Override
-	public Consumer<I_C_Invoice_Candidate> getSetInvoiceScheduleImplementation(
+	public Consumer<I_C_Invoice_Candidate> getInvoiceScheduleSetterFunction(
 			Consumer<I_C_Invoice_Candidate> IGNORED_defaultImplementation)
 	{
 		return ic -> {
-			final RefundConfigRepository refundConfigRepository = Adempiere.getBean(RefundConfigRepository.class);
 
-			final I_C_Flatrate_Term flatrateTermRecord = TableRecordReference.ofReferenced(ic).getModel(I_C_Flatrate_Term.class);
-			final BigDecimal minQty = ic.getQtyInvoiced().add(ic.getQtyToInvoice());
+			final FlatrateTermId flatrateTermId = FlatrateTermId.ofRepoId(ic.getRecord_ID());
 
-			final RefundConfigQuery query = RefundConfigQuery.builder()
-					.productId(ProductId.ofRepoId(flatrateTermRecord.getM_Product_ID()))
-					.conditionsId(ConditionsId.ofRepoId(flatrateTermRecord.getC_Flatrate_Conditions_ID()))
-					.minQty(minQty)
-					.build();
+			RefundContractRepository refundContractRepository = Adempiere.getBean(RefundContractRepository.class);
+			final RefundContract refundContract = refundContractRepository.getById(flatrateTermId);
+			final NextInvoiceDate nextInvoiceDate = refundContract.computeNextInvoiceDate(asLocalDate(ic.getDeliveryDate()));
 
-			// because we provided product, conditions and minQty there may be only one matching config.
-			final List<RefundConfig> refundConfigs = refundConfigRepository.getByQuery(query);
-			final RefundConfig refundConfig = CollectionUtils.singleElement(refundConfigs);
-
-			ic.setC_InvoiceSchedule_ID(refundConfig.getInvoiceSchedule().getId().getRepoId());
+			ic.setC_InvoiceSchedule_ID(nextInvoiceDate.getInvoiceSchedule().getId().getRepoId());
+			ic.setDateToInvoice(asTimestamp(nextInvoiceDate.getDateToInvoice()));
 		};
 	}
 
+	/** Just return the record's current date */
 	@Override
 	public Timestamp calculateDateOrdered(@NonNull final I_C_Invoice_Candidate invoiceCandidateRecord)
 	{

--- a/de.metas.contracts/src/main/java/de/metas/contracts/subscription/invoicecandidatehandler/FlatrateTermSubscription_Handler.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/subscription/invoicecandidatehandler/FlatrateTermSubscription_Handler.java
@@ -125,7 +125,7 @@ public class FlatrateTermSubscription_Handler implements ConditionTypeSpecificIn
 	}
 
 	@Override
-	public Consumer<I_C_Invoice_Candidate> getSetInvoiceScheduleImplementation(@NonNull final Consumer<I_C_Invoice_Candidate> defaultImplementation)
+	public Consumer<I_C_Invoice_Candidate> getInvoiceScheduleSetterFunction(@NonNull final Consumer<I_C_Invoice_Candidate> defaultImplementation)
 	{
 		return defaultImplementation;
 	}

--- a/de.metas.contracts/src/test/java/de/metas/contracts/refund/AssignableInvoiceCandidateFactoryTest.java
+++ b/de.metas.contracts/src/test/java/de/metas/contracts/refund/AssignableInvoiceCandidateFactoryTest.java
@@ -19,6 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import de.metas.adempiere.model.I_C_Currency;
+import de.metas.invoice.InvoiceScheduleRepository;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.util.time.SystemTime;
 
@@ -85,7 +86,13 @@ public class AssignableInvoiceCandidateFactoryTest
 		assignableIcRecord.setC_Currency(currencyRecord);
 		save(assignableIcRecord);
 
-		assignableInvoiceCandidateFactory = new AssignableInvoiceCandidateFactory();
+		final InvoiceScheduleRepository invoiceScheduleRepository = new InvoiceScheduleRepository();
+		final RefundConfigRepository refundConfigRepository = new RefundConfigRepository(invoiceScheduleRepository);
+		final RefundContractRepository refundContractRepository = new RefundContractRepository(refundConfigRepository);
+		final AssignmentAggregateService assignmentAggregateService = new AssignmentAggregateService(refundConfigRepository);
+		final RefundInvoiceCandidateFactory refundInvoiceCandidateFactory = new RefundInvoiceCandidateFactory(refundContractRepository, assignmentAggregateService);
+		final RefundInvoiceCandidateRepository refundInvoiceCandidateRepository = new RefundInvoiceCandidateRepository(refundContractRepository, refundInvoiceCandidateFactory);
+		assignableInvoiceCandidateFactory = new AssignableInvoiceCandidateFactory(new AssignmentToRefundCandidateRepository(refundInvoiceCandidateRepository));
 	}
 
 	@Test

--- a/de.metas.contracts/src/test/java/de/metas/contracts/refund/AssignableInvoiceCandidateRepositoryTest.java
+++ b/de.metas.contracts/src/test/java/de/metas/contracts/refund/AssignableInvoiceCandidateRepositoryTest.java
@@ -55,7 +55,7 @@ public class AssignableInvoiceCandidateRepositoryTest
 	{
 		AdempiereTestHelper.get().init();
 
-		assignableInvoiceCandidateRepository = new AssignableInvoiceCandidateRepository(new AssignableInvoiceCandidateFactory());
+		assignableInvoiceCandidateRepository = new AssignableInvoiceCandidateRepository(AssignableInvoiceCandidateFactory.newForUnitTesting());
 
 		refundTestTools = new RefundTestTools();
 	}

--- a/de.metas.contracts/src/test/java/de/metas/contracts/refund/AssignmentToRefundCandidateRepositoryTest.java
+++ b/de.metas.contracts/src/test/java/de/metas/contracts/refund/AssignmentToRefundCandidateRepositoryTest.java
@@ -160,17 +160,17 @@ public class AssignmentToRefundCandidateRepositoryTest
 	@Test
 	public void ofRecord_AssignableInvoiceCandidate_no_assignment_record()
 	{
-		final AssignableInvoiceCandidateFactory assignableInvoiceCandidateFactory = new AssignableInvoiceCandidateFactory();
+		final AssignableInvoiceCandidateFactory assignableInvoiceCandidateFactory = AssignableInvoiceCandidateFactory.newForUnitTesting();
 		final AssignableInvoiceCandidate assignableIc = assignableInvoiceCandidateFactory.ofRecord(assignableIcRecord);
 
 		// guards
-		final List<AssignmentToRefundCandidate> resultBeforeDeletion = assignmentToRefundCandidateRepository.getAssignmentsToRefundCandidate(assignableIc);
+		final List<AssignmentToRefundCandidate> resultBeforeDeletion = assignmentToRefundCandidateRepository.getAssignmentsByAssignableCandidateId(assignableIc.getRepoId());
 		assertThat(resultBeforeDeletion).isNotEmpty();
 
 		delete(assignmentRecord);
 
 		// invoke the method under test
-		final List<AssignmentToRefundCandidate> resultAfterDeletion = assignmentToRefundCandidateRepository.getAssignmentsToRefundCandidate(assignableIc);
+		final List<AssignmentToRefundCandidate> resultAfterDeletion = assignmentToRefundCandidateRepository.getAssignmentsByAssignableCandidateId(assignableIc.getRepoId());
 		assertThat(resultAfterDeletion).isEmpty();
 	}
 }

--- a/de.metas.contracts/src/test/java/de/metas/contracts/refund/CandidateAssignServiceTest.java
+++ b/de.metas.contracts/src/test/java/de/metas/contracts/refund/CandidateAssignServiceTest.java
@@ -45,7 +45,6 @@ import de.metas.money.MoneyService;
 import de.metas.quantity.Quantity;
 import de.metas.util.collections.CollectionUtils;
 import de.metas.util.lang.Percent;
-
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Singular;
@@ -130,7 +129,7 @@ public class CandidateAssignServiceTest
 
 		final MoneyService moneyService = new MoneyService(new CurrencyRepository());
 
-		final AssignableInvoiceCandidateFactory assignableInvoiceCandidateFactory = new AssignableInvoiceCandidateFactory();
+		final AssignableInvoiceCandidateFactory assignableInvoiceCandidateFactory = AssignableInvoiceCandidateFactory.newForUnitTesting();
 		assignableInvoiceCandidateRepository = new AssignableInvoiceCandidateRepository(assignableInvoiceCandidateFactory);
 
 		final RefundInvoiceCandidateService refundInvoiceCandidateService = new RefundInvoiceCandidateService(
@@ -447,7 +446,7 @@ public class CandidateAssignServiceTest
 				.getById(preparedAssignableCandidates.get(TEN).getRepoId())
 				.toBuilder()
 				.assignmentsToRefundCandidates(
-						assignmentToRefundCandidateRepository.getAssignmentsToRefundCandidate(preparedAssignableCandidates.get(TEN)))
+						assignmentToRefundCandidateRepository.getAssignmentsByAssignableCandidateId(preparedAssignableCandidates.get(TEN).getRepoId()))
 				.build();
 
 		final I_C_UOM uom = refundTestTools.getUomRecord();
@@ -502,7 +501,7 @@ public class CandidateAssignServiceTest
 				.getById(preparedAssignableCandidates.get(SEVEN).getRepoId())
 				.toBuilder()
 				.assignmentsToRefundCandidates(
-						assignmentToRefundCandidateRepository.getAssignmentsToRefundCandidate(preparedAssignableCandidates.get(SEVEN)))
+						assignmentToRefundCandidateRepository.getAssignmentsByAssignableCandidateId(preparedAssignableCandidates.get(SEVEN).getRepoId()))
 				.build();
 
 		final I_C_UOM uom = refundTestTools.getUomRecord();
@@ -629,14 +628,14 @@ public class CandidateAssignServiceTest
 				.getById(assignableCandidateWithSeven.getRepoId())
 				.toBuilder()
 				.assignmentsToRefundCandidates(
-						assignmentToRefundCandidateRepository.getAssignmentsToRefundCandidate(assignableCandidateWithSeven))
+						assignmentToRefundCandidateRepository.getAssignmentsByAssignableCandidateId(assignableCandidateWithSeven.getRepoId()))
 				.build();
 		final AssignableInvoiceCandidate //
 		reloadedAssignableCandidateWithTen = assignableInvoiceCandidateRepository
 				.getById(assignableCandidateWithTen.getRepoId())
 				.toBuilder()
 				.assignmentsToRefundCandidates(
-						assignmentToRefundCandidateRepository.getAssignmentsToRefundCandidate(assignableCandidateWithTen))
+						assignmentToRefundCandidateRepository.getAssignmentsByAssignableCandidateId(assignableCandidateWithTen.getRepoId()))
 				.build();
 
 		//

--- a/de.metas.contracts/src/test/java/de/metas/contracts/refund/CandidateAssignmentServiceTest.java
+++ b/de.metas.contracts/src/test/java/de/metas/contracts/refund/CandidateAssignmentServiceTest.java
@@ -1,0 +1,241 @@
+package de.metas.contracts.refund;
+
+import static java.math.BigDecimal.TEN;
+import static java.math.BigDecimal.ZERO;
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_UOM;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.contracts.ConditionsId;
+import de.metas.contracts.FlatrateTermId;
+import de.metas.contracts.refund.CandidateAssignmentService.UnassignResult;
+import de.metas.contracts.refund.RefundConfig.RefundBase;
+import de.metas.contracts.refund.RefundConfig.RefundInvoiceType;
+import de.metas.contracts.refund.RefundConfig.RefundMode;
+import de.metas.contracts.refund.allqties.refundconfigchange.RefundConfigChangeService;
+import de.metas.invoice.InvoiceSchedule;
+import de.metas.invoice.InvoiceSchedule.Frequency;
+import de.metas.invoice.InvoiceScheduleId;
+import de.metas.invoicecandidate.InvoiceCandidateId;
+import de.metas.money.CurrencyId;
+import de.metas.money.Money;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.util.lang.Percent;
+import mockit.Mocked;
+
+/*
+ * #%L
+ * de.metas.contracts
+ * %%
+ * Copyright (C) 2018 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+public class CandidateAssignmentServiceTest
+{
+	private static final BigDecimal FIFTEEN = new BigDecimal("15");
+
+	private static final BigDecimal FOURTEEN = new BigDecimal("14");
+
+	private static final BigDecimal TWELVE = new BigDecimal("12");
+
+	private static final BigDecimal TWENTY_SIX = new BigDecimal("26");
+
+	private I_C_UOM uomRecord;
+
+	@Mocked
+	private RefundContractRepository refundContractRepository;
+
+	@Mocked
+	private RefundInvoiceCandidateService refundInvoiceCandidateService;
+
+	@Mocked
+	private AssignableInvoiceCandidateRepository assignableInvoiceCandidateRepository;
+
+	@Mocked
+	private AssignmentToRefundCandidateRepository assignmentToRefundCandidateRepository;
+
+	@Mocked
+	private RefundInvoiceCandidateRepository refundInvoiceCandidateRepository;
+
+	@Mocked
+	private RefundConfigChangeService refundConfigChangeService;
+
+	@Before
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		uomRecord = newInstance(I_C_UOM.class);
+	}
+
+	@Test
+	public void unassignSingleCandidate()
+	{
+		final RefundConfig refundConfig_0 = RefundConfig.builder()
+				.id(RefundConfigId.ofRepoId(1000001))
+				.minQty(ZERO)
+				.refundInvoiceType(RefundInvoiceType.INVOICE)
+				.refundBase(RefundBase.PERCENTAGE)
+				.percent(Percent.of(TEN))
+				.productId(ProductId.ofRepoId(2005577))
+				.invoiceSchedule(InvoiceSchedule.builder()
+						.id(InvoiceScheduleId.ofRepoId(540006))
+						.frequency(Frequency.MONTLY)
+						.invoiceDayOfMonth(30)
+						.invoiceDistance(6)
+						.build())
+				.conditionsId(ConditionsId.ofRepoId(1000017))
+				.useInProfitCalculation(false)
+				.refundMode(RefundMode.APPLY_TO_EXCEEDING_QTY)
+				.build();
+
+		final RefundConfig refundConfig_15 = RefundConfig.builder()
+				.id(RefundConfigId.ofRepoId(1000002))
+				.minQty(FIFTEEN)
+				.refundInvoiceType(RefundInvoiceType.INVOICE)
+				.refundBase(RefundBase.PERCENTAGE)
+				.percent(Percent.of(new BigDecimal("20")))
+				.productId(ProductId.ofRepoId(2005577))
+				.invoiceSchedule(InvoiceSchedule.builder()
+						.id(InvoiceScheduleId.ofRepoId(540006))
+						.frequency(Frequency.MONTLY)
+						.invoiceDayOfMonth(30)
+						.invoiceDistance(6)
+						.build())
+				.conditionsId(ConditionsId.ofRepoId(1000017))
+				.useInProfitCalculation(false)
+				.refundMode(RefundMode.APPLY_TO_EXCEEDING_QTY)
+				.build();
+
+		final RefundContract refundContract = RefundContract.builder()
+				.id(FlatrateTermId.ofRepoId(1000000))
+				.refundConfig(refundConfig_15)
+				.refundConfig(refundConfig_0)
+				.startDate(LocalDate.parse("2018-12-01"))
+				.endDate(LocalDate.parse("2019-11-30"))
+				.bPartnerId(BPartnerId.ofRepoId(2156423))
+				.build();
+
+		final RefundInvoiceCandidate refundCandidate_26 = RefundInvoiceCandidate
+				.builder()
+				.id(InvoiceCandidateId.ofRepoId(1000024))
+				.bpartnerId(BPartnerId.ofRepoId(2156423))
+				.invoiceableFrom(LocalDate.parse("2019-11-30"))
+				.refundContract(refundContract)
+				.refundConfig(refundConfig_15)
+				.money(Money.of(new BigDecimal("5.2"), CurrencyId.ofRepoId(102)))
+				.assignedQuantity(Quantity.of(TWENTY_SIX, uomRecord))
+				.build();
+
+		final Money money_1_40 = Money.of(new BigDecimal("1.4"), CurrencyId.ofRepoId(102));
+		final Money money_2_40 = Money.of(new BigDecimal("2.4"), CurrencyId.ofRepoId(102));
+
+		final RefundInvoiceCandidate refundCandidate_14 = RefundInvoiceCandidate
+				.builder()
+				.id(InvoiceCandidateId.ofRepoId(1000025))
+				.bpartnerId(BPartnerId.ofRepoId(2156423))
+				.invoiceableFrom(LocalDate.parse("2019-11-30"))
+				.refundContract(refundContract)
+				.refundConfig(refundConfig_0)
+				.money(money_1_40)
+				.assignedQuantity(Quantity.of(FOURTEEN, uomRecord))
+
+				.build();
+
+		final AssignableInvoiceCandidate assignableCandidate = AssignableInvoiceCandidate.builder()
+				.repoId(InvoiceCandidateId.ofRepoId(1000023))
+				.bpartnerId(BPartnerId.ofRepoId(2156423))
+				.productId(ProductId.ofRepoId(2005577))
+				.invoiceableFrom(LocalDate.parse("2018-12-17"))
+				.money(Money.of(TWENTY_SIX, CurrencyId.ofRepoId(102)))
+				.precision(2)
+				.quantity(Quantity.of(TWENTY_SIX, uomRecord))
+				.assignmentToRefundCandidate(AssignmentToRefundCandidate
+						.builder()
+						.refundConfigId(RefundConfigId.ofRepoId(1000002))
+						.assignableInvoiceCandidateId(InvoiceCandidateId.ofRepoId(1000023))
+						.refundInvoiceCandidate(refundCandidate_26)
+						.moneyBase(Money.of(TWELVE, CurrencyId.ofRepoId(102)))
+						.moneyAssignedToRefundCandidate(money_2_40)
+						.quantityAssigendToRefundCandidate(Quantity.of(TWELVE, uomRecord))
+						.useAssignedQtyInSum(true)
+						.build())
+				.assignmentToRefundCandidate(AssignmentToRefundCandidate
+						.builder()
+						.refundConfigId(RefundConfigId.ofRepoId(1000001))
+						.assignableInvoiceCandidateId(InvoiceCandidateId.ofRepoId(1000023))
+						.refundInvoiceCandidate(refundCandidate_14)
+						.moneyBase(Money.of(FOURTEEN, CurrencyId.ofRepoId(102)))
+						.moneyAssignedToRefundCandidate(money_1_40)
+						.quantityAssigendToRefundCandidate(Quantity.of(FOURTEEN, uomRecord))
+						.useAssignedQtyInSum(true)
+						.build())
+				.build();
+
+		final CandidateAssignmentService candidateAssignmentService = new CandidateAssignmentService(
+				refundContractRepository,
+				refundInvoiceCandidateService,
+				assignableInvoiceCandidateRepository,
+				assignmentToRefundCandidateRepository,
+				refundInvoiceCandidateRepository,
+				refundConfigChangeService);
+
+		// invoke the method under test
+		final UnassignResult result = candidateAssignmentService.unassignSingleCandidate(assignableCandidate);
+
+		final AssignableInvoiceCandidate resultAssignableCandidate = result.getAssignableCandidate();
+		assertThat(resultAssignableCandidate.getAssignmentsToRefundCandidates()).isEmpty();
+		assertThat(resultAssignableCandidate.isAssigned()).isFalse();
+
+		final List<UnassignedPairOfCandidates> resultUnassignedPairs = result.getUnassignedPairs();
+		assertThat(resultUnassignedPairs)
+				.hasSize(2)
+				.allSatisfy(p -> assertThat(p.getAssignableInvoiceCandidate().getRepoId()).isEqualTo(InvoiceCandidateId.ofRepoId(1000023)))
+				.anySatisfy(p -> assertThat(p.getUnassignedQuantity().getAsBigDecimal()).isEqualByComparingTo(TWELVE))
+				.anySatisfy(p -> assertThat(p.getUnassignedQuantity().getAsBigDecimal()).isEqualByComparingTo(FOURTEEN));
+
+		assertThat(resultUnassignedPairs)
+				.filteredOn(p -> p.getUnassignedQuantity().getAsBigDecimal().compareTo(TWELVE) == 0)
+				.hasSize(1)
+				.allSatisfy(p -> assertThat(p.getRefundInvoiceCandidate().getId()).isEqualTo(refundCandidate_26.getId()))
+				.allSatisfy(p -> assertThat(p.getRefundInvoiceCandidate().getAssignedQuantity().getAsBigDecimal()).isEqualTo(FOURTEEN)/* 26-12 */)
+				.allSatisfy(p -> assertThat(p.getRefundInvoiceCandidate().getMoney().getValue()).isEqualByComparingTo(new BigDecimal("2.8"))) /*5.2 - (20% of 12=2.4)*/
+				.allSatisfy(p -> assertThat(p.getRefundInvoiceCandidate().getRefundConfigs()).hasSize(1))
+				.allSatisfy(p -> assertThat(p.getRefundInvoiceCandidate().getRefundConfigs().get(0).getMinQty()).isEqualByComparingTo(FIFTEEN));
+
+		assertThat(resultUnassignedPairs)
+				.filteredOn(p -> p.getUnassignedQuantity().getAsBigDecimal().compareTo(FOURTEEN) == 0)
+				.hasSize(1)
+				.allSatisfy(p -> assertThat(p.getRefundInvoiceCandidate().getId()).isEqualTo(refundCandidate_14.getId()))
+				.allSatisfy(p -> assertThat(p.getRefundInvoiceCandidate().getAssignedQuantity().getAsBigDecimal()).isZero()/* 14-14 */)
+				.allSatisfy(p -> assertThat(p.getRefundInvoiceCandidate().getMoney().getValue()).isZero()) /**/
+				.allSatisfy(p -> assertThat(p.getRefundInvoiceCandidate().getRefundConfigs()).hasSize(1))
+				.allSatisfy(p -> assertThat(p.getRefundInvoiceCandidate().getRefundConfigs().get(0).getMinQty()).isEqualByComparingTo(ZERO));
+
+	}
+}

--- a/de.metas.contracts/src/test/java/de/metas/contracts/refund/RefundInvoiceCandidateServiceTest.java
+++ b/de.metas.contracts/src/test/java/de/metas/contracts/refund/RefundInvoiceCandidateServiceTest.java
@@ -104,7 +104,7 @@ public class RefundInvoiceCandidateServiceTest
 		conditionsId = ConditionsId.ofRepoId(20);
 		refundConfigRecords = createAndVerifyBaseRefundconfigs(conditionsId);
 
-		assignableInvoiceCandidateRepository = new AssignableInvoiceCandidateRepository(new AssignableInvoiceCandidateFactory());
+		assignableInvoiceCandidateRepository = new AssignableInvoiceCandidateRepository(AssignableInvoiceCandidateFactory.newForUnitTesting());
 
 		final InvoiceScheduleRepository invoiceScheduleRepository = new InvoiceScheduleRepository();
 

--- a/de.metas.contracts/src/test/java/de/metas/contracts/refund/RefundTestTools.java
+++ b/de.metas.contracts/src/test/java/de/metas/contracts/refund/RefundTestTools.java
@@ -51,7 +51,6 @@ import de.metas.quantity.Quantity;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import de.metas.util.lang.Percent;
-
 import lombok.Getter;
 import lombok.NonNull;
 
@@ -175,7 +174,7 @@ public class RefundTestTools
 	 */
 	public RefundInvoiceCandidate createRefundCandidate()
 	{
-		final RefundContract refundContract = createRefundContract();
+		final RefundContract refundContract = createRefundContract_APPLY_TO_ALL_QTIES();
 
 		return createRefundCandidate(refundContract);
 	}
@@ -205,7 +204,10 @@ public class RefundTestTools
 				.get();
 	}
 
-	public RefundContract createRefundContract()
+	/**
+	 * Creates a refund contract with a single config that has {@link RefundMode#APPLY_TO_ALL_QTIES}, i.e. {@link X_C_Flatrate_RefundConfig#REFUNDMODE_Accumulated}.
+	 */
+	public RefundContract createRefundContract_APPLY_TO_ALL_QTIES()
 	{
 		final I_C_InvoiceSchedule invoiceScheduleRecord = newInstance(I_C_InvoiceSchedule.class);
 		invoiceScheduleRecord.setInvoiceFrequency(X_C_InvoiceSchedule.INVOICEFREQUENCY_Daily);
@@ -237,33 +239,6 @@ public class RefundTestTools
 
 		final RefundContractRepository refundContractRepository = new RefundContractRepository(new RefundConfigRepository(new InvoiceScheduleRepository()));
 		return refundContractRepository.getById(FlatrateTermId.ofRepoId(contractRecord.getC_Flatrate_Term_ID()));
-		//
-		// final InvoiceSchedule invoiceSchedule = InvoiceSchedule
-		// .builder()
-		// .id(InvoiceScheduleId.ofRepoId(invoiceScheduleRecord.getC_InvoiceSchedule_ID()))
-		// .frequency(Frequency.DAILY)
-		// .build();
-		//
-		// final RefundConfig refundConfig = RefundConfig
-		// .builder()
-		// .id(RefundConfigId.ofRepoId(refundConfigRecord.getC_Flatrate_RefundConfig_ID()))
-		// .productId(ProductId.ofRepoId(productRecord.getM_Product_ID()))
-		// .minQty(ZERO)
-		// .refundBase(RefundBase.PERCENTAGE)
-		// .percent(Percent.of(TWENTY))
-		// .conditionsId(ConditionsId.ofRepoId(contractRecord.getC_Flatrate_Conditions_ID()))
-		// .invoiceSchedule(invoiceSchedule)
-		// .refundInvoiceType(RefundInvoiceType.INVOICE) // keep in sync with the C_DocType's subType that we set up in the constructor.
-		// .refundMode(RefundMode.ALL_MAX_SCALE)
-		// .build();
-		//
-		// final RefundContract refundContract = RefundContract.builder()
-		// .id(FlatrateTermId.ofRepoId(contractRecord.getC_Flatrate_Term_ID()))
-		// .refundConfig(refundConfig)
-		// .startDate(CONTRACT_START_DATE)
-		// .endDate(CONTRACT_END_DATE)
-		// .build();
-		// return refundContract;
 	}
 
 	public AssignableInvoiceCandidate createAssignableCandidateStandlone()
@@ -315,7 +290,7 @@ public class RefundTestTools
 				assignableInvoiceCandidate.getMoney(),
 				Money.of(TWO, reloadedRefundCandidate.getMoney().getCurrencyId()),
 				Quantity.of(ONE, uomRecord),
-				true /*useAssignedQtyInSum*/);
+				true /* useAssignedQtyInSum */);
 		return assignableInvoiceCandidate
 				.toBuilder()
 				.assignmentToRefundCandidate(assignementToRefundCandidate)

--- a/de.metas.contracts/src/test/java/de/metas/contracts/refund/exceedingqty/CandidateAssignServiceExceedingQty_Mocked_Test.java
+++ b/de.metas.contracts/src/test/java/de/metas/contracts/refund/exceedingqty/CandidateAssignServiceExceedingQty_Mocked_Test.java
@@ -1,0 +1,252 @@
+package de.metas.contracts.refund.exceedingqty;
+
+import static java.math.BigDecimal.TEN;
+import static java.math.BigDecimal.ZERO;
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_UOM;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import de.metas.adempiere.model.I_C_Currency;
+import de.metas.bpartner.BPartnerId;
+import de.metas.contracts.ConditionsId;
+import de.metas.contracts.FlatrateTermId;
+import de.metas.contracts.refund.AssignableInvoiceCandidate;
+import de.metas.contracts.refund.AssignmentAggregateService;
+import de.metas.contracts.refund.AssignmentToRefundCandidate;
+import de.metas.contracts.refund.AssignmentToRefundCandidateRepository;
+import de.metas.contracts.refund.CandidateAssignmentService.UpdateAssignmentResult;
+import de.metas.contracts.refund.RefundConfig;
+import de.metas.contracts.refund.RefundConfig.RefundBase;
+import de.metas.contracts.refund.RefundConfig.RefundInvoiceType;
+import de.metas.contracts.refund.RefundConfig.RefundMode;
+import de.metas.contracts.refund.RefundConfigId;
+import de.metas.contracts.refund.RefundContract;
+import de.metas.contracts.refund.RefundInvoiceCandidate;
+import de.metas.contracts.refund.RefundInvoiceCandidateFactory;
+import de.metas.contracts.refund.RefundInvoiceCandidateRepository;
+import de.metas.contracts.refund.RefundInvoiceCandidateService;
+import de.metas.invoice.InvoiceSchedule;
+import de.metas.invoice.InvoiceSchedule.Frequency;
+import de.metas.invoice.InvoiceScheduleId;
+import de.metas.invoicecandidate.InvoiceCandidateId;
+import de.metas.money.CurrencyId;
+import de.metas.money.CurrencyRepository;
+import de.metas.money.Money;
+import de.metas.money.MoneyService;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.util.lang.Percent;
+import mockit.Mocked;
+import mockit.Tested;
+
+/*
+ * #%L
+ * de.metas.contracts
+ * %%
+ * Copyright (C) 2018 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+public class CandidateAssignServiceExceedingQty_Mocked_Test
+{
+	private static final CurrencyId CURRENCY_ID = CurrencyId.ofRepoId(102);
+
+	private static final BigDecimal FOURTEEN = new BigDecimal("14");
+
+	private static final BigDecimal TWELVE = new BigDecimal("12");
+
+	private static final BigDecimal TWENTY_SIX = new BigDecimal("26");
+
+	@Tested
+	private CandidateAssignServiceExceedingQty candidateAssignServiceExceedingQty;
+
+	@Mocked
+	private RefundInvoiceCandidateRepository refundInvoiceCandidateRepository;
+
+	@Mocked
+	private AssignmentToRefundCandidateRepository assignmentToRefundCandidateRepository;
+
+	@Mocked
+	private RefundInvoiceCandidateFactory refundInvoiceCandidateFactory;
+
+	@Mocked
+	private AssignmentAggregateService assignmentAggregateService;
+
+	@Before
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		final I_C_Currency currencyRecord = newInstance(I_C_Currency.class);
+		currencyRecord.setC_Currency_ID(CURRENCY_ID.getRepoId());
+		currencyRecord.setStdPrecision(2);
+		saveRecord(currencyRecord);
+
+		final RefundInvoiceCandidateService refundInvoiceCandidateService = new RefundInvoiceCandidateService(
+				refundInvoiceCandidateRepository,
+				refundInvoiceCandidateFactory,
+				new MoneyService(new CurrencyRepository()),
+				assignmentAggregateService);
+
+		candidateAssignServiceExceedingQty = new CandidateAssignServiceExceedingQty(
+				refundInvoiceCandidateRepository,
+				refundInvoiceCandidateService,
+				assignmentToRefundCandidateRepository);
+	}
+
+	@Test
+	public void updateAssignment()
+	{
+		final I_C_UOM uomRecord = newInstance(I_C_UOM.class);
+
+		final RefundConfig refundConfig_0 = RefundConfig.builder()
+				.id(RefundConfigId.ofRepoId(1000001))
+				.minQty(ZERO)
+				.refundInvoiceType(RefundInvoiceType.INVOICE)
+				.refundBase(RefundBase.PERCENTAGE)
+				.percent(Percent.of(TEN))
+				.productId(ProductId.ofRepoId(2005577))
+				.invoiceSchedule(InvoiceSchedule.builder()
+						.id(InvoiceScheduleId.ofRepoId(540006))
+						.frequency(Frequency.MONTLY)
+						.invoiceDayOfMonth(30)
+						.invoiceDistance(6)
+						.build())
+				.conditionsId(ConditionsId.ofRepoId(1000017))
+				.useInProfitCalculation(false)
+				.refundMode(RefundMode.APPLY_TO_EXCEEDING_QTY)
+				.build();
+
+		final RefundConfig refundConfig_15 = RefundConfig.builder()
+				.id(RefundConfigId.ofRepoId(1000002))
+				.minQty(new BigDecimal("15"))
+				.refundInvoiceType(RefundInvoiceType.INVOICE)
+				.refundBase(RefundBase.PERCENTAGE)
+				.percent(Percent.of(new BigDecimal("20")))
+				.productId(ProductId.ofRepoId(2005577))
+				.invoiceSchedule(InvoiceSchedule.builder()
+						.id(InvoiceScheduleId.ofRepoId(540006))
+						.frequency(Frequency.MONTLY)
+						.invoiceDayOfMonth(30)
+						.invoiceDistance(6)
+						.build())
+				.conditionsId(ConditionsId.ofRepoId(1000017))
+				.useInProfitCalculation(false)
+				.refundMode(RefundMode.APPLY_TO_EXCEEDING_QTY)
+				.build();
+
+		final RefundContract refundContract = RefundContract.builder()
+				.id(FlatrateTermId.ofRepoId(1000000))
+				.refundConfig(refundConfig_15)
+				.refundConfig(refundConfig_0)
+				.startDate(LocalDate.parse("2018-12-01"))
+				.endDate(LocalDate.parse("2019-11-30"))
+				.bPartnerId(BPartnerId.ofRepoId(2156423))
+				.build();
+
+		final Money money_2_80 = Money.of(new BigDecimal("2.8"), CURRENCY_ID);
+		final RefundInvoiceCandidate refundCandidate_14 = RefundInvoiceCandidate
+				.builder()
+				.id(InvoiceCandidateId.ofRepoId(1000024))
+				.bpartnerId(BPartnerId.ofRepoId(2156423))
+				.invoiceableFrom(LocalDate.parse("2019-11-30"))
+				.refundContract(refundContract)
+				.refundConfig(refundConfig_15)
+				.money(money_2_80)
+				.assignedQuantity(Quantity.of(FOURTEEN, uomRecord))
+				.build();
+
+		final Money money_1_40 = Money.of(new BigDecimal("1.4"), CURRENCY_ID);
+		final Money money_2_40 = Money.of(new BigDecimal("2.4"), CURRENCY_ID);
+
+		final RefundInvoiceCandidate refundCandidate_0 = RefundInvoiceCandidate
+				.builder()
+				.id(InvoiceCandidateId.ofRepoId(1000025))
+				.bpartnerId(BPartnerId.ofRepoId(2156423))
+				.invoiceableFrom(LocalDate.parse("2019-11-30"))
+				.refundContract(refundContract)
+				.refundConfig(refundConfig_0)
+				.money(Money.zero(CURRENCY_ID))
+				// .assignedQuantity(Quantity.of(new BigDecimal("14"), uomRecord))
+				.assignedQuantity(Quantity.zero(uomRecord))
+				.build();
+
+		final AssignableInvoiceCandidate assignableCandidate = AssignableInvoiceCandidate.builder()
+				.repoId(InvoiceCandidateId.ofRepoId(1000023))
+				.bpartnerId(BPartnerId.ofRepoId(2156423))
+				.productId(ProductId.ofRepoId(2005577))
+				.invoiceableFrom(LocalDate.parse("2018-12-17"))
+				.money(Money.of(TWENTY_SIX, CURRENCY_ID))
+				.precision(2)
+				.quantity(Quantity.of(TWENTY_SIX, uomRecord))
+				.assignmentToRefundCandidate(AssignmentToRefundCandidate
+						.builder()
+						.refundConfigId(RefundConfigId.ofRepoId(1000002))
+						.assignableInvoiceCandidateId(InvoiceCandidateId.ofRepoId(1000023))
+						.refundInvoiceCandidate(refundCandidate_14)
+						.moneyBase(Money.of(TWELVE, CURRENCY_ID))
+						.moneyAssignedToRefundCandidate(money_2_40)
+						.quantityAssigendToRefundCandidate(Quantity.of(TWELVE, uomRecord))
+						.useAssignedQtyInSum(true)
+						.build())
+				.assignmentToRefundCandidate(AssignmentToRefundCandidate
+						.builder()
+						.refundConfigId(RefundConfigId.ofRepoId(1000001))
+						.assignableInvoiceCandidateId(InvoiceCandidateId.ofRepoId(1000023))
+						.refundInvoiceCandidate(refundCandidate_0)
+						.moneyBase(Money.of(FOURTEEN, CURRENCY_ID))
+						.moneyAssignedToRefundCandidate(money_1_40)
+						.quantityAssigendToRefundCandidate(Quantity.of(FOURTEEN, uomRecord))
+						.useAssignedQtyInSum(true)
+						.build())
+				.build();
+
+		final List<RefundInvoiceCandidate> refundCandidatesToAssignTo = ImmutableList.of(
+				refundCandidate_14,
+				refundCandidate_0);
+
+		// invoke the method under test
+		final UpdateAssignmentResult updateAssignment = candidateAssignServiceExceedingQty.updateAssignment(assignableCandidate, refundCandidatesToAssignTo, refundContract);
+
+		assertThat(updateAssignment.isUpdateWasDone()).isTrue();
+
+		final List<AssignmentToRefundCandidate> assignmentsToRefundCandidates = updateAssignment.getAssignableInvoiceCandidate().getAssignmentsToRefundCandidates();
+		assertThat(assignmentsToRefundCandidates).hasSize(2);
+
+		final Optional<AssignmentToRefundCandidate> candidate_0 = assignmentsToRefundCandidates.stream().filter(a -> a.getRefundConfigId().equals(refundConfig_0.getId())).findAny();
+		assertThat(candidate_0)
+				.isPresent()
+				.hasValueSatisfying(a -> assertThat(a.getMoneyAssignedToRefundCandidate()).isEqualTo(money_1_40));
+
+		final Optional<AssignmentToRefundCandidate> candidate_15 = assignmentsToRefundCandidates.stream().filter(a -> a.getRefundConfigId().equals(refundConfig_15.getId())).findAny();
+		assertThat(candidate_15)
+				.isPresent()
+				.hasValueSatisfying(a -> assertThat(a.getMoneyAssignedToRefundCandidate()).isEqualTo(money_2_40));
+	}
+}

--- a/de.metas.contracts/src/test/java/de/metas/contracts/refund/exceedingqty/CandidateAssignServiceExceedingQty_RealRecords_Test.java
+++ b/de.metas.contracts/src/test/java/de/metas/contracts/refund/exceedingqty/CandidateAssignServiceExceedingQty_RealRecords_Test.java
@@ -22,7 +22,6 @@ import de.metas.contracts.refund.RefundInvoiceCandidateFactory;
 import de.metas.contracts.refund.RefundInvoiceCandidateRepository;
 import de.metas.contracts.refund.RefundInvoiceCandidateService;
 import de.metas.contracts.refund.RefundTestTools;
-import de.metas.contracts.refund.exceedingqty.CandidateAssignServiceExceedingQty;
 import de.metas.invoice.InvoiceScheduleRepository;
 import de.metas.invoicecandidate.InvoiceCandidateId;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
@@ -52,12 +51,13 @@ import de.metas.quantity.Quantity;
  * #L%
  */
 
-public class CandidateAssignServiceCurrentMinQtyConfigTest
+public class CandidateAssignServiceExceedingQty_RealRecords_Test
 {
-	private static final BigDecimal TWO = new BigDecimal("2");;
+	private static final BigDecimal TWO = new BigDecimal("2");
 
 	private static final BigDecimal HUNDRED = new BigDecimal("100");
-	private CandidateAssignServiceExceedingQty candidateAssignServiceCurrentMinQtyConfig;
+
+	private CandidateAssignServiceExceedingQty candidateAssignServiceExceedingQty;
 
 	private RefundTestTools refundTestTools;
 
@@ -86,7 +86,7 @@ public class CandidateAssignServiceCurrentMinQtyConfigTest
 				moneyService,
 				assignmentAggregateService);
 
-		candidateAssignServiceCurrentMinQtyConfig = new CandidateAssignServiceExceedingQty(
+		candidateAssignServiceExceedingQty = new CandidateAssignServiceExceedingQty(
 				refundInvoiceCandidateRepository,
 				refundInvoiceCandidateService,
 				assignmentToRefundCandidateRepository);
@@ -109,7 +109,7 @@ public class CandidateAssignServiceCurrentMinQtyConfigTest
 
 		// invoke the method under test
 		final IPair<AssignableInvoiceCandidate, Quantity> result = //
-				candidateAssignServiceCurrentMinQtyConfig.assignCandidates(
+				candidateAssignServiceExceedingQty.assignCandidates(
 						assignCandidatesRequest,
 						assignableCandidate.getQuantity());
 

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
@@ -462,4 +462,6 @@ public interface IInvoiceCandBL extends ISingletonService
 
 	void markInvoiceCandInDisputeForReceiptLine(I_M_InOutLine inOutLine);
 
+	void set_DateToInvoice_DefaultImpl(I_C_Invoice_Candidate ic);
+
 }

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandidateHandlerBL.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandidateHandlerBL.java
@@ -110,7 +110,7 @@ public interface IInvoiceCandidateHandlerBL extends ISingletonService
 
 	void setBPartnerData(I_C_Invoice_Candidate ic);
 
-	void setInvoiceSchedule(I_C_Invoice_Candidate ic);
+	void setInvoiceScheduleAndDateToInvoice(I_C_Invoice_Candidate ic);
 
 	void setLineNetAmt(I_C_Invoice_Candidate ic);
 }

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -185,11 +185,10 @@ public class InvoiceCandBL implements IInvoiceCandBL
 	 * <li>else (which should not happen, unless a new invoice rule is introduced): <code>Created</code>
 	 * </ul>
 	 *
-	 * @param ctx
-	 * @param ic
 	 * @task 08542
 	 */
-	void set_DateToInvoice(final Properties ctx, final I_C_Invoice_Candidate ic)
+	@Override
+	public void set_DateToInvoice_DefaultImpl(final I_C_Invoice_Candidate ic)
 	{
 		final Timestamp dateToInvoice;
 

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandInvalidUpdater.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandInvalidUpdater.java
@@ -282,7 +282,7 @@ import lombok.NonNull;
 		// update BPartner data from 'ic'
 		invoiceCandidateHandlerBL.setBPartnerData(ic);
 
-		invoiceCandidateHandlerBL.setInvoiceSchedule(ic);
+		invoiceCandidateHandlerBL.setInvoiceScheduleAndDateToInvoice(ic);
 
 		invoiceCandBL.set_QtyInvoiced_NetAmtInvoiced_Aggregation0(ctx, ic);
 
@@ -324,8 +324,6 @@ import lombok.NonNull;
 
 		// Note: ic.setProcessed is not invoked here, but in a model validator
 		// That's because QtyToOrder and QtyInvoiced could also be set somewhere else
-
-		invoiceCandBL.set_DateToInvoice(ctx, ic);
 
 		// We need to update the NetAmtToInvoice again because in some cases this value depends on overall in invoiceable amount
 		// e.g. see ManualCandidateHandler which is calculated how much we can invoice of a credit memo amount

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateHandlerBL.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateHandlerBL.java
@@ -526,10 +526,10 @@ public class InvoiceCandidateHandlerBL implements IInvoiceCandidateHandlerBL
 	}
 
 	@Override
-	public void setInvoiceSchedule(@NonNull final I_C_Invoice_Candidate ic)
+	public void setInvoiceScheduleAndDateToInvoice(@NonNull final I_C_Invoice_Candidate ic)
 	{
 		final IInvoiceCandidateHandler handler = createInvoiceCandidateHandler(ic);
-		handler.setInvoiceSchedule(ic);
+		handler.setInvoiceScheduleAndDateToInvoice(ic);
 	}
 
 	@Override

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/IInvoiceCandidateHandler.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/IInvoiceCandidateHandler.java
@@ -33,12 +33,14 @@ import org.adempiere.model.InterfaceWrapperHelper;
 
 import com.google.common.collect.ImmutableList;
 
+import de.metas.invoicecandidate.api.IInvoiceCandBL;
 import de.metas.invoicecandidate.api.IInvoiceCandidateHandlerBL;
 import de.metas.invoicecandidate.model.I_C_ILCandHandler;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.money.CurrencyId;
 import de.metas.pricing.PriceListVersionId;
 import de.metas.pricing.PricingSystemId;
+import de.metas.util.Services;
 import de.metas.util.lang.Percent;
 import lombok.NonNull;
 
@@ -254,9 +256,11 @@ public interface IInvoiceCandidateHandler
 	 */
 	void setBPartnerData(I_C_Invoice_Candidate ic);
 
-	default void setInvoiceSchedule(@NonNull final I_C_Invoice_Candidate ic)
+	default void setInvoiceScheduleAndDateToInvoice(@NonNull final I_C_Invoice_Candidate ic)
 	{
 		ic.setC_InvoiceSchedule_ID(ic.getBill_BPartner().getC_InvoiceSchedule_ID());
+
+		Services.get(IInvoiceCandBL.class).set_DateToInvoice_DefaultImpl(ic);
 	}
 
 	/**


### PR DESCRIPTION
* fix: the refund invoice candidates' DateToInvoice is computed correctly
  * it's now based on the start date of the respective contract
  * with this fix, we don't accidentally create too many refund invoice candidates anymore
* fix: if an assignable candidate is "moved" out of a contract's scope (e.g. by changing its dateToInvoice), then the assignments are removed
* fix: if a refund candidate with a tiered contract is invoiced, the assigments etws stay the same
* add comments etc

https://github.com/metasfresh/metasfresh/issues/4475