### PR TITLE
4798-app - AD_RefList Description shall be shown in webui

### DIFF
--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/adempiere/plaf/AdempierePLAF.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/adempiere/plaf/AdempierePLAF.java
@@ -303,10 +303,10 @@ public final class AdempierePLAF
 		final List<ValueNamePair> lafList = new ArrayList<>();
 		final List<ValueNamePair> plasticThemes = new ArrayList<>();
 
-		final ValueNamePair lafAdempiere = new ValueNamePair(AdempiereLookAndFeel.class.getName(), AdempiereLookAndFeel.NAME);
+		final ValueNamePair lafAdempiere = ValueNamePair.of(AdempiereLookAndFeel.class.getName(), AdempiereLookAndFeel.NAME);
 		lafList.add(lafAdempiere);
 
-		final ValueNamePair metasFreshTheme = new ValueNamePair(MetasFreshTheme.class.getName(), MetasFreshTheme.NAME);
+		final ValueNamePair metasFreshTheme = ValueNamePair.of(MetasFreshTheme.class.getName(), MetasFreshTheme.NAME);
 		plasticThemes.add(metasFreshTheme);
 
 		//

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/Lookup.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/Lookup.java
@@ -48,7 +48,7 @@ public abstract class Lookup extends AbstractListModel
 	implements MutableComboBoxModel, Serializable
 {
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = -2811763289904455349L;
 
@@ -79,9 +79,9 @@ public abstract class Lookup extends AbstractListModel
 	private final int m_displayType;
 	/**	Window No				*/
 	private final int m_WindowNo;
-	
+
 	private boolean 				m_mandatory;
-	
+
 	private boolean					m_loaded;
 
 	/**
@@ -101,7 +101,7 @@ public abstract class Lookup extends AbstractListModel
 	{
 		return m_WindowNo;
 	}	//	getWindowNo
-	
+
 	/**************************************************************************
 	 * Set the value of the selected item. The selected item may be null.
 	 * <p>
@@ -115,7 +115,7 @@ public abstract class Lookup extends AbstractListModel
 		{
 			return;
 		}
-		
+
 		if ((m_selectedObject != null && !m_selectedObject.equals( anObject ))
 			|| m_selectedObject == null && anObject != null)
 		{
@@ -166,7 +166,7 @@ public abstract class Lookup extends AbstractListModel
 
 	/**
 	 * Returns the index-position of the specified object in the list.
-	 * 
+	 *
 	 * @param anObject object
 	 * @return an int representing the index position, where 0 is the first position, or -1 if this list does not contain the element
 	 */
@@ -246,28 +246,17 @@ public abstract class Lookup extends AbstractListModel
 		m_loaded = false;
 	}   //  removeAllElements
 
-	
-	/**************************************************************************
-	 *	Put Value
-	 *  @param key key
-	 *  @param value value
-	 */
-	public void put (String key, String value)
+	public void put (String key, String value, String help)
 	{
-		NamePair pp = new ValueNamePair (key, value);
+		NamePair pp = ValueNamePair.of(key, value, help);
 		addElement(pp);
-	}	//	put
+	}
 
-	/**
-	 *	Put Value
-	 *  @param key key
-	 *  @param value value
-	 */
-	public void put (int key, String value)
+	public void put (int key, String value, String help)
 	{
-		NamePair pp = new KeyNamePair (key, value);
+		NamePair pp = KeyNamePair.of(key, value, help);
 		addElement(pp);
-	}	//	put
+	}
 
 	/**
 	 *  Fill ComboBox with lookup data (async using Worker).
@@ -298,7 +287,7 @@ public abstract class Lookup extends AbstractListModel
 
 		//  may cause delay *** The Actual Work ***
 		p_data = getData (mandatory, onlyValidated, onlyActive, temporary);
-		
+
 		//  Selected Object changed
 		if (selectedObjectOld != m_selectedObject)
 		{
@@ -314,8 +303,8 @@ public abstract class Lookup extends AbstractListModel
 		// 	log.trace(getColumnName() + ": SelectedValue SetToFirst=" + obj);
 		// //	fireContentsChanged(this, -1, -1);
 		// }
-		
-		m_loaded = true; 
+
+		m_loaded = true;
 		if (p_data.isEmpty())
 		{
 			fireContentsChanged(this, -1, -1);
@@ -348,7 +337,7 @@ public abstract class Lookup extends AbstractListModel
 			if (obj == null && p_data.size() > 0)
 				obj = p_data.get(0);
 			setSelectedItem(obj);
-			
+
 			fireContentsChanged(this, 0, p_data.size());
 			return;
 		}
@@ -356,12 +345,12 @@ public abstract class Lookup extends AbstractListModel
 			fillComboBox(isMandatory(), true, true, false);
 	}   //  fillComboBox
 
-	
+
 	/**
 	 * Get Display of Key Value
-	 * 
+	 *
 	 * NOTE: this method is checking if given key is valid in given context
-	 * 
+	 *
 	 * @param evalCtx
 	 * @param key key
 	 * @return String
@@ -370,9 +359,9 @@ public abstract class Lookup extends AbstractListModel
 
 	/**
 	 * Get Display of Key Value.
-	 * 
+	 *
 	 * NOTE: this method is not validating the record
-	 * 
+	 *
 	 * @param key
 	 * @return
 	 */
@@ -383,8 +372,8 @@ public abstract class Lookup extends AbstractListModel
 
 	/**
 	 * Get Object of Key Value
-	 * 
-	 * @param evalCtx evaluation context to be used 
+	 *
+	 * @param evalCtx evaluation context to be used
 	 * @param key key
 	 * @return Object or null
 	 */
@@ -392,9 +381,9 @@ public abstract class Lookup extends AbstractListModel
 
 	/**
 	 * Get Object of Key Value.
-	 * 
+	 *
 	 * NOTE: no validation will be performed
-	 * 
+	 *
 	 * @param key key
 	 * @return Object or null
 	 */
@@ -416,27 +405,27 @@ public abstract class Lookup extends AbstractListModel
 
 	/**
 	 * Gets Lookup TableName or null if the lookup is not based on a particular table
-	 * 
+	 *
 	 * @return TableName or null
 	 */
 	public abstract String getTableName();
-	
+
 	/** @return true if this lookup shall enable autocomplete feature in UI */
 	public boolean isAutoComplete()
 	{
 		return false;
 	}
-	
+
 	/**
 	 *	Get underlying fully qualified Table.Column Name.
 	 *	Used for VLookup.actionButton (Zoom)
 	 *  @return column name
 	 */
 	public abstract String getColumnName();
-	
+
 	/**
 	 * Get underlying NOT fully qualified Column Name.
-	 * 
+	 *
 	 * @return not fully qualified column name
 	 */
 	public abstract String getColumnNameNotFQ();
@@ -448,13 +437,13 @@ public abstract class Lookup extends AbstractListModel
 	 *  @return true if contains key
 	 */
 	public abstract boolean containsKey (final IValidationContext evalCtx, final Object key);
-	
+
 	public final boolean containsKey (Object key)
 	{
 		return containsKey(IValidationContext.DISABLED, key);
 	}
 
-	
+
 	/**************************************************************************
 	 *	Refresh Values - default implementation
 	 *  @return size
@@ -482,7 +471,7 @@ public abstract class Lookup extends AbstractListModel
 	{
 		return "";
 	}   //  getValidation
-	
+
 	public boolean hasValidation()
 	{
 		return !Check.isEmpty(getValidation(), true);
@@ -558,7 +547,7 @@ public abstract class Lookup extends AbstractListModel
 	public void loadComplete()
 	{
 	}   //  loadComplete
-	
+
 	/**
 	 * Set lookup model as mandatory, use in loading data
 	 * @param flag
@@ -567,7 +556,7 @@ public abstract class Lookup extends AbstractListModel
 	{
 		m_mandatory = flag;
 	}
-	
+
 	/**
 	 * Is lookup model mandatory
 	 * @return boolean
@@ -576,30 +565,30 @@ public abstract class Lookup extends AbstractListModel
 	{
 		return m_mandatory;
 	}
-	
+
 	/**
 	 * Is this lookup model populated
 	 * @return boolean
 	 */
-	public boolean isLoaded() 
+	public boolean isLoaded()
 	{
 		return m_loaded;
 	}
-	
+
 	/**
 	 * Get custom info factory class
 	 * @return info factory class name
 	 */
-	public String getInfoFactoryClass() 
+	public String getInfoFactoryClass()
 	{
 		return "";
 	}
 
 	/**
 	 * Returns a list of parameters on which this lookup depends.
-	 * 
+	 *
 	 * Those parameters will be fetched from context on validation time.
-	 * 
+	 *
 	 * @return list of parameter names
 	 */
 	public Set<String> getParameters()
@@ -608,7 +597,7 @@ public abstract class Lookup extends AbstractListModel
 	}
 
 	/**
-	 * 
+	 *
 	 * @return evaluation context
 	 */
 	public IValidationContext getValidationContext()
@@ -618,7 +607,7 @@ public abstract class Lookup extends AbstractListModel
 
 	/**
 	 * Suggests a valid value for given value
-	 * 
+	 *
 	 * @param value
 	 * @return equivalent valid value or same this value is valid; if there are no suggestions, null will be returned
 	 */
@@ -630,7 +619,7 @@ public abstract class Lookup extends AbstractListModel
 	/**
 	 * Returns true if given <code>display</code> value was rendered for a not found item.
 	 * To be used together with {@link #getDisplay} methods.
-	 * 
+	 *
 	 * @param display
 	 * @return true if <code>display</code> contains not found markers
 	 */

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MClickCount.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MClickCount.java
@@ -23,6 +23,7 @@ import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Properties;
+
 import org.compiere.util.DB;
 import org.compiere.util.DisplayType;
 import org.compiere.util.ValueNamePair;
@@ -36,7 +37,7 @@ import org.compiere.util.ValueNamePair;
 public class MClickCount extends X_W_ClickCount
 {
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = -5233509415147834823L;
 
@@ -56,11 +57,11 @@ public class MClickCount extends X_W_ClickCount
 		//	setTargetURL (null);
 		}
 	}	//	MClickCount
-	
-	/** 
+
+	/**
 	 * 	Load Constructor
 	 * 	@param ctx context
-	 * 	@param rs result set 
+	 * 	@param rs result set
 	 *	@param trxName transaction
 	 */
 	public MClickCount (Properties ctx, ResultSet rs, String trxName)
@@ -68,7 +69,7 @@ public class MClickCount extends X_W_ClickCount
 		super(ctx, rs, trxName);
 	}	//	MClickCount
 
-	/** 
+	/**
 	 * 	Parent Constructor
 	 * 	@param ad parent
 	 */
@@ -79,11 +80,11 @@ public class MClickCount extends X_W_ClickCount
 		setTargetURL("#");
 		setC_BPartner_ID(ad.getC_BPartner_ID());
 	}	//	MClickCount
-	
+
 	private SimpleDateFormat		m_dateFormat = DisplayType.getDateFormat(DisplayType.Date);
 	private DecimalFormat			m_intFormat = DisplayType.getNumberFormat(DisplayType.Integer);
 
-	
+
 	/**************************************************************************
 	 * 	Get Clicks
 	 *	@return clicks
@@ -121,7 +122,7 @@ public class MClickCount extends X_W_ClickCount
 			{
 				String value = m_dateFormat.format(rs.getTimestamp(1));
 				String name = m_intFormat.format(rs.getInt(2));
-				ValueNamePair pp = new ValueNamePair (value, name);
+				ValueNamePair pp = ValueNamePair.of(value, name);
 				list.add(pp);
 			}
 			rs.close();

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MLookupInfo.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MLookupInfo.java
@@ -1,18 +1,18 @@
 /******************************************************************************
- * Product: Adempiere ERP & CRM Smart Business Solution                       *
- * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
- * This program is free software; you can redistribute it and/or modify it    *
- * under the terms version 2 of the GNU General Public License as published   *
- * by the Free Software Foundation. This program is distributed in the hope   *
+ * Product: Adempiere ERP & CRM Smart Business Solution *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved. *
+ * This program is free software; you can redistribute it and/or modify it *
+ * under the terms version 2 of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope *
  * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
- * See the GNU General Public License for more details.                       *
- * You should have received a copy of the GNU General Public License along    *
- * with this program; if not, write to the Free Software Foundation, Inc.,    *
- * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
- * For the text or an alternative of this public license, you may reach us    *
- * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
- * or via info@compiere.org or http://www.compiere.org/license.html           *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. *
+ * See the GNU General Public License for more details. *
+ * You should have received a copy of the GNU General Public License along *
+ * with this program; if not, write to the Free Software Foundation, Inc., *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA. *
+ * For the text or an alternative of this public license, you may reach us *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA *
+ * or via info@compiere.org or http://www.compiere.org/license.html *
  *****************************************************************************/
 package org.compiere.model;
 
@@ -53,7 +53,7 @@ public final class MLookupInfo implements Serializable, Cloneable
 	/**************************************************************************
 	 * Constructor.
 	 * (called from MLookupFactory)
-	 * 
+	 *
 	 * @param sqlQuery SQL query
 	 * @param tableName table name
 	 * @param keyColumn key column
@@ -88,29 +88,31 @@ public final class MLookupInfo implements Serializable, Cloneable
 
 	/* package */static final CtxName CTXNAME_AD_Language = CtxNames.parse(Env.CTXNAME_AD_Language);
 
-	/** SQL Query */
 	private final TranslatableParameterizedString sqlQuery;
-	/** Table Name */
+
 	private final String TableName;
-	/** Key Column */
+
 	private final String KeyColumn;
-	/** Display Column SQL */
+
 	private TranslatableParameterizedString displayColumnSQL = TranslatableParameterizedString.EMPTY;
 	private List<ILookupDisplayColumn> displayColumns = Collections.emptyList();
+
+	private TranslatableParameterizedString descriptionColumnSQL = TranslatableParameterizedString.EMPTY;
+
 	private TranslatableParameterizedString selectSqlPart = TranslatableParameterizedString.EMPTY;
 	private TranslatableParameterizedString fromSqlPart = TranslatableParameterizedString.EMPTY;
 	private String whereClauseSqlPart = null;
+
 	/** SQL WHERE part (without WHERE keyword); this SQL includes context variables references */
 	private String whereClauseDynamicSqlPart = null;
 	private String orderBySqlPart = null;
+
 	/** True if this lookup does not need security validation (e.g. AD_Ref_Lists does not need security validation) */
 	private boolean securityDisabled = false;
-	/** Zoom Window */
+
 	private final int zoomSO_Window_ID;
 	private final int zoomAD_Window_ID_Override;
-	/** Zoom Window */
 	private final int zoomPO_Window_ID;
-	/** Zoom Query */
 	private final MQuery zoomQuery;
 
 	/** Direct Access Query (i.e. SELECT Key, Value, Name ... FROM TableName WHERE KeyColumn=?) */
@@ -135,12 +137,12 @@ public final class MLookupInfo implements Serializable, Cloneable
 	public String InfoFactoryClass = null;
 	private boolean autoComplete = false;
 	private boolean queryHasEntityType = false;
-	
+
 	private boolean translated = false;
 
 	/**
 	 * String representation
-	 * 
+	 *
 	 * @return info
 	 */
 	@Override
@@ -172,17 +174,17 @@ public final class MLookupInfo implements Serializable, Cloneable
 		}
 		return null;
 	}	// clone
-	
+
 	public int getZoomSO_Window_ID()
 	{
 		return zoomSO_Window_ID;
 	}
-	
+
 	public int getZoomPO_Window_ID()
 	{
 		return zoomPO_Window_ID;
 	}
-	
+
 	public int getZoomAD_Window_ID_Override()
 	{
 		return zoomAD_Window_ID_Override;
@@ -190,7 +192,7 @@ public final class MLookupInfo implements Serializable, Cloneable
 
 	/**
 	 * WARNING: this method is supported to be used EXCLUSIVELLY in Swing UI
-	 * 
+	 *
 	 * @return the whole SQL query, including SELECT, FROM, WHERE, ORDER BY
 	 */
 	public String getSqlQuery()
@@ -215,7 +217,7 @@ public final class MLookupInfo implements Serializable, Cloneable
 
 	/**
 	 * WARNING: this method is supported to be used EXCLUSIVELLY in Swing UI
-	 * 
+	 *
 	 * @return Direct Access Query (i.e. SELECT Key, Value, Name ... FROM TableName WHERE KeyColumn=?)
 	 */
 	public String getSqlQueryDirect()
@@ -302,6 +304,20 @@ public final class MLookupInfo implements Serializable, Cloneable
 	public List<ILookupDisplayColumn> getDisplayColumns()
 	{
 		return displayColumns;
+	}
+
+	public TranslatableParameterizedString getDescriptionColumnSQL()
+	{
+		return descriptionColumnSQL;
+	}
+
+	/* package */ void setDescriptionColumnSQL(
+			final String descriptionColumnSQL_BaseLang,
+			final String descriptionColumnSQL_Trl)
+	{
+		this.descriptionColumnSQL = TranslatableParameterizedString.of(CTXNAME_AD_Language,
+				descriptionColumnSQL_BaseLang,
+				descriptionColumnSQL_Trl);;
 	}
 
 	/**
@@ -398,7 +414,7 @@ public final class MLookupInfo implements Serializable, Cloneable
 	}
 
 	/**
-	 * 
+	 *
 	 * @return true if this lookup does not need security validation (e.g. AD_Ref_Lists does not need security validation)
 	 */
 	public boolean isSecurityDisabled()
@@ -546,12 +562,12 @@ public final class MLookupInfo implements Serializable, Cloneable
 	{
 		return zoomQuery;
 	}
-	
+
 	void setTranslated(final boolean translated)
 	{
 		this.translated = translated;
 	}
-	
+
 	public boolean isTranslated()
 	{
 		return translated;

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/PO.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/PO.java
@@ -16,6 +16,11 @@
  *****************************************************************************/
 package org.compiere.model;
 
+import static org.adempiere.model.InterfaceWrapperHelper.COLUMNNAME_Description;
+import static org.adempiere.model.InterfaceWrapperHelper.COLUMNNAME_DocumentNo;
+import static org.adempiere.model.InterfaceWrapperHelper.COLUMNNAME_Name;
+import static org.adempiere.model.InterfaceWrapperHelper.COLUMNNAME_Value;
+
 import java.io.Serializable;
 import java.io.StringWriter;
 import java.lang.reflect.Constructor;
@@ -464,13 +469,13 @@ public abstract class PO
 		// same class
 		if (o1.getClass().equals(o2.getClass()))
 		{
-			int index = get_ColumnIndex("DocumentNo");
+			int index = get_ColumnIndex(COLUMNNAME_DocumentNo);
 			if (index == -1)
-				index = get_ColumnIndex("Value");
+				index = get_ColumnIndex(COLUMNNAME_Value);
 			if (index == -1)
-				index = get_ColumnIndex("Name");
+				index = get_ColumnIndex(COLUMNNAME_Name);
 			if (index == -1)
-				index = get_ColumnIndex("Description");
+				index = get_ColumnIndex(COLUMNNAME_Description);
 			if (index != -1)
 			{
 				final PO po1 = (PO)o1;

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/print/DataEngine.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/print/DataEngine.java
@@ -50,7 +50,7 @@ import de.metas.util.Check;
  *
  * @author 	Jorg Janke
  * @version 	$Id: DataEngine.java,v 1.3 2006/07/30 00:53:02 jjanke Exp $
- * 
+ *
  * @author Teo Sarca, SC ARHIPAC SERVICE SRL
  * 				<li>BF [ 1761891 ] Included print format with report view attached issue
  * 				<li>BF [ 1807368 ] DataEngine does not close DB connection
@@ -60,7 +60,7 @@ import de.metas.util.Check;
  * @author Teo Sarca, teo.sarca@gmail.com
  * 				<li>BF [ 2876268 ] DataEngine: error on text long fields
  * 					https://sourceforge.net/tracker/?func=detail&aid=2876268&group_id=176962&atid=879332
- * @author victor.perez@e-evolution.com 
+ * @author victor.perez@e-evolution.com
  *				<li>FR [ 2011569 ] Implementing new Summary flag in Report View  http://sourceforge.net/tracker/index.php?func=detail&aid=2011569&group_id=176962&atid=879335
  * @author Paul Bowden (phib)
  * 				<li> BF 2908435 Virtual columns with lookup reference types can't be printed
@@ -76,7 +76,7 @@ public class DataEngine
 	{
 		this(language, null);
 	}	//	DataEngine
-	
+
 	/**
 	 *	Constructor
 	 *	@param language Language of the data (for translation)
@@ -106,7 +106,7 @@ public class DataEngine
 	private String			m_runningTotalString = null;
 	/** TrxName String					*/
 	private String			m_trxName = null;
-	/** Report Summary FR [ 2011569 ]**/ 
+	/** Report Summary FR [ 2011569 ]**/
 	private boolean 		m_summary = false;
 	/** Key Indicator in Report			*/
 	public static final String KEY = "*";
@@ -124,7 +124,7 @@ public class DataEngine
 	{
 		return getPrintData(ctx, format, query, false);
 	}
-	
+
 	/**************************************************************************
 	 * 	Load Data
 	 *
@@ -137,8 +137,8 @@ public class DataEngine
 	public PrintData getPrintData (Properties ctx, MPrintFormat format, MQuery query, boolean summary)
 	{
 
-		/** Report Summary FR [ 2011569 ]**/ 
-		m_summary = summary; 
+		/** Report Summary FR [ 2011569 ]**/
+		m_summary = summary;
 
 		if (format == null)
 			throw new IllegalStateException ("No print format");
@@ -154,7 +154,7 @@ public class DataEngine
 			PreparedStatement pstmt = null;
 			ResultSet rs = null;
 			try
-			{				
+			{
 				pstmt = DB.prepareStatement(sql, m_trxName);
 				pstmt.setInt(1, format.getAD_ReportView_ID());
 				rs = pstmt.executeQuery();
@@ -199,7 +199,7 @@ public class DataEngine
 		return pd;
 	}	//	getPrintData
 
-	
+
 	/**************************************************************************
 	 * 	Create Load SQL and update PrintData Info
 	 *
@@ -310,13 +310,13 @@ public class DataEngine
 					m_group.addFunction(ColumnName, PrintDataFunction.F_DEVIATION);
 				if ("Y".equals(rs.getString(20)))	//	isRunningTotal
 					//	RunningTotalLines only once - use max
-					m_runningTotalLines = Math.max(m_runningTotalLines, rs.getInt(21));	
+					m_runningTotalLines = Math.max(m_runningTotalLines, rs.getInt(21));
 
 				//	General Info
 				boolean IsPrinted = "Y".equals(rs.getString(15));
 				int SortNo = rs.getInt(16);
 				boolean isPageBreak = "Y".equals(rs.getString(17));
-				
+
 				String formatPattern = rs.getString(25);
 
 				//	Fully qualified Table.Column for ordering
@@ -338,7 +338,7 @@ public class DataEngine
 					;
 				}
 				//	-- Parent, TableDir (and unqualified Search) --
-				else if ( (IsParent && DisplayType.isLookup(AD_Reference_ID)) 
+				else if ( (IsParent && DisplayType.isLookup(AD_Reference_ID))
 						|| AD_Reference_ID == DisplayType.TableDir
 						|| (AD_Reference_ID == DisplayType.Search && AD_Reference_Value_ID == 0)
 					)
@@ -414,7 +414,7 @@ public class DataEngine
 				}
 
 				//	-- List or Button with ReferenceValue --
-				else if (AD_Reference_ID == DisplayType.List 
+				else if (AD_Reference_ID == DisplayType.List
 					|| (AD_Reference_ID == DisplayType.Button && AD_Reference_Value_ID != 0))
 				{
 					if (ColumnSQL.length() > 0)
@@ -479,9 +479,9 @@ public class DataEngine
 						lookupSQL = ColumnSQL;
 					}
 					//	TableName, DisplayColumn
-					String table = ""; 
-					String key = ""; 
-					String display = ""; 
+					String table = "";
+					String key = "";
+					String display = "";
 					String synonym = null;
 					//
 					if (AD_Reference_ID == DisplayType.Location)
@@ -568,7 +568,7 @@ public class DataEngine
 							groupByColumns.add(sb.toString());
 						orderName = ColumnName;		//	no prefix for synonym
 					}
-					pdc = new PrintDataColumn(AD_Column_ID, ColumnName, 
+					pdc = new PrintDataColumn(AD_Column_ID, ColumnName,
 						AD_Reference_ID, FieldLength, ColumnName, isPageBreak);
 				}
 
@@ -657,7 +657,7 @@ public class DataEngine
 			if (role.getAD_Role_ID() == 0 && !Ini.isClient())
 				;	//	System Access
 			else
-				finalSQL = new StringBuffer (role.addAccessSQL (finalSQL.toString (), 
+				finalSQL = new StringBuffer (role.addAccessSQL (finalSQL.toString (),
 					tableName, IUserRolePermissions.SQL_FULLYQUALIFIED, IUserRolePermissions.SQL_RO));
 		}
 
@@ -689,7 +689,7 @@ public class DataEngine
 				finalSQL.append(by);
 			}
 		}	//	order by
-		
+
 
 		//	Print Data
 		PrintData pd = new PrintData (ctx, reportName);
@@ -767,7 +767,7 @@ public class DataEngine
 					// TODO: implement support for table references without display column
 					final AdempiereException ex = new AdempiereException("Table references without AD_Display column are not supported (AD_Reference_ID="+AD_Reference_Value_ID+")");
 					log.warn(ex.getLocalizedMessage(), ex);
-					
+
 					// NOTE: until it's fixed it's better to display the KeyColumn instead of letting it fail in other parts.
 					tr.DisplayColumn = tr.KeyColumn;
 				}
@@ -787,7 +787,7 @@ public class DataEngine
 		return tr;
 	}	//  getTableReference
 
-	
+
 	/**************************************************************************
 	 * 	Load Data into PrintData
 	 * 	@param pd print data with SQL and ColumnInfo set
@@ -825,7 +825,7 @@ public class DataEngine
 						PrintDataColumn group_pdc = pd.getColumnInfo()[i];
 						if (!m_group.isGroupColumn(group_pdc.getColumnName()))
 							continue;
-						
+
 						//	Group change
 						Object value = m_group.groupChange(group_pdc.getColumnName(), rs.getObject(group_pdc.getAlias()));
 						if (value != null)	//	Group change
@@ -853,9 +853,9 @@ public class DataEngine
 									else if (m_group.isFunctionColumn(pdc.getColumnName(), functions[f]))
 									{
 										pd.addNode(new PrintDataElement(pdc.getColumnName(),
-											m_group.getValue(group_pdc.getColumnName(), 
-												pdc.getColumnName(), functions[f]), 
-											PrintDataFunction.getFunctionDisplayType(functions[f], pdc.getDisplayType()), 
+											m_group.getValue(group_pdc.getColumnName(),
+												pdc.getColumnName(), functions[f]),
+											PrintDataFunction.getFunctionDisplayType(functions[f], pdc.getDisplayType()),
 												false, pdc.isPageBreak(), pdc.getFormatPattern()));
 									}
 								}	//	 for all columns
@@ -873,8 +873,8 @@ public class DataEngine
 				//	new row ---------------------------------------------------
 				printRunningTotal(pd, levelNo, rowNo++);
 
-				/** Report Summary FR [ 2011569 ]**/ 
-				if(!m_summary)					
+				/** Report Summary FR [ 2011569 ]**/
+				if(!m_summary)
 					pd.addRow(false, levelNo);
 				int counter = 1;
 				//	get columns
@@ -892,7 +892,7 @@ public class DataEngine
 							int id = rs.getInt(counter++);
 							if (!rs.wasNull())
 							{
-								KeyNamePair pp = new KeyNamePair(id, KEY);	//	Key
+								KeyNamePair pp = KeyNamePair.of(id, KEY, null/*help*/);	//	Key
 								pde = new PrintDataElement(pdc.getColumnName(), pp, pdc.getDisplayType(),
 										true, pdc.isPageBreak(), pdc.getFormatPattern());
 							}
@@ -903,7 +903,7 @@ public class DataEngine
 							String id = rs.getString(counter++);
 							if (!rs.wasNull())
 							{
-								ValueNamePair pp = new ValueNamePair(id, KEY);	//	Key
+								ValueNamePair pp = ValueNamePair.of(id, KEY);	//	Key
 								pde = new PrintDataElement(pdc.getColumnName(), pp, pdc.getDisplayType(),
 										true, pdc.isPageBreak(), pdc.getFormatPattern());
 							}
@@ -922,7 +922,7 @@ public class DataEngine
 								int id = rs.getInt(counter++);
 								if (display != null && !rs.wasNull())
 								{
-									KeyNamePair pp = new KeyNamePair(id, display);
+									KeyNamePair pp = KeyNamePair.of(id, display);
 									pde = new PrintDataElement(pdc.getColumnName(), pp, pdc.getDisplayType(), pdc.getFormatPattern());
 								}
 							}
@@ -931,7 +931,7 @@ public class DataEngine
 								String id = rs.getString(counter++);
 								if (display != null && !rs.wasNull())
 								{
-									ValueNamePair pp = new ValueNamePair(id, display);
+									ValueNamePair pp = ValueNamePair.of(id, display);
 									pde = new PrintDataElement(pdc.getColumnName(), pp, pdc.getDisplayType(), pdc.getFormatPattern());
 								}
 							}
@@ -1000,7 +1000,7 @@ public class DataEngine
 					}	//	Non-Key Column
 					if (pde != null)
 					{
-						/** Report Summary FR [ 2011569 ]**/ 
+						/** Report Summary FR [ 2011569 ]**/
 						if(!m_summary)
 							pd.addNode(pde);
 						m_group.addValue(pde.getColumnName(), pde.getFunctionValue());
@@ -1052,7 +1052,7 @@ public class DataEngine
 							else if (m_group.isFunctionColumn(pdc.getColumnName(), functions[f]))
 							{
 								pd.addNode(new PrintDataElement(pdc.getColumnName(),
-									m_group.getValue(group_pdc.getColumnName(), 
+									m_group.getValue(group_pdc.getColumnName(),
 										pdc.getColumnName(), functions[f]),
 									PrintDataFunction.getFunctionDisplayType(functions[f],
 											pdc.getDisplayType()),pdc.getFormatPattern()));
@@ -1093,7 +1093,7 @@ public class DataEngine
 						final boolean displayTypeCategoryChanged = DisplayType.isNumeric(displayType) != DisplayType.isNumeric(functionDisplayType)
 								&& DisplayType.isDate(displayType) != DisplayType.isDate(functionDisplayType);
 						final String formatPattern = displayTypeCategoryChanged ? null : pdc.getFormatPattern();
-						
+
 						pd.addNode(new PrintDataElement(pdc.getColumnName(),
 							m_group.getValue(PrintDataGroup.TOTAL, pdc.getColumnName(), functions[f]),
 							functionDisplayType, formatPattern));
@@ -1106,10 +1106,10 @@ public class DataEngine
 		if (pd.getRowCount() == 0)
 		{
 			if (LogManager.isLevelFiner())
-				log.warn("NO Rows - ms=" + (System.currentTimeMillis()-m_startTime) 
+				log.warn("NO Rows - ms=" + (System.currentTimeMillis()-m_startTime)
 					+ " - " + pd.getSQL());
 			else
-				log.warn("NO Rows - ms=" + (System.currentTimeMillis()-m_startTime)); 
+				log.warn("NO Rows - ms=" + (System.currentTimeMillis()-m_startTime));
 		}
 		else
 			log.info("Rows=" + pd.getRowCount()
@@ -1126,11 +1126,11 @@ public class DataEngine
 	{
 		if (m_runningTotalLines < 1)	//	-1 = none
 			return;
-		log.debug("(" + m_runningTotalLines + ") - Row=" + rowNo 
+		log.debug("(" + m_runningTotalLines + ") - Row=" + rowNo
 			+ ", mod=" + rowNo % m_runningTotalLines);
 		if (rowNo % m_runningTotalLines != 0)
 			return;
-			
+
 		log.debug("Row=" + rowNo);
 		PrintDataColumn pdc = null;
 		int start = 0;

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/print/layout/LayoutEngine.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/print/layout/LayoutEngine.java
@@ -78,7 +78,7 @@ import de.metas.logging.LogManager;
  *
  * @author Jorg Janke
  * @version $Id: LayoutEngine.java,v 1.3 2006/07/30 00:53:02 jjanke Exp $
- * 
+ *
  * @author Teo Sarca, SC ARHIPAC SERVICE SRL <li>BF [ 1673505 ] BarCode/Image problem when print format is not form <li>BF [ 1673542 ] Can't add static image in report table cell <li>BF [ 1673548 ]
  *         Image is not scaled in a report table cell <li>BF [ 1807917 ] Layout positioning issue with m_maxHeightSinceNewLine <li>BF [ 1825876 ] Layout boxes with auto width not working <li>FR [
  *         1966406 ] Report Engine: AD_PInstance_Logs should be displayed <li>BF [ 2487307 ] LayoutEngine: NPE when Barcode field is null <li>BF [ 2828893 ] Problem with NextPage in Print Format
@@ -91,7 +91,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 {
 	/**
 	 * Detail Constructor
-	 * 
+	 *
 	 * @param format Print Format
 	 * @param data Print Data
 	 * @param query query for parameter info
@@ -103,7 +103,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Detail Constructor
-	 * 
+	 *
 	 * @param format Print Format
 	 * @param data Print Data
 	 * @param query query for parameter info
@@ -228,7 +228,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 	/**************************************************************************
 	 * Set Print Format
 	 * Optionally re-calculate layout
-	 * 
+	 *
 	 * @param doLayout if layout exists, redo it
 	 * @param format print Format
 	 */
@@ -264,7 +264,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 	/**
 	 * Set PrintData.
 	 * Optionally re-calculate layout
-	 * 
+	 *
 	 * @param data data
 	 * @param doLayout if layout exists, redo it
 	 * @param query query for parameter
@@ -288,7 +288,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**************************************************************************
 	 * Set Paper
-	 * 
+	 *
 	 * @param paper Paper
 	 */
 	public void setPaper(final CPaper paper)
@@ -299,7 +299,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 	/**
 	 * Set Paper
 	 * Optionally re-calculate layout
-	 * 
+	 *
 	 * @param paper Paper
 	 * @param headerHeight header height
 	 * @param footerHeight footer height
@@ -326,7 +326,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 	/**
 	 * Show Dialog and Set Paper
 	 * Optionally re-calculate layout
-	 * 
+	 *
 	 * @param job printer job
 	 */
 	public void pageSetupDialog(final PrinterJob job)
@@ -342,7 +342,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 	/**
 	 * Set Paper from Page Format.
 	 * PageFormat is derived from CPaper
-	 * 
+	 *
 	 * @param pf Optional PageFormat - if null standard paper Portrait
 	 */
 	protected void setPageFormat(final PageFormat pf)
@@ -355,7 +355,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get Page Format
-	 * 
+	 *
 	 * @return page format
 	 */
 	public PageFormat getPageFormat()
@@ -365,7 +365,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Calculate Page size based on Paper and header/footerHeight.
-	 * 
+	 *
 	 * <pre>
 	 *  Paper: 8.5x11.0" Portrait x=32.0,y=32.0 w=548.0,h=728.0
 	 *  +------------------------ Paper   612x792
@@ -409,7 +409,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Set Paper
-	 * 
+	 *
 	 * @return Paper
 	 */
 	public CPaper getPaper()
@@ -517,7 +517,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Build the string that tells that the current page is the x'th page of the set of n pages
-	 * 
+	 *
 	 * @param pageNo
 	 * @return
 	 */
@@ -538,7 +538,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/***************************************************************************
 	 * Get PrintLayout (Report) Context
-	 * 
+	 *
 	 * @return context
 	 */
 	public Properties getCtx()
@@ -548,7 +548,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get the number of printed Columns
-	 * 
+	 *
 	 * @return no of printed columns
 	 */
 	public int getColumnCount()
@@ -558,7 +558,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Set the current Print Area
-	 * 
+	 *
 	 * @param area see HEADER_.. constants
 	 */
 	protected void setArea(final int area)
@@ -572,7 +572,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get the current Print Area
-	 * 
+	 *
 	 * @return area see HEADER_.. constants
 	 */
 	public int getArea()
@@ -582,7 +582,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Return bounds of current Area
-	 * 
+	 *
 	 * @return rectangle with bounds
 	 */
 	public Rectangle getAreaBounds()
@@ -598,7 +598,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**************************************************************************
 	 * Create New Page, set position to top content
-	 * 
+	 *
 	 * @param force if false will check if nothing printed so far
 	 * @param preserveXPos preserve X Position of content area
 	 * @return new page no
@@ -668,7 +668,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get current Page Number (not zero based)
-	 * 
+	 *
 	 * @return Page No
 	 */
 	public int getPageNo()
@@ -678,7 +678,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get Page No
-	 * 
+	 *
 	 * @param pageNo page number (NOT zero based)
 	 * @return Page
 	 */
@@ -695,7 +695,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get Pages
-	 * 
+	 *
 	 * @return Pages in ArrayList
 	 */
 	public ArrayList<Page> getPages()
@@ -705,7 +705,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get Header & Footer info
-	 * 
+	 *
 	 * @return Header&Footer
 	 */
 	public HeaderFooter getHeaderFooter()
@@ -715,7 +715,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Set Current page to Page No
-	 * 
+	 *
 	 * @param pageNo page number (NOT zero based)
 	 */
 	protected void setPage(final int pageNo)
@@ -731,7 +731,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get Page Info for Multi-Page tables
-	 * 
+	 *
 	 * @param pageNo page
 	 * @return info e.g. (1,1) if there is more than 1 page vertically. 1 otherwise
 	 */
@@ -750,7 +750,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get Max Page Info ( Y dimension)
-	 * 
+	 *
 	 * @return info e.g. 1 ( if one page), 2 ( if 2pages) etc
 	 */
 	public String getPageInfoMax()
@@ -797,7 +797,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**************************************************************************
 	 * Set Position on current page (no check)
-	 * 
+	 *
 	 * @param p point relative in area
 	 */
 	protected void setRelativePosition(final Point2D p)
@@ -815,7 +815,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Set Position on current page (no check)
-	 * 
+	 *
 	 * @param x x position in 1/72 inch
 	 * @param y y position in 1/72 inch
 	 */
@@ -826,7 +826,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get the current position on current page
-	 * 
+	 *
 	 * @return current position
 	 */
 	public Point2D getPosition()
@@ -836,7 +836,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Set X Position on current page
-	 * 
+	 *
 	 * @param x x position in 1/72 inch
 	 */
 	protected void setX(final float x)
@@ -847,7 +847,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Add to X Position on current page
-	 * 
+	 *
 	 * @param xOffset add offset to x position in 1/72 inch
 	 */
 	protected void addX(final float xOffset)
@@ -860,7 +860,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get X Position on current page
-	 * 
+	 *
 	 * @return x position in 1/72 inch
 	 */
 	public float getX()
@@ -870,7 +870,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Set Y Position on current page
-	 * 
+	 *
 	 * @param y y position in 1/72 inch
 	 */
 	protected void setY(final int y)
@@ -881,7 +881,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Add to Y Position - may cause New Page
-	 * 
+	 *
 	 * @param yOffset add offset to y position in 1/72 inch
 	 */
 	protected void addY(final int yOffset)
@@ -909,7 +909,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get Y Position on current page
-	 * 
+	 *
 	 * @return y position in 1/72 inch
 	 */
 	public float getY()
@@ -919,7 +919,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**************************************************************************
 	 * Return remaining X dimension space _ on current page in Area
-	 * 
+	 *
 	 * @return space in 1/72 inch remaining in line
 	 */
 	public float getXspace()
@@ -935,7 +935,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Remaining Space is OK for Width in Area
-	 * 
+	 *
 	 * @param width width
 	 * @return true if width fits in area
 	 */
@@ -946,7 +946,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Return remaining Y dimension space | on current page in Area
-	 * 
+	 *
 	 * @return space in 1/72 inch remaining on page
 	 */
 	public float getYspace()
@@ -962,7 +962,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Remaining Space is OK for Height in Area
-	 * 
+	 *
 	 * @param height height
 	 * @return true if height fits in area
 	 */
@@ -973,7 +973,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**************************************************************************
 	 * Create Standard Header/Footer
-	 * 
+	 *
 	 * <pre>
 	 *  title           C        Page x of x
 	 *  Copyright      who         date&time
@@ -1385,7 +1385,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Create Field Element
-	 * 
+	 *
 	 * @param item Format Item
 	 * @param maxWidth max width
 	 * @param FieldAlignmentType alignment type (MPrintFormatItem.FIELD_ALIGN_*)
@@ -1436,9 +1436,9 @@ public class LayoutEngine implements Pageable, Printable, Doc
 		{	// Record_ID/ColumnName
 			Object value = data.getValue();
 			if (value instanceof KeyNamePair)
-				ID = new KeyNamePair(((KeyNamePair)value).getKey(), item.getColumnName());
+				ID = KeyNamePair.of(((KeyNamePair)value).getKey(), item.getColumnName());
 			else if (value instanceof ValueNamePair)
-				ID = new ValueNamePair(((ValueNamePair)value).getValue(), item.getColumnName());
+				ID = ValueNamePair.of(((ValueNamePair)value).getValue(), item.getColumnName());
 		}
 		else if (MPrintFormatItem.FIELDALIGNMENTTYPE_Default.equals(FieldAlignmentType))
 		{
@@ -1597,7 +1597,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 	/**************************************************************************
 	 * Layout Table.
 	 * Convert PrintData into TableElement
-	 * 
+	 *
 	 * @param format format to use
 	 * @param printData data to use
 	 * @param xOffset X Axis - offset (start of table) i.e. indentation
@@ -1667,8 +1667,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 						item.save();
 					}
 				}
-				columnHeader[col] = new ValueNamePair(item.getColumnName(),
-						item.getPrintName(format.getLanguage()));
+				columnHeader[col] = ValueNamePair.of(item.getColumnName(), item.getPrintName(format.getLanguage()));
 				columnMaxWidth[col] = item.getMaxWidth();
 				fixedWidth[col] = (columnMaxWidth[col] != 0 && item.isFixedWidth());
 				colSuppressRepeats[col] = item.isSuppressRepeats();
@@ -1874,7 +1873,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Layout Parameter based on MQuery
-	 * 
+	 *
 	 * @return PrintElement
 	 */
 	private PrintElement layoutParameter()
@@ -1889,7 +1888,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Layout Process Instance Logs (if any)
-	 * 
+	 *
 	 * @return PrintElement
 	 */
 	private PrintElement layoutPInstanceLogs()
@@ -1898,7 +1897,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 		{
 			return null;
 		}
-		
+
 		//
 		PInstanceLogElement e = new PInstanceLogElement(m_printCtx, m_query, m_format.getTableFormat());
 		if (e.getEffectiveRowCount() <= 0)
@@ -1911,7 +1910,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**************************************************************************
 	 * Get number of pages (Pageable Interface)
-	 * 
+	 *
 	 * @return number of pages
 	 */
 	@Override
@@ -1922,7 +1921,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get Page Format (Pageable Interface)
-	 * 
+	 *
 	 * @param pageIndex page index
 	 * @return Page Format
 	 * @throws IndexOutOfBoundsException
@@ -1937,7 +1936,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get Printable (PageableInterface)
-	 * 
+	 *
 	 * @param pageIndex page index
 	 * @return this
 	 * @throws IndexOutOfBoundsException
@@ -1952,7 +1951,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Print Page (Printable Interface)
-	 * 
+	 *
 	 * @param graphics graphics
 	 * @param pageFormat page format (ignored)
 	 * @param pageIndex page index
@@ -1978,7 +1977,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Do we have the page
-	 * 
+	 *
 	 * @param pageIndex page index
 	 * @return true if page exists
 	 */
@@ -2011,7 +2010,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**************************************************************************
 	 * Get the doc flavor (Doc Interface)
-	 * 
+	 *
 	 * @return SERVICE_FORMATTED.PAGEABLE
 	 */
 	@Override
@@ -2022,7 +2021,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 
 	/**
 	 * Get Print Data (Doc Interface)
-	 * 
+	 *
 	 * @return this
 	 * @throws IOException
 	 */
@@ -2047,7 +2046,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 	/**
 	 * Obtains a reader for extracting character print data from this doc.
 	 * (Doc Interface)
-	 * 
+	 *
 	 * @return null
 	 * @exception IOException
 	 */
@@ -2060,7 +2059,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 	/**
 	 * Obtains an input stream for extracting byte print data from this doc.
 	 * (Doc Interface)
-	 * 
+	 *
 	 * @return null
 	 * @exception IOException
 	 */
@@ -2071,7 +2070,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 	}	// getStreamForBytes
 
 	/**
-	 * 
+	 *
 	 * @param PrintInfo info
 	 */
 	public void setPrintInfo(final PrintInfo info)
@@ -2080,7 +2079,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 	}
 
 	/**
-	 * 
+	 *
 	 * @return PrintInfo
 	 */
 	public PrintInfo getPrintInfo()

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/DB.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/DB.java
@@ -18,15 +18,12 @@ package org.compiere.util;
 
 import static org.adempiere.model.InterfaceWrapperHelper.save;
 
-import lombok.NonNull;
-
-import javax.annotation.Nullable;
-
 import java.math.BigDecimal;
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
@@ -42,6 +39,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 
+import javax.annotation.Nullable;
 import javax.sql.RowSet;
 
 import org.adempiere.ad.dao.impl.InArrayQueryFilter;
@@ -87,6 +85,7 @@ import de.metas.util.StringUtils;
 import de.metas.util.lang.ReferenceListAwareEnum;
 import de.metas.util.lang.RepoIdAware;
 import de.metas.util.lang.RepoIdAwares;
+import lombok.NonNull;
 
 /**
  * General Database Interface
@@ -744,7 +743,7 @@ public final class DB
 	 * @param stmt statements
 	 * @param params parameters array; if null or empty array, no parameters are set
 	 */
-	public static void setParameters(final PreparedStatement stmt, final Object... params) throws SQLException
+	public static void setParameters(@NonNull final PreparedStatement stmt, @Nullable final Object... params) throws SQLException
 	{
 		if (params == null || params.length == 0)
 		{
@@ -800,7 +799,7 @@ public final class DB
 			pstmt.setTimestamp(index, (Timestamp)param);
 		else if (param instanceof java.util.Date) // metas: support for java.util.Date
 			pstmt.setTimestamp(index, new Timestamp(((java.util.Date)param).getTime()));
-		else if(param instanceof LocalDateTime)
+		else if (param instanceof LocalDateTime)
 			pstmt.setTimestamp(index, TimeUtil.asTimestamp((LocalDateTime)param));
 		else if (param instanceof LocalDate)
 			pstmt.setTimestamp(index, TimeUtil.asTimestamp((LocalDate)param));
@@ -808,9 +807,9 @@ public final class DB
 		else if (param instanceof Boolean)
 			pstmt.setString(index, ((Boolean)param).booleanValue() ? "Y" : "N");
 		//
-		else if(param instanceof RepoIdAware)
+		else if (param instanceof RepoIdAware)
 			pstmt.setInt(index, ((RepoIdAware)param).getRepoId());
-		else if(param instanceof ReferenceListAwareEnum)
+		else if (param instanceof ReferenceListAwareEnum)
 			pstmt.setString(index, ((ReferenceListAwareEnum)param).getCode());
 		//
 		else
@@ -820,10 +819,12 @@ public final class DB
 	/**
 	 * Execute Update. saves "DBExecuteError" in Log
 	 *
-	 * @param sql sql
 	 * @param trxName optional transaction name
 	 * @return number of rows updated or -1 if error
+	 *
+	 * @deprecated please use the {@code ...Ex} variant of this method.
 	 */
+	@Deprecated
 	public static int executeUpdate(String sql, String trxName)
 	{
 		final Object[] params = null;
@@ -836,11 +837,13 @@ public final class DB
 	/**
 	 * Execute Update. saves "DBExecuteError" in Log
 	 *
-	 * @param sql sql
 	 * @param ignoreError if true, no execution error is reported
 	 * @param trxName transaction
 	 * @return number of rows updated or -1 if error
+	 *
+	 * @deprecated please use the {@code ...Ex} variant of this method.
 	 */
+	@Deprecated
 	public static int executeUpdate(String sql, boolean ignoreError, String trxName)
 	{
 		final Object[] sqlParams = null;
@@ -853,11 +856,12 @@ public final class DB
 	/**
 	 * Execute Update. saves "DBExecuteError" in Log
 	 *
-	 * @param sql sql
-	 * @param param int param
 	 * @param trxName transaction
 	 * @return number of rows updated or -1 if error
+	 *
+	 * @deprecated please use the {@code ...Ex} variant of this method.
 	 */
+	@Deprecated
 	public static int executeUpdate(String sql, int param, String trxName)
 	{
 		final Object[] params = new Object[] { param };
@@ -870,12 +874,13 @@ public final class DB
 	/**
 	 * Execute Update. saves "DBExecuteError" in Log
 	 *
-	 * @param sql sql
-	 * @param params array of parameters
 	 * @param ignoreError if true, no execution error is reported
 	 * @param trxName optional transaction name
 	 * @return number of rows updated or -1 if error
+	 *
+	 * @deprecated please use the {@code ...Ex} variant of this method.
 	 */
+	@Deprecated
 	public static int executeUpdate(String sql, Object[] params, boolean ignoreError, String trxName)
 	{
 		final OnFail onFail = OnFail.valueOfIgnoreError(ignoreError);
@@ -887,15 +892,14 @@ public final class DB
 	/**
 	 * Execute SQL Update.
 	 *
-	 * @param sql
-	 * @param params
 	 * @param onFail what to do if the update fails
-	 * @param trxName
-	 * @param timeOut
 	 * @param updateReturnProcessor
 	 * @return update count
 	 * @throws DBException if update fails and {@link OnFail#ThrowException}.
+	 *
+	 * @deprecated please use the {@code ...Ex} variant of this method.
 	 */
+	@Deprecated
 	public static int executeUpdate(final String sql,
 			final Object[] params,
 			final OnFail onFail,
@@ -1277,7 +1281,10 @@ public final class DB
 	 * @param sql sql
 	 * @param params array of parameters
 	 * @return first value or -1 if not found or error
+	 *
+	 * @deprecated please use the {@code ...Ex} variant of this method.
 	 */
+	@Deprecated
 	public static int getSQLValue(String trxName, String sql, Object... params)
 	{
 		int retValue = -1;
@@ -1299,7 +1306,10 @@ public final class DB
 	 * @param sql sql
 	 * @param params collection of parameters
 	 * @return first value or null
+	 *
+	 * @deprecated please use the {@code ...Ex} variant of this method.
 	 */
+	@Deprecated
 	public static int getSQLValue(String trxName, String sql, List<Object> params)
 	{
 		return getSQLValue(trxName, sql, params.toArray(new Object[params.size()]));
@@ -1363,7 +1373,10 @@ public final class DB
 	 * @param sql sql
 	 * @param params array of parameters
 	 * @return first value or null
+	 *
+	 * @deprecated please use the {@code ...Ex} variant of this method.
 	 */
+	@Deprecated
 	public static String getSQLValueString(String trxName, String sql, Object... params)
 	{
 		String retValue = null;
@@ -1385,7 +1398,10 @@ public final class DB
 	 * @param sql sql
 	 * @param params collection of parameters
 	 * @return first value or null
+	 *
+	 * @deprecated please use the {@code ...Ex} variant of this method.
 	 */
+	@Deprecated
 	public static String getSQLValueString(String trxName, String sql, List<Object> params)
 	{
 		return getSQLValueString(trxName, sql, params.toArray(new Object[params.size()]));
@@ -1450,7 +1466,10 @@ public final class DB
 	 * @param sql sql
 	 * @param params array of parameters
 	 * @return first value or null
+	 *
+	 * @deprecated please use the {@code ...Ex} variant of this method.
 	 */
+	@Deprecated
 	public static BigDecimal getSQLValueBD(String trxName, String sql, Object... params)
 	{
 		try
@@ -1471,7 +1490,10 @@ public final class DB
 	 * @param sql sql
 	 * @param params collection of parameters
 	 * @return first value or null
+	 *
+	 * @deprecated please use the {@code ...Ex} variant of this method.
 	 */
+	@Deprecated
 	public static BigDecimal getSQLValueBD(String trxName, String sql, List<Object> params)
 	{
 		return getSQLValueBD(trxName, sql, params.toArray(new Object[params.size()]));
@@ -1535,7 +1557,10 @@ public final class DB
 	 * @param sql sql
 	 * @param params array of parameters
 	 * @return first value or null
+	 *
+	 * @deprecated please use the {@code ...Ex} variant of this method.
 	 */
+	@Deprecated
 	public static Timestamp getSQLValueTS(String trxName, String sql, Object... params)
 	{
 		try
@@ -1552,16 +1577,52 @@ public final class DB
 	/**
 	 * Get Timestamp Value from sql
 	 *
-	 * @param trxName trx
-	 * @param sql sql
-	 * @param params collection of parameters
 	 * @return first value or null
+	 *
+	 * @deprecated please use the {@code ...Ex} variant of this method.
 	 */
+	@Deprecated
 	public static Timestamp getSQLValueTS(String trxName, String sql, List<Object> params)
 	{
 		Object[] arr = new Object[params.size()];
 		params.toArray(arr);
 		return getSQLValueTS(trxName, sql, arr);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T[] getSQLValueArrayEx(
+			@Nullable final String trxName,
+			@NonNull final String sql,
+			@Nullable final Object... params)
+	{
+		final PreparedStatement pstmt = prepareStatement(sql, trxName);;
+		ResultSet rs = null;
+		try
+		{
+			setParameters(pstmt, params);
+			rs = pstmt.executeQuery();
+
+			if (rs.next())
+			{
+				return (T[])rs.getArray(1).getArray();
+			}
+
+			log.debug("Got no array value for sql={}; params={}", sql, params);
+			return null;
+		}
+		catch (SQLException e)
+		{
+			throw DBException.wrapIfNeeded(e)
+					.appendParametersToMessage()
+					.setParameter("trxName", trxName)
+					.setParameter("sql", sql)
+					.setParameter("params", params);
+		}
+		finally
+		{
+			close(rs, pstmt);
+		}
+
 	}
 
 	/**
@@ -1592,33 +1653,50 @@ public final class DB
 	/**
 	 * Get Array of Key Name Pairs
 	 *
-	 * @param trxName
-	 * @param sql select with id / name as first / second column
+	 * @param sql select with id as first column, name as second column and optionally description as third column
 	 * @param optional if true (-1,"") is added
 	 * @param params query parameters
 	 */
-	public static KeyNamePair[] getKeyNamePairs(String trxName, String sql, boolean optional, Object... params)
+	public static KeyNamePair[] getKeyNamePairs(
+			@Nullable String trxName,
+			@NonNull String sql,
+			boolean optional,
+			Object... params)
 	{
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
-		ArrayList<KeyNamePair> list = new ArrayList<>();
+		final ArrayList<KeyNamePair> list = new ArrayList<>();
 		if (optional)
 		{
-			list.add(new KeyNamePair(-1, ""));
+			list.add(KeyNamePair.EMPTY);
 		}
 		try
 		{
 			pstmt = DB.prepareStatement(sql, trxName);
 			setParameters(pstmt, params);
 			rs = pstmt.executeQuery();
+
+			final ResultSetMetaData rsmd = rs.getMetaData();
+			final int columnCount = rsmd.getColumnCount();
+			final boolean hasDescription = columnCount >= 3;
+
 			while (rs.next())
 			{
-				list.add(new KeyNamePair(rs.getInt(1), rs.getString(2)));
+				final String description = hasDescription ? rs.getString(3) : null;
+				final int key = rs.getInt(1);
+				final String name = rs.getString(2);
+
+				list.add(KeyNamePair.of(key, name, description));
 			}
 		}
 		catch (Exception e)
 		{
-			log.error(sql, DBException.extractSQLExceptionOrNull(e));
+			throw DBException.wrapIfNeeded(e)
+					.appendParametersToMessage()
+					.setParameter("trxName", trxName)
+					.setParameter("sql", sql)
+					.setParameter("optional", optional)
+					.setParameter("params", params);
 		}
 		finally
 		{
@@ -1814,7 +1892,7 @@ public final class DB
 		{
 			return String.valueOf(param);
 		}
-		else if(param instanceof RepoIdAware)
+		else if (param instanceof RepoIdAware)
 		{
 			return String.valueOf(((RepoIdAware)param).getRepoId());
 		}
@@ -1830,7 +1908,7 @@ public final class DB
 		{
 			return TO_DATE(TimeUtil.asTimestamp((java.util.Date)param));
 		}
-		else if(TimeUtil.isDateOrTimeObject(param))
+		else if (TimeUtil.isDateOrTimeObject(param))
 		{
 			return TO_DATE(TimeUtil.asTimestamp(param));
 		}
@@ -2129,100 +2207,6 @@ public final class DB
 	}
 
 	/**
-	 * Get Array of ValueNamePair items.
-	 *
-	 * <pre>
-	 * Example:
-	 * String sql = "SELECT Name, Description FROM AD_Ref_List WHERE AD_Reference_ID=?";
-	 * ValueNamePair[] list = DB.getValueNamePairs(sql, false, params);
-	 * </pre>
-	 *
-	 * @param sql SELECT Value_Column, Name_Column FROM ...
-	 * @param optional if {@link ValueNamePair#EMPTY} is added
-	 * @param params query parameters
-	 * @return array of {@link ValueNamePair} or empty array
-	 * @throws DBException if there is any SQLException
-	 */
-	public static ValueNamePair[] getValueNamePairs(String sql, boolean optional, List<Object> params)
-	{
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-		ArrayList<ValueNamePair> list = new ArrayList<>();
-		if (optional)
-		{
-			list.add(ValueNamePair.EMPTY);
-		}
-		try
-		{
-			pstmt = DB.prepareStatement(sql, null);
-			setParameters(pstmt, params);
-			rs = pstmt.executeQuery();
-			while (rs.next())
-			{
-				list.add(new ValueNamePair(rs.getString(1), rs.getString(2)));
-			}
-		}
-		catch (SQLException e)
-		{
-			throw new DBException(e, sql, params); // metas: tsa
-		}
-		finally
-		{
-			close(rs, pstmt);
-			rs = null;
-			pstmt = null;
-		}
-		return list.toArray(new ValueNamePair[list.size()]);
-	}
-
-	/**
-	 * Get Array of KeyNamePair items.
-	 *
-	 * <pre>
-	 * Example:
-	 * String sql = "SELECT C_City_ID, Name FROM C_City WHERE C_City_ID=?";
-	 * KeyNamePair[] list = DB.getKeyNamePairs(sql, false, params);
-	 * </pre>
-	 *
-	 * @param sql SELECT ID_Column, Name_Column FROM ...
-	 * @param optional if {@link ValueNamePair#EMPTY} is added
-	 * @param params query parameters
-	 * @return array of {@link KeyNamePair} or empty array
-	 * @throws DBException if there is any SQLException
-	 */
-	public static KeyNamePair[] getKeyNamePairs(String sql, boolean optional, List<Object> params)
-	{
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-		ArrayList<KeyNamePair> list = new ArrayList<>();
-		if (optional)
-		{
-			list.add(KeyNamePair.EMPTY);
-		}
-		try
-		{
-			pstmt = DB.prepareStatement(sql, null);
-			setParameters(pstmt, params);
-			rs = pstmt.executeQuery();
-			while (rs.next())
-			{
-				list.add(new KeyNamePair(rs.getInt(1), rs.getString(2)));
-			}
-		}
-		catch (SQLException e)
-		{
-			throw new DBException(e, sql, params); // metas: tsa
-		}
-		finally
-		{
-			close(rs, pstmt);
-			rs = null;
-			pstmt = null;
-		}
-		return list.toArray(new KeyNamePair[list.size()]);
-	}
-
-	/**
 	 * Create persistent selection in T_Selection table
 	 */
 	public static void createT_Selection(@NonNull final PInstanceId pinstanceId, Iterable<Integer> selection, String trxName)
@@ -2274,7 +2258,6 @@ public final class DB
 		final ImmutableList<Integer> ids = RepoIdAwares.asRepoIds(selection);
 		return createT_Selection(ids, trxName);
 	}
-
 
 	/**
 	 * Delete T_Selection
@@ -2379,7 +2362,7 @@ public final class DB
 				.setEmbedSqlParams(embedSqlParams);
 		final String sql = builder.getSql();
 
-		if(!embedSqlParams)
+		if (!embedSqlParams)
 		{
 			final List<Object> sqlParams = builder.getSqlParams(Env.getCtx());
 			paramsOut.addAll(sqlParams);
@@ -2677,12 +2660,12 @@ public final class DB
 			final Timestamp ts = rs.getTimestamp(columnIndex);
 			value = (AT)ts;
 		}
-		else if(returnType.isAssignableFrom(LocalDateTime.class))
+		else if (returnType.isAssignableFrom(LocalDateTime.class))
 		{
 			final Timestamp ts = rs.getTimestamp(columnIndex);
 			value = (AT)TimeUtil.asLocalDateTime(ts);
 		}
-		else if(returnType.isAssignableFrom(LocalDate.class))
+		else if (returnType.isAssignableFrom(LocalDate.class))
 		{
 			final Timestamp ts = rs.getTimestamp(columnIndex);
 			value = (AT)TimeUtil.asLocalDate(ts);
@@ -2703,18 +2686,16 @@ public final class DB
 		return value;
 	}
 
-
 	public static final <AT> AT retrieveValueOrDefault(final ResultSet rs, final int columnIndex, final Class<AT> returnType) throws SQLException
 	{
 		final AT value = retrieveValue(rs, columnIndex, returnType);
-		if(value != null)
+		if (value != null)
 		{
 			return value;
 		}
 
 		return retrieveDefaultValue(returnType);
 	}
-
 
 	@FunctionalInterface
 	public static interface ResultSetConsumer
@@ -2734,12 +2715,12 @@ public final class DB
 			pstmt = prepareStatement(sql, ITrx.TRXNAME_ThreadInherited);
 			setParameters(pstmt, sqlParams);
 			rs = pstmt.executeQuery();
-			while(rs.next())
+			while (rs.next())
 			{
 				rowConsumer.accept(rs);
 			}
 		}
-		catch(SQLException ex)
+		catch (SQLException ex)
 		{
 			throw new DBException(sql);
 		}
@@ -2769,7 +2750,7 @@ public final class DB
 			rs = pstmt.executeQuery();
 
 			final ArrayList<T> rows = new ArrayList<>();
-			while(rs.next())
+			while (rs.next())
 			{
 				T row = loader.retrieveRow(rs);
 				rows.add(row);
@@ -2777,7 +2758,7 @@ public final class DB
 
 			return rows;
 		}
-		catch(SQLException ex)
+		catch (SQLException ex)
 		{
 			throw new DBException(ex, sql, sqlParams);
 		}
@@ -2799,7 +2780,7 @@ public final class DB
 			pstmt = prepareStatement(sql, ITrx.TRXNAME_ThreadInherited);
 			setParameters(pstmt, sqlParams);
 			rs = pstmt.executeQuery();
-			if(rs.next())
+			if (rs.next())
 			{
 				return loader.retrieveRow(rs);
 			}
@@ -2808,7 +2789,7 @@ public final class DB
 				return null;
 			}
 		}
-		catch(SQLException ex)
+		catch (SQLException ex)
 		{
 			throw new DBException(ex, sql, sqlParams);
 		}

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/KeyNamePair.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/KeyNamePair.java
@@ -18,6 +18,7 @@ package org.compiere.util;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -35,20 +36,42 @@ import de.metas.util.lang.RepoIdAware;
 @Immutable
 public final class KeyNamePair extends NamePair
 {
+
+	public static final KeyNamePair of(
+			@Nullable final RepoIdAware key,
+			@Nullable final String name)
+	{
+		final int keyInt = key != null ? key.getRepoId() : EMPTY.getKey();
+		return of(keyInt, name, null/* description */);
+	}
+
+	public static final KeyNamePair of(
+			@Nullable final int key,
+			@Nullable final String name)
+	{
+		return of(key, name, null/* description */);
+	}
+
+	public static final KeyNamePair of(
+			@Nullable final RepoIdAware key,
+			@Nullable final String name,
+			@Nullable final String description)
+	{
+		final int keyInt = key != null ? key.getRepoId() : EMPTY.getKey();
+		return of(keyInt, name, description);
+	}
+
 	@JsonCreator
-	public static final KeyNamePair of(@JsonProperty("k") final int key, @JsonProperty("n") final String name)
+	public static final KeyNamePair of(
+			@JsonProperty("k") final int key,
+			@JsonProperty("n") final String name,
+			@JsonProperty("description") final String description)
 	{
 		if (key == EMPTY.getKey() && Objects.equals(name, EMPTY.getName()))
 		{
 			return EMPTY;
 		}
-		return new KeyNamePair(key, name);
-	}
-
-	public static final KeyNamePair of(final RepoIdAware key, final String name)
-	{
-		final int keyInt = key != null ? key.getRepoId() : EMPTY.getKey();
-		return of(keyInt, name);
+		return new KeyNamePair(key, name, description);
 	}
 
 	public static final KeyNamePair of(final int key)
@@ -57,31 +80,43 @@ public final class KeyNamePair extends NamePair
 		{
 			return EMPTY;
 		}
-		return new KeyNamePair(key, "<" + key + ">");
+		return new KeyNamePair(key, "<" + key + ">", null/* help */);
 	}
 
 	private static final long serialVersionUID = 6347385376010388473L;
 
-	public static final KeyNamePair EMPTY = new KeyNamePair(-1, "");
+	public static final KeyNamePair EMPTY = new KeyNamePair(-1, "", null/* description */);
+
+	/**
+	 * @deprecated please use the static creator methods instead.
+	 */
+	@Deprecated
+	public KeyNamePair(final int key, final String name)
+	{
+		super(name, null/* description */);
+		this.m_key = key;
+	}
 
 	/**
 	 * Constructor KeyValue Pair -
-	 * 
+	 *
 	 * @param key Key (-1 is considered as null)
 	 * @param name string representation
+	 * @deprecated please use the static creator methods instead.
 	 */
-	public KeyNamePair(final int key, final String name)
+	@Deprecated
+	public KeyNamePair(final int key, @Nullable final String name, @Nullable final String description)
 	{
-		super(name);
+		super(name, description);
 		this.m_key = key;
-	}   // KeyNamePair
+	}
 
 	/** The Key */
 	private final int m_key;
 
 	/**
 	 * Get Key
-	 * 
+	 *
 	 * @return key
 	 */
 	@JsonProperty("k")
@@ -106,7 +141,7 @@ public final class KeyNamePair extends NamePair
 
 	/**
 	 * Equals
-	 * 
+	 *
 	 * @param obj object
 	 * @return true if equal
 	 */

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/Login.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/Login.java
@@ -16,8 +16,6 @@
  *****************************************************************************/
 package org.compiere.util;
 
-import lombok.NonNull;
-
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -65,6 +63,7 @@ import de.metas.util.Check;
 import de.metas.util.Services;
 import de.metas.util.hash.HashableString;
 import de.metas.util.time.SystemTime;
+import lombok.NonNull;
 
 /**
  * Login Manager
@@ -268,7 +267,7 @@ public class Login
 				ctx.setSysAdmin(true);
 			}
 
-			final KeyNamePair roleKNP = KeyNamePair.of(role.getAD_Role_ID(), role.getName());
+			final KeyNamePair roleKNP = KeyNamePair.of(role.getAD_Role_ID(), role.getName(), role.getDescription());
 			roles.add(roleKNP);
 		}
 		//

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/NamePair.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/NamePair.java
@@ -1,20 +1,22 @@
 /******************************************************************************
- * Product: Adempiere ERP & CRM Smart Business Solution                       *
- * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
- * This program is free software; you can redistribute it and/or modify it    *
- * under the terms version 2 of the GNU General Public License as published   *
- * by the Free Software Foundation. This program is distributed in the hope   *
+ * Product: Adempiere ERP & CRM Smart Business Solution *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved. *
+ * This program is free software; you can redistribute it and/or modify it *
+ * under the terms version 2 of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope *
  * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
- * See the GNU General Public License for more details.                       *
- * You should have received a copy of the GNU General Public License along    *
- * with this program; if not, write to the Free Software Foundation, Inc.,    *
- * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
- * For the text or an alternative of this public license, you may reach us    *
- * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
- * or via info@compiere.org or http://www.compiere.org/license.html           *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. *
+ * See the GNU General Public License for more details. *
+ * You should have received a copy of the GNU General Public License along *
+ * with this program; if not, write to the Free Software Foundation, Inc., *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA. *
+ * For the text or an alternative of this public license, you may reach us *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA *
+ * or via info@compiere.org or http://www.compiere.org/license.html *
  *****************************************************************************/
 package org.compiere.util;
+
+import static org.compiere.util.Util.coalesce;
 
 import java.io.Serializable;
 import java.util.Comparator;
@@ -22,122 +24,121 @@ import java.util.Comparator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- *  Name Pair Interface
+ * Name Pair Interface
  *
- *  @author     Jorg Janke
- *  @version    $Id: NamePair.java,v 1.3 2006/07/30 00:52:23 jjanke Exp $
+ * @author Jorg Janke
+ * @version $Id: NamePair.java,v 1.3 2006/07/30 00:52:23 jjanke Exp $
  */
 public abstract class NamePair implements Comparator<Object>, Serializable, Comparable<Object>
 {
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = -8951176533385087242L;
 
-	/**
-	 *  Protected Constructor
-	 *  @param   name    (Display) Name of the Pair
-	 */
-	protected NamePair(final String name)
-	{
-		if (name == null)
-		{
-			m_name = "";
-		}
-		else
-		{
-			m_name = name;
-		}
-	}   //  NamePair
-
-	/** The Name        */
 	private final String m_name;
+	private final String m_description;
 
 	/**
-	 *  Returns display value
-	 *  @return name
+	 * @param name (Display) Name of the Pair
+	 */
+	protected NamePair(final String name, final String description)
+	{
+		m_name = coalesce(name, "");
+		m_description = description;
+	}
+
+	/**
+	 * Returns display value; never null, but might be an empty string.
 	 */
 	@JsonProperty("n")
 	public final String getName()
 	{
 		return m_name;
-	}   //  getName
+	}
+
+	@JsonProperty("description")
+	public final String getDescription()
+	{
+		return m_description;
+	}
 
 	/**
-	 *  Returns Key or Value as String
-	 *  @return String or null
+	 * Returns Key or Value as String
+	 *
+	 * @return String or null
 	 */
 	public abstract String getID();
 
 	/**
-	 *	Comparator Interface (based on toString value)
-	 *  @param o1 Object 1
-	 *  @param o2 Object 2
-	 *  @return compareTo value
+	 * Comparator Interface (based on toString value)
+	 *
+	 * @param o1 Object 1
+	 * @param o2 Object 2
+	 * @return compareTo value
 	 */
 	@Override
 	public final int compare(Object o1, Object o2)
 	{
 		String s1 = o1 == null ? "" : o1.toString();
 		String s2 = o2 == null ? "" : o2.toString();
-		return s1.compareTo (s2);    //  sort order ??
-	}	//	compare
+		return s1.compareTo(s2);    // sort order ??
+	}	// compare
 
 	/**
-	 *	Comparator Interface (based on toString value)
-	 *  @param o1 Object 1
-	 *  @param o2 Object 2
-	 *  @return compareTo value
+	 * Comparator Interface (based on toString value)
+	 *
+	 * @param o1 Object 1
+	 * @param o2 Object 2
+	 * @return compareTo value
 	 */
 	public final int compare(NamePair o1, NamePair o2)
 	{
 		String s1 = o1 == null ? "" : o1.toString();
 		String s2 = o2 == null ? "" : o2.toString();
-		return s1.compareTo (s2);    //  sort order ??
-	}	//	compare
+		return s1.compareTo(s2);    // sort order ??
+	}	// compare
 
 	/**
-	 * 	Comparable Interface (based on toString value)
-	 *  @param   o the Object to be compared.
-	 *  @return  a negative integer, zero, or a positive integer as this object
-	 *		is less than, equal to, or greater than the specified object.
+	 * Comparable Interface (based on toString value)
+	 *
+	 * @param o the Object to be compared.
+	 * @return a negative integer, zero, or a positive integer as this object
+	 *         is less than, equal to, or greater than the specified object.
 	 */
 	@Override
 	public final int compareTo(Object o)
 	{
-		return compare (this, o);
-	}	//	compareTo
+		return compare(this, o);
+	}	// compareTo
 
 	/**
-	 * 	Comparable Interface (based on toString value)
-	 *  @param   o the Object to be compared.
-	 *  @return  a negative integer, zero, or a positive integer as this object
-	 *		is less than, equal to, or greater than the specified object.
+	 * Comparable Interface (based on toString value)
+	 *
+	 * @param o the Object to be compared.
+	 * @return a negative integer, zero, or a positive integer as this object
+	 *         is less than, equal to, or greater than the specified object.
 	 */
 	public final int compareTo(NamePair o)
 	{
-		return compare (this, o);
-	}	//	compareTo
+		return compare(this, o);
+	}	// compareTo
 
 	/**
-	 *	To String - returns name
-	 *  @return Name
+	 * To String - returns name
 	 */
 	@Override
 	public String toString()
 	{
 		return m_name;
-	}	//	toString
+	}
 
 	/**
-	 *	To String - detail
-	 *  @return String in format ID=Name
+	 * To String - detail
+	 *
+	 * @return String in format ID=Name
 	 */
 	public final String toStringX()
 	{
 		StringBuilder sb = new StringBuilder(getID());
 		sb.append("=").append(m_name);
 		return sb.toString();
-	}	//	toStringX
-
-}	//	NamePair
+	}	// toStringX
+}	// NamePair

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/ValueNamePair.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/ValueNamePair.java
@@ -47,13 +47,13 @@ public final class ValueNamePair extends NamePair
 	public static final ValueNamePair of(
 			@JsonProperty("v") final String value,
 			@JsonProperty("n") final String name,
-			@JsonProperty("help") final String help)
+			@JsonProperty("description") final String description)
 	{
 		if (Objects.equals(value, EMPTY.getValue()) && Objects.equals(name, EMPTY.getName()))
 		{
 			return EMPTY;
 		}
-		return new ValueNamePair(value, name, help);
+		return new ValueNamePair(value, name, description);
 	}
 
 	public static final ValueNamePair EMPTY = new ValueNamePair("", "", null/* help */);

--- a/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/ValueNamePair.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/ValueNamePair.java
@@ -1,18 +1,18 @@
 /******************************************************************************
- * Product: Adempiere ERP & CRM Smart Business Solution                       *
- * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
- * This program is free software; you can redistribute it and/or modify it    *
- * under the terms version 2 of the GNU General Public License as published   *
- * by the Free Software Foundation. This program is distributed in the hope   *
+ * Product: Adempiere ERP & CRM Smart Business Solution *
+ * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved. *
+ * This program is free software; you can redistribute it and/or modify it *
+ * under the terms version 2 of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope *
  * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
- * See the GNU General Public License for more details.                       *
- * You should have received a copy of the GNU General Public License along    *
- * with this program; if not, write to the Free Software Foundation, Inc.,    *
- * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
- * For the text or an alternative of this public license, you may reach us    *
- * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
- * or via info@compiere.org or http://www.compiere.org/license.html           *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. *
+ * See the GNU General Public License for more details. *
+ * You should have received a copy of the GNU General Public License along *
+ * with this program; if not, write to the Free Software Foundation, Inc., *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA. *
+ * For the text or an alternative of this public license, you may reach us *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA *
+ * or via info@compiere.org or http://www.compiere.org/license.html *
  *****************************************************************************/
 package org.compiere.util;
 
@@ -35,17 +35,28 @@ public final class ValueNamePair extends NamePair
 {
 	private static final long serialVersionUID = -8315081335749462163L;
 
+
+	public static final ValueNamePair of(
+			@JsonProperty("v") final String value,
+			@JsonProperty("n") final String name)
+	{
+		return of(value, name, null/*help*/);
+	}
+
 	@JsonCreator
-	public static final ValueNamePair of(@JsonProperty("v") final String value, @JsonProperty("n") final String name)
+	public static final ValueNamePair of(
+			@JsonProperty("v") final String value,
+			@JsonProperty("n") final String name,
+			@JsonProperty("help") final String help)
 	{
 		if (Objects.equals(value, EMPTY.getValue()) && Objects.equals(name, EMPTY.getName()))
 		{
 			return EMPTY;
 		}
-		return new ValueNamePair(value, name);
+		return new ValueNamePair(value, name, help);
 	}
 
-	public static final ValueNamePair EMPTY = new ValueNamePair("", "");
+	public static final ValueNamePair EMPTY = new ValueNamePair("", "", null/* help */);
 
 	/**
 	 * Construct KeyValue Pair
@@ -53,9 +64,9 @@ public final class ValueNamePair extends NamePair
 	 * @param value value
 	 * @param name string representation
 	 */
-	public ValueNamePair(final String value, final String name)
+	public ValueNamePair(final String value, final String name, final String help)
 	{
-		super(name);
+		super(name, help);
 		m_value = value == null ? "" : value;
 	}   // ValueNamePair
 
@@ -88,11 +99,11 @@ public final class ValueNamePair extends NamePair
 	@Override
 	public boolean equals(final Object obj)
 	{
-		if(obj == this)
+		if (obj == this)
 		{
 			return true;
 		}
-		
+
 		if (obj instanceof ValueNamePair)
 		{
 			final ValueNamePair other = (ValueNamePair)obj;
@@ -114,4 +125,3 @@ public final class ValueNamePair extends NamePair
 	}   // hashCode
 
 }	// KeyValuePair
-

--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/TranslatableParameterizedString.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/TranslatableParameterizedString.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import org.compiere.util.CtxName;
 import org.compiere.util.Env;
 
@@ -52,13 +54,19 @@ public abstract class TranslatableParameterizedString
 	 * @param stringTrlPatternstring to be used for any other language; it might contain the <code>adLanguageParamName</code> parameter
 	 * @return
 	 */
-	public static final TranslatableParameterizedString of(final CtxName adLanguageParamName, final String stringBaseLang, final String stringTrlPattern)
+	public static final TranslatableParameterizedString of(
+			@Nullable final CtxName adLanguageParamName,
+			final String stringBaseLang,
+			@Nullable final String stringTrlPattern)
 	{
 		final String adLanguageParamNameStr = adLanguageParamName == null ? null : adLanguageParamName.toStringWithMarkers();
 		return of(adLanguageParamNameStr, stringBaseLang, stringTrlPattern);
 	}
 
-	public static final TranslatableParameterizedString of(final String adLanguageParamNameStr, final String stringBaseLang, final String stringTrlPattern)
+	public static final TranslatableParameterizedString of(
+			@Nullable final String adLanguageParamNameStr,
+			final String stringBaseLang,
+			@Nullable final String stringTrlPattern)
 	{
 		if (adLanguageParamNameStr == null)
 		{
@@ -78,7 +86,10 @@ public abstract class TranslatableParameterizedString
 		return new RegularTranslatableParameterizedString(adLanguageParamNameStr, stringBaseLang, stringTrlPattern);
 	}
 
-	private static final TranslatableParameterizedString constant(final String adLanguageParamName, final String stringBaseLang, final String stringTrl)
+	private static final TranslatableParameterizedString constant(
+			@Nullable final String adLanguageParamName,
+			@Nullable final String stringBaseLang,
+			final String stringTrl)
 	{
 		if (Objects.equals(stringBaseLang, stringTrl))
 		{
@@ -125,7 +136,7 @@ public abstract class TranslatableParameterizedString
 
 	/**
 	 * Transforms this object to a new instance by applying the mapping function to it's internal strings.
-	 * 
+	 *
 	 * @param mappingFunction a function which converts the old string to a new string
 	 * @return a new instance or the same one in case the transformation didn't change the strings
 	 */
@@ -261,7 +272,6 @@ public abstract class TranslatableParameterizedString
 
 		private ConstantTranslatableParameterizedString(final String adLanguageParamName, final String stringBaseLang, final String stringTrl)
 		{
-			super();
 			this.adLanguageParamName = adLanguageParamName;
 			this.stringBaseLang = stringBaseLang;
 			this.stringTrl = stringTrl;

--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/MetasfreshLastError.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/MetasfreshLastError.java
@@ -19,12 +19,12 @@ import org.slf4j.Logger;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -33,9 +33,9 @@ import org.slf4j.Logger;
 
 /**
  * Last error/warning/info holder.
- * 
+ *
  * NOTE: in future we will remove this class, because the feature is legacy.
- * 
+ *
  * @author metas-dev <dev@metasfresh.com>
  *
  */
@@ -77,7 +77,7 @@ public class MetasfreshLastError
 
 	private static final void saveError(final Logger logger, final String AD_Message, final String message, final Throwable exception, final boolean issueError)
 	{
-		final ValueNamePair lastError = new ValueNamePair(AD_Message, message);
+		final ValueNamePair lastError = ValueNamePair.of(AD_Message, message);
 
 		final LastErrorsInstance lastErrors = getLastErrorsInstance();
 		lastErrors.setLastError(lastError);
@@ -141,7 +141,7 @@ public class MetasfreshLastError
 	 */
 	public static void saveWarning(final Logger logger, final String AD_Message, final String message)
 	{
-		final ValueNamePair lastWarning = new ValueNamePair(AD_Message, message);
+		final ValueNamePair lastWarning = ValueNamePair.of(AD_Message, message);
 		getLastErrorsInstance().setLastWarning(lastWarning);
 
 		// print it

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/TranslatableParameterizedStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/TranslatableParameterizedStringExpression.java
@@ -70,7 +70,7 @@ public final class TranslatableParameterizedStringExpression implements IStringE
 		return of(adLanguageParam, translatableString.getStringBaseLanguage(), translatableString.getStringTrlPattern());
 	}
 
-	public static final IStringExpression of(final CtxName adLanguageParam, final String expressionBaseLang, final String expressionTrl)
+	public static final IStringExpression of(final CtxName adLanguageParam, @NonNull final String expressionBaseLang, final String expressionTrl)
 	{
 		if (Objects.equals(expressionBaseLang, expressionTrl))
 		{

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/ConstantStringExpression.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/impl/ConstantStringExpression.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-import de.metas.util.Check;
+import lombok.NonNull;
 
 /*
  * #%L
@@ -70,9 +70,8 @@ public final class ConstantStringExpression implements IStringExpression, ICache
 
 	private final String expressionStr;
 
-	private ConstantStringExpression(final String expressionStr)
+	private ConstantStringExpression(@NonNull final String expressionStr)
 	{
-		Check.assumeNotNull(expressionStr, "Parameter expressionStr is not null");
 		this.expressionStr = expressionStr;
 	}
 
@@ -118,7 +117,7 @@ public final class ConstantStringExpression implements IStringExpression, ICache
 	{
 		return expressionStr;
 	}
-	
+
 	@Override
 	public Set<CtxName> getParameters()
 	{

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/AbstractJavaValidationRule.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/AbstractJavaValidationRule.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import org.adempiere.ad.expression.api.IStringExpression;
 import org.compiere.util.NamePair;
 import org.compiere.util.ValueNamePair;
@@ -54,9 +56,12 @@ public abstract class AbstractJavaValidationRule implements IValidationRule, INa
 	}
 
 	@Override
-	public void registerException(@NonNull final String tableName, @NonNull final String columnName)
+	public void registerException(
+			@NonNull final String tableName,
+			@NonNull final String columnName,
+			@Nullable final String description)
 	{
-		final ValueNamePair exception = new ValueNamePair(tableName, columnName);
+		final ValueNamePair exception = new ValueNamePair(tableName, columnName, description);
 
 		exceptionTableAndColumns.add(exception);
 	}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/IValidationRule.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/IValidationRule.java
@@ -9,9 +9,11 @@ import org.compiere.util.ValueNamePair;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import lombok.NonNull;
+
 /**
  * Lookup Validation Rule Model
- * 
+ *
  * NOTE to developer: all implementations shall be <b>stateless</b>.
  *
  * @author tsa
@@ -36,7 +38,7 @@ public interface IValidationRule
 
 	/**
 	 * Returns a set of parameters on which this validation rule depends.
-	 * 
+	 *
 	 * Actually it's a concatenation of:
 	 * <ul>
 	 * <li>{@link #getPrefilterWhereClause()}'s parameters
@@ -44,7 +46,7 @@ public interface IValidationRule
 	 * </ul>
 	 *
 	 * It is assumed that the parameters set is static and not change over time.
-	 * 
+	 *
 	 * @return set of parameter names
 	 */
 	Set<String> getAllParameters();
@@ -64,17 +66,16 @@ public interface IValidationRule
 
 	/**
 	 * Specify for which table and column pair this validation rule shall not apply
-	 * 
-	 * @param tableName
-	 * @param columnName
+	 *
+	 * @param description may be null
 	 */
-	default void registerException(final String tableName, final String columnName)
+	default void registerException(@NonNull final String tableName, @NonNull final String columnName, final String description)
 	{
 		throw new UnsupportedOperationException("Class " + getClass().getName() + " does not support registering exceptions");
 	}
 
 	/**
-	 * 
+	 *
 	 * @return a list containing all the table+column pairs for which this validation rule shall not be applied
 	 */
 	default List<ValueNamePair> getExceptionTableAndColumns()

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/IValidationRuleFactory.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/IValidationRuleFactory.java
@@ -10,12 +10,12 @@ package org.adempiere.ad.validationRule;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -32,9 +32,9 @@ import de.metas.util.ISingletonService;
 
 /**
  * Factory class used to create {@link IValidationRule} instances
- * 
+ *
  * @author tsa
- * 
+ *
  * @task http://dewiki908/mediawiki/index.php/03271:_Extend_the_ValidationRule_feature_%282012091210000027%29
  */
 public interface IValidationRuleFactory extends ISingletonService
@@ -42,7 +42,7 @@ public interface IValidationRuleFactory extends ISingletonService
 
 	/**
 	 * Create {@link IValidationRule} for given AD_ValRule_ID, context table and column name
-	 * 
+	 *
 	 * @param tableName
 	 * @param adValRuleId
 	 * @param ctxTableName
@@ -53,7 +53,7 @@ public interface IValidationRuleFactory extends ISingletonService
 
 	/**
 	 * Create SQL {@link IValidationRule} for given whereClause
-	 * 
+	 *
 	 * @param whereClause
 	 * @return
 	 */
@@ -61,11 +61,11 @@ public interface IValidationRuleFactory extends ISingletonService
 
 	/**
 	 * Registers a table-wide validation rule.
-	 * 
+	 *
 	 * Each time we retrieve the validation rules for a column, if there are some table validation rules registered for target table, those rules will be composed too.
-	 * 
+	 *
 	 * E.g. If we register a validation rule for table "C_BPartner_Location" and we try to retrieve the validation rules for C_Order.Bill_Location_ID, our registered rule will be composed too.
-	 * 
+	 *
 	 * @param tableName
 	 * @param rule
 	 */
@@ -73,12 +73,10 @@ public interface IValidationRuleFactory extends ISingletonService
 
 	/**
 	 * Register a table+column pair that is an exception from a table-wide validation rule ( see {@code org.adempiere.ad.validationRule.IValidationRuleFactory.registerTableValidationRule(String, IValidationRule)}).
-	 * 
-	 * @param rule
-	 * @param ctxTableName
-	 * @param ctxColumnName
+	 *
+	 * @param description may be null
 	 */
-	void registerValidationRuleException(IValidationRule rule, String ctxTableName, String ctxColumnName);
+	void registerValidationRuleException(IValidationRule rule, String ctxTableName, String ctxColumnName, String description);
 
 	IValidationContext createValidationContext(Properties ctx, int windowNo, int tabNo, String tableName);
 
@@ -86,9 +84,9 @@ public interface IValidationRuleFactory extends ISingletonService
 
 	/**
 	 * Creates validation context for given <code>gridField</code>.
-	 * 
+	 *
 	 * If gridField is not a lookup then {@link IValidationContext#NULL} is returned.
-	 * 
+	 *
 	 * @param gridField
 	 * @return validation context or {@link IValidationContext#NULL}
 	 */

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/impl/ValidationRuleFactory.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/validationRule/impl/ValidationRuleFactory.java
@@ -8,6 +8,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import javax.annotation.Nullable;
+
 import org.adempiere.ad.validationRule.IValidationContext;
 import org.adempiere.ad.validationRule.IValidationRule;
 import org.adempiere.ad.validationRule.IValidationRuleDAO;
@@ -31,6 +33,7 @@ import com.google.common.collect.ImmutableList;
 import de.metas.logging.LogManager;
 import de.metas.util.Check;
 import de.metas.util.Services;
+import lombok.NonNull;
 
 public class ValidationRuleFactory implements IValidationRuleFactory
 {
@@ -57,11 +60,13 @@ public class ValidationRuleFactory implements IValidationRuleFactory
 	}
 
 	@Override
-	public void registerValidationRuleException(final IValidationRule rule, final String ctxTableName, final String ctxColumnName)
+	public void registerValidationRuleException(
+			@NonNull final IValidationRule rule,
+			@NonNull final String ctxTableName,
+			@NonNull final String ctxColumnName,
+			@Nullable final String help)
 	{
-		Check.assume(rule != null, "rule not null");
-
-		rule.registerException(ctxTableName, ctxColumnName);
+		rule.registerException(ctxTableName, ctxColumnName, help);
 	}
 
 	@Override

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/model/InterfaceWrapperHelper.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/model/InterfaceWrapperHelper.java
@@ -79,7 +79,6 @@ import de.metas.util.Services;
 import de.metas.util.StringUtils;
 import de.metas.util.lang.RepoIdAware;
 import de.metas.util.lang.RepoIdAwares;
-
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 
@@ -100,7 +99,11 @@ public class InterfaceWrapperHelper
 			.addFactory(new GridTabInterfaceWrapperHelper())
 			.addFactory(new POJOInterfaceWrapperHelper());
 
-	private static final String COLUMNNAME_IsActive = "IsActive";
+	public static final String COLUMNNAME_IsActive = "IsActive";
+	public static final String COLUMNNAME_Value = "Value";
+	public static final String COLUMNNAME_Name = "Name";
+	public static final String COLUMNNAME_DocumentNo = "DocumentNo";
+	public static final String COLUMNNAME_Description = "Description";
 
 	private static final POJOLookupMap getInMemoryDatabaseForModel(final Class<?> modelClass)
 	{

--- a/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/validationRule/impl/RegisteredValidationRuleTest.java
+++ b/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/validationRule/impl/RegisteredValidationRuleTest.java
@@ -35,12 +35,12 @@ import de.metas.util.Services;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -111,7 +111,7 @@ public class RegisteredValidationRuleTest
 	/**
 	 * This test is mocking the general validation rule for the table M_Warehouse, which applies to all the columns that point to the table M_Warehouse.
 	 * This validation rule has an exception for the M_ReceiptSchedule.M_Warehouse_Dest_ID.
-	 * 
+	 *
 	 * In this test, the validation Rule is build built for M_ReceiptSchedule.M_Warehouse_Dest_ID, which fits the exception, so the validation rule should be not applied
 	 */
 	@Test
@@ -135,7 +135,7 @@ public class RegisteredValidationRuleTest
 		InterfaceWrapperHelper.save(rs_Warehouse_Dest_ID);
 
 		Services.get(IValidationRuleFactory.class).registerTableValidationRule(M_Warehouse.getTableName(), ValRuleTest.instance);
-		Services.get(IValidationRuleFactory.class).registerValidationRuleException(ValRuleTest.instance, M_ReceiptSchedule.getTableName(), rs_Warehouse_Dest_ID.getColumnName());
+		Services.get(IValidationRuleFactory.class).registerValidationRuleException(ValRuleTest.instance, M_ReceiptSchedule.getTableName(), rs_Warehouse_Dest_ID.getColumnName(), "test");
 
 		final IValidationRule validationRule = Services.get(IValidationRuleFactory.class).create(M_Warehouse.getTableName(), 0, M_ReceiptSchedule.getTableName(), rs_Warehouse_Dest_ID.getColumnName());
 
@@ -145,14 +145,13 @@ public class RegisteredValidationRuleTest
 	}
 
 	/**
-	 * /**
+	 *
 	 * This test is mocking the general validation rule for the table M_Warehouse, which applies to all the columns that point to the table M_Warehouse.
 	 * This validation rule has an exception for the M_ReceiptSchedule.M_Warehouse_Dest_ID.
-	 * 
+	 *
 	 * In this test, the validation Rule is build built for M_ReceiptSchedule.M_Warehouse_Dest_ID, which fits the exception, so the validation rule should be not applied
 	 * The column M_ReceiptSchedule.M_Warehouse_Dest_ID has an SQL validation rule. This one will be applied so the final ValidationRule will be of type SQL
 	 */
-
 	@Test
 	public void registerValidationRuleException_WithExceptions_ExceptionTableAndColumn_ExistingValRuleInDatabase()
 	{
@@ -177,7 +176,7 @@ public class RegisteredValidationRuleTest
 		InterfaceWrapperHelper.save(rs_Warehouse_Dest_ID);
 
 		Services.get(IValidationRuleFactory.class).registerTableValidationRule(M_Warehouse.getTableName(), ValRuleTest.instance);
-		Services.get(IValidationRuleFactory.class).registerValidationRuleException(ValRuleTest.instance, M_ReceiptSchedule.getTableName(), rs_Warehouse_Dest_ID.getColumnName());
+		Services.get(IValidationRuleFactory.class).registerValidationRuleException(ValRuleTest.instance, M_ReceiptSchedule.getTableName(), rs_Warehouse_Dest_ID.getColumnName(), "test");
 
 		final IValidationRule validationRule = Services.get(IValidationRuleFactory.class).create(M_Warehouse.getTableName(), databaseValRule.getAD_Val_Rule_ID(), M_ReceiptSchedule.getTableName(), rs_Warehouse_Dest_ID.getColumnName());
 
@@ -189,7 +188,7 @@ public class RegisteredValidationRuleTest
 	/**
 	 * This test is mocking the general validation rule for the table M_Warehouse, which applies to all the columns that point to the table M_Warehouse.
 	 * This validation rule has an exception for the M_ReceiptSchedule.M_Warehouse_Dest_ID.
-	 * 
+	 *
 	 * In this test, the validation Rule is build built for M_InOut.M_Warehouse_ID, which doesn't fit the exception, so the validation rule should be applied
 	 */
 	@Test
@@ -213,11 +212,11 @@ public class RegisteredValidationRuleTest
 		InterfaceWrapperHelper.save(rs_Warehouse_Dest_ID);
 
 		Services.get(IValidationRuleFactory.class).registerTableValidationRule(M_Warehouse.getTableName(), ValRuleTest.instance);
-		Services.get(IValidationRuleFactory.class).registerValidationRuleException(ValRuleTest.instance, M_ReceiptSchedule.getTableName(), rs_Warehouse_Dest_ID.getColumnName());
+		Services.get(IValidationRuleFactory.class).registerValidationRuleException(ValRuleTest.instance, M_ReceiptSchedule.getTableName(), rs_Warehouse_Dest_ID.getColumnName(), "test");
 
 		final IValidationRule validationRule = Services.get(IValidationRuleFactory.class).create(M_Warehouse.getTableName(), 0, M_InOut.getTableName(), inout_M_Warehouse_ID.getColumnName());
 
-		final ValueNamePair tableAndColumnException = new ValueNamePair(M_ReceiptSchedule.getTableName(), rs_Warehouse_Dest_ID.getColumnName());
+		final ValueNamePair tableAndColumnException = ValueNamePair.of(M_ReceiptSchedule.getTableName(), rs_Warehouse_Dest_ID.getColumnName(), "test");
 
 		assertThat(validationRule).isInstanceOf(ValRuleTest.class);
 		assertThat(validationRule.getExceptionTableAndColumns()).containsOnly(tableAndColumnException);

--- a/de.metas.adempiere.adempiere/base/src/test/java/org/compiere/util/NamePairJsonTest.java
+++ b/de.metas.adempiere.adempiere/base/src/test/java/org/compiere/util/NamePairJsonTest.java
@@ -17,12 +17,12 @@ import com.fasterxml.jackson.databind.SerializationFeature;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -44,14 +44,14 @@ public class NamePairJsonTest
 	public void test_KeyNamePair() throws Exception
 	{
 		testJsonIdentical(KeyNamePair.EMPTY, KeyNamePair.class);
-		testJsonEquals(new KeyNamePair(1, "test 1"), KeyNamePair.class);
+		testJsonEquals(KeyNamePair.of(1, "test-name-1", "test-description-1"), KeyNamePair.class);
 	}
 
 	@Test
 	public void test_ValueNamePair() throws Exception
 	{
 		testJsonIdentical(ValueNamePair.EMPTY, ValueNamePair.class);
-		testJsonEquals(new ValueNamePair("1", "test 1"), ValueNamePair.class);
+		testJsonEquals(ValueNamePair.of("1", "test-name-1", "test-description-1"), ValueNamePair.class);
 	}
 
 	private <T> void testJsonEquals(final T value, final Class<T> type) throws Exception

--- a/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/acct/AcctViewer.java
+++ b/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/acct/AcctViewer.java
@@ -89,17 +89,17 @@ import de.metas.util.Services;
  *
  *  @author Jorg Janke
  *  @version  $Id: AcctViewer.java,v 1.3 2006/08/10 01:00:27 jjanke Exp $
- * 
+ *
  * @author Teo Sarca, SC ARHIPAC SERVICE SRL
  * 			BF [ 1778534 ] Info Account: can't find product
- * @author Colin Rooney (croo) 
+ * @author Colin Rooney (croo)
  * 			BF [ 2006668 ] Selection of Product in the Accounting Viewer
  */
-public class AcctViewer extends CFrame 
+public class AcctViewer extends CFrame
 	implements ActionListener, ChangeListener
 {
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = -6160970582569467185L;
 
@@ -139,7 +139,7 @@ public class AcctViewer extends CFrame
 		log.info("AD_Table_ID=" + AD_Table_ID + ", Record_ID=" + Record_ID);
 
 		setDefaultCloseOperation(DISPOSE_ON_CLOSE);
-		
+
 		// task 07393: find out the AD_Org_ID. we'll use that info to initially set the current document's accounting schema.
 		final int AD_Org_ID;
 		if (AD_Table_ID > 0 && Record_ID > 0)
@@ -152,7 +152,7 @@ public class AcctViewer extends CFrame
 		{
 			AD_Org_ID = 0; // assume AD_Org_ID=0
 		}
-		
+
 		m_data = new AcctViewerData(ctx, Env.createWindowNo(this), AD_Client_ID, AD_Org_ID, AD_Table_ID);
 		AEnv.addToWindowManager(this);
 		//
@@ -183,7 +183,7 @@ public class AcctViewer extends CFrame
 	private AcctViewerData m_data = null;
 	/** Image Icon			*/
 	private final ImageIcon m_iFind = Images.getImageIcon2("Find16");
-	
+
 	/**	Logger			*/
 	private static final Logger log = LogManager.getLogger(AcctViewer.class);
 
@@ -270,7 +270,7 @@ public class AcctViewer extends CFrame
 
 	/**
 	 *  Static Init.
-	 * 
+	 *
 	 *  <pre>
 	 *  - mainPanel
 	 *      - tabbedPane
@@ -278,7 +278,7 @@ public class AcctViewer extends CFrame
 	 *          - result
 	 *          - graphPanel
 	 *  </pre>
-	 * 
+	 *
 	 *  @throws Exception
 	 */
 	private void jbInit() throws Exception
@@ -616,13 +616,13 @@ public class AcctViewer extends CFrame
 			m_data.dispose();
 			m_data = null;
 		}
-		
+
 		super.dispose();
 	}   //  dispose;
 
 	/**
 	 * Tab Changed
-	 * 
+	 *
 	 * @param e ChangeEvent
 	 */
 	@Override
@@ -646,7 +646,7 @@ public class AcctViewer extends CFrame
 
 	/**
 	 * Action Performed (Action Listener)
-	 * 
+	 *
 	 * @param e ActionEvent
 	 */
 	@Override
@@ -742,26 +742,26 @@ public class AcctViewer extends CFrame
 		sortBy2.removeAllItems();
 		sortBy3.removeAllItems();
 		sortBy4.removeAllItems();
-		sortAddItem(new ValueNamePair("", ""));
-		sortAddItem(new ValueNamePair("DateAcct", msgBL.translate(Env.getCtx(), "DateAcct")));
-		sortAddItem(new ValueNamePair("DateTrx", msgBL.translate(Env.getCtx(), "DateTrx")));
-		sortAddItem(new ValueNamePair("C_Period_ID", msgBL.translate(Env.getCtx(), "C_Period_ID")));
+		sortAddItem(ValueNamePair.EMPTY);
+		sortAddItem(ValueNamePair.of("DateAcct", msgBL.translate(Env.getCtx(), "DateAcct")));
+		sortAddItem(ValueNamePair.of("DateTrx", msgBL.translate(Env.getCtx(), "DateTrx")));
+		sortAddItem(ValueNamePair.of("C_Period_ID", msgBL.translate(Env.getCtx(), "C_Period_ID")));
 		//
 		CLabel[] labels = new CLabel[] { lsel1, lsel2, lsel3, lsel4, lsel5, lsel6, lsel7, lsel8 };
 		CButton[] buttons = new CButton[] { sel1, sel2, sel3, sel4, sel5, sel6, sel7, sel8 };
 		int selectionIndex = 0;
-		
+
 		final List<I_C_AcctSchema_Element> elements = acctSchemaDAO.retrieveSchemaElements(m_data.getC_AcctSchema());
-		
+
 		for (final I_C_AcctSchema_Element ase : elements)
 		{
 			final String columnName = acctSchemaBL.getColumnName(ase);
 			final String displayColumnName = acctSchemaBL.getDisplayColumnName(ase);
 			final String displayColumnNameTrl = msgBL.translate(Env.getCtx(), displayColumnName);
-			
+
 			//  Add Sort Option
-			sortAddItem(new ValueNamePair(columnName, displayColumnNameTrl));
-			
+			sortAddItem(ValueNamePair.of(columnName, displayColumnNameTrl));
+
 			//  Additional Elements
 			if (!Check.equals(ase.getElementType(), X_C_AcctSchema_Element.ELEMENTTYPE_Organization)
 					&& !Check.equals(ase.getElementType(), X_C_AcctSchema_Element.ELEMENTTYPE_Account))
@@ -783,7 +783,7 @@ public class AcctViewer extends CFrame
 			buttons[selectionIndex++].setVisible(false);
 		}
 	}	//	actionAcctSchema
-	
+
 	/**
 	 * 	Add to Sort
 	 *
@@ -809,7 +809,7 @@ public class AcctViewer extends CFrame
 		m_data.setAD_Org_ID(0);
 
 		//  Save Selection Choices
-		
+
 		// Accounting Schema
 		{
 			final KeyNamePair kp = selAcctSchema.getSelectedItem();
@@ -851,13 +851,13 @@ public class AcctViewer extends CFrame
 			//
 			para.append(m_data.getAdditionalWhereClauseInfo());
 		}
-		
+
 		//
 		// Account From/To
 		{
 			final int accountId = getButtonSelectedId(selAcct);
 			m_data.setAccount_ID(accountId);
-			
+
 			final int accountToId = getButtonSelectedId(selAcctTo);
 			m_data.setAccountTo_ID(accountToId);
 		}
@@ -876,7 +876,7 @@ public class AcctViewer extends CFrame
 		para.append(", Doc=").append(m_data.displayDocumentInfo);
 		m_data.setDisplayEndingBalance(displayEndingBalance.isSelected());
 		para.append(", EndingBalance=").append(m_data.isDisplayEndingBalance());
-		
+
 		//
 		m_data.sortBy1 = (sortBy1.getSelectedItem()).getValue();
 		m_data.group1 = group1.isSelected();
@@ -956,7 +956,7 @@ public class AcctViewer extends CFrame
 		//  Reset Record
 		m_data.setRecord_ID(0);
 		selRecord.setText("");
-		
+
 		final String keyColumnName = tableName + "_ID";
 		selRecord.setActionCommand(keyColumnName);
 	}   //  actionTable
@@ -1050,7 +1050,7 @@ public class AcctViewer extends CFrame
 	{
 		final String keyColumn = button.getActionCommand();
 		log.info(keyColumn);
-		
+
 		String whereClause = "(IsSummary='N' OR IsSummary IS NULL)";
 		String lookupColumn = keyColumn;
 		if (Check.isEmpty(keyColumn, true))
@@ -1094,7 +1094,7 @@ public class AcctViewer extends CFrame
 		{
 			whereClause = "";
 		}
-		
+
 		final String tableName = MQuery.getZoomTableName(lookupColumn);
 		Info info = InfoBuilder.newBuilder()
 				.setParentFrame(this)
@@ -1112,11 +1112,11 @@ public class AcctViewer extends CFrame
 			m_data.resetAdditionalWhereClause(keyColumn);
 			return 0;
 		}
-		
+
 		// Show model Info panel and wait for it's close
 		// info.setVisible(true); // task: this has no effect. need to call info.showWindow() instead (thx teo)
 		info.showWindow();
-		
+
 		final String selectSQL = info.getSelectedSQL();       //  C_Project_ID=100 or ""
 		final Integer key = (Integer)info.getSelectedKey();
 		info = null;
@@ -1141,9 +1141,9 @@ public class AcctViewer extends CFrame
 		//  Display Selection and resize
 		final String buttonText = m_data.getButtonText(tableName, lookupColumn, selectSQL);
 		setButtonSelectedId(button, key, buttonText);
-		
+
 		pack();
-		
+
 		return key;
 	}   //  actionButton
 
@@ -1157,13 +1157,13 @@ public class AcctViewer extends CFrame
 		final int adTableId = m_data.getAD_Table_ID();
 		final int recordId = m_data.getRecord_ID();
 		final boolean force = forcePost.isSelected();
-		
-		if (m_data.isDocumentQuery() 
+
+		if (m_data.isDocumentQuery()
 			&& adTableId > 0 && recordId > 0
 			&& Services.get(IClientUI.class).ask(windowNo, "PostImmediate?"))
 		{
 			AEnv.postImmediate(windowNo, adClientId, adTableId, recordId, force);
-			
+
 			actionQuery();
 		}
 	}   //  actionRePost
@@ -1193,7 +1193,7 @@ public class AcctViewer extends CFrame
 				e.printStackTrace();
 		}
 	}
-	
+
 	private static final String PROPERTY_ButtonSelectedId = AcctViewer.class.getName() + "#SelectedId";
 
 	private void setButtonSelectedId(final CButton button, final int selectedId, final String text)
@@ -1201,7 +1201,7 @@ public class AcctViewer extends CFrame
 		button.setText(text);
 		button.putClientProperty(PROPERTY_ButtonSelectedId, selectedId);
 	}
-	
+
 	private int getButtonSelectedId(final CButton button)
 	{
 		final Integer selectedId = (Integer)button.getClientProperty(PROPERTY_ButtonSelectedId);

--- a/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/acct/AcctViewerData.java
+++ b/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/acct/AcctViewerData.java
@@ -49,21 +49,19 @@ import org.compiere.util.Env;
 import org.compiere.util.KeyNamePair;
 import org.compiere.util.ValueNamePair;
 import org.slf4j.Logger;
-import org.slf4j.Logger;
 
 import de.metas.i18n.IMsgBL;
 import de.metas.logging.LogManager;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import de.metas.util.StringUtils;
-import de.metas.logging.LogManager;
 
 /**
  * Account Viewer State - maintains State information for the Account Viewer
  *
  * @author Jorg Janke
  * @version $Id: AcctViewerData.java,v 1.3 2006/08/10 01:00:27 jjanke Exp $
- * 
+ *
  * @author Teo Sarca, SC ARHIPAC SERVICE SRL <li>BF [ 1748449 ] Info Account - Posting Type is not translated <li>BF [ 1778373 ] AcctViewer: data is not sorted proper
  */
 class AcctViewerData
@@ -153,12 +151,12 @@ class AcctViewerData
 	boolean displayDocumentInfo = false;
 	/** Display Account Ending Balance */
 	boolean displayEndingBalance = true;
-	
+
 	/**
 	 * task 09243: flag to tell if the void/reversed docs are to be displayed or not
 	 */
 	boolean displayVoidDocuments = true;
-	
+
 	//
 	String sortBy1 = "";
 	String sortBy2 = "";
@@ -195,7 +193,7 @@ class AcctViewerData
 
 	/**************************************************************************
 	 * Fill Accounting Schema
-	 * 
+	 *
 	 * @param cb JComboBox to be filled
 	 */
 	protected void fillAcctSchema(JComboBox<KeyNamePair> cb)
@@ -215,7 +213,7 @@ class AcctViewerData
 
 	/**
 	 * Fill Posting Type
-	 * 
+	 *
 	 * @param cb JComboBox to be filled
 	 */
 	protected void fillPostingType(JComboBox<ValueNamePair> cb)
@@ -253,7 +251,7 @@ class AcctViewerData
 				String tableName = rs.getString(2);
 				String name = msgBL.translate(Env.getCtx(), tableName + "_ID");
 				//
-				final ValueNamePair pp = new ValueNamePair(tableName, name);
+				final ValueNamePair pp = ValueNamePair.of(tableName, name);
 				cb.addItem(pp);
 				_tableInfo.put(tableName, new Integer(id));
 				if (id == AD_Table_ID)
@@ -357,7 +355,7 @@ class AcctViewerData
 
 	/**************************************************************************
 	 * /** Create Query and submit
-	 * 
+	 *
 	 * @return Report Model
 	 */
 	protected RModel query()
@@ -425,7 +423,7 @@ class AcctViewerData
 			// Add Account_ID between Account_ID and AccountTo_ID
 			appendAccountWhereClause(whereClause);
 		}
-		
+
 		if(!isDisplayVoidDocuments())
 		{
 			whereClause.append( "AND ").append(RModel.TABLE_ALIAS).append(".DocStatus NOT IN (")
@@ -552,7 +550,7 @@ class AcctViewerData
 
 	/**
 	 * Create Report Model (Columns)
-	 * 
+	 *
 	 * @return Report Model
 	 */
 	private RModel getRModel()
@@ -638,7 +636,7 @@ class AcctViewerData
 					RModel.TABLE_ALIAS + ".PostingType",
 					X_Fact_Acct.POSTINGTYPE_AD_Reference_ID,
 					null));
-		
+
 		// task 09243: add docstatus
 		rm.addColumn(new RColumn(ctx, "DocStatus", DisplayType.String));
 		return rm;
@@ -646,7 +644,7 @@ class AcctViewerData
 
 	/**
 	 * Create the key columns in sequence
-	 * 
+	 *
 	 * @return List of Key Columns
 	 */
 	private ArrayList<String> createKeyColumns()
@@ -943,9 +941,9 @@ class AcctViewerData
 	public void setDisplayVoidDocuments(boolean isDisplayVoidDocuments)
 	{
 		this.displayVoidDocuments = isDisplayVoidDocuments;
-		
+
 	}
-	
+
 	public boolean isDisplayVoidDocuments()
 	{
 		return displayVoidDocuments;

--- a/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/apps/Preference.java
+++ b/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/apps/Preference.java
@@ -88,7 +88,7 @@ import de.metas.util.Services;
  *
  * @author Jorg Janke
  * @version $Id: Preference.java,v 1.2 2006/07/30 00:51:27 jjanke Exp $
- * 
+ *
  * @author Low Heng Sin
  * @version 2006-11-27
  */
@@ -96,7 +96,7 @@ public final class Preference extends CDialog
 		implements ActionListener, ListSelectionListener
 {
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = -8923143271736597338L;
 
@@ -176,7 +176,7 @@ public final class Preference extends CDialog
 
 	/**
 	 * Standard Constructor
-	 * 
+	 *
 	 * @param frame frame
 	 * @param WindowNo window
 	 */
@@ -201,10 +201,10 @@ public final class Preference extends CDialog
 		statusBar.setStatusDB("");
 		AEnv.positionCenterWindow(frame, this);
 	}	// Preference
-	
+
 	/**
 	 * Static Init.
-	 * 
+	 *
 	 * <pre>
 	 *  - panel
 	 *      - tabPane
@@ -221,7 +221,7 @@ public final class Preference extends CDialog
 	 * 					- errorTable
 	 *      - southPanel
 	 * </pre>
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	private void jbInit() throws Exception
@@ -393,7 +393,7 @@ public final class Preference extends CDialog
 		charsetPanel.add(fCharset);
 		customizePane.add(charsetPanel, new GridBagConstraints(0, 6, 1, 1, 1.0, 0.0
 				, GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(2, 0, 2, 0), 0, 0));
-		
+
 		// gh #975: also add additional settings that were registered via addSettingsPanel()
 		// for now, the panels are just added one by one, below each other
 		for (int i = 0; i < additionalSettingsPanels.size(); i++)
@@ -454,7 +454,7 @@ public final class Preference extends CDialog
 
 	/**
 	 * List Selection Listener - show info in header/detail fields
-	 * 
+	 *
 	 * @param e evant
 	 */
 	@Override
@@ -481,7 +481,7 @@ public final class Preference extends CDialog
 
 	/**
 	 * ActionListener
-	 * 
+	 *
 	 * @param e event
 	 */
 	@Override
@@ -630,7 +630,7 @@ public final class Preference extends CDialog
 		final String[] context = Env.getEntireContext(Env.getCtx());
 		Arrays.sort(context);
 		infoList.setListData(context);
-		
+
 		// gh #975: also apply on-load consumers that where added via addSettingsPanel()
 		additionalSettingsPanels.forEach(p -> {
 			final Consumer<Preference> onLoad = p.getRight().getLeft();
@@ -740,7 +740,7 @@ public final class Preference extends CDialog
 					String sTheme = theme.getValue();
 					if (sTheme != null && sTheme.length() > 0 && !sTheme.equals(themeClass))
 					{
-						ValueNamePair plaf = new ValueNamePair(
+						ValueNamePair plaf = ValueNamePair.of(
 								UIManager.getLookAndFeel().getClass().getName(),
 								UIManager.getLookAndFeel().getName());
 						AdempierePLAF.setPLAF(plaf, theme, true);
@@ -755,18 +755,18 @@ public final class Preference extends CDialog
 			final Consumer<Preference> onSave = p.getRight().getRight();
 			onSave.accept(this);
 		});
-		
+
 		Ini.saveProperties();
 		dispose();
 	}	// cmd_save
 
 	/**
-	 * 
+	 *
 	 * @param panel
 	 * @param onLoad will be applied then this instance is loaded. Should contain code to load initial values into the given {@code panel}.
 	 * @param onSave will be applied when this instance is stored, right before {@link Ini#saveProperties()} is invoked.
 	 *            Should contain code to persist the values of the given {@code panel}.
-	 *            
+	 *
 	 * @task https://github.com/metasfresh/metasfresh/issues/975
 	 */
 	public static void addSettingsPanel(final CPanel panel,

--- a/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/apps/form/VAttributeGrid.java
+++ b/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/apps/form/VAttributeGrid.java
@@ -73,7 +73,7 @@ import de.metas.product.ProductId;
 /**
  * Product Attribute Table.
  * Select one or two attributes for view/etc.
- * 
+ *
  * @author Jorg Janke
  * @version $Id: VAttributeGrid.java,v 1.2 2006/07/30 00:51:28 jjanke Exp $
  */
@@ -81,13 +81,13 @@ public class VAttributeGrid extends CPanel
 		implements FormPanel, ChangeListener, ActionListener
 {
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 3207678550566202041L;
 
 	/**
 	 * Init
-	 * 
+	 *
 	 * @param WindowNo
 	 * @param frame
 	 */
@@ -108,7 +108,7 @@ public class VAttributeGrid extends CPanel
 		selectPanel.add(attributeLabel1, new ALayoutConstraint(0, 0));
 		m_attributes = retrieveAttributes(Env.getCtx(), true, true);
 		Vector<KeyNamePair> vector = new Vector<>();
-		vector.add(new KeyNamePair(0, ""));
+		vector.add(new KeyNamePair(0, "", null/* help */));
 		for (int i = 0; i < m_attributes.length; i++)
 			vector.add(toKeyNamePair(m_attributes[i]));
 		attributeCombo1 = new CComboBox(vector);
@@ -134,7 +134,7 @@ public class VAttributeGrid extends CPanel
 
 	private static KeyNamePair toKeyNamePair(final I_M_Attribute attribute)
 	{
-		return KeyNamePair.of(attribute.getM_Attribute_ID(), attribute.getName());
+		return KeyNamePair.of(attribute.getM_Attribute_ID(), attribute.getName(), attribute.getDescription());
 	}
 
 	/** Window No */
@@ -201,9 +201,10 @@ public class VAttributeGrid extends CPanel
 	{
 		// Price List
 		String sql = "SELECT M_PriceList_Version.M_PriceList_Version_ID,"
-				+ " M_PriceList_Version.Name || ' (' || c.Iso_Code || ')' AS ValueName "
-				+ "FROM M_PriceList_Version, M_PriceList pl, C_Currency c "
-				+ "WHERE M_PriceList_Version.M_PriceList_ID=pl.M_PriceList_ID"
+				+ " M_PriceList_Version.Name || ' (' || c.Iso_Code || ')' AS ValueName, "
+				+ " COALESCE(M_PriceList_Version.Description, M_PriceList.Description) AS Description"
+				+ " FROM M_PriceList_Version, M_PriceList pl, C_Currency c "
+				+ " WHERE M_PriceList_Version.M_PriceList_ID=pl.M_PriceList_ID"
 				+ " AND pl.C_Currency_ID=c.C_Currency_ID"
 				+ " AND M_PriceList_Version.IsActive='Y' AND pl.IsActive='Y'";
 		// Add Access & Order
@@ -211,30 +212,33 @@ public class VAttributeGrid extends CPanel
 				+ " ORDER BY M_PriceList_Version.Name";
 		try
 		{
-			pickPriceList.addItem(new KeyNamePair(0, ""));
+			pickPriceList.addItem(new KeyNamePair(0, "", null/* help */));
 			PreparedStatement pstmt = DB.prepareStatement(sql, null);
 			ResultSet rs = pstmt.executeQuery();
 			while (rs.next())
 			{
-				KeyNamePair kn = new KeyNamePair(rs.getInt(1), rs.getString(2));
+				KeyNamePair kn = new KeyNamePair(rs.getInt(1), rs.getString(2), rs.getString(3));
 				pickPriceList.addItem(kn);
 			}
 			rs.close();
 			pstmt.close();
 
 			// Warehouse
-			sql = "SELECT M_Warehouse_ID, Value || ' - ' || Name AS ValueName "
+			sql = "SELECT M_Warehouse_ID, Value || ' - ' || Name AS ValueName, Description"
 					+ "FROM M_Warehouse "
 					+ "WHERE IsActive='Y'";
 			sql = Env.getUserRolePermissions().addAccessSQL(sql,
 					"M_Warehouse", IUserRolePermissions.SQL_NOTQUALIFIED, IUserRolePermissions.SQL_RO)
 					+ " ORDER BY Value";
-			pickWarehouse.addItem(new KeyNamePair(0, ""));
+			pickWarehouse.addItem(new KeyNamePair(0, "", null/* help */));
 			pstmt = DB.prepareStatement(sql, null);
 			rs = pstmt.executeQuery();
 			while (rs.next())
 			{
-				KeyNamePair kn = new KeyNamePair(rs.getInt("M_Warehouse_ID"), rs.getString("ValueName"));
+				KeyNamePair kn = new KeyNamePair(
+						rs.getInt("M_Warehouse_ID"),
+						rs.getString("ValueName"),
+						rs.getString("Description"));
 				pickWarehouse.addItem(kn);
 			}
 			rs.close();
@@ -248,7 +252,7 @@ public class VAttributeGrid extends CPanel
 
 	/**
 	 * Change Listener
-	 * 
+	 *
 	 * @param e event
 	 */
 	@Override
@@ -262,7 +266,7 @@ public class VAttributeGrid extends CPanel
 
 	/**
 	 * Action Performed
-	 * 
+	 *
 	 * @param e event
 	 */
 	@Override
@@ -419,7 +423,7 @@ public class VAttributeGrid extends CPanel
 
 	/**
 	 * Get Grid Element
-	 * 
+	 *
 	 * @param xValue X value
 	 * @param yValue Y value
 	 * @return Panel with Info
@@ -501,7 +505,7 @@ public class VAttributeGrid extends CPanel
 
 	/**
 	 * Add Product
-	 * 
+	 *
 	 * @param element panel
 	 * @param product product
 	 */

--- a/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/grid/VSortTab.java
+++ b/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/grid/VSortTab.java
@@ -887,7 +887,7 @@ public class VSortTab extends CPanel implements APanelTab
 		private boolean	m_updateable;
 
 		public ListItem(int key, String name, int sortNo, boolean isYes, int AD_Client_ID, int AD_Org_ID) {
-			super(name);
+			super(name, null/* description */);
 			this.m_key = key;
 			this.m_AD_Client_ID = AD_Client_ID;
 			this.m_AD_Org_ID = AD_Org_ID;

--- a/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/grid/XLookup.java
+++ b/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/grid/XLookup.java
@@ -39,7 +39,7 @@ import de.metas.util.Check;
 public class XLookup extends Lookup
 {
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1388987648081532657L;
 
@@ -136,7 +136,7 @@ public class XLookup extends Lookup
 	 * 	@return list of data
 	 */
 	@Override
-	public List<Object> getData (boolean mandatory, 
+	public List<Object> getData (boolean mandatory,
 		boolean onlyValidated, boolean onlyActive, boolean temporary)
 	{
 		final int size = getSize();
@@ -151,14 +151,14 @@ public class XLookup extends Lookup
 		//	Sort Data
 		if (m_keyColumn.endsWith("_ID"))
 		{
-			KeyNamePair p = new KeyNamePair (-1, "");
+			KeyNamePair p = KeyNamePair.EMPTY;
 			if (!mandatory)
 				list.add (p);
 			Collections.sort (list, p);
 		}
 		else
 		{
-			ValueNamePair p = new ValueNamePair (null, "");
+			ValueNamePair p = ValueNamePair.EMPTY;
 			if (!mandatory)
 				list.add (p);
 			Collections.sort (list, p);
@@ -183,7 +183,7 @@ public class XLookup extends Lookup
 		{
 			return null;
 		}
-		
+
 		return MQuery.getZoomTableName(m_keyColumn);
 	}
 
@@ -196,7 +196,7 @@ public class XLookup extends Lookup
 	{
 		return m_keyColumn;
 	}   //  getColumnName
-	
+
 	@Override
 	public String getColumnNameNotFQ()
 	{

--- a/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/grid/ed/VLocatorDialog.java
+++ b/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/grid/ed/VLocatorDialog.java
@@ -74,7 +74,7 @@ public class VLocatorDialog extends CDialog
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param frame frame
 	 * @param title title
 	 * @param mLocator locator
@@ -146,7 +146,7 @@ public class VLocatorDialog extends CDialog
 
 	/**
 	 * Static component init
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	private void jbInit() throws Exception
@@ -208,7 +208,7 @@ public class VLocatorDialog extends CDialog
 	private void initLocator()
 	{
 		// Load Warehouse
-		String sql = "SELECT M_Warehouse_ID, Name FROM M_Warehouse";
+		String sql = "SELECT M_Warehouse_ID, Name, Description FROM M_Warehouse";
 		if (m_only_Warehouse_ID != null)
 		{
 			sql += " WHERE M_Warehouse_ID=" + m_only_Warehouse_ID.getRepoId();
@@ -227,7 +227,7 @@ public class VLocatorDialog extends CDialog
 			pstmt = DB.prepareStatement(sqlFinal, ITrx.TRXNAME_None);
 			rs = pstmt.executeQuery();
 			while (rs.next())
-				fWarehouse.addItem(KeyNamePair.of(rs.getInt(1), rs.getString(2)));
+				fWarehouse.addItem(KeyNamePair.of(rs.getInt(1), rs.getString(2), rs.getString(3)/*help*/));
 			rs.close();
 			pstmt.close();
 		}
@@ -265,7 +265,7 @@ public class VLocatorDialog extends CDialog
 
 	/**
 	 * ActionListener
-	 * 
+	 *
 	 * @param e event
 	 */
 	@Override
@@ -300,7 +300,7 @@ public class VLocatorDialog extends CDialog
 
 	/**
 	 * KeyListener - nop
-	 * 
+	 *
 	 * @param e event
 	 */
 	@Override
@@ -311,7 +311,7 @@ public class VLocatorDialog extends CDialog
 
 	/**
 	 * KeyListener
-	 * 
+	 *
 	 * @param e event
 	 */
 	@Override
@@ -323,7 +323,7 @@ public class VLocatorDialog extends CDialog
 
 	/**
 	 * KeyListener - nop
-	 * 
+	 *
 	 * @param e event
 	 */
 	@Override
@@ -396,7 +396,7 @@ public class VLocatorDialog extends CDialog
 		{
 			return;
 		}
-		
+
 		// Defaults
 		m_M_Warehouse_ID = null;
 		// m_M_WarehouseName = "";
@@ -489,9 +489,9 @@ public class VLocatorDialog extends CDialog
 					fX.getText(),
 					fY.getText(),
 					fZ.getText());
-			
+
 			m_M_Locator_ID = locator.getM_Locator_ID();
-			
+
 			final MLocator locatorPO = LegacyAdapters.convertToPO(locator);
 			fLocator.addItem(locatorPO);
 			fLocator.setSelectedItem(locatorPO);
@@ -502,7 +502,7 @@ public class VLocatorDialog extends CDialog
 
 	/**
 	 * Get Selected value
-	 * 
+	 *
 	 * @return value as Integer
 	 */
 	public Integer getValue()
@@ -515,7 +515,7 @@ public class VLocatorDialog extends CDialog
 
 	/**
 	 * Get result
-	 * 
+	 *
 	 * @return true if changed
 	 */
 	public boolean isChanged()

--- a/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/grid/ed/VLookup.java
+++ b/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/grid/ed/VLookup.java
@@ -784,12 +784,12 @@ public class VLookup extends JComponent
 				if (m_value instanceof Integer)
 				{
 					final int id = (Integer)m_value;
-					pp = new KeyNamePair(id, m_lastDisplay);
+					pp = KeyNamePair.of(id, m_lastDisplay);
 				}
 				else
 				{
 					final String valueStr = m_value == null ? "" : m_value.toString();
-					pp = new ValueNamePair(valueStr, m_lastDisplay);
+					pp = ValueNamePair.of(valueStr, m_lastDisplay);
 				}
 
 				m_combo.addItem(pp);

--- a/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/pos/PosOrderModel.java
+++ b/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/pos/PosOrderModel.java
@@ -42,9 +42,9 @@ import de.metas.util.Services;
 public class PosOrderModel extends MOrder {
 
 	private static final long serialVersionUID = 5253837037827124425L;
-	
+
 	private MPOS m_pos;
-	
+
 	public PosOrderModel(Properties ctx, int C_Order_ID, String trxName, MPOS pos) {
 		super(ctx, C_Order_ID, trxName);
 		m_pos = pos;
@@ -52,11 +52,11 @@ public class PosOrderModel extends MOrder {
 
 	/**
 	 * Get/create Order
-	 * 
+	 *
 	 * @return order or null
 	 */
 	public static PosOrderModel createOrder(MPOS pos, MBPartner partner) {
-		
+
 		PosOrderModel order = new PosOrderModel(Env.getCtx(), 0, null, pos);
 		order.setAD_Org_ID(pos.getAD_Org_ID());
 		order.setIsSOTrx(true);
@@ -81,13 +81,13 @@ public class PosOrderModel extends MOrder {
 			order = null;
 			throw new AdempierePOSException("Save order failed");
 		}
-		
+
 		return order;
 	} //	createOrder
 
 
 	/**
-	 * @author Comunidad de Desarrollo OpenXpertya 
+	 * @author Comunidad de Desarrollo OpenXpertya
 	 *         *Basado en Codigo Original Modificado, Revisado y Optimizado de:
 	 *         *Copyright ConSerTi
 	 */
@@ -117,16 +117,16 @@ public class PosOrderModel extends MOrder {
 
 	/**
 	 * Create new Line
-	 * 
+	 *
 	 * @return line or null
 	 */
 	public MOrderLine createLine(MProduct product, BigDecimal QtyOrdered,
 			BigDecimal PriceActual) {
-		
+
 		if (!getDocStatus().equals("DR") )
 			return null;
 		//add new line or increase qty
-		
+
 		// catch Exceptions at order.getLines()
 		int numLines = 0;
 		MOrderLine[] lines = null;
@@ -160,23 +160,23 @@ public class PosOrderModel extends MOrder {
 		MOrderLine line = new MOrderLine(this);
 		line.setProduct(product);
 		line.setQty(QtyOrdered);
-			
+
 		line.setPrice(); //	sets List/limit
 		if ( PriceActual.compareTo(Env.ZERO) > 0 )
 			line.setPrice(PriceActual);
 		line.save();
 		return line;
-			
+
 	} //	createLine
-	
-	
+
+
 	/**
 	 * Delete order from database
-	 * 
-	 * @author Comunidad de Desarrollo OpenXpertya 
+	 *
+	 * @author Comunidad de Desarrollo OpenXpertya
  *         *Basado en Codigo Original Modificado, Revisado y Optimizado de:
  *         *Copyright � ConSerTi
-	 */		
+	 */
 	public boolean deleteOrder () {
 		if (getDocStatus().equals("DR"))
 			{
@@ -191,7 +191,7 @@ public class PosOrderModel extends MOrder {
 								deleteLine(lines[i].getC_Order_ID());
 						}
 				}
-				
+
 				MOrderTax[] taxs = getTaxes(true);
 				if (taxs != null)
 				{
@@ -204,14 +204,14 @@ public class PosOrderModel extends MOrder {
 							taxs[i] = null;
 						}
 				}
-				
+
 				getLines(true, null);		// requery order
 				return delete(true);
 			}
 		return false;
 	} //	deleteOrder
-	
-	/** 
+
+	/**
 	 * to erase the lines from order
 	 * @return true if deleted
 	 */
@@ -222,7 +222,7 @@ public class PosOrderModel extends MOrder {
 			{
 				if ( line.getC_OrderLine_ID() == C_OrderLine_ID )
 				{
-					line.delete(true);	
+					line.delete(true);
 				}
 			}
 		}
@@ -230,17 +230,17 @@ public class PosOrderModel extends MOrder {
 
 	/**
 	 * 	Process Order
-	 *  @author Comunidad de Desarrollo OpenXpertya 
+	 *  @author Comunidad de Desarrollo OpenXpertya
 	 *         *Basado en Codigo Original Modificado, Revisado y Optimizado de:
 	 *         *Copyright � ConSerTi
 	 */
 	public boolean processOrder()
-	{		
+	{
 		//Returning orderCompleted to check for order completeness
 		boolean orderCompleted = false;
 		// check if order completed OK
 		if (getDocStatus().equals("DR") || getDocStatus().equals("IP") )
-		{ 
+		{
 			setDocAction(IDocument.ACTION_Complete);
 			try
 			{
@@ -250,7 +250,7 @@ public class PosOrderModel extends MOrder {
 				}
 				else
 				{
-					log.info( "Process Order FAILED");		
+					log.info( "Process Order FAILED");
 				}
 			}
 			catch (Exception e)
@@ -266,12 +266,12 @@ public class PosOrderModel extends MOrder {
 				else if( getDocStatus().equals("CO") )
 				{
 					orderCompleted = true;
-					log.info( "SubCheckout - processOrder OK");	 
-				}			
+					log.info( "SubCheckout - processOrder OK");
+				}
 				else
 				{
-					log.info( "SubCheckout - processOrder - unrecognized DocStatus"); 
-				}					
+					log.info( "SubCheckout - processOrder - unrecognized DocStatus");
+				}
 			} // try-finally
 
 		}
@@ -287,7 +287,7 @@ public class PosOrderModel extends MOrder {
 		}
 		return taxAmt;
 	}
-	
+
 	public BigDecimal getSubtotal() {
 		return getGrandTotal().subtract(getTaxAmt());
 	}
@@ -298,12 +298,12 @@ public class PosOrderModel extends MOrder {
 		BigDecimal received = DB.getSQLValueBD(null, sql, getC_Order_ID());
 		if ( received == null )
 			received = Env.ZERO;
-		
+
 		sql = "SELECT sum(Amount) FROM C_CashLine WHERE C_Invoice_ID = ? ";
 		BigDecimal cashline = DB.getSQLValueBD(null, sql, getC_Invoice_ID());
 		if ( cashline != null )
 			received = received.add(cashline);
-		
+
 		return received;
 	}
 
@@ -324,7 +324,7 @@ public class PosOrderModel extends MOrder {
 		else return false;
 	} // payCash
 
-	public boolean payCheck(BigDecimal amt, String accountNo, String routingNo, String checkNo) 
+	public boolean payCheck(BigDecimal amt, String accountNo, String routingNo, String checkNo)
 	{
 		MPayment payment = createPayment(MPayment.TENDERTYPE_Check);
 		payment.setAmount(getC_Currency_ID(), amt);
@@ -342,9 +342,9 @@ public class PosOrderModel extends MOrder {
 		}
 		else return false;
 	} // payCheck
-	
+
 	public boolean payCreditCard(BigDecimal amt, String accountName, int month, int year,
-			String cardNo, String cvc, String cardtype) 
+			String cardNo, String cvc, String cardtype)
 	{
 
 		MPayment payment = createPayment(MPayment.TENDERTYPE_Check);
@@ -378,7 +378,7 @@ public class PosOrderModel extends MOrder {
 		load( get_TrxName());
 		getLines(true, "");
 	}
-	
+
 	/**
 	 * Duplicated from MPayment
 	 * 	Get Accepted Credit Cards for amount
@@ -389,7 +389,7 @@ public class PosOrderModel extends MOrder {
 	{
 		try
 		{
-			MPaymentProcessor[] m_mPaymentProcessors = MPaymentProcessor.find (getCtx (), null, null, 
+			MPaymentProcessor[] m_mPaymentProcessors = MPaymentProcessor.find (getCtx (), null, null,
 					getAD_Client_ID (), getAD_Org_ID(), getC_Currency_ID (), amt, get_TrxName());
 			//
 			HashMap<String,ValueNamePair> map = new HashMap<>(); //	to eliminate duplicates
@@ -420,9 +420,9 @@ public class PosOrderModel extends MOrder {
 			return null;
 		}
 	}	//	getCreditCards
-	
+
 	/**
-	 * 
+	 *
 	 * Duplicated from MPayment
 	 * 	Get Type and name pair
 	 *	@param CreditCardType credit card Type
@@ -430,11 +430,11 @@ public class PosOrderModel extends MOrder {
 	 */
 	private ValueNamePair getCreditCardPair (String CreditCardType)
 	{
-		return new ValueNamePair (CreditCardType, getCreditCardName(CreditCardType));
+		return ValueNamePair.of(CreditCardType, getCreditCardName(CreditCardType));
 	}	//	getCreditCardPair
 
 	/**
-	 * 
+	 *
 	 * Duplicated from MPayment
 	 *	Get Name of Credit Card
 	 * 	@param CreditCardType credit card type
@@ -460,5 +460,5 @@ public class PosOrderModel extends MOrder {
 			return "PurchaseCard";
 		return "?" + CreditCardType + "?";
 	}	//	getCreditCardName
-	
+
 } // PosOrderModel.class

--- a/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/print/Viewer.java
+++ b/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/print/Viewer.java
@@ -123,7 +123,7 @@ import net.miginfocom.swing.MigLayout;
  *
  * 	@author 	Jorg Janke
  * 	@version 	$Id: Viewer.java,v 1.2 2006/07/30 00:51:28 jjanke Exp $
- * globalqss: integrate phib contribution from 
+ * globalqss: integrate phib contribution from
  *   http://sourceforge.net/tracker/index.php?func=detail&aid=1566335&group_id=176962&atid=879334
  * globalqss: integrate Teo Sarca bug fixing
  * Colin Rooney 2007/03/20 RFE#1670185 & BUG#1684142
@@ -198,7 +198,7 @@ public class Viewer extends CFrame
 	/** Table ID					*/
 	private int					m_AD_Table_ID = 0;
 	private boolean				m_isCanExport;
-	
+
 	private MQuery 		m_ddQ = null;
 	private MQuery 		m_daQ = null;
 	private CMenuItem 	m_ddM = null;
@@ -245,7 +245,7 @@ public class Viewer extends CFrame
 		contentPane.add(toolBar, BorderLayout.NORTH);
 		contentPane.add(centerScrollPane, BorderLayout.CENTER);
 		contentPane.add(statusBar, BorderLayout.SOUTH);
-		
+
 		centerScrollPane.setViewportView(m_viewPanel);
 
 		//	ToolBar
@@ -259,20 +259,20 @@ public class Viewer extends CFrame
 					, new AC().gap("0px")
 					));
 			toolBar.setFloatable(false);
-			
+
 			//
 			//	Page Control
 			toolBar.add(bPrevious);
 			toolBar.add(bNext);
 			toolBar.add(fPageNo);
 			toolBar.add(fPerLastPageNo);
-			
+
 			//
 			// Zoom Level
 			// toolBar.addSeparator();
 			// toolBar.add(comboZoom, null);
 			// comboZoom.setToolTipText(msgBL.getMsg(m_ctx, "Zoom"));
-			
+
 			//
 			//	Drill
 			toolBar.addSeparator();
@@ -282,7 +282,7 @@ public class Viewer extends CFrame
 			toolBar.add(comboDrill);
 			comboDrill.setMaximumSize(null); // make sure we are not using the VEditorUI's enforced height
 			comboDrill.setToolTipText(msgBL.getMsg(m_ctx, "Drill"));
-			
+
 			//
 			//	Format, Customize, Find
 			toolBar.addSeparator();
@@ -294,7 +294,7 @@ public class Viewer extends CFrame
 			toolBar.add(bFind);
 			bFind.setToolTipText(msgBL.getMsg(m_ctx, "Find"));
 			toolBar.addSeparator();
-			
+
 			//
 			//	Print/Export
 			toolBar.add(bPrint);
@@ -308,7 +308,7 @@ public class Viewer extends CFrame
 				bExport.setToolTipText(msgBL.getMsg(m_ctx, "Export"));
 				toolBar.add(bExport);
 			}
-			
+
 			toolBar.add(Box.createHorizontalGlue(), new CC().growX());
 		}
 	}	//	jbInit
@@ -320,7 +320,7 @@ public class Viewer extends CFrame
 	{
 		createMenu();
 //		comboZoom.addActionListener(this);
-		
+
 		//	Change Listener to set Page no
 		centerScrollPane.getViewport().addChangeListener(new ChangeListener()
 		{
@@ -340,7 +340,7 @@ public class Viewer extends CFrame
 			{
 				fPageNo.selectAll();
 			}
-			
+
 			@Override
 			public void focusLost(FocusEvent e)
 			{
@@ -353,7 +353,7 @@ public class Viewer extends CFrame
 		});
 		fPageNo.addActionListener(new ActionListener()
 		{
-			
+
 			@Override
 			public void actionPerformed(ActionEvent e)
 			{
@@ -377,8 +377,10 @@ public class Viewer extends CFrame
 		});
 
 		//	fill Drill Options (Name, TableName)
-		comboDrill.addItem(new ValueNamePair (null,""));
+		comboDrill.addItem(ValueNamePair.EMPTY);
+
 		String sql = "SELECT t.AD_Table_ID, t.TableName, e.PrintName, NULLIF(e.PO_PrintName,e.PrintName) "
+			+ ", e.Description "
 			+ "FROM AD_Column c "
 			+ " INNER JOIN AD_Column used ON (c.ColumnName=used.ColumnName)"
 			+ " INNER JOIN AD_Table t ON (used.AD_Table_ID=t.AD_Table_ID AND t.IsView='N' AND t.AD_Table_ID <> c.AD_Table_ID)"
@@ -386,9 +388,11 @@ public class Viewer extends CFrame
 			+ " INNER JOIN AD_Element e ON (cKey.ColumnName=e.ColumnName) "
 			+ "WHERE c.AD_Table_ID=? AND c.IsKey='Y' "
 			+ "ORDER BY 3";
+
 		boolean trl = !Env.isBaseLanguage(Env.getCtx(), "AD_Element");
 		if (trl)
 			sql = "SELECT t.AD_Table_ID, t.TableName, et.PrintName, NULLIF(et.PO_PrintName,et.PrintName) "
+				+ ", et.Description "
 				+ "FROM AD_Column c"
 				+ " INNER JOIN AD_Column used ON (c.ColumnName=used.ColumnName)"
 				+ " INNER JOIN AD_Table t ON (used.AD_Table_ID=t.AD_Table_ID AND t.IsView='N' AND t.AD_Table_ID <> c.AD_Table_ID)"
@@ -412,9 +416,11 @@ public class Viewer extends CFrame
 				String tableName = rs.getString(2);
 				String name = rs.getString(3);
 				String poName = rs.getString(4);
+				String description = rs.getString(5);
+
 				if (poName != null)
 					name += "/" + poName;
-				comboDrill.addItem(new ValueNamePair (tableName, name));
+				comboDrill.addItem(ValueNamePair.of(tableName, name, description));
 			}
 		}
 		catch (SQLException e)
@@ -480,7 +486,7 @@ public class Viewer extends CFrame
 		{
 			DB.close(rs, pstmt);
 		}
-		
+
 		StringBuilder sb = new StringBuilder("** ").append(msgBL.getMsg(m_ctx, "NewReport")).append(" **");
 		KeyNamePair pp = new KeyNamePair(-1, sb.toString());
 		comboReport.addItem(pp);
@@ -548,7 +554,7 @@ public class Viewer extends CFrame
 				.setParentWindowNo(m_WindowNo)
 				.setMenu(mView)
 				.build();
-		
+
 		//		Go
 		JMenu mGo = AEnv.getMenu("Go");
 		menuBar.add(mGo);
@@ -564,7 +570,7 @@ public class Viewer extends CFrame
 		{
 			AEnv.addMenuItem("Preference", null, null, mTools, this);
 		}
-		
+
 		//		Window
 		AMenu aMenu = (AMenu)Env.getWindow(0);
 		JMenu mWindow = new WindowMenu(aMenu.getWindowManager(), this);
@@ -591,7 +597,7 @@ public class Viewer extends CFrame
 			setButton(bArchive, "Archive", "Archive");
 			if (m_isCanExport)
 				setButton(bExport, "Export", "Export");
-			
+
 			setButton(bFind, "Find", "Find");
 			setButton(bCustomize, "PrintCustomize", "Preference");
 		}
@@ -630,7 +636,7 @@ public class Viewer extends CFrame
 		super.dispose();
 	}	//	dispose
 
-	
+
 	/**************************************************************************
 	 * 	Action Listener
 	 * 	@param e event
@@ -721,7 +727,7 @@ public class Viewer extends CFrame
 			m_pageNoSetting = false;
 		}
 	}	//	stateChanged
-	
+
 	private void setPageNoFromUI()
 	{
 		final Object pageNoObj = fPageNo.getValue();
@@ -747,7 +753,7 @@ public class Viewer extends CFrame
 				pageNo = m_pageNo;
 			}
 		}
-		
+
 		setPage(pageNo);
 	}
 
@@ -768,12 +774,12 @@ public class Viewer extends CFrame
 				m_pageNo = 1;
 			if (page > m_pageMax)
 				m_pageNo = m_pageMax;
-			
+
 			//
 			// Update bPrevious/bNext buttons
 			bPrevious.setEnabled (m_pageNo != 1);
 			bNext.setEnabled (m_pageNo != m_pageMax);
-			
+
 			//
 			// Scroll to page (if user is not currently scrolling)
 			if(!m_scrolling)
@@ -783,14 +789,14 @@ public class Viewer extends CFrame
 				pageRectangle.y -= View.MARGIN;
 				centerScrollPane.getViewport().setViewPosition(pageRectangle.getLocation());
 			}
-	
+
 			//	Update Page text field
 			fPageNo.setValue(m_pageNo);
 			fPerLastPageNo.setText(" / " + m_pageMax);
-			
+
 			//
 			// Status bar
-			final String pageInfo = m_viewPanel.updatePageInfo(m_pageNo);			
+			final String pageInfo = m_viewPanel.updatePageInfo(m_pageNo);
 			StringBuilder sb = new StringBuilder (msgBL.getMsg(m_ctx, "Page"))
 				.append(" ").append(pageInfo)
 				.append(" ").append(msgBL.getMsg(m_ctx, "slash")).append(" ")
@@ -803,7 +809,7 @@ public class Viewer extends CFrame
 		}
 	}	//	setPage
 
-	
+
 	/**************************************************************************
 	 * 	(Re)Set Drill Across Cursor
 	 */
@@ -854,7 +860,7 @@ public class Viewer extends CFrame
 			pop.show((Component)e.getSource(), pp.x, pp.y);
 			return;
 		}
-		
+
 		setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 		if (m_drillDown)
 		{
@@ -907,7 +913,7 @@ public class Viewer extends CFrame
 			return;
 		AEnv.zoom(query);
 	}	//	cmd_window
-	
+
 	/**************************************************************************
 	 * 	Print Report
 	 */
@@ -929,7 +935,7 @@ public class Viewer extends CFrame
 		String subject = m_reportEngine.getName();
 		String message = "";
 		File attachment = null;
-		
+
 		try
 		{
 			attachment = File.createTempFile("mail", ".pdf");
@@ -940,11 +946,11 @@ public class Viewer extends CFrame
 			log.error("", e);
 		}
 
-		//EMailDialog emd = 
+		//EMailDialog emd =
 		new EMailDialog (this,
 			msgBL.getMsg(Env.getCtx(), "SendMail"),
 			from, to, subject, message, attachment);
-		
+
 	}	//	cmd_sendMail
 
 	/**
@@ -998,7 +1004,7 @@ public class Viewer extends CFrame
 			ADialog.error(m_WindowNo, this, "AccessCannotExport", getTitle());
 			return;
 		}
-		
+
 		//
 		JFileChooser chooser = new JFileChooser();
 		chooser.setDialogType(JFileChooser.SAVE_DIALOG);
@@ -1020,7 +1026,7 @@ public class Viewer extends CFrame
 			final ExtensionFileFilter filter = new ExtensionFileFilter(excelFileExtension, excelFileExtension + " - " + formatName);
 			chooser.addChoosableFileFilter(filter);
 		}
-		
+
 		//
 		if (chooser.showSaveDialog(this) != JFileChooser.APPROVE_OPTION)
 		{
@@ -1075,7 +1081,7 @@ public class Viewer extends CFrame
 		cmd_drill();	//	setCursor
 	}	//	cmd_export
 
-	
+
 	/**
 	 * 	Report Combo - Start other Report or create new one
 	 */
@@ -1113,8 +1119,8 @@ public class Viewer extends CFrame
 		}
 		else
 			pf = MPrintFormat.get (Env.getCtx(), AD_PrintFormat_ID, true);
-		
-		//	Get Language from previous - thanks Gunther Hoppe 
+
+		//	Get Language from previous - thanks Gunther Hoppe
 		if (m_reportEngine.getPrintFormat() != null)
 		{
 			pf.setLanguage(m_reportEngine.getPrintFormat().getLanguage());		//	needs to be re-set - otherwise viewer will be blank
@@ -1133,7 +1139,7 @@ public class Viewer extends CFrame
 	{
 		setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 		final int AD_Table_ID = m_reportEngine.getPrintFormat().getAD_Table_ID();
-		
+
 		//	Get Find Tab Info
 		String sql = "SELECT t.AD_Tab_ID"
 				+ ", t." + I_AD_Tab.COLUMNNAME_Template_Tab_ID
@@ -1172,7 +1178,7 @@ public class Viewer extends CFrame
 					+ " AND AD_Language='" + Env.getAD_Language(Env.getCtx()) + "' " + ASPFilter;
 		}
 
-		String title = null; 
+		String title = null;
 		String tableName = null;
 		int maxQueryRecordsPerTab = 0;
 		PreparedStatement pstmt = null;
@@ -1185,7 +1191,7 @@ public class Viewer extends CFrame
 			//
 			if (rs.next())
 			{
-				title = rs.getString(1);				
+				title = rs.getString(1);
 				tableName = rs.getString(2);
 				maxQueryRecordsPerTab = rs.getInt(I_AD_Tab.COLUMNNAME_MaxQueryRecords);
 			}
@@ -1205,7 +1211,7 @@ public class Viewer extends CFrame
 		{
 			findFields = GridField.createSearchFields(m_ctx, m_WindowNo, 0, tabAndTemplateTabId.getTabId(), tabAndTemplateTabId.getTemplateTabId());
 		}
-		
+
 		if (findFields == null)		//	No Tab for Table exists
 		{
 			bFind.setEnabled(false);
@@ -1345,13 +1351,13 @@ public class Viewer extends CFrame
 		m_reportEngine.setPrintFormat(MPrintFormat.get (Env.getCtx(), AD_PrintFormat_ID, true));
 		revalidateViewer();
 	}	//	cmd_translate
-	
+
 	@lombok.Builder
 	@lombok.Value
 	private static class TabAndTemplateTabId
 	{
 		static final TabAndTemplateTabId NONE = builder().build();
-		
+
 		int tabId;
 		int templateTabId;
 	}

--- a/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/swing/ColorEditor.java
+++ b/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/swing/ColorEditor.java
@@ -57,13 +57,13 @@ public class ColorEditor extends CDialog
 		implements ActionListener, PropertyEditor
 {
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = -484760951046013782L;
 
 	/**
 	 * Get Background AdempiereColor
-	 * 
+	 *
 	 * @param owner owner
 	 * @param color optional initial color
 	 * @return AdempiereColor
@@ -78,7 +78,7 @@ public class ColorEditor extends CDialog
 
 	/**
 	 * Get Background AdempiereColor
-	 * 
+	 *
 	 * @param owner owner
 	 * @param color optional initial color
 	 * @return AdempiereColor
@@ -112,10 +112,10 @@ public class ColorEditor extends CDialog
 	};
 	/** Types */
 	private static final ValueNamePair[] TYPES = new ValueNamePair[] {
-			new ValueNamePair(TYPE_VALUES[0].getCode(), TYPE_NAMES[0]),
-			new ValueNamePair(TYPE_VALUES[1].getCode(), TYPE_NAMES[1]),
-			new ValueNamePair(TYPE_VALUES[2].getCode(), TYPE_NAMES[2]),
-			new ValueNamePair(TYPE_VALUES[3].getCode(), TYPE_NAMES[3])
+			 ValueNamePair.of(TYPE_VALUES[0].getCode(), TYPE_NAMES[0]),
+			 ValueNamePair.of(TYPE_VALUES[1].getCode(), TYPE_NAMES[1]),
+			 ValueNamePair.of(TYPE_VALUES[2].getCode(), TYPE_NAMES[2]),
+			 ValueNamePair.of(TYPE_VALUES[3].getCode(), TYPE_NAMES[3])
 	};
 
 	/** Gradient Starting Values */
@@ -134,19 +134,19 @@ public class ColorEditor extends CDialog
 	};
 	/** Gradient Starting Point */
 	private static final KeyNamePair[] GRADIENT_SP = new KeyNamePair[] {
-			new KeyNamePair(GRADIENT_SP_VALUES[0], GRADIENT_SP_NAMES[0]),
-			new KeyNamePair(GRADIENT_SP_VALUES[1], GRADIENT_SP_NAMES[1]),
-			new KeyNamePair(GRADIENT_SP_VALUES[2], GRADIENT_SP_NAMES[2]),
-			new KeyNamePair(GRADIENT_SP_VALUES[3], GRADIENT_SP_NAMES[3]),
-			new KeyNamePair(GRADIENT_SP_VALUES[4], GRADIENT_SP_NAMES[4]),
-			new KeyNamePair(GRADIENT_SP_VALUES[5], GRADIENT_SP_NAMES[5]),
-			new KeyNamePair(GRADIENT_SP_VALUES[6], GRADIENT_SP_NAMES[6]),
-			new KeyNamePair(GRADIENT_SP_VALUES[7], GRADIENT_SP_NAMES[7])
+			KeyNamePair.of(GRADIENT_SP_VALUES[0], GRADIENT_SP_NAMES[0]),
+			KeyNamePair.of(GRADIENT_SP_VALUES[1], GRADIENT_SP_NAMES[1]),
+			KeyNamePair.of(GRADIENT_SP_VALUES[2], GRADIENT_SP_NAMES[2]),
+			KeyNamePair.of(GRADIENT_SP_VALUES[3], GRADIENT_SP_NAMES[3]),
+			KeyNamePair.of(GRADIENT_SP_VALUES[4], GRADIENT_SP_NAMES[4]),
+			KeyNamePair.of(GRADIENT_SP_VALUES[5], GRADIENT_SP_NAMES[5]),
+			KeyNamePair.of(GRADIENT_SP_VALUES[6], GRADIENT_SP_NAMES[6]),
+			KeyNamePair.of(GRADIENT_SP_VALUES[7], GRADIENT_SP_NAMES[7])
 	};
 
 	/**
 	 * Create AdempiereColor Dialog with color
-	 * 
+	 *
 	 * @param owner owner
 	 * @param color Start Color
 	 */
@@ -158,7 +158,7 @@ public class ColorEditor extends CDialog
 
 	/**
 	 * Create AdempiereColor Dialog with color
-	 * 
+	 *
 	 * @param owner owner
 	 * @param color Start Color
 	 */
@@ -170,7 +170,7 @@ public class ColorEditor extends CDialog
 
 	/**
 	 * Init Dialog
-	 * 
+	 *
 	 * @param color Start Color
 	 */
 	private void init(MFColor color)
@@ -240,7 +240,7 @@ public class ColorEditor extends CDialog
 
 	/**
 	 * Static Layout.
-	 * 
+	 *
 	 * <pre>
 	 * -northPanel
 	 * 		- labels
@@ -248,7 +248,7 @@ public class ColorEditor extends CDialog
 	 * 				- centerPanel
 	 * 				- southPanel
 	 * </pre>
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	private void jbInit() throws Exception
@@ -303,7 +303,7 @@ public class ColorEditor extends CDialog
 
 	/**
 	 * Action Listener
-	 * 
+	 *
 	 * @param e event
 	 */
 	@Override
@@ -407,7 +407,7 @@ public class ColorEditor extends CDialog
 
 	/**
 	 * Set Color and update UI
-	 * 
+	 *
 	 * @param color color
 	 */
 	public void setColor(MFColor color)
@@ -555,7 +555,7 @@ public class ColorEditor extends CDialog
 
 	/**
 	 * Get Color
-	 * 
+	 *
 	 * @return Color, when saved - else null
 	 */
 	public MFColor getColor()
@@ -565,7 +565,7 @@ public class ColorEditor extends CDialog
 
 	/**
 	 * Was the selection saved
-	 * 
+	 *
 	 * @return true if saved
 	 */
 	public boolean isSaved()
@@ -612,7 +612,7 @@ public class ColorEditor extends CDialog
 
 	/**
 	 * Determines whether this property editor is paintable.
-	 * 
+	 *
 	 * @return True if the class will honor the paintValue method.
 	 */
 	@Override
@@ -681,7 +681,7 @@ public class ColorEditor extends CDialog
 	 * java.lang.IllegalArgumentException if either the String is
 	 * badly formatted or if this kind of property can't be expressed
 	 * as text.
-	 * 
+	 *
 	 * @param text The string to be parsed.
 	 * @throws IllegalArgumentException
 	 */
@@ -730,7 +730,7 @@ public class ColorEditor extends CDialog
 
 	/**
 	 * Determines whether this property editor supports a custom editor.
-	 * 
+	 *
 	 * @return True if the propertyEditor can provide a custom editor.
 	 */
 	@Override
@@ -756,7 +756,7 @@ public class ColorEditor extends CDialog
 
 	/**
 	 * Remove a listener for the PropertyChange event.
-	 * 
+	 *
 	 * @param listener The PropertyChange listener to be removed.
 	 */
 	@Override

--- a/de.metas.adempiere.adempiere/client/src/main/java/de/metas/i18n/TranslationController.java
+++ b/de.metas.adempiere.adempiere/client/src/main/java/de/metas/i18n/TranslationController.java
@@ -41,7 +41,7 @@ import org.compiere.util.ValueNamePair;
 import de.metas.util.Services;
 
 /**
- * 
+ *
  * @author metas-dev <dev@metasfresh.com>
  * @author based on initial version of Low Heng Sin, Idalica
  *
@@ -59,12 +59,12 @@ public class TranslationController
 	{
 		final List<KeyNamePair> list = new ArrayList<>();
 
-		list.add(new KeyNamePair(-1, ""));
+		list.add(new KeyNamePair(-1, "", null/* help */));
 
 		Services.get(IClientDAO.class).retrieveAllClients(Env.getCtx())
 				.stream()
 				.filter(I_AD_Client::isActive)
-				.map(adClient -> KeyNamePair.of(adClient.getAD_Client_ID(), adClient.getName()))
+				.map(adClient -> KeyNamePair.of(adClient.getAD_Client_ID(), adClient.getName(), adClient.getDescription()))
 				.forEach(list::add);
 
 		return list;
@@ -77,7 +77,7 @@ public class TranslationController
 
 	protected List<ValueNamePair> getTableList()
 	{
-		final String sql = "SELECT Name, TableName "
+		final String sql = "SELECT Name, TableName, Description "
 				+ " FROM AD_Table "
 				+ " WHERE TableName LIKE '%_Trl' AND TableName<>'AD_Column_Trl' "
 				+ " ORDER BY Name";
@@ -89,11 +89,14 @@ public class TranslationController
 			rs = pstmt.executeQuery();
 
 			final List<ValueNamePair> list = new ArrayList<>();
-			list.add(new ValueNamePair("", ""));
+			list.add(new ValueNamePair("", "", null/* help */));
 
 			while (rs.next())
 			{
-				final ValueNamePair vp = new ValueNamePair(rs.getString(2), rs.getString(1));
+				final ValueNamePair vp = new ValueNamePair(
+						rs.getString("TableName"),
+						rs.getString("Name"),
+						rs.getString("Description")/*help*/);
 				list.add(vp);
 			}
 

--- a/de.metas.adempiere.adempiere/client/src/main/java/org/adempiere/plaf/UIDefaultsEditorDialog.java
+++ b/de.metas.adempiere.adempiere/client/src/main/java/org/adempiere/plaf/UIDefaultsEditorDialog.java
@@ -10,12 +10,12 @@ package org.adempiere.plaf;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -100,7 +100,7 @@ public class UIDefaultsEditorDialog extends JDialog
 
 	/**
 	 * Creates and shows the {@link UIDefaultsEditorDialog}.
-	 * 
+	 *
 	 * @param parent parent component (used to get the parent frame)
 	 */
 	public static final void createAndShow(final Component parent)
@@ -183,7 +183,7 @@ public class UIDefaultsEditorDialog extends JDialog
 			uiDefaultsTable.getSelectionModel().setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 			add(new JScrollPane(uiDefaultsTable), BorderLayout.CENTER);
 		}
-		
+
 		//
 		// Bottom
 		{
@@ -195,15 +195,15 @@ public class UIDefaultsEditorDialog extends JDialog
 			bottomPanel.add(btnReapply);
 			btnReapply.addActionListener(new ActionListener()
 			{
-				
+
 				@Override
 				public void actionPerformed(ActionEvent e)
 				{
 					final LookAndFeel lookAndFeel = UIManager.getLookAndFeel();
-					final ValueNamePair lookAndFeelVNP = new ValueNamePair(lookAndFeel.getClass().getName(), lookAndFeel.getName());
+					final ValueNamePair lookAndFeelVNP = ValueNamePair.of(lookAndFeel.getClass().getName(), lookAndFeel.getName());
 					//
 					final MetalTheme theme = MetalLookAndFeel.getCurrentTheme();
-					final ValueNamePair themeVNP = new ValueNamePair(theme.getClass().getName(), theme.getName());
+					final ValueNamePair themeVNP = ValueNamePair.of(theme.getClass().getName(), theme.getName());
 					//
 					AdempierePLAF.setPLAF(lookAndFeelVNP, themeVNP, false); // updateIni=false
 					AEnv.updateUI();
@@ -242,7 +242,7 @@ public class UIDefaultsEditorDialog extends JDialog
 
 	/**
 	 * {@link UIDefaults} table model.
-	 * 
+	 *
 	 * @author tsa
 	 *
 	 */
@@ -801,14 +801,14 @@ public class UIDefaultsEditorDialog extends JDialog
 			setValue(table, rowIndexView, fontNew, font);
 
 		}
-		
+
 		private void editVEditorDialogButtonAlign(JTable table, int rowIndexView, VEditorDialogButtonAlign buttonAlign)
 		{
 			final Dialog owner = AEnv.getDialog(table);
 			final String key = getKey(table, rowIndexView);
 			final String title = "Editing: "+key;
 			final String message = "";
-			
+
 			final Object[] options = VEditorDialogButtonAlign.values();
 
 			final int optionIndex = JOptionPane.showOptionDialog(owner,
@@ -819,40 +819,40 @@ public class UIDefaultsEditorDialog extends JDialog
 					null, // icon
 					options,
 					buttonAlign);
-			
+
 			if (optionIndex == JOptionPane.CLOSED_OPTION)
 			{
 				return;
 			}
-			
+
 			final VEditorDialogButtonAlign buttonAlignNew = (VEditorDialogButtonAlign)options[optionIndex];
 			if (Check.equals(buttonAlign, buttonAlignNew))
 			{
 				return; // nothing changed
 			}
-			
+
 			setValue(table, rowIndexView, buttonAlignNew, buttonAlign);
 		}
-		
+
 		private void editInteger(final JTable table, final int rowIndexView, final Integer valueInt)
 		{
 			final Dialog owner = AEnv.getDialog(table);
 			final String key = getKey(table, rowIndexView);
 			final String title = "Editing: "+key;
-			
+
 			final String valueStrNew = JOptionPane.showInputDialog(owner, title, valueInt);
 			if(Check.isEmpty(valueStrNew, true))
 			{
 				return; // cancel
 			}
-			
+
 			final Integer valueIntNew = Integer.parseInt(valueStrNew.trim());
-			
+
 			if (Check.equals(valueInt, valueIntNew))
 			{
 				return; // nothing changed
 			}
-			
+
 			setValue(table, rowIndexView, valueIntNew, valueInt);
 		}
 
@@ -861,25 +861,25 @@ public class UIDefaultsEditorDialog extends JDialog
 			final Dialog owner = AEnv.getDialog(table);
 			final String key = getKey(table, rowIndexView);
 			final String title = "Editing: "+key;
-			
+
 			if (valueBoolean == null)
 			{
 				valueBoolean = false;
 			}
-			
+
 			final String valueStrNew = JOptionPane.showInputDialog(owner, title, valueBoolean.toString());
 			if(Check.isEmpty(valueStrNew, true))
 			{
 				return; // cancel
 			}
-			
+
 			final Boolean valueBooleanNew = Boolean.parseBoolean(valueStrNew);
-			
+
 			if (Check.equals(valueBoolean, valueBooleanNew))
 			{
 				return; // nothing changed
 			}
-			
+
 			setValue(table, rowIndexView, valueBooleanNew, valueBoolean);
 		}
 

--- a/de.metas.adempiere.adempiere/client/src/main/java/org/compiere/grid/ed/VLookupAutoCompleter.java
+++ b/de.metas.adempiere.adempiere/client/src/main/java/org/compiere/grid/ed/VLookupAutoCompleter.java
@@ -232,17 +232,17 @@ import de.metas.util.Services;
 	protected Object fetchUserObject(final ResultSet rs) throws SQLException
 	{
 		final String name = rs.getString(MLookupFactory.COLUMNINDEX_DisplayName);
-
+		// TODO see if this code is also used by the webui
 		final NamePair item;
 		if (lookupInfo.isNumericKey())
 		{
 			final int key = rs.getInt(MLookupFactory.COLUMNINDEX_Key);
-			item = new KeyNamePair(key, name);
+			item = KeyNamePair.of(key, name);
 		}
 		else
 		{
 			final String value = rs.getString(MLookupFactory.COLUMNINDEX_Value);
-			item = new ValueNamePair(value, name);
+			item = ValueNamePair.of(value, name);
 		}
 
 		// Validate the result

--- a/de.metas.adempiere.adempiere/client/src/test/java/org/adempiere/plaf/UIDefaultsEditorDialog_ManualTest.java
+++ b/de.metas.adempiere.adempiere/client/src/test/java/org/adempiere/plaf/UIDefaultsEditorDialog_ManualTest.java
@@ -10,12 +10,12 @@ package org.adempiere.plaf;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -28,7 +28,7 @@ import org.junit.Ignore;
 
 /**
  * Run {@link UIDefaultsEditorDialog}, database decoupled.
- * 
+ *
  * @author tsa
  *
  */
@@ -38,8 +38,8 @@ public class UIDefaultsEditorDialog_ManualTest
 
 	public static void main(String[] args)
 	{
-		final ValueNamePair plaf = new ValueNamePair(AdempiereLookAndFeel.class.getName(), AdempiereLookAndFeel.NAME);
-		final ValueNamePair theme = new ValueNamePair(MetasFreshTheme.class.getName(), MetasFreshTheme.NAME);
+		final ValueNamePair plaf = ValueNamePair.of(AdempiereLookAndFeel.class.getName(), AdempiereLookAndFeel.NAME);
+		final ValueNamePair theme = ValueNamePair.of(MetasFreshTheme.class.getName(), MetasFreshTheme.NAME);
 		AdempierePLAF.setPLAF(plaf, theme, false);
 
 		UIDefaultsEditorDialog.createAndShow(null);

--- a/de.metas.business/src/main/java-legacy/org/compiere/process/StorageCleanup.java
+++ b/de.metas.business/src/main/java-legacy/org/compiere/process/StorageCleanup.java
@@ -22,15 +22,17 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 
+import org.adempiere.ad.service.IADReferenceDAO;
 import org.adempiere.exceptions.DBException;
 import org.compiere.model.MLocator;
 import org.compiere.model.MMovement;
 import org.compiere.model.MMovementLine;
-import org.compiere.model.MRefList;
 import org.compiere.model.MStorage;
+import org.compiere.model.X_M_Movement;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
 
+import de.metas.i18n.ITranslatableString;
 import de.metas.process.JavaProcess;
 import de.metas.process.ProcessInfoParameter;
 import de.metas.product.IStorageBL;
@@ -181,9 +183,15 @@ public class StorageCleanup extends JavaProcess
 		mh.processIt(MMovement.ACTION_Complete);
 		mh.save();
 
-		addLog(0, null, new BigDecimal(lines), "@M_Movement_ID@ " + mh.getDocumentNo() + " ("
-			+ MRefList.get(getCtx(), MMovement.DOCSTATUS_AD_Reference_ID,
-				mh.getDocStatus(), get_TrxName()) + ")");
+		final ITranslatableString docStatus = Services.get(IADReferenceDAO.class)
+				.retrieveListNameTranslatableString(
+						X_M_Movement.DOCSTATUS_AD_Reference_ID,
+						mh.getDocStatus());
+
+		addLog(0,
+				null,
+				new BigDecimal(lines),
+				"@M_Movement_ID@ " + mh.getDocumentNo() + " (" + docStatus.translate(Env.getAD_Language()) + ")");
 
 		eliminateReservation(target);
 		return lines;
@@ -279,7 +287,7 @@ public class StorageCleanup extends JavaProcess
 			DB.close(rs, pstmt);
 			rs = null; pstmt = null;
 		}
-		
+
 		return retValue;
 	}	//	getDefault
 

--- a/de.metas.business/src/main/java/org/adempiere/mm/attributes/spi/impl/DefaultAttributeValuesProvider.java
+++ b/de.metas.business/src/main/java/org/adempiere/mm/attributes/spi/impl/DefaultAttributeValuesProvider.java
@@ -1,11 +1,11 @@
 package org.adempiere.mm.attributes.spi.impl;
 
-import javax.annotation.concurrent.Immutable;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.annotation.concurrent.Immutable;
 
 import org.adempiere.mm.attributes.api.IAttributeDAO;
 import org.adempiere.mm.attributes.api.IAttributeSet;
@@ -98,7 +98,8 @@ public class DefaultAttributeValuesProvider implements IAttributeValuesProvider
 	{
 		final String value = av.getValue();
 		final String name = av.getName();
-		final ValueNamePair vnp = new ValueNamePair(value, name);
+		final String description = av.getDescription();
+		final ValueNamePair vnp = ValueNamePair.of(value, name, description);
 		return vnp;
 	}
 

--- a/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.adempiere.ad.service.IADReferenceDAO;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.trx.api.ITrxManager;
@@ -59,7 +60,6 @@ import org.compiere.model.I_C_Year;
 import org.compiere.model.I_M_Product;
 import org.compiere.model.I_M_Warehouse;
 import org.compiere.model.Lookup;
-import org.compiere.model.MRefList;
 import org.compiere.model.POInfo;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
@@ -93,6 +93,7 @@ import de.metas.document.IDocTypeDAO;
 import de.metas.document.engine.IDocument;
 import de.metas.document.engine.IDocumentBL;
 import de.metas.i18n.IMsgBL;
+import de.metas.i18n.ITranslatableString;
 import de.metas.inout.model.I_M_InOutLine;
 import de.metas.invoicecandidate.api.IInvoiceCandidateHandlerDAO;
 import de.metas.invoicecandidate.model.I_C_ILCandHandler;
@@ -180,14 +181,18 @@ public class FlatrateBL implements IFlatrateBL
 				if (!X_C_Flatrate_DataEntry.DOCSTATUS_Completed.equals(invoicingEntry.getDocStatus()))
 				{
 					final Properties ctx = InterfaceWrapperHelper.getCtx(dataEntry);
-					final String trxName = InterfaceWrapperHelper.getTrxName(dataEntry);
+
+					final ITranslatableString competed = Services.get(IADReferenceDAO.class)
+							.retrieveListNameTranslatableString(
+									X_C_Flatrate_DataEntry.DOCSTATUS_AD_Reference_ID,
+									X_C_Flatrate_DataEntry.DOCSTATUS_Completed);
 
 					return msgBL.getMsg(ctx,
 							FlatrateBL.MSG_FLATRATEBL_INVOICING_ENTRY_NOT_CO_3P,
 							new Object[] {
 									invoicingEntry.getC_Period().getName(),
 									invoicingEntry.getC_UOM().getName(),
-									MRefList.get(ctx, X_C_Flatrate_DataEntry.DOCSTATUS_AD_Reference_ID, X_C_Flatrate_DataEntry.DOCSTATUS_Completed, trxName) });
+									competed.translate(Env.getAD_Language()) });
 				}
 			}
 

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductBL.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductBL.java
@@ -25,11 +25,11 @@ package de.metas.handlingunits;
 import java.util.List;
 
 import org.compiere.model.I_M_Product;
+import org.compiere.util.KeyNamePair;
 
 import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
-import de.metas.i18n.ITranslatableString;
 import de.metas.util.ISingletonService;
 
 public interface IHUPIItemProductBL extends ISingletonService
@@ -69,5 +69,5 @@ public interface IHUPIItemProductBL extends ISingletonService
 	 */
 	void setNameAndDescription(I_M_HU_PI_Item_Product itemProduct);
 
-	ITranslatableString getDisplayName(HUPIItemProductId piItemProductId);
+	KeyNamePair getDisplayName(HUPIItemProductId piItemProductId, String adLanguage);
 }

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductBL.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductBL.java
@@ -26,9 +26,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_M_Product;
+import org.compiere.util.KeyNamePair;
 
 import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.handlingunits.IHUPIItemProductBL;
@@ -39,7 +42,6 @@ import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
 import de.metas.handlingunits.model.X_M_HU_PI_Item;
-import de.metas.i18n.ITranslatableString;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import de.metas.util.time.SystemTime;
@@ -151,10 +153,15 @@ public class HUPIItemProductBL implements IHUPIItemProductBL
 	}
 
 	@Override
-	public ITranslatableString getDisplayName(@NonNull final HUPIItemProductId piItemProductId)
+	public KeyNamePair getDisplayName(
+			@NonNull final HUPIItemProductId piItemProductId,
+			@Nullable final String adLanguage)
 	{
-		final I_M_HU_PI_Item_Product piItemProduct = Services.get(IHUPIItemProductDAO.class).getById(piItemProductId);
-		return InterfaceWrapperHelper.getModelTranslationMap(piItemProduct)
-				.getColumnTrl(I_M_HU_PI_Item_Product.COLUMNNAME_Name, piItemProduct.getName());
+		final I_M_HU_PI_Item_Product piItemProduct = Services
+				.get(IHUPIItemProductDAO.class)
+				.getById(piItemProductId);
+
+		final I_M_HU_PI_Item_Product trl = InterfaceWrapperHelper.translate(piItemProduct, I_M_HU_PI_Item_Product.class, adLanguage);
+		return KeyNamePair.of(piItemProductId, trl.getName(), trl.getDescription());
 	}
 }

--- a/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/attributes/impl/AttributeValueTest.java
+++ b/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/attributes/impl/AttributeValueTest.java
@@ -164,14 +164,14 @@ public class AttributeValueTest extends AbstractHUTest
 			final IAttributeValueContext attributeValueContext = new HUAttributePropagationContext(NullAttributeStorage.instance, new NoPropagationHUAttributePropagator(), attribute);
 			attributeValue.setValue(attributeValueContext, "1");
 			Assert.assertEquals("Only current value shall be in available values for high volume attribute",
-					Collections.singletonList(new ValueNamePair("1", "Value1")),
+					Collections.singletonList(ValueNamePair.of("1", "Value1")),
 					attributeValue.getAvailableValues());
 
 			//
 			// Set current value as "2" and test
 			attributeValue.setValue(attributeValueContext, "2");
 			Assert.assertEquals("Only current value shall be in available values for high volume attribute",
-					Collections.singletonList(new ValueNamePair("2", "Value2")),
+					Collections.singletonList(ValueNamePair.of("2", "Value2")),
 					attributeValue.getAvailableValues());
 		}
 	}

--- a/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRValidationRuleTools.java
+++ b/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRValidationRuleTools.java
@@ -10,12 +10,12 @@ package de.metas.payment.esr;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -38,14 +38,12 @@ public final class ESRValidationRuleTools
 	}
 
 	/**
-	 * 
-	 * 
 	 * @param action Note that a {@code null} string is OK
 	 * @return
 	 */
 	public static NamePair mkListItem(final String action)
 	{
-		final NamePair item = new NamePair(action)
+		final NamePair item = new NamePair(action, null/* description */)
 		{
 			private static final long serialVersionUID = 1L;
 
@@ -74,7 +72,7 @@ public final class ESRValidationRuleTools
 	}
 
 	/**
-	 * 
+	 *
 	 * @param action may not be {@code null}.
 	 * @param plainValidationCtx
 	 * @return
@@ -89,7 +87,7 @@ public final class ESRValidationRuleTools
 	}
 
 	/**
-	 * 
+	 *
 	 * @param action may not be {@code null}.
 	 * @param importLine
 	 * @return

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ReceiptSchedule.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ReceiptSchedule.java
@@ -31,9 +31,7 @@ import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.ad.validationRule.IValidationRuleFactory;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.agg.key.IAggregationKeyBuilder;
-
 import org.adempiere.warehouse.validationrule.FilterWarehouseByDocTypeValidationRule;
-
 import org.compiere.model.I_C_OrderLine;
 import org.compiere.model.ModelValidator;
 
@@ -49,7 +47,11 @@ public class M_ReceiptSchedule
 	@Init
 	public void init()
 	{
-		Services.get(IValidationRuleFactory.class).registerValidationRuleException(FilterWarehouseByDocTypeValidationRule.instance, I_M_ReceiptSchedule.Table_Name, I_M_ReceiptSchedule.COLUMNNAME_M_Warehouse_Dest_ID);
+		Services.get(IValidationRuleFactory.class).registerValidationRuleException(
+				FilterWarehouseByDocTypeValidationRule.instance,
+				I_M_ReceiptSchedule.Table_Name,
+				I_M_ReceiptSchedule.COLUMNNAME_M_Warehouse_Dest_ID,
+				"Registered by " + this.getClass().getName());
 
 	}
 

--- a/de.metas.swat/de.metas.swat.base/src/main/java/org/adempiere/model/IniDefaultsValidator.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/org/adempiere/model/IniDefaultsValidator.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package org.adempiere.model;
 
@@ -13,12 +13,12 @@ package org.adempiere.model;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -111,7 +111,7 @@ public class IniDefaultsValidator implements ModelValidator
 					String sTheme = theme.getValue();
 					if (sTheme != null && sTheme.length() > 0 && !sTheme.equals(themeClass))
 					{
-						ValueNamePair plaf = new ValueNamePair(
+						ValueNamePair plaf = ValueNamePair.of(
 								UIManager.getLookAndFeel().getClass().getName(),
 								UIManager.getLookAndFeel().getName());
 						AdempierePLAF.setPLAF(plaf, theme, true);

--- a/de.metas.util/src/main/java/de/metas/i18n/ConstantTranslatableString.java
+++ b/de.metas.util/src/main/java/de/metas/i18n/ConstantTranslatableString.java
@@ -2,6 +2,8 @@ package de.metas.i18n;
 
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 
@@ -32,13 +34,13 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode
 /*package*/final class ConstantTranslatableString implements ITranslatableString
 {
-	static final ConstantTranslatableString of(final String value)
+	static final ConstantTranslatableString of(@Nullable final String value)
 	{
 		final boolean anyLanguage = false;
 		return of(value, anyLanguage);
 	}
-	
-	static final ConstantTranslatableString of(final String value, final boolean anyLanguage)
+
+	static final ConstantTranslatableString of(@Nullable final String value, final boolean anyLanguage)
 	{
 		if(value == null || value.isEmpty())
 		{
@@ -48,7 +50,7 @@ import lombok.EqualsAndHashCode;
 		{
 			return SPACE;
 		}
-		
+
 		return new ConstantTranslatableString(value, anyLanguage);
 	}
 
@@ -92,7 +94,7 @@ import lombok.EqualsAndHashCode;
 	{
 		return ImmutableSet.of();
 	}
-	
+
 	@Override
 	public boolean isTranslatedTo(final String adLanguage)
 	{

--- a/de.metas.util/src/main/java/de/metas/i18n/ImmutableTranslatableString.java
+++ b/de.metas.util/src/main/java/de/metas/i18n/ImmutableTranslatableString.java
@@ -67,7 +67,7 @@ public final class ImmutableTranslatableString implements ITranslatableString
 		return new ImmutableTranslatableString(trlMap, ConstantTranslatableString.EMPTY.getDefaultValue());
 	}
 
-	public static final ITranslatableString singleLanguage(final String adLanguage, final String value)
+	public static final ITranslatableString singleLanguage(@Nullable final String adLanguage, @Nullable final String value)
 	{
 		if (Check.isEmpty(adLanguage, true))
 		{
@@ -78,7 +78,7 @@ public final class ImmutableTranslatableString implements ITranslatableString
 		return new ImmutableTranslatableString(ImmutableMap.of(adLanguage, valueNorm), valueNorm);
 	}
 
-	public static final ITranslatableString constant(final String value)
+	public static final ITranslatableString constant(@Nullable final String value)
 	{
 		return ConstantTranslatableString.of(value);
 	}
@@ -161,7 +161,7 @@ public final class ImmutableTranslatableString implements ITranslatableString
 			return false;
 		}
 	}
-	
+
 	public static boolean isEmpty(final ITranslatableString trl)
 	{
 		if (trl == null)


### PR DESCRIPTION
* add a description field to NamePair (may be null)
  * when loading AD_RefLists into ValueNamePairs, also load the RefLists' Descriptions
* MLookupInfo - add getDescriptionColumnSQL() to enable downstream code to also select e.g. a C_BPartner's Description
* MLookupFactory - set the lookupInfo's descriptionColumnSQL for both table references (search, table direct) and AD_RefLists
* Modernize both KeyNamePair and ValueNamePair; when creating new instance throughout the code, use their "of(...)" methods instead of their constructors
* InterfaceWrapperHelper - add constants for some frequent column names such as Name or Description
* DB
  * deprecate those "get.." methods that don't throw an exception
  * remove two unused legacy methods
  * add a method that can return an array: in this issue, it's used to retrieve both name and description in one sql
* add @Nullable and @NonNull annotations here and there

https://github.com/metasfresh/metasfresh/issues/4798