### PR TITLE
4282-app - Order line is flagged as Temporary Pricing Conditions when..

### DIFF
--- a/de.metas.business/src/main/java/de/metas/order/OrderLinePriceUpdateRequest.java
+++ b/de.metas.business/src/main/java/de/metas/order/OrderLinePriceUpdateRequest.java
@@ -63,6 +63,8 @@ public class OrderLinePriceUpdateRequest
 	PricingSystemId pricingSystemIdOverride;
 	PriceListId priceListIdOverride;
 	Quantity qtyOverride;
+
+	/** If not {@code null}, then the pricing engine is requested to not revalidate the PricingConditionsBreak, but go with this one*/
 	PricingConditionsBreak pricingConditionsBreakOverride;
 
 	//
@@ -73,7 +75,9 @@ public class OrderLinePriceUpdateRequest
 	//
 	// Updating the order line options
 	boolean updatePriceEnteredAndDiscountOnlyIfNotAlreadySet; // task 06727
+
 	boolean updateLineNetAmt;
+
 	@Default
 	boolean applyPriceLimitRestrictions = true;
 

--- a/de.metas.business/src/main/java/de/metas/order/impl/OrderLinePricingConditions.java
+++ b/de.metas.business/src/main/java/de/metas/order/impl/OrderLinePricingConditions.java
@@ -45,7 +45,12 @@ public class OrderLinePricingConditions implements IOrderLinePricingConditions
 
 	private static enum HasPricingConditions
 	{
-		NO, YES, TEMPORARY
+		NO,
+
+		YES,
+
+		/** The respective order line has no {@code M_DiscountSchemaBreak_ID}, but manual discount etc. */
+		TEMPORARY
 	}
 
 	@Override

--- a/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_OrderLine.java
+++ b/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_OrderLine.java
@@ -277,7 +277,7 @@ public class C_OrderLine
 			ifColumnsChanged = I_C_OrderLine.COLUMNNAME_QtyEntered)
 	public void updatePricesOverrideExistingDiscounts(final I_C_OrderLine orderLine)
 	{
-		final boolean updatePriceEnteredAndDiscountOnlyIfNotAlreadySet = false;
+		final boolean updatePriceEnteredAndDiscountOnlyIfNotAlreadySet = false; // i.e. always update them
 
 		// make the BL revalidates the discounts..the new QtyEntered might also mean a new discount schema break
 		orderLine.setM_DiscountSchemaBreak(null);

--- a/de.metas.business/src/main/java/de/metas/pricing/IEditablePricingContext.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/IEditablePricingContext.java
@@ -44,7 +44,7 @@ public interface IEditablePricingContext extends IPricingContext
 	 * @param referencedObject
 	 */
 	IEditablePricingContext setReferencedObject(final Object referencedObject);
-	
+
 	IEditablePricingContext setSOTrx(final SOTrx soTrx);
 
 	IEditablePricingContext setQty(final BigDecimal qty);
@@ -67,8 +67,6 @@ public interface IEditablePricingContext extends IPricingContext
 
 	/**
 	 * Set this to <code>true</code> to indicate to the pricing engine that discounts shall <b>not</b> be computed and applied to the result.
-	 *
-	 * @param disallowDiscount
 	 */
 	IEditablePricingContext setDisallowDiscount(boolean disallowDiscount);
 

--- a/de.metas.business/src/main/java/de/metas/pricing/conditions/PricingConditionsBreakQuery.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/conditions/PricingConditionsBreakQuery.java
@@ -3,6 +3,9 @@ package de.metas.pricing.conditions;
 import java.math.BigDecimal;
 
 import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
+import org.compiere.model.I_C_OrderLine;
+
+import com.google.common.collect.ImmutableSet;
 
 import de.metas.product.ProductAndCategoryAndManufacturerId;
 import lombok.Builder;
@@ -38,7 +41,18 @@ public class PricingConditionsBreakQuery
 	ImmutableAttributeSet attributes;
 	BigDecimal qty;
 	BigDecimal price;
+
 	BigDecimal amt;
+
+	/** Please keep in sync with the field of this class. */
+	public static ImmutableSet<String> getRelevantOrderLineColumns()
+	{
+		return ImmutableSet.of(
+				I_C_OrderLine.COLUMNNAME_M_Product_ID,
+				I_C_OrderLine.COLUMNNAME_M_AttributeSetInstance_ID,
+				I_C_OrderLine.COLUMNNAME_QtyOrdered,
+				I_C_OrderLine.COLUMNNAME_PriceEntered);
+	}
 
 	@Builder
 	private PricingConditionsBreakQuery(

--- a/de.metas.business/src/main/java/de/metas/pricing/conditions/service/CalculatePricingConditionsRequest.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/conditions/service/CalculatePricingConditionsRequest.java
@@ -14,7 +14,6 @@ import de.metas.pricing.conditions.PricingConditionsBreakId;
 import de.metas.pricing.conditions.PricingConditionsBreakQuery;
 import de.metas.pricing.conditions.PricingConditionsId;
 import de.metas.util.lang.Percent;
-
 import lombok.Builder;
 import lombok.Value;
 
@@ -50,7 +49,10 @@ public class CalculatePricingConditionsRequest
 {
 	private final PricingConditionsId pricingConditionsId;
 
+	/** If set then the system will "calculate" this break. */
 	private final PricingConditionsBreak forcePricingConditionsBreak;
+
+	/** If {@link #getForcePricingConditionsBreak()} returns {@code null}, then the system will use this query to find a matching break. */
 	private final PricingConditionsBreakQuery pricingConditionsBreakQuery;
 
 	private final Percent bpartnerFlatDiscount;

--- a/de.metas.business/src/main/java/de/metas/pricing/rules/Discount.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/rules/Discount.java
@@ -51,7 +51,6 @@ import de.metas.product.ProductAndCategoryAndManufacturerId;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
 import de.metas.util.lang.Percent;
-
 import lombok.NonNull;
 
 /**
@@ -154,12 +153,14 @@ public class Discount implements IPricingRule
 			final ProductId productId = pricingCtx.getProductId();
 			final ProductAndCategoryAndManufacturerId product = productsRepo.retrieveProductAndCategoryAndManufacturerByProductId(productId);
 
-			builder.pricingConditionsBreakQuery(PricingConditionsBreakQuery.builder()
+			final PricingConditionsBreakQuery pricingConditionsBreakQuery = PricingConditionsBreakQuery
+					.builder()
 					.qty(pricingCtx.getQty())
 					.price(result.getPriceStd())
 					.product(product)
 					.attributes(getAttributes(pricingCtx))
-					.build());
+					.build();
+			builder.pricingConditionsBreakQuery(pricingConditionsBreakQuery);
 		}
 
 		return builder.build();

--- a/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingContext.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingContext.java
@@ -30,6 +30,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 
+import javax.annotation.Nullable;
+
 import org.adempiere.mm.attributes.api.IAttributeSetInstanceAware;
 import org.adempiere.mm.attributes.api.IAttributeSetInstanceAwareFactoryService;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -91,6 +93,7 @@ class PricingContext implements IEditablePricingContext
 	private boolean failIfNotCalculated = false;
 
 	private boolean disallowDiscount;
+
 	@Getter
 	private PricingConditionsBreak forcePricingConditionsBreak;
 
@@ -421,8 +424,9 @@ class PricingContext implements IEditablePricingContext
 		return skipCheckingPriceListSOTrxFlag;
 	}
 
+	/** If set to not-{@code null}, then the {@link de.metas.pricing.rules.Discount} rule with go with this break as opposed to look for the currently matching break. */
 	@Override
-	public IEditablePricingContext setForcePricingConditionsBreak(final PricingConditionsBreak forcePricingConditionsBreak)
+	public IEditablePricingContext setForcePricingConditionsBreak(@Nullable final PricingConditionsBreak forcePricingConditionsBreak)
 	{
 		this.forcePricingConditionsBreak = forcePricingConditionsBreak;
 		return this;

--- a/de.metas.device.adempiere/pom.xml
+++ b/de.metas.device.adempiere/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -33,6 +34,12 @@
 			<version>10.0.0</version>
 			<classifier>tests</classifier>
 			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 	</dependencies>

--- a/de.metas.device.adempiere/src/main/java/de/metas/device/adempiere/impl/SysConfigDeviceConfigPool.java
+++ b/de.metas.device.adempiere/src/main/java/de/metas/device/adempiere/impl/SysConfigDeviceConfigPool.java
@@ -27,6 +27,7 @@ import de.metas.util.Check;
 import de.metas.util.GuavaCollectors;
 import de.metas.util.Services;
 import de.metas.util.WeakList;
+import lombok.NonNull;
 
 /*
  * #%L
@@ -52,7 +53,7 @@ import de.metas.util.WeakList;
 
 /**
  * {@link IDeviceConfigPool} implementation which reads all the configs from {@link I_AD_SysConfig}.
- * 
+ *
  * @author metas-dev <dev@metasfresh.com>
  *
  */
@@ -67,7 +68,7 @@ import de.metas.util.WeakList;
 	private static final String DEVICE_PARAM_DeviceClass = "DeviceClass";
 	private static final String DEVICE_PARAM_AttributeInternalName = "AttributeInternalName";
 	private static final String DEVICE_PARAM_M_Warehouse_ID = "M_Warehouse_ID";
-	
+
 	/*package */static final String IPADDRESS_ANY = "0.0.0.0";
 
 	private final IHostIdentifier clientHost;
@@ -81,10 +82,8 @@ import de.metas.util.WeakList;
 
 	private final WeakList<IDeviceConfigPoolListener> listeners = new WeakList<>(true); // weakDefault=true
 
-	public SysConfigDeviceConfigPool(final IHostIdentifier clientHost, final int adClientId, final int adOrgId)
+	public SysConfigDeviceConfigPool(@NonNull final IHostIdentifier clientHost, final int adClientId, final int adOrgId)
 	{
-		super();
-
 		Check.assumeNotNull(clientHost, "Parameter clientHost is not null");
 
 		this.clientHost = clientHost;
@@ -224,7 +223,7 @@ import de.metas.util.WeakList;
 		final String paramValue = getSysconfigValueWithHostNameFallback(CFG_DEVICE_PREFIX + "." + deviceName, parameterName, defaultValue);
 		return paramValue;
 	}
-	
+
 	private Set<String> getDeviceAssignedAttributeCodes(final String deviceName)
 	{
 		final String attribSysConfigPrefix = CFG_DEVICE_PREFIX + "." + deviceName + "." + DEVICE_PARAM_AttributeInternalName;
@@ -234,7 +233,7 @@ import de.metas.util.WeakList;
 			logger.info("Found no SysConfig assigned attribute to device {}; SysConfig-prefix={}", deviceName, attribSysConfigPrefix);
 			return ImmutableSet.of();
 		}
-		
+
 		return ImmutableSet.copyOf(assignedAttributeCodes);
 	}
 

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/order/api/impl/HUOrderBL.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/order/api/impl/HUOrderBL.java
@@ -157,6 +157,8 @@ public class HUOrderBL implements IHUOrderBL
 			orderLineBL.updatePrices(OrderLinePriceUpdateRequest.builder()
 					.orderLine(ol)
 					.resultUOM(ResultUOM.PRICE_UOM_IF_ORDERLINE_IS_NEW)
+
+					// since the price and thus netAmt might have changed, we also need to revalidate the discounts
 					.updatePriceEnteredAndDiscountOnlyIfNotAlreadySet(false)
 					.updateLineNetAmt(true)
 					.build());

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/impl/OrderLineBL.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/impl/OrderLineBL.java
@@ -231,8 +231,10 @@ public class OrderLineBL implements IOrderLineBL
 			return orderLine.getC_Charge().getC_TaxCategory_ID();
 		}
 
+		final OrderLinePriceUpdateRequest request = OrderLinePriceUpdateRequest.ofOrderLine(orderLine);
+
 		return OrderLinePriceCalculator.builder()
-				.request(OrderLinePriceUpdateRequest.ofOrderLine(orderLine))
+				.request(request)
 				.orderLineBL(this)
 				.build()
 				.computeTaxCategoryId();
@@ -609,7 +611,7 @@ public class OrderLineBL implements IOrderLineBL
 	public Money getCostPrice(final org.compiere.model.I_C_OrderLine orderLine)
 	{
 		final CurrencyId currencyId = CurrencyId.ofRepoId(orderLine.getC_Currency_ID());
-		
+
 		final BigDecimal poCostPrice = orderLine.getPriceCost();
 		if (poCostPrice != null && poCostPrice.signum() != 0)
 		{
@@ -640,7 +642,7 @@ public class OrderLineBL implements IOrderLineBL
 		final BigDecimal priceActualWithoutTax = priceActual.subtract(taxAmt);
 		return Money.of(priceActualWithoutTax, currencyId);
 	}
-	
+
 	@Override
 	public int getC_PaymentTerm_ID(@NonNull final org.compiere.model.I_C_OrderLine orderLine)
 	{


### PR DESCRIPTION
...the conditions are actually missing

* Fix item 8. of https://github.com/metasfresh/metasfresh/issues/4282#issuecomment-401004955
  * PricingConditionsBreakQuery knows which C_OrderLine column names neccessitate a new query to be applied
  * OrderLinePriceCalculator consults PricingConditionsBreakQuery before deciding whether to go on with a preexisting discount schema break

* add some comments and `@Nullable` / `@NonNull` annodations to make the code clearer
  * OrderLinePriceUpdateRequest
  * OrderLinePricingConditions
  * C_OrderLine
  * IEditablePricingContext
  * CalculatePricingConditionsRequest
  * Discount
  * PricingContext
  * HUOrderBL
  * OrderLineBL

https://github.com/metasfresh/metasfresh/issues/4282