### PR TITLE
1125-api - Fix webui window update from remote editing

### DIFF
--- a/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5509760_sys_gh1125-api_fix_AD_Window_ParentChildTableNames_v1.sql
+++ b/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5509760_sys_gh1125-api_fix_AD_Window_ParentChildTableNames_v1.sql
@@ -1,3 +1,4 @@
+
 drop view if exists AD_Window_ParentChildTableNames_v1;
 create or replace view AD_Window_ParentChildTableNames_v1 as
 select
@@ -57,9 +58,9 @@ from (
 			left join AD_Table ct/*child-table*/ on (ct.AD_Table_ID=ctt.AD_Table_ID)
 		inner join AD_Window w on (w.AD_Window_ID=ptt.AD_Window_ID)
 	where true
-		// the parent tab needs to have the smallest SeqNo (but not neccesarly 10) 
+		// the parent tab needs to have the smallest SeqNo (but not neccesarly 10)
 		and ptt.SeqNo=(select min(siblings.SeqNo) from AD_Tab siblings where siblings.AD_Window_ID=w.AD_Window_ID and siblings.IsActive='Y') 
-		// the parent tab needs to have the smallest Tablevel (but not neccesarly 0) 
+		// the parent tab needs to have the smallest TabLevel (but not neccesarly 0)
 		and ptt.TabLevel=(select min(siblings.TabLevel) from AD_Tab siblings where siblings.AD_Window_ID=w.AD_Window_ID and siblings.IsActive='Y') 
 		and ptt.IsActive='Y'
 		and w.IsActive='Y'
@@ -73,5 +74,3 @@ select * from AD_Window_ParentChildTableNames_v1
 where true
 order by parentTableName, AD_Window_ID, childTableName;
 */
-
-


### PR DESCRIPTION
The fix is mostly in the view AD_Window_ParentChildTableNames_v1. There we
* now left-join the child table and tab.
* also return rows that don't have remote cache invalidation enabled
* also return the "remote cache invalidation" setting for both parent and child table
* also handle the case that a parent tab might not have exactly SeqNo=10 and TabLevel=0

Other fixes are in WindowBasedCacheInvalidateRequestInitializer where we now pay more attention to the stuff returned by the view.

https://github.com/metasfresh/metasfresh-webui-api/issues/1125