### PR TITLE
1128-api - Limit number of products shown in material cockpit

### DIFF
--- a/de.metas.material/cockpit/src/main/sql/postgresql/system/75-material-cockpit/5510320_sys_gh1128-api_materialcockpit_limit_empty_products.sql
+++ b/de.metas.material/cockpit/src/main/sql/postgresql/system/75-material-cockpit/5510320_sys_gh1128-api_materialcockpit_limit_empty_products.sql
@@ -1,0 +1,8 @@
+-- 2019-01-22T16:49:01.675
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541259,'S',TO_TIMESTAMP('2019-01-22 16:49:01','YYYY-MM-DD HH24:MI:SS'),100,'In material cockpit the system will also show rows with products that have no stock, no ordered quantities etc.
+This setting specifies how many of those products will be loaded.
+A value <= 0 means "no limit" which is convenient but can lead to OutOfMemoryErrors if you have a large product master.
+The default value if not specified is -1.','de.metas.material.cockpit','Y','de.metas.ui.web.material.cockpit.MaterialCockpitRowRepository.EmptyProductsLimit',TO_TIMESTAMP('2019-01-22 16:49:01','YYYY-MM-DD HH24:MI:SS'),100,'1000')
+;
+

--- a/de.metas.material/cockpit/src/main/sql/postgresql/system/75-material-cockpit/5510390_sys_gh1128-app_materialcockpit_sysconfig_cachesize.sql
+++ b/de.metas.material/cockpit/src/main/sql/postgresql/system/75-material-cockpit/5510390_sys_gh1128-app_materialcockpit_sysconfig_cachesize.sql
@@ -1,0 +1,37 @@
+-- 2019-01-23T06:06:58.617
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541260,'S',TO_TIMESTAMP('2019-01-23 06:06:58','YYYY-MM-DD HH24:MI:SS'),100,'Under the material cockpit''s hood, lists of "empty" products are cached to speed up paging back an forth between different dates.
+This value determines the number of cached lists. In order to save memory, you need to set this to a reltively small number if 
+the sysconfig "de.metas.ui.web.material.cockpit.MaterialCockpitRowRepository.EmptyProducts.Limit" is relatively big.
+The default if not set here is 10.','de.metas.material.cockpit','Y','de.metas.ui.web.material.cockpit.MaterialCockpitRowRepository.EmptyProducts.CacheSize',TO_TIMESTAMP('2019-01-23 06:06:58','YYYY-MM-DD HH24:MI:SS'),100,'10')
+;
+
+-- 2019-01-23T06:07:12.011
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_SysConfig SET Name='de.metas.ui.web.material.cockpit.MaterialCockpitRowRepository.EmptyProducts.Limit',Updated=TO_TIMESTAMP('2019-01-23 06:07:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_SysConfig_ID=541259
+;
+
+-- 2019-01-23T06:07:26.334
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_SysConfig SET Description='In material cockpit the system will also show rows with products that have no stock, no ordered quantities etc.
+This setting specifies how many of those products will be loaded.
+A value <= 0 means "no limit" which is convenient but can lead to OutOfMemoryErrors if you have a large product master.
+The default value if not specified is 2000.',Updated=TO_TIMESTAMP('2019-01-23 06:07:26','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_SysConfig_ID=541259
+;
+
+-- 2019-01-23T06:12:22.416
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_SysConfig SET Description='In material cockpit the system will also show rows with products that have no stock, no ordered quantities etc.
+This setting specifies how many of those products will be loaded. The default value if not specified is 2000.
+A value <= 0 means "no limit" which is convenient but can lead to OutOfMemoryErrors if you have a large product master.
+Also see the sysconfig "de.metas.ui.web.material.cockpit.MaterialCockpitRowRepository.EmptyProducts.CacheSize".',Updated=TO_TIMESTAMP('2019-01-23 06:12:22','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_SysConfig_ID=541259
+;
+
+-- 2019-01-23T06:13:29.006
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_SysConfig SET Description='In material cockpit the system will also show rows with products that have no stock, no ordered quantities etc.
+This setting specifies how many of those products will be loaded. The default value if not set here is 2000.
+A value <= 0 means "no limit" which is convenient but can lead to OutOfMemoryErrors if you have a large product master.
+Also see the sysconfig "de.metas.ui.web.material.cockpit.MaterialCockpitRowRepository.EmptyProducts.CacheSize".',Updated=TO_TIMESTAMP('2019-01-23 06:13:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_SysConfig_ID=541259
+;
+

--- a/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5510400_sys_gh1130-api_DocumentCollection_CacheSize.sql
+++ b/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5510400_sys_gh1130-api_DocumentCollection_CacheSize.sql
@@ -1,0 +1,8 @@
+-- 2019-01-23T06:45:50.579
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541261,'S',TO_TIMESTAMP('2019-01-23 06:45:50','YYYY-MM-DD HH24:MI:SS'),100,'Specifies the max side of the webui''s document cache.
+Note that on a machine with 1GB of memory (-Xmx1024M), we ran into an OOME and from the heap dump it turned out that this cache had contained 1474 documents and had reached a heap size of 507MB.
+The default if not set is 800.
+','de.metas.ui.web','Y','de.metas.ui.web.window.model.DocumentCollection.CacheSize',TO_TIMESTAMP('2019-01-23 06:45:50','YYYY-MM-DD HH24:MI:SS'),100,'800')
+;
+


### PR DESCRIPTION
add sysconfig to limit the number of "empty" products to be merged into the material cockpit

https://github.com/metasfresh/metasfresh-webui-api/issues/1128