### PR TITLE
5040-app Accounting for Payment Allocation and Vendor Credit Memo wrong

### DIFF
--- a/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -495,7 +495,7 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 	{
 		final AcctSchema as = fact.getAcctSchema();
 
-		final BigDecimal paymentAllocatedAmt = line.getAllocatedAmt_CMAdjusted();
+		final BigDecimal paymentAllocatedAmt = line.getAllocatedAmt();
 		if (paymentAllocatedAmt.signum() == 0)
 		{
 			// no amount to be allocated on payment
@@ -518,11 +518,25 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 
 		if (line.isSOTrxInvoice())
 		{
-			factLineBuilder.setAmtSource(paymentAllocatedAmt, null);
+			if (line.isCreditMemoInvoice())
+			{
+				factLineBuilder.setAmtSource(null, paymentAllocatedAmt.negate());
+			}
+			else
+			{
+				factLineBuilder.setAmtSource(paymentAllocatedAmt, null);
+			}
 		}
 		else
 		{
-			factLineBuilder.setAmtSource(null, paymentAllocatedAmt.negate());
+			if (line.isCreditMemoInvoice())
+			{
+				factLineBuilder.setAmtSource(paymentAllocatedAmt, null);
+			}
+			else
+			{
+				factLineBuilder.setAmtSource(null, paymentAllocatedAmt.negate());
+			}
 		}
 
 		final FactLine factLine = factLineBuilder.buildAndAdd();


### PR DESCRIPTION
Also handle the case for purchase credit memos with writeoff and discount
Basically, this is a "manual" cherry-pick of https://github.com/metasfresh/metasfresh/commit/173c441c8f923fba948dcb20e002db9864e0e38a
Accounting for Payment Allocation and Vendor Credit Memo wrong #5040