### PR TITLE
5306-app - Fallback for missing AD_WF_Node.S_Resource_ID

### DIFF
--- a/de.metas.adempiere.libero.libero/src/main/java/org/eevolution/api/IPPOrderBL.java
+++ b/de.metas.adempiere.libero.libero/src/main/java/org/eevolution/api/IPPOrderBL.java
@@ -99,8 +99,6 @@ public interface IPPOrderBL extends ISingletonService
 	/**
 	 * Sets manufacturing order's document type(s).
 	 *
-	 * @param ppOrder
-	 * @param docBaseType
 	 * @param docSubType document sub-type or {@link IDocTypeDAO#DOCSUBTYPE_Any}
 	 * @throws DocTypeNotFoundException if no document type was found
 	 */
@@ -117,6 +115,10 @@ public interface IPPOrderBL extends ISingletonService
 
 	void changeScheduling(PPOrderScheduleChangeRequest request);
 
+	/**
+	 * Note about the routing's {@code S_Ressource_ID}: if some of the {@code PP_Order}'s {@code AD_WorkFlow}'s activities don't have a resource,
+	 * then attempt to fall back to the {@code PP_Order}'s resource or to the {@code PP_POrder}'s {@code PP_Product_Planning}'s resource for those activities.
+	 */
 	void createOrderRouting(I_PP_Order ppOrder);
 
 	void closeAllActivities(PPOrderId orderId);

--- a/de.metas.adempiere.libero.libero/src/main/java/org/eevolution/api/impl/PPOrderBL.java
+++ b/de.metas.adempiere.libero.libero/src/main/java/org/eevolution/api/impl/PPOrderBL.java
@@ -57,6 +57,7 @@ import de.metas.material.planning.pporder.PPOrderUtil;
 import de.metas.material.planning.pporder.PPRoutingId;
 import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
+import de.metas.product.ResourceId;
 import de.metas.quantity.Quantity;
 import de.metas.uom.IUOMDAO;
 import de.metas.uom.UOMPrecision;
@@ -347,7 +348,10 @@ public class PPOrderBL implements IPPOrderBL
 	@Override
 	public void createOrderRouting(@NonNull final I_PP_Order ppOrderRecord)
 	{
+		final ResourceId defaultResourceIdOrNull = extractDefaultResourceIdOrNull(ppOrderRecord);
+
 		final PPOrderRouting orderRouting = CreateOrderRoutingCommand.builder()
+				.defaultResourceId(defaultResourceIdOrNull)
 				.routingId(PPRoutingId.ofRepoId(ppOrderRecord.getAD_Workflow_ID()))
 				.ppOrderId(PPOrderId.ofRepoId(ppOrderRecord.getPP_Order_ID()))
 				.dateStartSchedule(TimeUtil.asLocalDateTime(ppOrderRecord.getDateStartSchedule()))
@@ -357,6 +361,24 @@ public class PPOrderBL implements IPPOrderBL
 
 		final IPPOrderRoutingRepository orderRoutingsRepo = Services.get(IPPOrderRoutingRepository.class);
 		orderRoutingsRepo.save(orderRouting);
+	}
+
+	private ResourceId extractDefaultResourceIdOrNull(@NonNull final I_PP_Order ppOrderRecord)
+	{
+		final ResourceId result;
+		if (ppOrderRecord.getS_Resource_ID() > 0)
+		{
+			result = ResourceId.ofRepoId(ppOrderRecord.getS_Resource_ID());
+		}
+		else if (ppOrderRecord.getPP_Product_Planning_ID() > 0)
+		{
+			result = ResourceId.ofRepoIdOrNull(ppOrderRecord.getPP_Product_Planning().getS_Resource_ID());
+		}
+		else
+		{
+			result = null;
+		}
+		return result;
 	}
 
 	@Override

--- a/de.metas.material/planning/src/main/java/de/metas/material/planning/impl/DefaultRoutingServiceImpl.java
+++ b/de.metas.material/planning/src/main/java/de/metas/material/planning/impl/DefaultRoutingServiceImpl.java
@@ -29,6 +29,8 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Duration;
 
+import javax.annotation.Nullable;
+
 import de.metas.material.planning.IResourceProductService;
 import de.metas.material.planning.ResourceType;
 import de.metas.material.planning.RoutingService;
@@ -77,7 +79,10 @@ public class DefaultRoutingServiceImpl implements RoutingService
 	}
 
 	@Override
-	public int calculateDurationDays(final PPRoutingId routingId, final ResourceId plantId, final BigDecimal qty)
+	public int calculateDurationDays(
+			@NonNull final PPRoutingId routingId,
+			@Nullable final ResourceId plantId,
+			@NonNull final BigDecimal qty)
 	{
 		if (plantId == null)
 		{

--- a/de.metas.material/planning/src/main/java/de/metas/material/planning/pporder/PPRoutingActivity.java
+++ b/de.metas.material/planning/src/main/java/de/metas/material/planning/pporder/PPRoutingActivity.java
@@ -6,6 +6,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalUnit;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 
@@ -27,12 +29,12 @@ import lombok.Value;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -56,7 +58,11 @@ public class PPRoutingActivity
 	@Default
 	Range<LocalDate> validDates = Range.all();
 
-	@NonNull
+	/**
+	 * Resource/plant is (currently) not mandatory in {@code AD_WF_Node}; it's not clear to me if that makes sense or is an oversight.
+	 * In the case I'm currently debugging, the {@code S_Resource_ID} is coming from a {@code PP_Product_Planning} anyways and won't be used, so here it's not needed
+	 */
+	@Nullable
 	ResourceId resourceId;
 
 	@NonNull

--- a/de.metas.material/planning/src/main/java/de/metas/material/planning/pporder/impl/PPRoutingRepository.java
+++ b/de.metas.material/planning/src/main/java/de/metas/material/planning/pporder/impl/PPRoutingRepository.java
@@ -11,6 +11,8 @@ import java.time.temporal.TemporalUnit;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ClientId;
@@ -144,7 +146,7 @@ public class PPRoutingRepository implements IPPRoutingRepository
 		}
 	}
 
-	private static Range<LocalDate> toValidDateRange(final Timestamp from, final Timestamp to)
+	private static Range<LocalDate> toValidDateRange(@Nullable final Timestamp from, @Nullable final Timestamp to)
 	{
 		if (from == null)
 		{
@@ -187,7 +189,7 @@ public class PPRoutingRepository implements IPPRoutingRepository
 				.name(activityRecord.getName())
 				.validDates(toValidDateRange(activityRecord.getValidFrom(), activityRecord.getValidTo()))
 				//
-				.resourceId(ResourceId.ofRepoId(activityRecord.getS_Resource_ID()))
+				.resourceId(ResourceId.ofRepoIdOrNull(activityRecord.getS_Resource_ID())) // S_Resource_ID == null might not make sense in this case, but it's allowed
 				//
 				.durationUnit(durationUnit)
 				.queuingTime(Duration.of(activityRecord.getQueuingTime(), durationUnit))


### PR DESCRIPTION
If some of the `PP_Order`'s `AD_WorkFlow`'s activities don't have a resource, then attempt to fall back to the `PP_Order`'s resource or to the `PP_POrder`'s `PP_Product_Planning`'s resource for those activities.
#5306