### PR TITLE
5367-app - Issue different MaterialTracking-IDs to the same PP_Order

### DIFF
--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/IMaterialTrackingDAO.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/IMaterialTrackingDAO.java
@@ -112,10 +112,6 @@ public interface IMaterialTrackingDAO extends ISingletonService
 
 	/**
 	 * Retrieves references of given type, order by their chronological order.
-	 *
-	 * @param materialTracking
-	 * @param referenceType
-	 * @return
 	 */
 	<T> List<T> retrieveReferences(de.metas.materialtracking.model.I_M_Material_Tracking materialTracking, Class<T> referenceType);
 

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/IMaterialTrackingPPOrderBL.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/IMaterialTrackingPPOrderBL.java
@@ -10,12 +10,12 @@ package de.metas.materialtracking;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -41,9 +41,13 @@ public interface IMaterialTrackingPPOrderBL extends ISingletonService
 	boolean isQualityInspection(I_PP_Order ppOrder);
 
 	/**
+	 * Like {@link #isQualityInspection(I_PP_Order)}, but with just the PP_Order_ID; Might be better performance-wise.
+	 * TODO use PPOrderId when porting this to master
+	 */
+	boolean isQualityInspection(int ppOrderId);
+
+	/**
 	 * Asserts given manufacturing order is a Quality Inspection order
-	 *
-	 * @param ppOrder
 	 */
 	void assertQualityInspectionOrder(I_PP_Order ppOrder);
 
@@ -62,7 +66,7 @@ public interface IMaterialTrackingPPOrderBL extends ISingletonService
 
 	/**
 	 * Retrieve the inout lines that were issued with the given PP_Order.
-	 * 
+	 *
 	 * @param ppOrder
 	 * @return the found inout lines
 	 */

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/impl/MaterialTrackingDAO.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/impl/MaterialTrackingDAO.java
@@ -55,6 +55,7 @@ import de.metas.materialtracking.ch.lagerkonf.model.I_M_Material_Tracking_Report
 import de.metas.materialtracking.ch.lagerkonf.model.I_M_QualityInsp_LagerKonf_Version;
 import de.metas.materialtracking.model.IMaterialTrackingAware;
 import de.metas.materialtracking.model.I_M_Material_Tracking_Ref;
+import lombok.NonNull;
 
 public class MaterialTrackingDAO implements IMaterialTrackingDAO
 {
@@ -170,10 +171,8 @@ public class MaterialTrackingDAO implements IMaterialTrackingDAO
 	}
 
 	@Override
-	public <T> List<de.metas.materialtracking.model.I_M_Material_Tracking> retrieveMaterialTrackingForModels(final IQueryBuilder<T> modelsQuery)
+	public <T> List<de.metas.materialtracking.model.I_M_Material_Tracking> retrieveMaterialTrackingForModels(@NonNull final IQueryBuilder<T> modelsQuery)
 	{
-		Check.assumeNotNull(modelsQuery, "modelsQuery not null");
-
 		// 07669: Use the transaction of the thread and do not rely on the model's transaction
 		final IContextAware threadContextAware = Services.get(ITrxManager.class).createThreadContextAware(modelsQuery.getCtx());
 

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/impl/MaterialTrackingPPOrderBL.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/impl/MaterialTrackingPPOrderBL.java
@@ -1,5 +1,7 @@
 package de.metas.materialtracking.impl;
 
+import static org.adempiere.model.InterfaceWrapperHelper.loadOutOfTrx;
+
 /*
  * #%L
  * de.metas.materialtracking
@@ -13,11 +15,11 @@ package de.metas.materialtracking.impl;
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
@@ -39,6 +41,7 @@ import de.metas.materialtracking.IMaterialTrackingBL;
 import de.metas.materialtracking.IMaterialTrackingPPOrderBL;
 import de.metas.materialtracking.model.I_M_InOutLine;
 import de.metas.materialtracking.spi.IPPOrderMInOutLineRetrievalService;
+import lombok.NonNull;
 
 public class MaterialTrackingPPOrderBL implements IMaterialTrackingPPOrderBL
 {
@@ -53,19 +56,23 @@ public class MaterialTrackingPPOrderBL implements IMaterialTrackingPPOrderBL
 	private final IQueryFilter<I_PP_Order> qualityInspectionFilter = new EqualsQueryFilter<I_PP_Order>(I_PP_Order.COLUMN_OrderType, C_DocType_DOCSUBTYPE_QualityInspection);
 
 	@Override
-	public boolean isQualityInspection(final I_PP_Order ppOrder)
+	public boolean isQualityInspection(final int ppOrderId)
+	{
+		final I_PP_Order ppOrderRecord = loadOutOfTrx(ppOrderId, I_PP_Order.class);
+		return isQualityInspection(ppOrderRecord);
+	}
+
+	@Override
+	public boolean isQualityInspection(@NonNull final I_PP_Order ppOrder)
 	{
 		// NOTE: keep in sync with #qualityInspectionFilter
-
-		Check.assumeNotNull(ppOrder, "ppOrder not null");
 		final String orderType = ppOrder.getOrderType();
 		return C_DocType_DOCSUBTYPE_QualityInspection.equals(orderType);
 	}
 
 	@Override
-	public void assertQualityInspectionOrder(final I_PP_Order ppOrder)
+	public void assertQualityInspectionOrder(@NonNull final I_PP_Order ppOrder)
 	{
-		Check.assumeNotNull(ppOrder, "ppOrder not null");
 		Check.assume(isQualityInspection(ppOrder), "Order shall be Quality Inspection Order: {}", ppOrder);
 	}
 

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/model/IMaterialTrackingAware.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/model/IMaterialTrackingAware.java
@@ -32,11 +32,11 @@ package de.metas.materialtracking.model;
 public interface IMaterialTrackingAware
 {
 	// @formatter:off
-	public static final String COLUMNNAME_M_Material_Tracking_ID = "M_Material_Tracking_ID";
+	String COLUMNNAME_M_Material_Tracking_ID = "M_Material_Tracking_ID";
 
-	public void setM_Material_Tracking_ID(int M_HU_PackingMaterial_ID);
-	public int getM_Material_Tracking_ID();
-	public void setM_Material_Tracking(I_M_Material_Tracking M_Material_Tracking) throws RuntimeException;
-	public I_M_Material_Tracking getM_Material_Tracking() throws RuntimeException;
+	void setM_Material_Tracking_ID(int M_HU_PackingMaterial_ID);
+	int getM_Material_Tracking_ID();
+	void setM_Material_Tracking(I_M_Material_Tracking M_Material_Tracking) throws RuntimeException;
+	I_M_Material_Tracking getM_Material_Tracking() throws RuntimeException;
 	// @formatter:on
 }

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/model/I_PP_Order.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/model/I_PP_Order.java
@@ -57,9 +57,9 @@ public interface I_PP_Order extends
 		 */
 		ByProduct(X_PP_Cost_Collector.COSTCOLLECTORTYPE_MixVariance, X_PP_Order_BOMLine.COMPONENTTYPE_By_Product, -1);
 
-		private final String costCollectorType;
-		private final String bomLineComponentType;
-		private final int factor;
+		private String costCollectorType;
+		private String bomLineComponentType;
+		private int factor;
 
 		Type(final String costCollectorType,
 				final String bomLineComponentType,

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/MaterialTrackingDocuments.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/MaterialTrackingDocuments.java
@@ -52,6 +52,7 @@ import de.metas.materialtracking.qualityBasedInvoicing.IMaterialTrackingDocument
 import de.metas.materialtracking.qualityBasedInvoicing.IQualityInspectionOrder;
 import de.metas.materialtracking.qualityBasedInvoicing.IVendorInvoicingInfo;
 import de.metas.materialtracking.qualityBasedInvoicing.IVendorReceipt;
+import lombok.NonNull;
 
 /* package */class MaterialTrackingDocuments implements IMaterialTrackingDocuments
 {
@@ -77,11 +78,8 @@ import de.metas.materialtracking.qualityBasedInvoicing.IVendorReceipt;
 
 	private Set<Integer> ppOrdersToBeConsideredNotClosed = new HashSet<>();
 
-	public MaterialTrackingDocuments(final I_M_Material_Tracking materialTracking)
+	public MaterialTrackingDocuments(@NonNull final I_M_Material_Tracking materialTracking)
 	{
-		super();
-
-		Check.assumeNotNull(materialTracking, "materialTracking not null");
 		_materialTracking = materialTracking;
 	}
 

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/QualityBasedInvoicingDAO.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/QualityBasedInvoicingDAO.java
@@ -25,7 +25,6 @@ package de.metas.materialtracking.qualityBasedInvoicing.impl;
 import java.util.List;
 
 import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.util.Check;
 import org.adempiere.util.Services;
 
 import de.metas.materialtracking.IMaterialTrackingDAO;
@@ -34,6 +33,7 @@ import de.metas.materialtracking.qualityBasedInvoicing.IMaterialTrackingDocument
 import de.metas.materialtracking.qualityBasedInvoicing.IProductionMaterial;
 import de.metas.materialtracking.qualityBasedInvoicing.IProductionMaterialQuery;
 import de.metas.materialtracking.qualityBasedInvoicing.IQualityBasedInvoicingDAO;
+import lombok.NonNull;
 
 public class QualityBasedInvoicingDAO implements IQualityBasedInvoicingDAO
 {
@@ -58,7 +58,7 @@ public class QualityBasedInvoicingDAO implements IQualityBasedInvoicingDAO
 	}
 
 	@Override
-	public IMaterialTrackingDocuments retrieveMaterialTrackingDocumentsFor(final Object model)
+	public IMaterialTrackingDocuments retrieveMaterialTrackingDocumentsFor(@NonNull final Object model)
 	{
 		final IMaterialTrackingDocuments materialTrackingDocuments = retrieveMaterialTrackingDocumentsOrNullFor(model);
 		if (materialTrackingDocuments == null)
@@ -70,10 +70,8 @@ public class QualityBasedInvoicingDAO implements IQualityBasedInvoicingDAO
 	}
 
 	@Override
-	public IMaterialTrackingDocuments retrieveMaterialTrackingDocumentsOrNullFor(final Object model)
+	public IMaterialTrackingDocuments retrieveMaterialTrackingDocumentsOrNullFor(@NonNull final Object model)
 	{
-		Check.assumeNotNull(model, "model not null");
-
 		// Retrieve Material Tracking via material_tracklin
 		final IMaterialTrackingDAO materialTrackingDAO = Services.get(IMaterialTrackingDAO.class);
 		final I_M_Material_Tracking materialTracking = materialTrackingDAO.retrieveMaterialTrackingForModel(model);


### PR DESCRIPTION
* IMaterialTrackingDAO - add isQualityInspection method by might be better in terms of perf
* HUPPOrderIssueReceiptCandidatesProcessor - only attempts to set material-tracking-id if it's about a quality inspection. Background: these are the only ones where material-tracking-ids may not be mixed.
* minor changes/improvemwents

https://github.com/metasfresh/metasfresh/issues/5367