### PR TITLE
5485-app - PP_Orders with issues from multiple material-trackings

### DIFF
--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/IMaterialTrackingPPOrderDAO.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/IMaterialTrackingPPOrderDAO.java
@@ -1,5 +1,6 @@
 package de.metas.materialtracking;
 
+import de.metas.materialtracking.model.I_M_Material_Tracking;
 import de.metas.materialtracking.model.I_PP_Order;
 import de.metas.util.ISingletonService;
 
@@ -38,6 +39,5 @@ public interface IMaterialTrackingPPOrderDAO extends ISingletonService
 
 	int deleteRelatedUnprocessedICs(I_PP_Order ppOrder);
 
-	boolean isInvoiced(I_PP_Order ppOrder);
-
+	boolean isPPOrderInvoicedForMaterialTracking(I_PP_Order ppOrder, I_M_Material_Tracking materialTrackingRecord);
 }

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/impl/MaterialTrackingPPOrderDAO.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/impl/MaterialTrackingPPOrderDAO.java
@@ -6,11 +6,13 @@ import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.compiere.model.I_C_Invoice;
 
-import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
+
 import de.metas.materialtracking.IMaterialTrackingPPOrderDAO;
+import de.metas.materialtracking.model.I_C_Invoice_Candidate;
 import de.metas.materialtracking.model.I_C_Invoice_Detail;
+import de.metas.materialtracking.model.I_M_Material_Tracking;
 import de.metas.materialtracking.model.I_PP_Order;
-import de.metas.util.Services;
+import lombok.NonNull;
 
 /*
  * #%L
@@ -86,14 +88,17 @@ public class MaterialTrackingPPOrderDAO implements IMaterialTrackingPPOrderDAO
 	}
 
 	@Override
-	public boolean isInvoiced(final I_PP_Order ppOrder)
+	public boolean isPPOrderInvoicedForMaterialTracking(
+			@NonNull final I_PP_Order ppOrder,
+			@NonNull final I_M_Material_Tracking materialTrackingRecord)
 	{
 		final IQueryBL queryBL = Services.get(IQueryBL.class);
 		return queryBL.createQueryBuilder(I_C_Invoice_Detail.class, ppOrder)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_C_Invoice_Detail.COLUMNNAME_PP_Order_ID, ppOrder.getPP_Order_ID())
 				.andCollect(de.metas.invoicecandidate.model.I_C_Invoice_Detail.COLUMN_C_Invoice_Candidate_ID)
-				.addEqualsFilter(I_C_Invoice.COLUMNNAME_Processed, true)
+				.addEqualsFilter(I_C_Invoice_Candidate.COLUMN_Processed, true)
+				.addEqualsFilter(I_C_Invoice_Candidate.COLUMNNAME_M_Material_Tracking_ID, materialTrackingRecord.getM_Material_Tracking_ID())
 				.create()
 				.match();
 	}

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/impl/MaterialTrackingPPOrderDAO.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/impl/MaterialTrackingPPOrderDAO.java
@@ -4,14 +4,13 @@ import java.util.List;
 
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.table.api.IADTableDAO;
-import org.compiere.model.I_C_Invoice;
-
 
 import de.metas.materialtracking.IMaterialTrackingPPOrderDAO;
 import de.metas.materialtracking.model.I_C_Invoice_Candidate;
 import de.metas.materialtracking.model.I_C_Invoice_Detail;
 import de.metas.materialtracking.model.I_M_Material_Tracking;
 import de.metas.materialtracking.model.I_PP_Order;
+import de.metas.util.Services;
 import lombok.NonNull;
 
 /*

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/model/I_C_Invoice_Candidate.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/model/I_C_Invoice_Candidate.java
@@ -13,20 +13,20 @@ package de.metas.materialtracking.model;
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
-
 
 public interface I_C_Invoice_Candidate extends de.metas.invoicecandidate.model.I_C_Invoice_Candidate
 {
 	// @formatter:off
 	String COLUMNNAME_M_Material_Tracking_ID = "M_Material_Tracking_ID";
+
 	int getM_Material_Tracking_ID();
 	// void setM_Material_Tracking_ID(int M_Material_Tracking_ID); // shall not be used
 	I_M_Material_Tracking getM_Material_Tracking();
@@ -34,24 +34,26 @@ public interface I_C_Invoice_Candidate extends de.metas.invoicecandidate.model.I
 	// @formatter:on
 
 	// @formatter:off
-	public static final int QUALITYINVOICELINEGROUPTYPE_AD_Reference_ID=540617;
+	int QUALITYINVOICELINEGROUPTYPE_AD_Reference_ID=540617;
 	/** Scrap = 01 */
-	public static final String QUALITYINVOICELINEGROUPTYPE_Scrap = "01";
+	String QUALITYINVOICELINEGROUPTYPE_Scrap = "01";
 	/** ByProduct = 02 */
-	public static final String QUALITYINVOICELINEGROUPTYPE_ProducedByProducts = "02";
+	String QUALITYINVOICELINEGROUPTYPE_ProducedByProducts = "02";
 	/** Fee = 03 */
-	public static final String QUALITYINVOICELINEGROUPTYPE_AdditionalFee = "03";
+	String QUALITYINVOICELINEGROUPTYPE_AdditionalFee = "03";
 	/** MainProduct = 04 */
-	public static final String QUALITYINVOICELINEGROUPTYPE_ProducedMainProduct = "04";
+	String QUALITYINVOICELINEGROUPTYPE_ProducedMainProduct = "04";
 	/** CoProduct = 05 */
-	public static final String QUALITYINVOICELINEGROUPTYPE_ProducedCoProduct = "05";
+	String QUALITYINVOICELINEGROUPTYPE_ProducedCoProduct = "05";
 	/** Withholding = 06 */
-	public static final String QUALITYINVOICELINEGROUPTYPE_WithholdingAmount = "06";
+	String QUALITYINVOICELINEGROUPTYPE_WithholdingAmount = "06";
 	/** ProductionOrder = 07 */
-	public static final String QUALITYINVOICELINEGROUPTYPE_PreceeedingRegularOrderDeduction = "07";
+	String QUALITYINVOICELINEGROUPTYPE_PreceeedingRegularOrderDeduction = "07";
 
 	String COLUMNNAME_QualityInvoiceLineGroupType = "QualityInvoiceLineGroupType";
+	@Override
 	String getQualityInvoiceLineGroupType();
+	@Override
 	void setQualityInvoiceLineGroupType(final String QualityInvoiceLineGroupType);
 	// @formatter:on
 }

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/InOutLineAsVendorReceipt.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/InOutLineAsVendorReceipt.java
@@ -1,6 +1,6 @@
 package de.metas.materialtracking.qualityBasedInvoicing.impl;
 
-import static org.adempiere.model.InterfaceWrapperHelper.loadOutOfTrx;
+
 
 /*
  * #%L
@@ -32,11 +32,7 @@ import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_InOut;
 import org.compiere.model.I_M_PriceList_Version;
 import org.compiere.model.I_M_Product;
-import org.slf4j.Logger;
-
 import de.metas.document.engine.DocStatus;
-import de.metas.logging.LogManager;
-import de.metas.logging.LogManager;
 import de.metas.materialtracking.IHandlingUnitsInfo;
 import de.metas.materialtracking.model.I_M_InOutLine;
 import de.metas.materialtracking.qualityBasedInvoicing.IVendorReceipt;
@@ -47,8 +43,8 @@ import de.metas.uom.IUOMDAO;
 import de.metas.uom.UOMConversionContext;
 import de.metas.uom.UomId;
 import de.metas.util.Check;
+import de.metas.util.Loggables;
 import de.metas.util.Services;
-
 import lombok.NonNull;
 
 /**
@@ -59,10 +55,7 @@ import lombok.NonNull;
  */
 /* package */class InOutLineAsVendorReceipt implements IVendorReceipt<I_M_InOutLine>
 {
-	private static final transient Logger logger = LogManager.getLogger(InOutLineAsVendorReceipt.class);
-
 	// services
-	// private final IInvoiceCandDAO invoiceCandDAO = Services.get(IInvoiceCandDAO.class);
 	private final IUOMConversionBL uomConversionBL = Services.get(IUOMConversionBL.class);
 	private final IHandlingUnitsInfoFactory handlingUnitsInfoFactory = Services.get(IHandlingUnitsInfoFactory.class);
 
@@ -190,7 +183,7 @@ import lombok.NonNull;
 		{
 			if (inoutLine.getM_Product_ID() != productId)
 			{
-				Loggables.get().addLog("Not counting {} because its M_Product_ID={} is not the ID of product {}", new Object[] { inoutLine, inoutLine.getM_Product_ID(), _product });
+				Loggables.addLog("Not counting {} because its M_Product_ID={} is not the ID of product {}", new Object[] { inoutLine, inoutLine.getM_Product_ID(), _product });
 				continue;
 			}
 
@@ -225,7 +218,7 @@ import lombok.NonNull;
 		//
 		// Set loaded values
 		_qtyReceived = qtyReceivedTotal;
-		_qtyReceivedUOM = loadOutOfTrx(qtyReceivedTotalUomId, I_C_UOM.class);
+		_qtyReceivedUOM = uomDAO.getById(qtyReceivedTotalUomId);
 		_handlingUnitsInfo = handlingUnitsInfoTotal;
 		_loaded = true;
 	}

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/InOutLineAsVendorReceipt.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/InOutLineAsVendorReceipt.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 
 import de.metas.document.engine.DocStatus;
 import de.metas.logging.LogManager;
+import de.metas.logging.LogManager;
 import de.metas.materialtracking.IHandlingUnitsInfo;
 import de.metas.materialtracking.model.I_M_InOutLine;
 import de.metas.materialtracking.qualityBasedInvoicing.IVendorReceipt;
@@ -47,6 +48,8 @@ import de.metas.uom.UOMConversionContext;
 import de.metas.uom.UomId;
 import de.metas.util.Check;
 import de.metas.util.Services;
+
+import lombok.NonNull;
 
 /**
  * {@link IVendorReceipt} implementation which takes the values from the wrapped {@link I_M_InOutLine}.
@@ -80,9 +83,8 @@ import de.metas.util.Services;
 	}
 
 	@Override
-	public void add(final I_M_InOutLine inOutLine)
+	public void add(@NonNull final I_M_InOutLine inOutLine)
 	{
-		Check.assumeNotNull(inOutLine, "inOutLine not null");
 		if (inOutLine.getM_Product_ID() != _product.getM_Product_ID())
 		{
 			return; // nothing to do
@@ -188,7 +190,7 @@ import de.metas.util.Services;
 		{
 			if (inoutLine.getM_Product_ID() != productId)
 			{
-				logger.debug("Not counting {} because its M_Product_ID={} is not the ID of product {}", new Object[] { inoutLine, inoutLine.getM_Product_ID(), _product });
+				Loggables.get().addLog("Not counting {} because its M_Product_ID={} is not the ID of product {}", new Object[] { inoutLine, inoutLine.getM_Product_ID(), _product });
 				continue;
 			}
 
@@ -197,7 +199,7 @@ import de.metas.util.Services;
 			final DocStatus inoutDocStatus = DocStatus.ofCode(inout.getDocStatus());
 			if(!inoutDocStatus.isCompletedOrClosed())
 			{
-				logger.debug("Not counting {} because its M_InOut has docstatus {}", new Object[] { inoutLine, inoutDocStatus });
+				Loggables.addLog("Not counting {} because its M_InOut has docstatus {}", new Object[] { inoutLine, inoutDocStatus });
 				continue;
 			}
 

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/MaterialTrackingDocuments.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/MaterialTrackingDocuments.java
@@ -129,7 +129,7 @@ import lombok.NonNull;
 		final ArrayList<IQualityInspectionOrder> result = new ArrayList<>();
 		for (final IQualityInspectionOrder order : allProductionOrders)
 		{
-			if (materialTrackingPPOrderDAO.isInvoiced(order.getPP_Order()))
+			if (materialTrackingPPOrderDAO.isPPOrderInvoicedForMaterialTracking(order.getPP_Order(), _materialTracking))
 			{
 				continue;
 			}

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/MaterialTrackingDocumentsPricingInfo.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/MaterialTrackingDocumentsPricingInfo.java
@@ -82,10 +82,8 @@ import lombok.NonNull;
 	private final ImmutableMap<Integer, IVendorReceipt<I_M_InOutLine>> plvId2vendorReceipt;
 	private final ImmutableMap<Integer, I_M_PriceList_Version> plvs;
 
-	private MaterialTrackingDocumentsPricingInfo(final Builder builder)
+	private MaterialTrackingDocumentsPricingInfo(@NonNull final Builder builder)
 	{
-		super();
-
 		plvId2qiOrders = ImmutableListMultimap.copyOf(builder.plvId2qiOrders);
 		plvId2vendorReceipt = ImmutableMap.copyOf(builder.plvId2vendorReceipt);
 		plvs = ImmutableMap.copyOf(builder.plvs);
@@ -216,7 +214,7 @@ import lombok.NonNull;
 			return new MaterialTrackingDocumentsPricingInfo(this);
 		}
 
-		private ImmutablePair<I_M_PriceList_Version, List<I_M_InOutLine>> providePriceListVersionOrNullForPPOrder(final I_PP_Order ppOrder)
+		private ImmutablePair<I_M_PriceList_Version, List<I_M_InOutLine>> providePriceListVersionOrNullForPPOrder(@NonNull final I_PP_Order ppOrder)
 		{
 			I_M_PriceList_Version plv = null;
 

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/PPOrderQualityCalculator.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/PPOrderQualityCalculator.java
@@ -169,13 +169,12 @@ public class PPOrderQualityCalculator
 	}
 
 	/**
-	 *
-	 * @param materialTracking
-	 * @param product
-	 * @param uomTo
 	 * @return quantity received (in <code>uomTo</code>) from linked material receipt lines
 	 */
-	private final BigDecimal retrieveQtyReceived(final I_M_Material_Tracking materialTracking, final I_M_Product product, final I_C_UOM uomTo)
+	private final BigDecimal retrieveQtyReceived(
+			@NonNull final I_M_Material_Tracking materialTracking,
+			@NonNull final I_M_Product product,
+			@NonNull final I_C_UOM uomTo)
 	{
 		// Services
 		final IUOMConversionBL uomConversionBL = Services.get(IUOMConversionBL.class);

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/PlainVendorReceipt.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/PlainVendorReceipt.java
@@ -39,9 +39,6 @@ import de.metas.util.Check;
  * Plain implementation of {@link IVendorReceipt}.
  *
  * NOTE: getter methods will throw an exception if that value was not previously set because we consider all values as being mandatory.
- *
- * @author tsa
- *
  */
 public class PlainVendorReceipt implements IVendorReceipt<Object>
 {
@@ -50,11 +47,6 @@ public class PlainVendorReceipt implements IVendorReceipt<Object>
 	private I_C_UOM qtyReceivedUOM;
 	private IHandlingUnitsInfo handlingUnitsInfo;
 	private I_M_PriceList_Version plv;
-
-	public PlainVendorReceipt()
-	{
-		super();
-	}
 
 	@Override
 	public String toString()

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/QualityInspectionLinesBuilder.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/QualityInspectionLinesBuilder.java
@@ -113,10 +113,9 @@ public class QualityInspectionLinesBuilder
 		return getQualityInspectionOrder().getMainProductionMaterial();
 	}
 
-	public void setReceiptFromVendor(final IVendorReceipt<?> receiptFromVendor)
+	public void setReceiptFromVendor(@NonNull final IVendorReceipt<?> receiptsFromVendor)
 	{
-		Check.assumeNotNull(receiptFromVendor, "receiptFromVendor not null");
-		_receiptFromVendor = receiptFromVendor;
+		_receiptFromVendor = receiptsFromVendor;
 	}
 
 	private IVendorReceipt<?> getReceiptFromVendor()
@@ -125,10 +124,8 @@ public class QualityInspectionLinesBuilder
 		return _receiptFromVendor;
 	}
 
-	private BigDecimal getQtyReceivedFromVendor(final I_C_UOM uomTo)
+	private BigDecimal getQtyReceivedFromVendor(@NonNull final I_C_UOM uomTo)
 	{
-		Check.assumeNotNull(uomTo, "uomTo not null");
-
 		final IVendorReceipt<?> receiptFromVendor = getReceiptFromVendor();
 		final BigDecimal qtyReceivedFromVendor = receiptFromVendor.getQtyReceived();
 		final I_C_UOM qtyReceivedFromVendorUOM = receiptFromVendor.getQtyReceivedUOM();

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/QualityInspectionOrder.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/QualityInspectionOrder.java
@@ -13,11 +13,11 @@ package de.metas.materialtracking.qualityBasedInvoicing.impl;
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
@@ -91,8 +91,6 @@ import de.metas.util.Services;
 	 */
 	public QualityInspectionOrder(final org.eevolution.model.I_PP_Order ppOrder, final I_M_Material_Tracking materialTracking)
 	{
-		super();
-
 		//
 		// PP_Order
 		Check.assumeNotNull(ppOrder, "ppOrder not null");
@@ -205,7 +203,7 @@ import de.metas.util.Services;
 			{
 				continue;
 			}
-			if(productionMaterial.getM_Product().getM_Product_ID() != _materialTracking.getM_Product_ID())
+			if (productionMaterial.getM_Product().getM_Product_ID() != _materialTracking.getM_Product_ID())
 			{
 				continue; // beware of unrelated products that could have been issued together with "our" raw materials
 			}
@@ -236,7 +234,11 @@ import de.metas.util.Services;
 
 		if (rawProductionMaterials.size() > 1)
 		{
-			throw new AdempiereException("More than one raw production material lines where found: " + rawProductionMaterials);
+			throw new AdempiereException("More than one raw production material lines where found")
+					.appendParametersToMessage()
+					.setParameter("inspectionNumber", _inspectionNumber)
+					.setParameter("rawProductionMaterials", rawProductionMaterials)
+					.setParameter("ppOrderRecord", _ppOrder);
 		}
 
 		_productionMaterial_Raw = rawProductionMaterials.get(0);


### PR DESCRIPTION
A normal "Auslagerung" PP_Order can take part in multiple material trackings
Fix a bug where related material receipt lines where not taken into account and therefore the quantities were not correctly extrapolated.
Also minor code improvements
https://github.com/metasfresh/metasfresh/issues/5485

(cherry picked from commit ca876aaa05e255b068572ea07bd799f11ddf66a0)

solved Conflicts:
	de.metas.materialtracking/src/main/java/de/metas/materialtracking/IMaterialTrackingPPOrderDAO.java
	de.metas.materialtracking/src/main/java/de/metas/materialtracking/impl/MaterialTrackingPPOrderDAO.java
	de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/InOutLineAsVendorReceipt.java
	de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/PPOrderQualityCalculator.java
	de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/QualityInspectionLinesBuilder.java