### PR TITLE
5670-app - Solve async batch related deadlock

### DIFF
--- a/de.metas.async/src/main/java/de/metas/async/AsyncBatchId.java
+++ b/de.metas.async/src/main/java/de/metas/async/AsyncBatchId.java
@@ -1,0 +1,65 @@
+package de.metas.async;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import de.metas.util.Check;
+import de.metas.util.lang.RepoIdAware;
+import lombok.Value;
+
+/*
+ * #%L
+ * de.metas.async
+ * %%
+ * Copyright (C) 2019 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+@Value
+public class AsyncBatchId implements RepoIdAware
+{
+	int repoId;
+
+	@JsonCreator
+	public static AsyncBatchId ofRepoId(final int repoId)
+	{
+		return new AsyncBatchId(repoId);
+	}
+
+	public static AsyncBatchId ofRepoIdOrNull(final int repoId)
+	{
+		return repoId > 0 ? new AsyncBatchId(repoId) : null;
+	}
+
+	public static int toRepoId(@Nullable final AsyncBatchId asyncBatchId)
+	{
+		return asyncBatchId != null ? asyncBatchId.getRepoId() : -1;
+	}
+
+	private AsyncBatchId(final int repoId)
+	{
+		this.repoId = Check.assumeGreaterThanZero(repoId, "asyncBatchId");
+	}
+
+	@Override
+	@JsonValue
+	public int getRepoId()
+	{
+		return repoId;
+	}
+}

--- a/de.metas.async/src/main/java/de/metas/async/api/IAsyncBatchBL.java
+++ b/de.metas.async/src/main/java/de/metas/async/api/IAsyncBatchBL.java
@@ -3,6 +3,7 @@
  */
 package de.metas.async.api;
 
+import de.metas.async.AsyncBatchId;
 import de.metas.async.model.I_C_Async_Batch;
 import de.metas.async.model.I_C_Queue_WorkPackage;
 import de.metas.async.model.I_C_Queue_WorkPackage_Notified;
@@ -16,8 +17,8 @@ public interface IAsyncBatchBL extends ISingletonService
 {
 	String AD_SYSCONFIG_ASYNC_BOILERPLATE_ID = "de.metas.async.api.IAsyncBatchBL.BoilerPlate_ID";
 
-	public static String ENQUEUED = "Enqueued";
-	
+	String ENQUEUED = "Enqueued";
+
 	/**
 	 * @return {@link I_C_Async_Batch} builder
 	 */
@@ -25,8 +26,6 @@ public interface IAsyncBatchBL extends ISingletonService
 
 	/**
 	 * update first enqueued, last enqueued and count Enqueued
-	 * 
-	 * @param workPackage
 	 */
 	int increaseEnqueued(final I_C_Queue_WorkPackage workPackage);
 
@@ -34,7 +33,7 @@ public interface IAsyncBatchBL extends ISingletonService
 
 	/**
 	 * update last processed and count processed
-	 * 
+	 *
 	 * @param workPackage
 	 */
 	void increaseProcessed(final I_C_Queue_WorkPackage workPackage);
@@ -44,30 +43,25 @@ public interface IAsyncBatchBL extends ISingletonService
 	 *
 	 * NOTE: this method it is also saving the updated batch.
 	 *
-	 * @param asyncBatch
+	 * @return {@code true} iff the respective record was updated to {@code processed='Y'};
 	 */
-	void updateProcessed(final I_C_Async_Batch asyncBatch);
+	boolean updateProcessed(AsyncBatchId asyncBatchId);
 
 	/**
 	 * Enqueue batch for the de.metas.async.processor.impl.CheckProcessedAsynBatchWorkpackageProcessor processor. Call
 	 * {@link IWorkPackageQueue#enqueueWorkPackage(de.metas.async.model.I_C_Queue_Block, String)} with priority = <code>null</code>. This is OK because we assume that there is a dedicated queue/thread
 	 * for CheckProcessedAsynBatchWorkpackageProcessor
-	 *
-	 * @param asyncBatch
 	 */
-	void enqueueAsyncBatch(I_C_Async_Batch asyncBatch);
+	void enqueueAsyncBatch(AsyncBatchId asyncBatchId);
 
 	/**
 	 * check if the keep alive time has expired for the current batch
-	 * 
-	 * @param asyncBatch
-	 * @return
 	 */
-	boolean keepAliveTimeExpired(I_C_Async_Batch asyncBatch);
+	boolean keepAliveTimeExpired(AsyncBatchId asyncBatchId);
 
 	/**
 	 * create notification records in async batch has notification of type WPP
-	 * 
+	 *
 	 * @param workPackage
 	 */
 	void createNotificationRecord(I_C_Queue_WorkPackage workPackage);
@@ -75,7 +69,7 @@ public interface IAsyncBatchBL extends ISingletonService
 	/**
 	 * check is the given workpackage can be notified
 	 * if there is one below it, that can be notified, return that
-	 * 
+	 *
 	 * @param asyncBatch
 	 * @param workpackage
 	 * @return workpackage
@@ -84,7 +78,7 @@ public interface IAsyncBatchBL extends ISingletonService
 
 	/**
 	 * mark workpackage as notified
-	 * 
+	 *
 	 * @param workpackageNotified
 	 */
 	void markWorkpackageNotified(I_C_Queue_WorkPackage_Notified workpackageNotified);

--- a/de.metas.async/src/main/java/de/metas/async/api/IAsyncBatchDAO.java
+++ b/de.metas.async/src/main/java/de/metas/async/api/IAsyncBatchDAO.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package de.metas.async.api;
 
@@ -15,21 +15,21 @@ import java.util.List;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 
-
 import java.util.Properties;
 
+import de.metas.async.AsyncBatchId;
 import de.metas.async.model.I_C_Async_Batch;
 import de.metas.async.model.I_C_Async_Batch_Type;
 import de.metas.async.model.I_C_Queue_WorkPackage;
@@ -42,21 +42,21 @@ import de.metas.util.ISingletonService;
  */
 public interface IAsyncBatchDAO extends ISingletonService
 {
-	
-	public static final String ASYNC_BATCH_TYPE_DEFAULT = "Default";
-	
+
+	String ASYNC_BATCH_TYPE_DEFAULT = "Default";
+
+	I_C_Async_Batch retrieveAsyncBatchRecord(AsyncBatchId asyncBatchId);
+
 	/**
 	 * Retrieve async batch type by internal name which must be unique.
-	 * 
-	 * @param ctx
-	 * @param internalName
+	 *
 	 * @return {@link I_C_Async_Batch_Type}; never returns null
 	 */
 	I_C_Async_Batch_Type retrieveAsyncBatchType(Properties ctx, String internalName);
 
 	/**
 	 * retrieve workpackages for async batch
-	 * 
+	 *
 	 * @param asyncBatch
 	 * @return
 	 */
@@ -64,7 +64,7 @@ public interface IAsyncBatchDAO extends ISingletonService
 
 	/**
 	 * retrieve workpackages for async batch
-	 * 
+	 *
 	 * @param asyncBatch
 	 * @param processed
 	 * @return
@@ -73,7 +73,7 @@ public interface IAsyncBatchDAO extends ISingletonService
 
 	/**
 	 * retrieve notified workpackages fro an async batch
-	 * 
+	 *
 	 * @param asyncBatch
 	 * @param notified
 	 * @return
@@ -81,10 +81,7 @@ public interface IAsyncBatchDAO extends ISingletonService
 	List<I_C_Queue_WorkPackage_Notified> retrieveWorkPackagesNotified(I_C_Async_Batch asyncBatch, boolean notified);
 
 	/**
-	 * fetch the notifiable record for a given workpackage
-	 * 
-	 * @param workPackage
-	 * @return
+	 * fetch the notifyable record for a given workpackage
 	 */
 	I_C_Queue_WorkPackage_Notified fetchWorkPackagesNotified(I_C_Queue_WorkPackage workPackage);
 }

--- a/de.metas.async/src/main/java/de/metas/async/api/IWorkpackageProcessorContextFactory.java
+++ b/de.metas.async/src/main/java/de/metas/async/api/IWorkpackageProcessorContextFactory.java
@@ -1,35 +1,26 @@
 package de.metas.async.api;
 
-import de.metas.async.model.I_C_Async_Batch;
+import de.metas.async.AsyncBatchId;
 import de.metas.util.ISingletonService;
 
 public interface IWorkpackageProcessorContextFactory extends ISingletonService
 {
 	/**
-	 * Associate the given <code>asyncBatch</code> with the current thread
-	 * 
-	 * @param asyncBatch
-	 * @return the async batch that was formerly associate with the current thread, or <code>null</code>.
+	 * Associate the given {@code asyncBatchId} (or {@code null} with the current thread.
+	 *
+	 * @return the async batch Id that was formerly associate with the current thread, or <code>null</code>.
 	 */
-	I_C_Async_Batch setThreadInheritedAsyncBatch(I_C_Async_Batch asyncBatch);
+	AsyncBatchId setThreadInheritedAsyncBatch(AsyncBatchId asyncBatch);
 
 	/**
-	 * Get batch id from the inherited thread
-	 * 
-	 * @return
+	 * Get batch id from the inherited thread or {@code null}
 	 */
-	int getThreadInheritedAsyncBatchId();
+	AsyncBatchId getThreadInheritedAsyncBatchId();
 
-	/**
-	 * Get the async batch associated with the current thread (or <code>null</code>).
-	 * 
-	 * @return
-	 */
-	I_C_Async_Batch getThreadInheritedAsyncBatch();
 
 	/**
 	 * Get the priority associated with the current thread
-	 * 
+	 *
 	 * @return
 	 */
 	String getThreadInheritedPriority();
@@ -37,7 +28,7 @@ public interface IWorkpackageProcessorContextFactory extends ISingletonService
 	/**
 	 * Associate the given <code>priority</code> with the current thread. Method is called before a workpackage is processed. If the WP-processor itself creawtes a follow-up workpackage, then the
 	 * framework will assign this priority to the new workpackage, so that the follow-up package inherit the original package's priority.
-	 * 
+	 *
 	 * @param priority
 	 */
 	void setThreadInheritedPriority(String priority);

--- a/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchBuilder.java
+++ b/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchBuilder.java
@@ -10,12 +10,12 @@ package de.metas.async.api.impl;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -29,6 +29,7 @@ import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.ObjectUtils;
 
+import de.metas.async.AsyncBatchId;
 import de.metas.async.api.IAsyncBatchBuilder;
 import de.metas.async.api.IAsyncBatchDAO;
 import de.metas.async.api.IQueueDAO;
@@ -83,7 +84,7 @@ class AsyncBatchBuilder implements IAsyncBatchBuilder
 
 		// the orders it's very important: first enque and then set the batch
 		// otherwise, will be counted also the workpackage for the batch
-		asyncBatchBL.enqueueAsyncBatch(asyncBatch);
+		asyncBatchBL.enqueueAsyncBatch(AsyncBatchId.ofRepoId(asyncBatch.getC_Async_Batch_ID()));
 
 		return asyncBatch;
 	}
@@ -100,20 +101,20 @@ class AsyncBatchBuilder implements IAsyncBatchBuilder
 		Check.assumeNotNull(_ctx, "ctx not null");
 		return _ctx;
 	}
-	
-	
+
+
 	@Override
 	public IAsyncBatchBuilder setCountExpected(int expected)
 	{
 		_countExpected = expected;
 		return this;
 	}
-	
+
 	private final int getCountExpected()
 	{
 		return _countExpected;
 	}
-	
+
 	@Override
 	public IAsyncBatchBuilder setAD_PInstance_Creator_ID(final PInstanceId adPInstanceId)
 	{
@@ -130,14 +131,14 @@ class AsyncBatchBuilder implements IAsyncBatchBuilder
 	{
 		return parentAsycnBatchId;
 	}
-	
+
 	@Override
 	public IAsyncBatchBuilder setParentAsycnBatchId(int parentAsycnBatchId)
 	{
 		this.parentAsycnBatchId = parentAsycnBatchId;
 		return this;
 	}
-	
+
 	@Override
 	public IAsyncBatchBuilder setName(final String name)
 	{

--- a/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchDAO.java
+++ b/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchDAO.java
@@ -1,7 +1,9 @@
 /**
- * 
+ *
  */
 package de.metas.async.api.impl;
+
+import static org.adempiere.model.InterfaceWrapperHelper.loadOutOfTrx;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,12 +18,12 @@ import java.util.List;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -36,19 +38,24 @@ import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.Query;
 
+import de.metas.async.AsyncBatchId;
 import de.metas.async.api.IAsyncBatchDAO;
 import de.metas.async.model.I_C_Async_Batch;
 import de.metas.async.model.I_C_Async_Batch_Type;
 import de.metas.async.model.I_C_Queue_WorkPackage;
 import de.metas.async.model.I_C_Queue_WorkPackage_Notified;
 import de.metas.util.Services;
+import lombok.NonNull;
 
-/**
- * @author cg
- *
- */
 public class AsyncBatchDAO implements IAsyncBatchDAO
 {
+
+	@Override
+	public I_C_Async_Batch retrieveAsyncBatchRecord(@NonNull final AsyncBatchId asyncBatchId)
+	{
+		return loadOutOfTrx(asyncBatchId, I_C_Async_Batch.class);
+	}
+
 	@Override
 	public I_C_Async_Batch_Type retrieveAsyncBatchType(final Properties ctx, final String internalName)
 	{
@@ -128,5 +135,4 @@ public class AsyncBatchDAO implements IAsyncBatchDAO
 				.setParameters(params)
 				.firstOnly(I_C_Queue_WorkPackage_Notified.class);
 	}
-
 }

--- a/de.metas.async/src/main/java/de/metas/async/api/impl/WorkpackageProcessorContextFactory.java
+++ b/de.metas.async/src/main/java/de/metas/async/api/impl/WorkpackageProcessorContextFactory.java
@@ -1,5 +1,7 @@
 package de.metas.async.api.impl;
 
+import de.metas.async.AsyncBatchId;
+
 /*
  * #%L
  * de.metas.async
@@ -10,12 +12,12 @@ package de.metas.async.api.impl;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -24,34 +26,27 @@ package de.metas.async.api.impl;
 
 
 import de.metas.async.api.IWorkpackageProcessorContextFactory;
-import de.metas.async.model.I_C_Async_Batch;
 
 public class WorkpackageProcessorContextFactory implements IWorkpackageProcessorContextFactory
 {
 
-	private final InheritableThreadLocal<I_C_Async_Batch> threadLocalAsyncBatch = new InheritableThreadLocal<I_C_Async_Batch>();
+	private final InheritableThreadLocal<AsyncBatchId> threadLocalAsyncBatch = new InheritableThreadLocal<AsyncBatchId>();
 
 	private final InheritableThreadLocal<String> threadLocalPriority = new InheritableThreadLocal<String>();
 
 	@Override
-	public I_C_Async_Batch setThreadInheritedAsyncBatch(final I_C_Async_Batch asyncBatch)
+	public AsyncBatchId setThreadInheritedAsyncBatch(final AsyncBatchId asyncBatchId)
 	{
-		final I_C_Async_Batch asyncBatchOld = threadLocalAsyncBatch.get();
-		threadLocalAsyncBatch.set(asyncBatch);
-		return asyncBatchOld;
+		final AsyncBatchId asyncBatchIdOld = threadLocalAsyncBatch.get();
+		threadLocalAsyncBatch.set(asyncBatchId);
+		return asyncBatchIdOld;
 	}
 
 	@Override
-	public int getThreadInheritedAsyncBatchId()
+	public AsyncBatchId getThreadInheritedAsyncBatchId()
 	{
-		final I_C_Async_Batch asyncBatch = threadLocalAsyncBatch.get();
-		return asyncBatch == null ? -1 : asyncBatch.getC_Async_Batch_ID();
-	}
-
-	@Override
-	public I_C_Async_Batch getThreadInheritedAsyncBatch()
-	{
-		return threadLocalAsyncBatch.get();
+		final AsyncBatchId asyncBatchId = threadLocalAsyncBatch.get();
+		return asyncBatchId;
 	}
 
 	@Override

--- a/de.metas.async/src/main/java/de/metas/async/processor/impl/WorkpackageProcessorTask.java
+++ b/de.metas.async/src/main/java/de/metas/async/processor/impl/WorkpackageProcessorTask.java
@@ -1,5 +1,7 @@
 package de.metas.async.processor.impl;
 
+
+
 /*
  * #%L
  * de.metas.async
@@ -49,6 +51,7 @@ import org.compiere.util.TrxRunnable;
 import org.slf4j.Logger;
 
 import ch.qos.logback.classic.Level;
+import de.metas.async.AsyncBatchId;
 import de.metas.async.Async_Constants;
 import de.metas.async.api.IAsyncBatchBL;
 import de.metas.async.api.IQueueDAO;
@@ -56,7 +59,6 @@ import de.metas.async.api.IWorkPackageBL;
 import de.metas.async.api.IWorkpackageParamDAO;
 import de.metas.async.api.IWorkpackageProcessorContextFactory;
 import de.metas.async.exceptions.WorkpackageSkipRequestException;
-import de.metas.async.model.I_C_Async_Batch;
 import de.metas.async.model.I_C_Queue_Block;
 import de.metas.async.model.I_C_Queue_PackageProcessor;
 import de.metas.async.model.I_C_Queue_WorkPackage;
@@ -240,8 +242,7 @@ import lombok.NonNull;
 	private final void beforeWorkpackageProcessing()
 	{
 		// If the current workpackage's processor creates a follow-up-workpackage, the asyncBatch and priority will be forwarded.
-		final I_C_Async_Batch asyncBatch = workPackage.getC_Async_Batch();
-		contextFactory.setThreadInheritedAsyncBatch(asyncBatch);
+		contextFactory.setThreadInheritedAsyncBatch(AsyncBatchId.ofRepoIdOrNull(workPackage.getC_Async_Batch_ID()));
 
 		final String priority = workPackage.getPriority();
 		contextFactory.setThreadInheritedPriority(priority);

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/VoidAndRecreateInvoiceBuilder.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/VoidAndRecreateInvoiceBuilder.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package de.metas.invoicecandidate.api;
 
@@ -16,6 +16,7 @@ import org.compiere.util.TimeUtil;
 
 import de.metas.adempiere.form.IClientUI;
 import de.metas.allocation.api.IAllocationDAO;
+import de.metas.async.AsyncBatchId;
 import de.metas.async.api.IAsyncBatchBL;
 import de.metas.async.api.IQueueDAO;
 import de.metas.async.api.IWorkPackageQueue;
@@ -92,7 +93,7 @@ public class VoidAndRecreateInvoiceBuilder
 
 	/**
 	 * Set the list of invoices the needs to be recompute
-	 * 
+	 *
 	 * @param invoices
 	 */
 	public VoidAndRecreateInvoiceBuilder setInvoices(List<I_C_Invoice> invoices)
@@ -118,7 +119,7 @@ public class VoidAndRecreateInvoiceBuilder
 
 	/**
 	 * THis param is used in order to know when a warning message can be triggered
-	 * 
+	 *
 	 * @param canWarnUser
 	 */
 	public VoidAndRecreateInvoiceBuilder setCanWarnUser(boolean canWarnUser)
@@ -163,7 +164,7 @@ public class VoidAndRecreateInvoiceBuilder
 		queueWorkpackage.setC_Async_Batch(asyncBatch);
 		Services.get(IQueueDAO.class).save(queueWorkpackage);
 
-		queue.enqueueElement(queueWorkpackage, invoice);
+		queue.enqueueElement(queueWorkpackage, TableRecordReference.of(invoice));
 		queue.markReadyForProcessing(queueWorkpackage);
 	}
 
@@ -179,9 +180,9 @@ public class VoidAndRecreateInvoiceBuilder
 		asyncBatch.setName("Void and recreate invoices");
 		asyncBatch.setC_Async_Batch_Type(asyncBatchType);
 		queueDAO.save(asyncBatch);
-		// is very importing the order; first enque and then set the batch
+		// the is very important order; first enqueue and then set the batch
 		// otherwise, will be counted also the workpackage for the batch
-		asyncBatchBL.enqueueAsyncBatch(asyncBatch);
+		asyncBatchBL.enqueueAsyncBatch(AsyncBatchId.ofRepoId(asyncBatch.getC_Async_Batch_ID()));
 
 		final StringBuilder builder = new StringBuilder();
 


### PR DESCRIPTION
* introduce AsyncBatchId
* don't pass around I_C_AsyncBatch records - they might be stale or might have some not-really-sureabout internal trxName; instead, pass around AsyncBatchId
* when an I_C_AsyncBatch record is needed, then load it out-of-trx via the AsyncBatchId

That way we make sure that we don't have update-related logs on C_AsyncBatch records in the DB, and further:
  * we know that if we return a reentrant lock in AsyncBatchBL, then we also returned the C_AsyncBatch record's lock(s) in the DB, because already committed

https://github.com/metasfresh/metasfresh/issues/5670