### PR TITLE
5917-app - Product price not found if ASI was added to order line

### DIFF
--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/organization/impl/OrgDAO.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/organization/impl/OrgDAO.java
@@ -286,6 +286,10 @@ public class OrgDAO implements IOrgDAO
 	@Override
 	public ZoneId getTimeZone(@NonNull final OrgId orgId)
 	{
+		if (!orgId.isRegular())
+		{
+			return SystemTime.zoneId();
+		}
 		final ZoneId timeZone = getOrgInfoById(orgId).getTimeZone();
 		return timeZone != null ? timeZone : SystemTime.zoneId();
 	}

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/dao/impl/QueryOrderByBuilder.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/dao/impl/QueryOrderByBuilder.java
@@ -32,7 +32,6 @@ import org.adempiere.ad.dao.IQueryOrderBy.Nulls;
 import org.adempiere.ad.dao.IQueryOrderByBuilder;
 import org.adempiere.model.ModelColumn;
 
-import de.metas.util.Check;
 import lombok.NonNull;
 
 final class QueryOrderByBuilder<T> implements IQueryOrderByBuilder<T>
@@ -102,14 +101,13 @@ final class QueryOrderByBuilder<T> implements IQueryOrderByBuilder<T>
 	}
 
 	@Override
-	public IQueryOrderByBuilder<T> addColumn(final ModelColumn<T, ?> column, final Direction direction, final Nulls nulls)
+	public IQueryOrderByBuilder<T> addColumn(@NonNull final ModelColumn<T, ?> column, final Direction direction, final Nulls nulls)
 	{
-		Check.assumeNotNull(column, "column not null");
 		final String columnName = column.getColumnName();
 		return addColumn(columnName, direction, nulls);
 	}
 
-	private final Nulls getNulls(final Direction direction)
+	private Nulls getNulls(final Direction direction)
 	{
 		// NOTE: keeping backward compatibility
 		// i.e. postgresql 9.1. specifications:

--- a/de.metas.business/src/main/java-legacy/org/compiere/model/MProductPricing.java
+++ b/de.metas.business/src/main/java-legacy/org/compiere/model/MProductPricing.java
@@ -19,6 +19,7 @@ package org.compiere.model;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 
+import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 import org.slf4j.Logger;
 
@@ -38,10 +39,10 @@ import de.metas.util.lang.Percent;
 
 /**
  * Product Price Calculations
- * 
+ *
  * @author Jorg Janke
  * @version $Id: MProductPricing.java,v 1.2 2006/07/30 00:51:02 jjanke Exp $
- * 
+ *
  * @deprecated Please use {@link IPricingBL}
  */
 @Deprecated
@@ -53,7 +54,7 @@ public class MProductPricing
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param M_Product_ID product
 	 * @param C_BPartner_ID partner
 	 * @param Qty quantity
@@ -61,7 +62,7 @@ public class MProductPricing
 	 */
 	public MProductPricing(int M_Product_ID, int C_BPartner_ID, BigDecimal Qty, boolean isSOTrx)
 	{
-		pricingCtx = Services.get(IPricingBL.class).createInitialContext(M_Product_ID, C_BPartner_ID, 0, Qty, isSOTrx);
+		pricingCtx = Services.get(IPricingBL.class).createInitialContext(Env.getAD_Org_ID(Env.getCtx()), M_Product_ID, C_BPartner_ID, 0, Qty, isSOTrx);
 		result = Services.get(IPricingBL.class).createInitialResult(pricingCtx);
 	}	// MProductPricing
 
@@ -70,7 +71,7 @@ public class MProductPricing
 
 	/**
 	 * Calculate Price
-	 * 
+	 *
 	 * @return true if calculated
 	 */
 	public boolean recalculatePrice()
@@ -97,7 +98,7 @@ public class MProductPricing
 
 	/**
 	 * Is Tax Included
-	 * 
+	 *
 	 * @return tax included
 	 */
 	public boolean isTaxIncluded()
@@ -107,7 +108,7 @@ public class MProductPricing
 
 	/**************************************************************************
 	 * Calculate Discount Percentage based on Standard/List Price
-	 * 
+	 *
 	 * @return Discount
 	 */
 	public Percent getDiscount()
@@ -122,14 +123,14 @@ public class MProductPricing
 
 	/**
 	 * Set PriceList
-	 * 
+	 *
 	 * @param M_PriceList_ID pl
 	 */
 	public void setM_PriceList_ID(int M_PriceList_ID)
 	{
 		setPriceListId(PriceListId.ofRepoIdOrNull(M_PriceList_ID));
 	}	// setM_PriceList_ID
-	
+
 	public void setPriceListId(PriceListId priceListId)
 	{
 		pricingCtx.setPriceListId(priceListId);
@@ -138,7 +139,7 @@ public class MProductPricing
 
 	/**
 	 * Set PriceList Version
-	 * 
+	 *
 	 * @param M_PriceList_Version_ID plv
 	 */
 	public void setM_PriceList_Version_ID(int M_PriceList_Version_ID)
@@ -151,7 +152,7 @@ public class MProductPricing
 
 	/**
 	 * Set Price Date
-	 * 
+	 *
 	 * @param priceDate date
 	 */
 	public void setPriceDate(Timestamp priceDate)
@@ -162,7 +163,7 @@ public class MProductPricing
 
 	/**
 	 * Round
-	 * 
+	 *
 	 * @param bd number
 	 * @return rounded number
 	 */
@@ -178,7 +179,7 @@ public class MProductPricing
 
 	/**************************************************************************
 	 * Get C_UOM_ID
-	 * 
+	 *
 	 * @return uom
 	 */
 	public int getC_UOM_ID()
@@ -189,7 +190,7 @@ public class MProductPricing
 
 	/**
 	 * Get Price List
-	 * 
+	 *
 	 * @return list
 	 */
 	public BigDecimal getPriceList()
@@ -200,7 +201,7 @@ public class MProductPricing
 
 	/**
 	 * Get Price Std
-	 * 
+	 *
 	 * @return std
 	 */
 	public BigDecimal getPriceStd()
@@ -211,7 +212,7 @@ public class MProductPricing
 
 	/**
 	 * Get Price Limit
-	 * 
+	 *
 	 * @return limit
 	 */
 	public BigDecimal getPriceLimit()
@@ -222,7 +223,7 @@ public class MProductPricing
 
 	/**
 	 * Is Price List enforded?
-	 * 
+	 *
 	 * @return enforce limit
 	 */
 	public boolean isEnforcePriceLimit()
@@ -233,7 +234,7 @@ public class MProductPricing
 
 	/**
 	 * Is a DiscountSchema active?
-	 * 
+	 *
 	 * @return active Discount Schema
 	 */
 	public boolean isDiscountSchema()
@@ -244,7 +245,7 @@ public class MProductPricing
 
 	/**
 	 * Is the Price Calculated (i.e. found)?
-	 * 
+	 *
 	 * @return calculated
 	 */
 	public boolean isCalculated()
@@ -254,7 +255,7 @@ public class MProductPricing
 
 	/**
 	 * Convenience method to get priceStd with the discount already subtracted. Note that the result matches the former behavior of {@link #getPriceStd()}.
-	 * 
+	 *
 	 * @return
 	 */
 	// metas
@@ -288,7 +289,7 @@ public class MProductPricing
 	{
 		return TaxCategoryId.toRepoId(result.getTaxCategoryId());
 	}
-	
+
 	public boolean isManualPrice()
 	{
 		return pricingCtx.getManualPriceEnabled().isTrue();
@@ -298,7 +299,7 @@ public class MProductPricing
 	{
 		pricingCtx.setManualPriceEnabled(manualPrice);
 	}
-	
+
 	public void throwProductNotOnPriceListException()
 	{
 		throw new ProductNotOnPriceListException(pricingCtx);

--- a/de.metas.business/src/main/java/de/metas/inout/impl/InOutBL.java
+++ b/de.metas.business/src/main/java/de/metas/inout/impl/InOutBL.java
@@ -51,6 +51,7 @@ import de.metas.inout.IInOutBL;
 import de.metas.inout.IInOutDAO;
 import de.metas.invoice.IMatchInvDAO;
 import de.metas.lang.SOTrx;
+import de.metas.organization.OrgId;
 import de.metas.pricing.IEditablePricingContext;
 import de.metas.pricing.IPricingContext;
 import de.metas.pricing.IPricingResult;
@@ -84,6 +85,7 @@ public class InOutBL implements IInOutBL
 		final BPartnerId bPartnerId = BPartnerId.ofRepoId(inOut.getC_BPartner_ID());
 
 		final IEditablePricingContext pricingCtx = pricingBL.createInitialContext(
+				OrgId.ofRepoIdOrAny(inOutLine.getAD_Org_ID()),
 				ProductId.ofRepoId(inOutLine.getM_Product_ID()),
 				bPartnerId,
 				Quantitys.create(inOutLine.getQtyEntered(), UomId.ofRepoId(inOutLine.getC_UOM_ID())),

--- a/de.metas.business/src/main/java/de/metas/invoice/impl/InvoiceLineBL.java
+++ b/de.metas.business/src/main/java/de/metas/invoice/impl/InvoiceLineBL.java
@@ -319,6 +319,7 @@ public class InvoiceLineBL implements IInvoiceLineBL
 		final LocalDate date = TimeUtil.asLocalDate(invoice.getDateInvoiced());
 
 		final IEditablePricingContext pricingCtx = Services.get(IPricingBL.class).createInitialContext(
+				invoiceLine.getAD_Org_ID(),
 				productId,
 				bPartnerId,
 				invoiceLine.getPrice_UOM_ID(),

--- a/de.metas.business/src/main/java/de/metas/order/OrderFreightCostsService.java
+++ b/de.metas.business/src/main/java/de/metas/order/OrderFreightCostsService.java
@@ -303,6 +303,7 @@ public class OrderFreightCostsService
 			}
 
 			final IEditablePricingContext pricingContext = pricingBL.createInitialContext(
+					freightCost.getOrgId().getRepoId(),
 					freightCost.getFreightCostProductId().getRepoId(),
 					freightCostContext.getShipToBPartnerId().getRepoId(),
 					0,

--- a/de.metas.business/src/main/java/de/metas/order/impl/OrderLinePriceCalculator.java
+++ b/de.metas.business/src/main/java/de/metas/order/impl/OrderLinePriceCalculator.java
@@ -30,6 +30,7 @@ import de.metas.order.IOrderLineBL;
 import de.metas.order.OrderLinePriceUpdateRequest;
 import de.metas.order.OrderLinePriceUpdateRequest.ResultUOM;
 import de.metas.order.PriceAndDiscount;
+import de.metas.organization.OrgId;
 import de.metas.payment.paymentterm.PaymentTermId;
 import de.metas.pricing.IEditablePricingContext;
 import de.metas.pricing.IPricingContext;
@@ -316,6 +317,7 @@ final class OrderLinePriceCalculator
 		}
 
 		final IEditablePricingContext pricingCtx = pricingBL.createInitialContext(
+				OrgId.ofRepoId(orderLine.getAD_Org_ID()),
 				ProductId.ofRepoId(productId),
 				bpartnerId,
 				qtyInPriceUOM,

--- a/de.metas.business/src/main/java/de/metas/pricing/IEditablePricingContext.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/IEditablePricingContext.java
@@ -29,6 +29,7 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.lang.SOTrx;
 import de.metas.location.CountryId;
 import de.metas.money.CurrencyId;
+import de.metas.organization.OrgId;
 import de.metas.pricing.conditions.PricingConditionsBreak;
 import de.metas.product.ProductId;
 import de.metas.uom.UomId;
@@ -40,24 +41,24 @@ import de.metas.uom.UomId;
  */
 public interface IEditablePricingContext extends IPricingContext
 {
+	IEditablePricingContext setOrgId(OrgId orgId);
+
 	/**
 	 * Set's this context's referenced object to the given {@code referencedObject}, and set's this context's trxName to be the given referencedObject's trxName.
-	 *
-	 * @param referencedObject
 	 */
-	IEditablePricingContext setReferencedObject(final Object referencedObject);
+	IEditablePricingContext setReferencedObject(Object referencedObject);
 
-	IEditablePricingContext setSOTrx(final SOTrx soTrx);
+	IEditablePricingContext setSOTrx(SOTrx soTrx);
 
-	IEditablePricingContext setQty(final BigDecimal qty);
+	IEditablePricingContext setQty(BigDecimal qty);
 
-	IEditablePricingContext setBPartnerId(final BPartnerId bpartnerId);
+	IEditablePricingContext setBPartnerId(BPartnerId bpartnerId);
 
 	IEditablePricingContext setCurrencyId(CurrencyId currencyId);
 
-	IEditablePricingContext setUomId(final UomId uomId);
+	IEditablePricingContext setUomId(UomId uomId);
 
-	IEditablePricingContext setPriceDate(final LocalDate priceDate);
+	IEditablePricingContext setPriceDate(LocalDate priceDate);
 
 	IEditablePricingContext setPricingSystemId(PricingSystemId pricingSystemId);
 
@@ -65,7 +66,7 @@ public interface IEditablePricingContext extends IPricingContext
 
 	IEditablePricingContext setPriceListVersionId(PriceListVersionId priceListVersionId);
 
-	IEditablePricingContext setProductId(final ProductId productId);
+	IEditablePricingContext setProductId(ProductId productId);
 
 	/**
 	 * Set this to <code>true</code> to indicate to the pricing engine that discounts shall <b>not</b> be computed and applied to the result.

--- a/de.metas.business/src/main/java/de/metas/pricing/IPricingContext.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/IPricingContext.java
@@ -35,6 +35,7 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.lang.SOTrx;
 import de.metas.location.CountryId;
 import de.metas.money.CurrencyId;
+import de.metas.organization.OrgId;
 import de.metas.pricing.conditions.PricingConditionsBreak;
 import de.metas.product.ProductId;
 import de.metas.uom.UomId;
@@ -42,6 +43,8 @@ import de.metas.util.OptionalBoolean;
 
 public interface IPricingContext extends IContextAware
 {
+	OrgId getOrgId();
+
 	ProductId getProductId();
 
 	Optional<IAttributeSetInstanceAware> getAttributeSetInstanceAware();

--- a/de.metas.business/src/main/java/de/metas/pricing/attributebased/impl/AttributePricing.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/attributebased/impl/AttributePricing.java
@@ -280,7 +280,7 @@ public class AttributePricing implements IPricingRule
 						.setProductId(pricingCtx.getProductId())
 						.onlyValidPrices(true)
 						.matching(_defaultMatchers)
-						.matchingAttributes(attributeSetInstance)
+						.strictlyMatchingAttributes(attributeSetInstance)
 						.firstMatching(),
 
 				TimeUtil.asZonedDateTime(pricingCtx.getPriceDate(), SystemTime.zoneId()));

--- a/de.metas.business/src/main/java/de/metas/pricing/rules/PriceListVersion.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/rules/PriceListVersion.java
@@ -6,7 +6,6 @@ import java.time.ZonedDateTime;
 import org.compiere.model.I_M_PriceList;
 import org.compiere.model.I_M_PriceList_Version;
 import org.compiere.model.I_M_ProductPrice;
-import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 import org.slf4j.Logger;
 
@@ -61,7 +60,7 @@ public class PriceListVersion extends AbstractPriceListBasedRule
 			return;
 		}
 
-		final ZoneId timeZone = orgDAO.getTimeZone(Env.getOrgId(pricingCtx.getCtx()));
+		final ZoneId timeZone = orgDAO.getTimeZone(pricingCtx.getOrgId());
 		final I_M_ProductPrice productPrice = getProductPriceOrNull(pricingCtx.getProductId(),
 				ctxPriceListVersion,
 				TimeUtil.asZonedDateTime(pricingCtx.getPriceDate(), timeZone));

--- a/de.metas.business/src/main/java/de/metas/pricing/rules/PriceListVersion.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/rules/PriceListVersion.java
@@ -1,10 +1,12 @@
 package de.metas.pricing.rules;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import org.compiere.model.I_M_PriceList;
 import org.compiere.model.I_M_PriceList_Version;
 import org.compiere.model.I_M_ProductPrice;
+import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 import org.slf4j.Logger;
 
@@ -13,6 +15,7 @@ import de.metas.i18n.ITranslatableString;
 import de.metas.i18n.TranslatableStrings;
 import de.metas.logging.LogManager;
 import de.metas.money.CurrencyId;
+import de.metas.organization.IOrgDAO;
 import de.metas.pricing.IPricingContext;
 import de.metas.pricing.IPricingResult;
 import de.metas.pricing.InvoicableQtyBasedOn;
@@ -42,6 +45,7 @@ public class PriceListVersion extends AbstractPriceListBasedRule
 	private final IPriceListDAO priceListsRepo = Services.get(IPriceListDAO.class);
 	private final IProductBL productsService = Services.get(IProductBL.class);
 	private final IProductDAO productsRepo = Services.get(IProductDAO.class);
+	private final IOrgDAO orgDAO = Services.get(IOrgDAO.class);
 
 	@Override
 	public void calculate(final IPricingContext pricingCtx, final IPricingResult result)
@@ -57,9 +61,10 @@ public class PriceListVersion extends AbstractPriceListBasedRule
 			return;
 		}
 
+		final ZoneId timeZone = orgDAO.getTimeZone(Env.getOrgId(pricingCtx.getCtx()));
 		final I_M_ProductPrice productPrice = getProductPriceOrNull(pricingCtx.getProductId(),
 				ctxPriceListVersion,
-				TimeUtil.asZonedDateTime(pricingCtx.getPriceDate(), SystemTime.zoneId()));
+				TimeUtil.asZonedDateTime(pricingCtx.getPriceDate(), timeZone));
 
 		if (productPrice == null)
 		{

--- a/de.metas.business/src/main/java/de/metas/pricing/service/IPricingBL.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/service/IPricingBL.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import de.metas.bpartner.BPartnerId;
 import de.metas.lang.SOTrx;
 import de.metas.location.CountryId;
+import de.metas.organization.OrgId;
 import de.metas.pricing.IEditablePricingContext;
 import de.metas.pricing.IPricingContext;
 import de.metas.pricing.IPricingResult;
@@ -59,9 +60,9 @@ public interface IPricingBL extends ISingletonService
 	 * @deprecated please use {@link #createInitialContext(ProductId, BPartnerId, Quantity, SOTrx)} instead.
 	 */
 	@Deprecated
-	IEditablePricingContext createInitialContext(int M_Product_ID, int C_BPartner_ID, int C_UOM_ID, BigDecimal qty, boolean isSOTrx);
+	IEditablePricingContext createInitialContext(int AD_Org_ID, int M_Product_ID, int C_BPartner_ID, int C_UOM_ID, BigDecimal qty, boolean isSOTrx);
 
-	IEditablePricingContext createInitialContext(ProductId productId, BPartnerId bPartnerId, Quantity quantity, SOTrx soTrx);
+	IEditablePricingContext createInitialContext(OrgId orgId, ProductId productId, BPartnerId bPartnerId, Quantity quantity, SOTrx soTrx);
 
 	IPricingResult calculatePrice(IPricingContext pricingCtx);
 

--- a/de.metas.business/src/main/java/de/metas/pricing/service/ProductPriceQuery.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/service/ProductPriceQuery.java
@@ -131,10 +131,10 @@ public class ProductPriceQuery
 		final IQueryBuilder<I_M_ProductPrice> queryBuilder = toQueryBuilder();
 
 		final IQueryBuilderOrderByClause<I_M_ProductPrice> orderBy = queryBuilder.orderBy();
-		orderBy.clear();
+		orderBy.clear(); // note: orderBy is NOT immutable
 
 		if (AttributePricing.NOT_STRICT.equals(_attributePricing))
-		{ // we might have product prices with IsAttributeDependant both yes and no; prefer those with yes.
+		{ // we might have product prices with IsAttributeDependant both 'Y' and 'N'; prefer those with 'Y'.
 			orderBy.addColumnDescending(I_M_ProductPrice.COLUMNNAME_IsAttributeDependant);
 		}
 		orderBy.addColumn(I_M_ProductPrice.COLUMN_M_Product_ID, Direction.Ascending, Nulls.Last)

--- a/de.metas.business/src/main/java/de/metas/pricing/service/ProductPriceQuery.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/service/ProductPriceQuery.java
@@ -5,8 +5,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
+import org.adempiere.ad.dao.IQueryBuilderOrderByClause;
 import org.adempiere.ad.dao.IQueryFilter;
 import org.adempiere.ad.dao.IQueryOrderBy.Direction;
 import org.adempiere.ad.dao.IQueryOrderBy.Nulls;
@@ -60,12 +63,27 @@ import lombok.NonNull;
  */
 public class ProductPriceQuery
 {
+	public enum AttributePricing
+	{
+		/** Only match product prices with IsAttributeDependent='Y' */
+		STRICT,
+
+		/** Prefer product prices with IsAttributeDependent='Y', but also allow product prices with IsAttributeDependent='N' */
+		NOT_STRICT,
+
+		/** Only match product prices with IsAttributeDependent='N' */
+		NONE,
+
+		/** No ASI related matching at all */
+		IGNORE;
+	}
+
 	private static final Logger logger = LogManager.getLogger(ProductPriceQuery.class);
 
 	private PriceListVersionId _priceListVersionId;
 	private ProductId _productId;
 
-	private Boolean _attributePricing;
+	private AttributePricing _attributePricing = AttributePricing.IGNORE;
 	private I_M_AttributeSetInstance _attributePricing_asiToMatch;
 
 	private Boolean _scalePrice;
@@ -112,9 +130,14 @@ public class ProductPriceQuery
 	{
 		final IQueryBuilder<I_M_ProductPrice> queryBuilder = toQueryBuilder();
 
-		queryBuilder.orderBy()
-				.clear()
-				.addColumn(I_M_ProductPrice.COLUMN_M_Product_ID, Direction.Ascending, Nulls.Last)
+		final IQueryBuilderOrderByClause<I_M_ProductPrice> orderBy = queryBuilder.orderBy();
+		orderBy.clear();
+
+		if (AttributePricing.NOT_STRICT.equals(_attributePricing))
+		{ // we might have product prices with IsAttributeDependant both yes and no; prefer those with yes.
+			orderBy.addColumnDescending(I_M_ProductPrice.COLUMNNAME_IsAttributeDependant);
+		}
+		orderBy.addColumn(I_M_ProductPrice.COLUMN_M_Product_ID, Direction.Ascending, Nulls.Last)
 				.addColumn(I_M_ProductPrice.COLUMN_MatchSeqNo, Direction.Ascending, Nulls.Last)
 				.addColumn(I_M_ProductPrice.COLUMN_M_ProductPrice_ID, Direction.Ascending, Nulls.Last); // just to have a predictable order
 
@@ -143,7 +166,7 @@ public class ProductPriceQuery
 	 *
 	 * @param strictDefault if {@code true}, the method throws an exception if there is more than one match.
 	 *            If {@code false, it silently returns the first match which has the lowest sequence number.
-	 * 			@param type
+	 *            @param type
 	 * @return
 	 */
 	private <T extends I_M_ProductPrice> T retrieveDefault(final boolean strictDefault, @NonNull final Class<T> type)
@@ -209,25 +232,32 @@ public class ProductPriceQuery
 
 		//
 		// Attribute pricing records
-		final Boolean attributePricing = getAttributePricing();
-		if (attributePricing != null)
+		switch (_attributePricing)
 		{
-			// Attributes matching enabled => match given ASI (if any)
-			if (attributePricing)
-			{
-				queryBuilder.addEqualsFilter(I_M_ProductPrice.COLUMN_IsAttributeDependant, true);
-
-				final I_M_AttributeSetInstance attributePricingASIToMatch = getAttributePricingASIToMatch();
-				if (attributePricingASIToMatch != null)
-				{
-					queryBuilder.filter(ASIProductPriceAttributesFilter.of(attributePricingASIToMatch));
-				}
-			}
-			// Attributes matching disabled => match only those product prices which are not attribute dependent
-			else
-			{
+			case NONE:
+				// Attributes matching disabled => match only those product prices which are not attribute dependent
 				queryBuilder.addEqualsFilter(I_M_ProductPrice.COLUMN_IsAttributeDependant, false);
-			}
+				break;
+			case STRICT:
+				// Attributes matching enabled => match given ASI (if any)
+				queryBuilder.addEqualsFilter(I_M_ProductPrice.COLUMN_IsAttributeDependant, true); // don't even look at product prices that don't have the flag set
+
+				final I_M_AttributeSetInstance attributePricingASIToMatchStrict = getAttributePricingASIToMatch();
+				if (attributePricingASIToMatchStrict != null)
+				{
+					queryBuilder.filter(ASIProductPriceAttributesFilter.attributeDependantOnly(attributePricingASIToMatchStrict));
+				}
+				break;
+			case NOT_STRICT:
+				// Non-strict matching; if a productPrice is attribute dependent, then match it against the ASI
+				final I_M_AttributeSetInstance attributePricingASIToMatchNotStrict = getAttributePricingASIToMatch();
+				if (attributePricingASIToMatchNotStrict != null)
+				{
+					queryBuilder.filter(ASIProductPriceAttributesFilter.alsoAcceptIfNotAttributeDependant(attributePricingASIToMatchNotStrict));
+				}
+				break;
+			case IGNORE: // do noting
+				break;
 		}
 
 		//
@@ -277,7 +307,7 @@ public class ProductPriceQuery
 	/** Matches product price which is NOT marked as "attributed pricing" */
 	public ProductPriceQuery noAttributePricing()
 	{
-		_attributePricing = Boolean.FALSE;
+		_attributePricing = AttributePricing.NONE;
 		_attributePricing_asiToMatch = null;
 		return this;
 	}
@@ -296,34 +326,40 @@ public class ProductPriceQuery
 	/** Matches any product price which is marked as "attributed pricing" */
 	public ProductPriceQuery onlyAttributePricing()
 	{
-		_attributePricing = Boolean.TRUE;
+		_attributePricing = AttributePricing.STRICT;
 		// _attributePricing_asiToMatch = null;
 		return this;
 	}
 
 	/**
-	 * Matches product price which is marked as "attributed pricing" and the given ASI is matching.
+	 * Matches product prices which are marked as "attributed pricing" and the given ASI is matching.
 	 * If <code>asi</code> is null then any "attributed pricing" will be matched.
 	 *
 	 * @param asi ASI to match or <code>null</code>
 	 */
-	public ProductPriceQuery matchingAttributes(final I_M_AttributeSetInstance asi)
+	public ProductPriceQuery strictlyMatchingAttributes(@Nullable final I_M_AttributeSetInstance asi)
 	{
-		_attributePricing = Boolean.TRUE;
+		_attributePricing = AttributePricing.STRICT;
 		_attributePricing_asiToMatch = asi;
 		return this;
 	}
 
-	public ProductPriceQuery dontMatchAttributes()
+	/**
+	 * Like {@link #strictlyMatchingAttributes(I_M_AttributeSetInstance)}, but also accepts prices that are not attribute dependent at all.
+	 */
+	public ProductPriceQuery notStrictlyMatchingAttributes(@Nullable final I_M_AttributeSetInstance asi)
 	{
-		_attributePricing = null;
-		_attributePricing_asiToMatch = null;
+		_attributePricing = AttributePricing.NOT_STRICT;
+		_attributePricing_asiToMatch = asi;
 		return this;
+
 	}
 
-	private Boolean getAttributePricing()
+	public ProductPriceQuery dontMatchAttributes()
 	{
-		return _attributePricing;
+		_attributePricing = AttributePricing.IGNORE;
+		_attributePricing_asiToMatch = null;
+		return this;
 	}
 
 	private I_M_AttributeSetInstance getAttributePricingASIToMatch()
@@ -368,7 +404,7 @@ public class ProductPriceQuery
 		return this;
 	}
 
-	public ProductPriceQuery matching(final Collection<IProductPriceQueryMatcher> matchers)
+	public ProductPriceQuery matching(@Nullable final Collection<IProductPriceQueryMatcher> matchers)
 	{
 		if (matchers == null || matchers.isEmpty())
 		{
@@ -439,19 +475,28 @@ public class ProductPriceQuery
 
 	private static final class ASIProductPriceAttributesFilter implements IQueryFilter<I_M_ProductPrice>
 	{
-		public static ASIProductPriceAttributesFilter of(final I_M_AttributeSetInstance asi)
+		public static ASIProductPriceAttributesFilter attributeDependantOnly(final I_M_AttributeSetInstance asi)
 		{
-			return new ASIProductPriceAttributesFilter(asi);
+			return new ASIProductPriceAttributesFilter(asi, /* acceptNotAttributeDependent */false);
+		}
+
+		public static IQueryFilter<I_M_ProductPrice> alsoAcceptIfNotAttributeDependant(final I_M_AttributeSetInstance asi)
+		{
+			return new ASIProductPriceAttributesFilter(asi, /* acceptNotAttributeDependent */true);
 		}
 
 		private final transient IAttributeDAO attributeDAO = Services.get(IAttributeDAO.class);
 
 		private final I_M_AttributeSetInstance _asi;
+		private final boolean _acceptNotAttributeDependent;
 		private transient ImmutableMap<Integer, I_M_AttributeInstance> _asiAttributes;
 
-		private ASIProductPriceAttributesFilter(@NonNull final I_M_AttributeSetInstance asi)
+		private ASIProductPriceAttributesFilter(
+				@NonNull final I_M_AttributeSetInstance asi,
+				final boolean acceptNotAttributeDependent)
 		{
 			_asi = asi;
+			_acceptNotAttributeDependent = acceptNotAttributeDependent;
 		}
 
 		@Override
@@ -461,7 +506,7 @@ public class ProductPriceQuery
 		}
 
 		@Override
-		public boolean accept(final I_M_ProductPrice productPrice)
+		public boolean accept(@Nullable final I_M_ProductPrice productPrice)
 		{
 			// Guard against null, shall not happen
 			if (productPrice == null)
@@ -469,10 +514,9 @@ public class ProductPriceQuery
 				return false;
 			}
 
-			// Consider only those product prices which have the attributes matching option enabled
 			if (!productPrice.isAttributeDependant())
 			{
-				return false;
+				return _acceptNotAttributeDependent; // either way, there is nothing more to do or match here
 			}
 
 			// If our ASI does not have attributes set, consider this product price as matching
@@ -547,5 +591,4 @@ public class ProductPriceQuery
 			return productPriceAttributes;
 		}
 	}
-
 }

--- a/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingBL.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingBL.java
@@ -48,6 +48,7 @@ import de.metas.currency.CurrencyPrecision;
 import de.metas.lang.SOTrx;
 import de.metas.location.CountryId;
 import de.metas.logging.LogManager;
+import de.metas.organization.OrgId;
 import de.metas.pricing.IEditablePricingContext;
 import de.metas.pricing.IPricingContext;
 import de.metas.pricing.IPricingResult;
@@ -96,12 +97,14 @@ public class PricingBL implements IPricingBL
 
 	@Override
 	public IEditablePricingContext createInitialContext(
+			@NonNull final OrgId orgId,
 			@Nullable final ProductId productId,
 			@Nullable BPartnerId bPartnerId,
 			@Nullable final Quantity quantity,
 			@NonNull final SOTrx soTrx)
 	{
 		final IEditablePricingContext pricingCtx = createPricingContext();
+		pricingCtx.setOrgId(orgId);
 		pricingCtx.setProductId(productId);
 		pricingCtx.setBPartnerId(bPartnerId);
 		pricingCtx.setConvertPriceToContextUOM(true); // backward compatibility
@@ -125,6 +128,7 @@ public class PricingBL implements IPricingBL
 
 	@Override
 	public IEditablePricingContext createInitialContext(
+			final int AD_Org_ID,
 			final int M_Product_ID,
 			final int C_BPartner_ID,
 			final int C_UOM_ID,
@@ -132,6 +136,7 @@ public class PricingBL implements IPricingBL
 			final boolean isSOTrx)
 	{
 		final IEditablePricingContext pricingCtx = createPricingContext();
+		pricingCtx.setOrgId(OrgId.ofRepoIdOrAny(AD_Org_ID));
 		pricingCtx.setProductId(ProductId.ofRepoIdOrNull(M_Product_ID));
 		pricingCtx.setBPartnerId(BPartnerId.ofRepoIdOrNull(C_BPartner_ID));
 		pricingCtx.setConvertPriceToContextUOM(true); // backward compatibility

--- a/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingContext.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingContext.java
@@ -42,6 +42,7 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.lang.SOTrx;
 import de.metas.location.CountryId;
 import de.metas.money.CurrencyId;
+import de.metas.organization.OrgId;
 import de.metas.pricing.IEditablePricingContext;
 import de.metas.pricing.PriceListId;
 import de.metas.pricing.PriceListVersionId;
@@ -68,6 +69,8 @@ class PricingContext implements IEditablePricingContext
 	private I_M_PriceList_Version _priceListVersion = null;
 
 	private boolean skipCheckingPriceListSOTrxFlag;
+
+	private OrgId orgId;
 
 	private ProductId productId;
 
@@ -102,6 +105,7 @@ class PricingContext implements IEditablePricingContext
 	public IEditablePricingContext copy()
 	{
 		final PricingContext pricingCtxNew = new PricingContext();
+		pricingCtxNew.orgId = orgId;
 		pricingCtxNew.productId = productId;
 		pricingCtxNew.pricingSystemId = pricingSystemId;
 		pricingCtxNew.priceListId = priceListId;
@@ -138,6 +142,19 @@ class PricingContext implements IEditablePricingContext
 	public IEditablePricingContext setPricingSystemId(final PricingSystemId pricingSystemId)
 	{
 		this.pricingSystemId = pricingSystemId;
+		return this;
+	}
+
+	@Override
+	public OrgId getOrgId()
+	{
+		return orgId;
+	}
+
+	@Override
+	public IEditablePricingContext setOrgId(final OrgId orgId)
+	{
+		this.orgId = orgId;
 		return this;
 	}
 

--- a/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingContext.java
+++ b/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingContext.java
@@ -1,5 +1,7 @@
 package de.metas.pricing.service.impl;
 
+import static de.metas.util.lang.CoalesceUtil.coalesce;
+
 /*
  * #%L
  * de.metas.adempiere.adempiere.base
@@ -148,7 +150,7 @@ class PricingContext implements IEditablePricingContext
 	@Override
 	public OrgId getOrgId()
 	{
-		return orgId;
+		return coalesce(orgId, OrgId.ANY);
 	}
 
 	@Override

--- a/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/AttributeSetInstanceBL.java
+++ b/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/AttributeSetInstanceBL.java
@@ -158,7 +158,7 @@ public class AttributeSetInstanceBL implements IAttributeSetInstanceBL
 		}
 
 		// Create New
-		final I_M_AttributeInstance instanceNew = newInstance(I_M_AttributeInstance.class, asiId);
+		final I_M_AttributeInstance instanceNew = newInstance(I_M_AttributeInstance.class);
 		instanceNew.setM_Attribute_ID(attributeId.getRepoId());
 		instanceNew.setM_AttributeSetInstance_ID(asiId.getRepoId());
 		save(instanceNew);

--- a/de.metas.contracts/src/main/java/de/metas/contracts/FlatrateTermPricing.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/FlatrateTermPricing.java
@@ -106,6 +106,7 @@ public class FlatrateTermPricing
 
 		final boolean isSOTrx = true;
 		final IEditablePricingContext pricingCtx = pricingBL.createInitialContext(
+				term.getAD_Org_ID(),
 				termRelatedProductId.getRepoId(),
 				term.getBill_BPartner_ID(),
 				Services.get(IProductBL.class).getStockUOMId(termRelatedProductId).getRepoId(),

--- a/de.metas.contracts/src/main/java/de/metas/contracts/commission/invoicecandidate/CommissionShareHandler.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/commission/invoicecandidate/CommissionShareHandler.java
@@ -161,7 +161,10 @@ public class CommissionShareHandler extends AbstractInvoiceCandidateHandler
 	{
 		final I_C_Invoice_Candidate icRecord = newInstance(I_C_Invoice_Candidate.class, commissionShareRecord);
 
-		icRecord.setAD_Org_ID(commissionShareRecord.getAD_Org_ID());
+		// 07442 activity and tax
+		final OrgId orgId = OrgId.ofRepoId(commissionShareRecord.getAD_Org_ID());
+
+		icRecord.setAD_Org_ID(orgId.getRepoId());
 		icRecord.setC_ILCandHandler(getHandlerRecord());
 
 		final TableRecordReference commissionShareRef = TableRecordReference.of(commissionShareRecord);
@@ -187,6 +190,7 @@ public class CommissionShareHandler extends AbstractInvoiceCandidateHandler
 
 		final IEditablePricingContext pricingContext = pricingBL
 				.createInitialContext(
+						orgId,
 						CommissionConstants.COMMISSION_PRODUCT_ID,
 						bPartnerId,
 						Quantitys.create(ONE, CommissionConstants.COMMISSION_PRODUCT_ID),
@@ -224,9 +228,6 @@ public class CommissionShareHandler extends AbstractInvoiceCandidateHandler
 						.adOrgId(commissionShareRecord.getAD_Org_ID())
 						.build());
 		icRecord.setC_DocTypeInvoice_ID(docTypeId.getRepoId());
-
-		// 07442 activity and tax
-		final OrgId orgId = OrgId.ofRepoId(commissionShareRecord.getAD_Org_ID());
 
 		final ActivityId activityId = productAcctDAO.retrieveActivityForAcct(
 				ClientId.ofRepoId(commissionShareRecord.getAD_Client_ID()),

--- a/de.metas.contracts/src/main/java/de/metas/contracts/commission/invoicecandidate/CommissionShareHandler.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/commission/invoicecandidate/CommissionShareHandler.java
@@ -161,7 +161,6 @@ public class CommissionShareHandler extends AbstractInvoiceCandidateHandler
 	{
 		final I_C_Invoice_Candidate icRecord = newInstance(I_C_Invoice_Candidate.class, commissionShareRecord);
 
-		// 07442 activity and tax
 		final OrgId orgId = OrgId.ofRepoId(commissionShareRecord.getAD_Org_ID());
 
 		icRecord.setAD_Org_ID(orgId.getRepoId());
@@ -229,6 +228,7 @@ public class CommissionShareHandler extends AbstractInvoiceCandidateHandler
 						.build());
 		icRecord.setC_DocTypeInvoice_ID(docTypeId.getRepoId());
 
+		// 07442 activity and tax
 		final ActivityId activityId = productAcctDAO.retrieveActivityForAcct(
 				ClientId.ofRepoId(commissionShareRecord.getAD_Client_ID()),
 				orgId,

--- a/de.metas.contracts/src/test/java/de/metas/contracts/pricing/SubscriptionPricingRuleTest.java
+++ b/de.metas.contracts/src/test/java/de/metas/contracts/pricing/SubscriptionPricingRuleTest.java
@@ -13,6 +13,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import de.metas.organization.OrgId;
 import de.metas.pricing.IEditablePricingContext;
 import de.metas.pricing.IPricingResult;
 import de.metas.pricing.service.impl.PricingTestHelper;
@@ -48,6 +49,7 @@ public class SubscriptionPricingRuleTest
 				.build();
 
 		final IEditablePricingContext pricingCtx = helper.subscriptionPricingContextNew()
+				.orgId(OrgId.ANY)
 				.priceList(priceListDE)
 				.priceListVersion(plvDE)
 				.country(contryDE)
@@ -79,6 +81,7 @@ public class SubscriptionPricingRuleTest
 				.build();
 
 		final IEditablePricingContext pricingCtx = helper.subscriptionPricingContextNew()
+				.orgId(OrgId.ANY)
 				.priceList(priceListDE)
 				.priceListVersion(plvDE)
 				.country(contryDE)

--- a/de.metas.contracts/src/test/java/de/metas/contracts/pricing/SubscriptionPricingTestHelper.java
+++ b/de.metas.contracts/src/test/java/de/metas/contracts/pricing/SubscriptionPricingTestHelper.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableList;
 import de.metas.contracts.model.I_C_Flatrate_Conditions;
 import de.metas.location.CountryId;
 import de.metas.money.CurrencyId;
+import de.metas.organization.OrgId;
 import de.metas.pricing.IEditablePricingContext;
 import de.metas.pricing.PriceListId;
 import de.metas.pricing.PriceListVersionId;
@@ -81,11 +82,14 @@ public class SubscriptionPricingTestHelper extends PricingTestHelper
 	}
 
 	@Builder(builderMethodName = "subscriptionPricingContextNew")
-	public final IEditablePricingContext createSubscriptionPricingContext(@NonNull final I_M_PriceList priceList,
+	public final IEditablePricingContext createSubscriptionPricingContext(
+			@NonNull final OrgId orgId,
+			@NonNull final I_M_PriceList priceList,
 			@NonNull final I_M_PriceList_Version priceListVersion,
 			@NonNull final I_C_Country country)
 	{
 		final IEditablePricingContext pricingCtx = pricingBL.createPricingContext();
+		pricingCtx.setOrgId(orgId);
 		pricingCtx.setPricingSystemId(PricingSystemId.ofRepoId(getDefaultPricingSystem().getM_PricingSystem_ID()));
 		pricingCtx.setPriceListId(PriceListId.ofRepoId(priceList.getM_PriceList_ID()));
 		pricingCtx.setPriceListVersionId(PriceListVersionId.ofRepoId(priceListVersion.getM_PriceList_Version_ID()));

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pricing/spi/impl/HUPricing.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pricing/spi/impl/HUPricing.java
@@ -115,7 +115,7 @@ public class HUPricing extends AttributePricing
 		}
 		else
 		{
-			productPriceQuery.matchingAttributes(attributeSetInstance);
+			productPriceQuery.notStrictlyMatchingAttributes(attributeSetInstance);
 		}
 
 		return productPriceQuery.firstMatching(I_M_ProductPrice.class);

--- a/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/PricingContextBuilder.java
+++ b/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/PricingContextBuilder.java
@@ -65,11 +65,11 @@ public class PricingContextBuilder
 		final I_M_PriceList_Version plv = vendorInvoicingInfo.getM_PriceList_Version();
 		Check.assumeNotNull(plv,
 				"Param 'vendorInvoicingInfo.M_PriceList_Version' not null; vendorInvoicingInfo={}", vendorInvoicingInfo);
-		
+
 		final I_M_PriceList pl = plv.getM_PriceList();
 		Check.assumeNotNull(pl,
 				"Param 'vendorInvoicingInfo.M_PriceList_Version.M_PriceList' not null; vendorInvoicingInfo={}", vendorInvoicingInfo);
-		
+
 		final PricingSystemId pricingSystemId = PricingSystemId.ofRepoId(pl.getM_PricingSystem_ID());
 		final I_M_PricingSystem pricingSystem = priceListsRepo.getPricingSystemById(pricingSystemId);
 		Check.assumeNotNull(pricingSystem,
@@ -108,6 +108,7 @@ public class PricingContextBuilder
 		//
 		// Create Pricing Context
 		final IEditablePricingContext pricingCtx = pricingBL.createInitialContext(
+				-1, // AD_Org_ID - will be set later
 				-1, // M_Product_ID - will be set later
 				-1, // billBPartnerId - will be set later
 				-1, // C_UOM_ID - will be set later

--- a/de.metas.procurement.base/src/main/java/de/metas/procurement/base/impl/PMMPricingBL.java
+++ b/de.metas.procurement.base/src/main/java/de/metas/procurement/base/impl/PMMPricingBL.java
@@ -48,12 +48,12 @@ import de.metas.util.Services;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -133,7 +133,13 @@ public class PMMPricingBL implements IPMMPricingBL
 		// Fetch price from pricing engine
 		final IPricingBL pricingBL = Services.get(IPricingBL.class);
 		final BigDecimal qty = pricingAware.getQty();
-		final IEditablePricingContext pricingCtx = pricingBL.createInitialContext(product.getM_Product_ID(), bpartnerId.getRepoId(), uom.getC_UOM_ID(), qty, soTrx.toBoolean());
+		final IEditablePricingContext pricingCtx = pricingBL.createInitialContext(
+				product.getAD_Org_ID(),
+				product.getM_Product_ID(),
+				bpartnerId.getRepoId(),
+				uom.getC_UOM_ID(),
+				qty,
+				soTrx.toBoolean());
 		pricingCtx.setPricingSystemId(pricingSystemId);
 		pricingCtx.setPriceDate(date);
 		pricingCtx.setCountryId(countryId);

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/externallyreferenced/ManualCandidateService.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/externallyreferenced/ManualCandidateService.java
@@ -76,6 +76,7 @@ public class ManualCandidateService
 		final IPricingBL pricingBL = Services.get(IPricingBL.class);
 		final IEditablePricingContext pricingContext = pricingBL
 				.createInitialContext(
+						newIC.getOrgId(),
 						newIC.getProductId(),
 						newIC.getBillPartnerInfo().getBpartnerId(),
 						newIC.getQtyOrdered().getStockQty(),


### PR DESCRIPTION
* HUPricing - accept packaging prices that are not attribute-dependant, even if the referenced product is ASI-Aware (but do prefer attribute-dependenat prices)
* AttributeSetInstanceBL - fix warning that flooded the log
https://github.com/metasfresh/metasfresh/issues/5917