### PR TITLE
Make metasfresh more robust in case of unspecified selections

### DIFF
--- a/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessInfo.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessInfo.java
@@ -589,6 +589,7 @@ public final class ProcessInfo implements Serializable
 	}
 
 	/**
+	 * IMPORTANT: in most cases, {@link #getQueryFilterOrElseFalse()} is what you probably want to use.
 	 *
 	 * @return a query filter for the current {@code whereClause}, or an "all inclusive" {@link ConstantQueryFilter} if the {@code whereClause} is empty.<br>
 	 *         gh #1348: in both cases, the filter also contains a client and org restriction that is according to the logged-on user's role as returned by {@link Env#getUserRolePermissions(Properties)}.
@@ -596,10 +597,19 @@ public final class ProcessInfo implements Serializable
 	 * @task 03685
 	 * @see JavaProcess#retrieveSelectedRecordsQueryBuilder(Class)
 	 */
-	public <T> IQueryFilter<T> getQueryFilter()
+	public <T> IQueryFilter<T> getQueryFilterOrElseTrue()
 	{
 		// default: use a "neutral" filter that does not exclude anything
 		final ConstantQueryFilter<T> defaultQueryFilter = ConstantQueryFilter.of(true);
+		return getQueryFilterOrElse(defaultQueryFilter);
+	}
+
+	/**
+	 * Like {@link #getQueryFilterOrElseTrue()} but returns an "all exclusive" query filter if the {@code whereClause} is empty.
+	 */
+	public <T> IQueryFilter<T> getQueryFilterOrElseFalse()
+	{
+		final ConstantQueryFilter<T> defaultQueryFilter = ConstantQueryFilter.of(false);
 		return getQueryFilterOrElse(defaultQueryFilter);
 	}
 

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/table/process/AD_Column_CopySelectedToTable.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/table/process/AD_Column_CopySelectedToTable.java
@@ -10,12 +10,12 @@ package org.adempiere.ad.table.process;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -41,7 +41,7 @@ import de.metas.util.Services;
 
 /**
  * Copy selected columns to given table.
- * 
+ *
  * @author tsa
  *
  */
@@ -105,7 +105,7 @@ public class AD_Column_CopySelectedToTable extends JavaProcess
 
 	protected List<I_AD_Column> getSourceColumns()
 	{
-		final IQueryFilter<I_AD_Column> selectedColumnsFilter = getProcessInfo().getQueryFilter();
+		final IQueryFilter<I_AD_Column> selectedColumnsFilter = getProcessInfo().getQueryFilterOrElseFalse();
 		final IQueryBuilder<I_AD_Column> queryBuilder = Services.get(IQueryBL.class).createQueryBuilder(I_AD_Column.class, this)
 				.filter(selectedColumnsFilter);
 

--- a/de.metas.business/src/main/java/de/metas/invoice/process/C_Invoice_DiscountAllocation_Process.java
+++ b/de.metas.business/src/main/java/de/metas/invoice/process/C_Invoice_DiscountAllocation_Process.java
@@ -165,8 +165,8 @@ public class C_Invoice_DiscountAllocation_Process extends JavaProcess
 
 	private Iterator<I_C_Invoice> createIterator()
 	{
-	// user selection..if any
-		final IQueryFilter<I_C_Invoice> userSelectionFilter = getProcessInfo().getQueryFilter();
+		// user selection..if any. if none, then process all
+		final IQueryFilter<I_C_Invoice> userSelectionFilter = getProcessInfo().getQueryFilterOrElseTrue();
 
 		//
 		// Create the selection which we might need to update

--- a/de.metas.contracts/src/main/java/de/metas/contracts/process/C_Flatrate_Term_Create_For_BPartners.java
+++ b/de.metas.contracts/src/main/java/de/metas/contracts/process/C_Flatrate_Term_Create_For_BPartners.java
@@ -133,7 +133,7 @@ public class C_Flatrate_Term_Create_For_BPartners extends C_Flatrate_Term_Create
 	@Override
 	protected Iterable<I_C_BPartner> getBPartners()
 	{
-		final IQueryFilter<I_C_BPartner> selectedPartners = getProcessInfo().getQueryFilter();
+		final IQueryFilter<I_C_BPartner> selectedPartners = getProcessInfo().getQueryFilterOrElseFalse();
 
 		final IQueryBL queryBL = Services.get(IQueryBL.class);
 		final IQueryBuilder<I_C_BPartner> queryBuilder = queryBL.createQueryBuilder(I_C_BPartner.class, getCtx(), ITrx.TRXNAME_ThreadInherited);

--- a/de.metas.edi/src/main/java/de/metas/edi/process/EDIExportDocOutboundLog.java
+++ b/de.metas.edi/src/main/java/de/metas/edi/process/EDIExportDocOutboundLog.java
@@ -113,7 +113,7 @@ public class EDIExportDocOutboundLog extends JavaProcess implements IProcessPrec
 		final IQueryBL queryBL = Services.get(IQueryBL.class);
 		final int selectionCount = queryBL.createQueryBuilder(I_C_Doc_Outbound_Log.class, this)
 				.addOnlyActiveRecordsFilter()
-				.filter(pi.getQueryFilter())
+				.filter(pi.getQueryFilterOrElseFalse())
 				.create()
 				.createSelection(pinstanceId);
 

--- a/de.metas.edi/src/main/java/de/metas/edi/process/EDI_Desadv_Aggregate_M_InOuts.java
+++ b/de.metas.edi/src/main/java/de/metas/edi/process/EDI_Desadv_Aggregate_M_InOuts.java
@@ -64,7 +64,8 @@ public class EDI_Desadv_Aggregate_M_InOuts extends JavaProcess
 	{
 		final ProcessInfo pi = getProcessInfo();
 
-		final IQueryFilter<I_M_InOut> processQueryFilter = pi.getQueryFilter();
+		// this process is supposed to run "globally" on all matching M_InOuts
+		final IQueryFilter<I_M_InOut> processQueryFilter = pi.getQueryFilterOrElseTrue();
 
 		// subquery to select only inOuts with EDI-partners
 		final IQuery<I_C_BPartner> ediRecipient = queryBL

--- a/de.metas.edi/src/main/java/de/metas/edi/process/EDI_Desadv_EnqueueForExport.java
+++ b/de.metas.edi/src/main/java/de/metas/edi/process/EDI_Desadv_EnqueueForExport.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 
+import org.adempiere.ad.dao.ConstantQueryFilter;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.IQueryFilter;
@@ -168,7 +169,7 @@ public class EDI_Desadv_EnqueueForExport extends JavaProcess
 
 	private IQueryBuilder<I_EDI_Desadv> createEDIDesadvQueryBuilder()
 	{
-		final IQueryFilter<I_EDI_Desadv> processQueryFilter = getProcessInfo().getQueryFilter();
+		final IQueryFilter<I_EDI_Desadv> processQueryFilter = getProcessInfo().getQueryFilterOrElse(ConstantQueryFilter.of(false));
 
 		final IQueryBuilder<I_EDI_Desadv> queryBuilder = queryBL.createQueryBuilder(I_EDI_Desadv.class, getCtx(), get_TrxName())
 				.addOnlyActiveRecordsFilter()

--- a/de.metas.edi/src/main/java/de/metas/edi/process/EDI_Desadv_EnqueueForExport.java
+++ b/de.metas.edi/src/main/java/de/metas/edi/process/EDI_Desadv_EnqueueForExport.java
@@ -169,7 +169,7 @@ public class EDI_Desadv_EnqueueForExport extends JavaProcess
 
 	private IQueryBuilder<I_EDI_Desadv> createEDIDesadvQueryBuilder()
 	{
-		final IQueryFilter<I_EDI_Desadv> processQueryFilter = getProcessInfo().getQueryFilterOrElse(ConstantQueryFilter.of(false));
+		final IQueryFilter<I_EDI_Desadv> processQueryFilter = getProcessInfo().getQueryFilterOrElseFalse();
 
 		final IQueryBuilder<I_EDI_Desadv> queryBuilder = queryBL.createQueryBuilder(I_EDI_Desadv.class, getCtx(), get_TrxName())
 				.addOnlyActiveRecordsFilter()

--- a/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/process/M_ShipmentSchedule_EnqueueSelection.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/process/M_ShipmentSchedule_EnqueueSelection.java
@@ -114,7 +114,7 @@ public class M_ShipmentSchedule_EnqueueSelection
 		// Filter only selected shipment schedules
 		if (Ini.isSwingClient())
 		{
-			final IQueryFilter<I_M_ShipmentSchedule> selectionFilter = getProcessInfo().getQueryFilter();
+			final IQueryFilter<I_M_ShipmentSchedule> selectionFilter = getProcessInfo().getQueryFilterOrElseTrue();
 			filters.addFilter(selectionFilter);
 		}
 		else

--- a/de.metas.handlingunits.base/src/main/java/de/metas/inoutcandidate/process/M_ReceiptSchedule_Generate_M_InOuts.java
+++ b/de.metas.handlingunits.base/src/main/java/de/metas/inoutcandidate/process/M_ReceiptSchedule_Generate_M_InOuts.java
@@ -133,7 +133,7 @@ public class M_ReceiptSchedule_Generate_M_InOuts extends JavaProcess
 	private Iterator<I_M_ReceiptSchedule> createIterator()
 	{
 		// in case we were called from the window, then only process the current selection
-		final IQueryFilter<I_M_ReceiptSchedule> processInfoFilter = getProcessInfo().getQueryFilter();
+		final IQueryFilter<I_M_ReceiptSchedule> processInfoFilter = getProcessInfo().getQueryFilterOrElseTrue();
 
 		// only process records with an effective qty > 0
 		final ICompositeQueryFilter<I_M_ReceiptSchedule> overrideQtyFilter = queryBL

--- a/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/process/MD_Candidate_Request_MaterialDocument.java
+++ b/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/process/MD_Candidate_Request_MaterialDocument.java
@@ -73,7 +73,7 @@ public class MD_Candidate_Request_MaterialDocument extends JavaProcess implement
 
 		queryBL.createQueryBuilder(I_MD_Candidate.class)
 				.addOnlyActiveRecordsFilter()
-				.filter(getProcessInfo().getQueryFilter())
+				.filter(getProcessInfo().getQueryFilterOrElseFalse())
 				.create().list()
 				.stream()
 				.filter(hasSupportedBusinessCase)

--- a/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/process/C_Printing_Queue_ReEnqueue.java
+++ b/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/process/C_Printing_Queue_ReEnqueue.java
@@ -182,7 +182,7 @@ public class C_Printing_Queue_ReEnqueue extends JavaProcess
 
 	private int createWindowSelectionId(final PInstanceId selectionId)
 	{
-		final IQueryFilter<I_C_Printing_Queue> processQueryFilter = getProcessInfo().getQueryFilter();
+		final IQueryFilter<I_C_Printing_Queue> processQueryFilter = getProcessInfo().getQueryFilterOrElseFalse();
 
 		final IQuery<I_C_Printing_Queue> query = queryBL
 				.createQueryBuilder(I_C_Printing_Queue.class, getCtx(), ITrx.TRXNAME_None)

--- a/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/process/C_Printing_Queue_ResetAggregationKeys.java
+++ b/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/process/C_Printing_Queue_ResetAggregationKeys.java
@@ -10,12 +10,12 @@ package de.metas.printing.process;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -47,7 +47,7 @@ public class C_Printing_Queue_ResetAggregationKeys extends JavaProcess
 	@Override
 	protected String doIt() throws Exception
 	{
-		final IQueryFilter<I_C_Printing_Queue> queryFilter = getProcessInfo().getQueryFilter();
+		final IQueryFilter<I_C_Printing_Queue> queryFilter = getProcessInfo().getQueryFilterOrElseFalse();
 
 		final Iterator<I_C_Printing_Queue> iterator = Services.get(IQueryBL.class)
 				.createQueryBuilder(I_C_Printing_Queue.class, getCtx(), getTrxName())
@@ -60,7 +60,7 @@ public class C_Printing_Queue_ResetAggregationKeys extends JavaProcess
 				.iterate(I_C_Printing_Queue.class);
 
 		final IPrintingQueueBL printingQueueBL = Services.get(IPrintingQueueBL.class);
-		
+
 		for(final I_C_Printing_Queue item: IteratorUtils.asIterable(iterator))
 		{
 			printingQueueBL.setItemAggregationKey(item);

--- a/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/process/C_OLCand_Validate_Selected.java
+++ b/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/process/C_OLCand_Validate_Selected.java
@@ -56,7 +56,7 @@ public class C_OLCand_Validate_Selected extends JavaProcess
 	@Override
 	protected String doIt() throws Exception
 	{
-		final IQueryFilter<I_C_OLCand> queryFilter = getProcessInfo().getQueryFilter();
+		final IQueryFilter<I_C_OLCand> queryFilter = getProcessInfo().getQueryFilterOrElseFalse();
 
 		final IQueryBuilder<I_C_OLCand> queryBuilder = queryBL.createQueryBuilder(I_C_OLCand.class, getCtx(), get_TrxName())
 				.addEqualsFilter(I_C_OLCand.COLUMNNAME_Processed, false) // already processed records shall not be validated

--- a/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/process/OLCandSetOverrideValues.java
+++ b/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/process/OLCandSetOverrideValues.java
@@ -10,12 +10,12 @@ package de.metas.ordercandidate.process;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -58,12 +58,12 @@ public class OLCandSetOverrideValues extends JavaProcess
 
 	private Iterator<I_C_OLCand> createIterator()
 	{
-		final IQueryFilter<I_C_OLCand> queryFilter = getProcessInfo().getQueryFilter();
-		
+		final IQueryFilter<I_C_OLCand> queryFilter = getProcessInfo().getQueryFilterOrElseFalse();
+
 		final IQueryBuilder<I_C_OLCand> queryBuilder = Services.get(IQueryBL.class).createQueryBuilder(I_C_OLCand.class, getCtx(), get_TrxName())
 				.filter(queryFilter)
 				.filter(ActiveRecordQueryFilter.getInstance(I_C_OLCand.class));
-		
+
 		queryBuilder.orderBy()
 				.addColumn(I_C_OLCand.COLUMNNAME_C_OLCand_ID);
 

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_ChangeDeliveryDate.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_ChangeDeliveryDate.java
@@ -83,7 +83,7 @@ public class M_ShipmentSchedule_ChangeDeliveryDate extends JavaProcess implement
 
 		final IShipmentSchedulePA shipmentSchedulePA = Services.get(IShipmentSchedulePA.class);
 
-		final IQueryFilter<I_M_ShipmentSchedule> userSelectionFilter = getProcessInfo().getQueryFilter();
+		final IQueryFilter<I_M_ShipmentSchedule> userSelectionFilter = getProcessInfo().getQueryFilterOrElseFalse();
 		final IQueryBuilder<I_M_ShipmentSchedule> queryBuilderForShipmentSchedulesSelection = shipmentSchedulePA.createQueryForShipmentScheduleSelection(getCtx(), userSelectionFilter);
 
 		//

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedules.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedules.java
@@ -44,7 +44,7 @@ public class M_ShipmentSchedule_CloseShipmentSchedules extends JavaProcess
 		final IShipmentSchedulePA shipmentSchedulePA = Services.get(IShipmentSchedulePA.class);
 		final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
 
-		final IQueryFilter<I_M_ShipmentSchedule> userSelectionFilter = getProcessInfo().getQueryFilter();
+		final IQueryFilter<I_M_ShipmentSchedule> userSelectionFilter = getProcessInfo().getQueryFilterOrElseFalse();
 
 		IQueryBuilder<I_M_ShipmentSchedule> queryBuilderForShipmentScheduleSelection = shipmentSchedulePA.createQueryForShipmentScheduleSelection(getCtx(), userSelectionFilter);
 

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inventory/process/M_InventoryLine_AssignSelectedLines.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inventory/process/M_InventoryLine_AssignSelectedLines.java
@@ -56,7 +56,7 @@ public class M_InventoryLine_AssignSelectedLines extends JavaProcess
 
 	private List<I_M_InventoryLine> getSelectedInventoryLines()
 	{
-		final IQueryFilter<I_M_InventoryLine> selectedInventoryLines = getProcessInfo().getQueryFilter();
+		final IQueryFilter<I_M_InventoryLine> selectedInventoryLines = getProcessInfo().getQueryFilterOrElseFalse();
 
 		final IQueryBL queryBL = Services.get(IQueryBL.class);
 		final IQueryBuilder<I_M_InventoryLine> queryBuilder = queryBL.createQueryBuilder(I_M_InventoryLine.class);

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inventory/process/M_InventoryLine_MarkAsCounted.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inventory/process/M_InventoryLine_MarkAsCounted.java
@@ -58,7 +58,7 @@ public class M_InventoryLine_MarkAsCounted extends JavaProcess
 
 	private List<I_M_InventoryLine> getSelectedInventoryLines()
 	{
-		final IQueryFilter<I_M_InventoryLine> selectedInventoryLines = getProcessInfo().getQueryFilter();
+		final IQueryFilter<I_M_InventoryLine> selectedInventoryLines = getProcessInfo().getQueryFilterOrElseFalse();
 
 		final IQueryBL queryBL = Services.get(IQueryBL.class);
 		final IQueryBuilder<I_M_InventoryLine> queryBuilder = queryBL.createQueryBuilder(I_M_InventoryLine.class);

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/process/C_Invoice_Candidate_Close.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/process/C_Invoice_Candidate_Close.java
@@ -70,7 +70,7 @@ public class C_Invoice_Candidate_Close extends JavaProcess implements IProcessPr
 	private Iterator<I_C_Invoice_Candidate> retrieveSelectedCandidates()
 	{
 		final ProcessInfo processInfo = getProcessInfo();
-		final IQueryFilter<I_C_Invoice_Candidate> userSelectionFilter = processInfo.getQueryFilter();
+		final IQueryFilter<I_C_Invoice_Candidate> userSelectionFilter = processInfo.getQueryFilterOrElseFalse();
 
 		return queryBL
 				.createQueryBuilder(I_C_Invoice_Candidate.class)

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/process/C_Invoice_Candidate_EnqueueSelectionForInvoicing.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/process/C_Invoice_Candidate_EnqueueSelectionForInvoicing.java
@@ -198,7 +198,7 @@ public class C_Invoice_Candidate_EnqueueSelectionForInvoicing extends JavaProces
 		if (Ini.isSwingClient())
 		{
 			// In case of Swing, preserve the old functionality, i.e. if no where clause then select all
-			userSelectionFilter = getProcessInfo().getQueryFilter();
+			userSelectionFilter = getProcessInfo().getQueryFilterOrElseFalse();
 		}
 		else
 		{

--- a/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/payment/process/C_Payment_DiscountAllocation_Process.java
+++ b/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/payment/process/C_Payment_DiscountAllocation_Process.java
@@ -168,7 +168,7 @@ public class C_Payment_DiscountAllocation_Process extends JavaProcess
 	private Iterator<I_C_Payment> createIterator()
 	{
 		// user selection..if any
-		final IQueryFilter<I_C_Payment> userSelectionFilter = getProcessInfo().getQueryFilter();
+		final IQueryFilter<I_C_Payment> userSelectionFilter = getProcessInfo().getQueryFilterOrElseFalse();
 
 		//
 		// Create the selection which we might need to update


### PR DESCRIPTION
change ProcessInfo to force the dev to decide if she/he want's all or nothing in case no query filter is specified.
fix compile errors by choosing "nothing" in all current cases
IMPORTANT: this is branched from the 5.132_last_christmas branch