### PR TITLE
only set C_OLCand.ProductDescription if different from product-name

### DIFF
--- a/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/modelvalidator/C_OLCand.java
+++ b/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/modelvalidator/C_OLCand.java
@@ -1,5 +1,6 @@
 package de.metas.ordercandidate.modelvalidator;
 
+import static de.metas.util.lang.CoalesceUtil.firstNotEmptyTrimmed;
 import static org.adempiere.model.InterfaceWrapperHelper.loadOutOfTrx;
 
 /*
@@ -138,7 +139,6 @@ public class C_OLCand
 			return; // if olCand is new and product description is already set, do not copy anything
 		}
 
-		//
 		// Services
 		final IBPartnerProductDAO bpartnerProductDAO = Services.get(IBPartnerProductDAO.class);
 		final IOLCandEffectiveValuesBL olCandEffectiveValuesBL = Services.get(IOLCandEffectiveValuesBL.class);
@@ -155,30 +155,20 @@ public class C_OLCand
 		final I_C_BPartner_Product bpp = InterfaceWrapperHelper.create(
 				bpartnerProductDAO.retrieveBPartnerProductAssociation(partner, product, orgId),
 				I_C_BPartner_Product.class);
+		if (bpp == null)
+		{
+			return; // nothing that we can add here with any benefit
+		}
 
-		final String productDescriptionToUse;
-		if (bpp != null)
+		// If we have a BPP association, first try its ProductDescription, then its ProductName
+		final String productName = product.getName().trim();
+		final String productDescription = firstNotEmptyTrimmed(bpp.getProductDescription(), bpp.getProductName(), productName);
+
+		final boolean descriptionHasAddedValue = productName.contentEquals(productDescription.trim());
+		if (descriptionHasAddedValue)
 		{
-			//
-			// If we have a BPP association, first try it's ProductDescription, then it's ProductName, then fallback to M_Product.Name
-			String bppDescription = bpp.getProductDescription(); // BPP.ProductDescription
-			if (Check.isEmpty(bppDescription, true))
-			{
-				bppDescription = bpp.getProductName(); // BPP.ProductName fallback
-			}
-			if (Check.isEmpty(bppDescription, true))
-			{
-				bppDescription = product.getName(); // M_Product.Name fallback
-			}
-			productDescriptionToUse = bppDescription;
+			olCand.setProductDescription(productDescription);
 		}
-		else
-		{
-			//
-			// If we don't have a BPP association, just use the M_Product.Name
-			productDescriptionToUse = product.getName();
-		}
-		olCand.setProductDescription(productDescriptionToUse);
 	}
 
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_CHANGE, ifColumnsChanged = I_C_OLCand.COLUMNNAME_C_BPartner_Override_ID)

--- a/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/modelvalidator/C_OLCand.java
+++ b/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/modelvalidator/C_OLCand.java
@@ -164,7 +164,7 @@ public class C_OLCand
 		final String productName = product.getName().trim();
 		final String productDescription = firstNotEmptyTrimmed(bpp.getProductDescription(), bpp.getProductName(), productName);
 
-		final boolean descriptionHasAddedValue = productName.contentEquals(productDescription.trim());
+		final boolean descriptionHasAddedValue = !productName.contentEquals(productDescription.trim());
 		if (descriptionHasAddedValue)
 		{
 			olCand.setProductDescription(productDescription);

--- a/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/modelvalidator/C_OLCandMVTest.java
+++ b/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/modelvalidator/C_OLCandMVTest.java
@@ -1,5 +1,7 @@
 package de.metas.ordercandidate.modelvalidator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Optional;
 
 /*
@@ -173,8 +175,9 @@ public class C_OLCandMVTest extends AbstractOLCandTestSupport
 		Assert.assertEquals(olCand.getProductDescription(), bpp2.getProductName());
 	}
 
+	/** verifies that the ProductDescription is *not* set if it would be simply identical to the product's name. */
 	@Test
-	public void testMVSetProductDescriptionFallback_MProduct_Name()
+	public void testMVSetProductDescription_not_additional_value_provided()
 	{
 		final IContextAware context = PlainContextAware.newOutOfTrx(ctx);
 
@@ -184,7 +187,6 @@ public class C_OLCandMVTest extends AbstractOLCandTestSupport
 
 		InterfaceWrapperHelper.save(olCand);
 
-		// Assert same product description after saving (MV shall ignore)
-		Assert.assertEquals(olCand.getProductDescription(), product3.getName());
+		assertThat(olCand.getProductDescription()).isNull();
 	}
 }


### PR DESCRIPTION
otherwise there is no point, and e.g. invoice jaspers vill look as if the product name is printed twice on them