### PR TITLE
CompositeInterfaceWrapperHelper: getTrxName can throw exception

### DIFF
--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/wrapper/CompositeInterfaceWrapperHelper.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/wrapper/CompositeInterfaceWrapperHelper.java
@@ -49,14 +49,8 @@ public class CompositeInterfaceWrapperHelper implements IInterfaceWrapperHelper
 
 	private final CopyOnWriteArrayList<IInterfaceWrapperHelper> helpers = new CopyOnWriteArrayList<>();
 
-	public CompositeInterfaceWrapperHelper()
+	public CompositeInterfaceWrapperHelper addFactory(@NonNull final IInterfaceWrapperHelper factory)
 	{
-		super();
-	}
-
-	public CompositeInterfaceWrapperHelper addFactory(final IInterfaceWrapperHelper factory)
-	{
-		Check.assumeNotNull(factory, "factory not null");
 		helpers.addIfAbsent(factory);
 		return this;
 	}
@@ -153,13 +147,12 @@ public class CompositeInterfaceWrapperHelper implements IInterfaceWrapperHelper
 		{
 			if (!ignoreIfNotHandled)
 			{
-				final AdempiereException ex = new AdempiereException("Cannot get trxName from object: " + model + ". Returning null.");
-				logger.warn(ex.getLocalizedMessage(), ex);
+				// throw exception because returning null will probably result in a new trx that will end up idle in transaction
+				throw new AdempiereException("Cannot get trxName from object: " + model + ".");
 			}
-
+			logger.debug("getTrxName - The given model={} has no IInterfaceWrapperHelper and ignoreIfNotHandled=true; -> return null", model);
 			return ITrx.TRXNAME_None;
 		}
-
 		return helper.getTrxName(model, ignoreIfNotHandled);
 	}
 
@@ -171,6 +164,7 @@ public class CompositeInterfaceWrapperHelper implements IInterfaceWrapperHelper
 		{
 			if (ignoreIfNotHandled)
 			{
+				logger.debug("setTrxName - The given model={} has no IInterfaceWrapperHelper and ignoreIfNotHandled=true; -> return null", model);
 				return;
 			}
 
@@ -302,7 +296,7 @@ public class CompositeInterfaceWrapperHelper implements IInterfaceWrapperHelper
 	{
 		return getHelperThatCanHandle(model).isCopy(model);
 	}
-	
+
 	@Override
 	public boolean isCopying(@NonNull final Object model)
 	{

--- a/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/model/InterfaceWrapperHelper.java
+++ b/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/model/InterfaceWrapperHelper.java
@@ -533,9 +533,6 @@ public class InterfaceWrapperHelper
 
 	/**
 	 * Refreshes the given model, and if the model is handled by {@link POWrapper} or {@link POJOWrapper}, then uses the given <code>trxName</code>.
-	 *
-	 * @param model
-	 * @param trxName
 	 */
 	public static void refresh(final Object model, final String trxName)
 	{
@@ -722,6 +719,10 @@ public class InterfaceWrapperHelper
 		}
 	}
 
+	/**
+	 * IMPORTANT: only call with <b>model interfaces</b> such as {@code I_AD_Table}, {@code C_Order} (legacy classes like `MProduct` and {@link IContextAware}s will also work) and the like.
+	 * Despite the parameter type being "Object" it does not work with all objects.
+	 */
 	public static String getTrxName(final Object model)
 	{
 		final boolean ignoreIfNotHandled = false;
@@ -729,11 +730,10 @@ public class InterfaceWrapperHelper
 	}
 
 	/**
+	 * IMPORTANT: only call with <b>model interfaces</b> such as {@code I_AD_Table}, {@code C_Order} (legacy classes like `MProduct` and {@link IContextAware}s will also work) and the like.
+	 * Despite the parameter type being "Object" it does not work with all objects.
 	 *
-	 * @param model
-	 * @param ignoreIfNotHandled if <code>true</code> and the given model can not be handeled (no PO, GridTab etc), then just return {@link ITrx#TRXNAME_None} without loggin a warning.
-	 *
-	 * @return
+	 * @param ignoreIfNotHandled if <code>true</code> and the given model can not be handeled (no PO, GridTab etc), then just return {@link ITrx#TRXNAME_None} without throwing an exception.
 	 */
 	public static String getTrxName(final Object model, final boolean ignoreIfNotHandled)
 	{
@@ -781,7 +781,7 @@ public class InterfaceWrapperHelper
 		final boolean failIfProcessed = true;
 		delete(model, failIfProcessed);
 	}
-	
+
 	public static void delete(@NonNull final Object model, final boolean failIfProcessed)
 	{
 		if (POWrapper.isHandled(model))


### PR DESCRIPTION
instead of logging, because returning null will probably result in a new trx that will end up idle in transaction