### PR TITLE
Removed Krihelinator badge from Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/30ecd0d9ba8a4561a60335644b592418)](https://www.codacy.com/gh/metasfresh/metasfresh?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=metasfresh/metasfresh&amp;utm_campaign=Badge_Grade)
 [![release](https://img.shields.io/badge/release-5.144-blue.svg)](https://github.com/metasfresh/metasfresh/releases/tag/5.144)
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/metasfresh)
-[![Krihelimeter](http://krihelinator.xyz/badge/metasfresh/metasfresh)](http://krihelinator.xyz)
 [![license](https://img.shields.io/badge/license-GPL-blue.svg)](https://github.com/metasfresh/metasfresh/blob/master/LICENSE.md)
 
 ![Twitter Follow](https://img.shields.io/twitter/follow/metasfresh?style=social)


### PR DESCRIPTION
Hi, the Krihelinator project has reached its [end of life](https://github.com/Nagasaki45/krihelinator). Thats why i removed the badge.