### PR TITLE
Add back the picking tests 6557

### DIFF
--- a/e2e/cypress/integration/picking/pick_HUs_and_create_shipment.js
+++ b/e2e/cypress/integration/picking/pick_HUs_and_create_shipment.js
@@ -1,0 +1,197 @@
+import { salesOrders } from '../../page_objects/sales_orders';
+import { SalesOrder, SalesOrderLine } from '../../support/utils/sales_order';
+import { DocumentStatusKey } from '../../support/utils/constants';
+import { applyFilters, selectNotFrequentFilterWidget, toggleNotFrequentFilters } from '../../support/functions';
+import { Builder } from '../../support/utils/builder';
+
+let productName;
+let productQty;
+let locatorId;
+
+let businessPartnerName;
+let soProductQuantity;
+
+// shipment
+let shipmentQuantityTypeOption;
+let shipmentNotificationModalText;
+let expectedPackingStatus;
+
+// test columns
+const orderColumn = 'order';
+const huSelectionHuCodeColumn = 'Value';
+const pickingHuCodeColumn = 'huCode';
+const productPartnerColumn = 'ProductOrBPartner';
+const handlingUnitsShipmentColumn = 'M_HU_ID';
+
+// test
+let soDocNumber;
+let soRecordId;
+let huValue1;
+let huValue2;
+
+describe('Create test data', function() {
+  it('Read fixture and prepare the names', function() {
+    cy.fixture('picking/pick_HUs_and_create_shipment.json').then(f => {
+      productName = f['productName'];
+      productQty = f['productQty'];
+      locatorId = f['locatorId'];
+
+      businessPartnerName = f['businessPartnerName'];
+      soProductQuantity = f['soProductQuantity'];
+
+      shipmentQuantityTypeOption = f['shipmentQuantityTypeOption'];
+      shipmentNotificationModalText = f['shipmentNotificationModalText'];
+      expectedPackingStatus = f['expectedPackingStatus'];
+    });
+  });
+
+  it('Create first single-HU inventory doc', function() {
+    cy.fixture('picking/pick_HUs_and_create_shipment.json').then(f => {
+      Builder.createHUWithStock(f['productName'], f['productQty'], f['locatorId']).then(huVal => (huValue1 = huVal));
+    });
+  });
+
+  it('Create second single-HU inventory doc', function() {
+    cy.fixture('picking/pick_HUs_and_create_shipment.json').then(f => {
+      Builder.createHUWithStock(f['productName'], f['productQty'], f['locatorId']).then(huVal => (huValue2 = huVal));
+    });
+  });
+
+  it('Create Sales Order', function() {
+    cy.fixture('picking/pick_HUs_and_create_shipment.json').then(f => {
+      new SalesOrder()
+        .setBPartner(f['businessPartnerName'])
+        .addLine(new SalesOrderLine().setProduct(f['productName']).setQuantity(f['soProductQuantity']))
+        .apply();
+      cy.completeDocument();
+
+      cy.getCurrentWindowRecordId().then(id => (soRecordId = id));
+      cy.getStringFieldValue('DocumentNo').then(docNO => (soDocNumber = docNO));
+    });
+  });
+});
+
+describe('Pick the SO', function() {
+  it('Visit "Picking Terminal (Prototype)"', function() {
+    // unfortunately the picking assignment is not created instantly and there's no way to check when it is created except by refreshing the page,
+    // so i have to wait for it to be created :(
+    cy.waitUntilProcessIsFinished();
+    cy.visitWindow('540345');
+  });
+
+  it('Select first row and run action Pick', function() {
+    cy.selectRowByColumnAndValue({ column: productPartnerColumn, value: productName });
+    cy.executeQuickAction('WEBUI_Picking_Launcher');
+  });
+
+  it('Pick first HU', function() {
+    cy.selectLeftTable().within(() => {
+      cy.selectRowByColumnAndValue({ column: orderColumn, value: soDocNumber }, false, true);
+    });
+    cy.executeQuickActionWithRightSideTable('WEBUI_Picking_HUEditor_Launcher');
+
+    cy.selectItemUsingBarcodeFilter(huValue1);
+    // cy.selectRightTable().within(() => {
+    //   cy.selectRowByColumnAndValue({ column: huSelectionHuCodeColumn, value: huValue1 }, false, true);
+    // });
+
+    cy.executeQuickAction('WEBUI_Picking_HUEditor_PickHU', true, false);
+  });
+
+  it('Pick second HU', function() {
+    cy.selectLeftTable().within(() => {
+      cy.selectRowByColumnAndValue({ column: orderColumn, value: soDocNumber }, false, true);
+    });
+    cy.executeQuickActionWithRightSideTable('WEBUI_Picking_HUEditor_Launcher');
+    cy.selectItemUsingBarcodeFilter(huValue2);
+    // cy.selectRightTable().within(() => {
+    //   cy.selectRowByColumnAndValue({ column: huSelectionHuCodeColumn, value: huValue2 }, false, true);
+    // });
+    cy.executeQuickAction('WEBUI_Picking_HUEditor_PickHU', true, false);
+  });
+
+  it('Confirm Picks', function() {
+    cy.selectLeftTable().within(() => {
+      cy.selectRowByColumnAndValue({ column: orderColumn, value: soDocNumber }, false, true);
+    });
+    cy.selectRightTable().within(() => {
+      cy.selectRowByColumnAndValue({ column: pickingHuCodeColumn, value: huValue2 }, false, true);
+    });
+    cy.executeQuickAction('WEBUI_Picking_M_Picking_Candidate_Process', true, false);
+    cy.waitForSaveIndicator();
+
+    cy.selectLeftTable().within(() => {
+      cy.selectRowByColumnAndValue({ column: orderColumn, value: soDocNumber }, false, true);
+    });
+    cy.selectRightTable().within(() => {
+      cy.selectRowByColumnAndValue({ column: pickingHuCodeColumn, value: huValue1 }, false, true);
+    });
+    cy.executeQuickAction('WEBUI_Picking_M_Picking_Candidate_Process', true, false);
+    cy.waitForSaveIndicator();
+  });
+});
+
+// describe('Generate the Shipment', function() {
+//   it('Open the Referenced Shipment Disposition', function() {
+//     salesOrders.visit(soRecordId);
+//     cy.openReferencedDocuments('M_ShipmentSchedule');
+
+//     cy.expectNumberOfRows(1);
+//     cy.selectNthRow(0).dblclick();
+//   });
+
+//   it('Shipment Disposition checks', function() {
+//     cy.expectCheckboxValue('IsToRecompute', false);
+//     cy.getStringFieldValue('C_BPartner_ID').should('contain', businessPartnerName);
+//     cy.getStringFieldValue('M_Product_ID').should('contain', productName);
+//     cy.getStringFieldValue('C_Order_ID').should('equal', soDocNumber);
+//     cy.getStringFieldValue('QtyOrdered_Calculated').should('equal', soProductQuantity.toString(10));
+//     cy.getStringFieldValue('QtyToDeliver ').should('equal', '0');
+//     cy.getStringFieldValue('QtyPickList ').should('equal', soProductQuantity.toString(10));
+//   });
+
+//   it('Run action "Generate shipments"', function() {
+//     cy.readAllNotifications();
+//     cy.executeHeaderAction('M_ShipmentSchedule_EnqueueSelection');
+//     cy.selectInListField('QuantityType', shipmentQuantityTypeOption, true, null, true);
+//     cy.expectCheckboxValue('IsCompleteShipments', true, true);
+//     cy.expectCheckboxValue('IsShipToday', false, true);
+
+//     cy.pressStartButton();
+//     cy.getNotificationModal(shipmentNotificationModalText);
+//     cy.expectCheckboxValue('Processed', true);
+//   });
+
+//   it('Open notifications and go to the shipment', function() {
+//     cy.openInboxNotificationWithText(businessPartnerName);
+//   });
+
+//   it('Shipment checks', function() {
+//     cy.expectDocumentStatus(DocumentStatusKey.Completed);
+//     cy.getStringFieldValue('C_BPartner_ID').should('contain', businessPartnerName);
+//     cy.selectTab('M_HU_Assignment');
+//     cy.expectNumberOfRows(2);
+//     cy.selectRowByColumnAndValue({ column: handlingUnitsShipmentColumn, value: huValue1 });
+//     cy.selectRowByColumnAndValue({ column: handlingUnitsShipmentColumn, value: huValue2 });
+//   });
+
+//   it('Visit HU Editor and expect the 2 HUs have Packing Status Shipped', function() {
+//     cy.visitWindow(540189);
+//     toggleNotFrequentFilters();
+//     selectNotFrequentFilterWidget('default');
+//     cy.selectInListField('HUStatus', expectedPackingStatus, false, null, true);
+//     cy.writeIntoStringField('Value', huValue1, false, null, true);
+//     applyFilters();
+
+//     cy.expectNumberOfRows(1);
+
+//     cy.visitWindow(540189);
+//     toggleNotFrequentFilters();
+//     selectNotFrequentFilterWidget('default');
+//     cy.selectInListField('HUStatus', expectedPackingStatus, false, null, true);
+//     cy.writeIntoStringField('Value', huValue2, false, null, true);
+//     applyFilters();
+
+//     cy.expectNumberOfRows(1);
+//   });
+// });

--- a/e2e/cypress/support/commands/navigation.js
+++ b/e2e/cypress/support/commands/navigation.js
@@ -216,6 +216,8 @@ Cypress.Commands.add('selectItemUsingBarcodeFilter', huValue1 => {
     .find('input[type=text]')
     .wait(500)
     .type(`${huValue1}{enter}`)
+  cy.wait(500);
+  cy.get('[data-cy=cell-Value] > :nth-child(1) > .cell-text-wrapper').click();
 });
 
 /**


### PR DESCRIPTION
Added back tests from the picking
<img width="524" alt="Screenshot 2020-05-20 at 16 09 24" src="https://user-images.githubusercontent.com/1708561/82449706-50496700-9ab4-11ea-9bd2-306101d870ed.png">

Note that all the other tests from Generate the shipment and below are failing due to the changes in the references added a while back by Teo in the way references are loaded. I commented those for now and want to fix them in a separate Cypress chunk. 
