### PR TITLE
Refactor DocList and it's child components

### DIFF
--- a/frontend/src/components/Container.js
+++ b/frontend/src/components/Container.js
@@ -178,7 +178,9 @@ class Container extends PureComponent {
                   processStatus={processStatus}
                   includedView={includedView}
                   inBackground={
-                    includedView && includedView.windowType && includedView.viewId
+                    includedView &&
+                    includedView.windowType &&
+                    includedView.viewId
                   }
                   inModal={modal.visible}
                 />

--- a/frontend/src/components/Container.js
+++ b/frontend/src/components/Container.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
-import { viewState } from '../reducers/viewHandler';
+import { viewState, getView } from '../reducers/viewHandler';
 import {
   setRawModalTitle,
   setRawModalDescription,
@@ -19,207 +19,208 @@ import Header from './header/Header';
  * @module Container
  * @extends Component
  */
-const Container = (props) => {
-  const {
-    docActionElem,
-    docStatusData,
-    docNoData,
-    docId,
-    processStatus,
-    docSummaryData,
-    dataId,
-    windowType,
-    breadcrumb,
-    references,
-    actions,
-    showSidelist,
-    siteName,
-    connectionError,
-    noMargin,
-    entity,
-    children,
-    query,
-    attachments,
-    showIndicator,
-    // TODO: We should be using indicator from the state instead of another variable
-    isDocumentNotSaved,
-    hideHeader,
-    handleDeletedStatus,
-    dropzoneFocused,
-    notfound,
-    rawModal,
-    modal,
-    pluginModal,
-    indicator,
-    includedView,
-    closeModalCallback,
-    editmode,
-    handleEditModeToggle,
-    activeTab,
-    masterDocumentList,
-    pluginComponents,
-    setRawModalTitle,
-    setRawModalDescription,
-  } = props;
-  const pluginModalVisible = pluginModal.visible;
-  let PluginModalComponent = null;
+class Container extends PureComponent {
+  render() {
+    const {
+      docActionElem,
+      docStatusData,
+      docNoData,
+      docId,
+      processStatus,
+      docSummaryData,
+      dataId,
+      windowType,
+      breadcrumb,
+      references,
+      actions,
+      showSidelist,
+      siteName,
+      connectionError,
+      noMargin,
+      entity,
+      children,
+      viewId,
+      attachments,
+      showIndicator,
+      // TODO: We should be using indicator from the state instead of another variable
+      isDocumentNotSaved,
+      hideHeader,
+      handleDeletedStatus,
+      dropzoneFocused,
+      notfound,
+      rawModal,
+      modal,
+      pluginModal,
+      indicator,
+      includedView,
+      closeModalCallback,
+      editmode,
+      handleEditModeToggle,
+      activeTab,
+      masterDocumentList,
+      pluginComponents,
+      setRawModalTitle,
+      setRawModalDescription,
+    } = this.props;
+    const pluginModalVisible = pluginModal.visible;
+    let PluginModalComponent = null;
 
-  if (pluginModalVisible) {
-    // check if pluginModal's component is saved in the redux state
-    const modalPluginName = pluginComponents[pluginModal.id];
+    if (pluginModalVisible) {
+      // check if pluginModal's component is saved in the redux state
+      const modalPluginName = pluginComponents[pluginModal.id];
 
-    if (modalPluginName) {
-      // get the plugin holding the required component
-      const parentPlugin = window.META_HOST_APP.getRegistry().getEntry(
-        modalPluginName
-      );
+      if (modalPluginName) {
+        // get the plugin holding the required component
+        const parentPlugin = window.META_HOST_APP.getRegistry().getEntry(
+          modalPluginName
+        );
 
-      PluginModalComponent = parentPlugin.components.filter(
-        (component) => component.id === pluginModal.id
-      )[0].component;
+        PluginModalComponent = parentPlugin.components.filter(
+          (component) => component.id === pluginModal.id
+        )[0].component;
+      }
     }
-  }
 
-  return (
-    <div>
-      {!hideHeader && (
-        // Forcing refresh component
-        <Header
-          docStatus={docActionElem}
-          windowId={windowType}
-          {...{
-            entity,
-            docStatusData,
-            docNoData,
-            docSummaryData,
-            handleDeletedStatus,
-            isDocumentNotSaved,
-            showIndicator,
-            query,
-            siteName,
-            showSidelist,
-            attachments,
-            actions,
-            references,
-            breadcrumb,
-            dataId,
-            dropzoneFocused,
-            notfound,
-            docId,
-            editmode,
-            handleEditModeToggle,
-            activeTab,
-          }}
-        />
-      )}
-
-      {connectionError && <ErrorScreen />}
-
-      <div
-        className={
-          'header-sticky-distance js-unselect ' +
-          (noMargin ? 'dashboard' : 'container-fluid')
-        }
-      >
-        {modal.visible && (
-          <Modal
-            {...modal}
-            windowType={modal.type}
-            dataId={modal.dataId ? modal.dataId : dataId}
-            modalTitle={modal.title}
-            modalViewId={modal.viewId}
-            parentType={windowType}
-            parentDataId={dataId}
-            query={query}
-            viewId={query && query.viewId}
-            rawModalVisible={rawModal.visible}
-            indicator={indicator}
-            modalViewDocumentIds={modal.viewDocumentIds}
-            closeCallback={closeModalCallback}
-            modalSaveStatus={
-              modal.saveStatus && modal.saveStatus.saved !== undefined
-                ? modal.saveStatus.saved
-                : true
-            }
-            isDocumentNotSaved={
-              modal.saveStatus &&
-              !modal.saveStatus.saved &&
-              (modal.validStatus && !modal.validStatus.initialValue)
-            }
+    return (
+      <div>
+        {!hideHeader && (
+          // Forcing refresh component
+          <Header
+            docStatus={docActionElem}
+            windowId={windowType}
+            {...{
+              entity,
+              docStatusData,
+              docNoData,
+              docSummaryData,
+              handleDeletedStatus,
+              isDocumentNotSaved,
+              showIndicator,
+              viewId,
+              siteName,
+              showSidelist,
+              attachments,
+              actions,
+              references,
+              breadcrumb,
+              dataId,
+              dropzoneFocused,
+              notfound,
+              docId,
+              editmode,
+              handleEditModeToggle,
+              activeTab,
+            }}
           />
         )}
 
-        {rawModal.visible && (
-          <RawModal
-            modalTitle={rawModal.title}
-            modalDescription={rawModal.description}
-            allowedCloseActions={rawModal.allowedCloseActions}
-            windowType={rawModal.windowId}
-            viewId={rawModal.viewId}
-            masterDocumentList={masterDocumentList}
-          >
-            <div className="document-lists-wrapper">
-              <DocumentList
-                type="grid"
-                windowType={rawModal.windowId}
-                defaultViewId={rawModal.viewId}
-                viewProfileId={rawModal.profileId}
-                setModalTitle={setRawModalTitle}
-                setModalDescription={setRawModalDescription}
-                fetchQuickActionsOnInit={
-                  !(
-                    includedView &&
-                    includedView.windowType &&
-                    includedView.viewId
-                  )
-                }
-                modalDescription={rawModal.description}
-                isModal
-                processStatus={processStatus}
-                includedView={includedView}
-                inBackground={
-                  includedView && includedView.windowType && includedView.viewId
-                }
-                inModal={modal.visible}
-              />
+        {connectionError && <ErrorScreen />}
 
-              {includedView &&
-                includedView.windowType &&
-                includedView.viewId && (
-                  <DocumentList
-                    type="includedView"
-                    windowType={includedView.windowType}
-                    viewProfileId={includedView.viewProfileId}
-                    defaultViewId={includedView.viewId}
-                    parentDefaultViewId={rawModal.viewId}
-                    parentWindowType={rawModal.windowId}
-                    fetchQuickActionsOnInit
-                    isModal
-                    isIncluded
-                    processStatus={processStatus}
-                    inBackground={false}
-                    inModal={modal.visible}
-                  />
-                )}
-            </div>
-          </RawModal>
-        )}
+        <div
+          className={
+            'header-sticky-distance js-unselect ' +
+            (noMargin ? 'dashboard' : 'container-fluid')
+          }
+        >
+          {modal.visible && (
+            <Modal
+              {...modal}
+              windowType={modal.type}
+              dataId={modal.dataId ? modal.dataId : dataId}
+              modalTitle={modal.title}
+              modalViewId={modal.viewId}
+              parentType={windowType}
+              parentDataId={dataId}
+              viewId={viewId}
+              rawModalVisible={rawModal.visible}
+              indicator={indicator}
+              modalViewDocumentIds={modal.viewDocumentIds}
+              closeCallback={closeModalCallback}
+              modalSaveStatus={
+                modal.saveStatus && modal.saveStatus.saved !== undefined
+                  ? modal.saveStatus.saved
+                  : true
+              }
+              isDocumentNotSaved={
+                modal.saveStatus &&
+                !modal.saveStatus.saved &&
+                (modal.validStatus && !modal.validStatus.initialValue)
+              }
+            />
+          )}
 
-        {pluginModalVisible && (
-          <PluginModalComponent
-            docId={docId}
-            windowType={windowType}
-            dataId={dataId}
-            entity={entity}
-            query={query}
-          />
-        )}
+          {rawModal.visible && (
+            <RawModal
+              modalTitle={rawModal.title}
+              modalDescription={rawModal.description}
+              allowedCloseActions={rawModal.allowedCloseActions}
+              windowType={rawModal.windowId}
+              viewId={rawModal.viewId}
+              masterDocumentList={masterDocumentList}
+            >
+              <div className="document-lists-wrapper">
+                <DocumentList
+                  type="grid"
+                  windowType={rawModal.windowId}
+                  defaultViewId={rawModal.viewId}
+                  viewProfileId={rawModal.profileId}
+                  setModalTitle={setRawModalTitle}
+                  setModalDescription={setRawModalDescription}
+                  fetchQuickActionsOnInit={
+                    !(
+                      includedView &&
+                      includedView.windowType &&
+                      includedView.viewId
+                    )
+                  }
+                  modalDescription={rawModal.description}
+                  isModal
+                  processStatus={processStatus}
+                  includedView={includedView}
+                  inBackground={
+                    includedView && includedView.windowType && includedView.viewId
+                  }
+                  inModal={modal.visible}
+                />
 
-        {children}
+                {includedView &&
+                  includedView.windowType &&
+                  includedView.viewId && (
+                    <DocumentList
+                      type="includedView"
+                      windowType={includedView.windowType}
+                      viewProfileId={includedView.viewProfileId}
+                      defaultViewId={includedView.viewId}
+                      parentDefaultViewId={rawModal.viewId}
+                      parentWindowType={rawModal.windowId}
+                      fetchQuickActionsOnInit
+                      isModal
+                      isIncluded
+                      processStatus={processStatus}
+                      inBackground={false}
+                      inModal={modal.visible}
+                    />
+                  )}
+              </div>
+            </RawModal>
+          )}
+
+          {pluginModalVisible && (
+            <PluginModalComponent
+              docId={docId}
+              windowType={windowType}
+              dataId={dataId}
+              entity={entity}
+              viewId={viewId}
+            />
+          )}
+
+          {children}
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+}
 
 /**
  * @typedef {object} Props Component props
@@ -255,7 +256,7 @@ const Container = (props) => {
  * @prop {object} pluginModal
  * @prop {*} pluginComponents
  * @prop {*} processStatus
- * @prop {*} query
+ * @prop {*} viewId
  * @prop {*} rawModal
  * @prop {*} references
  * @prop {*} showIndicator
@@ -297,7 +298,7 @@ Container.propTypes = {
   pluginModal: PropTypes.object,
   pluginComponents: PropTypes.any,
   processStatus: PropTypes.any,
-  query: PropTypes.any,
+  viewId: PropTypes.any,
   rawModal: PropTypes.any,
   references: PropTypes.any,
   showIndicator: PropTypes.any,
@@ -314,7 +315,7 @@ Container.propTypes = {
  * @param {object} state
  */
 const mapStateToProps = (state, { windowType }) => {
-  let master = state.viewHandler.views[windowType];
+  let master = getView(windowType);
 
   if (!master || !windowType) {
     master = viewState;
@@ -324,6 +325,9 @@ const mapStateToProps = (state, { windowType }) => {
     notfound: master.notfound,
     connectionError: state.windowHandler.connectionError || false,
     pluginComponents: state.pluginsHandler.components,
+    pluginModal: state.windowHandler.pluginModal,
+    indicator: state.windowHandler.indicator,
+    breadcrumb: state.menuHandler.breadcrumb,
   };
 };
 

--- a/frontend/src/components/Container.js
+++ b/frontend/src/components/Container.js
@@ -29,7 +29,7 @@ class Container extends PureComponent {
       processStatus,
       docSummaryData,
       dataId,
-      windowType,
+      windowId,
       breadcrumb,
       references,
       actions,
@@ -87,7 +87,7 @@ class Container extends PureComponent {
           // Forcing refresh component
           <Header
             docStatus={docActionElem}
-            windowId={windowType}
+            windowId={windowId}
             {...{
               entity,
               docStatusData,
@@ -125,11 +125,11 @@ class Container extends PureComponent {
           {modal.visible && (
             <Modal
               {...modal}
-              windowType={modal.type}
+              windowId={modal.type}
               dataId={modal.dataId ? modal.dataId : dataId}
               modalTitle={modal.title}
               modalViewId={modal.viewId}
-              parentType={windowType}
+              parentType={windowId}
               parentDataId={dataId}
               viewId={viewId}
               rawModalVisible={rawModal.visible}
@@ -154,7 +154,7 @@ class Container extends PureComponent {
               modalTitle={rawModal.title}
               modalDescription={rawModal.description}
               allowedCloseActions={rawModal.allowedCloseActions}
-              windowType={rawModal.windowId}
+              windowId={rawModal.windowId}
               viewId={rawModal.viewId}
               masterDocumentList={masterDocumentList}
             >
@@ -210,7 +210,7 @@ class Container extends PureComponent {
           {pluginModalVisible && (
             <PluginModalComponent
               docId={docId}
-              windowType={windowType}
+              windowId={windowId}
               dataId={dataId}
               entity={entity}
               viewId={viewId}
@@ -250,23 +250,23 @@ class Container extends PureComponent {
  * @prop {bool} isDocumentNotSaved
  * @prop {*} masterDocumentList
  * @prop {*} modal
- * @prop {*} modalDescription
- * @prop {*} modalTitle
- * @prop {*} notfound
+ * @prop {string} modalDescription
+ * @prop {string} modalTitle
+ * @prop {bool} notfound
  * @prop {*} noMargin
  * @prop {*} pluginComponents
  * @prop {object} pluginModal
  * @prop {*} pluginComponents
  * @prop {*} processStatus
- * @prop {*} viewId
- * @prop {*} rawModal
+ * @prop {string} viewId
+ * @prop {object} rawModal
  * @prop {*} references
  * @prop {*} showIndicator
  * @prop {*} showSidelist
  * @prop {*} setModalDescription
  * @prop {*} setModalTitle
- * @prop {*} siteName
- * @prop {*} windowType
+ * @prop {string} siteName
+ * @prop {string} windowId
  */
 Container.propTypes = {
   actions: PropTypes.any,
@@ -293,14 +293,14 @@ Container.propTypes = {
   isDocumentNotSaved: PropTypes.any,
   masterDocumentList: PropTypes.any,
   modal: PropTypes.any,
-  modalDescription: PropTypes.any,
-  modalTitle: PropTypes.any,
+  modalDescription: PropTypes.string,
+  modalTitle: PropTypes.string,
   noMargin: PropTypes.any,
   notfound: PropTypes.bool,
   pluginModal: PropTypes.object,
   pluginComponents: PropTypes.any,
   processStatus: PropTypes.any,
-  viewId: PropTypes.any,
+  viewId: PropTypes.string,
   rawModal: PropTypes.any,
   references: PropTypes.any,
   showIndicator: PropTypes.any,
@@ -308,7 +308,7 @@ Container.propTypes = {
   siteName: PropTypes.any,
   setRawModalDescription: PropTypes.any,
   setRawModalTitle: PropTypes.any,
-  windowType: PropTypes.any,
+  windowId: PropTypes.string,
 };
 
 /**
@@ -316,10 +316,10 @@ Container.propTypes = {
  * @summary ToDo: Describe the method.
  * @param {object} state
  */
-const mapStateToProps = (state, { windowType }) => {
-  let master = getView(windowType);
+const mapStateToProps = (state, { windowId }) => {
+  let master = getView(windowId);
 
-  if (!master || !windowType) {
+  if (!master || !windowId) {
     master = viewState;
   }
 

--- a/frontend/src/components/app/DocumentList/index.js
+++ b/frontend/src/components/app/DocumentList/index.js
@@ -56,7 +56,6 @@ import {
 } from '../../../utils/documentListHelper';
 
 import DocumentList from './DocumentList';
-import withRouterAndRef from '../../hoc/WithRouterAndRef';
 
 class DocumentListContainer extends Component {
   constructor(props) {
@@ -854,33 +853,31 @@ class DocumentListContainer extends Component {
  */
 DocumentListContainer.propTypes = { ...DLpropTypes };
 
-export default withRouterAndRef(
-  connect(
-    DLmapStateToProps,
-    {
-      resetView,
-      deleteView,
-      fetchDocument,
-      fetchLayout,
-      createView,
-      filterView,
-      deleteTable,
-      setListIncludedView,
-      indicatorState,
-      closeListIncludedView,
-      setListPagination,
-      setListSorting,
-      setListId,
-      push,
-      updateRawModal,
-      selectTableItems,
-      deselectTableItems,
-      removeSelectedTableItems,
-      updateViewData,
-      fetchLocationConfig,
-      clearAllFilters,
-    },
-    null,
-    { forwardRef: true }
-  )(DocumentListContainer)
-);
+export default connect(
+  DLmapStateToProps,
+  {
+    resetView,
+    deleteView,
+    fetchDocument,
+    fetchLayout,
+    createView,
+    filterView,
+    deleteTable,
+    setListIncludedView,
+    indicatorState,
+    closeListIncludedView,
+    setListPagination,
+    setListSorting,
+    setListId,
+    push,
+    updateRawModal,
+    selectTableItems,
+    deselectTableItems,
+    removeSelectedTableItems,
+    updateViewData,
+    fetchLocationConfig,
+    clearAllFilters,
+  },
+  null,
+  { forwardRef: true }
+)(DocumentListContainer);

--- a/frontend/src/components/app/MasterWindow.js
+++ b/frontend/src/components/app/MasterWindow.js
@@ -344,7 +344,7 @@ export default class MasterWindow extends Component {
         closeModalCallback={this.closeModalCallback}
         setModalTitle={this.setModalTitle}
         docActionElem={docActionElement}
-        windowType={params.windowType}
+        windowId={params.windowType}
         docId={params.docId}
         showSidelist
         showIndicator={!modal.visible}

--- a/frontend/src/components/app/Modal.js
+++ b/frontend/src/components/app/Modal.js
@@ -181,9 +181,7 @@ class Modal extends Component {
       case 'static':
         {
           if (staticModalType === 'about') {
-            request = dispatch(
-              fetchChangeLog(windowId, dataId, tabId, rowId)
-            );
+            request = dispatch(fetchChangeLog(windowId, dataId, tabId, rowId));
           }
           if (staticModalType === 'comments') {
             request = dispatch(

--- a/frontend/src/components/app/Modal.js
+++ b/frontend/src/components/app/Modal.js
@@ -91,15 +91,15 @@ class Modal extends Component {
    * @method componentDidUpdate
    * @summary ToDo: Describe the method.
    * @param {object} prevProps
-   * @prop {*} windowType
-   * @prop {*} viewId
+   * @prop {string} windowId
+   * @prop {string} viewId
    * @prop {*} indicator
    */
   async componentDidUpdate(prevProps) {
-    const { windowType, viewId, indicator } = this.props;
+    const { windowId, viewId, indicator } = this.props;
     const { waitingFetch } = this.state;
 
-    if (prevProps.windowType !== windowType || prevProps.viewId !== viewId) {
+    if (prevProps.windowId !== windowId || prevProps.viewId !== viewId) {
       await this.init();
     }
 
@@ -158,7 +158,7 @@ class Modal extends Component {
   init = async () => {
     const {
       dispatch,
-      windowType,
+      windowId,
       dataId,
       tabId,
       rowId,
@@ -182,13 +182,13 @@ class Modal extends Component {
         {
           if (staticModalType === 'about') {
             request = dispatch(
-              fetchChangeLog(windowType, dataId, tabId, rowId)
+              fetchChangeLog(windowId, dataId, tabId, rowId)
             );
           }
           if (staticModalType === 'comments') {
             request = dispatch(
               callAPI({
-                windowId: windowType,
+                windowId: windowId,
                 docId: dataId,
                 tabId,
                 rowId,
@@ -211,7 +211,7 @@ class Modal extends Component {
       case 'window':
         try {
           await dispatch(
-            createWindow(windowType, dataId, tabId, rowId, true, isAdvanced)
+            createWindow(windowId, dataId, tabId, rowId, true, isAdvanced)
           );
         } catch (error) {
           this.handleClose();
@@ -228,7 +228,7 @@ class Modal extends Component {
 
         try {
           const options = {
-            processType: windowType,
+            processType: windowId,
             viewId: modalViewId,
             type: parentType,
             ids: modalViewId
@@ -280,7 +280,7 @@ class Modal extends Component {
       dispatch,
       closeCallback,
       dataId,
-      windowType,
+      windowId,
       parentType,
       parentDataId,
       triggerField,
@@ -290,7 +290,7 @@ class Modal extends Component {
     const { isNew, isNewDoc } = this.state;
 
     if (isNewDoc) {
-      processNewRecord('window', windowType, dataId).then((response) => {
+      processNewRecord('window', windowId, dataId).then((response) => {
         dispatch(
           patch(
             'window',
@@ -309,7 +309,7 @@ class Modal extends Component {
       if (closeCallback) {
         closeCallback({
           isNew,
-          windowType,
+          windowType: windowId,
           documentId: dataId,
           tabId,
           rowId,
@@ -373,7 +373,7 @@ class Modal extends Component {
    * @summary ToDo: Describe the method
    */
   handleStart = () => {
-    const { dispatch, layout, windowType, indicator } = this.props;
+    const { dispatch, layout, windowId, indicator } = this.props;
 
     if (indicator === 'pending') {
       this.setState({ waitingFetch: true, pending: true });
@@ -388,11 +388,11 @@ class Modal extends Component {
         let response;
 
         try {
-          response = await startProcess(windowType, layout.pinstanceId);
+          response = await startProcess(windowId, layout.pinstanceId);
 
           const action = handleProcessResponse(
             response,
-            windowType,
+            windowId,
             layout.pinstanceId
           );
 
@@ -425,7 +425,7 @@ class Modal extends Component {
       rowId,
       dataId,
       modalType,
-      windowType,
+      windowId,
       isAdvanced,
       staticModalType,
     } = this.props;
@@ -438,7 +438,7 @@ class Modal extends Component {
           content = <ChangeLogModal data={data} />;
         }
         if (staticModalType === 'comments') {
-          content = <CommentsPanel windowId={windowType} docId={dataId} />;
+          content = <CommentsPanel windowId={windowId} docId={dataId} />;
         }
         return (
           <div className="window-wrapper">
@@ -469,7 +469,7 @@ class Modal extends Component {
           <Process
             data={data}
             layout={layout}
-            type={windowType}
+            type={windowId}
             disabled={pending}
           />
         );
@@ -616,7 +616,7 @@ class Modal extends Component {
    * @summary ToDo: Describe the method
    */
   renderOverlay = () => {
-    const { data, layout, windowType, modalType, isNewDoc } = this.props;
+    const { data, layout, windowId, modalType, isNewDoc } = this.props;
     const { pending } = this.state;
 
     const applyHandler =
@@ -658,7 +658,7 @@ class Modal extends Component {
 
     return (
       <OverlayField
-        type={windowType}
+        type={windowId}
         disabled={pending}
         data={data}
         layout={layout}
@@ -730,8 +730,8 @@ class Modal extends Component {
  * @prop {*} [rawModalVisible]
  * @prop {string} [rowId]
  * @prop {*} [triggerField]
- * @prop {*} [viewId]
- * @prop {*} [windowType]
+ * @prop {string} [viewId]
+ * @prop {string} [windowId]
  */
 Modal.propTypes = {
   dispatch: PropTypes.func.isRequired,
@@ -761,8 +761,8 @@ Modal.propTypes = {
   rawModalVisible: PropTypes.any,
   rowId: PropTypes.string,
   triggerField: PropTypes.any,
-  viewId: PropTypes.any,
-  windowType: PropTypes.any,
+  viewId: PropTypes.string,
+  windowId: PropTypes.string,
 };
 
 /**

--- a/frontend/src/components/app/RawModal.js
+++ b/frontend/src/components/app/RawModal.js
@@ -195,7 +195,7 @@ class RawModal extends Component {
       dispatch,
       closeCallback,
       viewId,
-      windowType,
+      windowId,
       requests,
       rawModal,
     } = this.props;
@@ -232,7 +232,7 @@ class RawModal extends Component {
       }
 
       await this.removeModal();
-      await deleteViewRequest(windowType, viewId, type);
+      await deleteViewRequest(windowId, viewId, type);
     }
   };
 
@@ -242,14 +242,14 @@ class RawModal extends Component {
    * @summary ToDo: Describe the method.
    */
   removeModal = async () => {
-    const { dispatch, modalVisible, windowType, viewId } = this.props;
+    const { dispatch, modalVisible, windowId, viewId } = this.props;
 
     await Promise.all(
       [
         closeRawModal(),
         closeModal(),
         closeListIncludedView({
-          windowType,
+          windowType: windowId,
           viewId,
           forceClose: true,
         }),
@@ -419,7 +419,7 @@ ModalButton.propTypes = {
  * @prop {func} [closeCallback]
  * @prop {node} [children]
  * @prop {array} [allowedCloseActions]
- * @prop {string} [windowType]
+ * @prop {string} [windowId]
  * @prop {string} [viewId]
  * @prop {string|node} [masterDocumentList]
  * @prop {string|node} [modalTitle]
@@ -429,9 +429,9 @@ ModalButton.propTypes = {
  * @prop {object} requests
  * @prop {bool} success
  * @prop {*} [name]
- * @prop {*} [onShowTooltip]
- * @prop {*} [onHideTooltip]
- * @prop {*} [onClick]
+ * @prop {func} [onShowTooltip]
+ * @prop {func} [onHideTooltip]
+ * @prop {func} [onClick]
  * @prop {*} [tabIndex]
  */
 RawModal.propTypes = {
@@ -439,7 +439,7 @@ RawModal.propTypes = {
   closeCallback: PropTypes.func,
   children: PropTypes.node,
   allowedCloseActions: PropTypes.array,
-  windowType: PropTypes.string,
+  windowId: PropTypes.string,
   viewId: PropTypes.string,
   masterDocumentList: PropTypes.any,
   modalTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),

--- a/frontend/src/components/header/Header.js
+++ b/frontend/src/components/header/Header.js
@@ -281,7 +281,7 @@ class Header extends Component {
     childViewSelectedIds,
     staticModalType
   ) => {
-    const { dispatch, query } = this.props;
+    const { dispatch, viewId } = this.props;
 
     dispatch(
       openModal(
@@ -291,7 +291,7 @@ class Header extends Component {
         null,
         null,
         isAdvanced,
-        query && query.viewId,
+        viewId,
         selected,
         null,
         null,
@@ -549,7 +549,7 @@ class Header extends Component {
       showSidelist,
       inbox,
       entity,
-      query,
+      viewId,
       showIndicator,
       windowId,
       // TODO: We should be using indicator from the state instead of another variable
@@ -791,11 +791,10 @@ class Header extends Component {
             disableOnClickOutside={!isSubheaderShow}
             breadcrumb={breadcrumb}
             notfound={notfound}
-            query={query}
             entity={entity}
             dataId={dataId}
             windowId={windowId}
-            viewId={query && query.viewId}
+            viewId={viewId}
             siteName={siteName}
             editmode={editmode}
             handleEditModeToggle={handleEditModeToggle}
@@ -896,7 +895,7 @@ class Header extends Component {
  * @prop {object} me
  * @prop {*} notfound
  * @prop {*} plugins
- * @prop {*} query
+ * @prop {*} viewId
  * @prop {*} showSidelist
  * @prop {*} showIndicator
  * @prop {*} siteName
@@ -922,7 +921,7 @@ Header.propTypes = {
   me: PropTypes.object.isRequired,
   notfound: PropTypes.any,
   plugins: PropTypes.any,
-  query: PropTypes.any,
+  viewId: PropTypes.any,
   showSidelist: PropTypes.any,
   showIndicator: PropTypes.any,
   siteName: PropTypes.any,

--- a/frontend/src/components/header/Header.js
+++ b/frontend/src/components/header/Header.js
@@ -921,7 +921,7 @@ Header.propTypes = {
   me: PropTypes.object.isRequired,
   notfound: PropTypes.any,
   plugins: PropTypes.any,
-  viewId: PropTypes.any,
+  viewId: PropTypes.string,
   showSidelist: PropTypes.any,
   showIndicator: PropTypes.any,
   siteName: PropTypes.any,

--- a/frontend/src/components/header/SubHeader.js
+++ b/frontend/src/components/header/SubHeader.js
@@ -435,9 +435,11 @@ class SubHeader extends Component {
         {windowId && viewId && (
           <a
             className="subheader-item js-subheader-item"
-            href={`${config.API_URL}/documentView/${windowId}/${
-              viewId
-            }/export/excel?selectedIds=${selected.join(',')}`}
+            href={`${
+              config.API_URL
+            }/documentView/${windowId}/${viewId}/export/excel?selectedIds=${selected.join(
+              ','
+            )}`}
             download
             onClick={this.handleDownloadSelected}
             style={{
@@ -582,7 +584,6 @@ SubHeader.propTypes = {
   selected: PropTypes.any,
   siteName: PropTypes.any,
   standardActions: PropTypes.any,
-  viewId: PropTypes.string,
   windowId: PropTypes.string,
 };
 

--- a/frontend/src/components/header/SubHeader.js
+++ b/frontend/src/components/header/SubHeader.js
@@ -579,7 +579,7 @@ SubHeader.propTypes = {
   notfound: PropTypes.any,
   openModal: PropTypes.func,
   openModalRow: PropTypes.func,
-  viewId: PropTypes.any,
+  viewId: PropTypes.string,
   redirect: PropTypes.any,
   selected: PropTypes.any,
   siteName: PropTypes.any,

--- a/frontend/src/components/header/SubHeader.js
+++ b/frontend/src/components/header/SubHeader.js
@@ -353,7 +353,7 @@ class SubHeader extends Component {
       dataId,
       editmode,
       handleEditModeToggle,
-      query,
+      viewId,
       redirect,
       selected,
       siteName,
@@ -432,11 +432,11 @@ class SubHeader extends Component {
           </div>
         ) : null}
 
-        {windowId && query && query.viewId && (
+        {windowId && viewId && (
           <a
             className="subheader-item js-subheader-item"
             href={`${config.API_URL}/documentView/${windowId}/${
-              query.viewId
+              viewId
             }/export/excel?selectedIds=${selected.join(',')}`}
             download
             onClick={this.handleDownloadSelected}
@@ -483,7 +483,6 @@ class SubHeader extends Component {
       dataId,
       selected,
       entity,
-      query,
       openModal,
       openModalRow,
       closeSubheader,
@@ -501,7 +500,7 @@ class SubHeader extends Component {
         openModalRow={openModalRow}
         closeSubheader={closeSubheader}
         notfound={notfound}
-        docId={dataId ? dataId : query && query.viewId}
+        docId={dataId ? dataId : viewId}
         rowId={selected}
         activeTab={activeTab}
         activeTabSelected={activeTab && selected ? selected : []}
@@ -552,7 +551,7 @@ class SubHeader extends Component {
  * @prop {*} notfound
  * @prop {func} openModal
  * @prop {func} openModalRow
- * @prop {*} query
+ * @prop {*} viewId
  * @prop {*} redirect
  * @prop {*} selected
  * @prop {*} siteName
@@ -578,7 +577,7 @@ SubHeader.propTypes = {
   notfound: PropTypes.any,
   openModal: PropTypes.func,
   openModalRow: PropTypes.func,
-  query: PropTypes.any,
+  viewId: PropTypes.any,
   redirect: PropTypes.any,
   selected: PropTypes.any,
   siteName: PropTypes.any,

--- a/frontend/src/containers/Board.js
+++ b/frontend/src/containers/Board.js
@@ -284,7 +284,7 @@ class Board extends Component {
       <Container
         entity="board"
         siteName={board && board.caption}
-        windowType={board && board.boardId && String(board.boardId)}
+        windowId={board && board.boardId && String(board.boardId)}
         {...{ modal, rawModal, pluginModal, breadcrumb, indicator }}
       >
         {sidenav && (

--- a/frontend/src/containers/DocList.js
+++ b/frontend/src/containers/DocList.js
@@ -27,16 +27,12 @@ class DocList extends Component {
     const { query } = this.props;
     const { query: nextQuery } = nextProps;
 
-    if (_.isEqual(query, nextQuery)) {
-      return false;
-    }
-
-    return true;
+    return !_.isEqual(query, nextQuery);
   }
 
   componentDidMount = () => {
     const {
-      windowType,
+      windowId,
       latestNewDocument,
       query,
       getWindowBreadcrumb,
@@ -44,11 +40,11 @@ class DocList extends Component {
       selectTableItems,
     } = this.props;
 
-    getWindowBreadcrumb(windowType);
+    getWindowBreadcrumb(windowId);
 
     if (latestNewDocument) {
       selectTableItems({
-        windowType: windowType,
+        windowType: windowId,
         viewId: query.viewId,
         ids: [latestNewDocument],
       });
@@ -57,10 +53,10 @@ class DocList extends Component {
   };
 
   componentDidUpdate = (prevProps) => {
-    const { windowType, getWindowBreadcrumb } = this.props;
+    const { windowId, getWindowBreadcrumb } = this.props;
 
-    if (prevProps.windowType !== windowType) {
-      getWindowBreadcrumb(windowType);
+    if (prevProps.windowId !== windowId) {
+      getWindowBreadcrumb(windowId);
     }
   };
 
@@ -82,9 +78,17 @@ class DocList extends Component {
     this.masterDocumentList.updateQuickActions(childSelection);
   };
 
+  /**
+   * @method handleDocListRef
+   * @summary Store ref to the main DocumentList
+   */
+  handleDocListRef = (ref) => {
+    this.masterDocumentList = ref;
+  };
+
   render() {
     const {
-      windowType,
+      windowId,
       query,
       modal,
       rawModal,
@@ -109,7 +113,7 @@ class DocList extends Component {
         entity="documentView"
         modal={modal}
         rawModal={rawModal}
-        windowType={windowType}
+        windowId={windowId}
         viewId={viewId}
         processStatus={processStatus}
         includedView={includedView}
@@ -124,12 +128,10 @@ class DocList extends Component {
           })}
         >
           <DocumentList
-            ref={(element) => {
-              this.masterDocumentList = element ? element : null;
-            }}
+            ref={this.handleDocListRef}
             type="grid"
             updateUri={this.updateUriCallback}
-            windowType={windowType}
+            windowType={windowId}
             refRowIds={refRowIds}
             includedView={includedView}
             inBackground={rawModal.visible}
@@ -153,7 +155,7 @@ class DocList extends Component {
                 type="includedView"
                 windowType={includedView.windowType}
                 defaultViewId={includedView.viewId}
-                parentWindowType={windowType}
+                parentWindowType={windowId}
                 parentDefaultViewId={viewId}
                 updateParentSelectedIds={this.handleUpdateParentSelectedIds}
                 viewProfileId={includedView.viewProfileId}
@@ -190,7 +192,7 @@ class DocList extends Component {
  * @prop {string} processStatus
  * @prop {object} query - routing query
  * @prop {object} rawModal
- * @prop {object} windowType
+ * @prop {string} windowId
  */
 DocList.propTypes = {
   includedView: PropTypes.object,
@@ -201,7 +203,7 @@ DocList.propTypes = {
   query: PropTypes.object.isRequired,
   pathname: PropTypes.string.isRequired,
   rawModal: PropTypes.object.isRequired,
-  windowType: PropTypes.string,
+  windowId: PropTypes.string,
   getWindowBreadcrumb: PropTypes.func.isRequired,
   selectTableItems: PropTypes.func.isRequired,
   setLatestNewDocument: PropTypes.func.isRequired,

--- a/frontend/src/containers/DocList.js
+++ b/frontend/src/containers/DocList.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import _ from 'lodash';
 
 import { updateUri } from '../actions/AppActions';
 import { getWindowBreadcrumb } from '../actions/MenuActions';
@@ -13,45 +14,64 @@ import Container from '../components/Container';
 import DocumentList from '../components/app/DocumentList';
 import Overlay from '../components/app/Overlay';
 
+const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
+
 /**
  * @file Class based component.
  * @module DocList
  * @extends Component
  */
 class DocList extends Component {
-  componentDidMount = () => {
-    const { dispatch, windowType, latestNewDocument, query } = this.props;
+  shouldComponentUpdate(nextProps) {
+    const { query } = this.props;
+    const { query: nextQuery } = nextProps;
 
-    dispatch(getWindowBreadcrumb(windowType));
+    if (_.isEqual(query, nextQuery)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  componentDidMount = () => {
+    const {
+      windowType,
+      latestNewDocument,
+      query,
+      getWindowBreadcrumb,
+      setLatestNewDocument,
+      selectTableItems,
+    } = this.props;
+
+    getWindowBreadcrumb(windowType);
 
     if (latestNewDocument) {
-      dispatch(
-        selectTableItems({
-          windowType,
-          viewId: query.viewId,
-          ids: [latestNewDocument],
-        })
-      );
-      dispatch(setLatestNewDocument(null));
+      selectTableItems({
+        windowType: windowType,
+        viewId: query.viewId,
+        ids: [latestNewDocument],
+      });
+      setLatestNewDocument(null);
     }
   };
 
   componentDidUpdate = (prevProps) => {
-    const { dispatch, windowType } = this.props;
+    const { windowType, getWindowBreadcrumb } = this.props;
 
     if (prevProps.windowType !== windowType) {
-      dispatch(getWindowBreadcrumb(windowType));
+      getWindowBreadcrumb(windowType);
     }
   };
 
   /**
    * @method updateUriCallback
-   * @summary ToDo: Describe the method.
+   * @summary Update the url with query params if needed (ie add viewId, page etc)
    */
   updateUriCallback = (prop, value) => {
-    const { dispatch, query, pathname } = this.props;
+    const { updateUri, query, pathname } = this.props;
 
-    dispatch(updateUri(pathname, query, prop, value));
+    updateUri(pathname, query, prop, value);
   };
 
   /**
@@ -65,36 +85,32 @@ class DocList extends Component {
   render() {
     const {
       windowType,
-      breadcrumb,
       query,
       modal,
       rawModal,
-      pluginModal,
       overlay,
-      indicator,
       processStatus,
       includedView,
     } = this.props;
-    let refRowIds = [];
+    let refRowIds = EMPTY_ARRAY;
+    const queryCopy = query ? query : EMPTY_OBJECT;
 
-    if (query && query.refRowIds) {
+    if (queryCopy.refRowIds) {
       try {
-        refRowIds = JSON.parse(query.refRowIds);
+        refRowIds = JSON.parse(queryCopy.refRowIds);
       } catch (e) {
-        refRowIds = [];
+        refRowIds = null;
       }
     }
+    const viewId = queryCopy.viewId ? queryCopy.viewId : null;
 
     return (
       <Container
         entity="documentView"
         modal={modal}
         rawModal={rawModal}
-        pluginModal={pluginModal}
-        breadcrumb={breadcrumb}
         windowType={windowType}
-        query={query}
-        indicator={indicator}
+        viewId={viewId}
         processStatus={processStatus}
         includedView={includedView}
         showIndicator={!modal.visible && !rawModal.visible}
@@ -121,10 +137,15 @@ class DocList extends Component {
             fetchQuickActionsOnInit
             processStatus={processStatus}
             disablePaginationShortcuts={modal.visible || rawModal.visible}
+            sort={queryCopy.sort}
+            page={queryCopy.page}
+            viewId={queryCopy.viewId}
+            refType={queryCopy.refType}
+            refId={queryCopy.refId}
+            refTabId={queryCopy.refTabId}
           />
 
           {includedView &&
-            includedView.windowType &&
             includedView.viewId &&
             !rawModal.visible &&
             !modal.visible && (
@@ -133,7 +154,7 @@ class DocList extends Component {
                 windowType={includedView.windowType}
                 defaultViewId={includedView.viewId}
                 parentWindowType={windowType}
-                parentDefaultViewId={query.viewId}
+                parentDefaultViewId={viewId}
                 updateParentSelectedIds={this.handleUpdateParentSelectedIds}
                 viewProfileId={includedView.viewProfileId}
                 fetchQuickActionsOnInit
@@ -141,6 +162,12 @@ class DocList extends Component {
                 isIncluded
                 inBackground={false}
                 inModal={false}
+                sort={queryCopy.sort}
+                page={queryCopy.page}
+                viewId={queryCopy.viewId}
+                refType={queryCopy.refType}
+                refId={queryCopy.refId}
+                refTabId={queryCopy.refTabId}
               />
             )}
         </div>
@@ -166,19 +193,19 @@ class DocList extends Component {
  * @prop {object} windowType
  */
 DocList.propTypes = {
-  breadcrumb: PropTypes.array.isRequired,
-  dispatch: PropTypes.func.isRequired,
-  includedView: PropTypes.object.isRequired,
-  indicator: PropTypes.string.isRequired,
+  includedView: PropTypes.object,
   latestNewDocument: PropTypes.any,
   modal: PropTypes.object.isRequired,
   overlay: PropTypes.object,
-  pathname: PropTypes.string.isRequired,
-  pluginModal: PropTypes.object,
   processStatus: PropTypes.string.isRequired,
   query: PropTypes.object.isRequired,
+  pathname: PropTypes.string.isRequired,
   rawModal: PropTypes.object.isRequired,
-  windowType: PropTypes.any,
+  windowType: PropTypes.string,
+  getWindowBreadcrumb: PropTypes.func.isRequired,
+  selectTableItems: PropTypes.func.isRequired,
+  setLatestNewDocument: PropTypes.func.isRequired,
+  updateUri: PropTypes.func.isRequired,
 };
 
 /**
@@ -186,17 +213,26 @@ DocList.propTypes = {
  * @summary ToDo: Describe the method.
  * @param {object} state
  */
-const mapStateToProps = (state) => ({
-  modal: state.windowHandler.modal,
-  rawModal: state.windowHandler.rawModal,
-  pluginModal: state.windowHandler.pluginModal,
-  overlay: state.windowHandler.overlay,
-  latestNewDocument: state.windowHandler.latestNewDocument,
-  indicator: state.windowHandler.indicator,
-  includedView: state.listHandler.includedView,
-  processStatus: state.appHandler.processStatus,
-  breadcrumb: state.menuHandler.breadcrumb,
-  pathname: state.routing.locationBeforeTransitions.pathname,
-});
+const mapStateToProps = (state) => {
+  return {
+    modal: state.windowHandler.modal,
+    rawModal: state.windowHandler.rawModal,
+    overlay: state.windowHandler.overlay,
+    latestNewDocument: state.windowHandler.latestNewDocument,
+    includedView: state.listHandler.includedView.windowType
+      ? state.listHandler.includedView
+      : null,
+    processStatus: state.appHandler.processStatus,
+    pathname: state.routing.locationBeforeTransitions.pathname,
+  };
+};
 
-export default connect(mapStateToProps)(DocList);
+export default connect(
+  mapStateToProps,
+  {
+    getWindowBreadcrumb,
+    selectTableItems,
+    setLatestNewDocument,
+    updateUri,
+  }
+)(DocList);

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -125,7 +125,7 @@ export const getRoutes = (store, auth, plugins) => {
   const DocListRoute = (nextState) => (
     <DocList
       query={nextState.location.query}
-      windowType={nextState.params.windowType}
+      windowId={nextState.params.windowId}
     />
   );
   const BoardRoute = (nextState) => (
@@ -137,7 +137,7 @@ export const getRoutes = (store, auth, plugins) => {
 
   const childRoutes = [
     {
-      path: '/window/:windowType',
+      path: '/window/:windowId',
       // eslint-disable-next-line react/display-name
       component: DocListRoute,
     },

--- a/frontend/src/utils/documentListHelper.js
+++ b/frontend/src/utils/documentListHelper.js
@@ -20,6 +20,8 @@ const DLpropTypes = {
   page: PropTypes.number,
   sort: PropTypes.string,
   defaultViewId: PropTypes.string,
+
+  // TODO: Eventually this should be renamed to `refWindowId`
   refType: PropTypes.string,
   refId: PropTypes.string,
   refTabId: PropTypes.string,

--- a/frontend/src/utils/documentListHelper.js
+++ b/frontend/src/utils/documentListHelper.js
@@ -16,9 +16,13 @@ const DLpropTypes = {
   // from parent
   windowType: PropTypes.string.isRequired,
   viewId: PropTypes.string,
-
-  // from <DocList>
   updateParentSelectedIds: PropTypes.func,
+  page: PropTypes.number,
+  sort: PropTypes.string,
+  defaultViewId: PropTypes.string,
+  refType: PropTypes.string,
+  refId: PropTypes.string,
+  refTabId: PropTypes.string,
 
   // from @connect
   selections: PropTypes.object.isRequired,
@@ -27,27 +31,34 @@ const DLpropTypes = {
   selected: PropTypes.array.isRequired,
   isModal: PropTypes.bool,
   inModal: PropTypes.bool,
-
-  // from @react-router
-  location: PropTypes.object.isRequired,
 };
 
 /**
  * @typedef {object} Props Component context
  * @prop {object} DLcontextTypes
  */
-const DLmapStateToProps = (state, { location, ...props }) => {
-  const { query } = location;
-  const identifier = props.isModal ? props.defaultViewId : props.windowType;
+const DLmapStateToProps = (state, props) => {
+  const {
+    page: queryPage,
+    sort: querySort,
+    viewId: queryViewId,
+    isModal,
+    defaultViewId,
+    windowType,
+    refType: queryRefType,
+    refId: queryRefId,
+    refTabId: queryRefTabId,
+  } = props;
+  const identifier = isModal ? defaultViewId : windowType;
   let master = state.viewHandler.views[identifier];
 
   if (!master) {
     master = viewState;
   }
 
-  const sort = master.sort ? master.sort : query.sort;
-  const page = master.page ? master.page : parseInt(query.page);
-  let viewId = master.viewId ? master.viewId : query.viewId;
+  const sort = master.sort ? master.sort : querySort;
+  const page = master.page ? master.page : parseInt(queryPage);
+  let viewId = master.viewId ? master.viewId : queryViewId;
 
   // used for modals
   if (props.defaultViewId) {
@@ -64,9 +75,9 @@ const DLmapStateToProps = (state, { location, ...props }) => {
     viewId,
     reduxData: master,
     layout: master.layout,
-    refType: query.refType,
-    refId: query.refId,
-    refTabId: query.refTabId,
+    refType: queryRefType,
+    refId: queryRefId,
+    refTabId: queryRefTabId,
     selections: state.windowHandler.selections,
     selected: getSelectionInstant(
       state,

--- a/frontend/src/utils/documentReferencesHelper.js
+++ b/frontend/src/utils/documentReferencesHelper.js
@@ -11,7 +11,7 @@ export function buildRelatedDocumentsViewUrl({
     refType: windowId,
     refId: documentId,
     refTabId: tabId,
-    refRowIds: tabId ? JSON.stringify(rowIds || []) : undefined,
+    refRowIds: tabId && rowIds ? JSON.stringify(rowIds) : null,
   });
 
   return `/window/${targetWindowId}?${urlParams}`;


### PR DESCRIPTION
Remove some unnecessary imports, empty objects/arrays, props etc. This limits the number of re-renders by a great deal.

Related to #6666 

Tested on a sales order list with one order when logging renders, and on w101 for performance tests.

Before:
![before1](https://user-images.githubusercontent.com/513460/82456263-4aec1c80-9ab4-11ea-9471-4271a5f31166.png)

![before2](https://user-images.githubusercontent.com/513460/82456272-4e7fa380-9ab4-11ea-94c2-193b7437e35e.png)


After:
![after1](https://user-images.githubusercontent.com/513460/82456287-55a6b180-9ab4-11ea-9fbb-6bfb49dfb7d2.png)

![after2](https://user-images.githubusercontent.com/513460/82456298-58a1a200-9ab4-11ea-9984-f4453b62afdd.png)
