### PR TITLE
Proper fix over the temporary hotfix for DocList/quickactions

### DIFF
--- a/frontend/src/components/Container.js
+++ b/frontend/src/components/Container.js
@@ -47,7 +47,7 @@ class Container extends PureComponent {
       hideHeader,
       handleDeletedStatus,
       dropzoneFocused,
-      notfound,
+      notFound,
       rawModal,
       modal,
       pluginModal,
@@ -105,7 +105,7 @@ class Container extends PureComponent {
               breadcrumb,
               dataId,
               dropzoneFocused,
-              notfound,
+              notFound,
               docId,
               editmode,
               handleEditModeToggle,
@@ -252,7 +252,7 @@ class Container extends PureComponent {
  * @prop {*} modal
  * @prop {string} modalDescription
  * @prop {string} modalTitle
- * @prop {bool} notfound
+ * @prop {bool} notFound
  * @prop {*} noMargin
  * @prop {*} pluginComponents
  * @prop {object} pluginModal
@@ -296,7 +296,7 @@ Container.propTypes = {
   modalDescription: PropTypes.string,
   modalTitle: PropTypes.string,
   noMargin: PropTypes.any,
-  notfound: PropTypes.bool,
+  notFound: PropTypes.bool,
   pluginModal: PropTypes.object,
   pluginComponents: PropTypes.any,
   processStatus: PropTypes.any,
@@ -324,7 +324,7 @@ const mapStateToProps = (state, { windowId }) => {
   }
 
   return {
-    notfound: master.notfound,
+    notFound: master.notFound,
     connectionError: state.windowHandler.connectionError || false,
     pluginComponents: state.pluginsHandler.components,
     pluginModal: state.windowHandler.pluginModal,

--- a/frontend/src/components/app/DocumentList/DocumentList.js
+++ b/frontend/src/components/app/DocumentList/DocumentList.js
@@ -125,6 +125,7 @@ export default class DocumentList extends Component {
       parentWindowType,
       reduxData,
       layout,
+      layoutNotFound,
       page,
       pageLength,
       panelsState,
@@ -171,7 +172,7 @@ export default class DocumentList extends Component {
     const blurWhenOpen =
       layout && layout.includedView && layout.includedView.blurWhenOpen;
 
-    if (layout.notfound || reduxData.notfound) {
+    if (layoutNotFound || reduxData.notFound) {
       return (
         <BlankPage what={counterpart.translate('view.error.windowName')} />
       );

--- a/frontend/src/components/app/DocumentList/index.js
+++ b/frontend/src/components/app/DocumentList/index.js
@@ -322,7 +322,7 @@ class DocumentListContainer extends Component {
         if (this.mounted) {
           const { allowedCloseActions } = response;
 
-          if (allowedCloseActions) {
+          if (allowedCloseActions && isModal) {
             updateRawModal(windowType, { allowedCloseActions });
           }
 
@@ -479,6 +479,7 @@ class DocumentListContainer extends Component {
       updateRawModal,
       viewId,
       isModal,
+      rawModalVisible,
     } = this.props;
 
     indicatorState('pending');
@@ -562,14 +563,16 @@ class DocumentListContainer extends Component {
             }
           });
 
-          // process modal specific
-          const { parentViewId, parentWindowId, headerProperties } = response;
+          if (rawModalVisible) {
+            // process modal specific
+            const { parentViewId, parentWindowId, headerProperties } = response;
 
-          updateRawModal(windowType, {
-            parentViewId,
-            parentWindowId,
-            headerProperties,
-          });
+            updateRawModal(windowType, {
+              parentViewId,
+              parentWindowId,
+              headerProperties,
+            });
+          }
         }
 
         indicatorState('saved');
@@ -803,6 +806,7 @@ class DocumentListContainer extends Component {
     const {
       includedView,
       layout,
+      layoutPending,
       reduxData: { rowData, pending },
     } = this.props;
     let { selected } = this.getSelected();
@@ -827,7 +831,7 @@ class DocumentListContainer extends Component {
       <DocumentList
         {...this.props}
         {...this.state}
-        triggerSpinner={layout.pending || pending}
+        triggerSpinner={layoutPending || pending}
         hasIncluded={hasIncluded}
         selectionValid={selectionValid}
         onToggleState={this.toggleState}

--- a/frontend/src/components/header/Header.js
+++ b/frontend/src/components/header/Header.js
@@ -554,7 +554,7 @@ class Header extends Component {
       windowId,
       // TODO: We should be using indicator from the state instead of another variable
       isDocumentNotSaved,
-      notfound,
+      notFound,
       docId,
       me,
       editmode,
@@ -790,7 +790,7 @@ class Header extends Component {
             redirect={this.redirect}
             disableOnClickOutside={!isSubheaderShow}
             breadcrumb={breadcrumb}
-            notfound={notfound}
+            notfound={notFound}
             entity={entity}
             dataId={dataId}
             windowId={windowId}
@@ -893,7 +893,7 @@ class Header extends Component {
  * @prop {object} inbox
  * @prop {bool} isDocumentNotSaved
  * @prop {object} me
- * @prop {*} notfound
+ * @prop {*} notFound
  * @prop {*} plugins
  * @prop {*} viewId
  * @prop {*} showSidelist
@@ -919,7 +919,7 @@ Header.propTypes = {
   inbox: PropTypes.object.isRequired,
   isDocumentNotSaved: PropTypes.bool,
   me: PropTypes.object.isRequired,
-  notfound: PropTypes.any,
+  notFound: PropTypes.any,
   plugins: PropTypes.any,
   viewId: PropTypes.string,
   showSidelist: PropTypes.any,

--- a/frontend/src/containers/DocList.js
+++ b/frontend/src/containers/DocList.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 
@@ -21,7 +21,7 @@ const EMPTY_OBJECT = {};
  * @module DocList
  * @extends Component
  */
-class DocList extends Component {
+class DocList extends PureComponent {
   componentDidMount = () => {
     const {
       windowId,

--- a/frontend/src/reducers/viewHandler.js
+++ b/frontend/src/reducers/viewHandler.js
@@ -26,10 +26,11 @@ import {
 export const viewState = {
   layout: {
     activeTab: null,
-    pending: false,
-    error: null,
-    notfound: false,
   },
+  layoutPending: false,
+  layoutError: null,
+  layoutNotFound: false,
+
   // rowData is an immutable Map with tabId's as keys, and Lists as values.
   // List's elements are plain objects for now
   rowData: iMap(),
@@ -50,7 +51,7 @@ export const viewState = {
   orderBy: null,
   queryLimitHit: null,
   mapConfig: null,
-  notfound: false,
+  notFound: false,
   pending: false,
   error: null,
   isActive: false,
@@ -93,11 +94,8 @@ export default function viewHandler(state = initialState, action) {
           ...state.views,
           [`${id}`]: {
             ...view,
-            layout: {
-              ...view.layout,
-              notfound: false,
-              pending: true,
-            },
+            layoutPending: true,
+            layoutNotFound: false,
           },
         },
       };
@@ -112,11 +110,11 @@ export default function viewHandler(state = initialState, action) {
           ...state.views,
           [`${id}`]: {
             ...view,
+            layoutPending: false,
+            layoutError: false,
             layout: {
               ...view.layout,
               ...layout,
-              error: null,
-              pending: false,
             },
           },
         },
@@ -132,12 +130,9 @@ export default function viewHandler(state = initialState, action) {
           ...state.views,
           [`${id}`]: {
             ...view,
-            layout: {
-              ...view.layout,
-              notfound: true,
-              error,
-              pending: false,
-            },
+            layoutPending: false,
+            layoutError: error,
+            layoutNotFound: true,
           },
         },
       };
@@ -153,7 +148,7 @@ export default function viewHandler(state = initialState, action) {
           ...state.views,
           [`${id}`]: {
             ...view,
-            notfound: false,
+            notFound: false,
             pending: true,
             error: null,
           },
@@ -221,7 +216,7 @@ export default function viewHandler(state = initialState, action) {
           [`${id}`]: {
             ...view,
             pending: false,
-            notfound: true,
+            notFound: true,
             error,
           },
         },
@@ -257,7 +252,7 @@ export default function viewHandler(state = initialState, action) {
             ...view,
             viewId,
             pending: false,
-            notfound: false,
+            notFound: false,
           },
         },
       };
@@ -273,7 +268,7 @@ export default function viewHandler(state = initialState, action) {
           [`${id}`]: {
             ...view,
             pending: false,
-            notfound: true,
+            notFound: true,
             error,
           },
         },
@@ -289,7 +284,7 @@ export default function viewHandler(state = initialState, action) {
           ...state.views,
           [`${id}`]: {
             ...view,
-            notfound: false,
+            notFound: false,
             pending: true,
             error: null,
           },
@@ -330,7 +325,7 @@ export default function viewHandler(state = initialState, action) {
           [`${id}`]: {
             ...view,
             pending: false,
-            notfound: true,
+            notFound: true,
             error,
           },
         },

--- a/frontend/src/utils/documentListHelper.js
+++ b/frontend/src/utils/documentListHelper.js
@@ -5,7 +5,7 @@ import currentDevice from 'current-device';
 
 import { getItemsByProperty, nullToEmptyStrings } from './index';
 import { getSelectionInstant } from '../reducers/windowHandler';
-import { viewState } from '../reducers/viewHandler';
+import { viewState, getView } from '../reducers/viewHandler';
 import { TIME_REGEX_TEST } from '../constants/Constants';
 
 /**
@@ -33,6 +33,8 @@ const DLpropTypes = {
   selected: PropTypes.array.isRequired,
   isModal: PropTypes.bool,
   inModal: PropTypes.bool,
+  modal: PropTypes.object,
+  rawModalVisible: PropTypes.bool,
 };
 
 /**
@@ -52,7 +54,7 @@ const DLmapStateToProps = (state, props) => {
     refTabId: queryRefTabId,
   } = props;
   const identifier = isModal ? defaultViewId : windowType;
-  let master = state.viewHandler.views[identifier];
+  let master = getView(state, identifier);
 
   if (!master) {
     master = viewState;
@@ -77,6 +79,7 @@ const DLmapStateToProps = (state, props) => {
     viewId,
     reduxData: master,
     layout: master.layout,
+    layoutPending: master.layoutPending,
     refType: queryRefType,
     refId: queryRefId,
     refTabId: queryRefTabId,
@@ -110,6 +113,7 @@ const DLmapStateToProps = (state, props) => {
         )
       : NO_SELECTION,
     modal: state.windowHandler.modal,
+    rawModalVisible: state.windowHandler.rawModal.visible,
     filters: state.filters,
     table: state.table,
   };


### PR DESCRIPTION
Turns out using `PureComponent` works even better than trying to manually compare props before the update. Especially when opening modals, as it decreases the number of refreshes 3x

Related to #6666 