### PR TITLE
Cypress no longer needs an env variable

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -11,3 +11,6 @@ cypress/config.js
 /cypress/config.js.remote
 /cypress/config.js.local
 /metasfresh-e2e.iml
+
+/cypress/config.js_template_local
+/cypress/config.js_template_remote

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -67,7 +67,9 @@ Currently supported:
 
 Note that you might need to first install cypress; [this documentation](https://docs.cypress.io/guides/getting-started/installing-cypress.html#npm-install) tells you how:
 
-> npm install cypress --save-dev
+```
+npm install cypress --save-dev
+```
 
 Also note that in addition you might also need to do a full `npm install` afterwards.
 
@@ -76,27 +78,33 @@ Also, you'll need to configure the login credentials/API endpoints. One file is 
 - `cypress/config.js` - stores API endpoints and login credentials
 
 There is a file `cypress/config.js_template` which you can copy to `cypress/config.js` and edit according to your needs.
+There are 2 files: 
+- `cypress/config.js_template_local`
+- `cypress/config.js_template_remote`
+
+which you can copy to `cypress/config.js` and edit according to your needs.
+
 
 ## Running
 
-To run the tests, navigate to this repository's root folder type this in the terminal:
+To start cypress and run the tests, navigate to the e2e folder and type this in the terminal:
 
-> npm run cypress:open
-
-If the webui you test against is not running on http://localhost:3000 you can start cypress with the `CYPRESS_baseUrl` vairable (see examples).
-
-When it runs, you can select particular test suites, or the whole suite to run. 
+```
+npm run cypress:open
+```
 
 ## Examples:
 
-For my local minikube (with webui-api running in my IDE)
+#### Local machine
+For my local machine, where webui-api is running in my IDE
 
-...edit the `cypress/config.js` like this:
+...edit `cypress/config.js` like this (see: `cypress/config.js_template_local`)
 
 ```javascript
 module.exports = {
+  FRONTEND_URL: 'http://localhost:3000',
   API_URL: 'http://localhost:8080/rest/api',
-  WS_URL:  'http://localhost:8080/stomp',
+  WS_URL: 'http://localhost:8080/stomp',
   PLUGIN_API_URL: 'http://localhost:9192/',
   username: 'metasfresh',
   password: '<your-pw>',
@@ -105,17 +113,22 @@ module.exports = {
 
 ...and start cypress like this:
 
-> CYPRESS_baseUrl=http://localhost:30080 npm run cypress:open
+```
+npm run cypress:open
+```
 
-For a dev-instance (dev133 in this example)
+#### Dev instance
 
-...edit the `cypress/config.js` like this:
+For a dev instance (`dev333` in this example)
+
+...edit `cypress/config.js` like this (see `cypress/config.js_template_remote`):
 
 ```javascript
 module.exports = {
-  API_URL: 'https://dev133.metasfresh.com/rest/api/',
-  WS_URL:  'https://dev133.metasfresh.com/stomp',
-  PLUGIN_API_URL: 'http://localhost:9192/',
+  FRONTEND_URL: 'https://dev333.metasfresh.com',
+  API_URL: 'https://dev333.metasfresh.com/rest/api',
+  WS_URL: 'https://dev333.metasfresh.com/stomp',
+  PLUGIN_API_URL: 'http://dev333.metasfresh.com:9192/',
   username: 'dev',
   password: '<your-pw>',
 };
@@ -123,7 +136,9 @@ module.exports = {
 
 ...and start cypress like this:
 
-> CYPRESS_baseUrl=https://dev133.metasfresh.com:443 npm run cypress:open
+```
+npm run cypress:open
+```
 
 ## Setting up Visual Studio Code
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -77,7 +77,6 @@ Also, you'll need to configure the login credentials/API endpoints. One file is 
 
 - `cypress/config.js` - stores API endpoints and login credentials
 
-There is a file `cypress/config.js_template` which you can copy to `cypress/config.js` and edit according to your needs.
 There are 2 files: 
 - `cypress/config.js_template_local`
 - `cypress/config.js_template_remote`

--- a/e2e/cypress/config.js_template_local
+++ b/e2e/cypress/config.js_template_local
@@ -1,0 +1,8 @@
+module.exports = {
+  FRONTEND_URL: 'http://localhost:3000',
+  API_URL: 'http://localhost:8080/rest/api',
+  WS_URL: 'http://localhost:8080/stomp',
+  PLUGIN_API_URL: 'http://localhost:9192/',
+  username: 'metasfresh',
+  password: '<your-pw>',
+};

--- a/e2e/cypress/config.js_template_remote
+++ b/e2e/cypress/config.js_template_remote
@@ -1,0 +1,8 @@
+module.exports = {
+  FRONTEND_URL: 'https://dev333.metasfresh.com',
+  API_URL: 'https://dev333.metasfresh.com/rest/api',
+  WS_URL: 'https://dev333.metasfresh.com/stomp',
+  PLUGIN_API_URL: 'http://dev333.metasfresh.com:9192/',
+  username: 'dev',
+  password: '<your-pw>',
+};

--- a/e2e/cypress/plugins/index.js
+++ b/e2e/cypress/plugins/index.js
@@ -15,6 +15,7 @@ const webpackPre = require('@cypress/webpack-preprocessor');
 const webpack = require('webpack');
 const { initPlugin } = require('cypress-plugin-snapshots/plugin');
 const task = require('cypress-skip-and-only-ui/task');
+const ourConfig = require('../config.js');
 
 module.exports = (on, config) => {
   const options = {
@@ -46,6 +47,11 @@ module.exports = (on, config) => {
   //     return args
   //   }
   // })
+
+  // modify base url if it exists in our config.js file located in /e2e/cypress/config.js
+  if (ourConfig.FRONTEND_URL) {
+    config.baseUrl = ourConfig.FRONTEND_URL;
+  }
 
   return config;
 };


### PR DESCRIPTION
Make cypress take all its config from `/cypress/config.js`. In this way only the config can be modified whenever cypress has to be run