### PR TITLE
Fix accidental inactivation of not-IBAN bank accounts

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/banking/api/IBPBankAccountDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/banking/api/IBPBankAccountDAO.java
@@ -54,11 +54,16 @@ public interface IBPBankAccountDAO extends ISingletonService
 	 */
 	List<I_C_BP_BankAccount> retrieveBankAccountsForPartnerAndCurrency(Properties ctx, int partnerID, int currencyID);
 
-	Optional<BankAccountId> retrieveFirstIdByBPartnerAndCurrency(@NonNull BPartnerId bPartnerId, @NonNull CurrencyId currencyId);
-
 	Optional<BankAccountId> retrieveByBPartnerAndCurrencyAndIBAN(@NonNull BPartnerId bPartnerId, @NonNull CurrencyId currencyId, @NonNull String iban);
 
-	void deactivateByBPartnerExcept(BPartnerId bpartnerId, Collection<BPartnerBankAccountId> exceptIds);
+	/**
+	 * Deactivate all {@link I_C_BP_BankAccount} records for the given bPartnerId, besides
+	 * <li>
+	 *     <ul>the ones whose id is in the given {@code exceptIds}</ul>
+	 *     <ul>the ones that have no IBAN; why: this is used for persisting {@code BPartnerComposite}s which never have no-iban-backaccounts; so we need to prevent them from being deactivated.</ul>
+	 * </li>
+	 */
+	void deactivateIBANAccountsByBPartnerExcept(BPartnerId bpartnerId, Collection<BPartnerBankAccountId> exceptIds);
 
-	ImmutableListMultimap<BPartnerId, I_C_BP_BankAccount> getByBPartnerIds(Collection<BPartnerId> bpartnerIds);
+	ImmutableListMultimap<BPartnerId, I_C_BP_BankAccount> getAllByBPartnerIds(Collection<BPartnerId> bpartnerIds);
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/banking/api/impl/BPBankAccountDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/banking/api/impl/BPBankAccountDAO.java
@@ -66,7 +66,7 @@ public class BPBankAccountDAO implements IBPBankAccountDAO
 	}
 
 	@Override
-	public ImmutableListMultimap<BPartnerId, I_C_BP_BankAccount> getByBPartnerIds(@NonNull final Collection<BPartnerId> bpartnerIds)
+	public ImmutableListMultimap<BPartnerId, I_C_BP_BankAccount> getAllByBPartnerIds(@NonNull final Collection<BPartnerId> bpartnerIds)
 	{
 		if (bpartnerIds.isEmpty())
 		{
@@ -103,20 +103,6 @@ public class BPBankAccountDAO implements IBPBankAccountDAO
 				.list();
 
 		return bpBankAccounts;
-		// return LegacyAdapters.convertToPOArray(bpBankAccounts, MBPBankAccount.class);
-	}    // getOfBPartner
-
-	@Override
-	public Optional<BankAccountId> retrieveFirstIdByBPartnerAndCurrency(@NonNull final BPartnerId bPartnerId, @NonNull final CurrencyId currencyId)
-	{
-		final BankAccountId bankAccountId = queryBL.createQueryBuilder(I_C_BP_BankAccount.class)
-				.addEqualsFilter(I_C_BP_BankAccount.COLUMNNAME_C_BPartner_ID, bPartnerId)
-				.addEqualsFilter(I_C_BP_BankAccount.COLUMNNAME_C_Currency_ID, currencyId)
-				.addOnlyActiveRecordsFilter()
-				.create()
-				.firstId(BankAccountId::ofRepoIdOrNull);
-
-		return Optional.ofNullable(bankAccountId);
 	}
 
 	@Override
@@ -134,7 +120,7 @@ public class BPBankAccountDAO implements IBPBankAccountDAO
 	}
 
 	@Override
-	public void deactivateByBPartnerExcept(
+	public void deactivateIBANAccountsByBPartnerExcept(
 			@NonNull final BPartnerId bpartnerId,
 			@NonNull final Collection<BPartnerBankAccountId> exceptIds)
 	{
@@ -144,6 +130,7 @@ public class BPBankAccountDAO implements IBPBankAccountDAO
 
 		queryBL.createQueryBuilder(I_C_BP_BankAccount.class)
 				.addOnlyActiveRecordsFilter()
+				.addNotNull(I_C_BP_BankAccount.COLUMNNAME_IBAN)
 				.addEqualsFilter(I_C_BP_BankAccount.COLUMNNAME_C_BPartner_ID, bpartnerId)
 				.addNotInArrayFilter(I_C_BP_BankAccount.COLUMN_C_BP_BankAccount_ID, exceptIds)
 				.create()

--- a/backend/de.metas.business/src/main/java/de/metas/bpartner/composite/repository/BPartnerCompositeSaver.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner/composite/repository/BPartnerCompositeSaver.java
@@ -51,7 +51,6 @@ import de.metas.location.ICountryDAO;
 import de.metas.location.impl.PostalQueryFilter;
 import de.metas.logging.TableRecordMDC;
 import de.metas.organization.OrgId;
-import de.metas.logging.TableRecordMDC;
 import de.metas.security.PermissionServiceFactories;
 import de.metas.util.Check;
 import de.metas.util.Services;
@@ -428,7 +427,7 @@ final class BPartnerCompositeSaver
 		}
 
 		final IBPBankAccountDAO bpBankAccountsDAO = Services.get(IBPBankAccountDAO.class);
-		bpBankAccountsDAO.deactivateByBPartnerExcept(bpartnerId, savedBPBankAccountIds);
+		bpBankAccountsDAO.deactivateIBANAccountsByBPartnerExcept(bpartnerId, savedBPBankAccountIds);
 	}
 
 	private void saveBPartnerBankAccount(

--- a/misc/services/admin/src/main/resources/application.properties
+++ b/misc/services/admin/src/main/resources/application.properties
@@ -14,17 +14,3 @@ info.build.ciJobName=@env.JOB_NAME@
 
 spring.application.name=metasfresh-admin
 spring.application.title=metasfresh Spring Boot Admin web application
-#
-# Logging
-#
-
-# logstash; see https://github.com/metasfresh/metasfresh/issues/1504
-# This application sends log events to logstash, if enabled via this property. 
-# Not enabled by default, because it needs some infrastruction (i.e. an ELK stack) to work. If that infrastructure is in place, use it to enable this feature via command line param or centralized config.
-# If you are a dev and need a local ELK stack to benefit from logstash, take a look at https://github.com/metasfresh/metasfresh-dev/tree/master/vagrant
-# Note that the application won't hang or crash if logstash is not avaiable or too slow.
-logstash.enabled=false
-logstash.host=localhost
-logstash.port=5000
-
-logging.level.de.metas.manufacturing.dispo = WARN


### PR DESCRIPTION
* basically the fix is to not deactivate C_BP_BankAccounts that have no IBAN, because those
 * are not loaded into the bpartnercomposite and the API can't access them anyways
 * would otherwise always be deactiaved
* application.properties: unrelated cleanup