### PR TITLE
Add sql query to cleanup all ASIs which have description = ASI_ID

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5561410_gh6848_RemoveAll_ASI.Description_WhichAreAn_ASI_ID.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5561410_gh6848_RemoveAll_ASI.Description_WhichAreAn_ASI_ID.sql
@@ -1,5 +1,5 @@
 -- where clause is the same for both queries
-CREATE TABLE backup.m_attributesetinstance_gh6848_2020_06_15 AS
+CREATE TABLE backup.m_attributesetinstance_gh6848_2020_06_15_Part_2 AS
 SELECT *
 FROM m_attributesetinstance
 WHERE m_attributesetinstance_id IN
@@ -13,8 +13,8 @@ WHERE m_attributesetinstance_id IN
           FROM m_attributesetinstance asi
           WHERE TRUE
             -- all ASI whose description == an ASI_ID
-            AND asi.m_attributesetinstance_id::text IN (SELECT DISTINCT description::text
-                                                        FROM m_attributesetinstance)
+            AND asi.description::text IN (SELECT DISTINCT m_attributesetinstance_id::text
+                                          FROM m_attributesetinstance)
             -- don't update ASIs who have records
             AND NOT exists(SELECT 1 FROM m_attributeinstance ai WHERE ai.m_attributesetinstance_id = asi.m_attributesetinstance_id)
       )
@@ -34,8 +34,8 @@ WHERE m_attributesetinstance_id IN
           FROM m_attributesetinstance asi
           WHERE TRUE
             -- all ASI whose description == an ASI_ID
-            AND asi.m_attributesetinstance_id::text IN (SELECT DISTINCT description::text
-                                                        FROM m_attributesetinstance)
+            AND asi.description::text IN (SELECT DISTINCT m_attributesetinstance_id::text
+                                          FROM m_attributesetinstance)
             -- don't update ASIs who have records
             AND NOT exists(SELECT 1 FROM m_attributeinstance ai WHERE ai.m_attributesetinstance_id = asi.m_attributesetinstance_id)
       )


### PR DESCRIPTION
The query in `5561410_gh6848_RemoveAll_ASI.Description_WhichAreAn_ASI_ID.sql` is only partly correct as it checks if the current ASI_ID appears as a description.

What should have been checked instead is that the current description appears in any IDs, and in that case to NULL it.

https://github.com/metasfresh/metasfresh/issues/6848