### PR TITLE
Properly render dataEntries in tabs

### DIFF
--- a/frontend/src/components/Window.js
+++ b/frontend/src/components/Window.js
@@ -168,8 +168,13 @@ class Window extends PureComponent {
    * @param {*} parentTab
    */
   getTabs = (tabs, dataId, tabsArray, tabsByIds, parentTab) => {
-    const { windowId } = this.props.layout;
-    const { newRow, tabsInfo, sort, allowShortcut } = this.props;
+    const {
+      layout: { windowId },
+      newRow,
+      tabsInfo,
+      sort,
+      allowShortcut,
+    } = this.props;
     const { fullScreen, isSectionExpandTooltipShow } = this.state;
 
     tabs.forEach((elem) => {
@@ -328,23 +333,6 @@ class Window extends PureComponent {
     } = this.props;
     const { fullScreen } = this.state;
 
-    // const rowData = isDataEntry
-    //   ? this.props.rowData.get(extendedData.tabId)
-    //   : undefined;
-    // // console.log('extendedData: ', this.props)
-    // // const rowData = {};
-
-    const rowData = isDataEntry
-      ? get(this.props.rowData, [extendedData.tabId], {})
-      // ? getTable({ windowId, })
-      // ? {}
-      : undefined;
-
-    // if (isDataEntry) {
-    //   console.log('renderSections: ', this.props)
-    // }
-
-
     return sections.map((sectionLayout, sectionIndex) => {
       const isSectionCollapsed =
         isDataEntry &&
@@ -358,14 +346,13 @@ class Window extends PureComponent {
           sectionIndex={sectionIndex}
           //
           windowId={windowId}
-          tabId={tabId}
+          tabId={tabId || extendedData.tabId}
           rowId={rowId}
           dataId={dataId}
           //
           data={data}
           isDataEntry={isDataEntry}
           extendedData={extendedData}
-          rowData={rowData}
           //
           isModal={isModal}
           isAdvanced={isAdvanced}

--- a/frontend/src/components/Window.js
+++ b/frontend/src/components/Window.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 import counterpart from 'counterpart';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 
 import Table from '../containers/Table';
 import TableContextShortcuts from './keyshortcuts/TableContextShortcuts';
@@ -316,15 +317,33 @@ class Window extends PureComponent {
    * @param {*} extendedData
    */
   renderSections = (sections, isDataEntry, extendedData = {}) => {
-    const { windowId } = this.props.layout;
-    const { tabId, rowId, dataId } = this.props;
-    const { data } = this.props;
-    const { isModal, isAdvanced } = this.props;
+    const {
+      layout: { windowId },
+      tabId,
+      rowId,
+      dataId,
+      data,
+      isModal,
+      isAdvanced,
+    } = this.props;
     const { fullScreen } = this.state;
 
+    // const rowData = isDataEntry
+    //   ? this.props.rowData.get(extendedData.tabId)
+    //   : undefined;
+    // // console.log('extendedData: ', this.props)
+    // // const rowData = {};
+
     const rowData = isDataEntry
-      ? this.props.rowData.get(extendedData.tabId)
+      ? get(this.props.rowData, [extendedData.tabId], {})
+      // ? getTable({ windowId, })
+      // ? {}
       : undefined;
+
+    // if (isDataEntry) {
+    //   console.log('renderSections: ', this.props)
+    // }
+
 
     return sections.map((sectionLayout, sectionIndex) => {
       const isSectionCollapsed =

--- a/frontend/src/components/app/MasterWindow.js
+++ b/frontend/src/components/app/MasterWindow.js
@@ -284,7 +284,6 @@ export default class MasterWindow extends Component {
       includedView,
       processStatus,
       enableTutorial,
-      dataEntries,
     } = this.props;
     const {
       dropzoneFocused,
@@ -360,7 +359,6 @@ export default class MasterWindow extends Component {
             key="window"
             data={master.data}
             layout={master.layout}
-            rowData={dataEntries}
             tabsInfo={master.includedTabsInfo}
             sort={this.sort}
             dataId={dataId}

--- a/frontend/src/components/app/MasterWindow.js
+++ b/frontend/src/components/app/MasterWindow.js
@@ -284,6 +284,7 @@ export default class MasterWindow extends Component {
       includedView,
       processStatus,
       enableTutorial,
+      dataEntries,
     } = this.props;
     const {
       dropzoneFocused,
@@ -359,7 +360,7 @@ export default class MasterWindow extends Component {
             key="window"
             data={master.data}
             layout={master.layout}
-            rowData={master.rowData}
+            rowData={dataEntries}
             tabsInfo={master.includedTabsInfo}
             sort={this.sort}
             dataId={dataId}

--- a/frontend/src/components/window/Column.js
+++ b/frontend/src/components/window/Column.js
@@ -22,8 +22,7 @@ class Column extends PureComponent {
   }
 
   render() {
-    const { columnLayout, colWidth } = this.props;
-    const { isDataEntry } = this.props;
+    const { columnLayout, colWidth, isDataEntry } = this.props;
     const elementGroups = columnLayout.elementGroups;
 
     if (isDataEntry) {
@@ -44,10 +43,16 @@ class Column extends PureComponent {
   }
 
   renderElementGroups = (groups) => {
-    const { windowId, tabId, rowId, dataId } = this.props;
-    const { data } = this.props;
-    const { isFirst, isModal, isAdvanced, isFullScreen } = this.props;
     const {
+      windowId,
+      tabId,
+      rowId,
+      dataId,
+      data,
+      isFirst,
+      isModal,
+      isAdvanced,
+      isFullScreen,
       onBlurWidget,
       addRefToWidgets,
       requestElementGroupFocus,
@@ -88,7 +93,7 @@ class Column extends PureComponent {
   };
 
   renderEntryTable = (groups) => {
-    const rows = groups.reduce((rowsArray, group) => {
+    const columns = groups.reduce((columnsArray, group) => {
       const cols = [];
       group.elementsLine.forEach((line) => {
         if (line && line.elements && line.elements.length) {
@@ -96,17 +101,24 @@ class Column extends PureComponent {
         }
       });
 
-      rowsArray.push({
+      columnsArray.push({
         cols,
         colsCount: group.columnCount,
       });
 
-      return rowsArray;
+      return columnsArray;
     }, []);
 
-    const { windowId, dataId } = this.props;
-    const { data, extendedData, rowData, isFullScreen } = this.props;
-    const { addRefToWidgets, onBlurWidget } = this.props;
+    const {
+      windowId,
+      dataId,
+      tabId,
+      data,
+      extendedData,
+      isFullScreen,
+      addRefToWidgets,
+      onBlurWidget,
+    } = this.props;
 
     return (
       <div
@@ -117,17 +129,13 @@ class Column extends PureComponent {
         )}
       >
         <EntryTable
-          rows={rows}
-          //
+          columns={columns}
           windowId={windowId}
-          dataId={dataId}
-          //
+          documentId={dataId}
+          tabId={tabId}
           data={data}
-          rowData={rowData}
           extendedData={extendedData}
-          //
           isFullScreen={isFullScreen}
-          //
           addRefToWidgets={addRefToWidgets}
           onBlurWidget={onBlurWidget}
         />
@@ -148,7 +156,6 @@ Column.propTypes = {
   data: PropTypes.oneOfType([PropTypes.shape(), PropTypes.array]), // TODO: type here should point to a hidden issue?
   isDataEntry: PropTypes.bool,
   extendedData: PropTypes.object,
-  rowData: PropTypes.object,
   //
   isFirst: PropTypes.bool,
   isModal: PropTypes.bool,

--- a/frontend/src/components/window/Section.js
+++ b/frontend/src/components/window/Section.js
@@ -51,7 +51,6 @@ class Section extends PureComponent {
       data,
       isDataEntry,
       extendedData,
-      rowData,
       isModal,
       isAdvanced,
       isFullScreen,
@@ -62,8 +61,6 @@ class Section extends PureComponent {
     const maxRows = 12;
     const colWidth = Math.floor(maxRows / columns.length);
     const isFirstSection = sectionIndex === 0;
-
-    console.log('columns: ', columns)
 
     return columns.map((columnLayout, columnIndex) => {
       const isFirstColumn = isFirstSection && columnIndex === 0;
@@ -82,7 +79,6 @@ class Section extends PureComponent {
           data={data}
           isDataEntry={isDataEntry}
           extendedData={extendedData}
-          rowData={rowData}
           //
           isFirst={isFirstColumn}
           isModal={isModal}
@@ -110,7 +106,6 @@ Section.propTypes = {
   data: PropTypes.oneOfType([PropTypes.shape(), PropTypes.array]), // TODO: type here should point to a hidden issue?
   isDataEntry: PropTypes.bool,
   extendedData: PropTypes.object,
-  rowData: PropTypes.object,
   //
   isModal: PropTypes.bool,
   isAdvanced: PropTypes.bool,

--- a/frontend/src/components/window/Section.js
+++ b/frontend/src/components/window/Section.js
@@ -7,11 +7,13 @@ import { INITIALLY_OPEN, INITIALLY_CLOSED } from '../../constants/Constants';
 
 class Section extends PureComponent {
   render() {
-    const { sectionLayout, sectionIndex } = this.props;
-    const { extendedData } = this.props;
-    const { isSectionCollapsed, toggleSectionCollapsed } = this.props;
-
-    const { title, columns, closableMode } = sectionLayout;
+    const {
+      sectionLayout: { title, columns, closableMode },
+      sectionIndex,
+      extendedData,
+      isSectionCollapsed,
+      toggleSectionCollapsed,
+    } = this.props;
     const collapsible =
       closableMode === INITIALLY_OPEN || closableMode === INITIALLY_CLOSED;
 
@@ -40,20 +42,28 @@ class Section extends PureComponent {
   }
 
   renderColumns = (columns) => {
-    const { sectionIndex } = this.props;
-    const { windowId, tabId, rowId, dataId } = this.props;
-    const { data, isDataEntry, extendedData, rowData } = this.props;
-    const { isModal, isAdvanced, isFullScreen } = this.props;
     const {
+      sectionIndex,
+      windowId,
+      tabId,
+      rowId,
+      dataId,
+      data,
+      isDataEntry,
+      extendedData,
+      rowData,
+      isModal,
+      isAdvanced,
+      isFullScreen,
       addRefToWidgets,
       onBlurWidget,
       requestElementGroupFocus,
     } = this.props;
-
     const maxRows = 12;
     const colWidth = Math.floor(maxRows / columns.length);
-
     const isFirstSection = sectionIndex === 0;
+
+    console.log('columns: ', columns)
 
     return columns.map((columnLayout, columnIndex) => {
       const isFirstColumn = isFirstSection && columnIndex === 0;

--- a/frontend/src/containers/MasterWindow.js
+++ b/frontend/src/containers/MasterWindow.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import { forEach, get } from 'lodash';
 
-import { getTableId } from '../reducers/tables';
+import { getTableId, getTable } from '../reducers/tables';
 import { addNotification } from '../actions/AppActions';
 import {
   attachFileAction,
@@ -280,20 +280,39 @@ MasterWindowContainer.propTypes = {
  * @summary ToDo: Describe the method.
  * @param {object} state
  */
-const mapStateToProps = (state) => ({
-  master: state.windowHandler.master,
-  modal: state.windowHandler.modal,
-  rawModal: state.windowHandler.rawModal,
-  pluginModal: state.windowHandler.pluginModal,
-  overlay: state.windowHandler.overlay,
-  indicator: state.windowHandler.indicator,
-  includedView: state.listHandler.includedView,
-  allowShortcut: state.windowHandler.allowShortcut,
-  enableTutorial: state.appHandler.enableTutorial,
-  processStatus: state.appHandler.processStatus,
-  me: state.appHandler.me,
-  breadcrumb: state.menuHandler.breadcrumb,
-});
+const mapStateToProps = (state) => {
+  const entryData = {};
+  const master = state.windowHandler.master;
+
+  if (master.layout.sectionTables) {
+    entryData.dataEntries = {};
+    const windowId = master.layout.windowId;
+    const docId = master.docId;
+
+    master.layout.sectionTables.forEach((tabId) => {
+      const tableId = getTableId({ windowId, docId, tabId });
+      entryData.dataEntries[tableId] = getTable(state, tableId).rows;
+
+      // console.log('tabId, ', getTable(tableId, state));
+    });
+  }
+
+  return {
+    master,
+    modal: state.windowHandler.modal,
+    rawModal: state.windowHandler.rawModal,
+    pluginModal: state.windowHandler.pluginModal,
+    overlay: state.windowHandler.overlay,
+    indicator: state.windowHandler.indicator,
+    includedView: state.listHandler.includedView,
+    allowShortcut: state.windowHandler.allowShortcut,
+    enableTutorial: state.appHandler.enableTutorial,
+    processStatus: state.appHandler.processStatus,
+    me: state.appHandler.me,
+    breadcrumb: state.menuHandler.breadcrumb,
+    ...entryData,
+  };
+};
 
 export default connect(
   mapStateToProps,

--- a/frontend/src/containers/MasterWindow.js
+++ b/frontend/src/containers/MasterWindow.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import { forEach, get } from 'lodash';
 
-import { getTableId, getTable } from '../reducers/tables';
+import { getTableId } from '../reducers/tables';
 import { addNotification } from '../actions/AppActions';
 import {
   attachFileAction,
@@ -275,44 +275,20 @@ MasterWindowContainer.propTypes = {
   updateTabTableData: PropTypes.func.isRequired,
 };
 
-/**
- * @method mapStateToProps
- * @summary ToDo: Describe the method.
- * @param {object} state
- */
-const mapStateToProps = (state) => {
-  const entryData = {};
-  const master = state.windowHandler.master;
-
-  if (master.layout.sectionTables) {
-    entryData.dataEntries = {};
-    const windowId = master.layout.windowId;
-    const docId = master.docId;
-
-    master.layout.sectionTables.forEach((tabId) => {
-      const tableId = getTableId({ windowId, docId, tabId });
-      entryData.dataEntries[tableId] = getTable(state, tableId).rows;
-
-      // console.log('tabId, ', getTable(tableId, state));
-    });
-  }
-
-  return {
-    master,
-    modal: state.windowHandler.modal,
-    rawModal: state.windowHandler.rawModal,
-    pluginModal: state.windowHandler.pluginModal,
-    overlay: state.windowHandler.overlay,
-    indicator: state.windowHandler.indicator,
-    includedView: state.listHandler.includedView,
-    allowShortcut: state.windowHandler.allowShortcut,
-    enableTutorial: state.appHandler.enableTutorial,
-    processStatus: state.appHandler.processStatus,
-    me: state.appHandler.me,
-    breadcrumb: state.menuHandler.breadcrumb,
-    ...entryData,
-  };
-};
+const mapStateToProps = (state) => ({
+  master: state.windowHandler.master,
+  modal: state.windowHandler.modal,
+  rawModal: state.windowHandler.rawModal,
+  pluginModal: state.windowHandler.pluginModal,
+  overlay: state.windowHandler.overlay,
+  indicator: state.windowHandler.indicator,
+  includedView: state.listHandler.includedView,
+  allowShortcut: state.windowHandler.allowShortcut,
+  enableTutorial: state.appHandler.enableTutorial,
+  processStatus: state.appHandler.processStatus,
+  me: state.appHandler.me,
+  breadcrumb: state.menuHandler.breadcrumb,
+});
 
 export default connect(
   mapStateToProps,

--- a/frontend/src/reducers/windowHandler.js
+++ b/frontend/src/reducers/windowHandler.js
@@ -1,6 +1,7 @@
 import update from 'immutability-helper';
 import { Set as iSet } from 'immutable';
 import { createSelector } from 'reselect';
+import { get } from 'lodash';
 
 import {
   ACTIVATE_TAB,
@@ -311,15 +312,33 @@ export default function windowHandler(state = initialState, action) {
 
     // SCOPED ACTIONS
 
-    case INIT_LAYOUT_SUCCESS:
+    case INIT_LAYOUT_SUCCESS: {
+      const { scope, layout } = action;
+      const tabSections = {};
+
+      // store nested tabs ids to be able to easily get their data
+      // in MasterWindow
+      if (layout.tabs) {
+        layout.tabs.forEach((tab) => {
+          if (tab.tabs) {
+            if (!tabSections.sectionTables) {
+              tabSections.sectionTables = [];
+            }
+            tab.tabs.forEach((sectionTab) => {
+              tabSections.sectionTables.push(sectionTab.tabId);
+            });
+          }
+        });
+      }
+
       return {
         ...state,
         [action.scope]: {
           ...state[action.scope],
-          layout: action.layout,
+          layout: { ...action.layout, ...tabSections },
         },
       };
-
+    }
     case INIT_DATA_SUCCESS:
       return {
         ...state,

--- a/frontend/src/reducers/windowHandler.js
+++ b/frontend/src/reducers/windowHandler.js
@@ -1,7 +1,6 @@
 import update from 'immutability-helper';
 import { Set as iSet } from 'immutable';
 import { createSelector } from 'reselect';
-import { get } from 'lodash';
 
 import {
   ACTIVATE_TAB,
@@ -312,33 +311,15 @@ export default function windowHandler(state = initialState, action) {
 
     // SCOPED ACTIONS
 
-    case INIT_LAYOUT_SUCCESS: {
-      const { scope, layout } = action;
-      const tabSections = {};
-
-      // store nested tabs ids to be able to easily get their data
-      // in MasterWindow
-      if (layout.tabs) {
-        layout.tabs.forEach((tab) => {
-          if (tab.tabs) {
-            if (!tabSections.sectionTables) {
-              tabSections.sectionTables = [];
-            }
-            tab.tabs.forEach((sectionTab) => {
-              tabSections.sectionTables.push(sectionTab.tabId);
-            });
-          }
-        });
-      }
-
+    case INIT_LAYOUT_SUCCESS:
       return {
         ...state,
         [action.scope]: {
           ...state[action.scope],
-          layout: { ...action.layout, ...tabSections },
+          layout: action.layout,
         },
       };
-    }
+
     case INIT_DATA_SUCCESS:
       return {
         ...state,


### PR DESCRIPTION
Had to be changed due to the changes in how we handle data in tables now (and removing some unnecessary structures). Now it just reads data from redux, like any other tables.

Related to #6783 & #6706 

![Screenshot 2020-06-17 at 16 57 03](https://user-images.githubusercontent.com/513460/84914179-9b5a9800-b0bb-11ea-81bd-7b84d1fa3a06.png)
