### PR TITLE
[Frontend] Don't hit /filter endpoint on update

### DIFF
--- a/frontend/src/components/app/DocumentList.js
+++ b/frontend/src/components/app/DocumentList.js
@@ -65,27 +65,19 @@ export default class DocumentList extends Component {
   };
 
   /**
-   * @method updateQuickActions
-   * @summary ToDo: Describe the method.
-   */
-  updateQuickActions = (childSelection) => {
-    if (this.quickActionsComponent) {
-      this.quickActionsComponent.updateActions(childSelection);
-    }
-  };
-
-  /**
    * @method setTableRowEdited
    * @summary ToDo: Describe the method.
    * @todo TODO: This triggers re-fetching of quickactions. We should handle that via redux
    * or in the quickactions component somehow
    */
   setTableRowEdited = (val) => {
+    const { onUpdateQuickActions } = this.props;
+
     this.setState(
       {
         rowEdited: val,
       },
-      this.updateQuickActions
+      onUpdateQuickActions
     );
   };
 
@@ -103,14 +95,6 @@ export default class DocumentList extends Component {
     this.setState({
       toggleWidth: widthIdx,
     });
-  };
-
-  /**
-   * @method handleRefs
-   * @summary Store ref to the quick actions component
-   */
-  setQuickActionsRef = (ref) => {
-    this.quickActionsComponent = ref;
   };
 
   setTableRef = (ref) => {
@@ -164,6 +148,8 @@ export default class DocumentList extends Component {
       table,
       childSelected,
       parentSelected,
+      onUpdateQuickActions,
+      setQuickActionsComponentRef,
     } = this.props;
     const {
       staticFilters,
@@ -297,7 +283,7 @@ export default class DocumentList extends Component {
               <QuickActions
                 className="header-element align-items-center"
                 processStatus={processStatus}
-                ref={this.setQuickActionsRef}
+                ref={setQuickActionsComponentRef}
                 selected={selected}
                 viewId={viewId}
                 windowType={windowId}
@@ -343,7 +329,7 @@ export default class DocumentList extends Component {
                 readonly={true}
                 supportOpenRecord={layout.supportOpenRecord}
                 onRowEdited={this.setTableRowEdited}
-                updateQuickActions={this.updateQuickActions}
+                updateQuickActions={onUpdateQuickActions}
                 onDoubleClick={onRedirectToDocument}
                 handleChangePage={onChangePage}
                 mainTable={true}
@@ -433,4 +419,6 @@ DocumentList.propTypes = {
   onClearStaticFilters: PropTypes.func,
   onResetInitialFilters: PropTypes.func,
   onRedirectToNewDocument: PropTypes.func,
+  onUpdateQuickActions: PropTypes.func,
+  setQuickActionsComponentRef: PropTypes.func,
 };

--- a/frontend/src/containers/DocumentList.js
+++ b/frontend/src/containers/DocumentList.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, createRef } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import { Map as iMap, Set as iSet } from 'immutable';
@@ -65,7 +65,7 @@ class DocumentListContainer extends Component {
       currentDevice.type === 'mobile' || currentDevice.type === 'tablet'
         ? 9999
         : 20;
-
+    this.quickActionsComponent = createRef();
     this.state = {
       pageColumnInfosByFieldName: null,
       panelsState: GEO_PANEL_STATES[0],
@@ -207,7 +207,7 @@ class DocumentListContainer extends Component {
           (response) => {
             const tableId = getTableId({ windowId, viewId });
             const toRows = table.rows;
-            const { pageColumnInfosByFieldName, filtersActive } = this.state;
+            const { pageColumnInfosByFieldName } = this.state;
 
             // merge changed rows with data in the store
             // TODO: I think we can move this to reducer
@@ -221,11 +221,7 @@ class DocumentListContainer extends Component {
             if (removedRows.length) {
               deselectTableItems(tableId, removedRows);
             } else {
-              if (filtersActive.size) {
-                this.filterCurrentView();
-              }
-
-              // force updating actions
+              // TODO: Quick actions should probably be handled via redux
               this.updateQuickActions();
             }
 
@@ -239,6 +235,14 @@ class DocumentListContainer extends Component {
         this.updateQuickActions();
       }
     });
+  };
+
+  /**
+   * @method setQuickActionsComponentRef
+   * @summary Store ref to the quick actions component
+   */
+  setQuickActionsComponentRef = (ref) => {
+    this.quickActionsComponent = ref;
   };
 
   /**
@@ -768,6 +772,8 @@ class DocumentListContainer extends Component {
         onRedirectToNewDocument={this.onRedirectToNewDocument}
         onClearStaticFilters={this.clearStaticFilters}
         onResetInitialFilters={this.resetInitialFilters}
+        onUpdateQuickActions={this.updateQuickActions}
+        setQuickActionsComponentRef={this.setQuickActionsComponentRef}
       />
     );
   }


### PR DESCRIPTION
Remove the unnecessary request on WS event. Also fix functions for fetching quick actions.