### PR TITLE
#1253 No longer showing 'Clone Line' action when subtab's table is the same as the document's.

### DIFF
--- a/backend/metasfresh-webui-api/src/main/java/de/metas/ui/web/process/WEBUI_CloneLine.java
+++ b/backend/metasfresh-webui-api/src/main/java/de/metas/ui/web/process/WEBUI_CloneLine.java
@@ -73,6 +73,11 @@ public class WEBUI_CloneLine extends JavaProcess implements IProcessPrecondition
 		{
 			return ProcessPreconditionsResolution.rejectWithInternalReason("CopyRecordFactory not enabled for the table the row belongs to.");
 		}
+
+		if (ref.getTableName().equals(context.getTableName()))
+		{
+			return ProcessPreconditionsResolution.rejectWithInternalReason("Same Table as in document in sub-tab, can only have one line.");
+		}
 		return ProcessPreconditionsResolution.accept();
 	}
 }

--- a/backend/metasfresh-webui-api/src/main/java/de/metas/ui/web/process/WEBUI_CloneLine.java
+++ b/backend/metasfresh-webui-api/src/main/java/de/metas/ui/web/process/WEBUI_CloneLine.java
@@ -76,7 +76,9 @@ public class WEBUI_CloneLine extends JavaProcess implements IProcessPrecondition
 
 		if (ref.getTableName().equals(context.getTableName()))
 		{
-			return ProcessPreconditionsResolution.rejectWithInternalReason("Same Table as in document in sub-tab, can only have one line.");
+			// we have e.g. in the C_BPartner-window two subtabs ("Customer" and "Vendor") that show a different view on the same C_BPartner record. 
+			// There, cloning the subtab-line makes no sense
+			return ProcessPreconditionsResolution.rejectWithInternalReason("The main-window has the same Record as the sub-tab, there can only be one line.");
 		}
 		return ProcessPreconditionsResolution.accept();
 	}


### PR DESCRIPTION
#6911 