### PR TITLE
Upgrade lodash due to security advisory

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -142,7 +142,7 @@
     "immutable": "4.0.0-rc.12",
     "intro.js": "2.9.3",
     "intro.js-react": "0.1.5",
-    "lodash": "4.17.15",
+    "lodash": "4.17.19",
     "luxon": "1.22.0",
     "moment": "2.24.0",
     "moment-timezone": "0.5.27",


### PR DESCRIPTION
<img width="1634" alt="Screenshot 2020-07-20 at 08 20 17" src="https://user-images.githubusercontent.com/1708561/87902294-e58bbc00-ca61-11ea-99d5-1465734e3a63.png">
Got this advisory on the legacy repo. Still on the monorepo we are using the same version and we need to upgrade it.