### PR TITLE
fix(SEPA Export): schemaLocation

### DIFF
--- a/backend/de.metas.payment.sepa/base/src/main/java/de/metas/payment/sepa/sepamarshaller/impl/SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02.java
+++ b/backend/de.metas.payment.sepa/base/src/main/java/de/metas/payment/sepa/sepamarshaller/impl/SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02.java
@@ -146,6 +146,7 @@ public class SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02 implements 
 	 * Identifier of the <b>Pa</b>yment <b>In</b>itiation format (XSD) used by this marshaller.
 	 */
 	private static final String PAIN_001_001_03_CH_02 = "pain.001.001.03.ch.02";
+	private static final String PAIN_001_001_03_CH_02_SCHEMALOCATION = "http://www.six-interbank-clearing.com/de/";
 
 	/** Title: "ISR" */
 	private static final String PAYMENT_TYPE_1 = "PAYMENT_TYPE_1";
@@ -223,7 +224,7 @@ public class SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02 implements 
 
 			final Marshaller marshaller = jaxbContext.createMarshaller();
 			marshaller.setProperty("jaxb.formatted.output", Boolean.TRUE);
-			marshaller.setProperty("jaxb.schemaLocation", "urn:sepade:xsd:" + PAIN_001_001_03_CH_02 + " " + PAIN_001_001_03_CH_02 + ".xsd");
+			marshaller.setProperty("jaxb.schemaLocation", PAIN_001_001_03_CH_02_SCHEMALOCATION + PAIN_001_001_03_CH_02 + ".xsd " + PAIN_001_001_03_CH_02 + ".xsd");
 			marshaller.marshal(jaxbDocument, xmlWriter);
 		}
 		catch (final JAXBException e)

--- a/backend/de.metas.payment.sepa/base/src/test/java/de/metas/payment/sepa/sepamarshaller/impl/SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02_Test.java
+++ b/backend/de.metas.payment.sepa/base/src/test/java/de/metas/payment/sepa/sepamarshaller/impl/SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02_Test.java
@@ -21,6 +21,12 @@ import de.metas.payment.sepa.api.SEPAProtocol;
 import de.metas.payment.sepa.jaxb.sct.pain_001_001_03_ch_02.Document;
 import de.metas.payment.sepa.model.I_SEPA_Export;
 import de.metas.payment.sepa.model.I_SEPA_Export_Line;
+import de.metas.payment.sepa.sepamarshaller.impl.SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileInputStream;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 public class SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02_Test
 {
@@ -102,6 +108,51 @@ public class SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02_Test
 		return sepaExport;
 	}
 
+	@Test
+	public void marshalDocument() throws Exception
+	{
+		final I_SEPA_Export sepaExport = createSEPAExport(
+				"org", // SEPA_CreditorName
+				"12345", // SEPA_CreditorIdentifier
+				"INGBNL2A" // bic
+		);
+		createSEPAExportLine(sepaExport,
+				"001",// SEPA_MandateRefNo
+				"NL31INGB0000000044",// IBAN
+				"INGBNL2A", // BIC
+				new BigDecimal("100"), // amount
+				eur);
+		createSEPAExportLine(sepaExport,
+				"002", // SEPA_MandateRefNo
+				"NL31INGB0000000044", // IBAN
+				"INGBNL2A",// BIC
+				new BigDecimal("30"), // amount
+				eur);
+
+		createSEPAExportLine(sepaExport,
+				"002", // SEPA_MandateRefNo
+				"NL31INGB0000000044", // IBAN
+				"INGBNL2A",// BIC
+				new BigDecimal("40"), // amount
+				chf);
+
+		File fstream = File.createTempFile("sepaExport",".xml");
+		fstream.deleteOnExit();
+		FileOutputStream sepaExportOut = new FileOutputStream(fstream);
+		xmlGenerator.marshal(sepaExport, sepaExportOut);
+		sepaExportOut.close();
+
+	    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+	    DocumentBuilder builder = factory.newDocumentBuilder();
+		FileInputStream fis = new FileInputStream(fstream);
+		org.w3c.dom.Document sepaExportDoc = builder.parse(fis);
+
+		assertThat(sepaExportDoc.getDocumentElement().getAttributes().getNamedItem("xsi:schemaLocation").getNodeValue()).isEqualTo("http://www.six-interbank-clearing.com/de/pain.001.001.03.ch.02.xsd pain.001.001.03.ch.02.xsd");
+		
+		assertThat(sepaExportDoc.getDocumentElement().getAttributes().getNamedItem("xmlns").getNodeValue()).isEqualTo("http://www.six-interbank-clearing.com/de/pain.001.001.03.ch.02.xsd");
+
+	}
+	
 	private I_SEPA_Export_Line createSEPAExportLine(
 			final I_SEPA_Export sepaExport,
 			final String SEPA_MandateRefNo,


### PR DESCRIPTION
Issue #6526 

This change has been validated on PostFinance Test Platform/ SIX Swiss Payment Standards Validation.Portal / ZKB Test Platform

Answer from PostFinance because the SEPA File was not accepted:

Gemäss pain.001 xsd muss bei der xsi:schemaLocation eine gültige URL vorhanden sein. Siehe dazu auch die IG der SIX (https://www.six-group.com/interbank-clearing/dam/downloads/de/standardization/iso/swiss-recommendations/implementation-guidelines-ct.pdf )
