### PR TITLE
Set `dateTrx` when creating a new `R_Request` via process

### DIFF
--- a/backend/metasfresh-webui-api/src/main/java/de/metas/ui/web/request/process/WEBUI_CreateRequest.java
+++ b/backend/metasfresh-webui-api/src/main/java/de/metas/ui/web/request/process/WEBUI_CreateRequest.java
@@ -122,6 +122,7 @@ public class WEBUI_CreateRequest extends JavaProcess implements IProcessPrecondi
 		final I_R_Request request = requestDAO.createEmptyRequest();
 		request.setR_RequestType_ID(requestTypeDAO.retrieveDefaultRequestTypeIdOrFirstActive().getRepoId());
 		request.setDateTrx(SystemTime.asDayTimestamp());
+		request.setStartDate(SystemTime.asDayTimestamp());
 		return request;
 	}
 

--- a/backend/metasfresh-webui-api/src/main/java/de/metas/ui/web/request/process/WEBUI_CreateRequest.java
+++ b/backend/metasfresh-webui-api/src/main/java/de/metas/ui/web/request/process/WEBUI_CreateRequest.java
@@ -4,6 +4,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.save;
 
 import java.util.Optional;
 
+import de.metas.util.time.SystemTime;
 import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.SpringContextHolder;
@@ -120,6 +121,7 @@ public class WEBUI_CreateRequest extends JavaProcess implements IProcessPrecondi
 	{
 		final I_R_Request request = requestDAO.createEmptyRequest();
 		request.setR_RequestType_ID(requestTypeDAO.retrieveDefaultRequestTypeIdOrFirstActive().getRepoId());
+		request.setDateTrx(SystemTime.asDayTimestamp());
 		return request;
 	}
 


### PR DESCRIPTION
This makes creating Requests via process, similar to creating them via `Add New` button in the Request window

https://github.com/metasfresh/metasfresh/issues/7183