### PR TITLE
Have a swing at fixing failing e2e tests

### DIFF
--- a/e2e/cypress/integration/inventory/create_disposal_from_handling_unit_editor.js
+++ b/e2e/cypress/integration/inventory/create_disposal_from_handling_unit_editor.js
@@ -51,10 +51,10 @@ describe('Create a single HU', function() {
   });
 
   it('Create a new single-HU inventory doc', function() {
-    let uomName;
-    cy.fixture('product/simple_product.json').then(productJson => {
-      uomName = getLanguageSpecific(productJson, 'c_uom');
-    });
+    // let uomName;
+    // cy.fixture('product/simple_product.json').then(productJson => {
+    //   uomName = getLanguageSpecific(productJson, 'c_uom');
+    // });
 
     cy.fixture('inventory/inventory.json').then(inventoryJson => {
       const docTypeName = getLanguageSpecific(inventoryJson, 'singleHUInventoryDocTypeName');
@@ -62,7 +62,7 @@ describe('Create a single HU', function() {
       const inventoryLine = new InventoryLine()
         .setProductName(productName)
         .setQuantity(productQty)
-        .setC_UOM_ID(uomName)
+        // .setC_UOM_ID(uomName)
         .setM_Locator_ID(locatorId)
         .setIsCounted(true);
 

--- a/e2e/cypress/integration/inventory/create_disposal_from_handling_unit_editor.js
+++ b/e2e/cypress/integration/inventory/create_disposal_from_handling_unit_editor.js
@@ -51,18 +51,12 @@ describe('Create a single HU', function() {
   });
 
   it('Create a new single-HU inventory doc', function() {
-    // let uomName;
-    // cy.fixture('product/simple_product.json').then(productJson => {
-    //   uomName = getLanguageSpecific(productJson, 'c_uom');
-    // });
-
     cy.fixture('inventory/inventory.json').then(inventoryJson => {
       const docTypeName = getLanguageSpecific(inventoryJson, 'singleHUInventoryDocTypeName');
 
       const inventoryLine = new InventoryLine()
         .setProductName(productName)
         .setQuantity(productQty)
-        // .setC_UOM_ID(uomName)
         .setM_Locator_ID(locatorId)
         .setIsCounted(true);
 

--- a/e2e/cypress/integration/inventory/inventory_aggregatedHUs_spec.js
+++ b/e2e/cypress/integration/inventory/inventory_aggregatedHUs_spec.js
@@ -31,24 +31,20 @@ describe('Aggregated-HUs inventory test', function() {
   });
 
   it('Create a new single-HU inventory doc', function() {
-    cy.fixture('product/simple_product.json').then(productJson => {
-      const uomName = getLanguageSpecific(productJson, 'c_uom');
-      cy.fixture('inventory/inventory.json').then(inventoryJson => {
-        const docTypeName = getLanguageSpecific(inventoryJson, docTypeKey);
+    cy.fixture('inventory/inventory.json').then(inventoryJson => {
+      const docTypeName = getLanguageSpecific(inventoryJson, docTypeKey);
 
-        const inventoryLine = new InventoryLine()
-          .setProductName(productName)
-          .setQuantity(quantity)
-          .setC_UOM_ID(uomName)
-          .setM_Locator_ID(locatorId)
-          .setIsCounted(isCounted);
+      const inventoryLine = new InventoryLine()
+        .setProductName(productName)
+        .setQuantity(quantity)
+        .setM_Locator_ID(locatorId)
+        .setIsCounted(isCounted);
 
-        new Inventory()
-          .setWarehouse(inventoryJson.warehouseName)
-          .setDocType(docTypeName)
-          .addInventoryLine(inventoryLine)
-          .apply();
-      });
+      new Inventory()
+        .setWarehouse(inventoryJson.warehouseName)
+        .setDocType(docTypeName)
+        .addInventoryLine(inventoryLine)
+        .apply();
     });
   });
 });

--- a/e2e/cypress/integration/inventory/inventory_singleHU_spec.js
+++ b/e2e/cypress/integration/inventory/inventory_singleHU_spec.js
@@ -30,18 +30,12 @@ describe('Create a single HU', function() {
   });
 
   it('Create a new single-HU inventory doc', function() {
-    let uomName;
-    cy.fixture('product/simple_product.json').then(productJson => {
-      uomName = getLanguageSpecific(productJson, 'c_uom');
-    });
-
     cy.fixture('inventory/inventory.json').then(inventoryJson => {
       const docTypeName = getLanguageSpecific(inventoryJson, inventoryDoctypeKey);
 
       const inventoryLine = new InventoryLine()
         .setProductName(productName)
         .setQuantity(productQty)
-        .setC_UOM_ID(uomName)
         .setM_Locator_ID(locatorId)
         .setIsCounted(isCounted);
 

--- a/e2e/cypress/integration/picking/pick_HUs_and_create_shipment.js
+++ b/e2e/cypress/integration/picking/pick_HUs_and_create_shipment.js
@@ -75,7 +75,8 @@ describe('Pick the SO', function() {
 
   it('Select first row and run action Pick', function() {
     cy.selectRowByColumnAndValue({ column: productPartnerColumn, value: productName });
-    cy.executeQuickAction('WEBUI_Picking_Launcher');
+
+    cy.executeQuickAction('WEBUI_Picking_Launcher', false, false);
   });
 
   it('Pick first HU', function() {
@@ -88,7 +89,7 @@ describe('Pick the SO', function() {
       cy.selectItemUsingBarcodeFilter({ column: huSelectionHuCodeColumn, value: huValue1 }, false, true);
     });
 
-    cy.executeQuickAction('WEBUI_Picking_HUEditor_PickHU', true, false);
+    cy.executeQuickAction('WEBUI_Picking_HUEditor_PickHU', false, false);
   });
 
   it('Pick second HU', function() {
@@ -101,7 +102,7 @@ describe('Pick the SO', function() {
       cy.selectItemUsingBarcodeFilter({ column: huSelectionHuCodeColumn, value: huValue2 }, false, true);
     });
 
-    cy.executeQuickAction('WEBUI_Picking_HUEditor_PickHU', true, false);
+    cy.executeQuickAction('WEBUI_Picking_HUEditor_PickHU', false, false);
   });
 
   it('Confirm Picks', function() {
@@ -111,7 +112,7 @@ describe('Pick the SO', function() {
     cy.selectRightTable().within(() => {
       cy.selectRowByColumnAndValue({ column: pickingHuCodeColumn, value: huValue2 }, false, true);
     });
-    cy.executeQuickAction('WEBUI_Picking_M_Picking_Candidate_Process', true, false);
+    cy.executeQuickAction('WEBUI_Picking_M_Picking_Candidate_Process', false, false);
     cy.waitForSaveIndicator();
 
     cy.selectLeftTable().within(() => {
@@ -120,7 +121,7 @@ describe('Pick the SO', function() {
     cy.selectRightTable().within(() => {
       cy.selectRowByColumnAndValue({ column: pickingHuCodeColumn, value: huValue1 }, false, true);
     });
-    cy.executeQuickAction('WEBUI_Picking_M_Picking_Candidate_Process', true, false);
+    cy.executeQuickAction('WEBUI_Picking_M_Picking_Candidate_Process', false, false);
     cy.waitForSaveIndicator();
   });
 });

--- a/e2e/cypress/support/commands/action.js
+++ b/e2e/cypress/support/commands/action.js
@@ -82,12 +82,12 @@ Cypress.Commands.add('executeQuickAction', (actionName, modal = false, isDialogE
   cy.waitForSaveIndicator();
 });
 
-Cypress.Commands.add('executeQuickActionWithRightSideTable', actionName => {
+Cypress.Commands.add('executeQuickActionWithRightSideTable', (actionName, isModal = false) => {
   cy.log(`executeQuickActionWithRightSideTable ${actionName}`);
   const layoutAlias = 'layout_' + new Date().getTime();
   cy.waitForSaveIndicator();
   cy.server();
   cy.route('GET', new RegExp(RewriteURL.DocumentLayout)).as(layoutAlias);
-  cy.executeQuickAction(actionName, true, false);
+  cy.executeQuickAction(actionName, isModal, false);
   cy.wait(`@${layoutAlias}`);
 });

--- a/e2e/cypress/support/commands/form.js
+++ b/e2e/cypress/support/commands/form.js
@@ -165,6 +165,13 @@ Cypress.Commands.add('selectDateViaPicker', (fieldName, modal) => {
     .click();
 
   confirmCalendarDay();
+
+  cy.get(`${path} input`).should($input => {
+    const val = $input.val();
+
+    assert.isOk(val, 'date set');
+  });
+
   cy.get(path)
     .find('.form-control-label')
     .click();

--- a/e2e/cypress/support/commands/general.js
+++ b/e2e/cypress/support/commands/general.js
@@ -472,19 +472,25 @@ Cypress.Commands.add('openNotificationContaining', (expectedValue, destinationWi
   cy.waitForSaveIndicator();
 });
 
-Cypress.Commands.add('selectLeftTable', function() {
+Cypress.Commands.add('selectLeftTable', function(isModal = false) {
   cy.log('Select left table');
   cy.waitForSaveIndicator();
-  cy.get('.modal-content-wrapper .document-list-included').within(el => {
+
+  const parentWrapperPath = isModal ? '.modal-content-wrapper' : '.document-lists-wrapper';
+
+  cy.get(`${parentWrapperPath} .document-list-included`).within(el => {
     el = el[0];
     return cy.wrap(el);
   });
 });
 
-Cypress.Commands.add('selectRightTable', function() {
+Cypress.Commands.add('selectRightTable', function(isModal = false) {
   cy.log('Select right table');
   cy.waitForSaveIndicator();
-  cy.get('.modal-content-wrapper .document-list-included').within(el => {
+
+  const parentWrapperPath = isModal ? '.modal-content-wrapper' : '.document-lists-wrapper';
+
+  cy.get(`${parentWrapperPath} .document-list-included`).within(el => {
     el = el[1];
     return cy.wrap(el);
   });

--- a/e2e/cypress/support/functions/index.js
+++ b/e2e/cypress/support/functions/index.js
@@ -37,6 +37,7 @@ const clearNotFrequentFilters = () => {
     .click()
     .find('.filter-clear')
     .click();
+  cy.waitForSaveIndicator(true);
 }
 
 export {

--- a/e2e/cypress/support/utils/builder.js
+++ b/e2e/cypress/support/utils/builder.js
@@ -143,10 +143,11 @@ export class Builder {
    */
   static createHUWithStock(productName, productQty, locatorId) {
     // create HU
-    let uomName;
-    cy.fixture('product/simple_product.json').then(productJson => {
-      uomName = getLanguageSpecific(productJson, 'c_uom');
-    });
+    // see https://github.com/metasfresh/metasfresh/pull/10090#issue-500479284
+    // let uomName;
+    // cy.fixture('product/simple_product.json').then(productJson => {
+    //   uomName = getLanguageSpecific(productJson, 'c_uom');
+    // });
 
     cy.fixture('inventory/inventory.json').then(inventoryJson => {
       const docTypeName = getLanguageSpecific(inventoryJson, 'singleHUInventoryDocTypeName');
@@ -154,7 +155,7 @@ export class Builder {
       const inventoryLine = new InventoryLine()
         .setProductName(productName)
         .setQuantity(productQty)
-        .setC_UOM_ID(uomName)
+        // .setC_UOM_ID(uomName)
         .setM_Locator_ID(locatorId)
         .setIsCounted(true);
 

--- a/e2e/cypress/support/utils/inventory.js
+++ b/e2e/cypress/support/utils/inventory.js
@@ -104,13 +104,15 @@ export class Inventory {
       false /*typeList*/,
       true /*modal*/
     );
-    cy.writeIntoLookupListField(
-      'C_UOM_ID',
-      inventoryLine.uomName,
-      inventoryLine.uomName,
-      false /*typeList*/,
-      true /*modal*/
-    );
+    if (inventoryLine.uomName) {
+      cy.writeIntoLookupListField(
+        'C_UOM_ID',
+        inventoryLine.uomName,
+        inventoryLine.uomName,
+        false /*typeList*/,
+        true /*modal*/
+      );
+    }
     cy.writeIntoLookupListField(
       'M_Locator_ID',
       inventoryLine.M_Locator_ID,


### PR DESCRIPTION
Related to #10082.
- One of the problems here is that when we clear the filters, page is refreshed but cypress is so fast, it starts clicking elements before the reload finishes. Because of that it can't find some elements.
- A separate problem is that the UOM field is filled when the product is selected. So with the current architecture we won't do the request when nothing changed in the widget. And in this case prefilled value and the one we were typing are the same. I've tried adding a check for the current input value in the lookup helpers but looks like it's not gonna be that easy. 
- Also looks like picking from the picking terminal now doesn't open a modal, but a new window instead. So a lot of actions were tripping over that.