### PR TITLE
#10192 Custom queries now working as default filters, no longer inserting that column's validation rule from the table it refers to.

### DIFF
--- a/backend/metasfresh-webui-api/src/main/java/de/metas/ui/web/document/filter/provider/userQuery/UserQueryDocumentFilterDescriptorsProviderFactory.java
+++ b/backend/metasfresh-webui-api/src/main/java/de/metas/ui/web/document/filter/provider/userQuery/UserQueryDocumentFilterDescriptorsProviderFactory.java
@@ -88,7 +88,7 @@ final public class UserQueryDocumentFilterDescriptorsProviderFactory implements 
 				.columnName(field.getFieldName())
 				.displayName(field.getCaption())
 				.widgetType(field.getWidgetType())
-				.lookupDescriptor(field.getLookupDescriptor())
+				.lookupDescriptor(field.getLookupDescriptorForFiltering())
 				.build();
 	}
 }


### PR DESCRIPTION
#10192 