### PR TITLE
fix NPE on missing currency conversion

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/currency/ICurrencyBL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/currency/ICurrencyBL.java
@@ -76,7 +76,7 @@ public interface ICurrencyBL extends ISingletonService
 			OrgId adOrgId);
 
 	@Deprecated
-	@Nullable
+	@NonNull
 	BigDecimal convertBase(
 			BigDecimal amt,
 			CurrencyId currencyFromId,
@@ -86,7 +86,7 @@ public interface ICurrencyBL extends ISingletonService
 			@NonNull OrgId orgId);
 
 	@Deprecated
-	@Nullable
+	@NonNull
 	BigDecimal convert(
 			BigDecimal amt,
 			CurrencyId currencyFromId,
@@ -107,6 +107,7 @@ public interface ICurrencyBL extends ISingletonService
 	 * @return converted amount
 	 */
 	@Deprecated
+	@NonNull
 	BigDecimal convert(
 			BigDecimal amt,
 			CurrencyId currencyFromId,
@@ -114,13 +115,14 @@ public interface ICurrencyBL extends ISingletonService
 			@NonNull ClientId clientId,
 			@NonNull OrgId orgId);
 
-	@Nullable
+	@NonNull
 	CurrencyConversionResult convert(
 			CurrencyConversionContext conversionCtx,
 			BigDecimal amt,
 			CurrencyId currencyFromId,
 			CurrencyId currencyToId);
 
+	@NonNull
 	default CurrencyConversionResult convert(
 			@NonNull final CurrencyConversionContext conversionCtx,
 			@NonNull final Money amt,

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/currency/exceptions/NoCurrencyRateFoundException.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/currency/exceptions/NoCurrencyRateFoundException.java
@@ -27,8 +27,10 @@ import de.metas.currency.CurrencyCode;
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.ITranslatableString;
 import de.metas.i18n.TranslatableStrings;
+import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
 
+import javax.annotation.Nullable;
 import java.time.LocalDate;
 
 /**
@@ -41,19 +43,19 @@ public class NoCurrencyRateFoundException extends AdempiereException
 	private static final AdMessageKey MSG = AdMessageKey.of("NoCurrencyConversion");
 
 	public NoCurrencyRateFoundException(
-			final CurrencyCode currencyFrom,
-			final CurrencyCode currencyTo,
-			final LocalDate conversionDate,
-			final ConversionTypeMethod conversionTypeMethod)
+			@NonNull final CurrencyCode currencyFrom,
+			@NonNull final CurrencyCode currencyTo,
+			@Nullable final LocalDate conversionDate,
+			@Nullable final ConversionTypeMethod conversionTypeMethod)
 	{
 		super(buildMsg(currencyFrom, currencyTo, conversionDate, conversionTypeMethod));
 	}
 
 	private static ITranslatableString buildMsg(
-			final CurrencyCode currencyFrom,
-			final CurrencyCode currencyTo,
-			final LocalDate conversionDate,
-			final ConversionTypeMethod conversionTypeMethod)
+			@NonNull final CurrencyCode currencyFrom,
+			@NonNull final CurrencyCode currencyTo,
+			@Nullable final LocalDate conversionDate,
+			@Nullable final ConversionTypeMethod conversionTypeMethod)
 	{
 		return TranslatableStrings.builder()
 				.appendADMessage(MSG).append(" ")

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/currency/impl/CurrencyBL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/currency/impl/CurrencyBL.java
@@ -99,7 +99,7 @@ public class CurrencyBL implements ICurrencyBL
 		return convert(amt, currencyFromId, currencyToId, convDate, conversionTypeId, clientId, orgId);
 	}
 
-	@Nullable
+	@NonNull
 	@Override
 	public final BigDecimal convert(
 			final BigDecimal amt,
@@ -120,14 +120,10 @@ public class CurrencyBL implements ICurrencyBL
 				amt,
 				currencyFromId,
 				currencyToId);
-		if (conversionResult == null)
-		{
-			return null;
-		}
 		return conversionResult.getAmount();
 	}
 
-	@Nullable
+	@NonNull
 	@Override
 	public final CurrencyConversionResult convert(
 			@NonNull final CurrencyConversionContext conversionCtx,
@@ -153,8 +149,11 @@ public class CurrencyBL implements ICurrencyBL
 			final CurrencyRate currencyRate = getCurrencyRateOrNull(conversionCtx, currencyFromId, currencyToId);
 			if (currencyRate == null)
 			{
-				// TODO: evaluate if we can throw an exception here
-				return null;
+				throw new NoCurrencyRateFoundException(
+						currencyDAO.getCurrencyCodeById(currencyFromId),
+						currencyDAO.getCurrencyCodeById(currencyToId),
+						conversionCtx.getConversionDate(),
+						currencyDAO.getConversionTypeMethodById(conversionCtx.getConversionTypeId()));
 			}
 
 			conversionRateBD = currencyRate.getConversionRate();
@@ -179,7 +178,7 @@ public class CurrencyBL implements ICurrencyBL
 	}
 
 	@Override
-	@Nullable
+	@NonNull
 	public final BigDecimal convert(
 			final BigDecimal amt,
 			final CurrencyId currencyFromId,
@@ -188,7 +187,7 @@ public class CurrencyBL implements ICurrencyBL
 			@NonNull final OrgId orgId)
 	{
 		final CurrencyConversionContext conversionCtx = createCurrencyConversionContext(
-				(LocalDate)null, // convDate
+				null, // convDate
 				(CurrencyConversionTypeId)null, // C_ConversionType_ID,
 				clientId,
 				orgId);
@@ -197,10 +196,6 @@ public class CurrencyBL implements ICurrencyBL
 				amt,
 				currencyFromId,
 				currencyToId);
-		if (conversionResult == null)
-		{
-			return null;
-		}
 		return conversionResult.getAmount();
 	}
 

--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MCash.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MCash.java
@@ -438,11 +438,6 @@ public class MCash extends X_C_Cash implements IDocument
 						(CurrencyConversionTypeId)null,
 						ClientId.ofRepoId(getAD_Client_ID()),
 						OrgId.ofRepoId(getAD_Org_ID()));
-				if (amt == null)
-				{
-					m_processMsg = "No Conversion Rate found - @C_CashLine_ID@= " + line.getLine();
-					return IDocument.STATUS_Invalid;
-				}
 				difference = difference.add(amt);
 			}
 		}

--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MInvoice.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MInvoice.java
@@ -24,10 +24,8 @@ import de.metas.bpartner.service.IBPartnerDAO;
 import de.metas.bpartner.service.IBPartnerStatsBL;
 import de.metas.bpartner.service.IBPartnerStatsDAO;
 import de.metas.cache.CCache;
-import de.metas.currency.Currency;
 import de.metas.currency.CurrencyPrecision;
 import de.metas.currency.ICurrencyBL;
-import de.metas.currency.ICurrencyDAO;
 import de.metas.document.DocTypeId;
 import de.metas.document.IDocTypeDAO;
 import de.metas.document.engine.DocStatus;
@@ -35,7 +33,6 @@ import de.metas.document.engine.IDocument;
 import de.metas.document.engine.IDocumentBL;
 import de.metas.document.sequence.IDocumentNoBuilder;
 import de.metas.document.sequence.IDocumentNoBuilderFactory;
-import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.Msg;
 import de.metas.invoice.InvoiceId;
 import de.metas.invoice.service.IInvoiceBL;
@@ -101,8 +98,6 @@ import static org.adempiere.util.CustomColNames.C_Invoice_ISUSE_BPARTNER_ADDRESS
 @SuppressWarnings("serial")
 public class MInvoice extends X_C_Invoice implements IDocument
 {
-	private static final AdMessageKey ERR_NoBaseConversionBetweenCurrencies = AdMessageKey.of("NoBaseConversionBetweenCurrencies");
-
 	/**
 	 * Get Payments Of BPartner
 	 *
@@ -1184,32 +1179,6 @@ public class MInvoice extends X_C_Invoice implements IDocument
 			}
 		}    // for all lines
 
-		// verify that we can deal with the invoice's currency
-		// Update total revenue and balance / credit limit (reversed on AllocationLine.processIt)
-		final BigDecimal invAmt = Services.get(ICurrencyBL.class).convertBase(
-				getGrandTotal(true),    // CM adjusted
-				CurrencyId.ofRepoId(getC_Currency_ID()),
-				TimeUtil.asLocalDate(getDateAcct()),
-				CurrencyConversionTypeId.ofRepoIdOrNull(getC_ConversionType_ID()),
-				ClientId.ofRepoId(getAD_Client_ID()),
-				OrgId.ofRepoId(getAD_Org_ID()));
-
-		if (invAmt == null)
-		{
-			final Currency currency = Services.get(ICurrencyDAO.class).getById(CurrencyId.ofRepoId(getC_Currency_ID()));
-			final Currency currencyTo = Services.get(ICurrencyBL.class).getBaseCurrency(ClientId.ofRepoId(getAD_Client_ID()), OrgId.ofRepoId(getAD_Org_ID()));
-
-			final IBPartnerDAO bpartnerDAO = Services.get(IBPartnerDAO.class);
-			final I_C_BPartner bpartner = bpartnerDAO.getById(getC_BPartner_ID());
-
-			throw new AdempiereException(
-					ERR_NoBaseConversionBetweenCurrencies,
-					bpartner.getName(),
-					bpartner.getValue(),
-					currency.getCurrencyCode().toThreeLetterCode(),
-					currencyTo.getCurrencyCode().toThreeLetterCode());
-		}
-
 		// Update Project
 		if (isSOTrx() && getC_Project_ID() > 0)
 		{
@@ -1226,10 +1195,6 @@ public class MInvoice extends X_C_Invoice implements IDocument
 						(CurrencyConversionTypeId)null,
 						ClientId.ofRepoId(getAD_Client_ID()),
 						OrgId.ofRepoId(getAD_Org_ID()));
-			}
-			if (amt == null)
-			{
-				throw new AdempiereException("Could not convert C_Currency_ID=" + getC_Currency_ID() + " to Project C_Currency_ID=" + C_CurrencyTo_ID);
 			}
 			BigDecimal newAmt = project.getInvoicedAmt();
 			if (newAmt == null)

--- a/backend/de.metas.business/src/main/java/de/metas/costing/methods/CostingMethodHandlerUtils.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/methods/CostingMethodHandlerUtils.java
@@ -215,6 +215,7 @@ public class CostingMethodHandlerUtils
 		return CostAmount.of(result.getAmount(), acctCurrencyId);
 	}
 
+	@NonNull
 	public CurrencyConversionResult convert(
 			final CurrencyConversionContext conversionCtx,
 			final Money price,

--- a/backend/de.metas.business/src/main/java/de/metas/customs/CustomsInvoiceService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/customs/CustomsInvoiceService.java
@@ -248,11 +248,6 @@ public class CustomsInvoiceService
 				Env.getClientId(),
 				Env.getOrgId());
 
-		if (shipmentLinePriceConverted == null)
-		{
-			throw new AdempiereException("Please, add a conversion between the following currencies: " + priceActual.getCurrencyId() + ", " + currencyId);
-		}
-
 		return priceActual.toBuilder().money(Money.of(shipmentLinePriceConverted, currencyId)).build();
 	}
 

--- a/backend/de.metas.business/src/main/java/de/metas/money/MoneyService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/money/MoneyService.java
@@ -22,7 +22,6 @@ import de.metas.product.ProductPrice;
 import de.metas.quantity.Quantity;
 import de.metas.uom.IUOMConversionBL;
 import de.metas.uom.UOMConversionContext;
-import de.metas.util.Check;
 import de.metas.util.Services;
 import de.metas.util.lang.Percent;
 import de.metas.util.time.SystemTime;
@@ -101,12 +100,7 @@ public class MoneyService
 				money.getCurrencyId(),
 				targetCurrencyId);
 
-		final BigDecimal convertedAmount = Check.assumeNotNull(
-				conversionResult.getAmount(),
-				"CurrencyConversion from currencyId={} to currencyId={} needs to work; currencyConversionContext={}, currencyConversionResult={}",
-				money.getCurrencyId(), targetCurrencyId, currencyConversionContext, conversionResult);
-
-		return Money.of(convertedAmount, targetCurrencyId);
+		return Money.of(conversionResult.getAmount(), targetCurrencyId);
 	}
 
 	public Money percentage(@NonNull final Percent percent, @NonNull final Money input)

--- a/backend/de.metas.business/src/main/java/de/metas/order/OrderFreightCostsService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/OrderFreightCostsService.java
@@ -163,11 +163,6 @@ public class OrderFreightCostsService
 				Env.getClientId(),
 				Env.getOrgId());
 
-		if (freightAmtConverted == null)
-		{
-			throw new AdempiereException("Please, add a conversion between the following currencies: " + freightCostCurrencyId + ", " + orderCurrencyId);
-		}
-
 		final Money convertedFreightAmt = Money.of(freightAmtConverted, orderCurrencyId);
 
 		return convertedFreightAmt;


### PR DESCRIPTION
Avoid NPE in case of missing currency conversion. Instead throw a much more understandable exception.

The triggering exception was:
```
de.metas.acct.doc.PostingException: NullPointerException
 Buchungsstatus: Verbuchungs-Fehler (Error)
 Belegnummer: MMatchPO[1004524,Qty=26.00000,C_OrderLine_ID=1042334,M_InOutLine_ID=1030499,C_InvoiceLine_ID=0]
 Preserve Posted status: false
Additional parameters:
 issueCategory: ACCOUNTING
 recordRef: TableRecordReference{tableName=M_MatchPO, recordId=1004524}
	at org.compiere.acct.Doc.newPostingException(Doc.java:1844)
	at org.compiere.acct.Doc$1.doCatch(Doc.java:376)
	at org.adempiere.ad.trx.api.impl.TrxCallableWrappers$3.doCatch(TrxCallableWrappers.java:160)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.call0(AbstractTrxManager.java:786)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.call(AbstractTrxManager.java:666)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.call(AbstractTrxManager.java:567)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.call(AbstractTrxManager.java:498)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.run(AbstractTrxManager.java:484)
	at org.adempiere.ad.trx.api.ITrxManager.runInThreadInheritedTrx(ITrxManager.java:218)
	at de.metas.acct.doc.AcctDocRequiredServicesFacade.runInThreadInheritedTrx(AcctDocRequiredServicesFacade.java:147)
	at org.compiere.acct.Doc.post(Doc.java:363)
	at de.metas.acct.api.impl.PostingRequestBuilder.postIt_Directly(PostingRequestBuilder.java:178)
	at de.metas.acct.api.impl.PostingRequestBuilder.invokeRunnable(PostingRequestBuilder.java:398)
	at de.metas.acct.api.impl.PostingRequestBuilder.lambda$postAfterTrxCommit$0(PostingRequestBuilder.java:391)
	at org.adempiere.ad.trx.api.impl.AutoCommitTrxListenerManager.execute(AutoCommitTrxListenerManager.java:72)
	at org.adempiere.ad.trx.api.impl.AutoCommitTrxListenerManager.registerListener(AutoCommitTrxListenerManager.java:48)
	at org.adempiere.ad.trx.api.ITrxListenerManager$RegisterListenerRequest.registerHandlingMethod(ITrxListenerManager.java:140)
	at de.metas.acct.api.impl.PostingRequestBuilder.postAfterTrxCommit(PostingRequestBuilder.java:391)
	at de.metas.acct.api.impl.PostingRequestBuilder.postIt(PostingRequestBuilder.java:127)
	at de.metas.acct.posting.server.AccountingService.handleRequest(AccountingService.java:64)
	at de.metas.acct.posting.DocumentPostingBusService$DocumentPostRequestHandlerAsEventListener.handleRequest(DocumentPostingBusService.java:154)
	at de.metas.acct.posting.DocumentPostingBusService$DocumentPostRequestHandlerAsEventListener.lambda$onEvent$0(DocumentPostingBusService.java:147)
	at de.metas.event.log.EventLogUserService.invokeHandlerAndLog(EventLogUserService.java:164)
	at de.metas.acct.posting.DocumentPostingBusService$DocumentPostRequestHandlerAsEventListener.onEvent(DocumentPostingBusService.java:145)
	at de.metas.event.impl.EventBus.invokeEventListenerWithLogging(EventBus.java:329)
	at de.metas.event.impl.EventBus.invokeEventListener(EventBus.java:315)
	at de.metas.event.impl.EventBus.access$200(EventBus.java:58)
	at de.metas.event.impl.EventBus$GuavaEventListenerAdapter.onEvent(EventBus.java:304)
	at sun.reflect.GeneratedMethodAccessor142.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at reflect.Method.invoke(Method.java:498)
	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
	at de.metas.event.impl.EventBus.postEvent(EventBus.java:250)
	at de.metas.acct.posting.DocumentPostingBusService.postRequest(DocumentPostingBusService.java:75)
	at de.metas.acct.api.impl.PostingRequestBuilder.postIt_Enqueue(PostingRequestBuilder.java:148)
	at de.metas.acct.api.impl.PostingRequestBuilder.invokeRunnable(PostingRequestBuilder.java:398)
	at de.metas.acct.api.impl.PostingRequestBuilder.lambda$postAfterTrxCommit$0(PostingRequestBuilder.java:391)
	at org.adempiere.ad.trx.api.impl.AutoCommitTrxListenerManager.execute(AutoCommitTrxListenerManager.java:72)
	at org.adempiere.ad.trx.api.impl.AutoCommitTrxListenerManager.registerListener(AutoCommitTrxListenerManager.java:48)
	at org.adempiere.ad.trx.api.ITrxListenerManager$RegisterListenerRequest.registerHandlingMethod(ITrxListenerManager.java:140)
	at de.metas.acct.api.impl.PostingRequestBuilder.postAfterTrxCommit(PostingRequestBuilder.java:391)
	at de.metas.acct.api.impl.PostingRequestBuilder.postIt(PostingRequestBuilder.java:116)
	at de.metas.acct.posting.server.accouting_docs_to_repost_db_table.AccoutingDocsToRepostDBTableWatcher.enqueueForReposting(AccoutingDocsToRepostDBTableWatcher.java:125)
	at de.metas.acct.posting.server.accouting_docs_to_repost_db_table.AccoutingDocsToRepostDBTableWatcher.enqueueAllForReposting(AccoutingDocsToRepostDBTableWatcher.java:104)
	at de.metas.acct.posting.server.accouting_docs_to_repost_db_table.AccoutingDocsToRepostDBTableWatcher.run(AccoutingDocsToRepostDBTableWatcher.java:79)
	at Thread.run(Thread.java:748)
Caused by: NullPointerException
	at de.metas.costing.impl.CostingService.convertToAcctSchemaCurrency(CostingService.java:219)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.stream.Streams$StreamBuilderImpl.forEachRemaining(Streams.java:419)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485)
	at java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:272)
	at java.util.stream.Streams$StreamBuilderImpl.forEachRemaining(Streams.java:419)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:566)
	at de.metas.costing.impl.CostingService.createCostDetail(CostingService.java:138)
	at de.metas.acct.doc.AcctDocRequiredServicesFacade.createCostDetail(AcctDocRequiredServicesFacade.java:295)
	at org.compiere.acct.DocLine_MatchPO.createCostDetails(DocLine_MatchPO.java:141)
	at org.compiere.acct.Doc_MatchPO.createFacts(Doc_MatchPO.java:110)
	at org.compiere.acct.Doc.postLogic(Doc.java:566)
	at org.compiere.acct.Doc.post0(Doc.java:477)
	at org.compiere.acct.Doc.access$000(Doc.java:158)
	at org.compiere.acct.Doc$1.run(Doc.java:370)
	at org.adempiere.ad.trx.api.impl.TrxCallableWrappers$3.call(TrxCallableWrappers.java:147)
	at org.adempiere.ad.trx.api.impl.TrxCallableWrappers$3.call(TrxCallableWrappers.java:137)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.call0(AbstractTrxManager.java:753)
	... 48 more
```