### PR TITLE
No longer reset `R_Request.EndTime` when a Request is saved

### DIFF
--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MRequest.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MRequest.java
@@ -603,7 +603,6 @@ public class MRequest extends X_R_Request
 			// Reset
 			setConfidentialTypeEntry(getConfidentialType());
 			// setStartDate(null); //red1 - bug [ 1743159 ] Requests - Start Date is not retained.
-			setEndTime(null);
 			setR_StandardResponse_ID(0);
 			setR_MailText_ID(0);
 			setResult(null);


### PR DESCRIPTION
https://github.com/metasfresh/metasfresh/issues/10228
Signed-off-by: TheBestPessimist <cristian@tbp.land>