### PR TITLE
Fix ZoomInto path in the handleZoomInto function to use the entity

### DIFF
--- a/frontend/src/components/widget/MasterWidget.js
+++ b/frontend/src/components/widget/MasterWidget.js
@@ -217,17 +217,23 @@ class MasterWidget extends PureComponent {
    * @param {*} field
    */
   handleZoomInto = (field) => {
-    const { dataId, windowId, tabId, rowId } = this.props;
+    const { dataId, windowId, tabId, rowId, entity } = this.props;
+    const fallBackEntity = entity ? entity : 'window';
 
-    getZoomIntoWindow('window', windowId, dataId, tabId, rowId, field).then(
-      (res) => {
-        const url = `/window/${res.data.documentPath.windowId}/${
-          res.data.documentPath.documentId
-        }`;
+    getZoomIntoWindow(
+      fallBackEntity,
+      windowId,
+      dataId,
+      tabId,
+      rowId,
+      field
+    ).then((res) => {
+      const url = `/${fallBackEntity}/${res.data.documentPath.windowId}/${
+        res.data.documentPath.documentId
+      }`;
 
-        res && res.data && window.open(url, '_blank');
-      }
-    );
+      res && res.data && window.open(url, '_blank');
+    });
   };
 
   /**


### PR DESCRIPTION
Calls too zoomInto was done like 

```
rest//api/window/ADP_541124/1120502/field/AD_UserGroup_ID/zoomInto
```

After this PR is merged it will use the actual entity for forming the zoomInto path:
```
rest//api/process/ADP_541124/1120502/field/AD_UserGroup_ID/zoomInto
```

Even if this does not exist yet in the BE it fixes the frontend part.

https://www.loom.com/share/dc681d2049714ee4a2411ae1e4c785d9