### PR TITLE
redistribute syncadvise when creating bpartner from olcand-bpartnerinfo

### DIFF
--- a/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/ordercandidates/impl/OrderCandidatesRestControllerImplTest.java
+++ b/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/ordercandidates/impl/OrderCandidatesRestControllerImplTest.java
@@ -122,7 +122,6 @@ import static io.github.jsonSnapshot.SnapshotMatcher.expect;
 import static io.github.jsonSnapshot.SnapshotMatcher.start;
 import static io.github.jsonSnapshot.SnapshotMatcher.validateSnapshots;
 import static org.adempiere.model.InterfaceWrapperHelper.load;
-import static org.adempiere.model.InterfaceWrapperHelper.save;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -1165,7 +1164,7 @@ public class OrderCandidatesRestControllerImplTest
 				.countryId(countryId_DE)
 				.shipTo(false)
 				.billTo(true)
-				.billToDefault(false)
+				.billToDefault(false) // we will expect this to be updated to true by the json-request
 				.shipToDefault(false)
 				.build();
 		testMasterdata.prepareBPartnerLocation().bpartnerId(bpartnerId)
@@ -1181,7 +1180,7 @@ public class OrderCandidatesRestControllerImplTest
 				.countryId(countryId_DE)
 				.shipTo(false)
 				.billTo(true)
-				.billToDefault(false)
+				.billToDefault(true) //  we will expect this to be updated to false when "billToId-1-2" is updated to true
 				.shipToDefault(false)
 				.build();
 		testMasterdata.prepareBPartnerLocation().bpartnerId(bpartnerId)
@@ -1220,12 +1219,16 @@ public class OrderCandidatesRestControllerImplTest
 		assertThat(result.getBody().getResult()).hasSize(1);
 
 		final JsonOLCand jsonOLCand = result.getBody().getResult().get(0);
+
+		//bpartner's location
 		assertThat(jsonOLCand.getBpartner().getLocation())
 				.extracting("externalId.value", "billTo", "billToDefault", "shipTo")
 				.containsExactly("billToId-1-2", true, true, false);
+		//billBPartner's location
 		assertThat(jsonOLCand.getBillBPartner().getLocation())
 				.extracting("externalId.value", "billTo", "billToDefault", "shipTo")
 				.containsExactly("billToId-1-2", true, true, false);
+		//dropShipBPartner's location
 		assertThat(jsonOLCand.getDropShipBPartner().getLocation())
 				.extracting("externalId.value", "billTo", "billToDefault", "shipTo")
 				.containsExactly("shipToId-1-2", false, false, true);

--- a/backend/de.metas.business.rest-api-impl/src/test/resources/de/metas/rest_api/ordercandidates/impl/OrderCandidatesRestControllerImplTest_Create_UpdateMerge_1.json
+++ b/backend/de.metas.business.rest-api-impl/src/test/resources/de/metas/rest_api/ordercandidates/impl/OrderCandidatesRestControllerImplTest_Create_UpdateMerge_1.json
@@ -33,7 +33,7 @@
 			"shipTo": "false",
 			"syncAdvise": {
 				"ifNotExists": "CREATE",
-				"ifExists": "DONT_UPDATE"
+				"ifExists": "UPDATE_MERGE"
 			}
 		},
 		"contact": {
@@ -46,12 +46,12 @@
 			"email": "first_last@mail.org",
 			"syncAdvise": {
 				"ifNotExists": "CREATE",
-				"ifExists": "DONT_UPDATE"
+				"ifExists": "UPDATE_MERGE"
 			}
 		},
 		"syncAdvise": {
 			"ifNotExists": "CREATE",
-			"ifExists": "UPDATE_MERGE"
+			"ifExists": "DONT_UPDATE"
 		}
 	},
 	"billBPartner": {


### PR DESCRIPTION
the olcand's bpartners' "inner" syncadvices are now applied on the bpartner-request's middle level.
That way a user can specify a bpartner to be not updated, but new locators or contacts to be inserted if they don't yet exist