### PR TITLE
Adapts to fix the patching on hitting the Done button

### DIFF
--- a/frontend/src/components/app/Modal.js
+++ b/frontend/src/components/app/Modal.js
@@ -266,11 +266,11 @@ class Modal extends Component {
       closeCallback,
       dataId,
       windowId,
-      parentWindowId,
       parentDataId,
       triggerField,
       rowId,
       tabId,
+      documentType,
     } = this.props;
     const { isNew, isNewDoc } = this.state;
 
@@ -279,7 +279,7 @@ class Modal extends Component {
         dispatch(
           patch(
             'window',
-            parentWindowId,
+            documentType,
             parentDataId,
             null,
             null,


### PR DESCRIPTION
https://github.com/metasfresh/metasfresh/issues/10434

https://www.loom.com/share/79c989f2079344db91760aae2633eedc

Issue was introduced due to the removal of the parentWindowId in here https://github.com/metasfresh/metasfresh/pull/10392/files#diff-ddc5443e1773de9663c1851d07cbcc645f69f2065aea13b2aa8ffc37e9014808L125

Fixed by replacing and using the documentType instead to preserve the functionality.