### PR TITLE
Set the testing port to a higher one to avoid collitions

### DIFF
--- a/frontend/src/__tests__/containers/MasterWindow.test.js
+++ b/frontend/src/__tests__/containers/MasterWindow.test.js
@@ -13,6 +13,7 @@ import { waitFor } from '@testing-library/dom';
 import { createWaitForElement } from 'enzyme-wait';
 import hotkeys from '../../../test_setup/fixtures/hotkeys.json';
 import keymap from '../../../test_setup/fixtures/keymap.json';
+import { serverTestPort } from '../../../test_setup/jestSetup';
 
 import http from 'http';
 import StompServer from 'stomp-broker-js';
@@ -100,7 +101,7 @@ describe('MasterWindowContainer', () => {
         path: '/ws',
       });
 
-      server.listen(8080);
+      server.listen(serverTestPort); // this is defined in the jestSetup file
     });
 
     // afterEach stop server

--- a/frontend/test_setup/jestSetup.js
+++ b/frontend/test_setup/jestSetup.js
@@ -51,6 +51,8 @@ window.HTMLDivElement.prototype.getBoundingClientRect = function() {
 //   console.log('EXCEPTION', err);
 // });
 
+export const serverTestPort = '10001'; // everything from 10000-65535 should be fine, setting it lower could make it collide with other open ports
+
 global.EventSource = EventSource;
 global.window = window;
 global.document = window.document;
@@ -60,6 +62,6 @@ global.render = render;
 global.mount = mount;
 global.config = {
   API_URL: 'http://api.test.url/rest/api',
-  WS_URL: 'ws://localhost:8080/ws',
+  WS_URL: `ws://localhost:${serverTestPort}/ws`,
 };
 global.PLUGINS = [];


### PR DESCRIPTION
https://github.com/metasfresh/metasfresh/issues/10436

https://www.loom.com/share/29d2c6ae66fd465ab8e3ca7ec26580e4