### PR TITLE
#gh10501 bug fixes

### DIFF
--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/payment/JsonPaymentService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/payment/JsonPaymentService.java
@@ -158,7 +158,6 @@ public class JsonPaymentService
 				if (!Check.isEmpty(orderIdentifier))
 				{
 					final Optional<String> externalOrderId = getExternalOrderIdFromIdentifier(IdentifierString.of(orderIdentifier), orgId);
-					Check.assumeNotEmpty(externalOrderId, "Could not find externalOrderId for identifier: " + orderIdentifier);
 					payment.setExternalOrderId(externalOrderId.orElseGet(null));
 				}
 				payment.setIsAutoAllocateAvailableAmt(true);
@@ -193,7 +192,8 @@ public class JsonPaymentService
 		for (final JsonPaymentAllocationLine line : lines)
 		{
 			final String invoiceId = line.getInvoiceIdentifier();
-			final DocBaseAndSubType docType = DocBaseAndSubType.of(line.getDocBaseType(), line.getDocSubType());
+			final String docBaseType = line.getDocBaseType();
+			final DocBaseAndSubType docType = Check.isBlank(docBaseType) ? null : DocBaseAndSubType.of(docBaseType, line.getDocSubType());
 			final Optional<InvoiceId> invoice = retrieveInvoice(IdentifierString.of(invoiceId), OrgId.ofRepoIdOrNull(orgId), docType);
 			Check.assumeNotEmpty(invoice, "Cannot find invoice for identifier: " + invoiceId);
 			allocationBuilder.addLine()

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/payment/JsonPaymentService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/payment/JsonPaymentService.java
@@ -56,6 +56,7 @@ import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_Payment;
 import org.compiere.util.Env;
 import org.compiere.util.TrxRunnableAdapter;
@@ -104,7 +105,7 @@ public class JsonPaymentService
 			return ResponseEntity.unprocessableEntity().body("Wrong currency: " + jsonInboundPaymentInfo.getCurrencyCode());
 		}
 
-		final OrgId orgId = retrieveOrg(jsonInboundPaymentInfo);
+		final OrgId orgId = retrieveOrg(jsonInboundPaymentInfo.getOrgCode());
 		if (!orgId.isRegular())
 		{
 			return ResponseEntity.unprocessableEntity().body("Cannot find the orgId from either orgCode=" + jsonInboundPaymentInfo.getOrgCode() + " or the current user's context.");
@@ -154,11 +155,22 @@ public class JsonPaymentService
 						.externalId(externalId)
 						.createAndProcess();
 
-				final String orderIdentifier = jsonInboundPaymentInfo.getOrderIdentifier();
-				if (!Check.isEmpty(orderIdentifier))
+				final String orderIdentifierString = jsonInboundPaymentInfo.getOrderIdentifier();
+				if (!Check.isEmpty(orderIdentifierString))
 				{
-					final Optional<String> externalOrderId = getExternalOrderIdFromIdentifier(IdentifierString.of(orderIdentifier), orgId);
-					payment.setExternalOrderId(externalOrderId.orElseGet(null));
+					final IdentifierString orderIdentifier = IdentifierString.of(orderIdentifierString);
+					if (orderIdentifier.getType().equals(IdentifierString.Type.EXTERNAL_ID))
+					{
+						payment.setExternalOrderId(orderIdentifier.asExternalId().getValue());
+					}
+					else
+					{
+						final Optional<I_C_Order> potentialOrder = getOrderIdFromIdentifier(orderIdentifier, orgId);
+						Check.assumeNotEmpty(potentialOrder, "Could not find order for identifier: " + orderIdentifierString);
+						final I_C_Order order = potentialOrder.get();
+						payment.setExternalOrderId(order.getExternalId());
+						payment.setC_Order_ID(order.getC_Order_ID());
+					}
 				}
 				payment.setIsAutoAllocateAvailableAmt(true);
 				InterfaceWrapperHelper.save(payment);
@@ -219,13 +231,13 @@ public class JsonPaymentService
 		return !Check.isEmpty(lines) && lines.stream().anyMatch(line -> Check.isEmpty(line.getAmount()));
 	}
 
-	private OrgId retrieveOrg(@RequestBody @NonNull final JsonInboundPaymentInfo jsonInboundPaymentInfo)
+	private OrgId retrieveOrg(@Nullable final String orgCode)
 	{
 		final Optional<OrgId> orgId;
-		if (Check.isNotBlank(jsonInboundPaymentInfo.getOrgCode()))
+		if (Check.isNotBlank(orgCode))
 		{
 			final OrgQuery query = OrgQuery.builder()
-					.orgValue(jsonInboundPaymentInfo.getOrgCode())
+					.orgValue(orgCode)
 					.build();
 			orgId = orgDAO.retrieveOrgIdBy(query);
 		}
@@ -268,9 +280,9 @@ public class JsonPaymentService
 		}
 	}
 
-	private Optional<String> getExternalOrderIdFromIdentifier(final IdentifierString orderIdentifier, final OrgId orgId)
+	private Optional<I_C_Order> getOrderIdFromIdentifier(final IdentifierString orderIdentifier, final OrgId orgId)
 	{
-		return orderDAO.retrieveExternalIdByOrderCriteria(createOrderQuery(orderIdentifier, orgId));
+		return orderDAO.retrieveByOrderCriteria(createOrderQuery(orderIdentifier, orgId));
 	}
 
 	private OrderQuery createOrderQuery(final IdentifierString identifierString, final OrgId orgId)

--- a/backend/de.metas.business/src/main/java/de/metas/order/IOrderDAO.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/IOrderDAO.java
@@ -115,7 +115,7 @@ public interface IOrderDAO extends ISingletonService
 
 	/**
 	 * @param order
-	 * @param line
+	 * @param lineNo
 	 * @param clazz
 	 */
 	<T extends org.compiere.model.I_C_OrderLine> T retrieveOrderLine(I_C_Order order, int lineNo, Class<T> clazz);
@@ -164,5 +164,5 @@ public interface IOrderDAO extends ISingletonService
 
 	void save(org.compiere.model.I_C_OrderLine orderLine);
 
-	Optional<String> retrieveExternalIdByOrderCriteria(OrderQuery query);
+	Optional<I_C_Order> retrieveByOrderCriteria(OrderQuery query);
 }

--- a/backend/de.metas.business/src/main/java/de/metas/order/impl/AbstractOrderDAO.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/impl/AbstractOrderDAO.java
@@ -3,14 +3,12 @@ package de.metas.order.impl;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import de.metas.adempiere.model.I_C_Invoice;
 import de.metas.bpartner.BPartnerId;
 import de.metas.cache.annotation.CacheCtx;
 import de.metas.cache.annotation.CacheTrx;
 import de.metas.document.DocBaseAndSubType;
 import de.metas.document.engine.DocStatus;
 import de.metas.interfaces.I_C_OrderLine;
-import de.metas.invoice.InvoiceId;
 import de.metas.order.IOrderDAO;
 import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderId;
@@ -340,24 +338,20 @@ public abstract class AbstractOrderDAO implements IOrderDAO
 		InterfaceWrapperHelper.save(orderLine);
 	}
 
-	public Optional<String> retrieveExternalIdByOrderCriteria(@NonNull final OrderQuery query)
+	public Optional<I_C_Order> retrieveByOrderCriteria(@NonNull final OrderQuery query)
 	{
 		if (query.getOrderId() != null)
 		{
-			return Optional.ofNullable(InterfaceWrapperHelper.load(query.getOrderId(), I_C_Order.class).getExternalId());
-		}
-		if (query.getExternalId() != null)
-		{
-			return Optional.of(query.getExternalId().getValue());
+			return Optional.ofNullable(InterfaceWrapperHelper.load(query.getOrderId(), I_C_Order.class));
 		}
 		if (Check.isNotBlank(query.getDocumentNo()))
 		{
-			return Optional.ofNullable(getExternalIdByDocumentNo(query));
+			return Optional.ofNullable(getOrderByDocumentNumberQuery(query));
 		}
 		return Optional.empty();
 	}
 
-	private String getExternalIdByDocumentNo(final OrderQuery query)
+	private I_C_Order getOrderByDocumentNumberQuery(final OrderQuery query)
 	{
 		final String documentNo = assumeNotNull(query.getDocumentNo(), "Param query needs to have a non-null document number; query={}", query);
 		final OrgId orgId = assumeNotNull(query.getOrgId(), "Param query needs to have a non-null orgId; query={}", query);
@@ -370,6 +364,6 @@ public abstract class AbstractOrderDAO implements IOrderDAO
 				.addEqualsFilter(I_C_Order.COLUMNNAME_C_DocType_ID, NumberUtils.asInt(docType.getDocBaseType(), -1));
 
 		final I_C_Order order = queryBuilder.create().firstOnly(I_C_Order.class);
-		return order == null ? null : order.getExternalId();
+		return order == null ? null : order;
 	}
 }

--- a/misc/de-metas-common/de-metas-common-rest_api/src/main/java/de/metas/common/rest_api/payment/JsonInboundPaymentInfo.java
+++ b/misc/de-metas-common/de-metas-common-rest_api/src/main/java/de/metas/common/rest_api/payment/JsonInboundPaymentInfo.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 @Value
@@ -115,7 +116,7 @@ public class JsonInboundPaymentInfo
 	{
 
 		final List<JsonPaymentAllocationLine> lines = getLines();
-		return lines == null ? BigDecimal.ZERO : lines.stream().map(lineToPayAmt).filter(amt -> amt != null).reduce(BigDecimal.ZERO, BigDecimal::add);
+		return lines == null ? BigDecimal.ZERO : lines.stream().map(lineToPayAmt).filter(Objects::nonNull).reduce(BigDecimal.ZERO, BigDecimal::add);
 	}
 
 }


### PR DESCRIPTION
Allow a blank docBaseType if not using doc- as IdentifierString
If OrderIdentifier is of type external, persist to C_Payment.ExternalId;
if OrderIdentifier is not of type external retrieve and persist C_Payment.ExternalId and C_Payment.C_Order_ID
https://github.com/metasfresh/metasfresh/issues/10501