### PR TITLE
Don't show doc actions when they shouldn't be visible

### DIFF
--- a/frontend/src/containers/MasterWindow.js
+++ b/frontend/src/containers/MasterWindow.js
@@ -50,10 +50,10 @@ class MasterWindowContainer extends PureComponent {
   }
 
   componentWillUnmount() {
-    // const { clearMasterData } = this.props;
+    const { clearMasterData } = this.props;
 
-    // clearMasterData();
-    // this.deleteTabsTables();
+    clearMasterData();
+    this.deleteTabsTables();
     disconnectWS.call(this);
   }
 


### PR DESCRIPTION
Looks like this was disabled when I did some quick changes to unblock Petrica on his inline tab widget effort. So this looks like a temporary thing that should be reverted. 

https://github.com/metasfresh/metasfresh/pull/10301/commits/d97d319b84ba30256c7f73d94f2371114d7d6664#diff-1cfcb26643fbe64684980f1488db853ee0b5abe32b52125ee175f6e9054bd87aL55

@petrican where can the inline tab be tested to be sure it's not affected ?