### PR TITLE
Update babel packages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.11.4",
-    "@babel/eslint-parser": "^7.13.0",
+    "@babel/eslint-parser": "7.13.0",
     "@babel/plugin-proposal-class-properties": "7.10.4",
     "@babel/plugin-proposal-object-rest-spread": "7.11.0",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",


### PR DESCRIPTION
Move us to the latest version of babel transpiler and eslint. Also update `axios` because of a critical security fix.