### PR TITLE
Properly refresh quick actions when parent selection changes

### DIFF
--- a/frontend/src/actions/TableActions.js
+++ b/frontend/src/actions/TableActions.js
@@ -675,20 +675,17 @@ function handleToggleIncludedView({
       );
     }
 
-    if (openIncludedViewOnSelect) {
-      dispatch(
-        showIncludedView({
-          id: windowId,
-          showIncludedView: showIncluded,
-          forceClose,
-          windowId: includedWindowId,
-          viewId: includedViewId,
-          isModal,
-        })
-      );
-    } else {
-      dispatch(fetchQuickActions({ windowId, viewId, isModal }));
-    }
+    dispatch(
+      showIncludedView({
+        id: windowId,
+        showIncludedView: showIncluded,
+        forceClose,
+        windowId: includedWindowId,
+        viewId: includedViewId,
+        isModal,
+      })
+    );
+    dispatch(fetchQuickActions({ windowId, viewId, isModal }));
 
     return Promise.resolve(openIncludedViewOnSelect);
   };


### PR DESCRIPTION
Will add a better test coverage in a separate PR, but we need this for the release.

Related to #10721 