### PR TITLE
Gh10778 - manufacturing improvements

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pporder/api/impl/hu_pporder_issue_producer/ReverseDraftIssues.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pporder/api/impl/hu_pporder_issue_producer/ReverseDraftIssues.java
@@ -1,5 +1,7 @@
 package de.metas.handlingunits.pporder.api.impl.hu_pporder_issue_producer;
 
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.sourcehu.SourceHUsService;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.IContextAware;
 
@@ -45,7 +47,8 @@ public class ReverseDraftIssues
 	private final transient IHUPPOrderQtyDAO huPPOrderQtyDAO = Services.get(IHUPPOrderQtyDAO.class);
 	private final transient IPPOrderProductAttributeDAO ppOrderProductAttributeDAO = Services.get(IPPOrderProductAttributeDAO.class);
 	private final transient IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
-	
+	private final transient SourceHUsService sourceHuService = SourceHUsService.get();
+
 	public void reverseDraftIssue(@NonNull final I_PP_Order_Qty candidate)
 	{
 		if (candidate.isProcessed())
@@ -67,6 +70,9 @@ public class ReverseDraftIssues
 		//
 		// Delete the candidate
 		huPPOrderQtyDAO.delete(candidate);
+
+		// Make sure the HU is marked as source
+		sourceHuService.addSourceHuMarker(HuId.ofRepoId(huToIssue.getM_HU_ID()));
 	}
 
 }

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/api/ManufacturingOrderDocumentReportAdvisor.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/api/ManufacturingOrderDocumentReportAdvisor.java
@@ -73,8 +73,8 @@ public class ManufacturingOrderDocumentReportAdvisor implements DocumentReportAd
 	{
 		final PPOrderId manufacturingOrderId = recordRef.getIdAssumingTableName(I_PP_Order.Table_Name, PPOrderId::ofRepoId);
 		final I_PP_Order manufacturingOrder = ppOrderBL.getById(manufacturingOrderId);
-		final BPartnerId bpartnerId = BPartnerId.ofRepoId(manufacturingOrder.getC_BPartner_ID());
-		final I_C_BPartner bpartner = util.getBPartnerById(bpartnerId);
+		final BPartnerId bpartnerId = BPartnerId.ofRepoIdOrNull(manufacturingOrder.getC_BPartner_ID());
+		final I_C_BPartner bpartner = bpartnerId == null? null: util.getBPartnerById(bpartnerId);
 
 		final DocTypeId docTypeId = extractDocTypeId(manufacturingOrder);
 		final I_C_DocType docType = util.getDocTypeById(docTypeId);
@@ -83,7 +83,8 @@ public class ManufacturingOrderDocumentReportAdvisor implements DocumentReportAd
 
 		final PrintFormatId printFormatId = CoalesceUtil.coalesceSuppliers(
 				() -> adPrintFormatToUseId,
-				() -> util.getBPartnerPrintFormats(bpartnerId).getPrintFormatIdByDocTypeId(docTypeId).orElse(null),
+				() -> bpartnerId == null ? null :
+						util.getBPartnerPrintFormats(bpartnerId).getPrintFormatIdByDocTypeId(docTypeId).orElse(null),
 				() -> PrintFormatId.ofRepoIdOrNull(docType.getAD_PrintFormat_ID()),
 				() -> util.getDefaultPrintFormats(clientId).getManufacturingOrderPrintFormatId());
 		if (printFormatId == null)
@@ -91,7 +92,7 @@ public class ManufacturingOrderDocumentReportAdvisor implements DocumentReportAd
 			throw new AdempiereException("@NotFound@ @AD_PrintFormat_ID@");
 		}
 
-		final Language language = util.getBPartnerLanguage(bpartner).orElse(null);
+		final Language language = bpartner == null? null : util.getBPartnerLanguage(bpartner).orElse(null);
 
 		return DocumentReportInfo.builder()
 				.recordRef(TableRecordReference.of(I_PP_Order.Table_Name, manufacturingOrderId))


### PR DESCRIPTION
- avoid NPE when printing manufacturing orders that have no partner
- use FIFO for the source CUs even when they were split from a bigger CU and then removed