### PR TITLE
fix getC_BPartner_Product_Details performances

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/dao/impl/QueryStatisticsLogger.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/dao/impl/QueryStatisticsLogger.java
@@ -225,7 +225,7 @@ public class QueryStatisticsLogger implements IQueryStatisticsLogger, IQueryStat
 		return validFrom;
 	}
 
-	private final void traceSqlQuery(final String sql, final Map<Integer, Object> sqlParams, final String trxName, final CountAndDuration duration)
+	private void traceSqlQuery(final String sql, final Map<Integer, Object> sqlParams, final String trxName, final CountAndDuration duration)
 	{
 		final Thread thread = Thread.currentThread();
 		final String threadName = thread.getName();
@@ -236,13 +236,13 @@ public class QueryStatisticsLogger implements IQueryStatisticsLogger, IQueryStat
 		final int count = traceSqlQueries_Count.incrementAndGet();
 		final String prefix = "-- SQL[" + count + "]-" + threadName + "-";
 		final String prefixSQL = "                 ";
-		final String nl = "\r\n";
+		final String nl = "\n";
 
 		final StringBuilder message = new StringBuilder();
 
 		//
 		// Duration
-		message.append("-- Duration: " + durationStr);
+		message.append("-- Duration: ").append(durationStr);
 
 		//
 		// Dump the stacktrace as short as possible
@@ -263,26 +263,24 @@ public class QueryStatisticsLogger implements IQueryStatisticsLogger, IQueryStat
 		{
 			final String sqlNorm = sql
 					.trim()
-					.replace(nl, "\n").replace("\n", nl); // make sure we always have \r\n
-			message.append(nl + sqlNorm);
+					.replace("\r\n", "\n").replace("\n", nl); // make sure we always have `nl`
+			message.append(nl).append(sqlNorm);
 		}
 
 		//
 		// SQL query parameters
 		if (sqlParams != null && !sqlParams.isEmpty())
 		{
-			message.append(nl + "-- Parameters[" + sqlParams.size() + "]: " + sqlParams);
+			message.append(nl + "-- Parameters[").append(sqlParams.size()).append("]: ").append(sqlParams);
 		}
 
 		//
 		// Print the message
-		logMessage(new StringBuilder()
-				.append("\n")
-				.append("\n" + prefix + "-begin---------------------------------------------------------------------------")
-				.append("\n" + prefixSQL + message.toString().replaceAll("\n", prefixSQL))
-				.append("\n" + prefix + "-end-----------------------------------------------------------------------------")
-				.append("\n")
-				.toString());
+		logMessage("\n"
+				+ "\n" + prefix + "-begin---------------------------------------------------------------------------"
+				+ "\n" + prefixSQL + message.toString().replaceAll("\n", "\n" + prefixSQL)
+				+ "\n" + prefix + "-end-----------------------------------------------------------------------------"
+				+ "\n");
 
 	}
 

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/getC_BPartner_Product_Details.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/getC_BPartner_Product_Details.sql
@@ -21,17 +21,6 @@ DECLARE
     requiredAttributeInstances        character varying[];
 BEGIN
     --
-    -- Fetch required attributes
-    IF (COALESCE(p_M_AttributeSetInstance_ID, 0) > 0) THEN
-        SELECT COALESCE(asi.attributeinstances, ARRAY []::character varying[])
-        INTO requiredAttributeInstances
-        FROM M_AttributeSetInstance_ID_AttributeInstances asi
-        WHERE asi.m_attributesetinstance_id = p_M_AttributeSetInstance_ID;
-    ELSE
-        requiredAttributeInstances := ARRAY []::character varying[];
-    END IF;
-
-    --
     -- Iterate C_BPartner_Product table
     FOR ProductNo, ProductName, bpp_asi_id, C_BPartner_Product_ID IN
         (SELECT DISTINCT ON (bpp.M_AttributeSetInstance_ID, bpp.ProductNo, bpp.ProductName) bpp.ProductNo,
@@ -89,7 +78,7 @@ $BODY$
 ;
 
 COMMENT ON FUNCTION de_metas_endcustomer_fresh_reports.getC_BPartner_Product_Details(numeric, numeric, numeric)
-    IS 'This function returns a C_BPartner_Product record with a matching matching given product-Id, bpartner-Id and p_M_AttributeSetInstance_ID.
+    IS 'This function returns a C_BPartner_Product record with a matching given product-Id, bpartner-Id and p_M_AttributeSetInstance_ID.
 For the attribute-set-instance-id to match, its array as returned by the view M_AttributeSetInstance_ID_AttributeInstances 
 needs to be included in the given p_M_AttributeSetInstance_ID''s M_AttributeSetInstance_ID_AttributeInstances-array.
 C_BPartner_Product records that have no M_AttributeSetInstance_ID match every p_M_AttributeSetInstance_ID.

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5581710_sys_getC_BPartner_Product_Details.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5581710_sys_getC_BPartner_Product_Details.sql
@@ -21,17 +21,6 @@ DECLARE
     requiredAttributeInstances        character varying[];
 BEGIN
     --
-    -- Fetch required attributes
-    IF (COALESCE(p_M_AttributeSetInstance_ID, 0) > 0) THEN
-        SELECT COALESCE(asi.attributeinstances, ARRAY []::character varying[])
-        INTO requiredAttributeInstances
-        FROM M_AttributeSetInstance_ID_AttributeInstances asi
-        WHERE asi.m_attributesetinstance_id = p_M_AttributeSetInstance_ID;
-    ELSE
-        requiredAttributeInstances := ARRAY []::character varying[];
-    END IF;
-
-    --
     -- Iterate C_BPartner_Product table
     FOR ProductNo, ProductName, bpp_asi_id, C_BPartner_Product_ID IN
         (SELECT DISTINCT ON (bpp.M_AttributeSetInstance_ID, bpp.ProductNo, bpp.ProductName) bpp.ProductNo,
@@ -89,7 +78,7 @@ $BODY$
 ;
 
 COMMENT ON FUNCTION de_metas_endcustomer_fresh_reports.getC_BPartner_Product_Details(numeric, numeric, numeric)
-    IS 'This function returns a C_BPartner_Product record with a matching matching given product-Id, bpartner-Id and p_M_AttributeSetInstance_ID.
+    IS 'This function returns a C_BPartner_Product record with a matching given product-Id, bpartner-Id and p_M_AttributeSetInstance_ID.
 For the attribute-set-instance-id to match, its array as returned by the view M_AttributeSetInstance_ID_AttributeInstances
 needs to be included in the given p_M_AttributeSetInstance_ID''s M_AttributeSetInstance_ID_AttributeInstances-array.
 C_BPartner_Product records that have no M_AttributeSetInstance_ID match every p_M_AttributeSetInstance_ID.

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5581710_sys_getC_BPartner_Product_Details.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5581710_sys_getC_BPartner_Product_Details.sql
@@ -90,12 +90,12 @@ $BODY$
 
 COMMENT ON FUNCTION de_metas_endcustomer_fresh_reports.getC_BPartner_Product_Details(numeric, numeric, numeric)
     IS 'This function returns a C_BPartner_Product record with a matching matching given product-Id, bpartner-Id and p_M_AttributeSetInstance_ID.
-For the attribute-set-instance-id to match, its array as returned by the view M_AttributeSetInstance_ID_AttributeInstances 
+For the attribute-set-instance-id to match, its array as returned by the view M_AttributeSetInstance_ID_AttributeInstances
 needs to be included in the given p_M_AttributeSetInstance_ID''s M_AttributeSetInstance_ID_AttributeInstances-array.
 C_BPartner_Product records that have no M_AttributeSetInstance_ID match every p_M_AttributeSetInstance_ID.
 If multiple C_BPartner_Product records match, the one with the lowest SeqNo is returned.
 
-Also see 
+Also see
 view M_AttributeSetInstance_ID_AttributeInstances and
 issue https://github.com/metasfresh/metasfresh/issues/4795'
 ;


### PR DESCRIPTION
Test SQL:
```sql
SELECT *
FROM de_metas_endcustomer_fresh_reports.getC_BPartner_Product_Details
    (2006673,2156884,0)
;
```



Execution plan before the fix:
![plan_before_fix](https://user-images.githubusercontent.com/1244701/110637528-27669f80-81b6-11eb-979d-3c8166530dc5.png)


Execution plan after fix:
![plan_after_fix](https://user-images.githubusercontent.com/1244701/110637661-4ebd6c80-81b6-11eb-9443-d908c4c5db4f.png)
