### PR TITLE
Fix e2e tests - flaky

### DIFF
--- a/e2e/cypress/support/commands/form.js
+++ b/e2e/cypress/support/commands/form.js
@@ -215,15 +215,28 @@ Cypress.Commands.add('writeIntoStringField', (fieldName, stringValue, modal, rew
   cy.log(`writeIntoStringField - fieldName=${fieldName}; stringValue=${stringValue}; modal=${modal}; patchUrlPattern=${patchUrlPattern}`);
 
   const path = createFieldPath(fieldName, modal);
+
   cy.get(path)
     .find('input')
-    .type('{selectall}')
-    .wait(500)
+    .type('{selectall}');
+
+  cy.get('.indicator-pending').should('not.exist');
+
+  cy.get(path)
+    .find('input')
     .type(stringValue, { delay: 20 });
+
+  // ^^ the Code above removes the flakyness and does not use wait !!!
+  //
+  // cy.get(path)
+  //   .find('input')
+  //   .type('{selectall}')
+  //   .wait(500)
+  //   .type(stringValue, { delay: 20 });
   // if a typed string has missing characters, maybe the delay of type is not good and we should try another workaround.
   // for more details see: https://github.com/cypress-io/cypress/issues/3817
   // If you are wondering why we are using the wait(500) above ^^
-  // Notes: 
+  // Notes:
   //  - we tried to used `delay` but that did not worked and made the tests to fail with chopped text
   //  - we picked the easiest solution, there are more complex solutions also but imply much allocated time to fix
   //    there is such solution documented in the link above (there are two links within to a blog) with event listeners on elements
@@ -350,7 +363,7 @@ Cypress.Commands.add('selectInListField', (fieldName, listValue, modal, rewriteU
 
   cy.get(path)
     .find('.input-dropdown')
-    .click();  // -- removed click as dropdown shows up when you clear and type
+    .click(); // -- removed click as dropdown shows up when you clear and type
 
   // no f*cki'n clue why it started going ape shit when there was the correct '.input-dropdown-list-option' here
   cy.get('.input-dropdown-list')


### PR DESCRIPTION
https://github.com/metasfresh/metasfresh/issues/10826

<img width="1662" alt="Screenshot 2021-03-17 at 15 17 46" src="https://user-images.githubusercontent.com/1708561/111474006-47590e80-8734-11eb-869a-625fa3480c83.png">

https://dashboard.cypress.io/projects/5yp4q1/runs/983/specs

There is only one test remaining that is failing due to a BE bug (opened issue for it https://github.com/metasfresh/mf15/issues/725)