### PR TITLE
Return even inactive C_BPartner_Locations at many places

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/IBPartnerDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/IBPartnerDAO.java
@@ -115,7 +115,7 @@ public interface IBPartnerDAO extends ISingletonService
 
 	/**
 	 * @deprecated in all cases i can imagine, if the caller has a {@code bpartnerLocationId}, they need the actual record, even if it is inactive.
-	 * Think e.g. of a completed shipment. Therefore, please consder using {@link #getBPartnerLocationByIdEvenInactive(BPartnerLocationId)} instead.
+	 * Think e.g. of a completed shipment. Therefore, please consider using {@link #getBPartnerLocationByIdEvenInactive(BPartnerLocationId)} instead.
 	 */
 	@Deprecated
 	I_C_BPartner_Location getBPartnerLocationById(BPartnerLocationId bpartnerLocationId);

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/IBPartnerDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/IBPartnerDAO.java
@@ -119,7 +119,7 @@ public interface IBPartnerDAO extends ISingletonService
 
 	I_C_BPartner_Location getBPartnerLocationByIdInTrx(BPartnerLocationId bpartnerLocationId);
 
-	boolean exists(BPartnerLocationId bpartnerLocationId);
+	boolean existsAndIsActive(BPartnerLocationId bpartnerLocationId);
 
 	List<I_C_BPartner_Location> retrieveBPartnerLocations(BPartnerId bpartnerId);
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/IBPartnerDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/IBPartnerDAO.java
@@ -113,6 +113,11 @@ public interface IBPartnerDAO extends ISingletonService
 
 	Optional<BPartnerLocationId> getBPartnerLocationIdByGln(BPartnerId bpartnerId, GLN gln);
 
+	/**
+	 * @deprecated in all cases i can imagine, if the caller has a {@code bpartnerLocationId}, they need the actual record, even if it is inactive.
+	 * Think e.g. of a completed shipment. Therefore, please consder using {@link #getBPartnerLocationByIdEvenInactive(BPartnerLocationId)} instead.
+	 */
+	@Deprecated
 	I_C_BPartner_Location getBPartnerLocationById(BPartnerLocationId bpartnerLocationId);
 	
 	I_C_BPartner_Location getBPartnerLocationByIdEvenInactive(BPartnerLocationId bpartnerLocationId);

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerBL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerBL.java
@@ -571,7 +571,7 @@ public class BPartnerBL implements IBPartnerBL
 			return "?";
 		}
 
-		final I_C_BPartner_Location bpLocation = bpartnersRepo.getBPartnerLocationById(bpartnerLocationId);
+		final I_C_BPartner_Location bpLocation = bpartnersRepo.getBPartnerLocationByIdEvenInactive(bpartnerLocationId);
 		return bpLocation != null ? bpLocation.getAddress() : "<" + bpartnerLocationId.getRepoId() + ">";
 	}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerDAO.java
@@ -411,7 +411,7 @@ public class BPartnerDAO implements IBPartnerDAO
 	}
 
 	@Override
-	public boolean exists(@NonNull final BPartnerLocationId bpartnerLocationId)
+	public boolean existsAndIsActive(@NonNull final BPartnerLocationId bpartnerLocationId)
 	{
 		return getBPartnerLocationById(bpartnerLocationId) != null;
 	}
@@ -518,11 +518,8 @@ public class BPartnerDAO implements IBPartnerDAO
 	@Override
 	public CountryId retrieveBPartnerLocationCountryId(@NonNull final BPartnerLocationId bpLocationId)
 	{
-		final I_C_BPartner_Location bpLocation = getBPartnerLocationById(bpLocationId);
-		if (bpLocation == null)
-		{
-			throw new AdempiereException(MSG_ADDRESS_INACTIVE).markAsUserValidationError();
-		}
+		final I_C_BPartner_Location bpLocation = getBPartnerLocationByIdEvenInactive(bpLocationId);
+
 		final LocationId locationId = LocationId.ofRepoId(bpLocation.getC_Location_ID());
 
 		final ILocationDAO locationRepos = Services.get(ILocationDAO.class);

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerDAO.java
@@ -413,7 +413,8 @@ public class BPartnerDAO implements IBPartnerDAO
 	@Override
 	public boolean existsAndIsActive(@NonNull final BPartnerLocationId bpartnerLocationId)
 	{
-		return getBPartnerLocationById(bpartnerLocationId) != null;
+		final I_C_BPartner_Location bPartnerLocationRecord = getBPartnerLocationByIdEvenInactive(bpartnerLocationId);
+		return bPartnerLocationRecord != null && bPartnerLocationRecord.isActive();
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerOrgBL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerOrgBL.java
@@ -106,7 +106,7 @@ public class BPartnerOrgBL implements IBPartnerOrgBL
 			return null;
 		}
 
-		final I_C_BPartner_Location bpLocation = Services.get(IBPartnerDAO.class).getBPartnerLocationById(orgBPLocationId);
+		final I_C_BPartner_Location bpLocation = Services.get(IBPartnerDAO.class).getBPartnerLocationByIdEvenInactive(orgBPLocationId);
 		if (bpLocation != null) // 03378 : Temporary. Will be removed when OrgBP_Location is mandatory.
 		{
 			return bpLocation.getC_Location();

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/impl/DocumentLocationBL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/impl/DocumentLocationBL.java
@@ -69,7 +69,7 @@ public class DocumentLocationBL implements IDocumentLocationBL
 			return;
 		}
 		final BPartnerLocationId bpartnerLocationId = BPartnerLocationId.ofRepoId(location.getC_BPartner_ID(), location.getC_BPartner_Location_ID());
-		final I_C_BPartner_Location bpartnerLocation = bpartnersRepo.getBPartnerLocationById(bpartnerLocationId);
+		final I_C_BPartner_Location bpartnerLocation = bpartnersRepo.getBPartnerLocationByIdEvenInactive(bpartnerLocationId);
 
 		final de.metas.adempiere.model.I_AD_User user;
 		if (location.getAD_User_ID() > 0)
@@ -204,7 +204,7 @@ public class DocumentLocationBL implements IDocumentLocationBL
 
 		
 		final BPartnerLocationId bpLocationId = BPartnerLocationId.ofRepoIdOrNull(docHandOverLocation.getHandOver_Partner_ID(), docHandOverLocation.getHandOver_Location_ID());
-		final I_C_BPartner_Location bpartnerLocation = bpartnerDAO.getBPartnerLocationById(bpLocationId);
+		final I_C_BPartner_Location bpartnerLocation = bpartnerDAO.getBPartnerLocationByIdEvenInactive(bpLocationId);
 
 		final de.metas.adempiere.model.I_AD_User user;
 		if (docHandOverLocation.getHandOver_User_ID() > 0)

--- a/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/ordercandidates/impl/MasterdataProviderTest.java
+++ b/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/ordercandidates/impl/MasterdataProviderTest.java
@@ -184,7 +184,8 @@ public class MasterdataProviderTest
 		final OrgInfo orgInfo = orgsRepo.getOrgInfoById(orgId);
 		assertThat(orgInfo.getOrgBPartnerLocationId()).isNotNull();
 
-		final I_C_BPartner_Location orgBPLocation = Services.get(IBPartnerDAO.class).getBPartnerLocationById(orgInfo.getOrgBPartnerLocationId());
+		final I_C_BPartner_Location orgBPLocation = Services.get(IBPartnerDAO.class).getBPartnerLocationByIdEvenInactive(orgInfo.getOrgBPartnerLocationId());
+		assertThat(orgBPLocation.isActive()).isTrue(); // guard
 		assertThat(orgBPLocation.getExternalId()).isEqualTo(jsonBPartnerLocation.getExternalId().getValue());
 		assertThat(orgBPLocation.getC_Location().getC_Country_ID()).isEqualTo(countryRecord.getC_Country_ID());
 

--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MInvoiceLine.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MInvoiceLine.java
@@ -649,7 +649,7 @@ public class MInvoiceLine extends X_C_InvoiceLine
 		final BPartnerLocationId taxBPartnerLocationId = io != null ? BPartnerLocationId.ofRepoId(io.getC_BPartner_ID(), io.getC_BPartner_Location_ID())
 				: BPartnerLocationId.ofRepoId(invoice.getC_BPartner_ID(), invoice.getC_BPartner_Location_ID());
 
-		final I_C_BPartner_Location toBPLocation = bpartnerDAO.getBPartnerLocationById(taxBPartnerLocationId);
+		final I_C_BPartner_Location toBPLocation = bpartnerDAO.getBPartnerLocationByIdEvenInactive(taxBPartnerLocationId);
 
 		final boolean isSOTrx = io != null ? io.isSOTrx() : invoice.isSOTrx();
 

--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MOrderLine.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MOrderLine.java
@@ -316,7 +316,7 @@ public class MOrderLine extends X_C_OrderLine
 		final CountryId countryFromId = Services.get(IWarehouseBL.class).getCountryId(warehouseId);
 
 		final BPartnerLocationId bpLocationId = BPartnerLocationId.ofRepoId(getC_BPartner_ID(), getC_BPartner_Location_ID());
-		final I_C_BPartner_Location bpLocation = Services.get(IBPartnerDAO.class).getBPartnerLocationById(bpLocationId);
+		final I_C_BPartner_Location bpLocation = Services.get(IBPartnerDAO.class).getBPartnerLocationByIdEvenInactive(bpLocationId);
 
 		final int taxId = Services.get(ITaxBL.class).retrieveTaxIdForCategory(
 				getCtx(),

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/callout/C_Invoice.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/callout/C_Invoice.java
@@ -94,7 +94,7 @@ public class C_Invoice
 			dateInvoiced = SystemTime.asZonedDateTime();
 		}
 
-		final I_C_BPartner_Location bPartnerLocationRecord = bpartnerDAO.getBPartnerLocationById(BPartnerLocationId.ofRepoId(invoice.getC_BPartner_ID(), invoice.getC_BPartner_Location_ID()));
+		final I_C_BPartner_Location bPartnerLocationRecord = bpartnerDAO.getBPartnerLocationByIdEvenInactive(BPartnerLocationId.ofRepoId(invoice.getC_BPartner_ID(), invoice.getC_BPartner_Location_ID()));
 
 		final IPriceListBL priceListBL = Services.get(IPriceListBL.class);
 		final I_M_PriceList priceListNew = priceListBL.getCurrentPricelistOrNull(

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/export/InvoiceToExportFactory.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/export/InvoiceToExportFactory.java
@@ -260,7 +260,7 @@ public class InvoiceToExportFactory
 	{
 		final IBPartnerDAO bpartnerDAO = Services.get(IBPartnerDAO.class);
 
-		final I_C_BPartner_Location bPartnerLocationRecord = bpartnerDAO.getBPartnerLocationById(BPartnerLocationId.ofRepoId(invoiceRecord.getC_BPartner_ID(), invoiceRecord.getC_BPartner_Location_ID()));
+		final I_C_BPartner_Location bPartnerLocationRecord = bpartnerDAO.getBPartnerLocationByIdEvenInactive(BPartnerLocationId.ofRepoId(invoiceRecord.getC_BPartner_ID(), invoiceRecord.getC_BPartner_Location_ID()));
 
 		final BPartnerId bPartnerId = BPartnerId.ofRepoId(invoiceRecord.getC_BPartner_ID());
 

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/service/impl/InvoiceLineBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/service/impl/InvoiceLineBL.java
@@ -162,7 +162,7 @@ public class InvoiceLineBL implements IInvoiceLineBL
 		final InvoiceId invoiceId = InvoiceId.ofRepoId(il.getC_Invoice_ID());
 		final I_C_Invoice invoice = invoiceDAO.getByIdInTrx(invoiceId);
 
-		final I_C_BPartner_Location locationTo = bpartnerDAO.getBPartnerLocationById(partnerLocationId);
+		final I_C_BPartner_Location locationTo = bpartnerDAO.getBPartnerLocationByIdEvenInactive(partnerLocationId);
 
 		try (final MDCCloseable ignored = TableRecordMDC.putTableRecordReference(il))
 		{
@@ -194,7 +194,7 @@ public class InvoiceLineBL implements IInvoiceLineBL
 
 			if (taxId <= 0)
 			{
-				final I_C_BPartner_Location bPartnerLocationRecord = bpartnerDAO.getBPartnerLocationById(BPartnerLocationId.ofRepoId(invoice.getC_BPartner_ID(), invoice.getC_BPartner_Location_ID()));
+				final I_C_BPartner_Location bPartnerLocationRecord = bpartnerDAO.getBPartnerLocationByIdEvenInactive(BPartnerLocationId.ofRepoId(invoice.getC_BPartner_ID(), invoice.getC_BPartner_Location_ID()));
 
 				throw TaxNotFoundException.builder()
 						.taxCategoryId(taxCategoryId)
@@ -444,7 +444,7 @@ public class InvoiceLineBL implements IInvoiceLineBL
 		{
 			return null;
 		}
-		final I_C_BPartner_Location bPartnerLocationRecord = bpartnerDAO.getBPartnerLocationById(BPartnerLocationId.ofRepoId(invoice.getC_BPartner_ID(), invoice.getC_BPartner_Location_ID()));
+		final I_C_BPartner_Location bPartnerLocationRecord = bpartnerDAO.getBPartnerLocationByIdEvenInactive(BPartnerLocationId.ofRepoId(invoice.getC_BPartner_ID(), invoice.getC_BPartner_Location_ID()));
 
 		return CountryId.ofRepoId(bPartnerLocationRecord.getC_Location().getC_Country_ID());
 	}

--- a/backend/de.metas.business/src/test/java/de/metas/bpartner/impexp/BPartnerImportTestHelper.java
+++ b/backend/de.metas.business/src/test/java/de/metas/bpartner/impexp/BPartnerImportTestHelper.java
@@ -71,7 +71,7 @@ import lombok.experimental.UtilityClass;
 
 		final IBPartnerDAO partnerDAO = Services.get(IBPartnerDAO.class);
 
-		final I_C_BPartner_Location bplocation = partnerDAO.getBPartnerLocationById(BPartnerLocationId.ofRepoId(ibpartner.getC_BPartner_ID(), ibpartner.getC_BPartner_Location_ID()));
+		final I_C_BPartner_Location bplocation = partnerDAO.getBPartnerLocationByIdEvenInactive(BPartnerLocationId.ofRepoId(ibpartner.getC_BPartner_ID(), ibpartner.getC_BPartner_Location_ID()));
 		assertThat(bplocation).isNotNull();
 		assertThat(bplocation.getC_Location_ID()).isGreaterThan(0);
 		assertThat(bplocation.isBillToDefault()).isEqualTo(ibpartner.isBillToDefault());

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/EDIDocumentBL.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/EDIDocumentBL.java
@@ -128,7 +128,7 @@ public class EDIDocumentBL implements IEDIDocumentBL
 		feedback.addAll(isValidPartner(invoice.getC_BPartner(), true/* isPartOfInvoiceValidation */));
 
 		final IBPartnerDAO bpartnerDAO = Services.get(IBPartnerDAO.class);
-		final org.compiere.model.I_C_BPartner_Location bPartnerLocationRecord = bpartnerDAO.getBPartnerLocationById(BPartnerLocationId.ofRepoId(invoice.getC_BPartner_ID(), invoice.getC_BPartner_Location_ID()));
+		final org.compiere.model.I_C_BPartner_Location bPartnerLocationRecord = bpartnerDAO.getBPartnerLocationByIdEvenInactive(BPartnerLocationId.ofRepoId(invoice.getC_BPartner_ID(), invoice.getC_BPartner_Location_ID()));
 		feedback.addAll(isValidBPLocation(bPartnerLocationRecord));
 
 		// task 09182: for return material credit memos, we don't have or need an (imported) EDI ORDERS PoReference

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/picking/PickingSlotKey.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/picking/PickingSlotKey.java
@@ -64,6 +64,8 @@ import de.metas.util.Check;
 import de.metas.util.Services;
 import de.metas.util.StringUtils;
 
+import javax.annotation.Nullable;
+
 /**
  * Picking Slot Terminal Key
  *
@@ -355,15 +357,13 @@ public class PickingSlotKey extends TerminalKey
 	/**
 	 * Gets total capacity of the HU which is currently open this picking slot.
 	 *
-	 * @param product
-	 * @param uom
-	 *
 	 * @return
 	 *         <ul>
 	 *         <li>total capacity definition
 	 *         <li>or <code>null</code> if the capacity information is not available
 	 *         </ul>
 	 */
+	@Nullable
 	public Capacity getHUTotalCapacity(final ProductId productId, final I_C_UOM uom)
 	{
 		final I_M_HU_PI_Item_Product piItemProduct = getM_HU_PI_Item_Product();
@@ -431,7 +431,7 @@ public class PickingSlotKey extends TerminalKey
 		if (bpartnerLocationId != null)
 		{
 			final IBPartnerDAO bpartnersRepo = Services.get(IBPartnerDAO.class);
-			final I_C_BPartner_Location bpl = bpartnersRepo.getBPartnerLocationById(bpartnerLocationId);
+			final I_C_BPartner_Location bpl = bpartnersRepo.getBPartnerLocationByIdEvenInactive(bpartnerLocationId);
 			final String bplNameTrunc = truncatedString(bpl.getName(), maxLength);
 			pickingSlotName.append("<br>")
 					.append("<font size=\"3\">")

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/picking/ProductKey.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/picking/ProductKey.java
@@ -126,7 +126,7 @@ public class ProductKey extends TerminalKey
 		final String pValue = truncatedString(product.getValue(), maxLength);
 		final String pName = truncatedString(product.getName(), maxLength);
 		final String bpName = truncatedString(bpartnersRepo.getBPartnerNameById(bpartnerId), maxLength);
-		final String bplName = truncatedString(bpartnersRepo.getBPartnerLocationById(bpartnerLocationId).getName(), maxLength);
+		final String bplName = truncatedString(bpartnersRepo.getBPartnerLocationByIdEvenInactive(bpartnerLocationId).getName(), maxLength);
 		return pValue
 				+ "<br>"
 				+ pName

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/setup/process/ClientSetup.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/setup/process/ClientSetup.java
@@ -136,7 +136,7 @@ class ClientSetup
 					.orgId(OrgId.ofRepoId(adOrg.getAD_Org_ID()));
 			//
 			orgBPartner = partnerOrgBL.retrieveLinkedBPartner(adOrg);
-			orgBPartnerLocation = bpartnerDAO.getBPartnerLocationById(adOrgInfo.getOrgBPartnerLocationId());
+			orgBPartnerLocation = bpartnerDAO.getBPartnerLocationByIdEvenInactive(adOrgInfo.getOrgBPartnerLocationId());
 			orgContact = bpartnerDAO.retrieveDefaultContactOrNull(orgBPartner, I_AD_User.class);
 			Check.assumeNotNull(orgContact, "orgContact not null"); // TODO: create if does not exist
 			

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHandlingUnitsBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHandlingUnitsBL.java
@@ -446,7 +446,7 @@ public interface IHandlingUnitsBL extends ISingletonService
 	{
 		final BPartnerLocationId bpartnerLocationId = BPartnerLocationId.ofRepoIdOrNull(hu.getC_BPartner_ID(), hu.getC_BPartner_Location_ID());
 		return bpartnerLocationId != null
-				? Services.get(IBPartnerDAO.class).getBPartnerLocationById(bpartnerLocationId)
+				? Services.get(IBPartnerDAO.class).getBPartnerLocationByIdEvenInactive(bpartnerLocationId)
 				: null;
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleEffectiveBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleEffectiveBL.java
@@ -38,7 +38,7 @@ public class ShipmentScheduleEffectiveBL implements IShipmentScheduleEffectiveBL
 	public I_C_BPartner_Location getBPartnerLocation(@NonNull final I_M_ShipmentSchedule sched)
 	{
 		final BPartnerLocationId locationId = getBPartnerLocationId(sched);
-		return Services.get(IBPartnerDAO.class).getBPartnerLocationById(locationId);
+		return Services.get(IBPartnerDAO.class).getBPartnerLocationByIdEvenInactive(locationId);
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/agg/key/impl/ICLineAggregationKeyBuilder_OLD.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/agg/key/impl/ICLineAggregationKeyBuilder_OLD.java
@@ -219,7 +219,7 @@ public class ICLineAggregationKeyBuilder_OLD extends AbstractAggregationKeyBuild
 		final IBPartnerDAO bpartnerDAO = Services.get(IBPartnerDAO.class);
 		final ICurrencyDAO currencyDAO = Services.get(ICurrencyDAO.class);
 
-		final I_C_BPartner_Location billBPLocation = bpartnerDAO.getBPartnerLocationById(BPartnerLocationId.ofRepoId(ic.getBill_BPartner_ID(), ic.getBill_Location_ID()));
+		final I_C_BPartner_Location billBPLocation = bpartnerDAO.getBPartnerLocationByIdEvenInactive(BPartnerLocationId.ofRepoId(ic.getBill_BPartner_ID(), ic.getBill_Location_ID()));
 		Check.assumeNotNull(billBPLocation, "billBPLocation not null for {}", ic);
 
 		// We use the language of the bill location to determine the number format.

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -1026,7 +1026,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 		else if (icRecord.getM_PricingSystem_ID() > 0)
 		{
 			// take the precision from the bpartner price list
-			final I_C_BPartner_Location partnerLocation = bpartnerDAO.getBPartnerLocationById(
+			final I_C_BPartner_Location partnerLocation = bpartnerDAO.getBPartnerLocationByIdEvenInactive(
 					BPartnerLocationId.ofRepoIdOrNull(
 							icRecord.getBill_BPartner_ID(),
 							firstGreaterThanZero(icRecord.getBill_Location_Override_ID(), icRecord.getBill_Location_ID())));

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/org/adempiere/mm/attributes/countryattribute/impl/InvoiceLineCountryAware.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/org/adempiere/mm/attributes/countryattribute/impl/InvoiceLineCountryAware.java
@@ -88,7 +88,7 @@ public class InvoiceLineCountryAware implements ICountryAware
 		}
 
 		final IBPartnerDAO bpartnerDAO = Services.get(IBPartnerDAO.class);
-		final I_C_BPartner_Location bPartnerLocationRecord = bpartnerDAO.getBPartnerLocationById(BPartnerLocationId.ofRepoId(invoice.getC_BPartner_ID(), invoice.getC_BPartner_Location_ID()));
+		final I_C_BPartner_Location bPartnerLocationRecord = bpartnerDAO.getBPartnerLocationByIdEvenInactive(BPartnerLocationId.ofRepoId(invoice.getC_BPartner_ID(), invoice.getC_BPartner_Location_ID()));
 
 		return bPartnerLocationRecord.getC_Location().getC_Country();
 	}

--- a/backend/de.metas.vertical.pharma/src/main/java/de/metas/impexp/bpartner/IFABPartnerLocationImportHelper.java
+++ b/backend/de.metas.vertical.pharma/src/main/java/de/metas/impexp/bpartner/IFABPartnerLocationImportHelper.java
@@ -135,7 +135,7 @@ import lombok.experimental.UtilityClass;
 
 		if (filtered.size() > 0)
 		{
-			final I_C_BPartner_Location bpartnerLocation = Services.get(IBPartnerDAO.class).getBPartnerLocationById(BPartnerLocationId.ofRepoId(importRecord.getC_BPartner_ID(), matchedAddreses.get(0).getBpLocationId()));
+			final I_C_BPartner_Location bpartnerLocation = Services.get(IBPartnerDAO.class).getBPartnerLocationByIdEvenInactive(BPartnerLocationId.ofRepoId(importRecord.getC_BPartner_ID(), matchedAddreses.get(0).getBpLocationId()));
 			updateExistingBPartnerLocation(importRecord, bpartnerLocation);
 			return bpartnerLocation;
 		}


### PR DESCRIPTION
Because e.g. if you have a completed invoice and someone deactivated the bpartner-location that the invoice refers to, then the invoice should still be able to e.g. get the location's country.

=> In the end, after checking the call hierachy of `getBPartnerLocationById` i think that actually in every case, there should *not* be a `null` returned, even if the C_BPartner_Location was meanwhile deactivated.

