### PR TITLE
Elasticsearch restarting - docker compose 

### DIFF
--- a/misc/dev-support/docker/infrastructure/search/sources/start-custom.sh
+++ b/misc/dev-support/docker/infrastructure/search/sources/start-custom.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Give the folder to the docker image's elasticsearch user.
 # This is needed so that we can mount it on the dockerhost.

--- a/misc/dev-support/docker/infrastructure/search/sources/start-custom.sh
+++ b/misc/dev-support/docker/infrastructure/search/sources/start-custom.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Give the folder to the docker image's elasticsearch user.
 # This is needed so that we can mount it on the dockerhost.


### PR DESCRIPTION
The "search" docker container never started successfully and always stays in "Restarting" state. 

**To reproduce the error:** 
- clone metasfresh repository
- compile & setup intelij ultimate 
- run "Infrastructure: Compose Deployment" 

**Proposed change** 
- after the change of script type to "sh" the container is started successfully 
- tested on windows 10 pro with WSL2 and on Ubuntu 20.04 server VM

I am not really sure why this script doesn't run successfully if "bash" is the type of script file, after all the "sh" is only a symbolic link to "/usr/bin/bash" in the container (I checked). 


  