### PR TITLE
Fix the focus from the quick input table

### DIFF
--- a/frontend/src/components/table/TableQuickInput.js
+++ b/frontend/src/components/table/TableQuickInput.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import cx from 'classnames';
 import { connect } from 'react-redux';
-
+import onClickOutside from 'react-onclickoutside';
 import { completeRequest } from '../../api';
 import {
   fetchQuickInputData,
@@ -14,11 +14,13 @@ import {
 
 import WidgetWrapper from '../../containers/WidgetWrapper';
 
-class TableQuickInput extends Component {
+class TableQuickInput extends PureComponent {
   // promise with patching for queuing form submission after patch is done
   patchPromise;
   // widgets refs
   rawWidgets = [];
+  // local state
+  state = { hasFocus: true };
 
   componentDidMount() {
     this.initQuickInput();
@@ -44,9 +46,11 @@ class TableQuickInput extends Component {
    * @summary function to manually focus a widget
    */
   focusWidgetField = () => {
+    const { hasFocus } = this.state;
     let curWidget = this.rawWidgets[0];
 
     if (
+      hasFocus &&
       curWidget &&
       curWidget.rawWidget &&
       curWidget.rawWidget.current &&
@@ -267,12 +271,27 @@ class TableQuickInput extends Component {
     }
   };
 
+  /**
+   * @method handleClickOutside
+   * @summary Whenever we click outside of the Quick Input form we set the flag `hasFocus`
+   *          This is needed as by default the logic introduced in https://github.com/metasfresh/metasfresh/pull/11163/files
+   *          is setting by default the focus when the component receives new props (after the item was introduced its focusing on the first field)
+   */
+  handleClickOutside = () => this.setState({ hasFocus: false });
+
+  /**
+   * @method handleOnClick
+   * @summary When click is executed in the form we set the internal `hasFocus` flag indicating that we got the focus
+   */
+  handleOnClick = () => this.setState({ hasFocus: true });
+
   render() {
     return (
       <form
         onSubmit={this.onSubmit}
         className="row quick-input-container"
         ref={this.setRef}
+        onClick={this.handleOnClick}
       >
         {this.renderFields()}
         <div className="col-sm-12 col-md-3 col-lg-2 hint">
@@ -330,6 +349,6 @@ TableQuickInput.propTypes = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(TableQuickInput);
+)(onClickOutside(TableQuickInput));
 
 export { TableQuickInput };


### PR DESCRIPTION
https://www.loom.com/share/27ee8a7415264d5cbaf4ef7084e44c32

## 1) Go to a Sales Order and add some Order Line using the Batch Entry form
<img width="1455" alt="Screenshot 2021-06-11 at 09 51 18" src="https://user-images.githubusercontent.com/1708561/121643565-a19b0e80-ca9a-11eb-8013-cad996da4585.png">

## 2) Go on a Sales Order Line (whatever) or the latest added and choose Advanced Edit
<img width="1455" alt="Screenshot 2021-06-11 at 09 52 50" src="https://user-images.githubusercontent.com/1708561/121643805-ecb52180-ca9a-11eb-96d2-d89710f1c361.png">

## 3) Type `123` for example in the Trading Unit Quantity
<img width="1566" alt="Screenshot 2021-06-11 at 09 54 44" src="https://user-images.githubusercontent.com/1708561/121643989-225a0a80-ca9b-11eb-8a02-c23550480a2c.png">

The dropdown from behind should not be shown anymore.
