### PR TITLE
11371 dashboard indicators

### DIFF
--- a/frontend/src/assets/css/indicator.css
+++ b/frontend/src/assets/css/indicator.css
@@ -1,6 +1,5 @@
 .indicators-wrapper {
     border-radius: 3px;
-    overflow: hidden;
     margin: 1rem 0;
 }
 
@@ -36,6 +35,9 @@
     height: 130px;
     padding: 20px;
     overflow: hidden;
+    border-radius: 5px;
+    box-shadow: 0 2px 7px 0 rgba(0,0,0,0.2);
+    margin-right: 10px;
 }
 
 .indicator-draggable {

--- a/frontend/src/assets/css/indicator.css
+++ b/frontend/src/assets/css/indicator.css
@@ -32,9 +32,9 @@
     border-right: none;
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: left;
     height: 130px;
-    padding: 10px;
+    padding: 20px;
     overflow: hidden;
 }
 
@@ -46,16 +46,31 @@
     border-right: 1px solid $brand-border-color;
 }
 
-.indicator-value {
+.indicator-data {
+    padding-top: 0;
+    margin-top: -0.3rem;
+}
+
+.indicator-amount {
     font-size: 2.2rem;
     font-weight: bold;
-    text-align: center;
-    flex: 2;
-    display: flex;
-    align-items: flex-end;
+    text-align: left;
+    float: left;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    padding-right: 0.3rem
+}
+
+.indicator-unit {
+  font-size: 1rem;
+  font-weight: bold;
+  text-align: left;
+  float: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-top: 1.3rem;
 }
 
 .indicator-caption {
@@ -63,15 +78,14 @@
     font-weight: bold;
     font-size: 0.8rem;
     background: $brand-super-light-color;
-    padding: 5px;
+    padding: 0.2rem;
 }
 
 .indicator-kpi-caption {
     font-size: 0.8rem;
-    text-align: center;
-    flex: 1;
-    vertical-align: middle;
-    display: flex;
+    font-weight: bold;
+    text-align: left;
+    color: $brand-color-primary;
 }
 
 

--- a/frontend/src/components/charts/Indicator.js
+++ b/frontend/src/components/charts/Indicator.js
@@ -33,10 +33,11 @@ class Indicator extends Component {
         }
         style={fullWidth ? { width: '100%' } : {}}
       >
-        <div className="indicator-value">
-          {amount} {unit}
-        </div>
         <div className="indicator-kpi-caption">{caption}</div>
+        <div className="indicator-data">
+          <div className="indicator-amount">{amount}</div>
+          <div className="indicator-unit">{unit}</div>
+        </div>
       </div>
     );
   }
@@ -49,6 +50,8 @@ Indicator.propTypes = {
   fullWidth: PropTypes.bool,
   editmode: PropTypes.bool,
   framework: PropTypes.any,
+  amount: PropTypes.number,
+  unit: PropTypes.string,
 };
 
 export default Indicator;

--- a/frontend/src/components/charts/Indicator.js
+++ b/frontend/src/components/charts/Indicator.js
@@ -9,7 +9,8 @@ class Indicator extends Component {
 
   render() {
     const {
-      value,
+      amount,
+      unit,
       caption,
       loader,
       fullWidth,
@@ -32,7 +33,9 @@ class Indicator extends Component {
         }
         style={fullWidth ? { width: '100%' } : {}}
       >
-        <div className="indicator-value">{value}</div>
+        <div className="indicator-value">
+          {amount} {unit}
+        </div>
         <div className="indicator-kpi-caption">{caption}</div>
       </div>
     );

--- a/frontend/src/components/charts/RawChart.js
+++ b/frontend/src/components/charts/RawChart.js
@@ -148,12 +148,8 @@ class RawChart extends Component {
             )}
 
             <Indicator
-              value={
-                noData
-                  ? ''
-                  : dataset0[0][fields[0].fieldName] +
-                    (fields[0].unit ? ' ' + fields[0].unit : '')
-              }
+              amount={noData ? '' : dataset0[0][fields[0].fieldName]}
+              unit={noData ? '' : fields[0].unit}
               {...{ caption, editmode }}
             />
           </div>

--- a/frontend/src/components/charts/RawChart.js
+++ b/frontend/src/components/charts/RawChart.js
@@ -150,7 +150,11 @@ class RawChart extends Component {
             <Indicator
               amount={noData ? '' : dataset0[0][fields[0].fieldName]}
               unit={noData ? '' : fields[0].unit}
-              {...{ caption, editmode }}
+              {...{
+                caption:
+                  typeof caption === 'string' ? caption.toUpperCase() : caption,
+                editmode,
+              }}
             />
           </div>
         );


### PR DESCRIPTION
Reshape the dashboard indicators
<img width="1661" alt="Screenshot 2021-06-24 at 15 06 47" src="https://user-images.githubusercontent.com/1708561/123260095-db89fd00-d4fd-11eb-9487-31d5d575855c.png">
- pass separately the amount and the unit
- have the amount and unit to be rendered as separate divs to allow further customisation of these when the time comes
- make the caption to be with uppercase
- use our colors