### PR TITLE
Consider supportOpenRecord on FE side

### DIFF
--- a/frontend/src/components/keyshortcuts/DocumentListContextShortcuts.js
+++ b/frontend/src/components/keyshortcuts/DocumentListContextShortcuts.js
@@ -75,8 +75,8 @@ export default class DocumentListContextShortcuts extends PureComponent {
   };
 
   handleOpenNewTab = () => {
-    const { selected, windowId, onOpenNewTab } = this.props;
-
+    const { selected, windowId, onOpenNewTab, supportOpenRecord } = this.props;
+    if (supportOpenRecord === false) return false;
     onOpenNewTab({ rowIds: selected, windowId });
   };
 
@@ -140,4 +140,5 @@ DocumentListContextShortcuts.propTypes = {
   tabId: PropTypes.string,
   selected: PropTypes.array,
   onFastInlineEdit: PropTypes.func,
+  supportOpenRecord: PropTypes.bool,
 };

--- a/frontend/src/components/table/TableContextMenu.js
+++ b/frontend/src/components/table/TableContextMenu.js
@@ -195,6 +195,7 @@ class TableContextMenu extends Component {
       handleDelete,
       handleFieldEdit,
       handleZoomInto,
+      supportOpenRecord,
     } = this.props;
 
     const { contextMenu } = this.state;
@@ -217,6 +218,14 @@ class TableContextMenu extends Component {
         style={{
           left: contextMenu.x,
           top: contextMenu.y,
+          display:
+            supportOpenRecord === false &&
+            (!contextMenu.supportZoomInto ||
+              !showFieldEdit ||
+              !isSelectedOne ||
+              !handleDelete)
+              ? 'none'
+              : 'block',
         }}
         className={
           'context-menu context-menu-open panel-bordered panel-primary'
@@ -324,6 +333,7 @@ TableContextMenu.propTypes = {
   handleFieldEdit: PropTypes.func,
   handleZoomInto: PropTypes.func,
   updateTableHeight: PropTypes.func,
+  supportOpenRecord: PropTypes.bool,
 };
 
 export default connect()(TableContextMenu);

--- a/frontend/src/components/table/TableWrapper.js
+++ b/frontend/src/components/table/TableWrapper.js
@@ -333,6 +333,7 @@ class TableWrapper extends PureComponent {
       onGetAllLeaves,
       onHandleAdvancedEdit,
       onOpenTableModal,
+      supportOpenRecord,
     } = this.props;
 
     const { contextMenu, promptOpen, isBatchEntry } = this.state;
@@ -381,6 +382,7 @@ class TableWrapper extends PureComponent {
               }
               handleZoomInto={onHandleZoomInto}
               updateTableHeight={this.fwdUpdateHeight}
+              supportOpenRecord={supportOpenRecord}
             />
           )}
           {!readonly && (
@@ -458,6 +460,7 @@ class TableWrapper extends PureComponent {
             windowId={windowId}
             tabId={tabId}
             selected={selected}
+            supportOpenRecord={supportOpenRecord}
             onAdvancedEdit={
               selected && selected.length > 0 && selected[0]
                 ? onHandleAdvancedEdit


### PR DESCRIPTION
Tested on localhost
http://localhost:3000/window/143/1007847
<img width="1672" alt="Screenshot 2021-08-03 at 09 35 04" src="https://user-images.githubusercontent.com/1708561/127969072-d870f89a-db85-4a3b-803e-f40276c40740.png">

Going to Product Proposals ALT+B doesn't open the record. Also the TableContextMenu doesn't render it either if you right click. The supportOpenRecord that comes from the BE is considered

Tested also (as regression) other areas and this are showing it 
ex: BP

<img width="1672" alt="Screenshot 2021-08-03 at 09 39 37" src="https://user-images.githubusercontent.com/1708561/127969556-8505dfbc-0787-49fe-a140-cc892d78f593.png">

also SOL in a SO
<img width="1672" alt="Screenshot 2021-08-03 at 09 40 38" src="https://user-images.githubusercontent.com/1708561/127969632-788e292e-bf0c-45fa-a00b-e92afb2e3559.png">


