### PR TITLE
Routine that chops the label if that exceeds 10 chars

### DIFF
--- a/frontend/src/__tests__/components/table/TableCellLabel.test.js
+++ b/frontend/src/__tests__/components/table/TableCellLabel.test.js
@@ -29,7 +29,7 @@ describe('TableCellLabel', () => {
     expect(html).toContain(
       `table-cell-label-wrapper`
     );
-    expect(html).toContain(`Bildungsinstitut`);
+    expect(html).toContain(`Bildungsin`);
     expect(html).not.toContain(`...`);
   });
 

--- a/frontend/src/assets/css/table.css
+++ b/frontend/src/assets/css/table.css
@@ -799,6 +799,10 @@ $indent-collapsible-offset-lg: 24px;
     border-left: 1px solid #afbfca;
 }
 
+.table-cell-label-container {
+    width: 120px;
+}
+
 .table-cell-label-wrapper {
     float: left;
 }

--- a/frontend/src/assets/css/table.css
+++ b/frontend/src/assets/css/table.css
@@ -798,7 +798,7 @@ $indent-collapsible-offset-lg: 24px;
     height: 6px;
     border-left: 1px solid #afbfca;
 }
-
+/* Note: this has to be in sync with Constants.TBL_CELL_LABEL_MAX */
 .table-cell-label-container {
     width: 120px;
 }

--- a/frontend/src/components/table/TableCellLabel.js
+++ b/frontend/src/components/table/TableCellLabel.js
@@ -1,8 +1,22 @@
 import React, { PureComponent } from 'react';
 import Label from '../../components/widget/Labels/Label';
 import PropTypes from 'prop-types';
-
+import { TBL_CELL_LABEL_MAX } from '../../constants/Constants';
 class TableCellLabel extends PureComponent {
+  /**
+   * @method chopLabel
+   * @summary chops the label caption with a number of chars specified as param - maxNum starting from first pos
+   * @param {object} labelObj
+   * @param {integer} maxNum
+   */
+  chopLabel = (labelObj, maxNum) => {
+    let { caption } = labelObj;
+    const resLabel = { ...labelObj };
+    resLabel.caption =
+      caption.length > maxNum ? caption.slice(0, maxNum) : caption;
+    return resLabel;
+  };
+
   render() {
     const { tableCellData, rowId } = this.props;
     const tableCellValues = tableCellData.value.values;
@@ -12,14 +26,17 @@ class TableCellLabel extends PureComponent {
         : '';
 
     return (
-      <div>
+      <div className="table-cell-label-container">
         {tableCellData && tableCellValues[0] && (
           <div
             className="table-cell-label-wrapper"
             key={`${tableCellData.field}_${rowId}_0`}
           >
             <Label
-              label={tableCellData.value.values[0]}
+              label={this.chopLabel(
+                tableCellData.value.values[0],
+                TBL_CELL_LABEL_MAX
+              )}
               readonly={true}
               hideCloseIcon={true}
             />

--- a/frontend/src/constants/Constants.js
+++ b/frontend/src/constants/Constants.js
@@ -181,3 +181,10 @@ export const FILTERS_TYPE_NOT_INCLUDED = 'NotIncluded';
  * @type {integer} Used to indicate the number of px until we apply left offset
  */
 export const LOOKUP_SHOW_MORE_PIXEL_NO = 250;
+
+/**
+ * @constant
+ * @type {integer} Used to indicate the max number of character for a label before chopping it
+ *                 Note: it has to be in sync with `.table-cell-label-container` size
+ */
+export const TBL_CELL_LABEL_MAX = 10;


### PR DESCRIPTION
<img width="1628" alt="Screenshot 2021-08-06 at 10 02 38" src="https://user-images.githubusercontent.com/1708561/128471108-6dd0b275-7daa-4209-aeda-e83659285787.png">
- I didn't had bigger labels to test when first implemented. Now that I had I pushed this fix for those cases when the label is bigger.
- if this is fine it can be cp to other branches as well.
