### PR TITLE
Fix SwingUI automatic login

### DIFF
--- a/backend/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/apps/ALogin.java
+++ b/backend/de.metas.adempiere.adempiere/client/src/main/java-legacy/org/compiere/apps/ALogin.java
@@ -440,9 +440,9 @@ public final class ALogin extends CDialog
 		DB.setDBTarget(m_cc);
 
 		// direct
-		final boolean connectOK = DB.connect();
+		m_connectionOK = DB.connect();
 
-		if (connectOK)
+		if (m_connectionOK)
 		{
 			MLanguage.setBaseLanguage();
 			loadLanguagesFromDatabase(null); // no preselect suggestion

--- a/backend/de.metas.adempiere.adempiere/client/src/main/java/de/metas/SwingUIApplicationTemplate.java
+++ b/backend/de.metas.adempiere.adempiere/client/src/main/java/de/metas/SwingUIApplicationTemplate.java
@@ -92,14 +92,14 @@ public abstract class SwingUIApplicationTemplate
 		final Splash splash = Splash.getSplash();
 		final Properties ctx = Env.getCtx();
 		final ALogin login = new ALogin(splash, ctx);
-		if (login.initLogin())
-		{
-			return; // automatic login, nothing more to do
-		}
 
 		// Center the window
 		try (final IAutoCloseable c = ModelValidationEngine.postponeInit())
 		{
+			if (login.initLogin())
+			{
+				return; // automatic login, nothing more to do
+			}
 			AEnv.showCenterScreen(login);	// HTML load errors
 		}
 		catch (final Exception ex)


### PR DESCRIPTION
This commit contains two changes to fix automatic login for SwingUI:

1. Call ALogin.initLogin() after ModelValidationEngine.postponeInit()
2. Restore m_connectionOK in ALogin.connectToDatabase(), which is set to false in ALogin.validateConnection()

Fixes #11582