### PR TITLE
Fix rich text editor in grid mode in Swing UI

### DIFF
--- a/backend/de.metas.adempiere.adempiere/client/src/main/java/org/compiere/grid/ed/menu/TextEditorContextMenuAction.java
+++ b/backend/de.metas.adempiere.adempiere/client/src/main/java/org/compiere/grid/ed/menu/TextEditorContextMenuAction.java
@@ -31,6 +31,7 @@ import org.adempiere.ui.AbstractContextMenuAction;
 import org.compiere.grid.ed.Editor;
 import org.compiere.grid.ed.HTMLEditor;
 import org.compiere.grid.ed.VEditor;
+import org.compiere.grid.ed.VString;
 import org.compiere.model.GridField;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
@@ -138,7 +139,14 @@ public class TextEditorContextMenuAction extends AbstractContextMenuAction
 		final String textNew = startEditor(gridField, text, editable);
 		if (editable)
 		{
-			gridField.getGridTab().setValue(gridField, textNew);
+			if (editor instanceof VString)
+			{
+				((VString) editor).setText(textNew);
+			}
+			else
+			{
+				gridField.getGridTab().setValue(gridField, textNew);
+			}
 		}
 		// TODO: i think is handled above
 		// Data Binding


### PR DESCRIPTION
In rich text edit mode, trying to delegate the saving operation to
VString, to fix the saving problem in grid mode.

Fixes #11593