### PR TITLE
Fix rendering the popup when loading references is used

### DIFF
--- a/frontend/src/components/table/TableContextMenu.js
+++ b/frontend/src/components/table/TableContextMenu.js
@@ -21,6 +21,7 @@ import {
 class TableContextMenu extends Component {
   constructor(props) {
     super(props);
+    const { docId } = props;
     this.state = {
       contextMenu: {
         x: props.x,
@@ -28,6 +29,7 @@ class TableContextMenu extends Component {
       },
       loadingReferences: false,
       references: [],
+      display: docId ? 'none' : 'block',
     };
   }
 
@@ -142,6 +144,7 @@ class TableContextMenu extends Component {
           this.setState((prevState) => {
             const { y: lastY } = prevState.contextMenu;
             return {
+              display: 'block',
               contextMenu: {
                 ...prevState.contextMenu,
                 y: lastY - offset,
@@ -155,6 +158,7 @@ class TableContextMenu extends Component {
           let offset = initialY - mainPanel.scrollTop;
           this.setState((prevState) => {
             return {
+              display: 'block',
               contextMenu: {
                 ...prevState.contextMenu,
                 y: offset + beforeAssign,
@@ -203,7 +207,7 @@ class TableContextMenu extends Component {
       handleZoomInto,
     } = this.props;
 
-    const { contextMenu } = this.state;
+    const { contextMenu, display } = this.state;
 
     const isSelectedOne = selected.length === 1;
     const showFieldEdit =
@@ -223,6 +227,7 @@ class TableContextMenu extends Component {
         style={{
           left: contextMenu.x,
           top: contextMenu.y,
+          display,
         }}
         className={
           'context-menu context-menu-open panel-bordered panel-primary'


### PR DESCRIPTION
demo
https://www.loom.com/share/0a7646d599564b87b8b34164966bd492

display the popup only after the loading of resources completed (only for the cases when the resources are loaded, when docId is present).

