### PR TITLE
update the invoices' isPaid flag when allocation is completed

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/PO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/PO.java
@@ -2999,7 +2999,7 @@ public abstract class PO
 	 * @param success success
 	 * @return true if saved
 	 */
-	private final boolean saveFinish(final boolean newRecord, boolean success) throws Exception
+	private boolean saveFinish(final boolean newRecord, boolean success) throws Exception
 	{
 		// Translations
 		if (success)

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/modelvalidator/annotations/DocValidate.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/modelvalidator/annotations/DocValidate.java
@@ -49,7 +49,7 @@ public @interface DocValidate
 	/**
 	 * On which timings shall we call the annotated methods.
 	 *
-	 * For more information about timings, please check {@link DocTimingType#getTiming()} values.
+	 * For more information about timings, please check {@link org.compiere.model.ModelValidator} values.
 	 *
 	 * At least one event shall be specified.
 	 */

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/modelvalidator/C_AllocationHdr.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/modelvalidator/C_AllocationHdr.java
@@ -69,8 +69,7 @@ public class C_AllocationHdr
 	 * After {@link I_C_AllocationHdr} was completed/reversed/voided/reactivated,
 	 * update all {@link I_C_PaySelectionLine}s which were not already processed and which are about the invoices from this allocation.
 	 *
-	 * @param allocationHdr
-	 * @task 08972
+	 * task 08972
 	 */
 	@DocValidate(timings = {
 			ModelValidator.TIMING_AFTER_COMPLETE,

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/modelvalidator/C_AllocationHdr.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/modelvalidator/C_AllocationHdr.java
@@ -157,11 +157,8 @@ public class C_AllocationHdr
 	 * Update all given pay selection lines.
 	 * <p>
 	 * NOTE: pay selection lines shall ALL be part of the same {@link I_C_PaySelection}.
-	 *
-	 * @param context
-	 * @param paySelectionLines
 	 */
-	private final void updatePaySelectionLines(final Collection<I_C_PaySelectionLine> paySelectionLines)
+	private void updatePaySelectionLines(final Collection<I_C_PaySelectionLine> paySelectionLines)
 	{
 		// shall not happen
 		if (paySelectionLines.isEmpty())

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/IPaymentAllocationBL.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/IPaymentAllocationBL.java
@@ -29,7 +29,7 @@ public interface IPaymentAllocationBL extends ISingletonService
 {
 	/**
 	 * @return true if compensating customer invoices with purchase invoices shall be allowed
-	 * @task 09451
+	 * task 09451
 	 */
 	 boolean isPurchaseSalesInvoiceCompensationAllowed();
 }

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/service/AllocationLineCandidate.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/service/AllocationLineCandidate.java
@@ -24,7 +24,7 @@ import lombok.Value;
  *
  */
 @Value
-public final class AllocationLineCandidate
+public class AllocationLineCandidate
 {
 	public enum AllocationLineCandidateType
 	{
@@ -36,23 +36,23 @@ public final class AllocationLineCandidate
 		InboundPaymentToOutboundPayment, //
 	}
 
-	private final AllocationLineCandidateType type;
-	private final OrgId orgId;
-	private final BPartnerId bpartnerId;
+	AllocationLineCandidateType type;
+	OrgId orgId;
+	BPartnerId bpartnerId;
 
-	private final TableRecordReference payableDocumentRef;
-	private final TableRecordReference paymentDocumentRef;
+	TableRecordReference payableDocumentRef;
+	TableRecordReference paymentDocumentRef;
 
-	private final LocalDate dateTrx;
-	private final LocalDate dateAcct;
+	LocalDate dateTrx;
+	LocalDate dateAcct;
 
 	//
 	// Amounts
-	private final CurrencyId currencyId;
-	private final AllocationAmounts amounts;
-	private final Money payableOverUnderAmt;
-	private final Money paymentOverUnderAmt;
-	private final InvoiceProcessingFeeCalculation invoiceProcessingFeeCalculation;
+	CurrencyId currencyId;
+	AllocationAmounts amounts;
+	Money payableOverUnderAmt;
+	Money paymentOverUnderAmt;
+	InvoiceProcessingFeeCalculation invoiceProcessingFeeCalculation;
 
 	@Builder(toBuilder = true)
 	private AllocationLineCandidate(

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/remittanceadvice/process/C_RemittanceAdvice_CreateAndAllocatePayment.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/remittanceadvice/process/C_RemittanceAdvice_CreateAndAllocatePayment.java
@@ -105,7 +105,7 @@ public class C_RemittanceAdvice_CreateAndAllocatePayment extends JavaProcess
 	@RunOutOfTrx
 	protected String doIt() throws Exception
 	{
-		final IQueryFilter<I_C_RemittanceAdvice> processFilter = getProcessInfo().getQueryFilterOrElse(ConstantQueryFilter.of(false));
+		final IQueryFilter<I_C_RemittanceAdvice> processFilter = getProcessInfo().getQueryFilterOrElse(null);
 		if (processFilter == null)
 		{
 			throw new AdempiereException("@NoSelection@");

--- a/backend/de.metas.business/src/main/java/de/metas/allocation/api/C_AllocationHdr_Builder.java
+++ b/backend/de.metas.business/src/main/java/de/metas/allocation/api/C_AllocationHdr_Builder.java
@@ -49,6 +49,8 @@ import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.ToString;
 
+import javax.annotation.Nullable;
+
 /**
  * Convenient way to create (and maybe complete) and {@link I_C_AllocationHdr} with {@link I_C_AllocationLine}s.
  */
@@ -78,6 +80,7 @@ public class C_AllocationHdr_Builder
 		this.allocHdr = InterfaceWrapperHelper.newInstance(I_C_AllocationHdr.class);
 	}
 
+	@Nullable
 	public I_C_AllocationHdr create(final boolean complete)
 	{
 		markAsBuilt();
@@ -134,13 +137,13 @@ public class C_AllocationHdr_Builder
 		return create(complete);
 	}
 
-	private final void markAsBuilt()
+	private void markAsBuilt()
 	{
 		assertNotBuilt();
 		_built = true;
 	}
 
-	private final void assertNotBuilt()
+	private void assertNotBuilt()
 	{
 		Check.assume(!_built, "Not already built");
 	}

--- a/backend/de.metas.business/src/main/java/de/metas/allocation/api/IAllocationBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/allocation/api/IAllocationBL.java
@@ -24,7 +24,6 @@ public interface IAllocationBL extends ISingletonService
 	I_C_AllocationHdr autoAllocateAvailablePayments(I_C_Invoice invoice);
 
 	/**
-	 *
 	 * This method creates an allocation between the given invoice and incoming payment that belong to the same C_BPartner, have the {@link I_C_Payment#isAutoAllocateAvailableAmt()} flag set and is
 	 * not yet fully allocated.
 	 *

--- a/backend/de.metas.business/src/main/java/de/metas/allocation/api/IAllocationBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/allocation/api/IAllocationBL.java
@@ -19,7 +19,7 @@ public interface IAllocationBL extends ISingletonService
 	 *
 	 * @param invoice the invoice to allocate against.
 	 * @return the created an completed allocation or <code>null</code>, if the invoice is already fully paid, or is a PO-invoice, or is a credit memo.
-	 * @task 04193
+	 * task 04193
 	 */
 	I_C_AllocationHdr autoAllocateAvailablePayments(I_C_Invoice invoice);
 
@@ -32,8 +32,7 @@ public interface IAllocationBL extends ISingletonService
 	 * @param payment to allocate
 	 * @param ignoreIsAutoAllocateAvailableAmt if <code>false</code> then we only create the allocation if the payment has {@link I_C_Payment#COLUMN_IsAutoAllocateAvailableAmt} <code>='Y'</code>.
 	 * @return the created an completed allocation or <code>null</code>, if the invoice is already fully paid, or is a PO-invoice, or is a credit memo or payment and invoice are not matching
-	 * @task 07783
-	 * @return
+	 * task 07783
 	 */
 	I_C_AllocationHdr autoAllocateSpecificPayment(org.compiere.model.I_C_Invoice invoice,
 			I_C_Payment payment,

--- a/backend/de.metas.business/src/main/java/de/metas/allocation/api/IAllocationDAO.java
+++ b/backend/de.metas.business/src/main/java/de/metas/allocation/api/IAllocationDAO.java
@@ -98,4 +98,6 @@ public interface IAllocationDAO extends ISingletonService
 	List<I_C_Payment> retrieveInvoicePayments(I_C_Invoice invoice);
 
 	SetMultimap<PaymentId, InvoiceId> retrieveInvoiceIdsByPaymentIds(@NonNull Collection<PaymentId> paymentIds);
+
+	@NonNull I_C_AllocationHdr getById(@NonNull PaymentAllocationId allocationId);
 }

--- a/backend/de.metas.business/src/main/java/de/metas/allocation/api/impl/AllocationBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/allocation/api/impl/AllocationBL.java
@@ -21,6 +21,8 @@ import de.metas.payment.api.IPaymentDAO;
 import de.metas.util.Check;
 import de.metas.util.Services;
 
+import javax.validation.constraints.Null;
+
 public class AllocationBL implements IAllocationBL
 {
 	@Override
@@ -105,6 +107,7 @@ public class AllocationBL implements IAllocationBL
 				.createAndComplete();
 	}
 
+	@Null
 	@Override
 	public I_C_AllocationHdr autoAllocateSpecificPayment(
 			org.compiere.model.I_C_Invoice invoice,

--- a/backend/de.metas.business/src/main/java/de/metas/allocation/api/impl/AllocationDAO.java
+++ b/backend/de.metas.business/src/main/java/de/metas/allocation/api/impl/AllocationDAO.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
+import de.metas.allocation.api.PaymentAllocationId;
 import org.adempiere.ad.dao.ICompositeQueryFilter;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
@@ -147,7 +148,7 @@ public class AllocationDAO implements IAllocationDAO
 	}
 
 	@Cached(cacheName = I_C_AllocationLine.Table_Name + "#By#" + I_C_AllocationLine.COLUMNNAME_C_AllocationHdr_ID + "#retrieveAll")
-	/* package */ List<I_C_AllocationLine> retrieveLines(final @CacheCtx Properties ctx,
+		/* package */ List<I_C_AllocationLine> retrieveLines(final @CacheCtx Properties ctx,
 			final int allocationHdrId,
 			final boolean retrieveAll,
 			final @CacheTrx String trxName)
@@ -425,5 +426,11 @@ public class AllocationDAO implements IAllocationDAO
 				.collect(ImmutableSetMultimap.toImmutableSetMultimap(
 						record -> PaymentId.ofRepoId(record.getC_Payment_ID()),
 						record -> InvoiceId.ofRepoIdOrNull(record.getC_Invoice_ID())));
+	}
+
+	@Override
+	public @NonNull I_C_AllocationHdr getById(@NonNull final PaymentAllocationId allocationId)
+	{
+		return InterfaceWrapperHelper.load(allocationId, I_C_AllocationHdr.class);
 	}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/allocation/modelvalidator/C_AllocationHdr.java
+++ b/backend/de.metas.business/src/main/java/de/metas/allocation/modelvalidator/C_AllocationHdr.java
@@ -1,0 +1,69 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2021 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.allocation.modelvalidator;
+
+import de.metas.allocation.api.IAllocationDAO;
+import de.metas.allocation.api.PaymentAllocationId;
+import de.metas.invoice.service.IInvoiceBL;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.modelvalidator.annotations.DocValidate;
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.ad.trx.api.ITrxManager;
+import org.compiere.model.I_C_AllocationHdr;
+import org.compiere.model.I_C_AllocationLine;
+import org.compiere.model.ModelValidator;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Interceptor(I_C_AllocationHdr.class)
+@Component
+public class C_AllocationHdr
+{
+	private final IInvoiceBL invoiceBL = Services.get(IInvoiceBL.class);
+	private final IAllocationDAO allocationDAO = Services.get(IAllocationDAO.class);
+	private final ITrxManager trxManager = Services.get(ITrxManager.class);
+
+	@DocValidate(timings = { ModelValidator.TIMING_AFTER_COMPLETE,
+			ModelValidator.TIMING_AFTER_REACTIVATE,
+			ModelValidator.TIMING_AFTER_REVERSECORRECT,
+			ModelValidator.TIMING_AFTER_VOID })
+	public void testInvoiceAllocation(@NonNull final I_C_AllocationHdr allocationHdr)
+	{
+		trxManager.runAfterCommit(() -> testInvoiceAllocation0(PaymentAllocationId.ofRepoId(allocationHdr.getC_AllocationHdr_ID())));
+	}
+
+	private void testInvoiceAllocation0(@NonNull final PaymentAllocationId allocationId)
+	{
+		final I_C_AllocationHdr allocationHdrRecord = allocationDAO.getById(allocationId);
+		final List<I_C_AllocationLine> allocationLineRecords = allocationDAO.retrieveLines(allocationHdrRecord);
+		for (final I_C_AllocationLine allocationLineRecord : allocationLineRecords)
+		{
+			if (allocationLineRecord.getC_Invoice_ID() > 0)
+			{
+				invoiceBL.testAllocation(allocationLineRecord.getC_Invoice(), false);
+			}
+		}
+	}
+}

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/interceptor/C_AllocationHdr.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/interceptor/C_AllocationHdr.java
@@ -20,7 +20,7 @@
  * #L%
  */
 
-package de.metas.allocation.modelvalidator;
+package de.metas.invoice.interceptor;
 
 import de.metas.allocation.api.IAllocationDAO;
 import de.metas.allocation.api.PaymentAllocationId;
@@ -32,6 +32,7 @@ import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.compiere.model.I_C_AllocationHdr;
 import org.compiere.model.I_C_AllocationLine;
+import org.compiere.model.I_C_Invoice;
 import org.compiere.model.ModelValidator;
 import org.springframework.stereotype.Component;
 
@@ -45,6 +46,11 @@ public class C_AllocationHdr
 	private final IAllocationDAO allocationDAO = Services.get(IAllocationDAO.class);
 	private final ITrxManager trxManager = Services.get(ITrxManager.class);
 
+	/**
+	 * Updates C_Invoice.IsPaid on all referenced invoices each time an allocation is completed, reversed etc.
+	 * Background: when a credit memo was allocated against a zpayment and a service-invoice, the check was not done, so the credit memo remained with Paid=N.
+	 * TODO: see if we can get rid of all other calls to {@link IInvoiceBL#testAllocation(I_C_Invoice, boolean)}.
+	 */
 	@DocValidate(timings = { ModelValidator.TIMING_AFTER_COMPLETE,
 			ModelValidator.TIMING_AFTER_REACTIVATE,
 			ModelValidator.TIMING_AFTER_REVERSECORRECT,
@@ -62,7 +68,8 @@ public class C_AllocationHdr
 		{
 			if (allocationLineRecord.getC_Invoice_ID() > 0)
 			{
-				invoiceBL.testAllocation(allocationLineRecord.getC_Invoice(), false);
+				final boolean ignoreProcessed = false;
+				invoiceBL.testAllocation(allocationLineRecord.getC_Invoice(), ignoreProcessed);
 			}
 		}
 	}

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/interceptor/C_Invoice.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/interceptor/C_Invoice.java
@@ -95,7 +95,6 @@ public class C_Invoice // 03771
 	private void autoAllocateAvailablePayments(final I_C_Invoice invoice)
 	{
 		allocationBL.autoAllocateAvailablePayments(invoice);
-		testAndMarkAsPaid(invoice);
 	}
 
 	private void ensureUOMsAreNotNull(@NonNull final I_C_Invoice invoice)
@@ -236,7 +235,6 @@ public class C_Invoice // 03771
 			// Allocate the minimum between parent invoice open amt and what is left of the creditMemo's grand Total
 			invoiceBL.allocateCreditMemo(parentInvoice, creditMemo, amtToAllocate);
 		}
-		testAndMarkAsPaid(creditMemo);
 	}
 
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_DELETE })
@@ -294,7 +292,6 @@ public class C_Invoice // 03771
 			paymentDAO.save(payment);
 
 			allocationBL.autoAllocateSpecificPayment(invoice, payment, true);
-			testAndMarkAsPaid(invoice);
 		}
 	}
 
@@ -305,7 +302,6 @@ public class C_Invoice // 03771
 		{
 			final I_C_Payment payment = paymentBL.getById(PaymentId.ofRepoId(order.getC_Payment_ID()));
 			allocationBL.autoAllocateSpecificPayment(invoice, payment, true);
-			testAndMarkAsPaid(invoice);
 		}
 	}
 

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/service/IInvoiceBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/service/IInvoiceBL.java
@@ -186,7 +186,6 @@ public interface IInvoiceBL extends ISingletonService
 	boolean testAllocation(I_C_Invoice invoice, boolean ignoreProcessed);
 
 	/**
-	 * @param order
 	 * @param docTypeTargetId invoice's document type
 	 * @param dateInvoiced may be <code>null</code>
 	 * @param dateAcct may be <code>null</code> (see task 08438)

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/service/IInvoiceBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/service/IInvoiceBL.java
@@ -45,14 +45,11 @@ public interface IInvoiceBL extends ISingletonService
 	 * Copies a given invoice
 	 *
 	 * @param from the copy source
-	 * @param dateDoc
-	 * @param C_DocTypeTarget_ID
 	 * @param isSOTrx parameter is set as the copy's <code>IsSOtrx</code> value
 	 * @param isCounterpart if <code>true</code>, then the copy shall be the counter document of <code>from</code>
 	 * @param setOrderRef if true, then the copy shall reference the same C_Order that <code>from</code> references
 	 * @param isSetLineInvoiceRef if true, then the copy shall reference the <code>from</code> C_Invoice
 	 * @param isCopyLines if true, the invoice lines are also copied using {@link #copyLinesFrom(I_C_Invoice, I_C_Invoice, boolean, boolean, boolean, IDocLineCopyHandler)}
-	 * @return
 	 */
 	org.compiere.model.I_C_Invoice copyFrom(
 			org.compiere.model.I_C_Invoice from,
@@ -69,8 +66,6 @@ public interface IInvoiceBL extends ISingletonService
 	/**
 	 * Load and iterate the invoice lines from the given <code>fromInvoice</code> and create new invoice lines for the given <code>toInvoice</code>.
 	 *
-	 * @param fromInvoice
-	 * @param toInvoice
 	 * @param counter if <code>true</code>, then
 	 *            <ul>
 	 *            <li>The <code>C_InvoiceLine.Ref_InvoiceLine_ID</code> values of both the existing and new invoice line are set to the ID of their counterpart (independent of the setInvoiceRef
@@ -85,7 +80,7 @@ public interface IInvoiceBL extends ISingletonService
 	 * @param setInvoiceRef if <code>true</code>, then set <code>C_InvoiceLine.Ref_InvoiceLine_ID</code> as described for the counter parameter (do this independent of the counter parameter's value).
 	 * @param docLineCopyHandler allows copying of fields to be customized per implementation. This is e.g. used by {@link #creditInvoice(de.metas.adempiere.model.I_C_Invoice, InvoiceCreditContext)}.
 	 *            May be <code>null</code>.
-	 * @return
+	 * 
 	 * @see #copyFrom(I_C_Invoice, Timestamp, int, boolean, boolean, boolean, boolean, boolean)
 	 */
 	int copyLinesFrom(I_C_Invoice fromInvoice, I_C_Invoice toInvoice, boolean counter, boolean setOrderRef, boolean setInvoiceRef,
@@ -106,25 +101,21 @@ public interface IInvoiceBL extends ISingletonService
 	boolean isInvoice(@NonNull I_C_Invoice invoice);
 
 	/**
-	 * @param invoice
 	 * @return true if the given invoice is a CreditMemo (APC or ARC)
 	 */
 	boolean isCreditMemo(I_C_Invoice invoice);
 
 	/**
-	 * @param docBaseType
 	 * @return true if the given invoice DocBaseType is a CreditMemo (APC or ARC)
 	 */
 	boolean isCreditMemo(String docBaseType);
 
 	/**
-	 * @param invoice
 	 * @return <code>true</code> if the given invoice is the reversal of another invoice.
 	 */
 	boolean isReversal(I_C_Invoice invoice);
 
 	/**
-	 * @param invoice
 	 * @return true if the given invoice is a AR CreditMemo (ARC)
 	 */
 	boolean isARCreditMemo(I_C_Invoice invoice);
@@ -132,9 +123,7 @@ public interface IInvoiceBL extends ISingletonService
 	/**
 	 * Writes off the given openAmt from the given invoice.
 	 *
-	 * @param invoice
 	 * @param openAmt open amount (not absolute, the value is relative to IsSOTrx sign)
-	 * @param description
 	 */
 	void writeOffInvoice(I_C_Invoice invoice, BigDecimal openAmt, String description);
 
@@ -154,7 +143,6 @@ public interface IInvoiceBL extends ISingletonService
 	 * Depending in the <code>completeAndAllocate</code> parameter, the credit memo will also be allocated against the invoice, so that both have <code>IsPaid='Y'</code>.
 	 *
 	 * @param invoice the invoice to be credited. May not be fully paid/allocated and may not be a credit memo itself
-	 * @param creditCtx
 	 * @return the created credit memo
 	 * @throws AdempiereException if
 	 *             <ul>
@@ -170,9 +158,6 @@ public interface IInvoiceBL extends ISingletonService
 
 	/**
 	 * Creates a new invoice line for the given invoice. Note that the new line is not saved.
-	 *
-	 * @param invoice
-	 * @return
 	 */
 	I_C_InvoiceLine createLine(I_C_Invoice invoice);
 
@@ -209,16 +194,12 @@ public interface IInvoiceBL extends ISingletonService
 	/**
 	 * Sets Target Document Type and IsSOTrx.
 	 *
-	 * @param invoice
-	 * @param docBaseType
 	 * @return true if document type found and set
 	 */
 	boolean setDocTypeTargetId(I_C_Invoice invoice, String docBaseType);
 
 	/**
 	 * Set Target Document Type based on SO flag AP/AP Invoice
-	 *
-	 * @param invoice
 	 */
 	void setDocTypeTargetIdIfNotSet(I_C_Invoice invoice);
 
@@ -227,7 +208,6 @@ public interface IInvoiceBL extends ISingletonService
 	/**
 	 * Sort and then renumber all invoice lines.
 	 *
-	 * @param invoice
 	 * @param step start and step
 	 */
 	void renumberLines(de.metas.adempiere.model.I_C_Invoice invoice, int step);
@@ -235,18 +215,12 @@ public interface IInvoiceBL extends ISingletonService
 	/**
 	 * Similar to {@link #renumberLines(de.metas.adempiere.model.I_C_Invoice, int)}, but in addition, leave alone lines which were flagged using {@link #setHasFixedLineNumber(I_C_InvoiceLine, boolean)}
 	 * and don't assign their <code>Line</code> value to any other line.
-	 *
-	 * @param lines
-	 * @param step
 	 */
 	void renumberLines(List<I_C_InvoiceLine> lines, int step);
 
 	/**
 	 * Use {@link org.adempiere.ad.persistence.ModelDynAttributeAccessor ModelDynAttributeAccessor} to flag lines whose <code>C_InvoiceLine.Line</code> value shall not be changed by
 	 * {@link #renumberLines(List, int)}.
-	 *
-	 * @param line
-	 * @param value
 	 */
 	void setHasFixedLineNumber(I_C_InvoiceLine line, boolean value);
 
@@ -274,7 +248,6 @@ public interface IInvoiceBL extends ISingletonService
 	I_C_DocType getC_DocType(I_C_Invoice invoice);
 
 	/**
-	 * @param invoice
 	 * @return true if invoice's DocStatus is COmpleted, CLosed or REversed.
 	 */
 	boolean isComplete(org.compiere.model.I_C_Invoice invoice);
@@ -321,17 +294,11 @@ public interface IInvoiceBL extends ISingletonService
 	/**
 	 * If the given <code>invoiceLine</code> references a <code>C_Charge</code>, then the method returns that charge's tax category. Otherwise, it uses the pricing APO to get the tax category that is
 	 * referenced from the invoice line's pricing data (i.e. <code>M_ProductPrice</code> record).
-	 *
-	 * @param invoiceLine
-	 * @return
 	 */
 	TaxCategoryId getTaxCategoryId(I_C_InvoiceLine invoiceLine);
 
 	/**
 	 * Basically this method delegated to {@link ICopyHandlerBL#registerCopyHandler(Class, IQueryFilter, ICopyHandler)}, but makes sure that the correct types are used.
-	 *
-	 * @param filter
-	 * @param copyHandler
 	 */
 	void registerCopyHandler(
 			IQueryFilter<ImmutablePair<I_C_Invoice, I_C_Invoice>> filter,
@@ -347,17 +314,12 @@ public interface IInvoiceBL extends ISingletonService
 
 	/**
 	 * Calls {@link #isTaxIncluded(I_C_Invoice, I_C_Tax)} for the given <code>invoiceLine</code>'s <code>C_Invoice</code> and <code>C_Tax</code>.
-	 *
-	 * @param invoiceLine
-	 * @return
 	 */
 	boolean isTaxIncluded(org.compiere.model.I_C_InvoiceLine invoiceLine);
 
 	/**
 	 * Is Tax Included in Amount.
 	 *
-	 * @param invoice
-	 * @param tax
 	 * @return if the given <code>tax</code> is not <code>null</code> and if is has {@link I_C_Tax#isWholeTax()} equals <code>true</code>, then true is returned. Otherwise, the given invoice's
 	 */
 	boolean isTaxIncluded(I_C_Invoice invoice, I_C_Tax tax);
@@ -365,33 +327,21 @@ public interface IInvoiceBL extends ISingletonService
 	/**
 	 * Supposed to be called if an invoice is reversed. Iterate the given invoice's lines, iterate each line's <code>M_MatchInv</code> and create a reversal M_Matchinv that references the respective
 	 * reversal invoice line.
-	 *
-	 * @param invoice
 	 */
 	void handleReversalForInvoice(I_C_Invoice invoice);
 
 	/**
 	 * Allocate parent invoice against it's credit memo
-	 *
-	 * @param invoice
-	 * @param creditMemo
-	 * @param openAmt
 	 */
 	void allocateCreditMemo(de.metas.adempiere.model.I_C_Invoice invoice, de.metas.adempiere.model.I_C_Invoice creditMemo, BigDecimal openAmt);
 
 	/**
 	 * Decide if the given invoice is an Adjustment Charge
-	 *
-	 * @param invoice
-	 * @return
 	 */
 	boolean isAdjustmentCharge(I_C_Invoice invoice);
 
 	/**
 	 * Decide if the given doctype is of an Adjustment Charge
-	 *
-	 * @param docType
-	 * @return
 	 */
 	boolean isAdjustmentCharge(I_C_DocType docType);
 
@@ -414,10 +364,7 @@ public interface IInvoiceBL extends ISingletonService
 	void ensureUOMsAreNotNull(@NonNull InvoiceId invoiceId);
 
 	/**
-	 * 
-	 * @param invoice
 	 * @param discountAmt - the value is not AP corrected. The correction is done inside this function
-	 * @param date
 	 */
 	void discountInvoice(@NonNull I_C_Invoice invoice, @NonNull Amount discountAmt, @NonNull Timestamp date);
 

--- a/backend/de.metas.business/src/main/java/de/metas/remittanceadvice/RemittanceAdvice.java
+++ b/backend/de.metas.business/src/main/java/de/metas/remittanceadvice/RemittanceAdvice.java
@@ -170,9 +170,10 @@ public class RemittanceAdvice
 
 	public void validateCompleteAction()
 	{
-		final ImmutableList<RemittanceAdviceLineId> lineIdsWithProblems = lines.stream()
+		final ImmutableList<Integer> lineIdsWithProblems = lines.stream()
 				.filter(line -> !line.isReadyForCompletion())
 				.map(RemittanceAdviceLine::getRemittanceAdviceLineId)
+				.map(RemittanceAdviceLineId::getRepoId)
 				.collect(ImmutableList.toImmutableList());
 
 		if (lineIdsWithProblems.size() > 0)

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/actionhandler/impl/AbstractESRActionHandler.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/actionhandler/impl/AbstractESRActionHandler.java
@@ -73,9 +73,6 @@ public class AbstractESRActionHandler implements IESRActionHandler
 
 				InterfaceWrapperHelper.save(payment);
 				Services.get(IESRImportBL.class).linkInvoiceToPayment(line);
-
-				final boolean ignoreProcessed = false;
-				Services.get(IInvoiceBL.class).testAllocation(invoice, ignoreProcessed);
 			}
 		}
 		return true;

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/actionhandler/impl/WithCurrenttInvoiceESRActionHandler.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/actionhandler/impl/WithCurrenttInvoiceESRActionHandler.java
@@ -59,9 +59,6 @@ public class WithCurrenttInvoiceESRActionHandler implements IESRActionHandler
 		if (null != payment && null != invoice)
 		{
 			Services.get(IESRImportBL.class).linkInvoiceToPayment(line);
-
-			final boolean ignoreProcessed = false;
-			Services.get(IInvoiceBL.class).testAllocation(invoice, ignoreProcessed);
 		}
 		else
 		{

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
@@ -822,10 +822,6 @@ public class ESRImportBL implements IESRImportBL
 			documentBL.processEx(payment, IDocument.ACTION_Complete, IDocument.STATUS_Completed);
 			final boolean ignoreProcessed = false;
 
-			final IInvoiceBL invoiceBL = Services.get(IInvoiceBL.class);
-			invoiceBL.testAllocation(invoice, ignoreProcessed);
-			invoiceDAO.save(invoice);
-
 			importLine.setC_Payment_ID(payment.getC_Payment_ID());
 			esrImportDAO.save(importLine);
 

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/process/AllocatePayment.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/process/AllocatePayment.java
@@ -85,10 +85,7 @@ public class AllocatePayment extends de.metas.process.JavaProcess
 		final I_C_Invoice invoice = InterfaceWrapperHelper.create(getCtx(), p_C_Invoice_ID, I_C_Invoice.class, get_TrxName());
 		Services.get(IAllocationBL.class).autoAllocateSpecificPayment(invoice, payment, true);
 
-		final boolean ignoreProcessed = false;
-		Services.get(IInvoiceBL.class).testAllocation(invoice, ignoreProcessed);
-
-		return "OK";
+		return MSG_OK;
 	}
 
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/allocation/api/C_AllocationHdr_ProcessInterceptor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/allocation/api/C_AllocationHdr_ProcessInterceptor.java
@@ -28,6 +28,7 @@ package de.metas.allocation.api;
 
 import java.util.List;
 
+import lombok.NonNull;
 import org.adempiere.ad.wrapper.POJOWrapper;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_AllocationHdr;
@@ -49,7 +50,7 @@ import de.metas.util.Services;
 public class C_AllocationHdr_ProcessInterceptor implements IProcessInterceptor
 {
 	@Override
-	public boolean processIt(IDocument doc, String action) throws Exception
+	public boolean processIt(@NonNull final IDocument doc, @NonNull final String action) throws Exception
 	{
 		final POJOWrapper wrapper = POJOWrapper.getWrapper(doc);
 		final String trxName = InterfaceWrapperHelper.getTrxName(doc);


### PR DESCRIPTION
* if didn't happen if a credit memo was allocated against a payment and a service invoice (two allocatios)
* i did remove a bunch of now redundant calls too