### PR TITLE
consider uncollapseRowsOnChange

### DIFF
--- a/frontend/src/actions/TableActions.js
+++ b/frontend/src/actions/TableActions.js
@@ -345,13 +345,14 @@ export function updateGridTable(tableId, tableResponse) {
  * @method updateGridTableData
  * @summary Update grid table's rows and rebuild collapsed rows if necessary
  */
-export function updateGridTableData(tableId, rows) {
+export function updateGridTableData({ tableId, rows, customLayoutFlags }) {
+  const { uncollapseRowsOnChange } = customLayoutFlags;
   return (dispatch, getState) => {
     const state = getState();
 
     if (state.tables) {
       const table = state.tables[tableId];
-      const { uncollapseRowsOnChange, indentSupported, keyProperty } = table;
+      const { indentSupported, keyProperty } = table;
 
       if (rows.length && indentSupported) {
         rows = flattenRows(rows);

--- a/frontend/src/actions/TableActions.js
+++ b/frontend/src/actions/TableActions.js
@@ -349,6 +349,7 @@ export function updateGridTableData({
   tableId,
   rows,
   preserveCollapsedStateToRowIds,
+  customLayoutFlags,
 }) {
   return (dispatch, getState) => {
     const state = getState();
@@ -372,6 +373,7 @@ export function updateGridTableData({
             tableId,
             rows,
             preserveCollapsedStateToRowIds,
+            customLayoutFlags,
           })
         );
       }

--- a/frontend/src/actions/TableActions.js
+++ b/frontend/src/actions/TableActions.js
@@ -351,7 +351,7 @@ export function updateGridTableData(tableId, rows) {
 
     if (state.tables) {
       const table = state.tables[tableId];
-      const { indentSupported, keyProperty } = table;
+      const { uncollapseRowsOnChange, indentSupported, keyProperty } = table;
 
       if (rows.length && indentSupported) {
         rows = flattenRows(rows);
@@ -362,7 +362,7 @@ export function updateGridTableData(tableId, rows) {
 
       dispatch(updateTableData(tableId, rows, keyProperty));
 
-      if (indentSupported) {
+      if (indentSupported && uncollapseRowsOnChange) {
         dispatch(
           updateCollapsedRows({
             tableId,

--- a/frontend/src/actions/TableActions.js
+++ b/frontend/src/actions/TableActions.js
@@ -500,14 +500,19 @@ function createCollapsedRows({
  *
  * @param {string} tableId
  * @param {array} rows
- * @param {array} changedIds - array with ids of the rows to be changed that are sent with a websocket message
- *                             (if it's not empty it will preserve the previous state of the tree)
- *                             (if it's empty it will not preserve the state causing the tree to be uncollapsed )
+ * @param {array} preserveCollapsedStateToRowIds - array with ids of the rows to be changed that are sent with a websocket message
+ *                                                (if it's not empty it will preserve the previous state of the tree)
+ *                                                (if it's empty it will not preserve the state causing the tree to be uncollapsed )
  * @param {object} custom flags that come from the layout. i.e `uncollapseRowsOnChange`
  *        Note: this `uncollapseRowsOnChange` does not come yet from the backend response but if it was to be set to `true`
  *              it will force the rows to be uncollapsed. (`Create Purchase Order action` for a `Sales order line`)
  */
-function updateCollapsedRows({ tableId, rows, changedIds, customLayoutFlags }) {
+function updateCollapsedRows({
+  tableId,
+  rows,
+  preserveCollapsedStateToRowIds,
+  customLayoutFlags,
+}) {
   const { uncollapseRowsOnChange } = customLayoutFlags;
 
   return (dispatch, getState) => {
@@ -521,13 +526,18 @@ function updateCollapsedRows({ tableId, rows, changedIds, customLayoutFlags }) {
       collapsedParentRows,
     } = table;
 
-    const hasChangedIds = changedIds && changedIds.length > 0;
-    let newCollapsedParentRows =
-      hasChangedIds || !uncollapseRowsOnChange ? [...collapsedParentRows] : [];
-    let newCollapsedRows =
-      hasChangedIds || !uncollapseRowsOnChange ? [...collapsedRows] : [];
+    const hasChangedIds =
+      preserveCollapsedStateToRowIds &&
+      preserveCollapsedStateToRowIds.length > 0;
 
     if (collapsible) {
+      let newCollapsedParentRows =
+        hasChangedIds || !uncollapseRowsOnChange
+          ? [...collapsedParentRows]
+          : [];
+      let newCollapsedRows =
+        hasChangedIds || !uncollapseRowsOnChange ? [...collapsedRows] : [];
+
       if (rows.length) {
         rows.forEach((row) => {
           if (
@@ -556,7 +566,7 @@ function updateCollapsedRows({ tableId, rows, changedIds, customLayoutFlags }) {
           tableId,
           collapsedParentRows: newCollapsedParentRows,
           collapsedRows: newCollapsedRows,
-          changedIds,
+          preserveCollapsedStateToRowIds,
         })
       );
     }

--- a/frontend/src/actions/TableActions.js
+++ b/frontend/src/actions/TableActions.js
@@ -345,7 +345,11 @@ export function updateGridTable(tableId, tableResponse) {
  * @method updateGridTableData
  * @summary Update grid table's rows and rebuild collapsed rows if necessary
  */
-export function updateGridTableData({ tableId, rows, changedIds }) {
+export function updateGridTableData({
+  tableId,
+  rows,
+  preserveCollapsedStateToRowIds,
+}) {
   return (dispatch, getState) => {
     const state = getState();
 
@@ -367,7 +371,7 @@ export function updateGridTableData({ tableId, rows, changedIds }) {
           updateCollapsedRows({
             tableId,
             rows,
-            changedIds,
+            preserveCollapsedStateToRowIds,
           })
         );
       }
@@ -526,17 +530,19 @@ function updateCollapsedRows({
       collapsedParentRows,
     } = table;
 
-    const hasChangedIds =
+    const hasPreservedStateToRowIds =
       preserveCollapsedStateToRowIds &&
       preserveCollapsedStateToRowIds.length > 0;
 
     if (collapsible) {
       let newCollapsedParentRows =
-        hasChangedIds || !uncollapseRowsOnChange
+        hasPreservedStateToRowIds || !uncollapseRowsOnChange
           ? [...collapsedParentRows]
           : [];
       let newCollapsedRows =
-        hasChangedIds || !uncollapseRowsOnChange ? [...collapsedRows] : [];
+        hasPreservedStateToRowIds || !uncollapseRowsOnChange
+          ? [...collapsedRows]
+          : [];
 
       if (rows.length) {
         rows.forEach((row) => {

--- a/frontend/src/actions/TableActions.js
+++ b/frontend/src/actions/TableActions.js
@@ -500,8 +500,16 @@ function createCollapsedRows({
  *
  * @param {string} tableId
  * @param {array} rows
+ * @param {array} changedIds - array with ids of the rows to be changed that are sent with a websocket message
+ *                             (if it's not empty it will preserve the previous state of the tree)
+ *                             (if it's empty it will not preserve the state causing the tree to be uncollapsed )
+ * @param {object} custom flags that come from the layout. i.e `uncollapseRowsOnChange`
+ *        Note: this `uncollapseRowsOnChange` does not come yet from the backend response but if it was to be set to `true`
+ *              it will force the rows to be uncollapsed. (`Create Purchase Order action` for a `Sales order line`)
  */
-function updateCollapsedRows({ tableId, rows, changedIds }) {
+function updateCollapsedRows({ tableId, rows, changedIds, customLayoutFlags }) {
+  const { uncollapseRowsOnChange } = customLayoutFlags;
+
   return (dispatch, getState) => {
     const state = getState();
     const table = state.tables[tableId];
@@ -514,8 +522,10 @@ function updateCollapsedRows({ tableId, rows, changedIds }) {
     } = table;
 
     const hasChangedIds = changedIds && changedIds.length > 0;
-    let newCollapsedParentRows = hasChangedIds ? [...collapsedParentRows] : [];
-    let newCollapsedRows = hasChangedIds ? [...collapsedRows] : [];
+    let newCollapsedParentRows =
+      hasChangedIds || !uncollapseRowsOnChange ? [...collapsedParentRows] : [];
+    let newCollapsedRows =
+      hasChangedIds || !uncollapseRowsOnChange ? [...collapsedRows] : [];
 
     if (collapsible) {
       if (rows.length) {

--- a/frontend/src/components/table/TableRow.js
+++ b/frontend/src/components/table/TableRow.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import { F2_KEY } from '../../constants/Constants';
@@ -24,7 +24,7 @@ import WithMobileDoubleTap from '../WithMobileDoubleTap';
  * @module TableRow
  * @extends PureComponent
  */
-class TableRow extends Component {
+class TableRow extends PureComponent {
   constructor(props) {
     super(props);
 

--- a/frontend/src/components/table/TableRow.js
+++ b/frontend/src/components/table/TableRow.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import { F2_KEY } from '../../constants/Constants';
@@ -24,7 +24,7 @@ import WithMobileDoubleTap from '../WithMobileDoubleTap';
  * @module TableRow
  * @extends PureComponent
  */
-class TableRow extends PureComponent {
+class TableRow extends Component {
   constructor(props) {
     super(props);
 

--- a/frontend/src/containers/DocumentList.js
+++ b/frontend/src/containers/DocumentList.js
@@ -209,8 +209,10 @@ class DocumentListContainer extends Component {
       fetchQuickActions,
       isModal,
       viewProfileId,
+      viewData: layout,
     } = this.props;
     const viewId = customViewId ? customViewId : this.props.viewId;
+    const { uncollapseRowsOnChange } = layout;
 
     connectWS.call(this, `/view/${viewId}`, (msg) => {
       const { fullyChanged, changedIds, headerPropertiesChanged } = msg;
@@ -254,6 +256,7 @@ class DocumentListContainer extends Component {
               tableId,
               rows,
               changedIds,
+              customLayoutFlags: { uncollapseRowsOnChange },
             });
           }
         );

--- a/frontend/src/containers/DocumentList.js
+++ b/frontend/src/containers/DocumentList.js
@@ -209,10 +209,8 @@ class DocumentListContainer extends Component {
       fetchQuickActions,
       isModal,
       viewProfileId,
-      viewData: layout,
     } = this.props;
     const viewId = customViewId ? customViewId : this.props.viewId;
-    const { uncollapseRowsOnChange } = layout;
 
     connectWS.call(this, `/view/${viewId}`, (msg) => {
       const { fullyChanged, changedIds, headerPropertiesChanged } = msg;

--- a/frontend/src/containers/DocumentList.js
+++ b/frontend/src/containers/DocumentList.js
@@ -255,7 +255,7 @@ class DocumentListContainer extends Component {
             updateGridTableData({
               tableId,
               rows,
-              changedIds,
+              preserveCollapsedStateToRowIds: changedIds,
               customLayoutFlags: { uncollapseRowsOnChange },
             });
           }

--- a/frontend/src/containers/DocumentList.js
+++ b/frontend/src/containers/DocumentList.js
@@ -255,7 +255,7 @@ class DocumentListContainer extends Component {
             updateGridTableData({
               tableId,
               rows,
-              customLayoutFlags: { uncollapseRowsOnChange },
+              changedIds,
             });
           }
         );

--- a/frontend/src/containers/DocumentList.js
+++ b/frontend/src/containers/DocumentList.js
@@ -209,8 +209,10 @@ class DocumentListContainer extends Component {
       fetchQuickActions,
       isModal,
       viewProfileId,
+      viewData: layout,
     } = this.props;
     const viewId = customViewId ? customViewId : this.props.viewId;
+    const { uncollapseRowsOnChange } = layout;
 
     connectWS.call(this, `/view/${viewId}`, (msg) => {
       const { fullyChanged, changedIds, headerPropertiesChanged } = msg;
@@ -250,7 +252,11 @@ class DocumentListContainer extends Component {
               });
             }
 
-            updateGridTableData(tableId, rows);
+            updateGridTableData({
+              tableId,
+              rows,
+              customLayoutFlags: { uncollapseRowsOnChange },
+            });
           }
         );
       }


### PR DESCRIPTION
Updated the recording

https://www.loom.com/share/ff381115156249b99dc7c22942bf50ce

rel to https://github.com/metasfresh/metasfresh/issues/12032


Note: the case when the line is not updated is caused by a BE caching. Documented in the issue
