### PR TITLE
invoice candidate updating now can also set the invoice's C_Tax_ID

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/DB.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/DB.java
@@ -2134,7 +2134,7 @@ public class DB
 	/**
 	 * Create persistent selection in T_Selection table
 	 */
-	public void createT_Selection(@NonNull final PInstanceId pinstanceId, final Iterable<Integer> selection, @Nullable final String trxName)
+	public void createT_Selection(@NonNull final PInstanceId pinstanceId, @NonNull final Iterable<Integer> selection, @Nullable final String trxName)
 	{
 		final int pinstanceRepoId = pinstanceId.getRepoId();
 
@@ -2173,7 +2173,7 @@ public class DB
 	 *
 	 * @return generated AD_PInstance_ID that can be used to identify the selection
 	 */
-	public PInstanceId createT_Selection(final Iterable<Integer> selection, final String trxName)
+	public PInstanceId createT_Selection(@NonNull final Iterable<Integer> selection, @Nullable final String trxName)
 	{
 		final PInstanceId pinstanceId = Services.get(IADPInstanceDAO.class).createSelectionId();
 		createT_Selection(pinstanceId, selection, trxName);

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/refund/invoicecandidatehandler/FlatrateTermRefund_Handler.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/refund/invoicecandidatehandler/FlatrateTermRefund_Handler.java
@@ -60,7 +60,7 @@ public class FlatrateTermRefund_Handler
 	}
 
 	/**
-	 * @return an empty iterator; invoice candidates that need to be there are created from {@link InvoiceCandidateAssignmentService}.
+	 * @return an empty iterator; invoice candidates that need to be there are created from {@link de.metas.contracts.CandidateAssignmentService}.
 	 */
 	@Override
 	public Iterator<I_C_Flatrate_Term> retrieveTermsWithMissingCandidates(final int limit)
@@ -100,7 +100,7 @@ public class FlatrateTermRefund_Handler
 	}
 
 	/**
-	 * @return {@link PriceAndTax#NONE} because the tax remains unchanged and the price is updated in {@link InvoiceCandidateAssignmentService}.
+	 * @return {@link PriceAndTax#NONE} because the tax remains unchanged and the price is updated in {@link de.metas.contracts.CandidateAssignmentServive}.
 	 */
 	@Override
 	public PriceAndTax calculatePriceAndTax(@NonNull final I_C_Invoice_Candidate invoiceCandidateRecord)

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/subscription/invoicecandidatehandler/FlatrateTermSubscription_Handler.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/subscription/invoicecandidatehandler/FlatrateTermSubscription_Handler.java
@@ -11,10 +11,13 @@ import de.metas.contracts.model.I_C_Flatrate_Transition;
 import de.metas.contracts.model.X_C_Flatrate_Conditions;
 import de.metas.contracts.model.X_C_Flatrate_Term;
 import de.metas.contracts.model.X_C_Flatrate_Transition;
+import de.metas.invoicecandidate.api.IInvoiceCandInvalidUpdater;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.invoicecandidate.spi.IInvoiceCandidateHandler.PriceAndTax;
 import de.metas.lang.SOTrx;
+import de.metas.money.CurrencyId;
 import de.metas.organization.OrgId;
+import de.metas.pricing.PricingSystemId;
 import de.metas.quantity.Quantity;
 import de.metas.tax.api.ITaxBL;
 import de.metas.tax.api.TaxCategoryId;
@@ -57,23 +60,28 @@ public class FlatrateTermSubscription_Handler implements ConditionTypeSpecificIn
 
 	@Override
 	public void setSpecificInvoiceCandidateValues(
-			@NonNull final I_C_Invoice_Candidate ic,
+			@NonNull final I_C_Invoice_Candidate icRecord,
 			@NonNull final I_C_Flatrate_Term term)
 	{
-		ic.setPriceActual(term.getPriceActual()); // TODO document and make sure there is the correct value
-		ic.setPrice_UOM_ID(term.getC_UOM_ID()); // 07090 when we set PiceActual, we shall also set PriceUOM.
-		ic.setPriceEntered(term.getPriceActual()); // cg : task 04917 -- same as price actual
-
-		final boolean isSOTrx = true;
+		final PriceAndTax priceAndTax = calculatePriceAndTax(icRecord);
+		IInvoiceCandInvalidUpdater.updatePriceAndTax(icRecord, priceAndTax);
 
 		// 05265
-		ic.setIsSOTrx(isSOTrx);
+		icRecord.setIsSOTrx(true);
 
 		final TaxCategoryId taxCategoryId = TaxCategoryId.ofRepoIdOrNull(term.getC_TaxCategory_ID());
 
 		final BigDecimal qty = Services.get(IContractsDAO.class).retrieveSubscriptionProgressQtyForTerm(term);
-		ic.setQtyOrdered(qty);
+		icRecord.setQtyOrdered(qty);
+	}
 
+	@Override
+	public PriceAndTax calculatePriceAndTax(@NonNull final I_C_Invoice_Candidate ic)
+	{
+		final I_C_Flatrate_Term term = HandlerTools.retrieveTerm(ic);
+
+		final TaxCategoryId taxCategoryId = TaxCategoryId.ofRepoIdOrNull(term.getC_TaxCategory_ID());
+		
 		final TaxId taxId = Services.get(ITaxBL.class).getTaxNotNull(
 				Env.getCtx(),
 				term,
@@ -85,17 +93,17 @@ public class FlatrateTermSubscription_Handler implements ConditionTypeSpecificIn
 				CoalesceUtil.coalesceSuppliers(
 						() -> ContractLocationHelper.extractDropshipLocationId(term),
 						() -> ContractLocationHelper.extractBillToLocationId(term)),
-				SOTrx.ofBoolean(isSOTrx));
-		ic.setC_Tax_ID(taxId.getRepoId());
-	}
-
-	@Override
-	public PriceAndTax calculatePriceAndTax(@NonNull final I_C_Invoice_Candidate ic)
-	{
-		final I_C_Flatrate_Term term = HandlerTools.retrieveTerm(ic);
+				SOTrx.ofBoolean(ic.isSOTrx()));
+		
 		return PriceAndTax.builder()
+				.pricingSystemId(PricingSystemId.ofRepoId(term.getM_PricingSystem_ID()))
 				.priceActual(term.getPriceActual())
+				.priceEntered(term.getPriceActual()) // cg : task 04917 -- same as price actual
 				.priceUOMId(UomId.ofRepoId(term.getC_UOM_ID())) // 07090: when setting a priceActual, we also need to specify a PriceUOM
+				.taxCategoryId(TaxCategoryId.ofRepoId(term.getC_TaxCategory_ID()))
+				.taxId(taxId)
+				.taxIncluded(term.isTaxIncluded())
+				.currencyId(CurrencyId.ofRepoId(term.getC_Currency_ID()))
 				.build();
 	}
 

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/subscription/invoicecandidatehandler/FlatrateTermSubscription_Handler.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/subscription/invoicecandidatehandler/FlatrateTermSubscription_Handler.java
@@ -103,7 +103,7 @@ public class FlatrateTermSubscription_Handler implements ConditionTypeSpecificIn
 				.taxCategoryId(TaxCategoryId.ofRepoId(term.getC_TaxCategory_ID()))
 				.taxId(taxId)
 				.taxIncluded(term.isTaxIncluded())
-				.currencyId(CurrencyId.ofRepoId(term.getC_Currency_ID()))
+				.currencyId(CurrencyId.ofRepoIdOrNull(term.getC_Currency_ID()))
 				.build();
 	}
 

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/subscription/invoicecandidatehandler/FlatrateTermSubscription_Handler.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/subscription/invoicecandidatehandler/FlatrateTermSubscription_Handler.java
@@ -90,7 +90,7 @@ public class FlatrateTermSubscription_Handler implements ConditionTypeSpecificIn
 				ic.getDateOrdered(), // shipDate
 				OrgId.ofRepoId(term.getAD_Org_ID()),
 				(WarehouseId)null,
-				CoalesceUtil.coalesceSuppliers(
+				CoalesceUtil.coalesceSuppliersNotNull(
 						() -> ContractLocationHelper.extractDropshipLocationId(term),
 						() -> ContractLocationHelper.extractBillToLocationId(term)),
 				SOTrx.ofBoolean(ic.isSOTrx()));

--- a/backend/de.metas.contracts/src/test/java/de/metas/contracts/flatrate/impexp/IFlatrateTermFactory.java
+++ b/backend/de.metas.contracts/src/test/java/de/metas/contracts/flatrate/impexp/IFlatrateTermFactory.java
@@ -74,7 +74,6 @@ import lombok.Value;
 			iFlatrateTerm.setEndDate(endDate);
 			iFlatrateTerm.setMasterStartDate(masterStartDate);
 			iFlatrateTerm.setMasterEndDate(masterEndDate);
-
 			InterfaceWrapperHelper.save(iFlatrateTerm);
 			return iFlatrateTerm;
 		}

--- a/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/AbstractFlatrateTermTest.java
+++ b/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/AbstractFlatrateTermTest.java
@@ -33,6 +33,7 @@ import de.metas.organization.OrgId;
 import de.metas.product.ProductAndCategoryId;
 import de.metas.product.ProductId;
 import de.metas.tax.api.TaxCategoryId;
+import de.metas.uom.UomId;
 import de.metas.user.UserRepository;
 import de.metas.util.Services;
 import lombok.Getter;
@@ -356,6 +357,7 @@ public abstract class AbstractFlatrateTermTest
 				.onFlatrateTermExtend(X_C_Flatrate_Conditions.ONFLATRATETERMEXTEND_CalculatePrice)
 				.isCreateNoInvoice(false)
 				.extensionType(extensionType)
+				.uomId(UomId.ofRepoId(productAndPricingSystem.getProduct().getC_UOM_ID()))
 				.build();
 	}
 

--- a/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/FlatrateTermDataFactory.java
+++ b/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/FlatrateTermDataFactory.java
@@ -7,6 +7,7 @@ import de.metas.contracts.model.X_C_Flatrate_Conditions;
 import de.metas.contracts.model.X_C_Flatrate_Transition;
 import de.metas.money.CurrencyId;
 import de.metas.product.ProductAndCategoryId;
+import de.metas.uom.UomId;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
@@ -31,6 +32,7 @@ import org.compiere.model.X_C_Tax;
 import org.compiere.model.X_M_Product;
 import org.compiere.util.TimeUtil;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 
@@ -113,16 +115,24 @@ public class FlatrateTermDataFactory
 	}
 
 	@Builder(builderMethodName = "flatrateConditionsNew")
-	public static I_C_Flatrate_Conditions createFlatrateConditions(final String name, final String invoiceRule,
-			final String typeConditions, @NonNull final I_C_Calendar calendar, @NonNull final String onFlatrateTermExtend,
-			@NonNull final I_M_PricingSystem pricingSystem, final String extensionType, final boolean isCreateNoInvoice)
+	public static I_C_Flatrate_Conditions createFlatrateConditions(
+			final String name, 
+			final String invoiceRule,
+			final String typeConditions, 
+			@Nullable final UomId uomId,
+			@NonNull final I_C_Calendar calendar, 
+			@NonNull final String onFlatrateTermExtend,
+			@NonNull final I_M_PricingSystem pricingSystem, 
+			final String extensionType, 
+			final boolean isCreateNoInvoice)
 	{
 		final I_C_Flatrate_Conditions conditions = newInstance(I_C_Flatrate_Conditions.class);
-		conditions.setM_PricingSystem_ID(pricingSystem == null ? null : pricingSystem.getM_PricingSystem_ID());
+		conditions.setM_PricingSystem_ID(pricingSystem.getM_PricingSystem_ID());
 		conditions.setInvoiceRule(invoiceRule);
 		conditions.setType_Conditions(typeConditions);
 		conditions.setOnFlatrateTermExtend(onFlatrateTermExtend);
 		conditions.setName(name);
+		conditions.setC_UOM_ID(UomId.toRepoId(uomId));
 		save(conditions);
 
 		final I_C_Flatrate_Transition transition = flatrateTransitionNew()
@@ -147,8 +157,15 @@ public class FlatrateTermDataFactory
 	}
 
 	@Builder(builderMethodName = "flatrateTransitionNew")
-	private static I_C_Flatrate_Transition createFlatrateTransition(final I_C_Flatrate_Conditions conditions, @NonNull final I_C_Calendar calendar, final int termDuration, final String termDurationUnit,
-			final int deliveryInterval, final String deliveryIntervalUnit, final boolean isAutoCompleteNewTerm, final String extensionType)
+	private static I_C_Flatrate_Transition createFlatrateTransition(
+			final I_C_Flatrate_Conditions conditions, 
+			@NonNull final I_C_Calendar calendar, 
+			final int termDuration, 
+			final String termDurationUnit,
+			final int deliveryInterval, 
+			final String deliveryIntervalUnit, 
+			final boolean isAutoCompleteNewTerm, 
+			final String extensionType)
 	{
 		final I_C_Flatrate_Transition transition = newInstance(I_C_Flatrate_Transition.class);
 		transition.setC_Calendar_Contract(calendar);
@@ -189,6 +206,7 @@ public class FlatrateTermDataFactory
 		I_C_TaxCategory taxCategory;
 		I_C_Tax tax;
 
+		@Nullable
 		public ProductAndCategoryId getProductAndCategoryId()
 		{
 			return product != null

--- a/backend/de.metas.contracts/src/test/java/de/metas/contracts/invoicecandidate/FlatrateTermHandlerTest.java
+++ b/backend/de.metas.contracts/src/test/java/de/metas/contracts/invoicecandidate/FlatrateTermHandlerTest.java
@@ -23,6 +23,7 @@ import de.metas.invoicecandidate.spi.InvoiceCandidateGenerateRequest;
 import de.metas.invoicecandidate.spi.InvoiceCandidateGenerateResult;
 import de.metas.lang.SOTrx;
 import de.metas.organization.OrgId;
+import de.metas.pricing.PricingSystemId;
 import de.metas.product.ProductId;
 import de.metas.product.acct.api.ActivityId;
 import de.metas.tax.api.ITaxBL;
@@ -120,6 +121,8 @@ public class FlatrateTermHandlerTest extends ContractsTestBase
 				.conditions(conditions)
 				.product(product1)
 				.orderLine(orderLine)
+				.pricingSystemId(PricingSystemId.ofRepoId(10)) // note that while C_FlatrateTerm.C_PricingSystem_ID and C_TaxCategory_ID 
+				.taxCategoryId(TaxCategoryId.ofRepoId(20)) // are not mandatory, every subscription term receives one
 				.startDate(TimeUtil.getDay(2013, 5, 27)) // yesterday
 				.build();
 
@@ -142,7 +145,7 @@ public class FlatrateTermHandlerTest extends ContractsTestBase
 						term1.getStartDate(),
 						OrgId.ofRepoId(term1.getAD_Org_ID()),
 						(WarehouseId)null,
-						CoalesceUtil.coalesceSuppliers(
+						CoalesceUtil.coalesceSuppliersNotNull(
 								() -> ContractLocationHelper.extractDropshipLocationId(term1),
 								() -> ContractLocationHelper.extractBillToLocationId(term1)),
 						SOTrx.SALES))
@@ -245,6 +248,8 @@ public class FlatrateTermHandlerTest extends ContractsTestBase
 			@NonNull final BPartnerLocationAndCaptureId bPartnerLocationAndCaptureId,
 			@NonNull final I_C_Flatrate_Conditions conditions,
 			final I_M_Product product,
+			final PricingSystemId pricingSystemId,
+			final TaxCategoryId taxCategoryId,
 			final I_C_OrderLine orderLine,
 			@NonNull final Timestamp startDate,
 			final boolean isAutoRenew)
@@ -259,6 +264,8 @@ public class FlatrateTermHandlerTest extends ContractsTestBase
 		term.setStartDate(startDate);
 		term.setC_OrderLine_Term_ID(orderLine.getC_OrderLine_ID());
 		term.setC_Order_Term_ID(orderLine.getC_Order_ID());
+		term.setM_PricingSystem_ID(PricingSystemId.toRepoId(pricingSystemId));
+		term.setC_TaxCategory_ID(TaxCategoryId.toRepoId(taxCategoryId));
 		term.setIsAutoRenew(isAutoRenew);
 		term.setC_UOM_ID(uomId.getRepoId());
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/RunCucumberTest.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/RunCucumberTest.java
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 @CucumberOptions(
 		glue = "de.metas.cucumber.stepdefs",
 		tags = "not @ignore",
+		//tags = "@onlyThis",
 		plugin = {
 				"html:target/cucumber.html",
 				"json:target/cucumber.json" /* this json-output is needed for the Jenkins plugin that's supposed to publish it */,

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_StepDef.java
@@ -43,6 +43,7 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.trx.api.ITrx;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_BPartner_Location;
 import org.compiere.model.I_C_Invoice;
@@ -121,7 +122,7 @@ public class C_Invoice_StepDef
 		//enqueue invoice candidate
 		final I_C_Invoice_Candidate invoiceCandidateRecord = invoiceCandDAO.getById(invoiceCandidateId);
 
-		final PInstanceId invoiceCandidatesSelectionId = DB.createT_Selection(ImmutableList.of(invoiceCandidateId.getRepoId()), null);
+		final PInstanceId invoiceCandidatesSelectionId = DB.createT_Selection(ImmutableList.of(invoiceCandidateId.getRepoId()), ITrx.TRXNAME_None);
 
 		final PlainInvoicingParams invoicingParams = new PlainInvoicingParams();
 		invoicingParams.setIgnoreInvoiceSchedule(false);

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/invoicecandidate/spi/impl/C_OLCand_Handler.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/invoicecandidate/spi/impl/C_OLCand_Handler.java
@@ -17,6 +17,7 @@ import de.metas.lang.SOTrx;
 import de.metas.ordercandidate.api.IOLCandBL;
 import de.metas.ordercandidate.api.IOLCandEffectiveValuesBL;
 import de.metas.ordercandidate.model.I_C_OLCand;
+import de.metas.organization.IOrgDAO;
 import de.metas.organization.OrgId;
 import de.metas.pricing.IPricingResult;
 import de.metas.pricing.PricingSystemId;
@@ -31,6 +32,7 @@ import de.metas.uom.UomId;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.service.ClientId;
@@ -39,6 +41,7 @@ import org.adempiere.warehouse.WarehouseId;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 
+import java.time.ZoneId;
 import java.util.Iterator;
 import java.util.Properties;
 
@@ -60,6 +63,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 public class C_OLCand_Handler extends AbstractInvoiceCandidateHandler
 {
 	private final C_OLCand_HandlerDAO dao = new C_OLCand_HandlerDAO();
+	private final IOrgDAO orgDAO = Services.get(IOrgDAO.class);;
 
 	@Override
 	public boolean isCreateMissingCandidatesAutomatically()
@@ -85,7 +89,7 @@ public class C_OLCand_Handler extends AbstractInvoiceCandidateHandler
 	public Iterator<I_C_OLCand> retrieveAllModelsWithMissingCandidates(final int limit)
 	{
 		return dao.retrieveMissingCandidatesQuery(Env.getCtx(), ITrx.TRXNAME_ThreadInherited)
-				.setLimit(limit)
+				.setLimit(QueryLimit.ofInt(limit))
 				.create()
 				.iterate(I_C_OLCand.class);
 	}
@@ -265,8 +269,7 @@ public class C_OLCand_Handler extends AbstractInvoiceCandidateHandler
 
 	private I_C_OLCand getOLCand(@NonNull final I_C_Invoice_Candidate ic)
 	{
-		final I_C_OLCand olc = TableRecordCacheLocal.getReferencedValue(ic, I_C_OLCand.class);
-		return olc;
+		return TableRecordCacheLocal.getReferencedValue(ic, I_C_OLCand.class);
 	}
 
 	/**
@@ -290,12 +293,13 @@ public class C_OLCand_Handler extends AbstractInvoiceCandidateHandler
 	@Override
 	public PriceAndTax calculatePriceAndTax(@NonNull final I_C_Invoice_Candidate ic)
 	{
+		final ZoneId timeZone = orgDAO.getTimeZone(OrgId.ofRepoId(ic.getAD_Org_ID()));
 		final I_C_OLCand olc = getOLCand(ic);
 		final IPricingResult pricingResult = Services.get(IOLCandBL.class).computePriceActual(
 				olc,
 				null,
 				PricingSystemId.NULL,
-				TimeUtil.asLocalDate(olc.getDateCandidate()));
+				TimeUtil.asLocalDate(olc.getDateCandidate(), timeZone));
 
 		return PriceAndTax.builder()
 				.priceUOMId(pricingResult.getPriceUomId())

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/IOLCandBL.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/IOLCandBL.java
@@ -42,6 +42,7 @@ import de.metas.user.UserId;
 import de.metas.util.ISingletonService;
 import org.compiere.model.PO;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
@@ -75,7 +76,7 @@ public interface IOLCandBL extends ISingletonService
 	 * @param pricingSystemIdOverride if not <code>null</code>, then this value is used instead of {@link I_C_OLCand#getM_PricingSystem_ID()}
 	 * @param date to be used in retrieving the actual price
 	 */
-	IPricingResult computePriceActual(I_C_OLCand olCand, BigDecimal qtyOverride, PricingSystemId pricingSystemIdOverride, LocalDate date);
+	IPricingResult computePriceActual(I_C_OLCand olCand, @Nullable BigDecimal qtyOverride, PricingSystemId pricingSystemIdOverride, LocalDate date);
 
 	AttachmentEntry addAttachment(OLCandQuery olCandQuery, AttachmentEntryCreateRequest attachmentEntryCreateRequest);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
@@ -281,7 +281,7 @@ public interface IInvoiceCandBL extends ISingletonService
 	 *
 	 * @param askForDeleteRegeneration error message will append request to the user asking him/her to delete invoice candidate after problem was fixed and wait for its regeneration
 	 */
-	void setError(I_C_Invoice_Candidate ic, String errorMsg, I_AD_Note note, boolean askForDeleteRegeneration);
+	void setError(I_C_Invoice_Candidate ic, String errorMsg, @Nullable I_AD_Note note, boolean askForDeleteRegeneration);
 
 	void setError(I_C_Invoice_Candidate ic, Throwable e);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandInvalidUpdater.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandInvalidUpdater.java
@@ -135,7 +135,7 @@ public interface IInvoiceCandInvalidUpdater
 		}
 		if (priceAndTax.getDiscount() != null)
 		{
-			ic.setDiscount(Percent.toBigDecimalOrNull(priceAndTax.getDiscount()));
+			ic.setDiscount(Percent.toBigDecimalOrZero(priceAndTax.getDiscount()));
 		}
 		if (priceAndTax.getInvoicableQtyBasedOn() != null)
 		{
@@ -147,7 +147,11 @@ public interface IInvoiceCandInvalidUpdater
 		{
 			ic.setIsTaxIncluded(priceAndTax.getTaxIncluded());
 		}
-
+		if (priceAndTax.getTaxId() != null)
+		{
+			ic.setC_Tax_ID(priceAndTax.getTaxId().getRepoId());
+		}
+		
 		//
 		// Compensation group
 		if (priceAndTax.getCompensationGroupBaseAmt() != null)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationEngine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationEngine.java
@@ -414,7 +414,10 @@ public final class AggregationEngine
 					final String pricingSystemName = priceListDAO.getPricingSystemName(PricingSystemId.ofRepoIdOrNull(icRecord.getM_PricingSystem_ID()));
 					throw new AdempiereException(ERR_INVOICE_CAND_PRICE_LIST_MISSING_2P,
 												 pricingSystemName,
-												 invoiceHeader.getBillTo());
+												 invoiceHeader.getBillTo())
+							.appendParametersToMessage()
+							.setParameter("M_PricingSystem_ID", icRecord.getM_PricingSystem_ID())
+							.setParameter("C_Invoice_Candidate", icRecord);
 				}
 				M_PriceList_ID = plId.getRepoId();
 			}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -2240,7 +2240,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 		{
 			try (final MDCCloseable icRecordMDC = TableRecordMDC.putTableRecordReference(icRecord))
 			{
-				logger.debug("Set IsInDispute=true because ic bleongs to M_InOutLine_ID={}", receiptLine.getM_InOutLine_ID());
+				logger.debug("Set IsInDispute=true because ic belongs to M_InOutLine_ID={}", receiptLine.getM_InOutLine_ID());
 				icRecord.setIsInDispute(true);
 				save(icRecord);
 			}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/IInvoiceCandidateHandler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/IInvoiceCandidateHandler.java
@@ -11,6 +11,7 @@ import de.metas.pricing.InvoicableQtyBasedOn;
 import de.metas.pricing.PriceListVersionId;
 import de.metas.pricing.PricingSystemId;
 import de.metas.tax.api.TaxCategoryId;
+import de.metas.tax.api.TaxId;
 import de.metas.uom.UomId;
 import de.metas.util.Services;
 import de.metas.util.lang.Percent;
@@ -282,12 +283,14 @@ public interface IInvoiceCandidateHandler
 
 		Percent discount;
 
-		TaxCategoryId taxCategoryId;
+		InvoicableQtyBasedOn invoicableQtyBasedOn;
+
 		Boolean taxIncluded;
+		TaxId taxId;
+		TaxCategoryId taxCategoryId;
 
 		BigDecimal compensationGroupBaseAmt;
 
-		InvoicableQtyBasedOn invoicableQtyBasedOn;
 	}
 
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/invoicecandidate/C_OrderLine_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/invoicecandidate/C_OrderLine_Handler.java
@@ -15,6 +15,7 @@ import de.metas.interfaces.I_C_OrderLine;
 import de.metas.invoicecandidate.InvoiceCandidateIds;
 import de.metas.invoicecandidate.api.IInvoiceCandBL;
 import de.metas.invoicecandidate.api.IInvoiceCandDAO;
+import de.metas.invoicecandidate.api.IInvoiceCandInvalidUpdater;
 import de.metas.invoicecandidate.compensationGroup.InvoiceCandidateGroupRepository;
 import de.metas.invoicecandidate.internalbusinesslogic.InvoiceCandidateRecordService;
 import de.metas.invoicecandidate.location.adapter.InvoiceCandidateLocationAdapterFactory;
@@ -27,6 +28,7 @@ import de.metas.invoicecandidate.spi.IInvoiceCandidateHandler.PriceAndTax.PriceA
 import de.metas.invoicecandidate.spi.InvoiceCandidateGenerateRequest;
 import de.metas.invoicecandidate.spi.InvoiceCandidateGenerateResult;
 import de.metas.lang.SOTrx;
+import de.metas.money.CurrencyId;
 import de.metas.order.IOrderLineBL;
 import de.metas.order.OrderLineId;
 import de.metas.order.compensationGroup.Group;
@@ -38,6 +40,7 @@ import de.metas.order.location.adapter.OrderDocumentLocationAdapterFactory;
 import de.metas.organization.OrgId;
 import de.metas.payment.paymentterm.PaymentTermId;
 import de.metas.pricing.InvoicableQtyBasedOn;
+import de.metas.pricing.PricingSystemId;
 import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
 import de.metas.product.acct.api.ActivityId;
@@ -77,6 +80,10 @@ public class C_OrderLine_Handler extends AbstractInvoiceCandidateHandler
 	private final DimensionService dimensionService = SpringContextHolder.instance.getBean(DimensionService.class);
 	private final IShipmentSchedulePA shipmentSchedulePA = Services.get(IShipmentSchedulePA.class);
 	private final IDocTypeBL docTypeBL = Services.get(IDocTypeBL.class);
+	private final ITaxBL taxBL = Services.get(ITaxBL.class);
+	private final IInvoiceCandBL invoiceCandBL = Services.get(IInvoiceCandBL.class);
+	private final IProductBL productBL = Services.get(IProductBL.class);
+	private final IADTableDAO tableDAO = Services.get(IADTableDAO.class);
 
 	/**
 	 * @return <code>false</code>, the candidates will be created by {@link C_Order_Handler}.
@@ -128,8 +135,6 @@ public class C_OrderLine_Handler extends AbstractInvoiceCandidateHandler
 
 	private I_C_Invoice_Candidate createCandidateForOrderLine(final I_C_OrderLine orderLine)
 	{
-		final IProductBL productBL = Services.get(IProductBL.class);
-
 		final Properties ctx = InterfaceWrapperHelper.getCtx(orderLine);
 		final String trxName = InterfaceWrapperHelper.getTrxName(orderLine);
 
@@ -140,11 +145,11 @@ public class C_OrderLine_Handler extends AbstractInvoiceCandidateHandler
 		icRecord.setAD_Org_ID(orderLine.getAD_Org_ID());
 		icRecord.setC_ILCandHandler(getHandlerRecord());
 
-		icRecord.setAD_Table_ID(Services.get(IADTableDAO.class).retrieveTableId(org.compiere.model.I_C_OrderLine.Table_Name));
+		icRecord.setAD_Table_ID(tableDAO.retrieveTableId(org.compiere.model.I_C_OrderLine.Table_Name));
 		icRecord.setRecord_ID(orderLine.getC_OrderLine_ID());
 
-		icRecord.setC_OrderLine_ID(orderLine.getC_OrderLine_ID());
-
+		icRecord.setC_OrderLine(orderLine);
+		
 		final int productRecordId = orderLine.getM_Product_ID();
 		icRecord.setM_Product_ID(productRecordId);
 
@@ -158,13 +163,6 @@ public class C_OrderLine_Handler extends AbstractInvoiceCandidateHandler
 
 		setOrderedData(icRecord, orderLine);
 
-		icRecord.setInvoicableQtyBasedOn(orderLine.getInvoicableQtyBasedOn());
-		icRecord.setPriceActual(orderLine.getPriceActual());
-		icRecord.setPrice_UOM_ID(orderLine.getPrice_UOM_ID()); // 07090 when we set PiceActual, we shall also set PriceUOM.
-		icRecord.setPriceEntered(orderLine.getPriceEntered()); // cg : task 04917
-		icRecord.setDiscount(orderLine.getDiscount()); // cg: 04868
-		icRecord.setC_Currency_ID(orderLine.getC_Currency_ID());
-
 		icRecord.setQtyToInvoice(BigDecimal.ZERO); // to be computed
 
 		icRecord.setDescription(orderLine.getDescription()); // 03439
@@ -176,52 +174,28 @@ public class C_OrderLine_Handler extends AbstractInvoiceCandidateHandler
 
 		//
 		// Invoice Rule(s)
+		icRecord.setInvoiceRule(order.getInvoiceRule());
+
+		// If we are dealing with a non-receivable service set the InvoiceRule_Override to Immediate
+		// because we want to invoice those right away (08408)
+		if (isNotReceivebleService(icRecord))
 		{
-			icRecord.setInvoiceRule(order.getInvoiceRule());
-
-			// If we are dealing with a non-receivable service set the InvoiceRule_Override to Immediate
-			// because we want to invoice those right away (08408)
-			if (isNotReceivebleService(icRecord))
-			{
-				icRecord.setInvoiceRule_Override(X_C_Invoice_Candidate.INVOICERULE_OVERRIDE_Immediate); // immediate
-			}
+			icRecord.setInvoiceRule_Override(X_C_Invoice_Candidate.INVOICERULE_OVERRIDE_Immediate); // immediate
 		}
-
-		icRecord.setM_PricingSystem_ID(order.getM_PricingSystem_ID());
 
 		// 05265
 		icRecord.setIsSOTrx(orderLine.getC_Order().isSOTrx());
 
 		icRecord.setQtyOrderedOverUnder(orderLine.getQtyOrderedOverUnder());
 
+		// prices and tax
+		final PriceAndTax priceAndTax = calculatePriceAndTax(icRecord);
+		IInvoiceCandInvalidUpdater.updatePriceAndTax(icRecord, priceAndTax);
+		
 		//
 		// Dimension
 		final Dimension orderLineDimension = extractDimension(orderLine);
 		dimensionService.updateRecord(icRecord, orderLineDimension);
-
-		DocumentLocation orderDeliveryLocation = OrderDocumentLocationAdapterFactory
-				.deliveryLocationAdapter(order)
-				.toDocumentLocation();
-		if (orderDeliveryLocation.getBpartnerLocationId() == null)
-		{
-			orderDeliveryLocation = OrderDocumentLocationAdapterFactory
-					.locationAdapter(order)
-					.toDocumentLocation();
-		}
-
-		//
-		// Tax
-		final TaxId taxId = Services.get(ITaxBL.class).getTaxNotNull(
-				ctx,
-				icRecord,
-				TaxCategoryId.ofRepoIdOrNull(orderLine.getC_TaxCategory_ID()),
-				orderLine.getM_Product_ID(),
-				order.getDatePromised(), // shipDate
-				OrgId.ofRepoId(order.getAD_Org_ID()),
-				WarehouseId.ofRepoIdOrNull(order.getM_Warehouse_ID()),
-				orderDeliveryLocation.toBPartnerLocationAndCaptureId(), // ship location id
-				SOTrx.ofBoolean(order.isSOTrx()));
-		icRecord.setC_Tax_ID(TaxId.toRepoId(taxId)); // avoid NPE in tests
 
 		//DocType
 		final DocTypeId orderDocTypeId = CoalesceUtil.coalesceSuppliersNotNull(
@@ -237,7 +211,7 @@ public class C_OrderLine_Handler extends AbstractInvoiceCandidateHandler
 		final AttributeSetInstanceId asiId = AttributeSetInstanceId.ofRepoIdOrNone(orderLine.getM_AttributeSetInstance_ID());
 		final ImmutableAttributeSet attributes = Services.get(IAttributeDAO.class).getImmutableAttributeSetById(asiId);
 
-		Services.get(IInvoiceCandBL.class).setQualityDiscountPercent_Override(icRecord, attributes);
+		invoiceCandBL.setQualityDiscountPercent_Override(icRecord, attributes);
 
 		icRecord.setC_Async_Batch_ID(order.getC_Async_Batch_ID());
 
@@ -404,29 +378,55 @@ public class C_OrderLine_Handler extends AbstractInvoiceCandidateHandler
 	}
 
 	@Override
-	public PriceAndTax calculatePriceAndTax(@NonNull final I_C_Invoice_Candidate ic)
+	public PriceAndTax calculatePriceAndTax(@NonNull final I_C_Invoice_Candidate icRecord)
 	{
-		final I_C_OrderLine orderLine = InterfaceWrapperHelper.create(ic.getC_OrderLine(), I_C_OrderLine.class);
+		final I_C_OrderLine orderLine = InterfaceWrapperHelper.create(icRecord.getC_OrderLine(), I_C_OrderLine.class);
+		final org.compiere.model.I_C_Order order = orderLine.getC_Order();
+
+		DocumentLocation orderDeliveryLocation = OrderDocumentLocationAdapterFactory
+				.deliveryLocationAdapter(order)
+				.toDocumentLocation();
+		if (orderDeliveryLocation.getBpartnerLocationId() == null)
+		{
+			orderDeliveryLocation = OrderDocumentLocationAdapterFactory
+					.locationAdapter(order)
+					.toDocumentLocation();
+		}
+
+		// Tax
+		final TaxId taxId = taxBL.getTaxNotNull(
+				InterfaceWrapperHelper.getCtx(icRecord),
+				icRecord,
+				TaxCategoryId.ofRepoIdOrNull(orderLine.getC_TaxCategory_ID()),
+				orderLine.getM_Product_ID(),
+				order.getDatePromised(), // shipDate
+				OrgId.ofRepoId(order.getAD_Org_ID()),
+				WarehouseId.ofRepoIdOrNull(order.getM_Warehouse_ID()),
+				orderDeliveryLocation.toBPartnerLocationAndCaptureId(), // ship location id
+				SOTrx.ofBoolean(order.isSOTrx()));
 
 		// ts: we *must* use the order line's data
 		final PriceAndTaxBuilder priceAndTax = PriceAndTax.builder()
 				.invoicableQtyBasedOn(InvoicableQtyBasedOn.fromRecordString(orderLine.getInvoicableQtyBasedOn()))
+				.pricingSystemId(PricingSystemId.ofRepoId(order.getM_PricingSystem_ID()))
 				.priceEntered(orderLine.getPriceEntered())
 				.priceActual(orderLine.getPriceActual())
 				.priceUOMId(UomId.ofRepoIdOrNull(orderLine.getPrice_UOM_ID()))
-				.taxIncluded(orderLine.getC_Order().isTaxIncluded());
+				.taxId(taxId)
+				.taxIncluded(order.isTaxIncluded())
+				.currencyId(CurrencyId.ofRepoId(order.getC_Currency_ID()));
 
 		//
 		// Percent Group Compensation Line
-		if (ic.isGroupCompensationLine() && GroupCompensationAmtType.Percent.getAdRefListValue().equals(ic.getGroupCompensationAmtType()))
+		if (icRecord.isGroupCompensationLine() && GroupCompensationAmtType.Percent.getAdRefListValue().equals(icRecord.getGroupCompensationAmtType()))
 		{
 			final InvoiceCandidateGroupRepository groupsRepo = SpringContextHolder.instance.getBean(InvoiceCandidateGroupRepository.class);
 
-			final GroupId groupId = groupsRepo.extractGroupId(ic);
+			final GroupId groupId = groupsRepo.extractGroupId(icRecord);
 			final Group group = groupsRepo.retrieveGroup(groupId);
 			group.updateAllCompensationLines();
 
-			final GroupCompensationLine compensationLine = group.getCompensationLineById(groupsRepo.extractLineId(ic));
+			final GroupCompensationLine compensationLine = group.getCompensationLineById(groupsRepo.extractLineId(icRecord));
 			priceAndTax.priceEntered(compensationLine.getPrice());
 			priceAndTax.priceActual(compensationLine.getPrice());
 			priceAndTax.compensationGroupBaseAmt(compensationLine.getBaseAmt());
@@ -471,7 +471,7 @@ public class C_OrderLine_Handler extends AbstractInvoiceCandidateHandler
 		ic.setC_BPartner_SalesRep_ID(order.getC_BPartner_SalesRep_ID());
 	}
 
-	private void setGroupCompensationData(final I_C_Invoice_Candidate ic, final I_C_OrderLine fromOrderLine)
+	private void setGroupCompensationData(@NonNull final I_C_Invoice_Candidate ic, @NonNull final I_C_OrderLine fromOrderLine)
 	{
 		if (!OrderGroupCompensationUtils.isInGroup(fromOrderLine))
 		{

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/InvoiceCandidatesTestHelper.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/InvoiceCandidatesTestHelper.java
@@ -42,18 +42,16 @@ public class InvoiceCandidatesTestHelper
 {
 	/**
 	 * Creates all missing invoice candidates
-	 * 
-	 * Helper method to invoke {@link IInvoiceCandidateHandler#retrieveAllModelsWithMissingCandidates(Properties, int, String)} and then
+	 *  
+	 * Helper method to invoke {@link IInvoiceCandidateHandler#retrieveAllModelsWithMissingCandidates(int)} and then
 	 * {@link IInvoiceCandidateHandler#createCandidatesFor(InvoiceCandidateGenerateRequest)} for retrieved models.
 	 * 
-	 * @param handler
-	 * @param limit
 	 * @return invoice candidates
 	 */
 	public static List<I_C_Invoice_Candidate> createMissingCandidates(final IInvoiceCandidateHandler handler, final int limit)
 	{
 		final List<I_C_Invoice_Candidate> invoiceCandidatesAll = new ArrayList<>();
-		final Iterator<? extends Object> models = handler.retrieveAllModelsWithMissingCandidates(limit);
+		final Iterator<?> models = handler.retrieveAllModelsWithMissingCandidates(limit);
 		while (models.hasNext())
 		{
 			final Object model = models.next();

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/C_OrderLine_Handler_Test.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/C_OrderLine_Handler_Test.java
@@ -166,6 +166,7 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 			order1.setBill_Location_ID(bpartnerAndLocationId.getBpartnerLocationId().getRepoId());
 			order1.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
 			order1.setC_Currency_ID(10);
+			order1.setM_PricingSystem_ID(20);
 			InterfaceWrapperHelper.save(order1);
 
 			orderLine1 = orderLine("1");
@@ -187,6 +188,7 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 			order2.setBill_Location_ID(bpartnerAndLocationId.getBpartnerLocationId().getRepoId());
 			order2.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
 			order2.setC_Currency_ID(10);
+			order2.setM_PricingSystem_ID(20);
 			InterfaceWrapperHelper.save(order2);
 
 			orderLine2 = orderLine("2");
@@ -274,6 +276,7 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 		order1.setDocStatus(DocStatus.Completed.getCode());
 		order1.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
 		order1.setC_Currency_ID(10);
+		order1.setM_PricingSystem_ID(20);
 		InterfaceWrapperHelper.save(order1);
 
 		final I_C_OrderLine oL1 = orderLine("1");
@@ -299,6 +302,7 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 		order2.setDocStatus(DocStatus.Completed.getCode());
 		order2.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
 		order2.setC_Currency_ID(10);
+		order2.setM_PricingSystem_ID(20);
 		InterfaceWrapperHelper.save(order2);
 
 		final I_C_OrderLine oL2 = orderLine("2");
@@ -324,6 +328,7 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 		order3.setDocStatus(DocStatus.WaitingConfirmation.getCode());
 		order3.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
 		order3.setC_Currency_ID(10);
+		order3.setM_PricingSystem_ID(20);
 		InterfaceWrapperHelper.save(order3);
 
 		final I_C_OrderLine oL3 = orderLine("3");
@@ -349,6 +354,7 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 		order4.setDocStatus(DocStatus.Completed.getCode());
 		order4.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
 		order4.setC_Currency_ID(10);
+		order4.setM_PricingSystem_ID(20);
 		InterfaceWrapperHelper.save(order4);
 
 		final I_C_OrderLine oL4 = orderLine("4");
@@ -398,6 +404,7 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 			order1.setBill_Location_ID(bpartnerAndLocationId.getBpartnerLocationId().getRepoId());
 			order1.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
 			order1.setC_Currency_ID(10);
+			order1.setM_PricingSystem_ID(20);
 			InterfaceWrapperHelper.save(order1);
 
 			orderLine1 = orderLine("1");
@@ -435,6 +442,7 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 			order1.setBill_Location_Value_ID(differentLocationId.getRepoId());
 			order1.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
 			order1.setC_Currency_ID(10);
+			order1.setM_PricingSystem_ID(20);
 			InterfaceWrapperHelper.save(order1);
 
 			orderLine1 = orderLine("1");

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/C_OrderLine_Handler_Test.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/C_OrderLine_Handler_Test.java
@@ -50,7 +50,9 @@ import org.mockito.AdditionalMatchers;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.ArrayList;
@@ -162,6 +164,8 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 			order1.setC_BPartner_Location_ID(bpartnerAndLocationId.getBpartnerLocationId().getRepoId());
 			order1.setBill_BPartner_ID(bpartnerAndLocationId.getBpartnerId().getRepoId());
 			order1.setBill_Location_ID(bpartnerAndLocationId.getBpartnerLocationId().getRepoId());
+			order1.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
+			order1.setC_Currency_ID(10);
 			InterfaceWrapperHelper.save(order1);
 
 			orderLine1 = orderLine("1");
@@ -181,6 +185,8 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 			order2.setC_BPartner_Location_ID(bpartnerAndLocationId.getBpartnerLocationId().getRepoId());
 			order2.setBill_BPartner_ID(bpartnerAndLocationId.getBpartnerId().getRepoId());
 			order2.setBill_Location_ID(bpartnerAndLocationId.getBpartnerLocationId().getRepoId());
+			order2.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
+			order2.setC_Currency_ID(10);
 			InterfaceWrapperHelper.save(order2);
 
 			orderLine2 = orderLine("2");
@@ -266,6 +272,8 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 		order1.setBill_BPartner_ID(bpartnerAndLocationId.getBpartnerId().getRepoId());
 		order1.setBill_Location_ID(bpartnerAndLocationId.getBpartnerLocationId().getRepoId());
 		order1.setDocStatus(DocStatus.Completed.getCode());
+		order1.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
+		order1.setC_Currency_ID(10);
 		InterfaceWrapperHelper.save(order1);
 
 		final I_C_OrderLine oL1 = orderLine("1");
@@ -289,6 +297,8 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 		order2.setBill_BPartner_ID(bpartnerAndLocationId.getBpartnerId().getRepoId());
 		order2.setBill_Location_ID(bpartnerAndLocationId.getBpartnerLocationId().getRepoId());
 		order2.setDocStatus(DocStatus.Completed.getCode());
+		order2.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
+		order2.setC_Currency_ID(10);
 		InterfaceWrapperHelper.save(order2);
 
 		final I_C_OrderLine oL2 = orderLine("2");
@@ -312,6 +322,8 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 		order3.setBill_BPartner_ID(bpartnerAndLocationId.getBpartnerId().getRepoId());
 		order3.setBill_Location_ID(bpartnerAndLocationId.getBpartnerLocationId().getRepoId());
 		order3.setDocStatus(DocStatus.WaitingConfirmation.getCode());
+		order3.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
+		order3.setC_Currency_ID(10);
 		InterfaceWrapperHelper.save(order3);
 
 		final I_C_OrderLine oL3 = orderLine("3");
@@ -335,6 +347,8 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 		order4.setBill_BPartner_ID(bpartnerAndLocationId.getBpartnerId().getRepoId());
 		order4.setBill_Location_ID(bpartnerAndLocationId.getBpartnerLocationId().getRepoId());
 		order4.setDocStatus(DocStatus.Completed.getCode());
+		order4.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
+		order4.setC_Currency_ID(10);
 		InterfaceWrapperHelper.save(order4);
 
 		final I_C_OrderLine oL4 = orderLine("4");
@@ -369,7 +383,7 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 		test_PresetDateInvoiced(LocalDate.of(2019, Month.SEPTEMBER, 1));
 	}
 
-	private void test_PresetDateInvoiced(final LocalDate presetDateInvoiced)
+	private void test_PresetDateInvoiced(@Nullable final LocalDate presetDateInvoiced)
 	{
 		final BPartnerLocationAndCaptureId bpartnerAndLocationId = createBPartnerAndLocation();
 
@@ -382,6 +396,8 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 			order1.setC_BPartner_Location_ID(bpartnerAndLocationId.getBpartnerLocationId().getRepoId());
 			order1.setBill_BPartner_ID(bpartnerAndLocationId.getBpartnerId().getRepoId());
 			order1.setBill_Location_ID(bpartnerAndLocationId.getBpartnerLocationId().getRepoId());
+			order1.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
+			order1.setC_Currency_ID(10);
 			InterfaceWrapperHelper.save(order1);
 
 			orderLine1 = orderLine("1");
@@ -417,6 +433,8 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 			order1.setBill_BPartner_ID(bpartnerAndLocationId.getBpartnerId().getRepoId());
 			order1.setBill_Location_ID(bpartnerAndLocationId.getBpartnerLocationId().getRepoId());
 			order1.setBill_Location_Value_ID(differentLocationId.getRepoId());
+			order1.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
+			order1.setC_Currency_ID(10);
 			InterfaceWrapperHelper.save(order1);
 
 			orderLine1 = orderLine("1");

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/QtyDeliveredFromOrderToInvoiceTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/QtyDeliveredFromOrderToInvoiceTest.java
@@ -53,6 +53,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -219,6 +220,8 @@ public class QtyDeliveredFromOrderToInvoiceTest
 		order.setDocStatus(DocStatus.Completed.getCode());
 		order.setInvoiceRule(InvoiceRule.AfterDelivery.getCode());
 		order.setC_DocTypeTarget_ID(1000016);
+		order.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
+		order.setC_Currency_ID(10);
 		InterfaceWrapperHelper.save(order);
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/QtyDeliveredFromOrderToInvoiceTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/QtyDeliveredFromOrderToInvoiceTest.java
@@ -222,6 +222,7 @@ public class QtyDeliveredFromOrderToInvoiceTest
 		order.setC_DocTypeTarget_ID(1000016);
 		order.setDatePromised(Timestamp.valueOf("2021-11-30 00:00:00"));
 		order.setC_Currency_ID(10);
+		order.setM_PricingSystem_ID(20);
 		InterfaceWrapperHelper.save(order);
 	}
 

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/exceptions/DocumentFieldReadonlyException.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/exceptions/DocumentFieldReadonlyException.java
@@ -1,8 +1,11 @@
 package de.metas.ui.web.window.exceptions;
 
+import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
+
+import javax.annotation.Nullable;
 
 /*
  * #%L
@@ -30,12 +33,12 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ResponseStatus(code = HttpStatus.FORBIDDEN)
 public class DocumentFieldReadonlyException extends AdempiereException
 {
-	public DocumentFieldReadonlyException(final String fieldName, final Object value)
+	public DocumentFieldReadonlyException(@NonNull final String fieldName, @Nullable final Object value)
 	{
 		super(buildMsg(fieldName, value));
 	}
 
-	private static String buildMsg(final String fieldName, final Object value)
+	private static String buildMsg(@NonNull final String fieldName, @Nullable final Object value)
 	{
 		return "Changing " + fieldName + " to '" + value + "' is not allowed because the field is readonly";
 	}

--- a/backend/de.metas.util/src/main/java/de/metas/util/lang/Percent.java
+++ b/backend/de.metas.util/src/main/java/de/metas/util/lang/Percent.java
@@ -144,15 +144,25 @@ public class Percent
 	}
 
 	@Nullable
-	public static BigDecimal toBigDecimalOrNull(@Nullable final Percent paymentDiscountOverrideOrNull)
+	public static BigDecimal toBigDecimalOrNull(@Nullable final Percent percent)
 	{
-		if (paymentDiscountOverrideOrNull == null)
+		if (percent == null)
 		{
 			return null;
 		}
-		return paymentDiscountOverrideOrNull.toBigDecimal();
+		return percent.toBigDecimal();
 	}
 
+	@NonNull
+	public static BigDecimal toBigDecimalOrZero(@Nullable final Percent percent)
+	{
+		if (percent == null)
+		{
+			return BigDecimal.ZERO;
+		}
+		return percent.toBigDecimal();
+	}
+	
 	private static final BigDecimal ONE_HUNDRED_VALUE = BigDecimal.valueOf(100);
 	public static final Percent ONE_HUNDRED = new Percent(ONE_HUNDRED_VALUE);
 


### PR DESCRIPTION
..so the IC does not need to be deleted and recreated.

- implemented for orderLines, inoutLines and subscriptions
- the class PriceAndTax actually can contain the TaxId now