### PR TITLE
fix for e2e tests

### DIFF
--- a/frontend/src/utils/locale.js
+++ b/frontend/src/utils/locale.js
@@ -25,6 +25,7 @@ export function getCurrentActiveLocale() {
  * @returns {string} extracted language (e.g. 'en', 'de')
  */
 export function extractLanguageFromLocale(locale) {
+  if (!locale) return 'en';
   const idx = locale.indexOf('_');
   if (idx > 0) {
     return locale.substr(0, idx);
@@ -34,8 +35,7 @@ export function extractLanguageFromLocale(locale) {
 }
 
 export function getCurrentActiveLanguage() {
-  const currentActiveLocale = getCurrentActiveLocale();
-  return extractLanguageFromLocale(currentActiveLocale);
+  return extractLanguageFromLocale(getCurrentActiveLocale());
 }
 
 export function setCurrentActiveLocale(lang) {

--- a/frontend/src/utils/locale.js
+++ b/frontend/src/utils/locale.js
@@ -34,7 +34,8 @@ export function extractLanguageFromLocale(locale) {
 }
 
 export function getCurrentActiveLanguage() {
-  return extractLanguageFromLocale(getCurrentActiveLocale());
+  const currentActiveLocale = getCurrentActiveLocale();
+  return extractLanguageFromLocale(currentActiveLocale);
 }
 
 export function setCurrentActiveLocale(lang) {

--- a/frontend/src/utils/locale.js
+++ b/frontend/src/utils/locale.js
@@ -25,7 +25,7 @@ export function getCurrentActiveLocale() {
  * @returns {string} extracted language (e.g. 'en', 'de')
  */
 export function extractLanguageFromLocale(locale) {
-  if (!locale) return 'en';
+  if (!locale) return 'de';
   const idx = locale.indexOf('_');
   if (idx > 0) {
     return locale.substr(0, idx);


### PR DESCRIPTION
Fallback to en in case no locale passed

Without this fix cypress encounters thrown error and stops testing

![Screenshot 2021-12-17 at 16 21 59](https://user-images.githubusercontent.com/1708561/146558491-37141e85-70fb-46f1-9940-78aeac1dbb94.png)

this happens because at the mom of the call to get the LOCAL_LANG from localStorage this could not yet be set in the local storage (cypress is super fast) so we need to provide a fallback mechanism.
