### PR TITLE
Add extra safety check for calling getData within handleChangePage

### DIFF
--- a/frontend/src/containers/DocumentList.js
+++ b/frontend/src/containers/DocumentList.js
@@ -632,7 +632,7 @@ class DocumentListContainer extends Component {
     }
 
     this.lastViewedPage = currentPage;
-    this.getData(viewData.viewId, currentPage, sort);
+    viewData.viewId && this.getData(viewData.viewId, currentPage, sort);
   };
 
   /**


### PR DESCRIPTION
- fixes the edge case that was found during last QA testing (moving from one window to another using the menu and then go back)

https://www.loom.com/share/75b7a8089f2144f9ac9b5b24c19d3332