### PR TITLE
#11728 correct IfForeignDiscountsExist names, not just translations. Use isDiscountEditable to also drive order of discounts being applied

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/pricing/IPricingResult.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/IPricingResult.java
@@ -37,7 +37,6 @@ import de.metas.util.lang.Percent;
 import lombok.NonNull;
 
 import javax.annotation.Nullable;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collection;
@@ -192,4 +191,14 @@ public interface IPricingResult
 	void setTradedCommissionPercent(Percent tradedCommissionPercent);
 
 	Percent getTradedCommissionPercent();
+
+	/**
+	 * @return {@code true} if the current discount should not be overridden by any other pricing rule, {@code false} otherwise.
+	 */
+	boolean isDontOverrideDiscountAdvice();
+
+	/**
+	 * Can specify if the discount in the pricing rule can be overridden by any other pricing rule.
+	 */
+	void setDontOverrideDiscountAdvice(boolean dontOverrideDiscountAdvice);
 }

--- a/backend/de.metas.business/src/main/java/de/metas/pricing/rules/Discount.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/rules/Discount.java
@@ -80,9 +80,9 @@ public class Discount implements IPricingRule
 			return false;
 		}
 
-		if (result.isDiscountCalculated())
+		if (!result.isDiscountEditable())
 		{
-			log.debug("Discount was already calculated - {}", result);
+			log.debug("Discount is not editable - {}", result);
 			return false;
 		}
 

--- a/backend/de.metas.business/src/main/java/de/metas/pricing/rules/Discount.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/rules/Discount.java
@@ -80,9 +80,9 @@ public class Discount implements IPricingRule
 			return false;
 		}
 
-		if (!result.isDiscountEditable())
+		if (result.isDontOverrideDiscountAdvice())
 		{
-			log.debug("Discount is not editable - {}", result);
+			log.debug("Discount should not be modified - {}", result);
 			return false;
 		}
 

--- a/backend/de.metas.business/src/main/java/de/metas/pricing/rules/PriceListVersion.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/rules/PriceListVersion.java
@@ -1,15 +1,6 @@
 package de.metas.pricing.rules;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-
 import de.metas.common.util.time.SystemTime;
-import org.compiere.model.I_M_PriceList;
-import org.compiere.model.I_M_PriceList_Version;
-import org.compiere.model.I_M_ProductPrice;
-import org.compiere.util.TimeUtil;
-import org.slf4j.Logger;
-
 import de.metas.i18n.BooleanWithReason;
 import de.metas.i18n.ITranslatableString;
 import de.metas.i18n.TranslatableStrings;
@@ -30,6 +21,14 @@ import de.metas.tax.api.TaxCategoryId;
 import de.metas.uom.UomId;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.compiere.model.I_M_PriceList;
+import org.compiere.model.I_M_PriceList_Version;
+import org.compiere.model.I_M_ProductPrice;
+import org.compiere.util.TimeUtil;
+import org.slf4j.Logger;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 /**
  * Calculate Price using Price List Version
@@ -85,7 +84,7 @@ public class PriceListVersion extends AbstractPriceListBasedRule
 		result.setProductId(productId);
 		result.setProductCategoryId(productCategoryId);
 		result.setPriceEditable(productPrice.isPriceEditable());
-		result.setDiscountEditable(productPrice.isDiscountEditable());
+		result.setDiscountEditable(result.isDiscountEditable() && productPrice.isDiscountEditable());
 		result.setEnforcePriceLimit(extractEnforcePriceLimit(priceList));
 		result.setTaxIncluded(priceList.isTaxIncluded());
 		result.setTaxCategoryId(TaxCategoryId.ofRepoId(productPrice.getC_TaxCategory_ID()));
@@ -151,7 +150,7 @@ public class PriceListVersion extends AbstractPriceListBasedRule
 		final I_M_PriceList_Version plv = priceListsRepo.retrievePriceListVersionOrNull(
 				pricingCtx.getPriceListId(),
 				TimeUtil.asZonedDateTime(pricingCtx.getPriceDate(), SystemTime.zoneId()),
-				(Boolean)null // processed
+				null // processed
 		);
 
 		return plv != null && plv.isActive() ? plv : null;

--- a/backend/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingResult.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingResult.java
@@ -114,6 +114,12 @@ final class PricingResult implements IPricingResult
 
 	private boolean isDiscountCalculated;
 
+	/**
+	 * If this flag is set to true, then the discount should not be changed.
+	 *
+	 */
+	private boolean dontOverrideDiscountAdvice = false;
+
 	private InvoicableQtyBasedOn invoicableQtyBasedOn = InvoicableQtyBasedOn.NominalWeight;
 
 	@Getter(AccessLevel.NONE)
@@ -182,6 +188,10 @@ final class PricingResult implements IPricingResult
 			throw new AdempiereException("Attempt to set the discount although isDisallowDiscount()==true")
 					.appendParametersToMessage()
 					.setParameter("this", this);
+		}
+		if (isDontOverrideDiscountAdvice())
+		{
+			return;
 		}
 		this.discount = discount;
 		this.isDiscountCalculated = true;

--- a/backend/de.metas.business/src/test/java/de/metas/pricing/service/impl/PricingTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/pricing/service/impl/PricingTest.java
@@ -1,9 +1,9 @@
 package de.metas.pricing.service.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.math.BigDecimal;
-
+import de.metas.common.util.time.SystemTime;
+import de.metas.pricing.IEditablePricingContext;
+import de.metas.pricing.IPricingResult;
+import de.metas.util.lang.Percent;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
 import org.hamcrest.Matchers;
@@ -12,8 +12,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import de.metas.pricing.IEditablePricingContext;
-import de.metas.pricing.IPricingResult;
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /*
  * #%L
@@ -94,5 +95,23 @@ public class PricingTest
 			final IPricingResult result = helper.calculatePrice(pricingCtx);
 			Assert.assertThat("Bio PriceStd\n" + result, result.getPriceStd(), Matchers.comparesEqualTo(BigDecimal.valueOf(3)));
 		}
+	}
+
+	@Test
+	public void test_MultipleDiscountChanges_WithAdvice()
+	{
+		final PricingResult build = PricingResult.builder()
+				.priceDate(SystemTime.asLocalDate())
+				.build();
+		final Percent discount1 = Percent.of(10);
+		final Percent discount2 = Percent.of(20);
+
+		build.setDiscount(discount1);
+		assertThat(build.getDiscount()).isEqualTo(discount1);
+		assertThat(build.isDontOverrideDiscountAdvice()).isFalse();
+
+		build.setDontOverrideDiscountAdvice(true);
+		build.setDiscount(discount2);
+		assertThat(build.getDiscount()).isEqualTo(discount1);
 	}
 }

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/pricing/SubscriptionPricingRule.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/pricing/SubscriptionPricingRule.java
@@ -124,7 +124,7 @@ public class SubscriptionPricingRule implements IPricingRule
 			subscriptionPricingResult.setDiscount(subscriptionDiscountLine.getDiscount());
 			if (subscriptionDiscountLine.isPrioritiseOwnDiscount())
 			{
-				subscriptionPricingResult.setDiscountEditable(false);
+				subscriptionPricingResult.setDontOverrideDiscountAdvice(true);
 			}
 		}
 		return subscriptionPricingResult;
@@ -235,6 +235,7 @@ public class SubscriptionPricingRule implements IPricingRule
 			{
 				result.setDiscount(subscriptionPricingResult.getDiscount());
 				result.setDiscountEditable(subscriptionPricingResult.isDiscountEditable());
+				result.setDontOverrideDiscountAdvice(subscriptionPricingResult.isDontOverrideDiscountAdvice());
 			}
 		}
 	}

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/pricing/SubscriptionPricingRule.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/pricing/SubscriptionPricingRule.java
@@ -119,9 +119,13 @@ public class SubscriptionPricingRule implements IPricingRule
 	{
 		if (subscriptionDiscountLine != null
 				&& !subscriptionPricingResult.isDisallowDiscount()
-				&& (subscriptionDiscountLine.isPrioritiseOwnDiscount() || !subscriptionPricingResult.isDiscountCalculated()) )
+				&& (subscriptionDiscountLine.isPrioritiseOwnDiscount() || !subscriptionPricingResult.isDiscountCalculated()))
 		{
 			subscriptionPricingResult.setDiscount(subscriptionDiscountLine.getDiscount());
+			if (subscriptionDiscountLine.isPrioritiseOwnDiscount())
+			{
+				subscriptionPricingResult.setDiscountEditable(false);
+			}
 		}
 		return subscriptionPricingResult;
 	}
@@ -218,7 +222,6 @@ public class SubscriptionPricingRule implements IPricingRule
 		result.setTaxCategoryId(subscriptionPricingResult.getTaxCategoryId());
 
 		result.setPriceEditable(subscriptionPricingResult.isPriceEditable());
-		result.setDiscountEditable(subscriptionPricingResult.isDiscountEditable());
 	}
 
 	private static void copyDiscountIntoResultIfAllowedByPricingContext(
@@ -228,7 +231,11 @@ public class SubscriptionPricingRule implements IPricingRule
 	{
 		if (!pricingCtx.isDisallowDiscount())
 		{
-			result.setDiscount(subscriptionPricingResult.getDiscount());
+			if (result.isDiscountEditable())
+			{
+				result.setDiscount(subscriptionPricingResult.getDiscount());
+				result.setDiscountEditable(subscriptionPricingResult.isDiscountEditable());
+			}
 		}
 	}
 

--- a/backend/de.metas.contracts/src/main/sql/postgresql/system/50-de.metas.contracts/5619761_sys_gh11728_fix_IfForeignDiscountsExist_names.sql
+++ b/backend/de.metas.contracts/src/main/sql/postgresql/system/50-de.metas.contracts/5619761_sys_gh11728_fix_IfForeignDiscountsExist_names.sql
@@ -1,0 +1,10 @@
+-- 2022-01-04T09:55:51.661Z
+-- URL zum Konzept
+UPDATE AD_Ref_List SET Name='Abo-Rabatt anw.',Updated=TO_TIMESTAMP('2022-01-04 11:55:51','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Ref_List_ID=542871
+;
+
+-- 2022-01-04T09:55:55.746Z
+-- URL zum Konzept
+UPDATE AD_Ref_List SET Name='Anderen anw.',Updated=TO_TIMESTAMP('2022-01-04 11:55:55','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Ref_List_ID=542870
+;
+


### PR DESCRIPTION
https://github.com/metasfresh/metasfresh/issues/11728