### PR TITLE
Fix extra scroll on filter items

### DIFF
--- a/frontend/src/assets/css/styles.css
+++ b/frontend/src/assets/css/styles.css
@@ -1069,10 +1069,8 @@ body{
     max-height: 80vh;
     display: flex;
     flex-direction: column;
-
-    .form-group {
-        overflow-x: scroll;
-    }
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 
 .filter-menu li {


### PR DESCRIPTION
rel to https://github.com/metasfresh/metasfresh/issues/12160

Fixes this issue:
<img width="1243" alt="Screenshot 2022-01-05 at 08 28 56" src="https://user-images.githubusercontent.com/1708561/148170697-398c74f6-3b79-4354-a726-5ff5e66ae078.png">

After the fix:
<img width="1243" alt="Screenshot 2022-01-05 at 08 29 28" src="https://user-images.githubusercontent.com/1708561/148170790-5842a5d9-a2ff-44d2-b73c-e4a54188a098.png">

Tested also the cases done by Kuba from here https://recordit.co/ObafncCYtt and work as expected.