### PR TITLE
Improve retrieval performance of workpackage items for WP processors

### DIFF
--- a/backend/de.metas.async/src/main/java/de/metas/async/api/IQueueDAO.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/IQueueDAO.java
@@ -45,7 +45,6 @@ import de.metas.util.ISingletonService;
  * Async Queue related DAO
  *
  * @author tsa
- *
  */
 public interface IQueueDAO extends ISingletonService
 {
@@ -81,25 +80,29 @@ public interface IQueueDAO extends ISingletonService
 
 	/**
 	 * Retrieves the POs that are referenced by the given workPackage's {@link I_C_Queue_Element}s.
+	 * <p>
+	 * NOTE: this method is returning all those items which <b>were not already scheduled in a previous not-yet-processed work-package.</b>
 	 *
-	 * NOTE: this method is returning all those items which were not already scheduled in a previous not processed work-package.
-	 * 
 	 * @param clazz note that {@link TableRecordReference} is supported as well
-	 *
 	 * @throws de.metas.async.exceptions.PackageItemNotAvailableException if one of the work package's elements references a record which no longer exists.
+	 * @deprecated Please Consider using {@link #retrieveAllItems(I_C_Queue_WorkPackage, Class)} instead.
+	 * Filtering out items which were already enqueued in an older, not-yet-processed workpackage costs a lot of performance.
+	 * Since today we have just one thread per processor, this can't happen. Therefore AFAIS we don't need this anymore.
 	 */
+	@Deprecated
 	<T> List<T> retrieveItems(I_C_Queue_WorkPackage workPackage, Class<T> clazz, String trxName);
 
 	/**
-	 * Similar to {@link #retrieveItems(I_C_Queue_WorkPackage, Class, String)}, but does not make a fuzz about elements whose referenced records do no longer exist.
-	 * 
+	 * Similar to {@link #retrieveAllItems(I_C_Queue_WorkPackage, Class)}, but
+	 * <li>does not make a fuzz about elements whose referenced records do no longer exist.</li>
+	 *
 	 * @param clazz note that {@link TableRecordReference} is supported as well
 	 */
-	<T> List<T> retrieveItemsSkipMissing(I_C_Queue_WorkPackage workPackage, Class<T> clazz, String trxName);
+	<T> List<T> retrieveAllItemsSkipMissing(I_C_Queue_WorkPackage workPackage, Class<T> clazz);
 
 	/**
 	 * Return all active POs, even the ones that are caught in other packages
-	 * 
+	 *
 	 * @param clazz note that {@link TableRecordReference} is supported as well
 	 */
 	<T> List<T> retrieveAllItems(I_C_Queue_WorkPackage workPackage, Class<T> clazz);
@@ -107,7 +110,7 @@ public interface IQueueDAO extends ISingletonService
 	/**
 	 * Creates a query builder which is used to retrieve all records of given <code>clazz</code>.
 	 *
-	 * @param clazz model class
+	 * @param clazz                     model class
 	 * @param skipAlreadyScheduledItems true if we shall skip all elements which are pointing to records (AD_Table_ID/Record_ID) which were already enqueued
 	 * @return query builder
 	 */

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AbstractQueueDAO.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AbstractQueueDAO.java
@@ -81,7 +81,7 @@ public abstract class AbstractQueueDAO implements IQueueDAO
 	// Order by (very important): Priority (0 to 9), and ID
 	protected final IQueryOrderBy queueOrderByComparator = Services.get(IQueryBL.class)
 			.createQueryOrderByBuilder(I_C_Queue_WorkPackage.class)
-			.addColumn(I_C_Queue_WorkPackage.COLUMNNAME_Priority)
+			.addColumn(I_C_Queue_WorkPackage.COLUMNNAME_Priority) /* 1 is the most urgent */
 			.addColumn(I_C_Queue_WorkPackage.COLUMNNAME_C_Queue_WorkPackage_ID)
 			.createQueryOrderBy();
 

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AbstractQueueDAO.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AbstractQueueDAO.java
@@ -29,6 +29,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import ch.qos.logback.classic.Level;
+import de.metas.util.Loggables;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.IQueryFilter;
@@ -70,7 +72,7 @@ public abstract class AbstractQueueDAO implements IQueueDAO
 
 	/**
 	 * Filter used to skip all elements which are pointing to records (AD_Table_ID/Record_ID) which were already enqueued, even if in another working package
-	 *
+	 * <p>
 	 * NOTE: to be set by extending classes
 	 */
 	protected IQueryFilter<I_C_Queue_Element> filter_C_Queue_Element_SkipAlreadyScheduledItems;
@@ -89,6 +91,7 @@ public abstract class AbstractQueueDAO implements IQueueDAO
 
 	/**
 	 * Retrieve object from given <code>element</code>
+	 *
 	 * @param clazz note that {@link TableRecordReference} is supported as well
 	 * @throws PackageItemNotAvailableException if underlying object was not found at this moment. Never return <code>null</code>.
 	 */
@@ -242,15 +245,15 @@ public abstract class AbstractQueueDAO implements IQueueDAO
 	/**
 	 * Creates a {@link IQueryBuilder} which selects all {@link I_C_Queue_Element}s for given work package.
 	 *
-	 * @param workPackage
 	 * @param skipAlreadyScheduledItems true if we shall skip all elements which are pointing to records (AD_Table_ID/Record_ID) which were already enqueued earlier and not yet processed.
-	 * @param trxName transaction name
+	 * @param trxName                   transaction name
 	 * @return query builder already configured
 	 */
-	protected final IQueryBuilder<I_C_Queue_Element> createQueueElementsQueryBuilder(final I_C_Queue_WorkPackage workPackage, final boolean skipAlreadyScheduledItems, final String trxName)
+	protected final IQueryBuilder<I_C_Queue_Element> createQueueElementsQueryBuilder(
+			@NonNull final I_C_Queue_WorkPackage workPackage,
+			final boolean skipAlreadyScheduledItems,
+			@Nullable final String trxName)
 	{
-		Check.assume(workPackage != null, "workPackage not null");
-
 		final Properties ctx = InterfaceWrapperHelper.getCtx(workPackage);
 		final IQueryBuilder<I_C_Queue_Element> queryBuilder = Services.get(IQueryBL.class)
 				.createQueryBuilder(I_C_Queue_Element.class, ctx, trxName);
@@ -303,6 +306,7 @@ public abstract class AbstractQueueDAO implements IQueueDAO
 	}
 
 	@Override
+	@Deprecated
 	public final <T> List<T> retrieveItems(final I_C_Queue_WorkPackage workPackage, final Class<T> clazz, final String trxName)
 	{
 		return retrieveItems(workPackage, clazz, DEFAULT_skipAlreadyScheduledItems, false, trxName);
@@ -310,13 +314,11 @@ public abstract class AbstractQueueDAO implements IQueueDAO
 
 	@NonNull
 	@Override
-	public final <T> List<T> retrieveItemsSkipMissing(
-			@NonNull final I_C_Queue_WorkPackage workPackage, 
-			@NonNull final Class<T> clazz, 
-			@Nullable final String trxName)
+	public final <T> List<T> retrieveAllItemsSkipMissing(@NonNull final I_C_Queue_WorkPackage workPackage, @NonNull final Class<T> clazz)
 	{
+		final boolean skipAlreadyScheduledItems = false;
 		final boolean skipMissingItems = true;
-		return retrieveItems(workPackage, clazz, DEFAULT_skipAlreadyScheduledItems, skipMissingItems, trxName);
+		return retrieveItems(workPackage, clazz, skipAlreadyScheduledItems, skipMissingItems, ITrx.TRXNAME_ThreadInherited);
 	}
 
 	@Override
@@ -326,10 +328,10 @@ public abstract class AbstractQueueDAO implements IQueueDAO
 	}
 
 	private <T> List<T> retrieveItems(
-			@NonNull final I_C_Queue_WorkPackage workPackage, 
-			@NonNull final Class<T> clazz, 
-			final boolean skipAlreadyScheduledItems, 
-			final boolean skipMissingItems, 
+			@NonNull final I_C_Queue_WorkPackage workPackage,
+			@NonNull final Class<T> clazz,
+			final boolean skipAlreadyScheduledItems,
+			final boolean skipMissingItems,
 			@Nullable final String trxName)
 	{
 		final List<I_C_Queue_Element> queueElements = retrieveQueueElements(workPackage, skipAlreadyScheduledItems);
@@ -347,7 +349,9 @@ public abstract class AbstractQueueDAO implements IQueueDAO
 			{
 				if (skipMissingItems)
 				{
-					continue; // just skip, no stress
+					Loggables.withLogger(logger, Level.DEBUG)
+							.addLog("Skip C_Queue_Element_ID={} (C_Queue_WorkPackage_ID={}) because referenced AD_Table_ID={}/Record_ID={} does not exist and skipMissingItems=true",
+									e.getC_Queue_Element_ID(), e.getC_Queue_WorkPackage_ID(), e.getAD_Table_ID(), e.getRecord_ID());
 				}
 				else
 				{

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/impl/PlainQueueDAO.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/impl/PlainQueueDAO.java
@@ -52,52 +52,27 @@ public class PlainQueueDAO extends AbstractQueueDAO
 {
 	private static final transient Logger slogger = LogManager.getLogger(PlainQueueDAO.class);
 
-	private POJOLookupMap db = POJOLookupMap.get();
+	private final POJOLookupMap db = POJOLookupMap.get();
 
 	public PlainQueueDAO()
 	{
-		super();
-
-		this.filter_C_Queue_Element_SkipAlreadyScheduledItems = new IQueryFilter<I_C_Queue_Element>()
-		{
-
-			@Override
-			public boolean accept(I_C_Queue_Element model)
-			{
-				final List<I_C_Queue_Element> previousElements = retrievePreviousScheduledElements(model);
-				if (!previousElements.isEmpty())
-				{
-					return false;
-				}
-
-				return true;
-			}
+		this.filter_C_Queue_Element_SkipAlreadyScheduledItems = model -> {
+			final List<I_C_Queue_Element> previousElements = retrievePreviousScheduledElements(model);
+			return previousElements.isEmpty();
 		};
 	}
 
 	@Override
 	public List<I_C_Queue_Processor> retrieveAllProcessors()
 	{
-		return db.getRecords(I_C_Queue_Processor.class, new IQueryFilter<I_C_Queue_Processor>()
-		{
-
-			@Override
-			public boolean accept(I_C_Queue_Processor pojo)
-			{
-				if (!pojo.isActive())
-				{
-					return false;
-				}
-				return true;
-			}
-		});
+		return db.getRecords(I_C_Queue_Processor.class, I_C_Queue_Processor::isActive);
 	}
 
 	@Override
-	protected Map<Integer, I_C_Queue_PackageProcessor> retrieveWorkpackageProcessorsMap(Properties ctx)
+	protected Map<Integer, I_C_Queue_PackageProcessor> retrieveWorkpackageProcessorsMap(final Properties ctx)
 	{
 		final List<I_C_Queue_PackageProcessor> processors = db.getRecords(I_C_Queue_PackageProcessor.class);
-		final Map<Integer, I_C_Queue_PackageProcessor> map = new HashMap<Integer, I_C_Queue_PackageProcessor>(processors.size());
+		final Map<Integer, I_C_Queue_PackageProcessor> map = new HashMap<>(processors.size());
 		for (final I_C_Queue_PackageProcessor p : processors)
 		{
 			map.put(p.getC_Queue_PackageProcessor_ID(), p);
@@ -108,69 +83,58 @@ public class PlainQueueDAO extends AbstractQueueDAO
 	@Override
 	protected List<I_C_Queue_Processor_Assign> retrieveQueueProcessorAssignments(final I_C_Queue_Processor processor)
 	{
-		return db.getRecords(I_C_Queue_Processor_Assign.class, new IQueryFilter<I_C_Queue_Processor_Assign>()
-		{
-
-			@Override
-			public boolean accept(I_C_Queue_Processor_Assign pojo)
+		return db.getRecords(I_C_Queue_Processor_Assign.class, pojo -> {
+			if (pojo.getC_Queue_Processor_ID() != processor.getC_Queue_Processor_ID())
 			{
-				if (pojo.getC_Queue_Processor_ID() != processor.getC_Queue_Processor_ID())
-				{
-					return false;
-				}
-				if (!pojo.isActive())
-				{
-					return false;
-				}
-				return true;
+				return false;
 			}
+			if (!pojo.isActive())
+			{
+				return false;
+			}
+			return true;
 		});
 	}
 
 	private List<I_C_Queue_Element> retrievePreviousScheduledElements(final I_C_Queue_Element element)
 	{
-		return db.getRecords(I_C_Queue_Element.class, new IQueryFilter<I_C_Queue_Element>()
-		{
-			@Override
-			public boolean accept(I_C_Queue_Element pojo)
+		return db.getRecords(I_C_Queue_Element.class, pojo -> {
+			// Same record
+			if (pojo.getAD_Table_ID() != element.getAD_Table_ID())
 			{
-				// Same record
-				if (pojo.getAD_Table_ID() != element.getAD_Table_ID())
-				{
-					return false;
-				}
-				if (pojo.getRecord_ID() != element.getRecord_ID())
-				{
-					return false;
-				}
-				// But on different queue element
-				if (pojo.getC_Queue_Element_ID() == element.getC_Queue_Element_ID())
-				{
-					return false;
-				}
-				// Submitted in the past
-				if (pojo.getC_Queue_WorkPackage_ID() > element.getC_Queue_WorkPackage_ID())
-				{
-					return false;
-				}
-				// and those workpackages were not processed yet
-				if (pojo.getC_Queue_WorkPackage().isProcessed())
-				{
-					return false;
-				}
-
-				return true;
+				return false;
 			}
+			if (pojo.getRecord_ID() != element.getRecord_ID())
+			{
+				return false;
+			}
+			// But on different queue element
+			if (pojo.getC_Queue_Element_ID() == element.getC_Queue_Element_ID())
+			{
+				return false;
+			}
+			// Submitted in the past
+			if (pojo.getC_Queue_WorkPackage_ID() > element.getC_Queue_WorkPackage_ID())
+			{
+				return false;
+			}
+			// and those workpackages were not processed yet
+			if (pojo.getC_Queue_WorkPackage().isProcessed())
+			{
+				return false;
+			}
+
+			return true;
 		});
 	}
 
 	@Override
-	protected <T> T retrieveItem(I_C_Queue_Element element, Class<T> clazz, String trxName)
+	protected <T> T retrieveItem(final I_C_Queue_Element element, final Class<T> clazz, final String trxName)
 	{
 		final int tableId = element.getAD_Table_ID();
 		final int recordId = element.getRecord_ID();
 
-		T item = null;
+		T item;
 		try
 		{
 			item = db.lookup(tableId, recordId, clazz);
@@ -190,7 +154,7 @@ public class PlainQueueDAO extends AbstractQueueDAO
 	}
 
 	@Override
-	public IQuery<I_C_Queue_WorkPackage> createQuery(Properties ctx, IWorkPackageQuery packageQuery)
+	public IQuery<I_C_Queue_WorkPackage> createQuery(final Properties ctx, final IWorkPackageQuery packageQuery)
 	{
 		return new POJOQuery<>(ctx,
 				I_C_Queue_WorkPackage.class,
@@ -210,7 +174,7 @@ public class PlainQueueDAO extends AbstractQueueDAO
 		}
 
 		@Override
-		public boolean accept(I_C_Queue_WorkPackage workpackage)
+		public boolean accept(final I_C_Queue_WorkPackage workpackage)
 		{
 			if (packageQuery.getProcessed() != null && packageQuery.getProcessed() != workpackage.isProcessed())
 			{

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/impl/QueueDAO.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/impl/QueueDAO.java
@@ -57,8 +57,6 @@ public class QueueDAO extends AbstractQueueDAO
 {
 	public QueueDAO()
 	{
-		super();
-
 		//
 		// Create C_Queue_Element filter: Skip already enqueued, but not processed items
 		{

--- a/backend/de.metas.async/src/main/java/de/metas/async/exceptions/PackageItemNotAvailableException.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/exceptions/PackageItemNotAvailableException.java
@@ -36,9 +36,6 @@ import de.metas.async.model.I_C_Queue_Element;
  */
 public class PackageItemNotAvailableException extends AdempiereException
 {
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 4271514302298190437L;
 
 	private final String tableName;

--- a/backend/de.metas.async/src/main/java/de/metas/async/processor/impl/CheckProcessedAsynBatchWorkpackageProcessor.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/processor/impl/CheckProcessedAsynBatchWorkpackageProcessor.java
@@ -60,7 +60,7 @@ public class CheckProcessedAsynBatchWorkpackageProcessor implements IWorkpackage
 	{
 		boolean hasError = false;
 
-		final List<I_C_Async_Batch> batches = queueDAO.retrieveItems(workpackage, I_C_Async_Batch.class, localTrxName);
+		final List<I_C_Async_Batch> batches = queueDAO.retrieveAllItems(workpackage, I_C_Async_Batch.class);
 		for (final I_C_Async_Batch asyncBatch : batches)
 		{
 			if (asyncBatch.isProcessed() || !asyncBatch.isActive())

--- a/backend/de.metas.async/src/main/java/de/metas/async/spi/WorkpackageProcessorAdapter.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/spi/WorkpackageProcessorAdapter.java
@@ -11,7 +11,6 @@ import de.metas.util.Check;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
-import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.util.api.IParams;
 
 import java.util.List;
@@ -103,7 +102,7 @@ public abstract class WorkpackageProcessorAdapter implements IWorkpackageProcess
 
 	public final <T> List<T> retrieveItems(final Class<T> modelType)
 	{
-		return Services.get(IQueueDAO.class).retrieveItems(getC_Queue_WorkPackage(), modelType, ITrx.TRXNAME_ThreadInherited);
+		return Services.get(IQueueDAO.class).retrieveAllItemsSkipMissing(getC_Queue_WorkPackage(), modelType);
 	}
 
 	/**
@@ -121,8 +120,6 @@ public abstract class WorkpackageProcessorAdapter implements IWorkpackageProcess
 
 	/**
 	 * retrieves all active PO's IDs, even the ones that are caught in other packages
-	 *
-	 * @return
 	 */
 	public final Set<Integer> retrieveAllItemIds()
 	{

--- a/backend/de.metas.async/src/main/java/de/metas/async/spi/WorkpackagesOnCommitSchedulerTemplate.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/spi/WorkpackagesOnCommitSchedulerTemplate.java
@@ -3,7 +3,6 @@ package de.metas.async.spi;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import de.metas.async.AsyncBatchId;
-import de.metas.async.api.IAsyncBatchBL;
 import de.metas.async.api.IWorkPackageBlockBuilder;
 import de.metas.async.api.IWorkPackageBuilder;
 import de.metas.async.processor.IWorkPackageQueueFactory;
@@ -213,7 +212,7 @@ public abstract class WorkpackagesOnCommitSchedulerTemplate<ItemType>
 		protected String getTrxProperyName()
 		{
 			return WorkpackagesOnCommitSchedulerTemplate.this.trxPropertyName;
-		};
+		}
 
 		@Override
 		protected String extractTrxNameFromItem(final ItemType item)

--- a/backend/de.metas.async/src/main/java/de/metas/async/spi/impl/ConstantWorkpackagePrio.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/spi/impl/ConstantWorkpackagePrio.java
@@ -26,6 +26,7 @@ package de.metas.async.spi.impl;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
 import org.adempiere.ad.service.IADReferenceDAO;
 import org.adempiere.util.lang.EqualsBuilder;
 import org.adempiere.util.lang.HashcodeBuilder;
@@ -38,10 +39,9 @@ import de.metas.util.Services;
 
 /**
  * TODO: check if we can do this better (using enum??)
- * 
- * @author ts
  *
  */
+@EqualsAndHashCode
 public class ConstantWorkpackagePrio implements IWorkpackagePrioStrategy
 {
 	private final String prio;
@@ -114,31 +114,6 @@ public class ConstantWorkpackagePrio implements IWorkpackagePrioStrategy
 	public String toString()
 	{
 		return "ConstantWorkpackagePrio[" + prio + "]";
-	}
-
-	@Override
-	public int hashCode()
-	{
-		return new HashcodeBuilder()
-				.append(prio)
-				.toHashcode();
-	}
-
-	@Override
-	public boolean equals(Object obj)
-	{
-		if (this == obj)
-		{
-			return true;
-		}
-		final ConstantWorkpackagePrio other = EqualsBuilder.getOther(this, obj);
-		if (other == null)
-		{
-			return false;
-		}
-		return new EqualsBuilder()
-				.append(prio, other.prio)
-				.isEqual();
 	}
 
 }

--- a/backend/de.metas.async/src/main/java/de/metas/async/spi/impl/SizeBasedWorkpackagePrio.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/spi/impl/SizeBasedWorkpackagePrio.java
@@ -28,7 +28,8 @@ import com.google.common.annotations.VisibleForTesting;
 
 import de.metas.async.api.IWorkPackageQueue;
 import de.metas.async.spi.IWorkpackagePrioStrategy;
-import lombok.NonNull;
+
+import javax.annotation.Nullable;
 
 /**
  * Returns the workpackage priority based on the number of WPs that were already enqueued so far.<br>
@@ -62,7 +63,7 @@ public class SizeBasedWorkpackagePrio implements IWorkpackagePrioStrategy
 	 * Note that by default this implementation uses {@link SysconfigBackedSizeBasedWorkpackagePrioConfig}.
 	 */
 	@VisibleForTesting
-	public void setAlternativeSize2constantPrio(@NonNull final Function<Integer, ConstantWorkpackagePrio> size2constantPrio)
+	public void setAlternativeSize2constantPrio(@Nullable final Function<Integer, ConstantWorkpackagePrio> size2constantPrio)
 	{
 		this.alternativeSize2constantPrio = size2constantPrio;
 	}

--- a/backend/de.metas.async/src/main/java/de/metas/async/spi/impl/SizeBasedWorkpackagePrio.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/spi/impl/SizeBasedWorkpackagePrio.java
@@ -28,6 +28,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import de.metas.async.api.IWorkPackageQueue;
 import de.metas.async.spi.IWorkpackagePrioStrategy;
+import lombok.NonNull;
 
 /**
  * Returns the workpackage priority based on the number of WPs that were already enqueued so far.<br>
@@ -35,7 +36,7 @@ import de.metas.async.spi.IWorkpackagePrioStrategy;
  * For the case that no size-based priority was configured, <code>medium</code> is returned as the default priority.
  * 
  * @author metas-dev <dev@metasfresh.com>
- * @task http://dewiki908/mediawiki/index.php/09049_Priorit%C3%A4ten_Strategie_asynch_%28105016248827%29
+ * task http://dewiki908/mediawiki/index.php/09049_Priorit%C3%A4ten_Strategie_asynch_%28105016248827%29
  */
 public class SizeBasedWorkpackagePrio implements IWorkpackagePrioStrategy
 {
@@ -59,11 +60,9 @@ public class SizeBasedWorkpackagePrio implements IWorkpackagePrioStrategy
 	/**
 	 * Allow to inject an alternative function. Currently this is intended only for testing purposes, but that might change in future.
 	 * Note that by default this implementation uses {@link SysconfigBackedSizeBasedWorkpackagePrioConfig}.
-	 * 
-	 * @param size2constantPrio
 	 */
 	@VisibleForTesting
-	public void setAlternativeSize2constantPrio(Function<Integer, ConstantWorkpackagePrio> size2constantPrio)
+	public void setAlternativeSize2constantPrio(@NonNull final Function<Integer, ConstantWorkpackagePrio> size2constantPrio)
 	{
 		this.alternativeSize2constantPrio = size2constantPrio;
 	}

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/export/async/C_Invoice_CreateExportData.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/export/async/C_Invoice_CreateExportData.java
@@ -44,7 +44,7 @@ public class C_Invoice_CreateExportData implements IWorkpackageProcessor
 			@NonNull final I_C_Queue_WorkPackage workpackage,
 			@NonNull final String localTrxName)
 	{
-		final List<I_C_Invoice> invoiceRecords = queueDAO.retrieveItemsSkipMissing(workpackage, I_C_Invoice.class, localTrxName);
+		final List<I_C_Invoice> invoiceRecords = queueDAO.retrieveAllItemsSkipMissing(workpackage, I_C_Invoice.class);
 		for (final I_C_Invoice invoiceRecord : invoiceRecords)
 		{
 			try (final MDCCloseable ignore = TableRecordMDC.putTableRecordReference(invoiceRecord))

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/IContractsDAO.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/IContractsDAO.java
@@ -30,6 +30,7 @@ import de.metas.order.OrderId;
 import de.metas.util.ISingletonService;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBuilder;
+import org.adempiere.ad.dao.QueryLimit;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -40,23 +41,18 @@ public interface IContractsDAO extends ISingletonService
 	/**
 	 * @return the flatrate terms with missing candidates, gathered in a list.
 	 */
-	List<I_C_Flatrate_Term> retrieveSubscriptionTermsWithMissingCandidates(String typconditions, int limit);
+	List<I_C_Flatrate_Term> retrieveSubscriptionTermsWithMissingCandidates(String typconditions, QueryLimit limit);
 
 
 	/**
 	 *
 	 * Check if the term given as parameter was extended (has a predecessor).
-	 * @param term
-	 * @return
 	 */
 	boolean termHasAPredecessor (I_C_Flatrate_Term term);
 
 	/**
 	 * Sums up the <code>Qty</code> values of all {@link I_C_SubscriptionProgress} records that reference the given
 	 * term.
-	 *
-	 * @param term
-	 * @return
 	 */
 	BigDecimal retrieveSubscriptionProgressQtyForTerm(I_C_Flatrate_Term term);
 

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/IContractsDAO.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/IContractsDAO.java
@@ -41,11 +41,10 @@ public interface IContractsDAO extends ISingletonService
 	/**
 	 * @return the flatrate terms with missing candidates, gathered in a list.
 	 */
-	List<I_C_Flatrate_Term> retrieveSubscriptionTermsWithMissingCandidates(String typconditions, QueryLimit limit);
+	List<I_C_Flatrate_Term> retrieveSubscriptionTermsWithMissingCandidates(String typconditions, @NonNull QueryLimit limit);
 
 
 	/**
-	 *
 	 * Check if the term given as parameter was extended (has a predecessor).
 	 */
 	boolean termHasAPredecessor (I_C_Flatrate_Term term);

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/commission/invoicecandidate/CommissionShareHandler.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/commission/invoicecandidate/CommissionShareHandler.java
@@ -47,6 +47,7 @@ import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.service.ClientId;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.IQuery;
@@ -103,7 +104,7 @@ public class CommissionShareHandler extends AbstractInvoiceCandidateHandler
 	private final transient ITaxDAO taxDAO = Services.get(ITaxDAO.class);
 
 	@Override
-	public Iterator<?> retrieveAllModelsWithMissingCandidates(final int limit_IGNORED)
+	public Iterator<?> retrieveAllModelsWithMissingCandidates(final QueryLimit limit_IGNORED)
 	{
 		return createShareWithMissingICsQuery()
 				.iterate(I_C_Commission_Share.class);

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/ContractsDAO.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/ContractsDAO.java
@@ -21,6 +21,7 @@ import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.IQueryOrderBy.Direction;
 import org.adempiere.ad.dao.IQueryOrderBy.Nulls;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.dao.impl.CompareQueryFilter.Operator;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.proxy.Cached;
@@ -38,7 +39,7 @@ public class ContractsDAO implements IContractsDAO
 	@Override
 	public List<I_C_Flatrate_Term> retrieveSubscriptionTermsWithMissingCandidates(
 			@NonNull String typeConditions,
-			final int limit)
+			@NonNull final QueryLimit limit)
 	{
 		return createTermWithMissingCandidateQueryBuilder(typeConditions, false /* ignoreDateFilters */ )
 				.orderBy().addColumn(I_C_Flatrate_Term.COLUMN_C_Flatrate_Term_ID).endOrderBy()

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/invoicecandidate/ConditionTypeSpecificInvoiceCandidateHandler.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/invoicecandidate/ConditionTypeSpecificInvoiceCandidateHandler.java
@@ -11,6 +11,7 @@ import de.metas.invoicecandidate.spi.IInvoiceCandidateHandler.CandidatesAutoCrea
 import de.metas.invoicecandidate.spi.IInvoiceCandidateHandler.PriceAndTax;
 import de.metas.quantity.Quantity;
 import lombok.NonNull;
+import org.adempiere.ad.dao.QueryLimit;
 
 /*
  * #%L
@@ -38,7 +39,7 @@ public interface ConditionTypeSpecificInvoiceCandidateHandler
 {
 	String getConditionsType();
 
-	Iterator<I_C_Flatrate_Term> retrieveTermsWithMissingCandidates(int limit);
+	Iterator<I_C_Flatrate_Term> retrieveTermsWithMissingCandidates(QueryLimit limit);
 
 	void setSpecificInvoiceCandidateValues(I_C_Invoice_Candidate ic, I_C_Flatrate_Term term);
 

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/invoicecandidate/ConditionTypeSpecificInvoiceCandidateHandler.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/invoicecandidate/ConditionTypeSpecificInvoiceCandidateHandler.java
@@ -39,7 +39,7 @@ public interface ConditionTypeSpecificInvoiceCandidateHandler
 {
 	String getConditionsType();
 
-	Iterator<I_C_Flatrate_Term> retrieveTermsWithMissingCandidates(QueryLimit limit);
+	Iterator<I_C_Flatrate_Term> retrieveTermsWithMissingCandidates(@NonNull QueryLimit limit);
 
 	void setSpecificInvoiceCandidateValues(I_C_Invoice_Candidate ic, I_C_Flatrate_Term term);
 

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/invoicecandidate/FlatrateDataEntryHandler.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/invoicecandidate/FlatrateDataEntryHandler.java
@@ -38,6 +38,7 @@ import de.metas.invoicecandidate.spi.InvoiceCandidateGenerateRequest;
 import de.metas.invoicecandidate.spi.InvoiceCandidateGenerateResult;
 import de.metas.util.Check;
 import de.metas.util.Services;
+import org.adempiere.ad.dao.QueryLimit;
 
 public class FlatrateDataEntryHandler extends AbstractInvoiceCandidateHandler
 {
@@ -60,7 +61,7 @@ public class FlatrateDataEntryHandler extends AbstractInvoiceCandidateHandler
 	 * @return empty iterator
 	 */
 	@Override
-	public Iterator<I_C_Flatrate_DataEntry> retrieveAllModelsWithMissingCandidates(final int limit)
+	public Iterator<I_C_Flatrate_DataEntry> retrieveAllModelsWithMissingCandidates(final QueryLimit limit_IGNORED)
 	{
 		return Collections.emptyIterator();
 	}

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/invoicecandidate/FlatrateTerm_Handler.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/invoicecandidate/FlatrateTerm_Handler.java
@@ -28,6 +28,7 @@ import de.metas.uom.IUOMConversionBL;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.service.ISysConfigBL;
 
 import javax.annotation.Nullable;
@@ -86,7 +87,7 @@ public class FlatrateTerm_Handler extends AbstractInvoiceCandidateHandler
 	 * One invocation returns a maximum of <code>limit</code> {@link I_C_Flatrate_Term}s that are completed subscriptions and don't have an invoice candidate referencing them.
 	 */
 	@Override
-	public Iterator<I_C_Flatrate_Term> retrieveAllModelsWithMissingCandidates(final int limit)
+	public Iterator<I_C_Flatrate_Term> retrieveAllModelsWithMissingCandidates(@NonNull final QueryLimit limit)
 	{
 		final Collection<ConditionTypeSpecificInvoiceCandidateHandler> specificHandlers = conditionTypeSpecificInvoiceCandidateHandlers.values();
 		Iterator<I_C_Flatrate_Term> result = null;

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/refund/invoicecandidatehandler/FlatrateTermRefund_Handler.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/refund/invoicecandidatehandler/FlatrateTermRefund_Handler.java
@@ -12,6 +12,7 @@ import java.util.function.Consumer;
 import de.metas.contracts.refund.CandidateAssignmentService;
 import de.metas.invoicecandidate.spi.IInvoiceCandidateHandler;
 import de.metas.invoicecandidate.spi.IInvoiceCandidateHandler.CandidatesAutoCreateMode;
+import org.adempiere.ad.dao.QueryLimit;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_UOM;
 
@@ -66,7 +67,7 @@ public class FlatrateTermRefund_Handler
 	 * @return an empty iterator; invoice candidates that need to be there are created from {@link CandidateAssignmentService}.
 	 */
 	@Override
-	public Iterator<I_C_Flatrate_Term> retrieveTermsWithMissingCandidates(final int limit)
+	public Iterator<I_C_Flatrate_Term> retrieveTermsWithMissingCandidates(final QueryLimit limit_IGNORED)
 	{
 		return ImmutableList
 				.<I_C_Flatrate_Term> of()

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/subscription/invoicecandidatehandler/FlatrateTermSubscription_Handler.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/subscription/invoicecandidatehandler/FlatrateTermSubscription_Handler.java
@@ -46,7 +46,7 @@ public class FlatrateTermSubscription_Handler implements ConditionTypeSpecificIn
 	private final IFlatrateDAO flatrateDAO = Services.get(IFlatrateDAO.class);
 
 	@Override
-	public Iterator<I_C_Flatrate_Term> retrieveTermsWithMissingCandidates(final QueryLimit limit)
+	public Iterator<I_C_Flatrate_Term> retrieveTermsWithMissingCandidates(@NonNull final QueryLimit limit)
 	{
 		return Services.get(IContractsDAO.class)
 				.retrieveSubscriptionTermsWithMissingCandidates(X_C_Flatrate_Term.TYPE_CONDITIONS_Subscription, limit)

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/subscription/invoicecandidatehandler/FlatrateTermSubscription_Handler.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/subscription/invoicecandidatehandler/FlatrateTermSubscription_Handler.java
@@ -26,6 +26,7 @@ import de.metas.uom.UomId;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.I_C_UOM;
 import org.compiere.util.Env;
@@ -45,7 +46,7 @@ public class FlatrateTermSubscription_Handler implements ConditionTypeSpecificIn
 	private final IFlatrateDAO flatrateDAO = Services.get(IFlatrateDAO.class);
 
 	@Override
-	public Iterator<I_C_Flatrate_Term> retrieveTermsWithMissingCandidates(final int limit)
+	public Iterator<I_C_Flatrate_Term> retrieveTermsWithMissingCandidates(final QueryLimit limit)
 	{
 		return Services.get(IContractsDAO.class)
 				.retrieveSubscriptionTermsWithMissingCandidates(X_C_Flatrate_Term.TYPE_CONDITIONS_Subscription, limit)

--- a/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/ContractsDAOTest.java
+++ b/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/ContractsDAOTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import de.metas.common.util.time.SystemTime;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.wrapper.POJOWrapper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.compiere.util.TimeUtil;
@@ -67,7 +68,7 @@ public class ContractsDAOTest
 		term1.setStartDate(TimeUtil.getDay(2013, 5, 27)); // yesterday
 		save(term1);
 
-		final List<I_C_Flatrate_Term> termsWithMissingCandidates = new ContractsDAO().retrieveSubscriptionTermsWithMissingCandidates(X_C_Flatrate_Term.TYPE_CONDITIONS_Subscription, 50);
+		final List<I_C_Flatrate_Term> termsWithMissingCandidates = new ContractsDAO().retrieveSubscriptionTermsWithMissingCandidates(X_C_Flatrate_Term.TYPE_CONDITIONS_Subscription, QueryLimit.ofInt(50));
 
 		assertThat(termsWithMissingCandidates).hasSize(1);
 		assertThat(termsWithMissingCandidates.get(0)).isInstanceOf(I_C_Flatrate_Term.class);

--- a/backend/de.metas.dlm/base/src/main/java/de/metas/dlm/partitioner/async/DLMPartitionerWorkpackageProcessor.java
+++ b/backend/de.metas.dlm/base/src/main/java/de/metas/dlm/partitioner/async/DLMPartitionerWorkpackageProcessor.java
@@ -126,7 +126,7 @@ public class DLMPartitionerWorkpackageProcessor extends WorkpackageProcessorAdap
 		final ILoggable loggable = Loggables.get();
 
 		final ITableRecordReference tableRefToAttach;
-		final List<Object> recordsToAttach = queueDAO.retrieveItems(workPackage, Object.class, localTrxName); // note that according to the 'schedule' method, there can be max one item
+		final List<Object> recordsToAttach = queueDAO.retrieveAllItems(workPackage, Object.class); // note that according to the 'schedule' method, there can be max one item
 		if (recordsToAttach.isEmpty())
 		{
 			tableRefToAttach = null;

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/async/spi/impl/DocOutboundCCWorkpackageProcessor.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/async/spi/impl/DocOutboundCCWorkpackageProcessor.java
@@ -80,7 +80,7 @@ public class DocOutboundCCWorkpackageProcessor implements IWorkpackageProcessor
 			return Result.SUCCESS;
 		}
 
-		final List<I_AD_Archive> archives = queueDAO.retrieveItems(workpackage, I_AD_Archive.class, localTrxName);
+		final List<I_AD_Archive> archives = queueDAO.retrieveAllItems(workpackage, I_AD_Archive.class);
 		for (final I_AD_Archive archive : archives)
 		{
 			writeCCFile(archive);

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/async/spi/impl/DocOutboundWorkpackageProcessor.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/async/spi/impl/DocOutboundWorkpackageProcessor.java
@@ -79,7 +79,7 @@ public class DocOutboundWorkpackageProcessor implements IWorkpackageProcessor
 		final UserId userId = UserId.ofRepoIdOrNull(workpackage.getAD_User_ID());
 		final I_C_Async_Batch asyncBatch = workpackage.getC_Async_Batch_ID() > 0 ? workpackage.getC_Async_Batch() : null;
 
-		final List<Object> records = queueDAO.retrieveItems(workpackage, Object.class, localTrxName);
+		final List<Object> records = queueDAO.retrieveAllItems(workpackage, Object.class);
 		for (final Object record : records)
 		{
 			InterfaceWrapperHelper.setDynAttribute(record, Async_Constants.C_Async_Batch, asyncBatch);

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/async/spi/impl/MailWorkpackageProcessor.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/async/spi/impl/MailWorkpackageProcessor.java
@@ -91,7 +91,7 @@ public class MailWorkpackageProcessor implements IWorkpackageProcessor
 	@Override
 	public Result processWorkPackage(final I_C_Queue_WorkPackage workpackage, final String localTrxName)
 	{
-		final List<I_C_Doc_Outbound_Log_Line> logLines = queueDAO.retrieveItems(workpackage, I_C_Doc_Outbound_Log_Line.class, localTrxName);
+		final List<I_C_Doc_Outbound_Log_Line> logLines = queueDAO.retrieveAllItems(workpackage, I_C_Doc_Outbound_Log_Line.class);
 		for (final I_C_Doc_Outbound_Log_Line logLine : logLines)
 		{
 			final I_AD_Archive archive = logLine.getAD_Archive();

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/async/spi/impl/ProcessPrintingQueueWorkpackageProcessor.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/async/spi/impl/ProcessPrintingQueueWorkpackageProcessor.java
@@ -29,7 +29,7 @@ public class ProcessPrintingQueueWorkpackageProcessor implements IWorkpackagePro
 	{
 		final IQueueDAO queueDAO = Services.get(IQueueDAO.class);
 
-		final List<PO> list = queueDAO.retrieveItems(workpackage, PO.class, localTrxName);
+		final List<PO> list = queueDAO.retrieveAllItems(workpackage, PO.class);
 		for (final PO po : list)
 		{
 			fireVoidDocumentForArchive(po);

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/async/spi/impl/RecreateArchiveWorkpackageProcessor.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/async/spi/impl/RecreateArchiveWorkpackageProcessor.java
@@ -37,7 +37,7 @@ public class RecreateArchiveWorkpackageProcessor implements IWorkpackageProcesso
 		final Properties ctx = InterfaceWrapperHelper.getCtx(workpackage);
 		final String trxName = InterfaceWrapperHelper.getTrxName(workpackage);
 
-		final List<I_C_Doc_Outbound_Log> logs = queueDAO.retrieveItems(workpackage, I_C_Doc_Outbound_Log.class, localTrxName);
+		final List<I_C_Doc_Outbound_Log> logs = queueDAO.retrieveAllItems(workpackage, I_C_Doc_Outbound_Log.class);
 
 		logs.forEach(docOutboundLog -> {
 			final PO po = TableModelLoader.instance.getPO(ctx, adTableDAO.retrieveTableName(docOutboundLog.getAD_Table_ID()), docOutboundLog.getRecord_ID(), trxName);

--- a/backend/de.metas.dunning/src/main/java/de/metas/dunning/export/async/C_DunningDoc_CreateExportData.java
+++ b/backend/de.metas.dunning/src/main/java/de/metas/dunning/export/async/C_DunningDoc_CreateExportData.java
@@ -20,6 +20,8 @@ import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 
+import javax.annotation.Nullable;
+
 public class C_DunningDoc_CreateExportData implements IWorkpackageProcessor
 {
 	private static final Logger logger = LogManager.getLogger(C_DunningDoc_CreateExportData.class);
@@ -29,7 +31,7 @@ public class C_DunningDoc_CreateExportData implements IWorkpackageProcessor
 			.newModelScheduler(C_DunningDoc_CreateExportData.class, I_C_DunningDoc.class)
 			.setCreateOneWorkpackagePerModel(true);
 
-	public static final void scheduleOnTrxCommit(final I_C_DunningDoc dunningDocRecord)
+	public static void scheduleOnTrxCommit(final I_C_DunningDoc dunningDocRecord)
 	{
 		SCHEDULER.schedule(dunningDocRecord);
 	}
@@ -41,9 +43,9 @@ public class C_DunningDoc_CreateExportData implements IWorkpackageProcessor
 	@Override
 	public Result processWorkPackage(
 			@NonNull final I_C_Queue_WorkPackage workpackage,
-			@NonNull final String localTrxName)
+			@Nullable final String localTrxName)
 	{
-		final List<I_C_DunningDoc> dunningDocRecords = queueDAO.retrieveItemsSkipMissing(workpackage, I_C_DunningDoc.class, localTrxName);
+		final List<I_C_DunningDoc> dunningDocRecords = queueDAO.retrieveAllItemsSkipMissing(workpackage, I_C_DunningDoc.class);
 		for (final I_C_DunningDoc dunningDocRecord : dunningDocRecords)
 		{
 			Loggables.withLogger(logger, Level.DEBUG).addLog("Going to export data for dunningDocRecord={}", dunningDocRecord);

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/async/spi/impl/EDIWorkpackageProcessor.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/async/spi/impl/EDIWorkpackageProcessor.java
@@ -69,7 +69,7 @@ public class EDIWorkpackageProcessor implements IWorkpackageProcessor
 
 		final Set<TableRecordIdPair> seenDocumentRecordIds = new HashSet<>();
 
-		final List<I_EDI_Document> ediDocuments = queueDAO.retrieveItems(workpackage, I_EDI_Document.class, localTrxName);
+		final List<I_EDI_Document> ediDocuments = queueDAO.retrieveAllItems(workpackage, I_EDI_Document.class);
 		for (final I_EDI_Document ediDocument : ediDocuments)
 		{
 			// Create export processor

--- a/backend/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/ic/spi/impl/PP_Order_MaterialTracking_Handler.java
+++ b/backend/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/ic/spi/impl/PP_Order_MaterialTracking_Handler.java
@@ -25,6 +25,8 @@ package de.metas.materialtracking.qualityBasedInvoicing.ic.spi.impl;
 import java.util.Iterator;
 import java.util.List;
 
+import lombok.NonNull;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.modelvalidator.DocTimingType;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -125,9 +127,9 @@ public class PP_Order_MaterialTracking_Handler extends AbstractInvoiceCandidateH
 	 * @return all PP_Orders which are suitable for invoices and there are no invoice candidates created yet.
 	 */
 	@Override
-	public Iterator<I_PP_Order> retrieveAllModelsWithMissingCandidates(final int limit)
+	public Iterator<I_PP_Order> retrieveAllModelsWithMissingCandidates(@NonNull final QueryLimit limit)
 	{
-		return dao.retrievePPOrdersWithMissingICs(Env.getCtx(), limit, ITrx.TRXNAME_ThreadInherited);
+		return dao.retrievePPOrdersWithMissingICs(limit);
 	}
 
 	/**

--- a/backend/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/ic/spi/impl/PP_Order_MaterialTracking_HandlerDAO.java
+++ b/backend/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/ic/spi/impl/PP_Order_MaterialTracking_HandlerDAO.java
@@ -3,10 +3,12 @@ package de.metas.materialtracking.qualityBasedInvoicing.ic.spi.impl;
 import java.util.Iterator;
 import java.util.Properties;
 
+import lombok.NonNull;
 import org.adempiere.ad.dao.ICompositeQueryFilter;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.IQueryFilter;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.model.PlainContextAware;
 import org.compiere.model.IQuery;
 import org.eevolution.model.I_PP_Order;
@@ -100,11 +102,9 @@ public class PP_Order_MaterialTracking_HandlerDAO
 	/**
 	 * Uses a <b>DB</b> query to validate if the given <code>ppOrder</code> is still invoiceable.
 	 *
-	 * @param ppOrder
-	 *
 	 * @return true if given manufacturing order is invoiceable
 	 *
-	 * @see #getPP_OrderInvoiceableFilter()
+	 * @see #getPP_OrderInvoiceableFilter(Object)
 	 */
 	/* package */boolean isInvoiceable(final I_PP_Order ppOrder)
 	{
@@ -128,23 +128,18 @@ public class PP_Order_MaterialTracking_HandlerDAO
 	 * <li>don't have an invoice candidate linked to them
 	 * <li>reference an unprocessed M_Material_tracking
 	 * </ul>
-	 *
-	 * @param ctx
-	 * @param limit
-	 * @param trxName
-	 * @return
 	 */
-	/* package */Iterator<de.metas.materialtracking.model.I_PP_Order> retrievePPOrdersWithMissingICs(final Properties ctx, final int limit, final String trxName)
+	/* package */Iterator<de.metas.materialtracking.model.I_PP_Order> retrievePPOrdersWithMissingICs(@NonNull final QueryLimit limit)
 	{
 		final IQueryBL queryBL = Services.get(IQueryBL.class);
 
-		final IQueryBuilder<I_PP_Order> ppOrderQueryBuilder = queryBL.createQueryBuilder(I_PP_Order.class, ctx, trxName)
+		final IQueryBuilder<I_PP_Order> ppOrderQueryBuilder = queryBL.createQueryBuilder(I_PP_Order.class)
 				.addOnlyContextClient()
 				.addOnlyActiveRecordsFilter();
 
 		//
 		// Only those manufacturing orders which are invoiceable
-		ppOrderQueryBuilder.filter(getPP_OrderInvoiceableFilter(PlainContextAware.newWithTrxName(ctx, trxName)));
+		ppOrderQueryBuilder.filter(getPP_OrderInvoiceableFilter(PlainContextAware.newWithThreadInheritedTrx()));
 
 		//
 		// Order by

--- a/backend/de.metas.materialtracking/src/test/java/de/metas/materialtracking/qualityBasedInvoicing/ic/spi/impl/PP_Order_MaterialTracking_HandlerDAOTest.java
+++ b/backend/de.metas.materialtracking/src/test/java/de/metas/materialtracking/qualityBasedInvoicing/ic/spi/impl/PP_Order_MaterialTracking_HandlerDAOTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.model.PlainContextAware;
@@ -88,7 +89,7 @@ public class PP_Order_MaterialTracking_HandlerDAOTest
 
 	private void test_retrievePPOrdersWithMissingICs(final List<I_PP_Order> resultExpected)
 	{
-		final Iterator<I_PP_Order> resultActualIt = dao.retrievePPOrdersWithMissingICs(context.getCtx(), IQuery.NO_LIMIT, context.getTrxName());
+		final Iterator<I_PP_Order> resultActualIt = dao.retrievePPOrdersWithMissingICs(QueryLimit.NO_LIMIT);
 		final List<I_PP_Order> resultActual = IteratorUtils.toList(resultActualIt);
 
 		Assert.assertEquals("Invalid result", resultExpected, resultActual);

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/processor/impl/LoadESRImportFileWorkpackageProcessor.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/processor/impl/LoadESRImportFileWorkpackageProcessor.java
@@ -48,7 +48,7 @@ public class LoadESRImportFileWorkpackageProcessor implements IWorkpackageProces
 		final IQueueDAO queueDAO = Services.get(IQueueDAO.class);
 		final IESRImportBL esrImportBL = Services.get(IESRImportBL.class);
 
-		final List<I_ESR_Import> records = queueDAO.retrieveItems(workpackage, I_ESR_Import.class, localTrxName);
+		final List<I_ESR_Import> records = queueDAO.retrieveAllItems(workpackage, I_ESR_Import.class);
 
 		for (final I_ESR_Import esrImport : records)
 		{

--- a/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/async/spi/impl/PDFDocPrintingWorkpackageProcessor.java
+++ b/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/async/spi/impl/PDFDocPrintingWorkpackageProcessor.java
@@ -80,7 +80,7 @@ public class PDFDocPrintingWorkpackageProcessor implements IWorkpackageProcessor
 		this.asyncBatch = workpackage.getC_Async_Batch();
 		Check.assumeNotNull(asyncBatch, "Async batch is not null");
 
-		final List<I_C_Print_Job_Instructions> list = queueDAO.retrieveItems(workpackage, I_C_Print_Job_Instructions.class, ITrx.TRXNAME_ThreadInherited);
+		final List<I_C_Print_Job_Instructions> list = queueDAO.retrieveAllItems(workpackage, I_C_Print_Job_Instructions.class);
 		for (final I_C_Print_Job_Instructions printjobInstructions : list)
 		{
 			InterfaceWrapperHelper.refresh(printjobInstructions, ITrx.TRXNAME_ThreadInherited);

--- a/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/async/spi/impl/PDFPrintingAsyncBatchListener.java
+++ b/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/async/spi/impl/PDFPrintingAsyncBatchListener.java
@@ -77,7 +77,7 @@ public class PDFPrintingAsyncBatchListener implements IAsyncBatchListener
 
 				if (notifiableWP != null)
 				{
-					final List<I_C_Print_Job_Instructions> printJobInstructions = queueDAO.retrieveItems(notifiableWP, I_C_Print_Job_Instructions.class, trxName);
+					final List<I_C_Print_Job_Instructions> printJobInstructions = queueDAO.retrieveAllItems(notifiableWP, I_C_Print_Job_Instructions.class);
 					for (final I_C_Print_Job_Instructions pji : printJobInstructions)
 					{
 						final Iterator<I_C_Print_Job_Line> jobLines = dao.retrievePrintJobLines(pji);

--- a/backend/de.metas.procurement.base/src/main/java/de/metas/procurement/base/order/async/PMM_GenerateOrders.java
+++ b/backend/de.metas.procurement.base/src/main/java/de/metas/procurement/base/order/async/PMM_GenerateOrders.java
@@ -6,7 +6,6 @@ import de.metas.async.spi.WorkpackageProcessorAdapter;
 import de.metas.procurement.base.model.I_PMM_PurchaseCandidate;
 import de.metas.procurement.base.order.impl.OrdersGenerator;
 import de.metas.util.Services;
-import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
 
 import java.util.List;
@@ -40,7 +39,7 @@ import java.util.List;
  */
 public class PMM_GenerateOrders extends WorkpackageProcessorAdapter
 {
-	public static final PMM_GenerateOrdersEnqueuer prepareEnqueuing()
+	public static PMM_GenerateOrdersEnqueuer prepareEnqueuing()
 	{
 		return new PMM_GenerateOrdersEnqueuer();
 	}
@@ -63,7 +62,7 @@ public class PMM_GenerateOrders extends WorkpackageProcessorAdapter
 	private List<I_PMM_PurchaseCandidate> retrieveItems()
 	{
 		final I_C_Queue_WorkPackage workpackage = getC_Queue_WorkPackage();
-		return Services.get(IQueueDAO.class).retrieveItemsSkipMissing(workpackage, I_PMM_PurchaseCandidate.class, ITrx.TRXNAME_ThreadInherited);
+		return Services.get(IQueueDAO.class).retrieveAllItemsSkipMissing(workpackage, I_PMM_PurchaseCandidate.class);
 	}
 
 	@Override

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/async/C_PurchaseCandidates_GeneratePurchaseOrders.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/async/C_PurchaseCandidates_GeneratePurchaseOrders.java
@@ -135,7 +135,7 @@ public class C_PurchaseCandidates_GeneratePurchaseOrders extends WorkpackageProc
 
 	private List<PurchaseCandidate> getPurchaseCandidates()
 	{
-		final boolean skipAlreadyScheduledItems = true;
+		final boolean skipAlreadyScheduledItems = false; // there is just one processor-thread, so there won't be any elements in not yet-processed preceding WPs
 		final List<I_C_Queue_Element> queueElements = retrieveQueueElements(skipAlreadyScheduledItems);
 
 		final Set<PurchaseCandidateId> purchaseCandidateIds = queueElements

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/invoicecandidate/spi/impl/C_OLCand_Handler.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/invoicecandidate/spi/impl/C_OLCand_Handler.java
@@ -88,10 +88,10 @@ public class C_OLCand_Handler extends AbstractInvoiceCandidateHandler
 	}
 
 	@Override
-	public Iterator<I_C_OLCand> retrieveAllModelsWithMissingCandidates(final int limit)
+	public Iterator<I_C_OLCand> retrieveAllModelsWithMissingCandidates(@NonNull final QueryLimit limit)
 	{
 		return dao.retrieveMissingCandidatesQuery(Env.getCtx(), ITrx.TRXNAME_ThreadInherited)
-				.setLimit(QueryLimit.ofInt(limit))
+				.setLimit(limit)
 				.create()
 				.iterate(I_C_OLCand.class);
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/document/async/spi/impl/CreateCounterDocPP.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/document/async/spi/impl/CreateCounterDocPP.java
@@ -85,7 +85,7 @@ public class CreateCounterDocPP extends WorkpackageProcessorAdapter
 	@Override
 	public Result processWorkPackage(final I_C_Queue_WorkPackage workpackage, final String localTrxName)
 	{
-		final List<Object> models = queueDAO.retrieveItemsSkipMissing(workpackage, Object.class, localTrxName);
+		final List<Object> models = queueDAO.retrieveAllItemsSkipMissing(workpackage, Object.class);
 		for (final Object model : models)
 		{
 			final IDocument document = docActionBL.getDocument(model);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/InOutLinesWithMissingInvoiceCandidate.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/InOutLinesWithMissingInvoiceCandidate.java
@@ -27,10 +27,12 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import lombok.NonNull;
 import org.adempiere.ad.dao.ICompositeQueryFilter;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.IQueryFilter;
+import org.adempiere.ad.dao.QueryLimit;
 import org.compiere.model.IQuery;
 import org.compiere.model.I_M_InOut;
 import org.compiere.model.I_M_InOutLine;
@@ -64,13 +66,8 @@ public class InOutLinesWithMissingInvoiceCandidate
 	 * Get all {@link I_M_InOutLine}s which are not linked to an {@link I_C_OrderLine} and there is no invoice candidate already generated for them.
 	 * 
 	 * NOTE: this method will be used to identify those inout lines for which {@link M_InOutLine_Handler} will generate invoice candidates.
-	 * 
-	 * @param ctx
-	 * @param limit
-	 * @param trxName
-	 * @return inout lines
 	 */
-	public Iterator<I_M_InOutLine> retrieveLinesThatNeedAnInvoiceCandidate(final int limit)
+	public Iterator<I_M_InOutLine> retrieveLinesThatNeedAnInvoiceCandidate(@NonNull final QueryLimit limit)
 	{
 		final IQueryBL queryBL = Services.get(IQueryBL.class);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
@@ -66,6 +66,7 @@ import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBuilder;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.mm.attributes.api.IAttributeDAO;
@@ -161,7 +162,7 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 	}
 
 	@Override
-	public Iterator<org.compiere.model.I_M_InOutLine> retrieveAllModelsWithMissingCandidates(final int limit)
+	public Iterator<org.compiere.model.I_M_InOutLine> retrieveAllModelsWithMissingCandidates(@NonNull final QueryLimit limit)
 	{
 		final InOutLinesWithMissingInvoiceCandidate dao = SpringContextHolder.instance.getBean(InOutLinesWithMissingInvoiceCandidate.class);
 		return dao.retrieveLinesThatNeedAnInvoiceCandidate(limit);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOut_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOut_Handler.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_DocType;
 
@@ -108,7 +109,7 @@ public class M_InOut_Handler extends AbstractInvoiceCandidateHandler
 	 * @return empty iterator
 	 */
 	@Override
-	public Iterator<I_M_InOut> retrieveAllModelsWithMissingCandidates(final int limit)
+	public Iterator<I_M_InOut> retrieveAllModelsWithMissingCandidates(final QueryLimit limit_IGNORED)
 	{
 		return Collections.emptyIterator();
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/async/GenerateReceiptScheduleWorkpackageProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/async/GenerateReceiptScheduleWorkpackageProcessor.java
@@ -52,7 +52,7 @@ public class GenerateReceiptScheduleWorkpackageProcessor implements IWorkpackage
 		final IQueueDAO queueDAO = Services.get(IQueueDAO.class);
 
 		// maybe the underlying order line was deleted meanwhile, after the order was reactivated. Using retrieveItemsSkipMissing() because we don't need to make a fuss about that.
-		final List<Object> models = queueDAO.retrieveItemsSkipMissing(workpackage, Object.class, localTrxName);
+		final List<Object> models = queueDAO.retrieveAllItemsSkipMissing(workpackage, Object.class);
 		Loggables.addLog("Retrieved {} items for this work package", models.size());
 
 		for (final Object model : models)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandidateHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandidateHandlerBL.java
@@ -67,15 +67,12 @@ public interface IInvoiceCandidateHandlerBL extends ISingletonService
 	 *
 	 * Each created invoice candidate has a reference to the {@link I_C_ILCandHandler} from whose {@link IInvoiceCandidateHandler} implementation it has been created.
 	 *
-	 * @param model
 	 * @return generated invoice candidates
 	 */
 	List<I_C_Invoice_Candidate> createMissingCandidatesFor(Object model);
 
 	/**
 	 * Schedule invoice candidates generation for given model (asynchronously).
-	 *
-	 * @param model
 	 */
 	void scheduleCreateMissingCandidatesFor(Object model);
 
@@ -83,8 +80,6 @@ public interface IInvoiceCandidateHandlerBL extends ISingletonService
 
 	/**
 	 * Retrieve the {@link IInvoiceCandidateHandler} of the given <code>ic</code> and calls its {@link IInvoiceCandidateHandler#setOrderedData(I_C_Invoice_Candidate) setOrderedData()} method.
-	 *
-	 * @param ic
 	 */
 	void setOrderedData(I_C_Invoice_Candidate ic);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandDAO.java
@@ -911,11 +911,11 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 		invalidateCandsFor(icQueryBuilder);
 	}
 
-	protected final void invalidateCandsForSelection(final PInstanceId pinstanceId, final String trxName)
+	protected final void invalidateCandsForSelection(@NonNull final PInstanceId pinstanceId)
 	{
 		final Properties ctx = Env.getCtx();
 		final IQueryBuilder<I_C_Invoice_Candidate> icQueryBuilder = queryBL
-				.createQueryBuilder(I_C_Invoice_Candidate.class, ctx, trxName)
+				.createQueryBuilder(I_C_Invoice_Candidate.class, ctx, ITrx.TRXNAME_ThreadInherited)
 				.setOnlySelection(pinstanceId)
 				// Invalidate no matter if Processed or not
 				// .addEqualsFilter(I_C_Invoice_Candidate.COLUMN_Processed, false)
@@ -1303,7 +1303,7 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 						updateCount, selectionId, paymentTermId);
 
 		// Invalidate the candidates which we updated
-		invalidateCandsForSelection(selectionToUpdateId, ITrx.TRXNAME_ThreadInherited);
+		invalidateCandsForSelection(selectionToUpdateId);
 
 	}
 
@@ -1407,7 +1407,7 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 						updateCount, selectionId, columnName, updateOnlyIfNull, value);
 
 		// Invalidate the candidates which we updated
-		invalidateCandsForSelection(selectionToUpdateId, ITrx.TRXNAME_ThreadInherited);
+		invalidateCandsForSelection(selectionToUpdateId);
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandRecomputeTagger.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandRecomputeTagger.java
@@ -56,10 +56,8 @@ import java.util.Properties;
 	// State
 	private InvoiceCandRecomputeTag _recomputeTag;
 
-	public InvoiceCandRecomputeTagger(final InvoiceCandDAO invoiceCandDAO)
+	public InvoiceCandRecomputeTagger(@NonNull final InvoiceCandDAO invoiceCandDAO)
 	{
-		super();
-		Check.assumeNotNull(invoiceCandDAO, "invoiceCandDAO not null");
 		this.invoiceCandDAO = invoiceCandDAO;
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateHandlerBL.java
@@ -52,6 +52,7 @@ import de.metas.util.Loggables;
 import de.metas.util.Services;
 import de.metas.workflow.api.IWFExecutionFactory;
 import lombok.NonNull;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
@@ -204,7 +205,7 @@ public class InvoiceCandidateHandlerBL implements IInvoiceCandidateHandlerBL
 				final IInvoiceCandidateHandler creatorImpl = mkInstance(handlerRecord);
 
 				// HARDCODED BufferSize/Limit to be used when we are creating missing candidates
-				final int bufferSize = 500;
+				final QueryLimit bufferSize = QueryLimit.ofInt(500);
 
 				List<I_C_Invoice_Candidate> newCandidates = createCandidates(model, bufferSize, creatorImpl);
 				final int candidatesCount = newCandidates.size();
@@ -259,7 +260,7 @@ public class InvoiceCandidateHandlerBL implements IInvoiceCandidateHandlerBL
 	 */
 	private List<I_C_Invoice_Candidate> createCandidates(
 			final Object modelOrNoModel,
-			final int bufferSize,
+			final QueryLimit bufferSize,
 			final IInvoiceCandidateHandler invoiceCandiateHandler)
 	{
 		//

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/CreateMissingInvoiceCandidatesWorkpackageProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/CreateMissingInvoiceCandidatesWorkpackageProcessor.java
@@ -143,7 +143,7 @@ public class CreateMissingInvoiceCandidatesWorkpackageProcessor extends Workpack
 	{
 		try (final IAutoCloseable ignored = invoiceCandBL.setUpdateProcessInProgress())
 		{
-			final List<Object> models = queueDAO.retrieveItemsSkipMissing(workpackage, Object.class, localTrxName);
+			final List<Object> models = queueDAO.retrieveAllItemsSkipMissing(workpackage, Object.class);
 			for (final Object model : models)
 			{
 				try (final MDCCloseable ignored1 = TableRecordMDC.putTableRecordReference(model))

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/InvoiceCandWorkpackageProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/InvoiceCandWorkpackageProcessor.java
@@ -95,7 +95,7 @@ public class InvoiceCandWorkpackageProcessor extends WorkpackageProcessorAdapter
 		// use the workpackge's ctx. It contains the client, org and user that created the queu-block this package belongs to
 		final Properties localCtx = InterfaceWrapperHelper.getCtx(workPackage);
 
-		final List<I_C_Invoice_Candidate> candidatesOfPackage = queueDAO.retrieveItems(workPackage, I_C_Invoice_Candidate.class, localTrxName);
+		final List<I_C_Invoice_Candidate> candidatesOfPackage = queueDAO.retrieveAllItems(workPackage, I_C_Invoice_Candidate.class);
 
 		try (final IAutoCloseable ignored = invoiceCandBL.setUpdateProcessInProgress())
 		{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/IInvoiceCandidateHandler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/IInvoiceCandidateHandler.java
@@ -15,6 +15,7 @@ import de.metas.uom.UomId;
 import de.metas.util.Services;
 import de.metas.util.lang.Percent;
 import lombok.NonNull;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.modelvalidator.DocTimingType;
 import org.adempiere.model.InterfaceWrapperHelper;
 
@@ -119,7 +120,7 @@ public interface IInvoiceCandidateHandler
 	 *
 	 * @param limit advises how many models shall be retrieved. Note that this is an advise which could be respected or not by current implementations.
 	 */
-	Iterator<?> retrieveAllModelsWithMissingCandidates(int limit);
+	Iterator<?> retrieveAllModelsWithMissingCandidates(@NonNull QueryLimit limit);
 	
 	/**
 	 * Called by API to expand an initial invoice candidate generate request.

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/M_InventoryLine_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/M_InventoryLine_Handler.java
@@ -10,6 +10,7 @@ import java.util.Properties;
 
 import de.metas.lang.SOTrx;
 import de.metas.tax.api.TaxId;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.mm.attributes.api.IAttributeDAO;
@@ -132,9 +133,9 @@ public class M_InventoryLine_Handler extends AbstractInvoiceCandidateHandler
 	}
 
 	@Override
-	public Iterator<? extends Object> retrieveAllModelsWithMissingCandidates(final int limit)
+	public Iterator<? extends Object> retrieveAllModelsWithMissingCandidates(@NonNull final QueryLimit limit)
 	{
-		return inventoryLineHandlerDAO.retrieveAllLinesWithoutIC(Env.getCtx(), limit, ITrx.TRXNAME_ThreadInherited);
+		return inventoryLineHandlerDAO.retrieveAllLinesWithoutIC(Env.getCtx(), limit.toInt(), ITrx.TRXNAME_ThreadInherited);
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/M_Inventory_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/M_Inventory_Handler.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_M_Inventory;
 import org.compiere.model.I_M_InventoryLine;
@@ -85,7 +86,7 @@ public class M_Inventory_Handler extends AbstractInvoiceCandidateHandler
 	}
 
 	@Override
-	public Iterator<? extends Object> retrieveAllModelsWithMissingCandidates(final int limit)
+	public Iterator<? extends Object> retrieveAllModelsWithMissingCandidates(final QueryLimit limit_IGNORED)
 	{
 		return Collections.emptyIterator();
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/ManualCandidateHandler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/ManualCandidateHandler.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Properties;
 
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.slf4j.Logger;
 
@@ -75,7 +76,7 @@ public class ManualCandidateHandler extends AbstractInvoiceCandidateHandler
 
 	/** @return empty iterator */
 	@Override
-	public Iterator<Object> retrieveAllModelsWithMissingCandidates(final int limit)
+	public Iterator<Object> retrieveAllModelsWithMissingCandidates(final QueryLimit limit_IGNORED)
 	{
 		return Collections.emptyIterator();
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/invoicecandidate/C_OrderLine_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/invoicecandidate/C_OrderLine_Handler.java
@@ -47,6 +47,7 @@ import de.metas.uom.UomId;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
@@ -105,7 +106,7 @@ public class C_OrderLine_Handler extends AbstractInvoiceCandidateHandler
 	}
 
 	@Override
-	public Iterator<?> retrieveAllModelsWithMissingCandidates(final int limit)
+	public Iterator<?> retrieveAllModelsWithMissingCandidates(final QueryLimit limit_IGNORED)
 	{
 		return Services.get(IC_OrderLine_HandlerDAO.class).retrieveMissingOrderLinesQuery(Env.getCtx(), ITrx.TRXNAME_ThreadInherited)
 				.create()

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/invoicecandidate/C_Order_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/invoicecandidate/C_Order_Handler.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_Order;
 
@@ -104,7 +105,7 @@ public class C_Order_Handler extends AbstractInvoiceCandidateHandler
 	 * @return empty iterator
 	 */
 	@Override
-	public Iterator<I_C_Order> retrieveAllModelsWithMissingCandidates(final int limit)
+	public Iterator<I_C_Order> retrieveAllModelsWithMissingCandidates(final QueryLimit limit_IGNORED)
 	{
 		return Collections.emptyIterator();
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/request/service/async/spi/impl/C_Request_CreateFromDDOrder_Async.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/request/service/async/spi/impl/C_Request_CreateFromDDOrder_Async.java
@@ -50,7 +50,7 @@ public class C_Request_CreateFromDDOrder_Async extends WorkpackageProcessorAdapt
 		final IRequestBL requestBL = Services.get(IRequestBL.class);
 
 		// retrieve the items (DDOrder lines) that were enqueued and put them in a list
-		final List<I_DD_OrderLine> lines = queueDAO.retrieveItems(workPackage, I_DD_OrderLine.class, localTrxName);
+		final List<I_DD_OrderLine> lines = queueDAO.retrieveAllItems(workPackage, I_DD_OrderLine.class);
 
 		// for each line that was enqueued, create a R_Request containing the information from the DDOrder line and DDOrder
 		for (final I_DD_OrderLine line : lines)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/request/service/async/spi/impl/C_Request_CreateFromInout_Async.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/request/service/async/spi/impl/C_Request_CreateFromInout_Async.java
@@ -144,7 +144,7 @@ public class C_Request_CreateFromInout_Async extends WorkpackageProcessorAdapter
 		final IRequestBL requestBL = Services.get(IRequestBL.class);
 
 		// retrieve the items (inout lines) that were enqueued and put them in a list
-		final List<I_M_InOutLine> lines = queueDAO.retrieveItems(workPackage, I_M_InOutLine.class, localTrxName);
+		final List<I_M_InOutLine> lines = queueDAO.retrieveAllItems(workPackage, I_M_InOutLine.class);
 
 		// for each line that was enqueued, create a R_Request containing the information from the inout line and inout
 		for (final I_M_InOutLine line : lines)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/request/service/async/spi/impl/R_Request_CreateFromOrder_Async.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/request/service/async/spi/impl/R_Request_CreateFromOrder_Async.java
@@ -81,7 +81,7 @@ public class R_Request_CreateFromOrder_Async extends WorkpackageProcessorAdapter
 	public Result processWorkPackage(final I_C_Queue_WorkPackage workPackage, final String localTrxName)
 	{
 		// retrieve the order and generate requests
-		queueDAO.retrieveItems(workPackage, I_C_Order.class, localTrxName)
+		queueDAO.retrieveAllItems(workPackage, I_C_Order.class)
 				.forEach(requestBL::createRequestFromOrder);
 
 		return Result.SUCCESS;

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/InvoiceCandidatesTestHelper.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/InvoiceCandidatesTestHelper.java
@@ -9,6 +9,8 @@ import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.invoicecandidate.spi.IInvoiceCandidateHandler;
 import de.metas.invoicecandidate.spi.InvoiceCandidateGenerateRequest;
 import de.metas.invoicecandidate.spi.InvoiceCandidateGenerateResult;
+import lombok.NonNull;
+import org.adempiere.ad.dao.QueryLimit;
 
 /*
  * #%L
@@ -43,17 +45,15 @@ public class InvoiceCandidatesTestHelper
 	/**
 	 * Creates all missing invoice candidates
 	 * 
-	 * Helper method to invoke {@link IInvoiceCandidateHandler#retrieveAllModelsWithMissingCandidates(Properties, int, String)} and then
+	 * Helper method to invoke {@link IInvoiceCandidateHandler#retrieveAllModelsWithMissingCandidates(QueryLimit)} and then
 	 * {@link IInvoiceCandidateHandler#createCandidatesFor(InvoiceCandidateGenerateRequest)} for retrieved models.
 	 * 
-	 * @param handler
-	 * @param limit
 	 * @return invoice candidates
 	 */
-	public static List<I_C_Invoice_Candidate> createMissingCandidates(final IInvoiceCandidateHandler handler, final int limit)
+	public static List<I_C_Invoice_Candidate> createMissingCandidates(@NonNull final IInvoiceCandidateHandler handler, @NonNull final QueryLimit limit)
 	{
 		final List<I_C_Invoice_Candidate> invoiceCandidatesAll = new ArrayList<>();
-		final Iterator<? extends Object> models = handler.retrieveAllModelsWithMissingCandidates(limit);
+		final Iterator<?> models = handler.retrieveAllModelsWithMissingCandidates(limit);
 		while (models.hasNext())
 		{
 			final Object model = models.next();

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueueToInvoiceTestBase.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueueToInvoiceTestBase.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
+import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.wrapper.POJOLookupMap;
@@ -223,13 +224,13 @@ abstract class InvoiceCandidateEnqueueToInvoiceTestBase
 		}
 	}
 
-	protected void assertWorkpackageInvoiceCandidatesValid(I_C_Queue_WorkPackage workpackage)
+	protected void assertWorkpackageInvoiceCandidatesValid(@NonNull final I_C_Queue_WorkPackage workpackage)
 	{
 		final IQueueDAO queueDAO = Services.get(IQueueDAO.class);
 		final IWorkpackageParamDAO workpackageParamDAO = Services.get(IWorkpackageParamDAO.class);
 
 		final IParams workpackageParams = workpackageParamDAO.retrieveWorkpackageParams(workpackage);
-		final List<I_C_Invoice_Candidate> ics = queueDAO.retrieveItems(workpackage, I_C_Invoice_Candidate.class, ITrx.TRXNAME_None);
+		final List<I_C_Invoice_Candidate> ics = queueDAO.retrieveAllItems(workpackage, I_C_Invoice_Candidate.class);
 
 		//
 		// Create the invoice candidates processor.

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/C_OrderLine_Handler_Test.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/C_OrderLine_Handler_Test.java
@@ -31,6 +31,7 @@ import de.metas.tax.api.TaxCategoryId;
 import de.metas.tax.api.TaxId;
 import de.metas.user.UserRepository;
 import de.metas.util.Services;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.agg.key.IAggregationKeyBuilder;
@@ -347,7 +348,7 @@ public class C_OrderLine_Handler_Test extends AbstractICTestSupport
 
 		setUpActivityAndTaxRetrieval(order4, oL4);
 
-		final List<I_C_Invoice_Candidate> candidates = InvoiceCandidatesTestHelper.createMissingCandidates(orderLineHandler, 5);
+		final List<I_C_Invoice_Candidate> candidates = InvoiceCandidatesTestHelper.createMissingCandidates(orderLineHandler, QueryLimit.ofInt(5));
 
 		assertEquals(2, candidates.size());
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/PlainInvoiceCandidateHandler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/spi/impl/PlainInvoiceCandidateHandler.java
@@ -30,6 +30,7 @@ import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.invoicecandidate.spi.AbstractInvoiceCandidateHandler;
 import de.metas.invoicecandidate.spi.InvoiceCandidateGenerateRequest;
 import de.metas.invoicecandidate.spi.InvoiceCandidateGenerateResult;
+import org.adempiere.ad.dao.QueryLimit;
 
 public class PlainInvoiceCandidateHandler extends AbstractInvoiceCandidateHandler
 {
@@ -51,7 +52,7 @@ public class PlainInvoiceCandidateHandler extends AbstractInvoiceCandidateHandle
 	 * @return empty iterator
 	 */
 	@Override
-	public Iterator<Object> retrieveAllModelsWithMissingCandidates(final int limit)
+	public Iterator<Object> retrieveAllModelsWithMissingCandidates(final QueryLimit limit_IGNORED)
 	{
 		return Collections.emptyIterator();
 	}


### PR DESCRIPTION
 See deprecation notice in IQueueDAO for details.
Also, not strictly related: replace int with QueryLimit