### PR TITLE
12264 mobile UI vulnerable pkgs

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/package.json
+++ b/misc/services/mobile-webui/mobile-webui-frontend/package.json
@@ -17,7 +17,7 @@
     "classnames": "^2.3.1",
     "connected-react-router": "^6.9.1",
     "counterpart": "^0.18.6",
-    "immer": "^9.0.6",
+    "immer": "9.0.7",
     "js-cookie": "^3.0.1",
     "lodash": "^4.17.21",
     "react": "^17.0.2",
@@ -86,7 +86,7 @@
     "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "eslint-plugin-react": "7.24.0",
-    "node-sass": "^6.0.1",
+    "node-sass": "7.0.1",
     "prettier": "2.3.2",
     "react-hot-loader": "4.13.0"
   },

--- a/misc/services/mobile-webui/mobile-webui-frontend/package.json
+++ b/misc/services/mobile-webui/mobile-webui-frontend/package.json
@@ -86,9 +86,9 @@
     "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "eslint-plugin-react": "7.24.0",
-    "node-sass": "7.0.1",
     "prettier": "2.3.2",
-    "react-hot-loader": "4.13.0"
+    "react-hot-loader": "4.13.0",
+    "sass": "^1.46.0"
   },
   "homepage": "/mobile"
 }


### PR DESCRIPTION
- lock immer version to prevent future surprises introduced by possible breaking changes
- replaced node-sass because if it were to use the latest version this will bring incompatibility issues with the node version 16
- added `sass` package instead to prevent future issues 
- 
<img width="1606" alt="Screenshot 2022-01-06 at 10 40 33" src="https://user-images.githubusercontent.com/1708561/148354459-81b885bd-f62a-4441-9073-8b549eeefc9d.png">

