### PR TITLE
Activity Fix

### DIFF
--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/api/IProductAcctDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/api/IProductAcctDAO.java
@@ -27,7 +27,5 @@ public interface IProductAcctDAO extends IProductActivityProvider, ISingletonSer
 
 	Optional<AccountId> getProductAccount(AcctSchemaId acctSchemaId, ProductId productId, ProductAcctType acctType);
 
-	ActivityId getProductActivityId(ProductId productId);
-
 	Optional<AccountId> getProductCategoryAccount(@NonNull AcctSchemaId acctSchemaId, @NonNull ProductCategoryId productCategoryId, @NonNull ProductAcctType acctType);
 }

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/api/impl/ProductAcctDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/api/impl/ProductAcctDAO.java
@@ -118,20 +118,6 @@ public class ProductAcctDAO implements IProductAcctDAO
 		return Optional.of(AccountId.ofRepoId(validCombinationId));
 	}
 
-	@Override
-	public ActivityId getProductActivityId(@NonNull final ProductId productId)
-	{
-		final Properties ctx = Env.getCtx();
-		final AcctSchema schema = acctSchemaDAO.getByClientAndOrg(ctx);
-		final I_M_Product_Acct productAcct = getProductAcctRecord(schema.getId(), productId).orElse(null);
-		if (productAcct == null)
-		{
-			return null;
-		}
-
-		return ActivityId.ofRepoIdOrNull(productAcct.getC_Activity_ID());
-	}
-
 	private ProductCategoryAccountsCollection getProductCategoryAccountsCollection()
 	{
 		return this.productCategoryAcctCollectionCache.getOrLoad(0, this::retrieveProductCategoryAccountsCollection);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/activity/model/validator/C_InvoiceLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/activity/model/validator/C_InvoiceLine.java
@@ -40,7 +40,8 @@ import de.metas.util.Services;
 @Validator(I_C_InvoiceLine.class)
 public class C_InvoiceLine
 {
-	final DimensionService dimensionService = SpringContextHolder.instance.getBean(DimensionService.class);
+	private final DimensionService dimensionService = SpringContextHolder.instance.getBean(DimensionService.class);
+	private final IProductAcctDAO productAcctDAO = Services.get(IProductAcctDAO.class);
 
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE }, ifColumnsChanged = { I_C_InvoiceLine.COLUMNNAME_M_Product_ID })
 	public void updateActivity(final I_C_InvoiceLine invoiceLine)
@@ -56,14 +57,16 @@ public class C_InvoiceLine
 			return;
 		}
 
-		final ActivityId productActivityId = Services.get(IProductAcctDAO.class).retrieveActivityForAcct(ClientId.ofRepoId(invoiceLine.getAD_Client_ID()), OrgId.ofRepoId(invoiceLine.getAD_Org_ID()), productId);
+		final ActivityId productActivityId = productAcctDAO.retrieveActivityForAcct(
+				ClientId.ofRepoId(invoiceLine.getAD_Client_ID()),
+				OrgId.ofRepoId(invoiceLine.getAD_Org_ID()),
+				productId);
 		if (productActivityId == null)
 		{
 			return;
 		}
 		final Dimension orderLineDimension = dimensionService.getFromRecord(invoiceLine);
 		if (orderLineDimension == null)
-
 		{
 			//nothing to do
 			return;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/activity/model/validator/C_InvoiceLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/activity/model/validator/C_InvoiceLine.java
@@ -24,8 +24,10 @@ package de.metas.activity.model.validator;
 
 import de.metas.document.dimension.Dimension;
 import de.metas.document.dimension.DimensionService;
+import de.metas.organization.OrgId;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.ad.modelvalidator.annotations.Validator;
+import org.adempiere.service.ClientId;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.ModelValidator;
 
@@ -54,7 +56,7 @@ public class C_InvoiceLine
 			return;
 		}
 
-		final ActivityId productActivityId = Services.get(IProductAcctDAO.class).getProductActivityId(productId);
+		final ActivityId productActivityId = Services.get(IProductAcctDAO.class).retrieveActivityForAcct(ClientId.ofRepoId(invoiceLine.getAD_Client_ID()), OrgId.ofRepoId(invoiceLine.getAD_Org_ID()), productId);
 		if (productActivityId == null)
 		{
 			return;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/activity/model/validator/C_OrderLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/activity/model/validator/C_OrderLine.java
@@ -29,6 +29,7 @@ import de.metas.interfaces.I_C_OrderLine;
 import de.metas.order.compensationGroup.Group;
 import de.metas.order.compensationGroup.GroupId;
 import de.metas.order.compensationGroup.OrderGroupRepository;
+import de.metas.organization.OrgId;
 import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
 import de.metas.product.acct.api.ActivityId;
@@ -36,6 +37,7 @@ import de.metas.util.Services;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.ad.modelvalidator.annotations.Validator;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.ModelValidator;
 
@@ -78,7 +80,7 @@ public class C_OrderLine
 		orderLine.setIsDiverse(productBL.isDiverse(productId));
 
 		// Activity
-		final ActivityId productActivityId = Services.get(IProductAcctDAO.class).getProductActivityId(productId);
+		final ActivityId productActivityId = Services.get(IProductAcctDAO.class).retrieveActivityForAcct(ClientId.ofRepoId(orderLine.getAD_Client_ID()), OrgId.ofRepoId(orderLine.getAD_Org_ID()), productId);
 
 		if (productActivityId == null)
 		{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/activity/model/validator/C_OrderLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/activity/model/validator/C_OrderLine.java
@@ -44,8 +44,10 @@ import org.compiere.model.ModelValidator;
 @Validator(I_C_OrderLine.class)
 public class C_OrderLine
 {
-	final DimensionService dimensionService = SpringContextHolder.instance.getBean(DimensionService.class);
-	final OrderGroupRepository orderGroupRepo = SpringContextHolder.instance.getBean(OrderGroupRepository.class);
+	private final DimensionService dimensionService = SpringContextHolder.instance.getBean(DimensionService.class);
+	private final OrderGroupRepository orderGroupRepo = SpringContextHolder.instance.getBean(OrderGroupRepository.class);
+	private final IProductAcctDAO productAcctDAO = Services.get(IProductAcctDAO.class);
+	private final IProductBL productBL = Services.get(IProductBL.class);
 
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE },
 			ifColumnsChanged = { I_C_OrderLine.COLUMNNAME_M_Product_ID,
@@ -76,12 +78,13 @@ public class C_OrderLine
 		}
 
 		// IsDiverse flag
-		final IProductBL productBL = Services.get(IProductBL.class);
 		orderLine.setIsDiverse(productBL.isDiverse(productId));
 
 		// Activity
-		final ActivityId productActivityId = Services.get(IProductAcctDAO.class).retrieveActivityForAcct(ClientId.ofRepoId(orderLine.getAD_Client_ID()), OrgId.ofRepoId(orderLine.getAD_Org_ID()), productId);
-
+		final ActivityId productActivityId = productAcctDAO.retrieveActivityForAcct(
+				ClientId.ofRepoId(orderLine.getAD_Client_ID()),
+				OrgId.ofRepoId(orderLine.getAD_Org_ID()),
+				productId);
 		if (productActivityId == null)
 		{
 			return;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/activity/model/validator/M_InOutLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/activity/model/validator/M_InOutLine.java
@@ -24,8 +24,10 @@ package de.metas.activity.model.validator;
 
 import de.metas.document.dimension.Dimension;
 import de.metas.document.dimension.DimensionService;
+import de.metas.organization.OrgId;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.ad.modelvalidator.annotations.Validator;
+import org.adempiere.service.ClientId;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.ModelValidator;
 
@@ -53,8 +55,8 @@ public class M_InOutLine
 		{
 			return;
 		}
-		final ActivityId productActivityId = Services.get(IProductAcctDAO.class).getProductActivityId(productId);
 
+		final ActivityId productActivityId = Services.get(IProductAcctDAO.class).retrieveActivityForAcct(ClientId.ofRepoId(inOutLine.getAD_Client_ID()), OrgId.ofRepoId(inOutLine.getAD_Org_ID()), productId);
 		if (productActivityId == null)
 		{
 			return;
@@ -67,10 +69,6 @@ public class M_InOutLine
 			return;
 		}
 
-		if (productActivityId != null)
-		{
-			dimensionService.updateRecord(inOutLine, orderLineDimension.withActivityId(productActivityId));
-		}
-
+		dimensionService.updateRecord(inOutLine, orderLineDimension.withActivityId(productActivityId));
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/activity/model/validator/M_InOutLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/activity/model/validator/M_InOutLine.java
@@ -40,7 +40,8 @@ import de.metas.util.Services;
 @Validator(I_M_InOutLine.class)
 public class M_InOutLine
 {
-	final DimensionService dimensionService = SpringContextHolder.instance.getBean(DimensionService.class);
+	private final DimensionService dimensionService = SpringContextHolder.instance.getBean(DimensionService.class);
+	private final IProductAcctDAO productAcctDAO = Services.get(IProductAcctDAO.class);
 
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE }, ifColumnsChanged = { I_M_InOutLine.COLUMNNAME_M_Product_ID })
 	public void updateActivity(final I_M_InOutLine inOutLine)
@@ -56,7 +57,10 @@ public class M_InOutLine
 			return;
 		}
 
-		final ActivityId productActivityId = Services.get(IProductAcctDAO.class).retrieveActivityForAcct(ClientId.ofRepoId(inOutLine.getAD_Client_ID()), OrgId.ofRepoId(inOutLine.getAD_Org_ID()), productId);
+		final ActivityId productActivityId = productAcctDAO.retrieveActivityForAcct(
+				ClientId.ofRepoId(inOutLine.getAD_Client_ID()),
+				OrgId.ofRepoId(inOutLine.getAD_Org_ID()),
+				productId);
 		if (productActivityId == null)
 		{
 			return;

--- a/misc/services/camel/de-metas-camel-externalsystems/pom.xml
+++ b/misc/services/camel/de-metas-camel-externalsystems/pom.xml
@@ -27,9 +27,12 @@
 
     <dependencies>
         <dependency>
+            <!-- we include lombok in the actual build, as a curtesty to 3rd-parties who want to compile against this build's image -->
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <!-- we include lombok in the actual build, as a curtesty to 3rd-parties who want to compile against this build's image -->
+            <!-- some projects fail when building with java-17 and lombok-1.18.18 -->
+            <!-- <version>1.18.18</version> -->
+            <version>1.18.22</version>
         </dependency>
     </dependencies>
     

--- a/misc/services/procurement-webui/procurement-webui-backend/pom.xml
+++ b/misc/services/procurement-webui/procurement-webui-backend/pom.xml
@@ -63,6 +63,14 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <!-- some projects fail when building with java-17 and lombok-1.18.18 -->
+                <!-- <version>1.18.18</version> -->
+                <version>1.18.22</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Use respective record's ClientId and OrgId when getting the Activity.
We can't assume that the correct AD_Client_ID and AD_Org_ID are always in the context.
E.g. when processing workpackages they are not.