### PR TITLE
Remove the divider on top of Apply

### DIFF
--- a/frontend/src/assets/css/styles.css
+++ b/frontend/src/assets/css/styles.css
@@ -1151,7 +1151,6 @@ body{
 .filter-btn-wrapper {
     text-align: right;
     padding-top: 10px;
-    border-top: 1px solid $brand-light-color;
 }
 
 .dashboard-wrapper {


### PR DESCRIPTION
rel to: https://github.com/metasfresh/metasfresh/issues/12160

<img width="1655" alt="Screenshot 2022-01-07 at 10 59 26" src="https://user-images.githubusercontent.com/1708561/148519355-272d29eb-b3a4-4952-952a-0d69ce957ac0.png">

was added by Kuba as a separator. Agreed with Daniela that we should have consistent layout and that div should not be added.