### PR TITLE
#12221 Fix NPE

### DIFF
--- a/backend/de.metas.async/src/main/java/de/metas/async/api/IAsyncBatchBL.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/IAsyncBatchBL.java
@@ -18,6 +18,7 @@ import lombok.NonNull;
 import org.adempiere.util.lang.IAutoCloseable;
 import org.adempiere.util.lang.ImmutablePair;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 
@@ -113,7 +114,7 @@ public interface IAsyncBatchBL extends ISingletonService
 			@NonNull List<T> model,
 			@NonNull String asyncBatchInternalName);
 
-	IAutoCloseable assignTempAsyncBatchIdToModel(@NonNull Object model, @NonNull AsyncBatchId asyncBatchId);
+	IAutoCloseable assignTempAsyncBatchIdToModel(@NonNull Object model, @Nullable AsyncBatchId asyncBatchId);
 
 	I_C_Async_Batch getAsyncBatchById(AsyncBatchId asyncBatchId);
 

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchBL.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchBL.java
@@ -491,7 +491,7 @@ public class AsyncBatchBL implements IAsyncBatchBL
 	}
 
 	@Override
-	public IAutoCloseable assignTempAsyncBatchIdToModel(@NonNull final Object model, @NonNull final AsyncBatchId asyncBatchId)
+	public IAutoCloseable assignTempAsyncBatchIdToModel(@NonNull final Object model, @Nullable final AsyncBatchId asyncBatchId)
 	{
 		InterfaceWrapperHelper.setDynAttribute(model, DYN_ATTR_TEMPORARY_BATCH_ID, asyncBatchId);
 


### PR DESCRIPTION
Fix error:

```
org.adempiere.exceptions.AdempiereException: NullPointerException: NullPointerException
Additional parameters:
 I_C_Queue_WorkPackage: X_C_Queue_WorkPackage[C_Queue_WorkPackage_ID=2974401, trxName=null]
 IQueueProcessor: ThreadPoolQueueProcessor{name=DocOutboundWorkpackageProcessor, executor=BlockingExecutorWrapper(semaphore=java.util.concurrent.Semaphore@65f27dad[Permits = 0], delegate=java.util.concurrent.ThreadPoolExecutor@138b507e[Running, pool size = 1, active threads = 1, queued tasks = 0, completed tasks = 1], logger=Logger[org.adempiere.util.concurrent.BlockingExecutorWrapper])}
 trxName: <<ThreadInherited>>
	at org.adempiere.exceptions.AdempiereException.wrapIfNeeded(AdempiereException.java:81)
	at de.metas.async.processor.impl.WorkpackageProcessorTask.invokeProcessorAndHandleException(WorkpackageProcessorTask.java:386)
	at de.metas.async.processor.impl.WorkpackageProcessorTask.processWorkpackage(WorkpackageProcessorTask.java:362)
	at de.metas.async.processor.impl.WorkpackageProcessorTask.lambda$run0$0(WorkpackageProcessorTask.java:211)
```