### PR TITLE
Fix double dot in bundled images

### DIFF
--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -74,14 +74,14 @@ module.exports = {
         exclude: /\w*(logo)\w*\.(jpg|png)$/,
         type: 'asset/resource',
         generator: {
-          filename: '[path][name].[hash].[ext]',
+          filename: '[path][name]-[git-revision-hash][ext]',
         },
       },
       {
         test: /\w*(logo)\w*\.(jpg|png)$/,
         type: 'asset/resource',
         generator: {
-          filename: '[path][name].[ext]',
+          filename: '[path][name][ext]',
         },
       },
       {


### PR DESCRIPTION
![Screenshot 2022-01-13 at 10 03 11](https://user-images.githubusercontent.com/1708561/149289869-d7588dae-cf8d-4aa1-9888-6b17bffe6333.png)

Delete first the `dist` folder
To test locally run : `npm run build-prod` and check the dist folder.