### PR TITLE
webui: upgrade autoprefixer, webpack, webpack-dev-server, immer

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,7 @@
     "@testing-library/dom": "8.11.1",
     "@testing-library/react": "12.1.2",
     "@welldone-software/why-did-you-render": "6.2.3",
-    "autoprefixer": "10.3.4",
+    "autoprefixer": "10.4.2",
     "axios-mock-adapter": "1.20.0",
     "babel-jest": "27.4.6",
     "babel-loader": "8.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -146,7 +146,7 @@
     "detect-browser": "5.3.0",
     "google-map-react": "2.1.10",
     "history": "4.10.1",
-    "immer": "9.0.9",
+    "immer": "9.0.12",
     "immutability-helper": "3.1.1",
     "lodash": "4.17.21",
     "moment": "2.29.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -119,7 +119,7 @@
     "wait-for-expect": "3.0.2",
     "webpack": "5.66.0",
     "webpack-cli": "4.9.1",
-    "webpack-dev-server": "4.7.2",
+    "webpack-dev-server": "4.7.3",
     "webpack-node-externals": "3.0.0",
     "@mdx-js/loader": "1.6.22",
     "@mdx-js/mdx": "1.6.22",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,7 @@
     "@babel/plugin-transform-regenerator": "7.16.7",
     "@babel/preset-env": "7.16.8",
     "@babel/preset-react": "7.16.7",
-    "@babel/register": "7.16.8",
+    "@babel/register": "7.16.9",
     "@babel/runtime": "7.16.7",
     "@storybook/addon-actions": "6.4.12",
     "@storybook/addon-docs": "6.4.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -117,7 +117,7 @@
     "style-loader": "3.3.1",
     "stylelint": "14.2.0",
     "wait-for-expect": "3.0.2",
-    "webpack": "5.65.0",
+    "webpack": "5.66.0",
     "webpack-cli": "4.9.1",
     "webpack-dev-server": "4.7.2",
     "webpack-node-externals": "3.0.0",


### PR DESCRIPTION
rel to https://github.com/metasfresh/metasfresh/issues/12324

updates packages from the frontend structure that have a new version and can be updated without impact
