### PR TITLE
12359 hide dashboard logo

### DIFF
--- a/frontend/src/components/dashboard/DraggableWrapper.js
+++ b/frontend/src/components/dashboard/DraggableWrapper.js
@@ -290,6 +290,19 @@ export class DraggableWrapper extends Component {
     );
   };
 
+  renderLogo = () => {
+    const { indicators } = this.state;
+    return indicators.length > 0 ? (
+      false
+    ) : (
+      <div className="dashboard-wrapper dashboard-logo-wrapper">
+        <div className="logo-wrapper">
+          <img src={logo} />
+        </div>
+      </div>
+    );
+  };
+
   renderKpis = () => {
     const { cards, idMaximized } = this.state;
     const { editmode } = this.props;
@@ -314,52 +327,48 @@ export class DraggableWrapper extends Component {
 
     return (
       <div className="kpis-wrapper">
-        {cards.length > 0 ? (
-          cards.map((item, id) => {
-            return (
-              <DndWidget
-                key={id}
-                index={id}
-                id={item.id}
-                moveCard={this.moveCard}
-                addCard={this.addCard}
-                onDrop={this.onDrop}
-                removeCard={this.removeCard}
-                entity={'cards'}
-                className={
-                  'draggable-widget ' +
-                  (idMaximized === item.id ? 'draggable-widget-maximize ' : '')
-                }
-                transparent={!editmode}
-              >
-                <ChartWidget
-                  key={item.id}
-                  id={item.id}
+        {cards.length > 0
+          ? cards.map((item, id) => {
+              return (
+                <DndWidget
+                  key={id}
                   index={id}
-                  chartType={item.kpi.chartType}
-                  caption={item.caption}
-                  fields={item.kpi.fields}
-                  groupBy={item.kpi.groupByField}
-                  kpi={true}
+                  id={item.id}
                   moveCard={this.moveCard}
-                  idMaximized={idMaximized}
-                  maximizeWidget={this.maximizeWidget}
-                  text={item.caption}
-                  data={item.data}
-                  noData={item.fetchOnDrop}
-                  handleChartOptions={this.handleChartOptions}
-                  {...{ editmode }}
-                />
-              </DndWidget>
-            );
-          })
-        ) : (
-          <div className="dashboard-wrapper dashboard-logo-wrapper">
-            <div className="logo-wrapper">
-              <img src={logo} />
-            </div>
-          </div>
-        )}
+                  addCard={this.addCard}
+                  onDrop={this.onDrop}
+                  removeCard={this.removeCard}
+                  entity={'cards'}
+                  className={
+                    'draggable-widget ' +
+                    (idMaximized === item.id
+                      ? 'draggable-widget-maximize '
+                      : '')
+                  }
+                  transparent={!editmode}
+                >
+                  <ChartWidget
+                    key={item.id}
+                    id={item.id}
+                    index={id}
+                    chartType={item.kpi.chartType}
+                    caption={item.caption}
+                    fields={item.kpi.fields}
+                    groupBy={item.kpi.groupByField}
+                    kpi={true}
+                    moveCard={this.moveCard}
+                    idMaximized={idMaximized}
+                    maximizeWidget={this.maximizeWidget}
+                    text={item.caption}
+                    data={item.data}
+                    noData={item.fetchOnDrop}
+                    handleChartOptions={this.handleChartOptions}
+                    {...{ editmode }}
+                  />
+                </DndWidget>
+              );
+            })
+          : this.renderLogo()}
       </div>
     );
   };

--- a/frontend/src/components/dashboard/DraggableWrapper.js
+++ b/frontend/src/components/dashboard/DraggableWrapper.js
@@ -28,6 +28,7 @@ export class DraggableWrapper extends Component {
   state = {
     cards: [],
     indicators: [],
+    indicatorsUpdated: false,
     idMaximized: null,
     websocketEndpoint: null,
     chartOptions: false,
@@ -134,6 +135,7 @@ export class DraggableWrapper extends Component {
     getTargetIndicatorsDashboard().then((response) => {
       this.setState({
         indicators: response.data.items,
+        indicatorsUpdated: true,
       });
     });
   };
@@ -291,8 +293,9 @@ export class DraggableWrapper extends Component {
   };
 
   renderLogo = () => {
-    const { indicators } = this.state;
-    return indicators.length > 0 ? (
+    const { indicators, indicatorsUpdated } = this.state;
+
+    return indicators.length > 0 || !indicatorsUpdated ? (
       false
     ) : (
       <div className="dashboard-wrapper dashboard-logo-wrapper">

--- a/frontend/src/components/dashboard/DraggableWrapper.js
+++ b/frontend/src/components/dashboard/DraggableWrapper.js
@@ -28,7 +28,7 @@ export class DraggableWrapper extends Component {
   state = {
     cards: [],
     indicators: [],
-    indicatorsUpdated: false,
+    indicatorsLoaded: false,
     idMaximized: null,
     websocketEndpoint: null,
     chartOptions: false,
@@ -135,7 +135,7 @@ export class DraggableWrapper extends Component {
     getTargetIndicatorsDashboard().then((response) => {
       this.setState({
         indicators: response.data.items,
-        indicatorsUpdated: true,
+        indicatorsLoaded: true,
       });
     });
   };
@@ -293,9 +293,9 @@ export class DraggableWrapper extends Component {
   };
 
   renderLogo = () => {
-    const { indicators, indicatorsUpdated } = this.state;
+    const { indicators, indicatorsLoaded } = this.state;
 
-    return indicators.length > 0 || !indicatorsUpdated ? (
+    return indicators.length > 0 || !indicatorsLoaded ? (
       false
     ) : (
       <div className="dashboard-wrapper dashboard-logo-wrapper">


### PR DESCRIPTION
rel to: https://github.com/metasfresh/metasfresh/issues/12359

<img width="1656" alt="Screenshot 2022-01-20 at 07 42 32" src="https://user-images.githubusercontent.com/1708561/150280490-c5d899b0-5114-4eb6-b831-5c8460d507cb.png">

Note the use of `indicatorsUpdated` flag which is needed because the indicators are initially empty array([]]). Without using that we would see for a split second the logo until the state is updated with the indicators.
