### PR TITLE
Log migration scripts context info

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MTree_Base.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/MTree_Base.java
@@ -16,15 +16,13 @@
  *****************************************************************************/
 package org.compiere.model;
 
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-
+import de.metas.cache.CCache;
 import de.metas.logging.LogManager;
+import de.metas.util.Check;
+import de.metas.util.Services;
+import lombok.NonNull;
 import org.adempiere.ad.migration.logger.IMigrationLogger;
+import org.adempiere.ad.migration.logger.MigrationScriptFileLoggerHolder;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.trx.api.ITrxManager;
@@ -38,13 +36,14 @@ import org.adempiere.model.tree.TreeListenerSupport;
 import org.adempiere.model.tree.spi.IPOTreeSupport;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
-import org.compiere.util.TrxRunnable;
 import org.slf4j.Logger;
 
-import de.metas.cache.CCache;
-import de.metas.util.Check;
-import de.metas.util.Services;
-import lombok.NonNull;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
 
 /**
  * Base Tree Model. (see also MTree in project base)
@@ -63,10 +62,10 @@ public class MTree_Base extends X_AD_Tree
 	/**
 	 * Add Node to correct tree
 	 *
-	 * @param ctx cpntext
-	 * @param treeType tree type
+	 * @param ctx       cpntext
+	 * @param treeType  tree type
 	 * @param Record_ID id
-	 * @param trxName transaction
+	 * @param trxName   transaction
 	 * @return true if node added
 	 */
 	public static boolean addNode(Properties ctx, String treeType, int Record_ID, String trxName)
@@ -129,7 +128,7 @@ public class MTree_Base extends X_AD_Tree
 			saved = node.save();
 		}
 		return saved;
-	}	// addNode
+	}    // addNode
 
 	/**************************************************************************
 	 * Get Node TableName
@@ -146,8 +145,8 @@ public class MTree_Base extends X_AD_Tree
 			nodeTableName += "BP";
 		else if (TREETYPE_Product.equals(treeType))
 			nodeTableName += "PR";
-		// else if (TREETYPE_ProductCategory.equals(treeType))
-		// nodeTableName += TREETYPE_ProductCategory;
+			// else if (TREETYPE_ProductCategory.equals(treeType))
+			// nodeTableName += TREETYPE_ProductCategory;
 
 		else if (TREETYPE_CMContainer.equals(treeType))
 			nodeTableName += "CMC";
@@ -157,7 +156,7 @@ public class MTree_Base extends X_AD_Tree
 			nodeTableName += "CMM";
 		else if (TREETYPE_CMTemplate.equals(treeType))
 			nodeTableName += "CMT";
-		//
+			//
 		else if (TREETYPE_User1.equals(treeType))
 			nodeTableName += "U1";
 		else if (TREETYPE_User2.equals(treeType))
@@ -167,11 +166,11 @@ public class MTree_Base extends X_AD_Tree
 		else if (TREETYPE_User4.equals(treeType))
 			nodeTableName += "U4";
 		return nodeTableName;
-	}	// getNodeTableName
+	}    // getNodeTableName
 
 	/**
 	 * Get Source TableName
-	 * 
+	 *
 	 * @param treeType tree type
 	 * @return source table name, e.g. AD_Org or null
 	 */
@@ -182,8 +181,8 @@ public class MTree_Base extends X_AD_Tree
 
 	/**
 	 * Get Source TableName
-	 * 
-	 * @param treeType tree type
+	 *
+	 * @param treeType    tree type
 	 * @param AD_Table_ID
 	 * @return source table name, e.g. AD_Org or null
 	 */
@@ -214,7 +213,7 @@ public class MTree_Base extends X_AD_Tree
 			sourceTable = "C_Activity";
 		else if (treeType.equals(TREETYPE_SalesRegion))
 			sourceTable = "C_SalesRegion";
-		//
+			//
 		else if (treeType.equals(TREETYPE_CMContainer))
 			sourceTable = "CM_Container";
 		else if (treeType.equals(TREETYPE_CMContainerStage))
@@ -223,15 +222,15 @@ public class MTree_Base extends X_AD_Tree
 			sourceTable = "CM_Media";
 		else if (treeType.equals(TREETYPE_CMTemplate))
 			sourceTable = "CM_Template";
-		// User Trees
-		// afalcone [Bugs #1837219]
+			// User Trees
+			// afalcone [Bugs #1837219]
 		else if (treeType.equals(TREETYPE_User1) ||
 				treeType.equals(TREETYPE_User2) ||
 				treeType.equals(TREETYPE_User3) ||
 				treeType.equals(TREETYPE_User4))
 			sourceTable = "C_ElementValue";
-		//
-		// General Table
+			//
+			// General Table
 		else if (treeType.equals(TREETYPE_Other) && AD_Table_ID > 0)
 		{
 			sourceTable = Services.get(IADTableDAO.class).retrieveTableName(AD_Table_ID);
@@ -242,14 +241,14 @@ public class MTree_Base extends X_AD_Tree
 		// end afalcone
 
 		return sourceTable;
-	}	// getSourceTableName
+	}    // getSourceTableName
 
 	/**
 	 * Get MTree_Base from Cache
 	 *
-	 * @param ctx context
+	 * @param ctx        context
 	 * @param AD_Tree_ID id
-	 * @param trxName transaction
+	 * @param trxName    transaction
 	 * @return MTree_Base
 	 */
 	public static MTree_Base get(Properties ctx, int AD_Tree_ID, String trxName)
@@ -262,14 +261,16 @@ public class MTree_Base extends X_AD_Tree
 		if (retValue.get_ID() != 0)
 			s_cache.put(key, retValue);
 		return retValue;
-	}	// get
+	}    // get
 
 	public static MTree_Base getById(@NonNull final AdTreeId adTreeId)
 	{
 		return get(Env.getCtx(), adTreeId.getRepoId(), ITrx.TRXNAME_None);
 	}
 
-	/** Cache */
+	/**
+	 * Cache
+	 */
 	private static CCache<Integer, MTree_Base> s_cache = new CCache<Integer, MTree_Base>("AD_Tree", 10);
 
 	/**************************************************************************
@@ -286,28 +287,28 @@ public class MTree_Base extends X_AD_Tree
 		{
 			// setName (null);
 			// setTreeType (null);
-			setIsAllNodes(true);	// complete tree
+			setIsAllNodes(true);    // complete tree
 			setIsDefault(false);
 		}
-	}	// MTree_Base
+	}    // MTree_Base
 
 	/**
 	 * Load Constructor
 	 *
-	 * @param ctx context
-	 * @param rs result set
+	 * @param ctx     context
+	 * @param rs      result set
 	 * @param trxName transaction
 	 */
 	public MTree_Base(Properties ctx, ResultSet rs, String trxName)
 	{
 		super(ctx, rs, trxName);
-	}	// MTree_Base
+	}    // MTree_Base
 
 	/**
 	 * Parent Constructor
 	 *
-	 * @param client client
-	 * @param name name
+	 * @param client   client
+	 * @param name     name
 	 * @param treeType
 	 */
 	public MTree_Base(MClient client, String name, String treeType)
@@ -316,25 +317,25 @@ public class MTree_Base extends X_AD_Tree
 		setClientOrg(client);
 		setName(name);
 		setTreeType(treeType);
-	}	// MTree_Base
+	}    // MTree_Base
 
 	/**
 	 * Full Constructor
 	 *
-	 * @param ctx context
-	 * @param Name name
+	 * @param ctx      context
+	 * @param Name     name
 	 * @param TreeType tree type
-	 * @param trxName transaction
+	 * @param trxName  transaction
 	 */
 	public MTree_Base(Properties ctx, String Name, String TreeType,
-			String trxName)
+					  String trxName)
 	{
 		super(ctx, 0, trxName);
 		setName(Name);
 		setTreeType(TreeType);
-		setIsAllNodes(true);	// complete tree
+		setIsAllNodes(true);    // complete tree
 		setIsDefault(false);
-	}	// MTree_Base
+	}    // MTree_Base
 
 	/**
 	 * Get Node TableName
@@ -344,11 +345,11 @@ public class MTree_Base extends X_AD_Tree
 	public String getNodeTableName()
 	{
 		return getNodeTableName(getTreeType());
-	}	// getNodeTableName
+	}    // getNodeTableName
 
 	/**
 	 * Get Source TableName (i.e. where to get the name and color)
-	 * 
+	 *
 	 * @return source table name, e.g. AD_Org or null
 	 */
 	public String getSourceTableName()
@@ -374,7 +375,7 @@ public class MTree_Base extends X_AD_Tree
 		if (tableName != null)
 			tableName += " t";
 		return tableName;
-	}	// getSourceTableName
+	}    // getSourceTableName
 
 	public String getSourceKeyColumnName()
 	{
@@ -402,7 +403,7 @@ public class MTree_Base extends X_AD_Tree
 				|| "AD_Org".equals(tableName) || "C_Campaign".equals(tableName))
 			return "x.AD_PrintColor_ID";
 		return "NULL";
-	}	// getSourceTableName
+	}    // getSourceTableName
 
 	/**
 	 * Before Save
@@ -426,7 +427,7 @@ public class MTree_Base extends X_AD_Tree
 			else
 			{
 				final IADTableDAO adTableDAO = Services.get(IADTableDAO.class);
-				
+
 				final String tableName = getDefaultTableNameByTreeType(getTreeType());
 				final int AD_Table_ID = adTableDAO.retrieveTableId(tableName);
 				if (AD_Table_ID <= 0)
@@ -437,69 +438,64 @@ public class MTree_Base extends X_AD_Tree
 			}
 		}
 		return true;
-	}	// beforeSabe
+	}    // beforeSabe
 
 	/**
 	 * After Save
 	 *
 	 * @param newRecord new
-	 * @param success success
+	 * @param success   success
 	 * @return success
 	 */
 	@Override
 	protected boolean afterSave(boolean newRecord, boolean success)
 	{
-		if (newRecord)	// Base Node
+		if (newRecord)    // Base Node
 		{
 			verifyTree();
 		}
 
 		return success;
-	}	// afterSave
+	}    // afterSave
 
 	/**
 	 * Move node from parent to another
-	 * 
+	 *
 	 * @throws AdempiereException if an exception occurs
 	 */
 	public void updateNodeChildren(final MTreeNode parent, final List<MTreeNode> children)
 	{
-		Services.get(ITrxManager.class).runInNewTrx(new TrxRunnable()
-		{
-			@Override
-			public void run(String trxName)
-			{
-				updateNodeChildren(parent, children, trxName);
-			}
-		});
+		final ITrxManager trxManager = Services.get(ITrxManager.class);
+		trxManager.runInNewTrx(() -> updateNodeChildrenInTrx(parent, children));
 	}
 
-	private void updateNodeChildren(MTreeNode parent, List<MTreeNode> children, String trxName)
+	private void updateNodeChildrenInTrx(final MTreeNode parent, final List<MTreeNode> children)
 	{
+		MigrationScriptFileLoggerHolder.logComment("Reordering children of `" + parent.getName() + "`");
+
 		int seqNo = 0;
-		for (int i = 0; i < children.size(); i++)
+		for (final MTreeNode nd : children)
 		{
-			final MTreeNode nd = children.get(i);
 			if (nd.isPlaceholder())
 			{
 				for (final MTreeNode nd2 : nd.getPlaceholderNodes())
 				{
-					updateNode(nd2, parent.getNode_ID(), seqNo++, trxName);
+					updateNode(nd2, parent.getNode_ID(), seqNo++);
 				}
 			}
 			else
 			{
-				updateNode(nd, parent.getNode_ID(), seqNo++, trxName);
+				updateNode(nd, parent.getNode_ID(), seqNo++);
 			}
 		}
 	}
 
-	private void updateNode(MTreeNode node, int parentId, int seqNo, String trxName)
+	private void updateNode(MTreeNode node, int parentId, int seqNo)
 	{
 		//
 		// services
 		final IPOTreeSupportFactory treeSupportFactory = Services.get(IPOTreeSupportFactory.class);
-		
+
 		final int AD_Tree_ID = this.getAD_Tree_ID();
 		if (node.getAD_Tree_ID() < 0) // TODO: workaround, we should instantiate the MTreeNode by giving the tree
 		{
@@ -513,33 +509,34 @@ public class MTree_Base extends X_AD_Tree
 		final int nodeId = node.getNode_ID();
 		final int oldParentId = node.getParent_ID();
 
+		MigrationScriptFileLoggerHolder.logComment("Node name: `" + node.getName() + "`");
 		updateNode(null, this.getAD_Tree_ID(), this.getTreeType(),
 				this.getAD_Table_ID(),
 				nodeId,
 				parentId, oldParentId,
 				seqNo,
-				trxName);
+				ITrx.TRXNAME_ThreadInherited);
 
 		node.setParent_ID(parentId);
 		node.setSeqNo(seqNo);
-		
-		treeSupportFactory.get(getSourceTableName()).setParent_ID(this, node.getNode_ID(), parentId, trxName);
-		listeners.onParentChanged(node.getAD_Table_ID(), nodeId, parentId, oldParentId, trxName);
+
+		treeSupportFactory.get(getSourceTableName()).setParent_ID(this, node.getNode_ID(), parentId, ITrx.TRXNAME_ThreadInherited);
+		listeners.onParentChanged(node.getAD_Table_ID(), nodeId, parentId, oldParentId, ITrx.TRXNAME_ThreadInherited);
 	}
 
 	private static void updateNode(PO contextPO, int AD_Tree_ID, String treeType, int AD_Table_ID, int nodeId, int parentId, int oldParentId, int seqNo, String trxName)
 	{
 		final String nodeTableName = getNodeTableName(treeType);
 
-		StringBuffer sql = new StringBuffer("UPDATE ").append(nodeTableName)
+		StringBuilder sql = new StringBuilder("UPDATE ").append(nodeTableName)
 				.append(" SET ").append("Parent_ID").append("=").append(parentId);
 		if (seqNo >= 0)
 		{
-			sql.append(", SeqNo=" + seqNo);
+			sql.append(", SeqNo=").append(seqNo);
 		}
 		else
 		{
-			sql.append(", SeqNo=(SELECT COALESCE(MAX(SeqNo),0)+1 FROM " + nodeTableName + " n2 WHERE n2.Parent_ID=" + parentId + ")");
+			sql.append(", SeqNo=(SELECT COALESCE(MAX(SeqNo),0)+1 FROM ").append(nodeTableName).append(" n2 WHERE n2.Parent_ID=").append(parentId).append(")");
 		}
 		sql.append(", Updated=now()")
 				.append(", UpdatedBy=").append(Env.getAD_User_ID(Env.getCtx()))
@@ -571,7 +568,7 @@ public class MTree_Base extends X_AD_Tree
 
 	/**************************************************************************
 	 * Insert id data into Tree
-	 * 
+	 *
 	 * @return true if inserted
 	 */
 	protected static boolean insertTreeNode(PO po)
@@ -579,7 +576,7 @@ public class MTree_Base extends X_AD_Tree
 		//
 		// services 
 		final IPOTreeSupportFactory treeSupportFactory = Services.get(IPOTreeSupportFactory.class);
-		
+
 		// TODO: check self contained tree
 		final int AD_Table_ID = po.get_Table_ID();
 		if (!MTree.hasTree(AD_Table_ID))
@@ -591,7 +588,6 @@ public class MTree_Base extends X_AD_Tree
 		final String treeTableName = MTree.getNodeTableName(AD_Table_ID);
 		final String trxName = po.get_TrxName();
 
-		
 		final IPOTreeSupport treeSupport = treeSupportFactory.get(po.get_TableName());
 		final int AD_Tree_ID = treeSupport.getAD_Tree_ID(po);
 		int parentId = treeSupport.getParent_ID(po);
@@ -635,11 +631,11 @@ public class MTree_Base extends X_AD_Tree
 		listeners.onNodeInserted(po);
 
 		return true;
-	}	// insert_Tree
+	}    // insert_Tree
 
 	/**
 	 * Delete ID Tree Nodes
-	 * 
+	 *
 	 * @return true if actually deleted (could be non existing)
 	 */
 	protected static boolean deleteTreeNode(PO po)
@@ -686,7 +682,7 @@ public class MTree_Base extends X_AD_Tree
 		// TODO Update children
 
 		return true;
-	}	// delete_Tree
+	}    // delete_Tree
 
 	public static void updateTreeNode(PO po)
 	{
@@ -705,11 +701,11 @@ public class MTree_Base extends X_AD_Tree
 		{
 			return;
 		}
-		
+
 		//
 		// services 
 		final IPOTreeSupportFactory treeSupportFactory = Services.get(IPOTreeSupportFactory.class);
-		
+
 		final String trxName = po.get_TrxName();
 		final IPOTreeSupport treeSupport = treeSupportFactory.get(po.get_TableName());
 
@@ -806,7 +802,7 @@ public class MTree_Base extends X_AD_Tree
 	public void verifyTree()
 	{
 		final IPOTreeSupportFactory treeSupportFactory = Services.get(IPOTreeSupportFactory.class);
-		
+
 		final String nodeTableName = getNodeTableName();
 		final String sourceTableName = getSourceTableName();
 		final String sourceTableKey = getSourceKeyColumnName();
@@ -961,6 +957,4 @@ public class MTree_Base extends X_AD_Tree
 		listeners.removeTreeListener(listener);
 	}
 
-	
-
-}	// MTree_Base
+}    // MTree_Base

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/logger/MigrationScriptFileLogger.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/logger/MigrationScriptFileLogger.java
@@ -1,30 +1,26 @@
 package org.adempiere.ad.migration.logger;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-
+import com.google.common.base.MoreObjects;
+import de.metas.logging.LogManager;
+import lombok.NonNull;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.trx.spi.TrxOnCommitCollectorFactory;
 import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.service.ISysConfigBL;
 import org.compiere.model.I_AD_MigrationScript;
 import org.compiere.model.MSequence;
 import org.compiere.util.Ini;
 import org.slf4j.Logger;
 
-import com.google.common.base.MoreObjects;
-
-import de.metas.logging.LogManager;
-import de.metas.util.Check;
-import de.metas.util.Services;
-import lombok.NonNull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 /*
  * #%L
@@ -56,22 +52,22 @@ import lombok.NonNull;
  */
 public class MigrationScriptFileLogger
 {
-	public static final MigrationScriptFileLogger of(final String dbType)
+	public static MigrationScriptFileLogger of(final String dbType)
 	{
 		return new MigrationScriptFileLogger(dbType);
 	}
 
 	private static final Logger logger = LogManager.getLogger(MigrationScriptFileLogger.class);
 
-	private static final Charset CHARSET = Charset.forName("UTF8");
+	private static final Charset CHARSET = StandardCharsets.UTF_8;
 	private static final DateTimeFormatter FORMATTER_ScriptFilenameTimestamp = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
 	private final String dbType;
-	private Path _path;
-	private static Path _migrationScriptsDirectory;
+	@Nullable private Path _path;
+	@Nullable private static Path _migrationScriptsDirectory;
 
 	private static final String COLLECTOR_TRXPROPERTYNAME = MigrationScriptFileLogger.class.getName() + ".collectorFactory";
-	private final TrxOnCommitCollectorFactory<StringBuilder, String> collectorFactory = new TrxOnCommitCollectorFactory<StringBuilder, String>()
+	private final TrxOnCommitCollectorFactory<StringBuilder, Sql> collectorFactory = new TrxOnCommitCollectorFactory<StringBuilder, Sql>()
 	{
 
 		@Override
@@ -81,35 +77,24 @@ public class MigrationScriptFileLogger
 		}
 
 		@Override
-		protected String extractTrxNameFromItem(final String sqlStatement)
+		protected String extractTrxNameFromItem(final Sql sqlStatement)
 		{
 			return ITrx.TRXNAME_ThreadInherited;
 		}
 
 		@Override
-		protected StringBuilder newCollector(final String sqlStatement)
+		protected StringBuilder newCollector(final Sql sqlStatement)
 		{
 			return new StringBuilder();
 		}
 
 		@Override
-		protected void collectItem(final StringBuilder collector, final String sqlStatement)
+		protected void collectItem(final StringBuilder collector, final Sql sqlStatement)
 		{
-			if (Check.isEmpty(sqlStatement))
+			if (sqlStatement != null)
 			{
-				return;
+				collector.append(sqlStatement.toSql());
 			}
-
-			final String prm_COMMENT = Services.get(ISysConfigBL.class).getValue("DICTIONARY_ID_COMMENTS");
-
-			// log time and date
-			collector.append("-- ").append(Instant.now()).append("\n");
-			// log sysconfig comment
-			collector.append("-- ").append(prm_COMMENT).append("\n");
-			// log statement
-			collector.append(sqlStatement);
-			// close statement
-			collector.append("\n;\n\n");
 		}
 
 		@Override
@@ -135,7 +120,7 @@ public class MigrationScriptFileLogger
 			System.out.println("---------------------------------------------------------------------------");
 			System.out.println("\n");
 			System.out.flush();
-		};
+		}
 	};
 
 	private MigrationScriptFileLogger(@NonNull final String dbType)
@@ -158,7 +143,7 @@ public class MigrationScriptFileLogger
 		close();
 	}
 
-	private static final Path createPath(@NonNull final String dbType)
+	private static Path createPath(@NonNull final String dbType)
 	{
 		final int adClientId = 0;
 		final int scriptId = MSequence.getNextID(adClientId, I_AD_MigrationScript.Table_Name) * 10;
@@ -168,7 +153,7 @@ public class MigrationScriptFileLogger
 		return getMigrationScriptDirectory().resolve(filename);
 	}
 
-	private final synchronized Path getCreateFilePath()
+	private synchronized Path getCreateFilePath()
 	{
 		if (_path == null || !Files.exists(_path))
 		{
@@ -181,7 +166,7 @@ public class MigrationScriptFileLogger
 			{
 				Files.createDirectories(path.getParent());
 			}
-			catch (IOException ex)
+			catch (final IOException ex)
 			{
 				throw AdempiereException.wrapIfNeeded(ex);
 			}
@@ -191,23 +176,24 @@ public class MigrationScriptFileLogger
 		return _path;
 	}
 
+	@Nullable
 	public final synchronized Path getFilePathOrNull()
 	{
 		return _path;
 	}
 
-	public static final Path getMigrationScriptDirectory()
+	public static Path getMigrationScriptDirectory()
 	{
 		final Path migrationScriptsDirectory = _migrationScriptsDirectory;
 		return migrationScriptsDirectory != null ? migrationScriptsDirectory : getDefaultMigrationScriptDirectory();
 	}
 
-	private static final Path getDefaultMigrationScriptDirectory()
+	private static Path getDefaultMigrationScriptDirectory()
 	{
 		return Paths.get(Ini.getMetasfreshHome(), "migration_scripts");
 	}
 
-	public static final void setMigrationScriptDirectory(@NonNull final Path path)
+	public static void setMigrationScriptDirectory(@NonNull final Path path)
 	{
 		_migrationScriptsDirectory = path;
 		logger.info("Set migration scripts directory: {}", path);
@@ -218,10 +204,8 @@ public class MigrationScriptFileLogger
 	 *
 	 * If this method is called within a database transaction then the SQL statement will not be written to file directly,
 	 * but it will be collected and written when the transaction is committed.
-	 *
-	 * @param sqlStatement
 	 */
-	public synchronized void appendSqlStatement(final String sqlStatement)
+	public synchronized void appendSqlStatement(@NonNull final Sql sqlStatement)
 	{
 		collectorFactory.collect(sqlStatement);
 	}
@@ -249,7 +233,7 @@ public class MigrationScriptFileLogger
 	/**
 	 * Close underling file.
 	 *
-	 * Next time, {@link #appendSqlStatement(String)} will be called, a new file will be created, so it's safe to call this method as many times as needed.
+	 * Next time, {@link #appendSqlStatement(Sql)} will be called, a new file will be created, so it's safe to call this method as many times as needed.
 	 */
 	public synchronized void close()
 	{

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/logger/Sql.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/logger/Sql.java
@@ -1,0 +1,98 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2022 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.adempiere.ad.migration.logger;
+
+import de.metas.util.StringUtils;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+@EqualsAndHashCode
+final class Sql
+{
+	private final String sql;
+
+	public static Sql ofSql(@NonNull final String sql)
+	{
+		return ofSql(sql, null);
+	}
+
+	public static Sql ofSql(
+			@NonNull final String sql,
+			@Nullable final String comments)
+	{
+		final StringBuilder finalSql = new StringBuilder();
+
+		// Add provided comments
+		final String sqlComment = toSqlComment(comments);
+		if (sqlComment != null)
+		{
+			finalSql.append("\n").append(sqlComment);
+		}
+
+		finalSql.append("-- ").append(Instant.now()).append("\n");
+		finalSql.append(sql).append("\n;\n\n");
+
+		return new Sql(finalSql.toString());
+	}
+
+	public static Sql ofComment(@NonNull final String comment)
+	{
+		final String sqlComment = toSqlComment(comment);
+		return sqlComment != null ? new Sql(sqlComment) : new Sql("-- ");
+	}
+
+	@Nullable
+	private static String toSqlComment(@Nullable final String comment)
+	{
+		final String commentNorm = StringUtils.trimBlankToNull(comment);
+		if (commentNorm == null)
+		{
+			return null;
+		}
+		return "-- "
+				+ commentNorm
+				.replace("\r\n", "\n")
+				.replace("\n", "\n-- ")
+				+ "\n";
+	}
+
+	Sql(final String sql)
+	{
+		this.sql = sql;
+	}
+
+	@Override
+	@Deprecated
+	public String toString()
+	{
+		return toSql();
+	}
+
+	public String toSql()
+	{
+		return sql;
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/validator/sql_migration_context_info/AD_Column.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/validator/sql_migration_context_info/AD_Column.java
@@ -1,0 +1,51 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2022 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.adempiere.ad.migration.validator.sql_migration_context_info;
+
+import org.adempiere.ad.migration.logger.MigrationScriptFileLoggerHolder;
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.ad.modelvalidator.annotations.ModelChange;
+import org.adempiere.ad.table.api.AdTableId;
+import org.adempiere.ad.table.api.impl.TableIdsCache;
+import org.compiere.model.I_AD_Column;
+import org.compiere.model.ModelValidator;
+import org.springframework.stereotype.Component;
+
+@Interceptor(I_AD_Column.class)
+@Component
+public class AD_Column
+{
+	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE, ModelValidator.TYPE_BEFORE_DELETE })
+	public void logSqlMigrationContextInfo(final I_AD_Column adColumn)
+	{
+		if (MigrationScriptFileLoggerHolder.isDisabled())
+		{
+			return;
+		}
+
+		final AdTableId adTableId = AdTableId.ofRepoId(adColumn.getAD_Table_ID());
+		final String tableName = TableIdsCache.instance.getTableNameIfPresent(adTableId).orElseGet(() -> "<" + adTableId + ">");
+		final String columnNameFQ = tableName + "." + adColumn.getColumnName();
+		MigrationScriptFileLoggerHolder.logComment("Column: " + columnNameFQ);
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/validator/sql_migration_context_info/AD_Field.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/validator/sql_migration_context_info/AD_Field.java
@@ -1,0 +1,83 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2022 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.adempiere.ad.migration.validator.sql_migration_context_info;
+
+import de.metas.util.StringUtils;
+import org.adempiere.ad.column.AdColumnId;
+import org.adempiere.ad.migration.logger.MigrationScriptFileLoggerHolder;
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.ad.modelvalidator.annotations.ModelChange;
+import org.adempiere.ad.trx.api.ITrx;
+import org.compiere.model.I_AD_Field;
+import org.compiere.model.ModelValidator;
+import org.compiere.util.DB;
+import org.springframework.stereotype.Component;
+
+@Interceptor(I_AD_Field.class)
+@Component
+public class AD_Field
+{
+	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE, ModelValidator.TYPE_BEFORE_DELETE })
+	public void logSqlMigrationContextInfo(final I_AD_Field field)
+	{
+		if (MigrationScriptFileLoggerHolder.isDisabled())
+		{
+			return;
+		}
+
+		final String fieldNameFQ = retrieveTabNameFQ(field.getAD_Tab_ID()) + " -> " + field.getName();
+		MigrationScriptFileLoggerHolder.logComment("Field: "+fieldNameFQ);
+
+		final String columnNameFQ = retrieveColumnNameFQ(AdColumnId.ofRepoId(field.getAD_Column_ID()));
+		MigrationScriptFileLoggerHolder.logComment("Column: " + columnNameFQ);
+	}
+
+	static String retrieveTabNameFQ(final int adTabId)
+	{
+		final String tabName = DB.getSQLValueStringEx(
+				ITrx.TRXNAME_ThreadInherited,
+				"SELECT w.Name || ' -> ' || tt.Name"
+						+ " FROM AD_Tab tt "
+						+ " LEFT OUTER JOIN AD_Window w on w.AD_Window_ID=tt.AD_Window_ID "
+						+ " WHERE AD_Tab_ID=?",
+				adTabId);
+
+		return StringUtils.trimBlankToOptional(tabName)
+				.orElseGet(() -> "<" + adTabId + ">");
+	}
+
+	private static String retrieveColumnNameFQ(final AdColumnId adColumnId)
+	{
+		final String columnNameFQ = DB.getSQLValueStringEx(
+				ITrx.TRXNAME_ThreadInherited,
+				"SELECT t.TableName || '.' || c.ColumnName"
+						+ " FROM AD_Column c "
+						+ " LEFT OUTER JOIN AD_Table t on t.AD_Table_ID=c.AD_Table_ID "
+						+ " WHERE AD_Column_ID=?",
+				adColumnId);
+
+		return StringUtils.trimBlankToOptional(columnNameFQ)
+				.orElseGet(() -> "<" + adColumnId.getRepoId() + ">");
+	}
+
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/validator/sql_migration_context_info/AD_Tab.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/validator/sql_migration_context_info/AD_Tab.java
@@ -1,0 +1,67 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2022 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.adempiere.ad.migration.validator.sql_migration_context_info;
+
+import de.metas.util.StringUtils;
+import org.adempiere.ad.migration.logger.MigrationScriptFileLoggerHolder;
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.ad.modelvalidator.annotations.ModelChange;
+import org.adempiere.ad.table.api.AdTableId;
+import org.adempiere.ad.table.api.impl.TableIdsCache;
+import org.adempiere.ad.trx.api.ITrx;
+import org.compiere.model.I_AD_Tab;
+import org.compiere.model.ModelValidator;
+import org.compiere.util.DB;
+import org.springframework.stereotype.Component;
+
+@Interceptor(I_AD_Tab.class)
+@Component
+public class AD_Tab
+{
+	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE, ModelValidator.TYPE_BEFORE_DELETE })
+	public void logSqlMigrationContextInfo(final I_AD_Tab tab)
+	{
+		if (MigrationScriptFileLoggerHolder.isDisabled())
+		{
+			return;
+		}
+
+		final String tabNameFQ = retrieveWindowNameFQ(tab.getAD_Window_ID()) + " -> " + tab.getName();
+		MigrationScriptFileLoggerHolder.logComment("Tab: " + tabNameFQ);
+
+		final AdTableId adTableId = AdTableId.ofRepoId(tab.getAD_Table_ID());
+		final String tableName = TableIdsCache.instance.getTableNameIfPresent(adTableId).orElseGet(() -> "<" + adTableId + ">");
+		MigrationScriptFileLoggerHolder.logComment("Table: " + tableName);
+	}
+
+	private static String retrieveWindowNameFQ(final int adWindowId)
+	{
+		final String windowName = DB.getSQLValueStringEx(
+				ITrx.TRXNAME_ThreadInherited,
+				"SELECT Name FROM AD_Window WHERE AD_Window_ID=?",
+				adWindowId);
+
+		return StringUtils.trimBlankToOptional(windowName)
+				.orElseGet(() -> "<" + adWindowId + ">");
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/validator/sql_migration_context_info/AD_Table.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/validator/sql_migration_context_info/AD_Table.java
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2022 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.adempiere.ad.migration.validator.sql_migration_context_info;
+
+import org.adempiere.ad.migration.logger.MigrationScriptFileLoggerHolder;
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.ad.modelvalidator.annotations.ModelChange;
+import org.compiere.model.I_AD_Table;
+import org.compiere.model.ModelValidator;
+import org.springframework.stereotype.Component;
+
+@Interceptor(I_AD_Table.class)
+@Component
+public class AD_Table
+{
+	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE, ModelValidator.TYPE_BEFORE_DELETE })
+	public void logSqlMigrationContextInfo(final I_AD_Table adTable)
+	{
+		if (MigrationScriptFileLoggerHolder.isDisabled())
+		{
+			return;
+		}
+
+		MigrationScriptFileLoggerHolder.logComment("Table: " + adTable.getTableName());
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/validator/sql_migration_context_info/AD_UI_Element.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/validator/sql_migration_context_info/AD_UI_Element.java
@@ -1,0 +1,74 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2022 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.adempiere.ad.migration.validator.sql_migration_context_info;
+
+import de.metas.util.StringUtils;
+import org.adempiere.ad.element.api.AdFieldId;
+import org.adempiere.ad.migration.logger.MigrationScriptFileLoggerHolder;
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.ad.modelvalidator.annotations.ModelChange;
+import org.adempiere.ad.trx.api.ITrx;
+import org.compiere.model.I_AD_UI_Element;
+import org.compiere.model.ModelValidator;
+import org.compiere.util.DB;
+import org.springframework.stereotype.Component;
+
+@Interceptor(I_AD_UI_Element.class)
+@Component
+public class AD_UI_Element
+{
+	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE, ModelValidator.TYPE_BEFORE_DELETE })
+	public void logSqlMigrationContextInfo(final I_AD_UI_Element uiElement)
+	{
+		if (MigrationScriptFileLoggerHolder.isDisabled())
+		{
+			return;
+		}
+
+		final String tabNameFQ = AD_Field.retrieveTabNameFQ(uiElement.getAD_Tab_ID());
+		final String uiElementFQ = tabNameFQ + "." + uiElement.getName();
+		MigrationScriptFileLoggerHolder.logComment("UI Element: " + uiElementFQ);
+
+		final AdFieldId adFieldId = AdFieldId.ofRepoIdOrNull(uiElement.getAD_Field_ID());
+		if(adFieldId != null)
+		{
+			MigrationScriptFileLoggerHolder.logComment("Column: " + retrieveColumnNameFQ(adFieldId));
+		}
+	}
+
+	private static String retrieveColumnNameFQ(final AdFieldId adFieldId)
+	{
+		final String columnNameFQ = DB.getSQLValueStringEx(
+				ITrx.TRXNAME_ThreadInherited,
+				"SELECT t.TableName || '.' || c.ColumnName"
+						+ " FROM AD_Field f"
+						+ " LEFT OUTER JOIN AD_Column c on c.AD_Column_ID=f.AD_Column_ID"
+						+ " LEFT OUTER JOIN AD_Table t on t.AD_Table_ID=c.AD_Table_ID "
+						+ " WHERE AD_Field_ID=?",
+				adFieldId);
+
+		return StringUtils.trimBlankToOptional(columnNameFQ)
+				.orElseGet(() -> "<" + adFieldId.getRepoId() + ">");
+	}
+
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/validator/sql_migration_context_info/AD_Window.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/migration/validator/sql_migration_context_info/AD_Window.java
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2022 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.adempiere.ad.migration.validator.sql_migration_context_info;
+
+import org.adempiere.ad.migration.logger.MigrationScriptFileLoggerHolder;
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.ad.modelvalidator.annotations.ModelChange;
+import org.compiere.model.I_AD_Window;
+import org.compiere.model.ModelValidator;
+import org.springframework.stereotype.Component;
+
+@Interceptor(I_AD_Window.class)
+@Component
+public class AD_Window
+{
+	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE, ModelValidator.TYPE_BEFORE_DELETE })
+	public void logSqlMigrationContextInfo(final I_AD_Window window)
+	{
+		if (MigrationScriptFileLoggerHolder.isDisabled())
+		{
+			return;
+		}
+
+		MigrationScriptFileLoggerHolder.logComment("Window: " + window.getName() + ", InternalName=" + window.getInternalName());
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/table/api/impl/TableIdsCache.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/table/api/impl/TableIdsCache.java
@@ -98,6 +98,20 @@ public class TableIdsCache
 	}
 
 	@NonNull
+	public Optional<String> getTableNameIfPresent(@NonNull final AdTableId adTableId)
+	{
+		if (Adempiere.isUnitTestMode())
+		{
+			return Optional.of(junitGeneratedTableInfoMap.getTableName(adTableId));
+		}
+		else
+		{
+			final TableInfo tableInfo = getTableInfoMap().getTableInfoOrNull(adTableId);
+			return tableInfo != null ? Optional.of(tableInfo.getTableName()) : Optional.empty();
+		}
+	}
+
+	@NonNull
 	public String getEntityType(@NonNull final String tableName)
 	{
 		if (Adempiere.isUnitTestMode())


### PR DESCRIPTION
AIM: make our migration scripts easier to read/review.
To achieve this a simple change would be to log additional context info along with the actual SQL command.

Atm, the following application dictionary elements are handled:
* AD_Table
* AD_Column
* AD_Window
* AD_Tab
* AD_Field
* AD_UI_Element

Below you will find some self-explanatory examples
# Examples
## Example: insert a new AD_Column

```sql
-- Column: teo_test_3.Name
-- 2022-01-21T01:21:39.215Z
INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,Description,EntityType,FacetFilterSeqNo,FieldLength,Help,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version) VALUES (0,579117,469,0,10,541976,'Name',TO_TIMESTAMP('2022-01-21 03:21:39','YYYY-MM-DD HH24:MI:SS'),100,'N','','U',0,40,'','Y','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','Y','N','N','Y','N','N','N','N','N','N','N','Y','N',0,'Name',0,1,TO_TIMESTAMP('2022-01-21 03:21:39','YYYY-MM-DD HH24:MI:SS'),100,0)
;

-- 2022-01-21T01:21:39.221Z
INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=579117 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
;

-- 2022-01-21T01:21:39.228Z
/* DDL */  select update_Column_Translation_From_AD_Element(469) 
;
```

## Example: Update an AD_Field
```sql
-- Field: teo_test_3 -> teo_test_3 -> Sektion
-- Column: teo_test_3.AD_Org_ID
-- 2022-01-21T01:23:17.995Z
UPDATE AD_Field SET IsReadOnly='Y',Updated=TO_TIMESTAMP('2022-01-21 03:23:17','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=677935
;
```

### Example: Update and AD_UI_Element
```sql
-- UI Element: teo_test_3 -> teo_test_3.Mandant
-- Column: teo_test_3.AD_Client_ID
-- 2022-01-21T01:26:29.365Z
UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=10,Updated=TO_TIMESTAMP('2022-01-21 03:26:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=600071
;
```



