### PR TITLE
order's effective bill-contact - only fall back if consistent

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/order/IOrderBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/IOrderBL.java
@@ -80,11 +80,19 @@ public interface IOrderBL extends ISingletonService
 	 */
 	I_AD_User getShipToUser(I_C_Order order);
 
+	/**
+	 * @return the order's bill location <b>OR</b> falls back to the "general" contact ({@code C_Order.C_BParter_Location_ID}).
+	 */
+	@NonNull
 	BPartnerLocationAndCaptureId getBillToLocationId(I_C_Order order);
 
 	@Nullable
 	BPartnerId getEffectiveBillPartnerId(@NonNull I_C_Order orderRecord);
 
+	/**
+	 * @return the order's bill contact <b>but</b> falls back to the "general" contact ({@code C_Order.AD_User_ID}) if possible.
+	 * Be sure to first check with {@link #hasBillToContactId(I_C_Order)}.
+	 */
 	@NonNull BPartnerContactId getBillToContactId(I_C_Order order);
 
 	/**
@@ -202,6 +210,10 @@ public interface IOrderBL extends ISingletonService
 	 */
 	void reopenLine(I_C_OrderLine orderLine);
 
+	/**
+	 * @return {@code true} if the order has a bill contact
+	 * <b>OR</b> a "general" contact ({@code C_Order.AD_User_ID}) that is consistent with the order's Bill_BPartner.
+	 */
 	boolean hasBillToContactId(@NonNull I_C_Order order);
 
 	/**

--- a/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderBL.java
@@ -23,6 +23,7 @@
 package de.metas.order.impl;
 
 import ch.qos.logback.classic.Level;
+import com.google.common.annotations.VisibleForTesting;
 import de.metas.bpartner.BPartnerContactId;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationAndCaptureId;
@@ -269,6 +270,7 @@ public class OrderBL implements IOrderBL
 		return retrievePriceListIdOrNull(pricingSystemId, bpartnerAndLocationId, soTrx);
 	}
 
+	@Nullable
 	private PriceListId retrievePriceListIdOrNull(
 			final PricingSystemId pricingSystemId,
 			@Nullable final BPartnerLocationAndCaptureId shipToBPLocationId,
@@ -865,6 +867,7 @@ public class OrderBL implements IOrderBL
 		}
 	}
 
+	@Nullable
 	@Override
 	public org.compiere.model.I_AD_User getShipToUser(final I_C_Order order)
 	{
@@ -885,6 +888,7 @@ public class OrderBL implements IOrderBL
 				: null;
 	}
 
+	@NonNull
 	@Override
 	public BPartnerLocationAndCaptureId getBillToLocationId(@NonNull final I_C_Order order)
 	{
@@ -915,7 +919,7 @@ public class OrderBL implements IOrderBL
 
 		if (contactIdOrNull == null)
 		{
-			throw new AdempiereException("@Invalid@ @Contact_ID@ for Order " + order.getC_Order_ID())
+			throw new AdempiereException("@NotFound@ @Contact_ID@ for Order " + order.getC_Order_ID())
 					.appendParametersToMessage()
 					.setParameter("getBill_BPartner_ID", order.getBill_BPartner_ID())
 					.setParameter("getBill_Location_ID", order.getBill_Location_ID())
@@ -933,12 +937,28 @@ public class OrderBL implements IOrderBL
 	}
 
 	@Nullable
-	private BPartnerContactId getBillToContactIdOrNull(@NonNull final I_C_Order order)
+	@VisibleForTesting
+	BPartnerContactId getBillToContactIdOrNull(@NonNull final I_C_Order order)
 	{
 		final BPartnerContactId billToContactId = BPartnerContactId.ofRepoIdOrNull(order.getBill_BPartner_ID(), order.getBill_User_ID());
-		return billToContactId != null
-				? billToContactId
-				: BPartnerContactId.ofRepoIdOrNull(order.getC_BPartner_ID(), order.getAD_User_ID());
+		if (billToContactId != null)
+		{
+			return billToContactId; // we are done
+		}
+
+		if (order.getAD_User_ID() <= 0)
+		{
+			return null; // nothing we can fall back to
+		}
+
+		// see if we may return order.getAD_User_ID()
+		if (order.getBill_BPartner_ID() > 0 && order.getBill_BPartner_ID() != order.getC_BPartner_ID())
+		{
+			return null; // we can't return order.getAD_User_ID() as bill contact, because if we return a contact, it needs belong to the bill-partner
+		}
+
+		// we made sure that we may return this as the bill contact
+		return BPartnerContactId.ofRepoIdOrNull(order.getC_BPartner_ID(), order.getAD_User_ID());
 	}
 
 	private static final ModelDynAttributeAccessor<org.compiere.model.I_C_Order, BigDecimal> DYNATTR_QtyInvoicedSum = new ModelDynAttributeAccessor<>("QtyInvoicedSum", BigDecimal.class);

--- a/backend/de.metas.business/src/test/java/de/metas/order/impl/OrderBLTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/impl/OrderBLTest.java
@@ -1,0 +1,147 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2022 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.order.impl;
+
+import de.metas.bpartner.BPartnerContactId;
+import de.metas.bpartner.BPartnerLocationAndCaptureId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.compiere.model.I_C_Order;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OrderBLTest
+{
+	private OrderBL orderBL;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		orderBL = new OrderBL();
+	}
+
+	// bill-location - get Bill_Location_ID, maybe fallback to C_BPartner_Location_ID
+	////////////////////////////////
+	@Test
+	void givenNoBillPartner_whenGetBillToLocationId_thenReturnAD_User_ID()
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(10);
+		order.setC_BPartner_Location_ID(20);
+		assertThat(orderBL.getBillToLocationId(order)).isEqualTo(BPartnerLocationAndCaptureId.ofRepoId(10, 20, 0));
+	}
+
+	@Test
+	void givenSameBillPartnerWithoutLocation_whenGetBillToLocationId_thenReturnC_BPartner_Location_ID()
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(10);
+		order.setC_BPartner_Location_ID(20);
+		order.setBill_BPartner_ID(10);
+
+		assertThat(orderBL.getBillToLocationId(order)).isEqualTo(BPartnerLocationAndCaptureId.ofRepoId(10, 20, 0));
+	}
+
+	@Test
+	void givenDifferentBillPartnerWithoutLocation_whenGetBillToLocationId_thenReturnC_BPartner_Location_ID()
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(10);
+		order.setC_BPartner_Location_ID(20);
+		order.setBill_BPartner_ID(30); // Bill_BPartner_ID will be ignored! but in practice we never have a Bill_BPartner_ID without Bill_Location_ID
+
+		assertThat(orderBL.getBillToLocationId(order)).isEqualTo(BPartnerLocationAndCaptureId.ofRepoId(10, 20, 0));
+	}
+
+	@Test
+	void givenDifferentBillPartnerWithLocation_whenGetBillToLocationId_thenReturnBill_Location_ID()
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(10);
+		order.setC_BPartner_Location_ID(20);
+		order.setBill_BPartner_ID(30);
+		order.setBill_Location_ID(40);
+
+		assertThat(orderBL.getBillToLocationId(order)).isEqualTo(BPartnerLocationAndCaptureId.ofRepoId(30, 40, 0));
+	}
+
+	// bill-contact - get Bill_User_ID, maybe fallback to AD_User_ID
+	////////////////////////////////
+	@Test
+	void givenNoBillPartner_whenGetBillToContactId_thenReturnAD_User_ID()
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(10);
+		order.setAD_User_ID(20);
+
+		assertThat(orderBL.getBillToContactIdOrNull(order)).isEqualTo(BPartnerContactId.ofRepoId(10, 20));
+	}
+
+	@Test
+	void givenNoBillPartnerAndNotContact_whenGetBillToContactId_thenReturnNull()
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(10);
+
+		assertThat(orderBL.getBillToContactIdOrNull(order)).isNull();
+	}
+
+	@Test
+	void givenSameBillPartnerWithoutContact_whenGetBillToContactId_thenReturnAD_User_ID()
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(10);
+		order.setAD_User_ID(20);
+		order.setBill_BPartner_ID(10);
+
+		assertThat(orderBL.getBillToContactIdOrNull(order)).isEqualTo(BPartnerContactId.ofRepoId(10, 20));
+	}
+
+	@Test
+	void givenDifferentBillPartnerWithoutContact_whenGetBillToContactId_thenReturnNull()
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(10);
+		order.setAD_User_ID(20);
+		order.setBill_BPartner_ID(30);
+
+		assertThat(orderBL.getBillToContactIdOrNull(order)).isNull();
+	}
+
+	@Test
+	void givenDifferentBillPartnerWithContact_whenGetBillToContactId_thenReturnBill_User_ID()
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(10);
+		order.setAD_User_ID(20);
+		order.setBill_BPartner_ID(30);
+		order.setBill_User_ID(40);
+
+		assertThat(orderBL.getBillToContactIdOrNull(order)).isEqualTo(BPartnerContactId.ofRepoId(30, 40));
+	}
+}


### PR DESCRIPTION
only fall back to the order's AD_User as bill-contact if it's consisten with the order's Bill_Partner