### PR TITLE
create on-the-fly commission-term for a BPartner that has Org=*

### DIFF
--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/commission/commissioninstance/services/hierarchy/HierarchyCommissionConfigFactory.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/commission/commissioninstance/services/hierarchy/HierarchyCommissionConfigFactory.java
@@ -60,6 +60,7 @@ import de.metas.contracts.model.I_C_Flatrate_Term;
 import de.metas.contracts.process.FlatrateTermCreator;
 import de.metas.logging.LogManager;
 import de.metas.logging.TableRecordMDC;
+import de.metas.organization.OrgId;
 import de.metas.product.IProductDAO;
 import de.metas.product.ProductCategoryId;
 import de.metas.product.ProductId;
@@ -147,7 +148,7 @@ public class HierarchyCommissionConfigFactory implements ICommissionConfigFactor
 				.forEach(commissionTermRecordsBuilder::add);
 
 		getConditionsForSalesRepWithoutContract()
-				.map(flatrateConditions -> createGenericContract(flatrateConditions, commissionTermRecordsBuilder.build(), allBPartnerIds, beneficiary))
+				.map(flatrateConditions -> createGenericContract(contractRequest.getOrgId(), flatrateConditions, commissionTermRecordsBuilder.build(), allBPartnerIds, beneficiary))
 				.ifPresent(contractTermList -> contractTermList.forEach(commissionTermRecordsBuilder::add));
 
 		final ImmutableMap<FlatrateTermId, CommissionConfig> contractId2Config = createCommissionConfigsFor(
@@ -202,6 +203,7 @@ public class HierarchyCommissionConfigFactory implements ICommissionConfigFactor
 	 */
 	@NonNull
 	private ImmutableList<I_C_Flatrate_Term> createGenericContract(
+			@NonNull final OrgId orgId,
 			@NonNull final I_C_Flatrate_Conditions flatrateCondition,
 			@NonNull final ImmutableList<I_C_Flatrate_Term> existingCommissionTermRecords,
 			@NonNull final ImmutableList<BPartnerId> hierarchyBPartnerIds,
@@ -229,6 +231,7 @@ public class HierarchyCommissionConfigFactory implements ICommissionConfigFactor
 
 		final FlatrateTermCreator termCreator = FlatrateTermCreator.builder()
 				.ctx(Env.getCtx())
+				.orgId(orgId)
 				.products(ImmutableList.of(commissionProductRecord))
 				.startDate(Timestamp.from(Instant.now()))
 				.endDate(Timestamp.from(Instant.now().plus(NO_COMMISSION_AGREEMENT_DEFAULT_CONTRACT_DURATION)))

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
@@ -1655,7 +1655,7 @@ public class FlatrateBL implements IFlatrateBL
 		final I_C_Flatrate_Term newTerm = InterfaceWrapperHelper.newInstance(I_C_Flatrate_Term.class, bPartner);
 		newTerm.setC_Flatrate_Conditions(conditions);
 		newTerm.setC_UOM_ID(conditions.getC_UOM_ID());
-		newTerm.setAD_Org_ID(bPartner.getAD_Org_ID());
+		newTerm.setAD_Org_ID(request.getOrgId().getRepoId());
 
 		newTerm.setStartDate(startDate);
 		newTerm.setEndDate(startDate); // will be updated later

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/process/FlatrateTermCreator.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/process/FlatrateTermCreator.java
@@ -60,6 +60,9 @@ public class FlatrateTermCreator
 
 	Properties ctx;
 
+	@NonNull
+	OrgId orgId;
+	
 	Timestamp startDate;
 	Timestamp endDate;
 	I_C_Flatrate_Conditions conditions;
@@ -85,7 +88,7 @@ public class FlatrateTermCreator
 
 		for (final I_C_BPartner partner : bPartners)
 		{
-			try (MDCCloseable partnerMDC = TableRecordMDC.putTableRecordReference(partner))
+			try (MDCCloseable ignored = TableRecordMDC.putTableRecordReference(partner))
 			{
 				// create each term in its own transaction
 				trxManager.runInNewTrx(new TrxRunnableAdapter()
@@ -102,7 +105,7 @@ public class FlatrateTermCreator
 					// Please consult with mark or torby if we want to swallow or throw.
 					// Please remember that this can be run for 10000 Partners when proposing this idea.
 					@Override
-					public boolean doCatch(Throwable ex)
+					public boolean doCatch(final Throwable ex)
 					{
 						Loggables.addLog("@Error@ @C_BPartner_ID@:" + partner.getValue() + "_" + partner.getName() + ": " + ex.getLocalizedMessage());
 						logger.debug("Failed creating contract for {}", partner, ex);
@@ -124,7 +127,7 @@ public class FlatrateTermCreator
 		for (final I_M_Product product : products)
 		{
 			final CreateFlatrateTermRequest createFlatrateTermRequest = CreateFlatrateTermRequest.builder()
-					.orgId(OrgId.ofRepoId(conditions.getAD_Org_ID()))
+					.orgId(orgId)
 					.context(context)
 					.bPartner(partner)
 					.conditions(conditions)

--- a/backend/de.metas.procurement.base/src/main/java/de/metas/procurement/base/impl/PMM_RfQ_BL.java
+++ b/backend/de.metas.procurement.base/src/main/java/de/metas/procurement/base/impl/PMM_RfQ_BL.java
@@ -1,16 +1,10 @@
 package de.metas.procurement.base.impl;
 
-import java.math.BigDecimal;
-import java.util.Date;
-
-import org.adempiere.ad.trx.api.ITrx;
-import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.model.InterfaceWrapperHelper;
-
 import de.metas.contracts.IFlatrateBL;
 import de.metas.contracts.model.I_C_Flatrate_Conditions;
 import de.metas.document.engine.IDocumentBL;
 import de.metas.money.CurrencyId;
+import de.metas.organization.OrgId;
 import de.metas.procurement.base.IPMM_RfQ_BL;
 import de.metas.procurement.base.IPMM_RfQ_DAO;
 import de.metas.procurement.base.PMMContractBuilder;
@@ -24,6 +18,12 @@ import de.metas.rfq.exceptions.RfQException;
 import de.metas.rfq.model.I_C_RfQResponse;
 import de.metas.rfq.model.I_C_RfQResponseLineQty;
 import de.metas.util.Services;
+import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+
+import java.math.BigDecimal;
+import java.util.Date;
 
 /*
  * #%L
@@ -167,6 +167,7 @@ public class PMM_RfQ_BL implements IPMM_RfQ_BL
 		// Create a new contract
 		final PMMContractBuilder contractBuilder = PMMContractBuilder.newBuilder()
 				.setCtx(InterfaceWrapperHelper.getCtx(rfqResponseLine))
+				.setOrgId(OrgId.ofRepoId(rfqResponseLine.getAD_Org_ID()))
 				.setFailIfNotCreated(true)
 				.setComplete(false)
 				.setC_Flatrate_Conditions(conditions)

--- a/backend/de.metas.procurement.base/src/main/java/de/metas/procurement/base/process/C_Flatrate_Term_Create_ProcurementContract.java
+++ b/backend/de.metas.procurement.base/src/main/java/de/metas/procurement/base/process/C_Flatrate_Term_Create_ProcurementContract.java
@@ -1,18 +1,9 @@
 package de.metas.procurement.base.process;
 
-import java.sql.Timestamp;
-
-import org.adempiere.ad.trx.api.ITrx;
-import org.adempiere.ad.trx.api.ITrxRunConfig;
-import org.adempiere.ad.trx.api.TrxCallable;
-import org.adempiere.util.lang.impl.TableRecordReference;
-import org.compiere.model.I_AD_User;
-import org.compiere.model.I_C_BPartner;
-import org.compiere.model.I_C_UOM;
-import org.compiere.util.Ini;
-
+import de.metas.common.util.CoalesceUtil;
 import de.metas.contracts.model.I_C_Flatrate_Conditions;
 import de.metas.money.CurrencyId;
+import de.metas.organization.OrgId;
 import de.metas.process.IProcessDefaultParameter;
 import de.metas.process.IProcessDefaultParametersProvider;
 import de.metas.process.JavaProcess;
@@ -25,6 +16,17 @@ import de.metas.procurement.base.PMMContractBuilder;
 import de.metas.procurement.base.model.I_C_Flatrate_Term;
 import de.metas.procurement.base.model.I_PMM_Product;
 import de.metas.util.Services;
+import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.ad.trx.api.ITrxRunConfig;
+import org.adempiere.ad.trx.api.TrxCallable;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_AD_User;
+import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_C_UOM;
+import org.compiere.util.Env;
+import org.compiere.util.Ini;
+
+import java.sql.Timestamp;
 
 /*
  * #%L
@@ -115,6 +117,7 @@ public class C_Flatrate_Term_Create_ProcurementContract
 		final TrxCallable<I_C_Flatrate_Term> callable = () -> {
 			final I_C_Flatrate_Term term = PMMContractBuilder.newBuilder()
 					.setCtx(getCtx())
+					.setOrgId(OrgId.ofRepoId(CoalesceUtil.firstGreaterThanZero(p_C_BPartner.getAD_Org_ID(), Env.getAD_Org_ID(Env.getCtx()))))
 					.setFailIfNotCreated(true)
 					.setComplete(true)
 					.setC_Flatrate_Conditions(p_C_Flatrate_Conditions)
@@ -135,10 +138,6 @@ public class C_Flatrate_Term_Create_ProcurementContract
 		return trxManager.call(ITrx.TRXNAME_None, config, callable);
 	}
 
-	/**
-	 * If the given <code>parameterName</code> is {@value #PARAM_NAME_AD_USER_IN_CHARGE_ID},<br>
-	 * then the method returns the user set in <code>AD_SysConfig</code> {@value #SYSCONFIG_AD_USER_IN_CHARGE}.
-	 */
 	@Override
 	public Object getParameterDefaultValue(final IProcessDefaultParameter parameter)
 	{


### PR DESCRIPTION
this failed, because the term requires an Org_ID, but the C_BPArtner might have none. The fix is to use the commission-trigger's orgId