### PR TITLE
Open amt incorrect after vendor credit memo is created for a vendor invoice

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/invoice/service/impl/AbstractInvoiceBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/service/impl/AbstractInvoiceBL.java
@@ -1844,13 +1844,13 @@ public abstract class AbstractInvoiceBL implements IInvoiceBL
 				.orgId(invoice.getAD_Org_ID())
 				.bpartnerId(invoice.getC_BPartner_ID())
 				.invoiceId(invoice.getC_Invoice_ID())
-				.amount(openAmt)
+				.amount(invoice.isSOTrx() ? openAmt : openAmt.negate())
 			.lineDone()
 			.addLine()
 				.orgId(creditMemo.getAD_Org_ID())
 				.bpartnerId(creditMemo.getC_BPartner_ID())
 				.invoiceId(creditMemo.getC_Invoice_ID())
-				.amount(openAmt.negate())
+				.amount(invoice.isSOTrx() ? openAmt.negate() : openAmt)
 			.lineDone()
 			.create(true); // completeIt = true
 		// @formatter:on


### PR DESCRIPTION
fix OpenAmt incorrect value after vendor credit memo