### PR TITLE
DatePicker hotfix: clicking on calendar icon to open the calendar and then clicking on calendar icon again to close it was clearing the input field

### DIFF
--- a/frontend/src/components/widget/DateTime/DatePicker.js
+++ b/frontend/src/components/widget/DateTime/DatePicker.js
@@ -18,7 +18,7 @@ class DatePicker extends PureComponent {
     super(props);
     this.state = {
       isCalendarOpen: false,
-      datePatched: null,
+      datePatched: this.props.value,
     };
   }
 


### PR DESCRIPTION
fixes issue introduced by https://github.com/metasfresh/metasfresh/pull/12667