### PR TITLE
hotfix: don't fail when we open Receipt candidates -> Korrectur

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/references/related_documents/RelatedDocumentsFactory.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/references/related_documents/RelatedDocumentsFactory.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class RelatedDocumentsFactory
@@ -129,7 +130,7 @@ public class RelatedDocumentsFactory
 	 * <p>
 	 * NOTE: Records count is not checked
 	 */
-	public RelatedDocuments retrieveRelatedDocuments(
+	public Optional<RelatedDocuments> retrieveRelatedDocuments(
 			@NonNull final IZoomSource fromDocument,
 			@NonNull final AdWindowId targetWindowId,
 			@Nullable final RelatedDocumentsId relatedDocumentsId,
@@ -147,7 +148,6 @@ public class RelatedDocumentsFactory
 				.stream()
 				.filter(candidatesGroup -> relatedDocumentsId == null || candidatesGroup.isMatching(relatedDocumentsId))
 				.flatMap(candidatesGroup -> candidatesGroup.evaluateAndStream(context))
-				.findFirst()
-				.orElseThrow(() -> new AdempiereException("No related documents found for source=" + fromDocument + ", targetWindowId=" + targetWindowId));
+				.findFirst();
 	}
 }

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/document/references/service/WebuiDocumentReferencesService.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/document/references/service/WebuiDocumentReferencesService.java
@@ -29,13 +29,13 @@ import lombok.NonNull;
 import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrx;
-import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.I_AD_Column;
 import org.compiere.util.Evaluatee;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.Properties;
 
 /*
@@ -110,17 +110,17 @@ public class WebuiDocumentReferencesService
 		return documentReferences;
 	}
 
-	public DocumentFilter getDocumentReferenceFilter(
+	public Optional<DocumentFilter> getDocumentReferenceFilter(
 			@NonNull final DocumentPath sourceDocumentPath,
 			@NonNull final WindowId targetWindowId,
 			@Nullable final WebuiDocumentReferenceId documentReferenceId,
 			@NonNull final RelatedDocumentsPermissions permissions)
 	{
-		final WebuiDocumentReference documentReference = getDocumentReference(sourceDocumentPath, targetWindowId, documentReferenceId, permissions);
-		return documentReference.getFilter();
+		return getDocumentReference(sourceDocumentPath, targetWindowId, documentReferenceId, permissions)
+				.map(WebuiDocumentReference::getFilter);
 	}
 
-	private WebuiDocumentReference getDocumentReference(
+	private Optional<WebuiDocumentReference> getDocumentReference(
 			@NonNull final DocumentPath sourceDocumentPath,
 			@NonNull final WindowId targetWindowId,
 			@Nullable final WebuiDocumentReferenceId documentReferenceId,
@@ -129,20 +129,24 @@ public class WebuiDocumentReferencesService
 		return documentCollection.forDocumentReadonly(sourceDocumentPath, sourceDocument -> {
 			if (sourceDocument.isNew())
 			{
-				throw new AdempiereException("New documents cannot be referenced: " + sourceDocument);
+				//throw new AdempiereException("New documents cannot be referenced: " + sourceDocument);
+				return Optional.empty();
 			}
 
 			final DocumentAsZoomSource zoomSource = new DocumentAsZoomSource(sourceDocument);
-			final RelatedDocuments relatedDocuments = relatedDocumentsFactory.retrieveRelatedDocuments(
-					zoomSource,
-					targetWindowId.toAdWindowId(),
-					documentReferenceId != null ? documentReferenceId.toRelatedDocumentsId() : null,
-					permissions);
-
-			final ITranslatableString filterCaption = extractFilterCaption(sourceDocument, relatedDocuments);
-
-			return WebuiDocumentReferenceCandidate.toDocumentReference(relatedDocuments, filterCaption);
+			return relatedDocumentsFactory.retrieveRelatedDocuments(
+							zoomSource,
+							targetWindowId.toAdWindowId(),
+							documentReferenceId != null ? documentReferenceId.toRelatedDocumentsId() : null,
+							permissions)
+					.map(relatedDocument -> toWebuiDocumentReference(relatedDocument, sourceDocument));
 		});
+	}
+
+	private WebuiDocumentReference toWebuiDocumentReference(final RelatedDocuments relatedDocuments, final Document sourceDocument)
+	{
+		final ITranslatableString filterCaption = extractFilterCaption(sourceDocument, relatedDocuments);
+		return WebuiDocumentReferenceCandidate.toDocumentReference(relatedDocuments, filterCaption);
 	}
 
 	private ITranslatableString extractFilterCaption(

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/HUEditorViewFactoryTemplate.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/HUEditorViewFactoryTemplate.java
@@ -461,11 +461,13 @@ public abstract class HUEditorViewFactoryTemplate implements IViewFactory
 		}
 
 		return webuiDocumentReferencesService.getDocumentReferenceFilter(
-				referencedDocumentPath,
-				targetWindowId,
-				documentReferenceId,
-				RelatedDocumentsPermissionsFactory.allowAll());
+						referencedDocumentPath,
+						targetWindowId,
+						documentReferenceId,
+						RelatedDocumentsPermissionsFactory.allowAll())
+				.orElse(null);
 	}
+
 	/**
 	 * @param filterOnlyIds {@code null} means "no restriction". Empty means "select none"
 	 */

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/SqlViewFactory.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/SqlViewFactory.java
@@ -212,10 +212,14 @@ public class SqlViewFactory implements IViewFactory
 		else
 		{
 			return webuiDocumentReferencesService.getDocumentReferenceFilter(
-					referencedDocumentPath,
-					targetWindowId,
-					documentReferenceId,
-					RelatedDocumentsPermissionsFactory.allowAll());
+							referencedDocumentPath,
+							targetWindowId,
+							documentReferenceId,
+							RelatedDocumentsPermissionsFactory.allowAll())
+					.orElseThrow(() -> new AdempiereException("No related documents found")
+							.setParameter("targetWindowId", targetWindowId)
+							.setParameter("referencedDocumentPath", referencedDocumentPath)
+							.setParameter("documentReferenceId", documentReferenceId));
 		}
 	}
 


### PR DESCRIPTION
the previous error was:
```
Jun 10, 2022 8:56:28 AM org.apache.catalina.core.StandardWrapperValve invoke
SEVERE: Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is org.adempiere.exceptions.AdempiereException: No related documents found for source=DocumentAsZoomSource{tableName=M_ReceiptSchedule, recordId=1000000, AD_Window_ID=AdWindowId(repoId=541492)}, targetWindowId=AdWindowId(repoId=540189)] with root cause
org.adempiere.exceptions.AdempiereException: No related documents found for source=DocumentAsZoomSource{tableName=M_ReceiptSchedule, recordId=1000000, AD_Window_ID=AdWindowId(repoId=541492)}, targetWindowId=AdWindowId(repoId=540189)
	at de.metas.document.references.related_documents.RelatedDocumentsFactory.lambda$retrieveRelatedDocuments$3(RelatedDocumentsFactory.java:151)
	at java.base/java.util.Optional.orElseThrow(Optional.java:401)
	at de.metas.document.references.related_documents.RelatedDocumentsFactory.retrieveRelatedDocuments(RelatedDocumentsFactory.java:151)
	at de.metas.ui.web.document.references.service.WebuiDocumentReferencesService.lambda$getDocumentReference$2(WebuiDocumentReferencesService.java:136)
	at de.metas.ui.web.window.model.DocumentCollection.lambda$forDocumentReadonly$2(DocumentCollection.java:190)
	at de.metas.ui.web.window.model.DocumentCollection.forRootDocumentReadonly(DocumentCollection.java:235)
	at de.metas.ui.web.window.model.DocumentCollection.forDocumentReadonly(DocumentCollection.java:187)
	at de.metas.ui.web.document.references.service.WebuiDocumentReferencesService.getDocumentReference(WebuiDocumentReferencesService.java:129)
	at de.metas.ui.web.document.references.service.WebuiDocumentReferencesService.getDocumentReferenceFilter(WebuiDocumentReferencesService.java:119)
	at de.metas.ui.web.handlingunits.HUEditorViewFactoryTemplate.extractReferencedDocumentFilter(HUEditorViewFactoryTemplate.java:463)
	at de.metas.ui.web.handlingunits.HUEditorViewFactoryTemplate.createView(HUEditorViewFactoryTemplate.java:375)
	at de.metas.ui.web.handlingunits.HUEditorViewFactoryTemplate.createView(HUEditorViewFactoryTemplate.java:106)
	at de.metas.ui.web.view.ViewsRepository.createView(ViewsRepository.java:286)
	at de.metas.ui.web.process.adprocess.ADProcessPostProcessService.createResultAction(ADProcessPostProcessService.java:340)
	at de.metas.ui.web.process.adprocess.ADProcessPostProcessService.postProcess(ADProcessPostProcessService.java:111)
	at de.metas.ui.web.process.adprocess.ADProcessInstanceController.executeADProcess(ADProcessInstanceController.java:352)
	at de.metas.ui.web.process.adprocess.ADProcessInstanceController.startProcess(ADProcessInstanceController.java:322)
	at de.metas.ui.web.process.ProcessRestController.lambda$startProcess$6(ProcessRestController.java:315)
	at de.metas.ui.web.process.adprocess.ADProcessInstancesRepository.forProcessInstanceWritable(ADProcessInstancesRepository.java:460)
	at de.metas.ui.web.process.ProcessRestController.lambda$startProcess$7(ProcessRestController.java:314)
	at de.metas.ui.web.window.controller.Execution$ExecutionBuilder.lambda$execute$2(Execution.java:264)
	at de.metas.ui.web.window.controller.Execution$ExecutionBuilder.execute(Execution.java:287)
	at de.metas.ui.web.process.ProcessRestController.startProcess(ProcessRestController.java:314)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:197)
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:141)
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:106)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:894)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808)
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1060)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:962)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:626)
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:733)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:227)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at de.metas.ui.web.config.WebConfig$1.doFilter(WebConfig.java:69)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at de.metas.ui.web.CORSFilter.doFilter(CORSFilter.java:45)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at de.metas.ui.web.config.ServletLoggingFilter.doFilter(ServletLoggingFilter.java:91)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.springframework.session.web.http.SessionRepositoryFilter.doFilterInternal(SessionRepositoryFilter.java:141)
	at org.springframework.session.web.http.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:82)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter.doFilterInternal(WebMvcMetricsFilter.java:93)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:202)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:97)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:542)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:143)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:78)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:346)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:374)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:887)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1684)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.base/java.lang.Thread.run(Thread.java:832)
```