### PR TITLE
M_MatchPO posting: don't fail if no cost details were created

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_MatchPO.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_MatchPO.java
@@ -2,7 +2,6 @@ package org.compiere.acct;
 
 import de.metas.acct.api.AcctSchema;
 import de.metas.acct.api.AcctSchemaId;
-import de.metas.costing.AggregatedCostAmount;
 import de.metas.costing.CostAmount;
 import de.metas.costing.CostDetailCreateRequest;
 import de.metas.costing.CostPrice;
@@ -32,7 +31,6 @@ import org.compiere.model.I_M_MatchPO;
 import org.compiere.model.X_M_InOut;
 import org.compiere.util.TimeUtil;
 
-import java.math.BigDecimal;
 import java.sql.Timestamp;
 
 /*
@@ -77,7 +75,9 @@ final class DocLine_MatchPO extends DocLine<Doc_MatchPO>
 		setQty(qty, isSOTrx);
 	}
 
-	/** @return PO cost amount in accounting schema currency */
+	/**
+	 * @return PO cost amount in accounting schema currency
+	 */
 	CostAmount getPOCostAmount(final AcctSchema as)
 	{
 		final I_C_OrderLine orderLine = getOrderLine();
@@ -122,7 +122,7 @@ final class DocLine_MatchPO extends DocLine<Doc_MatchPO>
 		return costPrice.multiply(getQty());
 	}
 
-	AggregatedCostAmount createCostDetails(final AcctSchema as)
+	void createCostDetails(final AcctSchema as)
 	{
 		final I_M_InOutLine receiptLine = getReceiptLine();
 		Check.assumeNotNull(receiptLine, "Parameter receiptLine is not null");
@@ -138,7 +138,10 @@ final class DocLine_MatchPO extends DocLine<Doc_MatchPO>
 
 		final AcctSchemaId acctSchemaId = as.getId();
 
-		return services.createCostDetail(
+		// NOTE: there is no need to fail if no cost details were created because:
+		// * not all costing methods are creating cost details for MatchPO
+		// * we are not using the result of cost details
+		services.createCostDetailOrEmpty(
 				CostDetailCreateRequest.builder()
 						.acctSchemaId(acctSchemaId)
 						.clientId(ClientId.ofRepoId(orderLine.getAD_Client_ID()))

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/doc/AcctDocRequiredServicesFacade.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/doc/AcctDocRequiredServicesFacade.java
@@ -38,6 +38,7 @@ import de.metas.currency.ICurrencyDAO;
 import de.metas.error.AdIssueId;
 import de.metas.error.IErrorManager;
 import de.metas.i18n.AdMessageKey;
+import de.metas.i18n.ExplainedOptional;
 import de.metas.i18n.IMsgBL;
 import de.metas.i18n.ITranslatableString;
 import de.metas.money.CurrencyConversionTypeId;
@@ -293,6 +294,12 @@ public class AcctDocRequiredServicesFacade
 	public AggregatedCostAmount createCostDetail(@NonNull final CostDetailCreateRequest request)
 	{
 		return costingService.createCostDetail(request);
+	}
+
+	@SuppressWarnings("UnusedReturnValue")
+	public ExplainedOptional<AggregatedCostAmount> createCostDetailOrEmpty(@NonNull final CostDetailCreateRequest request)
+	{
+		return costingService.createCostDetailOrEmpty(request);
 	}
 
 	public MoveCostsResult moveCosts(@NonNull final MoveCostsRequest request)

--- a/backend/de.metas.business/src/main/java/de/metas/costing/ICostingService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/ICostingService.java
@@ -1,7 +1,8 @@
 package de.metas.costing;
 
+import de.metas.i18n.ExplainedOptional;
 import de.metas.order.OrderLineId;
-import de.metas.uom.UomId;
+import lombok.NonNull;
 
 import java.util.Optional;
 
@@ -30,6 +31,8 @@ import java.util.Optional;
 public interface ICostingService
 {
 	AggregatedCostAmount createCostDetail(CostDetailCreateRequest request);
+
+	ExplainedOptional<AggregatedCostAmount> createCostDetailOrEmpty(@NonNull CostDetailCreateRequest request);
 
 	AggregatedCostAmount createReversalCostDetails(CostDetailReverseRequest request);
 

--- a/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostingService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostingService.java
@@ -36,6 +36,7 @@ import de.metas.costing.methods.CostingMethodHandlerUtils;
 import de.metas.currency.CurrencyConversionContext;
 import de.metas.currency.CurrencyConversionResult;
 import de.metas.currency.ICurrencyBL;
+import de.metas.i18n.ExplainedOptional;
 import de.metas.logging.LogManager;
 import de.metas.money.CurrencyId;
 import de.metas.order.OrderLineId;
@@ -130,6 +131,12 @@ public class CostingService implements ICostingService
 	@Override
 	public AggregatedCostAmount createCostDetail(@NonNull final CostDetailCreateRequest request)
 	{
+		return createCostDetailOrEmpty(request).orElseThrow();
+	}
+
+	@Override
+	public ExplainedOptional<AggregatedCostAmount> createCostDetailOrEmpty(@NonNull final CostDetailCreateRequest request)
+	{
 		final ImmutableList<CostDetailCreateResult> costElementResults = Stream.of(request)
 				.flatMap(this::explodeAcctSchemas)
 				.map(this::convertToAcctSchemaCurrency)
@@ -139,10 +146,12 @@ public class CostingService implements ICostingService
 
 		if (costElementResults.isEmpty())
 		{
-			throw new AdempiereException("No costs created for " + request);
+			return ExplainedOptional.emptyBecause("No costs created for " + request);
 		}
-
-		return toAggregatedCostAmount(costElementResults);
+		else
+		{
+			return ExplainedOptional.of(toAggregatedCostAmount(costElementResults));
+		}
 	}
 
 	private static AggregatedCostAmount toAggregatedCostAmount(final List<CostDetailCreateResult> costElementResults)


### PR DESCRIPTION
Reason:
* not all costing methods are creating cost details for MatchPO
* we are not using the result of cost details