### PR TITLE
Fix Login Form: display backend error

### DIFF
--- a/frontend/src/components/app/LoginForm.js
+++ b/frontend/src/components/app/LoginForm.js
@@ -106,16 +106,22 @@ class LoginForm extends Component {
   /**
    * @method checkIfAlreadyLogged
    * @summary Used to verify if a user is already logged in. i.e user is authenticated in another tab and we are on the loging form screen.
-   * @param {*} err
+   * @param {*} axiosError
    */
-  checkIfAlreadyLogged(err) {
+  checkIfAlreadyLogged(axiosError) {
     const { history } = this.props;
-    return checkLoginRequest().then((response) => {
-      if (response.data) {
-        return history.push('/');
-      }
 
-      return Promise.reject(err);
+    console.log('Checking if already logged in...', { axiosError });
+    return checkLoginRequest().then((response) => {
+      const isLoggedIn = !!response.data;
+
+      if (isLoggedIn) {
+        console.log('Already logged in => forwarding to /');
+        return history.push('/');
+      } else {
+        console.log('Not already logged in');
+        return Promise.reject(axiosError);
+      }
     });
   }
 
@@ -139,51 +145,49 @@ class LoginForm extends Component {
     );
   };
 
-  /**
-   * @method mapStateToProps
-   * @summary ToDo: Describe the method.
-   * @param {*} resp
-   */
-  handleLoginRequest = (resp) => {
-    let request = null;
+  setLoginError = (message) => {
+    const messageEffective =
+      message || counterpart.translate('login.error.fallback');
 
-    if (resp) {
-      request = resp;
-    } else {
-      request = loginRequest(this.login.value, this.passwd.value);
-    }
+    console.log('setLoginError', { message, messageEffective });
+
+    this.setState({
+      err: messageEffective,
+      pending: false,
+    });
+  };
+
+  showRoleSelectPanel = (roles) => {
+    this.setState({
+      roleSelect: true,
+      roles,
+      role: roles?.[0],
+    });
+  };
+
+  handleLoginRequest = (resp) => {
+    const request = resp
+      ? resp
+      : loginRequest(this.login.value, this.passwd.value);
 
     request
       .then((response) => {
-        const errorType = response.data.status === 502 ? BAD_GATEWAY_ERROR : '';
+        const errorType = response.status === 502 ? BAD_GATEWAY_ERROR : '';
         this.props.dispatch(connectionError({ errorType }));
-        if (response.data.loginComplete) {
-          return this.handleSuccess();
-        }
-        const roles = response.data.roles;
 
-        this.setState({
-          roleSelect: true,
-          roles,
-          role: roles[0],
-        });
+        if (response.status !== 200) {
+          this.setLoginError(response?.data?.message);
+        } else if (response.data.loginComplete) {
+          return this.handleSuccess();
+        } else {
+          this.showRoleSelectPanel(response.data.roles);
+        }
       })
-      .then(() => {
-        this.setState({
-          pending: false,
-        });
-      })
-      .catch((err) => {
-        return this.checkIfAlreadyLogged(err);
-      })
-      .catch((err) => {
-        this.setState({
-          err: err.response
-            ? err.response.data.message
-            : counterpart.translate('login.error.fallback'),
-          pending: false,
-        });
-      });
+      .then(() => this.setState({ pending: false }))
+      .catch((axiosError) => this.checkIfAlreadyLogged(axiosError))
+      .catch((axiosError) =>
+        this.setLoginError(axiosError?.response?.data?.message)
+      );
   };
 
   /**

--- a/frontend/src/containers/App.js
+++ b/frontend/src/containers/App.js
@@ -130,7 +130,7 @@ const App = () => {
             });
           }
         } else if (error.response.status == 502) {
-          return; // silent erorr for 502 bad gateway (otherwise we will get a bunch of notif from the retries)
+          return; // silent error for 502 bad gateway (otherwise we will get a bunch of notif from the retries)
         } else if (error.response.status == 503) {
           dispatch(connectionError({ errorType: NO_CONNECTION_ERROR }));
         } else if (error.response.status != 404) {


### PR DESCRIPTION
Issue was introduced by https://github.com/metasfresh/metasfresh/pull/12082.

Test cases:
* using a user with single role: try login 
    * with OK password => directly login
    * with Wrong password => nice error message

* using a user with more than one role: try login 
    * with OK password => role selection panel => login OK
    * with Wrong password => nice error message

* using a non-existing user (e.g. login user `wfdjlksa`), try login
    * => nice error message

* Login using user token, try calling `https://<server>.metasfresh.com/token/<user token>`
   * => directly login

