### PR TITLE
#13364 update MD_Available_For_Sales when `M_ShipmentSchedule.IsClosed` is changed
Start shopware6 sync when `ExternalSystem_Config_Shopware6.IsSyncAvailableForSalesToShopware6` is checked

### DIFF
--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/shopware6/interceptor/ExternalSystem_Config_Shopware6.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/shopware6/interceptor/ExternalSystem_Config_Shopware6.java
@@ -73,7 +73,7 @@ public class ExternalSystem_Config_Shopware6
 	}
 
 	@ModelChange(timings = { ModelValidator.TYPE_AFTER_CHANGE },
-			ifColumnsChanged = { I_ExternalSystem_Config_Shopware6.COLUMNNAME_PercentageOfAvailableForSalesToSync })
+			ifColumnsChanged = { I_ExternalSystem_Config_Shopware6.COLUMNNAME_PercentageOfAvailableForSalesToSync, I_ExternalSystem_Config_Shopware6.COLUMNNAME_IsSyncAvailableForSalesToShopware6 })
 	public void syncAvailableForSalesToShopware(@NonNull final I_ExternalSystem_Config_Shopware6 config)
 	{
 		if (!config.isSyncAvailableForSalesToShopware6())

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/modelvalidator/M_ShipmentSchedule.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/modelvalidator/M_ShipmentSchedule.java
@@ -138,7 +138,8 @@ public class M_ShipmentSchedule
 					I_M_ShipmentSchedule.COLUMNNAME_M_AttributeSetInstance_ID,
 					I_M_ShipmentSchedule.COLUMNNAME_PreparationDate_Override,
 					I_M_ShipmentSchedule.COLUMNNAME_PreparationDate,
-					I_M_ShipmentSchedule.COLUMNNAME_C_OrderLine_ID })
+					I_M_ShipmentSchedule.COLUMNNAME_C_OrderLine_ID,
+					I_M_ShipmentSchedule.COLUMNNAME_IsClosed})
 	public void triggerSyncAvailableForSales(@NonNull final I_M_ShipmentSchedule shipmentScheduleRecord)
 	{
 		final AvailableForSalesConfig config = availableForSalesConfigRepo.getConfig(


### PR DESCRIPTION
https://github.com/metasfresh/metasfresh/issues/13364