### PR TITLE
rewritten from sales invoice to purchase invoice

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5649100_gh13368_rename_to_IsInterimInvoice.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5649100_gh13368_rename_to_IsInterimInvoice.sql
@@ -1,0 +1,222 @@
+ALTER TABLE c_invoice_candidate
+    RENAME COLUMN ispartialpayment TO IsInterimInvoice;
+
+-- 2022-08-03T10:10:30.159Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,DefaultValue,DisplayLength,EntityType,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,583863,702802,0,543052,0,TO_TIMESTAMP('2022-08-03 12:10:30','YYYY-MM-DD HH24:MI:SS'),100,'''N''',0,'de.metas.invoicecandidate',0,'Y','Y','N','N','N','N','N','N','Akontozahlung',0,570,0,1,1,TO_TIMESTAMP('2022-08-03 12:10:30','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2022-08-03T10:10:30.160Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y') AND t.AD_Field_ID=702802 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2022-08-03T10:10:30.162Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(581192)
+;
+
+-- 2022-08-03T10:10:30.165Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=702802
+;
+
+-- 2022-08-03T10:10:30.166Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+/* DDL */ select AD_Element_Link_Create_Missing_Field(702802)
+;
+
+-- 2022-08-03T10:13:02.393Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,702802,0,543052,544370,610838,'F',TO_TIMESTAMP('2022-08-03 12:13:02','YYYY-MM-DD HH24:MI:SS'),100,'Y','Y','N','Y','N','N','N',0,'Akontozahlung',55,0,0,TO_TIMESTAMP('2022-08-03 12:13:02','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2022-08-03T10:13:25.270Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=610781
+;
+
+-- 2022-08-03T10:13:33.175Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=702507
+;
+
+-- 2022-08-03T10:13:33.177Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM  AD_Field_Trl WHERE AD_Field_ID=702507
+;
+
+-- 2022-08-03T10:13:33.181Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+DELETE FROM AD_Field WHERE AD_Field_ID=702507
+;
+
+-- 2022-08-03T10:15:51.017Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=10,Updated=TO_TIMESTAMP('2022-08-03 12:15:51','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=575016
+;
+
+-- 2022-08-03T10:15:51.356Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=20,Updated=TO_TIMESTAMP('2022-08-03 12:15:51','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=544920
+;
+
+-- 2022-08-03T10:15:51.654Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=30,Updated=TO_TIMESTAMP('2022-08-03 12:15:51','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=551469
+;
+
+-- 2022-08-03T10:15:51.946Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=40,Updated=TO_TIMESTAMP('2022-08-03 12:15:51','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=569216
+;
+
+-- 2022-08-03T10:15:52.289Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=50,Updated=TO_TIMESTAMP('2022-08-03 12:15:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=551072
+;
+
+-- 2022-08-03T10:15:52.593Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=60,Updated=TO_TIMESTAMP('2022-08-03 12:15:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=551286
+;
+
+-- 2022-08-03T10:15:52.875Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=70,Updated=TO_TIMESTAMP('2022-08-03 12:15:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=546203
+;
+
+-- 2022-08-03T10:15:53.183Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=80,Updated=TO_TIMESTAMP('2022-08-03 12:15:53','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=546600
+;
+
+-- 2022-08-03T10:15:53.473Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=90,Updated=TO_TIMESTAMP('2022-08-03 12:15:53','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=551953
+;
+
+-- 2022-08-03T10:15:53.771Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=100,Updated=TO_TIMESTAMP('2022-08-03 12:15:53','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=544913
+;
+
+-- 2022-08-03T10:15:54.062Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=110,Updated=TO_TIMESTAMP('2022-08-03 12:15:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=546339
+;
+
+-- 2022-08-03T10:15:54.358Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=120,Updated=TO_TIMESTAMP('2022-08-03 12:15:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=551761
+;
+
+-- 2022-08-03T10:15:54.676Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=130,Updated=TO_TIMESTAMP('2022-08-03 12:15:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=551293
+;
+
+-- 2022-08-03T10:15:54.970Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=140,Updated=TO_TIMESTAMP('2022-08-03 12:15:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=552564
+;
+
+-- 2022-08-03T10:15:55.261Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=150,Updated=TO_TIMESTAMP('2022-08-03 12:15:55','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=546227
+;
+
+-- 2022-08-03T10:15:55.569Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=160,Updated=TO_TIMESTAMP('2022-08-03 12:15:55','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=551796
+;
+
+-- 2022-08-03T10:15:55.850Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=170,Updated=TO_TIMESTAMP('2022-08-03 12:15:55','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=545771
+;
+
+-- 2022-08-03T10:15:56.190Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=180,Updated=TO_TIMESTAMP('2022-08-03 12:15:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=549847
+;
+
+-- 2022-08-03T10:15:56.495Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=190,Updated=TO_TIMESTAMP('2022-08-03 12:15:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=550515
+;
+
+-- 2022-08-03T10:15:56.776Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=200,Updated=TO_TIMESTAMP('2022-08-03 12:15:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=583863
+;
+
+-- 2022-08-03T10:15:57.076Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=210,Updated=TO_TIMESTAMP('2022-08-03 12:15:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=551762
+;
+
+-- 2022-08-03T10:15:57.396Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=220,Updated=TO_TIMESTAMP('2022-08-03 12:15:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=551290
+;
+
+-- 2022-08-03T10:15:57.697Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=230,Updated=TO_TIMESTAMP('2022-08-03 12:15:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=545852
+;
+
+-- 2022-08-03T10:15:57.985Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=240,Updated=TO_TIMESTAMP('2022-08-03 12:15:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=552289
+;
+
+-- 2022-08-03T10:15:58.275Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=250,Updated=TO_TIMESTAMP('2022-08-03 12:15:58','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=544923
+;
+
+-- 2022-08-03T10:15:58.585Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=260,Updated=TO_TIMESTAMP('2022-08-03 12:15:58','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=545314
+;
+
+-- 2022-08-03T10:15:58.868Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=270,Updated=TO_TIMESTAMP('2022-08-03 12:15:58','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=545316
+;
+
+-- 2022-08-03T10:15:59.182Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=280,Updated=TO_TIMESTAMP('2022-08-03 12:15:59','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=544902
+;
+
+-- 2022-08-03T10:42:17.636Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Element SET ColumnName='IsInterimInvoice',Updated=TO_TIMESTAMP('2022-08-03 12:42:17','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=581192
+;
+
+-- 2022-08-03T10:42:17.646Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET ColumnName='IsInterimInvoice', Name='Akontozahlung', Description=NULL, Help=NULL WHERE AD_Element_ID=581192
+;
+
+-- 2022-08-03T10:42:17.648Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process_Para SET ColumnName='IsInterimInvoice', Name='Akontozahlung', Description=NULL, Help=NULL, AD_Element_ID=581192 WHERE UPPER(ColumnName)='ISINTERIMINVOICE' AND IsCentrallyMaintained='Y' AND AD_Element_ID IS NULL
+;
+
+-- 2022-08-03T10:42:17.654Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Process_Para SET ColumnName='IsInterimInvoice', Name='Akontozahlung', Description=NULL, Help=NULL WHERE AD_Element_ID=581192 AND IsCentrallyMaintained='Y'
+;
+
+-- 2022-08-03T10:42:58.342Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Element_Trl SET Name='Interim Invoice', PrintName='Interim Invoice',Updated=TO_TIMESTAMP('2022-08-03 12:42:58','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=581192 AND AD_Language='en_US'
+;
+
+-- 2022-08-03T10:42:58.369Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(581192,'en_US')
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/invoicecandidate/model/I_C_Invoice_Candidate.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/invoicecandidate/model/I_C_Invoice_Candidate.java
@@ -1902,6 +1902,27 @@ public interface I_C_Invoice_Candidate
 	String COLUMNNAME_IsInOutApprovedForInvoicing = "IsInOutApprovedForInvoicing";
 
 	/**
+	 * Set Interim Invoice.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsInterimInvoice (boolean IsInterimInvoice);
+
+	/**
+	 * Get Interim Invoice.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isInterimInvoice();
+
+	ModelColumn<I_C_Invoice_Candidate, Object> COLUMN_IsInterimInvoice = new ModelColumn<>(I_C_Invoice_Candidate.class, "IsInterimInvoice", null);
+	String COLUMNNAME_IsInterimInvoice = "IsInterimInvoice";
+
+	/**
 	 * Set Invoicing error.
 	 *
 	 * <br>Type: YesNo
@@ -1988,27 +2009,6 @@ public interface I_C_Invoice_Candidate
 
 	ModelColumn<I_C_Invoice_Candidate, Object> COLUMN_IsPackagingMaterial = new ModelColumn<>(I_C_Invoice_Candidate.class, "IsPackagingMaterial", null);
 	String COLUMNNAME_IsPackagingMaterial = "IsPackagingMaterial";
-
-	/**
-	 * Set Payment on account.
-	 *
-	 * <br>Type: YesNo
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	void setIsPartialPayment (boolean IsPartialPayment);
-
-	/**
-	 * Get Payment on account.
-	 *
-	 * <br>Type: YesNo
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	boolean isPartialPayment();
-
-	ModelColumn<I_C_Invoice_Candidate, Object> COLUMN_IsPartialPayment = new ModelColumn<>(I_C_Invoice_Candidate.class, "IsPartialPayment", null);
-	String COLUMNNAME_IsPartialPayment = "IsPartialPayment";
 
 	/**
 	 * Set andrucken.

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/invoicecandidate/model/X_C_Invoice_Candidate.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/invoicecandidate/model/X_C_Invoice_Candidate.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 public class X_C_Invoice_Candidate extends org.compiere.model.PO implements I_C_Invoice_Candidate, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = -639408032L;
+	private static final long serialVersionUID = 1853595142L;
 
     /** Standard Constructor */
     public X_C_Invoice_Candidate (final Properties ctx, final int C_Invoice_Candidate_ID, @Nullable final String trxName)
@@ -1344,6 +1344,18 @@ public class X_C_Invoice_Candidate extends org.compiere.model.PO implements I_C_
 	}
 
 	@Override
+	public void setIsInterimInvoice (final boolean IsInterimInvoice)
+	{
+		set_Value (COLUMNNAME_IsInterimInvoice, IsInterimInvoice);
+	}
+
+	@Override
+	public boolean isInterimInvoice() 
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsInterimInvoice);
+	}
+
+	@Override
 	public void setIsInvoicingError (final boolean IsInvoicingError)
 	{
 		set_Value (COLUMNNAME_IsInvoicingError, IsInvoicingError);
@@ -1388,18 +1400,6 @@ public class X_C_Invoice_Candidate extends org.compiere.model.PO implements I_C_
 	public boolean isPackagingMaterial() 
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsPackagingMaterial);
-	}
-
-	@Override
-	public void setIsPartialPayment (final boolean IsPartialPayment)
-	{
-		set_Value (COLUMNNAME_IsPartialPayment, IsPartialPayment);
-	}
-
-	@Override
-	public boolean isPartialPayment() 
-	{
-		return get_ValueAsBoolean(COLUMNNAME_IsPartialPayment);
 	}
 
 	@Override


### PR DESCRIPTION
_ change column name to IsInterimInvoice
- regenerated model invoice_candidate
- rewritten from sales invoice to purchase invoice candidate
- changed the filter row
- changed ad_element name fron ispartialpayment to isinteriminvoice

https://github.com/metasfresh/me03/issues/12608