### PR TITLE
hotfix: quick actions button remained disabled after openning a new record in a new browser tab

### DIFF
--- a/frontend/src/actions/ProcessActions.js
+++ b/frontend/src/actions/ProcessActions.js
@@ -154,12 +154,15 @@ export const handleProcessResponse = (
             break;
           }
           case 'newRecord': {
-            handleProcessResponse_newRecord(action, dispatch);
-            return false;
-            //break;
+            const { stopHere } = handleProcessResponse_newRecord(action);
+            if (stopHere) {
+              return;
+            }
+            break;
           }
           default: {
             console.warn('Unhandled action', action);
+            break;
           }
         }
       }
@@ -177,8 +180,8 @@ export const handleProcessResponse = (
   };
 };
 
-const handleProcessResponse_newRecord = (action, dispatch) => {
-  console.log('handleProcessResponse_newRecord', { action });
+const handleProcessResponse_newRecord = (action) => {
+  //console.log('handleProcessResponse_newRecord', { action });
 
   const { windowId, fieldValues, targetTab } = action;
   let urlPath = `/window/${windowId}/NEW`;
@@ -188,12 +191,16 @@ const handleProcessResponse_newRecord = (action, dispatch) => {
   }
 
   if (targetTab === 'NEW_TAB') {
-    openInNewTab({ urlPath, dispatch, actionName: setProcessSaved });
+    const newBrowserTab = window.open(urlPath, '_blank');
+    newBrowserTab.focus();
+    return { stopHere: false };
   } else if (targetTab === 'SAME_TAB' || !targetTab) {
     window.open(urlPath, '_self');
+    return { stopHere: true };
   } else {
     console.warn(`Unknown targetTab '${targetTab}'. Opening in same tab.`);
     window.open(urlPath, '_self');
+    return { stopHere: true };
   }
 };
 


### PR DESCRIPTION
follow-up of https://github.com/metasfresh/metasfresh/pull/13846