### PR TITLE
Extend size of AD_Role.Name to avoid errors if a role is cloned 

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/security/model/interceptor/AD_Role.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/security/model/interceptor/AD_Role.java
@@ -89,8 +89,9 @@ public class AD_Role
 
 		//
 		// Update role access records
-		if ((changeType.isNew() || InterfaceWrapperHelper.isValueChanged(role, I_AD_Role.COLUMNNAME_UserLevel))
-				&& !role.isManual())
+		final boolean userLevelChange = InterfaceWrapperHelper.isValueChanged(role, I_AD_Role.COLUMNNAME_UserLevel);
+		final boolean notManual = !role.isManual();
+		if ((changeType.isNew() || userLevelChange)	&& notManual)
 		{
 			final UserId userId = UserId.ofRepoId(role.getUpdatedBy());
 			Services.get(IUserRolePermissionsDAO.class).updateAccessRecords(roleId, userId);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5663460_sys_gh13887_set_column_AD_Role_IsManual_to_IsCalculated.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5663460_sys_gh13887_set_column_AD_Role_IsManual_to_IsCalculated.sql
@@ -1,0 +1,7 @@
+
+
+update ad_Column set iscalculated='Y', updatedby=99, updated='2022-11-07 12:04',
+                     technicalnote=technicalnote||'Set to IsCalculated=N and Default=Y because when cloning a not-manual role, ' ||
+                                   'then the generic clone support would collide with the DB-function role_access_update that is automatically run for every new not-manual role.'
+WHERE ad_Table_id = get_table_id('AD_Role') and columnname='IsManual';
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5663500_sys_gh13890_AD_Role_Name_Increase_FieldLength.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5663500_sys_gh13890_AD_Role_Name_Increase_FieldLength.sql
@@ -1,0 +1,4 @@
+
+SELECT public.db_alter_table('AD_Role','ALTER TABLE ad_role ALTER COLUMN name TYPE varchar(256) USING name::varchar(256)');
+
+UPDATE AD_Column Set fieldlength=256, updated='2022-11-07 14:58', updatedby=99 WHERE ad_Table_id = get_table_id('AD_Role') and columnname='Name';


### PR DESCRIPTION
...and the new role's name is set to a standard-string plus "cloned by <username>"
#13890