### PR TITLE
AD_Column.assertColumnNameValid: allow CreatedBy, UpdatedBy exceptional ID column names

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/column/model/interceptor/AD_Column.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/column/model/interceptor/AD_Column.java
@@ -1,8 +1,8 @@
 package org.adempiere.ad.column.model.interceptor;
 
+import de.metas.ad_reference.ReferenceId;
 import de.metas.i18n.po.POTrlRepository;
 import de.metas.logging.LogManager;
-import de.metas.ad_reference.ReferenceId;
 import de.metas.security.impl.ParsedSql;
 import de.metas.translation.api.IElementTranslationBL;
 import de.metas.util.Services;
@@ -239,11 +239,14 @@ public class AD_Column
 	{
 		assertColumnNameValid(adColumn.getColumnName(), adColumn.getAD_Reference_ID());
 	}
+
 	private void assertColumnNameValid(@NonNull final String columnName, final int displayType)
 	{
 		if (DisplayType.isID(displayType) && displayType != DisplayType.Account)
 		{
-			if (!columnName.endsWith("_ID"))
+			if (!columnName.endsWith("_ID")
+					&& !columnName.equals("CreatedBy")
+					&& !columnName.equals("UpdatedBy"))
 			{
 				throw new AdempiereException("Lookup or ID columns shall have the name ending with `_ID`");
 			}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/table/api/impl/ADTableDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/table/api/impl/ADTableDAO.java
@@ -129,7 +129,12 @@ public class ADTableDAO implements IADTableDAO
 	@Override
 	public boolean hasColumnName(final String tableName, final String columnName)
 	{
-		final AdTableId adTableId = AdTableId.ofRepoId(retrieveTableId(tableName));
+		final AdTableId adTableId = AdTableId.ofRepoIdOrNull(retrieveTableId(tableName));
+		if(adTableId == null)
+		{
+			return false;
+		}
+
 		return getMinimalColumnInfoMap().hasColumnName(adTableId, columnName);
 	}
 


### PR DESCRIPTION
fixes https://github.com/metasfresh/metasfresh/pull/13565


Test case:
* created a new table
* copied columns from X_TableTemplate

![2022-11-15_1800_46](https://user-images.githubusercontent.com/1244701/201967006-eb5fe974-3a63-435d-8a78-59b4d04b43c2.gif)
