### PR TITLE
Enable remote cache invalidation for M_Product_Allergen, M_Product_HazardSymbol

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5665030_sys_enable_remote_cache_invalidation_for_product_labels.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5665030_sys_enable_remote_cache_invalidation_for_product_labels.sql
@@ -1,0 +1,10 @@
+-- Table: M_Product_Allergen
+-- 2022-11-17T14:42:06.834Z
+UPDATE AD_Table SET IsEnableRemoteCacheInvalidation='Y',Updated=TO_TIMESTAMP('2022-11-17 16:42:06','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Table_ID=541006
+;
+
+-- Table: M_Product_HazardSymbol
+-- 2022-11-17T14:45:59.856Z
+UPDATE AD_Table SET IsEnableRemoteCacheInvalidation='Y',Updated=TO_TIMESTAMP('2022-11-17 16:45:59','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Table_ID=541965
+;
+


### PR DESCRIPTION
Fixes the issue when editing the product's allergens or hazard symbols are not reflected to mobile UI because cache was not invalidated.