### PR TITLE
webui: hotfix readonly fields (corner case: field flagged as readonly but isparent field, tab insert disabled)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ILogicExpression.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/expression/api/ILogicExpression.java
@@ -22,8 +22,10 @@ package org.adempiere.ad.expression.api;
  * #L%
  */
 
-import java.util.List;
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.ImmutableList;
+import de.metas.util.OptionalBoolean;
+import lombok.NonNull;
 import org.adempiere.ad.expression.api.IExpressionEvaluator.OnVariableNotFound;
 import org.adempiere.ad.expression.api.impl.LogicExpressionBuilder;
 import org.adempiere.ad.expression.api.impl.LogicExpressionEvaluator;
@@ -31,24 +33,20 @@ import org.adempiere.ad.expression.exceptions.ExpressionEvaluationException;
 import org.adempiere.ad.expression.json.JsonLogicExpressionDeserializer;
 import org.compiere.util.Evaluatee;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.collect.ImmutableList;
-
-import lombok.NonNull;
+import java.util.List;
 
 /**
  * Logic expression
- *
+ * <p>
  * NOTE: business logic expects that implementation of this interface to be immutable.
  *
  * @author metas-dev <dev@metas-fresh.com>
- *
  */
 @JsonDeserialize(using = JsonLogicExpressionDeserializer.class)
 public interface ILogicExpression extends IExpression<Boolean>
 {
-//	ILogicExpression TRUE = ConstantLogicExpression.TRUE;
-//	ILogicExpression FALSE = ConstantLogicExpression.FALSE;
+	//	ILogicExpression TRUE = ConstantLogicExpression.TRUE;
+	//	ILogicExpression FALSE = ConstantLogicExpression.FALSE;
 
 	String LOGIC_OPERATOR_AND = "&";
 	String LOGIC_OPERATOR_OR = "|";
@@ -69,7 +67,7 @@ public interface ILogicExpression extends IExpression<Boolean>
 
 	/**
 	 * Tries to partially evaluate this expression.
-	 * 
+	 *
 	 * @param ctx
 	 * @return partially evaluated expression.
 	 */
@@ -85,12 +83,12 @@ public interface ILogicExpression extends IExpression<Boolean>
 		final OnVariableNotFound onVariableNotFound = ignoreUnparsable ? OnVariableNotFound.ReturnNoResult : OnVariableNotFound.Fail;
 		return evaluate(ctx, onVariableNotFound);
 	}
-	
+
 	/**
 	 * Evaluates given expression and returns {@link LogicExpressionResult}.
-	 *
+	 * <p>
 	 * Use this method if you need more informations about the evaluation (e.g. which were the parameters used etc).
-	 *
+	 * <p>
 	 * If you are just interested about the boolean result, please use {@link #evaluate(Evaluatee, OnVariableNotFound)}.
 	 *
 	 * @param ctx
@@ -136,6 +134,13 @@ public interface ILogicExpression extends IExpression<Boolean>
 		return isConstant() && constantValue() == false;
 	}
 
+	default OptionalBoolean toOptionalBoolean()
+	{
+		return isConstant()
+				? OptionalBoolean.ofBoolean(constantValue())
+				: OptionalBoolean.UNKNOWN;
+	}
+
 	@Override
 	default boolean isNoResult(final Object result)
 	{
@@ -150,7 +155,9 @@ public interface ILogicExpression extends IExpression<Boolean>
 		return false;
 	}
 
-	/** Compose this logic expression with the given one, using logic AND and return it */
+	/**
+	 * Compose this logic expression with the given one, using logic AND and return it
+	 */
 	default ILogicExpression and(final ILogicExpression expression)
 	{
 		return LogicExpressionBuilder.build(this, LOGIC_OPERATOR_AND, expression);
@@ -161,7 +168,9 @@ public interface ILogicExpression extends IExpression<Boolean>
 		return LogicExpressionBuilder.build(this, LOGIC_OPERATOR_AND, expression.negate());
 	}
 
-	/** Compose this logic expression with the given one, using logic OR and return it */
+	/**
+	 * Compose this logic expression with the given one, using logic OR and return it
+	 */
 	default ILogicExpression or(final ILogicExpression expression)
 	{
 		return LogicExpressionBuilder.build(this, LOGIC_OPERATOR_OR, expression);

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/DocumentEntityDescriptor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/DocumentEntityDescriptor.java
@@ -925,7 +925,7 @@ public class DocumentEntityDescriptor
 			return this;
 		}
 
-		private ILogicExpression getAllowCreateNewLogic()
+		public ILogicExpression getAllowCreateNewLogic()
 		{
 			return _allowCreateNewLogic;
 		}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/GridTabVOBasedDocumentEntityDescriptorFactory.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/GridTabVOBasedDocumentEntityDescriptorFactory.java
@@ -35,6 +35,7 @@ import de.metas.ui.web.window.model.lookup.LookupDataSourceFactory;
 import de.metas.ui.web.window.model.lookup.TimeZoneLookupDescriptor;
 import de.metas.ui.web.window.model.sql.SqlDocumentsRepository;
 import de.metas.util.Check;
+import de.metas.util.OptionalBoolean;
 import de.metas.util.Services;
 import de.metas.util.StringUtils;
 import lombok.NonNull;
@@ -381,7 +382,8 @@ import java.util.Set;
 					gridFieldVO.isMandatory(),
 					gridFieldVO.isUseDocSequence());
 
-			readonlyLogic = extractReadOnlyLogic(gridFieldVO, keyColumn, isParentLinkColumn);
+			final OptionalBoolean tabAllowsCreateNew = entityDescriptorBuilder.getAllowCreateNewLogic().toOptionalBoolean();
+			readonlyLogic = extractReadOnlyLogic(gridFieldVO, keyColumn, isParentLinkColumn, tabAllowsCreateNew);
 			alwaysUpdateable = extractAlwaysUpdateable(gridFieldVO);
 		}
 
@@ -541,13 +543,13 @@ import java.util.Set;
 		// 		.build();
 	}
 
-	private static ILogicExpression extractReadOnlyLogic(final GridFieldVO gridFieldVO, final boolean keyColumn, final boolean isParentLinkColumn)
+	private static ILogicExpression extractReadOnlyLogic(final GridFieldVO gridFieldVO, final boolean keyColumn, final boolean isParentLinkColumn, final OptionalBoolean tabAllowsCreateNew)
 	{
 		if (keyColumn)
 		{
 			return ConstantLogicExpression.TRUE;
 		}
-		else if(gridFieldVO.isVirtualColumn())
+		else if (gridFieldVO.isVirtualColumn())
 		{
 			return ConstantLogicExpression.TRUE;
 		}
@@ -558,7 +560,8 @@ import java.util.Set;
 		// e.g. BPartner (pharma) window -> Product tab
 		else if (!gridFieldVO.isUpdateable()
 				&& gridFieldVO.isParentLink() && !isParentLinkColumn
-				&& gridFieldVO.isMandatory())
+				&& gridFieldVO.isMandatory()
+				&& tabAllowsCreateNew.isTrue())
 		{
 			return ConstantLogicExpression.FALSE;
 		}


### PR DESCRIPTION
## Corner case:
* field is flagged as readonly (AD_Field.IsReadOnly=Y)
* column is parent link (AD_Column.IsParent=Y)
* column is mandatory (AD_Column.IsMandatory=Y)
* but the tab does not allow new records (AD_Tab.IsInsertRecord=N)

## Expected result: 
field shall be readonly because there is no point to make it editable.
The initial intension to make it editable was because in case we want to create a new record we have to set those parent link columns.
But here is not the case, because creating a new record is disabled

NOTE: in our case we didn't made the tab readonly because we want to allow user deleting records.
So we made all the fields readonly.

## Actual result
Before the fix, the field is rendered as editable.

## Example
Manufacturing Order Source HU - http://localhost:3000/window/541633
![image](https://user-images.githubusercontent.com/1244701/202750807-cdade5c8-0c2e-4929-b314-00b83424fde6.png)
