### PR TITLE
fix timeout-problem with soehnle devices

### DIFF
--- a/backend/de.metas.device.adempiere/src/main/sql/postgresql/system/5667000_sys_gh13840_TcpEndPoint_preserve_behaviour.sql
+++ b/backend/de.metas.device.adempiere/src/main/sql/postgresql/system/5667000_sys_gh13840_TcpEndPoint_preserve_behaviour.sql
@@ -1,0 +1,3 @@
+
+-- preserve the old behavior
+UPDATE AD_SysConfig SET Value='de.metas.device.scales.endpoint.TcpConnectionReadLineEndPoint' WHERE name like 'de.metas.device.%.Endpoint.Class';

--- a/backend/de.metas.device.scales/pom.xml
+++ b/backend/de.metas.device.scales/pom.xml
@@ -33,6 +33,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		
+		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>

--- a/backend/de.metas.device.scales/src/main/java/de/metas/device/scales/endpoint/TcpConnectionEndPoint.java
+++ b/backend/de.metas.device.scales/src/main/java/de/metas/device/scales/endpoint/TcpConnectionEndPoint.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 
 public class TcpConnectionEndPoint implements ITcpConnectionEndPoint
@@ -81,13 +82,22 @@ public class TcpConnectionEndPoint implements ITcpConnectionEndPoint
 	{
 		final StringBuilder sb = new StringBuilder();
 		int i;
-		while ((i = in.read()) != -1)
+		try
 		{
-			sb.append((char)i);
+			while ((i = in.read()) != -1)
+			{
+				sb.append((char)i);
+			}
+		}
+		catch (final SocketTimeoutException e)
+		{
+			// if the device doesn't send "EOF", then there is nothing we can do here
+			// ..because at this place here we don't know how the response is terminated.
+			// so we just wait for the respective timeout
 		}
 		return sb.toString();
 	}
-	
+
 	public TcpConnectionEndPoint setHost(final String hostName)
 	{
 		this.hostName = hostName;

--- a/backend/de.metas.device.scales/src/main/java/de/metas/device/scales/endpoint/TcpConnectionEndPoint.java
+++ b/backend/de.metas.device.scales/src/main/java/de/metas/device/scales/endpoint/TcpConnectionEndPoint.java
@@ -25,14 +25,14 @@ package de.metas.device.scales.endpoint;
 import com.google.common.base.MoreObjects;
 import de.metas.device.scales.impl.ICmd;
 import de.metas.logging.LogManager;
+import lombok.NonNull;
 import org.slf4j.Logger;
 
-import java.io.BufferedReader;
+import javax.annotation.Nullable;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 
 public class TcpConnectionEndPoint implements ITcpConnectionEndPoint
@@ -41,11 +41,6 @@ public class TcpConnectionEndPoint implements ITcpConnectionEndPoint
 
 	private String hostName;
 	private int port;
-
-	/**
-	 * see {@link #setReturnLastLine(boolean)}.
-	 */
-	private boolean returnLastLine = false;
 
 	/**
 	 * see {@link #setReadTimeoutMillis(int)}.
@@ -57,11 +52,10 @@ public class TcpConnectionEndPoint implements ITcpConnectionEndPoint
 	 * Note: discards everything besides the last line.
 	 */
 	@Override
-	public String sendCmd(final String cmd)
+	@Nullable
+	public String sendCmd(@NonNull final String cmd)
 	{
-
 		try (final Socket clientSocket = new Socket(hostName, port);
-				final BufferedReader in = new BufferedReader(new InputStreamReader(clientSocket.getInputStream(), ICmd.DEFAULT_CMD_CHARSET));
 				final OutputStream out = clientSocket.getOutputStream();)
 		{
 			clientSocket.setSoTimeout(readTimeoutMillis);
@@ -70,23 +64,7 @@ public class TcpConnectionEndPoint implements ITcpConnectionEndPoint
 			out.write(cmd.getBytes(ICmd.DEFAULT_CMD_CHARSET));
 			out.flush();
 
-			String result = null;
-			String lastReadLine = in.readLine();
-			if (returnLastLine)
-			{
-				while (lastReadLine != null)
-				{
-					result = lastReadLine;
-					lastReadLine = readWithTimeout(in);
-				}
-				logger.debug("Result (last line) as read from the socket: {}", result);
-			}
-			else
-			{
-				result = lastReadLine;
-				logger.debug("Result (first line) as read from the socket: {}", result);
-			}
-			return result;
+			return readSocketResponse(clientSocket.getInputStream());
 		}
 		catch (final UnknownHostException e)
 		{
@@ -98,21 +76,18 @@ public class TcpConnectionEndPoint implements ITcpConnectionEndPoint
 		}
 	}
 
-	private String readWithTimeout(final BufferedReader in) throws IOException
+	@Nullable
+	String readSocketResponse(@NonNull final InputStream in) throws IOException
 	{
-		try
+		final StringBuilder sb = new StringBuilder();
+		int i;
+		while ((i = in.read()) != -1)
 		{
-			String lastReadLine = in.readLine();
-			logger.debug("Read line from the socket: {}", lastReadLine);
-			return lastReadLine;
+			sb.append((char)i);
 		}
-		catch (final SocketTimeoutException e)
-		{
-			logger.debug("Socket timeout; return null; exception-message={}", e.getMessage());
-			return null;
-		}
+		return sb.toString();
 	}
-
+	
 	public TcpConnectionEndPoint setHost(final String hostName)
 	{
 		this.hostName = hostName;
@@ -126,23 +101,7 @@ public class TcpConnectionEndPoint implements ITcpConnectionEndPoint
 	}
 
 	/**
-	 * If <code>false</code>, then the endpoint will return the first line coming out of the socket.
-	 * If <code>true</code>, if will discard all lines until there is nothing more coming out of the socket, and then return the last line if got.
-	 *
-	 * @param returnLastLine
-	 * @return
-	 */
-	public TcpConnectionEndPoint setReturnLastLine(final boolean returnLastLine)
-	{
-		this.returnLastLine = returnLastLine;
-		return this;
-	}
-
-	/**
 	 * Timeout for this endpoint for each read, before considering the result to be <code>null</code>. The default is 500ms.
-	 *
-	 * @param readTimeoutMillis
-	 * @return
 	 */
 	public TcpConnectionEndPoint setReadTimeoutMillis(final int readTimeoutMillis)
 	{

--- a/backend/de.metas.device.scales/src/main/java/de/metas/device/scales/endpoint/TcpConnectionReadLineEndPoint.java
+++ b/backend/de.metas.device.scales/src/main/java/de/metas/device/scales/endpoint/TcpConnectionReadLineEndPoint.java
@@ -1,0 +1,109 @@
+/*
+ * #%L
+ * de.metas.device.scales
+ * %%
+ * Copyright (C) 2022 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.device.scales.endpoint;
+
+import de.metas.device.scales.impl.ICmd;
+import de.metas.logging.LogManager;
+import lombok.NonNull;
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.SocketTimeoutException;
+
+/**
+ * Like its superclass, but
+ * assumes that each response from the external device will be terminated with a line-terminator like {@code \r}, {@code \r\n} or similar.
+ * Allows to be configured to use either use the first or last of those lines.
+ * Required for some scales that first send not-so-interesting stuff before getting to the point.
+ */
+public class TcpConnectionReadLineEndPoint extends TcpConnectionEndPoint
+{
+
+	private final static transient Logger logger = LogManager.getLogger(TcpConnectionReadLineEndPoint.class);
+
+	/**
+	 * see {@link #setReturnLastLine(boolean)}.
+	 */
+	private boolean returnLastLine = false;
+	
+	/**
+	 * If <code>false</code>, then the endpoint will return the first line coming out of the socket.
+	 * If <code>true</code>, if will discard all lines until there is nothing more coming out of the socket, and then return the last line if got.
+	 */
+	public TcpConnectionEndPoint setReturnLastLine(final boolean returnLastLine)
+	{
+		this.returnLastLine = returnLastLine;
+		return this;
+	}
+
+	 @Override
+	String readSocketResponse(@NonNull final InputStream in) throws IOException
+	{
+		return readLineSocketResponse(in);
+	}
+	
+	@Nullable
+	private String readLineSocketResponse(@NonNull final InputStream in) throws IOException
+	{
+		try (final BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(in, ICmd.DEFAULT_CMD_CHARSET)))
+		{
+			String result = null;
+			String lastReadLine = bufferedReader.readLine();
+			if (returnLastLine)
+			{
+				while (lastReadLine != null)
+				{
+					result = lastReadLine;
+					lastReadLine = readLineWithTimeout(bufferedReader);
+				}
+				logger.debug("Result (last line) as read from the socket: {}", result);
+			}
+			else
+			{
+				result = lastReadLine;
+				logger.debug("Result (first line) as read from the socket: {}", result);
+			}
+			return result;
+		}
+	}
+
+	@Nullable
+	private String readLineWithTimeout(@NonNull final BufferedReader in) throws IOException
+	{
+		try
+		{
+			final String lastReadLine = in.readLine();
+			logger.debug("Read line from the socket: {}", lastReadLine);
+			return lastReadLine;
+		}
+		catch (final SocketTimeoutException e)
+		{
+			logger.debug("Socket timeout; return null; exception-message={}", e.getMessage());
+			return null;
+		}
+	}
+}

--- a/backend/de.metas.device.scales/src/main/java/de/metas/device/scales/impl/ConfigureDeviceHandler.java
+++ b/backend/de.metas.device.scales/src/main/java/de/metas/device/scales/impl/ConfigureDeviceHandler.java
@@ -1,33 +1,6 @@
 package de.metas.device.scales.impl;
 
-import java.util.Map;
-
-import org.apache.commons.lang3.BooleanUtils;
-
 import com.google.common.base.MoreObjects;
-
-/*
- * #%L
- * de.metas.device.scales
- * %%
- * Copyright (C) 2015 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
-
 import de.metas.device.api.DeviceException;
 import de.metas.device.api.IDeviceRequestHandler;
 import de.metas.device.api.IDeviceResponse;
@@ -35,6 +8,11 @@ import de.metas.device.api.request.DeviceRequestConfigureDevice;
 import de.metas.device.api.request.IDeviceConfigParam;
 import de.metas.device.scales.AbstractTcpScales;
 import de.metas.device.scales.endpoint.TcpConnectionEndPoint;
+import de.metas.device.scales.endpoint.TcpConnectionReadLineEndPoint;
+import lombok.NonNull;
+import org.apache.commons.lang3.BooleanUtils;
+
+import java.util.Map;
 
 public class ConfigureDeviceHandler implements IDeviceRequestHandler<DeviceRequestConfigureDevice, IDeviceResponse>
 {
@@ -46,7 +24,7 @@ public class ConfigureDeviceHandler implements IDeviceRequestHandler<DeviceReque
 	}
 
 	@Override
-	public IDeviceResponse handleRequest(final DeviceRequestConfigureDevice request)
+	public IDeviceResponse handleRequest(@NonNull final DeviceRequestConfigureDevice request)
 	{
 		final Map<String, IDeviceConfigParam> parameters = request.getParameters();
 
@@ -66,22 +44,25 @@ public class ConfigureDeviceHandler implements IDeviceRequestHandler<DeviceReque
 			final Class<TcpConnectionEndPoint> c = (Class<TcpConnectionEndPoint>)Class.forName(epClass.getValue());
 			ep = c.newInstance();
 		}
-		catch (ClassNotFoundException e)
+		catch (final ClassNotFoundException e)
 		{
 			throw new DeviceException("Caught a ClassNotFoundException: " + e.getLocalizedMessage(), e);
 		}
-		catch (InstantiationException e)
+		catch (final InstantiationException e)
 		{
 			throw new DeviceException("Caught an InstantiationException: " + e.getLocalizedMessage(), e);
 		}
-		catch (IllegalAccessException e)
+		catch (final IllegalAccessException e)
 		{
 			throw new DeviceException("Caught an IllegalAccessException: " + e.getLocalizedMessage(), e);
 		}
 
 		ep.setHost(epHost.getValue());
 		ep.setPort(Integer.parseInt(epPort.getValue()));
-		ep.setReturnLastLine(BooleanUtils.toBoolean(epReturnLastLine.getValue()));
+		if (ep instanceof TcpConnectionReadLineEndPoint)
+		{
+			((TcpConnectionReadLineEndPoint)ep).setReturnLastLine(BooleanUtils.toBoolean(epReturnLastLine.getValue()));
+		}
 		ep.setReadTimeoutMillis(Integer.parseInt(epReadTimeoutMillis.getValue()));
 
 		device.setEndPoint(ep);

--- a/backend/de.metas.device.scales/src/test/java/de/metas/device/scales/endpoint/TcpConnectionReadLineEndPointTest.java
+++ b/backend/de.metas.device.scales/src/test/java/de/metas/device/scales/endpoint/TcpConnectionReadLineEndPointTest.java
@@ -46,12 +46,12 @@ import static org.junit.Assert.fail;
  */
 
 /** Deactivating it because it's too unstable when run ion jenkins; TODO rewrite or incorporate into e2e. */
-public class TcpConnectionEndPointTest
+public class TcpConnectionReadLineEndPointTest
 {
 	private static volatile int weight = 100;
 	private volatile boolean exitServerSocketThread = false;
 
-	private static TcpConnectionEndPoint tcpConnectionEndPoint;
+	private static TcpConnectionReadLineEndPoint tcpConnectionEndPoint;
 
 	private static List<String> serverSocketReceived = new ArrayList<>();
 
@@ -62,7 +62,7 @@ public class TcpConnectionEndPointTest
 	@BeforeClass
 	public static void setupEP()
 	{
-		tcpConnectionEndPoint = new TcpConnectionEndPoint();
+		tcpConnectionEndPoint = new TcpConnectionReadLineEndPoint();
 		tcpConnectionEndPoint.setHost("localhost");
 		tcpConnectionEndPoint.setReturnLastLine(true);
 
@@ -72,8 +72,6 @@ public class TcpConnectionEndPointTest
 	/**
 	 * Create a server socket to emulate the scale.
 	 * It picks a port each time it is run, in order to prevent issued with ports that are already in use.
-	 *
-	 * @throws InterruptedException
 	 */
 	@Before
 	public void setUpServer() throws InterruptedException
@@ -86,7 +84,7 @@ public class TcpConnectionEndPointTest
 			@Override
 			public void run()
 			{
-				try (ServerSocket myServer = new ServerSocket(0))
+				try (final ServerSocket myServer = new ServerSocket(0))
 				{
 					final int port = myServer.getLocalPort();
 					System.out.println("TcpConnectionEndPointTest" + ": server socked listening on port " + port);
@@ -190,8 +188,6 @@ public class TcpConnectionEndPointTest
 
 	/**
 	 * Makes sure that the server socked thread has finished.
-	 *
-	 * @throws InterruptedException
 	 */
 	@After
 	public void tearDown() throws InterruptedException


### PR DESCRIPTION
- change the default behavior of TcpConnectionEndPoint to **not** wait for an EOL when reading the device's response.
- add a subclass that implements the old behavior

(TODO: add migration-script so that exising scales work with the newly added  behavior-preserving endpoint)