### PR TITLE
M_Product_Trl: mark M_Product_ID and AD_Language as not lazy loading

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5668390_M_Product_Trl_fix_key_columns.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5668390_M_Product_Trl_fix_key_columns.sql
@@ -1,0 +1,10 @@
+-- 2022-12-13T08:49:36.681Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsLazyLoading='N', IsUpdateable='N',Updated=TO_TIMESTAMP('2022-12-13 10:49:36','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=3321
+;
+
+-- 2022-12-13T08:50:09.524Z
+-- I forgot to set the DICTIONARY_ID_COMMENTS System Configurator
+UPDATE AD_Column SET IsLazyLoading='N', IsUpdateable='N',Updated=TO_TIMESTAMP('2022-12-13 10:50:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=3322
+;
+


### PR DESCRIPTION
**IMPORANT** this PR is fixing only the data (application dictionary).

The code is fixed by
* https://github.com/metasfresh/metasfresh/pull/14134