### PR TITLE
hotfix get/create C_Doc_Outbound_Log

### DIFF
--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/api/IDocOutboundDAO.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/api/IDocOutboundDAO.java
@@ -27,7 +27,6 @@ import de.metas.document.archive.model.I_C_Doc_Outbound_Log;
 import de.metas.document.archive.model.I_C_Doc_Outbound_Log_Line;
 import de.metas.util.ISingletonService;
 import org.adempiere.ad.dao.IQueryBuilder;
-import org.adempiere.archive.ArchiveId;
 import org.adempiere.util.lang.IContextAware;
 import org.adempiere.util.lang.impl.TableRecordReference;
 
@@ -57,13 +56,6 @@ public interface IDocOutboundDAO extends ISingletonService
 	I_C_Doc_Outbound_Config retrieveConfigForModel(Object model);
 
 	I_C_Doc_Outbound_Config getConfigById(int docOutboundConfigId);
-
-	/**
-	 * Retrieve {@link I_C_Doc_Outbound_Log} for give archive (AD_Table_ID and Record_ID fields will be used for matching)
-	 *
-	 * @return {@link I_C_Doc_Outbound_Log} record or null if not found
-	 */
-	I_C_Doc_Outbound_Log retrieveLog(ArchiveId archiveId);
 
 	I_C_Doc_Outbound_Log retrieveLog(TableRecordReference tableRecordReference);
 

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/api/impl/DocOutboundDAO.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/api/impl/DocOutboundDAO.java
@@ -36,7 +36,6 @@ import org.adempiere.ad.dao.IQueryOrderBy;
 import org.adempiere.ad.dao.IQueryOrderBy.Direction;
 import org.adempiere.ad.dao.IQueryOrderBy.Nulls;
 import org.adempiere.ad.dao.impl.CompareQueryFilter.Operator;
-import org.adempiere.archive.ArchiveId;
 import org.adempiere.archive.api.ArchiveAction;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -182,12 +181,6 @@ public class DocOutboundDAO implements IDocOutboundDAO
 	}
 
 	@Override
-	public final I_C_Doc_Outbound_Log retrieveLog(@NonNull final ArchiveId archiveId)
-	{
-		return retrieveLog(TableRecordReference.of(I_AD_Archive.Table_Name, archiveId));
-	}
-
-	@Override
 	public I_C_Doc_Outbound_Log retrieveLog(@NonNull final TableRecordReference tableRecordReference)
 	{
 		return Services.get(IQueryBL.class)
@@ -197,6 +190,11 @@ public class DocOutboundDAO implements IDocOutboundDAO
 				.addEqualsFilter(I_C_Doc_Outbound_Log.COLUMN_Record_ID, tableRecordReference.getRecord_ID())
 				.create()
 				.firstOnly(I_C_Doc_Outbound_Log.class);
+	}
+
+	public static TableRecordReference extractRecordRef(@NonNull final I_AD_Archive archive)
+	{
+		return TableRecordReference.of(archive.getAD_Table_ID(), archive.getRecord_ID());
 	}
 
 	@Override

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/spi/impl/DocOutboundArchiveEventListener.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/spi/impl/DocOutboundArchiveEventListener.java
@@ -12,6 +12,7 @@ import de.metas.common.util.time.SystemTime;
 import de.metas.document.DocTypeId;
 import de.metas.document.archive.DocOutboundUtils;
 import de.metas.document.archive.api.IDocOutboundDAO;
+import de.metas.document.archive.api.impl.DocOutboundDAO;
 import de.metas.document.archive.mailrecipient.DocOutBoundRecipient;
 import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRegistry;
 import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRequest;
@@ -28,7 +29,6 @@ import de.metas.user.UserId;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
-import org.adempiere.archive.ArchiveId;
 import org.adempiere.archive.api.ArchiveAction;
 import org.adempiere.archive.api.ArchiveEmailSentStatus;
 import org.adempiere.archive.api.ArchivePrintOutStatus;
@@ -177,8 +177,8 @@ public class DocOutboundArchiveEventListener implements IArchiveEventListener
 	@VisibleForTesting
 	I_C_Doc_Outbound_Log_Line createLogLine(@NonNull final I_AD_Archive archive)
 	{
-		final ArchiveId archiveId = ArchiveId.ofRepoId(archive.getAD_Archive_ID());
-		I_C_Doc_Outbound_Log docOutboundLogRecord = Services.get(IDocOutboundDAO.class).retrieveLog(archiveId);
+		final IDocOutboundDAO docOutboundDAO = Services.get(IDocOutboundDAO.class);
+		I_C_Doc_Outbound_Log docOutboundLogRecord = docOutboundDAO.retrieveLog(DocOutboundDAO.extractRecordRef(archive));
 
 		if (docOutboundLogRecord == null)
 		{
@@ -213,8 +213,7 @@ public class DocOutboundArchiveEventListener implements IArchiveEventListener
 		// Services
 		final IDocumentBL docActionBL = Services.get(IDocumentBL.class);
 
-		final TableRecordReference reference = TableRecordReference.ofReferenced(archiveRecord);
-
+		final TableRecordReference reference = DocOutboundDAO.extractRecordRef(archiveRecord);
 		final int adTableId = reference.getAD_Table_ID();
 		final int recordId = reference.getRecord_ID();
 

--- a/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/printingdata/PrintingDataFactory.java
+++ b/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/printingdata/PrintingDataFactory.java
@@ -23,11 +23,11 @@
 package de.metas.printing.printingdata;
 
 import com.google.common.collect.ImmutableList;
-import de.metas.adempiere.model.X_AD_PrinterRouting;
 import de.metas.adempiere.service.IPrinterRoutingDAO;
 import de.metas.adempiere.service.PrinterRoutingsQuery;
 import de.metas.document.archive.api.ArchiveFileNameService;
 import de.metas.document.archive.api.IDocOutboundDAO;
+import de.metas.document.archive.api.impl.DocOutboundDAO;
 import de.metas.document.archive.model.I_C_Doc_Outbound_Log;
 import de.metas.logging.LogManager;
 import de.metas.organization.OrgId;
@@ -48,12 +48,12 @@ import de.metas.printing.model.I_AD_Printer_Matching;
 import de.metas.printing.model.I_C_Print_Job_Detail;
 import de.metas.printing.model.I_C_Print_Job_Line;
 import de.metas.printing.model.I_C_Printing_Queue;
-import de.metas.printing.model.I_C_Printing_Queue_Recipient;
 import de.metas.user.UserId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.archive.ArchiveId;
 import org.adempiere.archive.api.IArchiveBL;
+import org.adempiere.archive.api.IArchiveDAO;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_AD_Archive;
 import org.compiere.util.Env;
@@ -91,9 +91,11 @@ public class PrintingDataFactory
 
 	public ImmutableList<PrintingData> createPrintingDataForQueueItem(@NonNull final I_C_Printing_Queue queueItem)
 	{
+		final IArchiveDAO archiveDAO = Services.get(IArchiveDAO.class);
+
 		final ArchiveId archiveId = ArchiveId.ofRepoId(queueItem.getAD_Archive_ID());
-		final I_C_Doc_Outbound_Log outboundLogRecord = outboundDAO.retrieveLog(archiveId);
-		final I_AD_Archive archiveRecord = queueItem.getAD_Archive();
+		final I_AD_Archive archiveRecord = archiveDAO.getArchiveRecordById(archiveId);
+		final I_C_Doc_Outbound_Log outboundLogRecord = outboundDAO.retrieveLog(DocOutboundDAO.extractRecordRef(archiveRecord));
 
 		final String pdfFileName;
 		if (outboundLogRecord != null)


### PR DESCRIPTION
# Issue
Before this fix the C_Doc_Outbound_Log was searched by AD_Table_ID=AD_Archive, Record_ID=AD_Archive_ID,
and when was created it was using the AD_Archive.AD_Table_ID and Record_ID.

That was causing errors like
```
org.adempiere.exceptions.DBUniqueConstraintException: ERROR: duplicate key value violates unique constraint "c_doc_outbound_log_uc"
  Detail: Key (record_id, ad_table_id)=(1007017, 540516) already exists.
	SQL: INSERT INTO C_Doc_Outbound_Log (AD_Client_ID,AD_Org_ID,AD_Table_ID,C_Doc_Outbound_Log_ID,Created,CreatedBy,DateDoc,FileName,IsActive,IsInvoiceEmailEnabled,Record_ID,Updated,UpdatedBy) VALUES (1000000,1000000,540516,nextval('c_doc_outbound_log_seq'),TO_TIMESTAMP('2022-12-13 19:16:04','YYYY-MM-DD HH24:MI:SS'),540116,TO_TIMESTAMP('2022-12-13','YYYY-MM-DD'),'Finishedproduct Label','Y','N',1007017,TO_TIMESTAMP('2022-12-13 19:16:04','YYYY-MM-DD HH24:MI:SS'),540116) RETURNING C_Doc_Outbound_Log_ID
	at org.compiere.util.DB.executeUpdate(DB.java:847)
	at org.compiere.model.PO.saveNew(PO.java:3829)
	at org.compiere.model.PO.save0(PO.java:2984)
	at org.compiere.model.PO.access$100(PO.java:149)
	at org.compiere.model.PO$1.run(PO.java:2887)
	at org.adempiere.ad.trx.api.impl.TrxCallableWrappers$3.call(TrxCallableWrappers.java:147)
	at org.adempiere.ad.trx.api.impl.TrxCallableWrappers$3.call(TrxCallableWrappers.java:137)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.call0(AbstractTrxManager.java:750)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.call(AbstractTrxManager.java:663)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.call(AbstractTrxManager.java:564)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.call(AbstractTrxManager.java:495)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.run(AbstractTrxManager.java:481)
	at org.compiere.model.PO.saveEx(PO.java:2881)
	at org.adempiere.model.POWrapper.save(POWrapper.java:791)
	at org.adempiere.model.InterfaceWrapperHelper.save(InterfaceWrapperHelper.java:591)
	at de.metas.document.archive.spi.impl.DocOutboundArchiveEventListener.createLog(DocOutboundArchiveEventListener.java:250)
	at de.metas.document.archive.spi.impl.DocOutboundArchiveEventListener.createLogLine(DocOutboundArchiveEventListener.java:186)
	at de.metas.document.archive.spi.impl.DocOutboundArchiveEventListener.onPrintOut(DocOutboundArchiveEventListener.java:146)
	at org.adempiere.archive.api.impl.ArchiveEventManager.firePrintOut(ArchiveEventManager.java:109)
	at de.metas.printing.PrintOutputFacade.storePDFAndFireEvent(PrintOutputFacade.java:125)
	at de.metas.printing.PrintOutputFacade.print(PrintOutputFacade.java:91)
	at de.metas.printing.PrintOutputFacade.print(PrintOutputFacade.java:66)
	at de.metas.printing.api.impl.PrintingQueueBL.forwardToJob(PrintingQueueBL.java:227)
	at de.metas.printing.api.impl.PrintingQueueBL.printArchive(PrintingQueueBL.java:214)
```

# Solution

Search and create C_Doc_Outbound_Log using AD_Archive.AD_Table_ID and Record_ID.