### PR TITLE
Invalidate documents even if their window is not in menu

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5682130_AD_Window_ParentChildTableNames_v1.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5682130_AD_Window_ParentChildTableNames_v1.sql
@@ -67,7 +67,7 @@ FROM (SELECT w.AD_Window_ID
 ;
 
 /*
-select * from AD_Window_ParentChildTableNames_v1 
+select * from AD_Window_ParentChildTableNames_v1
 where true
 order by parentTableName, AD_Window_ID, childTableName;
 */


### PR DESCRIPTION
NOTE: in this commit, i just commented out the line about "AND EXISTS (... in menu)" and I've also formatted the code

Impact on data: instead of 1075 records in the view, now we have 1192... so, not much.