### PR TITLE
removed dos2unix to rule out potential cause for jenkins build fail

### DIFF
--- a/misc/services/camel/de-metas-camel-edi/Dockerfile
+++ b/misc/services/camel/de-metas-camel-edi/Dockerfile
@@ -6,7 +6,7 @@ FROM openjdk:17-jdk-alpine
 # thx to https://github.com/moby/moby/issues/1996#issuecomment-185872769
 ARG CACHEBUST=1
 
-RUN apk update && apk upgrade && apk add bash && apk add curl && apk add dos2unix --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ --allow-untrusted
+RUN apk update && apk upgrade && apk add bash && apk add curl --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ --allow-untrusted
 
 COPY ./target/de-metas-camel-edi-exec.jar /opt/metasfresh-esb-camel/
 COPY ./start_esb-camel_docker.sh /opt/metasfresh-esb-camel/
@@ -14,8 +14,6 @@ COPY ./start_esb-camel_docker.sh /opt/metasfresh-esb-camel/
 # get the APM agent binary
 # the preceeding COPY created the target folder on-the-fly
 RUN curl -s -o /opt/metasfresh-esb-camel/elastic-apm-agent.jar https://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/1.17.0/elastic-apm-agent-1.17.0.jar
-
-RUN dos2unix /opt/metasfresh-esb-camel/start_esb-camel_docker.sh
 
 RUN chmod 700 /opt/metasfresh-esb-camel/start_esb-camel_docker.sh
 RUN sh -c 'touch /opt/metasfresh-esb-camel/de-metas-edi-esb-camel.jar'


### PR DESCRIPTION
https://github.com/metasfresh/metasfresh/issues/15119

Jenkins build without dos2unix command succeeded: https://jenkins.metasfresh.com/job/metasfresh/job/master_gh15119/2/