### PR TITLE
remove hazelcast dependency from the shopware6 code

### DIFF
--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-shopware6/pom.xml
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-shopware6/pom.xml
@@ -91,6 +91,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-jcache-starter</artifactId>
+            <version>${camel.version}</version>
+        </dependency>
 
         <!-- unit test -->
         <dependency>
@@ -145,27 +150,14 @@
         </dependency>
 
         <dependency>
+             <groupId>org.apache.geronimo</groupId>
+            <artifactId>geronimo-jcache-simple</artifactId>
+            <version>1.0.5</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jackson</artifactId>
-        </dependency>
-
-
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-jcache</artifactId>
-            <version>${camel.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.cache</groupId>
-            <artifactId>cache-api</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast</artifactId>
-            <version>3.9-EA</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- version 3.9-EA is outdated
- we don't need distributed data-structures because we use just one camel container
- instead add geronimo-jcache-simple

(cherry picked from commit 09b0d0e6d91f2622e589855fc8d8571a95aa01c8)