### PR TITLE
Update affected M_ShipmentSchedules after stock change (#15461)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Order_StepDef.java
@@ -90,7 +90,7 @@ import static de.metas.cucumber.stepdefs.StepDefConstants.TABLECOLUMN_IDENTIFIER
 import static org.adempiere.model.InterfaceWrapperHelper.load;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.compiere.model.I_C_DocType.COLUMNNAME_DocBaseType;
 import static org.compiere.model.I_C_DocType.COLUMNNAME_DocSubType;
 import static org.compiere.model.I_C_Order.COLUMNNAME_AD_Org_ID;
@@ -217,6 +217,7 @@ public class C_Order_StepDef
 			final String deliveryRule = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_C_Order.COLUMNNAME_DeliveryRule);
 			if (Check.isNotBlank(deliveryRule))
 			{
+				// note that IF the C_BPartner has a deliveryRule set (not-mandatory there), this values will be overwritten by it
 				order.setDeliveryRule(deliveryRule);
 			}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -83,6 +83,7 @@ import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.mm.attributes.api.AttributesKeys;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.assertj.core.api.SoftAssertions;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.IQuery;
 import org.compiere.model.I_AD_User;
@@ -333,15 +334,6 @@ public class M_ShipmentSchedule_StepDef
 			final Supplier<Boolean> shipmentScheduleWasRecomputed = () -> !shipmentScheduleInvalidateRepository.isFlaggedForRecompute(ShipmentScheduleId.ofRepoId(shipmentScheduleRecord.getM_ShipmentSchedule_ID()));
 
 			StepDefUtil.tryAndWait(timeoutSec, 500, shipmentScheduleWasRecomputed);
-		}
-	}
-
-	@And("validate M_ShipmentSchedule:")
-	public void validate_M_ShipmentSchedule(@NonNull final DataTable dataTable)
-	{
-		for (final Map<String, String> row : dataTable.asMaps())
-		{
-			validateSchedule(row);
 		}
 	}
 
@@ -620,50 +612,183 @@ public class M_ShipmentSchedule_StepDef
 
 	private void validateShipmentSchedule(final int timeoutSec, @NonNull final Map<String, String> tableRow) throws InterruptedException
 	{
-		final BigDecimal qtyOrdered = DataTableUtil.extractBigDecimalForColumnName(tableRow, I_M_ShipmentSchedule.COLUMNNAME_QtyOrdered);
-		final BigDecimal qtyToDeliver = DataTableUtil.extractBigDecimalForColumnName(tableRow, I_M_ShipmentSchedule.COLUMNNAME_QtyToDeliver);
-		final BigDecimal qtyToDeliverOverride = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, I_M_ShipmentSchedule.COLUMNNAME_QtyToDeliver_Override);
+		final BigDecimal qtyOrdered = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_QtyOrdered);
+		final BigDecimal qtyToDeliver = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_QtyToDeliver);
+		final BigDecimal qtyToDeliverOverride = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_QtyToDeliver_Override);
 		final BigDecimal qtyPicked = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_QtyPickList);
-		final BigDecimal qtyDelivered = DataTableUtil.extractBigDecimalForColumnName(tableRow, I_M_ShipmentSchedule.COLUMNNAME_QtyDelivered);
-		final boolean isProcessed = DataTableUtil.extractBooleanForColumnName(tableRow, I_M_ShipmentSchedule.COLUMNNAME_Processed);
+		final BigDecimal qtyDelivered = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_QtyDelivered);
+		final BigDecimal qtyOnHand = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_QtyOnHand);
+		final Boolean isProcessed = DataTableUtil.extractBooleanForColumnNameOr(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_Processed, null);
 
 		final String shipmentScheduleIdentifier = DataTableUtil.extractStringForColumnName(tableRow, I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID + ".Identifier");
 		final I_M_ShipmentSchedule shipmentSchedule = shipmentScheduleTable.get(shipmentScheduleIdentifier);
 
-		final Supplier<Boolean> isShipmentScheduleFound = () -> queryBL
-				.createQueryBuilder(I_M_ShipmentSchedule.class)
-				.addOnlyActiveRecordsFilter()
-				.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID, shipmentSchedule.getM_ShipmentSchedule_ID())
-				.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_QtyToDeliver, qtyToDeliver)
-				.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_QtyToDeliver_Override, qtyToDeliverOverride)
-				.create()
-				.firstOnlyOptional(I_M_ShipmentSchedule.class)
-				.isPresent();
+		final Supplier<Boolean> isShipmentScheduleFound = () -> {
+			final IQueryBuilder<I_M_ShipmentSchedule> queryBuilder = queryBL
+					.createQueryBuilder(I_M_ShipmentSchedule.class)
+					.addOnlyActiveRecordsFilter()
+					.addEqualsFilter(COLUMNNAME_M_ShipmentSchedule_ID, shipmentSchedule.getM_ShipmentSchedule_ID());
+			if (qtyToDeliver != null)
+			{
+				queryBuilder.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_QtyToDeliver, qtyToDeliver);
+			}
+			if (qtyToDeliverOverride != null)
+			{
+				queryBuilder.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_QtyToDeliver_Override, qtyToDeliverOverride);
+			}
+			return queryBuilder
+					.create()
+					.firstOnlyOptional(I_M_ShipmentSchedule.class)
+					.isPresent();
+		};
 
 		StepDefUtil.tryAndWait(timeoutSec, 500, isShipmentScheduleFound);
 
 		InterfaceWrapperHelper.refresh(shipmentSchedule);
-
+		final SoftAssertions softly = new SoftAssertions();
 		if (qtyToDeliverOverride != null)
 		{
-			assertThat(shipmentSchedule.getQtyToDeliver_Override().stripTrailingZeros()).isEqualTo(qtyToDeliverOverride.stripTrailingZeros());
+			softly.assertThat(shipmentSchedule.getQtyToDeliver_Override().stripTrailingZeros()).as("QtyToDeliver_Override for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(qtyToDeliverOverride.stripTrailingZeros());
 		}
 
 		if (qtyPicked != null)
 		{
-			assertThat(shipmentSchedule.getQtyPickList().stripTrailingZeros()).isEqualTo(qtyPicked.stripTrailingZeros());
+			softly.assertThat(shipmentSchedule.getQtyPickList().stripTrailingZeros()).as("QtyPickList for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(qtyPicked.stripTrailingZeros());
 		}
 
-		assertThat(shipmentSchedule.getQtyToDeliver().stripTrailingZeros()).isEqualTo(qtyToDeliver.stripTrailingZeros());
-		assertThat(shipmentSchedule.getQtyOrdered().stripTrailingZeros()).isEqualTo(qtyOrdered.stripTrailingZeros());
-		assertThat(shipmentSchedule.getQtyDelivered().stripTrailingZeros()).isEqualTo(qtyDelivered.stripTrailingZeros());
-		assertThat(shipmentSchedule.isProcessed()).isEqualTo(isProcessed);
+		if (qtyToDeliver != null)
+		{
+			softly.assertThat(shipmentSchedule.getQtyToDeliver().stripTrailingZeros()).as("QtyToDeliver for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(qtyToDeliver.stripTrailingZeros());
+		}
+
+		if (qtyOrdered != null)
+		{
+			softly.assertThat(shipmentSchedule.getQtyOrdered().stripTrailingZeros()).as("QtyOrdered for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(qtyOrdered.stripTrailingZeros());
+		}
+
+		if (qtyDelivered != null)
+		{
+			softly.assertThat(shipmentSchedule.getQtyDelivered().stripTrailingZeros()).as("QtyDelivered for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(qtyDelivered.stripTrailingZeros());
+		}
+
+		if (isProcessed != null)
+		{
+			softly.assertThat(shipmentSchedule.isProcessed()).as("Processed for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(isProcessed);
+		}
 
 		final BigDecimal qtyOrderedTU = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_QtyOrdered_TU);
 		if (qtyOrderedTU != null)
 		{
-			assertThat(shipmentSchedule.getQtyOrdered_TU()).isEqualTo(qtyOrderedTU);
+			softly.assertThat(shipmentSchedule.getQtyOrdered_TU()).as("QtyOrdered_TU for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(qtyOrderedTU);
 		}
+
+		if (qtyOnHand != null)
+		{
+			softly.assertThat(shipmentSchedule.getQtyOnHand()).as("QtyOnHand for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(qtyOnHand);
+		}
+
+		final String bpartnerIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_C_BPartner_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (Check.isNotBlank(bpartnerIdentifier))
+		{
+			final I_C_BPartner bPartner = bpartnerTable.get(bpartnerIdentifier);
+			softly.assertThat(shipmentSchedule.getC_BPartner_ID()).as("C_BPartner_ID for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(bPartner.getC_BPartner_ID());
+		}
+
+		final String bpLocationIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_C_BPartner_Location_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (Check.isNotBlank(bpLocationIdentifier))
+		{
+			final I_C_BPartner_Location bpLocation = bpartnerLocationTable.get(bpLocationIdentifier);
+			softly.assertThat(shipmentSchedule.getC_BPartner_Location_ID()).as("C_BPartner_Location_ID for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(bpLocation.getC_BPartner_Location_ID());
+		}
+
+		final String billBPIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_Bill_BPartner_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (Check.isNotBlank(billBPIdentifier))
+		{
+			final I_C_BPartner billBP = bpartnerTable.get(billBPIdentifier);
+			softly.assertThat(shipmentSchedule.getBill_BPartner_ID()).as("Bill_BPartner_ID for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(billBP.getC_BPartner_ID());
+		}
+
+		final String billBPLocationIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_Bill_Location_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (Check.isNotBlank(billBPLocationIdentifier))
+		{
+			final I_C_BPartner_Location billBPLocation = bpartnerLocationTable.get(billBPLocationIdentifier);
+			softly.assertThat(shipmentSchedule.getBill_Location_ID()).as("Bill_Location_ID for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(billBPLocation.getC_BPartner_Location_ID());
+		}
+
+		final String productIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_M_Product_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (Check.isNotBlank(productIdentifier))
+		{
+			final I_M_Product product = productTable.get(productIdentifier);
+			softly.assertThat(shipmentSchedule.getM_Product_ID()).as("M_Product_ID for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(product.getM_Product_ID());
+		}
+
+		final String exportStatus = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_ExportStatus);
+		if (Check.isNotBlank(exportStatus))
+		{
+			softly.assertThat(shipmentSchedule.getExportStatus()).as("ExportStatus for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(exportStatus);
+		}
+		final String orderIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_C_Order_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (Check.isNotBlank(orderIdentifier))
+		{
+			final I_C_Order order = orderTable.get(orderIdentifier);
+			softly.assertThat(shipmentSchedule.getC_Order_ID()).as("C_Order_ID for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(order.getC_Order_ID());
+		}
+
+		final String orderLineIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_C_OrderLine_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (Check.isNotBlank(orderLineIdentifier))
+		{
+			final I_C_OrderLine orderLine = orderLineTable.get(orderLineIdentifier);
+			softly.assertThat(shipmentSchedule.getC_OrderLine_ID()).as("C_OrderLine_ID for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(orderLine.getC_OrderLine_ID());
+		}
+
+		final String userIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_AD_User_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (Check.isNotBlank(userIdentifier))
+		{
+			final I_AD_User user = userTable.get(userIdentifier);
+			softly.assertThat(shipmentSchedule.getAD_User_ID()).as("AD_User_ID for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(user.getAD_User_ID());
+		}
+
+		final String billUserIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_Bill_User_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (Check.isNotBlank(billUserIdentifier))
+		{
+			final I_AD_User billUser = userTable.get(billUserIdentifier);
+			softly.assertThat(shipmentSchedule.getBill_User_ID()).as("Bill_User_ID for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(billUser.getAD_User_ID());
+		}
+
+		final String shipperIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_M_Shipper_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (Check.isNotBlank(shipperIdentifier))
+		{
+			final I_M_Shipper shipper = shipperTable.get(shipperIdentifier);
+			softly.assertThat(shipmentSchedule.getM_Shipper_ID()).as("M_Shipper_ID for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(shipper.getM_Shipper_ID());
+		}
+
+		final String attributeSetInstanceIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + COLUMNNAME_M_AttributeSetInstance_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (Check.isNotBlank(attributeSetInstanceIdentifier))
+		{
+			final I_M_AttributeSetInstance expectedASI = attributeSetInstanceTable.get(attributeSetInstanceIdentifier);
+
+			final AttributesKey actualAttributesKeys = AttributesKeys.createAttributesKeyFromASIStorageAttributes(AttributeSetInstanceId.ofRepoId(shipmentSchedule.getM_AttributeSetInstance_ID()))
+					.orElse(AttributesKey.NONE);
+			final AttributesKey expectedAttributesKeys = AttributesKeys.createAttributesKeyFromASIStorageAttributes(AttributeSetInstanceId.ofRepoId(expectedASI.getM_AttributeSetInstance_ID()))
+					.orElse(AttributesKey.NONE);
+
+			softly.assertThat(actualAttributesKeys).as("AttributesKeys for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(expectedAttributesKeys);
+		}
+
+		final String internalName = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_AD_InputDataSource_ID + "." + I_AD_InputDataSource.COLUMNNAME_InternalName);
+		if (Check.isNotBlank(internalName))
+		{
+			final I_AD_InputDataSource dataSource = inputDataSourceDAO.retrieveInputDataSource(Env.getCtx(), internalName, true, Trx.TRXNAME_None);
+			softly.assertThat(shipmentSchedule.getAD_InputDataSource_ID()).as("AD_InputDataSource_ID for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(dataSource.getAD_InputDataSource_ID());
+		}
+
+		final String deliveryRule = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_DeliveryRule);
+		if (Check.isNotBlank(deliveryRule))
+		{
+			softly.assertThat(shipmentSchedule.getDeliveryRule()).as("DeliveryRule for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(deliveryRule);
+		}
+
+		softly.assertAll();
 	}
 
 	@Value
@@ -733,92 +858,6 @@ public class M_ShipmentSchedule_StepDef
 				return flaggedForRecompute == isToRecompute ? shipmentScheduleRecord : null;
 			}
 			return shipmentScheduleRecord;
-		}
-	}
-
-	private void validateSchedule(@NonNull final Map<String, String> row)
-	{
-		final String scheduleIdentifier = DataTableUtil.extractStringForColumnName(row, COLUMNNAME_M_ShipmentSchedule_ID + "." + TABLECOLUMN_IDENTIFIER);
-		final I_M_ShipmentSchedule schedule = shipmentScheduleTable.get(scheduleIdentifier);
-		InterfaceWrapperHelper.refresh(schedule);
-		assertThat(schedule).isNotNull();
-
-		final String bpartnerIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_ShipmentSchedule.COLUMNNAME_C_BPartner_ID + "." + TABLECOLUMN_IDENTIFIER);
-		final I_C_BPartner bPartner = bpartnerTable.get(bpartnerIdentifier);
-		assertThat(schedule.getC_BPartner_ID()).isEqualTo(bPartner.getC_BPartner_ID());
-
-		final String bpLocationIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_ShipmentSchedule.COLUMNNAME_C_BPartner_Location_ID + "." + TABLECOLUMN_IDENTIFIER);
-		final I_C_BPartner_Location bpLocation = bpartnerLocationTable.get(bpLocationIdentifier);
-		assertThat(schedule.getC_BPartner_Location_ID()).isEqualTo(bpLocation.getC_BPartner_Location_ID());
-
-		final String billBPIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_ShipmentSchedule.COLUMNNAME_Bill_BPartner_ID + "." + TABLECOLUMN_IDENTIFIER);
-		final I_C_BPartner billBP = bpartnerTable.get(billBPIdentifier);
-		assertThat(schedule.getBill_BPartner_ID()).isEqualTo(billBP.getC_BPartner_ID());
-
-		final String billBPLocationIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_ShipmentSchedule.COLUMNNAME_Bill_Location_ID + "." + TABLECOLUMN_IDENTIFIER);
-		final I_C_BPartner_Location billBPLocation = bpartnerLocationTable.get(billBPLocationIdentifier);
-		assertThat(schedule.getBill_Location_ID()).isEqualTo(billBPLocation.getC_BPartner_Location_ID());
-
-		final String productIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_ShipmentSchedule.COLUMNNAME_M_Product_ID + "." + TABLECOLUMN_IDENTIFIER);
-		final I_M_Product product = productTable.get(productIdentifier);
-		assertThat(schedule.getM_Product_ID()).isEqualTo(product.getM_Product_ID());
-
-		final String exportStatus = DataTableUtil.extractStringForColumnName(row, I_M_ShipmentSchedule.COLUMNNAME_ExportStatus);
-		assertThat(schedule.getExportStatus()).isEqualTo(exportStatus);
-
-		final String orderIdentifier = DataTableUtil.extractStringForColumnName(row, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_C_Order_ID + "." + TABLECOLUMN_IDENTIFIER);
-		if (Check.isNotBlank(orderIdentifier))
-		{
-			final I_C_Order order = orderTable.get(orderIdentifier);
-			assertThat(schedule.getC_Order_ID()).isEqualTo(order.getC_Order_ID());
-		}
-
-		final String orderLineIdentifier = DataTableUtil.extractStringForColumnName(row, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_C_OrderLine_ID + "." + TABLECOLUMN_IDENTIFIER);
-		if (Check.isNotBlank(orderLineIdentifier))
-		{
-			final I_C_OrderLine orderLine = orderLineTable.get(orderLineIdentifier);
-			assertThat(schedule.getC_OrderLine_ID()).isEqualTo(orderLine.getC_OrderLine_ID());
-		}
-
-		final String userIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_AD_User_ID + "." + TABLECOLUMN_IDENTIFIER);
-		if (Check.isNotBlank(userIdentifier))
-		{
-			final I_AD_User user = userTable.get(userIdentifier);
-			assertThat(schedule.getAD_User_ID()).isEqualTo(user.getAD_User_ID());
-		}
-
-		final String billUserIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_Bill_User_ID + "." + TABLECOLUMN_IDENTIFIER);
-		if (Check.isNotBlank(billUserIdentifier))
-		{
-			final I_AD_User billUser = userTable.get(billUserIdentifier);
-			assertThat(schedule.getBill_User_ID()).isEqualTo(billUser.getAD_User_ID());
-		}
-
-		final String shipperIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_M_Shipper_ID + "." + TABLECOLUMN_IDENTIFIER);
-		if (Check.isNotBlank(shipperIdentifier))
-		{
-			final I_M_Shipper shipper = shipperTable.get(shipperIdentifier);
-			assertThat(schedule.getM_Shipper_ID()).isEqualTo(shipper.getM_Shipper_ID());
-		}
-
-		final String attributeSetInstanceIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + COLUMNNAME_M_AttributeSetInstance_ID + "." + TABLECOLUMN_IDENTIFIER);
-		if (Check.isNotBlank(attributeSetInstanceIdentifier))
-		{
-			final I_M_AttributeSetInstance expectedASI = attributeSetInstanceTable.get(attributeSetInstanceIdentifier);
-
-			final AttributesKey actualAttributesKeys = AttributesKeys.createAttributesKeyFromASIStorageAttributes(AttributeSetInstanceId.ofRepoId(schedule.getM_AttributeSetInstance_ID()))
-					.orElse(AttributesKey.NONE);
-			final AttributesKey expectedAttributesKeys = AttributesKeys.createAttributesKeyFromASIStorageAttributes(AttributeSetInstanceId.ofRepoId(expectedASI.getM_AttributeSetInstance_ID()))
-					.orElse(AttributesKey.NONE);
-
-			assertThat(actualAttributesKeys).isEqualTo(expectedAttributesKeys);
-		}
-
-		final String internalName = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_AD_InputDataSource_ID + "." + I_AD_InputDataSource.COLUMNNAME_InternalName);
-		if (Check.isNotBlank(internalName))
-		{
-			final I_AD_InputDataSource dataSource = inputDataSourceDAO.retrieveInputDataSource(Env.getCtx(), internalName, true, Trx.TRXNAME_None);
-			assertThat(schedule.getAD_InputDataSource_ID()).isEqualTo(dataSource.getAD_InputDataSource_ID());
 		}
 	}
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceRules.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceRules.feature
@@ -270,9 +270,9 @@ Feature: invoice rules
     And after not more than 30s, shipment schedule is recomputed
       | M_ShipmentSchedule_ID.Identifier |
       | s_s_3                            |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver_Override | QtyToDeliver | QtyDelivered | QtyOrdered | QtyPickList | Processed |
-      | s_s_3                            |                       | 0            | 10           | 10         | 5           | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver_Override | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyPickList | OPT.Processed |
+      | s_s_3                            |                           | 0                | 10               | 10             | 5               | false         |
     And shipment is generated for the following shipment schedule
       | M_InOut_ID.Identifier  | M_ShipmentSchedule_ID.Identifier | quantityTypeToUse | isCompleteShipment |
       | shipment_1, shipment_2 | s_s_3                            | P                 | Y                  |
@@ -288,9 +288,9 @@ Feature: invoice rules
     And after not more than 30s, shipment schedule is recomputed
       | M_ShipmentSchedule_ID.Identifier |
       | s_s_3                            |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver_Override | QtyToDeliver | QtyDelivered | QtyOrdered | QtyPickList | Processed |
-      | s_s_3                            |                       | 0            | 15           | 10         | 0           | true      |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver_Override | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyPickList | OPT.Processed |
+      | s_s_3                            |                           | 0                | 15               | 10             | 0               | true          |
     And recompute invoice candidates if required
       | C_Invoice_Candidate_ID.Identifier | Bill_BPartner_ID.Identifier | M_Product_ID.Identifier | OPT.NetAmtToInvoice |
       | invoice_candidate_1               | endcustomer_3               | p_3                     | 100                 |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/packingmaterial/shipments.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/packingmaterial/shipments.feature
@@ -64,9 +64,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -115,9 +115,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -172,9 +172,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -228,9 +228,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -296,9 +296,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -367,9 +367,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.rocessed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false        |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -438,9 +438,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -521,9 +521,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -607,9 +607,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -693,9 +693,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -787,9 +787,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -873,9 +873,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -959,9 +959,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -1042,9 +1042,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -1127,9 +1127,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -1213,9 +1213,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -1281,9 +1281,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -1352,9 +1352,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -1423,9 +1423,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -1491,9 +1491,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -1562,9 +1562,9 @@ Feature: Packing material invoice candidates: shipments
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
-    And after not more than 30s, validate shipment schedules:
-      | M_ShipmentSchedule_ID.Identifier | QtyToDeliver | QtyDelivered | QtyOrdered | OPT.QtyOrdered_TU | Processed |
-      | s_s_1                            | 100          | 0            | 100        | 10                | false     |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOrdered_TU | OPT.Processed |
+      | s_s_1                            | 100              | 0                | 100            | 10                | false         |
 
     When 'generate shipments' process is invoked
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentSchedule.feature
@@ -1,0 +1,91 @@
+@from:cucumber
+@topic:shipmentScheduleExport
+Feature: Shipment schedule updating
+  Verifies that M_ShipmentSchedule is properly updated on various cases
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2023-06-01T13:30:13+01:00[Europe/Berlin]
+    And deactivate all M_ShipmentSchedule records
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    # we don't care about the export, and don't want it to interject in any way
+    And set sys config int value 999999 for sys config de.metas.inoutcandidate.M_ShipmentSchedule.canBeExportedAfterSeconds
+
+    # set up masterdata
+    And metasfresh contains M_Products:
+      | Identifier   | Name         | OPT.Description   |
+      | product_0601 | product_0601 | dummy description |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                | Value               |
+      | ps_0601    | pricing_system_0601 | pricing_system_0601 |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name               | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_so_0601 | ps_0601                       | DE                        | EUR                 | price_list_so_0601 | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier  | M_PriceList_ID.Identifier | Name        | ValidFrom  |
+      | plv_so_0601 | pl_so_0601                | plv_so_0601 | 2022-02-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier      | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_TaxCategory_ID.InternalName | C_UOM_ID.X12DE355 |
+      | pp_product_0601 | plv_so_0601                       | product_0601            | 10.0     | Normal                        | PCE               |
+
+    # with this bpartner, we will create the orders with DeliveryRule=Availability
+    And metasfresh contains C_BPartners:
+      | Identifier       | Name             | M_PricingSystem_ID.Identifier | OPT.IsCustomer | OPT.CompanyName      | OPT.AD_Language | OPT.DeliveryRule |
+      | customer_so_0601 | customer_so_0601 | ps_0601                       | Y              | customer_so_0601_cmp | de_DE           | A                |
+    And metasfresh contains C_Location:
+      | C_Location_ID.Identifier | CountryCode | OPT.Address1 | OPT.Postal | OPT.City |
+      | location_0601            | DE          | addr ship 10 | 123        | shipCity |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier          | GLN                 | C_BPartner_ID.Identifier | OPT.C_Location_ID.Identifier | OPT.IsShipTo | OPT.IsBillTo | OPT.EMail         | OPT.BPartnerName | OPT.Phone |
+      | shipBPLocation_0601 | ship_location_S0271 | customer_so_0601         | location_0601                | true         | true         | ship@location.com | shipBPName       | 321       |
+
+
+  @Id:S0271_010
+  Scenario: Create Inventory
+
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | i_1_0601   | 540008         | 2021-04-16   |
+    And metasfresh contains M_InventoriesLines:
+      | Identifier | M_Inventory_ID.Identifier | M_Product_ID.Identifier | UOM.X12DE355 | QtyCount | QtyBook |
+      | il_1_0601  | i_1_0601                  | product_0601            | PCE          | 5        | 0       |
+    When the inventory identified by i_1_0601 is completed
+
+    # create the orders (with DeliveryRule=Availability and verify the initial state of their shipment schedules
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | o_1_0601   | true    | customer_so_0601         | 2023-05-31  |
+      | o_2_0601   | true    | customer_so_0601         | 2023-06-01  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_1_0601  | o_1_0601              | product_0601            | 10         |
+      | ol_2_0601  | o_2_0601              | product_0601            | 10         |
+    And the order identified by o_1_0601 is completed
+    And the order identified by o_2_0601 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier      | C_OrderLine_ID.Identifier | IsToRecompute |
+      | schedule_1_0601 | ol_1_0601                 | N             |
+      | schedule_2_0601 | ol_2_0601                 | N             |
+    # initially expect the first sched to get our stock of 5 and the 2nd sched to get nothing
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOnHand | OPT.Processed | OPT.DeliveryRule |
+      | schedule_1_0601                  | 5                | 0                | 10             | 5             | false         | A                |
+      | schedule_2_0601                  | 0                | 0                | 10             | 0             | false         | A                |
+
+    # Prepare the inventory document
+    And metasfresh contains M_Inventories:
+      | Identifier | M_Warehouse_ID | MovementDate |
+      | i_2_0601   | 540008         | 2021-04-16   |
+    And metasfresh contains M_InventoriesLines:
+      | Identifier | M_Inventory_ID.Identifier | M_Product_ID.Identifier | UOM.X12DE355 | QtyCount | QtyBook |
+      | il_2_0601  | i_2_0601                  | product_0601            | PCE          | 11       | 0       |
+
+    # now change the stock from 5 to 16
+    When the inventory identified by i_2_0601 is completed
+
+    Then after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOnHand | OPT.Processed |
+      | schedule_1_0601                  | 10               | 0                | 10             | 16            | false         |
+      | schedule_2_0601                  | 6                | 0                | 10             | 6             | false         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentScheduleExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentScheduleExport.feature
@@ -39,9 +39,9 @@ Feature: Shipment schedule export rest-api
       | shipLocation             | DE          | addr ship 10 | 123        | shipCity |
       | billLocation             | DE          | addr bill 11 | 456        | billCity |
     And metasfresh contains C_BPartner_Locations:
-      | Identifier     | GLN              | C_BPartner_ID.Identifier | OPT.C_Location_ID.Identifier | OPT.IsShipTo | OPT.IsBillTo | OPT.EMail         | OPT.BPartnerName | OPT.Phone |
-      | shipBPLocation | ship_location123 | customer_so_25_02        | shipLocation                 | true         | false        | ship@location.com | shipBPName       | 321       |
-      | billBPLocation | bill_location123 | customer_so_25_02        | billLocation                 | false        | true         | bill@location.com | billBPName       | 654       |
+      | Identifier     | GLN                 | C_BPartner_ID.Identifier | OPT.C_Location_ID.Identifier | OPT.IsShipTo | OPT.IsBillTo | OPT.EMail         | OPT.BPartnerName | OPT.Phone |
+      | shipBPLocation | ship_location_S0150 | customer_so_25_02        | shipLocation                 | true         | false        | ship@location.com | shipBPName       | 321       |
+      | billBPLocation | bill_location_S0150 | customer_so_25_02        | billLocation                 | false        | true         | bill@location.com | billBPName       | 654       |
     And metasfresh contains AD_Users:
       | AD_User_ID.Identifier | Name     | OPT.EMail     | OPT.AD_Language | OPT.C_BPartner_ID.Identifier | OPT.C_Location_ID.Identifier | OPT.Phone |
       | shipUser              | shipUser | ship@user.com | de_DE           | customer_so_25_02            | shipBPLocation               | 123       |
@@ -71,13 +71,13 @@ Feature: Shipment schedule export rest-api
     "externalLineId": 1111,
     "dataSource": "int-Shopware",
     "bpartner": {
-        "bpartnerIdentifier": "gln-ship_location123",
-        "bpartnerLocationIdentifier": "gln-ship_location123",
+        "bpartnerIdentifier": "gln-ship_location_S0150",
+        "bpartnerLocationIdentifier": "gln-ship_location_S0150",
         "contactIdentifier": "ext-Shopware6-shipUser_reference"
     },
     "billBPartner": {
-        "bpartnerIdentifier": "gln-bill_location123",
-        "bpartnerLocationIdentifier": "gln-bill_location123",
+        "bpartnerIdentifier": "gln-bill_location_S0150",
+        "bpartnerLocationIdentifier": "gln-bill_location_S0150",
         "contactIdentifier": "ext-Shopware6-billUser_reference"
     },
     "dateRequired": "2022-02-10",
@@ -118,9 +118,9 @@ Feature: Shipment schedule export rest-api
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | schedule_1 | orderLine_1               | N             |
-    And validate M_ShipmentSchedule:
-      | M_ShipmentSchedule_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | Bill_BPartner_ID.Identifier | Bill_Location_ID.Identifier | M_Product_ID.Identifier | ExportStatus | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | OPT.AD_User_ID.Identifier | OPT.Bill_User_ID.Identifier | OPT.AD_InputDataSource_ID.InternalName |
-      | schedule_1                       | customer_so_25_02        | shipBPLocation                    | customer_so_25_02           | billBPLocation              | product_25_02           | PENDING      | order_1                   | orderLine_1                   | shipUser                  | billUser                    | Shopware                               |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.C_BPartner_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.Bill_BPartner_ID.Identifier | OPT.Bill_Location_ID.Identifier | OPT.M_Product_ID.Identifier | OPT.ExportStatus | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | OPT.AD_User_ID.Identifier | OPT.Bill_User_ID.Identifier | OPT.AD_InputDataSource_ID.InternalName |
+      | schedule_1                       | customer_so_25_02            | shipBPLocation                        | customer_so_25_02               | billBPLocation                  | product_25_02               | PENDING          | order_1                   | orderLine_1                   | shipUser                  | billUser                    | Shopware                               |
 
     And update AD_User:
       | AD_User_ID.Identifier | OPT.EMail           | OPT.Phone |
@@ -145,9 +145,9 @@ Feature: Shipment schedule export rest-api
       | M_ShipmentSchedule_ExportAudit_Item_ID.Identifier | M_ShipmentSchedule_ExportAudit_ID.Identifier | M_ShipmentSchedule_ID.Identifier | ExportStatus |
       | schedule_export_item_1                            | schedule_export_1                            | schedule_1                       | EXPORTED     |
 
-    And validate M_ShipmentSchedule:
-      | M_ShipmentSchedule_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | Bill_BPartner_ID.Identifier | Bill_Location_ID.Identifier | M_Product_ID.Identifier | ExportStatus | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | OPT.AD_User_ID.Identifier | OPT.Bill_User_ID.Identifier | OPT.AD_InputDataSource_ID.InternalName |
-      | schedule_1                       | customer_so_25_02        | shipBPLocation                    | customer_so_25_02           | billBPLocation              | product_25_02           | EXPORTED     | order_1                   | orderLine_1                   | shipUser                  | billUser                    | Shopware                               |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.C_BPartner_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.Bill_BPartner_ID.Identifier | OPT.Bill_Location_ID.Identifier | OPT.M_Product_ID.Identifier | OPT.ExportStatus | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | OPT.AD_User_ID.Identifier | OPT.Bill_User_ID.Identifier | OPT.AD_InputDataSource_ID.InternalName |
+      | schedule_1                       | customer_so_25_02            | shipBPLocation                        | customer_so_25_02               | billBPLocation                  | product_25_02               | EXPORTED         | order_1                   | orderLine_1                   | shipUser                  | billUser                    | Shopware                               |
 
     And set sys config int value -1 for sys config de.metas.rest_api.v2.shipping.c_olcand.OxidUserId
 
@@ -164,13 +164,13 @@ Feature: Shipment schedule export rest-api
     "externalLineId": 2222,
     "dataSource": "int-Shopware",
     "bpartner": {
-        "bpartnerIdentifier": "gln-ship_location123",
-        "bpartnerLocationIdentifier": "gln-ship_location123",
+        "bpartnerIdentifier": "gln-ship_location_S0150",
+        "bpartnerLocationIdentifier": "gln-ship_location_S0150",
         "contactIdentifier": "ext-Shopware6-shipUser_reference"
     },
     "billBPartner": {
-        "bpartnerIdentifier": "gln-bill_location123",
-        "bpartnerLocationIdentifier": "gln-bill_location123",
+        "bpartnerIdentifier": "gln-bill_location_S0150",
+        "bpartnerLocationIdentifier": "gln-bill_location_S0150",
         "contactIdentifier": "ext-Shopware6-billUser_reference"
     },
     "dateRequired": "2022-02-10",
@@ -210,9 +210,9 @@ Feature: Shipment schedule export rest-api
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | schedule_1 | orderLine_1               | N             |
-    And validate M_ShipmentSchedule:
-      | M_ShipmentSchedule_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | Bill_BPartner_ID.Identifier | Bill_Location_ID.Identifier | M_Product_ID.Identifier | ExportStatus | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | OPT.AD_User_ID.Identifier | OPT.Bill_User_ID.Identifier | OPT.AD_InputDataSource_ID.InternalName |
-      | schedule_1                       | customer_so_25_02        | shipBPLocation                    | customer_so_25_02           | billBPLocation              | product_25_02           | PENDING      | order_1                   | orderLine_1                   | shipUser                  | billUser                    | Shopware                               |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.C_BPartner_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.Bill_BPartner_ID.Identifier | OPT.Bill_Location_ID.Identifier | OPT.M_Product_ID.Identifier | OPT.ExportStatus | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | OPT.AD_User_ID.Identifier | OPT.Bill_User_ID.Identifier | OPT.AD_InputDataSource_ID.InternalName |
+      | schedule_1                       | customer_so_25_02            | shipBPLocation                        | customer_so_25_02               | billBPLocation                  | product_25_02               | PENDING          | order_1                   | orderLine_1                   | shipUser                  | billUser                    | Shopware                               |
 
     And update AD_User:
       | AD_User_ID.Identifier | OPT.EMail           | OPT.Phone |
@@ -237,9 +237,9 @@ Feature: Shipment schedule export rest-api
       | M_ShipmentSchedule_ExportAudit_Item_ID.Identifier | M_ShipmentSchedule_ExportAudit_ID.Identifier | M_ShipmentSchedule_ID.Identifier | ExportStatus |
       | schedule_export_item_1                            | schedule_export_1                            | schedule_1                       | EXPORTED     |
 
-    And validate M_ShipmentSchedule:
-      | M_ShipmentSchedule_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | Bill_BPartner_ID.Identifier | Bill_Location_ID.Identifier | M_Product_ID.Identifier | ExportStatus | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | OPT.AD_User_ID.Identifier | OPT.Bill_User_ID.Identifier | OPT.AD_InputDataSource_ID.InternalName |
-      | schedule_1                       | customer_so_25_02        | shipBPLocation                    | customer_so_25_02           | billBPLocation              | product_25_02           | EXPORTED     | order_1                   | orderLine_1                   | shipUser                  | billUser                    | Shopware                               |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.C_BPartner_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.Bill_BPartner_ID.Identifier | OPT.Bill_Location_ID.Identifier | OPT.M_Product_ID.Identifier | OPT.ExportStatus | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | OPT.AD_User_ID.Identifier | OPT.Bill_User_ID.Identifier | OPT.AD_InputDataSource_ID.InternalName |
+      | schedule_1                       | customer_so_25_02            | shipBPLocation                        | customer_so_25_02               | billBPLocation                  | product_25_02               | EXPORTED         | order_1                   | orderLine_1                   | shipUser                  | billUser                    | Shopware                               |
 
   Scenario: Export non-oxid shipment schedule from order
     Given set sys config int value -1 for sys config de.metas.rest_api.v2.shipping.c_olcand.OxidUserId
@@ -285,9 +285,9 @@ Feature: Shipment schedule export rest-api
     And after not more than 30s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | schedule_1 | orderLine_1               | N             |
-    And validate M_ShipmentSchedule:
-      | M_ShipmentSchedule_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | Bill_BPartner_ID.Identifier | Bill_Location_ID.Identifier | M_Product_ID.Identifier | ExportStatus | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | OPT.AD_User_ID.Identifier | OPT.M_AttributeSetInstance_ID.Identifier |
-      | schedule_1                       | customer_so_25_02        | shipBPLocation                    | customer_so_25_02           | shipBPLocation              | product_25_02           | PENDING      | order_1                   | orderLine_1                   | shipUser                  | olASI                                    |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.C_BPartner_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.Bill_BPartner_ID.Identifier | OPT.Bill_Location_ID.Identifier | OPT.M_Product_ID.Identifier | OPT.ExportStatus | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | OPT.AD_User_ID.Identifier | OPT.M_AttributeSetInstance_ID.Identifier |
+      | schedule_1                       | customer_so_25_02            | shipBPLocation                        | customer_so_25_02               | shipBPLocation                  | product_25_02               | PENDING          | order_1                   | orderLine_1                   | shipUser                  | olASI                                    |
 
     When the metasfresh REST-API endpoint path 'api/v2/shipments/shipmentCandidates' receives a 'GET' request
 
@@ -306,6 +306,6 @@ Feature: Shipment schedule export rest-api
       | M_ShipmentSchedule_ExportAudit_Item_ID.Identifier | M_ShipmentSchedule_ExportAudit_ID.Identifier | M_ShipmentSchedule_ID.Identifier | ExportStatus |
       | schedule_export_item_1                            | schedule_export_1                            | schedule_1                       | EXPORTED     |
 
-    And validate M_ShipmentSchedule:
-      | M_ShipmentSchedule_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | Bill_BPartner_ID.Identifier | Bill_Location_ID.Identifier | M_Product_ID.Identifier | ExportStatus | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | OPT.AD_User_ID.Identifier | OPT.M_AttributeSetInstance_ID.Identifier |
-      | schedule_1                       | customer_so_25_02        | shipBPLocation                    | customer_so_25_02           | shipBPLocation              | product_25_02           | EXPORTED     | order_1                   | orderLine_1                   | shipUser                  | olASI                                    |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.C_BPartner_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.Bill_BPartner_ID.Identifier | OPT.Bill_Location_ID.Identifier | OPT.M_Product_ID.Identifier | OPT.ExportStatus | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | OPT.AD_User_ID.Identifier | OPT.M_AttributeSetInstance_ID.Identifier |
+      | schedule_1                       | customer_so_25_02            | shipBPLocation                        | customer_so_25_02               | shipBPLocation                  | product_25_02               | EXPORTED         | order_1                   | orderLine_1                   | shipUser                  | olASI                                    |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/candidate/commands/ProcessHUsAndPickingCandidateCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/candidate/commands/ProcessHUsAndPickingCandidateCommand.java
@@ -119,7 +119,7 @@ public class ProcessHUsAndPickingCandidateCommand
 			@Nullable final PPOrderId ppOrderId)
 	{
 		Check.assumeNotEmpty(pickingCandidates, "pickingCandidates is not empty");
-		for (PickingCandidate pickingCandidate : pickingCandidates)
+		for (final PickingCandidate pickingCandidate : pickingCandidates)
 		{
 			pickingCandidate.assertDraft();
 			if (!pickingCandidate.getPickFrom().isPickFromHU())

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/segments/ShipmentScheduleSegmentFromHUAttribute.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/segments/ShipmentScheduleSegmentFromHUAttribute.java
@@ -22,14 +22,7 @@ package de.metas.handlingunits.shipmentschedule.segments;
  * #L%
  */
 
-import java.util.Collections;
-import java.util.Set;
-
-import org.adempiere.mm.attributes.AttributeId;
-import org.adempiere.model.InterfaceWrapperHelper;
-
 import com.google.common.collect.ImmutableSet;
-
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_Attribute;
@@ -38,6 +31,11 @@ import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleAttributeSe
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.ToString;
+import org.adempiere.mm.attributes.AttributeId;
+import org.adempiere.model.InterfaceWrapperHelper;
+
+import java.util.Collections;
+import java.util.Set;
 
 @ToString
 public class ShipmentScheduleSegmentFromHUAttribute implements IShipmentScheduleSegment
@@ -60,7 +58,7 @@ public class ShipmentScheduleSegmentFromHUAttribute implements IShipmentSchedule
 		attributeSegments = ImmutableSet.of(attributeSegment);
 	}
 
-	private final void loadIfNeeded()
+	private void loadIfNeeded()
 	{
 		if (loaded)
 		{
@@ -72,7 +70,7 @@ public class ShipmentScheduleSegmentFromHUAttribute implements IShipmentSchedule
 		loaded = true;
 	}
 
-	private final void load()
+	private void load()
 	{
 		//
 		// Load the HU

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleUpdater.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleUpdater.java
@@ -515,7 +515,7 @@ public class ShipmentScheduleUpdater implements IShipmentScheduleUpdater
 			// Delivery rule: Force
 			if (deliveryRule.isForce())
 			{
-				createLine(
+				createLine( // createLine will also subtract the respective qty from storages
 						olAndSched,
 						qtyToDeliver,
 						storages,
@@ -538,7 +538,7 @@ public class ShipmentScheduleUpdater implements IShipmentScheduleUpdater
 					// we invoke createLine even if ruleComplete is true and fullLine is false,
 					// because we want the quantity to be allocated.
 					// If the created line will make it into a real shipment will be decided later.
-					createLine(
+					createLine( // createLine will also subtract the respective qty from storages
 							olAndSched,
 							qtyToDeliverEffective,
 							storages,

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/ShipmentScheduleStockChangedEventHandler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/ShipmentScheduleStockChangedEventHandler.java
@@ -1,0 +1,83 @@
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2023 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.inoutcandidate.spi;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import de.metas.Profiles;
+import de.metas.inoutcandidate.invalidation.impl.ShipmentScheduleInvalidateBL;
+import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
+import de.metas.inoutcandidate.invalidation.segments.ImmutableShipmentScheduleSegment;
+import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleAttributeSegment;
+import de.metas.material.event.MaterialEventHandler;
+import de.metas.material.event.commons.ProductDescriptor;
+import de.metas.material.event.stock.StockChangedEvent;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
+import org.adempiere.warehouse.LocatorId;
+import org.adempiere.warehouse.WarehouseId;
+import org.adempiere.warehouse.api.IWarehouseDAO;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Set;
+
+@Component
+@Profile(Profiles.PROFILE_App)
+public class ShipmentScheduleStockChangedEventHandler implements MaterialEventHandler<StockChangedEvent>
+{
+	private final ShipmentScheduleInvalidateBL scheduleInvalidateBL;
+	private final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
+
+	public ShipmentScheduleStockChangedEventHandler(@NonNull final ShipmentScheduleInvalidateBL scheduleInvalidateBL)
+	{
+		this.scheduleInvalidateBL = scheduleInvalidateBL;
+	}
+
+	@Override
+	public Collection<Class<? extends StockChangedEvent>> getHandledEventType()
+	{
+		return ImmutableList.of(StockChangedEvent.class);
+	}
+
+	@Override
+	public void handleEvent(@NonNull final StockChangedEvent event)
+	{
+		final ProductDescriptor productDescriptor = event.getProductDescriptor();
+		final ShipmentScheduleAttributeSegment shipmentScheduleAttributeSegment = ShipmentScheduleAttributeSegment.ofAttributeSetInstanceId(AttributeSetInstanceId.ofRepoIdOrNone(productDescriptor.getAttributeSetInstanceId()));
+
+		final Set<WarehouseId> warehouseIds = warehouseDAO.getWarehouseIdsOfSamePickingGroup(event.getWarehouseId());
+		final ImmutableSet<LocatorId> locatorIds = warehouseDAO.getLocatorIdsByWarehouseIds(warehouseIds);
+
+		final IShipmentScheduleSegment storageSegment = ImmutableShipmentScheduleSegment.builder()
+				.productIds(ImmutableSet.of(productDescriptor.getProductId()))
+				.attributes(ImmutableSet.of(shipmentScheduleAttributeSegment))
+				.locatorIds(LocatorId.toRepoIds(locatorIds))
+				.bpartnerId(IShipmentScheduleSegment.ANY)
+				.build();
+
+		scheduleInvalidateBL.flagForRecomputeStorageSegment(storageSegment);
+	}
+}


### PR DESCRIPTION
* Add ShipmentScheduleStockChangedEventHandler to facilitate schedule-update

this is needed to because the allocated QtyToDeliver and QtyOnHand might change

* add shipmentSchedule.feature to verify the fixed behavior

also:
- M_ShipmentSchedule_StepDef - consolidate two fixtures into one
- minor code improvements

* fix scenario (that i broke before) where the deliveryrule is needed

* Port the rest api cucumber improvement from commit 9bfb9d8cafec7a8807a2dd4bb3bd27d926c1e830

Also add a little improvement from the code-review

* Fix newly introduced error (from the previous commit)

* Fix GLN to be different between two features

(cherry picked from commit f2378b5fdfa211128240b150a5efadf016185eb1)