### PR TITLE
hotfix: on webui login make sure we are using logged user language

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/notification/UserNotificationsService.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/notification/UserNotificationsService.java
@@ -86,13 +86,12 @@ public class UserNotificationsService
 		logger.trace("Enabling for sessionId={}, adUserId={}, jsonOptions={}", sessionId, adUserId, jsonOptions);
 
 		final UserNotificationsQueue notificationsQueue = adUserId2notifications.computeIfAbsent(adUserId, k -> UserNotificationsQueue.builder()
-
 				.userId(adUserId)
 				.jsonOptions(jsonOptions)
 				.notificationsRepo(Services.get(INotificationRepository.class))
 				.websocketSender(websocketSender)
 				.build());
-
+		notificationsQueue.setLanguage(jsonOptions.getAdLanguage()); // just to make sure in case user changed his language, we use his/her last option
 		notificationsQueue.addActiveSessionId(sessionId);
 
 		subscribeToEventTopicsIfNeeded();


### PR DESCRIPTION
Test case:
* login with a user which is using english language
* change the language to something else (e.g. german)
* logout / login
* before the fix the notifications where sent using the english language
