### PR TITLE
metas ts/intensive care uat/merge from tag/intensive care hotfix 60 (#16512)

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5707470_sys_Filter_Invoices_from_product_costs_recreate_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5707470_sys_Filter_Invoices_from_product_costs_recreate_from_date.sql
@@ -29,29 +29,6 @@ DROP FUNCTION IF EXISTS "de_metas_acct".product_costs_recreate_from_date(
 ;
 
 
-DROP FUNCTION IF EXISTS "de_metas_acct".product_costs_recreate_from_date(
-    p_C_AcctSchema_ID            numeric,
-    p_M_CostElement_ID           numeric,
-    p_M_Product_ID               numeric,
-    p_M_Product_IDs              numeric[],
-    p_ReorderDocs                char(1),
-    p_ReorderDocs_DateAcct_Trunc varchar,
-    p_StartDateAcct              timestamp WITH TIME ZONE,
-    p_DryRun           char(1))
-;
-
-DROP FUNCTION IF EXISTS "de_metas_acct".product_costs_recreate_from_date(
-    p_C_AcctSchema_ID            numeric,
-    p_M_CostElement_ID           numeric,
-    p_M_Product_ID               numeric,
-    p_M_Product_IDs              numeric[],
-    p_m_product_selection_id     numeric,
-    p_ReorderDocs                char(1),
-    p_ReorderDocs_DateAcct_Trunc varchar,
-    p_StartDateAcct              timestamp WITH TIME ZONE)
-;
-
-
 CREATE OR REPLACE FUNCTION "de_metas_acct".product_costs_recreate_from_date(
     p_C_AcctSchema_ID            numeric,
     p_M_CostElement_ID           numeric,
@@ -60,8 +37,7 @@ CREATE OR REPLACE FUNCTION "de_metas_acct".product_costs_recreate_from_date(
     p_m_product_selection_id     numeric = NULL,
     p_ReorderDocs                char(1) = 'Y',
     p_ReorderDocs_DateAcct_Trunc varchar = 'DD',
-    p_StartDateAcct              timestamp WITH TIME ZONE = '1970-01-01',
-    p_DryRun           char(1) = 'N')
+    p_StartDateAcct              timestamp WITH TIME ZONE = '1970-01-01')
     RETURNS text
 AS
 $BODY$
@@ -69,8 +45,6 @@ DECLARE
     v_productIds      numeric[];
     v_costingLevel    char(1);
     v_orgIds          numeric[];
-    v_costElement                      m_costelement%rowtype;
-    v_IsManualCostPrice                boolean; -- true if we are dealing with manual cost price (i.e. M_Cost.CurrentCostPrice is set by user and we MUST keep it)
     --
     rowcount          integer := 0;
     v_result          text    := '';
@@ -129,24 +103,9 @@ BEGIN
     RAISE NOTICE 'p_C_AcctSchema_ID=%: CostingLevel=%', p_C_AcctSchema_ID, v_costingLevel;
     RAISE NOTICE 'Orgs: %', v_orgIds;
 
-    --
-    -- Validate parameter: Cost Element
-    --
-    SELECT *
-    INTO v_costElement
-    FROM M_CostElement ce
-    WHERE ce.m_costelement_id = p_M_CostElement_ID;
-    IF (v_costElement IS NULL) THEN
-        RAISE EXCEPTION 'Cost Element % not found', p_M_CostElement_ID;
-    END IF;
-    v_IsManualCostPrice := v_costElement.costingmethod = 'S'; -- S=Standard Costing
-    RAISE NOTICE 'p_M_CostElement_ID=%: CostingMethod=% => IsManualCost=%', p_M_CostElement_ID, v_costElement.costingmethod, v_IsManualCostPrice;
-
-    --
-    -- Log other parameters
+    RAISE NOTICE 'p_M_CostElement_ID=%', p_M_CostElement_ID;
     RAISE NOTICE 'p_ReorderDocs=%', p_ReorderDocs;
     RAISE NOTICE 'p_StartDateAcct=%', p_StartDateAcct;
-    RAISE NOTICE 'p_DryRun=%', p_DryRun;
 
 
     --
@@ -226,11 +185,6 @@ BEGIN
     RAISE NOTICE 'Deleted % PP_Order_Cost records', rowcount;
     v_result := v_result || rowcount || ' PP_Order_Cost(s) deleted; ';
 
-    --
-    -- Stop here and ROLLBACK if DryRun
-    IF (p_DryRun = 'Y') THEN
-        RAISE EXCEPTION 'ROLLBACK because p_DryRun=Y';
-    END IF;
 
     --
     -- Un-post documents and enqueue them to posting queue.


### PR DESCRIPTION
* REST API: By default, don't wrap API response (#16375)

* change the sequences' maxvalue from from 2147483647 to the columns' max (#15654) (#16403)

(cherry picked from commit 88fdc92ba34d597d9d1fa998a4ebe7ad6d405e43)

Co-authored-by: Tobias Schöneberg <metas-ts@users.noreply.github.com>

* Filter Invoice when recomputing product sots (#16469)

---------

Co-authored-by: Teo Sarca <teo.sarca@metasfresh.com>
Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
Co-authored-by: Cristina Ghita <cristina.ghita@metasfresh.com>