### PR TITLE
Use `webui.lookup.pageLength` sysconfig to determine the default lookup items to be fetched on typeahead

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5711890_sys_gh16816_webui.lookup.pageLength.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5711890_sys_gh16816_webui.lookup.pageLength.sql
@@ -1,0 +1,8 @@
+-- Run mode: SWING_CLIENT
+
+-- SysConfig Name: webui.lookup.pageLength
+-- SysConfig Value: 10
+-- 2023-11-28T10:54:52.181Z
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541660,'S',TO_TIMESTAMP('2023-11-28 12:54:51.786','YYYY-MM-DD HH24:MI:SS.US'),100,'The number of maximum items that are displayed in any search field','D','Y','webui.lookup.pageLength',TO_TIMESTAMP('2023-11-28 12:54:51.786','YYYY-MM-DD HH24:MI:SS.US'),100,'10')
+;
+

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/LookupDescriptorProviders.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/LookupDescriptorProviders.java
@@ -6,11 +6,13 @@ import de.metas.ui.web.window.descriptor.LookupDescriptorProvider.LookupScope;
 import de.metas.ui.web.window.descriptor.sql.SqlLookupDescriptorProviderBuilder;
 import de.metas.util.Functions;
 import de.metas.util.Functions.MemoizingFunction;
+import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.ToString;
 import org.adempiere.ad.validationRule.AdValRuleId;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ISysConfigBL;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_M_AttributeSetInstance;
 import org.compiere.util.DisplayType;
@@ -57,7 +59,11 @@ public class LookupDescriptorProviders
 	 */
 	public static final LookupDescriptorProvider NULL = new NullLookupDescriptorProvider();
 
+	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private ADReferenceService _adReferenceService;
+
+	private static final String SYSCONFIG_PageLength = "webui.lookup.pageLength";
+	private static final int DEFAULT_PageLength = 10;
 
 	public LookupDescriptorProviders(
 			@Nullable final ADReferenceService adReferenceService)
@@ -75,7 +81,11 @@ public class LookupDescriptorProviders
 		return adReferenceService;
 	}
 
-	public SqlLookupDescriptorProviderBuilder sql() {return new SqlLookupDescriptorProviderBuilder(getAdReferenceService());}
+	public SqlLookupDescriptorProviderBuilder sql()
+	{
+		return new SqlLookupDescriptorProviderBuilder(getAdReferenceService())
+				.setPageLength(sysConfigBL.getIntValue(SYSCONFIG_PageLength, DEFAULT_PageLength));
+	}
 
 	public LookupDescriptorProvider searchByAD_Val_Rule_ID(
 			@NonNull final ReferenceId AD_Reference_Value_ID,

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/lookup/GenericSqlLookupDataSourceFetcher.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/lookup/GenericSqlLookupDataSourceFetcher.java
@@ -54,13 +54,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import static de.metas.common.util.CoalesceUtil.firstGreaterThanZero;
-
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class GenericSqlLookupDataSourceFetcher implements LookupDataSourceFetcher
 {
 	private static final Logger logger = LogManager.getLogger(GenericSqlLookupDataSourceFetcher.class);
-	public static final int DEFAULT_PAGE_SIZE = 1000;
+	private static final int DEFAULT_PAGE_SIZE = 1000;
 
 	@NonNull private final String lookupTableName;
 	@Getter private final boolean numericKey;
@@ -70,7 +68,7 @@ public class GenericSqlLookupDataSourceFetcher implements LookupDataSourceFetche
 	@Getter @NonNull private final Optional<WindowId> zoomIntoWindowId;
 	@NonNull private final TooltipType tooltipType;
 
-	@Nullable private final int pageLength;
+	private final int pageLength;
 
 	//
 	// Computed:
@@ -171,7 +169,7 @@ public class GenericSqlLookupDataSourceFetcher implements LookupDataSourceFetche
 	public LookupValuesPage retrieveEntities(final LookupDataSourceContext evalCtxParam)
 	{
 		final int offset = evalCtxParam.getOffset(0);
-		final int pageLength = firstGreaterThanZero(this.pageLength, evalCtxParam.getLimit(DEFAULT_PAGE_SIZE));
+		final int pageLength = getPageLength(evalCtxParam);
 
 		final LookupDataSourceContext evalCtxEffective = evalCtxParam
 				.withOffset(offset)
@@ -203,6 +201,23 @@ public class GenericSqlLookupDataSourceFetcher implements LookupDataSourceFetche
 
 			logger.trace("Returning values={} (executed sql: {})", values, sqlForFetching);
 			return LookupValuesPage.ofValuesAndHasMoreFlag(values, hasMoreResults);
+		}
+	}
+
+	private int getPageLength(final LookupDataSourceContext evalCtxParam)
+	{
+		final int ctxPageLength = evalCtxParam.getLimit(0);
+		if (ctxPageLength > 0)
+		{
+			return ctxPageLength;
+		}
+		if (this.pageLength > 0)
+		{
+			return this.pageLength;
+		}
+		else
+		{
+			return DEFAULT_PAGE_SIZE;
 		}
 	}
 

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/lookup/LookupDataSource.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/lookup/LookupDataSource.java
@@ -38,7 +38,6 @@ import java.util.Optional;
 public interface LookupDataSource extends LookupValueByIdSupplier
 {
 	int FIRST_ROW = 0;
-	int DEFAULT_PageLength = 10;
 
 	LookupValuesPage findEntities(Evaluatee ctx, int pageLength);
 
@@ -46,7 +45,7 @@ public interface LookupDataSource extends LookupValueByIdSupplier
 
 	default LookupValuesPage findEntities(final Evaluatee ctx, final String filter)
 	{
-		return findEntities(ctx, filter, FIRST_ROW, DEFAULT_PageLength);
+		return findEntities(ctx, filter, FIRST_ROW, -1);
 	}
 
 	/**

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/lookup/LookupDataSourceContext.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/lookup/LookupDataSourceContext.java
@@ -592,7 +592,7 @@ public final class LookupDataSourceContext implements Evaluatee2, IValidationCon
 			putValue(PARAM_FilterSql, convertFilterToSql(filter));
 			putValue(PARAM_FilterSqlWithoutWildcards, convertFilterToSqlWithoutWildcards(filter));
 			putValue(SqlForFetchingLookups.PARAM_Offset, offset);
-			putValue(SqlForFetchingLookups.PARAM_Limit, limit);
+			putValue(SqlForFetchingLookups.PARAM_Limit, Math.max(limit, 0));
 
 			return this;
 		}


### PR DESCRIPTION
https://github.com/metasfresh/metasfresh/issues/16816