### PR TITLE
Add template for doc requests (pointing to doc repo)

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-requests-suggestions
+++ b/.github/ISSUE_TEMPLATE/documentation-requests-suggestions
@@ -1,0 +1,9 @@
+---
+name: Documentation request/suggestion => Doc Repository
+about: Please use the template provided at https://github.com/metasfresh/metasfresh-documentation/issues/new/choose
+title: ''
+labels: ''
+assignees: ''
+---
+
+## Please use the [documentation request template](https://github.com/metasfresh/metasfresh-documentation/issues/new?template=documentation-request.md) in the [metasfresh documentation repository](https://github.com/metasfresh/metasfresh-documentation/issues) to create a parent issue for your me03. Do not create another issue in the metasfresh repository in addition to the doc request in order to keep the number of related issues to a minimum. Simply [go to the doc repo](https://github.com/metasfresh/metasfresh-documentation/issues) now and close this template without saving. Thank you.


### PR DESCRIPTION
This template shall serve as a note to anyone who wants to create an issue with a documentation request/suggestion and help redirect them to our documentation repository. This way we keep all documentation-related tasks in one place and avoid multiple recording of issues in several repositories.