### PR TITLE
Drop single primary key column on some of the AD_*Access tables

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Document_Action_Access.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Document_Action_Access.java
@@ -1,265 +1,200 @@
 package org.compiere.model;
 
+import org.adempiere.model.ModelColumn;
 
 /** Generated Interface for AD_Document_Action_Access
- *  @author Adempiere (generated) 
+ *  @author metasfresh (generated) 
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings("unused")
 public interface I_AD_Document_Action_Access 
 {
 
-    /** TableName=AD_Document_Action_Access */
-    public static final String Table_Name = "AD_Document_Action_Access";
+	String Table_Name = "AD_Document_Action_Access";
 
-    /** AD_Table_ID=53012 */
-//    public static final int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
+//	/** AD_Table_ID=53012 */
+//	int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
 
-//    org.compiere.util.KeyNamePair Model = new org.compiere.util.KeyNamePair(Table_ID, Table_Name);
-
-    /** AccessLevel = 6 - System - Client
-     */
-//    java.math.BigDecimal accessLevel = java.math.BigDecimal.valueOf(6);
-
-    /** Load Meta Data */
 
 	/**
-	 * Get Mandant.
+	 * Get Client.
 	 * Client/Tenant for this installation.
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Client_ID();
+	int getAD_Client_ID();
 
-	public org.compiere.model.I_AD_Client getAD_Client();
-
-    /** Column definition for AD_Client_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_AD_Client> COLUMN_AD_Client_ID = new org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_AD_Client>(I_AD_Document_Action_Access.class, "AD_Client_ID", org.compiere.model.I_AD_Client.class);
-    /** Column name AD_Client_ID */
-    public static final String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+	String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
 
 	/**
-	 * Set Document Action Access.
+	 * Set Organisation.
+	 * Organisational entity within client
 	 *
-	 * <br>Type: ID
+	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Document_Action_Access_ID (int AD_Document_Action_Access_ID);
+	void setAD_Org_ID (int AD_Org_ID);
 
 	/**
-	 * Get Document Action Access.
+	 * Get Organisation.
+	 * Organisational entity within client
 	 *
-	 * <br>Type: ID
+	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Document_Action_Access_ID();
+	int getAD_Org_ID();
 
-    /** Column definition for AD_Document_Action_Access_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, Object> COLUMN_AD_Document_Action_Access_ID = new org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, Object>(I_AD_Document_Action_Access.class, "AD_Document_Action_Access_ID", null);
-    /** Column name AD_Document_Action_Access_ID */
-    public static final String COLUMNNAME_AD_Document_Action_Access_ID = "AD_Document_Action_Access_ID";
+	String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
 
 	/**
-	 * Set Sektion.
-	 * Organisatorische Einheit des Mandanten
-	 *
-	 * <br>Type: TableDir
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	public void setAD_Org_ID (int AD_Org_ID);
-
-	/**
-	 * Get Sektion.
-	 * Organisatorische Einheit des Mandanten
-	 *
-	 * <br>Type: TableDir
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	public int getAD_Org_ID();
-
-	public org.compiere.model.I_AD_Org getAD_Org();
-
-	public void setAD_Org(org.compiere.model.I_AD_Org AD_Org);
-
-    /** Column definition for AD_Org_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_AD_Org> COLUMN_AD_Org_ID = new org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_AD_Org>(I_AD_Document_Action_Access.class, "AD_Org_ID", org.compiere.model.I_AD_Org.class);
-    /** Column name AD_Org_ID */
-    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
-
-	/**
-	 * Set Referenzliste.
+	 * Set Reference List.
 	 * Reference List based on Table
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Ref_List_ID (int AD_Ref_List_ID);
+	void setAD_Ref_List_ID (int AD_Ref_List_ID);
 
 	/**
-	 * Get Referenzliste.
+	 * Get Reference List.
 	 * Reference List based on Table
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Ref_List_ID();
+	int getAD_Ref_List_ID();
 
-	public org.compiere.model.I_AD_Ref_List getAD_Ref_List();
+	org.compiere.model.I_AD_Ref_List getAD_Ref_List();
 
-	public void setAD_Ref_List(org.compiere.model.I_AD_Ref_List AD_Ref_List);
+	void setAD_Ref_List(org.compiere.model.I_AD_Ref_List AD_Ref_List);
 
-    /** Column definition for AD_Ref_List_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_AD_Ref_List> COLUMN_AD_Ref_List_ID = new org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_AD_Ref_List>(I_AD_Document_Action_Access.class, "AD_Ref_List_ID", org.compiere.model.I_AD_Ref_List.class);
-    /** Column name AD_Ref_List_ID */
-    public static final String COLUMNNAME_AD_Ref_List_ID = "AD_Ref_List_ID";
+	ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_AD_Ref_List> COLUMN_AD_Ref_List_ID = new ModelColumn<>(I_AD_Document_Action_Access.class, "AD_Ref_List_ID", org.compiere.model.I_AD_Ref_List.class);
+	String COLUMNNAME_AD_Ref_List_ID = "AD_Ref_List_ID";
 
 	/**
-	 * Set Rolle.
+	 * Set Role.
 	 * Responsibility Role
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Role_ID (int AD_Role_ID);
+	void setAD_Role_ID (int AD_Role_ID);
 
 	/**
-	 * Get Rolle.
+	 * Get Role.
 	 * Responsibility Role
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Role_ID();
+	int getAD_Role_ID();
 
-	public org.compiere.model.I_AD_Role getAD_Role();
+	org.compiere.model.I_AD_Role getAD_Role();
 
-	public void setAD_Role(org.compiere.model.I_AD_Role AD_Role);
+	void setAD_Role(org.compiere.model.I_AD_Role AD_Role);
 
-    /** Column definition for AD_Role_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_AD_Role> COLUMN_AD_Role_ID = new org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_AD_Role>(I_AD_Document_Action_Access.class, "AD_Role_ID", org.compiere.model.I_AD_Role.class);
-    /** Column name AD_Role_ID */
-    public static final String COLUMNNAME_AD_Role_ID = "AD_Role_ID";
+	ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_AD_Role> COLUMN_AD_Role_ID = new ModelColumn<>(I_AD_Document_Action_Access.class, "AD_Role_ID", org.compiere.model.I_AD_Role.class);
+	String COLUMNNAME_AD_Role_ID = "AD_Role_ID";
 
 	/**
-	 * Set Belegart.
+	 * Set Document Type.
 	 * Document type or rules
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setC_DocType_ID (int C_DocType_ID);
+	void setC_DocType_ID (int C_DocType_ID);
 
 	/**
-	 * Get Belegart.
+	 * Get Document Type.
 	 * Document type or rules
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getC_DocType_ID();
+	int getC_DocType_ID();
 
-	public org.compiere.model.I_C_DocType getC_DocType();
-
-	public void setC_DocType(org.compiere.model.I_C_DocType C_DocType);
-
-    /** Column definition for C_DocType_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_C_DocType> COLUMN_C_DocType_ID = new org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_C_DocType>(I_AD_Document_Action_Access.class, "C_DocType_ID", org.compiere.model.I_C_DocType.class);
-    /** Column name C_DocType_ID */
-    public static final String COLUMNNAME_C_DocType_ID = "C_DocType_ID";
+	String COLUMNNAME_C_DocType_ID = "C_DocType_ID";
 
 	/**
-	 * Get Erstellt.
+	 * Get Created.
 	 * Date this record was created
 	 *
 	 * <br>Type: DateTime
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public java.sql.Timestamp getCreated();
+	java.sql.Timestamp getCreated();
 
-    /** Column definition for Created */
-    public static final org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, Object> COLUMN_Created = new org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, Object>(I_AD_Document_Action_Access.class, "Created", null);
-    /** Column name Created */
-    public static final String COLUMNNAME_Created = "Created";
+	ModelColumn<I_AD_Document_Action_Access, Object> COLUMN_Created = new ModelColumn<>(I_AD_Document_Action_Access.class, "Created", null);
+	String COLUMNNAME_Created = "Created";
 
 	/**
-	 * Get Erstellt durch.
+	 * Get Created By.
 	 * User who created this records
 	 *
 	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getCreatedBy();
+	int getCreatedBy();
 
-    /** Column definition for CreatedBy */
-    public static final org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_AD_User> COLUMN_CreatedBy = new org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_AD_User>(I_AD_Document_Action_Access.class, "CreatedBy", org.compiere.model.I_AD_User.class);
-    /** Column name CreatedBy */
-    public static final String COLUMNNAME_CreatedBy = "CreatedBy";
+	String COLUMNNAME_CreatedBy = "CreatedBy";
 
 	/**
-	 * Set Aktiv.
+	 * Set Active.
 	 * The record is active in the system
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setIsActive (boolean IsActive);
+	void setIsActive (boolean IsActive);
 
 	/**
-	 * Get Aktiv.
+	 * Get Active.
 	 * The record is active in the system
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public boolean isActive();
+	boolean isActive();
 
-    /** Column definition for IsActive */
-    public static final org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, Object> COLUMN_IsActive = new org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, Object>(I_AD_Document_Action_Access.class, "IsActive", null);
-    /** Column name IsActive */
-    public static final String COLUMNNAME_IsActive = "IsActive";
+	ModelColumn<I_AD_Document_Action_Access, Object> COLUMN_IsActive = new ModelColumn<>(I_AD_Document_Action_Access.class, "IsActive", null);
+	String COLUMNNAME_IsActive = "IsActive";
 
 	/**
-	 * Get Aktualisiert.
+	 * Get Updated.
 	 * Date this record was updated
 	 *
 	 * <br>Type: DateTime
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public java.sql.Timestamp getUpdated();
+	java.sql.Timestamp getUpdated();
 
-    /** Column definition for Updated */
-    public static final org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, Object> COLUMN_Updated = new org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, Object>(I_AD_Document_Action_Access.class, "Updated", null);
-    /** Column name Updated */
-    public static final String COLUMNNAME_Updated = "Updated";
+	ModelColumn<I_AD_Document_Action_Access, Object> COLUMN_Updated = new ModelColumn<>(I_AD_Document_Action_Access.class, "Updated", null);
+	String COLUMNNAME_Updated = "Updated";
 
 	/**
-	 * Get Aktualisiert durch.
+	 * Get Updated By.
 	 * User who updated this records
 	 *
 	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getUpdatedBy();
+	int getUpdatedBy();
 
-    /** Column definition for UpdatedBy */
-    public static final org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_AD_User> COLUMN_UpdatedBy = new org.adempiere.model.ModelColumn<I_AD_Document_Action_Access, org.compiere.model.I_AD_User>(I_AD_Document_Action_Access.class, "UpdatedBy", org.compiere.model.I_AD_User.class);
-    /** Column name UpdatedBy */
-    public static final String COLUMNNAME_UpdatedBy = "UpdatedBy";
+	String COLUMNNAME_UpdatedBy = "UpdatedBy";
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Form_Access.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Form_Access.java
@@ -1,66 +1,31 @@
 package org.compiere.model;
 
+import org.adempiere.model.ModelColumn;
 
 /** Generated Interface for AD_Form_Access
- *  @author Adempiere (generated) 
+ *  @author metasfresh (generated) 
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings("unused")
 public interface I_AD_Form_Access 
 {
 
-    /** TableName=AD_Form_Access */
-    public static final String Table_Name = "AD_Form_Access";
+	String Table_Name = "AD_Form_Access";
 
-    /** AD_Table_ID=378 */
-//    public static final int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
+//	/** AD_Table_ID=378 */
+//	int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
 
-//    org.compiere.util.KeyNamePair Model = new org.compiere.util.KeyNamePair(Table_ID, Table_Name);
-
-    /** AccessLevel = 6 - System - Client
-     */
-//    java.math.BigDecimal accessLevel = java.math.BigDecimal.valueOf(6);
-
-    /** Load Meta Data */
 
 	/**
-	 * Get Mandant.
+	 * Get Client.
 	 * Client/Tenant for this installation.
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Client_ID();
+	int getAD_Client_ID();
 
-	public org.compiere.model.I_AD_Client getAD_Client();
-
-    /** Column definition for AD_Client_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Form_Access, org.compiere.model.I_AD_Client> COLUMN_AD_Client_ID = new org.adempiere.model.ModelColumn<I_AD_Form_Access, org.compiere.model.I_AD_Client>(I_AD_Form_Access.class, "AD_Client_ID", org.compiere.model.I_AD_Client.class);
-    /** Column name AD_Client_ID */
-    public static final String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
-
-	/**
-	 * Set AD_Form_Access.
-	 *
-	 * <br>Type: ID
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	public void setAD_Form_Access_ID (int AD_Form_Access_ID);
-
-	/**
-	 * Get AD_Form_Access.
-	 *
-	 * <br>Type: ID
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	public int getAD_Form_Access_ID();
-
-    /** Column definition for AD_Form_Access_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Form_Access, Object> COLUMN_AD_Form_Access_ID = new org.adempiere.model.ModelColumn<I_AD_Form_Access, Object>(I_AD_Form_Access.class, "AD_Form_Access_ID", null);
-    /** Column name AD_Form_Access_ID */
-    public static final String COLUMNNAME_AD_Form_Access_ID = "AD_Form_Access_ID";
+	String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
 
 	/**
 	 * Set Special Form.
@@ -70,7 +35,7 @@ public interface I_AD_Form_Access
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Form_ID (int AD_Form_ID);
+	void setAD_Form_ID (int AD_Form_ID);
 
 	/**
 	 * Get Special Form.
@@ -80,182 +45,157 @@ public interface I_AD_Form_Access
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Form_ID();
+	int getAD_Form_ID();
 
-	public org.compiere.model.I_AD_Form getAD_Form();
+	org.compiere.model.I_AD_Form getAD_Form();
 
-	public void setAD_Form(org.compiere.model.I_AD_Form AD_Form);
+	void setAD_Form(org.compiere.model.I_AD_Form AD_Form);
 
-    /** Column definition for AD_Form_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Form_Access, org.compiere.model.I_AD_Form> COLUMN_AD_Form_ID = new org.adempiere.model.ModelColumn<I_AD_Form_Access, org.compiere.model.I_AD_Form>(I_AD_Form_Access.class, "AD_Form_ID", org.compiere.model.I_AD_Form.class);
-    /** Column name AD_Form_ID */
-    public static final String COLUMNNAME_AD_Form_ID = "AD_Form_ID";
+	ModelColumn<I_AD_Form_Access, org.compiere.model.I_AD_Form> COLUMN_AD_Form_ID = new ModelColumn<>(I_AD_Form_Access.class, "AD_Form_ID", org.compiere.model.I_AD_Form.class);
+	String COLUMNNAME_AD_Form_ID = "AD_Form_ID";
 
 	/**
-	 * Set Sektion.
-	 * Organisatorische Einheit des Mandanten
+	 * Set Organisation.
+	 * Organisational entity within client
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Org_ID (int AD_Org_ID);
+	void setAD_Org_ID (int AD_Org_ID);
 
 	/**
-	 * Get Sektion.
-	 * Organisatorische Einheit des Mandanten
+	 * Get Organisation.
+	 * Organisational entity within client
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Org_ID();
+	int getAD_Org_ID();
 
-	public org.compiere.model.I_AD_Org getAD_Org();
-
-	public void setAD_Org(org.compiere.model.I_AD_Org AD_Org);
-
-    /** Column definition for AD_Org_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Form_Access, org.compiere.model.I_AD_Org> COLUMN_AD_Org_ID = new org.adempiere.model.ModelColumn<I_AD_Form_Access, org.compiere.model.I_AD_Org>(I_AD_Form_Access.class, "AD_Org_ID", org.compiere.model.I_AD_Org.class);
-    /** Column name AD_Org_ID */
-    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+	String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
 
 	/**
-	 * Set Rolle.
+	 * Set Role.
 	 * Responsibility Role
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Role_ID (int AD_Role_ID);
+	void setAD_Role_ID (int AD_Role_ID);
 
 	/**
-	 * Get Rolle.
+	 * Get Role.
 	 * Responsibility Role
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Role_ID();
+	int getAD_Role_ID();
 
-	public org.compiere.model.I_AD_Role getAD_Role();
+	org.compiere.model.I_AD_Role getAD_Role();
 
-	public void setAD_Role(org.compiere.model.I_AD_Role AD_Role);
+	void setAD_Role(org.compiere.model.I_AD_Role AD_Role);
 
-    /** Column definition for AD_Role_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Form_Access, org.compiere.model.I_AD_Role> COLUMN_AD_Role_ID = new org.adempiere.model.ModelColumn<I_AD_Form_Access, org.compiere.model.I_AD_Role>(I_AD_Form_Access.class, "AD_Role_ID", org.compiere.model.I_AD_Role.class);
-    /** Column name AD_Role_ID */
-    public static final String COLUMNNAME_AD_Role_ID = "AD_Role_ID";
+	ModelColumn<I_AD_Form_Access, org.compiere.model.I_AD_Role> COLUMN_AD_Role_ID = new ModelColumn<>(I_AD_Form_Access.class, "AD_Role_ID", org.compiere.model.I_AD_Role.class);
+	String COLUMNNAME_AD_Role_ID = "AD_Role_ID";
 
 	/**
-	 * Get Erstellt.
+	 * Get Created.
 	 * Date this record was created
 	 *
 	 * <br>Type: DateTime
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public java.sql.Timestamp getCreated();
+	java.sql.Timestamp getCreated();
 
-    /** Column definition for Created */
-    public static final org.adempiere.model.ModelColumn<I_AD_Form_Access, Object> COLUMN_Created = new org.adempiere.model.ModelColumn<I_AD_Form_Access, Object>(I_AD_Form_Access.class, "Created", null);
-    /** Column name Created */
-    public static final String COLUMNNAME_Created = "Created";
+	ModelColumn<I_AD_Form_Access, Object> COLUMN_Created = new ModelColumn<>(I_AD_Form_Access.class, "Created", null);
+	String COLUMNNAME_Created = "Created";
 
 	/**
-	 * Get Erstellt durch.
+	 * Get Created By.
 	 * User who created this records
 	 *
 	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getCreatedBy();
+	int getCreatedBy();
 
-    /** Column definition for CreatedBy */
-    public static final org.adempiere.model.ModelColumn<I_AD_Form_Access, org.compiere.model.I_AD_User> COLUMN_CreatedBy = new org.adempiere.model.ModelColumn<I_AD_Form_Access, org.compiere.model.I_AD_User>(I_AD_Form_Access.class, "CreatedBy", org.compiere.model.I_AD_User.class);
-    /** Column name CreatedBy */
-    public static final String COLUMNNAME_CreatedBy = "CreatedBy";
+	String COLUMNNAME_CreatedBy = "CreatedBy";
 
 	/**
-	 * Set Aktiv.
+	 * Set Active.
 	 * The record is active in the system
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setIsActive (boolean IsActive);
+	void setIsActive (boolean IsActive);
 
 	/**
-	 * Get Aktiv.
+	 * Get Active.
 	 * The record is active in the system
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public boolean isActive();
+	boolean isActive();
 
-    /** Column definition for IsActive */
-    public static final org.adempiere.model.ModelColumn<I_AD_Form_Access, Object> COLUMN_IsActive = new org.adempiere.model.ModelColumn<I_AD_Form_Access, Object>(I_AD_Form_Access.class, "IsActive", null);
-    /** Column name IsActive */
-    public static final String COLUMNNAME_IsActive = "IsActive";
+	ModelColumn<I_AD_Form_Access, Object> COLUMN_IsActive = new ModelColumn<>(I_AD_Form_Access.class, "IsActive", null);
+	String COLUMNNAME_IsActive = "IsActive";
 
 	/**
-	 * Set Lesen und Schreiben.
-	 * Field is read / write
+	 * Set Read Write.
+	 * Feld / Eintrag / Bereich kann gelesen und verändert werden
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setIsReadWrite (boolean IsReadWrite);
+	void setIsReadWrite (boolean IsReadWrite);
 
 	/**
-	 * Get Lesen und Schreiben.
-	 * Field is read / write
+	 * Get Read Write.
+	 * Feld / Eintrag / Bereich kann gelesen und verändert werden
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public boolean isReadWrite();
+	boolean isReadWrite();
 
-    /** Column definition for IsReadWrite */
-    public static final org.adempiere.model.ModelColumn<I_AD_Form_Access, Object> COLUMN_IsReadWrite = new org.adempiere.model.ModelColumn<I_AD_Form_Access, Object>(I_AD_Form_Access.class, "IsReadWrite", null);
-    /** Column name IsReadWrite */
-    public static final String COLUMNNAME_IsReadWrite = "IsReadWrite";
+	ModelColumn<I_AD_Form_Access, Object> COLUMN_IsReadWrite = new ModelColumn<>(I_AD_Form_Access.class, "IsReadWrite", null);
+	String COLUMNNAME_IsReadWrite = "IsReadWrite";
 
 	/**
-	 * Get Aktualisiert.
+	 * Get Updated.
 	 * Date this record was updated
 	 *
 	 * <br>Type: DateTime
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public java.sql.Timestamp getUpdated();
+	java.sql.Timestamp getUpdated();
 
-    /** Column definition for Updated */
-    public static final org.adempiere.model.ModelColumn<I_AD_Form_Access, Object> COLUMN_Updated = new org.adempiere.model.ModelColumn<I_AD_Form_Access, Object>(I_AD_Form_Access.class, "Updated", null);
-    /** Column name Updated */
-    public static final String COLUMNNAME_Updated = "Updated";
+	ModelColumn<I_AD_Form_Access, Object> COLUMN_Updated = new ModelColumn<>(I_AD_Form_Access.class, "Updated", null);
+	String COLUMNNAME_Updated = "Updated";
 
 	/**
-	 * Get Aktualisiert durch.
+	 * Get Updated By.
 	 * User who updated this records
 	 *
 	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getUpdatedBy();
+	int getUpdatedBy();
 
-    /** Column definition for UpdatedBy */
-    public static final org.adempiere.model.ModelColumn<I_AD_Form_Access, org.compiere.model.I_AD_User> COLUMN_UpdatedBy = new org.adempiere.model.ModelColumn<I_AD_Form_Access, org.compiere.model.I_AD_User>(I_AD_Form_Access.class, "UpdatedBy", org.compiere.model.I_AD_User.class);
-    /** Column name UpdatedBy */
-    public static final String COLUMNNAME_UpdatedBy = "UpdatedBy";
+	String COLUMNNAME_UpdatedBy = "UpdatedBy";
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Process_Access.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Process_Access.java
@@ -1,261 +1,201 @@
 package org.compiere.model;
 
+import org.adempiere.model.ModelColumn;
 
 /** Generated Interface for AD_Process_Access
- *  @author Adempiere (generated) 
+ *  @author metasfresh (generated) 
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings("unused")
 public interface I_AD_Process_Access 
 {
 
-    /** TableName=AD_Process_Access */
-    public static final String Table_Name = "AD_Process_Access";
+	String Table_Name = "AD_Process_Access";
 
-    /** AD_Table_ID=197 */
-//    public static final int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
+//	/** AD_Table_ID=197 */
+//	int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
 
-//    org.compiere.util.KeyNamePair Model = new org.compiere.util.KeyNamePair(Table_ID, Table_Name);
-
-    /** AccessLevel = 6 - System - Client
-     */
-//    java.math.BigDecimal accessLevel = java.math.BigDecimal.valueOf(6);
-
-    /** Load Meta Data */
 
 	/**
-	 * Get Mandant.
+	 * Get Client.
 	 * Client/Tenant for this installation.
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Client_ID();
+	int getAD_Client_ID();
 
-	public org.compiere.model.I_AD_Client getAD_Client();
-
-    /** Column definition for AD_Client_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Process_Access, org.compiere.model.I_AD_Client> COLUMN_AD_Client_ID = new org.adempiere.model.ModelColumn<I_AD_Process_Access, org.compiere.model.I_AD_Client>(I_AD_Process_Access.class, "AD_Client_ID", org.compiere.model.I_AD_Client.class);
-    /** Column name AD_Client_ID */
-    public static final String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+	String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
 
 	/**
-	 * Set Sektion.
-	 * Organisatorische Einheit des Mandanten
+	 * Set Organisation.
+	 * Organisational entity within client
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Org_ID (int AD_Org_ID);
+	void setAD_Org_ID (int AD_Org_ID);
 
 	/**
-	 * Get Sektion.
-	 * Organisatorische Einheit des Mandanten
+	 * Get Organisation.
+	 * Organisational entity within client
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Org_ID();
+	int getAD_Org_ID();
 
-	public org.compiere.model.I_AD_Org getAD_Org();
-
-	public void setAD_Org(org.compiere.model.I_AD_Org AD_Org);
-
-    /** Column definition for AD_Org_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Process_Access, org.compiere.model.I_AD_Org> COLUMN_AD_Org_ID = new org.adempiere.model.ModelColumn<I_AD_Process_Access, org.compiere.model.I_AD_Org>(I_AD_Process_Access.class, "AD_Org_ID", org.compiere.model.I_AD_Org.class);
-    /** Column name AD_Org_ID */
-    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+	String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
 
 	/**
-	 * Set Process Access.
-	 *
-	 * <br>Type: ID
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	public void setAD_Process_Access_ID (int AD_Process_Access_ID);
-
-	/**
-	 * Get Process Access.
-	 *
-	 * <br>Type: ID
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	public int getAD_Process_Access_ID();
-
-    /** Column definition for AD_Process_Access_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Process_Access, Object> COLUMN_AD_Process_Access_ID = new org.adempiere.model.ModelColumn<I_AD_Process_Access, Object>(I_AD_Process_Access.class, "AD_Process_Access_ID", null);
-    /** Column name AD_Process_Access_ID */
-    public static final String COLUMNNAME_AD_Process_Access_ID = "AD_Process_Access_ID";
-
-	/**
-	 * Set Prozess.
+	 * Set Process.
 	 * Process or Report
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Process_ID (int AD_Process_ID);
+	void setAD_Process_ID (int AD_Process_ID);
 
 	/**
-	 * Get Prozess.
+	 * Get Process.
 	 * Process or Report
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Process_ID();
+	int getAD_Process_ID();
 
-	public org.compiere.model.I_AD_Process getAD_Process();
+	org.compiere.model.I_AD_Process getAD_Process();
 
-	public void setAD_Process(org.compiere.model.I_AD_Process AD_Process);
+	void setAD_Process(org.compiere.model.I_AD_Process AD_Process);
 
-    /** Column definition for AD_Process_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Process_Access, org.compiere.model.I_AD_Process> COLUMN_AD_Process_ID = new org.adempiere.model.ModelColumn<I_AD_Process_Access, org.compiere.model.I_AD_Process>(I_AD_Process_Access.class, "AD_Process_ID", org.compiere.model.I_AD_Process.class);
-    /** Column name AD_Process_ID */
-    public static final String COLUMNNAME_AD_Process_ID = "AD_Process_ID";
+	ModelColumn<I_AD_Process_Access, org.compiere.model.I_AD_Process> COLUMN_AD_Process_ID = new ModelColumn<>(I_AD_Process_Access.class, "AD_Process_ID", org.compiere.model.I_AD_Process.class);
+	String COLUMNNAME_AD_Process_ID = "AD_Process_ID";
 
 	/**
-	 * Set Rolle.
+	 * Set Role.
 	 * Responsibility Role
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Role_ID (int AD_Role_ID);
+	void setAD_Role_ID (int AD_Role_ID);
 
 	/**
-	 * Get Rolle.
+	 * Get Role.
 	 * Responsibility Role
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Role_ID();
+	int getAD_Role_ID();
 
-	public org.compiere.model.I_AD_Role getAD_Role();
+	org.compiere.model.I_AD_Role getAD_Role();
 
-	public void setAD_Role(org.compiere.model.I_AD_Role AD_Role);
+	void setAD_Role(org.compiere.model.I_AD_Role AD_Role);
 
-    /** Column definition for AD_Role_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Process_Access, org.compiere.model.I_AD_Role> COLUMN_AD_Role_ID = new org.adempiere.model.ModelColumn<I_AD_Process_Access, org.compiere.model.I_AD_Role>(I_AD_Process_Access.class, "AD_Role_ID", org.compiere.model.I_AD_Role.class);
-    /** Column name AD_Role_ID */
-    public static final String COLUMNNAME_AD_Role_ID = "AD_Role_ID";
+	ModelColumn<I_AD_Process_Access, org.compiere.model.I_AD_Role> COLUMN_AD_Role_ID = new ModelColumn<>(I_AD_Process_Access.class, "AD_Role_ID", org.compiere.model.I_AD_Role.class);
+	String COLUMNNAME_AD_Role_ID = "AD_Role_ID";
 
 	/**
-	 * Get Erstellt.
+	 * Get Created.
 	 * Date this record was created
 	 *
 	 * <br>Type: DateTime
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public java.sql.Timestamp getCreated();
+	java.sql.Timestamp getCreated();
 
-    /** Column definition for Created */
-    public static final org.adempiere.model.ModelColumn<I_AD_Process_Access, Object> COLUMN_Created = new org.adempiere.model.ModelColumn<I_AD_Process_Access, Object>(I_AD_Process_Access.class, "Created", null);
-    /** Column name Created */
-    public static final String COLUMNNAME_Created = "Created";
+	ModelColumn<I_AD_Process_Access, Object> COLUMN_Created = new ModelColumn<>(I_AD_Process_Access.class, "Created", null);
+	String COLUMNNAME_Created = "Created";
 
 	/**
-	 * Get Erstellt durch.
+	 * Get Created By.
 	 * User who created this records
 	 *
 	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getCreatedBy();
+	int getCreatedBy();
 
-    /** Column definition for CreatedBy */
-    public static final org.adempiere.model.ModelColumn<I_AD_Process_Access, org.compiere.model.I_AD_User> COLUMN_CreatedBy = new org.adempiere.model.ModelColumn<I_AD_Process_Access, org.compiere.model.I_AD_User>(I_AD_Process_Access.class, "CreatedBy", org.compiere.model.I_AD_User.class);
-    /** Column name CreatedBy */
-    public static final String COLUMNNAME_CreatedBy = "CreatedBy";
+	String COLUMNNAME_CreatedBy = "CreatedBy";
 
 	/**
-	 * Set Aktiv.
+	 * Set Active.
 	 * The record is active in the system
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setIsActive (boolean IsActive);
+	void setIsActive (boolean IsActive);
 
 	/**
-	 * Get Aktiv.
+	 * Get Active.
 	 * The record is active in the system
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public boolean isActive();
+	boolean isActive();
 
-    /** Column definition for IsActive */
-    public static final org.adempiere.model.ModelColumn<I_AD_Process_Access, Object> COLUMN_IsActive = new org.adempiere.model.ModelColumn<I_AD_Process_Access, Object>(I_AD_Process_Access.class, "IsActive", null);
-    /** Column name IsActive */
-    public static final String COLUMNNAME_IsActive = "IsActive";
+	ModelColumn<I_AD_Process_Access, Object> COLUMN_IsActive = new ModelColumn<>(I_AD_Process_Access.class, "IsActive", null);
+	String COLUMNNAME_IsActive = "IsActive";
 
 	/**
-	 * Set Lesen und Schreiben.
-	 * Field is read / write
+	 * Set Read Write.
+	 * Feld / Eintrag / Bereich kann gelesen und verändert werden
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setIsReadWrite (boolean IsReadWrite);
+	void setIsReadWrite (boolean IsReadWrite);
 
 	/**
-	 * Get Lesen und Schreiben.
-	 * Field is read / write
+	 * Get Read Write.
+	 * Feld / Eintrag / Bereich kann gelesen und verändert werden
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public boolean isReadWrite();
+	boolean isReadWrite();
 
-    /** Column definition for IsReadWrite */
-    public static final org.adempiere.model.ModelColumn<I_AD_Process_Access, Object> COLUMN_IsReadWrite = new org.adempiere.model.ModelColumn<I_AD_Process_Access, Object>(I_AD_Process_Access.class, "IsReadWrite", null);
-    /** Column name IsReadWrite */
-    public static final String COLUMNNAME_IsReadWrite = "IsReadWrite";
+	ModelColumn<I_AD_Process_Access, Object> COLUMN_IsReadWrite = new ModelColumn<>(I_AD_Process_Access.class, "IsReadWrite", null);
+	String COLUMNNAME_IsReadWrite = "IsReadWrite";
 
 	/**
-	 * Get Aktualisiert.
+	 * Get Updated.
 	 * Date this record was updated
 	 *
 	 * <br>Type: DateTime
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public java.sql.Timestamp getUpdated();
+	java.sql.Timestamp getUpdated();
 
-    /** Column definition for Updated */
-    public static final org.adempiere.model.ModelColumn<I_AD_Process_Access, Object> COLUMN_Updated = new org.adempiere.model.ModelColumn<I_AD_Process_Access, Object>(I_AD_Process_Access.class, "Updated", null);
-    /** Column name Updated */
-    public static final String COLUMNNAME_Updated = "Updated";
+	ModelColumn<I_AD_Process_Access, Object> COLUMN_Updated = new ModelColumn<>(I_AD_Process_Access.class, "Updated", null);
+	String COLUMNNAME_Updated = "Updated";
 
 	/**
-	 * Get Aktualisiert durch.
+	 * Get Updated By.
 	 * User who updated this records
 	 *
 	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getUpdatedBy();
+	int getUpdatedBy();
 
-    /** Column definition for UpdatedBy */
-    public static final org.adempiere.model.ModelColumn<I_AD_Process_Access, org.compiere.model.I_AD_User> COLUMN_UpdatedBy = new org.adempiere.model.ModelColumn<I_AD_Process_Access, org.compiere.model.I_AD_User>(I_AD_Process_Access.class, "UpdatedBy", org.compiere.model.I_AD_User.class);
-    /** Column name UpdatedBy */
-    public static final String COLUMNNAME_UpdatedBy = "UpdatedBy";
+	String COLUMNNAME_UpdatedBy = "UpdatedBy";
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Task_Access.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Task_Access.java
@@ -1,261 +1,199 @@
 package org.compiere.model;
 
+import org.adempiere.model.ModelColumn;
 
 /** Generated Interface for AD_Task_Access
- *  @author Adempiere (generated) 
+ *  @author metasfresh (generated) 
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings("unused")
 public interface I_AD_Task_Access 
 {
 
-    /** TableName=AD_Task_Access */
-    public static final String Table_Name = "AD_Task_Access";
+	String Table_Name = "AD_Task_Access";
 
-    /** AD_Table_ID=199 */
-//    public static final int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
+//	/** AD_Table_ID=199 */
+//	int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
 
-//    org.compiere.util.KeyNamePair Model = new org.compiere.util.KeyNamePair(Table_ID, Table_Name);
-
-    /** AccessLevel = 6 - System - Client
-     */
-//    java.math.BigDecimal accessLevel = java.math.BigDecimal.valueOf(6);
-
-    /** Load Meta Data */
 
 	/**
-	 * Get Mandant.
+	 * Get Client.
 	 * Client/Tenant for this installation.
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Client_ID();
+	int getAD_Client_ID();
 
-	public org.compiere.model.I_AD_Client getAD_Client();
-
-    /** Column definition for AD_Client_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Task_Access, org.compiere.model.I_AD_Client> COLUMN_AD_Client_ID = new org.adempiere.model.ModelColumn<I_AD_Task_Access, org.compiere.model.I_AD_Client>(I_AD_Task_Access.class, "AD_Client_ID", org.compiere.model.I_AD_Client.class);
-    /** Column name AD_Client_ID */
-    public static final String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+	String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
 
 	/**
-	 * Set Sektion.
-	 * Organisatorische Einheit des Mandanten
+	 * Set Organisation.
+	 * Organisational entity within client
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Org_ID (int AD_Org_ID);
+	void setAD_Org_ID (int AD_Org_ID);
 
 	/**
-	 * Get Sektion.
-	 * Organisatorische Einheit des Mandanten
+	 * Get Organisation.
+	 * Organisational entity within client
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Org_ID();
+	int getAD_Org_ID();
 
-	public org.compiere.model.I_AD_Org getAD_Org();
-
-	public void setAD_Org(org.compiere.model.I_AD_Org AD_Org);
-
-    /** Column definition for AD_Org_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Task_Access, org.compiere.model.I_AD_Org> COLUMN_AD_Org_ID = new org.adempiere.model.ModelColumn<I_AD_Task_Access, org.compiere.model.I_AD_Org>(I_AD_Task_Access.class, "AD_Org_ID", org.compiere.model.I_AD_Org.class);
-    /** Column name AD_Org_ID */
-    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+	String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
 
 	/**
-	 * Set Rolle.
+	 * Set Role.
 	 * Responsibility Role
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Role_ID (int AD_Role_ID);
+	void setAD_Role_ID (int AD_Role_ID);
 
 	/**
-	 * Get Rolle.
+	 * Get Role.
 	 * Responsibility Role
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Role_ID();
+	int getAD_Role_ID();
 
-	public org.compiere.model.I_AD_Role getAD_Role();
+	org.compiere.model.I_AD_Role getAD_Role();
 
-	public void setAD_Role(org.compiere.model.I_AD_Role AD_Role);
+	void setAD_Role(org.compiere.model.I_AD_Role AD_Role);
 
-    /** Column definition for AD_Role_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Task_Access, org.compiere.model.I_AD_Role> COLUMN_AD_Role_ID = new org.adempiere.model.ModelColumn<I_AD_Task_Access, org.compiere.model.I_AD_Role>(I_AD_Task_Access.class, "AD_Role_ID", org.compiere.model.I_AD_Role.class);
-    /** Column name AD_Role_ID */
-    public static final String COLUMNNAME_AD_Role_ID = "AD_Role_ID";
+	ModelColumn<I_AD_Task_Access, org.compiere.model.I_AD_Role> COLUMN_AD_Role_ID = new ModelColumn<>(I_AD_Task_Access.class, "AD_Role_ID", org.compiere.model.I_AD_Role.class);
+	String COLUMNNAME_AD_Role_ID = "AD_Role_ID";
 
 	/**
-	 * Set AD_Task_Access.
-	 *
-	 * <br>Type: ID
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	public void setAD_Task_Access_ID (int AD_Task_Access_ID);
-
-	/**
-	 * Get AD_Task_Access.
-	 *
-	 * <br>Type: ID
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	public int getAD_Task_Access_ID();
-
-    /** Column definition for AD_Task_Access_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Task_Access, Object> COLUMN_AD_Task_Access_ID = new org.adempiere.model.ModelColumn<I_AD_Task_Access, Object>(I_AD_Task_Access.class, "AD_Task_Access_ID", null);
-    /** Column name AD_Task_Access_ID */
-    public static final String COLUMNNAME_AD_Task_Access_ID = "AD_Task_Access_ID";
-
-	/**
-	 * Set Externer Prozess.
-	 * Operation System Task
+	 * Set External Process.
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Task_ID (int AD_Task_ID);
+	void setAD_Task_ID (int AD_Task_ID);
 
 	/**
-	 * Get Externer Prozess.
-	 * Operation System Task
+	 * Get External Process.
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Task_ID();
+	int getAD_Task_ID();
 
-	public org.compiere.model.I_AD_Task getAD_Task();
+	org.compiere.model.I_AD_Task getAD_Task();
 
-	public void setAD_Task(org.compiere.model.I_AD_Task AD_Task);
+	void setAD_Task(org.compiere.model.I_AD_Task AD_Task);
 
-    /** Column definition for AD_Task_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Task_Access, org.compiere.model.I_AD_Task> COLUMN_AD_Task_ID = new org.adempiere.model.ModelColumn<I_AD_Task_Access, org.compiere.model.I_AD_Task>(I_AD_Task_Access.class, "AD_Task_ID", org.compiere.model.I_AD_Task.class);
-    /** Column name AD_Task_ID */
-    public static final String COLUMNNAME_AD_Task_ID = "AD_Task_ID";
+	ModelColumn<I_AD_Task_Access, org.compiere.model.I_AD_Task> COLUMN_AD_Task_ID = new ModelColumn<>(I_AD_Task_Access.class, "AD_Task_ID", org.compiere.model.I_AD_Task.class);
+	String COLUMNNAME_AD_Task_ID = "AD_Task_ID";
 
 	/**
-	 * Get Erstellt.
+	 * Get Created.
 	 * Date this record was created
 	 *
 	 * <br>Type: DateTime
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public java.sql.Timestamp getCreated();
+	java.sql.Timestamp getCreated();
 
-    /** Column definition for Created */
-    public static final org.adempiere.model.ModelColumn<I_AD_Task_Access, Object> COLUMN_Created = new org.adempiere.model.ModelColumn<I_AD_Task_Access, Object>(I_AD_Task_Access.class, "Created", null);
-    /** Column name Created */
-    public static final String COLUMNNAME_Created = "Created";
+	ModelColumn<I_AD_Task_Access, Object> COLUMN_Created = new ModelColumn<>(I_AD_Task_Access.class, "Created", null);
+	String COLUMNNAME_Created = "Created";
 
 	/**
-	 * Get Erstellt durch.
+	 * Get Created By.
 	 * User who created this records
 	 *
 	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getCreatedBy();
+	int getCreatedBy();
 
-    /** Column definition for CreatedBy */
-    public static final org.adempiere.model.ModelColumn<I_AD_Task_Access, org.compiere.model.I_AD_User> COLUMN_CreatedBy = new org.adempiere.model.ModelColumn<I_AD_Task_Access, org.compiere.model.I_AD_User>(I_AD_Task_Access.class, "CreatedBy", org.compiere.model.I_AD_User.class);
-    /** Column name CreatedBy */
-    public static final String COLUMNNAME_CreatedBy = "CreatedBy";
+	String COLUMNNAME_CreatedBy = "CreatedBy";
 
 	/**
-	 * Set Aktiv.
+	 * Set Active.
 	 * The record is active in the system
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setIsActive (boolean IsActive);
+	void setIsActive (boolean IsActive);
 
 	/**
-	 * Get Aktiv.
+	 * Get Active.
 	 * The record is active in the system
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public boolean isActive();
+	boolean isActive();
 
-    /** Column definition for IsActive */
-    public static final org.adempiere.model.ModelColumn<I_AD_Task_Access, Object> COLUMN_IsActive = new org.adempiere.model.ModelColumn<I_AD_Task_Access, Object>(I_AD_Task_Access.class, "IsActive", null);
-    /** Column name IsActive */
-    public static final String COLUMNNAME_IsActive = "IsActive";
+	ModelColumn<I_AD_Task_Access, Object> COLUMN_IsActive = new ModelColumn<>(I_AD_Task_Access.class, "IsActive", null);
+	String COLUMNNAME_IsActive = "IsActive";
 
 	/**
-	 * Set Lesen und Schreiben.
-	 * Field is read / write
+	 * Set Read Write.
+	 * Feld / Eintrag / Bereich kann gelesen und verändert werden
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setIsReadWrite (boolean IsReadWrite);
+	void setIsReadWrite (boolean IsReadWrite);
 
 	/**
-	 * Get Lesen und Schreiben.
-	 * Field is read / write
+	 * Get Read Write.
+	 * Feld / Eintrag / Bereich kann gelesen und verändert werden
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public boolean isReadWrite();
+	boolean isReadWrite();
 
-    /** Column definition for IsReadWrite */
-    public static final org.adempiere.model.ModelColumn<I_AD_Task_Access, Object> COLUMN_IsReadWrite = new org.adempiere.model.ModelColumn<I_AD_Task_Access, Object>(I_AD_Task_Access.class, "IsReadWrite", null);
-    /** Column name IsReadWrite */
-    public static final String COLUMNNAME_IsReadWrite = "IsReadWrite";
+	ModelColumn<I_AD_Task_Access, Object> COLUMN_IsReadWrite = new ModelColumn<>(I_AD_Task_Access.class, "IsReadWrite", null);
+	String COLUMNNAME_IsReadWrite = "IsReadWrite";
 
 	/**
-	 * Get Aktualisiert.
+	 * Get Updated.
 	 * Date this record was updated
 	 *
 	 * <br>Type: DateTime
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public java.sql.Timestamp getUpdated();
+	java.sql.Timestamp getUpdated();
 
-    /** Column definition for Updated */
-    public static final org.adempiere.model.ModelColumn<I_AD_Task_Access, Object> COLUMN_Updated = new org.adempiere.model.ModelColumn<I_AD_Task_Access, Object>(I_AD_Task_Access.class, "Updated", null);
-    /** Column name Updated */
-    public static final String COLUMNNAME_Updated = "Updated";
+	ModelColumn<I_AD_Task_Access, Object> COLUMN_Updated = new ModelColumn<>(I_AD_Task_Access.class, "Updated", null);
+	String COLUMNNAME_Updated = "Updated";
 
 	/**
-	 * Get Aktualisiert durch.
+	 * Get Updated By.
 	 * User who updated this records
 	 *
 	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getUpdatedBy();
+	int getUpdatedBy();
 
-    /** Column definition for UpdatedBy */
-    public static final org.adempiere.model.ModelColumn<I_AD_Task_Access, org.compiere.model.I_AD_User> COLUMN_UpdatedBy = new org.adempiere.model.ModelColumn<I_AD_Task_Access, org.compiere.model.I_AD_User>(I_AD_Task_Access.class, "UpdatedBy", org.compiere.model.I_AD_User.class);
-    /** Column name UpdatedBy */
-    public static final String COLUMNNAME_UpdatedBy = "UpdatedBy";
+	String COLUMNNAME_UpdatedBy = "UpdatedBy";
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Window_Access.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Window_Access.java
@@ -1,261 +1,201 @@
 package org.compiere.model;
 
+import org.adempiere.model.ModelColumn;
 
 /** Generated Interface for AD_Window_Access
- *  @author Adempiere (generated) 
+ *  @author metasfresh (generated) 
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings("unused")
 public interface I_AD_Window_Access 
 {
 
-    /** TableName=AD_Window_Access */
-    public static final String Table_Name = "AD_Window_Access";
+	String Table_Name = "AD_Window_Access";
 
-    /** AD_Table_ID=201 */
-//    public static final int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
+//	/** AD_Table_ID=201 */
+//	int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
 
-//    org.compiere.util.KeyNamePair Model = new org.compiere.util.KeyNamePair(Table_ID, Table_Name);
-
-    /** AccessLevel = 6 - System - Client
-     */
-//    java.math.BigDecimal accessLevel = java.math.BigDecimal.valueOf(6);
-
-    /** Load Meta Data */
 
 	/**
-	 * Get Mandant.
+	 * Get Client.
 	 * Client/Tenant for this installation.
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Client_ID();
+	int getAD_Client_ID();
 
-	public org.compiere.model.I_AD_Client getAD_Client();
-
-    /** Column definition for AD_Client_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Window_Access, org.compiere.model.I_AD_Client> COLUMN_AD_Client_ID = new org.adempiere.model.ModelColumn<I_AD_Window_Access, org.compiere.model.I_AD_Client>(I_AD_Window_Access.class, "AD_Client_ID", org.compiere.model.I_AD_Client.class);
-    /** Column name AD_Client_ID */
-    public static final String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+	String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
 
 	/**
-	 * Set Sektion.
-	 * Organisatorische Einheit des Mandanten
+	 * Set Organisation.
+	 * Organisational entity within client
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Org_ID (int AD_Org_ID);
+	void setAD_Org_ID (int AD_Org_ID);
 
 	/**
-	 * Get Sektion.
-	 * Organisatorische Einheit des Mandanten
+	 * Get Organisation.
+	 * Organisational entity within client
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Org_ID();
+	int getAD_Org_ID();
 
-	public org.compiere.model.I_AD_Org getAD_Org();
-
-	public void setAD_Org(org.compiere.model.I_AD_Org AD_Org);
-
-    /** Column definition for AD_Org_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Window_Access, org.compiere.model.I_AD_Org> COLUMN_AD_Org_ID = new org.adempiere.model.ModelColumn<I_AD_Window_Access, org.compiere.model.I_AD_Org>(I_AD_Window_Access.class, "AD_Org_ID", org.compiere.model.I_AD_Org.class);
-    /** Column name AD_Org_ID */
-    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+	String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
 
 	/**
-	 * Set Rolle.
+	 * Set Role.
 	 * Responsibility Role
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Role_ID (int AD_Role_ID);
+	void setAD_Role_ID (int AD_Role_ID);
 
 	/**
-	 * Get Rolle.
+	 * Get Role.
 	 * Responsibility Role
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Role_ID();
+	int getAD_Role_ID();
 
-	public org.compiere.model.I_AD_Role getAD_Role();
+	org.compiere.model.I_AD_Role getAD_Role();
 
-	public void setAD_Role(org.compiere.model.I_AD_Role AD_Role);
+	void setAD_Role(org.compiere.model.I_AD_Role AD_Role);
 
-    /** Column definition for AD_Role_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Window_Access, org.compiere.model.I_AD_Role> COLUMN_AD_Role_ID = new org.adempiere.model.ModelColumn<I_AD_Window_Access, org.compiere.model.I_AD_Role>(I_AD_Window_Access.class, "AD_Role_ID", org.compiere.model.I_AD_Role.class);
-    /** Column name AD_Role_ID */
-    public static final String COLUMNNAME_AD_Role_ID = "AD_Role_ID";
+	ModelColumn<I_AD_Window_Access, org.compiere.model.I_AD_Role> COLUMN_AD_Role_ID = new ModelColumn<>(I_AD_Window_Access.class, "AD_Role_ID", org.compiere.model.I_AD_Role.class);
+	String COLUMNNAME_AD_Role_ID = "AD_Role_ID";
 
 	/**
-	 * Set AD_Window_Access.
-	 *
-	 * <br>Type: ID
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	public void setAD_Window_Access_ID (int AD_Window_Access_ID);
-
-	/**
-	 * Get AD_Window_Access.
-	 *
-	 * <br>Type: ID
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	public int getAD_Window_Access_ID();
-
-    /** Column definition for AD_Window_Access_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Window_Access, Object> COLUMN_AD_Window_Access_ID = new org.adempiere.model.ModelColumn<I_AD_Window_Access, Object>(I_AD_Window_Access.class, "AD_Window_Access_ID", null);
-    /** Column name AD_Window_Access_ID */
-    public static final String COLUMNNAME_AD_Window_Access_ID = "AD_Window_Access_ID";
-
-	/**
-	 * Set Fenster.
+	 * Set Window.
 	 * Data entry or display window
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Window_ID (int AD_Window_ID);
+	void setAD_Window_ID (int AD_Window_ID);
 
 	/**
-	 * Get Fenster.
+	 * Get Window.
 	 * Data entry or display window
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Window_ID();
+	int getAD_Window_ID();
 
-	public org.compiere.model.I_AD_Window getAD_Window();
+	org.compiere.model.I_AD_Window getAD_Window();
 
-	public void setAD_Window(org.compiere.model.I_AD_Window AD_Window);
+	void setAD_Window(org.compiere.model.I_AD_Window AD_Window);
 
-    /** Column definition for AD_Window_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Window_Access, org.compiere.model.I_AD_Window> COLUMN_AD_Window_ID = new org.adempiere.model.ModelColumn<I_AD_Window_Access, org.compiere.model.I_AD_Window>(I_AD_Window_Access.class, "AD_Window_ID", org.compiere.model.I_AD_Window.class);
-    /** Column name AD_Window_ID */
-    public static final String COLUMNNAME_AD_Window_ID = "AD_Window_ID";
+	ModelColumn<I_AD_Window_Access, org.compiere.model.I_AD_Window> COLUMN_AD_Window_ID = new ModelColumn<>(I_AD_Window_Access.class, "AD_Window_ID", org.compiere.model.I_AD_Window.class);
+	String COLUMNNAME_AD_Window_ID = "AD_Window_ID";
 
 	/**
-	 * Get Erstellt.
+	 * Get Created.
 	 * Date this record was created
 	 *
 	 * <br>Type: DateTime
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public java.sql.Timestamp getCreated();
+	java.sql.Timestamp getCreated();
 
-    /** Column definition for Created */
-    public static final org.adempiere.model.ModelColumn<I_AD_Window_Access, Object> COLUMN_Created = new org.adempiere.model.ModelColumn<I_AD_Window_Access, Object>(I_AD_Window_Access.class, "Created", null);
-    /** Column name Created */
-    public static final String COLUMNNAME_Created = "Created";
+	ModelColumn<I_AD_Window_Access, Object> COLUMN_Created = new ModelColumn<>(I_AD_Window_Access.class, "Created", null);
+	String COLUMNNAME_Created = "Created";
 
 	/**
-	 * Get Erstellt durch.
+	 * Get Created By.
 	 * User who created this records
 	 *
 	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getCreatedBy();
+	int getCreatedBy();
 
-    /** Column definition for CreatedBy */
-    public static final org.adempiere.model.ModelColumn<I_AD_Window_Access, org.compiere.model.I_AD_User> COLUMN_CreatedBy = new org.adempiere.model.ModelColumn<I_AD_Window_Access, org.compiere.model.I_AD_User>(I_AD_Window_Access.class, "CreatedBy", org.compiere.model.I_AD_User.class);
-    /** Column name CreatedBy */
-    public static final String COLUMNNAME_CreatedBy = "CreatedBy";
+	String COLUMNNAME_CreatedBy = "CreatedBy";
 
 	/**
-	 * Set Aktiv.
+	 * Set Active.
 	 * The record is active in the system
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setIsActive (boolean IsActive);
+	void setIsActive (boolean IsActive);
 
 	/**
-	 * Get Aktiv.
+	 * Get Active.
 	 * The record is active in the system
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public boolean isActive();
+	boolean isActive();
 
-    /** Column definition for IsActive */
-    public static final org.adempiere.model.ModelColumn<I_AD_Window_Access, Object> COLUMN_IsActive = new org.adempiere.model.ModelColumn<I_AD_Window_Access, Object>(I_AD_Window_Access.class, "IsActive", null);
-    /** Column name IsActive */
-    public static final String COLUMNNAME_IsActive = "IsActive";
+	ModelColumn<I_AD_Window_Access, Object> COLUMN_IsActive = new ModelColumn<>(I_AD_Window_Access.class, "IsActive", null);
+	String COLUMNNAME_IsActive = "IsActive";
 
 	/**
-	 * Set Lesen und Schreiben.
-	 * Field is read / write
+	 * Set Read Write.
+	 * Feld / Eintrag / Bereich kann gelesen und verändert werden
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setIsReadWrite (boolean IsReadWrite);
+	void setIsReadWrite (boolean IsReadWrite);
 
 	/**
-	 * Get Lesen und Schreiben.
-	 * Field is read / write
+	 * Get Read Write.
+	 * Feld / Eintrag / Bereich kann gelesen und verändert werden
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public boolean isReadWrite();
+	boolean isReadWrite();
 
-    /** Column definition for IsReadWrite */
-    public static final org.adempiere.model.ModelColumn<I_AD_Window_Access, Object> COLUMN_IsReadWrite = new org.adempiere.model.ModelColumn<I_AD_Window_Access, Object>(I_AD_Window_Access.class, "IsReadWrite", null);
-    /** Column name IsReadWrite */
-    public static final String COLUMNNAME_IsReadWrite = "IsReadWrite";
+	ModelColumn<I_AD_Window_Access, Object> COLUMN_IsReadWrite = new ModelColumn<>(I_AD_Window_Access.class, "IsReadWrite", null);
+	String COLUMNNAME_IsReadWrite = "IsReadWrite";
 
 	/**
-	 * Get Aktualisiert.
+	 * Get Updated.
 	 * Date this record was updated
 	 *
 	 * <br>Type: DateTime
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public java.sql.Timestamp getUpdated();
+	java.sql.Timestamp getUpdated();
 
-    /** Column definition for Updated */
-    public static final org.adempiere.model.ModelColumn<I_AD_Window_Access, Object> COLUMN_Updated = new org.adempiere.model.ModelColumn<I_AD_Window_Access, Object>(I_AD_Window_Access.class, "Updated", null);
-    /** Column name Updated */
-    public static final String COLUMNNAME_Updated = "Updated";
+	ModelColumn<I_AD_Window_Access, Object> COLUMN_Updated = new ModelColumn<>(I_AD_Window_Access.class, "Updated", null);
+	String COLUMNNAME_Updated = "Updated";
 
 	/**
-	 * Get Aktualisiert durch.
+	 * Get Updated By.
 	 * User who updated this records
 	 *
 	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getUpdatedBy();
+	int getUpdatedBy();
 
-    /** Column definition for UpdatedBy */
-    public static final org.adempiere.model.ModelColumn<I_AD_Window_Access, org.compiere.model.I_AD_User> COLUMN_UpdatedBy = new org.adempiere.model.ModelColumn<I_AD_Window_Access, org.compiere.model.I_AD_User>(I_AD_Window_Access.class, "UpdatedBy", org.compiere.model.I_AD_User.class);
-    /** Column name UpdatedBy */
-    public static final String COLUMNNAME_UpdatedBy = "UpdatedBy";
+	String COLUMNNAME_UpdatedBy = "UpdatedBy";
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Workflow_Access.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Workflow_Access.java
@@ -1,124 +1,80 @@
 package org.compiere.model;
 
+import org.adempiere.model.ModelColumn;
 
 /** Generated Interface for AD_Workflow_Access
- *  @author Adempiere (generated) 
+ *  @author metasfresh (generated) 
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings("unused")
 public interface I_AD_Workflow_Access 
 {
 
-    /** TableName=AD_Workflow_Access */
-    public static final String Table_Name = "AD_Workflow_Access";
+	String Table_Name = "AD_Workflow_Access";
 
-    /** AD_Table_ID=202 */
-//    public static final int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
+//	/** AD_Table_ID=202 */
+//	int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
 
-//    org.compiere.util.KeyNamePair Model = new org.compiere.util.KeyNamePair(Table_ID, Table_Name);
-
-    /** AccessLevel = 6 - System - Client
-     */
-//    java.math.BigDecimal accessLevel = java.math.BigDecimal.valueOf(6);
-
-    /** Load Meta Data */
 
 	/**
-	 * Get Mandant.
+	 * Get Client.
 	 * Client/Tenant for this installation.
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Client_ID();
+	int getAD_Client_ID();
 
-	public org.compiere.model.I_AD_Client getAD_Client();
-
-    /** Column definition for AD_Client_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Workflow_Access, org.compiere.model.I_AD_Client> COLUMN_AD_Client_ID = new org.adempiere.model.ModelColumn<I_AD_Workflow_Access, org.compiere.model.I_AD_Client>(I_AD_Workflow_Access.class, "AD_Client_ID", org.compiere.model.I_AD_Client.class);
-    /** Column name AD_Client_ID */
-    public static final String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+	String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
 
 	/**
-	 * Set Sektion.
-	 * Organisatorische Einheit des Mandanten
+	 * Set Organisation.
+	 * Organisational entity within client
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Org_ID (int AD_Org_ID);
+	void setAD_Org_ID (int AD_Org_ID);
 
 	/**
-	 * Get Sektion.
-	 * Organisatorische Einheit des Mandanten
+	 * Get Organisation.
+	 * Organisational entity within client
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Search
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Org_ID();
+	int getAD_Org_ID();
 
-	public org.compiere.model.I_AD_Org getAD_Org();
-
-	public void setAD_Org(org.compiere.model.I_AD_Org AD_Org);
-
-    /** Column definition for AD_Org_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Workflow_Access, org.compiere.model.I_AD_Org> COLUMN_AD_Org_ID = new org.adempiere.model.ModelColumn<I_AD_Workflow_Access, org.compiere.model.I_AD_Org>(I_AD_Workflow_Access.class, "AD_Org_ID", org.compiere.model.I_AD_Org.class);
-    /** Column name AD_Org_ID */
-    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+	String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
 
 	/**
-	 * Set Rolle.
+	 * Set Role.
 	 * Responsibility Role
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Role_ID (int AD_Role_ID);
+	void setAD_Role_ID (int AD_Role_ID);
 
 	/**
-	 * Get Rolle.
+	 * Get Role.
 	 * Responsibility Role
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Role_ID();
+	int getAD_Role_ID();
 
-	public org.compiere.model.I_AD_Role getAD_Role();
+	org.compiere.model.I_AD_Role getAD_Role();
 
-	public void setAD_Role(org.compiere.model.I_AD_Role AD_Role);
+	void setAD_Role(org.compiere.model.I_AD_Role AD_Role);
 
-    /** Column definition for AD_Role_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Workflow_Access, org.compiere.model.I_AD_Role> COLUMN_AD_Role_ID = new org.adempiere.model.ModelColumn<I_AD_Workflow_Access, org.compiere.model.I_AD_Role>(I_AD_Workflow_Access.class, "AD_Role_ID", org.compiere.model.I_AD_Role.class);
-    /** Column name AD_Role_ID */
-    public static final String COLUMNNAME_AD_Role_ID = "AD_Role_ID";
-
-	/**
-	 * Set AD_Workflow_Access.
-	 *
-	 * <br>Type: ID
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	public void setAD_Workflow_Access_ID (int AD_Workflow_Access_ID);
-
-	/**
-	 * Get AD_Workflow_Access.
-	 *
-	 * <br>Type: ID
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	public int getAD_Workflow_Access_ID();
-
-    /** Column definition for AD_Workflow_Access_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Workflow_Access, Object> COLUMN_AD_Workflow_Access_ID = new org.adempiere.model.ModelColumn<I_AD_Workflow_Access, Object>(I_AD_Workflow_Access.class, "AD_Workflow_Access_ID", null);
-    /** Column name AD_Workflow_Access_ID */
-    public static final String COLUMNNAME_AD_Workflow_Access_ID = "AD_Workflow_Access_ID";
+	ModelColumn<I_AD_Workflow_Access, org.compiere.model.I_AD_Role> COLUMN_AD_Role_ID = new ModelColumn<>(I_AD_Workflow_Access.class, "AD_Role_ID", org.compiere.model.I_AD_Role.class);
+	String COLUMNNAME_AD_Role_ID = "AD_Role_ID";
 
 	/**
 	 * Set Workflow.
@@ -128,7 +84,7 @@ public interface I_AD_Workflow_Access
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setAD_Workflow_ID (int AD_Workflow_ID);
+	void setAD_Workflow_ID (int AD_Workflow_ID);
 
 	/**
 	 * Get Workflow.
@@ -138,124 +94,103 @@ public interface I_AD_Workflow_Access
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getAD_Workflow_ID();
+	int getAD_Workflow_ID();
 
-	public org.compiere.model.I_AD_Workflow getAD_Workflow();
-
-	public void setAD_Workflow(org.compiere.model.I_AD_Workflow AD_Workflow);
-
-    /** Column definition for AD_Workflow_ID */
-    public static final org.adempiere.model.ModelColumn<I_AD_Workflow_Access, org.compiere.model.I_AD_Workflow> COLUMN_AD_Workflow_ID = new org.adempiere.model.ModelColumn<I_AD_Workflow_Access, org.compiere.model.I_AD_Workflow>(I_AD_Workflow_Access.class, "AD_Workflow_ID", org.compiere.model.I_AD_Workflow.class);
-    /** Column name AD_Workflow_ID */
-    public static final String COLUMNNAME_AD_Workflow_ID = "AD_Workflow_ID";
+	String COLUMNNAME_AD_Workflow_ID = "AD_Workflow_ID";
 
 	/**
-	 * Get Erstellt.
+	 * Get Created.
 	 * Date this record was created
 	 *
 	 * <br>Type: DateTime
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public java.sql.Timestamp getCreated();
+	java.sql.Timestamp getCreated();
 
-    /** Column definition for Created */
-    public static final org.adempiere.model.ModelColumn<I_AD_Workflow_Access, Object> COLUMN_Created = new org.adempiere.model.ModelColumn<I_AD_Workflow_Access, Object>(I_AD_Workflow_Access.class, "Created", null);
-    /** Column name Created */
-    public static final String COLUMNNAME_Created = "Created";
+	ModelColumn<I_AD_Workflow_Access, Object> COLUMN_Created = new ModelColumn<>(I_AD_Workflow_Access.class, "Created", null);
+	String COLUMNNAME_Created = "Created";
 
 	/**
-	 * Get Erstellt durch.
+	 * Get Created By.
 	 * User who created this records
 	 *
 	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getCreatedBy();
+	int getCreatedBy();
 
-    /** Column definition for CreatedBy */
-    public static final org.adempiere.model.ModelColumn<I_AD_Workflow_Access, org.compiere.model.I_AD_User> COLUMN_CreatedBy = new org.adempiere.model.ModelColumn<I_AD_Workflow_Access, org.compiere.model.I_AD_User>(I_AD_Workflow_Access.class, "CreatedBy", org.compiere.model.I_AD_User.class);
-    /** Column name CreatedBy */
-    public static final String COLUMNNAME_CreatedBy = "CreatedBy";
+	String COLUMNNAME_CreatedBy = "CreatedBy";
 
 	/**
-	 * Set Aktiv.
+	 * Set Active.
 	 * The record is active in the system
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setIsActive (boolean IsActive);
+	void setIsActive (boolean IsActive);
 
 	/**
-	 * Get Aktiv.
+	 * Get Active.
 	 * The record is active in the system
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public boolean isActive();
+	boolean isActive();
 
-    /** Column definition for IsActive */
-    public static final org.adempiere.model.ModelColumn<I_AD_Workflow_Access, Object> COLUMN_IsActive = new org.adempiere.model.ModelColumn<I_AD_Workflow_Access, Object>(I_AD_Workflow_Access.class, "IsActive", null);
-    /** Column name IsActive */
-    public static final String COLUMNNAME_IsActive = "IsActive";
+	ModelColumn<I_AD_Workflow_Access, Object> COLUMN_IsActive = new ModelColumn<>(I_AD_Workflow_Access.class, "IsActive", null);
+	String COLUMNNAME_IsActive = "IsActive";
 
 	/**
-	 * Set Lesen und Schreiben.
-	 * Field is read / write
+	 * Set Read Write.
+	 * Feld / Eintrag / Bereich kann gelesen und verändert werden
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public void setIsReadWrite (boolean IsReadWrite);
+	void setIsReadWrite (boolean IsReadWrite);
 
 	/**
-	 * Get Lesen und Schreiben.
-	 * Field is read / write
+	 * Get Read Write.
+	 * Feld / Eintrag / Bereich kann gelesen und verändert werden
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public boolean isReadWrite();
+	boolean isReadWrite();
 
-    /** Column definition for IsReadWrite */
-    public static final org.adempiere.model.ModelColumn<I_AD_Workflow_Access, Object> COLUMN_IsReadWrite = new org.adempiere.model.ModelColumn<I_AD_Workflow_Access, Object>(I_AD_Workflow_Access.class, "IsReadWrite", null);
-    /** Column name IsReadWrite */
-    public static final String COLUMNNAME_IsReadWrite = "IsReadWrite";
+	ModelColumn<I_AD_Workflow_Access, Object> COLUMN_IsReadWrite = new ModelColumn<>(I_AD_Workflow_Access.class, "IsReadWrite", null);
+	String COLUMNNAME_IsReadWrite = "IsReadWrite";
 
 	/**
-	 * Get Aktualisiert.
+	 * Get Updated.
 	 * Date this record was updated
 	 *
 	 * <br>Type: DateTime
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public java.sql.Timestamp getUpdated();
+	java.sql.Timestamp getUpdated();
 
-    /** Column definition for Updated */
-    public static final org.adempiere.model.ModelColumn<I_AD_Workflow_Access, Object> COLUMN_Updated = new org.adempiere.model.ModelColumn<I_AD_Workflow_Access, Object>(I_AD_Workflow_Access.class, "Updated", null);
-    /** Column name Updated */
-    public static final String COLUMNNAME_Updated = "Updated";
+	ModelColumn<I_AD_Workflow_Access, Object> COLUMN_Updated = new ModelColumn<>(I_AD_Workflow_Access.class, "Updated", null);
+	String COLUMNNAME_Updated = "Updated";
 
 	/**
-	 * Get Aktualisiert durch.
+	 * Get Updated By.
 	 * User who updated this records
 	 *
 	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	public int getUpdatedBy();
+	int getUpdatedBy();
 
-    /** Column definition for UpdatedBy */
-    public static final org.adempiere.model.ModelColumn<I_AD_Workflow_Access, org.compiere.model.I_AD_User> COLUMN_UpdatedBy = new org.adempiere.model.ModelColumn<I_AD_Workflow_Access, org.compiere.model.I_AD_User>(I_AD_Workflow_Access.class, "UpdatedBy", org.compiere.model.I_AD_User.class);
-    /** Column name UpdatedBy */
-    public static final String COLUMNNAME_UpdatedBy = "UpdatedBy";
+	String COLUMNNAME_UpdatedBy = "UpdatedBy";
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Document_Action_Access.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Document_Action_Access.java
@@ -1,179 +1,105 @@
-/** Generated Model - DO NOT CHANGE */
+// Generated Model - DO NOT CHANGE
 package org.compiere.model;
 
 import java.sql.ResultSet;
 import java.util.Properties;
+import javax.annotation.Nullable;
 
 /** Generated Model for AD_Document_Action_Access
- *  @author Adempiere (generated) 
+ *  @author metasfresh (generated) 
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings("unused")
 public class X_AD_Document_Action_Access extends org.compiere.model.PO implements I_AD_Document_Action_Access, org.compiere.model.I_Persistent 
 {
 
-	/**
-	 *
-	 */
-	private static final long serialVersionUID = -2013389825L;
+	private static final long serialVersionUID = 739447442L;
 
     /** Standard Constructor */
-    public X_AD_Document_Action_Access (Properties ctx, int AD_Document_Action_Access_ID, String trxName)
+    public X_AD_Document_Action_Access (final Properties ctx, final int AD_Document_Action_Access_ID, @Nullable final String trxName)
     {
       super (ctx, AD_Document_Action_Access_ID, trxName);
-      /** if (AD_Document_Action_Access_ID == 0)
-        {
-			setAD_Document_Action_Access_ID (0);
-			setAD_Ref_List_ID (0);
-			setAD_Role_ID (0);
-			setC_DocType_ID (0);
-        } */
     }
 
     /** Load Constructor */
-    public X_AD_Document_Action_Access (Properties ctx, ResultSet rs, String trxName)
+    public X_AD_Document_Action_Access (final Properties ctx, final ResultSet rs, @Nullable final String trxName)
     {
       super (ctx, rs, trxName);
     }
 
 
-    /** Load Meta Data */
-    @Override
-    protected org.compiere.model.POInfo initPO (Properties ctx)
-    {
-      org.compiere.model.POInfo poi = org.compiere.model.POInfo.getPOInfo (ctx, Table_Name, get_TrxName());
-      return poi;
-    }
-
-	/** Set Document Action Access.
-		@param AD_Document_Action_Access_ID Document Action Access	  */
+	/** Load Meta Data */
 	@Override
-	public void setAD_Document_Action_Access_ID (int AD_Document_Action_Access_ID)
+	protected org.compiere.model.POInfo initPO(final Properties ctx)
 	{
-		if (AD_Document_Action_Access_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_AD_Document_Action_Access_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Document_Action_Access_ID, Integer.valueOf(AD_Document_Action_Access_ID));
-	}
-
-	/** Get Document Action Access.
-		@return Document Action Access	  */
-	@Override
-	public int getAD_Document_Action_Access_ID () 
-	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Document_Action_Access_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return org.compiere.model.POInfo.getPOInfo(Table_Name);
 	}
 
 	@Override
-	public org.compiere.model.I_AD_Ref_List getAD_Ref_List() throws RuntimeException
+	public org.compiere.model.I_AD_Ref_List getAD_Ref_List()
 	{
 		return get_ValueAsPO(COLUMNNAME_AD_Ref_List_ID, org.compiere.model.I_AD_Ref_List.class);
 	}
 
 	@Override
-	public void setAD_Ref_List(org.compiere.model.I_AD_Ref_List AD_Ref_List)
+	public void setAD_Ref_List(final org.compiere.model.I_AD_Ref_List AD_Ref_List)
 	{
 		set_ValueFromPO(COLUMNNAME_AD_Ref_List_ID, org.compiere.model.I_AD_Ref_List.class, AD_Ref_List);
 	}
 
-	/** Set Referenzliste.
-		@param AD_Ref_List_ID 
-		Reference List based on Table
-	  */
 	@Override
-	public void setAD_Ref_List_ID (int AD_Ref_List_ID)
+	public void setAD_Ref_List_ID (final int AD_Ref_List_ID)
 	{
 		if (AD_Ref_List_ID < 1) 
 			set_ValueNoCheck (COLUMNNAME_AD_Ref_List_ID, null);
 		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Ref_List_ID, Integer.valueOf(AD_Ref_List_ID));
+			set_ValueNoCheck (COLUMNNAME_AD_Ref_List_ID, AD_Ref_List_ID);
 	}
 
-	/** Get Referenzliste.
-		@return Reference List based on Table
-	  */
 	@Override
-	public int getAD_Ref_List_ID () 
+	public int getAD_Ref_List_ID() 
 	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Ref_List_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return get_ValueAsInt(COLUMNNAME_AD_Ref_List_ID);
 	}
 
 	@Override
-	public org.compiere.model.I_AD_Role getAD_Role() throws RuntimeException
+	public org.compiere.model.I_AD_Role getAD_Role()
 	{
 		return get_ValueAsPO(COLUMNNAME_AD_Role_ID, org.compiere.model.I_AD_Role.class);
 	}
 
 	@Override
-	public void setAD_Role(org.compiere.model.I_AD_Role AD_Role)
+	public void setAD_Role(final org.compiere.model.I_AD_Role AD_Role)
 	{
 		set_ValueFromPO(COLUMNNAME_AD_Role_ID, org.compiere.model.I_AD_Role.class, AD_Role);
 	}
 
-	/** Set Rolle.
-		@param AD_Role_ID 
-		Responsibility Role
-	  */
 	@Override
-	public void setAD_Role_ID (int AD_Role_ID)
+	public void setAD_Role_ID (final int AD_Role_ID)
 	{
 		if (AD_Role_ID < 0) 
 			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, null);
 		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, Integer.valueOf(AD_Role_ID));
+			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, AD_Role_ID);
 	}
 
-	/** Get Rolle.
-		@return Responsibility Role
-	  */
 	@Override
-	public int getAD_Role_ID () 
+	public int getAD_Role_ID() 
 	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Role_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return get_ValueAsInt(COLUMNNAME_AD_Role_ID);
 	}
 
 	@Override
-	public org.compiere.model.I_C_DocType getC_DocType() throws RuntimeException
-	{
-		return get_ValueAsPO(COLUMNNAME_C_DocType_ID, org.compiere.model.I_C_DocType.class);
-	}
-
-	@Override
-	public void setC_DocType(org.compiere.model.I_C_DocType C_DocType)
-	{
-		set_ValueFromPO(COLUMNNAME_C_DocType_ID, org.compiere.model.I_C_DocType.class, C_DocType);
-	}
-
-	/** Set Belegart.
-		@param C_DocType_ID 
-		Document type or rules
-	  */
-	@Override
-	public void setC_DocType_ID (int C_DocType_ID)
+	public void setC_DocType_ID (final int C_DocType_ID)
 	{
 		if (C_DocType_ID < 0) 
 			set_ValueNoCheck (COLUMNNAME_C_DocType_ID, null);
 		else 
-			set_ValueNoCheck (COLUMNNAME_C_DocType_ID, Integer.valueOf(C_DocType_ID));
+			set_ValueNoCheck (COLUMNNAME_C_DocType_ID, C_DocType_ID);
 	}
 
-	/** Get Belegart.
-		@return Document type or rules
-	  */
 	@Override
-	public int getC_DocType_ID () 
+	public int getC_DocType_ID() 
 	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_C_DocType_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return get_ValueAsInt(COLUMNNAME_C_DocType_ID);
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Form_Access.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Form_Access.java
@@ -1,168 +1,102 @@
-/** Generated Model - DO NOT CHANGE */
+// Generated Model - DO NOT CHANGE
 package org.compiere.model;
 
 import java.sql.ResultSet;
 import java.util.Properties;
+import javax.annotation.Nullable;
 
 /** Generated Model for AD_Form_Access
- *  @author Adempiere (generated) 
+ *  @author metasfresh (generated) 
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings("unused")
 public class X_AD_Form_Access extends org.compiere.model.PO implements I_AD_Form_Access, org.compiere.model.I_Persistent 
 {
 
-	/**
-	 *
-	 */
-	private static final long serialVersionUID = -798455141L;
+	private static final long serialVersionUID = 507238373L;
 
     /** Standard Constructor */
-    public X_AD_Form_Access (Properties ctx, int AD_Form_Access_ID, String trxName)
+    public X_AD_Form_Access (final Properties ctx, final int AD_Form_Access_ID, @Nullable final String trxName)
     {
       super (ctx, AD_Form_Access_ID, trxName);
-      /** if (AD_Form_Access_ID == 0)
-        {
-			setAD_Form_Access_ID (0);
-			setAD_Form_ID (0);
-			setAD_Role_ID (0);
-			setIsReadWrite (false);
-        } */
     }
 
     /** Load Constructor */
-    public X_AD_Form_Access (Properties ctx, ResultSet rs, String trxName)
+    public X_AD_Form_Access (final Properties ctx, final ResultSet rs, @Nullable final String trxName)
     {
       super (ctx, rs, trxName);
     }
 
 
-    /** Load Meta Data */
-    @Override
-    protected org.compiere.model.POInfo initPO (Properties ctx)
-    {
-      org.compiere.model.POInfo poi = org.compiere.model.POInfo.getPOInfo (ctx, Table_Name, get_TrxName());
-      return poi;
-    }
-
-	/** Set AD_Form_Access.
-		@param AD_Form_Access_ID AD_Form_Access	  */
+	/** Load Meta Data */
 	@Override
-	public void setAD_Form_Access_ID (int AD_Form_Access_ID)
+	protected org.compiere.model.POInfo initPO(final Properties ctx)
 	{
-		if (AD_Form_Access_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_AD_Form_Access_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Form_Access_ID, Integer.valueOf(AD_Form_Access_ID));
-	}
-
-	/** Get AD_Form_Access.
-		@return AD_Form_Access	  */
-	@Override
-	public int getAD_Form_Access_ID () 
-	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Form_Access_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return org.compiere.model.POInfo.getPOInfo(Table_Name);
 	}
 
 	@Override
-	public org.compiere.model.I_AD_Form getAD_Form() throws RuntimeException
+	public org.compiere.model.I_AD_Form getAD_Form()
 	{
 		return get_ValueAsPO(COLUMNNAME_AD_Form_ID, org.compiere.model.I_AD_Form.class);
 	}
 
 	@Override
-	public void setAD_Form(org.compiere.model.I_AD_Form AD_Form)
+	public void setAD_Form(final org.compiere.model.I_AD_Form AD_Form)
 	{
 		set_ValueFromPO(COLUMNNAME_AD_Form_ID, org.compiere.model.I_AD_Form.class, AD_Form);
 	}
 
-	/** Set Special Form.
-		@param AD_Form_ID 
-		Special Form
-	  */
 	@Override
-	public void setAD_Form_ID (int AD_Form_ID)
+	public void setAD_Form_ID (final int AD_Form_ID)
 	{
 		if (AD_Form_ID < 1) 
 			set_ValueNoCheck (COLUMNNAME_AD_Form_ID, null);
 		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Form_ID, Integer.valueOf(AD_Form_ID));
+			set_ValueNoCheck (COLUMNNAME_AD_Form_ID, AD_Form_ID);
 	}
 
-	/** Get Special Form.
-		@return Special Form
-	  */
 	@Override
-	public int getAD_Form_ID () 
+	public int getAD_Form_ID() 
 	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Form_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return get_ValueAsInt(COLUMNNAME_AD_Form_ID);
 	}
 
 	@Override
-	public org.compiere.model.I_AD_Role getAD_Role() throws RuntimeException
+	public org.compiere.model.I_AD_Role getAD_Role()
 	{
 		return get_ValueAsPO(COLUMNNAME_AD_Role_ID, org.compiere.model.I_AD_Role.class);
 	}
 
 	@Override
-	public void setAD_Role(org.compiere.model.I_AD_Role AD_Role)
+	public void setAD_Role(final org.compiere.model.I_AD_Role AD_Role)
 	{
 		set_ValueFromPO(COLUMNNAME_AD_Role_ID, org.compiere.model.I_AD_Role.class, AD_Role);
 	}
 
-	/** Set Rolle.
-		@param AD_Role_ID 
-		Responsibility Role
-	  */
 	@Override
-	public void setAD_Role_ID (int AD_Role_ID)
+	public void setAD_Role_ID (final int AD_Role_ID)
 	{
 		if (AD_Role_ID < 0) 
 			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, null);
 		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, Integer.valueOf(AD_Role_ID));
+			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, AD_Role_ID);
 	}
 
-	/** Get Rolle.
-		@return Responsibility Role
-	  */
 	@Override
-	public int getAD_Role_ID () 
+	public int getAD_Role_ID() 
 	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Role_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return get_ValueAsInt(COLUMNNAME_AD_Role_ID);
 	}
 
-	/** Set Lesen und Schreiben.
-		@param IsReadWrite 
-		Field is read / write
-	  */
 	@Override
-	public void setIsReadWrite (boolean IsReadWrite)
+	public void setIsReadWrite (final boolean IsReadWrite)
 	{
-		set_Value (COLUMNNAME_IsReadWrite, Boolean.valueOf(IsReadWrite));
+		set_Value (COLUMNNAME_IsReadWrite, IsReadWrite);
 	}
 
-	/** Get Lesen und Schreiben.
-		@return Field is read / write
-	  */
 	@Override
-	public boolean isReadWrite () 
+	public boolean isReadWrite() 
 	{
-		Object oo = get_Value(COLUMNNAME_IsReadWrite);
-		if (oo != null) 
-		{
-			 if (oo instanceof Boolean) 
-				 return ((Boolean)oo).booleanValue(); 
-			return "Y".equals(oo);
-		}
-		return false;
+		return get_ValueAsBoolean(COLUMNNAME_IsReadWrite);
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Process_Access.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Process_Access.java
@@ -1,168 +1,102 @@
-/** Generated Model - DO NOT CHANGE */
+// Generated Model - DO NOT CHANGE
 package org.compiere.model;
 
 import java.sql.ResultSet;
 import java.util.Properties;
+import javax.annotation.Nullable;
 
 /** Generated Model for AD_Process_Access
- *  @author Adempiere (generated) 
+ *  @author metasfresh (generated) 
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings("unused")
 public class X_AD_Process_Access extends org.compiere.model.PO implements I_AD_Process_Access, org.compiere.model.I_Persistent 
 {
 
-	/**
-	 *
-	 */
-	private static final long serialVersionUID = 500429489L;
+	private static final long serialVersionUID = 380016108L;
 
     /** Standard Constructor */
-    public X_AD_Process_Access (Properties ctx, int AD_Process_Access_ID, String trxName)
+    public X_AD_Process_Access (final Properties ctx, final int AD_Process_Access_ID, @Nullable final String trxName)
     {
       super (ctx, AD_Process_Access_ID, trxName);
-      /** if (AD_Process_Access_ID == 0)
-        {
-			setAD_Process_Access_ID (0);
-			setAD_Process_ID (0);
-			setAD_Role_ID (0);
-			setIsReadWrite (false);
-        } */
     }
 
     /** Load Constructor */
-    public X_AD_Process_Access (Properties ctx, ResultSet rs, String trxName)
+    public X_AD_Process_Access (final Properties ctx, final ResultSet rs, @Nullable final String trxName)
     {
       super (ctx, rs, trxName);
     }
 
 
-    /** Load Meta Data */
-    @Override
-    protected org.compiere.model.POInfo initPO (Properties ctx)
-    {
-      org.compiere.model.POInfo poi = org.compiere.model.POInfo.getPOInfo (ctx, Table_Name, get_TrxName());
-      return poi;
-    }
-
-	/** Set Process Access.
-		@param AD_Process_Access_ID Process Access	  */
+	/** Load Meta Data */
 	@Override
-	public void setAD_Process_Access_ID (int AD_Process_Access_ID)
+	protected org.compiere.model.POInfo initPO(final Properties ctx)
 	{
-		if (AD_Process_Access_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_AD_Process_Access_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Process_Access_ID, Integer.valueOf(AD_Process_Access_ID));
-	}
-
-	/** Get Process Access.
-		@return Process Access	  */
-	@Override
-	public int getAD_Process_Access_ID () 
-	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Process_Access_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return org.compiere.model.POInfo.getPOInfo(Table_Name);
 	}
 
 	@Override
-	public org.compiere.model.I_AD_Process getAD_Process() throws RuntimeException
+	public org.compiere.model.I_AD_Process getAD_Process()
 	{
 		return get_ValueAsPO(COLUMNNAME_AD_Process_ID, org.compiere.model.I_AD_Process.class);
 	}
 
 	@Override
-	public void setAD_Process(org.compiere.model.I_AD_Process AD_Process)
+	public void setAD_Process(final org.compiere.model.I_AD_Process AD_Process)
 	{
 		set_ValueFromPO(COLUMNNAME_AD_Process_ID, org.compiere.model.I_AD_Process.class, AD_Process);
 	}
 
-	/** Set Prozess.
-		@param AD_Process_ID 
-		Process or Report
-	  */
 	@Override
-	public void setAD_Process_ID (int AD_Process_ID)
+	public void setAD_Process_ID (final int AD_Process_ID)
 	{
 		if (AD_Process_ID < 1) 
 			set_ValueNoCheck (COLUMNNAME_AD_Process_ID, null);
 		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Process_ID, Integer.valueOf(AD_Process_ID));
+			set_ValueNoCheck (COLUMNNAME_AD_Process_ID, AD_Process_ID);
 	}
 
-	/** Get Prozess.
-		@return Process or Report
-	  */
 	@Override
-	public int getAD_Process_ID () 
+	public int getAD_Process_ID() 
 	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Process_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return get_ValueAsInt(COLUMNNAME_AD_Process_ID);
 	}
 
 	@Override
-	public org.compiere.model.I_AD_Role getAD_Role() throws RuntimeException
+	public org.compiere.model.I_AD_Role getAD_Role()
 	{
 		return get_ValueAsPO(COLUMNNAME_AD_Role_ID, org.compiere.model.I_AD_Role.class);
 	}
 
 	@Override
-	public void setAD_Role(org.compiere.model.I_AD_Role AD_Role)
+	public void setAD_Role(final org.compiere.model.I_AD_Role AD_Role)
 	{
 		set_ValueFromPO(COLUMNNAME_AD_Role_ID, org.compiere.model.I_AD_Role.class, AD_Role);
 	}
 
-	/** Set Rolle.
-		@param AD_Role_ID 
-		Responsibility Role
-	  */
 	@Override
-	public void setAD_Role_ID (int AD_Role_ID)
+	public void setAD_Role_ID (final int AD_Role_ID)
 	{
 		if (AD_Role_ID < 0) 
 			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, null);
 		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, Integer.valueOf(AD_Role_ID));
+			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, AD_Role_ID);
 	}
 
-	/** Get Rolle.
-		@return Responsibility Role
-	  */
 	@Override
-	public int getAD_Role_ID () 
+	public int getAD_Role_ID() 
 	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Role_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return get_ValueAsInt(COLUMNNAME_AD_Role_ID);
 	}
 
-	/** Set Lesen und Schreiben.
-		@param IsReadWrite 
-		Field is read / write
-	  */
 	@Override
-	public void setIsReadWrite (boolean IsReadWrite)
+	public void setIsReadWrite (final boolean IsReadWrite)
 	{
-		set_Value (COLUMNNAME_IsReadWrite, Boolean.valueOf(IsReadWrite));
+		set_Value (COLUMNNAME_IsReadWrite, IsReadWrite);
 	}
 
-	/** Get Lesen und Schreiben.
-		@return Field is read / write
-	  */
 	@Override
-	public boolean isReadWrite () 
+	public boolean isReadWrite() 
 	{
-		Object oo = get_Value(COLUMNNAME_IsReadWrite);
-		if (oo != null) 
-		{
-			 if (oo instanceof Boolean) 
-				 return ((Boolean)oo).booleanValue(); 
-			return "Y".equals(oo);
-		}
-		return false;
+		return get_ValueAsBoolean(COLUMNNAME_IsReadWrite);
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Task_Access.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Task_Access.java
@@ -1,168 +1,102 @@
-/** Generated Model - DO NOT CHANGE */
+// Generated Model - DO NOT CHANGE
 package org.compiere.model;
 
 import java.sql.ResultSet;
 import java.util.Properties;
+import javax.annotation.Nullable;
 
 /** Generated Model for AD_Task_Access
- *  @author Adempiere (generated) 
+ *  @author metasfresh (generated) 
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings("unused")
 public class X_AD_Task_Access extends org.compiere.model.PO implements I_AD_Task_Access, org.compiere.model.I_Persistent 
 {
 
-	/**
-	 *
-	 */
-	private static final long serialVersionUID = 984772113L;
+	private static final long serialVersionUID = 220818308L;
 
     /** Standard Constructor */
-    public X_AD_Task_Access (Properties ctx, int AD_Task_Access_ID, String trxName)
+    public X_AD_Task_Access (final Properties ctx, final int AD_Task_Access_ID, @Nullable final String trxName)
     {
       super (ctx, AD_Task_Access_ID, trxName);
-      /** if (AD_Task_Access_ID == 0)
-        {
-			setAD_Role_ID (0);
-			setAD_Task_Access_ID (0);
-			setAD_Task_ID (0);
-			setIsReadWrite (false);
-        } */
     }
 
     /** Load Constructor */
-    public X_AD_Task_Access (Properties ctx, ResultSet rs, String trxName)
+    public X_AD_Task_Access (final Properties ctx, final ResultSet rs, @Nullable final String trxName)
     {
       super (ctx, rs, trxName);
     }
 
 
-    /** Load Meta Data */
-    @Override
-    protected org.compiere.model.POInfo initPO (Properties ctx)
-    {
-      org.compiere.model.POInfo poi = org.compiere.model.POInfo.getPOInfo (ctx, Table_Name, get_TrxName());
-      return poi;
-    }
+	/** Load Meta Data */
+	@Override
+	protected org.compiere.model.POInfo initPO(final Properties ctx)
+	{
+		return org.compiere.model.POInfo.getPOInfo(Table_Name);
+	}
 
 	@Override
-	public org.compiere.model.I_AD_Role getAD_Role() throws RuntimeException
+	public org.compiere.model.I_AD_Role getAD_Role()
 	{
 		return get_ValueAsPO(COLUMNNAME_AD_Role_ID, org.compiere.model.I_AD_Role.class);
 	}
 
 	@Override
-	public void setAD_Role(org.compiere.model.I_AD_Role AD_Role)
+	public void setAD_Role(final org.compiere.model.I_AD_Role AD_Role)
 	{
 		set_ValueFromPO(COLUMNNAME_AD_Role_ID, org.compiere.model.I_AD_Role.class, AD_Role);
 	}
 
-	/** Set Rolle.
-		@param AD_Role_ID 
-		Responsibility Role
-	  */
 	@Override
-	public void setAD_Role_ID (int AD_Role_ID)
+	public void setAD_Role_ID (final int AD_Role_ID)
 	{
 		if (AD_Role_ID < 0) 
 			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, null);
 		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, Integer.valueOf(AD_Role_ID));
+			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, AD_Role_ID);
 	}
 
-	/** Get Rolle.
-		@return Responsibility Role
-	  */
 	@Override
-	public int getAD_Role_ID () 
+	public int getAD_Role_ID() 
 	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Role_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
-	}
-
-	/** Set AD_Task_Access.
-		@param AD_Task_Access_ID AD_Task_Access	  */
-	@Override
-	public void setAD_Task_Access_ID (int AD_Task_Access_ID)
-	{
-		if (AD_Task_Access_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_AD_Task_Access_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Task_Access_ID, Integer.valueOf(AD_Task_Access_ID));
-	}
-
-	/** Get AD_Task_Access.
-		@return AD_Task_Access	  */
-	@Override
-	public int getAD_Task_Access_ID () 
-	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Task_Access_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return get_ValueAsInt(COLUMNNAME_AD_Role_ID);
 	}
 
 	@Override
-	public org.compiere.model.I_AD_Task getAD_Task() throws RuntimeException
+	public org.compiere.model.I_AD_Task getAD_Task()
 	{
 		return get_ValueAsPO(COLUMNNAME_AD_Task_ID, org.compiere.model.I_AD_Task.class);
 	}
 
 	@Override
-	public void setAD_Task(org.compiere.model.I_AD_Task AD_Task)
+	public void setAD_Task(final org.compiere.model.I_AD_Task AD_Task)
 	{
 		set_ValueFromPO(COLUMNNAME_AD_Task_ID, org.compiere.model.I_AD_Task.class, AD_Task);
 	}
 
-	/** Set Externer Prozess.
-		@param AD_Task_ID 
-		Operation System Task
-	  */
 	@Override
-	public void setAD_Task_ID (int AD_Task_ID)
+	public void setAD_Task_ID (final int AD_Task_ID)
 	{
 		if (AD_Task_ID < 1) 
 			set_ValueNoCheck (COLUMNNAME_AD_Task_ID, null);
 		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Task_ID, Integer.valueOf(AD_Task_ID));
+			set_ValueNoCheck (COLUMNNAME_AD_Task_ID, AD_Task_ID);
 	}
 
-	/** Get Externer Prozess.
-		@return Operation System Task
-	  */
 	@Override
-	public int getAD_Task_ID () 
+	public int getAD_Task_ID() 
 	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Task_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return get_ValueAsInt(COLUMNNAME_AD_Task_ID);
 	}
 
-	/** Set Lesen und Schreiben.
-		@param IsReadWrite 
-		Field is read / write
-	  */
 	@Override
-	public void setIsReadWrite (boolean IsReadWrite)
+	public void setIsReadWrite (final boolean IsReadWrite)
 	{
-		set_Value (COLUMNNAME_IsReadWrite, Boolean.valueOf(IsReadWrite));
+		set_Value (COLUMNNAME_IsReadWrite, IsReadWrite);
 	}
 
-	/** Get Lesen und Schreiben.
-		@return Field is read / write
-	  */
 	@Override
-	public boolean isReadWrite () 
+	public boolean isReadWrite() 
 	{
-		Object oo = get_Value(COLUMNNAME_IsReadWrite);
-		if (oo != null) 
-		{
-			 if (oo instanceof Boolean) 
-				 return ((Boolean)oo).booleanValue(); 
-			return "Y".equals(oo);
-		}
-		return false;
+		return get_ValueAsBoolean(COLUMNNAME_IsReadWrite);
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Window_Access.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Window_Access.java
@@ -1,168 +1,102 @@
-/** Generated Model - DO NOT CHANGE */
+// Generated Model - DO NOT CHANGE
 package org.compiere.model;
 
 import java.sql.ResultSet;
 import java.util.Properties;
+import javax.annotation.Nullable;
 
 /** Generated Model for AD_Window_Access
- *  @author Adempiere (generated) 
+ *  @author metasfresh (generated) 
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings("unused")
 public class X_AD_Window_Access extends org.compiere.model.PO implements I_AD_Window_Access, org.compiere.model.I_Persistent 
 {
 
-	/**
-	 *
-	 */
-	private static final long serialVersionUID = -1015854001L;
+	private static final long serialVersionUID = 1752574265L;
 
     /** Standard Constructor */
-    public X_AD_Window_Access (Properties ctx, int AD_Window_Access_ID, String trxName)
+    public X_AD_Window_Access (final Properties ctx, final int AD_Window_Access_ID, @Nullable final String trxName)
     {
       super (ctx, AD_Window_Access_ID, trxName);
-      /** if (AD_Window_Access_ID == 0)
-        {
-			setAD_Role_ID (0);
-			setAD_Window_Access_ID (0);
-			setAD_Window_ID (0);
-			setIsReadWrite (false);
-        } */
     }
 
     /** Load Constructor */
-    public X_AD_Window_Access (Properties ctx, ResultSet rs, String trxName)
+    public X_AD_Window_Access (final Properties ctx, final ResultSet rs, @Nullable final String trxName)
     {
       super (ctx, rs, trxName);
     }
 
 
-    /** Load Meta Data */
-    @Override
-    protected org.compiere.model.POInfo initPO (Properties ctx)
-    {
-      org.compiere.model.POInfo poi = org.compiere.model.POInfo.getPOInfo (ctx, Table_Name, get_TrxName());
-      return poi;
-    }
+	/** Load Meta Data */
+	@Override
+	protected org.compiere.model.POInfo initPO(final Properties ctx)
+	{
+		return org.compiere.model.POInfo.getPOInfo(Table_Name);
+	}
 
 	@Override
-	public org.compiere.model.I_AD_Role getAD_Role() throws RuntimeException
+	public org.compiere.model.I_AD_Role getAD_Role()
 	{
 		return get_ValueAsPO(COLUMNNAME_AD_Role_ID, org.compiere.model.I_AD_Role.class);
 	}
 
 	@Override
-	public void setAD_Role(org.compiere.model.I_AD_Role AD_Role)
+	public void setAD_Role(final org.compiere.model.I_AD_Role AD_Role)
 	{
 		set_ValueFromPO(COLUMNNAME_AD_Role_ID, org.compiere.model.I_AD_Role.class, AD_Role);
 	}
 
-	/** Set Rolle.
-		@param AD_Role_ID 
-		Responsibility Role
-	  */
 	@Override
-	public void setAD_Role_ID (int AD_Role_ID)
+	public void setAD_Role_ID (final int AD_Role_ID)
 	{
 		if (AD_Role_ID < 0) 
 			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, null);
 		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, Integer.valueOf(AD_Role_ID));
+			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, AD_Role_ID);
 	}
 
-	/** Get Rolle.
-		@return Responsibility Role
-	  */
 	@Override
-	public int getAD_Role_ID () 
+	public int getAD_Role_ID() 
 	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Role_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
-	}
-
-	/** Set AD_Window_Access.
-		@param AD_Window_Access_ID AD_Window_Access	  */
-	@Override
-	public void setAD_Window_Access_ID (int AD_Window_Access_ID)
-	{
-		if (AD_Window_Access_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_AD_Window_Access_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Window_Access_ID, Integer.valueOf(AD_Window_Access_ID));
-	}
-
-	/** Get AD_Window_Access.
-		@return AD_Window_Access	  */
-	@Override
-	public int getAD_Window_Access_ID () 
-	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Window_Access_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return get_ValueAsInt(COLUMNNAME_AD_Role_ID);
 	}
 
 	@Override
-	public org.compiere.model.I_AD_Window getAD_Window() throws RuntimeException
+	public org.compiere.model.I_AD_Window getAD_Window()
 	{
 		return get_ValueAsPO(COLUMNNAME_AD_Window_ID, org.compiere.model.I_AD_Window.class);
 	}
 
 	@Override
-	public void setAD_Window(org.compiere.model.I_AD_Window AD_Window)
+	public void setAD_Window(final org.compiere.model.I_AD_Window AD_Window)
 	{
 		set_ValueFromPO(COLUMNNAME_AD_Window_ID, org.compiere.model.I_AD_Window.class, AD_Window);
 	}
 
-	/** Set Fenster.
-		@param AD_Window_ID 
-		Data entry or display window
-	  */
 	@Override
-	public void setAD_Window_ID (int AD_Window_ID)
+	public void setAD_Window_ID (final int AD_Window_ID)
 	{
 		if (AD_Window_ID < 1) 
 			set_ValueNoCheck (COLUMNNAME_AD_Window_ID, null);
 		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Window_ID, Integer.valueOf(AD_Window_ID));
+			set_ValueNoCheck (COLUMNNAME_AD_Window_ID, AD_Window_ID);
 	}
 
-	/** Get Fenster.
-		@return Data entry or display window
-	  */
 	@Override
-	public int getAD_Window_ID () 
+	public int getAD_Window_ID() 
 	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Window_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return get_ValueAsInt(COLUMNNAME_AD_Window_ID);
 	}
 
-	/** Set Lesen und Schreiben.
-		@param IsReadWrite 
-		Field is read / write
-	  */
 	@Override
-	public void setIsReadWrite (boolean IsReadWrite)
+	public void setIsReadWrite (final boolean IsReadWrite)
 	{
-		set_Value (COLUMNNAME_IsReadWrite, Boolean.valueOf(IsReadWrite));
+		set_Value (COLUMNNAME_IsReadWrite, IsReadWrite);
 	}
 
-	/** Get Lesen und Schreiben.
-		@return Field is read / write
-	  */
 	@Override
-	public boolean isReadWrite () 
+	public boolean isReadWrite() 
 	{
-		Object oo = get_Value(COLUMNNAME_IsReadWrite);
-		if (oo != null) 
-		{
-			 if (oo instanceof Boolean) 
-				 return ((Boolean)oo).booleanValue(); 
-			return "Y".equals(oo);
-		}
-		return false;
+		return get_ValueAsBoolean(COLUMNNAME_IsReadWrite);
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Workflow_Access.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Workflow_Access.java
@@ -1,168 +1,90 @@
-/** Generated Model - DO NOT CHANGE */
+// Generated Model - DO NOT CHANGE
 package org.compiere.model;
 
 import java.sql.ResultSet;
 import java.util.Properties;
+import javax.annotation.Nullable;
 
 /** Generated Model for AD_Workflow_Access
- *  @author Adempiere (generated) 
+ *  @author metasfresh (generated) 
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings("unused")
 public class X_AD_Workflow_Access extends org.compiere.model.PO implements I_AD_Workflow_Access, org.compiere.model.I_Persistent 
 {
 
-	/**
-	 *
-	 */
-	private static final long serialVersionUID = 1624986497L;
+	private static final long serialVersionUID = 1985595464L;
 
     /** Standard Constructor */
-    public X_AD_Workflow_Access (Properties ctx, int AD_Workflow_Access_ID, String trxName)
+    public X_AD_Workflow_Access (final Properties ctx, final int AD_Workflow_Access_ID, @Nullable final String trxName)
     {
       super (ctx, AD_Workflow_Access_ID, trxName);
-      /** if (AD_Workflow_Access_ID == 0)
-        {
-			setAD_Role_ID (0);
-			setAD_Workflow_Access_ID (0);
-			setAD_Workflow_ID (0);
-			setIsReadWrite (false);
-        } */
     }
 
     /** Load Constructor */
-    public X_AD_Workflow_Access (Properties ctx, ResultSet rs, String trxName)
+    public X_AD_Workflow_Access (final Properties ctx, final ResultSet rs, @Nullable final String trxName)
     {
       super (ctx, rs, trxName);
     }
 
 
-    /** Load Meta Data */
-    @Override
-    protected org.compiere.model.POInfo initPO (Properties ctx)
-    {
-      org.compiere.model.POInfo poi = org.compiere.model.POInfo.getPOInfo (ctx, Table_Name, get_TrxName());
-      return poi;
-    }
+	/** Load Meta Data */
+	@Override
+	protected org.compiere.model.POInfo initPO(final Properties ctx)
+	{
+		return org.compiere.model.POInfo.getPOInfo(Table_Name);
+	}
 
 	@Override
-	public org.compiere.model.I_AD_Role getAD_Role() throws RuntimeException
+	public org.compiere.model.I_AD_Role getAD_Role()
 	{
 		return get_ValueAsPO(COLUMNNAME_AD_Role_ID, org.compiere.model.I_AD_Role.class);
 	}
 
 	@Override
-	public void setAD_Role(org.compiere.model.I_AD_Role AD_Role)
+	public void setAD_Role(final org.compiere.model.I_AD_Role AD_Role)
 	{
 		set_ValueFromPO(COLUMNNAME_AD_Role_ID, org.compiere.model.I_AD_Role.class, AD_Role);
 	}
 
-	/** Set Rolle.
-		@param AD_Role_ID 
-		Responsibility Role
-	  */
 	@Override
-	public void setAD_Role_ID (int AD_Role_ID)
+	public void setAD_Role_ID (final int AD_Role_ID)
 	{
 		if (AD_Role_ID < 0) 
 			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, null);
 		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, Integer.valueOf(AD_Role_ID));
+			set_ValueNoCheck (COLUMNNAME_AD_Role_ID, AD_Role_ID);
 	}
 
-	/** Get Rolle.
-		@return Responsibility Role
-	  */
 	@Override
-	public int getAD_Role_ID () 
+	public int getAD_Role_ID() 
 	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Role_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
-	}
-
-	/** Set AD_Workflow_Access.
-		@param AD_Workflow_Access_ID AD_Workflow_Access	  */
-	@Override
-	public void setAD_Workflow_Access_ID (int AD_Workflow_Access_ID)
-	{
-		if (AD_Workflow_Access_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_AD_Workflow_Access_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Workflow_Access_ID, Integer.valueOf(AD_Workflow_Access_ID));
-	}
-
-	/** Get AD_Workflow_Access.
-		@return AD_Workflow_Access	  */
-	@Override
-	public int getAD_Workflow_Access_ID () 
-	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Workflow_Access_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return get_ValueAsInt(COLUMNNAME_AD_Role_ID);
 	}
 
 	@Override
-	public org.compiere.model.I_AD_Workflow getAD_Workflow() throws RuntimeException
-	{
-		return get_ValueAsPO(COLUMNNAME_AD_Workflow_ID, org.compiere.model.I_AD_Workflow.class);
-	}
-
-	@Override
-	public void setAD_Workflow(org.compiere.model.I_AD_Workflow AD_Workflow)
-	{
-		set_ValueFromPO(COLUMNNAME_AD_Workflow_ID, org.compiere.model.I_AD_Workflow.class, AD_Workflow);
-	}
-
-	/** Set Workflow.
-		@param AD_Workflow_ID 
-		Workflow or combination of tasks
-	  */
-	@Override
-	public void setAD_Workflow_ID (int AD_Workflow_ID)
+	public void setAD_Workflow_ID (final int AD_Workflow_ID)
 	{
 		if (AD_Workflow_ID < 1) 
 			set_ValueNoCheck (COLUMNNAME_AD_Workflow_ID, null);
 		else 
-			set_ValueNoCheck (COLUMNNAME_AD_Workflow_ID, Integer.valueOf(AD_Workflow_ID));
+			set_ValueNoCheck (COLUMNNAME_AD_Workflow_ID, AD_Workflow_ID);
 	}
 
-	/** Get Workflow.
-		@return Workflow or combination of tasks
-	  */
 	@Override
-	public int getAD_Workflow_ID () 
+	public int getAD_Workflow_ID() 
 	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Workflow_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
+		return get_ValueAsInt(COLUMNNAME_AD_Workflow_ID);
 	}
 
-	/** Set Lesen und Schreiben.
-		@param IsReadWrite 
-		Field is read / write
-	  */
 	@Override
-	public void setIsReadWrite (boolean IsReadWrite)
+	public void setIsReadWrite (final boolean IsReadWrite)
 	{
-		set_Value (COLUMNNAME_IsReadWrite, Boolean.valueOf(IsReadWrite));
+		set_Value (COLUMNNAME_IsReadWrite, IsReadWrite);
 	}
 
-	/** Get Lesen und Schreiben.
-		@return Field is read / write
-	  */
 	@Override
-	public boolean isReadWrite () 
+	public boolean isReadWrite() 
 	{
-		Object oo = get_Value(COLUMNNAME_IsReadWrite);
-		if (oo != null) 
-		{
-			 if (oo instanceof Boolean) 
-				 return ((Boolean)oo).booleanValue(); 
-			return "Y".equals(oo);
-		}
-		return false;
+		return get_ValueAsBoolean(COLUMNNAME_IsReadWrite);
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/interceptor/C_DocType.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/interceptor/C_DocType.java
@@ -58,7 +58,7 @@ public class C_DocType
 	{
 		Services.get(IQueryBL.class)
 				.createQueryBuilder(I_AD_Document_Action_Access.class)
-				.addEqualsFilter(I_AD_Document_Action_Access.COLUMN_C_DocType_ID, docTypeRecord.getC_DocType_ID())
+				.addEqualsFilter(I_AD_Document_Action_Access.COLUMNNAME_C_DocType_ID, docTypeRecord.getC_DocType_ID())
 				.create()
 				.delete();
 	}

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5712650_drop_AD_Document_Action_Access_ID.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5712650_drop_AD_Document_Action_Access_ID.sql
@@ -1,0 +1,54 @@
+-- Run mode: SWING_CLIENT
+
+-- 2023-12-06T07:50:02.569Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=558411
+;
+
+-- Field: Rolle - Verwaltung(111,D) -> Belegaktion-Zugriff(53013,D) -> Document Action Access
+-- Column: AD_Document_Action_Access.AD_Document_Action_Access_ID
+-- 2023-12-06T07:50:02.663Z
+DELETE FROM  AD_Field_Trl WHERE AD_Field_ID=558411
+;
+
+-- 2023-12-06T07:50:02.674Z
+DELETE FROM AD_Field WHERE AD_Field_ID=558411
+;
+
+-- 2023-12-06T07:50:02.748Z
+/* DDL */ SELECT public.db_alter_table('AD_Document_Action_Access','ALTER TABLE AD_Document_Action_Access DROP COLUMN IF EXISTS AD_Document_Action_Access_ID')
+;
+
+-- Column: AD_Document_Action_Access.AD_Document_Action_Access_ID
+-- 2023-12-06T07:50:02.798Z
+DELETE FROM  AD_Column_Trl WHERE AD_Column_ID=556778
+;
+
+-- 2023-12-06T07:50:02.807Z
+DELETE FROM AD_Column WHERE AD_Column_ID=556778
+;
+
+
+
+
+
+
+
+
+--
+--
+--
+--
+--
+
+/*
+select t.tablename, c.columnname
+    from ad_table t
+    inner join ad_column c on c.ad_table_id=t.ad_table_id
+    where t.tablename ilike 'AD_Document_Action_Access' and c.isparent='Y';
+*/
+
+
+ALTER TABLE AD_Document_Action_Access DROP CONSTRAINT IF EXISTS ad_document_action_access_pkey;
+ALTER TABLE AD_Document_Action_Access ADD CONSTRAINT ad_document_action_access_pkey PRIMARY KEY (ad_role_id, c_doctype_id, ad_ref_list_id);
+DROP SEQUENCE IF EXISTS ad_document_action_access_seq;
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5712680_drop_AD_Window_Access_ID.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5712680_drop_AD_Window_Access_ID.sql
@@ -1,0 +1,64 @@
+-- Run mode: SWING_CLIENT
+
+-- 2023-12-06T08:49:58.566Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=558409
+;
+
+-- Field: Rolle - Verwaltung(111,D) -> Fenster-Zugriff(304,D) -> AD_Window_Access
+-- Column: AD_Window_Access.AD_Window_Access_ID
+-- 2023-12-06T08:49:58.577Z
+DELETE FROM  AD_Field_Trl WHERE AD_Field_ID=558409
+;
+
+-- 2023-12-06T08:49:58.586Z
+DELETE FROM AD_Field WHERE AD_Field_ID=558409
+;
+
+-- 2023-12-06T08:49:58.603Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=558410
+;
+
+-- Field: Fenster Verwaltung(102,D) -> Berechtigung(311,D) -> AD_Window_Access
+-- Column: AD_Window_Access.AD_Window_Access_ID
+-- 2023-12-06T08:49:58.610Z
+DELETE FROM  AD_Field_Trl WHERE AD_Field_ID=558410
+;
+
+-- 2023-12-06T08:49:58.615Z
+DELETE FROM AD_Field WHERE AD_Field_ID=558410
+;
+
+-- 2023-12-06T08:49:58.621Z
+/* DDL */ SELECT public.db_alter_table('AD_Window_Access','ALTER TABLE AD_Window_Access DROP COLUMN IF EXISTS AD_Window_Access_ID')
+;
+
+-- Column: AD_Window_Access.AD_Window_Access_ID
+-- 2023-12-06T08:49:58.646Z
+DELETE FROM  AD_Column_Trl WHERE AD_Column_ID=556777
+;
+
+-- 2023-12-06T08:49:58.729Z
+DELETE FROM AD_Column WHERE AD_Column_ID=556777
+;
+
+
+
+
+
+--
+--
+--
+--
+--
+
+/*
+select t.tablename, c.columnname
+    from ad_table t
+    inner join ad_column c on c.ad_table_id=t.ad_table_id
+    where t.tablename ilike 'ad_window_access' and c.isparent='Y';
+*/
+
+ALTER TABLE ad_window_access DROP CONSTRAINT IF EXISTS ad_window_access_pkey;
+ALTER TABLE ad_window_access ADD CONSTRAINT ad_window_access_pkey PRIMARY KEY (ad_role_id, ad_window_id);
+DROP SEQUENCE IF EXISTS ad_window_access_seq;
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5712690_drop_AD_Form_Access_ID.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5712690_drop_AD_Form_Access_ID.sql
@@ -1,0 +1,60 @@
+-- Run mode: SWING_CLIENT
+
+-- 2023-12-06T08:51:07.358Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=558412
+;
+
+-- Field: Rolle - Verwaltung(111,D) -> Fenster (nicht dynamisch)-Zugriff(306,D) -> AD_Form_Access
+-- Column: AD_Form_Access.AD_Form_Access_ID
+-- 2023-12-06T08:51:07.362Z
+DELETE FROM  AD_Field_Trl WHERE AD_Field_ID=558412
+;
+
+-- 2023-12-06T08:51:07.368Z
+DELETE FROM AD_Field WHERE AD_Field_ID=558412
+;
+
+-- 2023-12-06T08:51:07.381Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=558413
+;
+
+-- Field: Fenster (nicht dynamisch)(187,D) -> Berechtigung(309,D) -> AD_Form_Access
+-- Column: AD_Form_Access.AD_Form_Access_ID
+-- 2023-12-06T08:51:07.385Z
+DELETE FROM  AD_Field_Trl WHERE AD_Field_ID=558413
+;
+
+-- 2023-12-06T08:51:07.391Z
+DELETE FROM AD_Field WHERE AD_Field_ID=558413
+;
+
+-- 2023-12-06T08:51:07.409Z
+/* DDL */ SELECT public.db_alter_table('AD_Form_Access','ALTER TABLE AD_Form_Access DROP COLUMN IF EXISTS AD_Form_Access_ID')
+;
+
+-- Column: AD_Form_Access.AD_Form_Access_ID
+-- 2023-12-06T08:51:07.428Z
+DELETE FROM  AD_Column_Trl WHERE AD_Column_ID=556779
+;
+
+-- 2023-12-06T08:51:07.434Z
+DELETE FROM AD_Column WHERE AD_Column_ID=556779
+;
+
+--
+--
+--
+--
+--
+
+/*
+select t.tablename, c.columnname
+    from ad_table t
+    inner join ad_column c on c.ad_table_id=t.ad_table_id
+    where t.tablename ilike 'ad_form_access' and c.isparent='Y';
+*/
+
+ALTER TABLE ad_form_access DROP CONSTRAINT IF EXISTS ad_form_access_pkey;
+ALTER TABLE ad_form_access ADD CONSTRAINT ad_form_access_pkey PRIMARY KEY (ad_role_id, ad_form_id);
+DROP SEQUENCE IF EXISTS ad_form_access_seq;
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5712710_drop_AD_Process_Access_ID.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5712710_drop_AD_Process_Access_ID.sql
@@ -1,0 +1,61 @@
+-- Run mode: SWING_CLIENT
+
+-- 2023-12-06T08:52:23.978Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=558414
+;
+
+-- Field: Rolle - Verwaltung(111,D) -> Prozess-Zugriff(305,D) -> Process Access
+-- Column: AD_Process_Access.AD_Process_Access_ID
+-- 2023-12-06T08:52:23.981Z
+DELETE FROM  AD_Field_Trl WHERE AD_Field_ID=558414
+;
+
+-- 2023-12-06T08:52:23.988Z
+DELETE FROM AD_Field WHERE AD_Field_ID=558414
+;
+
+-- 2023-12-06T08:52:23.995Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=558415
+;
+
+-- Field: Bericht & Prozess(165,D) -> Berechtigung Berichts Zugriff(308,D) -> Process Access
+-- Column: AD_Process_Access.AD_Process_Access_ID
+-- 2023-12-06T08:52:23.998Z
+DELETE FROM  AD_Field_Trl WHERE AD_Field_ID=558415
+;
+
+-- 2023-12-06T08:52:24.004Z
+DELETE FROM AD_Field WHERE AD_Field_ID=558415
+;
+
+-- 2023-12-06T08:52:24.008Z
+/* DDL */ SELECT public.db_alter_table('AD_Process_Access','ALTER TABLE AD_Process_Access DROP COLUMN IF EXISTS AD_Process_Access_ID')
+;
+
+-- Column: AD_Process_Access.AD_Process_Access_ID
+-- 2023-12-06T08:52:24.018Z
+DELETE FROM  AD_Column_Trl WHERE AD_Column_ID=556780
+;
+
+-- 2023-12-06T08:52:24.025Z
+DELETE FROM AD_Column WHERE AD_Column_ID=556780
+;
+
+
+--
+--
+--
+--
+--
+
+/*
+select t.tablename, c.columnname
+    from ad_table t
+    inner join ad_column c on c.ad_table_id=t.ad_table_id
+    where t.tablename ilike 'ad_process_access' and c.isparent='Y';
+*/
+
+ALTER TABLE ad_process_access DROP CONSTRAINT IF EXISTS ad_process_access_pkey;
+ALTER TABLE ad_process_access ADD CONSTRAINT ad_process_access_pkey PRIMARY KEY (ad_role_id, ad_process_id);
+DROP SEQUENCE IF EXISTS ad_process_access_seq;
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5712740_drop_AD_Task_Access_ID.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5712740_drop_AD_Task_Access_ID.sql
@@ -1,0 +1,61 @@
+-- Run mode: SWING_CLIENT
+
+-- 2023-12-06T08:58:20.801Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=558416
+;
+
+-- Field: Rolle - Verwaltung(111,D) -> Aufgaben-Zugriff(313,D) -> AD_Task_Access
+-- Column: AD_Task_Access.AD_Task_Access_ID
+-- 2023-12-06T08:58:20.805Z
+DELETE FROM  AD_Field_Trl WHERE AD_Field_ID=558416
+;
+
+-- 2023-12-06T08:58:20.810Z
+DELETE FROM AD_Field WHERE AD_Field_ID=558416
+;
+
+-- 2023-12-06T08:58:20.821Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=558417
+;
+
+-- Field: Aufgabe(114,D) -> Berechtigung(310,D) -> AD_Task_Access
+-- Column: AD_Task_Access.AD_Task_Access_ID
+-- 2023-12-06T08:58:20.824Z
+DELETE FROM  AD_Field_Trl WHERE AD_Field_ID=558417
+;
+
+-- 2023-12-06T08:58:20.833Z
+DELETE FROM AD_Field WHERE AD_Field_ID=558417
+;
+
+-- 2023-12-06T08:58:20.837Z
+/* DDL */ SELECT public.db_alter_table('AD_Task_Access','ALTER TABLE AD_Task_Access DROP COLUMN IF EXISTS AD_Task_Access_ID')
+;
+
+-- Column: AD_Task_Access.AD_Task_Access_ID
+-- 2023-12-06T08:58:20.855Z
+DELETE FROM  AD_Column_Trl WHERE AD_Column_ID=556781
+;
+
+-- 2023-12-06T08:58:20.860Z
+DELETE FROM AD_Column WHERE AD_Column_ID=556781
+;
+
+
+--
+--
+--
+--
+--
+
+/*
+select t.tablename, c.columnname
+    from ad_table t
+    inner join ad_column c on c.ad_table_id=t.ad_table_id
+    where t.tablename ilike 'ad_task_access' and c.isparent='Y';
+*/
+
+ALTER TABLE ad_task_access DROP CONSTRAINT IF EXISTS ad_task_access_pkey;
+ALTER TABLE ad_task_access ADD CONSTRAINT ad_task_access_pkey PRIMARY KEY (ad_role_id, ad_task_id);
+DROP SEQUENCE IF EXISTS ad_task_access_seq;
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5712770_drop_AD_Workflow_Access_ID.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5712770_drop_AD_Workflow_Access_ID.sql
@@ -1,0 +1,57 @@
+-- Run mode: SWING_CLIENT
+
+-- 2023-12-06T09:00:35.490Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=558419
+;
+
+-- Field: Workflow(113,D) -> Berechtigung(312,D) -> AD_Workflow_Access
+-- Column: AD_Workflow_Access.AD_Workflow_Access_ID
+-- 2023-12-06T09:00:35.493Z
+DELETE FROM  AD_Field_Trl WHERE AD_Field_ID=558419
+;
+
+-- 2023-12-06T09:00:35.497Z
+DELETE FROM AD_Field WHERE AD_Field_ID=558419
+;
+
+-- 2023-12-06T09:00:35.505Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=558420
+;
+
+-- Field: Produktion Arbeitsablauf(53005,EE01) -> Access(53020,EE01) -> AD_Workflow_Access
+-- Column: AD_Workflow_Access.AD_Workflow_Access_ID
+-- 2023-12-06T09:00:35.508Z
+DELETE FROM  AD_Field_Trl WHERE AD_Field_ID=558420
+;
+
+-- 2023-12-06T09:00:35.512Z
+DELETE FROM AD_Field WHERE AD_Field_ID=558420
+;
+
+-- 2023-12-06T09:00:35.522Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=558418
+;
+
+-- Field: Rolle - Verwaltung(111,D) -> Workflow-Zugriff(307,D) -> AD_Workflow_Access
+-- Column: AD_Workflow_Access.AD_Workflow_Access_ID
+-- 2023-12-06T09:00:35.526Z
+DELETE FROM  AD_Field_Trl WHERE AD_Field_ID=558418
+;
+
+-- 2023-12-06T09:00:35.529Z
+DELETE FROM AD_Field WHERE AD_Field_ID=558418
+;
+
+-- 2023-12-06T09:00:35.535Z
+/* DDL */ SELECT public.db_alter_table('AD_Workflow_Access','ALTER TABLE AD_Workflow_Access DROP COLUMN IF EXISTS AD_Workflow_Access_ID')
+;
+
+-- Column: AD_Workflow_Access.AD_Workflow_Access_ID
+-- 2023-12-06T09:00:35.546Z
+DELETE FROM  AD_Column_Trl WHERE AD_Column_ID=556782
+;
+
+-- 2023-12-06T09:00:35.553Z
+DELETE FROM AD_Column WHERE AD_Column_ID=556782
+;
+


### PR DESCRIPTION
- drop AD_Document_Action_Access_ID
- drop AD_Window_Access_ID
- drop AD_Form_Access_ID
- drop AD_Process_Access_ID
- drop AD_Task_Access_ID
- drop AD_Workflow_Access_ID
