### PR TITLE
change QtyDemand_QtySupply_V to always return qtys in the stocking-UO…

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/MaterialCockpitRowsData.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/MaterialCockpitRowsData.java
@@ -22,6 +22,7 @@
 
 package de.metas.ui.web.material.cockpit;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -137,7 +138,15 @@ public class MaterialCockpitRowsData implements IRowsData<MaterialCockpitRow>
 
 			final ProductId productId = ProductId.ofRepoId(row.getProductId());
 
-			final List<I_QtyDemand_QtySupply_V> quantitiesRecords = loadQuantitiesRecords(productId);
+			final List<I_QtyDemand_QtySupply_V> quantitiesRecords;
+			if (MaterialCockpitUtil.isI_QtyDemand_QtySupply_VActive())
+			{
+				quantitiesRecords = loadQuantitiesRecords(productId);
+			}
+			else
+			{
+				quantitiesRecords = ImmutableList.of();
+			}
 			builder.quantitiesRecords(quantitiesRecords);
 
 			builder.productIdToListEvenIfEmpty(productId);

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/MaterialCockpitRowsLoader.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/MaterialCockpitRowsLoader.java
@@ -22,6 +22,7 @@
 
 package de.metas.ui.web.material.cockpit;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import de.metas.cache.CCache;
 import de.metas.material.cockpit.model.I_MD_Cockpit;
@@ -97,9 +98,17 @@ public class MaterialCockpitRowsLoader
 				.createStockQueryFor(filters)
 				.list();
 
-		final List<I_QtyDemand_QtySupply_V> quantitiesRecords = QtyDemandSupplyFilters
-				.createQuantitiesQueryFor(filters)
-				.list();
+		final List<I_QtyDemand_QtySupply_V> quantitiesRecords;
+		if (MaterialCockpitUtil.isI_QtyDemand_QtySupply_VActive())
+		{
+			quantitiesRecords = QtyDemandSupplyFilters
+					.createQuantitiesQueryFor(filters)
+					.list();
+		}
+		else
+		{
+			quantitiesRecords = ImmutableList.of();
+		}
 		
 		final MaterialCockpitRowFactory.CreateRowsRequest request = MaterialCockpitRowFactory.CreateRowsRequest
 				.builder()

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/MaterialCockpitUtil.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/MaterialCockpitUtil.java
@@ -47,7 +47,7 @@ public final class MaterialCockpitUtil
 
 	public static final String SYSCONFIG_INCLUDE_PER_PLANT_DETAIL_ROWS = "de.metas.ui.web.material.cockpit.DisplayPerPlantDetailRows";
 
-	private static final String SYSCFG_I_QtyDemand_QtySupply_V_ACTIVE = "de.metas.ui.web.material.cockpit..I_QtyDemand_QtySupply_V.IsActive";
+	private static final String SYSCFG_I_QtyDemand_QtySupply_V_ACTIVE = "de.metas.ui.web.material.cockpit.I_QtyDemand_QtySupply_V.IsActive";
 
 	public static final String DONT_FILTER = "DONT_FILTER";
 	public static final String NON_EMPTY = "NON_EMPTY";

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/MaterialCockpitUtil.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/MaterialCockpitUtil.java
@@ -1,14 +1,13 @@
 package de.metas.ui.web.material.cockpit;
 
-import org.adempiere.service.ISysConfigBL;
-import org.compiere.util.Env;
-
+import de.metas.common.util.CoalesceUtil;
 import de.metas.dimension.DimensionSpec;
 import de.metas.dimension.IDimensionspecDAO;
 import de.metas.ui.web.window.datatypes.WindowId;
 import de.metas.util.Check;
 import de.metas.util.Services;
-import de.metas.common.util.CoalesceUtil;
+import org.adempiere.service.ISysConfigBL;
+import org.compiere.util.Env;
 
 /*
  * #%L
@@ -48,6 +47,8 @@ public final class MaterialCockpitUtil
 
 	public static final String SYSCONFIG_INCLUDE_PER_PLANT_DETAIL_ROWS = "de.metas.ui.web.material.cockpit.DisplayPerPlantDetailRows";
 
+	private static final String SYSCFG_I_QtyDemand_QtySupply_V_ACTIVE = "de.metas.ui.web.material.cockpit..I_QtyDemand_QtySupply_V.IsActive";
+
 	public static final String DONT_FILTER = "DONT_FILTER";
 	public static final String NON_EMPTY = "NON_EMPTY";
 
@@ -71,5 +72,10 @@ public final class MaterialCockpitUtil
 				DEFAULT_DIM_SPEC_INTERNAL_NAME));
 
 		return Check.assumeNotNull(dimensionSpec, "Unable to load DIM_Dimension_Spec record with InternalName={}", dimSpecName);
+	}
+
+	public static boolean isI_QtyDemand_QtySupply_VActive()
+	{
+		return Services.get(ISysConfigBL.class).getBooleanValue(SYSCFG_I_QtyDemand_QtySupply_V_ACTIVE, true);
 	}
 }

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5690040_sys_gh15452_QtyDemand_QtySupply_V_always_in_product_uom.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5690040_sys_gh15452_QtyDemand_QtySupply_V_always_in_product_uom.sql
@@ -1,5 +1,4 @@
-DROP VIEW IF EXISTS QtyDemand_QtySupply_V
-;
+-- no need to drop it - we don't change its output
 
 CREATE OR REPLACE VIEW QtyDemand_QtySupply_V AS
 

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5713720_sys_syscfg_qtyDemand_qty_Supply_V.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5713720_sys_syscfg_qtyDemand_qty_Supply_V.sql
@@ -1,0 +1,5 @@
+-- 2023-12-17T08:37:14.265Z
+INSERT INTO AD_SysConfig (AD_Client_ID, AD_Org_ID, AD_SysConfig_ID, ConfigurationLevel, Created, CreatedBy, EntityType, IsActive, Name, Updated, UpdatedBy, Value)
+VALUES (0, 0, 541678, 'S', TO_TIMESTAMP('2023-12-17 08:37:14.068000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp WITHOUT TIME ZONE AT TIME ZONE 'UTC', 100, 'de.metas.material.cockpit', 'Y', 'de.metas.ui.web.material.cockpit..I_QtyDemand_QtySupply_V.IsActive', TO_TIMESTAMP('2023-12-17 08:37:14.068000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp WITHOUT TIME ZONE AT TIME ZONE 'UTC', 100, 'Y')
+;
+

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5713720_sys_syscfg_qtyDemand_qty_Supply_V.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5713720_sys_syscfg_qtyDemand_qty_Supply_V.sql
@@ -1,5 +1,5 @@
 -- 2023-12-17T08:37:14.265Z
 INSERT INTO AD_SysConfig (AD_Client_ID, AD_Org_ID, AD_SysConfig_ID, ConfigurationLevel, Created, CreatedBy, EntityType, IsActive, Name, Updated, UpdatedBy, Value)
-VALUES (0, 0, 541678, 'S', TO_TIMESTAMP('2023-12-17 08:37:14.068000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp WITHOUT TIME ZONE AT TIME ZONE 'UTC', 100, 'de.metas.material.cockpit', 'Y', 'de.metas.ui.web.material.cockpit..I_QtyDemand_QtySupply_V.IsActive', TO_TIMESTAMP('2023-12-17 08:37:14.068000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp WITHOUT TIME ZONE AT TIME ZONE 'UTC', 100, 'Y')
+VALUES (0, 0, 541678, 'S', TO_TIMESTAMP('2023-12-17 08:37:14.068000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp WITHOUT TIME ZONE AT TIME ZONE 'UTC', 100, 'de.metas.material.cockpit', 'Y', 'de.metas.ui.web.material.cockpit.I_QtyDemand_QtySupply_V.IsActive', TO_TIMESTAMP('2023-12-17 08:37:14.068000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp WITHOUT TIME ZONE AT TIME ZONE 'UTC', 100, 'Y')
 ;
 


### PR DESCRIPTION
🍒 ⛏️ (#15453)

this avoids an error if m_receiptschedule has a different UOM, because `de.metas.ui.web.material.cockpit.MaterialCockpitRow` assumes all Qtys to be in the same UOM

Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
(cherry picked from commit e8fcdfdaa152d1efd61c90dea6b3c955810af9b2) (cherry picked from commit 9a6af861adeb10f34338f30537ae43beb5009ac8)