### PR TITLE
windowHandler.js reducer: preserve layout.activeTab when updating the layout

### DIFF
--- a/frontend/src/containers/MasterWindow.js
+++ b/frontend/src/containers/MasterWindow.js
@@ -179,8 +179,13 @@ class MasterWindowContainer extends PureComponent {
 
   isActiveTab(tabId) {
     const { master } = this.props;
+    const activeTab = master.layout.activeTab;
+    if (!activeTab) {
+      console.log('No active activeTab found', { master });
+      return false;
+    }
 
-    return tabId === master.layout.activeTab;
+    return tabId === activeTab;
   }
 
   mergeDataIntoIncludedTab({ response, tabId }) {
@@ -414,8 +419,6 @@ const isLayoutLoaded = (layout) => {
 };
 
 const getFieldFromLayout = (layout, fieldName) => {
-  console.log('getFieldFromLayout', { layout, fieldName });
-
   for (const section of layout.sections ?? []) {
     // console.log('section', section);
 

--- a/frontend/src/reducers/windowHandler.js
+++ b/frontend/src/reducers/windowHandler.js
@@ -424,15 +424,18 @@ export default function windowHandler(state = initialState, action) {
 
     // SCOPED ACTIONS
 
-    case INIT_LAYOUT_SUCCESS:
+    case INIT_LAYOUT_SUCCESS: {
       return {
         ...state,
         [action.scope]: {
           ...state[action.scope],
-          layout: action.layout,
+          layout: {
+            activeTab: state[action.scope].layout.activeTab, // preserve activeTab. In future consider extracting activeTab out of layout object
+            ...action.layout,
+          },
         },
       };
-
+    }
     case INIT_DATA_SUCCESS: {
       const layout = state[action.scope].layout ?? {};
       if (action.notFoundMessage !== undefined) {


### PR DESCRIPTION
- windowHandler.js reducer: preserve layout.activeTab when updating the layout
- MasterWindow.isActiveTab: log a warning in case there is no active tab (that might be a problem/development bug)
