### PR TITLE
FE Load documents correctly when going back and forward to/from profile and a given page

### DIFF
--- a/frontend/src/__tests__/actions/WindowActions.test.js
+++ b/frontend/src/__tests__/actions/WindowActions.test.js
@@ -73,6 +73,7 @@ describe('WindowActions thunks', () => {
                 { type: ACTION_TYPES.INIT_WINDOW },
                 {
                   type: ACTION_TYPES.INIT_DATA_SUCCESS,
+                  windowId: "143",
                   data: {},
                   docId: undefined,
                   hasComments: undefined,
@@ -240,6 +241,7 @@ describe('WindowActions thunks', () => {
               { type: ACTION_TYPES.INIT_WINDOW },
               {
                 type: ACTION_TYPES.INIT_DATA_SUCCESS,
+                windowId,
                 data: parseToDisplay(dataResponse[0].fieldsByName),
                 docId,
                 saveStatus: dataResponse[0].saveStatus,

--- a/frontend/src/actions/WindowActions.js
+++ b/frontend/src/actions/WindowActions.js
@@ -213,6 +213,7 @@ export function initLayoutSuccess(layout, scope) {
 
 // @VisibleForTesting
 export function initDataSuccess({
+  windowId,
   data,
   docId,
   includedTabsInfo,
@@ -227,6 +228,7 @@ export function initDataSuccess({
 }) {
   return {
     type: INIT_DATA_SUCCESS,
+    windowId,
     data,
     docId,
     includedTabsInfo,
@@ -639,6 +641,7 @@ export function createWindow({
         disconnected !== 'inlineTab' &&
           dispatch(
             initDataSuccess({
+              windowId,
               data: parseToDisplay(responseDocuments[elem].fieldsByName),
               docId,
               saveStatus: data.saveStatus,

--- a/frontend/src/reducers/windowHandler.js
+++ b/frontend/src/reducers/windowHandler.js
@@ -437,12 +437,18 @@ export default function windowHandler(state = initialState, action) {
       };
     }
     case INIT_DATA_SUCCESS: {
-      const layout = state[action.scope].layout ?? {};
+      let layout = state[action.scope].layout ?? {};
       if (action.notFoundMessage !== undefined) {
-        layout.notFoundMessage = action.notFoundMessage;
+        layout = {
+          ...layout,
+          notFoundMessage: action.notFoundMessage,
+        };
       }
       if (action.notFoundMessageDetail !== undefined) {
-        layout.notFoundMessageDetail = action.notFoundMessageDetail;
+        layout = {
+          ...layout,
+          notFoundMessageDetail: action.notFoundMessageDetail,
+        };
       }
 
       return {

--- a/frontend/src/reducers/windowHandler.js
+++ b/frontend/src/reducers/windowHandler.js
@@ -438,6 +438,16 @@ export default function windowHandler(state = initialState, action) {
     }
     case INIT_DATA_SUCCESS: {
       let layout = state[action.scope].layout ?? {};
+
+      // If the action data is for another windowId then reset the layout.
+      // "INIT_LAYOUT_SUCCESS" action to come afterward and set the actual layout.
+      if (
+        action.windowId !== undefined &&
+        layout.windowId !== action.windowId
+      ) {
+        layout = {};
+      }
+
       if (action.notFoundMessage !== undefined) {
         layout = {
           ...layout,


### PR DESCRIPTION
- windowHandler.js - INIT_DATA_SUCCESS - don't change current state
- windowHandler.js - INIT_DATA_SUCCESS - reset the layout in case we are setting data for a different windowId
