### PR TITLE
DatePicker: fix setTimezone, convertToTimezone - don't fail when moment is ''

### DIFF
--- a/frontend/src/components/widget/DateTime/DatePicker.js
+++ b/frontend/src/components/widget/DateTime/DatePicker.js
@@ -214,7 +214,7 @@ class DatePicker extends PureComponent {
   };
 
   setTimezone = (moment) => {
-    if (moment == null) {
+    if (!moment) {
       return null;
     }
 
@@ -227,7 +227,7 @@ class DatePicker extends PureComponent {
   };
 
   convertToTimezone = (moment) => {
-    if (moment == null) {
+    if (!moment) {
       return null;
     }
 


### PR DESCRIPTION
fixes
* https://github.com/metasfresh/metasfresh/pull/17287