### PR TITLE
Revert "PickingJobCompleteCommand now returns directly after shipment-scheds are enqueued"

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobCompleteCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobCompleteCommand.java
@@ -100,8 +100,6 @@ public class PickingJobCompleteCommand
 					.onTheFlyPickToPackingInstructions(true)
 					.isCompleteShipment(createShipmentPolicy.isCreateAndCompleteShipment())
 					.isCloseShipmentSchedules(createShipmentPolicy.isCloseShipmentSchedules())
-					// since we are not going to immediately create invoices, we want to move on and to wait for shipments
-					.waitForShipments(false) 
 					.build());
 		}
 	}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/GenerateShipmentsForSchedulesRequest.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/GenerateShipmentsForSchedulesRequest.java
@@ -51,13 +51,4 @@ public class GenerateShipmentsForSchedulesRequest
 
 	@Nullable
 	Boolean isShipDateToday;
-
-	/**
-	 * The shipments are generally created via async-workpackage and this flag decides if the caller wants to wait for it.
-	 * By default, it is set to {@code true} for backwards compatibility.
-	 *
-	 * @see ShipmentService#generateShipmentsForScheduleIds(GenerateShipmentsForSchedulesRequest)
-	 */
-	@Builder.Default
-	boolean waitForShipments = true;
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/GenerateShipmentsRequest.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/GenerateShipmentsRequest.java
@@ -68,15 +68,6 @@ public class GenerateShipmentsRequest
 	@Nullable
 	Boolean isShipDateToday;
 
-	/**
-	 * The shipments are created via async-workpackage and this flag decides if the caller wants to wait for them.
-	 * By default, it is set to true for backwards compatibility.
-	 * 
-	 * @see ShipmentService#generateShipments(GenerateShipmentsRequest) 
-	 */
-	@Builder.Default
-	boolean waitForShipments = true;
-	
 	public ImmutableMap<ShipmentScheduleId, String> extractShipmentDocumentNos()
 	{
 		final ImmutableMap.Builder<ShipmentScheduleId, String> result = ImmutableMap.builder();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentServiceTestImpl.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentServiceTestImpl.java
@@ -58,10 +58,6 @@ public class ShipmentServiceTestImpl implements IShipmentService
 		this.shipmentScheduleWithHUService = shipmentScheduleWithHUService;
 	}
 
-	/**
-	 * Always creates shipments synchronously and directly.
-	 * Ignores {@link GenerateShipmentsForSchedulesRequest#isWaitForShipments()}.
-	 */
 	@NonNull
 	@VisibleForTesting
 	public Set<InOutId> generateShipmentsForScheduleIds(@NonNull final GenerateShipmentsForSchedulesRequest request)


### PR DESCRIPTION
Reverts metasfresh/metasfresh#17380 because there is now a new problem. 
- It tried addressing it here: https://github.com/metasfresh/metasfresh/pull/17389 but there needs to be more QA before we can integrate that thas well

