### PR TITLE
intensive care/uat/mobileui picking dont wait for shipment 2

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobCompleteCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobCompleteCommand.java
@@ -100,6 +100,8 @@ public class PickingJobCompleteCommand
 					.onTheFlyPickToPackingInstructions(true)
 					.isCompleteShipment(createShipmentPolicy.isCreateAndCompleteShipment())
 					.isCloseShipmentSchedules(createShipmentPolicy.isCloseShipmentSchedules())
+					// since we are not going to immediately create invoices, we want to move on and to wait for shipments
+					.waitForShipments(false) 
 					.build());
 		}
 	}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/GenerateShipmentsForSchedulesRequest.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/GenerateShipmentsForSchedulesRequest.java
@@ -51,4 +51,13 @@ public class GenerateShipmentsForSchedulesRequest
 
 	@Nullable
 	Boolean isShipDateToday;
+
+	/**
+	 * The shipments are generally created via async-workpackage and this flag decides if the caller wants to wait for it.
+	 * By default, it is set to {@code true} for backwards compatibility.
+	 *
+	 * @see ShipmentService#generateShipmentsForScheduleIds(GenerateShipmentsForSchedulesRequest)
+	 */
+	@Builder.Default
+	boolean waitForShipments = true;
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/GenerateShipmentsRequest.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/GenerateShipmentsRequest.java
@@ -68,6 +68,15 @@ public class GenerateShipmentsRequest
 	@Nullable
 	Boolean isShipDateToday;
 
+	/**
+	 * The shipments are created via async-workpackage and this flag decides if the caller wants to wait for them.
+	 * By default, it is set to true for backwards compatibility.
+	 * 
+	 * @see ShipmentService#generateShipments(GenerateShipmentsRequest) 
+	 */
+	@Builder.Default
+	boolean waitForShipments = true;
+	
 	public ImmutableMap<ShipmentScheduleId, String> extractShipmentDocumentNos()
 	{
 		final ImmutableMap.Builder<ShipmentScheduleId, String> result = ImmutableMap.builder();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentService.java
@@ -114,6 +114,11 @@ public class ShipmentService implements IShipmentService
 		this.asyncBatchService = asyncBatchService;
 	}
 
+	/**
+	 * <b>Important:</b> if called with {@link GenerateShipmentsRequest#isWaitForShipments()} {@code false},<br/>
+	 * and there is already an unprocessed workpackage with the same shipment-schedules, the method will fail.<br/>
+	 * Also see {@link ShipmentScheduleEnqueuer#acquireLock(de.metas.process.PInstanceId, org.adempiere.ad.dao.IQueryFilter)}.
+	 */
 	@NonNull
 	public ShipmentScheduleEnqueuer.Result generateShipments(@NonNull final GenerateShipmentsRequest request)
 	{
@@ -130,12 +135,22 @@ public class ShipmentService implements IShipmentService
 			return enqueueShipmentSchedules(request);
 		};
 
-		// The process will wait until the schedules are processed because the next call might contain the same shipment schedules as the current one.
-		// In this case enqueing the same shipmentschedule will fail, because it requires an exclusive lock and the sched is still enqueued from the current lock
-		// See ShipmentScheduleEnqueuer.acquireLock(...)
-		return asyncBatchService.executeBatch(generateShipmentsSupplier, request.getAsyncBatchId());
+		if (request.isWaitForShipments())
+		{
+			// The thread will wait until the schedules are processed, because the next call might contain the same shipment schedules as the current one.
+			return asyncBatchService.executeBatch(generateShipmentsSupplier, request.getAsyncBatchId());
+		}
+		else
+		{
+			// Just enqueue the workpackages and move on
+			return enqueueShipmentSchedules(request);
+		}
 	}
 
+	/**
+	 * <b>Important:</b> if called with {@link GenerateShipmentsForSchedulesRequest#isWaitForShipments()} {@code false},<br/>
+	 * the warning from {@link #generateShipments(GenerateShipmentsRequest)} applies.
+	 */
 	@NonNull
 	public Set<InOutId> generateShipmentsForScheduleIds(@NonNull final GenerateShipmentsForSchedulesRequest request)
 	{
@@ -162,6 +177,7 @@ public class ShipmentService implements IShipmentService
 									.isShipDateToday(request.getIsShipDateToday())
 									.isCompleteShipment(request.getIsCompleteShipment())
 									.isCloseShipmentSchedules(request.isCloseShipmentSchedules())
+									.waitForShipments(request.isWaitForShipments())
 									.build()
 					);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentServiceTestImpl.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentServiceTestImpl.java
@@ -58,6 +58,10 @@ public class ShipmentServiceTestImpl implements IShipmentService
 		this.shipmentScheduleWithHUService = shipmentScheduleWithHUService;
 	}
 
+	/**
+	 * Always creates shipments synchronously and directly.
+	 * Ignores {@link GenerateShipmentsForSchedulesRequest#isWaitForShipments()}.
+	 */
 	@NonNull
 	@VisibleForTesting
 	public Set<InOutId> generateShipmentsForScheduleIds(@NonNull final GenerateShipmentsForSchedulesRequest request)


### PR DESCRIPTION
- PickingJobCompleteCommand now returns directly after shipment-scheds are enqueued.
- Don't select M_Packageable_V records whose M_ShipmentSchedules are currently locked
