### PR TITLE
Fix Payment allocation posting for the case of foreign currency, discount/writeoff invoice tax correction

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -24,6 +24,7 @@ import de.metas.currency.CurrencyConversionContext;
 import de.metas.currency.ICurrencyBL;
 import de.metas.invoice.service.IInvoiceBL;
 import de.metas.money.CurrencyConversionTypeId;
+import de.metas.money.Money;
 import de.metas.organization.OrgId;
 import de.metas.payment.PaymentId;
 import de.metas.payment.api.IPaymentBL;
@@ -108,8 +109,8 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 		// Amounts
 		m_AllocatedAmt = line.getAmount();
 		setAmount(m_AllocatedAmt);
-		m_DiscountAmt = line.getDiscountAmt();
-		m_WriteOffAmt = line.getWriteOffAmt();
+		m_DiscountAmt = Money.of(line.getDiscountAmt(), doc.getCurrencyId());
+		m_WriteOffAmt = Money.of(line.getWriteOffAmt(), doc.getCurrencyId());
 		m_OverUnderAmt = line.getOverUnderAmt();
 		m_PaymentWriteOffAmt = line.getPaymentWriteOffAmt();
 	}    // DocLine_Allocation
@@ -133,8 +134,8 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 	private final I_C_CashLine cashLine;
 
 	private final BigDecimal m_AllocatedAmt;
-	private final BigDecimal m_DiscountAmt;
-	private final BigDecimal m_WriteOffAmt;
+	private final Money m_DiscountAmt;
+	private final Money m_WriteOffAmt;
 	private final BigDecimal m_OverUnderAmt;
 	private final BigDecimal m_PaymentWriteOffAmt;
 
@@ -149,7 +150,7 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 		final StringBuilder sb = new StringBuilder("DocLine_Allocation[");
 		sb.append(get_ID())
 				.append(",Amt=").append(getAllocatedAmt())
-				.append(",Discount=").append(getDiscountAmt())
+				.append(",Discount=").append(getDiscountAmt().toBigDecimal())
 				.append(",WriteOff=").append(getWriteOffAmt())
 				.append(",OverUnderAmt=").append(getOverUnderAmt())
 				.append(" - C_Payment_ID=").append(_payment)
@@ -180,14 +181,14 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 	/**
 	 * @return Returns the discountAmt.
 	 */
-	public BigDecimal getDiscountAmt()
+	public Money getDiscountAmt()
 	{
 		return m_DiscountAmt;
 	}
 
-	public BigDecimal getDiscountAmt_CMAdjusted()
+	public Money getDiscountAmt_CMAdjusted()
 	{
-		BigDecimal discountAmt = getDiscountAmt();
+		Money discountAmt = getDiscountAmt();
 		if (isCreditMemoInvoice())
 		{
 			discountAmt = discountAmt.negate();
@@ -206,14 +207,14 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 	/**
 	 * @return Returns the writeOffAmt.
 	 */
-	public BigDecimal getWriteOffAmt()
+	public Money getWriteOffAmt()
 	{
 		return m_WriteOffAmt;
 	}
 
-	public BigDecimal getWriteOffAmt_CMAdjusted()
+	public Money getWriteOffAmt_CMAdjusted()
 	{
-		BigDecimal writeOffAmt = getWriteOffAmt();
+		Money writeOffAmt = getWriteOffAmt();
 		if (isCreditMemoInvoice())
 		{
 			writeOffAmt = writeOffAmt.negate();

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -1149,9 +1149,9 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 	 * Allocation Tax Adjustment
 	 */
 	public Doc_AllocationTax(final Doc_AllocationHdr doc,
-			final MAccount DiscountAccount, final BigDecimal DiscountAmt,
-			final MAccount WriteOffAccount, final BigDecimal WriteOffAmt,
-			final boolean isDiscountExpense)
+							 final MAccount DiscountAccount, final BigDecimal DiscountAmt,
+							 final MAccount WriteOffAccount, final BigDecimal WriteOffAmt,
+							 final boolean isDiscountExpense)
 	{
 		super();
 		this.doc = doc;
@@ -1174,9 +1174,9 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 	private final boolean isDiscountExpense;
 	//
 	private I_Fact_Acct _invoiceGrandTotalFact;
-	private final List<I_Fact_Acct> _invoiceTaxFacts = new ArrayList<>();
+	private final ArrayList<I_Fact_Acct> _invoiceTaxFacts = new ArrayList<>();
 
-	private final PostingException newPostingException()
+	private PostingException newPostingException()
 	{
 		return doc.newPostingException();
 	}
@@ -1331,18 +1331,47 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 						// Discount expense
 						if (isDiscountExpense)
 						{
-							final FactLine flDR = fact.createLine(line, discountAcct, as.getCurrencyId(), amountCMAdjusted, null);
-							updateFactLine(flDR, taxId, description);
-							final FactLine flCR = fact.createLine(line, taxAcct, as.getCurrencyId(), null, amountCMAdjusted);
-							updateFactLine(flCR, taxId, description);
+							// DR
+							fact.createLine()
+									.setDocLine(line)
+									.setAccount(discountAcct)
+									.setAmtSource(as.getCurrencyId(), amountCMAdjusted, null)
+									.setC_Tax_ID(taxId)
+									.additionalDescription(description)
+									.buildAndAdd();
+
+							// CR
+							fact.createLine()
+									.setDocLine(line)
+									.setAccount(taxAcct)
+									.setAmtSource(as.getCurrencyId(), null, amountCMAdjusted)
+									.setC_Tax_ID(taxId)
+									.alsoAddZeroLine()
+									.additionalDescription(description)
+									.buildAndAdd();
 						}
 						// Discount revenue
 						else
 						{
-							final FactLine flDR = fact.createLine(line, discountAcct, as.getCurrencyId(), amountCMAdjusted.negate(), null);
-							updateFactLine(flDR, taxId, description);
-							final FactLine flCR = fact.createLine(line, taxAcct, as.getCurrencyId(), null, amountCMAdjusted.negate());
-							updateFactLine(flCR, taxId, description);
+							// DR
+							fact.createLine()
+									.setDocLine(line)
+									.setAccount(discountAcct)
+									.setAmtSource(as.getCurrencyId(), amountCMAdjusted.negate(), null)
+									.setC_Tax_ID(taxId)
+									.additionalDescription(description)
+									.buildAndAdd();
+
+							// CR
+							fact.createLine()
+									.setDocLine(line)
+									.setAccount(taxAcct)
+									.setAmtSource(as.getCurrencyId(), null, amountCMAdjusted.negate())
+									.setC_Tax_ID(taxId)
+									.alsoAddZeroLine()
+									.additionalDescription(description)
+									.buildAndAdd();
+
 						}
 
 					}
@@ -1367,18 +1396,48 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 						// Discount expense
 						if (isDiscountExpense)
 						{
-							final FactLine flDR = fact.createLine(line, taxAcct, as.getCurrencyId(), amountCMAdjusted, null);
-							updateFactLine(flDR, taxId, description);
-							final FactLine flCR = fact.createLine(line, discountAcct, as.getCurrencyId(), null, amountCMAdjusted);
-							updateFactLine(flCR, taxId, description);
+							// DR
+							fact.createLine()
+									.setDocLine(line)
+									.setAccount(taxAcct)
+									.setAmtSource(as.getCurrencyId(), amountCMAdjusted, null)
+									.setC_Tax_ID(taxId)
+									.alsoAddZeroLine()
+									.additionalDescription(description)
+									.buildAndAdd();
+
+							// CR
+							fact.createLine()
+									.setDocLine(line)
+									.setAccount(discountAcct)
+									.setAmtSource(as.getCurrencyId(), null, amountCMAdjusted)
+									.setC_Tax_ID(taxId)
+									.additionalDescription(description)
+									.buildAndAdd();
+
 						}
 						// Discount revenue
 						else
 						{
-							final FactLine flDR = fact.createLine(line, taxAcct, as.getCurrencyId(), amountCMAdjusted.negate(), null);
-							updateFactLine(flDR, taxId, description);
-							final FactLine flCR = fact.createLine(line, discountAcct, as.getCurrencyId(), null, amountCMAdjusted.negate());
-							updateFactLine(flCR, taxId, description);
+							//DR
+							fact.createLine()
+									.setDocLine(line)
+									.setAccount(taxAcct)
+									.setAmtSource(as.getCurrencyId(), amountCMAdjusted.negate(), null)
+									.setC_Tax_ID(taxId)
+									.alsoAddZeroLine()
+									.additionalDescription(description)
+									.buildAndAdd();
+
+							// CR
+							fact.createLine()
+									.setDocLine(line)
+									.setAccount(discountAcct)
+									.setAmtSource(as.getCurrencyId(), null, amountCMAdjusted.negate())
+									.setC_Tax_ID(taxId)
+									.additionalDescription(description)
+									.buildAndAdd();
+
 						}
 					}
 				}
@@ -1400,10 +1459,24 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 						final Fact fact = createEmptyFact(as);
 						result.add(fact);
 
-						final FactLine flDR = fact.createLine(line, m_WriteOffAccount, as.getCurrencyId(), amountCMAdjusted, null);
-						updateFactLine(flDR, taxId, description);
-						final FactLine flCR = fact.createLine(line, taxAcct, as.getCurrencyId(), null, amountCMAdjusted);
-						updateFactLine(flCR, taxId, description);
+						//DR
+						fact.createLine()
+								.setDocLine(line)
+								.setAccount(m_WriteOffAccount)
+								.setAmtSource(as.getCurrencyId(), amountCMAdjusted, null)
+								.setC_Tax_ID(taxId)
+								.additionalDescription(description)
+								.buildAndAdd();
+
+						// CR
+						fact.createLine()
+								.setDocLine(line)
+								.setAccount(taxAcct)
+								.setAmtSource(as.getCurrencyId(), null, amountCMAdjusted)
+								.setC_Tax_ID(taxId)
+								.alsoAddZeroLine()
+								.additionalDescription(description)
+								.buildAndAdd();
 					}
 				}
 				// Original Tax is CR - need to correct it DR
@@ -1418,10 +1491,24 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 						final Fact fact = createEmptyFact(as);
 						result.add(fact);
 
-						final FactLine flDR = fact.createLine(line, taxAcct, as.getCurrencyId(), amountCMAdjusted, null);
-						updateFactLine(flDR, taxId, description);
-						final FactLine flCR = fact.createLine(line, m_WriteOffAccount, as.getCurrencyId(), null, amountCMAdjusted);
-						updateFactLine(flCR, taxId, description);
+						// DR
+						fact.createLine()
+								.setDocLine(line)
+								.setAccount(taxAcct)
+								.setAmtSource(as.getCurrencyId(), amountCMAdjusted, null)
+								.setC_Tax_ID(taxId)
+								.alsoAddZeroLine()
+								.additionalDescription(description)
+								.buildAndAdd();
+
+						// CR
+						fact.createLine()
+								.setDocLine(line)
+								.setAccount(m_WriteOffAccount)
+								.setAmtSource(as.getCurrencyId(), null, amountCMAdjusted)
+								.setC_Tax_ID(taxId)
+								.additionalDescription(description)
+								.buildAndAdd();
 					}
 				}
 			}                // WriteOff
@@ -1444,7 +1531,7 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 	 * @param precision            precision
 	 * @return (taxAmt / invoice grand total amount) * taxAmt
 	 */
-	private static final BigDecimal calcAmount(
+	private static BigDecimal calcAmount(
 			final BigDecimal taxAmt,
 			final BigDecimal invoiceGrandTotalAmt,
 			final BigDecimal discountAmt,
@@ -1476,25 +1563,4 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		final BigDecimal taxAmtPartCMAdjusted = isCreditMemoInvoice ? taxAmtPart.negate() : taxAmtPart;
 		return taxAmtPartCMAdjusted;
 	}    // calcAmount
-
-	/**
-	 * Convenient method to update {@link FactLine}'s infos if the line is not null.
-	 *
-	 * @param fl
-	 * @param taxId
-	 * @param description description to add
-	 */
-	private static final void updateFactLine(final FactLine fl, final int taxId, final String description)
-	{
-		if (fl == null)
-		{
-			return;
-		}
-
-		fl.setC_Tax_ID(taxId);
-		if (!Check.isEmpty(description, true))
-		{
-			fl.addDescription(description);
-		}
-	}
 }    // Doc_AllocationTax

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Fact.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Fact.java
@@ -16,23 +16,7 @@
  *****************************************************************************/
 package org.compiere.acct;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.function.Consumer;
-
-import org.adempiere.ad.trx.api.ITrx;
-import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.model.InterfaceWrapperHelper;
-import org.compiere.acct.FactTrxLines.FactTrxLinesType;
-import org.compiere.model.I_C_ElementValue;
-import org.compiere.model.MAccount;
-import org.slf4j.Logger;
-
 import com.google.common.collect.ImmutableList;
-
 import de.metas.acct.api.AcctSchema;
 import de.metas.acct.api.AcctSchemaElement;
 import de.metas.acct.api.AcctSchemaElementType;
@@ -46,8 +30,21 @@ import de.metas.money.CurrencyId;
 import de.metas.util.Check;
 import de.metas.util.collections.CollectionUtils;
 import lombok.NonNull;
+import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.acct.FactTrxLines.FactTrxLinesType;
+import org.compiere.model.I_C_ElementValue;
+import org.compiere.model.MAccount;
+import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Accounting Fact
@@ -144,9 +141,9 @@ public final class Fact
 	}
 
 	public FactLine createLine(final DocLine<?> docLine,
-			final MAccount account,
-			final int C_Currency_ID,
-			final BigDecimal debitAmt, final BigDecimal creditAmt)
+							   final MAccount account,
+							   final int C_Currency_ID,
+							   final BigDecimal debitAmt, final BigDecimal creditAmt)
 	{
 		final CurrencyId currencyId = CurrencyId.ofRepoId(C_Currency_ID);
 		return createLine(docLine, account, currencyId, debitAmt, creditAmt);
@@ -169,10 +166,10 @@ public final class Fact
 	 * @return Fact Line or null
 	 */
 	public FactLine createLine(final DocLine<?> docLine,
-			final MAccount account,
-			final CurrencyId currencyId,
-			final BigDecimal debitAmt, final BigDecimal creditAmt,
-			final BigDecimal qty)
+							   final MAccount account,
+							   final CurrencyId currencyId,
+							   final BigDecimal debitAmt, final BigDecimal creditAmt,
+							   final BigDecimal qty)
 	{
 		return createLine()
 				.setDocLine(docLine)
@@ -183,10 +180,10 @@ public final class Fact
 	}    // createLine
 
 	public FactLine createLine(final DocLine<?> docLine,
-			final MAccount account,
-			final int C_Currency_ID,
-			final BigDecimal debitAmt, final BigDecimal creditAmt,
-			final BigDecimal qty)
+							   final MAccount account,
+							   final int C_Currency_ID,
+							   final BigDecimal debitAmt, final BigDecimal creditAmt,
+							   final BigDecimal qty)
 	{
 		final CurrencyId currencyId = CurrencyId.ofRepoIdOrNull(C_Currency_ID);
 		return createLine(docLine, account, currencyId, debitAmt, creditAmt, qty);
@@ -256,6 +253,8 @@ public final class Fact
 	{
 		return getAcctSchema().getId();
 	}
+
+	public CurrencyId getAcctCurrencyId() {return getAcctSchema().getCurrencyId();}
 
 	private AcctSchemaElementsMap getAcctSchemaElements()
 	{

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/FactLineBuilder.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/FactLineBuilder.java
@@ -2,6 +2,7 @@ package org.compiere.acct;
 
 import java.math.BigDecimal;
 
+import de.metas.util.StringUtils;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MAccount;
 import org.compiere.util.Env;
@@ -62,6 +63,8 @@ public final class FactLineBuilder
 	@Nullable private CurrencyConversionContext currencyConversionCtx;
 	@Nullable private BigDecimal amtSourceDr;
 	@Nullable private BigDecimal amtSourceCr;
+	@Nullable private BigDecimal amtAcctDr;
+	@Nullable private BigDecimal amtAcctCr;
 
 	private BigDecimal qty = null;
 	private UomId uomId;
@@ -74,6 +77,8 @@ public final class FactLineBuilder
 	@Nullable private TaxId C_Tax_ID;
 	private Integer locatorId;
 	private ActivityId activityId;
+
+	private String additionalDescription = null;
 
 	FactLineBuilder(@NonNull final Fact fact)
 	{
@@ -178,7 +183,11 @@ public final class FactLineBuilder
 
 		//
 		// Optionally overwrite Acct Amount
-		if (docLine != null && (docLine.getAmtAcctDr() != null || docLine.getAmtAcctCr() != null))
+		if(amtAcctDr != null || amtAcctCr != null)
+		{
+			line.setAmtAcct(amtAcctDr, amtAcctCr);
+		}
+		else if (docLine != null && (docLine.getAmtAcctDr() != null || docLine.getAmtAcctCr() != null))
 		{
 			line.setAmtAcct(docLine.getAmtAcctDr(), docLine.getAmtAcctCr());
 		}
@@ -218,6 +227,11 @@ public final class FactLineBuilder
 		if (activityId != null)
 		{
 			line.setC_Activity_ID(activityId.getRepoId());
+		}
+
+		if (additionalDescription != null)
+		{
+			line.addDescription(additionalDescription);
 		}
 
 		//
@@ -485,5 +499,12 @@ public final class FactLineBuilder
 	private ActivityId getActivityId()
 	{
 		return activityId;
+	}
+
+	public FactLineBuilder additionalDescription(@Nullable final String additionalDescription)
+	{
+		assertNotBuild();
+		this.additionalDescription = StringUtils.trimBlankToNull(additionalDescription);
+		return this;
 	}
 }

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/MoneySourceAndAcct.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/MoneySourceAndAcct.java
@@ -1,0 +1,99 @@
+/*
+ * #%L
+ * de.metas.acct.base
+ * %%
+ * Copyright (C) 2024 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.compiere.acct;
+
+import de.metas.currency.CurrencyPrecision;
+import de.metas.money.CurrencyId;
+import de.metas.money.Money;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+
+import java.math.BigDecimal;
+
+@Getter
+@EqualsAndHashCode
+public class MoneySourceAndAcct
+{
+	@NonNull private final Money source;
+	@NonNull private final Money acct;
+
+	private MoneySourceAndAcct(@NonNull final Money source, @NonNull final Money acct)
+	{
+		this.source = source;
+		this.acct = acct;
+	}
+
+	public static MoneySourceAndAcct ofSourceAndAcct(@NonNull final Money source, @NonNull final Money acct)
+	{
+		return new MoneySourceAndAcct(source, acct);
+	}
+
+	public String toString()
+	{
+		return source + "/" + acct;
+	}
+
+	public int signum() {return source.signum();}
+
+	public CurrencyId getSourceCurrencyId() {return source.getCurrencyId();}
+
+	private MoneySourceAndAcct newOfSourceAndAcct(@NonNull final Money newSource, @NonNull final Money newAcct)
+	{
+		if (Money.equals(this.source, newSource) && Money.equals(this.acct, newAcct))
+		{
+			return this;
+		}
+		return ofSourceAndAcct(newSource, newAcct);
+	}
+
+	public MoneySourceAndAcct divide(@NonNull final MoneySourceAndAcct divisor, @NonNull final CurrencyPrecision precision)
+	{
+		return newOfSourceAndAcct(source.divide(divisor.source, precision), acct.divide(divisor.acct, precision));
+	}
+
+	public MoneySourceAndAcct multiply(@NonNull final BigDecimal multiplicand)
+	{
+		return newOfSourceAndAcct(source.multiply(multiplicand), acct.multiply(multiplicand));
+	}
+
+	public MoneySourceAndAcct negate()
+	{
+		return newOfSourceAndAcct(source.negate(), acct.negate());
+	}
+
+	public MoneySourceAndAcct negateIf(final boolean condition)
+	{
+		return condition ? negate() : this;
+	}
+
+	public MoneySourceAndAcct toZero()
+	{
+		return newOfSourceAndAcct(source.toZero(), acct.toZero());
+	}
+
+	public MoneySourceAndAcct roundIfNeeded(@NonNull final CurrencyPrecision sourcePrecision, @NonNull final CurrencyPrecision acctPrecision)
+	{
+		return newOfSourceAndAcct(source.roundIfNeeded(sourcePrecision), acct.roundIfNeeded(acctPrecision));
+	}
+}

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/doc/AcctDocRequiredServicesFacade.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/doc/AcctDocRequiredServicesFacade.java
@@ -50,11 +50,13 @@ import de.metas.tax.api.TaxId;
 import de.metas.uom.UomId;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.acct.api.IFactAcctBL;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.service.ClientId;
 import org.adempiere.service.ISysConfigBL;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_Fact_Acct;
 import org.compiere.model.I_M_Product;
 import org.compiere.model.MAccount;
 import org.compiere.model.PO;
@@ -100,6 +102,7 @@ public class AcctDocRequiredServicesFacade
 	private final IModelCacheInvalidationService modelCacheInvalidationService = Services.get(IModelCacheInvalidationService.class);
 
 	private final IFactAcctDAO factAcctDAO = Services.get(IFactAcctDAO.class);
+	private final IFactAcctBL factAcctBL = Services.get(IFactAcctBL.class);
 	private final IAccountDAO accountDAO = Services.get(IAccountDAO.class);
 
 	private final ICurrencyDAO currencyDAO = Services.get(ICurrencyDAO.class);
@@ -174,6 +177,11 @@ public class AcctDocRequiredServicesFacade
 	public MAccount getAccountById(@NonNull final AccountId accountId)
 	{
 		return accountDAO.getById(accountId);
+	}
+
+	public MAccount getAccount(@NonNull final I_Fact_Acct factAcct)
+	{
+		return factAcctBL.getAccount(factAcct);
 	}
 
 	public CurrencyPrecision getCurrencyStandardPrecision(@NonNull final CurrencyId currencyId)

--- a/backend/de.metas.acct.base/src/test/java/de/metas/acct/PostDocumentNow_ManualTest.java
+++ b/backend/de.metas.acct.base/src/test/java/de/metas/acct/PostDocumentNow_ManualTest.java
@@ -1,0 +1,112 @@
+/*
+ * #%L
+ * de.metas.acct.base
+ * %%
+ * Copyright (C) 2024 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.acct;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.acct.api.AcctSchema;
+import de.metas.acct.api.IAcctSchemaDAO;
+import de.metas.acct.doc.AcctDocContext;
+import de.metas.acct.doc.AcctDocRequiredServicesFacade;
+import de.metas.banking.api.BankAccountAcctRepository;
+import de.metas.banking.api.BankAccountService;
+import de.metas.banking.api.BankRepository;
+import de.metas.costing.impl.CostDetailRepository;
+import de.metas.costing.impl.CostDetailService;
+import de.metas.costing.impl.CostElementRepository;
+import de.metas.costing.impl.CostingService;
+import de.metas.costing.impl.CurrentCostsRepository;
+import de.metas.costing.methods.AverageInvoiceCostingMethodHandler;
+import de.metas.costing.methods.AveragePOCostingMethodHandler;
+import de.metas.costing.methods.CostingMethodHandlerUtils;
+import de.metas.costing.methods.StandardCostingMethodHandler;
+import de.metas.currency.CurrencyRepository;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.tools.AdempiereToolsHelper;
+import org.compiere.acct.Doc_AllocationHdr;
+import org.compiere.model.I_C_AllocationHdr;
+import org.junit.jupiter.api.Disabled;
+
+import java.util.List;
+
+@Disabled
+public class PostDocumentNow_ManualTest
+{
+	public static void main(String[] args)
+	{
+		AdempiereToolsHelper.getInstance().startupMinimal();
+
+		final I_C_AllocationHdr documentModel = InterfaceWrapperHelper.load(1228748, I_C_AllocationHdr.class);
+
+		final Doc_AllocationHdr doc = new Doc_AllocationHdr(
+				AcctDocContext.builder()
+						.services(newAcctDocRequiredServicesFacade())
+						.acctSchemas(getAcctSchemas(ClientId.ofRepoId(documentModel.getAD_Client_ID())))
+						.documentModel(documentModel)
+						.build()
+		);
+
+		doc.post(true, true);
+	}
+
+	private static AcctDocRequiredServicesFacade newAcctDocRequiredServicesFacade()
+	{
+		final CurrencyRepository currenciesRepo = new CurrencyRepository();
+		final @NonNull BankAccountService bankAccountService = new BankAccountService(
+				new BankRepository(),
+				new BankAccountAcctRepository(),
+				currenciesRepo);
+		return new AcctDocRequiredServicesFacade(bankAccountService, newCostingService(currenciesRepo));
+	}
+
+	@NonNull
+	private static CostingService newCostingService(final CurrencyRepository currenciesRepo)
+	{
+		final CostElementRepository costElementRepo = new CostElementRepository();
+		final CostDetailService costDetailsService = new CostDetailService(new CostDetailRepository(), costElementRepo);
+		final CurrentCostsRepository currentCostsRepo = new CurrentCostsRepository(costElementRepo);
+		final CostingMethodHandlerUtils costingMethodHandlerUtils = new CostingMethodHandlerUtils(
+				currenciesRepo,
+				currentCostsRepo,
+				costDetailsService
+		);
+		return new CostingService(
+				costingMethodHandlerUtils,
+				costDetailsService,
+				costElementRepo,
+				currentCostsRepo,
+				ImmutableList.of(
+						new AveragePOCostingMethodHandler(costingMethodHandlerUtils),
+						new AverageInvoiceCostingMethodHandler(costingMethodHandlerUtils),
+						new StandardCostingMethodHandler(costingMethodHandlerUtils)
+				)
+		);
+	}
+
+	private static List<AcctSchema> getAcctSchemas(final ClientId clientId)
+	{
+		return Services.get(IAcctSchemaDAO.class).getAllByClient(clientId);
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/currency/CurrencyPrecision.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/currency/CurrencyPrecision.java
@@ -1,16 +1,15 @@
 package de.metas.currency;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-
 import de.metas.util.Check;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 /*
  * #%L
@@ -50,13 +49,14 @@ public final class CurrencyPrecision
 		}
 	}
 
-	public static final CurrencyPrecision ZERO = new CurrencyPrecision(0);
-	public static final CurrencyPrecision TWO = new CurrencyPrecision(2);
+	public static final CurrencyPrecision ZERO;
+	public static final CurrencyPrecision TWO;
+	public static final CurrencyPrecision TEN;
 
 	private static final CurrencyPrecision[] CACHED_VALUES = new CurrencyPrecision[] {
-			ZERO,
+			ZERO = new CurrencyPrecision(0),
 			new CurrencyPrecision(1),
-			TWO,
+			TWO = new CurrencyPrecision(2),
 			new CurrencyPrecision(3),
 			new CurrencyPrecision(4),
 			new CurrencyPrecision(5),
@@ -64,7 +64,7 @@ public final class CurrencyPrecision
 			new CurrencyPrecision(7),
 			new CurrencyPrecision(8),
 			new CurrencyPrecision(9),
-			new CurrencyPrecision(10),
+			TEN = new CurrencyPrecision(10),
 			new CurrencyPrecision(11),
 			new CurrencyPrecision(12),
 	};

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/money/CurrencyConversionTypeId.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/money/CurrencyConversionTypeId.java
@@ -1,16 +1,14 @@
 package de.metas.money;
 
-import java.util.Objects;
-import java.util.Optional;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-
 import de.metas.util.Check;
 import de.metas.util.lang.RepoIdAware;
 import lombok.Value;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.Optional;
 
 /*
  * #%L
@@ -54,7 +52,7 @@ public class CurrencyConversionTypeId implements RepoIdAware
 		return Optional.ofNullable(ofRepoIdOrNull(repoId));
 	}
 
-	public static int toRepoId(final CurrencyConversionTypeId CurrencyConversionTypeId)
+	public static int toRepoId(@Nullable final CurrencyConversionTypeId CurrencyConversionTypeId)
 	{
 		return CurrencyConversionTypeId != null ? CurrencyConversionTypeId.getRepoId() : -1;
 	}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/money/CurrencyId.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/money/CurrencyId.java
@@ -38,10 +38,29 @@ import java.util.function.Function;
 @Value
 public class CurrencyId implements RepoIdAware
 {
+	public static final CurrencyId USD = new CurrencyId(100);
+	public static final CurrencyId EUR = new CurrencyId(102);
+	public static final CurrencyId CHF = new CurrencyId(318);
+
 	@JsonCreator
 	public static CurrencyId ofRepoId(final int repoId)
 	{
-		return new CurrencyId(repoId);
+		if (repoId == USD.repoId)
+		{
+			return USD;
+		}
+		else if (repoId == EUR.repoId)
+		{
+			return EUR;
+		}
+		else if (repoId == CHF.repoId)
+		{
+			return CHF;
+		}
+		else
+		{
+			return new CurrencyId(repoId);
+		}
 	}
 
 	@Nullable

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/money/CurrencyId.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/money/CurrencyId.java
@@ -1,16 +1,18 @@
 package de.metas.money;
 
-import java.util.Objects;
-import java.util.Optional;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-
 import de.metas.util.Check;
 import de.metas.util.lang.RepoIdAware;
+import lombok.NonNull;
 import lombok.Value;
+import org.adempiere.exceptions.AdempiereException;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
 
 /*
  * #%L
@@ -76,4 +78,81 @@ public class CurrencyId implements RepoIdAware
 	{
 		return Objects.equals(currencyId1, currencyId2);
 	}
+
+	@NonNull
+	@SafeVarargs
+	public static <T> CurrencyId getCommonCurrencyIdOfAll(
+			@NonNull final Function<T, CurrencyId> getCurrencyId,
+			@NonNull final String name,
+			@Nullable final T... objects)
+	{
+		if (objects == null || objects.length == 0)
+		{
+			throw new AdempiereException("No " + name + " provided");
+		}
+		else if (objects.length == 1 && objects[0] != null)
+		{
+			return getCurrencyId.apply(objects[0]);
+		}
+		else
+		{
+			CurrencyId commonCurrencyId = null;
+			for (final T object : objects)
+			{
+				if (object == null)
+				{
+					continue;
+				}
+
+				final CurrencyId currencyId = getCurrencyId.apply(object);
+				if (commonCurrencyId == null)
+				{
+					commonCurrencyId = currencyId;
+				}
+				else if (!CurrencyId.equals(commonCurrencyId, currencyId))
+				{
+					throw new AdempiereException("All given " + name + "(s) shall have the same currency: " + Arrays.asList(objects));
+				}
+			}
+
+			if (commonCurrencyId == null)
+			{
+				throw new AdempiereException("At least one non null " + name + " instance was expected: " + Arrays.asList(objects));
+			}
+
+			return commonCurrencyId;
+		}
+	}
+
+	@SafeVarargs
+	public static <T> void assertCurrencyMatching(
+			@NonNull final Function<T, CurrencyId> getCurrencyId,
+			@NonNull final String name,
+			@Nullable final T... objects)
+	{
+		if (objects == null || objects.length <= 1)
+		{
+			return;
+		}
+
+		CurrencyId expectedCurrencyId = null;
+		for (final T object : objects)
+		{
+			if (object == null)
+			{
+				continue;
+			}
+
+			final CurrencyId currencyId = getCurrencyId.apply(object);
+			if (expectedCurrencyId == null)
+			{
+				expectedCurrencyId = currencyId;
+			}
+			else if (!CurrencyId.equals(currencyId, expectedCurrencyId))
+			{
+				throw new AdempiereException("" + name + " has invalid currency: " + object + ". Expected: " + expectedCurrencyId);
+			}
+		}
+	}
+
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/money/Money.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/money/Money.java
@@ -118,6 +118,31 @@ public class Money implements Comparable<Money>
 		this.currencyId = currencyId;
 	}
 
+	@Override
+	public String toString()
+	{
+		final StringBuilder sb = new StringBuilder();
+		sb.append(value);
+		if (CurrencyId.equals(currencyId, CurrencyId.USD))
+		{
+			sb.append(" USD");
+		}
+		else if (CurrencyId.equals(currencyId, CurrencyId.EUR))
+		{
+			sb.append(" EUR");
+		}
+		else if (CurrencyId.equals(currencyId, CurrencyId.CHF))
+		{
+			sb.append(" CHF");
+		}
+		else
+		{
+			sb.append(" [").append(currencyId.getRepoId()).append("]");
+		}
+
+		return sb.toString();
+	}
+
 	public BigDecimal toBigDecimal()
 	{
 		return value;

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/money/Money.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/money/Money.java
@@ -59,7 +59,7 @@ import static java.math.BigDecimal.ZERO;
 
 @Value
 @JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, isGetterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
-public class Money
+public class Money implements Comparable<Money>
 {
 	public static Money of(@NonNull final String value, @NonNull final CurrencyId currencyId)
 	{
@@ -142,6 +142,11 @@ public class Money
 		return signum() == 0;
 	}
 
+	public boolean isNegative()
+	{
+		return signum() < 0;
+	}
+
 	public Money negate()
 	{
 		if (value.signum() == 0)
@@ -166,37 +171,22 @@ public class Money
 		return Money.zero(currencyId);
 	}
 
+	public Money toZeroIfNegative()
+	{
+		return signum() >= 0 ? this : zero(currencyId);
+	}
+
+	public Money abs() {return withValue(value.abs());}
+
+	public static void assertSameCurrency(final Money... moneys)
+	{
+		getCommonCurrencyIdOfAll(moneys);
+	}
+
+	@NonNull
 	public static CurrencyId getCommonCurrencyIdOfAll(final Money... moneys)
 	{
-		if (moneys == null || moneys.length == 0)
-		{
-			throw new AdempiereException("The given moneys may not be empty");
-		}
-
-		CurrencyId commonCurrencyId = null;
-		for (final Money money : moneys)
-		{
-			if (money == null)
-			{
-				continue;
-			}
-
-			if (commonCurrencyId == null)
-			{
-				commonCurrencyId = money.getCurrencyId();
-			}
-			else if (!CurrencyId.equals(commonCurrencyId, money.getCurrencyId()))
-			{
-				throw new AdempiereException("Moneys shall have the same currency: " + Arrays.asList(moneys));
-			}
-		}
-
-		if(commonCurrencyId == null)
-		{
-			throw new AdempiereException("The given moneys may not be empty");
-		}
-
-		return commonCurrencyId;
+		return CurrencyId.getCommonCurrencyIdOfAll(Money::getCurrencyId, "Money", moneys);
 	}
 
 	public static boolean isSameCurrency(@NonNull final Money... moneys)
@@ -269,6 +259,18 @@ public class Money
 				: this;
 	}
 
+	public Money divide(@NonNull final Money divisor, @NonNull final CurrencyPrecision precision)
+	{
+		assertCurrencyIdMatching(divisor);
+		return divide(divisor.value, precision);
+	}
+
+	public Money divide(@NonNull final BigDecimal divisor, @NonNull final CurrencyPrecision precision)
+	{
+		final BigDecimal resultingValue = this.value.divide(divisor, precision.toInt(), precision.getRoundingMode());
+		return of(resultingValue, this.currencyId);
+	}
+
 	public Money min(@NonNull final Money other)
 	{
 		assertCurrencyIdMatching(other);
@@ -289,11 +291,29 @@ public class Money
 		}
 	}
 
-	public boolean isLessThanOrEqualTo(@NonNull final Money other)
+	public Money assertCurrencyId(@NonNull final CurrencyId expectedCurrencyId)
+	{
+		if (!Objects.equals(currencyId, expectedCurrencyId))
+		{
+			throw new AdempiereException("Amount has invalid currencyId: " + this + ". Expected: " + expectedCurrencyId);
+		}
+		return this;
+	}
+
+	@Override
+	public int compareTo(@NonNull final Money other)
 	{
 		assertCurrencyIdMatching(other);
-		return this.value.compareTo(other.value) <= 0;
+		return this.value.compareTo(other.value);
 	}
+
+	public boolean isLessThan(@NonNull final Money other) {return compareTo(other) < 0;}
+
+	public boolean isLessThanOrEqualTo(@NonNull final Money other) {return compareTo(other) <= 0;}
+
+	public boolean isGreaterThanOrEqualTo(@NonNull final Money other) {return compareTo(other) >= 0;}
+
+	public boolean isGreaterThan(@NonNull final Money other) {return compareTo(other) > 0;}
 
 	public boolean isEqualByComparingTo(@Nullable final Money other)
 	{
@@ -336,6 +356,21 @@ public class Money
 		return withValue(precision.round(this.value));
 	}
 
+	public Money roundIfNeeded(@NonNull final CurrencyPrecision precision)
+	{
+		return withValue(precision.roundIfNeeded(this.value));
+	}
+
+	public Money round(@NonNull final Function<CurrencyId, CurrencyPrecision> precisionProvider)
+	{
+		final CurrencyPrecision precision = precisionProvider.apply(currencyId);
+		if (precision == null)
+		{
+			throw new AdempiereException("No precision was returned by " + precisionProvider + " for " + currencyId);
+		}
+		return round(precision);
+	}
+
 	private Money withValue(@NonNull final BigDecimal newValue)
 	{
 		return value.compareTo(newValue) != 0 ? of(newValue, currencyId) : this;
@@ -358,5 +393,13 @@ public class Money
 		}
 
 		return count;
+	}
+
+	public static boolean equals(@Nullable Money money1, @Nullable Money money2) {return Objects.equals(money1, money2);}
+
+	public Percent percentageOf(@NonNull final Money whole)
+	{
+		assertCurrencyIdMatching(whole);
+		return Percent.of(toBigDecimal(), whole.toBigDecimal());
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/money/CurrencyIdTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/money/CurrencyIdTest.java
@@ -1,0 +1,136 @@
+package de.metas.money;
+
+import lombok.NonNull;
+import lombok.Value;
+import org.adempiere.exceptions.AdempiereException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CurrencyIdTest
+{
+	@Value(staticConstructor = "of")
+	private static class CurrencyAware
+	{
+		@NonNull CurrencyId currencyId;
+
+		// setting it here just to make sure 2 instances with same currency are not equal
+		@NonNull UUID unique = UUID.randomUUID();
+	}
+
+	private static CurrencyAware ca(final int currencyRepoId) {return CurrencyAware.of(CurrencyId.ofRepoId(currencyRepoId));}
+
+	@Nested
+	class getCommonCurrencyIdOfAll
+	{
+		void assertFails(String messageStartingWith, CurrencyAware... amts)
+		{
+			assertThatThrownBy(() -> CurrencyId.getCommonCurrencyIdOfAll(CurrencyAware::getCurrencyId, "CurrencyAware", amts))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageStartingWith(messageStartingWith);
+		}
+
+		@SuppressWarnings("SameParameterValue")
+		void assertSuccess(int expectedCurrencyRepoId, CurrencyAware... amts)
+		{
+			assertThat(CurrencyId.getCommonCurrencyIdOfAll(CurrencyAware::getCurrencyId, "CurrencyAware", amts))
+					.isEqualTo(CurrencyId.ofRepoId(expectedCurrencyRepoId));
+		}
+
+		@Test
+		void nullParam()
+		{
+			assertFails("No CurrencyAware provided",
+					(CurrencyAware[])null);
+		}
+
+		@Test
+		void singleNullParam()
+		{
+			assertFails("At least one non null CurrencyAware instance was expected",
+					(CurrencyAware)null);
+		}
+
+		@Test
+		void multipleNullParams()
+		{
+			assertFails(
+					"At least one non null CurrencyAware instance was expected",
+					null, null, null);
+		}
+
+		@Test
+		void singleAmount() {assertSuccess(1, ca(1));}
+
+		@Test
+		void singleAmountAndNullFirst() {assertSuccess(1, null, ca(1));}
+
+		@Test
+		void singleAmountAndNulls() {assertSuccess(1, null, ca(1), null);}
+
+		@Test
+		void multipleAmountSameCurrency() {assertSuccess(1, ca(1), ca(1));}
+
+		@Test
+		void multipleAmountSameCurrencyAndSomeNulls() {assertSuccess(1, ca(1), null, ca(1), null);}
+
+		@Test
+		void multipleAmountDifferentCurrency()
+		{
+			assertFails("All given CurrencyAware(s) shall have the same currency",
+					ca(1), ca(2));
+		}
+
+		@Test
+		void multipleAmountDifferentCurrencyAndSomeNulls()
+		{
+			assertFails("All given CurrencyAware(s) shall have the same currency",
+					ca(1), null, ca(2), null);
+		}
+	}
+
+	@Nested
+	class assertCurrencyMatching
+	{
+		void assertNotMatching(final CurrencyAware... amts)
+		{
+			assertThatThrownBy(() -> CurrencyId.assertCurrencyMatching(CurrencyAware::getCurrencyId, "CurrencyAware", amts))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageStartingWith("CurrencyAware has invalid currency");
+		}
+
+		void assertMatching(final CurrencyAware... amts)
+		{
+			CurrencyId.assertCurrencyMatching(CurrencyAware::getCurrencyId, "CurrencyAware", amts);
+		}
+
+		@Test
+		void nullParam() {assertMatching((CurrencyAware[])null);}
+
+		@Test
+		void nullsParams() {assertMatching(null, null, null);}
+
+		@Test
+		void singleAmount() {assertMatching(ca(1));}
+
+		@Test
+		void singleAmountAndNulls() {assertMatching(null, ca(1), null);}
+
+		@Test
+		void multipleAmountSameCurrency() {assertMatching(ca(1), ca(1));}
+
+		@Test
+		void multipleAmountSameCurrencyAndSomeNulls() {assertMatching(ca(1), null, ca(1), null);}
+
+		@Test
+		void multipleAmountDifferentCurrency() {assertNotMatching(ca(1), ca(2));}
+
+		@Test
+		void multipleAmountDifferentCurrencyAndSomeNulls() {assertNotMatching(null, ca(1), null, ca(2), null);}
+	}
+
+}

--- a/backend/de.metas.banking/de.metas.banking.base/src/test/java/de/metas/banking/payment/paymentallocation/service/AllocationAmountsTest.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/test/java/de/metas/banking/payment/paymentallocation/service/AllocationAmountsTest.java
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /*
  * #%L
@@ -94,12 +95,12 @@ public class AllocationAmountsTest
 		public void differentCurrencies()
 		{
 			final AllocationAmountsBuilder builder = AllocationAmounts.builder()
-					.discountAmt(Money.of(1, CurrencyId.ofRepoId(1)))
-					.invoiceProcessingFee(Money.of(2, CurrencyId.ofRepoId(2)));
+					.discountAmt(Money.of(1, CurrencyId.EUR))
+					.invoiceProcessingFee(Money.of(2, CurrencyId.USD));
 
 			assertThatThrownBy(builder::build)
 					.isInstanceOf(AdempiereException.class)
-					.hasMessageStartingWith("Moneys shall have the same currency");
+					.hasMessageStartingWith("All given Money(s) shall have the same currency");
 		}
 	}
 

--- a/backend/de.metas.business/src/test/java/de/metas/money/MoneyTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/money/MoneyTest.java
@@ -1,17 +1,16 @@
 package de.metas.money;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.metas.JsonObjectMapperHolder;
+import lombok.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import de.metas.JsonObjectMapperHolder;
-import lombok.NonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /*
  * #%L
@@ -109,8 +108,21 @@ public class MoneyTest
 		final String json = objectMapper.writeValueAsString(money);
 		System.out.println("Serialized " + money + " to " + json);
 
-		final Money moneyDeserialized = objectMapper.readValue(json, money.getClass());
+		final Money moneyDeserialized = objectMapper.readValue(json, Money.class);
 		assertThat(moneyDeserialized).isEqualTo(money);
+	}
+
+	@Test
+	public void test_isLessThan()
+	{
+		final Money money_1EUR = Money.of(1, EUR);
+		final Money money_2EUR = Money.of(2, EUR);
+		final Money money_2CHF = Money.of(2, CHF);
+
+		assertThat(money_1EUR.isLessThan(money_2EUR)).isTrue();
+		assertThat(money_2EUR.isLessThan(money_2EUR)).isFalse();
+		assertThat(money_2EUR.isLessThan(money_1EUR)).isFalse();
+		assertThatThrownBy(() -> money_1EUR.isLessThan(money_2CHF)).isNotNull();
 	}
 
 	@Test
@@ -122,9 +134,33 @@ public class MoneyTest
 
 		assertThat(money_1EUR.isLessThanOrEqualTo(money_2EUR)).isTrue();
 		assertThat(money_2EUR.isLessThanOrEqualTo(money_2EUR)).isTrue();
-
 		assertThat(money_2EUR.isLessThanOrEqualTo(money_1EUR)).isFalse();
-
 		assertThatThrownBy(() -> money_1EUR.isLessThanOrEqualTo(money_2CHF)).isNotNull();
+	}
+
+	@Nested
+	public class abs
+	{
+		@Test
+		void zero()
+		{
+			final Money zero = Money.zero(EUR);
+			assertThat(zero.abs()).isSameAs(zero);
+		}
+
+		@Test
+		void positive()
+		{
+			final Money amt = Money.of(123, EUR);
+			assertThat(amt.abs()).isSameAs(amt);
+		}
+
+		@Test
+		void negative()
+		{
+			final Money amt = Money.of(-123, EUR);
+			assertThat(amt.abs()).isEqualTo(Money.of(123, EUR));
+		}
+
 	}
 }

--- a/backend/de.metas.contracts/src/test/java/de/metas/contracts/refund/CandidateAssignmentServiceTest.java
+++ b/backend/de.metas.contracts/src/test/java/de/metas/contracts/refund/CandidateAssignmentServiceTest.java
@@ -1,5 +1,7 @@
 package de.metas.contracts.refund;
 
+import static de.metas.contracts.refund.RefundTestTools.CONTRACT_END_DATE;
+import static de.metas.contracts.refund.RefundTestTools.CONTRACT_START_DATE;
 import static de.metas.contracts.refund.RefundTestTools.extractSingleConfig;
 import static de.metas.util.collections.CollectionUtils.singleElement;
 import static java.math.BigDecimal.ONE;
@@ -12,7 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,8 +21,6 @@ import javax.annotation.Nullable;
 
 import de.metas.document.dimension.DimensionFactory;
 import de.metas.document.dimension.DimensionService;
-import de.metas.document.dimension.OrderLineDimensionFactory;
-import de.metas.inoutcandidate.document.dimension.ReceiptScheduleDimensionFactory;
 import de.metas.invoicecandidate.document.dimension.InvoiceCandidateDimensionFactory;
 import org.adempiere.ad.wrapper.POJOLookupMap;
 import org.adempiere.test.AdempiereTestHelper;
@@ -95,8 +94,6 @@ public class CandidateAssignmentServiceTest
 	private static final BigDecimal SIXTEEN = new BigDecimal("16");
 	private static final BigDecimal TWENTY = new BigDecimal("20");
 	private static final BigDecimal HUNDRED = new BigDecimal("100");
-
-	private static final LocalDate NOW = LocalDate.now();
 
 	private AssignableInvoiceCandidateRepository assignableInvoiceCandidateRepository;
 
@@ -761,8 +758,8 @@ public class CandidateAssignmentServiceTest
 
 		assertThat(POJOLookupMap.get().getRecords(I_C_Flatrate_Term.class)).isEmpty(); // guard
 		final RefundContract refundContract = RefundContract.builder()
-				.startDate(NOW)
-				.endDate(NOW.plusDays(5))
+				.startDate(CONTRACT_START_DATE)
+				.endDate(CONTRACT_END_DATE)
 				.refundConfig(refundConfig1)
 				.refundConfig(refundConfig2)
 				.bPartnerId(RefundTestTools.BPARTNER_ID)


### PR DESCRIPTION
- Doc_AllocationHdr: sync minor changes from master
- Doc_AllocationHdr: sync Money, CurrencyId and CurrencyConversionTypeId from master
- sync Money, CurrencyId and CurrencyConversionTypeId from master
- improve Money.toString()
- CurrencyPrecision.TEN
- Fact.getAcctCurrencyId()
- Doc_AllocationHdr: fix how we calculate the tax correction
- PostDocumentNow_ManualTest: helper class to post a given document (manual testing)
