### PR TITLE
mobile UI picking: manual lot-no field; use text field for date input

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/assets/get-qty-dialog.scss
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/assets/get-qty-dialog.scss
@@ -1,25 +1,30 @@
 .get-qty-dialog {
 
-  table {
-    width: 100%;
+  .table-container {
+    overflow-x: auto;
+    overflow-y: auto;
 
-    tbody {
-      tr {
-        th {
-          min-width: 38vw !important;
+    .table {
+      width: 100%;
 
-          text-align: left !important;
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-        }
+      tbody {
+        tr {
+          th {
+            min-width: 38vw !important;
 
-        td {
-          text-align: right;
-          white-space: pre-wrap;
+            text-align: left !important;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
 
-          input {
-            text-align: right
+          td {
+            text-align: right;
+            white-space: pre-wrap;
+
+            input {
+              text-align: right
+            }
           }
         }
       }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/DateInput.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/DateInput.jsx
@@ -1,0 +1,118 @@
+import React, { useCallback } from 'react';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import { useBooleanSetting } from '../reducers/settings';
+
+const DateInput = ({ value, readOnly, onChange }) => {
+  const isUseNativeComponent = useBooleanSetting('dateInput.isUseNativeComponent');
+
+  if (isUseNativeComponent) {
+    return <DateInputNative value={value} readOnly={readOnly} onChange={onChange} />;
+  } else {
+    return <DateInputLegacy value={value} readOnly={readOnly} onChange={onChange} />;
+  }
+};
+
+DateInput.propTypes = {
+  value: PropTypes.any,
+  readOnly: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+};
+
+export default DateInput;
+
+//
+//
+//
+//
+//
+
+const DateInputNative = ({ value, readOnly, onChange }) => {
+  const handleChange = useCallback(
+    (e) => {
+      const dateNew = e.target.value ? e.target.value : '';
+      onChange({ date: dateNew, isValid: true });
+    },
+    [onChange]
+  );
+  return <input className="input" type="date" value={value} disabled={readOnly} onChange={handleChange} />;
+};
+DateInputNative.propTypes = {
+  value: PropTypes.any,
+  readOnly: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+};
+
+//
+//
+//
+//
+//
+
+const DateInputLegacy = ({ value, readOnly, onChange }) => {
+  let displayedDate = value;
+  let isValid = true;
+  try {
+    displayedDate = convertDateToDisplay(value);
+  } catch (error) {
+    console.log('Got error while converting date to display format. Returning empty.', { value, displayedDate, error });
+    isValid = false;
+  }
+
+  const handleChange = useCallback(
+    (e) => {
+      const displayedDateNew = e.target.value ? e.target.value : '';
+      let dateNew = displayedDateNew;
+      let isValidNew;
+      try {
+        dateNew = convertDateFromDisplay(displayedDateNew);
+        isValidNew = true;
+      } catch (error) {
+        isValidNew = false;
+        console.log('Got error while converting from display. Returning empty.', { displayedDateNew, error });
+      }
+
+      onChange({ date: dateNew, isValid: isValidNew });
+    },
+    [onChange]
+  );
+
+  return (
+    <input
+      className={cx('input', { 'is-danger': !isValid })}
+      type="text"
+      value={displayedDate}
+      placeholder="DD.MM.YYYY"
+      disabled={readOnly}
+      onChange={handleChange}
+    />
+  );
+};
+DateInputLegacy.propTypes = {
+  value: PropTypes.any,
+  readOnly: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+};
+
+const DISPLAY_DATE_FORMAT = /^(\d{2}).(\d{2}).(\d{4})$/;
+const convertDateFromDisplay = (displayedDate) => {
+  if (!displayedDate) return '';
+
+  const [, day, month, year] = DISPLAY_DATE_FORMAT.exec(displayedDate);
+  assertDayMonthYearValid({ day, month, year, dateString: displayedDate });
+  return `${year}-${month}-${day}`;
+};
+
+const STANDARD_DATE_FORMAT = /^(\d{4})-(\d{2})-(\d{2})$/;
+const convertDateToDisplay = (date) => {
+  if (!date) return '';
+  const [, year, month, day] = STANDARD_DATE_FORMAT.exec(date);
+  assertDayMonthYearValid({ day, month, year, dateString: date });
+  return `${day}.${month}.${year}`;
+};
+
+const assertDayMonthYearValid = ({ day, month, year, dateString }) => {
+  if (day < 1 || day > 31) throw `Invalid day ${day} in ${dateString}`;
+  if (month < 1 || month > 12) throw `Invalid month ${month} in ${dateString}`;
+  if (year < 2000 || year > 2500) throw `Invalid year ${year} in ${dateString}`;
+};

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/QtyReasonsRadioGroup.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/QtyReasonsRadioGroup.jsx
@@ -16,7 +16,7 @@ const QtyReasonsRadioGroup = ({ reasons, selectedReason, disabled, onReasonSelec
     <div className="control">
       {reasons.map((reason, idx) => (
         <div key={idx} className="columns is-mobile">
-          <div className="column is-full">
+          <div className="column">
             <label className="radio">
               <input
                 className="mr-2"

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/dialogs/GetQuantityDialog.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/dialogs/GetQuantityDialog.jsx
@@ -32,6 +32,8 @@ const GetQuantityDialog = ({
   //
   isShowBestBeforeDate = false,
   bestBeforeDate: bestBeforeDateParam = '',
+  isShowLotNo = false,
+  lotNo: lotNoParam = '',
   //
   validateQtyEntered,
   onQtyChange,
@@ -57,6 +59,13 @@ const GetQuantityDialog = ({
     const bestBeforeDateNew = e.target.value ? e.target.value : '';
     //console.log('onBestBeforeDateEntered', { bestBeforeDateNew, e });
     setBestBeforeDate(bestBeforeDateNew);
+  };
+
+  const [lotNo, setLotNo] = useState(lotNoParam);
+  const onLotNoEntered = (e) => {
+    const lotNoNew = e.target.value ? e.target.value : '';
+    //console.log('onLotNoEntered', { lotNoNew, e });
+    setLotNo(lotNoNew);
   };
 
   const isQtyRejectedRequired = Array.isArray(qtyRejectedReasons) && qtyRejectedReasons.length > 0;
@@ -88,6 +97,7 @@ const GetQuantityDialog = ({
         catchWeight: useCatchWeight ? qtyInfos.toNumberOrString(catchWeight) : null,
         catchWeightUom: useCatchWeight ? catchWeightUom : null,
         bestBeforeDate: isShowBestBeforeDate ? bestBeforeDate : null,
+        lotNo: isShowLotNo ? lotNo : null,
       });
     }
   };
@@ -283,6 +293,24 @@ const GetQuantityDialog = ({
                         </td>
                       </tr>
                     )}
+                    {isShowLotNo && (
+                      <tr>
+                        <th>{trl('general.LotNo')}</th>
+                        <td>
+                          <div className="field">
+                            <div className="control">
+                              <input
+                                className="input"
+                                type="text"
+                                value={lotNo}
+                                disabled={readOnly}
+                                onChange={onLotNoEntered}
+                              />
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
                     {useCatchWeight && (
                       <tr>
                         <th>{trl('general.CatchWeight')}</th>
@@ -370,6 +398,8 @@ GetQuantityDialog.propTypes = {
   catchWeightUom: PropTypes.string,
   isShowBestBeforeDate: PropTypes.bool,
   bestBeforeDate: PropTypes.string,
+  isShowLotNo: PropTypes.bool,
+  lotNo: PropTypes.string,
 
   // Callbacks
   validateQtyEntered: PropTypes.func,

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/dialogs/GetQuantityDialog.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/dialogs/GetQuantityDialog.jsx
@@ -222,133 +222,138 @@ const GetQuantityDialog = ({
             {isCustomView() && getCustomView()}
             {!isCustomView() && (
               <>
-                <table className="table">
-                  <tbody>
-                    {qtyCaption && (
-                      <tr>
-                        <th>{qtyCaption}</th>
-                        <td>{formatQtyToHumanReadableStr({ qty: Math.max(qtyTarget, 0), uom })}</td>
-                      </tr>
-                    )}
-                    {userInfo &&
-                      userInfo.map((item) => (
-                        <tr key={computeKeyFromUserInfoItem(item)}>
-                          <th>{computeCaptionFromUserInfoItem(item)}</th>
-                          <td>{item.value}</td>
+                <div className="table-container">
+                  <table className="table">
+                    <tbody>
+                      {qtyCaption && (
+                        <tr>
+                          <th>{qtyCaption}</th>
+                          <td>{formatQtyToHumanReadableStr({ qty: Math.max(qtyTarget, 0), uom })}</td>
                         </tr>
-                      ))}
-                    {!hideQtyInput && (
-                      <tr>
-                        <th>Qty</th>
-                        <td>
-                          <QtyInputField
-                            qty={qtyInfos.toNumberOrString(qtyInfo)}
-                            uom={uom}
-                            validateQtyEntered={validateQtyEntered}
-                            readonly={useScaleDevice || readOnly}
-                            onQtyChange={onQtyEntered}
-                            isRequestFocus={true}
-                          />
-                        </td>
-                      </tr>
-                    )}
-                    {scaleDevice && allowManualInput && (
-                      <tr>
-                        <td colSpan="2">
-                          <div className="buttons has-addons">
-                            <button
-                              className={cx('button', { 'is-success': useScaleDevice, 'is-selected': useScaleDevice })}
-                              onClick={() => setUseScaleDevice(true)}
-                            >
-                              {scaleDevice.caption}
-                            </button>
-                            <button
-                              className={cx('button', {
-                                'is-success': !useScaleDevice,
-                                'is-selected': !useScaleDevice,
-                              })}
-                              onClick={() => setUseScaleDevice(false)}
-                            >
-                              Manual
-                            </button>
-                          </div>
-                        </td>
-                      </tr>
-                    )}
-                    {isShowBestBeforeDate && (
-                      <tr>
-                        <th>{trl('general.BestBeforeDate')}</th>
-                        <td>
-                          <div className="field">
-                            <div className="control">
-                              <input
-                                className="input"
-                                type="date"
-                                value={bestBeforeDate}
-                                disabled={readOnly}
-                                onChange={onBestBeforeDateEntered}
-                              />
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                    )}
-                    {isShowLotNo && (
-                      <tr>
-                        <th>{trl('general.LotNo')}</th>
-                        <td>
-                          <div className="field">
-                            <div className="control">
-                              <input
-                                className="input"
-                                type="text"
-                                value={lotNo}
-                                disabled={readOnly}
-                                onChange={onLotNoEntered}
-                              />
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                    )}
-                    {useCatchWeight && (
-                      <tr>
-                        <th>{trl('general.CatchWeight')}</th>
-                        <td>
-                          <>
+                      )}
+                      {userInfo &&
+                        userInfo.map((item) => (
+                          <tr key={computeKeyFromUserInfoItem(item)}>
+                            <th>{computeCaptionFromUserInfoItem(item)}</th>
+                            <td>{item.value}</td>
+                          </tr>
+                        ))}
+                      {!hideQtyInput && (
+                        <tr>
+                          <th>Qty</th>
+                          <td>
                             <QtyInputField
-                              qty={qtyInfos.toNumberOrString(catchWeight)}
-                              uom={catchWeightUom}
-                              onQtyChange={onCatchWeightEntered}
-                              readonly={readOnly}
-                            />
-                            <button className="button" onClick={() => setShowCatchWeightQRCodeReader(true)}>
-                              {trl('activities.picking.switchToQrCodeInput')}
-                            </button>
-                          </>
-                        </td>
-                      </tr>
-                    )}
-                    {qtyRejected > 0 && (
-                      <>
-                        <tr>
-                          <th>{trl('general.QtyRejected')}</th>
-                          <td>{formatQtyToHumanReadableStr({ qty: qtyRejected, uom })}</td>
-                        </tr>
-                        <tr>
-                          <td colSpan={2}>
-                            <QtyReasonsRadioGroup
-                              reasons={qtyRejectedReasons}
-                              selectedReason={rejectedReason}
-                              disabled={qtyRejected === 0}
-                              onReasonSelected={onReasonSelected}
+                              qty={qtyInfos.toNumberOrString(qtyInfo)}
+                              uom={uom}
+                              validateQtyEntered={validateQtyEntered}
+                              readonly={useScaleDevice || readOnly}
+                              onQtyChange={onQtyEntered}
+                              isRequestFocus={true}
                             />
                           </td>
                         </tr>
-                      </>
-                    )}
-                  </tbody>
-                </table>
+                      )}
+                      {scaleDevice && allowManualInput && (
+                        <tr>
+                          <td colSpan="2">
+                            <div className="buttons has-addons">
+                              <button
+                                className={cx('button', {
+                                  'is-success': useScaleDevice,
+                                  'is-selected': useScaleDevice,
+                                })}
+                                onClick={() => setUseScaleDevice(true)}
+                              >
+                                {scaleDevice.caption}
+                              </button>
+                              <button
+                                className={cx('button', {
+                                  'is-success': !useScaleDevice,
+                                  'is-selected': !useScaleDevice,
+                                })}
+                                onClick={() => setUseScaleDevice(false)}
+                              >
+                                Manual
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                      {isShowBestBeforeDate && (
+                        <tr>
+                          <th>{trl('general.BestBeforeDate')}</th>
+                          <td>
+                            <div className="field">
+                              <div className="control">
+                                <input
+                                  className="input"
+                                  type="date"
+                                  value={bestBeforeDate}
+                                  disabled={readOnly}
+                                  onChange={onBestBeforeDateEntered}
+                                />
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                      {isShowLotNo && (
+                        <tr>
+                          <th>{trl('general.LotNo')}</th>
+                          <td>
+                            <div className="field">
+                              <div className="control">
+                                <input
+                                  className="input"
+                                  type="text"
+                                  value={lotNo}
+                                  disabled={readOnly}
+                                  onChange={onLotNoEntered}
+                                />
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                      {useCatchWeight && (
+                        <tr>
+                          <th>{trl('general.CatchWeight')}</th>
+                          <td>
+                            <>
+                              <QtyInputField
+                                qty={qtyInfos.toNumberOrString(catchWeight)}
+                                uom={catchWeightUom}
+                                onQtyChange={onCatchWeightEntered}
+                                readonly={readOnly}
+                              />
+                              <button className="button" onClick={() => setShowCatchWeightQRCodeReader(true)}>
+                                {trl('activities.picking.switchToQrCodeInput')}
+                              </button>
+                            </>
+                          </td>
+                        </tr>
+                      )}
+                      {qtyRejected > 0 && (
+                        <>
+                          <tr>
+                            <th>{trl('general.QtyRejected')}</th>
+                            <td>{formatQtyToHumanReadableStr({ qty: qtyRejected, uom })}</td>
+                          </tr>
+                          <tr>
+                            <td colSpan={2}>
+                              <QtyReasonsRadioGroup
+                                reasons={qtyRejectedReasons}
+                                selectedReason={rejectedReason}
+                                disabled={qtyRejected === 0}
+                                onReasonSelected={onReasonSelected}
+                              />
+                            </td>
+                          </tr>
+                        </>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
                 <div className="buttons is-centered">
                   <button className="button is-success" disabled={!allValid} onClick={onDialogYes}>
                     {trl('activities.picking.confirmDone')}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/dialogs/GetQuantityDialog.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/dialogs/GetQuantityDialog.jsx
@@ -6,6 +6,7 @@ import { trl } from '../../utils/translations';
 
 import QtyInputField from '../QtyInputField';
 import QtyReasonsRadioGroup from '../QtyReasonsRadioGroup';
+import DateInput from '../DateInput';
 import * as ws from '../../utils/websocket';
 import { qtyInfos } from '../../utils/qtyInfos';
 import { formatQtyToHumanReadableStr } from '../../utils/qtys';
@@ -55,10 +56,10 @@ const GetQuantityDialog = ({
   const onCatchWeightEntered = (qtyInfo) => setCatchWeight(qtyInfo);
 
   const [bestBeforeDate, setBestBeforeDate] = useState(bestBeforeDateParam);
-  const onBestBeforeDateEntered = (e) => {
-    const bestBeforeDateNew = e.target.value ? e.target.value : '';
-    //console.log('onBestBeforeDateEntered', { bestBeforeDateNew, e });
-    setBestBeforeDate(bestBeforeDateNew);
+  const [isBestBeforeDateValid, setIsBestBeforeDateValid] = useState(true);
+  const onBestBeforeDateEntered = ({ date, isValid }) => {
+    setBestBeforeDate(date);
+    setIsBestBeforeDateValid(isValid);
   };
 
   const [lotNo, setLotNo] = useState(lotNoParam);
@@ -74,12 +75,12 @@ const GetQuantityDialog = ({
       ? Math.max(qtyTarget - qtyInfos.toNumberOrString(qtyInfo), 0)
       : 0;
 
-  const allValid =
-    readOnly ||
+  const isQtyValid =
     doNotValidateQty ||
     (qtyInfo?.isQtyValid &&
       (qtyRejected === 0 || rejectedReason != null) &&
       (!useCatchWeight || catchWeight?.isQtyValid));
+  const allValid = readOnly || (isQtyValid && (!isShowBestBeforeDate || isBestBeforeDateValid));
 
   const onDialogYes = () => {
     if (allValid) {
@@ -285,8 +286,7 @@ const GetQuantityDialog = ({
                           <td>
                             <div className="field">
                               <div className="control">
-                                <input
-                                  className="input"
+                                <DateInput
                                   type="date"
                                   value={bestBeforeDate}
                                   disabled={readOnly}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -24,6 +24,7 @@ const translations = {
     QtyRejected: 'Menge verworfen',
     CatchWeight: 'Gewicht',
     BestBeforeDate: 'MHD',
+    LotNo: 'Lot-Nr',
     DropToLocator: 'Ziel Lagerort',
     cancelText: 'Abbrechen',
     closeText: 'Schließen',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -21,7 +21,7 @@ const translations = {
     QtyPicked: 'Menge gepickt',
     QtyMoved: 'Menge bewegt',
     QtyToMove: 'Bewegungsmenge',
-    QtyRejected: 'Menge verworfen',
+    QtyRejected: 'verworfen',
     CatchWeight: 'Gewicht',
     BestBeforeDate: 'MHD',
     LotNo: 'Lot-Nr',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -24,6 +24,7 @@ const translations = {
     QtyRejected: 'Qty Rejected',
     CatchWeight: 'Weight',
     BestBeforeDate: 'Best Before',
+    LotNo: 'Lot',
     DropToLocator: 'Drop to locator',
     cancelText: 'Cancel',
     closeText: 'Close',


### PR DESCRIPTION
- mobile UI: manual picking: show LotNo field
- GetQuantityDialog.jsx in case the modal does not fit into page, add scrolls
- Introduce DateInput component. Use legacy text field for date by default
