### PR TITLE
fix error surfaced by different test-execution-ordering

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/SpringContextHolder.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/SpringContextHolder.java
@@ -23,6 +23,7 @@
 package org.compiere;
 
 import com.google.common.collect.ImmutableList;
+import de.metas.common.util.CoalesceUtil;
 import de.metas.logging.LogManager;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -142,10 +143,7 @@ public final class SpringContextHolder
 		if (Adempiere.isUnitTestMode())
 		{
 			final T beanImpl = junitRegisteredBeans.getBeanOrNull(requiredType);
-			if (beanImpl != null)
-			{
-				return beanImpl;
-			}
+			return CoalesceUtil.coalesce(beanImpl, defaultImplementation);
 		}
 
 		final ApplicationContext springApplicationContext = getApplicationContext();


### PR DESCRIPTION
```
java.lang.IllegalStateException: org.springframework.web.context.support.GenericWebApplicationContext@7c680fe1 has been closed already
	at org.springframework.context.support.AbstractApplicationContext.assertBeanFactoryActive(AbstractApplicationContext.java:1137)
	at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1170)
	at org.compiere.SpringContextHolder.getBeanOr(SpringContextHolder.java:159)
	at de.metas.cache.CacheMgt.getPerfMonService(CacheMgt.java:199)
	at de.metas.cache.CacheMgt.reset(CacheMgt.java:358)
	at de.metas.cache.CacheMgt.reset(CacheMgt.java:302)
	at org.adempiere.ad.wrapper.POJOLookupMap.putCopy(POJOLookupMap.java:494)
	at org.adempiere.ad.wrapper.POJOLookupMap.access$200(POJOLookupMap.java:87)
	at org.adempiere.ad.wrapper.POJOLookupMap$1.run(POJOLookupMap.java:424)
	at org.adempiere.ad.trx.api.impl.TrxCallableWrappers$3.call(TrxCallableWrappers.java:147)
	at org.adempiere.ad.trx.api.impl.TrxCallableWrappers$3.call(TrxCallableWrappers.java:137)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.call0(AbstractTrxManager.java:753)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.call(AbstractTrxManager.java:666)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.call(AbstractTrxManager.java:567)
	at org.adempiere.ad.trx.api.impl.AbstractTrxManager.run(AbstractTrxManager.java:514)
	at org.adempiere.ad.wrapper.POJOLookupMap.runInTrx(POJOLookupMap.java:447)
	at org.adempiere.ad.wrapper.POJOLookupMap.save(POJOLookupMap.java:376)
	at org.adempiere.ad.wrapper.POJOWrapper.save(POJOWrapper.java:432)
	at org.adempiere.ad.wrapper.POJOWrapper.createADTableInstanceIfNeccesary(POJOWrapper.java:256)
	at org.adempiere.ad.wrapper.POJOWrapper.create(POJOWrapper.java:147)
	at org.adempiere.ad.wrapper.POJOWrapper.create(POJOWrapper.java:93)
	at org.adempiere.ad.wrapper.POJOWrapper.create(POJOWrapper.java:98)
	at org.adempiere.model.InterfaceWrapperHelper.create(InterfaceWrapperHelper.java:287)
	at org.adempiere.model.InterfaceWrapperHelper.newInstance(InterfaceWrapperHelper.java:192)
	at org.adempiere.test.AdempiereTestHelper.createSystemRecords(AdempiereTestHelper.java:268)
	at org.adempiere.test.AdempiereTestHelper.init(AdempiereTestHelper.java:225)
```