### PR TITLE
Do no return Spare Part as BOM Type (#17238)

### DIFF
--- a/backend/de.metas.business/src/main/java/org/eevolution/api/PPOrderDocBaseType.java
+++ b/backend/de.metas.business/src/main/java/org/eevolution/api/PPOrderDocBaseType.java
@@ -22,13 +22,16 @@
 
 package org.eevolution.api;
 
+import com.google.common.collect.ImmutableSet;
 import de.metas.document.DocBaseType;
 import de.metas.util.lang.ReferenceListAwareEnum;
 import de.metas.util.lang.ReferenceListAwareEnums;
 import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
+import java.util.Set;
 
 public enum PPOrderDocBaseType implements ReferenceListAwareEnum
 {
@@ -67,4 +70,18 @@ public enum PPOrderDocBaseType implements ReferenceListAwareEnum
 	public boolean isQualityOrder() {return QUALITY_ORDER.equals(this);}
 
 	public boolean isRepairOrder() {return REPAIR_ORDER.equals(this);}
+
+	public Set<BOMType> getBOMTypes()
+	{
+		switch (this)
+		{
+			case REPAIR_ORDER:
+			case QUALITY_ORDER:
+			case MAINTENANCE_ORDER:
+			case MANUFACTURING_ORDER:
+				return ImmutableSet.of(BOMType.CurrentActive, BOMType.MakeToOrder);
+			default:
+				throw new AdempiereException("Unsupported type=" + this);
+		}
+	}
 }

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5716360_AdjustTheValidationRuleForBOMVersionInPP_Order.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5716360_AdjustTheValidationRuleForBOMVersionInPP_Order.sql
@@ -1,0 +1,3 @@
+update ad_val_rule
+set code ='(PP_Product_BOM.ValidTo IS NULL OR PP_Product_BOM.ValidTo >= ''@DateOrdered@'') AND ( PP_Product_BOM.BomType = ''A'')'
+where ad_val_rule_id=540667;


### PR DESCRIPTION
* Do no return SparePart as BOM Type

* Adjust the validation rule

(cherry picked from commit a17615d0b36b6c1b10b504b7bd52faa6e1981535)

solved Conflicts:
	backend/de.metas.business/src/main/java/org/eevolution/api/PPOrderDocBaseType.java