### PR TITLE
Product planning data is being ignored when manufacturing orders are generated automatically (#16875)

### DIFF
--- a/backend/de.metas.business/src/main/java/org/eevolution/api/IProductBOMDAO.java
+++ b/backend/de.metas.business/src/main/java/org/eevolution/api/IProductBOMDAO.java
@@ -13,11 +13,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface IProductBOMDAO extends ISingletonService
 {
-	Optional<I_PP_Product_BOM> getDefaultBOM(@NonNull ProductId productId, @NonNull BOMType bomType);
-
 	I_PP_Product_BOM getById(ProductBOMId bomId);
 
 	@Deprecated
@@ -58,11 +57,22 @@ public interface IProductBOMDAO extends ISingletonService
 
 	ProductId getBOMProductId(ProductBOMId bomId);
 
-	Optional<ProductBOMId> getLatestBOMByVersion(@NonNull ProductBOMVersionsId bomVersionsId);
+	boolean hasBOMs(@NonNull ProductBOMVersionsId bomVersionsId);
 
-	Optional<I_PP_Product_BOM> getLatestBOMRecordByVersionId(ProductBOMVersionsId bomVersionsId);
-
-	Optional<I_PP_Product_BOM> getPreviousVersion(I_PP_Product_BOM bomVersion, DocStatus docStatus);
+	Optional<I_PP_Product_BOM> getPreviousVersion(@NonNull I_PP_Product_BOM bomVersion, @Nullable Set<BOMType> bomTypes, @Nullable DocStatus docStatus);
 
 	boolean isComponent(ProductId productId);
+
+	Optional<I_PP_Product_BOM> getLatestBOMRecordByVersionAndType(@NonNull ProductBOMVersionsId bomVersionsId, @Nullable Set<BOMType> bomTypes);
+
+	Optional<ProductBOMId> getLatestBOMIdByVersionAndType(@NonNull ProductBOMVersionsId bomVersionsId, @Nullable Set<BOMType> bomTypes);
+
+	Optional<I_PP_Product_BOM> getByProductIdAndType(@NonNull ProductId productId, @NonNull Set<BOMType> bomTypes);
+
+	default Optional<ProductBOMId> getIdByProductIdAndType(@NonNull final ProductId productId, @NonNull final Set<BOMType> bomTypes)
+	{
+		return getByProductIdAndType(productId, bomTypes)
+				.map(I_PP_Product_BOM::getPP_Product_BOM_ID)
+				.map(ProductBOMId::ofRepoId);
+	}
 }

--- a/backend/de.metas.business/src/main/java/org/eevolution/api/PPOrderDocBaseType.java
+++ b/backend/de.metas.business/src/main/java/org/eevolution/api/PPOrderDocBaseType.java
@@ -51,9 +51,15 @@ public enum PPOrderDocBaseType implements ReferenceListAwareEnum
 	}
 
 	@Nullable
-	public static PPOrderDocBaseType ofNullableCode(@Nullable final String code) {return index.ofNullableCode(code);}
+	public static PPOrderDocBaseType ofNullableCode(@Nullable final String code)
+	{
+		return index.ofNullableCode(code);
+	}
 
-	public static PPOrderDocBaseType ofCode(@NonNull final String code) {return index.ofCode(code);}
+	public static PPOrderDocBaseType ofCode(@NonNull final String code)
+	{
+		return index.ofCode(code);
+	}
 
 	@NonNull
 	public static Optional<PPOrderDocBaseType> optionalOfNullable(@Nullable final String code) {return Optional.ofNullable(ofNullableCode(code));}
@@ -67,10 +73,14 @@ public enum PPOrderDocBaseType implements ReferenceListAwareEnum
 
 	public boolean isManufacturingOrder() {return MANUFACTURING_ORDER.equals(this);}
 
-	public boolean isQualityOrder() {return QUALITY_ORDER.equals(this);}
+	public boolean isQualityOrder()
+	{
+		return QUALITY_ORDER.equals(this);
+	}
 
 	public boolean isRepairOrder() {return REPAIR_ORDER.equals(this);}
 
+	@NonNull
 	public Set<BOMType> getBOMTypes()
 	{
 		switch (this)

--- a/backend/de.metas.business/src/main/java/org/eevolution/api/PPOrderDocBaseType.java
+++ b/backend/de.metas.business/src/main/java/org/eevolution/api/PPOrderDocBaseType.java
@@ -89,6 +89,7 @@ public enum PPOrderDocBaseType implements ReferenceListAwareEnum
 			case QUALITY_ORDER:
 			case MAINTENANCE_ORDER:
 			case MANUFACTURING_ORDER:
+			case MODULAR_ORDER:
 				return ImmutableSet.of(BOMType.CurrentActive, BOMType.MakeToOrder);
 			default:
 				throw new AdempiereException("Unsupported type=" + this);

--- a/backend/de.metas.business/src/main/java/org/eevolution/api/impl/ProductBOMBL.java
+++ b/backend/de.metas.business/src/main/java/org/eevolution/api/impl/ProductBOMBL.java
@@ -24,6 +24,7 @@ package org.eevolution.api.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimaps;
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.IMsgBL;
@@ -284,7 +285,7 @@ public class ProductBOMBL implements IProductBOMBL
 		{
 			final ProductId finishedGoodProductId = ProductId.ofRepoId(finishGood.getM_Product_ID());
 
-			bomDAO.getDefaultBOM(finishedGoodProductId, bomType)
+			bomDAO.getByProductIdAndType(finishedGoodProductId, ImmutableSet.of(bomType))
 					.ifPresent(bom -> boms.put(ProductBOMId.ofRepoId(bom.getPP_Product_BOM_ID()), bom));
 		}
 

--- a/backend/de.metas.business/src/main/java/org/eevolution/api/impl/ProductBOMDAO.java
+++ b/backend/de.metas.business/src/main/java/org/eevolution/api/impl/ProductBOMDAO.java
@@ -2,6 +2,7 @@ package org.eevolution.api.impl;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import de.metas.cache.annotation.CacheCtx;
 import de.metas.cache.annotation.CacheTrx;
 import de.metas.document.DocBaseType;
@@ -35,6 +36,7 @@ import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.proxy.Cached;
 import org.compiere.SpringContextHolder;
+import org.compiere.model.IQuery;
 import org.compiere.model.I_M_Product;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
@@ -57,6 +59,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -136,15 +139,15 @@ public class ProductBOMDAO implements IProductBOMDAO
 	{
 		return getProductBOMVersionsDAO()
 				.retrieveBOMVersionsId(productId)
-				.flatMap(this::getDefaultBOM);
+				.flatMap(this::getDefaultBOMRecordByVersionId);
 	}
 
 	@Override
-	public Optional<I_PP_Product_BOM> getDefaultBOM(@NonNull final ProductId productId, @NonNull final BOMType bomType)
+	public Optional<I_PP_Product_BOM> getByProductIdAndType(@NonNull final ProductId productId, @NonNull final Set<BOMType> bomTypes)
 	{
 		return getProductBOMVersionsDAO()
 				.retrieveBOMVersionsId(productId)
-				.flatMap(bomVersionsId -> getLatestBOMRecordByVersion(bomVersionsId, bomType));
+				.flatMap(bomVersionsId -> getLatestBOMRecordByVersionAndType(bomVersionsId, bomTypes));
 	}
 
 	@Override
@@ -397,19 +400,12 @@ public class ProductBOMDAO implements IProductBOMDAO
 	}
 
 	@Override
-	@NonNull
-	public Optional<ProductBOMId> getLatestBOMByVersion(final @NonNull ProductBOMVersionsId bomVersionsId)
+	public boolean hasBOMs(final @NonNull ProductBOMVersionsId bomVersionsId)
 	{
-		return getLatestBOMRecordByVersion(bomVersionsId, null)
-				.map(I_PP_Product_BOM::getPP_Product_BOM_ID)
-				.map(ProductBOMId::ofRepoId);
-	}
-
-	@Override
-	@NonNull
-	public Optional<I_PP_Product_BOM> getLatestBOMRecordByVersionId(final @NonNull ProductBOMVersionsId bomVersionsId)
-	{
-		return getLatestBOMRecordByVersion(bomVersionsId, null);
+		return queryBL.createQueryBuilder(I_PP_Product_BOM.class)
+				.addEqualsFilter(I_PP_Product_BOM.COLUMNNAME_PP_Product_BOMVersions_ID, bomVersionsId)
+				.create()
+				.anyMatch();
 	}
 
 	/**
@@ -417,7 +413,7 @@ public class ProductBOMDAO implements IProductBOMDAO
 	 */
 	@Override
 	@NonNull
-	public Optional<I_PP_Product_BOM> getPreviousVersion(final @NonNull I_PP_Product_BOM bomVersion, final @Nullable DocStatus docStatus)
+	public Optional<I_PP_Product_BOM> getPreviousVersion(final @NonNull I_PP_Product_BOM bomVersion, final @Nullable Set<BOMType> bomTypes, final @Nullable DocStatus docStatus)
 	{
 		final IQueryBuilder<I_PP_Product_BOM> queryBuilder = queryBL
 				.createQueryBuilderOutOfTrx(I_PP_Product_BOM.class)
@@ -429,6 +425,11 @@ public class ProductBOMDAO implements IProductBOMDAO
 		if (docStatus != null)
 		{
 			queryBuilder.addEqualsFilter(I_PP_Product_BOM.COLUMNNAME_DocStatus, docStatus.getCode());
+		}
+
+		if (bomTypes != null)
+		{
+			queryBuilder.addInArrayFilter(I_PP_Product_BOM.COLUMNNAME_BOMType, bomTypes);
 		}
 
 		return queryBuilder
@@ -451,10 +452,27 @@ public class ProductBOMDAO implements IProductBOMDAO
 				.anyMatch();
 	}
 
+	@Override
+	public Optional<ProductBOMId> getLatestBOMIdByVersionAndType(@NonNull final ProductBOMVersionsId bomVersionsId, final @Nullable Set<BOMType> bomTypes)
+	{
+		return Optional.ofNullable(
+				queryLatestBOMRecordByVersionAndType(bomVersionsId, bomTypes).firstId(ProductBOMId::ofRepoIdOrNull)
+		);
+	}
+
+	@Override
 	@NonNull
-	private Optional<I_PP_Product_BOM> getLatestBOMRecordByVersion(
+	public Optional<I_PP_Product_BOM> getLatestBOMRecordByVersionAndType(
 			final @NonNull ProductBOMVersionsId bomVersionsId,
-			final @Nullable BOMType bomType)
+			final @Nullable Set<BOMType> bomTypes)
+	{
+		return queryLatestBOMRecordByVersionAndType(bomVersionsId, bomTypes).firstOptional(I_PP_Product_BOM.class);
+	}
+
+	@NonNull
+	private IQuery<I_PP_Product_BOM> queryLatestBOMRecordByVersionAndType(
+			final @NonNull ProductBOMVersionsId bomVersionsId,
+			final @Nullable Set<BOMType> bomTypes)
 	{
 		final I_PP_Product_BOMVersions bomVersions = getProductBOMVersionsDAO().getBOMVersions(bomVersionsId);
 
@@ -464,25 +482,24 @@ public class ProductBOMDAO implements IProductBOMDAO
 				.createQueryBuilder(I_PP_Product_BOM.class)
 				.addOnlyActiveRecordsFilter();
 
-		if (bomType != null)
+		if (!Check.isEmpty(bomTypes))
 		{
-			productBOMQueryBuilder.addEqualsFilter(I_PP_Product_BOM.COLUMNNAME_BOMType, bomType.getCode());
+			productBOMQueryBuilder.addInArrayFilter(I_PP_Product_BOM.COLUMNNAME_BOMType, bomTypes);
 		}
 
 		return productBOMQueryBuilder
 				.addEqualsFilter(I_PP_Product_BOM.COLUMNNAME_PP_Product_BOMVersions_ID, bomVersionsId.getRepoId())
 				.addCompareFilter(I_PP_Product_BOM.COLUMNNAME_ValidFrom, CompareQueryFilter.Operator.LESS_OR_EQUAL, TimeUtil.asTimestamp(ZonedDateTime.now(zoneId)))
 				.orderByDescending(I_PP_Product_BOM.COLUMNNAME_ValidFrom)
-				.create()
-				.firstOptional(I_PP_Product_BOM.class);
+				.create();
 	}
 
 	@NonNull
-	private Optional<I_PP_Product_BOM> getDefaultBOM(@NonNull final ProductBOMVersionsId bomVersionsId)
+	private Optional<I_PP_Product_BOM> getDefaultBOMRecordByVersionId(@NonNull final ProductBOMVersionsId bomVersionsId)
 	{
 		return Optionals.firstPresentOfSuppliers(
-				() -> getLatestBOMRecordByVersion(bomVersionsId, BOMType.CurrentActive),
-				() -> getLatestBOMRecordByVersion(bomVersionsId, BOMType.MakeToOrder));
+				() -> getLatestBOMRecordByVersionAndType(bomVersionsId, ImmutableSet.of(BOMType.CurrentActive)),
+				() -> getLatestBOMRecordByVersionAndType(bomVersionsId, ImmutableSet.of(BOMType.MakeToOrder)));
 	}
 
 	@NonNull

--- a/backend/de.metas.business/src/test/java/org/eevolution/api/PPOrderDocBaseTypeTests.java
+++ b/backend/de.metas.business/src/test/java/org/eevolution/api/PPOrderDocBaseTypeTests.java
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2023 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.eevolution.api;
+
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.Arrays;
+
+public class PPOrderDocBaseTypeTests
+{
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+	}
+
+	@Test
+	public void givenAnyDocBaseType_whenGetBOMType_thenNoErrorIsThrown()
+	{
+		Arrays.stream(PPOrderDocBaseType.values()).forEach(PPOrderDocBaseType::getBOMTypes);
+	}
+}

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/api/IPPOrderBL.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/api/IPPOrderBL.java
@@ -116,4 +116,6 @@ public interface IPPOrderBL extends ISingletonService
 	void updateDraftedOrdersMatchingBOM(@NonNull ProductBOMVersionsId bomVersionsId, @NonNull ProductBOMId newVersionId);
 	
 	boolean isModularOrder(@NonNull PPOrderId ppOrderId);
+
+	PPOrderDocBaseType getPPOrderDocBaseType(@NonNull I_PP_Order ppOrder);
 }

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/api/impl/PPOrderBL.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/api/impl/PPOrderBL.java
@@ -72,6 +72,7 @@ import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.Adempiere;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_AD_WF_Node_Template;
+import org.compiere.model.I_C_DocType;
 import org.compiere.model.I_C_OrderLine;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
@@ -332,10 +333,10 @@ public class PPOrderBL implements IPPOrderBL
 	{
 		final DocTypeId docTypeId = docTypesRepo.getDocTypeId(DocTypeQuery.builder()
 				.docBaseType(docBaseType.toDocBaseType())
-				.docSubType(docSubType)
-				.adClientId(ppOrder.getAD_Client_ID())
-				.adOrgId(ppOrder.getAD_Org_ID())
-				.build());
+																	  .docSubType(docSubType)
+																	  .adClientId(ppOrder.getAD_Client_ID())
+																	  .adOrgId(ppOrder.getAD_Org_ID())
+																	  .build());
 
 		ppOrder.setC_DocTypeTarget_ID(docTypeId.getRepoId());
 		ppOrder.setC_DocType_ID(docTypeId.getRepoId());
@@ -477,13 +478,13 @@ public class PPOrderBL implements IPPOrderBL
 						.build();
 
 				costCollectorsService.createActivityControl(ActivityControlCreateRequest.builder()
-						.order(orderRecord)
-						.orderActivity(activity)
-						.movementDate(reportDate)
-						.qtyMoved(qtyToProcess)
-						.durationSetup(setupTimeRemaining)
-						.duration(durationRemaining.getDuration())
-						.build());
+																	.order(orderRecord)
+																	.orderActivity(activity)
+																	.movementDate(reportDate)
+																	.qtyMoved(qtyToProcess)
+																	.durationSetup(setupTimeRemaining)
+																	.duration(durationRemaining.getDuration())
+																	.build());
 			}
 		}
 	}
@@ -627,7 +628,7 @@ public class PPOrderBL implements IPPOrderBL
 
 		final ImmutableList<I_PP_OrderCandidate_PP_Order> orderAllocations = ppOrderDAO.getPPOrderAllocations(PPOrderId.ofRepoId(ppOrder.getPP_Order_ID()));
 		String lotForLot = "";
-		if(orderAllocations.size() == 1)
+		if (orderAllocations.size() == 1)
 		{
 			final PPOrderCandidateId ppOrderCandidateId = PPOrderCandidateId.ofRepoId(orderAllocations.get(0).getPP_Order_Candidate_ID());
 			lotForLot = ppOrderCandidateDAO.getById(ppOrderCandidateId).getIsLotForLot();
@@ -685,10 +686,18 @@ public class PPOrderBL implements IPPOrderBL
 				});
 	}
 
+	@Override
 	public boolean isModularOrder(@NonNull final PPOrderId ppOrderId)
 	{
 		final I_PP_Order ppOrder = getById(ppOrderId);
 
 		return docTypeBL.isModularManufacturingOrder(DocTypeId.ofRepoId(ppOrder.getC_DocTypeTarget_ID()));
+	}
+	
+	@Override
+	public PPOrderDocBaseType getPPOrderDocBaseType(@NonNull final I_PP_Order ppOrder)
+	{
+		final I_C_DocType docTypeTarget = docTypesRepo.getById(DocTypeId.ofRepoId(ppOrder.getC_DocTypeTarget_ID()));
+		return PPOrderDocBaseType.ofCode(docTypeTarget.getDocBaseType());
 	}
 }

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/callout/PP_Order.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/callout/PP_Order.java
@@ -31,6 +31,7 @@ import org.compiere.model.I_C_DocType;
 import org.compiere.model.I_C_UOM;
 import org.eevolution.api.IPPOrderBL;
 import org.eevolution.api.IProductBOMDAO;
+import org.eevolution.api.PPOrderDocBaseType;
 import org.eevolution.api.ProductBOMId;
 import org.eevolution.api.ProductBOMVersionsId;
 import org.eevolution.api.impl.ProductBOMVersionsDAO;
@@ -100,7 +101,7 @@ public class PP_Order extends CalloutEngine
 		}
 	}
 
-	@CalloutMethod(columnNames = I_PP_Order.COLUMNNAME_M_Product_ID)
+	@CalloutMethod(columnNames = { I_PP_Order.COLUMNNAME_M_Product_ID, I_PP_Order.COLUMNNAME_C_DocTypeTarget_ID })
 	public void onProductChanged(final I_PP_Order ppOrder)
 	{
 		final ProductId productId = ProductId.ofRepoIdOrNull(ppOrder.getM_Product_ID());
@@ -118,7 +119,8 @@ public class PP_Order extends CalloutEngine
 		final ProductBOMVersionsId productBOMVersionsId = Optional.ofNullable(ProductBOMVersionsId.ofRepoIdOrNull(pp.getPP_Product_BOMVersions_ID()))
 				.orElseThrow(() -> new MrpException("@FillMandatory@ @PP_Product_BOMVersions_ID@ ( @M_Product_ID@=" + productId.getRepoId() + ")"));
 
-		final ProductBOMId productBOMId = bomsRepo.getLatestBOMByVersion(productBOMVersionsId)
+		final PPOrderDocBaseType docBaseType = ppOrderBL.getPPOrderDocBaseType(ppOrder);
+		final ProductBOMId productBOMId = bomsRepo.getLatestBOMIdByVersionAndType(productBOMVersionsId, docBaseType.getBOMTypes())
 				.orElseThrow(() -> new MrpException("@FillMandatory@ @PP_Product_BOM_ID@ ( @M_Product_ID@=" + productId.getRepoId() + ")"));
 
 		ppOrder.setPP_Product_BOM_ID(productBOMId.getRepoId());

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/costing/BatchProcessBOMCostCalculatorRepository.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/costing/BatchProcessBOMCostCalculatorRepository.java
@@ -33,6 +33,7 @@ import org.compiere.model.I_C_UOM;
 import org.eevolution.api.BOMComponentType;
 import org.eevolution.api.IProductBOMBL;
 import org.eevolution.api.IProductBOMDAO;
+import org.eevolution.api.PPOrderDocBaseType;
 import org.eevolution.api.ProductBOMId;
 import org.eevolution.api.ProductBOMVersionsId;
 import org.eevolution.model.I_PP_Product_BOM;
@@ -121,10 +122,10 @@ public class BatchProcessBOMCostCalculatorRepository implements BOMCostCalculato
 			createNotice(productId, "@NotFound@ @PP_Product_Planning_ID@");
 		}
 
-		ProductBOMId productBOMId;
+		final ProductBOMId productBOMId;
 		if (bomVersionsId != null)
 		{
-			productBOMId = productBOMsRepo.getLatestBOMByVersion(bomVersionsId).orElse(null);
+			productBOMId = productBOMsRepo.getLatestBOMIdByVersionAndType(bomVersionsId, PPOrderDocBaseType.MANUFACTURING_ORDER.getBOMTypes()).orElse(null);
 		}
 		else
 		{

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/model/validator/PP_Product_BOMVersions.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/model/validator/PP_Product_BOMVersions.java
@@ -46,10 +46,7 @@ public class PP_Product_BOMVersions
 	public void validateProductChange(final I_PP_Product_BOMVersions bomVersions)
 	{
 		final ProductBOMVersionsId bomVersionsId = ProductBOMVersionsId.ofRepoId(bomVersions.getPP_Product_BOMVersions_ID());
-
-		final Optional<ProductBOMId> productBomId = bomsRepo.getLatestBOMByVersion(bomVersionsId);
-
-		if (productBomId.isPresent())
+		if (bomsRepo.hasBOMs(bomVersionsId))
 		{
 			throw new AdempiereException(AdMessageKey.of("PP_Product_BOMVersions_BOMs_Already_Linked"))
 					.markAsUserValidationError();

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/model/validator/PP_Product_Planning.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/model/validator/PP_Product_Planning.java
@@ -14,6 +14,7 @@ import org.adempiere.mm.attributes.api.AttributesKeys;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.ModelValidator;
 import org.eevolution.api.IProductBOMDAO;
+import org.eevolution.api.PPOrderDocBaseType;
 import org.eevolution.api.ProductBOMVersionsId;
 import org.eevolution.api.impl.ProductBOMService;
 import org.eevolution.api.impl.ProductBOMVersionsDAO;
@@ -21,6 +22,7 @@ import org.eevolution.model.I_PP_Product_BOM;
 import org.eevolution.model.I_PP_Product_BOMVersions;
 import org.eevolution.model.I_PP_Product_Planning;
 
+import java.util.Arrays;
 import java.util.Optional;
 
 /*
@@ -79,7 +81,7 @@ public class PP_Product_Planning
 	}
 
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_CHANGE,
-			ifColumnsChanged = {I_PP_Product_Planning.COLUMNNAME_M_Product_ID, I_PP_Product_Planning.COLUMNNAME_PP_Product_BOMVersions_ID})
+			ifColumnsChanged = { I_PP_Product_Planning.COLUMNNAME_M_Product_ID, I_PP_Product_Planning.COLUMNNAME_PP_Product_BOMVersions_ID })
 	public void validateBOMVersionsAndProductId(final I_PP_Product_Planning planning)
 	{
 		final ProductId productId = ProductId.ofRepoIdOrNull(planning.getM_Product_ID());
@@ -117,9 +119,9 @@ public class PP_Product_Planning
 
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE },
 			ifColumnsChanged = {
-				I_PP_Product_Planning.COLUMNNAME_PP_Product_BOMVersions_ID,
-				I_PP_Product_Planning.COLUMNNAME_IsAttributeDependant,
-				I_PP_Product_Planning.COLUMNNAME_M_AttributeSetInstance_ID,
+					I_PP_Product_Planning.COLUMNNAME_PP_Product_BOMVersions_ID,
+					I_PP_Product_Planning.COLUMNNAME_IsAttributeDependant,
+					I_PP_Product_Planning.COLUMNNAME_M_AttributeSetInstance_ID,
 			})
 	public void validateProductBOMASI(@NonNull final I_PP_Product_Planning productPlanning)
 	{
@@ -128,18 +130,16 @@ public class PP_Product_Planning
 			return;
 		}
 
-		if (productPlanning.getPP_Product_BOMVersions_ID() <= 0)
+		final ProductBOMVersionsId bomVersionsId = ProductBOMVersionsId.ofRepoIdOrNull(productPlanning.getPP_Product_BOMVersions_ID());
+		if (bomVersionsId == null)
 		{
 			return;
 		}
 
-		final Optional<I_PP_Product_BOM> bom = bomDAO.getLatestBOMRecordByVersionId(ProductBOMVersionsId.ofRepoId(productPlanning.getPP_Product_BOMVersions_ID()));
-
-		if (!bom.isPresent())
-		{
-			return;
-		}
-
-		productBOMService.verifyBOMAssignment(productPlanning, bom.get());
+		Arrays.stream(PPOrderDocBaseType.values())
+				.map(docType -> bomDAO.getLatestBOMRecordByVersionAndType(bomVersionsId, docType.getBOMTypes()))
+				.filter(Optional::isPresent)
+				.map(Optional::get)
+				.forEach(bom -> productBOMService.verifyBOMAssignment(productPlanning, bom));
 	}
 }

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/order/PP_Product_BOM.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/order/PP_Product_BOM.java
@@ -22,6 +22,7 @@
 
 package org.eevolution.order;
 
+import com.google.common.collect.ImmutableSet;
 import de.metas.document.engine.DocStatus;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -29,6 +30,7 @@ import org.adempiere.ad.modelvalidator.annotations.DocValidate;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.compiere.model.ModelValidator;
+import org.eevolution.api.BOMType;
 import org.eevolution.api.IPPOrderBL;
 import org.eevolution.api.IProductBOMDAO;
 import org.eevolution.api.ProductBOMId;
@@ -49,7 +51,11 @@ public class PP_Product_BOM
 	@DocValidate(timings = { ModelValidator.TIMING_AFTER_COMPLETE })
 	public void onComplete(@NonNull final I_PP_Product_BOM productBOMRecord)
 	{
-		final Optional<I_PP_Product_BOM> previousBOMVersion = productBOMDAO.getPreviousVersion(productBOMRecord, DocStatus.Completed);
+		final BOMType bomType = Optional.ofNullable(BOMType.ofNullableCode(productBOMRecord.getBOMType()))
+				.orElse(BOMType.CurrentActive);
+
+		final Optional<I_PP_Product_BOM> previousBOMVersion = productBOMDAO.getPreviousVersion(productBOMRecord,
+																							   ImmutableSet.of(bomType), DocStatus.Completed);
 
 		if (!previousBOMVersion.isPresent())
 		{

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/productioncandidate/model/interceptor/PP_Product_BOM.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/productioncandidate/model/interceptor/PP_Product_BOM.java
@@ -35,6 +35,7 @@ import org.adempiere.mm.attributes.api.IAttributeDAO;
 import org.compiere.model.ModelValidator;
 import org.eevolution.api.IPPOrderDAO;
 import org.eevolution.api.IProductBOMDAO;
+import org.eevolution.api.PPOrderDocBaseType;
 import org.eevolution.api.ProductBOMId;
 import org.eevolution.model.I_PP_Product_BOM;
 import org.eevolution.productioncandidate.model.dao.IPPOrderCandidateDAO;
@@ -57,7 +58,7 @@ public class PP_Product_BOM
 	@DocValidate(timings = { ModelValidator.TIMING_AFTER_COMPLETE })
 	public void onComplete(@NonNull final I_PP_Product_BOM productBOMRecord)
 	{
-		final Optional<I_PP_Product_BOM> previousBOMVersion = productBOMDAO.getPreviousVersion(productBOMRecord, DocStatus.Completed);
+		final Optional<I_PP_Product_BOM> previousBOMVersion = productBOMDAO.getPreviousVersion(productBOMRecord, PPOrderDocBaseType.MANUFACTURING_ORDER.getBOMTypes(), DocStatus.Completed);
 
 		if (!previousBOMVersion.isPresent())
 		{

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/productioncandidate/service/CreateOrderCandidateCommand.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/productioncandidate/service/CreateOrderCandidateCommand.java
@@ -27,7 +27,6 @@ import de.metas.inout.ShipmentScheduleId;
 import de.metas.material.planning.IProductPlanningDAO;
 import de.metas.material.planning.ProductPlanningId;
 import de.metas.order.OrderLineId;
-import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
@@ -37,6 +36,7 @@ import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.util.TimeUtil;
 import org.eevolution.api.IProductBOMDAO;
+import org.eevolution.api.PPOrderDocBaseType;
 import org.eevolution.api.ProductBOMVersionsId;
 import org.eevolution.model.I_PP_Order_Candidate;
 import org.eevolution.model.I_PP_Product_BOM;
@@ -115,7 +115,7 @@ public class CreateOrderCandidateCommand
 
 		ppOrderCandidateRecord.setM_HU_PI_Item_Product_ID(HUPIItemProductId.toRepoId(request.getPackingMaterialId()));
 
-		if(!Utils.isEmpty(request.getLotForLot()))
+		if (!Utils.isEmpty(request.getLotForLot()))
 		{
 			ppOrderCandidateRecord.setIsLotForLot(request.getLotForLot());
 		}
@@ -136,20 +136,17 @@ public class CreateOrderCandidateCommand
 		{
 			final I_PP_Product_Planning productPlanning = productPlanningsRepo.getById(productPlanningId);
 
-			final Optional<I_PP_Product_BOM> productBOMFromPlanning = Optional.ofNullable(productPlanning)
+			return Optional.ofNullable(productPlanning)
 					.filter(presentProductPlanning -> presentProductPlanning.getPP_Product_BOMVersions_ID() > 0)
 					.map(presentProductPlanning -> ProductBOMVersionsId.ofRepoId(presentProductPlanning.getPP_Product_BOMVersions_ID()))
-					.flatMap(bomRepo::getLatestBOMRecordByVersionId);
-
-			if (productBOMFromPlanning.isPresent())
-			{
-				return productBOMFromPlanning.get();
-			}
+					.flatMap(bomVersionsId -> bomRepo.getLatestBOMRecordByVersionAndType(bomVersionsId, PPOrderDocBaseType.MANUFACTURING_ORDER.getBOMTypes()))
+					.orElseThrow(() -> new AdempiereException("@NotFound@ @PP_Product_BOM_ID@")
+							.appendParametersToMessage()
+							.setParameter("request", request)
+							.setParameter("productPlanningId", productPlanningId));
 		}
 
-		final ProductId productId = request.getProductId();
-
-		return bomRepo.getDefaultBOMByProductId(productId)
+		return bomRepo.getDefaultBOMByProductId(request.getProductId())
 				.orElseThrow(() -> new AdempiereException("@NotFound@ @PP_Product_BOM_ID@")
 						.appendParametersToMessage()
 						.setParameter("request", request)

--- a/backend/de.metas.manufacturing/src/test/java/org/eevolution/event/PPOrderRequestedEventHandlerTests.java
+++ b/backend/de.metas.manufacturing/src/test/java/org/eevolution/event/PPOrderRequestedEventHandlerTests.java
@@ -46,6 +46,7 @@ import org.compiere.model.X_AD_Workflow;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 import org.eevolution.api.BOMComponentType;
+import org.eevolution.api.BOMType;
 import org.eevolution.api.IProductBOMDAO;
 import org.eevolution.api.PPOrderDocBaseType;
 import org.eevolution.api.ProductBOMId;
@@ -161,6 +162,7 @@ public class PPOrderRequestedEventHandlerTests
 		productBom.setValidFrom(TimeUtil.asTimestamp(Instant.now().minus(1, ChronoUnit.HOURS)));
 		productBom.setDocStatus(X_PP_Product_BOM.DOCSTATUS_Completed);
 		productBom.setPP_Product_BOMVersions_ID(productBomVersions.getPP_Product_BOMVersions_ID());
+		productBom.setBOMType(BOMType.CurrentActive.getCode());
 		save(productBom);
 
 
@@ -286,7 +288,9 @@ public class PPOrderRequestedEventHandlerTests
 		final IProductBOMDAO productBOMsRepo = Services.get(IProductBOMDAO.class);
 
 		final ProductBOMVersionsId productBOMVersionsId = ProductBOMVersionsId.ofRepoId(productPlanning.getPP_Product_BOMVersions_ID());
-		final ProductBOMId productBOMId = productBOMsRepo.getLatestBOMByVersion(productBOMVersionsId).orElse(null);
+		final ProductBOMId productBOMId = productBOMsRepo
+				.getLatestBOMIdByVersionAndType(productBOMVersionsId, PPOrderDocBaseType.MANUFACTURING_ORDER.getBOMTypes())
+				.orElse(null);
 
 		assertThat(ppOrder.getPP_Product_BOM_ID()).isEqualTo(ProductBOMId.toRepoId(productBOMId));
 

--- a/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/ppordercandidate/PPOrderCandidatePojoSupplier.java
+++ b/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/ppordercandidate/PPOrderCandidatePojoSupplier.java
@@ -50,6 +50,7 @@ import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.mm.attributes.api.AttributesKeys;
 import org.adempiere.service.ClientId;
 import org.eevolution.api.IProductBOMDAO;
+import org.eevolution.api.PPOrderDocBaseType;
 import org.eevolution.api.ProductBOMVersionsId;
 import org.eevolution.model.I_PP_Product_Planning;
 import org.springframework.stereotype.Service;
@@ -113,7 +114,7 @@ public class PPOrderCandidatePojoSupplier
 
 		final ProductBOMVersionsId bomVersionsId = ProductBOMVersionsId.ofRepoId(productPlanningData.getPP_Product_BOMVersions_ID());
 
-		productBOMDAO.getLatestBOMByVersion(bomVersionsId)
+		productBOMDAO.getLatestBOMIdByVersionAndType(bomVersionsId, PPOrderDocBaseType.MANUFACTURING_ORDER.getBOMTypes())
 				.orElseThrow(() -> new MrpException("@FillMandatory@ @PP_Product_BOM_ID@ ( @M_Product_ID@=" + productId + ")"));
 
 		//

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/picking_bom/PickingBOMService.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/picking_bom/PickingBOMService.java
@@ -20,6 +20,7 @@ import org.adempiere.exceptions.FillMandatoryException;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.warehouse.WarehouseId;
 import org.eevolution.api.IProductBOMDAO;
+import org.eevolution.api.PPOrderDocBaseType;
 import org.eevolution.api.ProductBOMId;
 import org.eevolution.api.ProductBOMVersionsId;
 import org.eevolution.model.I_PP_Product_BOM;
@@ -115,7 +116,7 @@ public class PickingBOMService
 					.appendParametersToMessage();
 		}
 
-		final ProductBOMId bomId = bomsRepo.getLatestBOMByVersion(bomVersionsId)
+		final ProductBOMId bomId = bomsRepo.getLatestBOMIdByVersionAndType(bomVersionsId, PPOrderDocBaseType.MANUFACTURING_ORDER.getBOMTypes())
 				.orElseThrow(() -> new MrpException("@FillMandatory@ @PP_Product_BOM_ID@ ( @M_Product_ID@=" + productPlanning.getM_Product_ID() + ")"));
 
 		return Optional.of(PickingOrderConfig.builder()
@@ -175,7 +176,7 @@ public class PickingBOMService
 	private Set<ProductBOMId> getPickingBOMIds(@NonNull final Set<ProductBOMVersionsId> bomVersionsIds)
 	{
 		return bomVersionsIds.stream()
-				.map(bomsRepo::getLatestBOMByVersion)
+				.map(bomVersionsId -> bomsRepo.getLatestBOMIdByVersionAndType(bomVersionsId, PPOrderDocBaseType.MANUFACTURING_ORDER.getBOMTypes()))
 				.filter(Optional::isPresent)
 				.map(Optional::get)
 				.collect(ImmutableSet.toImmutableSet());


### PR DESCRIPTION
* Product planning data is being ignored when manufacturing orders are generated automatically
refs https://github.com/metasfresh/metasfresh/issues/16873

(cherry picked from commit a23f5f474adf5e247bc1fb5300be2089e123abba)

solved Conflicts:
	backend/de.metas.business/src/main/java/org/eevolution/api/PPOrderDocBaseType.java
	backend/de.metas.business/src/main/java/org/eevolution/api/impl/ProductBOMDAO.java
	backend/de.metas.manufacturing/src/main/java/org/eevolution/api/IPPOrderBL.java
	backend/de.metas.manufacturing/src/main/java/org/eevolution/api/impl/CreateOrderCommand.java
	backend/de.metas.manufacturing/src/main/java/org/eevolution/api/impl/PPOrderBL.java
	backend/de.metas.manufacturing/src/main/java/org/eevolution/model/validator/PP_Product_Planning.java
	backend/de.metas.manufacturing/src/main/java/org/eevolution/productioncandidate/service/CreateOrderCandidateCommand.java
	backend/de.metas.material/planning/src/main/java/de/metas/material/planning/ppordercandidate/PPOrderCandidatePojoSupplier.java
