### PR TITLE
Update Jasper to latest version 6.21.2 (#17871)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/pom.xml
+++ b/backend/de.metas.adempiere.adempiere/base/pom.xml
@@ -195,8 +195,8 @@
         </dependency>
         <!-- itext is required by org.adempiere.pdf.Document.java-->
         <dependency>
-            <groupId>com.lowagie</groupId>
-            <artifactId>itext</artifactId>
+            <groupId>com.itextpdf</groupId>
+            <artifactId>itextpdf</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>bouncycastle</groupId>

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/adempiere/pdf/Document.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/adempiere/pdf/Document.java
@@ -13,13 +13,12 @@
  *****************************************************************************/
 package org.adempiere.pdf;
 
-import com.lowagie.text.FontFactory;
-import com.lowagie.text.Image;
-import com.lowagie.text.Rectangle;
-import com.lowagie.text.pdf.DefaultFontMapper;
-import com.lowagie.text.pdf.PdfContentByte;
-import com.lowagie.text.pdf.PdfTemplate;
-import com.lowagie.text.pdf.PdfWriter;
+import com.itextpdf.text.Image;
+import com.itextpdf.awt.DefaultFontMapper;
+import com.itextpdf.text.FontFactory;
+import com.itextpdf.text.pdf.PdfContentByte;
+import com.itextpdf.text.pdf.PdfTemplate;
+import com.itextpdf.text.pdf.PdfWriter;
 import de.metas.util.Services;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.pdf.viewer.PDFViewerBean;
@@ -37,101 +36,118 @@ import java.io.OutputStream;
 
 /**
  * Generate PDF document using iText
- * @author Low Heng Sin
  *
+ * @author Low Heng Sin
  */
-public class Document {
+public class Document
+{
 
-	static {
+	static
+	{
 		FontFactory.registerDirectories();
 	}
-	
+
 	private final static String PDF_FONT_DIR = "PDF_FONT_DIR";
-	
+
 	private static void writePDF(Pageable pageable, OutputStream output)
 	{
-		try {
-            final PageFormat pf = pageable.getPageFormat(0);
-            
-            final com.lowagie.text.Document document =
-            	new com.lowagie.text.Document(new Rectangle(
-            			(int) pf.getWidth(), (int) pf.getHeight()));
-            final PdfWriter writer = PdfWriter.getInstance(
-                    document, output);
-            writer.setPdfVersion(PdfWriter.VERSION_1_2);
-            document.open();
-            final DefaultFontMapper mapper = new DefaultFontMapper();     
-            
-            //Elaine 2009/02/17 - load additional font from directory set in PDF_FONT_DIR of System Configurator 
-            String pdfFontDir = Services.get(ISysConfigBL.class).getValue(PDF_FONT_DIR, "");
-            if(pdfFontDir != null && pdfFontDir.trim().length() > 0)
-            {
-            	pdfFontDir = pdfFontDir.trim();
-	            File dir = new File(pdfFontDir);
-	            if(dir.exists() && dir.isDirectory())
-	            	mapper.insertDirectory(pdfFontDir);
-            }
-            //
-            
-            final float w = (float) pf.getWidth();
-            final float h = (float) pf.getHeight();
-            final PdfContentByte cb = writer.getDirectContent();
-            for (int page = 0; page < pageable.getNumberOfPages(); page++) {
-            	if (page != 0) {
-            		document.newPage();
-            	}
-            	
-	            final PdfTemplate tp = cb.createTemplate(w, h);
-	            final Graphics2D g2 = tp.createGraphics(w, h, mapper);
-	            tp.setWidth(w);
-	            tp.setHeight(h);
-	            pageable.getPrintable(page).print(g2, pf, page);
-	            g2.dispose();
-	            cb.addTemplate(tp, 0, 0);
-            }
-            document.close();
-            
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-	}
-	
-	public static File getPDFAsFile(String filename, Pageable pageable) {
-        final File result = new File(filename);
-        
-        try {
-        	writePDF(pageable, new FileOutputStream(result));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        
-        return result;
-    }
-    
-    public static byte[] getPDFAsArray(Pageable pageable) {
-        try {
-            ByteArrayOutputStream output = new ByteArrayOutputStream(10240);
-            writePDF(pageable, output);
-            return output.toByteArray();
-        } catch (Exception e) {
-            e.printStackTrace();
-        } 
+		try
+		{
+			final PageFormat pf = pageable.getPageFormat(0);
 
-        return null;
-    }
-    
-    public static PDFViewerBean getViewer() {
-    	return new PDFViewerBean();
-    }
-    
-    public static boolean isValid(Pageable layout) {
-    	return true;
-    }
-    
-    public static boolean isLicensed() {
-    	return true;
-    }    
-    
+			final com.itextpdf.text.Document document =
+					new com.itextpdf.text.Document(new com.itextpdf.text.Rectangle((int)pf.getWidth(), (int)pf.getHeight()));
+			final PdfWriter writer = PdfWriter.getInstance(
+					document, output);
+			writer.setPdfVersion(PdfWriter.VERSION_1_2);
+			document.open();
+			final DefaultFontMapper mapper = new DefaultFontMapper();
+
+			//Elaine 2009/02/17 - load additional font from directory set in PDF_FONT_DIR of System Configurator
+			String pdfFontDir = Services.get(ISysConfigBL.class).getValue(PDF_FONT_DIR, "");
+			if (pdfFontDir != null && pdfFontDir.trim().length() > 0)
+			{
+				pdfFontDir = pdfFontDir.trim();
+				File dir = new File(pdfFontDir);
+				if (dir.exists() && dir.isDirectory())
+					mapper.insertDirectory(pdfFontDir);
+			}
+			//
+
+			final float w = (float)pf.getWidth();
+			final float h = (float)pf.getHeight();
+			final PdfContentByte cb = writer.getDirectContent();
+			for (int page = 0; page < pageable.getNumberOfPages(); page++)
+			{
+				if (page != 0)
+				{
+					document.newPage();
+				}
+
+				final PdfTemplate tp = cb.createTemplate(w, h);
+				final Graphics2D g2 = tp.createGraphics(w, h, mapper);
+				tp.setWidth(w);
+				tp.setHeight(h);
+				pageable.getPrintable(page).print(g2, pf, page);
+				g2.dispose();
+				cb.addTemplate(tp, 0, 0);
+			}
+			document.close();
+
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+		}
+	}
+
+	public static File getPDFAsFile(String filename, Pageable pageable)
+	{
+		final File result = new File(filename);
+
+		try
+		{
+			writePDF(pageable, new FileOutputStream(result));
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+		}
+
+		return result;
+	}
+
+	public static byte[] getPDFAsArray(Pageable pageable)
+	{
+		try
+		{
+			ByteArrayOutputStream output = new ByteArrayOutputStream(10240);
+			writePDF(pageable, output);
+			return output.toByteArray();
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+		}
+
+		return null;
+	}
+
+	public static PDFViewerBean getViewer()
+	{
+		return new PDFViewerBean();
+	}
+
+	public static boolean isValid(Pageable layout)
+	{
+		return true;
+	}
+
+	public static boolean isLicensed()
+	{
+		return true;
+	}
+
 	/**
 	 * Converts given image to PDF.
 	 *
@@ -150,12 +166,12 @@ public class Document {
 
 			//
 			// PDF page size: image size + margins
-			final Rectangle pageSize = new Rectangle(0, 0,
-					pdfImage.getWidth() + 100,
-					pdfImage.getHeight() + 100);
+			final com.itextpdf.text.Rectangle pageSize = new com.itextpdf.text.Rectangle(0, 0,
+																						 (int)(pdfImage.getWidth() + 100),
+																						 (int)(pdfImage.getHeight() + 100));
 
 			// PDF document
-			final com.lowagie.text.Document document = new com.lowagie.text.Document(pageSize, 50, 50, 50, 50);
+			final com.itextpdf.text.Document document = new com.itextpdf.text.Document(pageSize, 50, 50, 50, 50);
 
 			//
 			// Add image to document

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/report/ExecuteReportStrategyUtil.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/report/ExecuteReportStrategyUtil.java
@@ -1,10 +1,11 @@
 package de.metas.report;
 
 import com.google.common.collect.ImmutableList;
-import com.lowagie.text.Document;
-import com.lowagie.text.pdf.BadPdfFormatException;
-import com.lowagie.text.pdf.PdfCopy;
-import com.lowagie.text.pdf.PdfReader;
+
+import com.itextpdf.text.Document;
+import com.itextpdf.text.pdf.BadPdfFormatException;
+import com.itextpdf.text.pdf.PdfCopy;
+import com.itextpdf.text.pdf.PdfReader;
 import de.metas.printing.IMassPrintingService;
 import de.metas.process.ProcessExecutor;
 import de.metas.process.ProcessInfo;

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/api/impl/BPartnerBL.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/api/impl/BPartnerBL.java
@@ -3,7 +3,8 @@ package de.metas.document.archive.api.impl;
 import de.metas.document.archive.api.IBPartnerBL;
 import de.metas.document.archive.model.I_C_BPartner;
 import de.metas.util.Check;
-import org.apache.commons.lang.BooleanUtils;
+
+import org.apache.commons.lang3.BooleanUtils;
 import org.compiere.model.I_AD_User;
 
 import javax.annotation.Nullable;

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Current_Vs_Previous_Pricelist_Comparison_Report.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Current_Vs_Previous_Pricelist_Comparison_Report.sql
@@ -60,7 +60,7 @@ WITH plvvr AS
                      AND plv.issotrx = p_IsSoTrx
                      AND (p_C_BPartner_ID IS NULL OR plv.c_bpartner_id = p_C_BPartner_ID)
                      AND (p_C_BP_Group_ID IS NULL OR plv.c_bpartner_id IN (SELECT bpg.c_bpartner_id FROM bpg))
-                   ORDER BY TRUE,
+                   ORDER BY --TRUE,
                             plv.validfrom DESC,
                             plv.m_pricelist_version_id DESC) t
              WHERE t.rank <= 2
@@ -130,7 +130,7 @@ SELECT --
        r.AD_Org_ID,
        p_show_product_price_pi_flag as show_product_price_pi_flag
 FROM result r
-ORDER BY TRUE,
+ORDER BY --TRUE,
          r.bp_value,
          r.productCategory,
          r.value

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Current_Vs_Previous_Pricelist_Comparison_Report_With_PP_PI.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Current_Vs_Previous_Pricelist_Comparison_Report_With_PP_PI.sql
@@ -62,7 +62,7 @@ WITH plvvr AS
                      AND plv.issotrx = p_IsSoTrx
                      AND (p_C_BPartner_ID IS NULL OR plv.c_bpartner_id = p_C_BPartner_ID)
                      AND (p_C_BP_Group_ID IS NULL OR plv.c_bpartner_id IN (SELECT bpg.c_bpartner_id FROM bpg))
-                   ORDER BY TRUE,
+                   ORDER BY --TRUE,
                             plv.validfrom DESC,
                             plv.m_pricelist_version_id DESC) t
              WHERE t.rank <= 2
@@ -132,7 +132,7 @@ SELECT --
        r.AD_Org_ID,
        p_show_product_price_pi_flag as show_product_price_pi_flag
 FROM result r
-ORDER BY TRUE,
+ORDER BY --TRUE,
          r.bp_value,
          r.productCategory,
          r.value

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5721390_sys_gh2819_Current_Vs_Previous_Pricelist_Comparison_Report.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5721390_sys_gh2819_Current_Vs_Previous_Pricelist_Comparison_Report.sql
@@ -1,0 +1,140 @@
+DROP FUNCTION IF EXISTS report.Current_Vs_Previous_Pricelist_Comparison_Report(numeric,
+                                                                               numeric,
+                                                                               text,
+                                                                               text,
+                                                                               text)
+;
+
+
+CREATE FUNCTION report.Current_Vs_Previous_Pricelist_Comparison_Report(p_c_bpartner_id              numeric DEFAULT NULL::numeric,
+                                                                       p_c_bp_group_id              numeric DEFAULT NULL::numeric,
+                                                                       p_issotrx                    text DEFAULT 'Y'::text,
+                                                                       p_ad_language                text DEFAULT 'en_US'::text,
+                                                                       p_show_product_price_pi_flag text DEFAULT 'Y'::text)
+    RETURNS TABLE
+            (
+                bp_value                   text,
+                bp_name                    text,
+                productcategory            text,
+                m_product_id               integer,
+                value                      text,
+                customerproductnumber      text,
+                productname                text,
+                isseasonfixedprice         text,
+                itemproductname            text,
+                qtycuspertu                numeric,
+                packingmaterialname        text,
+                pricestd                   numeric,
+                pricepattern1              text,
+                altpricestd                numeric,
+                pricepattern2              text,
+                hasaltprice                integer,
+                uomsymbol                  text,
+                uom_x12de355               text,
+                attributes                 text,
+                m_productprice_id          integer,
+                m_attributesetinstance_id  integer,
+                m_hu_pi_item_product_id    integer,
+                currency                   text,
+                currency2                  text,
+                validfromplv1              timestamp WITHOUT TIME ZONE,
+                validfromplv2              timestamp WITHOUT TIME ZONE,
+                nameplv1                   text,
+                nameplv2                   text,
+                c_bpartner_location_id     numeric,
+                ad_org_id                  numeric,
+                show_product_price_pi_flag text
+            )
+    STABLE
+    LANGUAGE sql
+AS
+$$
+WITH plvvr AS
+         (SELECT plv.* FROM Report.Fresh_PriceList_Version_Val_Rule plv),
+     bpg AS (SELECT DISTINCT b.c_bpartner_id FROM c_bpartner b WHERE b.c_bp_group_id = p_C_BP_Group_ID),
+     PriceListVersionsByValidFrom AS
+         (SELECT t.*
+          FROM (SELECT --
+                       plv.c_bpartner_id,
+                       plv.m_pricelist_version_id,
+                       plv.validfrom,
+                       plv.name,
+                       ROW_NUMBER() OVER (PARTITION BY plv.c_bpartner_id ORDER BY plv.validfrom DESC, plv.m_pricelist_version_id DESC) rank
+                FROM plvvr plv
+                WHERE TRUE
+                  AND plv.validfrom <= NOW()
+                  AND plv.issotrx = p_IsSoTrx
+                  AND (p_C_BPartner_ID IS NULL OR plv.c_bpartner_id = p_C_BPartner_ID)
+                  AND (p_C_BP_Group_ID IS NULL OR plv.c_bpartner_id IN (SELECT bpg.c_bpartner_id FROM bpg))
+                ORDER BY plv.validfrom DESC,
+                         plv.m_pricelist_version_id DESC) t
+          WHERE t.rank <= 2),
+     currentAndPreviousPLV AS
+         (
+             -- implementation detail: all these sub-selects would be better implemented with a pivot. Unfortunately i cant understand how pivots work.
+             SELECT DISTINCT --
+                             plvv.c_bpartner_id,
+                             (SELECT plvv2.m_pricelist_version_id FROM PriceListVersionsByValidFrom plvv2 WHERE plvv2.rank = 1 AND plvv2.c_bpartner_id = plvv.c_bpartner_id) PLV1_ID,
+                             (SELECT plvv2.m_pricelist_version_id FROM PriceListVersionsByValidFrom plvv2 WHERE plvv2.rank = 2 AND plvv2.c_bpartner_id = plvv.c_bpartner_id) PLV2_ID,
+                             (SELECT plvv2.validfrom FROM PriceListVersionsByValidFrom plvv2 WHERE plvv2.rank = 1 AND plvv2.c_bpartner_id = plvv.c_bpartner_id)              validFromPLV1,
+                             (SELECT plvv2.validfrom FROM PriceListVersionsByValidFrom plvv2 WHERE plvv2.rank = 2 AND plvv2.c_bpartner_id = plvv.c_bpartner_id)              validFromPLV2,
+                             (SELECT plvv2.name FROM PriceListVersionsByValidFrom plvv2 WHERE plvv2.rank = 1 AND plvv2.c_bpartner_id = plvv.c_bpartner_id)                   namePLV1,
+                             (SELECT plvv2.name FROM PriceListVersionsByValidFrom plvv2 WHERE plvv2.rank = 2 AND plvv2.c_bpartner_id = plvv.c_bpartner_id)                   namePLV2
+             FROM PriceListVersionsByValidFrom plvv
+             ORDER BY plvv.c_bpartner_id),
+     result AS
+         (SELECT t.*,
+                 plv.validFromPLV1,
+                 plv.validFromPLV2,
+                 plv.namePLV1,
+                 plv.namePLV2,
+                 (SELECT bpl.c_bpartner_location_id FROM c_bpartner_location bpl WHERE bpl.c_bpartner_id = plv.c_bpartner_id ORDER BY bpl.isbilltodefault DESC LIMIT 1) c_bpartner_location_id,
+                 (SELECT plv2.ad_org_id FROM m_pricelist_version plv2 WHERE plv2.m_pricelist_version_id = plv.PLV1_ID)                                                  AD_Org_ID
+          FROM currentAndPreviousPLV plv
+                   INNER JOIN LATERAL report.fresh_PriceList_Details_Report(
+                  plv.c_bpartner_id,
+                  plv.PLV1_ID,
+                  plv.PLV2_ID,
+                  p_AD_Language,
+                  p_show_product_price_pi_flag
+                                      ) AS t ON TRUE)
+SELECT --
+       r.bp_value,
+       r.bp_name,
+       r.productcategory,
+       r.m_product_id,
+       r.value,
+       r.customerproductnumber,
+       r.productname,
+       r.isseasonfixedprice::text,
+       r.itemproductname,
+       r.qtycuspertu,
+       r.packingmaterialname,
+       r.pricestd,
+       PricePattern1,
+       r.altpricestd,
+       PricePattern2,
+       r.hasaltprice,
+       r.uomsymbol,
+       r.uom_x12de355,
+       r.attributes,
+       r.m_productprice_id,
+       r.m_attributesetinstance_id,
+       r.m_hu_pi_item_product_id,
+       r.currency::text,
+       r.currency2::text,
+       r.validFromPLV1,
+       r.validFromPLV2,
+       r.namePLV1,
+       r.namePLV2,
+       r.c_bpartner_location_id,
+       r.AD_Org_ID,
+       p_show_product_price_pi_flag AS show_product_price_pi_flag
+FROM result r
+ORDER BY r.bp_value,
+         r.productCategory,
+         r.value
+$$
+;
+
+

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5721400_sys_gh2819_Current_Vs_Previous_Pricelist_Comparison_Report_With_PP_PI.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5721400_sys_gh2819_Current_Vs_Previous_Pricelist_Comparison_Report_With_PP_PI.sql
@@ -1,0 +1,138 @@
+DROP FUNCTION IF EXISTS report.Current_Vs_Previous_Pricelist_Comparison_Report_With_PP_PI(numeric,
+                                                                                          numeric,
+                                                                                          text,
+                                                                                          text,
+                                                                                          text)
+;
+
+CREATE FUNCTION report.Current_Vs_Previous_Pricelist_Comparison_Report_With_PP_PI(p_c_bpartner_id              numeric DEFAULT NULL::numeric,
+                                                                                  p_c_bp_group_id              numeric DEFAULT NULL::numeric,
+                                                                                  p_issotrx                    text DEFAULT 'Y'::text,
+                                                                                  p_ad_language                text DEFAULT 'en_US'::text,
+                                                                                  p_show_product_price_pi_flag text DEFAULT 'Y'::text)
+    RETURNS TABLE
+            (
+                bp_value                   text,
+                bp_name                    text,
+                productcategory            text,
+                m_product_id               integer,
+                value                      text,
+                customerproductnumber      text,
+                productname                text,
+                isseasonfixedprice         text,
+                itemproductname            text,
+                qtycuspertu                numeric,
+                packingmaterialname        text,
+                pricestd                   numeric,
+                pricepattern1              text,
+                altpricestd                numeric,
+                pricepattern2              text,
+                hasaltprice                integer,
+                uomsymbol                  text,
+                uom_x12de355               text,
+                attributes                 text,
+                m_productprice_id          integer,
+                m_attributesetinstance_id  integer,
+                m_hu_pi_item_product_id    integer,
+                currency                   text,
+                currency2                  text,
+                validfromplv1              timestamp WITHOUT TIME ZONE,
+                validfromplv2              timestamp WITHOUT TIME ZONE,
+                nameplv1                   text,
+                nameplv2                   text,
+                c_bpartner_location_id     numeric,
+                ad_org_id                  numeric,
+                show_product_price_pi_flag text
+            )
+    STABLE
+    LANGUAGE sql
+AS
+$$
+WITH plvvr AS
+         (SELECT plv.* FROM Report.Fresh_PriceList_Version_Val_Rule plv),
+     bpg AS (SELECT DISTINCT b.c_bpartner_id FROM c_bpartner b WHERE b.c_bp_group_id = p_C_BP_Group_ID),
+     PriceListVersionsByValidFrom AS
+         (SELECT t.*
+          FROM (SELECT --
+                       plv.c_bpartner_id,
+                       plv.m_pricelist_version_id,
+                       plv.validfrom,
+                       plv.name,
+                       ROW_NUMBER() OVER (PARTITION BY plv.c_bpartner_id ORDER BY plv.validfrom DESC, plv.m_pricelist_version_id DESC) rank
+                FROM plvvr plv
+                WHERE TRUE
+                  AND plv.validfrom <= NOW()
+                  AND plv.issotrx = p_IsSoTrx
+                  AND (p_C_BPartner_ID IS NULL OR plv.c_bpartner_id = p_C_BPartner_ID)
+                  AND (p_C_BP_Group_ID IS NULL OR plv.c_bpartner_id IN (SELECT bpg.c_bpartner_id FROM bpg))
+                ORDER BY plv.validfrom DESC,
+                         plv.m_pricelist_version_id DESC) t
+          WHERE t.rank <= 2),
+     currentAndPreviousPLV AS
+         (
+             -- implementation detail: all these sub-selects would be better implemented with a pivot. Unfortunately i cant understand how pivots work.
+             SELECT DISTINCT --
+                             plvv.c_bpartner_id,
+                             (SELECT plvv2.m_pricelist_version_id FROM PriceListVersionsByValidFrom plvv2 WHERE plvv2.rank = 1 AND plvv2.c_bpartner_id = plvv.c_bpartner_id) PLV1_ID,
+                             (SELECT plvv2.m_pricelist_version_id FROM PriceListVersionsByValidFrom plvv2 WHERE plvv2.rank = 2 AND plvv2.c_bpartner_id = plvv.c_bpartner_id) PLV2_ID,
+                             (SELECT plvv2.validfrom FROM PriceListVersionsByValidFrom plvv2 WHERE plvv2.rank = 1 AND plvv2.c_bpartner_id = plvv.c_bpartner_id)              validFromPLV1,
+                             (SELECT plvv2.validfrom FROM PriceListVersionsByValidFrom plvv2 WHERE plvv2.rank = 2 AND plvv2.c_bpartner_id = plvv.c_bpartner_id)              validFromPLV2,
+                             (SELECT plvv2.name FROM PriceListVersionsByValidFrom plvv2 WHERE plvv2.rank = 1 AND plvv2.c_bpartner_id = plvv.c_bpartner_id)                   namePLV1,
+                             (SELECT plvv2.name FROM PriceListVersionsByValidFrom plvv2 WHERE plvv2.rank = 2 AND plvv2.c_bpartner_id = plvv.c_bpartner_id)                   namePLV2
+             FROM PriceListVersionsByValidFrom plvv
+             ORDER BY plvv.c_bpartner_id),
+     result AS
+         (SELECT t.*,
+                 plv.validFromPLV1,
+                 plv.validFromPLV2,
+                 plv.namePLV1,
+                 plv.namePLV2,
+                 (SELECT bpl.c_bpartner_location_id FROM c_bpartner_location bpl WHERE bpl.c_bpartner_id = plv.c_bpartner_id ORDER BY bpl.isbilltodefault DESC LIMIT 1) c_bpartner_location_id,
+                 (SELECT plv2.ad_org_id FROM m_pricelist_version plv2 WHERE plv2.m_pricelist_version_id = plv.PLV1_ID)                                                  AD_Org_ID
+          FROM currentAndPreviousPLV plv
+                   INNER JOIN LATERAL report.fresh_PriceList_Details_Report_With_PP_PI(
+                  plv.c_bpartner_id,
+                  plv.PLV1_ID,
+                  plv.PLV2_ID,
+                  p_AD_Language,
+                  p_show_product_price_pi_flag
+                                      ) AS t ON TRUE)
+SELECT --
+       r.bp_value,
+       r.bp_name,
+       r.productcategory,
+       r.m_product_id,
+       r.value,
+       r.customerproductnumber,
+       r.productname,
+       r.isseasonfixedprice::text,
+       r.itemproductname,
+       r.qtycuspertu,
+       r.packingmaterialname,
+       r.pricestd,
+       PricePattern1,
+       r.altpricestd,
+       PricePattern2,
+       r.hasaltprice,
+       r.uomsymbol,
+       r.uom_x12de355,
+       r.attributes,
+       r.m_productprice_id,
+       r.m_attributesetinstance_id,
+       r.m_hu_pi_item_product_id,
+       r.currency::text,
+       r.currency2::text,
+       r.validFromPLV1,
+       r.validFromPLV2,
+       r.namePLV1,
+       r.namePLV2,
+       r.c_bpartner_location_id,
+       r.AD_Org_ID,
+       p_show_product_price_pi_flag AS show_product_price_pi_flag
+FROM result r
+ORDER BY r.bp_value,
+         r.productCategory,
+         r.value
+$$
+;
+

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/spi/impl/ESRCreaLogixStringParser.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/spi/impl/ESRCreaLogixStringParser.java
@@ -27,13 +27,14 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+
 
 import de.metas.banking.payment.IPaymentStringDataProvider;
 import de.metas.banking.payment.PaymentString;
 import de.metas.payment.api.impl.ESRPaymentStringDataProvider;
 import de.metas.payment.esr.api.impl.ESRBPBankAccountDAO;
 import lombok.NonNull;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Using this name for lack of better inspiration to differentiate from the {@link ESRRegularLineParser}.<br>

--- a/backend/de.metas.printing/de.metas.printing.base/pom.xml
+++ b/backend/de.metas.printing/de.metas.printing.base/pom.xml
@@ -53,8 +53,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.lowagie</groupId>
-			<artifactId>itext</artifactId>
+			<groupId>com.itextpdf</groupId>
+			<artifactId>itextpdf</artifactId>
 		</dependency>
 
 		<dependency>

--- a/backend/de.metas.procurement.base/src/main/java/de/metas/procurement/base/order/impl/PMMPricingAware_C_OrderLine.java
+++ b/backend/de.metas.procurement.base/src/main/java/de/metas/procurement/base/order/impl/PMMPricingAware_C_OrderLine.java
@@ -7,7 +7,8 @@ import java.util.Properties;
 import de.metas.bpartner.BPartnerId;
 import de.metas.product.ProductId;
 import org.adempiere.model.InterfaceWrapperHelper;
-import org.apache.commons.lang.NotImplementedException;
+
+import org.apache.commons.lang3.NotImplementedException;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_AttributeSetInstance;

--- a/backend/de.metas.report/de.metas.report.jasper.client/pom.xml
+++ b/backend/de.metas.report/de.metas.report.jasper.client/pom.xml
@@ -36,22 +36,12 @@
 					<groupId>org.apache.lucene</groupId>
 					<artifactId>lucene-queryparser</artifactId>
 				</exclusion>
-				<!-- exclude itext, because jasper 6.2.1 accidentally uses version 2.1.7.js5-SNAPSHOT -->
-				<exclusion>
-					<groupId>com.lowagie</groupId>
-					<artifactId>itext</artifactId>
-				</exclusion>
-				<!--  exclude commons-logging because jasperreports 6.2.1 uses 1.1.1, and we use 1.2 -->
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
 			</exclusions>
 		</dependency>
 
 		<dependency>
-			<groupId>com.lowagie</groupId>
-			<artifactId>itext</artifactId>
+			<groupId>com.itextpdf</groupId>
+			<artifactId>itextpdf</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>

--- a/backend/de.metas.report/de.metas.report.jasper.commons/pom.xml
+++ b/backend/de.metas.report/de.metas.report.jasper.commons/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <batik.version>1.9</batik.version>
+        <batik.version>1.17</batik.version>
         <barcode4j.version>2.1</barcode4j.version>
     </properties>
 

--- a/backend/de.metas.report/metasfresh-report-service/pom.xml
+++ b/backend/de.metas.report/metasfresh-report-service/pom.xml
@@ -49,7 +49,7 @@
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports</artifactId>
 			<exclusions>
-				<!-- 
+				<!--
 					Exclude lucene stuff from jasperreports because it's old.
 					Explicitly add them because they might be needed...but with versions implied by spring-boot.
 				-->

--- a/backend/de.metas.shipper.gateway.derkurier/src/main/java/de/metas/shipper/gateway/derkurier/misc/ParcelNumberGenerator.java
+++ b/backend/de.metas.shipper.gateway.derkurier/src/main/java/de/metas/shipper/gateway/derkurier/misc/ParcelNumberGenerator.java
@@ -1,6 +1,7 @@
 package de.metas.shipper.gateway.derkurier.misc;
 
-import org.apache.commons.lang.StringUtils;
+
+import org.apache.commons.lang3.StringUtils;
 import org.compiere.util.Env;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/misc/parent-pom/pom.xml
+++ b/misc/parent-pom/pom.xml
@@ -37,9 +37,9 @@
         <jackson.version>2.11.4</jackson.version>
         <amqp-client.version>5.10.0</amqp-client.version>
         
-        <jasperreports.version>6.7.0</jasperreports.version>
+        <jasperreports.version>6.21.2</jasperreports.version>
 
-        <itext.version>2.1.7.js6</itext.version>
+        <itextpdf.version>5.5.13.3</itextpdf.version>
 
         <!-- https://github.com/codecentric/spring-boot-admin -->
         <spring-boot-admin.version>2.3.1</spring-boot-admin.version>
@@ -225,9 +225,9 @@
             </dependency>
 
             <dependency>
-                <groupId>com.lowagie</groupId>
-                <artifactId>itext</artifactId>
-                <version>${itext.version}</version>
+                <groupId>com.itextpdf</groupId>
+                <artifactId>itextpdf</artifactId>
+                <version>${itextpdf.version}</version>
             </dependency>
 
             <!-- this also contains the javax.annotations -->


### PR DESCRIPTION
* fix external system startup (#17496) (#17703)

(cherry picked from commit f9e9dc2cbb8dbcd7bd170da031e2157205503940)



* Update Jasper to latest version `6.21.2`

* Resolving import conflicts after updating Jasper to latest version `6.21.2`

* Resolving import conflicts after updating Jasper to latest version `6.21.2`

* Update `itext` version: After release `2.1.7`, iText moved from the MPLicense to the AGPLicense. The groupId changed from `com.lowagie` to `com.itextpdf` and the artifactId from `itext` to `itextpdf`

* Remove jasper exclusions

* Remove jasper exclusions

* Update `Batik` Version

* Remove `TRUE` from `Order By`

* Remove `TRUE` from `Order By`

* Using `com.itextpdf.text.Rectangle`

---------