### PR TITLE
Discount/Write-off allocation posting shall always use invoice's currency rate

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -24,6 +24,7 @@ import de.metas.currency.CurrencyConversionContext;
 import de.metas.currency.ICurrencyBL;
 import de.metas.invoice.service.IInvoiceBL;
 import de.metas.money.CurrencyConversionTypeId;
+import de.metas.money.CurrencyId;
 import de.metas.money.Money;
 import de.metas.organization.OrgId;
 import de.metas.payment.PaymentId;
@@ -368,16 +369,12 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 		return creditMemoInvoice;
 	}
 
-	/**
-	 * Get Invoice C_Currency_ID
-	 *
-	 * @return 0 if no invoice -1 if not found
-	 */
-	public int getInvoiceC_Currency_ID()
+	@NonNull
+	public CurrencyId getInvoiceCurrencyId()
 	{
-		final I_C_Invoice invoice = getC_Invoice();
-		return invoice == null ? -1 : invoice.getC_Currency_ID();
-	}    // getInvoiceC_Currency_ID
+		final I_C_Invoice invoice = Check.assumeNotNull(getC_Invoice(), "invoice not null");
+		return CurrencyId.ofRepoId(invoice.getC_Currency_ID());
+	}
 
 	public OrgId getInvoiceOrgId()
 	{

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -819,7 +819,7 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		//
 		// Determine which currency conversion we shall use
 		final CurrencyConversionContext invoiceCurrencyConversionCtx;
-		if (line.getInvoiceC_Currency_ID() == as.getCurrencyId().getRepoId())
+		if (fact.isAccountingCurrency(line.getInvoiceCurrencyId()))
 		{
 			// use default context because the invoice is in accounting currency, so we shall have no currency gain/loss
 			invoiceCurrencyConversionCtx = null;

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -580,6 +580,19 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			isDiscountExpense = !isDiscountExpense;
 		}
 
+		//
+		// Determine which currency conversion we shall use
+		final CurrencyConversionContext invoiceCurrencyConversionCtx;
+		if (fact.isAccountingCurrency(line.getInvoiceCurrencyId()))
+		{
+			// use default context because the invoice is in accounting currency, so we shall have no currency gain/loss
+			invoiceCurrencyConversionCtx = null;
+		}
+		else
+		{
+			invoiceCurrencyConversionCtx = line.getInvoiceCurrencyConversionCtx();
+		}
+
 		final AmountSourceAndAcct.Builder discountAmtSourceAndAcct = AmountSourceAndAcct.builder();
 
 		final MInvoice invoicePO = LegacyAdapters.convertToPO(invoice);
@@ -590,12 +603,22 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			final FactLine fl;
 			if (isDiscountExpense)
 			{
-				fl = fact.createLine(line, getAccount(AccountType.DiscountExp, as), getCurrencyId(), discountAmt_CMAdjusted.toBigDecimal(), null);
+				fl = fact.createLine()
+						.setDocLine(line)
+						.setAccount(getAccount(AccountType.DiscountExp, as))
+						.setAmtSource(discountAmt_CMAdjusted.toBigDecimal(), null)
+						.setCurrencyConversionCtx(invoiceCurrencyConversionCtx)
+						.buildAndAdd();
 				discountAmtSourceAndAcct.addAmtSource(fl.getAmtSourceDr()).addAmtAcct(fl.getAmtAcctDr());
 			}
 			else
 			{
-				fl = fact.createLine(line, getAccount(AccountType.DiscountRev, as), getCurrencyId(), null, discountAmt_CMAdjusted.negate().toBigDecimal());
+				fl = fact.createLine()
+						.setDocLine(line)
+						.setAccount(getAccount(AccountType.DiscountRev, as))
+						.setAmtSource(null, discountAmt_CMAdjusted.negate().toBigDecimal())
+						.setCurrencyConversionCtx(invoiceCurrencyConversionCtx)
+						.buildAndAdd();
 				discountAmtSourceAndAcct.addAmtSource(fl.getAmtSourceCr()).addAmtAcct(fl.getAmtAcctCr());
 			}
 			if (payment != null)
@@ -649,14 +672,24 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 				//
 				// Create discount fact line
 				final Money taxDiscountAmt_CMAdjusted = isCreditMemoInvoice ? taxDiscountAmt.negate() : taxDiscountAmt;
-				FactLine fl = null;
+				final FactLine fl;
 				if (isDiscountExpense)
 				{
-					fl = fact.createLine(line, account, getCurrencyId(), taxDiscountAmt_CMAdjusted.toBigDecimal(), null);
+					fl = fact.createLine()
+							.setDocLine(line)
+							.setAccount(account)
+							.setAmtSource(taxDiscountAmt_CMAdjusted, null)
+							.setCurrencyConversionCtx(invoiceCurrencyConversionCtx)
+							.buildAndAdd();
 				}
 				else
 				{
-					fl = fact.createLine(line, account, getCurrencyId(), null, taxDiscountAmt_CMAdjusted.negate().toBigDecimal());
+					fl = fact.createLine()
+							.setDocLine(line)
+							.setAccount(account)
+							.setAmtSource(null, taxDiscountAmt_CMAdjusted.negate())
+							.setCurrencyConversionCtx(invoiceCurrencyConversionCtx)
+							.buildAndAdd();
 				}
 				if (fl != null)
 				{

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -791,6 +791,12 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			}
 		}
 
+		// IMPORTANT: we shall write off using the same currency rate as the invoice
+		if (!fact.isAccountingCurrency(line.getInvoiceCurrencyId()))
+		{
+			factLineBuilder.setCurrencyConversionCtx(line.getInvoiceCurrencyConversionCtx());
+		}
+
 		final FactLine factLine = factLineBuilder.buildAndAdd();
 
 		return factLine.getAmtSourceAndAcctDrOrCr();

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Fact.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Fact.java
@@ -256,6 +256,8 @@ public final class Fact
 
 	public CurrencyId getAcctCurrencyId() {return getAcctSchema().getCurrencyId();}
 
+	public boolean isAccountingCurrency(@NonNull final CurrencyId currencyId) {return getAcctSchema().isAccountingCurrency(currencyId);}
+
 	private AcctSchemaElementsMap getAcctSchemaElements()
 	{
 		return getAcctSchema().getSchemaElements();

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/acct/api/AcctSchema.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/acct/api/AcctSchema.java
@@ -120,4 +120,9 @@ public class AcctSchema
 	{
 		return getSchemaElements().getChartOfAccountsId();
 	}
+
+	public boolean isAccountingCurrency(@NonNull final CurrencyId currencyId)
+	{
+		return CurrencyId.equals(this.currencyId, currencyId);
+	}
 }


### PR DESCRIPTION
- **Fact.isAccountingCurrency**
- **DocLine_Allocation.getInvoiceCurrencyId (refactored from getInvoiceC_Currency_ID)**
- **Doc_AllocationHdr.createInvoiceWriteOffFacts - use invoice currency context**
- **Doc_AllocationHdr.createInvoiceDiscountFacts - use invoice currency context**
