### PR TITLE
StorageCostComputingMethod: no need to negate price

### DIFF
--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/modular/computing/purchasecontract/storagecost/StorageCostComputingMethod.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/modular/computing/purchasecontract/storagecost/StorageCostComputingMethod.java
@@ -121,7 +121,7 @@ public class StorageCostComputingMethod implements IComputingMethodHandler
 		final UomId stockUOMId = productBL.getStockUOMId(request.getProductId());
 		final ProductPrice priceWithStockUOM = ProductPrice.builder()
 				.productId(request.getProductId())
-				.money(storageCosts.negateIf(request.isCostInvoicingGroup()))
+				.money(storageCosts)
 				.uomId(stockUOMId)
 				.build();
 


### PR DESCRIPTION
since the logs are created with a negative price for cost invoicing group, StorageCostComputingMethod#compute doesn't have to negate again