### PR TITLE
Prevend DBuniqueConstraintException when updating invoice candidates …

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
@@ -41,8 +41,8 @@ import de.metas.money.Money;
 import de.metas.order.InvoiceRule;
 import de.metas.order.OrderLineId;
 import de.metas.organization.OrgId;
-import de.metas.payment.paymentterm.PaymentTermId;
 import de.metas.payment.paymentterm.PaymentTerm;
+import de.metas.payment.paymentterm.PaymentTermId;
 import de.metas.process.PInstanceId;
 import de.metas.product.ProductPrice;
 import de.metas.quantity.Quantity;
@@ -326,7 +326,7 @@ public interface IInvoiceCandBL extends ISingletonService
 	/**
 	 * Update the POReference of a candidate based on the POReference from the order.
 	 * <p>
-	 * For both sales and purchase orders (purchases added as of <a href="https://github.com/metasfresh/metasfresh/issues/292">...</a>).
+	 * For both sales and purchase orders (purchases added as of <a href="https://github.com/metasfresh/metasfresh/issues/292">https://github.com/metasfresh/metasfresh/issues/292</a>).
 	 * <p>
 	 * Candidate will not be saved.
 	 */
@@ -426,6 +426,12 @@ public interface IInvoiceCandBL extends ISingletonService
 	boolean isCreatedByInvoicingJustNow(org.compiere.model.I_C_Invoice invoiceRecord);
 
 	Set<InvoiceCandidateId> voidAndReturnInvoiceCandIds(org.compiere.model.I_C_Invoice invoice);
+
+	/**
+	 * Wait until the given ICs were validated - usually by the async-processor. In unit-test-mode, update them directly. 
+	 *
+	 */
+	void ensureICsAreUpdated(@NonNull InvoiceCandidateIdsSelection invoiceCandidateIdsSelection);
 
 	@NonNull
 	InvoiceCandidatesAmtSelectionSummary calculateAmtSelectionSummary(@Nullable String extraWhereClause);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandDAO.java
@@ -110,7 +110,7 @@ public interface IInvoiceCandDAO extends ISingletonService
 
 	boolean hasInvalidInvoiceCandidates(@NonNull Collection<InvoiceCandidateId> invoiceCandidateIds);
 
-	boolean hasInvalidInvoiceCandidatesForSelection(@NonNull PInstanceId selectionId);
+	boolean hasInvalidInvoiceCandidatesForSelection(@NonNull InvoiceCandidateIdsSelection selectionId);
 
 	List<I_C_InvoiceLine> retrieveIlForIc(I_C_Invoice_Candidate invoiceCand);
 
@@ -245,8 +245,8 @@ public interface IInvoiceCandDAO extends ISingletonService
 	// /**
 	//  * Updates the {@link I_C_Invoice_Candidate#COLUMNNAME_C_PaymentTerm_ID} of those candidates that don't have a payment term ID.
 	//  * The ID those ICs are updated with is taken from the selected IC with the smallest {@code C_Invoice_Candidate_ID} that has a {@code C_PaymentTerm_ID}.
-	//  *
-	//  * task https://github.com/metasfresh/metasfresh/issues/3809
+	//  * <p>
+	//  * task <a href="https://github.com/metasfresh/metasfresh/issues/3809">https://github.com/metasfresh/metasfresh/issues/3809</a>
 	//  */
 	// void updateMissingPaymentTermIds(PInstanceId selectionId);
 
@@ -284,7 +284,7 @@ public interface IInvoiceCandDAO extends ISingletonService
 	 * <li>belong to an {@code M_InOut} record that is active and completed or closed (i.e. <b>not</b> reversed)</li>
 	 * </ul>
 	 *
-	 * task https://github.com/metasfresh/metasfresh/issues/1566
+	 * task <a href="https://github.com/metasfresh/metasfresh/issues/1566">https://github.com/metasfresh/metasfresh/issues/1566</a>
 	 */
 	List<I_C_InvoiceCandidate_InOutLine> retrieveICIOLAssociationsExclRE(InvoiceCandidateId invoiceCandidateId);
 
@@ -292,8 +292,8 @@ public interface IInvoiceCandDAO extends ISingletonService
 
 	/**
 	 * Returns the number of {@link I_C_InvoiceCandidate_InOutLine}s for a given invoiceCandidateId regardless of {@link I_M_InOut} status
-	 *
-	 * task https://github.com/metasfresh/metasfresh/issues/13376
+	 * <p>
+	 * task <a href="https://github.com/metasfresh/metasfresh/issues/13376">https://github.com/metasfresh/metasfresh/issues/13376</a>
 	 */
 	int countICIOLAssociations(final InvoiceCandidateId invoiceCandidateId);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/InvoiceCandidateIdsSelection.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/InvoiceCandidateIdsSelection.java
@@ -65,6 +65,8 @@ public final class InvoiceCandidateIdsSelection
 		this.ids = ids;
 	}
 
+	public boolean isEmpty() {return selectionId == null && (ids == null || ids.isEmpty());}
+
 	public boolean isDatabaseSelection()
 	{
 		return selectionId != null;
@@ -74,9 +76,9 @@ public final class InvoiceCandidateIdsSelection
 	{
 		void empty();
 
-		void fixedSet(ImmutableSet<InvoiceCandidateId> ids);
+		void fixedSet(@NonNull ImmutableSet<InvoiceCandidateId> ids);
 
-		void selectionId(PInstanceId selectionId);
+		void selectionId(@NonNull PInstanceId selectionId);
 	}
 
 	public void apply(@NonNull final CaseMapper mapper)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/InvoiceCandidate_Constants.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/InvoiceCandidate_Constants.java
@@ -1,8 +1,7 @@
 package de.metas.invoicecandidate.api;
 
-import org.slf4j.Logger;
-
 import de.metas.logging.LogManager;
+import org.slf4j.Logger;
 
 /*
  * #%L
@@ -30,7 +29,7 @@ public class InvoiceCandidate_Constants
 {
 	public static final String LOGGERNAME_ROOT = InvoiceCandidate_Constants.class.getPackage().getName();
 
-	public static final Logger getLogger(Class<?> clazz)
+	public static Logger getLogger(final Class<?> clazz)
 	{
 		return LogManager.getLogger(clazz);
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -48,6 +48,7 @@ import de.metas.bpartner.service.IBPartnerBL;
 import de.metas.bpartner.service.IBPartnerDAO;
 import de.metas.cache.CCache;
 import de.metas.common.util.CoalesceUtil;
+import de.metas.common.util.TryAndWaitUtil;
 import de.metas.common.util.pair.IPair;
 import de.metas.common.util.pair.ImmutablePair;
 import de.metas.common.util.time.SystemTime;
@@ -76,7 +77,6 @@ import de.metas.invoice.matchinv.service.MatchInvoiceService;
 import de.metas.invoice.service.IInvoiceBL;
 import de.metas.invoice.service.IInvoiceDAO;
 import de.metas.invoice.service.InvoiceScheduleRepository;
-import de.metas.invoice.service.impl.InvoiceDAO;
 import de.metas.invoicecandidate.InvoiceCandidateId;
 import de.metas.invoicecandidate.InvoiceCandidateIds;
 import de.metas.invoicecandidate.api.IAggregationBL;
@@ -164,11 +164,13 @@ import org.adempiere.ad.trx.api.OnTrxMissingPolicy;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.model.PlainContextAware;
 import org.adempiere.service.ClientId;
 import org.adempiere.service.ISysConfigBL;
 import org.adempiere.util.concurrent.AutoClosableThreadLocalBoolean;
 import org.adempiere.util.lang.IAutoCloseable;
 import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.Adempiere;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_AD_Note;
 import org.compiere.model.I_C_BPartner;
@@ -521,7 +523,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 	public void set_QtyInvoiced_NetAmtInvoiced_Aggregation(final Properties ctx, final I_C_Invoice_Candidate ic)
 	{
 		Check.assume(ic.isManual(), ic + " has IsManual='Y'");
-		set_QtyInvoiced_NetAmtInvoiced_Aggregation0(ctx, ic);
+		set_QtyInvoiced_NetAmtInvoiced_Aggregation0(ic);
 	}
 
 	/**
@@ -529,7 +531,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 	 * <p>
 	 * <b>Also invokes {@link #updateProcessedFlag(I_C_Invoice_Candidate)}</b>
 	 */
-	void set_QtyInvoiced_NetAmtInvoiced_Aggregation0(final Properties ctx, @NonNull final I_C_Invoice_Candidate ic)
+	void set_QtyInvoiced_NetAmtInvoiced_Aggregation0(@NonNull final I_C_Invoice_Candidate ic)
 	{
 		if (ic.isToClear())
 		{
@@ -1189,7 +1191,8 @@ public class InvoiceCandBL implements IInvoiceCandBL
 				.setFrom(ic);
 
 		splitCand.setC_Invoice_Candidate_Agg_ID(ic.getC_Invoice_Candidate_Agg_ID());
-		aggregationBL.setHeaderAggregationKey(splitCand);
+		// this shall be done later by IInvoiceCandInvalidUpdater. // Otherwise we might have concurrent access to I_C_Invoice_Candidate_HeaderAggregation and DBUniqueConstraintExceptions
+		//aggregationBL.setHeaderAggregationKey(splitCand);
 		splitCand.setLineAggregationKey(null);
 		splitCand.setLineAggregationKey_Suffix(ic.getLineAggregationKey_Suffix());
 		splitCand.setDescription(ic.getDescription());
@@ -2577,17 +2580,14 @@ public class InvoiceCandBL implements IInvoiceCandBL
 			return ImmutableSet.of();
 		}
 
-		final Properties ctx = InterfaceWrapperHelper.getCtx(invoice);
 		final String trxName = InterfaceWrapperHelper.getTrxName(invoice);
 
 		// void invoice
 		Services.get(IDocumentBL.class).processEx(invoice, IDocument.ACTION_Reverse_Correct, IDocument.STATUS_Reversed);
 
 		// update invalids
-		invoiceCandBL.updateInvalid()
-				.setContext(ctx, trxName)
-				.setOnlyInvoiceCandidateIds(InvoiceCandidateIdsSelection.extractFixedIdsSet(invoiceCands))
-				.update();
+		final InvoiceCandidateIdsSelection invoiceCandidateIdsSelection = InvoiceCandidateIdsSelection.extractFixedIdsSet(invoiceCands);
+		ensureICsAreUpdated(invoiceCandidateIdsSelection);
 
 		for (final I_C_Invoice_Candidate ic : invoiceCands)
 		{
@@ -2613,6 +2613,51 @@ public class InvoiceCandBL implements IInvoiceCandBL
 				.collect(ImmutableSet.toImmutableSet());
 	}
 
+	@Override
+	public void ensureICsAreUpdated(@NonNull final InvoiceCandidateIdsSelection invoiceCandidateIdsSelection)
+	{
+		if (Adempiere.isUnitTestMode())
+		{
+			// In unit-test-mode we don't have the app-server running to do this for us, so we need to do it here.
+			// Updating invalid candidates to make sure that they e.g. have the correct header aggregation key and thus the correct ordering
+			// also, we need to make sure that each ICs was updated at least once, so that it has a QtyToInvoice > 0 (task 08343)
+			updateInvalid()
+					.setContext(PlainContextAware.newWithThreadInheritedTrx())
+					.setTaggedWithAnyTag()
+					.setOnlyInvoiceCandidateIds(invoiceCandidateIdsSelection)
+					.update();
+		}
+		else
+		{
+			// in later code-versions this might also be achieved by using AsyncBatchService.executeBatch(..), but here we just wait...
+			waitForInvoiceCandidatesUpdated(invoiceCandidateIdsSelection);
+		}
+	}
+
+	private void waitForInvoiceCandidatesUpdated(@NonNull final InvoiceCandidateIdsSelection invoiceCandidateIdsSelection)
+	{
+		Loggables.withLogger(logger, Level.DEBUG).addLog("InvoiceCandidateEnqueuer - Start waiting for ICs to be updated async-queue; Selection={}",invoiceCandidateIdsSelection);
+		try
+		{
+			TryAndWaitUtil.tryAndWait(
+					3600 /*let's wait a full hour*/,
+					1000 /*check once a second*/,
+					() -> !invoiceCandDAO.hasInvalidInvoiceCandidatesForSelection(invoiceCandidateIdsSelection),
+					null);
+		}
+		catch (final InterruptedException e)
+		{
+			throw AdempiereException.wrapIfNeeded(e)
+					.appendParametersToMessage()
+					.setParameter("InvoiceCandidateIdsSelection (ICs-selection)", invoiceCandidateIdsSelection);
+		}
+		finally
+		{
+			Loggables.withLogger(logger, Level.DEBUG).addLog("InvoiceCandidateEnqueuer - Stop waiting for ICs to be updated async-queue; Selection={}",invoiceCandidateIdsSelection);
+		}
+	}
+	
+	
 	// TODO: would be nice to use de.metas.ui.web.view.descriptor.SqlAndParams but that is in module webui-api, and here we don't have access to it
 	@Override
 	public @NonNull InvoiceCandidatesAmtSelectionSummary calculateAmtSelectionSummary(@Nullable final String extraWhereClause)
@@ -2639,10 +2684,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 	{
 		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(candidates, Spliterator.ORDERED), false)
 				.filter(c -> !processedRecords.contains(c.getC_Invoice_Candidate_ID()))
-				.map(ic -> {
-					set_DateToInvoice_DefaultImpl(ic);
-					return ic;
-				})
+				.peek(this::set_DateToInvoice_DefaultImpl)
 				.collect(Collectors.toSet());
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
@@ -67,6 +67,7 @@ import de.metas.util.Loggables;
 import de.metas.util.Services;
 import de.metas.util.collections.IdentityHashSet;
 import de.metas.workflow.api.IWFExecutionFactory;
+import lombok.Getter;
 import lombok.NonNull;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.trx.api.ITrxListenerManager.TrxEventTiming;
@@ -396,7 +397,7 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 				invoice.setDateAcct(TimeUtil.asTimestamp(invoiceHeader.getDateAcct(), timeZone)); // 03905: also updating DateAcct
 
 				invoice.setM_PriceList_ID(invoiceHeader.getM_PriceList_ID()); // #367: get M_PriceList_ID directly from invoiceHeader.
-				Set<String> externalIds = invoiceHeader.getAllInvoiceCandidates().stream().map(I_C_Invoice_Candidate::getExternalHeaderId).filter(Objects::nonNull).collect(Collectors.toSet());
+				final Set<String> externalIds = invoiceHeader.getAllInvoiceCandidates().stream().map(I_C_Invoice_Candidate::getExternalHeaderId).filter(Objects::nonNull).collect(Collectors.toSet());
 				Check.assume(externalIds.size() <= 1, "Unexpectedly found multiple externalId candidates for the same invoice: {}", externalIds);
 				invoice.setExternalId(externalIds.stream().findFirst().orElse(null));
 			}
@@ -579,6 +580,7 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 	// NOTE: not static because we share the services
 	private class DefaultInvoiceLineGeneratorRunnable implements TrxRunnable2
 	{
+		@Getter
 		private final List<I_C_InvoiceLine> createdLines;
 		private final I_C_Invoice invoice;
 		private final List<I_C_Invoice_Candidate> errorCandidates;
@@ -898,11 +900,6 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 				errorException[0] = null;
 			}
 		}
-
-		public List<I_C_InvoiceLine> getCreatedLines()
-		{
-			return createdLines;
-		}
 	}
 
 	/**
@@ -1083,7 +1080,7 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 					userInChargeId = USERINCHARGE_NA;
 				}
 
-				List<I_C_Invoice_Candidate> candsOfUserId = userId2cands.computeIfAbsent(userInChargeId, k -> new ArrayList<>());
+				final List<I_C_Invoice_Candidate> candsOfUserId = userId2cands.computeIfAbsent(userInChargeId, k -> new ArrayList<>());
 				candsOfUserId.add(ic);
 			}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandDAO.java
@@ -73,6 +73,7 @@ import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.exceptions.DBException;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.model.PlainContextAware;
 import org.adempiere.service.ClientId;
 import org.adempiere.util.lang.IContextAware;
 import org.adempiere.util.lang.impl.TableRecordReference;
@@ -99,7 +100,6 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1080,13 +1080,13 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 				}
 
 				@Override
-				public void fixedSet(final ImmutableSet<InvoiceCandidateId> ids)
+				public void fixedSet(final @NonNull ImmutableSet<InvoiceCandidateId> ids)
 				{
 					queryBuilder.addInArrayOrAllFilter(I_C_Invoice_Candidate_Recompute.COLUMN_C_Invoice_Candidate_ID, ids);
 				}
 
 				@Override
-				public void selectionId(final PInstanceId selectionId)
+				public void selectionId(final @NonNull PInstanceId selectionId)
 				{
 					queryBuilder.addInSubQueryFilter(
 							I_C_Invoice_Candidate_Recompute.COLUMNNAME_C_Invoice_Candidate_ID,
@@ -1225,10 +1225,40 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 	}
 
 	@Override
-	public final boolean hasInvalidInvoiceCandidatesForSelection(@NonNull final PInstanceId selectionId)
+	public final boolean hasInvalidInvoiceCandidatesForSelection(@NonNull final InvoiceCandidateIdsSelection invoiceCandidateIdsSelection)
 	{
-		return queryBL.createQueryBuilder(I_C_Invoice_Candidate.class)
-				.setOnlySelection(selectionId)
+		if(invoiceCandidateIdsSelection.isEmpty())
+		{
+			return false;
+		}
+		
+		// Without the newOutOfTrx-context, we had InvoiceCandBL.waitForInvoiceCandidatesUpdated consistently hit the 1hr-timeout on one instance,
+		// although multiple UpdateInvalidInvoiceCandidatesWorkpackageProcessors executed successfully during that hour.
+		final IQueryBuilder<I_C_Invoice_Candidate> queryBuilder = queryBL.createQueryBuilder(I_C_Invoice_Candidate.class, PlainContextAware.newOutOfTrx());
+
+		// apply the invoiceCandidateIdsSelection to our queryBuilder
+		invoiceCandidateIdsSelection.apply(new InvoiceCandidateIdsSelection.CaseMapper()
+		{
+			@Override
+			public void empty()
+			{
+				queryBuilder.filter(ConstantQueryFilter.of(false));
+			}
+
+			@Override
+			public void fixedSet(@NonNull final ImmutableSet<InvoiceCandidateId> ids)
+			{
+				queryBuilder.addInArrayFilter(I_C_Invoice_Candidate.COLUMN_C_Invoice_Candidate_ID, ids);
+			}
+
+			@Override
+			public void selectionId(@NonNull final PInstanceId selectionId)
+			{
+				queryBuilder.setOnlySelection(selectionId);
+			}
+		});
+
+		return queryBuilder
 				.andCollectChildren(I_C_Invoice_Candidate_Recompute.COLUMN_C_Invoice_Candidate_ID)
 				.create()
 				.anyMatch();
@@ -1685,7 +1715,7 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 		// Only filter invoice candidates of the organizations this role has access to
 		final IUserRolePermissions userRolePermissions = Env.getUserRolePermissions(ctx);
 
-		final StringBuilder defaultFilter = new StringBuilder("");
+		final StringBuilder defaultFilter = new StringBuilder();
 
 		final String orgIDsAsString = userRolePermissions.getAD_Org_IDs_AsString();
 
@@ -1717,7 +1747,7 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 	public Set<String> retrieveOrderDocumentNosForIncompleteGroupsFromSelection(final PInstanceId adPInstanceId)
 	{
 		final String sql = "SELECT * FROM C_Invoice_Candidate_SelectionIncompleteGroups WHERE AD_PInstance_ID=?";
-		final List<Object> sqlParams = Arrays.asList(adPInstanceId);
+		final List<Object> sqlParams = ImmutableList.of(adPInstanceId);
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
 		try

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandInvalidUpdater.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandInvalidUpdater.java
@@ -368,7 +368,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 		// update BPartner data from 'ic'
 		invoiceCandidateHandlerBL.setBPartnerData(icRecord);
 
-		invoiceCandBL.set_QtyInvoiced_NetAmtInvoiced_Aggregation0(ctx, icRecord);
+		invoiceCandBL.set_QtyInvoiced_NetAmtInvoiced_Aggregation0(icRecord);
 
 		// 06539 add qty overdelivery to qty delivered
 		final org.compiere.model.I_C_OrderLine ol = icRecord.getC_OrderLine();
@@ -451,7 +451,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 
 			Loggables.withLogger(logger, Level.DEBUG)
 					.addLog(MessageFormat.format("Populate icIols_IDs={0} for C_Invoice_Candidate_ID={1}",
-												 iciol.getC_InvoiceCandidate_InOutLine_ID()), ic.getC_Invoice_Candidate_ID());
+												 iciol.getC_InvoiceCandidate_InOutLine_ID(), ic.getC_Invoice_Candidate_ID()));
 
 			Services.get(IInvoiceCandBL.class).updateICIOLAssociationFromIOL(iciol, inOutLine);
 		}
@@ -544,7 +544,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 	}
 
 	@Override
-	public IInvoiceCandInvalidUpdater setOnlyInvoiceCandidateIds(final InvoiceCandidateIdsSelection onlyInvoiceCandidateIds)
+	public IInvoiceCandInvalidUpdater setOnlyInvoiceCandidateIds(@NonNull final InvoiceCandidateIdsSelection onlyInvoiceCandidateIds)
 	{
 		assertNotExecuted();
 		icTagger.setOnlyInvoiceCandidateIds(onlyInvoiceCandidateIds);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
@@ -5,7 +5,6 @@ import de.metas.async.model.I_C_Async_Batch;
 import de.metas.async.spi.IWorkpackagePrioStrategy;
 import de.metas.async.spi.impl.ConstantWorkpackagePrio;
 import de.metas.async.spi.impl.SizeBasedWorkpackagePrio;
-import de.metas.common.util.TryAndWaitUtil;
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.IMsgBL;
 import de.metas.invoicecandidate.InvoiceCandidateId;
@@ -31,7 +30,6 @@ import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.PlainContextAware;
 import org.adempiere.service.ISysConfigBL;
-import org.compiere.Adempiere;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.slf4j.MDC.MDCCloseable;
@@ -101,12 +99,12 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 
 		// make sure that we don't have a ton of ICs being updated by the app-Server while we do our own updates over here
 		// otherwise, we can easly run into DB-deadloacks
-		ensureICsAreUpdated(pInstanceId);
+		invoiceCandBL.ensureICsAreUpdated(InvoiceCandidateIdsSelection.ofSelectionId(pInstanceId));
 
 		// Prepare them in a dedicated trx so that the update-WP-processor "sees" them
 		trxManager.runInNewTrx(() -> updateSelectionBeforeEnqueueing(pInstanceId));
 
-		ensureICsAreUpdated(pInstanceId);
+		invoiceCandBL.ensureICsAreUpdated(InvoiceCandidateIdsSelection.ofSelectionId(pInstanceId));
 
 		//
 		// Make sure there are no changes in amounts or relevant fields (if that is required)
@@ -225,49 +223,6 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 				workpackageQueueSizeBeforeEnqueueing,
 				totalNetAmtToInvoiceChecksum.getValue(),
 				icLock);
-	}
-
-	private void ensureICsAreUpdated(final @NonNull PInstanceId pinstanceId)
-	{
-		if (Adempiere.isUnitTestMode())
-		{
-			// In unit-test-mode we don't have the app-server running to do this for us, so we need to do it here.
-			// Updating invalid candidates to make sure that they e.g. have the correct header aggregation key and thus the correct ordering
-			// also, we need to make sure that each ICs was updated at least once, so that it has a QtyToInvoice > 0 (task 08343)
-			invoiceCandBL.updateInvalid()
-					.setContext(getCtx(), ITrx.TRXNAME_ThreadInherited)
-					.setTaggedWithAnyTag()
-					.setOnlyInvoiceCandidateIds(InvoiceCandidateIdsSelection.ofSelectionId(pinstanceId))
-					.update();
-		}
-		else
-		{
-			// in later code-versions this might also be achieved by using AsyncBatchService.executeBatch(..), but here we just wait...
-			waitForInvoiceCandidatesUpdated(pinstanceId);
-		}
-	}
-
-	private void waitForInvoiceCandidatesUpdated(final @NonNull PInstanceId pinstanceId)
-	{
-		Loggables.addLog("waitForInvoiceCandidatesUpdated - Start waiting for the IC-selection with AD_PInstance_ID={} to be updated.", pinstanceId.getRepoId());
-		try
-		{
-			TryAndWaitUtil.tryAndWait(
-					3600 /*let's wait a full hour*/,
-					1000 /*check once a second*/,
-					() -> !invoiceCandDAO.hasInvalidInvoiceCandidatesForSelection(pinstanceId),
-					null);
-		}
-		catch (final InterruptedException e)
-		{
-			throw AdempiereException.wrapIfNeeded(e)
-					.appendParametersToMessage()
-					.setParameter("AD_PInstance_ID (ICs-selection)", pinstanceId.getRepoId());
-		}
-		finally
-		{
-			Loggables.addLog("waitForInvoiceCandidatesUpdated - Done waiting for the IC-selection with AD_PInstance_ID={} to be updated.", pinstanceId.getRepoId());
-		}
 	}
 
 	/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/UpdateInvalidInvoiceCandidatesWorkpackageProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/UpdateInvalidInvoiceCandidatesWorkpackageProcessor.java
@@ -54,7 +54,7 @@ public class UpdateInvalidInvoiceCandidatesWorkpackageProcessor extends Workpack
 {
 	/**
 	 * Schedule a new "update invalid invoice candidates" run.
-	 *
+	 * <p>
 	 * NOTE: the workpackages are not created right away, but the models are collected per database transaction and a workpackage is enqueued when the transaction is committed.
 	 */
 	public static void schedule(@NonNull final IInvoiceCandUpdateSchedulerRequest request)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_Invoice_Candidate.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_Invoice_Candidate.java
@@ -6,7 +6,6 @@ import de.metas.bpartner.service.IBPartnerStatisticsUpdater;
 import de.metas.bpartner.service.IBPartnerStatisticsUpdater.BPartnerStatisticsUpdateRequest;
 import de.metas.cache.model.impl.TableRecordCacheLocal;
 import de.metas.document.location.IDocumentLocationBL;
-import de.metas.invoicecandidate.api.IAggregationBL;
 import de.metas.invoicecandidate.api.IInvoiceCandBL;
 import de.metas.invoicecandidate.api.IInvoiceCandDAO;
 import de.metas.invoicecandidate.api.IInvoiceCandidateHandlerBL;
@@ -54,7 +53,6 @@ public class C_Invoice_Candidate
 
 	private final IInvoiceCandidateHandlerBL invoiceCandidateHandlerBL = Services.get(IInvoiceCandidateHandlerBL.class);
 	private final IInvoiceCandDAO invoiceCandDAO = Services.get(IInvoiceCandDAO.class);
-	private final IAggregationBL aggregationBL = Services.get(IAggregationBL.class);
 
 	private final AttachmentEntryService attachmentEntryService;
 	private final InvoiceCandidateGroupCompensationChangesHandler groupChangesHandler;
@@ -223,8 +221,6 @@ public class C_Invoice_Candidate
 
 	/**
 	 * For new invoice candidates, this method sets the <code>C_Order_ID</code>, if the referenced record is either a <code>C_OrderLine_ID</code> or a <code>M_InOutLine_ID</code>.
-	 * <p>
-	 * @implSpec <a href="http://dewiki908/mediawiki/index.php/07242_Error_creating_invoice_from_InOutLine-IC_%28104224060697%29">task</a>
 	 */
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW })
 	public void updateOrderId(final I_C_Invoice_Candidate ic)
@@ -354,8 +350,6 @@ public class C_Invoice_Candidate
 
 	/**
 	 * After an invoice candidate was deleted, schedule the recreation of it.
-	 * <p>
-	 * @implSpec <a href="http://dewiki908/mediawiki/index.php/09531_C_Invoice_candidate%3A_deleted_ICs_are_not_coming_back_%28107964479343%29">task</a>
 	 */
 	@ModelChange(timings = ModelValidator.TYPE_AFTER_DELETE)
 	public void scheduleRecreate(final I_C_Invoice_Candidate ic)
@@ -425,11 +419,13 @@ public class C_Invoice_Candidate
 			return; // nothing to do
 		}
 
-		if (InterfaceWrapperHelper.isNew(ic) || ic.getC_Invoice_Candidate_ID() <= 0)
-		{
-			aggregationBL.setHeaderAggregationKey(ic);
-			return;
-		}
+		// This shall be done later by IInvoiceCandInvalidUpdater. 
+		// Otherwise we might have concurrent access to I_C_Invoice_Candidate_HeaderAggregation and DBUniqueConstraintExceptions
+		// if (InterfaceWrapperHelper.isNew(ic) || ic.getC_Invoice_Candidate_ID() <= 0)
+		// {
+		// 	aggregationBL.setHeaderAggregationKey(ic);
+		// 	return;
+		// }
 
 		invoiceCandDAO.invalidateCand(ic);
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/InvoiceCandidateWithInOutLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/InvoiceCandidateWithInOutLine.java
@@ -20,6 +20,7 @@ import lombok.NonNull;
 import org.adempiere.util.lang.ObjectUtils;
 import org.compiere.model.I_M_InOutLine;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.Set;
 
@@ -79,18 +80,14 @@ public final class InvoiceCandidateWithInOutLine
 	}
 
 	/** @return shipment/receipt line; could be <code>null</code> */
+	@Nullable
 	public I_M_InOutLine getM_InOutLine()
 	{
 		if (iciol == null)
 		{
 			return null;
 		}
-		final I_M_InOutLine inOutLine = iciol.getM_InOutLine();
-		if (inOutLine == null)
-		{
-			return null;
-		}
-		return inOutLine;
+		return iciol.getM_InOutLine();
 	}
 
 	public StockQtyAndUOMQty getQtysAlreadyInvoiced()

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/InvoiceCandidateIdsSelectionTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/InvoiceCandidateIdsSelectionTest.java
@@ -1,0 +1,18 @@
+package de.metas.invoicecandidate.api;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.invoicecandidate.InvoiceCandidateId;
+import de.metas.process.PInstanceId;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class InvoiceCandidateIdsSelectionTest
+{
+	@Test
+	void isEmpty()
+	{
+		Assertions.assertThat(InvoiceCandidateIdsSelection.ofIdsSet(ImmutableSet.of()).isEmpty()).isTrue();
+		Assertions.assertThat(InvoiceCandidateIdsSelection.ofIdsSet(ImmutableSet.of(InvoiceCandidateId.ofRepoId(1))).isEmpty()).isFalse();
+		Assertions.assertThat(InvoiceCandidateIdsSelection.ofSelectionId(PInstanceId.ofRepoId(1)).isEmpty()).isFalse();
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/impl/PlainAggregationDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/impl/PlainAggregationDAO.java
@@ -22,13 +22,12 @@ package de.metas.invoicecandidate.api.impl;
  * #L%
  */
 
-
-import java.util.List;
-
-import org.adempiere.ad.wrapper.POJOLookupMap;
-
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate_Agg;
+import lombok.NonNull;
+import org.adempiere.ad.wrapper.POJOLookupMap;
+
+import java.util.List;
 
 public class PlainAggregationDAO extends AggregationDAO
 {
@@ -37,7 +36,7 @@ public class PlainAggregationDAO extends AggregationDAO
 	private I_C_Invoice_Candidate_Agg defaultAgg = null;
 
 	@Override
-	public I_C_Invoice_Candidate_Agg retrieveAggregate(I_C_Invoice_Candidate ic)
+	public I_C_Invoice_Candidate_Agg retrieveAggregate(@NonNull I_C_Invoice_Candidate ic)
 	{
 		if (defaultAgg != null)
 		{


### PR DESCRIPTION
…(#18192)

* Reduce concurrent access to I_C_Invoice_Candidate_HeaderAggregation and if it still happens and causes a DBUniqueConstraintException, then retry
* This includes a port of some parts of https://github.com/metasfresh/metasfresh/commit/e0ed808fbc965829a358ffcadfb44640c78c8028#diff-5bd9c56cac93b21f5ac696fde6aaad8c4b087ef8780a707ab1cedfa5f68c483f
* InvoiceCandDAO.hasInvalidInvoiceCandidatesForSelection: shortcut in case the selection is empty

---------

Co-authored-by: Teodor Sarca <teo.sarca@metasfresh.com>
(cherry picked from commit 389c9c4bc089ea4ba5fec2f19300a64e853e1b1b)

solved Conflicts:
	backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
	backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandDAO.java
	backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationDAO.java
	backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
	backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
	backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandInvalidUpdater.java
	backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
	backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_Invoice_Candidate.java
	backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/InvoiceCandidateWithInOutLine.java
	backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/impl/PlainInvoiceCandDAO.java