### PR TITLE
Prevend DBuniqueConstraintException when updating invoice candidates …

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
@@ -43,7 +43,6 @@ import de.metas.organization.OrgId;
 import de.metas.process.PInstanceId;
 import de.metas.product.ProductPrice;
 import de.metas.quantity.Quantity;
-import de.metas.quantity.StockQtyAndUOMQty;
 import de.metas.tax.api.Tax;
 import de.metas.util.ISingletonService;
 import de.metas.util.OptionalBoolean;
@@ -229,7 +228,6 @@ public interface IInvoiceCandBL extends ISingletonService
 	 * <p>
 	 * IMPORTANT: as of now we suppose this to be the only way of creating ilas! Please don't create them yourself somewhere in the code.
 	 *
-	 * @param note may be null or empty. Use it to provide a user-friendly note that can be displayed to the customer admin/user
 	 * @return returns the invoiceLine allocation that was created or updated never returns <code>null</code>
 	 */
 	I_C_Invoice_Line_Alloc createUpdateIla(InvoiceCandidateAllocCreateRequest request);
@@ -314,7 +312,7 @@ public interface IInvoiceCandBL extends ISingletonService
 	/**
 	 * Update the POReference of a candidate based on the POReference from the order.
 	 * <p>
-	 * For both sales and purchase orders (purchases added as of https://github.com/metasfresh/metasfresh/issues/292).
+	 * For both sales and purchase orders (purchases added as of <a href="https://github.com/metasfresh/metasfresh/issues/292">https://github.com/metasfresh/metasfresh/issues/292</a>).
 	 * <p>
 	 * Candidate will not be saved.
 	 */
@@ -410,6 +408,12 @@ public interface IInvoiceCandBL extends ISingletonService
 	boolean isCreatedByInvoicingJustNow(org.compiere.model.I_C_Invoice invoiceRecord);
 
 	Set<InvoiceCandidateId> voidAndReturnInvoiceCandIds(org.compiere.model.I_C_Invoice invoice);
+
+	/**
+	 * Wait until the given ICs were validated - usually by the async-processor. In unit-test-mode, update them directly. 
+	 *
+	 */
+	void ensureICsAreUpdated(@NonNull InvoiceCandidateIdsSelection invoiceCandidateIdsSelection);
 
 	@NonNull
 	InvoiceCandidatesAmtSelectionSummary calculateAmtSelectionSummary(@Nullable String extraWhereClause);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandDAO.java
@@ -107,7 +107,7 @@ public interface IInvoiceCandDAO extends ISingletonService
 
 	boolean hasInvalidInvoiceCandidatesForTag(InvoiceCandRecomputeTag tag);
 
-	boolean hasInvalidInvoiceCandidatesForSelection(@NonNull PInstanceId selectionId);
+	boolean hasInvalidInvoiceCandidatesForSelection(@NonNull InvoiceCandidateIdsSelection selectionId);
 
 	List<I_C_InvoiceLine> retrieveIlForIc(I_C_Invoice_Candidate invoiceCand);
 
@@ -242,8 +242,8 @@ public interface IInvoiceCandDAO extends ISingletonService
 	/**
 	 * Updates the {@link I_C_Invoice_Candidate#COLUMNNAME_C_PaymentTerm_ID} of those candidates that don't have a payment term ID.
 	 * The ID those ICs are updated with is taken from the selected IC with the smallest {@code C_Invoice_Candidate_ID} that has a {@code C_PaymentTerm_ID}.
-	 *
-	 * task https://github.com/metasfresh/metasfresh/issues/3809
+	 * <p>
+	 * task <a href="https://github.com/metasfresh/metasfresh/issues/3809">https://github.com/metasfresh/metasfresh/issues/3809</a>
 	 */
 	void updateMissingPaymentTermIds(PInstanceId selectionId);
 
@@ -281,14 +281,14 @@ public interface IInvoiceCandDAO extends ISingletonService
 	 * <li>belong to an {@code M_InOut} record that is active and completed or closed (i.e. <b>not</b> reversed)</li>
 	 * </ul>
 	 *
-	 * task https://github.com/metasfresh/metasfresh/issues/1566
+	 * task <a href="https://github.com/metasfresh/metasfresh/issues/1566">https://github.com/metasfresh/metasfresh/issues/1566</a>
 	 */
 	List<I_C_InvoiceCandidate_InOutLine> retrieveICIOLAssociationsExclRE(InvoiceCandidateId invoiceCandidateId);
 
 	/**
 	 * Returns the number of {@link I_C_InvoiceCandidate_InOutLine}s for a given invoiceCandidateId regardless of {@link I_M_InOut} status
-	 *
-	 * task https://github.com/metasfresh/metasfresh/issues/13376
+	 * <p>
+	 * task <a href="https://github.com/metasfresh/metasfresh/issues/13376">https://github.com/metasfresh/metasfresh/issues/13376</a>
 	 */
 	int countICIOLAssociations(final InvoiceCandidateId invoiceCandidateId);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/InvoiceCandidateIdsSelection.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/InvoiceCandidateIdsSelection.java
@@ -65,6 +65,8 @@ public final class InvoiceCandidateIdsSelection
 		this.ids = ids;
 	}
 
+	public boolean isEmpty() {return selectionId == null && (ids == null || ids.isEmpty());}
+
 	public boolean isDatabaseSelection()
 	{
 		return selectionId != null;
@@ -74,9 +76,9 @@ public final class InvoiceCandidateIdsSelection
 	{
 		void empty();
 
-		void fixedSet(ImmutableSet<InvoiceCandidateId> ids);
+		void fixedSet(@NonNull ImmutableSet<InvoiceCandidateId> ids);
 
-		void selectionId(PInstanceId selectionId);
+		void selectionId(@NonNull PInstanceId selectionId);
 	}
 
 	public void apply(@NonNull final CaseMapper mapper)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/InvoiceCandidate_Constants.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/InvoiceCandidate_Constants.java
@@ -1,8 +1,7 @@
 package de.metas.invoicecandidate.api;
 
-import org.slf4j.Logger;
-
 import de.metas.logging.LogManager;
+import org.slf4j.Logger;
 
 /*
  * #%L
@@ -30,7 +29,7 @@ public class InvoiceCandidate_Constants
 {
 	public static final String LOGGERNAME_ROOT = InvoiceCandidate_Constants.class.getPackage().getName();
 
-	public static final Logger getLogger(Class<?> clazz)
+	public static Logger getLogger(final Class<?> clazz)
 	{
 		return LogManager.getLogger(clazz);
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationDAO.java
@@ -129,7 +129,7 @@ public class AggregationDAO implements IAggregationDAO
 		}
 	}
 
-	private static int findC_Invoice_Candidate_HeaderAggregationKey_ID0(@NonNull final I_C_Invoice_Candidate ic)
+	private int findC_Invoice_Candidate_HeaderAggregationKey_ID0(@NonNull final I_C_Invoice_Candidate ic)
 	{
 		final String headerAggregationKeyCalc = ic.getHeaderAggregationKey_Calc();
 		if (Check.isBlank(headerAggregationKeyCalc))

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationDAO.java
@@ -37,18 +37,30 @@ import de.metas.invoicecandidate.model.I_C_Invoice_Candidate_Agg;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate_HeaderAggregation;
 import de.metas.invoicecandidate.model.I_M_ProductGroup;
 import de.metas.invoicecandidate.model.I_M_ProductGroup_Product;
+import de.metas.logging.LogManager;
 import de.metas.product.IProductDAO;
 import de.metas.product.ProductId;
 import de.metas.security.permissions.Access;
 import de.metas.util.Check;
+import de.metas.util.Loggables;
 import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.exceptions.DBUniqueConstraintException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.Query;
+import org.slf4j.Logger;
+
+import java.util.Properties;
 
 public class AggregationDAO implements IAggregationDAO
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
+	private final Logger logger = LogManager.getLogger(InvoiceCandBL.class);
+
 	@Override
-	public I_C_Invoice_Candidate_Agg retrieveAggregate(final I_C_Invoice_Candidate ic)
+	public I_C_Invoice_Candidate_Agg retrieveAggregate(@NonNull final I_C_Invoice_Candidate ic)
 	{
 		final IProductDAO productDAO = Services.get(IProductDAO.class);
 
@@ -99,10 +111,28 @@ public class AggregationDAO implements IAggregationDAO
 	}
 
 	@Override
-	public int findC_Invoice_Candidate_HeaderAggregationKey_ID(I_C_Invoice_Candidate ic)
+	public int findC_Invoice_Candidate_HeaderAggregationKey_ID(@NonNull final I_C_Invoice_Candidate ic)
+	{
+		try
+		{
+			return findC_Invoice_Candidate_HeaderAggregationKey_ID0(ic);
+		}
+		catch (final DBUniqueConstraintException e)
+		{
+			final String msg = "Caught DBUniqueConstraintException while trying to get or create C_Invoice_Candidate_HeaderAggregationKey for C_Invoice_Candidate_ID=" + ic.getC_Invoice_Candidate_ID() + ". => Retrying";
+			logger.info(msg, e);
+			Loggables.get().addLog(msg);
+
+			// retrying is not super-cool and we minimized the possibility for concurrent invocations, 
+			// but I couldn't figure out how to get rid of them at de.metas.invoicecandidate.api.impl.InvoiceCandBL.handleCompleteForInvoice
+			return findC_Invoice_Candidate_HeaderAggregationKey_ID0(ic);
+		}
+	}
+
+	private static int findC_Invoice_Candidate_HeaderAggregationKey_ID0(@NonNull final I_C_Invoice_Candidate ic)
 	{
 		final String headerAggregationKeyCalc = ic.getHeaderAggregationKey_Calc();
-		if (Check.isEmpty(headerAggregationKeyCalc, true))
+		if (Check.isBlank(headerAggregationKeyCalc))
 		{
 			return -1;
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -26,7 +26,6 @@ import ch.qos.logback.classic.Level;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import de.metas.ad_reference.ADReferenceService;
 import de.metas.adempiere.model.I_C_Invoice;
 import de.metas.adempiere.model.I_C_InvoiceLine;
 import de.metas.adempiere.model.I_C_Order;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -26,6 +26,7 @@ import ch.qos.logback.classic.Level;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import de.metas.ad_reference.ADReferenceService;
 import de.metas.adempiere.model.I_C_Invoice;
 import de.metas.adempiere.model.I_C_InvoiceLine;
 import de.metas.adempiere.model.I_C_Order;
@@ -46,6 +47,7 @@ import de.metas.bpartner.BPartnerLocationId;
 import de.metas.bpartner.service.IBPartnerBL;
 import de.metas.bpartner.service.IBPartnerDAO;
 import de.metas.cache.CCache;
+import de.metas.common.util.TryAndWaitUtil;
 import de.metas.common.util.time.SystemTime;
 import de.metas.currency.Currency;
 import de.metas.currency.CurrencyPrecision;
@@ -153,6 +155,7 @@ import org.adempiere.ad.trx.api.OnTrxMissingPolicy;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.model.PlainContextAware;
 import org.adempiere.service.ClientId;
 import org.adempiere.service.ISysConfigBL;
 import org.adempiere.util.concurrent.AutoClosableThreadLocalBoolean;
@@ -160,6 +163,7 @@ import org.adempiere.util.lang.IAutoCloseable;
 import org.adempiere.util.lang.IPair;
 import org.adempiere.util.lang.ImmutablePair;
 import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.Adempiere;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_AD_Note;
 import org.compiere.model.I_C_BPartner;
@@ -510,7 +514,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 	public void set_QtyInvoiced_NetAmtInvoiced_Aggregation(final Properties ctx, final I_C_Invoice_Candidate ic)
 	{
 		Check.assume(ic.isManual(), ic + " has IsManual='Y'");
-		set_QtyInvoiced_NetAmtInvoiced_Aggregation0(ctx, ic);
+		set_QtyInvoiced_NetAmtInvoiced_Aggregation0(ic);
 	}
 
 	/**
@@ -518,7 +522,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 	 * <p>
 	 * <b>Also invokes {@link #updateProcessedFlag(I_C_Invoice_Candidate)}</b>
 	 */
-	void set_QtyInvoiced_NetAmtInvoiced_Aggregation0(final Properties ctx, @NonNull final I_C_Invoice_Candidate ic)
+	void set_QtyInvoiced_NetAmtInvoiced_Aggregation0(@NonNull final I_C_Invoice_Candidate ic)
 	{
 		if (ic.isToClear())
 		{
@@ -1136,7 +1140,8 @@ public class InvoiceCandBL implements IInvoiceCandBL
 				.setFrom(ic);
 
 		splitCand.setC_Invoice_Candidate_Agg_ID(ic.getC_Invoice_Candidate_Agg_ID());
-		aggregationBL.setHeaderAggregationKey(splitCand);
+		// this shall be done later by IInvoiceCandInvalidUpdater. // Otherwise we might have concurrent access to I_C_Invoice_Candidate_HeaderAggregation and DBUniqueConstraintExceptions
+		//aggregationBL.setHeaderAggregationKey(splitCand);
 		splitCand.setLineAggregationKey(null);
 		splitCand.setLineAggregationKey_Suffix(ic.getLineAggregationKey_Suffix());
 		splitCand.setDescription(ic.getDescription());
@@ -1245,7 +1250,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 	}
 
 	@Override
-	public I_C_Invoice_Line_Alloc createUpdateIla(InvoiceCandidateAllocCreateRequest request)
+	public I_C_Invoice_Line_Alloc createUpdateIla(final InvoiceCandidateAllocCreateRequest request)
 	{
 		final I_C_Invoice_Candidate invoiceCand = request.getInvoiceCand();
 		final I_C_InvoiceLine invoiceLine = request.getInvoiceLine();
@@ -1419,7 +1424,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 			return ic.isTaxIncluded();
 		}
 
-		return taxIncludedOverride.booleanValue();
+		return taxIncludedOverride;
 	}
 
 	@Override
@@ -2439,17 +2444,14 @@ public class InvoiceCandBL implements IInvoiceCandBL
 			return ImmutableSet.of();
 		}
 
-		final Properties ctx = InterfaceWrapperHelper.getCtx(invoice);
 		final String trxName = InterfaceWrapperHelper.getTrxName(invoice);
 
 		// void invoice
 		Services.get(IDocumentBL.class).processEx(invoice, IDocument.ACTION_Reverse_Correct, IDocument.STATUS_Reversed);
 
 		// update invalids
-		invoiceCandBL.updateInvalid()
-				.setContext(ctx, trxName)
-				.setOnlyInvoiceCandidateIds(InvoiceCandidateIdsSelection.extractFixedIdsSet(invoiceCands))
-				.update();
+		final InvoiceCandidateIdsSelection invoiceCandidateIdsSelection = InvoiceCandidateIdsSelection.extractFixedIdsSet(invoiceCands);
+		ensureICsAreUpdated(invoiceCandidateIdsSelection);
 
 		for (final I_C_Invoice_Candidate ic : invoiceCands)
 		{
@@ -2475,6 +2477,51 @@ public class InvoiceCandBL implements IInvoiceCandBL
 				.collect(ImmutableSet.toImmutableSet());
 	}
 
+	@Override
+	public void ensureICsAreUpdated(@NonNull final InvoiceCandidateIdsSelection invoiceCandidateIdsSelection)
+	{
+		if (Adempiere.isUnitTestMode())
+		{
+			// In unit-test-mode we don't have the app-server running to do this for us, so we need to do it here.
+			// Updating invalid candidates to make sure that they e.g. have the correct header aggregation key and thus the correct ordering
+			// also, we need to make sure that each ICs was updated at least once, so that it has a QtyToInvoice > 0 (task 08343)
+			updateInvalid()
+					.setContext(PlainContextAware.newWithThreadInheritedTrx())
+					.setTaggedWithAnyTag()
+					.setOnlyInvoiceCandidateIds(invoiceCandidateIdsSelection)
+					.update();
+		}
+		else
+		{
+			// in later code-versions this might also be achieved by using AsyncBatchService.executeBatch(..), but here we just wait...
+			waitForInvoiceCandidatesUpdated(invoiceCandidateIdsSelection);
+		}
+	}
+
+	private void waitForInvoiceCandidatesUpdated(@NonNull final InvoiceCandidateIdsSelection invoiceCandidateIdsSelection)
+	{
+		Loggables.withLogger(logger, Level.DEBUG).addLog("InvoiceCandidateEnqueuer - Start waiting for ICs to be updated async-queue; Selection={}",invoiceCandidateIdsSelection);
+		try
+		{
+			TryAndWaitUtil.tryAndWait(
+					3600 /*let's wait a full hour*/,
+					1000 /*check once a second*/,
+					() -> !invoiceCandDAO.hasInvalidInvoiceCandidatesForSelection(invoiceCandidateIdsSelection),
+					null);
+		}
+		catch (final InterruptedException e)
+		{
+			throw AdempiereException.wrapIfNeeded(e)
+					.appendParametersToMessage()
+					.setParameter("InvoiceCandidateIdsSelection (ICs-selection)", invoiceCandidateIdsSelection);
+		}
+		finally
+		{
+			Loggables.withLogger(logger, Level.DEBUG).addLog("InvoiceCandidateEnqueuer - Stop waiting for ICs to be updated async-queue; Selection={}",invoiceCandidateIdsSelection);
+		}
+	}
+	
+	
 	// TODO: would be nice to use de.metas.ui.web.view.descriptor.SqlAndParams but that is in module webui-api, and here we don't have access to it
 	@Override
 	public @NonNull InvoiceCandidatesAmtSelectionSummary calculateAmtSelectionSummary(@Nullable final String extraWhereClause)
@@ -2501,10 +2548,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 	{
 		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(candidates, Spliterator.ORDERED), false)
 				.filter(c -> !processedRecords.contains(c.getC_Invoice_Candidate_ID()))
-				.map(ic -> {
-					set_DateToInvoice_DefaultImpl(ic);
-					return ic;
-				})
+				.peek(this::set_DateToInvoice_DefaultImpl)
 				.collect(Collectors.toSet());
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
@@ -58,6 +58,7 @@ import de.metas.util.Loggables;
 import de.metas.util.Services;
 import de.metas.util.collections.IdentityHashSet;
 import de.metas.workflow.api.IWFExecutionFactory;
+import lombok.Getter;
 import lombok.NonNull;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.trx.api.ITrxListenerManager.TrxEventTiming;
@@ -129,7 +130,7 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 
 	//
 	// Services
-	private static final transient Logger logger = InvoiceCandidate_Constants.getLogger(InvoiceCandBLCreateInvoices.class);
+	private static final Logger logger = InvoiceCandidate_Constants.getLogger(InvoiceCandBLCreateInvoices.class);
 
 	private final transient IOrgDAO orgDAO = Services.get(IOrgDAO.class);
 	private final transient IDocTypeDAO docTypeDAO = Services.get(IDocTypeDAO.class);
@@ -370,7 +371,7 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 				invoice.setDateAcct(TimeUtil.asTimestamp(invoiceHeader.getDateAcct(), timeZone)); // 03905: also updating DateAcct
 
 				invoice.setM_PriceList_ID(invoiceHeader.getM_PriceList_ID()); // #367: get M_PriceList_ID directly from invoiceHeader.
-				Set<String> externalIds = invoiceHeader.getAllInvoiceCandidates().stream().map(I_C_Invoice_Candidate::getExternalHeaderId).filter(Objects::nonNull).collect(Collectors.toSet());
+				final Set<String> externalIds = invoiceHeader.getAllInvoiceCandidates().stream().map(I_C_Invoice_Candidate::getExternalHeaderId).filter(Objects::nonNull).collect(Collectors.toSet());
 				Check.assume(externalIds.size() <= 1, "Unexpectedly found multiple externalId candidates for the same invoice: {}", externalIds);
 				invoice.setExternalId(externalIds.stream().findFirst().orElse(null));
 			}
@@ -524,6 +525,7 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 	// NOTE: not static because we share the services
 	private class DefaultInvoiceLineGeneratorRunnable implements TrxRunnable2
 	{
+		@Getter
 		private final List<I_C_InvoiceLine> createdLines;
 		private final I_C_Invoice invoice;
 		private final List<I_C_Invoice_Candidate> errorCandidates;
@@ -821,7 +823,7 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 		}
 
 		@Override
-		public boolean doCatch(final Throwable e) throws Throwable
+		public boolean doCatch(final Throwable e)
 		{
 			if (errorException[0] == null)
 			{
@@ -843,11 +845,6 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 				errorCandidates.clear();
 				errorException[0] = null;
 			}
-		}
-
-		public List<I_C_InvoiceLine> getCreatedLines()
-		{
-			return createdLines;
 		}
 	}
 
@@ -1024,7 +1021,7 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 					userInChargeId = USERINCHARGE_NA;
 				}
 
-				List<I_C_Invoice_Candidate> candsOfUserId = userId2cands.computeIfAbsent(userInChargeId, k -> new ArrayList<>());
+				final List<I_C_Invoice_Candidate> candsOfUserId = userId2cands.computeIfAbsent(userInChargeId, k -> new ArrayList<>());
 				candsOfUserId.add(ic);
 			}
 
@@ -1193,7 +1190,7 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 	}
 
 	@Override
-	public IInvoiceGenerator setInvoicingParams(IInvoicingParams invoicingParams)
+	public IInvoiceGenerator setInvoicingParams(final IInvoicingParams invoicingParams)
 	{
 		this._invoicingParams = invoicingParams;
 		return this;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandDAO.java
@@ -72,6 +72,7 @@ import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.exceptions.DBException;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.model.PlainContextAware;
 import org.adempiere.service.ClientId;
 import org.adempiere.util.lang.IContextAware;
 import org.adempiere.util.lang.impl.TableRecordReference;
@@ -96,7 +97,6 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1065,13 +1065,13 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 				}
 
 				@Override
-				public void fixedSet(final ImmutableSet<InvoiceCandidateId> ids)
+				public void fixedSet(final @NonNull ImmutableSet<InvoiceCandidateId> ids)
 				{
 					queryBuilder.addInArrayOrAllFilter(I_C_Invoice_Candidate_Recompute.COLUMN_C_Invoice_Candidate_ID, ids);
 				}
 
 				@Override
-				public void selectionId(final PInstanceId selectionId)
+				public void selectionId(final @NonNull PInstanceId selectionId)
 				{
 					queryBuilder.addInSubQueryFilter(
 							I_C_Invoice_Candidate_Recompute.COLUMNNAME_C_Invoice_Candidate_ID,
@@ -1216,10 +1216,40 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 	}
 
 	@Override
-	public final boolean hasInvalidInvoiceCandidatesForSelection(@NonNull final PInstanceId selectionId)
+	public final boolean hasInvalidInvoiceCandidatesForSelection(@NonNull final InvoiceCandidateIdsSelection invoiceCandidateIdsSelection)
 	{
-		return queryBL.createQueryBuilder(I_C_Invoice_Candidate.class)
-				.setOnlySelection(selectionId)
+		if(invoiceCandidateIdsSelection.isEmpty())
+		{
+			return false;
+		}
+		
+		// Without the newOutOfTrx-context, we had InvoiceCandBL.waitForInvoiceCandidatesUpdated consistently hit the 1hr-timeout on one instance,
+		// although multiple UpdateInvalidInvoiceCandidatesWorkpackageProcessors executed successfully during that hour.
+		final IQueryBuilder<I_C_Invoice_Candidate> queryBuilder = queryBL.createQueryBuilder(I_C_Invoice_Candidate.class, PlainContextAware.newOutOfTrx());
+
+		// apply the invoiceCandidateIdsSelection to our queryBuilder
+		invoiceCandidateIdsSelection.apply(new InvoiceCandidateIdsSelection.CaseMapper()
+		{
+			@Override
+			public void empty()
+			{
+				queryBuilder.filter(ConstantQueryFilter.of(false));
+			}
+
+			@Override
+			public void fixedSet(@NonNull final ImmutableSet<InvoiceCandidateId> ids)
+			{
+				queryBuilder.addInArrayFilter(I_C_Invoice_Candidate.COLUMN_C_Invoice_Candidate_ID, ids);
+			}
+
+			@Override
+			public void selectionId(@NonNull final PInstanceId selectionId)
+			{
+				queryBuilder.setOnlySelection(selectionId);
+			}
+		});
+
+		return queryBuilder
 				.andCollectChildren(I_C_Invoice_Candidate_Recompute.COLUMN_C_Invoice_Candidate_ID)
 				.create()
 				.anyMatch();
@@ -1709,7 +1739,7 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 		// Only filter invoice candidates of the organizations this role has access to
 		final IUserRolePermissions userRolePermissions = Env.getUserRolePermissions(ctx);
 
-		final StringBuilder defaultFilter = new StringBuilder("");
+		final StringBuilder defaultFilter = new StringBuilder();
 
 		final String orgIDsAsString = userRolePermissions.getAD_Org_IDs_AsString();
 
@@ -1741,7 +1771,7 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 	public Set<String> retrieveOrderDocumentNosForIncompleteGroupsFromSelection(final PInstanceId adPInstanceId)
 	{
 		final String sql = "SELECT * FROM C_Invoice_Candidate_SelectionIncompleteGroups WHERE AD_PInstance_ID=?";
-		final List<Object> sqlParams = Arrays.asList(adPInstanceId);
+		final List<Object> sqlParams = ImmutableList.of(adPInstanceId);
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
 		try

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandInvalidUpdater.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandInvalidUpdater.java
@@ -69,7 +69,6 @@ import java.math.BigDecimal;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
@@ -366,7 +365,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 		// update BPartner data from 'ic'
 		invoiceCandidateHandlerBL.setBPartnerData(icRecord);
 
-		invoiceCandBL.set_QtyInvoiced_NetAmtInvoiced_Aggregation0(ctx, icRecord);
+		invoiceCandBL.set_QtyInvoiced_NetAmtInvoiced_Aggregation0(icRecord);
 
 		// 06539 add qty overdelivery to qty delivered
 		final org.compiere.model.I_C_OrderLine ol = icRecord.getC_OrderLine();
@@ -440,7 +439,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 
 			Loggables.withLogger(logger, Level.DEBUG)
 					.addLog(MessageFormat.format("Populate icIols_IDs={0} for C_Invoice_Candidate_ID={1}",
-												 iciol.getC_InvoiceCandidate_InOutLine_ID()), ic.getC_Invoice_Candidate_ID());
+												 iciol.getC_InvoiceCandidate_InOutLine_ID(), ic.getC_Invoice_Candidate_ID()));
 			
 			Services.get(IInvoiceCandBL.class).updateICIOLAssociationFromIOL(iciol, inOutLine);
 		}
@@ -533,7 +532,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 	}
 
 	@Override
-	public IInvoiceCandInvalidUpdater setOnlyInvoiceCandidateIds(final InvoiceCandidateIdsSelection onlyInvoiceCandidateIds)
+	public IInvoiceCandInvalidUpdater setOnlyInvoiceCandidateIds(@NonNull final InvoiceCandidateIdsSelection onlyInvoiceCandidateIds)
 	{
 		assertNotExecuted();
 		icTagger.setOnlyInvoiceCandidateIds(onlyInvoiceCandidateIds);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
@@ -5,7 +5,6 @@ import de.metas.async.model.I_C_Async_Batch;
 import de.metas.async.spi.IWorkpackagePrioStrategy;
 import de.metas.async.spi.impl.ConstantWorkpackagePrio;
 import de.metas.async.spi.impl.SizeBasedWorkpackagePrio;
-import de.metas.common.util.TryAndWaitUtil;
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.IMsgBL;
 import de.metas.invoicecandidate.InvoiceCandidateId;
@@ -31,7 +30,6 @@ import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.PlainContextAware;
 import org.adempiere.service.ISysConfigBL;
-import org.compiere.Adempiere;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.slf4j.MDC.MDCCloseable;
@@ -99,11 +97,14 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 		final IInvoiceCandidatesChangesChecker icChangesChecker = newInvoiceCandidatesChangesChecker();
 		icChangesChecker.setBeforeChanges(unorderedICs);
 
-		//
+		// make sure that we don't have a ton of ICs being updated by the app-Server while we do our own updates over here
+		// otherwise, we can easly run into DB-deadloacks
+		invoiceCandBL.ensureICsAreUpdated(InvoiceCandidateIdsSelection.ofSelectionId(pInstanceId));
+
 		// Prepare them in a dedicated trx so that the update-WP-processor "sees" them
 		trxManager.runInNewTrx(() -> updateSelectionBeforeEnqueueing(pInstanceId));
 
-		ensureICsAreUpdated(pInstanceId);
+		invoiceCandBL.ensureICsAreUpdated(InvoiceCandidateIdsSelection.ofSelectionId(pInstanceId));
 
 		//
 		// Make sure there are no changes in amounts or relevant fields (if that is required)
@@ -222,44 +223,6 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 				workpackageQueueSizeBeforeEnqueueing,
 				totalNetAmtToInvoiceChecksum.getValue(),
 				icLock);
-	}
-
-	private void ensureICsAreUpdated(final @NonNull PInstanceId pinstanceId)
-	{
-		if (Adempiere.isUnitTestMode())
-		{
-			// In unit-test-mode we don't have the app-server running to do this for us, so we need to do it here.
-			// Updating invalid candidates to make sure that they e.g. have the correct header aggregation key and thus the correct ordering
-			// also, we need to make sure that each ICs was updated at least once, so that it has a QtyToInvoice > 0 (task 08343)
-			invoiceCandBL.updateInvalid()
-					.setContext(getCtx(), ITrx.TRXNAME_ThreadInherited)
-					.setTaggedWithAnyTag()
-					.setOnlyInvoiceCandidateIds(InvoiceCandidateIdsSelection.ofSelectionId(pinstanceId))
-					.update();
-		}
-		else
-		{
-			// in later code-versions this might also be achieved by using AsyncBatchService.executeBatch(..), but here we just wait...
-			waitForInvoiceCandidatesUpdated(pinstanceId);
-		}
-	}
-
-	private void waitForInvoiceCandidatesUpdated(final @NonNull PInstanceId pinstanceId)
-	{
-		try
-		{
-			TryAndWaitUtil.tryAndWait(
-					3600 /*let's wait a full hour*/,
-					1000 /*check once a second*/,
-					() -> !invoiceCandDAO.hasInvalidInvoiceCandidatesForSelection(pinstanceId),
-					null);
-		}
-		catch (final InterruptedException e)
-		{
-			throw AdempiereException.wrapIfNeeded(e)
-					.appendParametersToMessage()
-					.setParameter("AD_PInstance_ID (ICs-selection)", pinstanceId.getRepoId());
-		}
 	}
 
 	/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/UpdateInvalidInvoiceCandidatesWorkpackageProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/UpdateInvalidInvoiceCandidatesWorkpackageProcessor.java
@@ -54,7 +54,7 @@ public class UpdateInvalidInvoiceCandidatesWorkpackageProcessor extends Workpack
 {
 	/**
 	 * Schedule a new "update invalid invoice candidates" run.
-	 *
+	 * <p>
 	 * NOTE: the workpackages are not created right away, but the models are collected per database transaction and a workpackage is enqueued when the transaction is committed.
 	 */
 	public static void schedule(@NonNull final IInvoiceCandUpdateSchedulerRequest request)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_Invoice_Candidate.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_Invoice_Candidate.java
@@ -6,7 +6,6 @@ import de.metas.bpartner.service.IBPartnerStatisticsUpdater;
 import de.metas.bpartner.service.IBPartnerStatisticsUpdater.BPartnerStatisticsUpdateRequest;
 import de.metas.cache.model.impl.TableRecordCacheLocal;
 import de.metas.document.location.IDocumentLocationBL;
-import de.metas.invoicecandidate.api.IAggregationBL;
 import de.metas.invoicecandidate.api.IInvoiceCandBL;
 import de.metas.invoicecandidate.api.IInvoiceCandDAO;
 import de.metas.invoicecandidate.api.IInvoiceCandidateHandlerBL;
@@ -54,7 +53,6 @@ public class C_Invoice_Candidate
 
 	private final IInvoiceCandidateHandlerBL invoiceCandidateHandlerBL = Services.get(IInvoiceCandidateHandlerBL.class);
 	private final IInvoiceCandDAO invoiceCandDAO = Services.get(IInvoiceCandDAO.class);
-	private final IAggregationBL aggregationBL = Services.get(IAggregationBL.class);
 
 	private final AttachmentEntryService attachmentEntryService;
 	private final InvoiceCandidateGroupCompensationChangesHandler groupChangesHandler;
@@ -223,8 +221,6 @@ public class C_Invoice_Candidate
 
 	/**
 	 * For new invoice candidates, this method sets the <code>C_Order_ID</code>, if the referenced record is either a <code>C_OrderLine_ID</code> or a <code>M_InOutLine_ID</code>.
-	 * <p>
-	 * Task http://dewiki908/mediawiki/index.php/07242_Error_creating_invoice_from_InOutLine-IC_%28104224060697%29
 	 */
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW })
 	public void updateOrderId(final I_C_Invoice_Candidate ic)
@@ -354,8 +350,6 @@ public class C_Invoice_Candidate
 
 	/**
 	 * After an invoice candidate was deleted, schedule the recreation of it.
-	 * <p>
-	 * Task http://dewiki908/mediawiki/index.php/09531_C_Invoice_candidate%3A_deleted_ICs_are_not_coming_back_%28107964479343%29
 	 */
 	@ModelChange(timings = ModelValidator.TYPE_AFTER_DELETE)
 	public void scheduleRecreate(final I_C_Invoice_Candidate ic)
@@ -425,11 +419,13 @@ public class C_Invoice_Candidate
 			return; // nothing to do
 		}
 
-		if (InterfaceWrapperHelper.isNew(ic) || ic.getC_Invoice_Candidate_ID() <= 0)
-		{
-			aggregationBL.setHeaderAggregationKey(ic);
-			return;
-		}
+		// This shall be done later by IInvoiceCandInvalidUpdater. 
+		// Otherwise we might have concurrent access to I_C_Invoice_Candidate_HeaderAggregation and DBUniqueConstraintExceptions
+		// if (InterfaceWrapperHelper.isNew(ic) || ic.getC_Invoice_Candidate_ID() <= 0)
+		// {
+		// 	aggregationBL.setHeaderAggregationKey(ic);
+		// 	return;
+		// }
 
 		invoiceCandDAO.invalidateCand(ic);
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/InvoiceCandidateWithInOutLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/InvoiceCandidateWithInOutLine.java
@@ -1,40 +1,6 @@
 package de.metas.invoicecandidate.spi.impl.aggregator.standard;
 
-import static de.metas.util.Check.fail;
-import static de.metas.common.util.CoalesceUtil.coalesce;
-import static org.adempiere.model.InterfaceWrapperHelper.isNull;
-
-import java.math.BigDecimal;
-
-/*
- * #%L
- * de.metas.swat.base
- * %%
- * Copyright (C) 2015 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
-
-import java.util.Set;
-
-import org.adempiere.util.lang.ObjectUtils;
-import org.compiere.model.I_M_InOutLine;
-
 import com.google.common.collect.ImmutableSet;
-
 import de.metas.inout.IInOutBL;
 import de.metas.invoice.service.IMatchInvDAO;
 import de.metas.invoicecandidate.InvoiceCandidateId;
@@ -51,6 +17,16 @@ import de.metas.uom.UomId;
 import de.metas.util.Services;
 import lombok.Getter;
 import lombok.NonNull;
+import org.adempiere.util.lang.ObjectUtils;
+import org.compiere.model.I_M_InOutLine;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.util.Set;
+
+import static de.metas.common.util.CoalesceUtil.coalesce;
+import static de.metas.util.Check.fail;
+import static org.adempiere.model.InterfaceWrapperHelper.isNull;
 
 public final class InvoiceCandidateWithInOutLine
 {
@@ -101,18 +77,14 @@ public final class InvoiceCandidateWithInOutLine
 	}
 
 	/** @return shipment/receipt line; could be <code>null</code> */
+	@Nullable
 	public I_M_InOutLine getM_InOutLine()
 	{
 		if (iciol == null)
 		{
 			return null;
 		}
-		final I_M_InOutLine inOutLine = iciol.getM_InOutLine();
-		if (inOutLine == null)
-		{
-			return null;
-		}
-		return inOutLine;
+		return iciol.getM_InOutLine();
 	}
 
 	public StockQtyAndUOMQty getQtysAlreadyInvoiced()

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/InvoiceCandidateIdsSelectionTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/InvoiceCandidateIdsSelectionTest.java
@@ -1,0 +1,18 @@
+package de.metas.invoicecandidate.api;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.invoicecandidate.InvoiceCandidateId;
+import de.metas.process.PInstanceId;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class InvoiceCandidateIdsSelectionTest
+{
+	@Test
+	void isEmpty()
+	{
+		Assertions.assertThat(InvoiceCandidateIdsSelection.ofIdsSet(ImmutableSet.of()).isEmpty()).isTrue();
+		Assertions.assertThat(InvoiceCandidateIdsSelection.ofIdsSet(ImmutableSet.of(InvoiceCandidateId.ofRepoId(1))).isEmpty()).isFalse();
+		Assertions.assertThat(InvoiceCandidateIdsSelection.ofSelectionId(PInstanceId.ofRepoId(1)).isEmpty()).isFalse();
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/impl/PlainAggregationDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/impl/PlainAggregationDAO.java
@@ -22,13 +22,12 @@ package de.metas.invoicecandidate.api.impl;
  * #L%
  */
 
-
-import java.util.List;
-
-import org.adempiere.ad.wrapper.POJOLookupMap;
-
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate_Agg;
+import lombok.NonNull;
+import org.adempiere.ad.wrapper.POJOLookupMap;
+
+import java.util.List;
 
 public class PlainAggregationDAO extends AggregationDAO
 {
@@ -37,7 +36,7 @@ public class PlainAggregationDAO extends AggregationDAO
 	private I_C_Invoice_Candidate_Agg defaultAgg = null;
 
 	@Override
-	public I_C_Invoice_Candidate_Agg retrieveAggregate(I_C_Invoice_Candidate ic)
+	public I_C_Invoice_Candidate_Agg retrieveAggregate(@NonNull I_C_Invoice_Candidate ic)
 	{
 		if (defaultAgg != null)
 		{

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/impl/PlainInvoiceCandDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/impl/PlainInvoiceCandDAO.java
@@ -22,23 +22,10 @@ package de.metas.invoicecandidate.api.impl;
  * #L%
  */
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
-
-import de.metas.common.util.time.SystemTime;
-import org.adempiere.ad.dao.IQueryBL;
-import org.adempiere.ad.wrapper.POJOLookupMap;
-import org.adempiere.ad.wrapper.POJOWrapper;
-import org.adempiere.service.ClientId;
-import org.slf4j.Logger;
-
 import com.google.common.collect.ImmutableSet;
-
+import de.metas.common.util.time.SystemTime;
 import de.metas.currency.ICurrencyBL;
+import de.metas.invoicecandidate.api.InvoiceCandRecomputeTag;
 import de.metas.invoicecandidate.api.InvoiceCandidateMultiQuery;
 import de.metas.invoicecandidate.api.InvoiceCandidateQuery;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
@@ -47,6 +34,19 @@ import de.metas.money.CurrencyConversionTypeId;
 import de.metas.money.CurrencyId;
 import de.metas.process.PInstanceId;
 import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.wrapper.POJOLookupMap;
+import org.adempiere.ad.wrapper.POJOWrapper;
+import org.adempiere.service.ClientId;
+import org.slf4j.Logger;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
 
 public class PlainInvoiceCandDAO extends InvoiceCandDAO
 {
@@ -55,7 +55,7 @@ public class PlainInvoiceCandDAO extends InvoiceCandDAO
 	private final POJOLookupMap db = POJOLookupMap.get();
 
 	/**
-	 * Comparator to order a list of order candidates the same way it would be returned by {@link InvoiceCandDAO#fetchInvalidInvoiceCandidates(Properties, int, String)}. Please keep in sync if the
+	 * Comparator to order a list of order candidates the same way it would be returned by {@link InvoiceCandDAO#fetchInvalidInvoiceCandidates(Properties, InvoiceCandRecomputeTag, String)}. Please keep in sync if the
 	 * orderBy clause of that method.
 	 */
 	public static final Comparator<I_C_Invoice_Candidate> INVALID_CANDIDATES_ORDERING = Services.get(IQueryBL.class)
@@ -68,8 +68,8 @@ public class PlainInvoiceCandDAO extends InvoiceCandDAO
 	@Override
 	public BigDecimal retrieveInvoicableAmount(
 			final Properties ctx,
-			final InvoiceCandidateQuery query,
-			final CurrencyId targetCurrencyId,
+			final @NonNull InvoiceCandidateQuery query,
+			final @NonNull CurrencyId targetCurrencyId,
 			final int adClientId,
 			final String amountColumnName,
 			final String trxName)


### PR DESCRIPTION
…(#18192)

* Reduce concurrent access to I_C_Invoice_Candidate_HeaderAggregation and if it still happens and causes a DBUniqueConstraintException, then retry
* This includes a port of some parts of https://github.com/metasfresh/metasfresh/commit/e0ed808fbc965829a358ffcadfb44640c78c8028#diff-5bd9c56cac93b21f5ac696fde6aaad8c4b087ef8780a707ab1cedfa5f68c483f
* InvoiceCandDAO.hasInvalidInvoiceCandidatesForSelection: shortcut in case the selection is empty

---------

Co-authored-by: Teodor Sarca <teo.sarca@metasfresh.com>
(cherry picked from commit 389c9c4bc089ea4ba5fec2f19300a64e853e1b1b)

solved Conflicts:
	backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationDAO.java