### PR TITLE
Return our CU-GTIN as buyer-CU-GTIN by default

### DIFF
--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5726670_sys_tweak_edi_cctop_invoic_500_v.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5726670_sys_tweak_edi_cctop_invoic_500_v.sql
@@ -7,7 +7,7 @@ CREATE OR REPLACE VIEW public.edi_cctop_invoic_500_v AS
 SELECT SUM(il.qtyEntered)                                                                                                            AS QtyInvoiced,
        CASE
            WHEN u.x12de355 = 'TU' THEN 'PCE'
-                                              ELSE u.x12de355
+                                  ELSE u.x12de355
        END                                                                                                                           AS eancom_uom, /* C_InvoiceLine's UOM */
        CASE
            WHEN u_ordered.x12de355 IN ('TU', 'COLI') THEN CEIL(il.QtyInvoiced / GREATEST(ol.QtyItemCapacity, 1))
@@ -31,7 +31,7 @@ SELECT SUM(il.qtyEntered)                                                       
        t.rate,
        CASE /* be lenient if il.price_uom_id is not set; see https://github.com/metasfresh/metasfresh/issues/6458 */
            WHEN COALESCE(u_price.x12de355, u.x12de355) = 'TU' THEN 'PCE'
-                                                                          ELSE COALESCE(u_price.x12de355, u.x12de355)
+                                                              ELSE COALESCE(u_price.x12de355, u.x12de355)
        END                                                                                                                           AS eancom_price_uom /* C_InvoiceLine's Price-UOM */,
        CASE
            WHEN t.rate = 0 THEN 'Y'
@@ -99,17 +99,17 @@ GROUP BY il.c_invoice_id,
          t.rate,
          (CASE
               WHEN u.x12de355 = 'TU' THEN 'PCE'
-                                                    ELSE u.x12de355
-             END),
+                                     ELSE u.x12de355
+          END),
          (CASE /* be lenient if il.price_uom_id is not set; see https://github.com/metasfresh/metasfresh/issues/6458 */
               WHEN COALESCE(u_price.x12de355, u.x12de355) = 'TU' THEN 'PCE'
-                                                                                ELSE COALESCE(u_price.x12de355, u.x12de355)
-             END),
+                                                                 ELSE COALESCE(u_price.x12de355, u.x12de355)
+          END),
          (
              CASE
-              WHEN u_ordered.x12de355 IN ('TU', 'COLI') THEN CEIL(il.QtyInvoiced / GREATEST(ol.QtyItemCapacity, 1))
-                                                        ELSE uomconvert(il.M_Product_ID, p.C_UOM_ID, u_ordered.C_UOM_ID, il.QtyInvoiced)
-          END),
+                 WHEN u_ordered.x12de355 IN ('TU', 'COLI') THEN CEIL(il.QtyInvoiced / GREATEST(ol.QtyItemCapacity, 1))
+                                                           ELSE uomconvert(il.M_Product_ID, p.C_UOM_ID, u_ordered.C_UOM_ID, il.QtyInvoiced)
+             END),
          u_ordered.x12de355,
          (CASE
               WHEN t.rate = 0 THEN 'Y'


### PR DESCRIPTION
If there is no explicit bpartner-GTIN, then assume that the G from GTIN is respected and thus buyer&supplier work with the same value