### PR TITLE
intensive care uat pickAggregatedTUs fixes

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/quantity/Capacity.java
+++ b/backend/de.metas.business/src/main/java/de/metas/quantity/Capacity.java
@@ -26,6 +26,7 @@ import de.metas.product.ProductId;
 import de.metas.uom.UomId;
 import de.metas.util.Check;
 import lombok.EqualsAndHashCode;
+ import lombok.Getter;
 import lombok.NonNull;
 import org.compiere.model.I_C_UOM;
 
@@ -38,7 +39,7 @@ import java.util.Optional;
  *
  * @author metas-dev <dev@metasfresh.com>
  */
-@EqualsAndHashCode(exclude = "uom")
+@EqualsAndHashCode(exclude = "uom", doNotUseGetters = true)
 public final class Capacity
 {
 
@@ -73,11 +74,11 @@ public final class Capacity
 		return new Capacity(qty.toBigDecimal(), productId, qty.getUOM(), false);
 	}
 
-	private final ProductId productId;
+	@Getter private final ProductId productId;
 	private final UomId uomId;
 	private final I_C_UOM uom;
 	private final BigDecimal capacity;
-	private final boolean infiniteCapacity;
+	@Getter private final boolean infiniteCapacity;
 	private final boolean allowNegativeCapacity;
 
 	/**
@@ -112,11 +113,6 @@ public final class Capacity
 
 		infiniteCapacity = true;
 		allowNegativeCapacity = true;
-	}
-
-	public boolean isInfiniteCapacity()
-	{
-		return infiniteCapacity;
 	}
 
 	public boolean isAllowNegativeCapacity()
@@ -268,11 +264,6 @@ public final class Capacity
 				productId,
 				uom,
 				allowNegativeCapacity);
-	}
-
-	public ProductId getProductId()
-	{
-		return productId;
 	}
 
 	public I_C_UOM getC_UOM()

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_QtyPicked_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_QtyPicked_StepDef.java
@@ -109,7 +109,7 @@ public class M_ShipmentSchedule_QtyPicked_StepDef
 			final ImmutableList<I_M_ShipmentSchedule_QtyPicked> records = retrieveRecordsOrdered(shipmentScheduleId);
 			assertThat(records).hasSize(rows.size());
 
-			DataTableRows.of(dataTable).forEach((expected, index) -> {
+			rows.forEach((expected, index) -> {
 				final I_M_ShipmentSchedule_QtyPicked actual = records.get(index);
 				SharedTestContext.put("actual", actual);
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/Pick_MultipleProducts_to_LU.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/Pick_MultipleProducts_to_LU.feature
@@ -1,0 +1,171 @@
+@from:cucumber
+@ghActions:run_on_executor7
+Feature: mobileUI Picking - Pick multiple products to LU
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-03-26T13:30:13+01:00[Europe/Berlin]
+
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
+    And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
+
+    And metasfresh contains M_PickingSlot:
+      | Identifier | PickingSlot | IsDynamic |
+      | 200.0      | 200.0       | Y         |
+
+    And metasfresh contains M_Products:
+      | Identifier | X12DE355 |
+      | product1   | PCE      |
+      | product2   | PCE      |
+
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID |
+      | TU         |
+      | LU         |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID.Identifier | M_HU_PI_ID.Identifier | Name | HU_UnitType | IsCurrent |
+      | TU                            | TU                    | TU   | TU          | Y         |
+      | LU                            | LU                    | LU   | LU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType | OPT.Included_HU_PI_ID.Identifier |
+      | TU                         | TU                            | 0   | MI       |                                  |
+      | LU                         | LU                            | 10  | HU       | TU                               |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | TUx4_P1                            | TU                         | product1                | 4   | 2000-01-01 |
+      | TUx4_P2                            | TU                         | product2                | 4   | 2000-01-01 |
+
+
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | PS         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx |
+      | PL         | PS                 | DE                    | EUR                 | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | PLV        | PL             |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | InvoicableQtyBasedOn | C_TaxCategory_ID.InternalName |
+      | PLV                    | product1     | 6.0      | PCE               | Nominal              | Normal                        |
+      | PLV                    | product2     | 8.0      | PCE               | Nominal              | Normal                        |
+
+    And set mobile UI picking profile
+      | IsAllowPickingAnyHU | CreateShipmentPolicy  |
+      | Y                   | CREATE_COMPLETE_CLOSE |
+
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | Name     | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | customer   | customer | N            | Y              | PS                            |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier       | GLN       | C_BPartner_ID.Identifier | OPT.IsBillToDefault | OPT.IsShipTo |
+      | customerLocation | Dummy_GLN | customer                 | true                | true         |
+
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inventory                 | 2024-03-20   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inventory                 | line1                         | product1                | 0       | 1000     | PCE          |
+      | inventory                 | line2                         | product2                | 0       | 1000     | PCE          |
+    And complete inventory with inventoryIdentifier 'inventory'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID | M_HU_ID     |
+      | line1              | pickFromCU1 |
+      | line2              | pickFromCU2 |
+
+
+    
+    
+# ######################################################################################################################
+# ######################################################################################################################
+# ######################################################################################################################
+# ######################################################################################################################
+  @from:cucumber
+  Scenario: Pick TUs from LU with aggregated TUs - into a new LU
+    When transform CU to new LU
+      | sourceCU    | newLU                 | TU_PI_ID | QtyCUsPerTU | QtyTUsPerLU |
+      | pickFromCU1 | pickFromAggregatedLU1 | TU       | 4           | 10          |
+      | pickFromCU2 | pickFromAggregatedLU2 | TU       | 4           | 10          |
+    And M_HU are validated:
+      | M_HU_ID               | HUStatus |
+      | pickFromAggregatedLU1 | A        |
+      | pickFromAggregatedLU2 | A        |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | SO         | true    | customer                 | 2024-03-26  |
+    And metasfresh contains C_OrderLines:
+      | C_Order_ID.Identifier | Identifier | M_Product_ID.Identifier | QtyEntered | OPT.M_HU_PI_Item_Product_ID.Identifier |
+      | SO                    | L1         | product1                | 160        | TUx4_P1                                |
+      | SO                    | L2         | product2                | 160        | TUx4_P2                                |
+    And the order identified by SO is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier        | C_OrderLine_ID.Identifier | IsToRecompute |
+      | shipmentSchedule1 | L1                        | N             |
+      | shipmentSchedule2 | L2                        | N             |
+
+    And start picking job for sales order identified by SO
+    And scan picking slot identified by 200.0
+    And set picking target as new LU identified by LU
+    And pick lines
+      | PickingLine.byProduct | PickFromHU            | QtyPicked | QtyRejected | QtyRejectedReasonCode | BestBeforeDate | LotNo |
+      | product1              | pickFromAggregatedLU1 | 3         | 1           | N                     | 2027-03-01     | 9876  |
+      | product2              | pickFromAggregatedLU2 | 4         | 0           |                       | 2028-04-02     | 5432  |
+    And expect current picking target
+      | Existing_LU |
+      | lu          |
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule1
+      | QtyDeliveredCatch | Catch_UOM_ID | QtyPicked | VHU_ID   | QtyTU | M_TU_HU_ID | QtyLU | M_LU_HU_ID | Processed |
+      |                   |              | 12        | tus_agg1 | 3     | tus_agg1   | 1     | lu         | N         |
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule2
+      | QtyDeliveredCatch | Catch_UOM_ID | QtyPicked | VHU_ID   | QtyTU | M_TU_HU_ID | QtyLU | M_LU_HU_ID | Processed |
+      |                   |              | 16        | tus_agg2 | 4     | tus_agg2   | 1     | lu         | N         |
+    And M_HU are validated:
+      | M_HU_ID  | HUStatus |
+      | tus_agg1 | S        |
+      | tus_agg2 | S        |
+      | lu       | S        |
+
+    And complete picking job
+
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | shipmentSchedule1                | shipment              | CO            |
+      | shipmentSchedule2                | shipment              | CO            |
+
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule1
+      | QtyDeliveredCatch | Catch_UOM_ID | QtyPicked | VHU_ID   | QtyTU | M_TU_HU_ID | QtyLU | M_LU_HU_ID | Processed | M_InOutLine_ID |
+      |                   |              | 12        | tus_agg1 | 3     | tus_agg1   | 1     | lu         | Y         | shipmentLine1  |
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule2
+      | QtyDeliveredCatch | Catch_UOM_ID | QtyPicked | VHU_ID   | QtyTU | M_TU_HU_ID | QtyLU | M_LU_HU_ID | Processed | M_InOutLine_ID |
+      |                   |              | 16        | tus_agg2 | 4     | tus_agg2   | 1     | lu         | Y         | shipmentLine2  |
+
+    And validate the created shipment lines by id
+      | Identifier    | M_Product_ID | movementqty | QtyDeliveredCatch | QtyEnteredTU | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID |
+      | shipmentLine1 | product1     | 12          |                   | 3            | TUx4_P1                 | asi1                      |
+      | shipmentLine2 | product2     | 16          |                   | 4            | TUx4_P2                 | asi2                      |
+
+    And M_HU are validated:
+      | M_HU_ID  | HUStatus |
+      | tus_agg1 | E        |
+      | tus_agg2 | E        |
+      | lu       | E        |
+
+    And M_HU_Attribute is validated
+      | M_HU_ID  | M_Attribute_ID.Value | Value | ValueDate  |
+      | tus_agg1 | HU_BestBeforeDate    |       | 2027-03-01 |
+      | tus_agg1 | Lot-Nummer           | 9876  |            |
+      | tus_agg2 | HU_BestBeforeDate    |       | 2028-04-02 |
+      | tus_agg2 | Lot-Nummer           | 5432  |            |
+      | lu       | HU_BestBeforeDate    | -     | -          |
+      | lu       | Lot-Nummer           | -     | -          |
+
+    And validate M_AttributeInstance:
+      | M_AttributeSetInstance_ID | AttributeCode     | Value                 |
+      | asi1                      | HU_BestBeforeDate | 2027-03-01 00:00:00.0 |
+      | asi1                      | Lot-Nummer        | 9876                  |
+      | asi2                      | HU_BestBeforeDate | 2028-04-02 00:00:00.0 |
+      | asi2                      | Lot-Nummer        | 5432                  |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/Pick_MultipleProducts_to_LU.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/Pick_MultipleProducts_to_LU.feature
@@ -169,3 +169,91 @@ Feature: mobileUI Picking - Pick multiple products to LU
       | asi1                      | Lot-Nummer        | 9876                  |
       | asi2                      | HU_BestBeforeDate | 2028-04-02 00:00:00.0 |
       | asi2                      | Lot-Nummer        | 5432                  |
+
+
+
+
+
+
+
+# ######################################################################################################################
+# ######################################################################################################################
+# ######################################################################################################################
+# ######################################################################################################################
+  @from:cucumber
+  Scenario: Pick from CUs into a new LU
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | SO         | true    | customer                 | 2024-03-26  |
+    And metasfresh contains C_OrderLines:
+      | C_Order_ID.Identifier | Identifier | M_Product_ID.Identifier | QtyEntered | OPT.M_HU_PI_Item_Product_ID.Identifier |
+      | SO                    | L1         | product1                | 160        | TUx4_P1                                |
+      | SO                    | L2         | product2                | 160        | TUx4_P2                                |
+    And the order identified by SO is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier        | C_OrderLine_ID.Identifier | IsToRecompute |
+      | shipmentSchedule1 | L1                        | N             |
+      | shipmentSchedule2 | L2                        | N             |
+
+    And start picking job for sales order identified by SO
+    And scan picking slot identified by 200.0
+    And set picking target as new LU identified by LU
+    And pick lines
+      | PickingLine.byProduct | PickFromHU  | QtyPicked | QtyRejected | QtyRejectedReasonCode | BestBeforeDate | LotNo |
+      | product1              | pickFromCU1 | 3         | 1           | N                     | 2027-03-01     | 9876  |
+      | product2              | pickFromCU2 | 4         | 0           |                       | 2028-04-02     | 5432  |
+    And expect current picking target
+      | Existing_LU |
+      | lu          |
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule1
+      | QtyDeliveredCatch | Catch_UOM_ID | QtyPicked | VHU_ID   | QtyTU | M_TU_HU_ID | QtyLU | M_LU_HU_ID | Processed |
+      |                   |              | 12        | tus_agg1 | 3     | tus_agg1   | 1     | lu         | N         |
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule2
+      | QtyDeliveredCatch | Catch_UOM_ID | QtyPicked | VHU_ID   | QtyTU | M_TU_HU_ID | QtyLU | M_LU_HU_ID | Processed |
+      |                   |              | 16        | tus_agg2 | 4     | tus_agg2   | 1     | lu         | N         |
+    And M_HU are validated:
+      | M_HU_ID  | HUStatus |
+      | tus_agg1 | S        |
+      | tus_agg2 | S        |
+      | lu       | S        |
+
+    And complete picking job
+
+    Then after not more than 99960s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | shipmentSchedule1                | shipment              | CO            |
+      | shipmentSchedule2                | shipment              | CO            |
+
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule1
+      | QtyDeliveredCatch | Catch_UOM_ID | QtyPicked | VHU_ID   | QtyTU | M_TU_HU_ID | QtyLU | M_LU_HU_ID | Processed | M_InOutLine_ID |
+      |                   |              | 12        | tus_agg1 | 3     | tus_agg1   | 1     | lu         | Y         | shipmentLine1  |
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule2
+      | QtyDeliveredCatch | Catch_UOM_ID | QtyPicked | VHU_ID   | QtyTU | M_TU_HU_ID | QtyLU | M_LU_HU_ID | Processed | M_InOutLine_ID |
+      |                   |              | 16        | tus_agg2 | 4     | tus_agg2   | 1     | lu         | Y         | shipmentLine2  |
+
+    And validate the created shipment lines by id
+      | Identifier    | M_Product_ID | movementqty | QtyDeliveredCatch | QtyEnteredTU | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID |
+      | shipmentLine1 | product1     | 12          |                   | 3            | TUx4_P1                 | asi1                      |
+      | shipmentLine2 | product2     | 16          |                   | 4            | TUx4_P2                 | asi2                      |
+
+    And M_HU are validated:
+      | M_HU_ID  | HUStatus |
+      | tus_agg1 | E        |
+      | tus_agg2 | E        |
+      | lu       | E        |
+
+    And M_HU_Attribute is validated
+      | M_HU_ID  | M_Attribute_ID.Value | Value | ValueDate  |
+      | tus_agg1 | HU_BestBeforeDate    |       | 2027-03-01 |
+      | tus_agg1 | Lot-Nummer           | 9876  |            |
+      | tus_agg2 | HU_BestBeforeDate    |       | 2028-04-02 |
+      | tus_agg2 | Lot-Nummer           | 5432  |            |
+      | lu       | HU_BestBeforeDate    | -     | -          |
+      | lu       | Lot-Nummer           | -     | -          |
+
+    And validate M_AttributeInstance:
+      | M_AttributeSetInstance_ID | AttributeCode     | Value                 |
+      | asi1                      | HU_BestBeforeDate | 2027-03-01 00:00:00.0 |
+      | asi1                      | Lot-Nummer        | 9876                  |
+      | asi2                      | HU_BestBeforeDate | 2028-04-02 00:00:00.0 |
+      | asi2                      | Lot-Nummer        | 5432                  |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/HUPIItemProduct.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/HUPIItemProduct.java
@@ -105,8 +105,8 @@ public class HUPIItemProduct
 		{
 			throw new AdempiereException("Cannot calculate qty of CUs for infinite capacity");
 		}
-
-		return qtyCUsPerTU.multiply(qtyTU.toInt());
+		
+		return qtyTU.computeTotalQtyCUsUsingQtyCUsPerTU(qtyCUsPerTU);
 	}
 
 	public Capacity toCapacity()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHandlingUnitsBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHandlingUnitsBL.java
@@ -300,6 +300,8 @@ public interface IHandlingUnitsBL extends ISingletonService
 			@NonNull ImmutableSet<HuPackingInstructionsItemId> tuPIItemIds,
 			@Nullable BPartnerId bpartnerId);
 
+	boolean isTUIncludedInLU(@NonNull I_M_HU tu, @NonNull I_M_HU expectedLU);
+
 	@Builder
 	@Value
 	class TopLevelHusQuery

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHandlingUnitsDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHandlingUnitsDAO.java
@@ -199,6 +199,8 @@ public interface IHandlingUnitsDAO extends ISingletonService
 	 */
 	List<I_M_HU_PI_Item> retrievePIItems(final I_M_HU_PI_Version version, final BPartnerId bpartnerId);
 
+	I_M_HU_PI_Item retrievePIItemMaterial(@NonNull I_M_HU_PI_Version version);
+
 	/**
 	 * Retrieve all {@link I_M_HU_PI_Item}s (active or inactive) for given M_HU_PI_Version.
 	 */

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/QtyTU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/QtyTU.java
@@ -26,11 +26,13 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import de.metas.quantity.Quantity;
 import de.metas.util.Check;
 import de.metas.util.NumberUtils;
 import de.metas.util.StringUtils;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
 
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
@@ -192,5 +194,26 @@ public final class QtyTU implements Comparable<QtyTU>
 	public QtyTU min(@NonNull final QtyTU other)
 	{
 		return this.intValue <= other.intValue ? this : other;
+	}
+
+	public Quantity computeQtyCUsPerTUUsingTotalQty(@NonNull final Quantity qtyCUsTotal)
+	{
+		if (isZero())
+		{
+			throw new AdempiereException("Cannot determine Qty CUs/TU when QtyTU is zero of total CUs " + qtyCUsTotal);
+		}
+		else if (isOne())
+		{
+			return qtyCUsTotal;
+		}
+		else
+		{
+			return qtyCUsTotal.divide(toInt());
+		}
+	}
+
+	public Quantity computeTotalQtyCUsUsingQtyCUsPerTU(@NonNull final Quantity qtyCUsPerTU)
+	{
+		return qtyCUsPerTU.multiply(toInt());
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/HUTransformService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/HUTransformService.java
@@ -51,6 +51,7 @@ import de.metas.handlingunits.allocation.impl.HULoader;
 import de.metas.handlingunits.allocation.impl.HUProducerDestination;
 import de.metas.handlingunits.allocation.spi.impl.AggregateHUTrxListener;
 import de.metas.handlingunits.allocation.strategy.AllocationStrategyType;
+import de.metas.handlingunits.allocation.transfer.LUTUResult.LU;
 import de.metas.handlingunits.allocation.transfer.LUTUResult.TU;
 import de.metas.handlingunits.allocation.transfer.LUTUResult.TUsList;
 import de.metas.handlingunits.allocation.transfer.impl.HUSplitBuilderCoreEngine;
@@ -363,11 +364,9 @@ public class HUTransformService
 		return createdHUs;
 	}
 
-	private IHUProductStorage getSingleProductStorage(@NonNull final I_M_HU cuHU)
+	private IHUProductStorage getSingleProductStorage(@NonNull final I_M_HU hu)
 	{
-		final List<IHUProductStorage> storages = huContext.getHUStorageFactory().getStorage(cuHU).getProductStorages();
-		Check.errorUnless(storages.size() == 1, "Param' cuHU' needs to have *one* storage; storages={}; cuHU={};", storages, cuHU);
-		return storages.get(0);
+		return huContext.getHUStorageFactory().getStorage(hu).getSingleHUProductStorage();
 	}
 
 	/**
@@ -551,6 +550,7 @@ public class HUTransformService
 			@NonNull final QtyTU qtyTU,
 			@NonNull final I_M_HU luHU)
 	{
+		LUTUResult result = LUTUResult.EMPTY;
 		final List<I_M_HU> tuHUsToAttachToLU;
 
 		final boolean qtyTuExceedsSourceTuHU = qtyTU.compareTo(getMaximumQtyTU(sourceTuHU)) >= 0;
@@ -576,8 +576,35 @@ public class HUTransformService
 		}
 		else
 		{
-			// create one or many new TUs for qtyTU
-			tuHUsToAttachToLU = tuToNewTUs(sourceTuHU, qtyTU).getTopLevelTURecords();
+			if (handlingUnitsBL.isAggregateHU(sourceTuHU))
+			{
+				final Capacity tuCapacity = extractTUCapacity(sourceTuHU);
+				final LUTUProducerDestination lutuProducer = new LUTUProducerDestination();
+				lutuProducer.setLU(luHU);
+				lutuProducer.setMaxLUs(0);
+				lutuProducer.setMaxTUsPerLUInfinite();
+				lutuProducer.setTUPI(handlingUnitsBL.getEffectivePI(sourceTuHU));
+				lutuProducer.addCUPerTU(tuCapacity);
+
+				HULoader.builder()
+						.source(HUListAllocationSourceDestination.of(sourceTuHU))
+						.destination(lutuProducer)
+						.load(AllocationUtils.builder()
+								.setHUContext(huContext)
+								.setProduct(tuCapacity.getProductId())
+								.setQuantity(qtyTU.computeTotalQtyCUsUsingQtyCUsPerTU(tuCapacity.toQuantity()))
+								.setFromReferencedModel(sourceTuHU)
+								.setForceQtyAllocation(true)
+								.create());
+
+				result = result.mergeWith(lutuProducer.getResult());
+				tuHUsToAttachToLU = ImmutableList.of();
+			}
+			else
+			{
+				// create one or many new TUs for qtyTU
+				tuHUsToAttachToLU = tuToNewTUs(sourceTuHU, qtyTU).getTopLevelTURecords();
+			}
 		}
 
 		tuHUsToAttachToLU.forEach(tuToAttach -> {
@@ -608,7 +635,10 @@ public class HUTransformService
 					});
 		});
 
-		return LUTUResult.ofLU(luHU, TUsList.ofSingleTUsList(tuHUsToAttachToLU));
+		final LU lu = LU.of(luHU, TUsList.ofSingleTUsList(tuHUsToAttachToLU)).markedAsPreExistingLU();
+		result = result.mergeWith(lu);
+
+		return result;
 	}
 
 	/**
@@ -1188,6 +1218,15 @@ public class HUTransformService
 		}
 
 		return result;
+	}
+
+	private Capacity extractTUCapacity(final I_M_HU tu)
+	{
+		final QtyTU qtyTUs = getMaximumQtyTU(tu);
+		final IHUProductStorage productStorage = getSingleProductStorage(tu);
+		final Quantity qtyCUsTotal = productStorage.getQty();
+		final Quantity qtyCUsPerTU = qtyTUs.computeQtyCUsPerTUUsingTotalQty(qtyCUsTotal);
+		return Capacity.createCapacity(qtyCUsPerTU, productStorage.getProductId());
 	}
 
 	private List<IHUProductStorage> retrieveAllProductStoragesOfTU(final I_M_HU tuHU)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/HUTransformService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/HUTransformService.java
@@ -576,7 +576,8 @@ public class HUTransformService
 		}
 		else
 		{
-			if (handlingUnitsBL.isAggregateHU(sourceTuHU))
+			if (handlingUnitsBL.isAggregateHU(sourceTuHU)
+					&& !handlingUnitsBL.isTUIncludedInLU(sourceTuHU, luHU))
 			{
 				final Capacity tuCapacity = extractTUCapacity(sourceTuHU);
 				final LUTUProducerDestination lutuProducer = new LUTUProducerDestination();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/LUTUResult.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/LUTUResult.java
@@ -33,25 +33,15 @@ public class LUTUResult
 	@NonNull @Singular("lu") ImmutableList<LU> lus;
 	@NonNull @Builder.Default TUsList topLevelTUs = TUsList.EMPTY;
 
-	public static LUTUResult ofLU(@NonNull final I_M_HU lu, @NonNull final TU... tus)
-	{
-		return builder().lu(LU.of(lu, tus)).build();
-	}
+	public static LUTUResult ofLU(@NonNull final I_M_HU lu, @NonNull final TU... tus) {return ofLU(LU.of(lu, tus));}
 
-	public static LUTUResult ofLU(@NonNull final I_M_HU lu, @NonNull final TUsList tus)
-	{
-		return builder().lu(LU.of(lu, tus)).build();
-	}
+	public static LUTUResult ofLU(@NonNull final I_M_HU lu, @NonNull final TUsList tus) {return ofLU(LU.of(lu, tus));}
 
-	public static LUTUResult ofSingleTopLevelTU(final I_M_HU tu)
-	{
-		return ofTopLevelTUs(TUsList.ofSingleTU(tu));
-	}
+	public static LUTUResult ofLU(@NonNull final LU lu) {return builder().lu(lu).build();}
 
-	public static LUTUResult ofTopLevelTUs(final Collection<I_M_HU> tus)
-	{
-		return ofTopLevelTUs(TUsList.ofSingleTUsList(tus));
-	}
+	public static LUTUResult ofSingleTopLevelTU(final I_M_HU tu) {return ofTopLevelTUs(TUsList.ofSingleTU(tu));}
+
+	public static LUTUResult ofTopLevelTUs(final Collection<I_M_HU> tus) {return ofTopLevelTUs(TUsList.ofSingleTUsList(tus));}
 
 	public static LUTUResult ofTopLevelTUs(@NonNull final TUsList tus)
 	{
@@ -140,6 +130,11 @@ public class LUTUResult
 				lus.stream().flatMap(LU::streamAllLUAndTURecords),
 				topLevelTUs.streamHURecords()
 		);
+	}
+
+	public LUTUResult mergeWith(final LU lu)
+	{
+		return mergeWith(ofLU(lu));
 	}
 
 	public LUTUResult mergeWith(final LUTUResult other)
@@ -345,7 +340,7 @@ public class LUTUResult
 			{
 				throw new AdempiereException("Cannot merge " + this + " with " + other + " because they don't have the same HU");
 			}
-			
+
 			return builder()
 					.hu(this.hu)
 					.isPreExistingLU(this.isPreExistingLU && other.isPreExistingLU)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/LUTUResult.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/LUTUResult.java
@@ -341,7 +341,13 @@ public class LUTUResult
 
 		public LU mergeWith(@NonNull final LU other)
 		{
+			if (this.hu.getM_HU_ID() != other.hu.getM_HU_ID())
+			{
+				throw new AdempiereException("Cannot merge " + this + " with " + other + " because they don't have the same HU");
+			}
+			
 			return builder()
+					.hu(this.hu)
 					.isPreExistingLU(this.isPreExistingLU && other.isPreExistingLU)
 					.tus(this.tus.mergeWith(other.tus))
 					.build();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/impl/LUTUProducerDestination.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/impl/LUTUProducerDestination.java
@@ -448,8 +448,13 @@ public class LUTUProducerDestination
 	public void setLU(@NonNull final HuId luId)
 	{
 		assertConfigurable();
+		setLU(handlingUnitsBL.getById(luId));
+	}
 
-		final I_M_HU lu = handlingUnitsBL.getById(luId);
+	public void setLU(@NonNull final I_M_HU lu)
+	{
+		assertConfigurable();
+
 		final I_M_HU_PI luPI = handlingUnitsBL.getPI(lu);
 
 		this._existingLU = lu;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/impl/LUTUProducerDestination.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/impl/LUTUProducerDestination.java
@@ -38,7 +38,6 @@ import de.metas.handlingunits.allocation.transfer.LUTUResult;
 import de.metas.handlingunits.document.IHUAllocations;
 import de.metas.handlingunits.exceptions.HUException;
 import de.metas.handlingunits.hutransaction.IHUTransactionBL;
-import de.metas.handlingunits.hutransaction.IHUTransactionCandidate;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_Item;
 import de.metas.handlingunits.model.I_M_HU_LUTU_Configuration;
@@ -563,9 +562,11 @@ public class LUTUProducerDestination
 		final IMutableAllocationResult result = AllocationUtils.createMutableAllocationResult(request);
 
 		// 06647: create and add a HU-trx just so that HULoader.load0() will later on transfer the source's attributes also to the LU and not just to the TUs
-		final I_M_HU_PI_Item luItemPI = getLUItemPI();
-		final IHUTransactionCandidate luTrx = huTransactionBL.createLUTransactionForAttributeTransfer(luHU, luItemPI, request);
-		result.addTransaction(luTrx);
+		// do this only if we created the LU, else we would override the attributes of already existing TUs
+		if (!isExistingLU(luHU))
+		{
+			result.addTransaction(huTransactionBL.createLUTransactionForAttributeTransfer(luHU, getLUItemPI(), request));
+		}
 
 		final TUProducerDestination tuProducer = getOrCreateTUProducer(luHU);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/impl/HUTransactionAttributeBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/impl/HUTransactionAttributeBuilder.java
@@ -22,13 +22,6 @@ package de.metas.handlingunits.attribute.impl;
  * #L%
  */
 
-import java.math.BigDecimal;
-import java.util.Collections;
-import java.util.List;
-
-import org.compiere.model.I_M_Attribute;
-import org.slf4j.Logger;
-
 import de.metas.handlingunits.IHUContext;
 import de.metas.handlingunits.allocation.IAllocationResult;
 import de.metas.handlingunits.allocation.impl.AllocationUtils;
@@ -39,21 +32,26 @@ import de.metas.handlingunits.attribute.storage.IAttributeStorageFactory;
 import de.metas.handlingunits.attribute.strategy.IHUAttributeTransferRequest;
 import de.metas.handlingunits.attribute.strategy.IHUAttributeTransferStrategy;
 import de.metas.handlingunits.hutransaction.IHUTransactionAttribute;
-import de.metas.handlingunits.hutransaction.IHUTransactionCandidate;
 import de.metas.handlingunits.hutransaction.IHUTrxBL;
 import de.metas.logging.LogManager;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.mm.attributes.api.IAttributeSet;
+import org.compiere.model.I_M_Attribute;
+import org.slf4j.Logger;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Standard {@link IHUTransactionAttributeBuilder} implementation.
- *
+ * <p>
  * <br/>
  * <br/>
  * <b>WARNING: To be used internally by {@link HUContextProcessorExecutor} only. DO NOT use it directly.</b>
  *
  * @author tsa
- *
  */
 public class HUTransactionAttributeBuilder implements IHUTransactionAttributeBuilder
 {
@@ -114,7 +112,7 @@ public class HUTransactionAttributeBuilder implements IHUTransactionAttributeBui
 	{
 		logger.trace("Transfering attributes for {}", request);
 
-		final IAttributeStorage attributesFrom = request.getAttributesFrom();
+		final IAttributeSet attributesFrom = request.getAttributesFrom();
 		final IAttributeStorage attributesTo = request.getAttributesTo();
 
 		for (final I_M_Attribute attribute : attributesFrom.getAttributes())
@@ -144,8 +142,14 @@ public class HUTransactionAttributeBuilder implements IHUTransactionAttributeBui
 
 	private IHUAttributeTransferStrategy getHUAttributeTransferStrategy(final IHUAttributeTransferRequest request, final I_M_Attribute attribute)
 	{
-		final IAttributeStorage attributesFrom = request.getAttributesFrom();
-		return attributesFrom.retrieveTransferStrategy(attribute);
+		final IAttributeSet attributesFrom = request.getAttributesFrom();
+		if (attributesFrom instanceof IAttributeStorage)
+		{
+			return ((IAttributeStorage)attributesFrom).retrieveTransferStrategy(attribute);
+		}
+
+		final IAttributeStorage attributesTo = request.getAttributesTo();
+		return attributesTo.retrieveTransferStrategy(attribute);
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/ASIAttributeStorage.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/storage/ASIAttributeStorage.java
@@ -3,6 +3,7 @@ package de.metas.handlingunits.attribute.storage;
 import java.util.List;
 import java.util.Map;
 
+import lombok.Getter;
 import org.adempiere.mm.attributes.AttributeId;
 import org.adempiere.mm.attributes.api.IAttributeDAO;
 import org.adempiere.mm.attributes.spi.IAttributeValueContext;
@@ -27,30 +28,24 @@ import lombok.NonNull;
 public class ASIAttributeStorage extends AbstractAttributeStorage
 {
 
-	public static IAttributeStorage createNew(
+	public static ASIAttributeStorage createNew(
 			@NonNull final IAttributeStorageFactory attributeStorageFactory,
 			@NonNull final I_M_AttributeSetInstance attributeSetInstance)
 	{
 		return new ASIAttributeStorage(attributeStorageFactory, attributeSetInstance);
 	}
 
-	private final String id;
-	private final I_M_AttributeSetInstance asi;
+	@NonNull @Getter private final String id;
+	@NonNull private final I_M_AttributeSetInstance asi;
 
 	private ASIAttributeStorage(
-			final IAttributeStorageFactory storageFactory,
+			@NonNull final IAttributeStorageFactory storageFactory,
 			@NonNull final I_M_AttributeSetInstance asi)
 	{
-		super(Check.assumeNotNull(storageFactory, "storageFactory"));
+		super(storageFactory);
 
 		this.asi = asi;
 		this.id = I_M_AttributeSetInstance.COLUMNNAME_M_AttributeSetInstance_ID + "=" + asi.getM_AttributeSetInstance_ID();
-	}
-
-	@Override
-	public String getId()
-	{
-		return id;
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/strategy/IHUAttributeTransferRequest.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/strategy/IHUAttributeTransferRequest.java
@@ -10,27 +10,26 @@ package de.metas.handlingunits.attribute.strategy;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 
-
-import java.math.BigDecimal;
-
-import org.compiere.model.I_C_UOM;
-
 import de.metas.handlingunits.IHUContext;
 import de.metas.handlingunits.attribute.storage.IAttributeStorage;
 import de.metas.handlingunits.storage.IHUStorage;
 import de.metas.product.ProductId;
+import org.adempiere.mm.attributes.api.IAttributeSet;
+import org.compiere.model.I_C_UOM;
+
+import java.math.BigDecimal;
 
 /**
  * Provides necessary data from to the transfer strategies when re-propagating values post-transfer to the other storage.
@@ -59,14 +58,8 @@ public interface IHUAttributeTransferRequest
 	 */
 	I_C_UOM getC_UOM();
 
-	/**
-	 * @return {@link IAttributeStorage} from which the attributes are transferred
-	 */
-	IAttributeStorage getAttributesFrom();
+	IAttributeSet getAttributesFrom();
 
-	/**
-	 * @return {@link IAttributeStorage} to which the attributes are transferred
-	 */
 	IAttributeStorage getAttributesTo();
 
 	/**
@@ -85,7 +78,6 @@ public interface IHUAttributeTransferRequest
 	BigDecimal getQtyUnloaded();
 
 	/**
-	 *
 	 * @return true if this request is about transfering attributes between virtual HUs.
 	 */
 	boolean isVHUTransfer();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/strategy/IHUAttributeTransferRequestBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/strategy/IHUAttributeTransferRequestBuilder.java
@@ -10,99 +10,66 @@ package de.metas.handlingunits.attribute.strategy;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 
-
-import java.math.BigDecimal;
-
-import org.compiere.model.I_C_UOM;
-
 import de.metas.handlingunits.attribute.storage.IAttributeStorage;
 import de.metas.handlingunits.storage.IHUStorage;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
+import org.adempiere.mm.attributes.api.IAttributeSet;
+import org.compiere.model.I_C_UOM;
 
+import java.math.BigDecimal;
+
+@SuppressWarnings("UnusedReturnValue")
 public interface IHUAttributeTransferRequestBuilder
 {
-	/**
-	 * Set product that's being transferred
-	 *
-	 * @param product
-	 * @return builder
-	 */
 	IHUAttributeTransferRequestBuilder setProductId(ProductId productId);
 
-	/**
-	 * Set qty that's being transferred
-	 *
-	 * @param qty
-	 * @return builder
-	 */
 	IHUAttributeTransferRequestBuilder setQty(BigDecimal qty);
 
 	/**
 	 * Set UOM for the product that's being transferred
-	 *
-	 * @param uom
-	 * @return builder
 	 */
 	IHUAttributeTransferRequestBuilder setUOM(I_C_UOM uom);
 
 	/**
 	 * Set Qty/UOM for the product that's being transferred
-	 *
-	 * @param quantity
-	 * @return builder
 	 */
 	IHUAttributeTransferRequestBuilder setQuantity(Quantity quantity);
 
 	/**
 	 * Set attribute storage for the HU storage FROM which we're transferring attributes (Source)
-	 *
-	 * @param attributeStorageFrom
-	 * @return builder
 	 */
-	IHUAttributeTransferRequestBuilder setAttributeStorageFrom(IAttributeStorage attributeStorageFrom);
+	IHUAttributeTransferRequestBuilder setAttributeStorageFrom(IAttributeSet attributeStorageFrom);
 
 	/**
 	 * Set attribute storage for the HU storage TO which we're transferring attributes (Target)
-	 *
-	 * @param attributeStorageTo
-	 * @return builder
 	 */
 	IHUAttributeTransferRequestBuilder setAttributeStorageTo(IAttributeStorage attributeStorageTo);
 
 	/**
 	 * Set HU storage FROM which we're transferring attributes (Source)
-	 *
-	 * @param huStorageFrom
-	 * @return builder
 	 */
 	IHUAttributeTransferRequestBuilder setHUStorageFrom(IHUStorage huStorageFrom);
 
 	/**
 	 * Set HU storage TO which we're transferring attributes (Target)
-	 *
-	 * @param huStorageTo
-	 * @return builder
 	 */
 	IHUAttributeTransferRequestBuilder setHUStorageTo(IHUStorage huStorageTo);
 
 	/**
 	 * Set qty already unloaded
-	 *
-	 * @param qtyUnloaded
-	 * @return builder
 	 */
 	IHUAttributeTransferRequestBuilder setQtyUnloaded(BigDecimal qtyUnloaded);
 
@@ -115,9 +82,6 @@ public interface IHUAttributeTransferRequestBuilder
 
 	/**
 	 * Sets if this is a transfer for Virtual HU attributes
-	 *
-	 * @param vhuTransfer
-	 * @return
 	 */
 	IHUAttributeTransferRequestBuilder setVHUTransfer(boolean vhuTransfer);
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/strategy/impl/CopyHUAttributeTransferStrategy.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/strategy/impl/CopyHUAttributeTransferStrategy.java
@@ -23,6 +23,7 @@ package de.metas.handlingunits.attribute.strategy.impl;
  */
 
 
+import org.adempiere.mm.attributes.api.IAttributeSet;
 import org.compiere.model.I_M_Attribute;
 
 import de.metas.handlingunits.attribute.storage.IAttributeStorage;
@@ -40,7 +41,7 @@ public final class CopyHUAttributeTransferStrategy implements IHUAttributeTransf
 	@Override
 	public void transferAttribute(final IHUAttributeTransferRequest request, final I_M_Attribute attribute)
 	{
-		final IAttributeStorage attributesFrom = request.getAttributesFrom();
+		final IAttributeSet attributesFrom = request.getAttributesFrom();
 		final Object value = attributesFrom.getValue(attribute);
 
 		final IAttributeStorage attributesTo = request.getAttributesTo();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/strategy/impl/HUAttributeTransferRequest.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/strategy/impl/HUAttributeTransferRequest.java
@@ -10,22 +10,17 @@ package de.metas.handlingunits.attribute.strategy.impl;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
-
-
-import java.math.BigDecimal;
-
-import org.compiere.model.I_C_UOM;
 
 import de.metas.handlingunits.IHUContext;
 import de.metas.handlingunits.attribute.storage.IAttributeStorage;
@@ -33,6 +28,10 @@ import de.metas.handlingunits.attribute.strategy.IHUAttributeTransferRequest;
 import de.metas.handlingunits.storage.IHUStorage;
 import de.metas.product.ProductId;
 import de.metas.util.Check;
+import org.adempiere.mm.attributes.api.IAttributeSet;
+import org.compiere.model.I_C_UOM;
+
+import java.math.BigDecimal;
 
 /* package */final class HUAttributeTransferRequest implements IHUAttributeTransferRequest
 {
@@ -42,7 +41,7 @@ import de.metas.util.Check;
 	private final BigDecimal qty;
 	private final I_C_UOM uom;
 
-	private final IAttributeStorage attributeStorageFrom;
+	private final IAttributeSet attributeStorageFrom;
 	private final IAttributeStorage attributeStorageTo;
 
 	private final IHUStorage huStorageFrom;
@@ -53,15 +52,15 @@ import de.metas.util.Check;
 	private final boolean vhuTransfer;
 
 	public HUAttributeTransferRequest(final IHUContext huContext,
-			final ProductId productId,
-			final BigDecimal qty,
-			final I_C_UOM uom,
-			final IAttributeStorage attributeStorageFrom,
-			final IAttributeStorage attributeStorageTo,
-			final IHUStorage huStorageFrom,
-			final IHUStorage huStorageTo,
-			final BigDecimal qtyUnloaded,
-			final boolean vhuTransfer)
+									  final ProductId productId,
+									  final BigDecimal qty,
+									  final I_C_UOM uom,
+									  final IAttributeSet attributeStorageFrom,
+									  final IAttributeStorage attributeStorageTo,
+									  final IHUStorage huStorageFrom,
+									  final IHUStorage huStorageTo,
+									  final BigDecimal qtyUnloaded,
+									  final boolean vhuTransfer)
 	{
 		super();
 
@@ -123,7 +122,7 @@ import de.metas.util.Check;
 	}
 
 	@Override
-	public IAttributeStorage getAttributesFrom()
+	public IAttributeSet getAttributesFrom()
 	{
 		return attributeStorageFrom;
 	}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/strategy/impl/HUAttributeTransferRequestBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/strategy/impl/HUAttributeTransferRequestBuilder.java
@@ -10,22 +10,17 @@ package de.metas.handlingunits.attribute.strategy.impl;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
-
-
-import java.math.BigDecimal;
-
-import org.compiere.model.I_C_UOM;
 
 import de.metas.handlingunits.IHUContext;
 import de.metas.handlingunits.attribute.storage.IAttributeStorage;
@@ -35,6 +30,10 @@ import de.metas.handlingunits.storage.IHUStorage;
 import de.metas.handlingunits.storage.IProductStorage;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
+import org.adempiere.mm.attributes.api.IAttributeSet;
+import org.compiere.model.I_C_UOM;
+
+import java.math.BigDecimal;
 
 /**
  * @author al
@@ -50,12 +49,14 @@ public final class HUAttributeTransferRequestBuilder implements IHUAttributeTran
 	private IHUStorage huStorageFrom = null;
 	private IHUStorage huStorageTo = null;
 
-	private IAttributeStorage attributeStorageFrom = null;
+	private IAttributeSet attributeStorageFrom = null;
 	private IAttributeStorage attributeStorageTo = null;
 
 	private BigDecimal qtyUnloaded = null;
 
-	/** Virtual HU attributes transfer */
+	/**
+	 * Virtual HU attributes transfer
+	 */
 	private boolean vhuTransfer = false;
 
 	public HUAttributeTransferRequestBuilder(final IHUContext huContext)
@@ -111,7 +112,7 @@ public final class HUAttributeTransferRequestBuilder implements IHUAttributeTran
 	}
 
 	@Override
-	public IHUAttributeTransferRequestBuilder setAttributeStorageFrom(final IAttributeStorage attributeStorageFrom)
+	public IHUAttributeTransferRequestBuilder setAttributeStorageFrom(final IAttributeSet attributeStorageFrom)
 	{
 		this.attributeStorageFrom = attributeStorageFrom;
 		return this;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/strategy/impl/RedistributeQtyHUAttributeTransferStrategy.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/strategy/impl/RedistributeQtyHUAttributeTransferStrategy.java
@@ -22,22 +22,21 @@ package de.metas.handlingunits.attribute.strategy.impl;
  * #L%
  */
 
-
-import java.math.BigDecimal;
-import java.math.MathContext;
-import java.math.RoundingMode;
-
-import org.adempiere.mm.attributes.api.CurrentAttributeValueContextProvider;
-import org.adempiere.mm.attributes.api.IAttributesBL;
-import org.compiere.model.I_C_UOM;
-import org.compiere.model.I_M_Attribute;
-
 import de.metas.handlingunits.attribute.storage.IAttributeStorage;
 import de.metas.handlingunits.attribute.strategy.IHUAttributeTransferRequest;
 import de.metas.handlingunits.attribute.strategy.IHUAttributeTransferStrategy;
 import de.metas.handlingunits.storage.IHUStorage;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
+import org.adempiere.mm.attributes.api.CurrentAttributeValueContextProvider;
+import org.adempiere.mm.attributes.api.IAttributeSet;
+import org.adempiere.mm.attributes.api.IAttributesBL;
+import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_M_Attribute;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 
 public class RedistributeQtyHUAttributeTransferStrategy implements IHUAttributeTransferStrategy
 {
@@ -53,7 +52,7 @@ public class RedistributeQtyHUAttributeTransferStrategy implements IHUAttributeT
 	{
 		CurrentAttributeValueContextProvider.assertNoCurrentContext();
 
-		final IAttributeStorage attributesFrom = request.getAttributesFrom();
+		final IAttributeSet attributesFrom = request.getAttributesFrom();
 
 		//
 		// Transfer ratio is used to proportionally distribute qty

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/hutransaction/IHUTransactionBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/hutransaction/IHUTransactionBL.java
@@ -10,22 +10,19 @@ import org.adempiere.util.lang.impl.TableRecordReference;
 
 /**
  * Declare business logic to create different {@link IHUTransactionCandidate}s for different purposes.
- * 
- * @author metas-dev <dev@metasfresh.com>
  *
+ * @author metas-dev <dev@metasfresh.com>
  */
 public interface IHUTransactionBL extends ISingletonService
 {
 	/**
 	 * Current use: creates a IHUTransaction for a LU, which is created from a receipt schedule.<br>
 	 * Just so that HULoader.load0() will later on transfer the source's attributes also to the LU and not just to the TUs (task 06748).
-	 *
-	 * @param luHU
-	 * @param luItemPI
-	 * @param request
-	 * @return
 	 */
-	IHUTransactionCandidate createLUTransactionForAttributeTransfer(I_M_HU luHU, I_M_HU_PI_Item luItemPI, IAllocationRequest request);
+	IHUTransactionCandidate createLUTransactionForAttributeTransfer(
+			@NonNull I_M_HU luHU,
+			@NonNull I_M_HU_PI_Item luItemPI,
+			@NonNull IAllocationRequest request);
 
 	/**
 	 * This method is used to find out for a given document, an HU was changed another time after having been affected by a particular document.

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/hutransaction/IHUTransactionCandidate.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/hutransaction/IHUTransactionCandidate.java
@@ -1,23 +1,21 @@
 package de.metas.handlingunits.hutransaction;
 
-import java.time.ZonedDateTime;
-
-import org.adempiere.warehouse.LocatorId;
-
 import de.metas.handlingunits.hutransaction.impl.HUTransactionCandidate;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_Item;
 import de.metas.handlingunits.model.I_M_HU_Trx_Line;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
+import org.adempiere.warehouse.LocatorId;
+
+import java.time.ZonedDateTime;
 
 /**
  * Transaction Line Candidate. Use the constructor of {@link HUTransactionCandidate} to get instances.
- *
+ * <p>
  * Based on this object the actual {@link I_M_HU_Trx_Line}s can be created.
  *
  * @author tsa
- *
  */
 public interface IHUTransactionCandidate
 {
@@ -42,7 +40,9 @@ public interface IHUTransactionCandidate
 	 */
 	I_M_HU getM_HU();
 
-	/** @see #getM_HU() */
+	/**
+	 * @see #getM_HU()
+	 */
 	default int getM_HU_ID()
 	{
 		final I_M_HU hu = getM_HU();
@@ -51,7 +51,7 @@ public interface IHUTransactionCandidate
 
 	/**
 	 * Gets affected HU Item.
-	 *
+	 * <p>
 	 * If this value is null it means that no HU Item is affected by this transaction but in most of the cases its counter part transaction will affect an HU Item.
 	 *
 	 * <p>
@@ -65,7 +65,7 @@ public interface IHUTransactionCandidate
 
 	/**
 	 * Gets actual Virtual HU Item to be used for storing the Qty.
-	 *
+	 * <p>
 	 * NOTE: this VHU needs to be included in {@link #getM_HU_Item()}.
 	 *
 	 * @return VHU item or <code>null</code>
@@ -81,7 +81,7 @@ public interface IHUTransactionCandidate
 
 	/**
 	 * Gets transaction product
-	 *
+	 * <p>
 	 * i.e. the product which was transfered.
 	 *
 	 * @return transaction product; never returns null
@@ -101,7 +101,7 @@ public interface IHUTransactionCandidate
 
 	/**
 	 * Gets counterpart transaction.
-	 *
+	 * <p>
 	 * NOTE: each transaction shall have a counterpart. i.e. when qty was subtracted from one place, there shall be another place where the Qty was added.
 	 *
 	 * @return counterpart transaction
@@ -110,10 +110,8 @@ public interface IHUTransactionCandidate
 
 	/**
 	 * Cross link this transaction with given transaction by cross setting their {@link #getCounterpart()} properties.
-	 *
+	 * <p>
 	 * NOTE: DON'T call it directly. It will be called by API
-	 *
-	 * @param counterpartTrx
 	 */
 	void pair(IHUTransactionCandidate counterpartTrx);
 
@@ -134,7 +132,7 @@ public interface IHUTransactionCandidate
 
 	/**
 	 * Force trxLine to be considered processed and never be actually processed.
-	 *
+	 * <p>
 	 * i.e. don't change HU's storage
 	 */
 	void setSkipProcessing();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/hutransaction/impl/HUTransactionBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/hutransaction/impl/HUTransactionBL.java
@@ -23,17 +23,22 @@ public class HUTransactionBL implements IHUTransactionBL
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 	@Override
-	public IHUTransactionCandidate createLUTransactionForAttributeTransfer(final I_M_HU luHU, final I_M_HU_PI_Item luItemPI, final IAllocationRequest request)
+	public IHUTransactionCandidate createLUTransactionForAttributeTransfer(
+			@NonNull final I_M_HU luHU,
+			@NonNull final I_M_HU_PI_Item luItemPI,
+			@NonNull final IAllocationRequest request)
 	{
-		final I_M_HU_Item luItem = Services.get(IHandlingUnitsDAO.class).retrieveItemIfExists(luHU, luItemPI).orElse(null);
+		final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
+		final I_M_HU_Item luItem = handlingUnitsDAO.retrieveItemIfExists(luHU, luItemPI).orElse(null);
 
-		return new HUTransactionCandidate(AllocationUtils.getReferencedModel(request), // receipt schedule
-				luItem, // huItem,
-				null, // vhuItem (note: at this level we're not talking about VHUs but actual LU-HUs)
-				request.getProductId(),
-				request.getQuantity().toZero(),
-				request.getDate()
-		);
+		return HUTransactionCandidate.builder()
+				.model(AllocationUtils.getReferencedModel(request))
+				.huItem(luItem)
+				.vhuItem(null)
+				.productId(request.getProductId())
+				.quantity(request.getQuantity().toZero())
+				.date(request.getDate())
+				.build();
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/hutransaction/impl/HUTransactionCandidate.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/hutransaction/impl/HUTransactionCandidate.java
@@ -1,16 +1,5 @@
 package de.metas.handlingunits.hutransaction.impl;
 
-import java.time.ZonedDateTime;
-import java.util.UUID;
-
-import javax.annotation.Nullable;
-
-import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.model.InterfaceWrapperHelper;
-import org.adempiere.warehouse.LocatorId;
-import org.adempiere.warehouse.api.IWarehouseDAO;
-import org.slf4j.Logger;
-
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.allocation.IAllocationRequest;
 import de.metas.handlingunits.exceptions.HUException;
@@ -26,42 +15,44 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.warehouse.LocatorId;
+import org.adempiere.warehouse.api.IWarehouseDAO;
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+import java.time.ZonedDateTime;
+import java.util.UUID;
 
 public final class HUTransactionCandidate implements IHUTransactionCandidate
 {
-	private static final transient Logger logger = LogManager.getLogger(HUTransactionCandidate.class);
+	private static final Logger logger = LogManager.getLogger(HUTransactionCandidate.class);
 
 	// Dimension
-	@Getter
-	@Setter
-	private Object referencedModel;
+	@Getter @Setter private Object referencedModel;
 
-	private final I_M_HU_Item huItem;
+	@Nullable private final I_M_HU_Item huItem;
 
-	private final I_M_HU_Item vhuItem;
+	@Nullable private final I_M_HU_Item vhuItem;
+
 	// Product/Qty/UOM
 
-	@Getter
-	private final ProductId productId;
-
-	@Getter
-	private final Quantity quantity;
+	@Getter private final ProductId productId;
+	@Getter private final Quantity quantity;
 
 	// Physical position and status
 	private final LocatorId locatorId;
-
 	private final String huStatus;
 
 	// Reference
 	private final String id;
 
-	@Getter
-	private final ZonedDateTime date;
+	@Getter private final ZonedDateTime date;
 
 	private IHUTransactionCandidate counterpartTrx;
 
-	@Getter
-	private boolean skipProcessing = false;
+	@Getter private boolean skipProcessing = false;
 
 	public HUTransactionCandidate(
 			final Object referencedModel,
@@ -91,21 +82,23 @@ public final class HUTransactionCandidate implements IHUTransactionCandidate
 			final Quantity quantity,
 			final ZonedDateTime date)
 	{
-		this(model,
+		this(
+				model,
 				huItem,
 				vhuItem,
 				productId,
 				quantity,
 				date,
 				null, // locator, will be handled
-				null); // huStatus, will be handled
+				null // huStatus, will be handled
+		);
 	}
 
 	@Builder
 	public HUTransactionCandidate(
 			final Object model,
-			final I_M_HU_Item huItem,
-			final I_M_HU_Item vhuItem,
+			@Nullable final I_M_HU_Item huItem,
+			@Nullable final I_M_HU_Item vhuItem,
 			@NonNull final ProductId productId,
 			@NonNull final Quantity quantity,
 			@NonNull final ZonedDateTime date,
@@ -150,16 +143,9 @@ public final class HUTransactionCandidate implements IHUTransactionCandidate
 			this.huItem = null;
 		}
 
-		// vhuItem
 		this.vhuItem = vhuItem;
-
-		// Product
 		this.productId = productId;
-
-		// Qty/UOM
 		this.quantity = quantity;
-
-		// Transaction date
 		this.date = date;
 
 		final I_M_HU effectiveHU = getEffectiveHU();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HandlingUnitsBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HandlingUnitsBL.java
@@ -1359,4 +1359,11 @@ public class HandlingUnitsBL implements IHandlingUnitsBL
 	{
 		return handlingUnitsRepo.retrieveParentLUPIs(tuPIItemIds, bpartnerId);
 	}
+
+	@Override
+	public boolean isTUIncludedInLU(@NonNull final I_M_HU tu, @NonNull final I_M_HU expectedLU)
+	{
+		final I_M_HU actualLU = getLoadingUnitHU(tu);
+		return actualLU != null && actualLU.getM_HU_ID() == expectedLU.getM_HU_ID();
+	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HandlingUnitsDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HandlingUnitsDAO.java
@@ -519,6 +519,24 @@ public class HandlingUnitsDAO implements IHandlingUnitsDAO
 		return retrievePIItems(version, null, bpartnerId, null);
 	}
 
+	@Override
+	public I_M_HU_PI_Item retrievePIItemMaterial(@NonNull final I_M_HU_PI_Version version)
+	{
+		final List<I_M_HU_PI_Item> materialItems = retrievePIItems(version, X_M_HU_PI_Item.ITEMTYPE_Material, null, null);
+		if (materialItems.isEmpty())
+		{
+			throw new AdempiereException("No material items found for " + version);
+		}
+		else if (materialItems.size() == 1)
+		{
+			return materialItems.get(0);
+		}
+		else
+		{
+			throw new AdempiereException("More than one material item found for " + version + ": " + materialItems);
+		}
+	}
+
 	private List<I_M_HU_PI_Item> retrievePIItems(
 			@NonNull final I_M_HU_PI_Version version,
 			@Nullable String expectedItemType,

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/HUTransformServiceReservationTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/HUTransformServiceReservationTests.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.not;
 import java.math.BigDecimal;
 import java.util.List;
 
+import de.metas.handlingunits.util.HUTracerInstance;
 import org.adempiere.test.AdempiereTestHelper;
 import org.junit.Assert;
 import org.junit.Before;
@@ -186,6 +187,7 @@ public class HUTransformServiceReservationTests
 		final I_M_HU cuToSplit = data.mkAggregateHUWithTotalQtyCU("200");
 
 		final I_M_HU topLevelParent = handlingUnitsBL.getTopLevelParent(cuToSplit);
+		new HUTracerInstance().dump("topLevelParent - before husToNewCUs", topLevelParent);
 
 		final HUsToNewCUsRequest husToNewCUsRequest = HUsToNewCUsRequest.builder()
 				.sourceHU(topLevelParent)
@@ -196,6 +198,8 @@ public class HUTransformServiceReservationTests
 
 		final List<I_M_HU> newCUs = huTransformService.husToNewCUs(husToNewCUsRequest);
 		// data.helper.commitAndDumpHU(topLevelParent);
+		new HUTracerInstance().dump("topLevelParent - after husToNewCUs", topLevelParent);
+		new HUTracerInstance().dump("newCUs", newCUs);
 
 		final Node existingLUXML = HUXmlConverter.toXml(topLevelParent);
 		Assert.assertThat(existingLUXML, hasXPath("count(HU-LU_Palet[@HUStatus='A'])", is("1")));

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/util/HUTracerInstance.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/util/HUTracerInstance.java
@@ -75,6 +75,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -248,6 +249,12 @@ public class HUTracerInstance
 	{
 		printTitle(title);
 		dump(hu);
+	}
+
+	public void dump(final String title, final List<I_M_HU> hus)
+	{
+		printTitle(title);
+		dump(hus);
 	}
 
 	private void printTitle(final String title)


### PR DESCRIPTION
- **QA**
- **QA**
- **QtyTU - more helper methods**
- **IHandlingUnitsDAO.retrievePIItemMaterial**
- **LUTUResult.LU.mergeWith fix**
- **LUTUProducerDestination.setLU(I_M_HU)**
- **ShipmentScheduleWithHU: fix how we determine M_HU_PI_Item_Product_ID for aggregated TUs**
- **HUTransformService.tuToExistingLU: use aggregated TUs as much as possible**
- **LUTUProducerDestination don't override attributes of already existing TUs**
- **PickingJobPickCommand: update attributes of pre-existing LUs**
- **ShipmentLineBuilder: transfer the TUs ASI in case we are dealing with TUs from multiple lines on the same LU**
- **Pick_MultipleProducts_to_LU.feature**
