### PR TITLE
Split shipments: support for shipments with no HUs

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
@@ -124,7 +124,7 @@ public class ShipmentScheduleWithHU
 	@Getter private final boolean adviseManualPackingMaterial;
 
 	ShipmentScheduleWithHU(
-			@NonNull ShipmentScheduleWithHUSupportingServices services,
+			@NonNull final ShipmentScheduleWithHUSupportingServices services,
 			@NonNull final IHUContext huContext,
 			@NonNull final I_M_ShipmentSchedule_QtyPicked allocRecord,
 			@NonNull final M_ShipmentSchedule_QuantityTypeToUse qtyTypeToUse,
@@ -159,7 +159,7 @@ public class ShipmentScheduleWithHU
 	 * Creates a HU-"empty" instance that just references the given shipment schedule.
 	 */
 	ShipmentScheduleWithHU(
-			@NonNull ShipmentScheduleWithHUSupportingServices services, 
+			@NonNull final ShipmentScheduleWithHUSupportingServices services,
 			@NonNull final IHUContext huContext,
 			@NonNull final I_M_ShipmentSchedule shipmentSchedule,
 			@NonNull final StockQtyAndUOMQty stockQtyAndCatchQty,
@@ -187,14 +187,15 @@ public class ShipmentScheduleWithHU
 			@NonNull final ShipmentScheduleWithHUSupportingServices services,
 			@NonNull final IHUContext huContext,
 			@NonNull final I_M_ShipmentSchedule shipmentSchedule,
-			@NonNull final ShipmentScheduleSplit split)
+			@NonNull final ShipmentScheduleSplit split,
+			@NonNull final Quantity qtyToAllocate)
 	{
 		this.services = services;
 		this.huContext = huContext;
 		this.shipmentSchedule = shipmentSchedule;
 		this.split = split;
 
-		this.pickedQty = split.getQtyToDeliver();
+		this.pickedQty = qtyToAllocate;
 		this.catchQty = Optional.empty();
 
 		this.vhu = null; // no VHU
@@ -534,6 +535,7 @@ public class ShipmentScheduleWithHU
 		return dimension;
 	}
 
+	@Nullable
 	public ShipmentScheduleSplitId getSplitId() {return split != null ? split.getIdNotNull() : null;}
 
 	public Optional<LocalDate> getDeliveryDate()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUFactory.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUFactory.java
@@ -4,6 +4,7 @@ import de.metas.handlingunits.IHUContext;
 import de.metas.handlingunits.model.I_M_ShipmentSchedule_QtyPicked;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.inoutcandidate.split.ShipmentScheduleSplit;
+import de.metas.quantity.Quantity;
 import de.metas.quantity.StockQtyAndUOMQty;
 import lombok.Builder;
 import lombok.Getter;
@@ -65,9 +66,10 @@ public class ShipmentScheduleWithHUFactory
 
 	public ShipmentScheduleWithHU ofSplit(
 			@NonNull final I_M_ShipmentSchedule shipmentSchedule,
-			@NonNull final ShipmentScheduleSplit split)
+			@NonNull final ShipmentScheduleSplit split,
+			@NonNull final Quantity qtyToAllocate)
 	{
-		return new ShipmentScheduleWithHU(supportingServices, huContext, shipmentSchedule, split);
+		return new ShipmentScheduleWithHU(supportingServices, huContext, shipmentSchedule, split, qtyToAllocate);
 	}
 
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
@@ -122,6 +122,7 @@ import lombok.Value;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.model.PlainContextAware;
 import org.adempiere.service.ClientId;
 import org.adempiere.service.ISysConfigBL;
 import org.adempiere.util.lang.IContextAware;
@@ -470,6 +471,10 @@ public class ShipmentScheduleWithHUService
 
 			final List<I_M_HU> newHURecords = createNewlyPickedHUs(scheduleRecord, sourceHURecord, quantityToSplit, pickAccordingToPackingInstruction);
 
+			if(!newHURecords.isEmpty() && remainingQtyToAllocate.isGreaterThan(qtyOfSourceHU))
+			{
+				handlingUnitsBL.setHUStatus(sourceHURecord, PlainContextAware.newWithThreadInheritedTrx(), X_M_HU.HUSTATUS_Picked);
+			}
 			// we stumbled over HUs with null-trx, which caused some trouble down the line
 			InterfaceWrapperHelper.setThreadInheritedTrxName(newHURecords);
 


### PR DESCRIPTION
Regression: make sure that shipments are created via the split process also for the old values of the sys config `de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PickAvailableHUsOnTheFly`