### PR TITLE
Add sysconfig `de.metas.email.Debug` and other minor improvements

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/EMail.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/EMail.java
@@ -52,7 +52,6 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 import javax.mail.internet.MimePart;
 import java.io.File;
-import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.ArrayList;
@@ -879,7 +878,7 @@ public final class EMail implements Serializable
 	/**
 	 * Set the message content and attachments.
 	 */
-	private void setContent(final MimeMessage msg) throws MessagingException, IOException
+	private void setContent(final MimeMessage msg) throws MessagingException
 	{
 		final String subject = getSubject();
 		msg.setSubject(subject, getCharsetName());
@@ -971,7 +970,7 @@ public final class EMail implements Serializable
 
 	/**
 	 * Checks if the email is valid and can be sent.
-	 *
+	 * <p>
 	 * NOTE: this method is NOT setting the {@link #isValid()} flag.
 	 *
 	 * @return true if email is valid and can be sent

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/EMail.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/EMail.java
@@ -361,7 +361,7 @@ public final class EMail implements Serializable
 		final Properties props = new Properties(System.getProperties());
 		props.put("mail.store.protocol", "smtp");
 		props.put("mail.transport.protocol", "smtp");
-		props.put("mail.smtp.host", smtpHost);
+		props.put("mail.host", smtpHost);
 		props.put("mail.smtp.port", mailbox.getSmtpPort());
 		if (mailbox.isStartTLS())
 		{

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/EMail.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/EMail.java
@@ -28,7 +28,9 @@ import de.metas.common.util.EmptyUtil;
 import de.metas.email.mailboxes.Mailbox;
 import de.metas.logging.LogManager;
 import de.metas.util.Check;
+import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.service.ISysConfigBL;
 import org.compiere.util.Ini;
 import org.slf4j.Logger;
 import org.springframework.core.io.Resource;
@@ -61,20 +63,21 @@ import java.util.Properties;
 
 /**
  * EMail builder and sender.
- *
+ * <p>
  * To create a new email, please use {@link MailService}'s createMail methods.
- *
+ * <p>
  * To send the message, please use {@link #send()}.
- *
+ * <p>
  * NOTE: This is basically a reimplementation of the class <code>org.compiere.util.EMail</code> which was authored (according to the javadoc) by author Joerg Janke.
  *
  * @author metas-dev <dev@metasfresh.com>
  */
-@SuppressWarnings("serial")
 @JsonAutoDetect(getterVisibility = Visibility.NONE, isGetterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public final class EMail implements Serializable
 {
-	private static final transient Logger logger = LogManager.getLogger(EMail.class);
+	private static final String SYSCFG_DEBUG = "de.metas.email.Debug";
+	
+	private static final Logger logger = LogManager.getLogger(EMail.class);
 
 	@JsonProperty("mailbox")
 	private final Mailbox _mailbox;
@@ -103,6 +106,7 @@ public final class EMail implements Serializable
 	private InternetAddress _replyToAddress;
 
 	@JsonIgnore
+	@Nullable
 	private InternetAddress _debugMailToAddress;
 
 	/** Mail Subject */
@@ -358,7 +362,7 @@ public final class EMail implements Serializable
 		final Properties props = new Properties(System.getProperties());
 		props.put("mail.store.protocol", "smtp");
 		props.put("mail.transport.protocol", "smtp");
-		props.put("mail.host", smtpHost);
+		props.put("mail.smtp.host", smtpHost);
 		props.put("mail.smtp.port", mailbox.getSmtpPort());
 		if (mailbox.isStartTLS())
 		{
@@ -368,13 +372,14 @@ public final class EMail implements Serializable
 		{
 			props.put("mail.smtp.auth", "true");
 		}
-		if (logger.isTraceEnabled())
+		final boolean mailDebugMode = Services.get(ISysConfigBL.class).getBooleanValue(SYSCFG_DEBUG, false);
+		if (mailDebugMode)
 		{
 			props.put("mail.debug", "true");
 		}
 
 		final Session session = Session.getInstance(props, auth);
-		session.setDebug(logger.isDebugEnabled());
+		session.setDebug(mailDebugMode);
 		return session;
 	}
 
@@ -401,7 +406,7 @@ public final class EMail implements Serializable
 
 	/**
 	 * Sets recipients.
-	 *
+	 * <b>
 	 * <b>NOTE: If {@link #getDebugMailToAddress()} returns a valid mail address, it will send to that instead!</b>
 	 */
 	private void setRecipients(
@@ -429,7 +434,7 @@ public final class EMail implements Serializable
 		}
 		else
 		{
-			final Address[] addressesArr = addresses.toArray(new Address[addresses.size()]);
+			final Address[] addressesArr = addresses.toArray(new Address[0]);
 			message.setRecipients(Message.RecipientType.TO, addressesArr);
 		}
 	}
@@ -483,7 +488,6 @@ public final class EMail implements Serializable
 		if (from == null)
 		{
 			markInvalid();
-			return;
 		}
 		else
 		{
@@ -529,7 +533,7 @@ public final class EMail implements Serializable
 	 */
 	public EMailAddress getTo()
 	{
-		if (_to == null || _to.isEmpty())
+		if (_to.isEmpty())
 		{
 			return null;
 		}
@@ -776,19 +780,18 @@ public final class EMail implements Serializable
 	public void setMessageHTML(final String subject, final String message)
 	{
 		_subject = subject;
-		final StringBuilder sb = new StringBuilder("<HTML>\n")
-				.append("<HEAD>\n")
-				.append("<TITLE>\n")
-				.append(subject + "\n")
-				.append("</TITLE>\n")
-				.append("</HEAD>\n");
-		sb.append("<BODY>\n")
-				.append("<H2>" + subject + "</H2>" + "\n")
-				.append(message)
-				.append("\n")
-				.append("</BODY>\n");
-		sb.append("</HTML>\n");
-		_messageHTML = sb.toString();
+		_messageHTML = "<HTML>\n"
+				+ "<HEAD>\n"
+				+ "<TITLE>\n"
+				+ subject + "\n"
+				+ "</TITLE>\n"
+				+ "</HEAD>\n"
+				+ "<BODY>\n"
+				+ "<H2>" + subject + "</H2>" + "\n"
+				+ message
+				+ "\n"
+				+ "</BODY>\n"
+				+ "</HTML>\n";
 	}
 
 	/**
@@ -875,10 +878,6 @@ public final class EMail implements Serializable
 
 	/**
 	 * Set the message content and attachments.
-	 *
-	 * @param msg
-	 * @throws MessagingException
-	 * @throws IOException
 	 */
 	private void setContent(final MimeMessage msg) throws MessagingException, IOException
 	{
@@ -991,10 +990,9 @@ public final class EMail implements Serializable
 
 	/**
 	 * Checks if the email is valid and can be sent.
-	 *
+	 * <p>
 	 * NOTE: this method is NOT setting the {@link #isValid()} flag.
 	 *
-	 * @param notValidReasonCollector
 	 * @return true if email is valid and can be sent
 	 */
 	private boolean checkValid(final StringBuilder notValidReasonCollector)
@@ -1084,7 +1082,7 @@ public final class EMail implements Serializable
 		{
 			return isValidAddress(emailAddress.toInternetAddress());
 		}
-		catch (AddressException e)
+		catch (final AddressException e)
 		{
 			return false;
 		}
@@ -1099,7 +1097,7 @@ public final class EMail implements Serializable
 
 		final String addressStr = emailAddress.getAddress();
 		return addressStr != null
-				&& addressStr.length() > 0
+				&& !addressStr.isEmpty()
 				&& addressStr.indexOf(' ') < 0;
 	}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/MailAuthenticator.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/MailAuthenticator.java
@@ -1,17 +1,15 @@
 package de.metas.email;
 
-import java.io.Serializable;
-
-import javax.annotation.concurrent.Immutable;
-import javax.mail.Authenticator;
-import javax.mail.PasswordAuthentication;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-
 import de.metas.util.Check;
+
+import javax.annotation.concurrent.Immutable;
+import javax.mail.Authenticator;
+import javax.mail.PasswordAuthentication;
+import java.io.Serializable;
 
 /*
  * #%L
@@ -43,11 +41,10 @@ import de.metas.util.Check;
  * @author metas-dev <dev@metasfresh.com>
  *
  */
-@SuppressWarnings("serial")
 @Immutable
 final class MailAuthenticator extends Authenticator implements Serializable
 {
-	public static final MailAuthenticator of(final String username, final String password)
+	public static MailAuthenticator of(final String username, final String password)
 	{
 		return new MailAuthenticator(username, password);
 	}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/mailboxes/Mailbox.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/mailboxes/Mailbox.java
@@ -1,14 +1,9 @@
 package de.metas.email.mailboxes;
 
-import java.util.Objects;
-
-import javax.annotation.Nullable;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import de.metas.email.EMailAddress;
 import de.metas.logging.LogManager;
 import de.metas.util.Check;
@@ -17,6 +12,9 @@ import lombok.NonNull;
 import lombok.ToString;
 import lombok.Value;
 import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
 
 /*
  * #%L
@@ -48,35 +46,35 @@ import org.slf4j.Logger;
 @JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, isGetterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 @Value
 @ToString(exclude = "password")
-public final class Mailbox
+public class Mailbox
 {
-	private final static transient Logger logger = LogManager.getLogger(Mailbox.class);
+	private final static Logger logger = LogManager.getLogger(Mailbox.class);
 
 	private static final int DEFAULT_SMTP_PORT = 25;
 	private static final int DEFAULT_SMTPS_PORT = 587;
 
 	@JsonProperty("smtpHost")
-	private final String smtpHost;
+	String smtpHost;
 	@JsonProperty("smtpPort")
-	private final int smtpPort;
+	int smtpPort;
 
 	@JsonProperty("email")
-	private final EMailAddress email;
+	EMailAddress email;
 
 	@JsonProperty("username")
-	private final String username;
+	String username;
 	@JsonProperty("password")
-	private final String password;
+	String password;
 	@JsonProperty("smtpAuthorization")
-	private final boolean smtpAuthorization;
+	boolean smtpAuthorization;
 
 	@JsonProperty("startTLS")
-	private final boolean startTLS;
+	boolean startTLS;
 
 	@JsonProperty("sendEmailsFromServer")
-	private final boolean sendEmailsFromServer;
+	boolean sendEmailsFromServer;
 	@JsonProperty("userToColumnName")
-	private final String userToColumnName;
+	String userToColumnName;
 
 	@JsonCreator
 	@Builder(toBuilder = true)

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5730650_sys_add_AD_SysConfig_Email_Debug.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5730650_sys_add_AD_SysConfig_Email_Debug.sql
@@ -1,0 +1,6 @@
+-- 2024-08-01T13:59:51.231Z
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541727,'S',TO_TIMESTAMP('2024-08-01 13:59:51.031000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'If Y, then:
+- javax.mail property "mail.debug" to true
+- javax.mail.Session.setDebug(true) is called','D','Y','de.metas.email.Debug',TO_TIMESTAMP('2024-08-01 13:59:51.031000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N')
+;
+

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/mail/MailRestController.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/mail/MailRestController.java
@@ -263,7 +263,9 @@ public class MailRestController
 		final EMailSentStatus sentStatus = email.send();
 		if (!sentStatus.isSentOK())
 		{
-			throw new AdempiereException("Failed sending the email: " + sentStatus.getSentMsg());
+			throw new AdempiereException("Failed sending the email: " + sentStatus.getSentMsg()).appendParametersToMessage()
+					.setParameter("UserEMailConfig", userEmailConfig)
+					.setParameter("ClientEMailConfig", tenantEmailConfig);
 		}
 
 		//


### PR DESCRIPTION
- Before this, `javax.mail`s debug feature was activated whenever the logger of `backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/EMail.java` was set to logevel `debug` resp `trace` (at 2 different places)
  Now it can be switched on and off via sysconfig
- In case of a `AuthenticationFailedException` we don't just output "Invalid Username/Password", but also the actual localized exception message
- when sending a mail via `de.metas.ui.web.mail.MailRestController.java` failed, we now also output the mailconfigs that were used