### PR TITLE
Port - Crreate Invoice Candidates directy with a payment-term

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_Movement.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_Movement.java
@@ -1,17 +1,6 @@
 package de.metas.handlingunits.model.validator;
 
-import java.util.List;
-
-import org.adempiere.ad.modelvalidator.annotations.DocValidate;
-import org.adempiere.ad.modelvalidator.annotations.Init;
-import org.adempiere.ad.modelvalidator.annotations.Interceptor;
-import org.adempiere.mmovement.api.IMovementBL;
-import org.adempiere.mmovement.api.IMovementDAO;
-import org.adempiere.model.InterfaceWrapperHelper;
-import org.compiere.model.ModelValidator;
-
 import de.metas.event.IEventBusFactory;
-import de.metas.handlingunits.IHUAssignmentBL;
 import de.metas.handlingunits.IHUAssignmentDAO;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_MovementLine;
@@ -20,11 +9,20 @@ import de.metas.inout.model.I_M_InOutLine;
 import de.metas.interfaces.I_M_Movement;
 import de.metas.movement.event.MovementUserNotificationsProducer;
 import de.metas.util.Services;
+import org.adempiere.ad.modelvalidator.annotations.DocValidate;
+import org.adempiere.ad.modelvalidator.annotations.Init;
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.mmovement.api.IMovementBL;
+import org.adempiere.mmovement.api.IMovementDAO;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.ModelValidator;
+
+import java.util.List;
 
 @Interceptor(I_M_Movement.class)
 public class M_Movement
 {
-	public static final transient M_Movement instance = new M_Movement();
+	public static final M_Movement instance = new M_Movement();
 
 	private final IHUMovementBL huMovementBL = Services.get(IHUMovementBL.class);
 
@@ -41,8 +39,6 @@ public class M_Movement
 
 	/**
 	 * Iterate all movement lines. In case a movement line is generated from a receipt, retrieve the HUs from that receipt and assign them to movement line.
-	 *
-	 * @param movement
 	 */
 	@DocValidate(timings = ModelValidator.TIMING_BEFORE_PREPARE)
 	public void assignHUsFromReceipt(final I_M_Movement movement)
@@ -73,8 +69,6 @@ public class M_Movement
 
 	/**
 	 * Iterate each movement line, collect the packing materials and generate movement lines which also move those packing materials.
-	 *
-	 * @param movement
 	 */
 	@DocValidate(timings = ModelValidator.TIMING_AFTER_PREPARE)
 	public void createPackingMaterialMovementLines(final I_M_Movement movement)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/api/impl/InOutMovementBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/api/impl/InOutMovementBL.java
@@ -1,54 +1,7 @@
 package de.metas.inout.api.impl;
 
-import static org.adempiere.model.InterfaceWrapperHelper.loadOutOfTrx;
-import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
-import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
-
-/*
- * #%L
- * de.metas.swat.base
- * %%
- * Copyright (C) 2015 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
-
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
-
-import javax.annotation.Nullable;
-
-import org.adempiere.ad.dao.IQueryBL;
-import org.adempiere.ad.trx.api.ITrxManager;
-import org.adempiere.mmovement.api.IMovementBL;
-import org.adempiere.model.InterfaceWrapperHelper;
-import org.adempiere.warehouse.LocatorId;
-import org.compiere.model.I_M_InOut;
-import org.compiere.model.I_M_InOutLine;
-import org.compiere.model.I_M_Locator;
-import org.compiere.util.Env;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
 import de.metas.document.engine.IDocument;
 import de.metas.document.engine.IDocumentBL;
 import de.metas.inout.IInOutDAO;
@@ -62,6 +15,28 @@ import de.metas.interfaces.I_M_MovementLine;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.trx.api.ITrxManager;
+import org.adempiere.mmovement.api.IMovementBL;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.warehouse.LocatorId;
+import org.compiere.model.I_M_InOut;
+import org.compiere.model.I_M_InOutLine;
+import org.compiere.model.I_M_Locator;
+import org.compiere.util.Env;
+
+import javax.annotation.Nullable;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import static org.adempiere.model.InterfaceWrapperHelper.loadOutOfTrx;
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 
 public class InOutMovementBL implements IInOutMovementBL
 {
@@ -270,16 +245,13 @@ public class InOutMovementBL implements IInOutMovementBL
 
 	/**
 	 * Retrieve ALL movements which are linked to given shipment/receipt.
-	 *
+	 * <p/>
 	 * NOTE: this is DAO method, but we are adding it here to keep all BL together
 	 *
-	 * @param inout
 	 * @return movements
 	 */
-	private final List<I_M_Movement> retrieveMovementsForInOut(final I_M_InOut inout)
+	private List<I_M_Movement> retrieveMovementsForInOut(@NonNull final I_M_InOut inout)
 	{
-		Check.assumeNotNull(inout, "inout not null");
-
 		return Services.get(IQueryBL.class)
 				.createQueryBuilder(I_M_Movement.class, inout)
 				.addEqualsFilter(I_M_Movement.COLUMNNAME_M_InOut_ID, inout.getM_InOut_ID())

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
@@ -418,6 +418,7 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 
 		//
 		// Save the Invoice Candidate, so that we can use its ID further down
+		invoiceCandBL.setPaymentTermIfMissing(icRecord);
 		saveRecord(icRecord);
 
 		// set Quality Issue Percentage Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
@@ -128,6 +128,8 @@ public interface IInvoiceCandBL extends ISingletonService
 
 	IInvoiceGenerateResult generateInvoicesFromQueue(Properties ctx);
 
+	void setPaymentTermIfMissing(@NonNull I_C_Invoice_Candidate icRecord);
+
 	void setNetAmtToInvoice(I_C_Invoice_Candidate ic);
 
 	/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandDAO.java
@@ -240,14 +240,6 @@ public interface IInvoiceCandDAO extends ISingletonService
 	void updateApprovalForInvoicingToTrue(@NonNull PInstanceId selectionId);
 
 	/**
-	 * Updates the {@link I_C_Invoice_Candidate#COLUMNNAME_C_PaymentTerm_ID} of those candidates that don't have a payment term ID.
-	 * The ID those ICs are updated with is taken from the selected IC with the smallest {@code C_Invoice_Candidate_ID} that has a {@code C_PaymentTerm_ID}.
-	 * <p>
-	 * task <a href="https://github.com/metasfresh/metasfresh/issues/3809">https://github.com/metasfresh/metasfresh/issues/3809</a>
-	 */
-	void updateMissingPaymentTermIds(PInstanceId selectionId);
-
-	/**
 	 * Gets the sum of all {@link I_C_Invoice_Candidate#COLUMNNAME_NetAmtToInvoice} values of the invoice candidates that have the given bPartner and are invoiceable before or at the given date. The
 	 * amounts are converted to the currency which is set in the accounting schema of the bPartner's clients AD_ClientInfo.
 	 */

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateEnqueuer.java
@@ -306,12 +306,6 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 			invoiceCandDAO.updatePOReference(poReference, selectionId);
 		}
 
-		// issue https://github.com/metasfresh/metasfresh/issues/3809
-		if (invoicingParams.isSupplementMissingPaymentTermIds())
-		{
-			invoiceCandDAO.updateMissingPaymentTermIds(selectionId);
-		}
-
 		//
 		// Flag those invoice candidates as approved, since user decided to invoice them.
 		// Also, this will prevent changing the prices, net amounts etc while invoicing.

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateHandlerBL.java
@@ -84,7 +84,7 @@ public class InvoiceCandidateHandlerBL implements IInvoiceCandidateHandlerBL
 		}
 	};
 
-	private static final transient Logger logger = InvoiceCandidate_Constants.getLogger(InvoiceCandidateHandlerBL.class);
+	private static final Logger logger = InvoiceCandidate_Constants.getLogger(InvoiceCandidateHandlerBL.class);
 
 	@Override
 	public List<IInvoiceCandidateHandler> retrieveImplementationsForTable(final Properties ctx, final String tableName)
@@ -388,8 +388,6 @@ public class InvoiceCandidateHandlerBL implements IInvoiceCandidateHandlerBL
 			@NonNull final IInvoiceCandidateHandler handler,
 			@NonNull final I_C_Invoice_Candidate ic)
 	{
-		Check.assumeNotNull(handler, "handler not null");
-
 		//
 		// Make sure there is a link to creator/handler.
 		// We are setting the handler only if it was not set because it might be that the handler was set by a delegated handler which is not this one.
@@ -405,6 +403,9 @@ public class InvoiceCandidateHandlerBL implements IInvoiceCandidateHandlerBL
 			final int adUserInChargeId = handler.getAD_User_InCharge_ID(ic);
 			ic.setAD_User_InCharge_ID(adUserInChargeId);
 		}
+
+		final IInvoiceCandBL invoiceCandBL = Services.get(IInvoiceCandBL.class); // not having this as field bc there might be problems with circular dependencies
+		invoiceCandBL.setPaymentTermIfMissing(ic);
 
 		// Save it
 		InterfaceWrapperHelper.save(ic);

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/impl/InvoiceCandDAOTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/impl/InvoiceCandDAOTest.java
@@ -1,6 +1,5 @@
 package de.metas.invoicecandidate.api.impl;
 
-import com.google.common.collect.ImmutableList;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.invoicecandidate.InvoiceCandidateId;
 import de.metas.invoicecandidate.api.InvoiceCandidateMultiQuery;
@@ -8,13 +7,10 @@ import de.metas.invoicecandidate.api.InvoiceCandidateQuery;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.payment.paymentterm.PaymentTermId;
 import de.metas.process.PInstanceId;
-import de.metas.util.Services;
 import de.metas.util.lang.ExternalHeaderIdWithExternalLineIds;
 import de.metas.util.lang.ExternalId;
 import lombok.NonNull;
-import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.test.AdempiereTestHelper;
-import org.compiere.model.I_C_PaymentTerm;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,8 +18,6 @@ import javax.annotation.Nullable;
 import java.util.List;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
-import static org.adempiere.model.InterfaceWrapperHelper.refreshAll;
-import static org.adempiere.model.InterfaceWrapperHelper.save;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.*;
 
@@ -69,67 +63,6 @@ public class InvoiceCandDAOTest
 	{
 		AdempiereTestHelper.get().init();
 		invoiceCandDAO = new InvoiceCandDAO();
-	}
-
-	@Test
-	public void updateMissingPaymentTermIds()
-	{
-		// create two ICs without a payment term; those shall be updated by the method under test
-		final I_C_Invoice_Candidate invoiceCandidateWithoutPaymentTerm1 = newInstance(I_C_Invoice_Candidate.class);
-		save(invoiceCandidateWithoutPaymentTerm1);
-
-		final I_C_Invoice_Candidate invoiceCandidateWithoutPaymentTerm2 = newInstance(I_C_Invoice_Candidate.class);
-		save(invoiceCandidateWithoutPaymentTerm2);
-
-		// Create two ICs with different payment terms.
-		// By virtue of it's lower C_Invoice_Candidate_ID, the first IC's payment term ID shall be set in the first two ICs we creates
-		final PaymentTermId paymentTermId1 = createPaymentTerm();
-		final I_C_Invoice_Candidate invoiceCandidateWithPaymentTerm1 = newInstance(I_C_Invoice_Candidate.class);
-		invoiceCandidateWithPaymentTerm1.setC_PaymentTerm_ID(paymentTermId1.getRepoId());
-		save(invoiceCandidateWithPaymentTerm1);
-
-		final PaymentTermId paymentTermId2 = createPaymentTerm();
-		final I_C_Invoice_Candidate invoiceCandidateWithPaymentTerm2 = newInstance(I_C_Invoice_Candidate.class);
-		invoiceCandidateWithPaymentTerm2.setC_PaymentTerm_ID(paymentTermId2.getRepoId());
-		save(invoiceCandidateWithPaymentTerm2);
-
-		final PInstanceId selectionId = Services.get(IQueryBL.class).createQueryBuilder(I_C_Invoice_Candidate.class)
-				.create()
-				.createSelection();
-
-		// create an unrelated IC that also has no payment term; it shall be left untouched
-		final I_C_Invoice_Candidate unrelatedInvoiceCandidateWithoutPaymentTerm = newInstance(I_C_Invoice_Candidate.class);
-		save(unrelatedInvoiceCandidateWithoutPaymentTerm);
-
-		// invoke the method under test and refresh all ICs
-		invoiceCandDAO.updateMissingPaymentTermIds(selectionId);
-
-		refreshAll(ImmutableList.of(
-				invoiceCandidateWithoutPaymentTerm1,
-				invoiceCandidateWithoutPaymentTerm2,
-				invoiceCandidateWithPaymentTerm1,
-				invoiceCandidateWithPaymentTerm2,
-				unrelatedInvoiceCandidateWithoutPaymentTerm));
-
-		// verify
-		assertThat(getPaymentTermId(invoiceCandidateWithoutPaymentTerm1)).isEqualTo(paymentTermId1);
-		assertThat(getPaymentTermId(invoiceCandidateWithoutPaymentTerm2)).isEqualTo(paymentTermId1);
-		assertThat(getPaymentTermId(invoiceCandidateWithPaymentTerm1)).isEqualTo(paymentTermId1);
-
-		assertThat(getPaymentTermId(invoiceCandidateWithPaymentTerm2))
-				.as("invoiceCandidateWithPaymentTerm2 shall be left unchanged because it already has a C_PaymentTerm_ID")
-				.isEqualTo(paymentTermId2);
-
-		assertThat(getPaymentTermId(unrelatedInvoiceCandidateWithoutPaymentTerm))
-				.as("unrelatedInvoiceCandidateWithoutPaymentTerm shall be left unchanged because it's not part of the selection")
-				.isNull();
-	}
-
-	private PaymentTermId createPaymentTerm()
-	{
-		final I_C_PaymentTerm record = newInstance(I_C_PaymentTerm.class);
-		saveRecord(record);
-		return PaymentTermId.ofRepoId(record.getC_PaymentTerm_ID());
 	}
 
 	private PaymentTermId getPaymentTermId(@NonNull final I_C_Invoice_Candidate ic)


### PR DESCRIPTION
- the code is mostly a copy&paste of `master` code, so when merging to `master`, if in doubt, stick with the code on `master`
   - only the removal of the unused private methods `retrievePaymentTermId` and `retrieveIcsToUpdateSelectionId` in InvoiceCandDAO.java might be taken towards master
- I didn't yet remove the `SupplementMissingPaymentTermIds` parameter from the processes `C_Invoice_Candidate_EnqueueSelectionForInvoicing` and `C_Invoice_Candidate_EnqueueSelectionForInvoicingAndPDFConcatenating`, so this still needs to be done