### PR TITLE
Fix bug where `C_Order.M_PriceList_ID` was set to the wrong value (CP)

### DIFF
--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/CalloutOrder.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/CalloutOrder.java
@@ -224,19 +224,17 @@ public class CalloutOrder extends CalloutEngine
 					PaymentRule paymentRule = isSOTrx
 							? PaymentRule.ofCode(bpartner.getPaymentRule())
 							: PaymentRule.ofCode(bpartner.getPaymentRulePO());
-					if (paymentRule != null)
+
+					if (isSOTrx && paymentRule.isCashOrCheck()) // No Cash/Check/Transfer:
 					{
-						if (isSOTrx && paymentRule.isCashOrCheck()) // No Cash/Check/Transfer:
-						{
-							// for SO_Trx
-							paymentRule = PaymentRule.OnCredit; // Payment Term
-						}
-						if (!isSOTrx && paymentRule.isCash())  // No Cash for PO_Trx
-						{
-							paymentRule = PaymentRule.OnCredit; // Payment Term
-						}
-						order.setPaymentRule(paymentRule.getCode());
+						// for SO_Trx
+						paymentRule = PaymentRule.OnCredit; // Payment Term
 					}
+					if (!isSOTrx && paymentRule.isCash())  // No Cash for PO_Trx
+					{
+						paymentRule = PaymentRule.OnCredit; // Payment Term
+					}
+					order.setPaymentRule(paymentRule.getCode());
 				}
 
 				// Payment Term
@@ -272,7 +270,7 @@ public class CalloutOrder extends CalloutEngine
 				// FreightCostRule
 				{
 					final String freightCostRule = bpartner.getFreightCostRule();
-					if (freightCostRule != null && freightCostRule.length() != 0)
+					if (freightCostRule != null && !freightCostRule.isEmpty())
 					{
 						order.setFreightCostRule(freightCostRule);
 					}
@@ -281,7 +279,7 @@ public class CalloutOrder extends CalloutEngine
 				// DeliveryViaRule
 				{
 					final String deliveryViaRule = bpartner.getDeliveryViaRule();
-					if (deliveryViaRule != null && deliveryViaRule.length() != 0)
+					if (deliveryViaRule != null && !deliveryViaRule.isEmpty())
 					{
 						order.setDeliveryViaRule(deliveryViaRule);
 					}
@@ -771,20 +769,11 @@ public class CalloutOrder extends CalloutEngine
 			{
 				// #4463 don't change the pricelist of a sales order it its bill partner was changed.
 				if (!order.isSOTrx())
-				{
-					// PriceList (indirect: IsTaxIncluded & Currency)
-					final int priceListId = rs.getInt(IsSOTrx ? "M_PriceList_ID" : "PO_PriceList_ID");
-					if (!rs.wasNull())
+				{ // get default PriceList
+					final int i = calloutField.getGlobalContextAsInt("#M_PriceList_ID");
+					if (i > 0)
 					{
-						order.setM_PriceList_ID(priceListId);
-					}
-					else
-					{ // get default PriceList
-						final int i = calloutField.getGlobalContextAsInt("#M_PriceList_ID");
-						if (i > 0)
-						{
-							order.setM_PriceList_ID(i);
-						}
+						order.setM_PriceList_ID(i);
 					}
 				}
 

--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MOrder.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MOrder.java
@@ -440,11 +440,6 @@ public class MOrder extends X_C_Order implements IDocument
 			setC_PaymentTerm_ID(paymentTermID);
 		}
 		//
-		final int priceLisId = isSOTrx() ? bp.getM_PriceList_ID() : bp.getPO_PriceList_ID();
-		if (priceLisId != 0)
-		{
-			setM_PriceList_ID(priceLisId);
-		}
 		// Default Delivery/Via Rule
 		String ss = bp.getDeliveryRule();
 		if (!Check.isEmpty(ss, true))

--- a/backend/de.metas.business/src/main/java/de/metas/order/IOrderBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/IOrderBL.java
@@ -67,7 +67,9 @@ public interface IOrderBL extends ISingletonService
 	I_C_Order getById(OrderId orderId);
 
 	/**
-	 * Sets price list if there is a price list for the given location and pricing system.
+	 * Sets price list if there is a price list for the given order's location and pricing system.
+	 * <p>
+	 * ! If {@link I_C_Order#COLUMNNAME_C_BPartner_Location_Value_ID} is set, its country takes precendence over the country of {@link I_C_Order#COLUMNNAME_C_BPartner_Location_ID}.
 	 * <p>
 	 * This method does nothing if:
 	 * <ul>

--- a/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderBL.java
@@ -248,7 +248,7 @@ public class OrderBL implements IOrderBL
 	}
 
 	@Override
-	public void setPriceList(final I_C_Order order)
+	public void setPriceList(@NonNull final I_C_Order order)
 	{
 		final PricingSystemId pricingSystemId = PricingSystemId.ofRepoIdOrNull(order.getM_PricingSystem_ID());
 		if (pricingSystemId == null)
@@ -628,22 +628,6 @@ public class OrderBL implements IOrderBL
 		if (paymentTermId > 0)
 		{
 			order.setC_PaymentTerm_ID(paymentTermId);
-		}
-
-		//
-		// Default Price List
-		final int priceListId;
-		if (isSOTrx)
-		{
-			priceListId = bp.getM_PriceList_ID();
-		}
-		else
-		{
-			priceListId = bp.getPO_PriceList_ID();
-		}
-		if (priceListId > 0)
-		{
-			order.setM_PriceList_ID(priceListId);
 		}
 
 		//

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5731470_sys_gh_Delete_2_legacy_Callouts.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5731470_sys_gh_Delete_2_legacy_Callouts.sql
@@ -1,0 +1,9 @@
+
+-- This deletes AD_ColumnCallout_IDs 540784 and 540788 from 2010
+-- updating the pricelist is now done in de.metas.order.callout.C_Order (**after** C_BPartner_Location_Value_ID was updated)
+DELETE
+FROM ad_columncallout
+WHERE classname IN (
+                    'de.metas.adempiere.callout.OrderPricingSystem.cBPartnerId',
+                    'de.metas.adempiere.callout.OrderPricingSystem.cBPartnerLocationId')
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/adempiere/callout/OrderPricingSystem.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/adempiere/callout/OrderPricingSystem.java
@@ -1,41 +1,13 @@
 package de.metas.adempiere.callout;
 
-import org.adempiere.ad.callout.api.ICalloutField;
-import org.compiere.model.CalloutEngine;
-
 import de.metas.adempiere.model.I_C_Order;
 import de.metas.order.IOrderBL;
 import de.metas.util.Services;
+import org.adempiere.ad.callout.api.ICalloutField;
+import org.compiere.model.CalloutEngine;
 
 public class OrderPricingSystem extends CalloutEngine
 {
-	public String cBPartnerId(final ICalloutField calloutField)
-	{
-		if (isCalloutActive())
-		{
-			return NO_ERROR;
-		}
-
-		final I_C_Order order = calloutField.getModel(I_C_Order.class);
-		final boolean overridePricingSystem = true;
-		Services.get(IOrderBL.class).setM_PricingSystem_ID(order, overridePricingSystem);
-		
-		return NO_ERROR;
-	}
-
-	public String cBPartnerLocationId(final ICalloutField calloutField)
-	{
-		if (isCalloutActive())
-		{
-			return NO_ERROR;
-		}
-		
-		final I_C_Order order = calloutField.getModel(I_C_Order.class);
-		Services.get(IOrderBL.class).setPriceList(order);
-		
-		return NO_ERROR;
-	}
-
 	public String mPricingSystemId(final ICalloutField calloutField)
 	{
 		if (isCalloutActive())

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/callout/C_Order.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/callout/C_Order.java
@@ -89,6 +89,8 @@ public class C_Order
 	public void updateBPartnerAddress(final I_C_Order order)
 	{
 		documentLocationBL.updateRenderedAddressAndCapturedLocation(OrderDocumentLocationAdapterFactory.locationAdapter(order));
+
+		orderBL.setPriceList(order); // changed location might imply a changed PL
 	}
 
 	@CalloutMethod(columnNames = {
@@ -98,6 +100,8 @@ public class C_Order
 	public void updateBPartnerAddressForceUpdateCapturedLocation(final I_C_Order order)
 	{
 		documentLocationBL.updateCapturedLocation(OrderDocumentLocationAdapterFactory.locationAdapter(order));
+
+		orderBL.setPriceList(order); // changed location might imply a changed PL
 	}
 
 	@CalloutMethod(columnNames = {


### PR DESCRIPTION
Remove Callout-Code that was called too early; call it at the right time
OrderPricingSystem: the two callouts were fired before C_Order.C_BPartner_Location_Value_ID was updated and therefore always set the M_PriceList_ID for the country of the location that we are changing **away** from just now.

Instead, set the pricelist now in C_Order => no need to assume the right ordering of callouts

CP of https://github.com/metasfresh/metasfresh/pull/18690
(cherry picked from commit d47634d57209e86a5083525497ca9ebe49b2af34)

solved Conflicts:
	backend/de.metas.business/src/main/java-legacy/org/compiere/model/CalloutOrder.java