### PR TITLE
Reduce flakyness of effortControlPurchaseInvoiceCandidate.feature by fixing AdRefListRepositoryOverJdbc

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/ad_reference/AdRefListRepositoryOverJdbc.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/ad_reference/AdRefListRepositoryOverJdbc.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import de.metas.cache.CCache;
+import de.metas.common.util.TryAndWaitUtil;
 import de.metas.i18n.ImmutableTranslatableString;
 import de.metas.logging.LogManager;
 import de.metas.util.ColorId;
@@ -25,6 +26,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstanceOutOfTrx;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
@@ -33,6 +35,16 @@ import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 public class AdRefListRepositoryOverJdbc implements AdRefListRepository
 {
 	private static final Logger logger = LogManager.getLogger(AdRefListRepositoryOverJdbc.class);
+	public static final int SINGLE_CACHE_KEY = 0;
+
+	/**
+	 * When calling createRefListItem + getById + createRefListItem for the same ref-list value fast (in cucumber),
+	 * then sometimes getById does not contain the previously created ref-list and then the 2nd createRefListItem call fails with a DBUniqueConstraintException.
+	 * The only reasons i can think of are
+	 * <li>that cache.clear() doesn't cause the cache to be really empty **before** it returns</li>
+	 * <li>that there is some other element of concurrency between reading and writing</li>
+	 */
+	private final transient ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
 
 	private final CCache<Integer, AdRefListsMap> cache = CCache.<Integer, AdRefListsMap>builder()
 			.tableName(I_AD_Ref_List.Table_Name)
@@ -44,27 +56,57 @@ public class AdRefListRepositoryOverJdbc implements AdRefListRepository
 	@Override
 	public void createRefListItem(@NonNull final ADRefListItemCreateRequest request)
 	{
-		final I_AD_Ref_List record = newInstanceOutOfTrx(I_AD_Ref_List.class);
+		readWriteLock.writeLock().lock();
+		try
+		{
+			final I_AD_Ref_List record = newInstanceOutOfTrx(I_AD_Ref_List.class);
 
-		record.setAD_Reference_ID(request.getReferenceId().getRepoId());
+			record.setAD_Reference_ID(request.getReferenceId().getRepoId());
 
-		record.setName(request.getName().getDefaultValue());
-		record.setValue(request.getValue());
+			record.setName(request.getName().getDefaultValue());
+			record.setValue(request.getValue());
+			try
+			{
+				saveRecord(record);
+			}
+			catch (final AdempiereException e)
+			{
+				throw AdempiereException.wrapIfNeeded(e)
+						.appendParametersToMessage()
+						.setParameter("Request", request);
+			}
+			cache.reset();
 
-		saveRecord(record);
-
-		cache.reset();
+			// make sure that the cached value is really gone!
+			TryAndWaitUtil.tryAndWait(3, 100, () -> cache.get(SINGLE_CACHE_KEY) == null, () -> logger.warn("AdRefListRepositoryOverJdbc - cache not cleared after 3seconds!"));
+		}
+		catch (final InterruptedException e)
+		{
+			throw AdempiereException.wrapIfNeeded(e).appendParametersToMessage().appendParametersToMessage().setParameter("Request", request);
+		}
+		finally
+		{
+			readWriteLock.writeLock().unlock();
+		}
 	}
 
 	@Override
 	public ADRefList getById(final ReferenceId adReferenceId)
 	{
-		return getMap().getById(adReferenceId);
+		readWriteLock.readLock().lock();
+		try
+		{
+			return getMap().getById(adReferenceId);
+		}
+		finally
+		{
+			readWriteLock.readLock().unlock();
+		}
 	}
 
 	private AdRefListsMap getMap()
 	{
-		return cache.getOrLoad(0, this::retrieveMap);
+		return cache.getOrLoad(SINGLE_CACHE_KEY, this::retrieveMap);
 	}
 
 	private AdRefListsMap retrieveMap()
@@ -89,17 +131,18 @@ public class AdRefListRepositoryOverJdbc implements AdRefListRepository
 				.stream()
 				.collect(ImmutableListMultimap.toImmutableListMultimap(ADRefListItem::getReferenceId, item -> item));
 
-		@NonNull final ImmutableList<ADRefList> lists = DB.retrieveRows("SELECT "
-						+ " r." + I_AD_Reference.COLUMNNAME_AD_Reference_ID
-						+ " , r." + I_AD_Reference.COLUMNNAME_Name
-						+ " , r." + I_AD_Reference.COLUMNNAME_IsOrderByValue
-						+ " FROM " + I_AD_Reference.Table_Name + " r"
-						+ " WHERE "
-						+ " r." + I_AD_Reference.COLUMNNAME_ValidationType + "=?"
-						// NOTE fetch all, even if not active
-						+ " ORDER BY r.AD_Reference_ID",
-				ImmutableList.of(X_AD_Reference.VALIDATIONTYPE_ListValidation),
-				rs -> retrieveADRefList(rs, itemsByReferenceId));
+		@NonNull
+		final ImmutableList<ADRefList> lists = DB.retrieveRows("SELECT "
+																	   + " r." + I_AD_Reference.COLUMNNAME_AD_Reference_ID
+																	   + " , r." + I_AD_Reference.COLUMNNAME_Name
+																	   + " , r." + I_AD_Reference.COLUMNNAME_IsOrderByValue
+																	   + " FROM " + I_AD_Reference.Table_Name + " r"
+																	   + " WHERE "
+																	   + " r." + I_AD_Reference.COLUMNNAME_ValidationType + "=?"
+																	   // NOTE fetch all, even if not active
+																	   + " ORDER BY r.AD_Reference_ID",
+															   ImmutableList.of(X_AD_Reference.VALIDATIONTYPE_ListValidation),
+															   rs -> retrieveADRefList(rs, itemsByReferenceId));
 
 		final AdRefListsMap result = new AdRefListsMap(lists);
 		logger.info("Loaded {} in {}", result, stopwatch.stop());

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/ad_reference/AdRefListRepositoryOverJdbc.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/ad_reference/AdRefListRepositoryOverJdbc.java
@@ -65,24 +65,19 @@ public class AdRefListRepositoryOverJdbc implements AdRefListRepository
 
 			record.setName(request.getName().getDefaultValue());
 			record.setValue(request.getValue());
-			try
-			{
-				saveRecord(record);
-			}
-			catch (final AdempiereException e)
-			{
-				throw AdempiereException.wrapIfNeeded(e)
-						.appendParametersToMessage()
-						.setParameter("Request", request);
-			}
+
+			saveRecord(record);
+
 			cache.reset();
 
 			// make sure that the cached value is really gone!
 			TryAndWaitUtil.tryAndWait(3, 100, () -> cache.get(SINGLE_CACHE_KEY) == null, () -> logger.warn("AdRefListRepositoryOverJdbc - cache not cleared after 3seconds!"));
 		}
-		catch (final InterruptedException e)
+		catch (final AdempiereException|InterruptedException e)
 		{
-			throw AdempiereException.wrapIfNeeded(e).appendParametersToMessage().appendParametersToMessage().setParameter("Request", request);
+			throw AdempiereException.wrapIfNeeded(e)
+					.appendParametersToMessage()
+					.setParameter("Request", request);
 		}
 		finally
 		{

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/cache/CCache.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/cache/CCache.java
@@ -487,6 +487,7 @@ public class CCache<K, V> implements CacheInterface
 		}
 	}
 
+	@Nullable
 	public V remove(final K key)
 	{
 		try (final IAutoCloseable ignored = CacheMDC.putCache(this))
@@ -525,6 +526,7 @@ public class CCache<K, V> implements CacheInterface
 	 * <p>
 	 * For more informations, see {@link #get(Object, Callable)}.
 	 */
+	@Nullable
 	public V get(final K key, final Supplier<V> valueInitializer)
 	{
 		if (valueInitializer == null)
@@ -558,6 +560,7 @@ public class CCache<K, V> implements CacheInterface
 	 * @param valueInitializer optional cache initializer.
 	 * @return cached value or <code>null</code>
 	 */
+	@Nullable
 	public V get(final K key, final Callable<V> valueInitializer)
 	{
 		try (final IAutoCloseable ignored = CacheMDC.putCache(this))
@@ -604,6 +607,7 @@ public class CCache<K, V> implements CacheInterface
 	 * @see #get(Object, Callable).
 	 * @see #get(Object, Supplier)
 	 */
+	@Nullable
 	public V getOrLoad(final K key, final Callable<V> valueLoader)
 	{
 		try (final IAutoCloseable ignored = CacheMDC.putCache(this))
@@ -612,6 +616,7 @@ public class CCache<K, V> implements CacheInterface
 		}
 	}
 
+	@Nullable
 	public V getOrLoad(final K key, @NonNull final Function<K, V> valueLoader)
 	{
 		try (final IAutoCloseable ignored = CacheMDC.putCache(this))
@@ -793,10 +798,7 @@ public class CCache<K, V> implements CacheInterface
 		try (final IAutoCloseable ignored = CacheMDC.putCache(this))
 		{
 			logger.debug("Running finalize");
-			if (cache != null)
-			{
-				cache.invalidateAll();
-			}
+			cache.invalidateAll();
 		}
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/serviceIssue/S_Issue_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/serviceIssue/S_Issue_StepDef.java
@@ -34,6 +34,7 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.exceptions.AdempiereException;
 import org.assertj.core.api.SoftAssertions;
 import org.compiere.model.I_AD_User;
 import org.compiere.model.I_C_Activity;
@@ -89,6 +90,15 @@ public class S_Issue_StepDef
 	public void add_S_Issue(@NonNull final DataTable dataTable)
 	{
 		for (final Map<String, String> row : dataTable.asMaps())
+		{
+			addIssue(row);
+		}
+	}
+
+	private void addIssue(@NonNull final Map<String, String> row)
+	{
+		final String issueIdentifier = DataTableUtil.extractStringForColumnName(row, COLUMNNAME_S_Issue_ID + "." + TABLECOLUMN_IDENTIFIER);
+		try
 		{
 			final String value = DataTableUtil.extractStringForColumnName(row, COLUMNNAME_Value);
 			final String name = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + COLUMNNAME_Name);
@@ -163,9 +173,12 @@ public class S_Issue_StepDef
 			}
 
 			saveRecord(issue);
-
-			final String issueIdentifier = DataTableUtil.extractStringForColumnName(row, COLUMNNAME_S_Issue_ID + "." + TABLECOLUMN_IDENTIFIER);
 			sIssueTable.put(issueIdentifier, issue);
+		}
+		catch (final Exception e)
+		{
+			throw AdempiereException.wrapIfNeeded(e).appendParametersToMessage()
+					.setParameter("S_Issue_ID.Identifier", issueIdentifier);
 		}
 	}
 
@@ -236,7 +249,7 @@ public class S_Issue_StepDef
 	}
 
 	@And("S_IssueLabel is removed:")
-	public void removed_S_IssueLabel(@NonNull final DataTable dataTable) throws InterruptedException
+	public void removed_S_IssueLabel(@NonNull final DataTable dataTable)
 	{
 		for (final Map<String, String> row : dataTable.asMaps())
 		{


### PR DESCRIPTION
AdRefListRepositoryOverJdbc:
When calling createRefListItem + getById + createRefListItem for the same ref-list value fast (in cucumber), then sometimes getById does not contain the previously created ref-list and then the 2nd createRefListItem call fails with a DBUniqueConstraintException. The only reasons i can think of are
 * that cache.clear() doesn't cause the cache to be really empty **before** it returns
 * that there is some other element of concurrency between reading and writing

 Also make S_Issue_StepDef output in which row it failed (in case the problem persists)