### PR TITLE
DESADV-Fixes

### DIFF
--- a/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/pack/EDIDesadvPackService.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/pack/EDIDesadvPackService.java
@@ -416,12 +416,16 @@ public class EDIDesadvPackService
 			return StockQtyAndUOMQtys.createZero(productId, desadvUomId);
 		}
 
-		final StockQtyAndUOMQty qtyCUsPerLU = getQuantity(rootLU, productId);
+		// topLevelHU's quantity can be bigger than the inOutLine's quantity,
+		// if there are multiple lines with the same product and if those lines were picked onto the same LU.
+		// That's why we need to invoke min(..)
+		final StockQtyAndUOMQty qtyCUsPerTopLevelHU = getQuantity(rootLU, productId)
+				.min(inOutBL.extractInOutLineQty(inOutLineRecord, invoicableQtyBasedOn));
 
 		final CreateEDIDesadvPackRequest createEDIDesadvPackRequest = buildCreateDesadvPackRequest(
 				rootLU,
 				bPartnerId,
-				qtyCUsPerLU,
+				qtyCUsPerTopLevelHU,
 				productId,
 				desadvLineRecord,
 				inOutLineRecord,
@@ -432,7 +436,7 @@ public class EDIDesadvPackService
 
 		ediDesadvPackRepository.createDesadvPack(createEDIDesadvPackRequest);
 
-		return qtyCUsPerLU;
+		return qtyCUsPerTopLevelHU;
 	}
 
 	@NonNull

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attributes/sscc18/impl/SSCC18AttributeValueGenerator.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attributes/sscc18/impl/SSCC18AttributeValueGenerator.java
@@ -39,7 +39,7 @@ import java.util.Properties;
 public class SSCC18AttributeValueGenerator extends AbstractAttributeValueGenerator
 {
 
-	private ISSCC18CodeBL sscc18CodeBL = Services.get(ISSCC18CodeBL.class);
+	private final ISSCC18CodeBL sscc18CodeBL = Services.get(ISSCC18CodeBL.class);
 
 	@Override
 	public String getAttributeValueType()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attributes/sscc18/impl/SSCC18AttributeValueGenerator.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attributes/sscc18/impl/SSCC18AttributeValueGenerator.java
@@ -22,21 +22,19 @@ package de.metas.handlingunits.attributes.sscc18.impl;
  * #L%
  */
 
-import java.util.Properties;
-
-import org.adempiere.mm.attributes.api.IAttributeSet;
-import org.adempiere.mm.attributes.spi.AbstractAttributeValueGenerator;
-import org.compiere.model.I_M_Attribute;
-import org.compiere.model.X_M_Attribute;
-
 import de.metas.handlingunits.attribute.IHUAttributesBL;
 import de.metas.handlingunits.attributes.sscc18.ISSCC18CodeBL;
 import de.metas.handlingunits.attributes.sscc18.SSCC18;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.organization.OrgId;
-import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.mm.attributes.api.IAttributeSet;
+import org.adempiere.mm.attributes.spi.AbstractAttributeValueGenerator;
+import org.compiere.model.I_M_Attribute;
+import org.compiere.model.X_M_Attribute;
+
+import java.util.Properties;
 
 public class SSCC18AttributeValueGenerator extends AbstractAttributeValueGenerator
 {
@@ -63,11 +61,8 @@ public class SSCC18AttributeValueGenerator extends AbstractAttributeValueGenerat
 	{
 		final I_M_HU hu = Services.get(IHUAttributesBL.class).getM_HU(attributeSet);
 
-		// We use M_HU_ID for SSCC18 serial number (06852)
-		final int serialNumber = hu.getM_HU_ID();
-		Check.errorIf(serialNumber <= 0, "M_HU_ID={} for M_HU={}", serialNumber, hu);
-
-		final SSCC18 sscc18 = sscc18CodeBL.generate(OrgId.ofRepoIdOrAny(hu.getAD_Org_ID()), serialNumber);
+		// Just don't use the M_HU_ID as serial number. It introduced FUD as multiple packs can have the same HU and each pack needs an individual SSCC.
+		final SSCC18 sscc18 = sscc18CodeBL.generate(OrgId.ofRepoIdOrAny(hu.getAD_Org_ID()));
 		return sscc18.asString();
 	}
 }


### PR DESCRIPTION
- guard agains lines with the same product: Don't fail if there are multiple inout/order-lines with the same product that were picked onto the same LU.
- never use the M_HU_ID in SSCCs, see comment in SSCC18AttributeValueGenerator.java