### PR TITLE
fix RecreateInvoiceWorkpackageProcessor DB deadlock (#16997)

### DIFF
--- a/backend/de-metas-salesorder/src/main/java/de/metas/salesorder/candidate/AutoProcessingOLCandService.java
+++ b/backend/de-metas-salesorder/src/main/java/de/metas/salesorder/candidate/AutoProcessingOLCandService.java
@@ -25,6 +25,7 @@ package de.metas.salesorder.candidate;
 import ch.qos.logback.classic.Level;
 import com.google.common.collect.ImmutableSet;
 import de.metas.async.AsyncBatchId;
+import de.metas.async.api.IAsyncBatchBL;
 import de.metas.handlingunits.shipmentschedule.api.ShipmentService;
 import de.metas.inout.IInOutDAO;
 import de.metas.inout.InOutId;
@@ -45,9 +46,13 @@ import org.compiere.model.I_M_InOutLine;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static de.metas.async.Async_Constants.C_Async_Batch_InternalName_InvoiceCandidate_Processing;
 
 @Service
 public class AutoProcessingOLCandService
@@ -58,6 +63,7 @@ public class AutoProcessingOLCandService
 	private final IOrderBL orderBL = Services.get(IOrderBL.class);
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	private final ITrxManager trxManager = Services.get(ITrxManager.class);
+	private final IAsyncBatchBL asyncBatchBL = Services.get(IAsyncBatchBL.class);
 
 	private final OrderService orderService;
 	private final ShipmentService shipmentService;
@@ -108,9 +114,24 @@ public class AutoProcessingOLCandService
 
 		if (request.isInvoice())
 		{
+			final HashMap<AsyncBatchId, ArrayList<I_M_InOutLine>> asyncBatchId2Shipmentline = new HashMap<>();
 			final List<I_M_InOutLine> shipmentLines = inOutDAO.retrieveShipmentLinesForOrderId(orderIds);
 
-			invoiceService.generateInvoicesFromShipmentLines(shipmentLines);
+			for (final I_M_InOutLine shipmentLine : shipmentLines)
+			{
+				final AsyncBatchId asyncBatchId = AsyncBatchId.ofRepoIdOr(
+						shipmentLine.getM_InOut().getC_Async_Batch_ID(),
+						() -> asyncBatchBL.newAsyncBatch(C_Async_Batch_InternalName_InvoiceCandidate_Processing));
+
+				final ArrayList<I_M_InOutLine> iolsForAsyncBatchId = asyncBatchId2Shipmentline.computeIfAbsent(
+						asyncBatchId, key -> new ArrayList<>());
+				iolsForAsyncBatchId.add(shipmentLine);
+			}
+
+			for (final Map.Entry<AsyncBatchId, ArrayList<I_M_InOutLine>> entry : asyncBatchId2Shipmentline.entrySet())
+			{
+				invoiceService.generateInvoicesFromShipmentLines(entry.getValue(), entry.getKey());
+			}
 		}
 
 		if (request.isCloseOrder())

--- a/backend/de-metas-salesorder/src/main/java/de/metas/salesorder/service/AutoProcessingOrderService.java
+++ b/backend/de-metas-salesorder/src/main/java/de/metas/salesorder/service/AutoProcessingOrderService.java
@@ -24,6 +24,9 @@ package de.metas.salesorder.service;
 
 import ch.qos.logback.classic.Level;
 import com.google.common.collect.ImmutableSet;
+import de.metas.async.AsyncBatchId;
+import de.metas.async.api.IAsyncBatchBL;
+import de.metas.async.model.I_C_Async_Batch;
 import de.metas.bpartner.BPartnerLocationAndCaptureId;
 import de.metas.handlingunits.shipmentschedule.api.GenerateShipmentsForSchedulesRequest;
 import de.metas.handlingunits.shipmentschedule.api.M_ShipmentSchedule_QuantityTypeToUse;
@@ -38,19 +41,25 @@ import de.metas.invoicecandidate.InvoiceCandidateId;
 import de.metas.invoicecandidate.api.IInvoiceCandBL;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.logging.LogManager;
+import de.metas.order.IOrderBL;
 import de.metas.order.OrderId;
+import de.metas.organization.OrgId;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.I_C_Order;
 import org.compiere.model.I_M_InOut;
 import org.compiere.model.I_M_InOutLine;
+import org.compiere.util.Env;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static de.metas.async.Async_Constants.C_Async_Batch_InternalName_InvoiceCandidate_Processing;
 
 @Service
 public class AutoProcessingOrderService
@@ -59,6 +68,8 @@ public class AutoProcessingOrderService
 
 	private final IInOutDAO inOutDAO = Services.get(IInOutDAO.class);
 	private final IInvoiceCandBL invoiceCandBL = Services.get(IInvoiceCandBL.class);
+	private final IOrderBL orderBL = Services.get(IOrderBL.class);
+	private final IAsyncBatchBL asyncBatchBL = Services.get(IAsyncBatchBL.class);
 
 	private final OrderService orderService;
 	private final ShipmentService shipmentService;
@@ -96,7 +107,7 @@ public class AutoProcessingOrderService
 		final GenerateShipmentsForSchedulesRequest request = GenerateShipmentsForSchedulesRequest.builder()
 				.scheduleIds(scheduleIds)
 				.quantityTypeToUse(M_ShipmentSchedule_QuantityTypeToUse.TYPE_QTY_TO_DELIVER)
-				
+
 				// Usually we want only *CUs* to be picked on-the-fly, because we don't know and care which HUs are shipped and don't want to make assumptions regarding their TU-Packaging.
 				// But here it is different: we want that whatever HUs are picked, exactly those HUs shall be boxed and send to the customer.
 				.onTheFlyPickToPackingInstructions(true)
@@ -133,7 +144,29 @@ public class AutoProcessingOrderService
 				.map(InvoiceCandidateId::ofRepoId)
 				.collect(ImmutableSet.toImmutableSet());
 
-		invoiceService.generateInvoicesFromInvoiceCandidateIds(invoiceCandidateIds);
+		final AsyncBatchId asyncBatchId = extractOrCreateAsyncBatchId(orderId);
+
+		invoiceService.generateInvoicesFromInvoiceCandidateIds(invoiceCandidateIds, asyncBatchId);
+	}
+
+	@NonNull
+	private AsyncBatchId extractOrCreateAsyncBatchId(final @NonNull OrderId orderId)
+	{
+		final I_C_Order orderRecord = orderBL.getById(orderId);
+		final int asyncBatchIdInt = orderRecord.getC_Async_Batch_ID();
+
+		if (orderRecord.getC_Async_Batch_ID() > 0)
+		{
+			return AsyncBatchId.ofRepoId(asyncBatchIdInt);
+		}
+
+		final I_C_Async_Batch asyncBatchRecord = asyncBatchBL.newAsyncBatch()
+				.setContext(Env.getCtx())
+				.setC_Async_Batch_Type(C_Async_Batch_InternalName_InvoiceCandidate_Processing)
+				.setName("Process ICs for C_Order_ID=" + OrderId.toRepoId(orderId))
+				.setOrgId(OrgId.ofRepoId(orderRecord.getAD_Org_ID()))
+				.build();
+		return AsyncBatchId.ofRepoId(asyncBatchRecord.getC_Async_Batch_ID());
 	}
 
 	private boolean sameShippingAndBillingAddress(

--- a/backend/de.metas.async/src/main/java/de/metas/async/AsyncBatchId.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/AsyncBatchId.java
@@ -8,6 +8,7 @@ import lombok.NonNull;
 import lombok.Value;
 
 import javax.annotation.Nullable;
+import java.util.function.Supplier;
 
 /*
  * #%L
@@ -44,6 +45,7 @@ public class AsyncBatchId implements RepoIdAware
 		return new AsyncBatchId(repoId);
 	}
 
+	@Nullable
 	public static AsyncBatchId ofRepoIdOrNull(final int repoId)
 	{
 		return repoId > 0 ? new AsyncBatchId(repoId) : null;
@@ -53,6 +55,12 @@ public class AsyncBatchId implements RepoIdAware
 	public static AsyncBatchId ofRepoIdOrNone(final int repoId)
 	{
 		return repoId > 0 ? new AsyncBatchId(repoId) : NONE_ASYNC_BATCH_ID;
+	}
+
+	@NonNull
+	public static AsyncBatchId ofRepoIdOr(final int repoId, @NonNull final Supplier<AsyncBatchId> supplier)
+	{
+		return repoId > 0 ? new AsyncBatchId(repoId) : supplier.get();
 	}
 
 	public static int toRepoId(@Nullable final AsyncBatchId asyncBatchId)

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/shipping/JsonShipmentService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/shipping/JsonShipmentService.java
@@ -208,7 +208,7 @@ public class JsonShipmentService
 			if (request.getInvoice())
 			{
 				loggable.addLog("processShipmentSchedules - start creating invoices with currentBatchId={}", AsyncBatchId.toRepoId(currentBatchId));
-				final List<JSONInvoiceInfoResponse> createInvoiceInfos = generateInvoicesForShipmentScheduleIds(generateShipmentRequest.getScheduleIds());
+				final List<JSONInvoiceInfoResponse> createInvoiceInfos = generateInvoicesForShipmentScheduleIds(generateShipmentRequest);
 
 				loggable.addLog("processShipmentSchedules - finished creating invoices with currentBatchId={}; invoiceIds={}",
 								currentBatchId, createdInoutIds);
@@ -246,11 +246,11 @@ public class JsonShipmentService
 	}
 
 	@NonNull
-	private List<JSONInvoiceInfoResponse> generateInvoicesForShipmentScheduleIds(@NonNull final Set<ShipmentScheduleId> shipmentScheduleIds)
+	private List<JSONInvoiceInfoResponse> generateInvoicesForShipmentScheduleIds(@NonNull final GenerateShipmentsRequest generateShipmentsRequest)
 	{
-		final List<I_M_InOutLine> shipmentLines = shipmentService.retrieveInOutLineByShipScheduleId(shipmentScheduleIds);
+		final List<I_M_InOutLine> shipmentLines = shipmentService.retrieveInOutLineByShipScheduleId(generateShipmentsRequest.getScheduleIds());
 
-		final Set<InvoiceId> invoiceIds = invoiceService.generateInvoicesFromShipmentLines(shipmentLines);
+		final Set<InvoiceId> invoiceIds = invoiceService.generateInvoicesFromShipmentLines(shipmentLines, generateShipmentsRequest.getAsyncBatchId());
 
 		return invoiceIds.stream()
 				.map(invoiceId -> jsonInvoiceService.getInvoiceInfo(invoiceId, Env.getAD_Language()))

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
@@ -542,8 +542,6 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 					.map(InvoiceCandidateId::ofRepoId)
 					.collect(ImmutableSet.toImmutableSet());
 
-			invoiceCandidateIds.forEach(invoiceCandidateId -> invoiceCandBL.setAsyncBatch(invoiceCandidateId, asyncBatchId));
-
 			invoiceCandDAO.invalidateCandsFor(invoiceCandidateIds);
 			return;
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoice/InvoiceService.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoice/InvoiceService.java
@@ -24,7 +24,6 @@ package de.metas.invoice;
 
 import ch.qos.logback.classic.Level;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import de.metas.async.AsyncBatchId;
 import de.metas.async.api.IAsyncBatchBL;
@@ -42,7 +41,6 @@ import de.metas.logging.LogManager;
 import de.metas.process.PInstanceId;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
-import de.metas.util.collections.CollectionUtils;
 import lombok.NonNull;
 import org.compiere.model.I_M_InOutLine;
 import org.compiere.util.DB;
@@ -51,15 +49,10 @@ import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import static de.metas.async.Async_Constants.C_Async_Batch_InternalName_InvoiceCandidate_Processing;
 import static org.compiere.util.Env.getCtx;
 
 @Service
@@ -79,7 +72,7 @@ public class InvoiceService
 	}
 
 	@NonNull
-	public Set<InvoiceId> generateInvoicesFromShipmentLines(@NonNull final List<I_M_InOutLine> shipmentLines)
+	public Set<InvoiceId> generateInvoicesFromShipmentLines(@NonNull final List<I_M_InOutLine> shipmentLines, @NonNull final AsyncBatchId asyncBatchId)
 	{
 		if (shipmentLines.isEmpty())
 		{
@@ -93,12 +86,13 @@ public class InvoiceService
 				.map(InvoiceCandidateId::ofRepoId)
 				.collect(ImmutableSet.toImmutableSet());
 
-		return generateInvoicesFromInvoiceCandidateIds(invoiceCandidateIds);
+		return generateInvoicesFromInvoiceCandidateIds(invoiceCandidateIds, asyncBatchId);
 	}
 
-	public ImmutableSet<InvoiceId> generateInvoicesFromInvoiceCandidateIds(@NonNull final Set<InvoiceCandidateId> invoiceCandidateIds)
+	public ImmutableSet<InvoiceId> generateInvoicesFromInvoiceCandidateIds(@NonNull final Set<InvoiceCandidateId> invoiceCandidateIds,
+			@NonNull final AsyncBatchId asyncBatchId)
 	{
-		processInvoiceCandidates(invoiceCandidateIds);
+		processInvoiceCandidates(ImmutableSet.copyOf(invoiceCandidateIds), asyncBatchId);
 
 		return invoiceCandidateIds.stream()
 				.map(invoiceCandDAO::retrieveIlForIc)
@@ -108,14 +102,9 @@ public class InvoiceService
 				.collect(ImmutableSet.toImmutableSet());
 	}
 
-	private void processInvoiceCandidates(@NonNull final Set<InvoiceCandidateId> invoiceCandidateIds)
+	private void processInvoiceCandidates(@NonNull final Set<InvoiceCandidateId> invoiceCandidateIds, @NonNull final AsyncBatchId asyncBatchId)
 	{
-		final ImmutableMap<AsyncBatchId, List<InvoiceCandidateId>> asyncBatchId2InvoiceCandIds = getAsyncBatchId2InvoiceCandidateIds(invoiceCandidateIds);
-
-		for (final Map.Entry<AsyncBatchId, List<InvoiceCandidateId>> entry : asyncBatchId2InvoiceCandIds.entrySet())
-		{
-			generateInvoicesForAsyncBatch(ImmutableSet.copyOf(entry.getValue()), entry.getKey());
-		}
+			generateInvoicesForAsyncBatch(invoiceCandidateIds, asyncBatchId);
 	}
 
 	@NonNull
@@ -125,41 +114,6 @@ public class InvoiceService
 				.map(invoiceCandDAO::retrieveInvoiceCandidatesForInOutLine)
 				.flatMap(List::stream)
 				.collect(ImmutableList.toImmutableList());
-	}
-
-	@NonNull
-	private ImmutableMap<AsyncBatchId, List<InvoiceCandidateId>> getAsyncBatchId2InvoiceCandidateIds(@NonNull final Set<InvoiceCandidateId> invoiceCandidateIds)
-	{
-		if (invoiceCandidateIds.isEmpty())
-		{
-			return ImmutableMap.of();
-		}
-
-		final List<I_C_Invoice_Candidate> invoiceCandidates = invoiceCandDAO.getByIds(invoiceCandidateIds);
-
-		final HashMap<AsyncBatchId, ArrayList<InvoiceCandidateId>> asyncBatchId2InvoiceCand = new HashMap<>();
-
-		invoiceCandidates
-				.forEach(invoiceCandidate -> {
-					final AsyncBatchId currentAsyncBatchId = AsyncBatchId.ofRepoIdOrNone(invoiceCandidate.getC_Async_Batch_ID());
-
-					final ArrayList<InvoiceCandidateId> currentInvoiceCands = new ArrayList<>();
-					currentInvoiceCands.add(InvoiceCandidateId.ofRepoId(invoiceCandidate.getC_Invoice_Candidate_ID()));
-
-					asyncBatchId2InvoiceCand.merge(currentAsyncBatchId, currentInvoiceCands, CollectionUtils::mergeLists);
-				});
-
-		Optional.ofNullable(asyncBatchId2InvoiceCand.get(AsyncBatchId.NONE_ASYNC_BATCH_ID))
-				.ifPresent(noAsyncBatchICIds -> {
-					final AsyncBatchId asyncBatchId = asyncBatchBL.newAsyncBatch(C_Async_Batch_InternalName_InvoiceCandidate_Processing);
-
-					noAsyncBatchICIds.forEach(icID -> invoiceCandBL.setAsyncBatch(icID, asyncBatchId));
-
-					asyncBatchId2InvoiceCand.put(asyncBatchId, noAsyncBatchICIds);
-					asyncBatchId2InvoiceCand.remove(AsyncBatchId.NONE_ASYNC_BATCH_ID);
-				});
-
-		return ImmutableMap.copyOf(asyncBatchId2InvoiceCand);
 	}
 
 	private void generateInvoicesForAsyncBatch(@NonNull final Set<InvoiceCandidateId> invoiceCandIds, @NonNull final AsyncBatchId asyncBatchId)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
@@ -424,8 +424,6 @@ public interface IInvoiceCandBL extends ISingletonService
 	@NonNull
 	InvoiceCandidatesAmtSelectionSummary calculateAmtSelectionSummary(@Nullable String extraWhereClause);
 
-	void setAsyncBatch(InvoiceCandidateId invoiceCandidateId, AsyncBatchId asyncBatchId);
-
 	Quantity getQtyOrderedStockUOM(I_C_Invoice_Candidate ic);
 
 	Quantity getQtyInvoicedStockUOM(I_C_Invoice_Candidate ic);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -34,7 +34,6 @@ import de.metas.aggregation.api.Aggregation;
 import de.metas.aggregation.api.AggregationId;
 import de.metas.aggregation.api.IAggregationDAO;
 import de.metas.allocation.api.IAllocationDAO;
-import de.metas.async.AsyncBatchId;
 import de.metas.async.api.IQueueDAO;
 import de.metas.async.model.I_C_Queue_PackageProcessor;
 import de.metas.async.model.I_C_Queue_WorkPackage;
@@ -2618,23 +2617,6 @@ public class InvoiceCandBL implements IInvoiceCandBL
 				.filter(c -> !processedRecords.contains(c.getC_Invoice_Candidate_ID()))
 				.peek(this::set_DateToInvoice_DefaultImpl)
 				.collect(Collectors.toSet());
-	}
-
-	@Override
-	public void setAsyncBatch(@NonNull final InvoiceCandidateId invoiceCandidateId, @NonNull final AsyncBatchId asyncBatchId)
-	{
-		final I_C_Invoice_Candidate invoiceCandidate = invoiceCandDAO.getById(invoiceCandidateId);
-
-		if (invoiceCandidate.isProcessed())
-		{
-			Loggables.withLogger(logger, Level.WARN).addLog("InvoiceCandBL.setAsyncBatch(): C_Invoice_Candidate already processed,"
-																	+ " nothing to do! InvoiceCandidateId: {}", invoiceCandidate.getC_Invoice_Candidate_ID());
-			return;
-		}
-
-		invoiceCandidate.setC_Async_Batch_ID(asyncBatchId.getRepoId());
-
-		invoiceCandDAO.save(invoiceCandidate);
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/RecreateInvoiceWorkpackageProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/RecreateInvoiceWorkpackageProcessor.java
@@ -24,10 +24,12 @@ import de.metas.notification.INotificationBL;
 import de.metas.notification.UserNotificationRequest;
 import de.metas.process.PInstanceId;
 import de.metas.util.Check;
+import de.metas.util.ILoggable;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_AD_PInstance;
@@ -53,6 +55,7 @@ public class RecreateInvoiceWorkpackageProcessor extends WorkpackageProcessorAda
 	private final IInvoiceCandBL invoiceCandBL = Services.get(IInvoiceCandBL.class);
 	private final transient INotificationBL notificationBL = Services.get(INotificationBL.class);
 	private final ILockManager lockManager = Services.get(ILockManager.class);
+	private final ITrxManager trxManager = Services.get(ITrxManager.class);
 
 	private final ICommissionTriggerService commissionTriggerService = SpringContextHolder.instance.getBean(ICommissionTriggerService.class);
 
@@ -60,15 +63,18 @@ public class RecreateInvoiceWorkpackageProcessor extends WorkpackageProcessorAda
 	private static final AdMessageKey MSG_SKIPPED_INVOICE_DUE_TO_COMMISSION = AdMessageKey.of("MSG_SKIPPED_INVOICE_DUE_TO_COMMISSION");
 
 	@Override
+	public boolean isRunInTransaction() {return false;}
+
+	@Override
 	public Result processWorkPackage(@NonNull final I_C_Queue_WorkPackage workpackage, @Nullable final String trxName_IGNORED)
 	{
 		final int pinstanceInt = getParameters().getParameterAsInt(I_AD_PInstance.COLUMNNAME_AD_PInstance_ID, workpackage.getAD_PInstance_ID());
 		Check.assume(pinstanceInt > 0, "pinstanceInt>=0 on workpackage={}", workpackage);
-
 		final PInstanceId pinstanceId = PInstanceId.ofRepoId(pinstanceInt);
 
 		Check.assume(workpackage.getC_Async_Batch_ID() > 0, "workpackage.getC_Async_Batch_ID() > 0 for workpackage=", workpackage);
 		final AsyncBatchId asyncBatchId = AsyncBatchId.ofRepoId(workpackage.getC_Async_Batch_ID());
+		final I_C_Async_Batch asyncBatch = asyncBatchBL.getAsyncBatchById(asyncBatchId);
 
 		final ILockCommand elementsLocker = lockManager.lock()
 				.setOwner(LockOwner.newOwner(getClass().getSimpleName()))
@@ -76,47 +82,60 @@ public class RecreateInvoiceWorkpackageProcessor extends WorkpackageProcessorAda
 				.setFailIfAlreadyLocked(true)
 				.setRecordsBySelection(I_C_Invoice_Candidate.class, pinstanceId);
 
-		try (final ILockAutoCloseable lock = elementsLocker.acquire().asAutoCloseable())
+		try (final ILockAutoCloseable ignored = elementsLocker.acquire().asAutoCloseable())
 		{
-			processWorkPackage0(pinstanceId, asyncBatchId);
+			processWorkPackage0(pinstanceId, asyncBatch);
 		}
 
 		return Result.SUCCESS;
 	}
 
-	private void processWorkPackage0(@NonNull final PInstanceId pinstanceId, @NonNull final AsyncBatchId asyncBatchId)
+	private void processWorkPackage0(@NonNull final PInstanceId pinstanceId, @NonNull final I_C_Async_Batch asyncBatch)
 	{
-		final Iterator<I_C_Invoice> invoiceIterator = retrieveSelection(pinstanceId);
+		final ILoggable loggable = Loggables.withLogger(logger, Level.DEBUG);
 
+		final Iterator<I_C_Invoice> invoiceIterator = retrieveSelection(pinstanceId);
 		while (invoiceIterator.hasNext())
 		{
 			final I_C_Invoice invoice = invoiceIterator.next();
 
 			if (!canVoidPaidInvoice(invoice))
 			{
-				Loggables.withLogger(logger, Level.DEBUG).addLog("C_Invoice_ID={}: Skipping paid invoice because we can't void it.", invoice.getC_Invoice_ID());
+				loggable.addLog("C_Invoice_ID={}: Skipping paid invoice because we can't void it.", invoice.getC_Invoice_ID());
 				continue;
 			}
 
-			final Set<InvoiceCandidateId> invoiceCandIds = invoiceCandBL.voidAndReturnInvoiceCandIds(invoice);
-
+			final Set<InvoiceCandidateId> invoiceCandIds = voidAndReturnInvoiceCandIds(invoice);
 			if (invoiceCandIds.isEmpty())
 			{
-				Loggables.withLogger(logger, Level.DEBUG).addLog("C_Invoice_ID={}: Skipping invoice that is not based on invoice candidates.", invoice.getC_Invoice_ID());
+				loggable.addLog("C_Invoice_ID={}: Skipping invoice that is not based on invoice candidates.", invoice.getC_Invoice_ID());
 				continue;
 			}
 
-			invoiceCandIds.forEach(invoiceCandId -> invoiceCandBL.setAsyncBatch(invoiceCandId, asyncBatchId));
-
-			final I_C_Async_Batch asyncBatch = asyncBatchBL.getAsyncBatchById(asyncBatchId);
-
-			invoiceCandBL.enqueueForInvoicing()
-					.setContext(getCtx())
-					.setC_Async_Batch(asyncBatch)
-					.setInvoicingParams(getIInvoicingParams())
-					.setFailIfNothingEnqueued(true)
-					.enqueueInvoiceCandidateIds(invoiceCandIds);
+			enqueueForInvoicing(invoiceCandIds, asyncBatch);
 		}
+	}
+
+	private Set<InvoiceCandidateId> voidAndReturnInvoiceCandIds(final I_C_Invoice invoice)
+	{
+		// NOTE: we have to separate voidAndReturnInvoiceCandIds and enqueueForInvoicing in 2 transactions because
+		// InvoiceCandidateEnqueuer is calling updateSelectionBeforeEnqueueing in a new transaction (for some reason?!?)
+		// and that is introducing a deadlock in case we are also changing C_Invoice_Candidate table here.
+		trxManager.assertThreadInheritedTrxNotExists();
+
+		return trxManager.callInNewTrx(() -> invoiceCandBL.voidAndReturnInvoiceCandIds(invoice));
+	}
+
+	private void enqueueForInvoicing(final Set<InvoiceCandidateId> invoiceCandIds, final @NonNull I_C_Async_Batch asyncBatch)
+	{
+		trxManager.assertThreadInheritedTrxNotExists();
+
+		invoiceCandBL.enqueueForInvoicing()
+				.setContext(getCtx())
+				.setC_Async_Batch(asyncBatch)
+				.setInvoicingParams(getIInvoicingParams())
+				.setFailIfNothingEnqueued(true)
+				.enqueueInvoiceCandidateIds(invoiceCandIds);
 	}
 
 	@NonNull


### PR DESCRIPTION
Cherry-pick of https://github.com/metasfresh/metasfresh/pull/16997 and adapted `de.metas.invoice.InvoiceService#generateInvoicesFromInvoiceCandidateIds` to mirror the master code