### PR TITLE
RabbitMQ prefetch size and consumer count (#19249)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/cache/CacheInvalidationRemoteHandler.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/cache/CacheInvalidationRemoteHandler.java
@@ -19,10 +19,9 @@ import org.adempiere.ad.dao.cache.CacheInvalidateMultiRequestSerializer;
 import org.slf4j.Logger;
 import org.slf4j.MDC.MDCCloseable;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
-
-import javax.annotation.Nullable;
 
 /*
  * #%L
@@ -49,7 +48,7 @@ import javax.annotation.Nullable;
 /** Bidirectional binding between local cache system and remote cache systems */
 final class CacheInvalidationRemoteHandler implements IEventListener
 {
-	public static final transient CacheInvalidationRemoteHandler instance = new CacheInvalidationRemoteHandler();
+	public static final CacheInvalidationRemoteHandler instance = new CacheInvalidationRemoteHandler();
 
 	private static final Logger logger = LogManager.getLogger(CacheInvalidationRemoteHandler.class);
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/util/agg/key/AbstractHeaderAggregationKeyBuilder.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/util/agg/key/AbstractHeaderAggregationKeyBuilder.java
@@ -22,12 +22,12 @@
 
 package de.metas.util.agg.key;
 
-import java.util.List;
-
 import org.adempiere.util.agg.key.AbstractAggregationKeyBuilder;
 import org.adempiere.util.agg.key.IAggregationKeyRegistry;
 import org.compiere.util.Util;
 import org.compiere.util.Util.ArrayKey;
+
+import java.util.List;
 
 /**
  * Base class for header aggregation key builders that uses {@link IAggregationKeyRegistry#getValuesForModel(String, Object)} to for the aggregation keys' components.
@@ -55,7 +55,7 @@ public class AbstractHeaderAggregationKeyBuilder<T> extends AbstractAggregationK
 		return aggregationKey1.equals(aggregationKey2);
 	}
 
-	private final ArrayKey buildArrayKey(final T item)
+	private ArrayKey buildArrayKey(final T item)
 	{
 		final List<Object> keyValues = aggregationKeyRegistry.getValuesForModel(registrationKey, item);
 		return Util.mkKey(keyValues.toArray());

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/server/rpl/imp/RabbitMqListener.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/server/rpl/imp/RabbitMqListener.java
@@ -28,6 +28,7 @@ import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.w3c.dom.Document;
 
+import javax.annotation.Nullable;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
@@ -59,6 +60,7 @@ import static de.metas.common.util.CoalesceUtil.firstNotEmptyTrimmed;
 
 public class RabbitMqListener implements MessageListener
 {
+	@Nullable
 	private CachingConnectionFactory connectionFactory;
 
 	private final String host;
@@ -155,7 +157,10 @@ public class RabbitMqListener implements MessageListener
 		container.setConsumerTagStrategy(q -> consumerTag);
 		container.setConnectionFactory(connectionFactory);
 		container.setQueueNames(queueName);
-
+		container.setPrefetchCount(1); // here, the default is 250
+		container.setConcurrentConsumers(1); // 1 is actually the default anyways
+		container.setMaxConcurrentConsumers(1);
+		
 		container.setErrorHandler(t -> {
 			if (isStopping)
 			{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleBL.java
@@ -53,8 +53,6 @@ import java.util.Set;
 
 public interface IShipmentScheduleBL extends ISingletonService
 {
-	String MSG_ShipmentSchedules_To_Recompute = "ShipmentSchedules_To_Recompute";
-
 	/**
 	 * Please use this method to avoid unneeded work packages.
 	 *
@@ -87,7 +85,7 @@ public interface IShipmentScheduleBL extends ISingletonService
 	 * <p>
 	 * <b>IMPORTANT</b> this column does not evaluate the actual schedule's own {@link I_M_ShipmentSchedule#isAllowConsolidateInOut()} value. As of now, that flag is only for the user's information.
 	 */
-	boolean isSchedAllowsConsolidate(I_M_ShipmentSchedule sched);
+	boolean isSchedAllowsConsolidate(@NonNull I_M_ShipmentSchedule sched);
 
 	/**
 	 * Creates a new aggregation key builder which can be used to decide if two given shipment schedules can go into the same shipment.
@@ -99,7 +97,7 @@ public interface IShipmentScheduleBL extends ISingletonService
 	/**
 	 * If the given <code>shipmentSchedule</code> has its {@link I_M_ShipmentSchedule#COLUMN_QtyOrdered_Override QtyOrdered_Override} set, then override its <code>QtyOrdered</code> value with it. If
 	 * QtyOrdered_Override is <code>null</code>, then reset <code>QtyOrdered</code> to the value of <code>QtyOrdered_Calculated</code>.
-	 *
+	 * <p>
 	 * Task 08255
 	 *
 	 */
@@ -107,7 +105,7 @@ public interface IShipmentScheduleBL extends ISingletonService
 
 	/**
 	 * Close the given Shipment Schedule.
-	 *
+	 * <p>
 	 * Closing a shipment schedule means overriding its QtyOrdered to the qty which was already delivered.
 	 */
 	void closeShipmentSchedule(I_M_ShipmentSchedule schedule);
@@ -158,7 +156,7 @@ public interface IShipmentScheduleBL extends ISingletonService
 
 	WarehouseId getWarehouseId(I_M_ShipmentSchedule schedule);
 
-	ZonedDateTime getPreparationDate(I_M_ShipmentSchedule schedule);
+	ZonedDateTime getPreparationDate(@NonNull I_M_ShipmentSchedule schedule);
 
 	ShipmentAllocationBestBeforePolicy getBestBeforePolicy(ShipmentScheduleId id);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleEffectiveBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleEffectiveBL.java
@@ -22,25 +22,23 @@ package de.metas.inoutcandidate.api;
  * #L%
  */
 
-import java.math.BigDecimal;
-import java.time.ZonedDateTime;
-
 import de.metas.bpartner.BPartnerContactId;
+import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.BPartnerLocationId;
 import de.metas.document.location.DocumentLocation;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.interfaces.I_C_BPartner;
+import de.metas.order.DeliveryRule;
+import de.metas.util.ISingletonService;
 import lombok.NonNull;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.I_AD_User;
 import org.compiere.model.I_C_BPartner_Location;
 
-import de.metas.bpartner.BPartnerId;
-import de.metas.bpartner.BPartnerLocationId;
-import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
-import de.metas.interfaces.I_C_BPartner;
-import de.metas.order.DeliveryRule;
-import de.metas.util.ISingletonService;
-
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
 
 /**
  * Returns the "effective" values for a given shipment schedules when it has both an "original" and an "override" column.
@@ -102,5 +100,5 @@ public interface IShipmentScheduleEffectiveBL extends ISingletonService
 	 * If none of them is set, try to fallback to the given {@code sched}'s order's preparation date. If the order has no proparation date, falls back to the order's promised date.
 	 * If the given {@code sched} doesn't have an order, return the current time.,
 	 */
-	ZonedDateTime getPreparationDate(I_M_ShipmentSchedule sched);
+	ZonedDateTime getPreparationDate(@NonNull I_M_ShipmentSchedule sched);
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
@@ -248,7 +248,7 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 	}
 
 	@Override
-	public boolean isSchedAllowsConsolidate(final I_M_ShipmentSchedule sched)
+	public boolean isSchedAllowsConsolidate(@NonNull final I_M_ShipmentSchedule sched)
 	{
 		final ShipmentScheduleAllowConsolidatePredicateComposite shipmentScheduleAllowConsolidatePredicateComposite = SpringContextHolder.instance
 				.getBean(ShipmentScheduleAllowConsolidatePredicateComposite.class);
@@ -361,12 +361,7 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 		}
 
 		final boolean wasClosed = createOld(shipmentScheduleRecord, I_M_ShipmentSchedule.class).isClosed();
-		if (!wasClosed)
-		{
-			return false;
-		}
-
-		return true; // was closed, but is now open
+		return wasClosed;// was closed, but is now open
 	}
 
 	@Override
@@ -452,7 +447,7 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 	}
 
 	@Override
-	public void updateCatchUoms(@NonNull final ProductId productId, long delayMs)
+	public void updateCatchUoms(@NonNull final ProductId productId, final long delayMs)
 	{
 		if (delayMs < 0)
 		{
@@ -555,7 +550,7 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 	}
 
 	@Override
-	public ZonedDateTime getPreparationDate(I_M_ShipmentSchedule schedule)
+	public ZonedDateTime getPreparationDate(@NonNull final I_M_ShipmentSchedule schedule)
 	{
 		return shipmentScheduleEffectiveBL.getPreparationDate(schedule);
 	}
@@ -582,14 +577,14 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 		trxManager.runInThreadInheritedTrx(() -> applyUserChangesInTrx0(userChanges));
 	}
 
-	private void applyUserChangesInTrx0(@NonNull ShipmentScheduleUserChangeRequestsList userChanges)
+	private void applyUserChangesInTrx0(@NonNull final ShipmentScheduleUserChangeRequestsList userChanges)
 	{
 		final Set<ShipmentScheduleId> shipmentScheduleIds = userChanges.getShipmentScheduleIds();
 		final Map<ShipmentScheduleId, I_M_ShipmentSchedule> recordsById = shipmentSchedulePA.getByIds(shipmentScheduleIds);
 
 		for (final ShipmentScheduleId shipmentScheduleId : shipmentScheduleIds)
 		{
-			try (final MDCCloseable shipmentScheduleMDC = TableRecordMDC.putTableRecordReference(I_M_ShipmentSchedule.Table_Name, shipmentScheduleId))
+			try (final MDCCloseable ignored = TableRecordMDC.putTableRecordReference(I_M_ShipmentSchedule.Table_Name, shipmentScheduleId))
 			{
 
 				final ShipmentScheduleUserChangeRequest userChange = userChanges.getByShipmentScheduleId(shipmentScheduleId);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleEffectiveBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleEffectiveBL.java
@@ -200,7 +200,7 @@ public class ShipmentScheduleEffectiveBL implements IShipmentScheduleEffectiveBL
 	}
 
 	@Override
-	public ZonedDateTime getPreparationDate(final I_M_ShipmentSchedule sched)
+	public ZonedDateTime getPreparationDate(@NonNull final I_M_ShipmentSchedule sched)
 	{
 		final ZonedDateTime preparationDateOverride = TimeUtil.asZonedDateTime(sched.getPreparationDate_Override());
 		if (preparationDateOverride != null)

--- a/backend/de.metas.util/src/main/java/org/adempiere/util/agg/key/impl/AggregationKeyRegistry.java
+++ b/backend/de.metas.util/src/main/java/org/adempiere/util/agg/key/impl/AggregationKeyRegistry.java
@@ -22,15 +22,15 @@ package org.adempiere.util.agg.key.impl;
  * #L%
  */
 
+import lombok.NonNull;
+import org.adempiere.util.agg.key.IAggregationKeyRegistry;
+import org.adempiere.util.agg.key.IAggregationKeyValueHandler;
+import org.adempiere.util.lang.ObjectUtils;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.adempiere.util.agg.key.IAggregationKeyRegistry;
-import org.adempiere.util.agg.key.IAggregationKeyValueHandler;
-import org.adempiere.util.lang.ObjectUtils;
 
 /**
  * {@link IAggregationKeyRegistry} default implementation
@@ -39,9 +39,9 @@ import org.adempiere.util.lang.ObjectUtils;
  */
 public class AggregationKeyRegistry implements IAggregationKeyRegistry
 {
-	private static final Map<String, List<String>> dependsOnColumnNames = new HashMap<String, List<String>>();
+	private static final Map<String, List<String>> dependsOnColumnNames = new HashMap<>();
 
-	private static final Map<String, CompositeAggregationKeyValueHandler> _valueHandlers = new HashMap<String, CompositeAggregationKeyValueHandler>();
+	private static final Map<String, CompositeAggregationKeyValueHandler> _valueHandlers = new HashMap<>();
 
 	@Override
 	public void registerDependsOnColumnnames(final String registrationKey, final String... columnNames)
@@ -55,7 +55,7 @@ public class AggregationKeyRegistry implements IAggregationKeyRegistry
 		return dependsOnColumnNames.get(registrationKey);
 	}
 
-	private final CompositeAggregationKeyValueHandler getCompositeKeyValueHandler(final String registrationKey)
+	private CompositeAggregationKeyValueHandler getCompositeKeyValueHandler(@NonNull final String registrationKey)
 	{
 		CompositeAggregationKeyValueHandler compositeKeyValueHandler = _valueHandlers.get(registrationKey);
 		if (compositeKeyValueHandler == null)

--- a/backend/metasfresh-dist/base/src/main/resources/application.properties
+++ b/backend/metasfresh-dist/base/src/main/resources/application.properties
@@ -45,3 +45,13 @@ logging.level.root=INFO
 # Elasticsearch
 # --------------------------------------------------------------------------------
 metasfresh.elasticsearch.host=search:9200
+
+# --------------------------------------------------------------------------------
+# RabbitMQ
+# --------------------------------------------------------------------------------
+# Goal: make sure to have strict in-order processing of messages
+# Source for property-names: https://docs.spring.io/spring-boot/docs/2.4.3/reference/html/appendix-application-properties.html#common-application-properties
+spring.rabbitmq.listener.direct.consumers-per-queue=1
+spring.rabbitmq.listener.direct.prefetch=1
+spring.rabbitmq.listener.simple.max-concurrency=1
+spring.rabbitmq.listener.simple.prefetch=1

--- a/backend/metasfresh-webui-api/src/main/resources/application.properties
+++ b/backend/metasfresh-webui-api/src/main/resources/application.properties
@@ -91,7 +91,14 @@ spring.data.elasticsearch.cluster-nodes=localhost:9300
 # NOTE: Avoid spamming the console in case there is no connection to elasticsearch. Those "Connection refused" are logged as INFO
 logging.level.org.elasticsearch.client.transport=WARN
 
-
+# --------------------------------------------------------------------------------
 # RabbitMQ
+# --------------------------------------------------------------------------------
+# Goal: make sure to have strict in-order processing of messages
+# Source for property-names: https://docs.spring.io/spring-boot/docs/2.4.3/reference/html/appendix-application-properties.html#common-application-properties
+spring.rabbitmq.listener.direct.consumers-per-queue=1
+spring.rabbitmq.listener.direct.prefetch=1
+spring.rabbitmq.listener.simple.max-concurrency=1
+spring.rabbitmq.listener.simple.prefetch=1
 # avoid order problems with multithreading and channel size default 25
 spring.rabbitmq.cache.channel.size=1


### PR DESCRIPTION
* minor unrelated improvements in the shipment-schedule logic
* set prefetch-count and concurrent consumers to 1

goal: no more FUD about message ordering
(cherry picked from commit 9be34ced04c0a30ba7f48a7e27c427b21516f33d)