### PR TITLE
Improve invoice performance (#19438)

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5740590_sys_c_invoice_detail_indexes.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5740590_sys_c_invoice_detail_indexes.sql
@@ -1,0 +1,13 @@
+DROP INDEX IF EXISTS c_invoice_detail_c_invoice_candidate_id
+;
+
+CREATE INDEX c_invoice_detail_c_invoice_candidate_id
+    ON c_invoice_detail (c_invoice_candidate_id)
+;
+
+DROP INDEX IF EXISTS c_invoice_detail_c_invoice_id
+;
+
+CREATE INDEX c_invoice_detail_c_invoice_id
+    ON c_invoice_detail (c_invoice_id)
+;


### PR DESCRIPTION
* c_invoice_candidate_headeraggregation_invoicinggroupno_ft: hotfix huge performances drop (#15859)

i.e. avoid using generate_series(1,10000000) because generate_series as used there
* is causing a huge performance issue anyways and increasing the number just exponantially drops the performances
* it's exponentially increasing the used temp space to over 260 Gb

(cherry picked from commit b8234b00015ce0d1d68f8d95738f8b2a6ada23a7)

* C_Invoice_Detail indexes

---------