### PR TITLE
Corrections for accounting (#19484)

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5740790_sys_C_ValidCombination_Alt_Index_OnlyActive.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5740790_sys_C_ValidCombination_Alt_Index_OnlyActive.sql
@@ -1,0 +1,22 @@
+
+DROP INDEX IF EXISTS c_validcombination_alt
+;
+
+CREATE UNIQUE INDEX c_validcombination_alt
+    ON c_validcombination (ad_client_id, c_acctschema_id, ad_org_id, account_id,
+                           (COALESCE(c_subacct_id, 0::numeric)),
+                           (COALESCE(m_product_id, 0::numeric)),
+                           (COALESCE(c_bpartner_id, 0::numeric)),
+                           (COALESCE(ad_orgtrx_id, 0::numeric)),
+                           (COALESCE(c_locfrom_id, 0::numeric)),
+                           (COALESCE(c_locto_id, 0::numeric)),
+                           (COALESCE(c_salesregion_id, 0::numeric)),
+                           (COALESCE(c_project_id, 0::numeric)),
+                           (COALESCE(c_campaign_id, 0::numeric)),
+                           (COALESCE(c_activity_id, 0::numeric)),
+                           (COALESCE(user1_id, 0::numeric)),
+                           (COALESCE(user2_id, 0::numeric)),
+                           (COALESCE(userelement1_id, 0::numeric)),
+                           (COALESCE(userelement2_id, 0::numeric)))
+    WHERE (isactive = 'Y'::bpchar)
+;

--- a/backend/de.metas.business/src/main/java/de/metas/costing/ICurrentCostsRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/ICurrentCostsRepository.java
@@ -61,6 +61,8 @@ public interface ICurrentCostsRepository
 
 	List<CurrentCost> getByCostSegmentAndCostElements(CostSegment costSegment, Set<CostElementId> costElementIds);
 
+	void updateUOMForProduct(I_M_Product product);
+
 	void updateCostRecord(CostSegmentAndElement costSegmentAndElement, Consumer<I_M_Cost> updater);
 
 	Stream<CurrentCost> stream(CurrentCostQuery query);

--- a/backend/de.metas.business/src/main/java/de/metas/costing/impl/CurrentCostsRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/impl/CurrentCostsRepository.java
@@ -29,6 +29,7 @@ import de.metas.uom.IUOMDAO;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.ad.dao.ICompositeQueryUpdater;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
@@ -335,6 +336,18 @@ public class CurrentCostsRepository implements ICurrentCostsRepository
 		forEachCostSegmentAndElement(product, costSegmentAndElement -> toSqlQuery(CurrentCostQuery.builderFrom(costSegmentAndElement).build())
 				.create()
 				.delete());
+	}
+
+	@Override
+	public void updateUOMForProduct(final I_M_Product product)
+	{
+		final ICompositeQueryUpdater<I_M_Cost> queryUpdater = queryBL
+				.createCompositeQueryUpdater(I_M_Cost.class)
+				.addSetColumnValue(I_M_Cost.COLUMNNAME_C_UOM_ID, product.getC_UOM_ID());
+
+		forEachCostSegmentAndElement(product, costSegmentAndElement -> toSqlQuery(CurrentCostQuery.builderFrom(costSegmentAndElement).build())
+				.create()
+				.update(queryUpdater));
 	}
 
 	private void forEachCostSegmentAndElement(

--- a/backend/de.metas.business/src/main/java/de/metas/costing/interceptors/M_Product.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/interceptors/M_Product.java
@@ -2,6 +2,7 @@ package de.metas.costing.interceptors;
 
 import de.metas.costing.ICostDetailService;
 import de.metas.costing.ICurrentCostsRepository;
+import de.metas.product.ProductConstants;
 import de.metas.product.ProductId;
 import lombok.NonNull;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
@@ -49,12 +50,24 @@ class M_Product
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_CHANGE, ifColumnsChanged = I_M_Product.COLUMNNAME_C_UOM_ID)
 	public void assertNoCosts(final I_M_Product product)
 	{
+		assertNoCost(product);
+	}
+
+	private void assertNoCost(final I_M_Product product)
+	{
 		final ProductId productId = ProductId.ofRepoId(product.getM_Product_ID());
+
 		if (costDetailsService.hasCostDetailsForProductId(productId))
 		{
-			throw new AdempiereException("@CannotDeleteProductsWithCostDetails@");
+			throw new AdempiereException(ProductConstants.MSG_PRODUCT_ALREADY_USED);
 		}
+	}
 
+	@ModelChange(timings = ModelValidator.TYPE_AFTER_CHANGE, ifColumnsChanged = I_M_Product.COLUMNNAME_C_UOM_ID)
+	public void updateCostUom(final I_M_Product product)
+	{
+		assertNoCost(product);
+		currentCostsRepository.updateUOMForProduct(product);
 	}
 
 	@ModelChange(timings = { ModelValidator.TYPE_AFTER_NEW, ModelValidator.TYPE_AFTER_CHANGE }, ifColumnsChanged = I_M_Product.COLUMNNAME_M_Product_Category_ID)

--- a/backend/de.metas.business/src/main/java/de/metas/product/ProductConstants.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/ProductConstants.java
@@ -22,9 +22,10 @@ package de.metas.product;
  * #L%
  */
 
+import de.metas.i18n.AdMessageKey;
+
 /**
  * @author metas-dev <dev@metasfresh.com>
- *
  *         Class of constants to have an organized way of keeping the names of the fields used in process parameters but that are not present in any interface of a table.
  *
  *         IMPORTANT: Please, change these if you change the names of such fields.
@@ -34,5 +35,6 @@ public class ProductConstants
 
 	public final static String TARGET_PRODUCT_ID = "M_Product_Target_ID";
 
-	public final static String TARGET_ORG_ID = "AD_Org_Target_ID";
+	public final static AdMessageKey MSG_PRODUCT_ALREADY_USED = AdMessageKey.of("de.metas.order.model.interceptor.M_Product.MSG_PRODUCT_ALREADY_USED");
+
 }

--- a/backend/de.metas.business/src/main/java/de/metas/product/model/interceptor/M_Product.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/model/interceptor/M_Product.java
@@ -4,6 +4,7 @@ import de.metas.i18n.AdMessageKey;
 import de.metas.organization.OrgId;
 import de.metas.product.IProductBL;
 import de.metas.product.IProductPlanningSchemaBL;
+import de.metas.product.ProductConstants;
 import de.metas.product.ProductId;
 import de.metas.product.ProductPlanningSchemaSelector;
 import de.metas.product.impl.ProductDAO;
@@ -55,7 +56,6 @@ public class M_Product
 
 	private static final AdMessageKey MSG_PRODUCT_UOM_CONVERSION_ALREADY_LINKED = AdMessageKey.of("de.metas.order.model.interceptor.M_Product.Product_UOM_Conversion_Already_Linked");
 
-	private static final AdMessageKey MSG_PRODUCT_ALREADY_USED = AdMessageKey.of("de.metas.order.model.interceptor.M_Product.MSG_PRODUCT_ALREADY_USED");
 
 	private final IProductPlanningSchemaBL productPlanningSchemaBL = Services.get(IProductPlanningSchemaBL.class);
 
@@ -148,7 +148,7 @@ public class M_Product
 	{
 		if (productBL.isProductUsed(productId))
 		{
-			return Optional.of(MSG_PRODUCT_ALREADY_USED);
+			return Optional.of(ProductConstants.MSG_PRODUCT_ALREADY_USED);
 		}
 
 		return Optional.empty();


### PR DESCRIPTION
* Unique index only on active entries

* Update uom for initial costs of product when the product's uom is updated

* Sync error messages from M_Product UOM change interceptors