### PR TITLE
fix mobile UI view header layout

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/assets/view-header.scss
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/assets/view-header.scss
@@ -11,6 +11,8 @@
       }
 
       td {
+        max-width: 60vw !important;
+        overflow: hidden;
         text-align: right;
       }
     }


### PR DESCRIPTION
it was rendering horizontal scroll when the view header property value string was very long
