### PR TITLE
mobile POS: allow entering weights using comma or dot as decimal separator

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/numbers.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/numbers.test.js
@@ -1,0 +1,27 @@
+import { toNumberOrNaN } from '../../utils/numbers';
+
+describe('numbers tests', () => {
+  describe('toNumberOrNaN', () => {
+    const expectations = [
+      // [ input, expected ]
+      [null, Number.NaN],
+      [undefined, Number.NaN],
+      ['', 0],
+      ['.3', Number(0.3)],
+      [',3', Number(0.3)],
+      ['0.3', Number(0.3)],
+      ['0,3', Number(0.3)],
+      ['0.3', Number(0.3)],
+      ['    0.3     ', Number(0.3)],
+      ['    0,3     ', Number(0.3)],
+      [',', Number.NaN],
+      ['.', Number.NaN],
+      ['0,300,200', Number.NaN],
+      [Number('123.456'), Number('123.456')],
+    ];
+
+    for (const [input, expected] of expectations) {
+      it('"' + input + '"(' + typeof input + ') -> ' + expected, () => expect(toNumberOrNaN(input)).toBe(expected));
+    }
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/pos/containers/order_panel/GetCatchWeightModal.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/pos/containers/order_panel/GetCatchWeightModal.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import useEscapeKey from '../../../../hooks/useEscapeKey';
 import { trl } from '../../../../utils/translations';
-import { useWhyDidYouUpdate } from '../../../../hooks/useWhyDidYouUpdate';
 
 const _ = (key, args = {}) => trl(`pos.currentOrder.getWeightModal.${key}`, args);
 
@@ -13,7 +12,6 @@ const GetCatchWeightModal = ({ catchWeightUomSymbol, onOk, onCancel }) => {
   const weight = Number(weightStr);
   const isValid = weight > 0;
 
-  useWhyDidYouUpdate('AAAA', { weightRef_current: weightRef.current });
   useEffect(() => {
     if (weightRef?.current) {
       weightRef.current.focus();

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/pos/containers/order_panel/GetCatchWeightModal.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/pos/containers/order_panel/GetCatchWeightModal.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import useEscapeKey from '../../../../hooks/useEscapeKey';
 import { trl } from '../../../../utils/translations';
+import { toNumberOrNaN } from '../../../../utils/numbers';
 
 const _ = (key, args = {}) => trl(`pos.currentOrder.getWeightModal.${key}`, args);
 
@@ -9,7 +10,7 @@ const GetCatchWeightModal = ({ catchWeightUomSymbol, onOk, onCancel }) => {
   const [weightStr, setWeightStr] = useState(0);
   const weightRef = useRef();
 
-  const weight = Number(weightStr);
+  const weight = toNumberOrNaN(weightStr);
   const isValid = weight > 0;
 
   useEffect(() => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickLineScanScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickLineScanScreen.jsx
@@ -42,7 +42,7 @@ import { useHeaderUpdate } from './PickLineScreen';
 import { pickingLineScanScreenLocation } from '../../../routes/picking';
 import { getWFProcessScreenLocation } from '../../../routes/workflow_locations';
 import { useCurrentPickTarget } from '../../../reducers/wfProcesses/picking/useCurrentPickTarget';
-import { toNumberOrZero } from '../../../utils/numberUtils';
+import { toNumberOrZero } from '../../../utils/numbers';
 import { isBarcodeProductNoMatching } from '../../../utils/qrCode/common';
 
 export const NEXT_PickingJob = 'pickingJob';

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickStepScanScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickStepScanScreen.jsx
@@ -17,7 +17,7 @@ import { postStepPicked } from '../../../api/picking';
 import ScanHUAndGetQtyComponent from '../../../components/ScanHUAndGetQtyComponent';
 import { toQRCodeString } from '../../../utils/qrCode/hu';
 import { updateWFProcess } from '../../../actions/WorkflowActions';
-import { toNumberOrZero } from '../../../utils/numberUtils';
+import { toNumberOrZero } from '../../../utils/numbers';
 
 const PickStepScanScreen = () => {
   const {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/numberUtils.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/numberUtils.js
@@ -1,7 +1,0 @@
-export const toNumberOrZero = (arg) => {
-  try {
-    return Number(arg);
-  } catch (e) {
-    return 0;
-  }
-};

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/numbers.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/numbers.js
@@ -1,3 +1,11 @@
 export const round = (number, precision) => {
   return parseFloat(Number(number).toFixed(precision));
 };
+
+export const toNumberOrZero = (arg) => {
+  try {
+    return Number(arg);
+  } catch (e) {
+    return 0;
+  }
+};

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/numbers.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/numbers.js
@@ -9,3 +9,38 @@ export const toNumberOrZero = (arg) => {
     return 0;
   }
 };
+
+export const toNumberOrNaN = (arg) => {
+  if (arg == null) {
+    return Number.NaN;
+  } else if (typeof arg === 'number') {
+    return arg;
+  } else if (typeof arg === 'string') {
+    const string = arg.trim();
+    if (!string) {
+      return 0;
+    }
+
+    try {
+      const number = Number(string);
+      if (Number.isFinite(number)) {
+        return number;
+      }
+    } catch (ex) {
+      // ignore it
+    }
+
+    try {
+      const number = Number(string.replaceAll(',', '.'));
+      if (Number.isFinite(number)) {
+        return number;
+      }
+    } catch (ex) {
+      // ignore it
+    }
+
+    return Number.NaN;
+  } else {
+    return Number(arg);
+  }
+};


### PR DESCRIPTION
- **move toNumberOrZero to numbers.js, so we can remove numberUtils.js**
- **cleanup**
- **GetCatchWeightModal: allow entering qtys with comma or dot**
