### PR TITLE
Add Support SCOR type when Importing esr  files (#19560) to new_dawn_uat

### DIFF
--- a/backend/de.metas.payment.esr/src/main/java-gen/de/metas/payment/esr/model/X_ESR_ImportLine.java
+++ b/backend/de.metas.payment.esr/src/main/java-gen/de/metas/payment/esr/model/X_ESR_ImportLine.java
@@ -433,6 +433,8 @@ public class X_ESR_ImportLine extends org.compiere.model.PO implements I_ESR_Imp
 	public static final String ESR_PAYMENT_ACTION_Discount = "T";
 	/** Duplicate_Payment = P */
 	public static final String ESR_PAYMENT_ACTION_Duplicate_Payment = "P";
+	/** Unknown_Invoice = U */
+	public static final String ESR_PAYMENT_ACTION_Unknown_Invoice = "U";
 	@Override
 	public void setESR_Payment_Action (final @Nullable java.lang.String ESR_Payment_Action)
 	{
@@ -601,6 +603,8 @@ public class X_ESR_ImportLine extends org.compiere.model.PO implements I_ESR_Imp
 	public static final String TYPE_QRR = "QRR";
 	/** ESR = ISR Reference */
 	public static final String TYPE_ESR = "ISR Reference";
+	/** SCOR = SCOR Reference */
+	public static final String TYPE_SCOR = "SCOR";
 	@Override
 	public void setType (final java.lang.String Type)
 	{

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/actionhandler/impl/DiscountESRActionHandler.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/actionhandler/impl/DiscountESRActionHandler.java
@@ -16,7 +16,7 @@ import de.metas.util.Check;
 import de.metas.util.Services;
 
 /**
- * Handler for {@link de.metas.payment.esr.model.X_ESR_ImportLine#EESR_PAYMENT_ACTION_Discount}. This handler discounts the open amount of the line's invoice. For lines that don't have an
+ * Handler for {@link de.metas.payment.esr.model.X_ESR_ImportLine#ESR_PAYMENT_ACTION_Discount}. This handler discounts the open amount of the line's invoice. For lines that don't have an
  * invoice, the handler does nothing.
  * 
  */

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/actionhandler/impl/UnknownInvoiceESRActionHandler.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/actionhandler/impl/UnknownInvoiceESRActionHandler.java
@@ -1,0 +1,31 @@
+package de.metas.payment.esr.actionhandler.impl;
+
+import de.metas.logging.LogManager;
+import de.metas.payment.PaymentId;
+import de.metas.payment.esr.api.impl.ESRImportBL;
+import de.metas.payment.esr.model.I_ESR_ImportLine;
+import de.metas.payment.esr.dataimporter.ESRDataLoaderUtil;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_C_Payment;
+import org.slf4j.Logger;
+
+import java.util.Optional;
+
+/**
+ * Handler for {@link de.metas.payment.esr.model.X_ESR_ImportLine#ESR_PAYMENT_ACTION_Unknown_Invoice}.
+ * Does nothing, just informs the user that is an external invoice
+ */
+public class UnknownInvoiceESRActionHandler extends AbstractESRActionHandler
+{
+	private static final transient Logger logger = LogManager.getLogger(UnknownInvoiceESRActionHandler.class);
+
+	@Override
+	public boolean process(final I_ESR_ImportLine line, final String message)
+	{
+		super.process(line, message);
+
+		logger.info("Nothing to do here; We can not match any invoice, nor partner");
+		return true;
+
+	}
+}

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
@@ -44,6 +44,7 @@ import de.metas.payment.esr.dataimporter.ESRImportEnqueuer;
 import de.metas.payment.esr.dataimporter.ESRImportEnqueuerDataSource;
 import de.metas.payment.esr.dataimporter.ESRStatement;
 import de.metas.payment.esr.dataimporter.ESRTransaction;
+import de.metas.payment.esr.dataimporter.ESRType;
 import de.metas.payment.esr.dataimporter.IESRDataImporter;
 import de.metas.payment.esr.dataimporter.impl.v11.ESRTransactionLineMatcherUtil;
 import de.metas.payment.esr.exception.ESRImportLockedException;
@@ -604,6 +605,16 @@ public class ESRImportBL implements IESRImportBL
 			return true;
 		}
 
+		// Check for SCOR ESR Type
+		if (ESRTransactionLineMatcherUtil.isSCORLine(line))
+		{
+			line.setESR_Payment_Action(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Unknown_Invoice);
+			line.setIsValid(true);
+			line.setProcessed(true);
+			esrImportDAO.save(line);
+			return true;
+		}
+
 		// skip reverse booking lines from regular processing
 		// the admin should deal with them manually
 		if (isReverseBookingLine(line))
@@ -664,6 +675,7 @@ public class ESRImportBL implements IESRImportBL
 
 		return existentPaymentId.orElse(null);
 	}
+
 
 	/**
 	 * @task https://github.com/metasfresh/metasfresh/issues/2118

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRType.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRType.java
@@ -33,7 +33,8 @@ import lombok.NonNull;
 public enum ESRType implements ReferenceListAwareEnum
 {
 	TYPE_QRR(X_ESR_ImportLine.TYPE_QRR),
-	TYPE_ESR(X_ESR_ImportLine.TYPE_ESR);
+	TYPE_ESR(X_ESR_ImportLine.TYPE_ESR),
+	TYPE_SCOR(X_ESR_ImportLine.TYPE_SCOR);
 
 	@Getter
 	private final String code;

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/impl/camt54/ESRDataImporterCamt54v02.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/impl/camt54/ESRDataImporterCamt54v02.java
@@ -190,7 +190,7 @@ public class ESRDataImporterCamt54v02
 	{
 		final List<ESRTransaction> transactions = new ArrayList<>();
 
-		int countQRR = 0;
+		int countQRR_SCOR = 0;
 		for (final EntryTransaction2 txDtl : ntryDtl.getTxDtls())
 		{
 			final ESRTransactionBuilder trxBuilder = ESRTransaction.builder();
@@ -211,13 +211,14 @@ public class ESRDataImporterCamt54v02
 					.build();
 			transactions.add(esrTransaction);
 
-			if (ESRType.TYPE_QRR.equals(esrTransaction.getType()))
+			// we need to put  qrr and scor in the same basket
+			if (ESRType.TYPE_QRR.equals(esrTransaction.getType()) || ESRType.TYPE_SCOR.equals(esrTransaction.getType()))
 			{
-				countQRR++;
+				countQRR_SCOR++;
 			}
 		}
 
-		if (countQRR != 0 && countQRR != transactions.size())
+		if (countQRR_SCOR != 0 && countQRR_SCOR != transactions.size())
 		{
 			throw new AdempiereException(ESRDataImporterCamt54.MSG_MULTIPLE_TRANSACTIONS_TYPES);
 		}

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/impl/camt54/ESRDataImporterCamt54v06.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/impl/camt54/ESRDataImporterCamt54v06.java
@@ -188,7 +188,7 @@ public class ESRDataImporterCamt54v06
 	{
 		final List<ESRTransaction> transactions = new ArrayList<>();
 
-		int countQRR = 0;
+		int countQRR_SCOR = 0;
 
 		for (final EntryTransaction8 txDtl : ntryDtl.getTxDtls())
 		{
@@ -210,13 +210,14 @@ public class ESRDataImporterCamt54v06
 					.build();
 			transactions.add(esrTransaction);
 
-			if (ESRType.TYPE_QRR.equals(esrTransaction.getType()))
+			// we need to put  qrr and scor in the same basket
+			if (ESRType.TYPE_QRR.equals(esrTransaction.getType()) || ESRType.TYPE_SCOR.equals(esrTransaction.getType()))
 			{
-				countQRR++;
+				countQRR_SCOR++;
 			}
 		}
 
-		if (countQRR != 0 && countQRR != transactions.size())
+		if (countQRR_SCOR != 0 && countQRR_SCOR != transactions.size())
 		{
 			throw new AdempiereException(ESRDataImporterCamt54.MSG_MULTIPLE_TRANSACTIONS_TYPES);
 		}

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/impl/camt54/ReferenceStringHelper.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/impl/camt54/ReferenceStringHelper.java
@@ -1,19 +1,21 @@
 package de.metas.payment.esr.dataimporter.impl.camt54;
 
-import java.util.Optional;
-
-import org.compiere.util.Env;
-
 import com.google.common.annotations.VisibleForTesting;
-
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.IMsgBL;
 import de.metas.payment.camt054_001_02.EntryTransaction2;
+import de.metas.payment.camt054_001_06.DocumentType3Code;
 import de.metas.payment.camt054_001_06.EntryTransaction8;
 import de.metas.payment.esr.dataimporter.ESRTransaction.ESRTransactionBuilder;
 import de.metas.payment.esr.dataimporter.ESRType;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.util.Env;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.Optional;
 
 /*
  * #%L
@@ -25,12 +27,12 @@ import lombok.NonNull;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program. If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -40,11 +42,10 @@ import lombok.NonNull;
 /**
  * This little helper class has the job of getting the (ESR) reference and passing it to an {@link ESRTransactionBuilder}.
  * There is also some fallback and error messages to be done in case of some not-so-happy scenarios.
- * 
+ * <p>
  * Note: codebeat keeps complaining about how spagetti {@link ESRDataImporterCamt54} is, so from time to time I extract something :-D.
- * 
- * @author metas-dev <dev@metasfresh.com>
  *
+ * @author metas-dev <dev@metasfresh.com>
  */
 public class ReferenceStringHelper
 {
@@ -55,9 +56,59 @@ public class ReferenceStringHelper
 	@VisibleForTesting
 	static final AdMessageKey MSG_MISSING_ESR_REFERENCE = AdMessageKey.of("ESR_CAMT54_Missing_ESR_Reference");
 
+	private static boolean isSupportedESRType(final de.metas.payment.camt054_001_02.CreditorReferenceInformation2 cdtrRefInf)
+	{
+		if (cdtrRefInf == null || cdtrRefInf.getTp() == null || cdtrRefInf.getTp().getCdOrPrtry() == null)
+		{
+			return false;
+		}
+
+		final de.metas.payment.camt054_001_02.CreditorReferenceType1Choice cdOrPrtry = cdtrRefInf.getTp().getCdOrPrtry();
+
+		// Check both getCd() (enum) and getPrtry() (string)
+		return isSupportedDocumentType(cdOrPrtry.getCd()) || isESRorQRRType(cdOrPrtry.getPrtry());
+	}
+
+	private static boolean isSupportedDocumentType(final de.metas.payment.camt054_001_02.DocumentType3Code cd)
+	{
+		if (cd == null)
+		{
+			return false;
+		}
+		return DocumentType3Code.SCOR.equals(cd); // Only SCOR is valid from DocumentType3Code
+	}
+
+	private static boolean isSupportedESRType(final de.metas.payment.camt054_001_06.CreditorReferenceInformation2 cdtrRefInf)
+	{
+		if (cdtrRefInf == null || cdtrRefInf.getTp() == null || cdtrRefInf.getTp().getCdOrPrtry() == null)
+		{
+			return false;
+		}
+
+		final de.metas.payment.camt054_001_06.CreditorReferenceType1Choice cdOrPrtry = cdtrRefInf.getTp().getCdOrPrtry();
+
+		// Check both getCd() (enum) and getPrtry() (string)
+		return isSupportedDocumentType(cdOrPrtry.getCd()) || isESRorQRRType(cdOrPrtry.getPrtry());
+	}
+
+	private static boolean isSupportedDocumentType(final de.metas.payment.camt054_001_06.DocumentType3Code cd)
+	{
+		if (cd == null)
+		{
+			return false;
+		}
+		return DocumentType3Code.SCOR.equals(cd); // Only SCOR is valid from DocumentType3Code
+	}
+
+	private static boolean isESRorQRRType(final String value)
+	{
+		return ESRType.TYPE_ESR.getCode().equals(value)
+				|| ESRType.TYPE_QRR.getCode().equals(value);
+	}
 
 	/**
 	 * extractAndSetEsrReference for version 6 <code>BankToCustomerDebitCreditNotificationV06</code>
+	 *
 	 * @param txDtls
 	 * @param trxBuilder
 	 */
@@ -86,9 +137,10 @@ public class ReferenceStringHelper
 			}
 		}
 	}
-	
+
 	/**
 	 * extractAndSetEsrReference for version 2 <code>BankToCustomerDebitCreditNotificationV02</code>
+	 *
 	 * @param txDtls
 	 * @param trxBuilder
 	 */
@@ -117,8 +169,7 @@ public class ReferenceStringHelper
 			}
 		}
 	}
-	
-	
+
 	public void extractAndSetType(
 			@NonNull final EntryTransaction8 txDtls,
 			@NonNull final ESRTransactionBuilder trxBuilder)
@@ -150,17 +201,15 @@ public class ReferenceStringHelper
 			trxBuilder.type(ESRType.TYPE_ESR);
 		}
 	}
-	
 
 	/**
 	 * Gets <code>TxDtls/RmtInf/Strd/CdtrRefInf/Ref</code><br>
 	 * from a <code>CdtrRefInf</code> element<br>
 	 * that has <code>CdtrRefInf/Tp/CdOrPrtry == "ISR Reference"</code>.
-	 * extractEsrReference for version 6 <code>BankToCustomerDebitCreditNotificationV06</code> 
-	 * 
+	 * extractEsrReference for version 6 <code>BankToCustomerDebitCreditNotificationV06</code>
+	 *
 	 * @param txDtls
 	 * @return
-	 * 
 	 * @task https://github.com/metasfresh/metasfresh/issues/2107
 	 */
 	private Optional<String> extractEsrReference(@NonNull final EntryTransaction8 txDtls)
@@ -175,17 +224,15 @@ public class ReferenceStringHelper
 				.findFirst();
 		return esrReferenceNumberString;
 	}
-	
-	
+
 	/**
 	 * Gets <code>TxDtls/RmtInf/Strd/CdtrRefInf/Ref</code><br>
 	 * from a <code>CdtrRefInf</code> element<br>
 	 * that has <code>CdtrRefInf/Tp/CdOrPrtry == "ISR Reference"</code>.
 	 * extractEsrReference for version 2 <code>BankToCustomerDebitCreditNotificationV02</code>
-	 * 
+	 *
 	 * @param txDtls
 	 * @return
-	 * 
 	 * @task https://github.com/metasfresh/metasfresh/issues/2107
 	 */
 	private Optional<String> extractEsrReference(@NonNull final EntryTransaction2 txDtls)
@@ -201,13 +248,11 @@ public class ReferenceStringHelper
 		return esrReferenceNumberString;
 	}
 
-
 	/**
 	 * extractReferenceFallback for version 6 <code>BankToCustomerDebitCreditNotificationV06</code>
-	 * 
+	 *
 	 * @param txDtls
 	 * @return
-	 * 
 	 * @task https://github.com/metasfresh/metasfresh/issues/2107
 	 */
 	private Optional<String> extractReferenceFallback(@NonNull final EntryTransaction8 txDtls)
@@ -223,51 +268,102 @@ public class ReferenceStringHelper
 
 	private Optional<ESRType> extractType(@NonNull final EntryTransaction8 txDtls)
 	{
-		return txDtls.getRmtInf().getStrd().stream()
-				.map(strd -> strd.getCdtrRefInf())
-				.filter(cdtrRefInf -> isSupportedESRType(cdtrRefInf))
-				.map(cdtrRefInf -> cdtrRefInf.getTp().getCdOrPrtry().getPrtry())
-				.map(r ->  ESRType.ofNullableCode(r))
+		return txDtls.getRmtInf()
+				.getStrd()
+				.stream()
+				.map(strd -> Optional.ofNullable(strd.getCdtrRefInf())) // Safely map to CreditorReferenceInformation2
+				.filter(Optional::isPresent)
+				.map(Optional::get)
+				.filter(ReferenceStringHelper::isSupportedESRType) // Validate the ESR type
+				.map(this::extractESRType)       // Extract ESRType
+				.filter(Objects::nonNull)
 				.findFirst();
+	}
 
+	private ESRType extractESRType(final de.metas.payment.camt054_001_06.CreditorReferenceInformation2 cdtrRefInf)
+	{
+		final String code = Optional.ofNullable(cdtrRefInf.getTp())
+				.map(tp -> tp.getCdOrPrtry())
+				.map(cdOrPrtry -> {
+					if (cdOrPrtry.getCd() != null)
+					{
+						return cdOrPrtry.getCd().value(); // Check the enum (DocumentType3Code)
+					}
+					else
+					{
+						return cdOrPrtry.getPrtry(); // Check the string (Prtry)
+					}
+				})
+				.orElse(null);
+
+		if (code == null)
+		{
+			return null;
+		}
+
+		ESRType esrType = ESRType.ofNullableCode(code);
+		validateESRType(esrType, code); // Validate the extracted ESRType
+		return esrType;
 	}
 
 	private Optional<ESRType> extractType(@NonNull final EntryTransaction2 txDtls)
 	{
-		
-		return txDtls.getRmtInf().getStrd().stream()
-				.map(strd -> strd.getCdtrRefInf())
-				.filter(cdtrRefInf -> isSupportedESRType(cdtrRefInf))
-				.map(cdtrRefInf -> cdtrRefInf.getTp().getCdOrPrtry().getPrtry())
-				.map(r ->  ESRType.ofNullableCode(r))
+		return txDtls.getRmtInf()
+				.getStrd()
+				.stream()
+				.map(strd -> Optional.ofNullable(strd.getCdtrRefInf())) // Safely map to CreditorReferenceInformation2
+				.filter(Optional::isPresent)
+				.map(Optional::get)
+				.filter(ReferenceStringHelper::isSupportedESRType) // Validate the ESR type
+				.map(this::extractESRType)       // Extract ESRType
+				.filter(Objects::nonNull)
 				.findFirst();
-
 	}
 
-	private static boolean isSupportedESRType(de.metas.payment.camt054_001_02.CreditorReferenceInformation2 cdtrRefInf)
+	private ESRType extractESRType(final de.metas.payment.camt054_001_02.CreditorReferenceInformation2 cdtrRefInf)
 	{
-		return cdtrRefInf != null
-				&& cdtrRefInf.getTp() != null
-				&& cdtrRefInf.getTp().getCdOrPrtry() != null
-				&& (cdtrRefInf.getTp().getCdOrPrtry().getPrtry().equals(ESRType.TYPE_ESR.getCode())
-						|| cdtrRefInf.getTp().getCdOrPrtry().getPrtry().equals(ESRType.TYPE_QRR.getCode()));
+		final String code = Optional.ofNullable(cdtrRefInf.getTp())
+				.map(tp -> tp.getCdOrPrtry())
+				.map(cdOrPrtry -> {
+					if (cdOrPrtry.getCd() != null)
+					{
+						return cdOrPrtry.getCd().value(); // Check the enum (DocumentType3Code)
+					}
+					else
+					{
+						return cdOrPrtry.getPrtry(); // Check the string (Prtry)
+					}
+				})
+				.orElse(null);
+
+		if (code == null)
+		{
+			return null;
+		}
+
+		ESRType esrType = ESRType.ofNullableCode(code);
+		validateESRType(esrType, code); // Validate the extracted ESRType
+		return esrType;
 	}
 
-	private static boolean isSupportedESRType(de.metas.payment.camt054_001_06.CreditorReferenceInformation2 cdtrRefInf)
+	private void validateESRType(@Nullable final ESRType esrType, final String rawCode)
 	{
-		return cdtrRefInf != null
-				&& cdtrRefInf.getTp() != null
-				&& cdtrRefInf.getTp().getCdOrPrtry() != null
-				&& (cdtrRefInf.getTp().getCdOrPrtry().getPrtry().equals(ESRType.TYPE_ESR.getCode())
-						|| cdtrRefInf.getTp().getCdOrPrtry().getPrtry().equals(ESRType.TYPE_QRR.getCode()));
+		if (esrType == null ||
+				!(esrType == ESRType.TYPE_ESR || esrType == ESRType.TYPE_QRR || esrType == ESRType.TYPE_SCOR))
+		{
+			// Log the error with the invalid value
+			final String errorMsg = String.format("Invalid ESRType: '%s'. Accepted types are: ESR, QRR, SCOR.", rawCode);
+
+			// Optionally, throw an exception to halt processing
+			throw new AdempiereException(errorMsg);
+		}
 	}
-	
+
 	/**
 	 * extractReferenceFallback for version 2 <code>BankToCustomerDebitCreditNotificationV02</code>
-	 * 
+	 *
 	 * @param txDtls
 	 * @return
-	 * 
 	 * @task https://github.com/metasfresh/metasfresh/issues/2107
 	 */
 	private Optional<String> extractReferenceFallback(@NonNull final EntryTransaction2 txDtls)

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/impl/v11/ESRTransactionLineMatcherUtil.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/impl/v11/ESRTransactionLineMatcherUtil.java
@@ -1,23 +1,23 @@
 package de.metas.payment.esr.dataimporter.impl.v11;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
-import org.compiere.util.Env;
-
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.IMsgBL;
 import de.metas.payment.esr.ESRConstants;
+import de.metas.payment.esr.dataimporter.ESRType;
 import de.metas.payment.esr.model.I_ESR_ImportLine;
 import de.metas.util.Check;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
+import org.compiere.util.Env;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 /*
  * #%L
@@ -86,6 +86,13 @@ public class ESRTransactionLineMatcherUtil
 		return ESRConstants.ESRTRXTYPE_Payment.equals(trxType)
 				|| ESRConstants.ESRTRXTYPE_Receipt.equals(trxType);
 	}
+
+	public boolean isSCORLine(@NonNull final I_ESR_ImportLine importLine)
+	{
+		final String type = importLine.getType();
+		return ESRType.TYPE_SCOR.getCode().equals(type);
+	}
+
 
 	public boolean isCorrectTransactionLineLength(@NonNull final String v11LineStr)
 	{

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/model/validator/ESR_Main_Validator.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/model/validator/ESR_Main_Validator.java
@@ -1,5 +1,6 @@
 package de.metas.payment.esr.model.validator;
 
+import de.metas.payment.esr.actionhandler.impl.UnknownInvoiceESRActionHandler;
 import org.adempiere.ad.modelvalidator.AbstractModuleInterceptor;
 import org.adempiere.ad.modelvalidator.IModelValidationEngine;
 
@@ -54,6 +55,7 @@ public class ESR_Main_Validator extends AbstractModuleInterceptor
 		esrImportBL.registerActionHandler(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Unable_To_Assign_Income, new UnableToAssignESRActionHandler());
 		esrImportBL.registerActionHandler(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Discount, new DiscountESRActionHandler());
 		esrImportBL.registerActionHandler(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment, new DuplicatePaymentESRActionHandler());
+		esrImportBL.registerActionHandler(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Unknown_Invoice, new UnknownInvoiceESRActionHandler());
 		
 		//
 		// Register ESR Payment Parsers

--- a/backend/de.metas.payment.esr/src/main/sql/postgresql/system/5740950_sys_AddSCORTypeForESRIMport.sql
+++ b/backend/de.metas.payment.esr/src/main/sql/postgresql/system/5740950_sys_AddSCORTypeForESRIMport.sql
@@ -1,0 +1,13 @@
+-- Run mode: SWING_CLIENT
+
+-- Reference: ESR_ype
+-- Value: SCOR
+-- ValueName: SCOR
+-- 2024-12-09T11:20:59.228Z
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName) VALUES (0,0,541287,543779,TO_TIMESTAMP('2024-12-09 13:20:59.04','YYYY-MM-DD HH24:MI:SS.US'),100,'de.metas.payment.esr','Y','SCOR reference',TO_TIMESTAMP('2024-12-09 13:20:59.04','YYYY-MM-DD HH24:MI:SS.US'),100,'SCOR','SCOR')
+;
+
+-- 2024-12-09T11:20:59.230Z
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Ref_List t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Ref_List_ID=543779 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+

--- a/backend/de.metas.payment.esr/src/main/sql/postgresql/system/5741590_sys_Add_Unknown_Invoice_Action.sql
+++ b/backend/de.metas.payment.esr/src/main/sql/postgresql/system/5741590_sys_Add_Unknown_Invoice_Action.sql
@@ -1,0 +1,26 @@
+--
+-- Script: /tmp/webui_migration_scripts_2024-12-12_4880948788846457504/10000020_migration_2024-12-12_postgresql.sql
+-- User: metasfresh
+-- OS user: root
+--
+
+
+-- 2024-12-12T14:53:28.267Z
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName) VALUES (0,0,540386,1000000,TO_TIMESTAMP('2024-12-12 15:53:28','YYYY-MM-DD HH24:MI:SS'),100,'U','Y','Unknown_Invoic',TO_TIMESTAMP('2024-12-12 15:53:28','YYYY-MM-DD HH24:MI:SS'),100,'U','Unknown_Invoic')
+;
+
+-- 2024-12-12T14:53:28.269Z
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Ref_List t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y') AND t.AD_Ref_List_ID=1000000 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+-- 2024-12-12T14:53:32.442Z
+UPDATE AD_Ref_List SET ValueName='Unknown_Invoice',Updated=TO_TIMESTAMP('2024-12-12 15:53:32','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Ref_List_ID=1000000
+;
+
+-- 2024-12-12T14:53:42.383Z
+UPDATE AD_Ref_List SET EntityType='de.metas.payment.esr',Updated=TO_TIMESTAMP('2024-12-12 15:53:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Ref_List_ID=1000000
+;
+
+-- 2024-12-12T14:54:10.414Z
+UPDATE AD_Ref_List SET Name='Systemfremde Rechnung',Updated=TO_TIMESTAMP('2024-12-12 15:54:10','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Ref_List_ID=1000000
+;


### PR DESCRIPTION
* Support SCOR type when Importing esr  files

* Validate file type

* Support SCOR payments - do not create payment - just process the line with action UNKNOW Invoice

* Add Unknown_Invoice ESR Action

* Avoid NPE

* Support SCO explicitelly

* Format code

* Avoid NPE

* Improve processing ZIP files

* Fix reference value

* Set to valid and processed scor line