### PR TITLE
Run each org-change in its own trx

### DIFF
--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/bpartner/process/C_BPartner_MoveToAnotherOrg_Mass.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/bpartner/process/C_BPartner_MoveToAnotherOrg_Mass.java
@@ -61,7 +61,7 @@ public class C_BPartner_MoveToAnotherOrg_Mass extends JavaProcess implements
 	public static final String PARAM_WhereClause = "WhereClause";
 
 	private final static Logger logger = LogManager.getLogger(C_BPartner_MoveToAnotherOrg_Mass.class);
-	
+
 	final OrgChangeService service = SpringContextHolder.instance.getBean(OrgChangeService.class);
 	final IBPartnerDAO bpartnerDAO = Services.get(IBPartnerDAO.class);
 	private final ITrxManager trxManager = Services.get(ITrxManager.class);
@@ -85,15 +85,14 @@ public class C_BPartner_MoveToAnotherOrg_Mass extends JavaProcess implements
 	protected String doIt() throws Exception
 	{
 		final Iterator<I_C_BPartner> partnerIterator = retrievePartnersToMove(p_WhereClause);
-		
-		trxManager.runInNewTrx(() -> {
-			while (partnerIterator.hasNext())
-			{
+		while (partnerIterator.hasNext())
+		{
+			trxManager.runInNewTrx(() -> {
 				final I_C_BPartner partner = partnerIterator.next();
 				movePartnerToNewOrg(partner);
-			}
-		});
-		
+			});
+		}
+
 		return "@Processed@ (OK=#" + this.countOK + ", Error=#" + this.countError + ")";
 	}
 


### PR DESCRIPTION
...fixing bug from hard_encoded_uat_ToAnotherOrg_Mass 
Inspired by org.adempiere.ad.process.ProcessDocuments