### PR TITLE
GRS-metasfresh Interface - Do not fail when attachmentFilePath is null (#19398)

### DIFF
--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-grssignum/src/main/java/de/metas/camel/externalsystems/grssignum/to_grs/api/model/JsonBPartnerAttachment.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-grssignum/src/main/java/de/metas/camel/externalsystems/grssignum/to_grs/api/model/JsonBPartnerAttachment.java
@@ -30,6 +30,8 @@ import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 
+import javax.annotation.Nullable;
+
 @Value
 @JsonDeserialize(builder = JsonBPartnerAttachment.JsonBPartnerAttachmentBuilder.class)
 public class JsonBPartnerAttachment
@@ -42,7 +44,7 @@ public class JsonBPartnerAttachment
 	@JsonProperty("METASFRESHID")
 	String metasfreshId;
 
-	@NonNull
+	@Nullable
 	@JsonProperty("ANHANGDATEI")
 	String attachmentFilePath;
 
@@ -50,7 +52,7 @@ public class JsonBPartnerAttachment
 	public JsonBPartnerAttachment(
 			@JsonProperty("FLAG") final @NonNull Integer flag,
 			@JsonProperty("METASFRESHID") final @NonNull String metasfreshId,
-			@JsonProperty("ANHANGDATEI") final @NonNull String attachmentFilePath)
+			@JsonProperty("ANHANGDATEI") final @Nullable String attachmentFilePath)
 	{
 		this.flag = flag;
 		this.metasfreshId = metasfreshId;

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-grssignum/src/test/java/de/metas/camel/externalsystems/grssignum/from_grs/attachment/BPartnerAttachmentsRouteBuilderTest.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-grssignum/src/test/java/de/metas/camel/externalsystems/grssignum/from_grs/attachment/BPartnerAttachmentsRouteBuilderTest.java
@@ -61,6 +61,8 @@ public class BPartnerAttachmentsRouteBuilderTest extends CamelTestSupport
 	private static final String MOCK_ATTACH_FILE = "mock:attachFile";
 
 	private static final String JSON_BPARTNER_ATTACHMENT = "0_JsonBPartnerAttachment.json";
+	private static final String JSON_BPARTNER_ATTACHMENT_MISSING_ANHANGDATEI = "0_JsonBPartnerAttachment_missing_ANHANGDATEI.json";
+	private static final String JSON_BPARTNER_ATTACHMENT_NULL_ANHANGDATEI = "0_JsonBPartnerAttachment_null_ANHANGDATEI.json";
 	private static final String JSON_RETRIEVE_EXTERNAL_SYSTEM_INFO_CAMEL_REQ = "10_RetrieveExternalSystemInfoCamelRequest.json";
 	private static final String JSON_EXTERNAL_SYSTEM_INFO_RES = "10_JsonExternalSystemInfo.json";
 	private static final String JSON_ATTACHMENT_REQ = "20_JsonAttachmentRequest.json";
@@ -143,6 +145,62 @@ public class BPartnerAttachmentsRouteBuilderTest extends CamelTestSupport
 		assertThat(mockAttachFileEP.called).isEqualTo(1);
 	}
 
+	@Test
+	void attachFileToBPartner_missing_ANHANGDATEI() throws Exception
+	{
+		//given
+		final TokenCredentials tokenCredentials = TokenCredentials.builder()
+				.orgCode("orgCode")
+				.pInstance(JsonMetasfreshId.of(1))
+				.externalSystemValue("childConfigValue")
+				.build();
+
+		Mockito.when(authentication.getCredentials()).thenReturn(tokenCredentials);
+
+		final MockRetrieveExternalSysInfoEP mockRetrieveExternalSysInfoEP = new MockRetrieveExternalSysInfoEP();
+		final MockAttachFileEP mockAttachFileEP = new MockAttachFileEP();
+		preparePushRouteForTesting(mockRetrieveExternalSysInfoEP, mockAttachFileEP);
+
+		context.start();
+
+		final String requestBodyAsString = loadAsString(JSON_BPARTNER_ATTACHMENT_MISSING_ANHANGDATEI);
+
+		//when
+		template.sendBody("direct:" + BPartnerAttachmentsRouteBuilder.ATTACH_FILE_TO_BPARTNER_ROUTE_ID, requestBodyAsString);
+
+		//then
+		assertThat(mockRetrieveExternalSysInfoEP.called).isEqualTo(0);
+		assertThat(mockAttachFileEP.called).isEqualTo(0);
+	}
+
+	@Test
+	void attachFileToBPartner_null_ANHANGDATEI() throws Exception
+	{
+		//given
+		final TokenCredentials tokenCredentials = TokenCredentials.builder()
+				.orgCode("orgCode")
+				.pInstance(JsonMetasfreshId.of(1))
+				.externalSystemValue("childConfigValue")
+				.build();
+
+		Mockito.when(authentication.getCredentials()).thenReturn(tokenCredentials);
+
+		final MockRetrieveExternalSysInfoEP mockRetrieveExternalSysInfoEP = new MockRetrieveExternalSysInfoEP();
+		final MockAttachFileEP mockAttachFileEP = new MockAttachFileEP();
+		preparePushRouteForTesting(mockRetrieveExternalSysInfoEP, mockAttachFileEP);
+
+		context.start();
+
+		final String requestBodyAsString = loadAsString(JSON_BPARTNER_ATTACHMENT_NULL_ANHANGDATEI);
+
+		//when
+		template.sendBody("direct:" + BPartnerAttachmentsRouteBuilder.ATTACH_FILE_TO_BPARTNER_ROUTE_ID, requestBodyAsString);
+
+		//then
+		assertThat(mockRetrieveExternalSysInfoEP.called).isEqualTo(0);
+		assertThat(mockAttachFileEP.called).isEqualTo(0);
+	}
+	
 	private void preparePushRouteForTesting(
 			@NonNull final BPartnerAttachmentsRouteBuilderTest.MockRetrieveExternalSysInfoEP mockRetrieveExternalSysInfoEP,
 			@NonNull final BPartnerAttachmentsRouteBuilderTest.MockAttachFileEP mockAttachFileEP) throws Exception

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-grssignum/src/test/resources/de/metas/camel/externalsystems/grssignum/from_grs/attachment/0_JsonBPartnerAttachment_missing_ANHANGDATEI.json
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-grssignum/src/test/resources/de/metas/camel/externalsystems/grssignum/from_grs/attachment/0_JsonBPartnerAttachment_missing_ANHANGDATEI.json
@@ -1,0 +1,4 @@
+{
+  "FLAG" : 110,
+  "METASFRESHID" : "100"
+}

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-grssignum/src/test/resources/de/metas/camel/externalsystems/grssignum/from_grs/attachment/0_JsonBPartnerAttachment_null_ANHANGDATEI.json
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-grssignum/src/test/resources/de/metas/camel/externalsystems/grssignum/from_grs/attachment/0_JsonBPartnerAttachment_null_ANHANGDATEI.json
@@ -1,0 +1,5 @@
+{
+  "FLAG" : 110,
+  "METASFRESHID" : "100",
+  "ANHANGDATEI": null
+}


### PR DESCRIPTION
refs: https://github.com/metasfresh/metasfresh/issues/19397 (cherry picked from commit 7482c9bad73a6d5e8fda9168b5b139d2face3f7d)