### PR TITLE
Port a shipmentSchedule related fix from master

### DIFF
--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/model/MPPOrder.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/model/MPPOrder.java
@@ -445,10 +445,11 @@ public class MPPOrder extends X_PP_Order implements IDocument
 		final PPOrderId orderId = PPOrderId.ofRepoId(getPP_Order_ID());
 		orderBOMsRepo.markBOMLinesAsNotProcessed(orderId);
 
-		ModelValidationEngine.get().fireDocValidate(this, ModelValidator.TIMING_AFTER_REACTIVATE);
-
 		setDocAction(IDocument.ACTION_Complete);
 		setProcessed(false);
+
+		ModelValidationEngine.get().fireDocValidate(this, ModelValidator.TIMING_AFTER_REACTIVATE);
+		
 		return true;
 	} // reActivateIt
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleUpdater.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleUpdater.java
@@ -269,6 +269,8 @@ public class ShipmentScheduleUpdater implements IShipmentScheduleUpdater
 			{
 				final I_M_ShipmentSchedule sched = olAndSched.getSched();
 
+				shipmentScheduleHandlerBL.updateShipmentScheduleFromReferencedRecord(sched);
+
 				updateCatchUomId(sched);
 
 				updateWarehouseId(sched);
@@ -339,7 +341,8 @@ public class ShipmentScheduleUpdater implements IShipmentScheduleUpdater
 			// task 09869: don't rely on ol anyways
 			final BigDecimal qtyDelivered = shipmentScheduleAllocDAO.retrieveQtyDelivered(schedRecord);
 			schedRecord.setQtyDelivered(qtyDelivered);
-			schedRecord.setQtyReserved(getQtyReserved(schedRecord, olAndSched));
+			// takes into consideration isClosed flag 
+			schedRecord.setQtyReserved(BigDecimal.ZERO.max(shipmentScheduleEffectiveBL.computeQtyOrdered(olAndSched.getSched()).subtract(schedRecord.getQtyDelivered())));
 
 			updateLineNetAmt(olAndSched);
 
@@ -929,19 +932,6 @@ public class ShipmentScheduleUpdater implements IShipmentScheduleUpdater
 				}
 			}
 			return segments.stream();
-		}
-	}
-
-	@NonNull
-	private static BigDecimal getQtyReserved(@NonNull final I_M_ShipmentSchedule schedRecord, @NonNull final OlAndSched olAndSched)
-	{
-		if (schedRecord.isClosed())
-		{
-			return BigDecimal.ZERO;
-		}
-		else
-		{
-			return BigDecimal.ZERO.max(olAndSched.getQtyOrdered().subtract(schedRecord.getQtyDelivered()));
 		}
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBLTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBLTest.java
@@ -1,22 +1,13 @@
 package de.metas.inoutcandidate.api.impl;
 
-import de.metas.inout.ShipmentScheduleId;
-import de.metas.inoutcandidate.api.IDeliverRequest;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
-import de.metas.inoutcandidate.api.IShipmentScheduleHandlerBL;
-import de.metas.inout.ShipmentScheduleId;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
-import de.metas.inoutcandidate.spi.ModelWithoutShipmentScheduleVetoer;
-import de.metas.inoutcandidate.spi.ShipmentScheduleHandler;
 import de.metas.util.Services;
 import org.adempiere.test.AdempiereTestHelper;
-import org.compiere.model.I_C_OrderLine;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
-import java.util.Properties;
-import java.util.Set;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.refresh;
@@ -52,51 +43,6 @@ public class ShipmentScheduleBLTest
 				.as("closing a shipmentschedule may not fiddle with its QtyOrdered_Override value");
 		assertThat(schedule.getQtyToDeliver_Override()).isEqualByComparingTo("24")
 				.as("closing a shipmentschedule may not fiddle with its QtyToDeliver_Override value");
-	}
-
-	@Test
-	public void openProcessedShipmentSchedule()
-	{
-		setupMockShipmentScheduleHandlerBL();
-
-		final I_M_ShipmentSchedule schedule = newInstance(I_M_ShipmentSchedule.class);
-		schedule.setIsClosed(true);
-
-		schedule.setQtyOrdered_Calculated(BigDecimal.TEN);
-		schedule.setQtyOrdered(new BigDecimal("5"));
-		schedule.setQtyDelivered(new BigDecimal("5"));
-		schedule.setQtyOrdered_Override(new BigDecimal("23"));
-		schedule.setQtyToDeliver_Override(new BigDecimal("24"));
-
-		shipmentScheduleBL.openShipmentSchedule(schedule);
-
-		assertThat(schedule.isClosed()).isFalse();
-		assertThat(schedule.getQtyOrdered_Override())
-				.as("opening a shipmentschedule may not fiddle with its QtyOrdered_Override value")
-				.isEqualByComparingTo("23");
-		assertThat(schedule.getQtyOrdered_Calculated())
-				.as("opening a shipmentschedule may not fiddle with its QtyOrdered_Calculated value")
-				.isEqualByComparingTo(BigDecimal.TEN);
-
-		assertThat(schedule.getQtyOrdered())
-				.as("opening a shipmentschedule shall restore its QtyOrdered from its QtyOrdered_Override or .._Calculated value")
-				.isEqualByComparingTo("23");
-	}
-
-	private void setupMockShipmentScheduleHandlerBL()
-	{
-		final IShipmentScheduleHandlerBL mockHandler = new IShipmentScheduleHandlerBL()
-		{
-			// @formatter:off
-			@Override public void updateShipmentScheduleFromReferencedRecord(I_M_ShipmentSchedule shipmentScheduleRecord)	{ }
-			@Override public void registerVetoer(ModelWithoutShipmentScheduleVetoer vetoer, String tableName) { }
-			@Override public <T extends ShipmentScheduleHandler> void registerHandler(T handler) { }
-			@Override public ShipmentScheduleHandler getHandlerFor(I_M_ShipmentSchedule sched) { return null; }
-			@Override public Set<ShipmentScheduleId> createMissingCandidates(Properties ctx) { return null; }
-			@Override public IDeliverRequest createDeliverRequest(I_M_ShipmentSchedule sched, I_C_OrderLine salesOrderLine) { return null; }
-			// @formatter:on
-		};
-		Services.registerService(IShipmentScheduleHandlerBL.class, mockHandler);
 	}
 
 	@Test


### PR DESCRIPTION
The fix is part of commit https://github.com/metasfresh/metasfresh/commit/178ede5a9c0b2f0134324408c4b2eeb6d4ac6be4

It avoids a race-condition that might happen to M_ShipmentSchedule.QtyReserved when an order is reactivated and completed again in short order