### PR TITLE
Import NonQRR transactions as they are (#18648)

### DIFF
--- a/backend/de.metas.banking/de.metas.banking.camt53/src/main/java/de/metas/banking/camt53/BankStatementCamt53Service.java
+++ b/backend/de.metas.banking/de.metas.banking.camt53/src/main/java/de/metas/banking/camt53/BankStatementCamt53Service.java
@@ -246,6 +246,21 @@ public class BankStatementCamt53Service
 
 			buildBankStatementLineCreateRequestForSummaryLine(summaryRequest)
 					.forEach(bankStatementDAO::createBankStatementLine);
+
+			// now, create lines for the remaining non QRR transactions
+			if (accountStatementWrapper.hasNonQRRTransactions())
+			{
+				accountStatementWrapper.getStatementLines()
+						.stream()
+						.filter(line -> !line.isQRRTransaction())
+						.map(entry -> ImportBankStatementLineRequest.builder()
+								.entryWrapper(entry)
+								.bankStatementId(bankStatementId)
+								.orgId(bankStatementCreateRequest.getOrgId())
+								.isMatchAmounts(importBankStatementRequest.isMatchAmounts())
+								.build())
+						.forEach(this::importBankStatementLine);
+			}
 		}
 		else
 		{
@@ -295,13 +310,13 @@ public class BankStatementCamt53Service
 		final ZonedDateTime statementDate = accountStatementWrapper.getStatementDate(timeZone);
 
 		return Optional.of(BankStatementCreateRequest.builder()
-								   .orgId(orgId)
-								   .orgBankAccountId(bankAccountId)
-								   .statementDate(TimeUtil.asLocalDate(statementDate, timeZone))
-								   .name(statementDate.toString())
-								   .beginningBalance(beginningBalance)
-								   .bankStatementImportFileId(bankStatementImportFileId)
-								   .build());
+				.orgId(orgId)
+				.orgBankAccountId(bankAccountId)
+				.statementDate(TimeUtil.asLocalDate(statementDate, timeZone))
+				.name(statementDate.toString())
+				.beginningBalance(beginningBalance)
+				.bankStatementImportFileId(bankStatementImportFileId)
+				.build());
 	}
 
 	private void importBankStatementLine(@NonNull final ImportBankStatementLineRequest importBankStatementLineRequest)
@@ -385,8 +400,14 @@ public class BankStatementCamt53Service
 
 		for (final IStatementLineWrapper entry : accountStatementWrapper.getStatementLines())
 		{
+			if (!entry.isQRRTransaction())
+			{
+				continue;
+			}
+
 			// compute totat amount
 			final Money stmtAmount = entry.getStatementAmount().toMoney(moneyService::getCurrencyIdByCurrencyCode);
+
 			summaryAmt = summaryAmt.add(stmtAmount);
 
 			// build the description
@@ -474,8 +495,8 @@ public class BankStatementCamt53Service
 		if (statementLineDate == null)
 		{
 			final String msg = TranslatableStrings.adMessage(MSG_MISSING_REPORT_ENTRY_DATE,
-															 entryWrapper.getLineReference(),
-															 importBankStatementLineRequest.getBankStatementId())
+							entryWrapper.getLineReference(),
+							importBankStatementLineRequest.getBankStatementId())
 					.getDefaultValue();
 			Loggables.withLogger(logger, Level.INFO).addLog(msg);
 			return Collections.emptyList();
@@ -533,8 +554,8 @@ public class BankStatementCamt53Service
 		}
 
 		final UnpaidInvoiceMatchingAmtQuery unpaidInvoiceMatchingAmtQuery = buildUnpaidInvoiceMatchingAmtQuery(statementLineDate,
-																											   importBankStatementLineRequest,
-																											   documentReferenceCandidates);
+				importBankStatementLineRequest,
+				documentReferenceCandidates);
 
 		return Optional.of(paymentAllocationService.retrieveUnpaidInvoices(unpaidInvoiceMatchingAmtQuery))
 				.flatMap(invoices -> getSingleInvoice(invoices, entryWrapper));
@@ -683,8 +704,7 @@ public class BankStatementCamt53Service
 			final JAXBContext context = JAXBContext.newInstance(de.metas.banking.camt53.jaxb.camt053_001_04.ObjectFactory.class);
 			final Unmarshaller unmarshaller = context.createUnmarshaller();
 
-			@SuppressWarnings("unchecked")
-			final JAXBElement<de.metas.banking.camt53.jaxb.camt053_001_04.Document> docV04 =
+			@SuppressWarnings("unchecked") final JAXBElement<de.metas.banking.camt53.jaxb.camt053_001_04.Document> docV04 =
 					(JAXBElement<de.metas.banking.camt53.jaxb.camt053_001_04.Document>)unmarshaller.unmarshal(xmlStreamReader);
 
 			return BatchBankToCustomerStatementV04Wrapper
@@ -705,8 +725,7 @@ public class BankStatementCamt53Service
 			final JAXBContext context = JAXBContext.newInstance(de.metas.banking.camt53.jaxb.camt053_001_02.ObjectFactory.class);
 			final Unmarshaller unmarshaller = context.createUnmarshaller();
 
-			@SuppressWarnings("unchecked")
-			final JAXBElement<de.metas.banking.camt53.jaxb.camt053_001_02.Document> docV02 =
+			@SuppressWarnings("unchecked") final JAXBElement<de.metas.banking.camt53.jaxb.camt053_001_02.Document> docV02 =
 					(JAXBElement<de.metas.banking.camt53.jaxb.camt053_001_02.Document>)unmarshaller.unmarshal(xmlStreamReader);
 
 			return BatchBankToCustomerStatementV02Wrapper

--- a/backend/de.metas.banking/de.metas.banking.camt53/src/main/java/de/metas/banking/camt53/wrapper/IAccountStatementWrapper.java
+++ b/backend/de.metas.banking/de.metas.banking.camt53/src/main/java/de/metas/banking/camt53/wrapper/IAccountStatementWrapper.java
@@ -54,4 +54,6 @@ public interface IAccountStatementWrapper
 	ImmutableList<IStatementLineWrapper> getStatementLines();
 
 	boolean hasNoBankStatementLines();
+
+	default boolean hasNonQRRTransactions() {return getStatementLines().stream().anyMatch(entry -> !entry.isQRRTransaction());}
 }

--- a/backend/de.metas.banking/de.metas.banking.camt53/src/main/java/de/metas/banking/camt53/wrapper/IStatementLineWrapper.java
+++ b/backend/de.metas.banking/de.metas.banking.camt53/src/main/java/de/metas/banking/camt53/wrapper/IStatementLineWrapper.java
@@ -36,6 +36,8 @@ import java.util.Optional;
 
 public interface IStatementLineWrapper
 {
+	String QRR_LINE_DESCRIPTION_MARKER = "QRR";
+
 	@NonNull
 	ImmutableSet<String> getDocumentReferenceCandidates();
 
@@ -77,4 +79,6 @@ public interface IStatementLineWrapper
 	boolean isBatchTransaction();
 
 	List<ITransactionDtlsWrapper> getTransactionDtlsWrapper();
+
+	default boolean isQRRTransaction() {return getLineDescription().contains(QRR_LINE_DESCRIPTION_MARKER);}
 }

--- a/backend/de.metas.banking/de.metas.banking.camt53/src/main/java/de/metas/banking/camt53/wrapper/v02/BatchReportEntry2Wrapper.java
+++ b/backend/de.metas.banking/de.metas.banking.camt53/src/main/java/de/metas/banking/camt53/wrapper/v02/BatchReportEntry2Wrapper.java
@@ -216,7 +216,7 @@ public class BatchReportEntry2Wrapper extends BatchReportEntryWrapper
 		final List<String> lineDesc = new ArrayList<>();
 
 		final String addtlNtryInfStr = entry.getAddtlNtryInf();
-		if( addtlNtryInfStr != null )
+		if (addtlNtryInfStr != null)
 		{
 			lineDesc.addAll( Arrays.stream(addtlNtryInfStr.split(" "))
 									 .filter(Check::isNotBlank)

--- a/backend/de.metas.banking/de.metas.banking.camt53/src/main/java/de/metas/banking/camt53/wrapper/v04/BatchReportEntry4Wrapper.java
+++ b/backend/de.metas.banking/de.metas.banking.camt53/src/main/java/de/metas/banking/camt53/wrapper/v04/BatchReportEntry4Wrapper.java
@@ -221,7 +221,7 @@ public class BatchReportEntry4Wrapper extends BatchReportEntryWrapper
 		final List<String> lineDesc = new ArrayList<>();
 
 		final String addtlNtryInfStr = entry.getAddtlNtryInf();
-		if( addtlNtryInfStr != null )
+		if (addtlNtryInfStr != null)
 		{
 			lineDesc.addAll( Arrays.stream(addtlNtryInfStr.split(" "))
 									 .filter(Check::isNotBlank)
@@ -256,10 +256,7 @@ public class BatchReportEntry4Wrapper extends BatchReportEntryWrapper
 		return entry.getAmt().getValue();
 	}
 
-	public boolean isBatchTransaction()
-	{
-		return getEntryTransaction().size() > 1;
-	}
+	public boolean isBatchTransaction() {return getEntryTransaction().size() > 1;}
 
 	@Override
 	public List<ITransactionDtlsWrapper> getTransactionDtlsWrapper()

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bankStatement/camt.53.001.04-Import.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bankStatement/camt.53.001.04-Import.feature
@@ -1118,14 +1118,14 @@ Feature: import bank statement in camt.53.001.04 import format
       | di_1_S0337_500             | 540009              |
     And metasfresh contains C_Bank:
       | C_Bank_ID.Identifier | Name           | RoutingNo | SwiftCode   | C_DataImport_ID.Identifier | OPT.IsImportAsSingleSummaryLine |
-	  | di_1_S0337_500       | bank_S0337_500 | 2234567   | AAAAAAAA82A | di_1_S0337_500             | Y                               |
+      | di_1_S0337_500       | bank_S0337_500 | 2234567   | AAAAAAAA82A | di_1_S0337_500             | Y                               |
     And load C_BP_BankAccount:
       | C_BP_BankAccount_ID.Identifier       | OPT.C_BP_BankAccount_ID | OPT.C_Bank_ID  |
       | bp_bank_account_metasfresh_S0337_500 | 2000257                 | di_1_S0337_500 |
 
     And update C_BP_BankAccount:
-		| C_BP_BankAccount_ID.Identifier       | OPT.C_Currency.ISO_Code | OPT.IsEsrAccount | OPT.AccountNo | OPT.ESR_RenderedAccountNo | OPT.IBAN              | OPT.C_Bank_ID.Identifier |
-		| bp_bank_account_metasfresh_S0337_500 | CHF                     | Y                | 1234567890    | 123456789                 | CH3908704016075473007 | di_1_S0337_500           |
+      | C_BP_BankAccount_ID.Identifier       | OPT.C_Currency.ISO_Code | OPT.IsEsrAccount | OPT.AccountNo | OPT.ESR_RenderedAccountNo | OPT.IBAN              | OPT.C_Bank_ID.Identifier |
+      | bp_bank_account_metasfresh_S0337_500 | CHF                     | Y                | 1234567890    | 123456789                 | CH3908704016075473007 | di_1_S0337_500           |
 
 	  # create 2 invoices; we expect the sales invoice to end up with the ESR-reference 123456700102156434010001795
     Given metasfresh contains C_Invoice:
@@ -1266,7 +1266,7 @@ Feature: import bank statement in camt.53.001.04 import format
 						<AddtlTxInf>Incoming payment</AddtlTxInf>
 					</TxDtls>
 				</NtryDtls>
-				<AddtlNtryInf>Incoming payment</AddtlNtryInf>
+				<AddtlNtryInf>QRR Incoming payment</AddtlNtryInf>
 			</Ntry>
 			<Ntry>
 				<!-- plus 119 CHF -->
@@ -1310,7 +1310,7 @@ Feature: import bank statement in camt.53.001.04 import format
 						<AddtlTxInf>Incoming payment</AddtlTxInf>
 					</TxDtls>
 				</NtryDtls>
-				<AddtlNtryInf>Incoming payment</AddtlNtryInf>
+				<AddtlNtryInf>QRR Incoming payment</AddtlNtryInf>
 			</Ntry>
 		</Stmt>
 	</BkToCstmrStmt>
@@ -1328,10 +1328,239 @@ Feature: import bank statement in camt.53.001.04 import format
     And validate C_BankStatementLine
       | C_BankStatementLine_ID.Identifier | OPT.ValutaDate | OPT.DateAcct | OPT.C_Currency_ID.ISO_Code | OPT.TrxAmt | OPT.C_BPartner_ID.Identifier | OPT.C_Invoice_ID.Identifier |
       | bsl_1_S0337_500                   | 2023-10-27     | 2023-10-27   | CHF                        | 226.1      |                              |                             |
-	  | bsl_2_S0337_500                   | 2023-10-24     | 2023-10-24   | CHF                        | 0          | bpartner_1_S0337             | inv_2_S0337_500             |
-	  | bsl_3_S0337_500                   | 2023-10-26     | 2023-10-26   | CHF                        | 0          | bpartner_1_S0337             | inv_1_S0337_500             |
+      | bsl_2_S0337_500                   | 2023-10-24     | 2023-10-24   | CHF                        | 0          | bpartner_1_S0337             | inv_2_S0337_500             |
+      | bsl_3_S0337_500                   | 2023-10-26     | 2023-10-26   | CHF                        | 0          | bpartner_1_S0337             | inv_1_S0337_500             |
 
     And the C_BankStatement identified by bs_1_S0337_500 is completed
+
+    And set sys config boolean value false for sys config de.metas.payment.esr.Enabled
+
+
+  @from:cucumber
+  @Id:S0337_600
+  Scenario: Import one statement, identify org-account by IBAN, split QRR transactions from regular transactions and import as only QRR transacations as one summary line
+
+    Given set sys config boolean value true for sys config de.metas.payment.esr.Enabled
+	# change the bankaccount of the AD_Org bpartner ("metasfresh") to be an ESR-Account
+    And load C_DataImport:
+      | C_DataImport_ID.Identifier | OPT.C_DataImport_ID |
+      | di_1_S0337_600             | 540009              |
+    And metasfresh contains C_Bank:
+      | C_Bank_ID.Identifier | Name           | RoutingNo | SwiftCode   | C_DataImport_ID.Identifier | OPT.IsImportAsSingleSummaryLine |
+      | di_1_S0337_600       | bank_S0337_600 | 2234567   | AAAAAAAA82A | di_1_S0337_600             | Y                               |
+    And load C_BP_BankAccount:
+      | C_BP_BankAccount_ID.Identifier       | OPT.C_BP_BankAccount_ID | OPT.C_Bank_ID  |
+      | bp_bank_account_metasfresh_S0337_600 | 2000257                 | di_1_S0337_600 |
+
+    And update C_BP_BankAccount:
+      | C_BP_BankAccount_ID.Identifier       | OPT.C_Currency.ISO_Code | OPT.IsEsrAccount | OPT.AccountNo | OPT.ESR_RenderedAccountNo | OPT.IBAN              | OPT.C_Bank_ID.Identifier |
+      | bp_bank_account_metasfresh_S0337_600 | CHF                     | Y                | 1234567890    | 123456789                 | CH3908704016075473007 | di_1_S0337_600           |
+
+	  # create 2 invoices; we expect the sales invoice to end up with the ESR-reference 123456700102156434010001795
+    Given metasfresh contains C_Invoice:
+      | Identifier      | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code | OPT.DocumentNo        |
+      | inv_1_S0337_600 | bpartner_1_S0337         | Ausgangsrechnung        | 2022-05-12   | Spot                     | true    | CHF                 | 511004_1_SO_S0337_600 |
+      | inv_2_S0337_600 | bpartner_1_S0337         | Ausgangsrechnung        | 2022-05-12   | Spot                     | true    | CHF                 | 511004_2_SO_S0337_600 |
+
+    And metasfresh contains C_InvoiceLines
+      | Identifier       | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
+      | invl_1_S0337_600 | inv_1_S0337_600         | p_1_S0337               | 10          | PCE               |
+      | invl_2_S0337_600 | inv_2_S0337_600         | p_1_S0337               | 9           | PCE               |
+    And the invoice identified by inv_1_S0337_600 is completed
+    And the invoice identified by inv_2_S0337_600 is completed
+
+    And load C_ReferenceNo:
+      | C_ReferenceNo_ID.Identifier        | Record_ID.Identifier | C_ReferenceNo_Type_ID.Identifier |
+      | ReferenceNo_metasfresh_S0337_600_1 | inv_1_S0337_600      | 540006                           |
+      | ReferenceNo_metasfresh_S0337_600_2 | inv_2_S0337_600      | 540006                           |
+
+    And update C_ReferenceNo:
+      | C_ReferenceNo_ID.Identifier        | Record_ID.Identifier | C_ReferenceNo_Type_ID.Identifier | OPT.ReferenceNo                    |
+      | ReferenceNo_metasfresh_S0337_600_1 | inv_1_S0337_600      | 540006                           | ReferenceNo_metasfresh_S0337_600_1 |
+      | ReferenceNo_metasfresh_S0337_600_2 | inv_2_S0337_600      | 540006                           | ReferenceNo_metasfresh_S0337_600_2 |
+
+    When bank statement is imported with identifiers bs_1_S0337_600, matching invoice amounts
+    """
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.04">
+	<BkToCstmrStmt>
+		<GrpHdr>
+			<MsgId>2023102706963268</MsgId>
+			<CreDtTm>2023-10-27T15:15:37</CreDtTm>
+			<MsgPgntn>
+				<PgNb>1</PgNb>
+				<LastPgInd>true</LastPgInd>
+			</MsgPgntn>
+		</GrpHdr>
+		<Stmt>
+			<Id>2023102706963268</Id>
+			<ElctrncSeqNb>39</ElctrncSeqNb>
+			<CreDtTm>2023-10-27T15:15:37</CreDtTm>
+			<FrToDt>
+				<FrDtTm>2023-10-24T00:00:00</FrDtTm>
+				<ToDtTm>2023-10-26T23:59:59</ToDtTm>
+			</FrToDt>
+			<CpyDplctInd>DUPL</CpyDplctInd>
+			<Acct>
+				<Id>
+					<IBAN>CH3908704016075473007</IBAN>
+				</Id>
+				<Ccy>CHF</Ccy>
+				<Ownr>
+					<Nm>Our-Name</Nm>
+					<PstlAdr>
+						<AdrLine>Our-AdrLine 1</AdrLine>
+						<AdrLine>Our AdrLine 2</AdrLine>
+					</PstlAdr>
+				</Ownr>
+				<Svcr>
+					<FinInstnId>
+						<BICFI>AAAAAAAA82A</BICFI>
+						<Nm>Our Bank</Nm>
+					</FinInstnId>
+				</Svcr>
+			</Acct>
+			<Bal>
+				<!-- opening balance -->
+				<Tp>
+					<CdOrPrtry>
+						<Cd>OPBD</Cd>
+					</CdOrPrtry>
+				</Tp>
+				<Amt Ccy="CHF">1000.07</Amt>
+				<CdtDbtInd>CRDT</CdtDbtInd>
+				<Dt>
+					<Dt>2023-10-23</Dt>
+				</Dt>
+			</Bal>
+			<Bal>
+				<!-- closing balance -->
+				<Tp>
+					<CdOrPrtry>
+						<Cd>CLBD</Cd>
+					</CdOrPrtry>
+				</Tp>
+				<Amt Ccy="CHF">869.17</Amt>
+				<CdtDbtInd>CRDT</CdtDbtInd>
+				<Dt>
+					<Dt>2023-10-26</Dt>
+				</Dt>
+			</Bal>
+			<Ntry>
+				<!-- plus 107.1 CHF -->
+				<Amt Ccy="CHF">107.1</Amt>
+				<CdtDbtInd>CRDT</CdtDbtInd>
+				<RvslInd>false</RvslInd>
+				<Sts>BOOK</Sts>
+				<BookgDt>
+					<Dt>2023-10-24</Dt>
+				</BookgDt>
+				<ValDt>
+					<Dt>2023-10-24</Dt>
+				</ValDt>
+				<BkTxCd>
+					<Domn>
+						<Cd>PMNT</Cd>
+						<Fmly>
+							<Cd>RCDT</Cd>
+							<SubFmlyCd>OTHR</SubFmlyCd>
+						</Fmly>
+					</Domn>
+				</BkTxCd>
+				<NtryDtls>
+					<Btch>
+						<NbOfTxs>1</NbOfTxs>
+						<TtlAmt Ccy="CHF">107.1</TtlAmt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+					</Btch>
+					<TxDtls>
+						<Refs>
+							<AcctSvcrRef>AcctSvcrRef/1/1</AcctSvcrRef>
+							<EndToEndId>EndToEndId/1/1</EndToEndId>
+							<TxId>TxId/1/1</TxId>
+						</Refs>
+						<Amt Ccy="CHF">107.1</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<AmtDtls>
+							<InstdAmt>
+								<Amt Ccy="CHF">107.1</Amt>
+							</InstdAmt>
+							<TxAmt>
+								<Amt Ccy="CHF">107.1</Amt>
+							</TxAmt>
+						</AmtDtls>
+						<RmtInf>
+							<Ustrd>ESR-Referenz ReferenceNo_metasfresh_S0337_600_2</Ustrd>
+						</RmtInf>
+						<AddtlTxInf>Incoming payment</AddtlTxInf>
+					</TxDtls>
+				</NtryDtls>
+				<AddtlNtryInf>QRR Incoming payment</AddtlNtryInf>
+			</Ntry>
+			<Ntry>
+				<!-- plus 119 CHF -->
+				<Amt Ccy="CHF">119</Amt>
+				<CdtDbtInd>CRDT</CdtDbtInd>
+				<RvslInd>false</RvslInd>
+				<Sts>BOOK</Sts>
+				<BookgDt>
+					<Dt>2023-10-26</Dt>
+				</BookgDt>
+				<ValDt>
+					<Dt>2023-10-26</Dt>
+				</ValDt>
+				<NtryDtls>
+					<Btch>
+						<NbOfTxs>1</NbOfTxs>
+						<TtlAmt Ccy="CHF">119</TtlAmt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+					</Btch>
+					<TxDtls>
+						<Refs>
+							<MsgId>MsgId/2</MsgId>
+							<AcctSvcrRef>AcctSvcrRef/2/1</AcctSvcrRef>
+							<PmtInfId>PmtInfId/2/1</PmtInfId>
+							<InstrId>InstrId/2/1</InstrId>
+							<EndToEndId>EndToEndId/2/1</EndToEndId>
+						</Refs>
+						<Amt Ccy="CHF">119</Amt>
+						<CdtDbtInd>CRDT</CdtDbtInd>
+						<AmtDtls>
+							<InstdAmt>
+								<Amt Ccy="CHF">119</Amt>
+							</InstdAmt>
+							<TxAmt>
+								<Amt Ccy="CHF">119</Amt>
+							</TxAmt>
+						</AmtDtls>
+						<RmtInf>
+							<Ustrd>511004_1_SO_S0337_600</Ustrd>
+						</RmtInf>
+						<AddtlTxInf>Incoming payment</AddtlTxInf>
+					</TxDtls>
+				</NtryDtls>
+				<AddtlNtryInf>Incoming payment</AddtlNtryInf>
+			</Ntry>
+		</Stmt>
+	</BkToCstmrStmt>
+</Document>
+    """
+
+    Then validate C_BankStatement
+      | C_BankStatement_ID.Identifier | OPT.BeginningBalance | OPT.EndingBalance | OPT.StatementDifference | OPT.Processed | OPT.C_BP_BankAccount_ID.Identifier   | OPT.StatementDate | OPT.IsReconciled |
+      | bs_1_S0337_600                | 1000.07              | 1226.17           | 226.1                   | false         | bp_bank_account_metasfresh_S0337_600 | 2023-10-27        | false            |
+    And load C_BankStatementLine
+      | C_BankStatementLine_ID.Identifier | C_BankStatement_ID.Identifier | Line |
+      | bsl_1_S0337_600                   | bs_1_S0337_600                | 10   |
+      | bsl_2_S0337_600                   | bs_1_S0337_600                | 20   |
+      | bsl_3_S0337_600                   | bs_1_S0337_600                | 30   |
+    And validate C_BankStatementLine
+      | C_BankStatementLine_ID.Identifier | OPT.ValutaDate | OPT.DateAcct | OPT.C_Currency_ID.ISO_Code | OPT.TrxAmt | OPT.C_BPartner_ID.Identifier | OPT.C_Invoice_ID.Identifier |
+      | bsl_1_S0337_600                   | 2023-10-27     | 2023-10-27   | CHF                        | 107.1      |                              |                             |
+      | bsl_2_S0337_600                   | 2023-10-24     | 2023-10-24   | CHF                        | 0          | bpartner_1_S0337             | inv_2_S0337_600             |
+      | bsl_3_S0337_600                   | 2023-10-26     | 2023-10-26   | CHF                        | 119        | bpartner_1_S0337             | inv_1_S0337_600             |
+
+    And the C_BankStatement identified by bs_1_S0337_600 is completed
 
     And set sys config boolean value false for sys config de.metas.payment.esr.Enabled
 


### PR DESCRIPTION
* we import the detail lines with amount 0 and all other details that we can find in the XML file IF they are related to QRR ESR. All lines that are not related to QRR ESR should be imported with their payment amount.

* Move method hasNonQRRTransactions to proper class

* QA together with Cristina

* Add cucumber to case when Non QRR transactions exists

* Fix invoice number

* Fix invoice number

* Fix logic for skipping non-QRR transactions

* Fix bankstatement identifier

* Fix bank identifier

(cherry picked from commit abebb8f713b04059b878eaf68c387116d176b220)