### PR TITLE
javax.mail SMTP fix: exclude geronimo-javamail_1.4_mail because that'…

### DIFF
--- a/backend/de.metas.postfinance.base/pom.xml
+++ b/backend/de.metas.postfinance.base/pom.xml
@@ -219,6 +219,12 @@
             <groupId>org.apache.wss4j</groupId>
             <artifactId>wss4j-ws-security-common</artifactId>
             <version>2.4.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.geronimo.javamail</groupId>
+                    <artifactId>geronimo-javamail_1.4_mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>de.metas.document.archive</groupId>


### PR DESCRIPTION
…s breaking it (#19217)

(cherry picked from commit 8aa1662ab03d1ccd5d6a2fdd338f73cf1b8529d8)