### PR TITLE
When updating trl tables from base record always use getBaseLanguage()

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/po/POTrlRepository.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/po/POTrlRepository.java
@@ -214,15 +214,16 @@ public class POTrlRepository
 		final String keyColumnName = trlInfo.getKeyColumnName();
 		final int keyColumnValue = baseRecord.get_ID();
 		final ClientId clientId = ClientId.ofRepoId(baseRecord.getAD_Client_ID());
+		final String sqlBaseLanguage = "getBaseLanguage()"; // IMPORTANT: don't use Language.getBaseAD_Language() because this script will be logged and will be run on an intance where we might have a different base language 
 		final String sqlWhereClause;
 		if (isMasterdataTable(clientId, tableName))
 		{
-			sqlWhereClause = "(IsTranslated='N' OR AD_Language=" + DB.TO_STRING(Language.getBaseAD_Language()) + ")";
+			sqlWhereClause = "(IsTranslated='N' OR AD_Language=" + sqlBaseLanguage + ")";
 		}
 		else
 		{
 			// Application dictionary tables
-			sqlWhereClause = "AD_Language=" + DB.TO_STRING(Language.getBaseAD_Language());
+			sqlWhereClause = "AD_Language=" + sqlBaseLanguage;
 		}
 
 		//

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/getBaseLanguage.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/getBaseLanguage.sql
@@ -1,0 +1,19 @@
+DROP FUNCTION IF EXISTS getBaseLanguage();
+
+CREATE OR REPLACE FUNCTION getBaseLanguage(
+)
+    RETURNS character varying
+    LANGUAGE SQL
+    STABLE
+AS
+$$
+SELECT AD_Language FROM AD_Language WHERE IsBaseLanguage='Y' AND IsActive = 'Y';
+$$
+;
+
+
+-- Tests
+/*
+SELECT getBaseLanguage();
+ */
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5745700_getBaseLanguage.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5745700_getBaseLanguage.sql
@@ -1,0 +1,19 @@
+DROP FUNCTION IF EXISTS getBaseLanguage();
+
+CREATE OR REPLACE FUNCTION getBaseLanguage(
+)
+    RETURNS character varying
+    LANGUAGE SQL
+    STABLE
+AS
+$$
+SELECT AD_Language FROM AD_Language WHERE IsBaseLanguage='Y' AND IsActive = 'Y';
+$$
+;
+
+
+-- Tests
+/*
+SELECT getBaseLanguage();
+ */
+


### PR DESCRIPTION
Before this change, the migration scripts of updating a base record looked like:
```sql
UPDATE AD_Message_Trl trl SET MsgText='aaabb' WHERE AD_Message_ID=545494 AND AD_Language='de_DE'
;
```

after this PR, it looks like:
```sql
UPDATE AD_Message_Trl trl SET MsgText='aaabb' WHERE AD_Message_ID=545494 AND AD_Language=getBaseLanguage()
;
```