### PR TITLE
Make sure translations don't get broken when running migration scripts produced on a system with a different base language

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/po/POTrlRepository.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/po/POTrlRepository.java
@@ -4,7 +4,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import de.metas.cache.CacheMgt;
-import de.metas.common.util.time.SystemTime;
 import de.metas.i18n.IModelTranslation;
 import de.metas.i18n.IModelTranslationMap;
 import de.metas.i18n.Language;
@@ -24,7 +23,6 @@ import org.compiere.model.I_AD_Language;
 import org.compiere.model.PO;
 import org.compiere.model.POInfo;
 import org.compiere.util.DB;
-import org.compiere.util.DisplayType;
 import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
@@ -184,6 +182,11 @@ public class POTrlRepository
 	 */
 	public boolean onBaseRecordChanged(@NonNull final PO baseRecord)
 	{
+		return sync_base_to_trl(baseRecord);
+	}
+
+	private boolean sync_base_to_trl(@NonNull final PO baseRecord)
+	{
 		final POTrlInfo trlInfo = baseRecord.getPOInfo().getTrlInfo();
 		if (!trlInfo.isTranslated())
 		{
@@ -242,6 +245,11 @@ public class POTrlRepository
 
 	public void onTrlRecordChanged(@NonNull final PO trlRecord)
 	{
+		sync_trl_to_base_ifBaseLanguage(trlRecord);
+	}
+
+	private static void sync_trl_to_base_ifBaseLanguage(@NonNull final PO trlRecord)
+	{
 		final String trlTableName = trlRecord.get_TableName();
 		final String baseTableName = toBaseTableNameOrNull(trlTableName);
 		if (baseTableName == null)
@@ -249,13 +257,8 @@ public class POTrlRepository
 			return;
 		}
 
-		final POTrlInfo trlInfo = POInfo.getPOInfoNotNull(baseTableName).getTrlInfo();
-
-		final String recordAdLanguage = trlRecord.get_ValueAsString(COLUMNNAME_AD_Language);
-		if (!Language.isBaseLanguage(recordAdLanguage))
-		{
-			return;
-		}
+		final POInfo baseTablePOInfo = POInfo.getPOInfoNotNull(baseTableName);
+		final POTrlInfo trlInfo = baseTablePOInfo.getTrlInfo();
 
 		final StringBuilder sqlSet = new StringBuilder();
 		for (final String columnName : trlInfo.getTranslatedColumnNames())
@@ -265,12 +268,11 @@ public class POTrlRepository
 				continue;
 			}
 
-			final String sqlValue = convertValueToSql(trlRecord.get_Value(columnName));
 			if (sqlSet.length() > 0)
 			{
 				sqlSet.append(", ");
 			}
-			sqlSet.append(columnName).append("=").append(sqlValue);
+			sqlSet.append(columnName).append("=trl.").append(columnName);
 		}
 
 		if (sqlSet.length() == 0)
@@ -278,24 +280,29 @@ public class POTrlRepository
 			return;
 		}
 
-		final boolean isUpdatedColumnPresent = Optional.ofNullable(POInfo.getPOInfo(baseTableName))
-				.map(poInfo -> poInfo.getColumnIndex("Updated") > -1)
-				.orElse(false);
-
-		if (isUpdatedColumnPresent)
+		if (baseTablePOInfo.hasColumnName("Updated"))
 		{
-			sqlSet.append(", Updated").append("=").append(DB.TO_DATE(SystemTime.asTimestamp(), DisplayType.DateTime));
+			sqlSet.append(", Updated").append("=trl.Updated");
+		}
+		if (baseTablePOInfo.hasColumnName("UpdatedBy"))
+		{
+			sqlSet.append(", UpdatedBy").append("=trl.UpdatedBy");
 		}
 
 		final String keyColumnName = trlInfo.getKeyColumnName();
-		final Object keyColumnValue = trlRecord.get_Value(keyColumnName);
+		final String adLanguage = trlRecord.get_ValueAsString(COLUMNNAME_AD_Language);
 
-		final String sql = "UPDATE " + baseTableName + " SET " + sqlSet + " WHERE " + keyColumnName + "=" + convertValueToSql(keyColumnValue);
+		final String sql = "UPDATE " + baseTableName + " base SET " + sqlSet
+				+ " FROM " + trlTableName + " trl "
+				+ " WHERE trl." + keyColumnName + "=base." + keyColumnName
+				+ " AND trl.AD_Language=" + DB.TO_STRING(adLanguage)
+				+ " AND trl.AD_Language=getBaseLanguage()"; // IMPORTANT: since this script will be logged, make sure the base language is checked on the database where this command will be executed
 		final int updatedCount = DB.executeUpdateAndThrowExceptionOnFail(sql, ITrx.TRXNAME_ThreadInherited);
 		logger.debug("Updated {} base records for {}", updatedCount, trlRecord);
 
 		//
 		final CacheMgt cacheMgt = CacheMgt.get();
+		final Object keyColumnValue = trlRecord.get_Value(keyColumnName);
 		if (keyColumnValue instanceof Integer)
 		{
 			cacheMgt.reset(baseTableName, (int)keyColumnValue);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/getBaseLanguage.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/getBaseLanguage.sql
@@ -1,0 +1,19 @@
+DROP FUNCTION IF EXISTS getBaseLanguage();
+
+CREATE OR REPLACE FUNCTION getBaseLanguage(
+)
+    RETURNS character varying
+    LANGUAGE SQL
+    STABLE
+AS
+$$
+SELECT AD_Language FROM AD_Language WHERE IsBaseLanguage='Y' AND IsActive = 'Y';
+$$
+;
+
+
+-- Tests
+/*
+SELECT getBaseLanguage();
+ */
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/triggers/check_is_system_language_tg.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/triggers/check_is_system_language_tg.sql
@@ -1,0 +1,38 @@
+DROP TRIGGER IF EXISTS check_is_system_language_tg ON ad_language
+;
+
+DROP FUNCTION IF EXISTS check_is_system_language_tgfn()
+;
+
+
+CREATE OR REPLACE FUNCTION check_is_system_language_tgfn()
+    RETURNS TRIGGER
+AS
+$$
+DECLARE
+    supported_languages CONSTANT TEXT[] := ARRAY ['de_DE', 'de_CH', 'en_US'];
+BEGIN
+
+    -- Make sure nobody is deactivating one of the languages that we have support on each instance we have
+    IF NEW.ad_language = ANY (supported_languages) THEN
+        IF NEW.issystemlanguage != 'Y' THEN
+            RAISE EXCEPTION 'IsSystemLanguage must be ''Y'' for ad_language = %', NEW.ad_language;
+        END IF;
+        IF NEW.isactive != 'Y' THEN
+            RAISE EXCEPTION 'IsActive must be ''Y'' for ad_language = %', NEW.ad_language;
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$
+    LANGUAGE plpgsql
+;
+
+CREATE TRIGGER check_is_system_language_tg
+    BEFORE INSERT OR UPDATE
+    ON ad_language
+    FOR EACH ROW
+EXECUTE PROCEDURE check_is_system_language_tgfn()
+;
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/triggers/check_is_system_language_tg.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/triggers/check_is_system_language_tg.sql
@@ -15,8 +15,8 @@ BEGIN
 
     -- Make sure nobody is deactivating one of the languages that we have support on each instance we have
     IF NEW.ad_language = ANY (supported_languages) THEN
-        IF NEW.issystemlanguage != 'Y' THEN
-            RAISE EXCEPTION 'IsSystemLanguage must be ''Y'' for ad_language = %', NEW.ad_language;
+        IF NEW.issystemlanguage != 'Y' AND NEW.isbaselanguage != 'Y' THEN
+            RAISE EXCEPTION 'IsSystemLanguage or IsBaseLanguage must be ''Y'' for ad_language = %', NEW.ad_language;
         END IF;
         IF NEW.isactive != 'Y' THEN
             RAISE EXCEPTION 'IsActive must be ''Y'' for ad_language = %', NEW.ad_language;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5745700_getBaseLanguage.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5745700_getBaseLanguage.sql
@@ -1,0 +1,19 @@
+DROP FUNCTION IF EXISTS getBaseLanguage();
+
+CREATE OR REPLACE FUNCTION getBaseLanguage(
+)
+    RETURNS character varying
+    LANGUAGE SQL
+    STABLE
+AS
+$$
+SELECT AD_Language FROM AD_Language WHERE IsBaseLanguage='Y' AND IsActive = 'Y';
+$$
+;
+
+
+-- Tests
+/*
+SELECT getBaseLanguage();
+ */
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5746020_enable_standard_AD_Languages.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5746020_enable_standard_AD_Languages.sql
@@ -1,0 +1,5 @@
+UPDATE ad_language
+SET issystemlanguage='Y', isactive='Y'
+WHERE ad_language IN ('de_CH', 'de_DE', 'en_US')
+;
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5746030_enforce_standard_languages_to_be_active.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5746030_enforce_standard_languages_to_be_active.sql
@@ -1,0 +1,37 @@
+DROP TRIGGER IF EXISTS check_is_system_language_tg ON ad_language
+;
+
+DROP FUNCTION IF EXISTS check_is_system_language_tgfn()
+;
+
+
+CREATE OR REPLACE FUNCTION check_is_system_language_tgfn()
+    RETURNS TRIGGER
+AS
+$$
+DECLARE
+    supported_languages CONSTANT TEXT[] := ARRAY ['de_DE', 'de_CH', 'en_US'];
+BEGIN
+    
+    -- Make sure nobody is deactivating one of the languages that we have support on each instance we have
+    IF NEW.ad_language = ANY (supported_languages) THEN
+        IF NEW.issystemlanguage != 'Y' THEN
+            RAISE EXCEPTION 'IsSystemLanguage must be ''Y'' for ad_language = %', NEW.ad_language;
+        END IF;
+        IF NEW.isactive != 'Y' THEN
+            RAISE EXCEPTION 'IsActive must be ''Y'' for ad_language = %', NEW.ad_language;
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$
+    LANGUAGE plpgsql
+;
+
+CREATE TRIGGER check_is_system_language_tg
+    BEFORE INSERT OR UPDATE
+    ON ad_language
+    FOR EACH ROW
+EXECUTE PROCEDURE check_is_system_language_tgfn()
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5746030_enforce_standard_languages_to_be_active.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5746030_enforce_standard_languages_to_be_active.sql
@@ -12,11 +12,11 @@ $$
 DECLARE
     supported_languages CONSTANT TEXT[] := ARRAY ['de_DE', 'de_CH', 'en_US'];
 BEGIN
-    
+
     -- Make sure nobody is deactivating one of the languages that we have support on each instance we have
     IF NEW.ad_language = ANY (supported_languages) THEN
-        IF NEW.issystemlanguage != 'Y' THEN
-            RAISE EXCEPTION 'IsSystemLanguage must be ''Y'' for ad_language = %', NEW.ad_language;
+        IF NEW.issystemlanguage != 'Y' AND NEW.isbaselanguage != 'Y' THEN
+            RAISE EXCEPTION 'IsSystemLanguage or IsBaseLanguage must be ''Y'' for ad_language = %', NEW.ad_language;
         END IF;
         IF NEW.isactive != 'Y' THEN
             RAISE EXCEPTION 'IsActive must be ''Y'' for ad_language = %', NEW.ad_language;
@@ -35,3 +35,4 @@ CREATE TRIGGER check_is_system_language_tg
     FOR EACH ROW
 EXECUTE PROCEDURE check_is_system_language_tgfn()
 ;
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5746040_ad_language_isbaselanguage_uq_index.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5746040_ad_language_isbaselanguage_uq_index.sql
@@ -1,0 +1,4 @@
+drop index if exists ad_language_isbaselanguage_uq;
+
+create unique index ad_language_isbaselanguage_uq on ad_language(isbaselanguage) where isbaselanguage='Y';
+


### PR DESCRIPTION
- **getBaseLanguage() db function**
- **make sure all standard ad_languages are system languages**
- **when syncing trl to base make sure we do only for base language of the system where the SQL command is running**
