### PR TITLE
Fix severe performance problem with C_BPartner_UpdateStats (#19947)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerStatsDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerStatsDAO.java
@@ -110,9 +110,9 @@ public class BPartnerStatsDAO implements IBPartnerStatsDAO
 
 		BigDecimal openItems = null;
 
-		final Object[] sqlParams = new Object[] { stats.getC_BPartner_ID() };
+		final Object[] sqlParams = new Object[] { SystemTime.asTimestamp(), stats.getC_BPartner_ID() };
 		final String sql = "SELECT "
-				+ "currencyBase(openamt,C_Currency_ID,DateInvoiced,AD_Client_ID,AD_Org_ID) from de_metas_endcustomer_fresh_reports.OpenItems_Report(now()::date) where  C_BPartner_ID=?";
+				+ "COALESCE((SELECT SUM(currencyBase(openamt,C_Currency_ID,DateInvoiced,AD_Client_ID,AD_Org_ID)) from de_metas_endcustomer_fresh_reports.OpenItems_Report(p_Reference_Date=>?, p_c_bpartner_id=>?)), 0)";
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
 

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5745090_sys_gh19946_openitems_report.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5745090_sys_gh19946_openitems_report.sql
@@ -1,4 +1,8 @@
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.OpenItems_Report(date,
+                                                                            character varying)
+;
+
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.OpenItems_Report(date,
                                                                             character varying,
                                                                             numeric)
 ;
@@ -106,7 +110,7 @@ FROM (SELECT i.AD_Org_ID,
              COALESCE(
                      PaymentTermDueDays(i.C_PaymentTerm_ID, i.DateInvoiced::timestamp WITH TIME ZONE, p_Reference_Date),
                      DaysBetween(p_Reference_Date, ips.DueDate::timestamp WITH TIME ZONE)
-             )                                                                                                             AS DaysDue,
+                 )                                                                                                             AS DaysDue,
              COALESCE(AddDays(i.DateInvoiced::timestamp WITH TIME ZONE, p.DiscountDays), ips.DiscountDate)                     AS DiscountDate,
              COALESCE(ROUND(i.GrandTotal * p.Discount / 100::numeric, 2), ips.DiscountAmt)                                     AS DiscountAmt,
              COALESCE(ips.DueAmt, i.GrandTotal)                                                                                AS GrandTotal,


### PR DESCRIPTION
* Fix severe performance problem with C_BPartner_UpdateStats refs: https://github.com/metasfresh/metasfresh/issues/19946
* use parameterized statements refs: https://github.com/metasfresh/metasfresh/issues/19946

(cherry picked from commit a9131677b0e082b9d678a036534eeafbb6c0288b)
solved Conflict:
	backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/openitems_report.sql