### PR TITLE
Fix problem where LU-Qty were counted multiple times when creating DESADV-Packs (#20665)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/TimeUtil.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/TimeUtil.java
@@ -1142,7 +1142,7 @@ public class TimeUtil
 			cal.set(Calendar.MINUTE, mm);
 			return cal.getTimeInMillis();
 		}
-		
+
 		// M - Minute
 		if (TRUNC_MINUTE.equals(trunc))
 		{
@@ -1324,6 +1324,7 @@ public class TimeUtil
 	/**
 	 * @return date as timestamp or null if the date is null
 	 */
+	@Contract("!null -> !null")
 	@Nullable
 	public static Timestamp asTimestamp(@Nullable final Date date)
 	{
@@ -1337,6 +1338,7 @@ public class TimeUtil
 	/**
 	 * @return instant as timestamp or null if the instant is null; note: use {@link Timestamp#toInstant()} for the other direction.
 	 */
+	@Contract("!null -> !null")
 	@Nullable
 	public static Timestamp asTimestamp(@Nullable final Instant instant)
 	{
@@ -1353,6 +1355,7 @@ public class TimeUtil
 	 * NOTE: please consider using {@link #asTimestamp(LocalDate, ZoneId)} with the respective org's time zone instead (see {@link de.metas.organization.IOrgDAO#getTimeZone(de.metas.organization.OrgId)}).
 	 * Will be deprecated in future but atm we cannot because there are a lot of cases when we have to use it.
 	 */
+	@Contract("!null -> !null")
 	@Nullable
 	public static Timestamp asTimestamp(@Nullable final LocalDate localDate)
 	{
@@ -1360,6 +1363,7 @@ public class TimeUtil
 		return asTimestamp(localDate, timezone);
 	}
 
+	@Contract("!null -> !null")
 	@Nullable
 	public static Timestamp asTimestamp(
 			@Nullable final LocalDate localDate,
@@ -1686,7 +1690,7 @@ public class TimeUtil
 			return asLocalDateTime(obj, zoneId).toLocalDate();
 		}
 	}
-	
+
 	@Contract("!null, _ -> !null")
 	@Nullable
 	public static LocalDate asLocalDate(@Nullable final Timestamp timestamp, @NonNull final ZoneId zoneId)
@@ -2023,17 +2027,17 @@ public class TimeUtil
 		else if (obj instanceof LocalDateTime)
 		{
 			final LocalDateTime localDateTime = (LocalDateTime)obj;
-            return localDateTime.atZone(zoneId).toInstant();
+			return localDateTime.atZone(zoneId).toInstant();
 		}
 		else if (obj instanceof LocalDate)
 		{
 			final LocalDate localDate = (LocalDate)obj;
-            return localDate.atStartOfDay(zoneId).toInstant();
+			return localDate.atStartOfDay(zoneId).toInstant();
 		}
 		else if (obj instanceof LocalTime)
 		{
 			final LocalTime localTime = (LocalTime)obj;
-            return localTime.atDate(DATE_1970_01_01).atZone(zoneId).toInstant();
+			return localTime.atDate(DATE_1970_01_01).atZone(zoneId).toInstant();
 		}
 		else if (obj instanceof XMLGregorianCalendar)
 		{
@@ -2386,7 +2390,7 @@ public class TimeUtil
 	 */
 	public static long getDaysBetween360(@NonNull final ZonedDateTime from, @NonNull final ZonedDateTime to)
 	{
-		if(from.isEqual(to))
+		if (from.isEqual(to))
 		{
 			return 0;
 		}

--- a/backend/de.metas.business/src/test/java/de/metas/SimpleDateFormatTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/SimpleDateFormatTest.java
@@ -1,0 +1,55 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class SimpleDateFormatTest
+{
+    /**
+     * Make sure that when parsing dates with the pattern {@code "dd.MM.yy"}, both yy and yyyy works.
+     * <p> 
+     * Background: we sometimes get 21.03.2025 and sometimes 21.03.25 when importing csv-Data.
+     */
+	@Test
+	public void parse() throws ParseException
+	{
+        // given
+		final String date1 = "21.03.2025";
+        final String date2 = "21.03.25";
+
+        // when
+		final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd.MM.yy");
+        final Date parsedDate1 = simpleDateFormat.parse(date1);
+        final Date parsedDate2 = simpleDateFormat.parse(date2);
+
+        // then
+		assertThat(parsedDate1).isEqualTo(parsedDate2);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Pack_Item_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Pack_Item_StepDef.java
@@ -22,16 +22,18 @@
 
 package de.metas.cucumber.stepdefs.edi;
 
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
-import de.metas.cucumber.stepdefs.M_HU_PackagingCode_StepDefData;
-import de.metas.cucumber.stepdefs.StepDefConstants;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.StepDefUtil;
+import de.metas.cucumber.stepdefs.hu.M_HU_PackagingCode_StepDefData;
 import de.metas.cucumber.stepdefs.shipment.M_InOutLine_StepDefData;
 import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
-import de.metas.esb.edi.model.I_EDI_Desadv_Pack;
+import de.metas.edi.api.impl.pack.EDIDesadvPackId;
 import de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item;
+import de.metas.inout.InOutLineId;
 import de.metas.logging.LogManager;
-import de.metas.util.Check;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Given;
@@ -41,8 +43,6 @@ import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.trx.api.ITrx;
 import org.assertj.core.api.SoftAssertions;
-import org.compiere.model.I_M_InOut;
-import org.compiere.model.I_M_InOutLine;
 import org.compiere.util.DB;
 import org.slf4j.Logger;
 
@@ -52,6 +52,7 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -92,10 +93,8 @@ public class EDI_Desadv_Pack_Item_StepDef
 	public void packItemsAreFound(final int timeoutSec, @NonNull final DataTable table) throws InterruptedException
 	{
 		final List<Map<String, String>> dataTable = table.asMaps();
-		for (final Map<String, String> row : dataTable)
-		{
-			packItemIsFound(row, timeoutSec);
-		}
+		DataTableRows.of(table)
+				.forEach(row -> packItemIsFound(row, timeoutSec));
 
 		final int storedItemsSize = queryBL.createQueryBuilder(I_EDI_Desadv_Pack_Item.class)
 				.addOnlyActiveRecordsFilter()
@@ -158,142 +157,136 @@ public class EDI_Desadv_Pack_Item_StepDef
 	}
 
 	private void packItemIsFound(
-			@NonNull final Map<String, String> tableRow,
+			@NonNull final DataTableRow dataTableRow,
 			final int timeoutSec) throws InterruptedException
 	{
-		final String packIdentifier = DataTableUtil.extractStringForColumnName(tableRow, I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_ID + "." + StepDefConstants.TABLECOLUMN_IDENTIFIER);
+		final StepDefDataIdentifier packIdentifier = dataTableRow.getAsIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_ID);
 
-		final Integer packID = packTable.getOptional(packIdentifier)
-				.map(I_EDI_Desadv_Pack::getEDI_Desadv_Pack_ID)
-				.orElseGet(() -> Integer.parseInt(packIdentifier));
-
+		final EDIDesadvPackId packID = packTable.getId(packIdentifier);
 		final IQueryBuilder<I_EDI_Desadv_Pack_Item> queryBuilder = queryBL.createQueryBuilder(I_EDI_Desadv_Pack_Item.class)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_ID, packID);
 
-		final BigDecimal movementQty = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_EDI_Desadv_Pack_Item.COLUMNNAME_MovementQty);
-		if (movementQty != null)
-		{
-			queryBuilder.addEqualsFilter(I_EDI_Desadv_Pack_Item.COLUMNNAME_MovementQty, movementQty);
-		}
+		final Optional<BigDecimal> movementQty = dataTableRow.getAsOptionalBigDecimal(I_EDI_Desadv_Pack_Item.COLUMNNAME_MovementQty);
+		movementQty.ifPresent(qty -> queryBuilder.addEqualsFilter(I_EDI_Desadv_Pack_Item.COLUMNNAME_MovementQty, qty));
+
+		final Optional<InOutLineId> inOutLineId = dataTableRow.getAsOptionalIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_M_InOutLine_ID).map(shipmentLineTable::getId);
+		inOutLineId.ifPresent(
+				iolId -> queryBuilder.addEqualsFilter(I_EDI_Desadv_Pack_Item.COLUMNNAME_M_InOutLine_ID, iolId));
 
 		final Supplier<Boolean> packItemFound = () -> queryBuilder
 				.create()
 				.firstOnly(I_EDI_Desadv_Pack_Item.class) != null;
 
-		StepDefUtil.tryAndWait(timeoutSec, 500, packItemFound, () -> logCurrentContext(packID, movementQty));
+		StepDefUtil.tryAndWait(timeoutSec, 500, packItemFound, () -> logCurrentContext(packID, movementQty.orElse(null), inOutLineId.orElse(null)));
 
-		final BigDecimal qtyCUsPerTU = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerTU);
-		final BigDecimal qtyCUsPerTU_InInvoiceUOM = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerTU_InInvoiceUOM);
-		final BigDecimal qtyCUsPerLU = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerLU);
-		final BigDecimal qtyCUsPerLU_InInvoiceUOM = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerLU_InInvoiceUOM);
-		final BigDecimal qtyItemCapacity = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyItemCapacity);
-		final Integer qtyTu = DataTableUtil.extractIntegerOrNullForColumnName(tableRow, "OPT." + I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyTU);
-
+		final SoftAssertions softly = new SoftAssertions();
 		final I_EDI_Desadv_Pack_Item desadvPackItemRecord = queryBuilder.create().firstOnlyNotNull(I_EDI_Desadv_Pack_Item.class);
 		final int packItemId = desadvPackItemRecord.getEDI_Desadv_Pack_Item_ID();
 
-		final SoftAssertions softly = new SoftAssertions();
-		if (qtyCUsPerTU != null)
-		{
-			softly.assertThat(desadvPackItemRecord.getQtyCUsPerTU()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - QtyCUsPerTU", packIdentifier, packItemId).isEqualByComparingTo(qtyCUsPerTU);
-		}
+		dataTableRow.getAsOptionalBigDecimal(I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerTU)
+				.ifPresent(qtyCUsPerTU -> softly
+						.assertThat(desadvPackItemRecord.getQtyCUsPerTU())
+						.as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - QtyCUsPerTU", packIdentifier, packItemId)
+						.isEqualByComparingTo(qtyCUsPerTU));
+		dataTableRow.getAsOptionalBigDecimal(I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerTU_InInvoiceUOM)
+				.ifPresent(qtyCUsPerTU_InInvoiceUOM -> softly
+						.assertThat(desadvPackItemRecord.getQtyCUsPerTU_InInvoiceUOM())
+						.as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - QtyCUsPerTU_InInvoiceUOM", packIdentifier, packItemId)
+						.isEqualByComparingTo(qtyCUsPerTU_InInvoiceUOM));
 
-		if (qtyCUsPerTU_InInvoiceUOM != null)
-		{
-			softly.assertThat(desadvPackItemRecord.getQtyCUsPerTU_InInvoiceUOM()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - QtyCUsPerTU_InInvoiceUOM", packIdentifier, packItemId).isEqualByComparingTo(qtyCUsPerTU_InInvoiceUOM);
-		}
+		dataTableRow.getAsOptionalBigDecimal(I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerLU)
+				.ifPresent(qtyCUsPerLU -> softly
+						.assertThat(desadvPackItemRecord.getQtyCUsPerLU())
+						.as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - QtyCUsPerLU", packIdentifier, packItemId)
+						.isEqualByComparingTo(qtyCUsPerLU));
 
-		if (qtyCUsPerLU != null)
-		{
-			softly.assertThat(desadvPackItemRecord.getQtyCUsPerLU()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - QtyCUsPerLU", packIdentifier, packItemId).isEqualByComparingTo(qtyCUsPerLU);
-		}
+		dataTableRow.getAsOptionalBigDecimal(I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerLU_InInvoiceUOM)
+				.ifPresent(qtyCUsPerLU_InInvoiceUOM -> softly
+						.assertThat(desadvPackItemRecord.getQtyCUsPerLU_InInvoiceUOM())
+						.as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - QtyCUsPerLU_InInvoiceUOM", packIdentifier, packItemId)
+						.isEqualByComparingTo(qtyCUsPerLU_InInvoiceUOM));
 
-		if (qtyCUsPerLU_InInvoiceUOM != null)
-		{
-			softly.assertThat(desadvPackItemRecord.getQtyCUsPerLU_InInvoiceUOM()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - QtyCUsPerLU_InInvoiceUOM", packIdentifier, packItemId).isEqualByComparingTo(qtyCUsPerLU_InInvoiceUOM);
-		}
+		dataTableRow.getAsOptionalBigDecimal(I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyItemCapacity)
+				.ifPresent(qtyItemCapacity -> softly
+						.assertThat(desadvPackItemRecord.getQtyItemCapacity())
+						.as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - QtyItemCapacity", packIdentifier, packItemId)
+						.isEqualByComparingTo(qtyItemCapacity));
 
-		if (qtyItemCapacity != null)
-		{
-			softly.assertThat(desadvPackItemRecord.getQtyItemCapacity()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - QtyItemCapacity", packIdentifier, packItemId).isEqualByComparingTo(qtyItemCapacity);
-		}
+		dataTableRow.getAsOptionalInt(I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyTU)
+				.ifPresent(qtyTu -> softly
+						.assertThat(desadvPackItemRecord.getQtyTU())
+						.as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - QtyTU", packIdentifier, packItemId)
+						.isEqualByComparingTo(qtyTu));
 
-		if (qtyTu != null)
-		{
-			softly.assertThat(desadvPackItemRecord.getQtyTU()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - QtyTU", packIdentifier, packItemId).isEqualByComparingTo(qtyTu);
-		}
+		dataTableRow.getAsOptionalIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_M_InOut_ID)
+				.ifPresent(shipmentIdentifier -> softly
+						.assertThat(desadvPackItemRecord.getM_InOut_ID())
+						.as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s; M_InOut_ID.Identifier=%s - M_InOut_ID", packIdentifier, packItemId, shipmentIdentifier)
+						.isEqualTo(shipmentTable.getId(shipmentIdentifier).getRepoId()));
 
-		final String shipmentIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_EDI_Desadv_Pack_Item.COLUMNNAME_M_InOut_ID + "." + StepDefConstants.TABLECOLUMN_IDENTIFIER);
-		if (Check.isNotBlank(shipmentIdentifier))
-		{
-			final I_M_InOut shipmentRecord = shipmentTable.get(shipmentIdentifier);
+		dataTableRow.getAsOptionalString(I_EDI_Desadv_Pack_Item.COLUMNNAME_LotNumber)
+				.ifPresent(lotNumber -> softly
+						.assertThat(desadvPackItemRecord.getLotNumber())
+						.as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - LotNumber", packIdentifier, packItemId)
+						.isEqualTo(DataTableUtil.nullToken2Null(lotNumber)));
 
-			softly.assertThat(desadvPackItemRecord.getM_InOut_ID()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s; M_InOut_ID.Identifier=%s - M_InOut_ID", packIdentifier, packItemId, shipmentIdentifier).isEqualTo(shipmentRecord.getM_InOut_ID());
-		}
+		dataTableRow.getAsOptionalString(I_EDI_Desadv_Pack_Item.COLUMNNAME_BestBeforeDate)
+				.ifPresent(nullableBestBeforeDateString -> {
+					if (DataTableUtil.nullToken2Null(nullableBestBeforeDateString) == null)
+					{
+						softly.assertThat(desadvPackItemRecord.getBestBeforeDate()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - BestBeforeDate", packIdentifier, packItemId).isNull();
+					}
+					else
+					{
+						final Timestamp bestBeforeDateExpected = Timestamp.valueOf(LocalDate.parse(nullableBestBeforeDateString).atStartOfDay());
+						softly.assertThat(desadvPackItemRecord.getBestBeforeDate()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - BestBeforeDate", packIdentifier, packItemId).isEqualTo(bestBeforeDateExpected);
+					}
+				});
 
-		final String shipmentLineIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_EDI_Desadv_Pack_Item.COLUMNNAME_M_InOutLine_ID + "." + StepDefConstants.TABLECOLUMN_IDENTIFIER);
-		if (Check.isNotBlank(shipmentLineIdentifier))
-		{
-			final I_M_InOutLine shipmentLine = shipmentLineTable.get(shipmentLineIdentifier);
+		dataTableRow.getAsOptionalIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_M_HU_PackagingCode_TU_ID)
+				.ifPresent(huPackagingCodeTuIdentifier -> {
 
-			softly.assertThat(desadvPackItemRecord.getM_InOutLine_ID()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - M_InOutLine_ID", packIdentifier, packItemId).isEqualTo(shipmentLine.getM_InOutLine_ID());
-		}
+					final int huPackingCodeTuId = huPackagingCodeTuIdentifier.isNullPlaceholder()
+							? 0
+							: huPackagingCodeTable.get(huPackagingCodeTuIdentifier).getM_HU_PackagingCode_ID();
 
-		final String lotNumber = DataTableUtil.extractNullableStringForColumnName(tableRow, "OPT." + I_EDI_Desadv_Pack_Item.COLUMNNAME_LotNumber);
-		if (Check.isNotBlank(lotNumber))
-		{
-			softly.assertThat(desadvPackItemRecord.getLotNumber()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - LotNumber", packIdentifier, packItemId).isEqualTo(DataTableUtil.nullToken2Null(lotNumber));
-		}
+					softly
+							.assertThat(desadvPackItemRecord.getM_HU_PackagingCode_TU_ID())
+							.as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - M_HU_PackagingCode_TU_ID", packIdentifier, packItemId)
+							.isEqualTo(huPackingCodeTuId);
+				});
 
-		final String nullableBestBeforeDateString = DataTableUtil.extractNullableStringForColumnName(tableRow, "OPT." + I_EDI_Desadv_Pack_Item.COLUMNNAME_BestBeforeDate);
-		if (Check.isNotBlank(nullableBestBeforeDateString))
-		{
-			if (DataTableUtil.nullToken2Null(nullableBestBeforeDateString) == null)
-			{
-				softly.assertThat(desadvPackItemRecord.getBestBeforeDate()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - BestBeforeDate", packIdentifier, packItemId).isNull();
-			}
-			else
-			{
-				final Timestamp bestBeforeDateExpected = Timestamp.valueOf(LocalDate.parse(nullableBestBeforeDateString).atStartOfDay());
-				softly.assertThat(desadvPackItemRecord.getBestBeforeDate()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - BestBeforeDate", packIdentifier, packItemId).isEqualTo(bestBeforeDateExpected);
-			}
-		}
-
-		final String huPackagingCodeTuIdentifier = DataTableUtil.extractNullableStringForColumnName(tableRow, "OPT." + I_EDI_Desadv_Pack_Item.COLUMNNAME_M_HU_PackagingCode_TU_ID + "." + StepDefConstants.TABLECOLUMN_IDENTIFIER);
-		if (Check.isNotBlank(huPackagingCodeTuIdentifier))
-		{
-			final int huPackingCodeTuId = DataTableUtil.nullToken2Null(huPackagingCodeTuIdentifier) == null
-					? 0
-					: huPackagingCodeTable.get(huPackagingCodeTuIdentifier).getM_HU_PackagingCode_ID();
-
-			softly.assertThat(desadvPackItemRecord.getM_HU_PackagingCode_TU_ID()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - M_HU_PackagingCode_TU_ID", packIdentifier, packItemId).isEqualTo(huPackingCodeTuId);
-		}
-
-		final String gtinTuPackingMaterial = DataTableUtil.extractNullableStringForColumnName(tableRow, "OPT." + I_EDI_Desadv_Pack_Item.COLUMNNAME_GTIN_TU_PackingMaterial);
-		if (Check.isNotBlank(gtinTuPackingMaterial))
-		{
-			softly.assertThat(desadvPackItemRecord.getGTIN_TU_PackingMaterial()).as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - GTIN_TU_PackingMaterial", packIdentifier, packItemId).isEqualTo(DataTableUtil.nullToken2Null(gtinTuPackingMaterial));
-		}
+		dataTableRow.getAsOptionalString(I_EDI_Desadv_Pack_Item.COLUMNNAME_GTIN_TU_PackingMaterial)
+				.ifPresent(gtinTuPackingMaterial -> softly
+						.assertThat(desadvPackItemRecord.getGTIN_TU_PackingMaterial())
+						.as("EDI_Desadv_Pack_ID.Identifier=%s; EDI_Desadv_Pack_Item_ID=%s - GTIN_TU_PackingMaterial", packIdentifier, packItemId)
+						.isEqualTo(DataTableUtil.nullToken2Null(gtinTuPackingMaterial)));
 
 		softly.assertAll();
 
-		final String packItemIdentifier = DataTableUtil.extractStringForColumnName(tableRow, I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_Item_ID + "." + StepDefConstants.TABLECOLUMN_IDENTIFIER);
+		final StepDefDataIdentifier packItemIdentifier = dataTableRow.getAsIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_Item_ID);
 		packItemTable.put(packItemIdentifier, desadvPackItemRecord);
 	}
 
 	private void logCurrentContext(
-			@NonNull final Integer packID,
-			@Nullable final BigDecimal movementQty)
+			@NonNull final EDIDesadvPackId packID,
+			@Nullable final BigDecimal movementQty,
+			@Nullable final InOutLineId inOutLineId)
 	{
 		final StringBuilder message = new StringBuilder();
 
 		message.append("Looking for instance with:").append("\n")
-				.append(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_ID).append(" : ").append(packID).append("\n");
+				.append(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_ID).append(" : ").append(packID.getRepoId()).append("\n");
 
 		if (movementQty != null)
 		{
 			message.append(I_EDI_Desadv_Pack_Item.COLUMNNAME_MovementQty).append(" : ").append(movementQty).append("\n");
+		}
+
+		if (inOutLineId != null)
+		{
+			message.append(I_EDI_Desadv_Pack_Item.COLUMNNAME_M_InOutLine_ID).append(" : ").append(inOutLineId.getRepoId()).append("\n");
 		}
 
 		logItemRecords(message);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Pack_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Pack_StepDef.java
@@ -25,7 +25,7 @@ package de.metas.cucumber.stepdefs.edi;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
-import de.metas.cucumber.stepdefs.M_HU_PackagingCode_StepDefData;
+import de.metas.cucumber.stepdefs.hu.M_HU_PackagingCode_StepDefData;
 import de.metas.cucumber.stepdefs.StepDefConstants;
 import de.metas.cucumber.stepdefs.StepDefDataGetIdAware;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Item_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Item_StepDefData.java
@@ -20,14 +20,19 @@
  * #L%
  */
 
-package de.metas.cucumber.stepdefs;
+package de.metas.cucumber.stepdefs.hu;
 
-import de.metas.handlingunits.model.I_M_HU_PackagingCode;
+import de.metas.cucumber.stepdefs.StepDefData;
+import de.metas.handlingunits.model.I_M_HU_Item;
+import de.metas.handlingunits.model.I_M_HU_PI_Item;
 
-public class M_HU_PackagingCode_StepDefData extends StepDefData<I_M_HU_PackagingCode>
+/**
+ * Having a dedicated class to help the IOC-framework injecting the right instances, if a step-def needs more than one.
+ */
+public class M_HU_Item_StepDefData extends StepDefData<I_M_HU_Item>
 {
-	public M_HU_PackagingCode_StepDefData()
+	public M_HU_Item_StepDefData()
 	{
-		super(I_M_HU_PackagingCode.class);
+		super(I_M_HU_Item.class);
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Item_Product_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Item_Product_StepDef.java
@@ -28,7 +28,6 @@ import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
-import de.metas.cucumber.stepdefs.M_HU_PackagingCode_StepDefData;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.context.TestContext;
 import de.metas.handlingunits.HUPIItemProductId;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Version_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Version_StepDef.java
@@ -25,7 +25,6 @@ package de.metas.cucumber.stepdefs.hu;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
-import de.metas.cucumber.stepdefs.M_HU_PackagingCode_StepDefData;
 import de.metas.handlingunits.model.I_M_HU_PI;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
 import de.metas.util.Services;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PackagingCode_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PackagingCode_StepDef.java
@@ -2,7 +2,7 @@
  * #%L
  * de.metas.cucumber
  * %%
- * Copyright (C) 2022 metas GmbH
+ * Copyright (C) 2025 metas GmbH
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -20,8 +20,9 @@
  * #L%
  */
 
-package de.metas.cucumber.stepdefs;
+package de.metas.cucumber.stepdefs.hu;
 
+import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.handlingunits.model.I_M_HU_PackagingCode;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PackagingCode_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PackagingCode_StepDefData.java
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.hu;
+
+import de.metas.cucumber.stepdefs.StepDefData;
+import de.metas.handlingunits.model.I_M_HU_PackagingCode;
+
+public class M_HU_PackagingCode_StepDefData extends StepDefData<I_M_HU_PackagingCode>
+{
+	public M_HU_PackagingCode_StepDefData()
+	{
+		super(I_M_HU_PackagingCode.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_Line_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_Line_StepDef.java
@@ -66,6 +66,7 @@ import java.util.Map;
 
 import static de.metas.cucumber.stepdefs.StepDefConstants.TABLECOLUMN_IDENTIFIER;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.compiere.model.I_M_InOutLine.COLUMNNAME_C_OrderLine_ID;
 import static org.compiere.model.I_M_InOutLine.COLUMNNAME_M_InOutLine_ID;
 import static org.compiere.model.I_M_InOutLine.COLUMNNAME_M_InOut_ID;
 import static org.compiere.model.I_M_InOutLine.COLUMNNAME_M_Locator_ID;
@@ -120,7 +121,7 @@ public class M_InOut_Line_StepDef
 		row.getAsIdentifier(I_M_InOutLine.COLUMNNAME_M_InOutLine_ID).putOrReplace(shipmentLineTable, shipmentLineRecord);
 	}
 
-	private static I_M_InOutLine getSingleShipmentLine(final IQuery<I_M_InOutLine> query)
+	private static I_M_InOutLine getSingleShipmentLine(@NonNull final IQuery<I_M_InOutLine> query)
 	{
 		final List<I_M_InOutLine> lines = query.list();
 		if (lines.isEmpty())
@@ -311,6 +312,12 @@ public class M_InOut_Line_StepDef
 				.map(X12DE355::ofCode)
 				.map(uomDAO::getUomIdByX12DE355)
 				.ifPresent(uomId -> softly.assertThat(UomId.ofRepoIdOrNull(actual.getC_UOM_ID())).as("C_UOM_ID").isEqualTo(uomId));
+
+		expected.getAsOptionalIdentifier(COLUMNNAME_C_OrderLine_ID)
+				.ifPresent(orderLineIdentifier -> {
+					final I_C_OrderLine orderLine = orderLineTable.get(orderLineIdentifier);
+					softly.assertThat(actual.getC_OrderLine_ID()).as("C_OrderLine_ID").isEqualTo(orderLine.getC_OrderLine_ID());
+				});
 
 		expected.getAsOptionalIdentifier(I_M_InOutLine.COLUMNNAME_M_AttributeSetInstance_ID)
 				.ifPresent(asiIdentifier -> {

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvPack_with_TU_UOM.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvPack_with_TU_UOM.feature
@@ -13,6 +13,9 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a TU-UOM
     And metasfresh initially has no EDI_Desadv_Pack_Item data
     And metasfresh initially has no EDI_Desadv_Pack data
     And destroy existing M_HUs
+    And load M_Warehouse:
+      | M_Warehouse_ID | Value        |
+      | warehouseStd   | StdWarehouse |
 
   @Id:S0317_010
   Scenario: S0317_010 - 1 Pack from 1 line with no HU & 1 packing item
@@ -109,8 +112,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a TU-UOM
       | p_1_S0317_010                 | true                | null                   | huPackagingCode_1_S0317_010          | gtinPiItemProduct        | 1         |
 
     And after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
-      | EDI_Desadv_Pack_Item_ID.Identifier | EDI_Desadv_Pack_ID.Identifier | OPT.MovementQty | OPT.QtyCUsPerTU | OPT.QtyCUsPerTU_InInvoiceUOM | OPT.QtyCUsPerLU | OPT.QtyCUsPerLU_InInvoiceUOM | OPT.QtyItemCapacity | OPT.QtyTU | OPT.M_InOut_ID.Identifier | OPT.M_InOutLine_ID.Identifier | OPT.M_HU_PackagingCode_TU_ID.Identifier | OPT.GTIN_TU_PackingMaterial |
-      | pi_1_S0317_010                     | p_1_S0317_010                 | 40              | 10              | 2.5                          | 40              | 10                           | 10                  | 4         | s_1_S0317_010             | shipmentLine_1_S0317_010      | huPackagingCode_2_S0317_010             | bPartnerProductGTIN         |
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerTU_InInvoiceUOM | QtyCUsPerLU | QtyCUsPerLU_InInvoiceUOM | QtyItemCapacity | QtyTU | M_InOut_ID    | M_InOutLine_ID           | M_HU_PackagingCode_TU_ID    | GTIN_TU_PackingMaterial |
+      | pi_1_S0317_010          | p_1_S0317_010      | 40          | 10          | 2.5                      | 40          | 10                       | 10              | 4     | s_1_S0317_010 | shipmentLine_1_S0317_010 | huPackagingCode_2_S0317_010 | bPartnerProductGTIN     |
 
     And the shipment identified by s_1_S0317_010 is reversed
 
@@ -212,12 +215,12 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a TU-UOM
   }
   """
 
-    And metasfresh initially has M_Inventory data
-      | M_Inventory_ID.Identifier     | MovementDate | DocumentNo     |
-      | huProduct_inventory_S0317_020 | 2021-04-16   | inventoryDocNo |
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID.Identifier     | M_InventoryLine_ID.Identifier     | M_Product_ID.Identifier | QtyBook | QtyCount |
-      | huProduct_inventory_S0317_020 | huProduct_inventoryLine_S0317_020 | p_1_S0317_020           | 0       | 5        |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier     | MovementDate | DocumentNo     | M_Warehouse_ID |
+      | huProduct_inventory_S0317_020 | 2021-04-16   | inventoryDocNo | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier     | M_InventoryLine_ID.Identifier     | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | huProduct_inventory_S0317_020 | huProduct_inventoryLine_S0317_020 | p_1_S0317_020           | 0       | 5        | PCE          |
     And complete inventory with inventoryIdentifier 'huProduct_inventory_S0317_020'
     And after not more than 30s, there are added M_HUs for inventory
       | M_InventoryLine_ID.Identifier     | M_HU_ID.Identifier  |
@@ -248,8 +251,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a TU-UOM
 
     And metasfresh contains M_HU_Item:
       | M_HU_Item_ID.Identifier | M_HU_ID.Identifier  | M_HU_PI_Item_ID.Identifier | Qty | M_HU_PackingMaterial_ID.Identifier | OPT.ItemType |
-      | huPiItemLU_S0317_020    | createdLU_S0317_020 | huPiItemLU_S0317_020       | 10  | pm_1_S0317_020                     | PM           |
-      | huPiItemTU_S0317_020    | createdTU_S0317_020 | huPiItemTU_S0317_020       | 10  | pm_2_S0317_020                     | PM           |
+      | huItemLU_S0317_020      | createdLU_S0317_020 | huPiItemLU_S0317_020       | 10  | pm_1_S0317_020                     | PM           |
+      | huItemTU_S0317_020      | createdTU_S0317_020 | huPiItemTU_S0317_020       | 10  | pm_2_S0317_020                     | PM           |
 
     And metasfresh contains C_Orders:
       | Identifier    | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference | OPT.C_PaymentTerm_ID | deliveryRule |
@@ -288,9 +291,9 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a TU-UOM
       | p_2_S0317_020      | true                | createdLU_S0317_020 | huPackagingCode_1_S0317_020 | bPartnerProductGTIN_LU |
 
     And after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
-      | EDI_Desadv_Pack_Item_ID.Identifier | EDI_Desadv_Pack_ID.Identifier | OPT.MovementQty | OPT.QtyCUsPerTU | OPT.QtyCUsPerTU_InInvoiceUOM | OPT.QtyCUsPerLU | OPT.QtyCUsPerLU_InInvoiceUOM | OPT.QtyItemCapacity | OPT.QtyTU | OPT.BestBeforeDate | OPT.LotNumber | OPT.M_HU_PackagingCode_TU_ID.Identifier | OPT.GTIN_TU_PackingMaterial |
-      | pi_1_S0317_020                     | p_1_S0317_020                 | 95              | 10              | 10                           | 95              | 95                           | 10                  | 10        | 2021-04-20         | lotNumber     | huPackagingCode_2_S0317_020             | bPartnerProductGTIN         |
-      | pi_2_S0317_020                     | p_2_S0317_020                 | 5               | 5               | 5                            | 5               | 5                            | 5                   | 1         | 2021-04-20         | luLotNumber   | huPackagingCode_2_S0317_020             | bPartnerProductGTIN_TU      |
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerTU_InInvoiceUOM | QtyCUsPerLU | QtyCUsPerLU_InInvoiceUOM | QtyItemCapacity | QtyTU | BestBeforeDate | LotNumber   | M_HU_PackagingCode_TU_ID    | GTIN_TU_PackingMaterial |
+      | pi_1_S0317_020          | p_1_S0317_020      | 95          | 10          | 10                       | 95          | 95                       | 10              | 10    | 2021-04-20     | lotNumber   | huPackagingCode_2_S0317_020 | bPartnerProductGTIN     |
+      | pi_2_S0317_020          | p_2_S0317_020      | 5           | 5           | 5                        | 5           | 5                        | 5               | 1     | 2021-04-20     | luLotNumber | huPackagingCode_2_S0317_020 | bPartnerProductGTIN_TU  |
 
     And EDI_Desadv_Pack records are updated
       | EDI_Desadv_Pack_ID.Identifier | OPT.IPA_SSCC18       |
@@ -418,10 +421,10 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a TU-UOM
       | p_3_S0317_030                 | true                | null                   | huPackagingCode_1_S0317_030          | 1234567890123            | 3         |
 
     And after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
-      | EDI_Desadv_Pack_Item_ID.Identifier | EDI_Desadv_Pack_ID.Identifier | OPT.MovementQty | OPT.QtyCUsPerTU | OPT.QtyCUsPerLU | OPT.QtyItemCapacity | OPT.QtyTU | OPT.M_InOut_ID.Identifier | OPT.M_InOutLine_ID.Identifier | OPT.M_HU_PackagingCode_TU_ID.Identifier | OPT.GTIN_TU_PackingMaterial |
-      | pi_1_S0317_030                     | p_1_S0317_030                 | 1               | 1               | 1               | 1                   | 1         | s_1_S0317_030             | shipmentLine_1_S0317_030      | huPackagingCode_2_S0317_030             | 2234567890123               |
-      | pi_2_S0317_030                     | p_2_S0317_030                 | 1               | 1               | 1               | 1                   | 1         | s_1_S0317_030             | shipmentLine_1_S0317_030      | huPackagingCode_2_S0317_030             | 2234567890123               |
-      | pi_3_S0317_030                     | p_3_S0317_030                 | 1               | 1               | 1               | 1                   | 1         | s_1_S0317_030             | shipmentLine_2_S0317_030      | huPackagingCode_2_S0317_030             | 2234567890123               |
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerLU | QtyItemCapacity | QtyTU | M_InOut_ID.Identifier | M_InOutLine_ID           | M_HU_PackagingCode_TU_ID    | GTIN_TU_PackingMaterial |
+      | pi_1_S0317_030          | p_1_S0317_030      | 1           | 1           | 1           | 1               | 1     | s_1_S0317_030         | shipmentLine_1_S0317_030 | huPackagingCode_2_S0317_030 | 2234567890123           |
+      | pi_2_S0317_030          | p_2_S0317_030      | 1           | 1           | 1           | 1               | 1     | s_1_S0317_030         | shipmentLine_1_S0317_030 | huPackagingCode_2_S0317_030 | 2234567890123           |
+      | pi_3_S0317_030          | p_3_S0317_030      | 1           | 1           | 1           | 1               | 1     | s_1_S0317_030         | shipmentLine_2_S0317_030 | huPackagingCode_2_S0317_030 | 2234567890123           |
 
     And the shipment identified by s_1_S0317_030 is reversed
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvPack_with_normal_UOM.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvPack_with_normal_UOM.feature
@@ -11,7 +11,9 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
     And metasfresh initially has no EDI_Desadv_Pack_Item data
     And metasfresh initially has no EDI_Desadv_Pack data
     And destroy existing M_HUs
-
+    And load M_Warehouse:
+      | M_Warehouse_ID | Value        |
+      | warehouseStd   | StdWarehouse |
     
     
     
@@ -89,8 +91,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | p_1_S0316_010                 | true                | null                   | null                                 | null                     | 1         |
 
     And after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
-      | EDI_Desadv_Pack_Item_ID.Identifier | EDI_Desadv_Pack_ID.Identifier | OPT.MovementQty | OPT.QtyCUsPerTU | OPT.QtyCUsPerTU_InInvoiceUOM | OPT.QtyCUsPerLU | OPT.QtyCUsPerLU_InInvoiceUOM | OPT.QtyItemCapacity | OPT.QtyTU | OPT.M_InOut_ID.Identifier | OPT.M_InOutLine_ID.Identifier | OPT.BestBeforeDate | OPT.LotNumber | OPT.M_HU_PackagingCode_TU_ID.Identifier | OPT.GTIN_TU_PackingMaterial |
-      | pi_1_S0316_010                     | p_1_S0316_010                 | 10              | 10              | 10                           | 10              | 10                           | 0                   | 1         | s_1_S0316_010             | shipmentLine_1_S0316_010      | null               | null          | null                                    | null                        |
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerTU_InInvoiceUOM | QtyCUsPerLU | QtyCUsPerLU_InInvoiceUOM | QtyItemCapacity | OPT.QtyTU | OPT.M_InOut_ID.Identifier | M_InOutLine_ID           | BestBeforeDate | LotNumber | M_HU_PackagingCode_TU_ID | GTIN_TU_PackingMaterial |
+      | pi_1_S0316_010          | p_1_S0316_010      | 10          | 10          | 10                       | 10          | 10                       | 0               | 1         | s_1_S0316_010             | shipmentLine_1_S0316_010 | null           | null      | null                     | null                    |
 
     And the shipment identified by s_1_S0316_010 is reversed
 
@@ -179,8 +181,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | p_1_11212023_4     | true                | null    | null                  | null                 | 1     |
 
     And after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
-      | EDI_Desadv_Pack_Item_ID.Identifier | EDI_Desadv_Pack_ID.Identifier | OPT.MovementQty | OPT.QtyCUsPerTU | OPT.QtyCUsPerTU_InInvoiceUOM | OPT.QtyCUsPerLU | OPT.QtyCUsPerLU_InInvoiceUOM | OPT.QtyTU | OPT.M_InOut_ID.Identifier | OPT.M_InOutLine_ID.Identifier | OPT.BestBeforeDate | OPT.LotNumber | OPT.M_HU_PackagingCode_TU_ID.Identifier | OPT.GTIN_TU_PackingMaterial |
-      | pi_1_11212023_4                    | p_1_11212023_4                | 10              | 10              | 2.5                          | 10              | 2.5                          | 1         | s_1_11212023_4            | shipmentLine_1_11212023_4     | null               | null          | null                                    | null                        |
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerTU_InInvoiceUOM | QtyCUsPerLU | QtyCUsPerLU_InInvoiceUOM | QtyTU | M_InOut_ID     | M_InOutLine_ID            | BestBeforeDate | LotNumber | M_HU_PackagingCode_TU_ID | GTIN_TU_PackingMaterial |
+      | pi_1_11212023_4         | p_1_11212023_4     | 10          | 10          | 2.5                      | 10          | 2.5                      | 1     | s_1_11212023_4 | shipmentLine_1_11212023_4 | null           | null      | null                     | null                    |
 
     And the shipment identified by s_1_11212023_4 is reversed
 
@@ -275,8 +277,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | p_1_11212023_1     | true                | null    | null                  | null                 | 1     |
 
     And after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
-      | EDI_Desadv_Pack_Item_ID.Identifier | EDI_Desadv_Pack_ID.Identifier | OPT.MovementQty | OPT.QtyCUsPerTU | OPT.QtyCUsPerTU_InInvoiceUOM | OPT.QtyCUsPerLU | OPT.QtyCUsPerLU_InInvoiceUOM | OPT.QtyTU | OPT.M_InOut_ID.Identifier | OPT.M_InOutLine_ID.Identifier | OPT.BestBeforeDate | OPT.LotNumber | OPT.M_HU_PackagingCode_TU_ID.Identifier | OPT.GTIN_TU_PackingMaterial |
-      | pi_1_11212023_1                    | p_1_11212023_1                | 10              | 10              | 3                            | 10              | 3                            | 1         | s_1_11212023_1            | shipmentLine_1_11212023_1     | null               | null          | null                                    | null                        |
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerTU_InInvoiceUOM | QtyCUsPerLU | QtyCUsPerLU_InInvoiceUOM | QtyTU | M_InOut_ID     | M_InOutLine_ID            | BestBeforeDate | LotNumber | M_HU_PackagingCode_TU_ID | GTIN_TU_PackingMaterial |
+      | pi_1_11212023_1         | p_1_11212023_1     | 10          | 10          | 3                        | 10          | 3                        | 1     | s_1_11212023_1 | shipmentLine_1_11212023_1 | null           | null      | null                     | null                    |
 
     And the shipment identified by s_1_11212023_1 is reversed
 
@@ -402,8 +404,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | p_1_S0316_020                 | true                | null        | huPackagingCode_1_S0316_020 | gtinPiItemProduct    | 1     |
 
     And after not more than 60s, the EDI_Desadv_Pack_Item has only the following records:
-      | EDI_Desadv_Pack_Item_ID.Identifier | EDI_Desadv_Pack_ID.Identifier | OPT.MovementQty | OPT.QtyCUsPerTU | OPT.QtyCUsPerTU_InInvoiceUOM | OPT.QtyCUsPerLU | OPT.QtyCUsPerLU_InInvoiceUOM | OPT.QtyItemCapacity | OPT.QtyTU | OPT.M_InOut_ID.Identifier | OPT.M_InOutLine_ID.Identifier | OPT.BestBeforeDate | OPT.LotNumber | OPT.M_HU_PackagingCode_TU_ID.Identifier | OPT.GTIN_TU_PackingMaterial |
-      | pi_1_S0316_020                     | p_1_S0316_020                 | 100             | 10              | 10                           | 100             | 100                          | 10                  | 10        | s_1_S0316_020             | shipmentLine_1_S0316_020      | 2021-04-20         | lotNumber     | huPackagingCode_2_S0316_020             | bPartnerProductGTIN         |
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerTU_InInvoiceUOM | QtyCUsPerLU | QtyCUsPerLU_InInvoiceUOM | QtyItemCapacity | QtyTU | M_InOut_ID    | M_InOutLine_ID           | BestBeforeDate | LotNumber | M_HU_PackagingCode_TU_ID    | GTIN_TU_PackingMaterial |
+      | pi_1_S0316_020          | p_1_S0316_020      | 100         | 10          | 10                       | 100         | 100                      | 10              | 10    | s_1_S0316_020 | shipmentLine_1_S0316_020 | 2021-04-20     | lotNumber | huPackagingCode_2_S0316_020 | bPartnerProductGTIN     |
 
     And the shipment identified by s_1_S0316_020 is reversed
 
@@ -484,12 +486,12 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
       | huProductTU_S0316_030              | huPiItemTU_S0316_030       | p_1_S0316_030           | 10  | 2021-01-01 |
 
-    And metasfresh initially has M_Inventory data
-      | M_Inventory_ID.Identifier     | MovementDate | DocumentNo     |
-      | huProduct_inventory_S0316_030 | 2021-04-16   | inventoryDocNo |
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID.Identifier     | M_InventoryLine_ID.Identifier     | M_Product_ID.Identifier | QtyBook | QtyCount |
-      | huProduct_inventory_S0316_030 | huProduct_inventoryLine_S0316_030 | p_1_S0316_030           | 0       | 10       |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier     | MovementDate | DocumentNo     | M_Warehouse_ID |
+      | huProduct_inventory_S0316_030 | 2021-04-16   | inventoryDocNo | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier     | M_InventoryLine_ID.Identifier     | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | huProduct_inventory_S0316_030 | huProduct_inventoryLine_S0316_030 | p_1_S0316_030           | 0       | 10       | PCE          |
     And complete inventory with inventoryIdentifier 'huProduct_inventory_S0316_030'
     And after not more than 30s, there are added M_HUs for inventory
       | M_InventoryLine_ID.Identifier     | M_HU_ID.Identifier  |
@@ -523,8 +525,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
 
     And metasfresh contains M_HU_Item:
       | M_HU_Item_ID.Identifier | M_HU_ID.Identifier  | M_HU_PI_Item_ID.Identifier | Qty | M_HU_PackingMaterial_ID.Identifier | OPT.ItemType |
-      | huPiItemLU_S0316_030    | createdLU_S0316_030 | huPiItemLU_S0316_030       | 10  | pm_1_S0316_030                     | PM           |
-      | huPiItemTU_S0316_030    | createdTU_S0316_030 | huPiItemTU_S0316_030       | 10  | pm_2_S0316_030                     | PM           |
+      | huItemLU_S0316_030      | createdLU_S0316_030 | huPiItemLU_S0316_030       | 10  | pm_1_S0316_030                     | PM           |
+      | huItemTU_S0316_030      | createdTU_S0316_030 | huPiItemTU_S0316_030       | 10  | pm_2_S0316_030                     | PM           |
 
     And metasfresh contains C_Orders:
       | Identifier    | IsSOTrx | C_BPartner_ID | DateOrdered | POReference   | C_PaymentTerm_ID | deliveryRule |
@@ -567,8 +569,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | p_1_S0316_030      | true                | createdLU_S0316_030 | huPackagingCode_1_S0316_030 | bPartnerProductGTIN_LU | 1     |
 
     And after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
-      | EDI_Desadv_Pack_Item_ID.Identifier | EDI_Desadv_Pack_ID.Identifier | OPT.MovementQty | OPT.QtyCUsPerTU | OPT.QtyCUsPerLU | OPT.QtyItemCapacity | OPT.QtyTU | OPT.M_InOut_ID.Identifier | OPT.M_InOutLine_ID.Identifier | OPT.BestBeforeDate | OPT.LotNumber | OPT.M_HU_PackagingCode_TU_ID.Identifier | OPT.GTIN_TU_PackingMaterial |
-      | pi_1_S0316_030                     | p_1_S0316_030                 | 10              | 10              | 10              | 10                  | 1         | s_1_S0316_030             | shipmentLine_1_S0316_030      | 2021-04-20         | luLotNumber   | huPackagingCode_2_S0316_030             | bPartnerProductGTIN_TU      |
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerLU | QtyItemCapacity | QtyTU | M_InOut_ID    | M_InOutLine_ID           | BestBeforeDate | LotNumber   | M_HU_PackagingCode_TU_ID    | GTIN_TU_PackingMaterial |
+      | pi_1_S0316_030          | p_1_S0316_030      | 10          | 10          | 10          | 10              | 1     | s_1_S0316_030 | shipmentLine_1_S0316_030 | 2021-04-20     | luLotNumber | huPackagingCode_2_S0316_030 | bPartnerProductGTIN_TU  |
 
     And EDI_Desadv_Pack records are updated
       | EDI_Desadv_Pack_ID.Identifier | OPT.IPA_SSCC18     |
@@ -658,12 +660,12 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
       | huProductTU_11212023_2             | huPiItemTU_11212023_2      | p_1_11212023_2          | 10  | 2021-01-01 |
 
-    And metasfresh initially has M_Inventory data
-      | M_Inventory_ID.Identifier      | MovementDate | DocumentNo     |
-      | huProduct_inventory_11212023_2 | 2021-04-16   | inventoryDocNo |
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID.Identifier      | M_InventoryLine_ID.Identifier      | M_Product_ID.Identifier | QtyBook | QtyCount |
-      | huProduct_inventory_11212023_2 | huProduct_inventoryLine_11212023_2 | p_1_11212023_2          | 0       | 10       |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier      | MovementDate | DocumentNo     | M_Warehouse_ID |
+      | huProduct_inventory_11212023_2 | 2021-04-16   | inventoryDocNo | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier      | M_InventoryLine_ID.Identifier      | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | huProduct_inventory_11212023_2 | huProduct_inventoryLine_11212023_2 | p_1_11212023_2          | 0       | 10       | PCE          |
     And complete inventory with inventoryIdentifier 'huProduct_inventory_11212023_2'
     And after not more than 30s, there are added M_HUs for inventory
       | M_InventoryLine_ID.Identifier      | M_HU_ID.Identifier   |
@@ -697,8 +699,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
 
     And metasfresh contains M_HU_Item:
       | M_HU_Item_ID.Identifier | M_HU_ID.Identifier   | M_HU_PI_Item_ID.Identifier | Qty | M_HU_PackingMaterial_ID.Identifier | OPT.ItemType |
-      | huPiItemLU_11212023_2   | createdLU_11212023_2 | huPiItemLU_11212023_2      | 10  | pm_1_11212023_2                    | PM           |
-      | huPiItemTU_11212023_2   | createdTU_11212023_2 | huPiItemTU_11212023_2      | 10  | pm_2_11212023_2                    | PM           |
+      | huItemLU_11212023_2     | createdLU_11212023_2 | huPiItemLU_11212023_2      | 10  | pm_1_11212023_2                    | PM           |
+      | huItemTU_11212023_2     | createdTU_11212023_2 | huPiItemTU_11212023_2      | 10  | pm_2_11212023_2                    | PM           |
 
     And metasfresh contains C_Orders:
       | Identifier     | IsSOTrx | C_BPartner_ID | DateOrdered | POReference   | C_PaymentTerm_ID | deliveryRule |
@@ -741,8 +743,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | p_1_11212023_2                | true                | createdLU_11212023_2 | huPackagingCode_1_11212023_2 | bPartnerProductGTIN_LU | 1     |
 
     And after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
-      | EDI_Desadv_Pack_Item_ID.Identifier | EDI_Desadv_Pack_ID.Identifier | OPT.MovementQty | OPT.QtyCUsPerTU | OPT.QtyCUsPerTU_InInvoiceUOM | OPT.QtyCUsPerLU | OPT.QtyCUsPerLU_InInvoiceUOM | OPT.QtyItemCapacity | OPT.QtyTU | OPT.M_InOut_ID.Identifier | OPT.M_InOutLine_ID.Identifier | OPT.LotNumber | OPT.M_HU_PackagingCode_TU_ID.Identifier | OPT.GTIN_TU_PackingMaterial |
-      | pi_1_11212023_2                    | p_1_11212023_2                | 10              | 10              | 2.5                          | 10              | 2.5                          | 10                  | 1         | s_1_11212023_2            | shipmentLine_1_11212023_2     | luLotNumber   | huPackagingCode_2_11212023_2            | bPartnerProductGTIN_TU      |
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerTU_InInvoiceUOM | QtyCUsPerLU | QtyCUsPerLU_InInvoiceUOM | QtyItemCapacity | QtyTU | M_InOut_ID.Identifier | M_InOutLine_ID.Identifier | LotNumber   | M_HU_PackagingCode_TU_ID     | GTIN_TU_PackingMaterial |
+      | pi_1_11212023_2         | p_1_11212023_2     | 10          | 10          | 2.5                      | 10          | 2.5                      | 10              | 1     | s_1_11212023_2        | shipmentLine_1_11212023_2 | luLotNumber | huPackagingCode_2_11212023_2 | bPartnerProductGTIN_TU  |
 
     And the shipment identified by s_1_11212023_2 is reversed
 
@@ -823,12 +825,12 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
       | huProductTU_11212023_3             | huPiItemTU_11212023_3      | p_1_11212023_3          | 10  | 2021-01-01 |
 
-    And metasfresh initially has M_Inventory data
-      | M_Inventory_ID.Identifier      | MovementDate | DocumentNo     |
-      | huProduct_inventory_11212023_3 | 2021-04-16   | inventoryDocNo |
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID.Identifier      | M_InventoryLine_ID.Identifier      | M_Product_ID.Identifier | QtyBook | QtyCount |
-      | huProduct_inventory_11212023_3 | huProduct_inventoryLine_11212023_3 | p_1_11212023_3          | 0       | 10       |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier      | MovementDate | DocumentNo     | M_Warehouse_ID |
+      | huProduct_inventory_11212023_3 | 2021-04-16   | inventoryDocNo | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier      | M_InventoryLine_ID.Identifier      | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | huProduct_inventory_11212023_3 | huProduct_inventoryLine_11212023_3 | p_1_11212023_3          | 0       | 10       | PCE          |
     And complete inventory with inventoryIdentifier 'huProduct_inventory_11212023_3'
     And after not more than 30s, there are added M_HUs for inventory
       | M_InventoryLine_ID.Identifier      | M_HU_ID.Identifier   |
@@ -862,8 +864,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
 
     And metasfresh contains M_HU_Item:
       | M_HU_Item_ID.Identifier | M_HU_ID.Identifier   | M_HU_PI_Item_ID.Identifier | Qty | M_HU_PackingMaterial_ID.Identifier | OPT.ItemType |
-      | huPiItemLU_11212023_3   | createdLU_11212023_3 | huPiItemLU_11212023_3      | 10  | pm_1_11212023_3                    | PM           |
-      | huPiItemTU_11212023_3   | createdTU_11212023_3 | huPiItemTU_11212023_3      | 10  | pm_2_11212023_3                    | PM           |
+      | huItemLU_11212023_3     | createdLU_11212023_3 | huPiItemLU_11212023_3      | 10  | pm_1_11212023_3                    | PM           |
+      | huItemTU_11212023_3     | createdTU_11212023_3 | huPiItemTU_11212023_3      | 10  | pm_2_11212023_3                    | PM           |
 
     And metasfresh contains C_Orders:
       | Identifier     | IsSOTrx | C_BPartner_ID | DateOrdered | POReference   | C_PaymentTerm_ID | deliveryRule |
@@ -907,9 +909,9 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | p_1_11212023_4     | true                | null                 | null                         | null                   |
 
     And after not more than 120s, the EDI_Desadv_Pack_Item has only the following records:
-      | EDI_Desadv_Pack_Item_ID.Identifier | EDI_Desadv_Pack_ID.Identifier | OPT.MovementQty | OPT.QtyCUsPerTU | OPT.QtyCUsPerTU_InInvoiceUOM | OPT.QtyCUsPerLU | OPT.QtyCUsPerLU_InInvoiceUOM | OPT.QtyItemCapacity | OPT.QtyTU | OPT.M_InOut_ID.Identifier | OPT.LotNumber | OPT.M_HU_PackagingCode_TU_ID.Identifier | OPT.GTIN_TU_PackingMaterial |
-      | pi_1_11212023_3                    | p_1_11212023_3                | 10              | 10              | 2.5                          | 10              | 2.5                          | 10                  | 1         | s_1_11212023_3            | luLotNumber   | huPackagingCode_2_11212023_3            | bPartnerProductGTIN_TU      |
-      | pi_1_11212023_4                    | p_1_11212023_4                | 5               | 5               | 1.25                         | 5               | 1.25                         | 0                   | 1         | s_1_11212023_3            |               |                                         |                             |
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerTU_InInvoiceUOM | QtyCUsPerLU | QtyCUsPerLU_InInvoiceUOM | QtyItemCapacity | QtyTU | M_InOut_ID     | LotNumber   | M_HU_PackagingCode_TU_ID     | GTIN_TU_PackingMaterial |
+      | pi_1_11212023_3         | p_1_11212023_3     | 10          | 10          | 2.5                      | 10          | 2.5                      | 10              | 1     | s_1_11212023_3 | luLotNumber | huPackagingCode_2_11212023_3 | bPartnerProductGTIN_TU  |
+      | pi_1_11212023_4         | p_1_11212023_4     | 5           | 5           | 1.25                     | 5           | 1.25                     | 0               | 1     | s_1_11212023_3 |             |                              |                         |
 
     And the shipment identified by s_1_11212023_3 is reversed
 
@@ -1024,12 +1026,12 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
   }
   """
 
-    And metasfresh initially has M_Inventory data
-      | M_Inventory_ID.Identifier     | MovementDate | DocumentNo     |
-      | huProduct_inventory_S0316_040 | 2021-04-16   | inventoryDocNo |
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID.Identifier     | M_InventoryLine_ID.Identifier     | M_Product_ID.Identifier | QtyBook | QtyCount |
-      | huProduct_inventory_S0316_040 | huProduct_inventoryLine_S0316_040 | p_1_S0316_040           | 0       | 5        |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier     | MovementDate | DocumentNo     | M_Warehouse_ID |
+      | huProduct_inventory_S0316_040 | 2021-04-16   | inventoryDocNo | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier     | M_InventoryLine_ID.Identifier     | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | huProduct_inventory_S0316_040 | huProduct_inventoryLine_S0316_040 | p_1_S0316_040           | 0       | 5        | PCE          |
     And complete inventory with inventoryIdentifier 'huProduct_inventory_S0316_040'
     And after not more than 30s, there are added M_HUs for inventory
       | M_InventoryLine_ID.Identifier     | M_HU_ID.Identifier  |
@@ -1060,8 +1062,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
 
     And metasfresh contains M_HU_Item:
       | M_HU_Item_ID.Identifier | M_HU_ID.Identifier  | M_HU_PI_Item_ID.Identifier | Qty | M_HU_PackingMaterial_ID.Identifier | OPT.ItemType |
-      | huPiItemLU_S0316_040    | createdLU_S0316_040 | huPiItemLU_S0316_040       | 10  | pm_1_S0316_040                     | PM           |
-      | huPiItemTU_S0316_040    | createdTU_S0316_040 | huPiItemTU_S0316_040       | 10  | pm_2_S0316_040                     | PM           |
+      | huItemLU_S0316_040      | createdLU_S0316_040 | huPiItemLU_S0316_040       | 10  | pm_1_S0316_040                     | PM           |
+      | huItemTU_S0316_040      | createdTU_S0316_040 | huPiItemTU_S0316_040       | 10  | pm_2_S0316_040                     | PM           |
 
     And metasfresh contains C_Orders:
       | Identifier    | IsSOTrx | C_BPartner_ID | DateOrdered | POReference   | C_PaymentTerm_ID | deliveryRule |
@@ -1097,9 +1099,9 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | p_2_S0316_040                 | true                | createdLU_S0316_040 | huPackagingCode_1_S0316_040 | bPartnerProductGTIN_LU |
 
     And after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
-      | EDI_Desadv_Pack_Item_ID.Identifier | EDI_Desadv_Pack_ID.Identifier | OPT.MovementQty | OPT.QtyCUsPerTU | OPT.QtyCUsPerLU | OPT.QtyItemCapacity | OPT.QtyTU | OPT.BestBeforeDate | OPT.LotNumber | OPT.M_HU_PackagingCode_TU_ID.Identifier | OPT.GTIN_TU_PackingMaterial |
-      | pi_1_S0316_040                     | p_1_S0316_040                 | 5               | 10              | 5               | 10                  | 1         | 2021-04-20         | lotNumber     | huPackagingCode_2_S0316_040             | bPartnerProductGTIN         |
-      | pi_2_S0316_040                     | p_2_S0316_040                 | 5               | 5               | 5               | 5                   | 1         | 2021-04-20         | luLotNumber   | huPackagingCode_2_S0316_040             | bPartnerProductGTIN_TU      |
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerLU | QtyItemCapacity | QtyTU | BestBeforeDate | LotNumber   | M_HU_PackagingCode_TU_ID    | GTIN_TU_PackingMaterial |
+      | pi_1_S0316_040          | p_1_S0316_040      | 5           | 10          | 5           | 10              | 1     | 2021-04-20     | lotNumber   | huPackagingCode_2_S0316_040 | bPartnerProductGTIN     |
+      | pi_2_S0316_040          | p_2_S0316_040      | 5           | 5           | 5           | 5               | 1     | 2021-04-20     | luLotNumber | huPackagingCode_2_S0316_040 | bPartnerProductGTIN_TU  |
 
     And EDI_Desadv_Pack records are updated
       | EDI_Desadv_Pack_ID.Identifier | OPT.IPA_SSCC18       |
@@ -1114,6 +1116,7 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | "1","ipaSSCC18_14092022_2","@o_1_S0316_040@","16.04.2021","","@p_1_S0316_040@","1","0","210420","luLotNumber","","","","","","","","","","","","" |
 
 
+  @Id:S0457_010
   Scenario: S0457_010 - 1 Pack from 2 lines with HUs for entire qty.
   There are no packing-infos to go with, but the lines are picked onto two actual HUs, so we use the qtys from that HU.
   in:
@@ -1185,13 +1188,13 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | huProductTU_1_S0457_010            | huPiItemTU_S0457_010       | p_1_S0457_010           | 10  | 2021-01-01 |
       | huProductTU_2_S0457_010            | huPiItemTU_S0457_010       | p_2_S0457_010           | 10  | 2021-01-01 |
 
-    And metasfresh initially has M_Inventory data
-      | M_Inventory_ID.Identifier     | MovementDate | DocumentNo     |
-      | huProduct_inventory_S0457_010 | 2021-04-16   | inventoryDocNo |
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID.Identifier     | M_InventoryLine_ID.Identifier       | M_Product_ID.Identifier | QtyBook | QtyCount |
-      | huProduct_inventory_S0457_010 | huProduct_inventoryLine_1_S0457_010 | p_1_S0457_010           | 0       | 10       |
-      | huProduct_inventory_S0457_010 | huProduct_inventoryLine_2_S0457_010 | p_2_S0457_010           | 0       | 20       |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier     | MovementDate | DocumentNo     | M_Warehouse_ID |
+      | huProduct_inventory_S0457_010 | 2021-04-16   | inventoryDocNo | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier     | M_InventoryLine_ID.Identifier       | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | huProduct_inventory_S0457_010 | huProduct_inventoryLine_1_S0457_010 | p_1_S0457_010           | 0       | 10       | PCE          |
+      | huProduct_inventory_S0457_010 | huProduct_inventoryLine_2_S0457_010 | p_2_S0457_010           | 0       | 20       | PCE          |
     And complete inventory with inventoryIdentifier 'huProduct_inventory_S0457_010'
     And after not more than 30s, there are added M_HUs for inventory
       | M_InventoryLine_ID.Identifier       | M_HU_ID.Identifier    |
@@ -1235,10 +1238,10 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
 
     And metasfresh contains M_HU_Item:
       | M_HU_Item_ID.Identifier | M_HU_ID.Identifier      | M_HU_PI_Item_ID.Identifier | Qty | M_HU_PackingMaterial_ID.Identifier | OPT.ItemType |
-      | huPiItemLU_S0457_010    | createdLU_S0457_010     | huPiItemLU_S0457_010       | 10  | pm_1_S0457_010                     | PM           |
-      | huPiItemTU_S0457_010    | createdTU_1_S0457_010   | huPiItemTU_S0457_010       | 10  | pm_2_S0457_010                     | PM           |
-      | huPiItemTU_2_S0457_010  | createdTU_2_1_S0457_010 | huPiItemTU_S0457_010       | 20  | pm_2_S0457_010                     | PM           |
-      | huPiItemTU_2_S0457_010  | createdTU_2_2_S0457_010 | huPiItemTU_S0457_010       | 20  | pm_2_S0457_010                     | PM           |
+      | huItemLU_S0457_010      | createdLU_S0457_010     | huPiItemLU_S0457_010       | 10  | pm_1_S0457_010                     | PM           |
+      | huItemTU_S0457_010      | createdTU_1_S0457_010   | huPiItemTU_S0457_010       | 10  | pm_2_S0457_010                     | PM           |
+      | huItemTU_2_S0457_010    | createdTU_2_1_S0457_010 | huPiItemTU_S0457_010       | 20  | pm_2_S0457_010                     | PM           |
+      | huItemTU_2_S0457_010    | createdTU_2_2_S0457_010 | huPiItemTU_S0457_010       | 20  | pm_2_S0457_010                     | PM           |
 
     And metasfresh contains C_Orders:
       | Identifier    | IsSOTrx | C_BPartner_ID | DateOrdered | POReference   | C_PaymentTerm_ID | deliveryRule |
@@ -1292,9 +1295,9 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | p_1_S0457_010      | false                   | createdLU_S0457_010 | huPackagingCode_1_S0457_010 | bPartnerProductGTIN_LU   | 1         | 012345670010000005 |
 
     And after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
-      | EDI_Desadv_Pack_Item_ID.Identifier | EDI_Desadv_Pack_ID.Identifier | OPT.MovementQty | OPT.QtyCUsPerTU | OPT.QtyCUsPerLU | OPT.QtyItemCapacity | OPT.QtyTU | OPT.M_InOut_ID.Identifier | OPT.M_InOutLine_ID.Identifier | OPT.BestBeforeDate | OPT.LotNumber | OPT.M_HU_PackagingCode_TU_ID.Identifier | OPT.GTIN_TU_PackingMaterial |
-      | pi_1_S0457_010                     | p_1_S0457_010                 | 10              | 10              | 10              | 10                  | 1         | s_1_S0457_010             | shipmentLine_1_S0457_010      | 2021-04-20         | luLotNumber   | huPackagingCode_2_S0457_010             | bPartnerProductGTIN_TU      |
-      | pi_2_S0457_010                     | p_1_S0457_010                 | 20              | 10              | 20              | 10                  | 2         | s_2_S0457_010             | shipmentLine_2_S0457_010      | 2021-04-20         | luLotNumber   | huPackagingCode_2_S0457_010             | bPartnerProductGTIN_TU      |
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerLU | QtyItemCapacity | QtyTU | M_InOut_ID    | M_InOutLine_ID           | BestBeforeDate | LotNumber   | M_HU_PackagingCode_TU_ID    | GTIN_TU_PackingMaterial |
+      | pi_1_S0457_010          | p_1_S0457_010      | 10          | 10          | 10          | 10              | 1     | s_1_S0457_010 | shipmentLine_1_S0457_010 | 2021-04-20     | luLotNumber | huPackagingCode_2_S0457_010 | bPartnerProductGTIN_TU  |
+      | pi_2_S0457_010          | p_1_S0457_010      | 20          | 10          | 20          | 10              | 2     | s_2_S0457_010 | shipmentLine_2_S0457_010 | 2021-04-20     | luLotNumber | huPackagingCode_2_S0457_010 | bPartnerProductGTIN_TU  |
 
     And generate csv file for sscc labels for 'p_1_S0457_010'
       | ReportDataLine                                                                                                                                  |
@@ -1305,6 +1308,208 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
 
     And the shipment identified by s_1_S0457_010 is reversed
     And the shipment identified by s_2_S0457_010 is reversed
+
+    Then after not more than 30s, there are no records in EDI_Desadv_Pack_Item
+
+    And after not more than 30s, there are no records in EDI_Desadv_Pack
+
+
+  @Id:S0457_020
+  Scenario: S0457_020 - one orderLine, shipped TUs contain different LotNumbers and BestBefores
+  in:
+  C_OrderLine 1:
+  - QtyEntered = 30
+  - M_HU_PI_Item_Product_ID = 101 (No Packing Item)
+  LU 1
+  - TU 1_1 with LotNumber1 and BestBefore 2021-04-20
+  - TU 1_2 with LotNumber2 and BestBefore 2021-04-30
+  LU 2
+  - TU 2 with LotNumber1 and BestBefore 2021-04-20
+
+  We then expect:
+  - Two InOutLines with the respective LotNuber and Besbefore-Values as ASIs
+  - Two Desadv-Packs (one Per LU) with among them three Desadv-Pack-Items
+
+    Given metasfresh contains M_Products:
+      | Identifier                  |
+      | p_1_S0457_020               |
+      | p_3_S0457_020_LU_packingMat |
+      | p_4_S0457_020_TU_packingMat |
+    And metasfresh contains M_PricingSystems
+      | Identifier     |
+      | ps_1_S0457_020 |
+    And metasfresh contains M_PriceLists
+      | Identifier     | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_1_S0457_020 | ps_1_S0457_020     | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier      | M_PriceList_ID |
+      | plv_1_S0457_020 | pl_1_S0457_020 |
+    And metasfresh contains M_ProductPrices
+      | Identifier                   | M_PriceList_Version_ID | M_Product_ID                | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | pp_1_S0457_020               | plv_1_S0457_020        | p_1_S0457_020               | 10.0     | PCE      | Normal           |
+      | pp_3_S0457_020_LU_packingMat | plv_1_S0457_020        | p_3_S0457_020_LU_packingMat | 10.0     | PCE      | Normal           |
+      | pp_4_S0457_020_TU_packingMat | plv_1_S0457_020        | p_4_S0457_020_TU_packingMat | 10.0     | PCE      | Normal           |
+
+    And metasfresh contains C_BPartners:
+      | Identifier  | IsCustomer | M_PricingSystem_ID |
+      | endcustomer | Y          | ps_1_S0457_020     |
+    And the following c_bpartner is changed
+      | C_BPartner_ID.Identifier | OPT.IsEdiDesadvRecipient | OPT.EdiDesadvRecipientGLN  |
+      | endcustomer              | true                     | bPartnerDesadvRecipientGLN |
+    And load M_HU_PackagingCode:
+      | M_HU_PackagingCode_ID.Identifier | PackagingCode | HU_UnitType |
+      | huPackagingCode_1_S0457_020      | ISO1          | LU          |
+      | huPackagingCode_2_S0457_020      | CART          | TU          |
+
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID.Identifier        |
+      | huPackingLU_S0457_020        |
+      | huPackingTU_S0457_020        |
+      | huPackingVirtualPI_S0457_020 |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID.Identifier | M_HU_PI_ID                   | HU_UnitType | IsCurrent | M_HU_PackagingCode_ID       |
+      | packingVersionLU_S0457_020    | huPackingLU_S0457_020        | LU          | Y         | huPackagingCode_1_S0457_020 |
+      | packingVersionTU_S0457_020    | huPackingTU_S0457_020        | TU          | Y         | huPackagingCode_2_S0457_020 |
+      | packingVersionCU_S0457_020    | huPackingVirtualPI_S0457_020 | V           | Y         |                             |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType | OPT.Included_HU_PI_ID.Identifier |
+      | huPiItemLU_S0457_020       | packingVersionLU_S0457_020    | 10  | HU       | huPackingTU_S0457_020            |
+      | huPiItemTU_S0457_020       | packingVersionTU_S0457_020    | 0   | MI       |                                  |
+    And metasfresh contains M_HU_PI_Attribute:
+      | M_HU_PI_Attribute.Identifier   | M_HU_PI_Version_ID.Identifier | M_Attribute.Value |
+      | huPiAttribute_SSCC18_S0457_020 | packingVersionLU_S0457_020    | SSCC18            |
+
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | huProductTU_1_S0457_020            | huPiItemTU_S0457_020       | p_1_S0457_020           | 10  | 2021-01-01 |
+
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier     | MovementDate | DocumentNo     | M_Warehouse_ID |
+      | huProduct_inventory_S0457_020 | 2021-04-16   | inventoryDocNo | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier     | M_InventoryLine_ID.Identifier       | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | huProduct_inventory_S0457_020 | huProduct_inventoryLine_1_S0457_020 | p_1_S0457_020           | 0       | 30       | PCE          |
+    And complete inventory with inventoryIdentifier 'huProduct_inventory_S0457_020'
+    And after not more than 30s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier       | M_HU_ID.Identifier    |
+      | huProduct_inventoryLine_1_S0457_020 | createdCU_1_S0457_020 |
+
+    And transform CU to new TUs
+      | sourceCU.Identifier   | cuQty | M_HU_PI_Item_Product_ID.Identifier | OPT.resultedNewTUs.Identifier                                           | OPT.resultedNewCUs.Identifier                                                    |
+      | createdCU_1_S0457_020 | 30    | huProductTU_1_S0457_020            | createdTU_1_1_S0457_020, createdTU_1_2_S0457_020, createdTU_2_S0457_020 | newcreatedCU_1_1_S0457_020, newcreatedCU_1_2_S0457_020, newcreatedCU_2_S0457_020 |
+
+    And after not more than 30s, M_HUs should have
+      | M_HU_ID.Identifier      | OPT.M_HU_PI_Item_Product_ID.Identifier |
+      | createdTU_1_1_S0457_020 | huProductTU_1_S0457_020                |
+      | createdTU_1_2_S0457_020 | huProductTU_1_S0457_020                |
+      | createdTU_2_S0457_020   | huProductTU_1_S0457_020                |
+
+     # This controls the SSCC18 value that such our LU and desc-pack get SSCC18-value 012345670010000005
+    And setup the SSCC18 code generator with GS1ManufacturerCode 1234567, GS1ExtensionDigit 0 and next sequence number always=1000000.
+    And aggregate TUs to new LU
+      | sourceTUs                                        | newLUs                |
+      | createdTU_1_1_S0457_020, createdTU_1_2_S0457_020 | createdLU_1_S0457_020 |
+    # Same for our 2nd LU
+    And setup the SSCC18 code generator with GS1ManufacturerCode 1234568, GS1ExtensionDigit 0 and next sequence number always=1000000.
+    And aggregate TUs to new LU
+      | sourceTUs             | newLUs                |
+      | createdTU_2_S0457_020 | createdLU_2_S0457_020 |
+
+    # cleanup; otherwise, all HUs with an SSCC18 will have the same SSCC18-value for the remainder of this test-run
+    And reset the SSCC18 code generator's next sequence number back to its actual sequence.
+
+    And update M_HU_Attribute:
+      | M_HU_ID.Identifier      | M_Attribute_ID | Value        | AttributeValueType |
+      | createdTU_1_1_S0457_020 | 1000017        | luLotNumber1 | S                  |
+      | createdTU_1_1_S0457_020 | 540020         | 2021-04-20   | D                  |
+      | createdTU_1_2_S0457_020 | 1000017        | luLotNumber2 | S                  |
+      | createdTU_1_2_S0457_020 | 540020         | 2021-04-30   | D                  |
+      | createdTU_2_S0457_020   | 1000017        | luLotNumber1 | S                  |
+      | createdTU_2_S0457_020   | 540020         | 2021-04-20   | D                  |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_Product_ID.Identifier | C_BPartner_ID.Identifier | M_Product_ID.Identifier     | OPT.GTIN               |
+      | bp_1_S0457_020                   | endcustomer              | p_3_S0457_020_LU_packingMat | bPartnerProductGTIN_LU |
+      | bp_3_S0457_020_LU_packingMat     | endcustomer              | p_4_S0457_020_TU_packingMat | bPartnerProductGTIN_TU |
+    And metasfresh contains M_HU_PackingMaterial:
+      | M_HU_PackingMaterial_ID.Identifier | OPT.M_Product_ID.Identifier | Name                             |
+      | pm_1_S0457_020                     | p_3_S0457_020_LU_packingMat | packingMaterialTest_LU_S0457_020 |
+      | pm_2_S0457_020                     | p_4_S0457_020_TU_packingMat | packingMaterialTest_TU_S0457_020 |
+
+    And metasfresh contains M_HU_Item:
+      | M_HU_Item_ID.Identifier | M_HU_ID.Identifier      | M_HU_PI_Item_ID.Identifier | Qty | M_HU_PackingMaterial_ID.Identifier | OPT.ItemType |
+      | huItemLU_1_S0457_020    | createdLU_1_S0457_020   | huPiItemLU_S0457_020       | 2   | pm_1_S0457_020                     | PM           |
+      | huItemTU_1_1_S0457_020  | createdTU_1_1_S0457_020 | huPiItemTU_S0457_020       | 10  | pm_2_S0457_020                     | PM           |
+      | huItemTU_1_2_S0457_020  | createdTU_1_2_S0457_020 | huPiItemTU_S0457_020       | 10  | pm_2_S0457_020                     | PM           |
+      | huItemLU_2_S0457_020    | createdLU_2_S0457_020   | huPiItemLU_S0457_020       | 1   | pm_1_S0457_020                     | PM           |
+      | huItemTU_2_S0457_020    | createdTU_2_S0457_020   | huPiItemTU_S0457_020       | 10  | pm_2_S0457_020                     | PM           |
+
+    And metasfresh contains C_Orders:
+      | Identifier    | IsSOTrx | C_BPartner_ID | DateOrdered | POReference   | C_PaymentTerm_ID | deliveryRule |
+      | o_1_S0457_020 | true    | endcustomer   | 2021-04-17  | po_ref_@Date@ | 1000012          | F            |
+
+    And metasfresh contains C_OrderLines:
+      | Identifier     | C_Order_ID    | M_Product_ID  | QtyEntered |
+      | ol_1_S0457_020 | o_1_S0457_020 | p_1_S0457_020 | 30         |
+
+    When the order identified by o_1_S0457_020 is completed
+
+    And after not more than 30s, M_ShipmentSchedules are found:
+      | Identifier      | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_1_S0457_020 | ol_1_S0457_020            | N             |
+
+    When create M_PickingCandidate for M_HU
+      | M_HU_ID.Identifier      | M_ShipmentSchedule_ID.Identifier | QtyPicked | Status | PickStatus | ApprovalStatus |
+      | createdTU_1_1_S0457_020 | s_s_1_S0457_020                  | 10        | IP     | P          | ?              |
+      | createdTU_1_2_S0457_020 | s_s_1_S0457_020                  | 10        | IP     | P          | ?              |
+      | createdTU_2_S0457_020   | s_s_1_S0457_020                  | 10        | IP     | P          | ?              |
+
+    And process picking
+      | M_HU_ID.Identifier      | M_ShipmentSchedule_ID.Identifier |
+      | createdTU_1_1_S0457_020 | s_s_1_S0457_020                  |
+      | createdTU_1_2_S0457_020 | s_s_1_S0457_020                  |
+      | createdTU_2_S0457_020   | s_s_1_S0457_020                  |
+
+    And validate that there are no M_ShipmentSchedule_Recompute records after no more than 30 seconds for order 'o_1_S0457_020'
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_1_S0457_020                  | PD           | true                | false       |
+
+    Then after not more than 30s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | DocStatus |
+      | s_s_1_S0457_020                  | s_1_S0457_020         | CO        |
+
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by s_s_1_S0457_020
+      | QtyDeliveredCatch | Catch_UOM_ID | QtyPicked | VHU_ID                     | QtyTU | M_TU_HU_ID              | QtyLU | M_LU_HU_ID            | Processed | M_InOutLine_ID             |
+      |                   |              | 10        | newcreatedCU_1_1_S0457_020 | 1     | createdTU_1_1_S0457_020 | 1     | createdLU_1_S0457_020 | Y         | shipmentLine_1_1_S0457_020 |
+      |                   |              | 10        | newcreatedCU_1_2_S0457_020 | 1     | createdTU_1_2_S0457_020 | 1     | createdLU_1_S0457_020 | Y         | shipmentLine_1_2_S0457_020 |
+      |                   |              | 10        | newcreatedCU_2_S0457_020   | 1     | createdTU_2_S0457_020   | 1     | createdLU_2_S0457_020 | Y         | shipmentLine_1_1_S0457_020 |
+
+    And validate the created shipment lines by id
+      | Identifier                 | M_Product_ID  | movementqty | QtyDeliveredCatch | QtyEnteredTU | M_AttributeSetInstance_ID | C_OrderLine_ID |
+      | shipmentLine_1_1_S0457_020 | p_1_S0457_020 | 20          |                   | 2            | asi_1_S0457_020           | ol_1_S0457_020 |
+      | shipmentLine_1_2_S0457_020 | p_1_S0457_020 | 10          |                   | 1            | asi_2_S0457_020           | ol_1_S0457_020 |
+
+    And validate M_AttributeInstance:
+      | M_AttributeSetInstance_ID | AttributeCode     | Value                 |
+      | asi_1_S0457_020           | HU_BestBeforeDate | 2021-04-20 00:00:00.0 |
+      | asi_1_S0457_020           | Lot-Nummer        | luLotNumber1          |
+      | asi_2_S0457_020           | HU_BestBeforeDate | 2021-04-30 00:00:00.0 |
+      | asi_2_S0457_020           | Lot-Nummer        | luLotNumber2          |
+
+    Then after not more than 30s, EDI_Desadv_Pack records are found:
+      | EDI_Desadv_Pack_ID | IsManual_IPA_SSCC18 | M_HU_ID               | M_HU_PackagingCode_ID       | GTIN_PackingMaterial   | SeqNo | IPA_SSCC18         |
+      | p_1_S0457_020      | false               | createdLU_1_S0457_020 | huPackagingCode_1_S0457_020 | bPartnerProductGTIN_LU | 1     | 012345670010000005 |
+      | p_2_S0457_020      | false               | createdLU_2_S0457_020 | huPackagingCode_1_S0457_020 | bPartnerProductGTIN_LU | 2     | 012345680010000005 |
+
+    And after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | M_InOutLine_ID             | QtyCUsPerTU | QtyCUsPerLU | QtyItemCapacity | QtyTU | M_InOut_ID    | BestBeforeDate | LotNumber    | M_HU_PackagingCode_TU_ID    | GTIN_TU_PackingMaterial |
+      | pi_1_1_S0457_020        | p_1_S0457_020      | 10          | shipmentLine_1_1_S0457_020 | 10          | 10          | 10              | 1     | s_1_S0457_020 | 2021-04-20     | luLotNumber1 | huPackagingCode_2_S0457_020 | bPartnerProductGTIN_TU  |
+      | pi_1_2_S0457_020        | p_1_S0457_020      | 10          | shipmentLine_1_2_S0457_020 | 10          | 10          | 10              | 1     | s_1_S0457_020 | 2021-04-30     | luLotNumber2 | huPackagingCode_2_S0457_020 | bPartnerProductGTIN_TU  |
+      | pi_2_S0457_020          | p_2_S0457_020      | 10          | shipmentLine_1_1_S0457_020 | 10          | 10          | 10              | 1     | s_1_S0457_020 | 2021-04-20     | luLotNumber1 | huPackagingCode_2_S0457_020 | bPartnerProductGTIN_TU  |
+
+    And the shipment identified by s_1_S0457_020 is reversed
 
     Then after not more than 30s, there are no records in EDI_Desadv_Pack_Item
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/groupInvoiceCandidates.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/groupInvoiceCandidates.feature
@@ -7,6 +7,9 @@ Feature: Group invoices and credit memos into a single document
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
     And metasfresh has date and time 2022-04-16T13:30:13+01:00[Europe/Berlin]
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And load M_Warehouse:
+      | M_Warehouse_ID | Value        |
+      | warehouseStd   | StdWarehouse |
 
   @from:cucumber
   @Id:S0242_100
@@ -92,12 +95,12 @@ Feature: Group invoices and credit memos into a single document
       | Identifier  | C_OrderLine_ID.Identifier | IsToRecompute | OPT.QtyDelivered |
       | schedule_SO | orderLine_SO              | N             | 8                |
 
-    And metasfresh initially has M_Inventory data
-      | M_Inventory_ID.Identifier | MovementDate | DocumentNo      |
-      | inventory                 | 2022-06-16   | inventoryDocNo2 |
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount |
-      | inventory                 | inventoryLine                 | product_SO              | 0       | 10       |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | DocumentNo      | M_Warehouse_ID |
+      | inventory                 | 2022-06-16   | inventoryDocNo2 | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inventory                 | inventoryLine                 | product_SO              | 0       | 10       | PCE          |
 
     And complete inventory with inventoryIdentifier 'inventory'
 
@@ -267,12 +270,12 @@ Feature: Group invoices and credit memos into a single document
       | Identifier  | C_OrderLine_ID.Identifier | IsToRecompute | OPT.QtyDelivered |
       | schedule_SO | orderLine_SO              | N             | 12               |
 
-    And metasfresh initially has M_Inventory data
-      | M_Inventory_ID.Identifier | MovementDate | DocumentNo      |
-      | inventory                 | 2022-06-16   | inventoryDocNo2 |
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount |
-      | inventory                 | inventoryLine                 | product_SO              | 0       | 10       |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | DocumentNo      | M_Warehouse_ID |
+      | inventory                 | 2022-06-16   | inventoryDocNo2 | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inventory                 | inventoryLine                 | product_SO              | 0       | 10       | PCE          |
 
     And complete inventory with inventoryIdentifier 'inventory'
 
@@ -437,12 +440,12 @@ Feature: Group invoices and credit memos into a single document
       | Identifier  | C_OrderLine_ID.Identifier | IsToRecompute | OPT.QtyDelivered |
       | schedule_SO | orderLine_SO              | N             | 12               |
 
-    And metasfresh initially has M_Inventory data
-      | M_Inventory_ID.Identifier | MovementDate | DocumentNo      |
-      | inventory                 | 2022-06-16   | inventoryDocNo2 |
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount |
-      | inventory                 | inventoryLine                 | product_SO              | 0       | 10       |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | DocumentNo      | M_Warehouse_ID |
+      | inventory                 | 2022-06-16   | inventoryDocNo2 | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inventory                 | inventoryLine                 | product_SO              | 0       | 10       | PCE          |
 
     And complete inventory with inventoryIdentifier 'inventory'
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huClearance/cleared/issue.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huClearance/cleared/issue.feature
@@ -37,12 +37,12 @@ Feature: Cleared HU can be issued to production order
       | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
       | huProductTU                        | huPiItemTU                 | huProduct               | 10  | 2022-01-01 |
 
-    And metasfresh initially has M_Inventory data
-      | M_Inventory_ID.Identifier | MovementDate | DocumentNo      |
-      | huProduct_inventory       | 2022-03-20   | inventoryDocNo2 |
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount |
-      | huProduct_inventory       | huProduct_inventoryLine       | huProduct               | 0       | 10       |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | DocumentNo      | M_Warehouse_ID |
+      | huProduct_inventory       | 2022-03-20   | inventoryDocNo2 | warehouseStd   |
+    And  metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | huProduct_inventory       | huProduct_inventoryLine       | huProduct               | 0       | 10       | PCE          |
     And complete inventory with inventoryIdentifier 'huProduct_inventory'
 
     And after not more than 60s, there are added M_HUs for inventory
@@ -51,7 +51,7 @@ Feature: Cleared HU can be issued to production order
 
     And transform CU to new TUs
       | sourceCU.Identifier | cuQty | M_HU_PI_Item_Product_ID.Identifier | OPT.resultedNewTUs.Identifier | OPT.resultedNewCUs.Identifier |
-      | createdCU           | 10    | huProductTU                        | createdTU                 | newCreatedCU              |
+      | createdCU           | 10    | huProductTU                        | createdTU                     | newCreatedCU                  |
 
     And after not more than 60s, M_HUs should have
       | M_HU_ID.Identifier | OPT.M_HU_PI_Item_Product_ID.Identifier |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huClearance/cleared/pick.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huClearance/cleared/pick.feature
@@ -40,12 +40,12 @@ Feature: Cleared HU can be picked on the fly and manually picked
       | M_HU_PI_Version_ID.Identifier | M_HU_PI_ID.Identifier | Name            | HU_UnitType | IsCurrent |
       | packingVersionCU              | huPackingVirtualPI    | No Packing Item | V           | Y         |
 
-    And metasfresh initially has M_Inventory data
-      | M_Inventory_ID.Identifier | MovementDate | DocumentNo     |
-      | huProduct_inventory       | 2022-03-20   | inventoryDocNo |
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount |
-      | huProduct_inventory       | huProduct_inventoryLine       | huProduct               | 0       | 10       |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | DocumentNo     | M_Warehouse_ID |
+      | huProduct_inventory       | 2022-03-20   | inventoryDocNo | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | huProduct_inventory       | huProduct_inventoryLine       | huProduct               | 0       | 10       | PCE          |
     And complete inventory with inventoryIdentifier 'huProduct_inventory'
     And after not more than 60s, there are added M_HUs for inventory
       | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huClearance/locked/issue.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huClearance/locked/issue.feature
@@ -37,12 +37,12 @@ Feature: Locked HUs can not be issued to production order
       | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
       | huProductTU                        | huPiItemTU                 | huProduct               | 10  | 2022-01-01 |
 
-    And metasfresh initially has M_Inventory data
-      | M_Inventory_ID      | MovementDate | DocumentNo      |
-      | huProduct_inventory | 2022-03-20   | inventoryDocNo2 |
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID      | M_InventoryLine_ID      | M_Product_ID | QtyBook | QtyCount |
-      | huProduct_inventory | huProduct_inventoryLine | huProduct    | 0       | 10       |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID      | MovementDate | DocumentNo      | M_Warehouse_ID |
+      | huProduct_inventory | 2022-03-20   | inventoryDocNo2 | warehouseStd   |
+    And  metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID      | M_InventoryLine_ID      | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | huProduct_inventory | huProduct_inventoryLine | huProduct    | 0       | 10       | PCE          |
     And complete inventory with inventoryIdentifier 'huProduct_inventory'
     And after not more than 60s, there are added M_HUs for inventory
       | M_InventoryLine_ID      | M_HU_ID   |
@@ -50,7 +50,7 @@ Feature: Locked HUs can not be issued to production order
 
     And transform CU to new TUs
       | sourceCU  | cuQty | M_HU_PI_Item_Product_ID | OPT.resultedNewTUs | OPT.resultedNewCUs |
-      | createdCU | 10    | huProductTU             | createdTU      | newCreatedCU   |
+      | createdCU | 10    | huProductTU             | createdTU          | newCreatedCU       |
 
     And after not more than 60s, M_HUs should have
       | M_HU_ID   | M_HU_PI_Item_Product_ID |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huClearance/locked/pick.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/huClearance/locked/pick.feature
@@ -49,12 +49,12 @@ Feature: Locked HUs can not be picked
       | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
       | huProductTU                        | huPiItemTU                 | huProduct               | 10  | 2022-01-01 |
 
-    And metasfresh initially has M_Inventory data
-      | M_Inventory_ID.Identifier | MovementDate | DocumentNo      |
-      | huProduct_inventory       | 2022-03-20   | inventoryDocNo2 |
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount |
-      | huProduct_inventory       | huProduct_inventoryLine       | huProduct               | 0       | 10       |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | DocumentNo      | M_Warehouse_ID |
+      | huProduct_inventory       | 2022-03-20   | inventoryDocNo2 | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | huProduct_inventory       | huProduct_inventoryLine       | huProduct               | 0       | 10       | PCE          |
     And complete inventory with inventoryIdentifier 'huProduct_inventory'
     And after not more than 60s, there are added M_HUs for inventory
       | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
@@ -62,7 +62,7 @@ Feature: Locked HUs can not be picked
 
     And transform CU to new TUs
       | sourceCU.Identifier | cuQty | M_HU_PI_Item_Product_ID.Identifier | OPT.resultedNewTUs.Identifier | OPT.resultedNewCUs.Identifier |
-      | createdCU           | 10    | huProductTU                        | createdTU                 | newCreatedCU              |
+      | createdCU           | 10    | huProductTU                        | createdTU                     | newCreatedCU                  |
 
     And after not more than 60s, M_HUs should have
       | M_HU_ID.Identifier | OPT.M_HU_PI_Item_Product_ID.Identifier |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
@@ -42,9 +42,9 @@ Feature: Maturing scenarios
   @Id:S0382_100
   @flaky
   Scenario: Happy flow, raw good product HU created via inventory, maturing candidate created and processed
-    When metasfresh initially has M_Inventory data
-      | M_Inventory_ID | MovementDate | DocumentNo   |
-      | maturingInv    | 2024-01-01   | maturingInv1 |
+    When metasfresh contains M_Inventories:
+      | M_Inventory_ID | MovementDate | DocumentNo   | M_Warehouse_ID    |
+      | maturingInv    | 2024-01-01   | maturingInv1 | maturingWarehouse |
 
     And metasfresh contains M_AttributeSetInstance with identifier "huASI_10":
   """
@@ -58,9 +58,9 @@ Feature: Maturing scenarios
   }
   """
 
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID | M_InventoryLine_ID | M_Product_ID | QtyBook | QtyCount | M_AttributeSetInstance_ID |
-      | maturingInv    | maturing_inv_10    | rawGood      | 0       | 10       | huASI_10                  |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | M_InventoryLine_ID | M_Product_ID | QtyBook | QtyCount | M_AttributeSetInstance_ID | UOM.X12DE355 |
+      | maturingInv    | maturing_inv_10    | rawGood      | 0       | 10       | huASI_10                  | PCE          |
     And complete inventory with inventoryIdentifier 'maturingInv'
 
     And after not more than 60s, there are added M_HUs for inventory
@@ -109,9 +109,9 @@ Feature: Maturing scenarios
   @Id:S0382_200
   @flaky
   Scenario: Maturing candidate created, then HU qty is adjusted. Maturing candidate is updated
-    When metasfresh initially has M_Inventory data
-      | M_Inventory_ID.Identifier | MovementDate | DocumentNo   |
-      | maturingInv2              | 2024-01-01   | maturingInv2 |
+    When metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | DocumentNo   | M_Warehouse_ID    |
+      | maturingInv2              | 2024-01-01   | maturingInv2 | maturingWarehouse |
 
     And metasfresh contains M_AttributeSetInstance with identifier "huASI_20":
   """
@@ -125,9 +125,9 @@ Feature: Maturing scenarios
   }
   """
 
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | OPT.M_AttributeSetInstance_ID.Identifier |
-      | maturingInv2              | maturing_inv_20               | rawGood                 | 0       | 20       | huASI_20                                 |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | OPT.M_AttributeSetInstance_ID.Identifier | UOM.X12DE355 |
+      | maturingInv2              | maturing_inv_20               | rawGood                 | 0       | 20       | huASI_20                                 | PCE          |
     And complete inventory with inventoryIdentifier 'maturingInv2'
 
     And after not more than 60s, there are added M_HUs for inventory
@@ -157,9 +157,9 @@ Feature: Maturing scenarios
   @from:cucumber
   @Id:S0382_300
   Scenario: Maturing candidate created, then HU is disposed. Maturing candidate is deleted.
-    When metasfresh initially has M_Inventory data
-      | M_Inventory_ID | MovementDate | DocumentNo   |
-      | maturingInv3   | 2024-01-01   | maturingInv3 |
+    When metasfresh contains M_Inventories:
+      | M_Inventory_ID | MovementDate | DocumentNo   | M_Warehouse_ID    |
+      | maturingInv3   | 2024-01-01   | maturingInv3 | maturingWarehouse |
 
     And metasfresh contains M_AttributeSetInstance with identifier "huASI_30":
   """
@@ -173,9 +173,9 @@ Feature: Maturing scenarios
   }
   """
 
-    And metasfresh initially has M_InventoryLine data
-      | M_Inventory_ID | M_InventoryLine_ID | M_Product_ID | QtyBook | QtyCount | M_AttributeSetInstance_ID |
-      | maturingInv3   | maturing_inv_30    | rawGood      | 0       | 30       | huASI_30                  |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | M_InventoryLine_ID | M_Product_ID | QtyBook | QtyCount | M_AttributeSetInstance_ID | UOM.X12DE355 |
+      | maturingInv3   | maturing_inv_30    | rawGood      | 0       | 30       | huASI_30                  | PCE          |
     And complete inventory with inventoryIdentifier 'maturingInv3'
 
     And after not more than 60s, there are added M_HUs for inventory

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/pack/EDIDesadvPackService.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/pack/EDIDesadvPackService.java
@@ -26,6 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner_product.IBPartnerProductDAO;
+import de.metas.common.util.CoalesceUtil;
 import de.metas.common.util.SimpleSequence;
 import de.metas.edi.api.EDIDesadvId;
 import de.metas.edi.api.EDIDesadvLineId;
@@ -81,6 +82,7 @@ import org.adempiere.mm.attributes.api.AttributeConstants;
 import org.adempiere.mm.attributes.api.IAttributeDAO;
 import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.I_C_BPartner_Product;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
@@ -445,19 +447,21 @@ public class EDIDesadvPackService
 
 		final HU topLevelHU = huRepository
 				.getById(HuId.ofRepoId(topLevelHURecord.getM_HU_ID()))
-				.retainProduct(productId) // no need to blindly hope that the HU is homogenous
-				.orElseThrow(() -> new AdempiereException("Missing M_HU").appendParametersToMessage()
-						.setParameter("M_HU_ID", topLevelHURecord.getM_HU_ID())
-						.setParameter("M_InOutLine_ID", inOutLineRecord.getM_InOutLine_ID())
-						.setParameter("EDI_DesadvLin_ID", desadvLineRecord.getEDI_DesadvLine_ID()));
+				.retainReference(TableRecordReference.of(inOutLineRecord)); // we just want the qty related to the current inoutLine
+		if (topLevelHU == null)
+		{
+			throw new AdempiereException("Missing M_HU").appendParametersToMessage()
+					.setParameter("M_HU_ID", topLevelHURecord.getM_HU_ID())
+					.setParameter("M_InOutLine_ID", inOutLineRecord.getM_InOutLine_ID())
+					.setParameter("EDI_DesadvLine_ID", desadvLineRecord.getEDI_DesadvLine_ID());
+		}
 
 		final StockQtyAndUOMQty inOutLineQty = inOutBL.extractInOutLineQty(inOutLineRecord, invoicableQtyBasedOn);
-		
-		// topLevelHU's quantity can be bigger than the inOutLine's quantity,
-		// if there are multiple lines with the same product and if those lines were picked onto the same LU.
-		// That's why we need to invoke minStockAndUom(..)
-		final StockQtyAndUOMQty qtyCUsPerTopLevelHU = getQuantity(topLevelHU, inOutLineQty).minStockAndUom(inOutLineQty);
-				
+
+		// topLevelHU's quantity cannot be bigger than the inOutLine's quantity,
+		// because we retained only the current inOutLine
+		final StockQtyAndUOMQty qtyCUsPerTopLevelHU = getQuantity(topLevelHU, inOutLineQty);
+
 		final RequestParameters parameters = new RequestParameters(topLevelHU,
 				bPartnerId,
 				qtyCUsPerTopLevelHU,
@@ -496,22 +500,21 @@ public class EDIDesadvPackService
 			@NonNull final HU rootHU,
 			@NonNull final StockQtyAndUOMQty inOutLineQty)
 	{
-
-		// note that rootHU only contains children, quantities and weights for productId
+		// note that rootHU only contains children, quantities and weights for the current inoutLine.
 		final Quantity qtyInStockUOM = rootHU.getProductQtysInStockUOM().get(inOutLineQty.getProductId());
-		final Optional<Quantity> weight = rootHU.getWeightNet();
+		final Quantity weight = rootHU.getWeightNet();
 
-		// Even if the HU contains a weight, we will not use if, unless the inOutLineQty *also* contains a weight in the same UOM!
+		// Even if the HU contains a weight, we will not use it, unless the inOutLineQty *also* contains a weight in the same UOM!
 		// That's because we are going to subtract the HU's qty from the inoutLine's Qty.
-		final boolean canUseWeight = weight.isPresent() 
-				&& inOutLineQty.isUOMQtySet() 
-				&& weight.get().getUomId().equals(inOutLineQty.getUOMQtyNotNull().getUomId());
+		final boolean canUseWeight = weight != null
+				&& inOutLineQty.isUOMQtySet()
+				&& weight.getUomId().equals(inOutLineQty.getUOMQtyNotNull().getUomId());
 		if (canUseWeight)
 		{
 			return StockQtyAndUOMQty.builder()
 					.productId(inOutLineQty.getProductId())
 					.stockQty(qtyInStockUOM)
-					.uomQty(weight.get())
+					.uomQty(weight)
 					.build();
 		}
 		else
@@ -553,7 +556,9 @@ public class EDIDesadvPackService
 
 		// get minimum best before of all HUs and sub-HUs
 		final Date bestBefore = parameters.topLevelHU.extractSingleAttributeValue(
-				attrSet -> attrSet.hasAttribute(AttributeConstants.ATTR_BestBeforeDate) ? attrSet.getValueAsDate(AttributeConstants.ATTR_BestBeforeDate) : null,
+				attrSet -> attrSet.hasAttribute(AttributeConstants.ATTR_BestBeforeDate)
+						? attrSet.getValueAsDate(AttributeConstants.ATTR_BestBeforeDate)
+						: null,
 				TimeUtil::min);
 
 		final CreateEDIDesadvPackItemRequest.CreateEDIDesadvPackItemRequestBuilder createPackItemRequestBuilder =
@@ -566,7 +571,7 @@ public class EDIDesadvPackService
 						.bestBeforeDate(TimeUtil.asTimestamp(bestBefore))
 						.qtyTu(parameters.topLevelHU.getChildHUs().size());
 
-		final String lotNumber = parameters.topLevelHU.getAttributes().getValueAsString(AttributeConstants.ATTR_LotNumber);
+		final String lotNumber = parameters.topLevelHU.extractSingleLotNumber();
 		if (Check.isNotBlank(lotNumber))
 		{
 			createPackItemRequestBuilder.lotNumber(lotNumber);
@@ -719,7 +724,10 @@ public class EDIDesadvPackService
 			@NonNull final HU rootHU,
 			@NonNull final CreateEDIDesadvPackRequest.CreateEDIDesadvPackRequestBuilder createEDIDesadvPackRequestBuilder)
 	{
-		rootHU.getPackagingCode().ifPresent(code -> createEDIDesadvPackRequestBuilder.huPackagingCodeID(code.getId()));
+		if (rootHU.getPackagingCode() != null)
+		{
+			createEDIDesadvPackRequestBuilder.huPackagingCodeID(rootHU.getPackagingCode().getId());
+		}
 	}
 
 	/**
@@ -731,7 +739,7 @@ public class EDIDesadvPackService
 	{
 		final PackagingCode tuPackagingCode = CollectionUtils.extractSingleElementOrDefault(
 				childHUs, // don't iterate all HUs; we just care for the level below our LU (aka TU level).
-				hu -> hu.getPackagingCode().orElse(PackagingCode.NONE), // don't use null because CollectionUtils runs with ImmutableList
+				hu -> CoalesceUtil.coalesceNotNull(hu.getPackagingCode(), PackagingCode.NONE), // don't use null because CollectionUtils runs with ImmutableList
 				PackagingCode.NONE);
 
 		if (!tuPackagingCode.isNone())
@@ -782,7 +790,7 @@ public class EDIDesadvPackService
 	}
 
 	/**
-	 * All thast needed to create with a pack-request that includes a pack-item-request or just a single pack-item-request.
+	 * All that's needed to create with a pack-request that includes a pack-item-request or just a single pack-item-request.
 	 */
 	@Value
 	@RequiredArgsConstructor

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/model/validator/EDI_Desadv_Pack_Item.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/model/validator/EDI_Desadv_Pack_Item.java
@@ -68,13 +68,14 @@ public class EDI_Desadv_Pack_Item
 
 		final BigDecimal allLinePacksSum = otherPackItemsForLineSum.add(desadvPackItem.getMovementQty());
 		final BigDecimal lineSum = desadvPackItem.getEDI_DesadvLine().getQtyDeliveredInStockingUOM();
-
+		
 		if (allLinePacksSum.compareTo(lineSum) > 0)
 		{
 			throw new AdempiereException("EDI_DesadvLine.QtyDeliveredInStockingUOM=" + lineSum + ",but the sum of all EDI_Desadv_Pack_Item.MovementQtys=" + allLinePacksSum)
 					.appendParametersToMessage()
 					.setParameter("EDI_Desadv_Pack_Item_ID", desadvPackItem.getEDI_Desadv_Pack_Item_ID())
-					.setParameter("EDI_DesadvLine_ID", desadvPackItem.getEDI_DesadvLine_ID());
+					.setParameter("EDI_DesadvLine_ID", desadvPackItem.getEDI_DesadvLine_ID())
+					.setParameter("EDI_Desadv_ID", desadvPackItem.getEDI_DesadvLine().getEDI_Desadv_ID());
 		}
 	}
 }

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_addToDesadvCreateForInOutIfNotExist_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_addToDesadvCreateForInOutIfNotExist_Test.java
@@ -320,8 +320,8 @@ class DesadvBL_addToDesadvCreateForInOutIfNotExist_Test
 	}
 
 	/**
-	 * tests inoutLine whose quantity is partially covered by an HU
-	 * setting new qty and uom on inOutLine due to {@link de.metas.quantity.StockQtyAndUOMQty#minStockAndUom}
+	 * Tests inoutLine whose quantity is partially covered by an HU.
+	 * Setting new qty and uom on inOutLine due to {@link de.metas.quantity.StockQtyAndUOMQty#minStockAndUom}
 	 */
 	@Test
 	void addToDesadvCreateForInOutIfNotExist_HU()
@@ -350,7 +350,11 @@ class DesadvBL_addToDesadvCreateForInOutIfNotExist_Test
 		assertThat(ssccItemRecords)
 				.extracting(COLUMNNAME_EDI_Desadv_Pack_ID, COLUMNNAME_BestBeforeDate, COLUMNNAME_QtyTU, COLUMNNAME_QtyCUsPerTU, COLUMNNAME_QtyCUsPerLU)
 				.containsOnly(
-						tuple(ssccRecords.get(0).getEDI_Desadv_Pack_ID(), TimeUtil.parseTimestamp("2019-12-02"), 10, new BigDecimal("2.500"), new BigDecimal("24.500")/* 49 times 0.5, i.e. the Hus qty converted to the pack's UOM */),
+						tuple(ssccRecords.get(0).getEDI_Desadv_Pack_ID(), 
+								TimeUtil.parseTimestamp("2019-12-02"), 
+								10, 
+								new BigDecimal("2.500"), 
+								new BigDecimal("24.500")/* 49 times 0.5, i.e. the Hus qty converted to the pack's UOM */),
 						tuple(ssccRecords.get(1).getEDI_Desadv_Pack_ID(), null, 7, new BigDecimal("2.500"), new BigDecimal("17.500")) //
 				);
 	}
@@ -433,14 +437,35 @@ class DesadvBL_addToDesadvCreateForInOutIfNotExist_Test
 
 		final I_M_HU_PI_Attribute bestBeforeHUPIAttributeRecord = huTestHelper.createM_HU_PI_Attribute(HUPIAttributeBuilder.newInstance(bestBeforeAttrRecord)
 																											   .setM_HU_PI(handlingUnitsDAO.getIncludedPI(huPIItemPallet)));
-		for (final I_M_HU childHU : handlingUnitsDAO.retrieveIncludedHUs(lu))
+		for (final I_M_HU tu : handlingUnitsDAO.retrieveIncludedHUs(lu))
 		{
 			final I_M_HU_Attribute childHUAttrRecord = newInstance(I_M_HU_Attribute.class);
 			childHUAttrRecord.setM_Attribute_ID(bestBeforeHUPIAttributeRecord.getM_Attribute_ID());
-			childHUAttrRecord.setM_HU_ID(childHU.getM_HU_ID());
+			childHUAttrRecord.setM_HU_ID(tu.getM_HU_ID());
 			childHUAttrRecord.setValueDate(TimeUtil.parseTimestamp("2019-12-02"));
 			childHUAttrRecord.setM_HU_PI_Attribute_ID(bestBeforeHUPIAttributeRecord.getM_HU_PI_Attribute_ID());
 			saveRecord(childHUAttrRecord);
+
+			// need to make sure all TUs and CUs are asociated - like when we do actual picking
+			huAssignmentBL.createHUAssignmentBuilder()
+					.initializeAssignment(ctx, ITrx.TRXNAME_None)
+					.setModel(inOutLineRecord)
+					.setTopLevelHU(lu)
+					.setM_LU_HU(lu)
+					.setM_TU_HU(tu)
+					.build();
+
+			for (final I_M_HU cu : handlingUnitsDAO.retrieveIncludedHUs(tu))
+			{
+				huAssignmentBL.createHUAssignmentBuilder()
+						.initializeAssignment(ctx, ITrx.TRXNAME_None)
+						.setModel(inOutLineRecord)
+						.setTopLevelHU(lu)
+						.setM_LU_HU(lu)
+						.setM_TU_HU(tu)
+						.setVHU(cu)
+						.build();
+			}
 		}
 
 		huAssignmentBL.createHUAssignmentBuilder()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUAssignmentBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUAssignmentBuilder.java
@@ -28,6 +28,8 @@ import java.util.Properties;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_Assignment;
 
+import javax.annotation.Nullable;
+
 /**
  * Builder for {@link I_M_HU_Assignment}s. Use {@link IHUAssignmentBL#createHUAssignmentBuilder()} to get an instance.
  * <p>
@@ -40,36 +42,26 @@ public interface IHUAssignmentBuilder
 {
 	/**
 	 * Set document model which will be referenced
-	 *
-	 * @param model
 	 */
 	IHUAssignmentBuilder setModel(Object model);
 
 	/**
 	 * Set {@link I_M_HU_Assignment#setM_HU(I_M_HU)}
-	 *
-	 * @param topLevelHU
 	 */
 	IHUAssignmentBuilder setTopLevelHU(I_M_HU topLevelHU);
 
 	/**
 	 * Set {@link I_M_HU_Assignment#setM_LU_HU(I_M_HU)}
-	 *
-	 * @param luHU
 	 */
 	IHUAssignmentBuilder setM_LU_HU(I_M_HU luHU);
 
 	/**
 	 * Set {@link I_M_HU_Assignment#setM_TU_HU(I_M_HU)}
-	 *
-	 * @param tuHU
 	 */
 	IHUAssignmentBuilder setM_TU_HU(I_M_HU tuHU);
 
 	/**
 	 * Sets {@link I_M_HU_Assignment#setVHU(I_M_HU)}.
-	 *
-	 * @param vhu
 	 */
 	IHUAssignmentBuilder setVHU(I_M_HU vhu);
 
@@ -85,11 +77,8 @@ public interface IHUAssignmentBuilder
 
 	/**
 	 * Initialize this builder with an "empty" assignment.
-	 *
-	 * @param ctx
-	 * @param trxName
 	 */
-	IHUAssignmentBuilder initializeAssignment(Properties ctx, String trxName);
+	IHUAssignmentBuilder initializeAssignment(Properties ctx, @Nullable String trxName);
 
 	/**
 	 * Initialize this builder with values from the given pre-existing {@code assignment}.

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUAssignmentDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUAssignmentDAO.java
@@ -22,6 +22,7 @@ package de.metas.handlingunits;
  * #L%
  */
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSetMultimap;
 import de.metas.handlingunits.exceptions.HUException;
 import de.metas.handlingunits.model.I_M_HU;
@@ -220,7 +221,14 @@ public interface IHUAssignmentDAO extends ISingletonService
 	 * @param topLevel if <code>true</code>, then only assignments which reference the given <code>hu</code> via <code>M_HU_ID</code> are considered, and none which reference the <code>hu</code> via
 	 *                 <code>M_LU_HU_ID</code>. If <code>false</code>, then it is the other way round.
 	 */
-	<T> List<T> retrieveModelsForHU(I_M_HU hu, Class<T> clazz, boolean topLevel);
+	<T> List<T> retrieveModelsForHU(@NonNull I_M_HU hu, Class<T> clazz, boolean topLevel);
+
+	/**
+	 * Similar to {@link #retrieveModelsForHU(I_M_HU, Class)}, but returns {@link TableRecordReference}s instead.
+	 * Those references may have different {@code AD_Table_ID}s.
+	 */
+	@NonNull
+	ImmutableList<TableRecordReference> retrieveReferencingRecordsForHU(@NonNull I_M_HU hu, boolean topLevel);
 
 	/**
 	 * Retrieve the table hu assignments for the given HU even if they have LU and/or TU set. This is useful in the shipment hu assignments.

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/generichumodel/HUTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/generichumodel/HUTest.java
@@ -1,26 +1,25 @@
 package de.metas.handlingunits.generichumodel;
 
-import static java.math.BigDecimal.ONE;
-import static java.math.BigDecimal.TEN;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.math.BigDecimal;
-import java.util.Optional;
-
-import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
-import org.adempiere.test.AdempiereTestHelper;
-import org.compiere.model.I_C_UOM;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-
 import de.metas.business.BusinessTestHelper;
 import de.metas.handlingunits.HuId;
 import de.metas.organization.OrgId;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
+import lombok.NonNull;
+import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static java.math.BigDecimal.ONE;
+import static java.math.BigDecimal.TEN;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /*
  * #%L
@@ -46,7 +45,6 @@ import de.metas.quantity.Quantity;
 
 class HUTest
 {
-
 	private I_C_UOM stockUOMRecord;
 	private I_C_UOM weightUOMRecord;
 
@@ -60,74 +58,91 @@ class HUTest
 	}
 
 	@Test
-	void retainProduct()
+	void retainReference_1()
 	{
+		final TableRecordReference ref1 = TableRecordReference.of(1, 2);
+
 		final HU cu1_1 = HU.builder()
 				.id(HuId.ofRepoId(1))
 				.orgId(OrgId.ofRepoId(20))
 				.type(HUType.VirtualPI)
-				.packagingCode(Optional.empty())
+				.packagingCode(null)
 				.attributes(ImmutableAttributeSet.EMPTY)
 				.productQtyInStockUOM(ProductId.ofRepoId(31), Quantity.of(ONE, stockUOMRecord))
-				.weightNet(Optional.of(Quantity.of(new BigDecimal("4"), weightUOMRecord)))
+				.weightNet(Quantity.of(new BigDecimal("4"), weightUOMRecord))
+				.referencingModel(ref1)
 				.build();
 
 		final HU cu1_2 = cu1_1.toBuilder()
 				.clearProductQtysInStockUOM()
+				.clearReferencingModels()
 				.id(HuId.ofRepoId(2))
 				.productQtyInStockUOM(ProductId.ofRepoId(32), Quantity.of(TEN, stockUOMRecord))
-				.weightNet(Optional.of(Quantity.of(new BigDecimal("6"), weightUOMRecord)))
+				.weightNet(Quantity.of(new BigDecimal("6"), weightUOMRecord))
 				.build();
 
-		final HU tu1 = cu1_1.toBuilder().clearChildHUs().clearProductQtysInStockUOM()
+		// contains cu1_1 and cu1_2
+		final HU tu1 = cu1_1.toBuilder()
+				.clearChildHUs()
+				.clearProductQtysInStockUOM()
+				.clearReferencingModels()
 				.id(HuId.ofRepoId(10))
 				.type(HUType.TransportUnit)
 				.childHU(cu1_1)
 				.childHU(cu1_2)
 				.productQtyInStockUOM(ProductId.ofRepoId(31), Quantity.of(ONE, stockUOMRecord))
 				.productQtyInStockUOM(ProductId.ofRepoId(32), Quantity.of(TEN, stockUOMRecord))
-				.weightNet(Optional.of(Quantity.of(new BigDecimal("10"), weightUOMRecord)))
+				.weightNet(Quantity.of(new BigDecimal("10"), weightUOMRecord))
 				.build();
 
-		final HU tu2 = tu1.toBuilder().clearChildHUs().clearProductQtysInStockUOM()
+		// contains no CUs but references ref1
+		final HU tu2 = tu1.toBuilder()
+				.clearChildHUs()
 				.clearProductQtysInStockUOM()
 				.id(HuId.ofRepoId(20))
 				.productQtyInStockUOM(ProductId.ofRepoId(31), Quantity.of(new BigDecimal("20"), stockUOMRecord))
-				.weightNet(Optional.of(Quantity.of(new BigDecimal("20"), weightUOMRecord)))
+				.weightNet(Quantity.of(new BigDecimal("20"), weightUOMRecord))
+				.referencingModel(ref1)
 				.build();
 
-		final HU tu3 = tu1.toBuilder().clearChildHUs().clearProductQtysInStockUOM()
+		// contains no CUs
+		final HU tu3 = tu1.toBuilder()
+				.clearChildHUs()
 				.clearProductQtysInStockUOM()
+				.clearPackagingGTINs()
 				.id(HuId.ofRepoId(30))
 				.productQtyInStockUOM(ProductId.ofRepoId(32), Quantity.of(new BigDecimal("30"), stockUOMRecord))
-				.weightNet(Optional.of(Quantity.of(new BigDecimal("30"), weightUOMRecord)))
+				.weightNet(Quantity.of(new BigDecimal("30"), weightUOMRecord))
 				.build();
 
-		final HU lu = tu1.toBuilder().clearChildHUs().clearProductQtysInStockUOM()
+		final HU lu = tu1.toBuilder()
+				.clearChildHUs()
+				.clearProductQtysInStockUOM()
+				.clearReferencingModels()
 				.id(HuId.ofRepoId(100))
 				.type(HUType.LoadLogistiqueUnit)
 				.childHU(tu1)
 				.childHU(tu2)
 				.childHU(tu3)
-				.weightNet(Optional.of(Quantity.of(new BigDecimal("60"), weightUOMRecord)))
+				.weightNet(Quantity.of(new BigDecimal("60"), weightUOMRecord))
 				.productQtyInStockUOM(ProductId.ofRepoId(31), Quantity.of(new BigDecimal("21"), stockUOMRecord))
 				.productQtyInStockUOM(ProductId.ofRepoId(32), Quantity.of(new BigDecimal("40"), stockUOMRecord))
 				.build();
 
 		// invoke the method under test
-		final Optional<HU> luResult = lu.retainProduct(ProductId.ofRepoId(31));
+		final HU luResult = lu.retainReference(ref1);
 
-		assertThat(luResult).isPresent();
-		assertThat(luResult.get().getChildHUs()).as("tu3 should not have been retained").hasSize(2);
-		assertThat(luResult.get().getWeightNet()).isPresent();
-		assertThat(luResult.get().getWeightNet().get())
+		assertThat(luResult).isNotNull();
+		assertThat(luResult.getChildHUs()).as("tu3 should not have been retained").hasSize(2);
+		assertThat(luResult.getWeightNet()).isNotNull();
+		assertThat(luResult.getWeightNet())
 				.as("lu shall have a weight of 4 + 20 (from cu1_1 and tu2)").isEqualTo(Quantity.of(new BigDecimal("24"), weightUOMRecord));
 
-		assertThat(luResult.get().getProductQtysInStockUOM())
+		assertThat(luResult.getProductQtysInStockUOM())
 				.as("lu shall only have productId 31").containsOnlyKeys(ProductId.ofRepoId(31))
 				.as("lu shall have a qty of 20 + 1 (from tu1 and tu2)").containsValue(Quantity.of(new BigDecimal("21"), stockUOMRecord));
 
-		final ImmutableMap<HuId, HU> tuId2tu = Maps.uniqueIndex(luResult.get().getChildHUs(), HU::getId);
+		final ImmutableMap<HuId, HU> tuId2tu = Maps.uniqueIndex(luResult.getChildHUs(), HU::getId);
 		final HU tu1Result = tuId2tu.get(HuId.ofRepoId(10));
 		final HU tu2Result = tuId2tu.get(HuId.ofRepoId(20));
 
@@ -135,8 +150,8 @@ class HUTest
 				.containsOnlyKeys(ProductId.ofRepoId(31))
 				.containsValue(Quantity.of(ONE, stockUOMRecord));
 		assertThat(tu1Result.getChildHUs()).as("cu1_2 should not have been retained").hasSize(1);
-		assertThat(tu1Result.getWeightNet()).isPresent();
-		assertThat(tu1Result.getWeightNet().get())
+		assertThat(tu1Result.getWeightNet()).isNotNull();
+		assertThat(tu1Result.getWeightNet())
 				.as("lu shall have a weight of 4 (from cu1_1)").isEqualTo(Quantity.of(new BigDecimal("4"), weightUOMRecord));
 
 		assertThat(tu2Result.getProductQtysInStockUOM())
@@ -144,4 +159,145 @@ class HUTest
 				.containsValue(Quantity.of(new BigDecimal("20"), stockUOMRecord));
 	}
 
+	/**
+	 * Expect that the 1st and 3rd CU are both retained.
+	 * The first one because it explicitly has ref1 and the third one because it has no reference, but its parent has ref1.
+	 */
+	@Test
+	void retainReference_2()
+	{
+		// given
+		final ProductId productId = BusinessTestHelper.createProductId("product", stockUOMRecord);
+		final TableRecordReference ref1 = TableRecordReference.of(1, 2);
+		final TableRecordReference ref2 = TableRecordReference.of(3, 4);
+
+		final HU tu1 = prepareTU(productId, ref1, ref2);
+
+		// when
+		final HU result = tu1.retainReference(ref1);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getId()).isEqualTo(HuId.ofRepoId(10));
+		assertThat(result.getProductQtysInStockUOM().get(productId)).isEqualByComparingTo(Quantity.of("1", stockUOMRecord));
+		assertThat(result.getChildHUs()).hasSize(1); // we expect c1_1 and c1_3 to be retained
+		assertThat(result.getProductQtysInStockUOM()).hasSize(1);
+		assertThat(result.getWeightNet()).isNotNull();
+		assertThat(result.getWeightNet()).isEqualByComparingTo(Quantity.of("3", weightUOMRecord));
+		assertThat(result.getReferencingModels()).containsExactly(ref1);
+
+		assertThat(result.getChildHUs().get(0).getId()).isEqualTo(HuId.ofRepoId(1));
+		assertThat(result.getChildHUs().get(0).getProductQtysInStockUOM().get(productId)).isEqualByComparingTo(Quantity.of("1", stockUOMRecord));
+		assertThat(result.getChildHUs().get(0).getWeightNet()).isNotNull();
+		assertThat(result.getChildHUs().get(0).getWeightNet()).isEqualByComparingTo(Quantity.of("3", weightUOMRecord));
+		assertThat(result.getChildHUs().get(0).getReferencingModels()).containsExactly(ref1);
+	}
+
+	/**
+	 * Expect that only the 2nd CU is retained.
+	 */
+	@Test
+	void retainReference_3()
+	{
+		// given
+		final ProductId productId = BusinessTestHelper.createProductId("product", stockUOMRecord);
+		final TableRecordReference ref1 = TableRecordReference.of(1, 2);
+		final TableRecordReference ref2 = TableRecordReference.of(3, 4);
+
+		final HU tu1 = prepareTU(productId, ref1, ref2);
+
+		// when
+		final HU result = tu1.retainReference(ref2);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getId()).isEqualTo(HuId.ofRepoId(10));
+		assertThat(result.getProductQtysInStockUOM().get(productId)).isEqualByComparingTo(Quantity.of("110", stockUOMRecord));
+		assertThat(result.getChildHUs()).hasSize(2); // we expect c1_2 and c1_3 to be retained
+		assertThat(result.getWeightNet()).isNotNull();
+		assertThat(result.getWeightNet()).isEqualByComparingTo(Quantity.of("9", weightUOMRecord));
+		assertThat(result.getReferencingModels()).containsExactly(ref2);
+
+		assertThat(result.getChildHUs().get(0).getId()).isEqualTo(HuId.ofRepoId(2));
+		assertThat(result.getChildHUs().get(0).getProductQtysInStockUOM().get(productId)).isEqualByComparingTo(Quantity.of("10", stockUOMRecord));
+		assertThat(result.getChildHUs().get(0).getWeightNet()).isNotNull();
+		assertThat(result.getChildHUs().get(0).getWeightNet()).isEqualByComparingTo(Quantity.of("4", weightUOMRecord));
+		assertThat(result.getChildHUs().get(0).getReferencingModels()).containsExactly(ref2);
+
+		assertThat(result.getChildHUs().get(1).getId()).isEqualTo(HuId.ofRepoId(3));
+		assertThat(result.getChildHUs().get(1).getProductQtysInStockUOM().get(productId)).isEqualByComparingTo(Quantity.of("100", stockUOMRecord));
+		assertThat(result.getChildHUs().get(1).getWeightNet()).isNotNull();
+		assertThat(result.getChildHUs().get(1).getWeightNet()).isEqualByComparingTo(Quantity.of("5", weightUOMRecord));
+		assertThat(result.getChildHUs().get(1).getReferencingModels()).containsExactly(ref2);
+	}
+
+	@Test
+	public void extractMedianCUQtyPerChildHU()
+	{
+		final ProductId productId = BusinessTestHelper.createProductId("product", stockUOMRecord);
+		final TableRecordReference ref1 = TableRecordReference.of(1, 2);
+		final TableRecordReference ref2 = TableRecordReference.of(3, 4);
+		
+		final HU tu1 = prepareTU(productId, ref1, ref2);
+
+		assertThat(tu1.extractMedianCUQtyPerChildHU(productId)).isEqualByComparingTo(Quantity.of(TEN, stockUOMRecord));
+	}
+	
+	/**
+	 * The HUs all have the same product
+	 */
+	private HU prepareTU(
+			@NonNull final ProductId productId,
+			@NonNull final TableRecordReference ref1,
+			@NonNull final TableRecordReference ref2)
+	{
+		final HU cu1_1 = HU.builder()
+				.id(HuId.ofRepoId(1))
+				.orgId(OrgId.ofRepoId(20))
+				.type(HUType.VirtualPI)
+				.packagingCode(null)
+				.attributes(ImmutableAttributeSet.EMPTY)
+				.productQtyInStockUOM(productId, Quantity.of(ONE, stockUOMRecord))
+				.weightNet(Quantity.of(new BigDecimal("3"), weightUOMRecord))
+				.referencingModel(ref1)
+				.build();
+
+		// explicitly references ref2 tableRecordReference, so it shall not be retained if ref1 is asked for
+		final HU cu1_2 = HU.builder()
+				.id(HuId.ofRepoId(2))
+				.orgId(OrgId.ofRepoId(20))
+				.type(HUType.VirtualPI)
+				.packagingCode(null)
+				.attributes(ImmutableAttributeSet.EMPTY)
+				.productQtyInStockUOM(productId, Quantity.of(TEN, stockUOMRecord))
+				.weightNet(Quantity.of(new BigDecimal("4"), weightUOMRecord))
+				.referencingModel(ref2)
+				.build();
+
+		// explicitly references ref2 tableRecordReference, so it shall not be retained if ref1 is asked for
+		final HU cu1_3 = HU.builder()
+				.id(HuId.ofRepoId(3))
+				.orgId(OrgId.ofRepoId(20))
+				.type(HUType.VirtualPI)
+				.packagingCode(null)
+				.attributes(ImmutableAttributeSet.EMPTY)
+				.productQtyInStockUOM(productId, Quantity.of("100", stockUOMRecord))
+				.weightNet(Quantity.of(new BigDecimal("5"), weightUOMRecord))
+				.referencingModel(ref2)
+				.build();
+
+		return HU.builder()
+				.id(HuId.ofRepoId(10))
+				.orgId(OrgId.ofRepoId(20))
+				.type(HUType.TransportUnit)
+				.attributes(ImmutableAttributeSet.EMPTY)
+				.childHU(cu1_1)
+				.childHU(cu1_2)
+				.childHU(cu1_3)
+				.productQtyInStockUOM(productId, Quantity.of("111", stockUOMRecord))
+				.weightNet(Quantity.of(new BigDecimal("12"), weightUOMRecord))
+				.referencingModel(ref1)
+				.build();
+	}
 }
+

--- a/misc/dev-support/docker/infrastructure/env-files/intensive_care_uat.env
+++ b/misc/dev-support/docker/infrastructure/env-files/intensive_care_uat.env
@@ -6,6 +6,8 @@
 BRANCH_NAME=intensive_care_uat
 
 DB_PORT=10432
+DB_DOCKER_IMG=metasfresh/metas-db:5.175-release-5.175
+# DB_DOCKER_IMG=ghcr.io/metasfresh/ic114/metasfresh-db:5.175-intensive-care-hotfix.1352-compat
 
 RABBITMQ_PORT=10672
 RABBITMQ_MGMT_PORT=10673


### PR DESCRIPTION
Fix problem where LU-Qty were counted multiple times when creating DESADV-Packs (#20665)

- Actually finish the job started at https://github.com/metasfresh/metasfresh/commit/0c47469a64706889f96542bc4cd2c9035b2c0382
   - i now count just the parts of an HU-tree that belong via `M_HU_Assignent` to a particular inOutLine (=> also method `HU.retainReference(...)`  for this)
- Also 
   - EDIDesadvPackService.java: set common LotNumber to Pack-Item even if the toplevel-HU doesn't have it among its HU-Attributes
   - remove optionals from HU.java. They cluttered the code and aren't better than `null`
   - modernize docker dev-support files
   - move 3 HU-related cucumber-classes to the hu package
   - modernize M_HU_Item_StepDef
   - cleanup up M_Inventory_StepDef: remove two reduncant definitions that didn't set the inventory's warehouse
   - unrelated: add a test for the behavior of SimpleDateFormat. background: we sometimes need to import 21.03.2025 and sometimes 21.03.25.
   - cleanup up M_Inventory_StepDef: remove two reduncant definitions that didn't even set the inventory's warehouse
   - ediDesadvPack_with_normal_UOM.feature: add test `@Id:S0457_020` for this fix
   - EDI_Desadv_Pack_Item_StepDef: make more use of TableRow
   - M_InOut_Line_StepDef: allow to validate C_OrderLine_ID