### PR TITLE
Another fix for extraction of Qty and LotNo from HU when creating a DESADV-Pack (#20719)

### DIFF
--- a/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/pack/EDIDesadvPackService.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/pack/EDIDesadvPackService.java
@@ -447,13 +447,15 @@ public class EDIDesadvPackService
 
 		final HU topLevelHU = huRepository
 				.getById(HuId.ofRepoId(topLevelHURecord.getM_HU_ID()))
-				.retainReference(TableRecordReference.of(inOutLineRecord)); // we just want the qty related to the current inoutLine
+				.retain(TableRecordReference.of(inOutLineRecord), productId); // we just want the qty related to the current inoutLine
 		if (topLevelHU == null)
 		{
 			throw new AdempiereException("Missing M_HU").appendParametersToMessage()
 					.setParameter("M_HU_ID", topLevelHURecord.getM_HU_ID())
-					.setParameter("M_InOutLine_ID", inOutLineRecord.getM_InOutLine_ID())
+					.setParameter("EDI_DesadvLine.EDI_Desadv_ID", desadvLineRecord.getEDI_Desadv_ID())
+					.setParameter("EDI_DesadvLine.Line", desadvLineRecord.getLine())
 					.setParameter("EDI_DesadvLine_ID", desadvLineRecord.getEDI_DesadvLine_ID());
+				// no need for a parameter with the InOutLine-ID, because the InOutLine is rolled back anyways
 		}
 
 		final StockQtyAndUOMQty inOutLineQty = inOutBL.extractInOutLineQty(inOutLineRecord, invoicableQtyBasedOn);
@@ -571,7 +573,7 @@ public class EDIDesadvPackService
 						.bestBeforeDate(TimeUtil.asTimestamp(bestBefore))
 						.qtyTu(parameters.topLevelHU.getChildHUs().size());
 
-		final String lotNumber = parameters.topLevelHU.extractSingleLotNumber();
+		final String lotNumber = parameters.topLevelHU.extractLotNumber();
 		if (Check.isNotBlank(lotNumber))
 		{
 			createPackItemRequestBuilder.lotNumber(lotNumber);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUAssignmentBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUAssignmentBL.java
@@ -85,27 +85,34 @@ public class HUAssignmentBL implements IHUAssignmentBL
 	}
 
 	@Override
-	public void assignHUs(final Object model, final Collection<I_M_HU> huList, final String trxName)
+	public void assignHUs(
+			@NonNull final Object model,
+			@NonNull final Collection<I_M_HU> huList, 
+			@Nullable final String trxName)
 	{
-		Check.assumeNotNull(model, "model not null");
-		Check.assumeNotNull(huList, "huList not null");
 		if (huList.isEmpty())
 		{
-			// Nothing to do.
-			return;
+			return; // Nothing to do.
 		}
 
 		huList.forEach(hu -> assignHU(model, hu, trxName));
 	}
 
 	@Override
-	public I_M_HU_Assignment assignHU(final Object model, final I_M_HU hu, final String trxName)
+	public I_M_HU_Assignment assignHU(
+			@NonNull final Object model,
+			@NonNull final I_M_HU hu, 
+			@Nullable final String trxName)
 	{
 		return assignHU0(model, hu, IsTransferPackingMaterials_DoNotChange, trxName);
 	}
 
 	@Override
-	public I_M_HU_Assignment assignHU(final Object model, final I_M_HU hu, final boolean isTransferPackingMaterials, final String trxName)
+	public I_M_HU_Assignment assignHU(
+			@NonNull final Object model,
+			@NonNull final I_M_HU hu, 
+			final boolean isTransferPackingMaterials,
+			@Nullable final String trxName)
 	{
 		return assignHU0(model, hu, isTransferPackingMaterials, trxName);
 	}
@@ -114,7 +121,7 @@ public class HUAssignmentBL implements IHUAssignmentBL
 			@NonNull final Object model,
 			@NonNull final I_M_HU hu,
 			@Nullable final Boolean isTransferPackingMaterials,
-			final String trxName)
+			@Nullable final String trxName)
 	{
 		// Validate the HU
 		final int huId = Check.assumeGreaterThanZero(hu.getM_HU_ID(), "hu.getM_HU_ID()");

--- a/backend/de.metas.util/src/main/java/de/metas/util/Check.java
+++ b/backend/de.metas.util/src/main/java/de/metas/util/Check.java
@@ -325,6 +325,7 @@ public final class Check
 	 * @see #assume(boolean, String, Object...)
 	 * @see #isEmpty(String, boolean)
 	 */
+	@Contract("null, _, _ -> fail")
 	public static String assumeNotEmpty(@Nullable final String str, final String assumptionMessage, final Object... params)
 	{
 		return assumeNotEmpty(str, defaultExClazz, assumptionMessage, params);


### PR DESCRIPTION
Another fix for extraction of Qty and LotNo from HU when creating a DESADV-Pack (#20719)

* Fix an issue that occured with aggregated HUs
* If the HU in question has a LotNo then return that, also if its children have diverging LotNos
   * Only look at the children if the HU in question has no LotNo of its own