### PR TITLE
Fix pricingEngine picks up priceListVersion with wrong isSOTrx with break discount

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/pricing/conditions/service/impl/CalculatePricingConditionsCommand.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/conditions/service/impl/CalculatePricingConditionsCommand.java
@@ -242,7 +242,7 @@ import java.util.Optional;
 		newPricingCtx.setPricingSystemId(basePricingSystemId);
 		newPricingCtx.setPriceListId(null); // will be recomputed
 		newPricingCtx.setPriceListVersionId(null); // will be recomputed
-		newPricingCtx.setSkipCheckingPriceListSOTrxFlag(true);
+		newPricingCtx.setSkipCheckingPriceListSOTrxFlag(false);
 		newPricingCtx.setDisallowDiscount(true);
 		newPricingCtx.setFailIfNotCalculated();
 


### PR DESCRIPTION
💡 Only happens if purchase priceListVersion.validFrom > sales priceListVersion.validFrom