### PR TITLE
Improve error handling on webui view patching

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5758580_M_Material_Needs_Planner_V_make_it_editable_2.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5758580_M_Material_Needs_Planner_V_make_it_editable_2.sql
@@ -1,0 +1,22 @@
+-- Run mode: SWING_CLIENT
+
+-- Column: M_Material_Needs_Planner_V.Level_Max
+-- 2025-06-25T07:46:08.400Z
+UPDATE AD_Column SET ReadOnlyLogic='@M_Product_ID/0@<1 | @M_Warehouse_ID/0@<1',Updated=TO_TIMESTAMP('2025-06-25 07:46:08.399000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=589753
+;
+
+-- Column: M_Material_Needs_Planner_V.Level_Min
+-- 2025-06-25T07:46:15.553Z
+UPDATE AD_Column SET ReadOnlyLogic='@M_Product_ID/0@<1 | @M_Warehouse_ID/0@<1',Updated=TO_TIMESTAMP('2025-06-25 07:46:15.553000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=589752
+;
+
+-- Column: M_Material_Needs_Planner_V.Level_Min
+-- 2025-06-25T07:54:01.017Z
+UPDATE AD_Column SET IsUpdateable='Y',Updated=TO_TIMESTAMP('2025-06-25 07:54:01.017000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=589752
+;
+
+-- Column: M_Material_Needs_Planner_V.Level_Max
+-- 2025-06-25T07:54:04.182Z
+UPDATE AD_Column SET IsUpdateable='Y',Updated=TO_TIMESTAMP('2025-06-25 07:54:04.181000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=589753
+;
+

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/json/JSONViewRow.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/json/JSONViewRow.java
@@ -22,18 +22,11 @@
 
 package de.metas.ui.web.view.json;
 
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
+import de.metas.common.rest_api.v2.JsonErrorItem;
 import de.metas.ui.web.comments.ViewRowCommentsSummary;
 import de.metas.ui.web.view.IViewRow;
 import de.metas.ui.web.view.IViewRowOverrides;
@@ -49,7 +42,15 @@ import de.metas.ui.web.window.descriptor.DocumentFieldWidgetType;
 import de.metas.ui.web.window.descriptor.ViewEditorRenderMode;
 import de.metas.util.GuavaCollectors;
 import lombok.NonNull;
+import lombok.Setter;
 import lombok.Value;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * View document (row).
@@ -209,6 +210,10 @@ public class JSONViewRow extends JSONDocumentBase implements JSONViewRowBase
 	@JsonProperty("caption")
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private String caption;
+
+	@JsonProperty("error")
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@Setter private JsonErrorItem error;
 
 	private JSONViewRow(final DocumentId documentId)
 	{

--- a/frontend/src/actions/ViewActions.js
+++ b/frontend/src/actions/ViewActions.js
@@ -47,6 +47,7 @@ import { createFilter, deleteFilter } from './FiltersActions';
 import { deleteQuickActions, fetchQuickActions } from './Actions';
 import { closeModal, closeRawModal, setRawModalTitle } from './WindowActions';
 import { patchModalView } from '../api/view';
+import { addNotification } from './AppActions';
 
 /**
  * @method resetView
@@ -651,6 +652,19 @@ export function patchViewAction({ windowId, viewId, rowId, fieldName, value }) {
             rowsToUpdate: [row],
           })
         );
+
+        const error = row.error;
+        if (error?.userFriendlyError) {
+          const message = error.message ?? '';
+          dispatch(
+            addNotification(
+              'Error: ' + message.split(' ', 4).join(' ') + '...',
+              message,
+              5000,
+              'error'
+            )
+          );
+        }
       }
     );
   };

--- a/frontend/src/actions/WindowActions.js
+++ b/frontend/src/actions/WindowActions.js
@@ -896,7 +896,7 @@ export function patch(
   isEdit,
   disconnected
 ) {
-  if (entity === 'documentView' && isModal) {
+  if (entity === 'documentView') {
     return patchViewAction({
       windowId: windowType,
       viewId,


### PR DESCRIPTION
- **ViewRowEditRestController: when patching a row, if there is an exception, return the original row and fill the new error field.**
- **FE: when patching a view, handle the new error field from the response**
- **pimp M_Material_needs_Planner_V, make it really editable only when applicable**
