### PR TITLE
When creating an AsyncBatch-Workpackage, don't store the C_AsyncBatch_ID thread-locally (#20369)

### DIFF
--- a/backend/de-metas-salesorder/src/main/java/de/metas/salesorder/service/AutoProcessingOrderService.java
+++ b/backend/de-metas-salesorder/src/main/java/de/metas/salesorder/service/AutoProcessingOrderService.java
@@ -26,7 +26,6 @@ import ch.qos.logback.classic.Level;
 import com.google.common.collect.ImmutableSet;
 import de.metas.async.AsyncBatchId;
 import de.metas.async.api.IAsyncBatchBL;
-import de.metas.async.model.I_C_Async_Batch;
 import de.metas.bpartner.BPartnerLocationAndCaptureId;
 import de.metas.handlingunits.shipmentschedule.api.GenerateShipmentsForSchedulesRequest;
 import de.metas.handlingunits.shipmentschedule.api.M_ShipmentSchedule_QuantityTypeToUse;
@@ -145,7 +144,6 @@ public class AutoProcessingOrderService
 				.collect(ImmutableSet.toImmutableSet());
 
 		final AsyncBatchId asyncBatchId = extractOrCreateAsyncBatchId(orderId);
-
 		invoiceService.generateInvoicesFromInvoiceCandidateIds(invoiceCandidateIds, asyncBatchId);
 	}
 
@@ -160,13 +158,12 @@ public class AutoProcessingOrderService
 			return AsyncBatchId.ofRepoId(asyncBatchIdInt);
 		}
 
-		final I_C_Async_Batch asyncBatchRecord = asyncBatchBL.newAsyncBatch()
+		return asyncBatchBL.newAsyncBatch()
 				.setContext(Env.getCtx())
 				.setC_Async_Batch_Type(C_Async_Batch_InternalName_InvoiceCandidate_Processing)
 				.setName("Process ICs for C_Order_ID=" + OrderId.toRepoId(orderId))
 				.setOrgId(OrgId.ofRepoId(orderRecord.getAD_Org_ID()))
-				.build();
-		return AsyncBatchId.ofRepoId(asyncBatchRecord.getC_Async_Batch_ID());
+				.buildAndEnqueue();
 	}
 
 	private boolean sameShippingAndBillingAddress(

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/wrapper/IInterfaceWrapperHelper.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/wrapper/IInterfaceWrapperHelper.java
@@ -59,8 +59,6 @@ public interface IInterfaceWrapperHelper
 	Properties getCtx(final Object model, final boolean useClientOrgFromModel);
 
 	/**
-	 *
-	 * @param model
 	 * @param ignoreIfNotHandled if <code>true</code> and the given model can not be handeled (no PO, GridTab etc), then just return {@link ITrx#TRXNAME_None} without logging a warning.
 	 *
 	 * @return trxName
@@ -68,9 +66,6 @@ public interface IInterfaceWrapperHelper
 	String getTrxName(final Object model, final boolean ignoreIfNotHandled);
 
 	/**
-	 *
-	 * @param model
-	 * @param trxName
 	 * @param ignoreIfNotHandled <code>true</code> and the given model can not be handled (no PO, GridTab etc), then don't throw an exception,
 	 *
 	 * @throws AdempiereException if the given model is not handled and ignoreIfNotHandled is <code>false</code>.
@@ -87,20 +82,18 @@ public interface IInterfaceWrapperHelper
 
 	/**
 	 * Get TableName of wrapped model.
-	 *
+	 * <p>
 	 * This method returns null when:
 	 * <ul>
 	 * <li>model is null
 	 * <li>model is not supported
 	 * </ul>
 	 *
-	 * @param model
 	 * @return table name or null
 	 */
 	String getModelTableNameOrNull(Object model);
 
 	/**
-	 * @param model
 	 * @return true if model is a new record (not yet saved in database)
 	 */
 	boolean isNew(Object model);
@@ -127,7 +120,7 @@ public interface IInterfaceWrapperHelper
 	boolean isNull(Object model, String columnName);
 	
 	@Nullable
-	<T> T getDynAttribute(@NonNull final Object model, final String attributeName);
+	<T> T getDynAttribute(@NonNull Object model, final String attributeName);
 
 	Object setDynAttribute(final Object model, final String attributeName, final Object value);
 

--- a/backend/de.metas.async/src/main/java/de/metas/async/AsyncHelper.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/AsyncHelper.java
@@ -1,0 +1,47 @@
+/*
+ * #%L
+ * de.metas.async
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.async;
+
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+import org.adempiere.model.InterfaceWrapperHelper;
+
+import javax.annotation.Nullable;
+
+import static de.metas.async.Async_Constants.DYNATTR_AsyncBatchId;
+
+@UtilityClass
+public class AsyncHelper
+{
+	public static void setAsyncBatchId(final Object record, @Nullable final AsyncBatchId asyncBatchId)
+	{
+		InterfaceWrapperHelper.setDynAttribute(record, DYNATTR_AsyncBatchId, asyncBatchId);
+	}
+
+	@Nullable
+	public static AsyncBatchId getAsyncBatchId(@NonNull final Object record)
+	{
+		return InterfaceWrapperHelper.getDynAttribute(record, DYNATTR_AsyncBatchId);
+	}
+
+}

--- a/backend/de.metas.async/src/main/java/de/metas/async/Async_Constants.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/Async_Constants.java
@@ -45,7 +45,7 @@ public final class Async_Constants
 	 */
 	public static final int DEFAULT_RETRY_TIMEOUT_MILLIS = 5000;
 
-	public static final String C_Async_Batch = "C_Async_Batch";
+	static final String DYNATTR_AsyncBatchId = "AsyncBatchId";
 
 	public static final Topic WORKPACKAGE_ERROR_USER_NOTIFICATIONS_TOPIC = Topic.builder()
 			.name("de.metas.async.UserNotifications.WorkpackageProcessingErrors")

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/IAsyncBatchBL.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/IAsyncBatchBL.java
@@ -57,12 +57,13 @@ public interface IAsyncBatchBL extends ISingletonService
 	boolean updateProcessedOutOfTrx(AsyncBatchId asyncBatchId);
 
 	/**
-	 * Enqueue batch for the de.metas.async.processor.impl.CheckProcessedAsynBatchWorkpackageProcessor processor. Call
-	 * {@link IWorkPackageQueue#enqueueWorkPackage(I_C_Queue_WorkPackage, IWorkpackagePrioStrategy)} with priority = <code>null</code>.
+	 * Enqueue batch for the de.metas.async.processor.impl.CheckProcessedAsynBatchWorkpackageProcessor processor.
+	 * <p>
+	 * Call {@link IWorkPackageQueue#enqueueWorkPackage(I_C_Queue_WorkPackage, IWorkpackagePrioStrategy)} with priority = <code>null</code>.
 	 * This is OK because we assume that there is a dedicated queue/thread
 	 * for CheckProcessedAsynBatchWorkpackageProcessor
 	 */
-	void enqueueAsyncBatch(AsyncBatchId asyncBatchId);
+	 void enqueueAsyncBatch(@NonNull AsyncBatchId asyncBatchId);
 
 	/**
 	 * check if the keep alive time has expired for the current batch

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/IAsyncBatchBuilder.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/IAsyncBatchBuilder.java
@@ -10,18 +10,17 @@ package de.metas.async.api;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
-
 
 import de.metas.async.AsyncBatchId;
 import de.metas.async.model.I_C_Async_Batch;
@@ -33,32 +32,32 @@ import java.util.Properties;
 
 /**
  * Builds {@link I_C_Async_Batch}.
- * 
- * @author tsa
  *
+ * @author tsa
  */
 public interface IAsyncBatchBuilder
 {
 	/**
 	 * Builds the {@link I_C_Async_Batch} and it also enqueue a workpackage to watch for it.
-	 * 
+	 *
 	 * @return built {@link I_C_Async_Batch}
 	 */
-	I_C_Async_Batch build();
+	AsyncBatchId buildAndEnqueue();
 
 	IAsyncBatchBuilder setContext(Properties ctx);
 
 	IAsyncBatchBuilder setC_Async_Batch_Type(final String internalName);
 
 	IAsyncBatchBuilder setName(final String name);
-	
+
 	IAsyncBatchBuilder setCountExpected(final int expected);
 
 	IAsyncBatchBuilder setDescription(final String description);
 
 	IAsyncBatchBuilder setAD_PInstance_Creator_ID(PInstanceId adPInstanceId);
-	
+
 	IAsyncBatchBuilder setParentAsyncBatchId(@Nullable AsyncBatchId parentAsyncBatchId);
 
-	 IAsyncBatchBuilder setOrgId(@Nullable final OrgId orgId);
+	IAsyncBatchBuilder setOrgId(@Nullable final OrgId orgId);
+
 }

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/IWorkPackageQueue.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/IWorkPackageQueue.java
@@ -163,11 +163,6 @@ public interface IWorkPackageQueue
 	Future<IWorkpackageProcessorExecutionResult> markReadyForProcessingAfterTrxCommit(I_C_Queue_WorkPackage workPackage, String trxName);
 
 	/**
-	 * Set the async batch Id every new workpackage will be associated with.
-	 */
-	IWorkPackageQueue setAsyncBatchIdForNewWorkpackages(AsyncBatchId asyncBatchId);
-
-	/**
 	 * For queues that were created with {@link IWorkPackageQueueFactory#getQueueForEnqueuing(Properties, Class)}, this method returns the <code>InternalName</code> value of the queue's
 	 * {@link I_C_Queue_PackageProcessor}. If the queue doesn't have an internal name, it returns the <code>ClassName</code> value.
 	 *

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/IWorkpackageProcessorContextFactory.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/IWorkpackageProcessorContextFactory.java
@@ -3,20 +3,10 @@ package de.metas.async.api;
 import de.metas.async.AsyncBatchId;
 import de.metas.util.ISingletonService;
 
+import javax.annotation.Nullable;
+
 public interface IWorkpackageProcessorContextFactory extends ISingletonService
 {
-	/**
-	 * Associate the given {@code asyncBatchId} (or {@code null} with the current thread.
-	 *
-	 * @return the async batch Id that was formerly associate with the current thread, or <code>null</code>.
-	 */
-	AsyncBatchId setThreadInheritedAsyncBatch(AsyncBatchId asyncBatch);
-
-	/**
-	 * Get batch id from the inherited thread or {@code null}
-	 */
-	AsyncBatchId getThreadInheritedAsyncBatchId();
-
 
 	/**
 	 * Get the priority associated with the current thread
@@ -27,7 +17,7 @@ public interface IWorkpackageProcessorContextFactory extends ISingletonService
 	 * Associate the given <code>priority</code> with the current thread. Method is called before a workpackage is processed. If the WP-processor itself creawtes a follow-up workpackage, then the
 	 * framework will assign this priority to the new workpackage, so that the follow-up package inherit the original package's priority.
 	 */
-	void setThreadInheritedPriority(String priority);
+	void setThreadInheritedPriority(@Nullable String priority);
 
 	/**
 	 * Associate the given {@code asyncBatchId} (or {@code null} with the current thread as the current workpackge async batch Id.
@@ -36,7 +26,7 @@ public interface IWorkpackageProcessorContextFactory extends ISingletonService
 	 *
 	 * @return the async batch Id that was formerly associated with the current thread, or {@code null}.
 	 */
-	AsyncBatchId setThreadInheritedWorkpackageAsyncBatch(AsyncBatchId asyncBatch);
+	AsyncBatchId setThreadInheritedWorkpackageAsyncBatch(@Nullable AsyncBatchId asyncBatch);
 
 	/**
 	 * Get batch id from the inherited thread or {@code null}

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/impl/WorkpackageProcessorContextFactory.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/impl/WorkpackageProcessorContextFactory.java
@@ -5,27 +5,9 @@ import de.metas.async.api.IWorkpackageProcessorContextFactory;
 
 public class WorkpackageProcessorContextFactory implements IWorkpackageProcessorContextFactory
 {
-
-	private final InheritableThreadLocal<AsyncBatchId> threadLocalAsyncBatch = new InheritableThreadLocal<>();
-
 	private final InheritableThreadLocal<AsyncBatchId> threadLocalWorkpackageAsyncBatch = new InheritableThreadLocal<>();
 
 	private final InheritableThreadLocal<String> threadLocalPriority = new InheritableThreadLocal<>();
-
-	@Override
-	public AsyncBatchId setThreadInheritedAsyncBatch(final AsyncBatchId asyncBatchId)
-	{
-		final AsyncBatchId asyncBatchIdOld = threadLocalAsyncBatch.get();
-		threadLocalAsyncBatch.set(asyncBatchId);
-		return asyncBatchIdOld;
-	}
-
-	@Override
-	public AsyncBatchId getThreadInheritedAsyncBatchId()
-	{
-		final AsyncBatchId asyncBatchId = threadLocalAsyncBatch.get();
-		return asyncBatchId;
-	}
 
 	@Override
 	public String getThreadInheritedPriority()

--- a/backend/de.metas.async/src/main/java/de/metas/async/processor/impl/WorkpackageProcessorTask.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/processor/impl/WorkpackageProcessorTask.java
@@ -103,7 +103,6 @@ import static de.metas.async.event.WorkpackageProcessedEvent.Status.SKIPPED;
 class WorkpackageProcessorTask implements Runnable
 {
 	private static final AdMessageKey MSG_PROCESSING_ERROR_NOTIFICATION_TEXT = AdMessageKey.of("de.metas.async.WorkpackageProcessorTask.ProcessingErrorNotificationText");
-	private static final AdMessageKey MSG_PROCESSING_ERROR_NOTIFICATION_TITLE = AdMessageKey.of("de.metas.async.WorkpackageProcessorTask.ProcessingErrorNotificationTitle");
 	// services
 	private static final Logger logger = LogManager.getLogger(WorkpackageProcessorTask.class);
 
@@ -330,7 +329,6 @@ class WorkpackageProcessorTask implements Runnable
 	private void beforeWorkpackageProcessing()
 	{
 		// If the current workpackage's processor creates a follow-up-workpackage, the asyncBatch and priority will be forwarded.
-		contextFactory.setThreadInheritedAsyncBatch(AsyncBatchId.ofRepoIdOrNull(workPackage.getC_Async_Batch_ID()));
 		contextFactory.setThreadInheritedWorkpackageAsyncBatch(AsyncBatchId.ofRepoIdOrNull(workPackage.getC_Async_Batch_ID()));
 
 		final String priority = workPackage.getPriority();
@@ -440,7 +438,6 @@ class WorkpackageProcessorTask implements Runnable
 	{
 		// get rid of inherited AsyncBatchId and priority
 		// actually it's not necessary, but we are doing it for safety reasons
-		contextFactory.setThreadInheritedAsyncBatch(null);
 		contextFactory.setThreadInheritedWorkpackageAsyncBatch(null);
 		contextFactory.setThreadInheritedPriority(null);
 
@@ -598,20 +595,12 @@ class WorkpackageProcessorTask implements Runnable
 			issueId = Services.get(IErrorManager.class).createIssue(ex);
 		}
 
-		//
-		// Allow retry processing this workpackage?
-		if (workPackageProcessorWrapped.isAllowRetryOnError())
-		{
-			workPackage.setProcessed(false); // just in case it was true
-		}
-		else
-		{
-			// Flag the workpackage as processed in order to:
-			// * not allow future retries
-			// * avoid discarding items from this workpackage on future workpackages because they were enqueued here
-			// TODO shall we also release the elements lock if any?
-			workPackage.setProcessed(true);
-		}
+		// If we don't allow retry processing this workpackage, then flag it as processed in order to:
+		// * not allow future retries
+		// * avoid discarding items from this workpackage on future workpackages because they were enqueued here
+		// TODO shall we also release the elements lock if any?
+		// Otherwise, just set it as unprocessed (even if it was marked as processed), because we're dealing with an error.
+		workPackage.setProcessed(!workPackageProcessorWrapped.isAllowRetryOnError());
 
 		workPackage.setIsError(true);
 		workPackage.setErrorMsg(ex.getLocalizedMessage());

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/async/spi/impl/DocOutboundWorkpackageProcessor.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/async/spi/impl/DocOutboundWorkpackageProcessor.java
@@ -22,12 +22,11 @@ package de.metas.document.archive.async.spi.impl;
  * #L%
  */
 
-import de.metas.async.AsyncBatchId;
 import ch.qos.logback.classic.Level;
-import de.metas.async.Async_Constants;
+import de.metas.async.AsyncBatchId;
+import de.metas.async.AsyncHelper;
 import de.metas.async.api.IAsyncBatchBL;
 import de.metas.async.api.IQueueDAO;
-import de.metas.async.model.I_C_Async_Batch;
 import de.metas.async.model.I_C_Queue_WorkPackage;
 import de.metas.async.spi.IWorkpackageProcessor;
 import de.metas.document.archive.mailrecipient.DocOutBoundRecipient;
@@ -92,13 +91,13 @@ public class DocOutboundWorkpackageProcessor implements IWorkpackageProcessor
 		}
 
 		final UserId userId = UserId.ofRepoIdOrNull(workpackage.getAD_User_ID());
-		final I_C_Async_Batch asyncBatch = workpackage.getC_Async_Batch_ID() > 0 ? workpackage.getC_Async_Batch() : null;
+		final AsyncBatchId asyncBatchId = AsyncBatchId.ofRepoIdOrNull(workpackage.getC_Async_Batch_ID());
 
 		final List<Object> records = queueDAO.retrieveAllItems(workpackage, Object.class);
 		for (final Object record : records)
 		{
-			InterfaceWrapperHelper.setDynAttribute(record, Async_Constants.C_Async_Batch, asyncBatch);
-			try (final IAutoCloseable ignored = asyncBatchBL.assignTempAsyncBatchIdToModel(record, AsyncBatchId.ofRepoIdOrNull(asyncBatch != null ? asyncBatch.getC_Async_Batch_ID() : -1)))
+			AsyncHelper.setAsyncBatchId(record, asyncBatchId);
+			try (final IAutoCloseable ignored = asyncBatchBL.assignTempAsyncBatchIdToModel(record, asyncBatchId))
 			{
 				generateOutboundDocument(record, userId);
 			}

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/async/spi/impl/RecreateArchiveWorkpackageProcessor.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/async/spi/impl/RecreateArchiveWorkpackageProcessor.java
@@ -1,6 +1,7 @@
 package de.metas.document.archive.async.spi.impl;
 
-import de.metas.async.Async_Constants;
+import de.metas.async.AsyncBatchId;
+import de.metas.async.AsyncHelper;
 import de.metas.async.api.IQueueDAO;
 import de.metas.async.model.I_C_Async_Batch;
 import de.metas.async.model.I_C_Queue_WorkPackage;
@@ -38,16 +39,17 @@ public class RecreateArchiveWorkpackageProcessor implements IWorkpackageProcesso
 
 		final List<I_C_Doc_Outbound_Log> logs = queueDAO.retrieveAllItems(workpackage, I_C_Doc_Outbound_Log.class);
 
-		logs.forEach(docOutboundLog -> {
+		for (final I_C_Doc_Outbound_Log docOutboundLog : logs)
+		{
 			final PO po = TableModelLoader.instance.getPO(ctx, adTableDAO.retrieveTableName(docOutboundLog.getAD_Table_ID()), docOutboundLog.getRecord_ID(), trxName);
 			if (workpackage.getC_Async_Batch_ID() > 0)
 			{
-				InterfaceWrapperHelper.setDynAttribute(po, Async_Constants.C_Async_Batch, workpackage.getC_Async_Batch());
+				AsyncHelper.setAsyncBatchId(po, AsyncBatchId.ofRepoIdOrNull(workpackage.getC_Async_Batch_ID()));
 			}
 
 			DefaultModelArchiver.of(po).archive();
 			InterfaceWrapperHelper.save(docOutboundLog);
-		});
+		}
 		return Result.SUCCESS;
 	}
 

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/spi/impl/DefaultModelArchiver.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/spi/impl/DefaultModelArchiver.java
@@ -3,9 +3,8 @@ package de.metas.document.archive.spi.impl;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import de.metas.async.AsyncBatchId;
-import de.metas.async.Async_Constants;
+import de.metas.async.AsyncHelper;
 import de.metas.async.api.IAsyncBatchBL;
-import de.metas.async.model.I_C_Async_Batch;
 import de.metas.document.archive.api.IDocOutboundDAO;
 import de.metas.document.archive.async.spi.impl.DocOutboundCCWorkpackageProcessor;
 import de.metas.document.archive.model.I_AD_Archive;
@@ -243,10 +242,10 @@ public class DefaultModelArchiver
 
 		//
 		// forward async batch if there is one
-		final I_C_Async_Batch asyncBatch = InterfaceWrapperHelper.getDynAttribute(getRecord(), Async_Constants.C_Async_Batch);
-		if (asyncBatch != null)
+		final AsyncBatchId asyncBatchId = AsyncHelper.getAsyncBatchId(getRecord());
+		if (asyncBatchId != null)
 		{
-			InterfaceWrapperHelper.setDynAttribute(archive, Async_Constants.C_Async_Batch, asyncBatch);
+			AsyncHelper.setAsyncBatchId(archive, asyncBatchId);
 		}
 
 		InterfaceWrapperHelper.save(archive);

--- a/backend/de.metas.dunning/src/main/java/de/metas/dunning/api/IDunningBL.java
+++ b/backend/de.metas.dunning/src/main/java/de/metas/dunning/api/IDunningBL.java
@@ -82,17 +82,15 @@ public interface IDunningBL extends ISingletonService
 	/**
 	 * Process {@link I_C_Dunning_Candidate}s and produces {@link I_C_DunningDoc}s.
 	 *
-	 * @param context
 	 * @param candidates candidates source to be used
 	 */
 	void processCandidates(IDunningContext context, IDunningCandidateSource candidates);
 
 	/**
 	 * Get previous dunning levels of given dunning level.
-	 *
+	 * <p/>
 	 * For determining previous levels the {@link I_C_DunningLevel#getDaysAfterDue()} + {@link I_C_DunningLevel#getDaysBetweenDunning()} is compared.
 	 *
-	 * @param level
 	 * @return list of previous dunning levels.
 	 */
 	List<I_C_DunningLevel> getPreviousLevels(I_C_DunningLevel level);

--- a/backend/de.metas.dunning/src/main/java/de/metas/dunning/api/IDunningProducer.java
+++ b/backend/de.metas.dunning/src/main/java/de/metas/dunning/api/IDunningProducer.java
@@ -47,7 +47,7 @@ public interface IDunningProducer
 	/**
 	 * If this option is set in context, the producer will use the async batch when enqueueing
 	 */
-	String CONTEXT_AsyncBatchDunningDoc = IDunningProducer.class.getName() + "#" + "AsyncBatch";
+	String CONTEXT_AsyncBatchIdDunningDoc = IDunningProducer.class.getName() + "#" + "AsyncBatch";
 
 	/**
 	 * If this option is set in context, the producer will also process the {@link I_C_DunningDoc}s.
@@ -59,15 +59,11 @@ public interface IDunningProducer
 
 	/**
 	 * Adds another aggregator that is consulted on aggregation issues during invocations of {@link #addCandidate(I_C_Dunning_Candidate)}.
-	 * 
-	 * @param aggregator
 	 */
 	void addAggregator(IDunningAggregator aggregator);
 
 	/**
 	 * Add a dunning candidate. Implementation of this method can generate an {@link I_C_DunningDoc} right away or can put the line in a queue and generate the document later.
-	 * 
-	 * @param candidate
 	 */
 	void addCandidate(I_C_Dunning_Candidate candidate);
 

--- a/backend/de.metas.dunning/src/main/java/de/metas/dunning/api/impl/DefaultDunningProducer.java
+++ b/backend/de.metas.dunning/src/main/java/de/metas/dunning/api/impl/DefaultDunningProducer.java
@@ -22,23 +22,10 @@ package de.metas.dunning.api.impl;
  * #L%
  */
 
-
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Properties;
-
+import de.metas.async.AsyncBatchId;
+import de.metas.async.AsyncHelper;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.service.IBPartnerBL;
-import de.metas.user.UserId;
-import org.adempiere.model.InterfaceWrapperHelper;
-import org.compiere.util.Env;
-import org.compiere.util.TimeUtil;
-import org.slf4j.Logger;
-
-import de.metas.async.Async_Constants;
-import de.metas.async.model.I_C_Async_Batch;
 import de.metas.document.engine.IDocument;
 import de.metas.document.engine.IDocumentBL;
 import de.metas.dunning.api.IDunningContext;
@@ -53,36 +40,43 @@ import de.metas.dunning.model.I_C_Dunning_Candidate;
 import de.metas.dunning.model.X_C_DunningDoc;
 import de.metas.dunning.spi.IDunningAggregator;
 import de.metas.logging.LogManager;
-import de.metas.util.Check;
+import de.metas.user.UserId;
 import de.metas.util.Services;
+import lombok.Getter;
+import lombok.NonNull;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.util.Env;
+import org.compiere.util.TimeUtil;
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
 
 public class DefaultDunningProducer implements IDunningProducer
 {
-	private final static transient Logger logger = LogManager.getLogger(DefaultDunningProducer.class);
+	private final static Logger logger = LogManager.getLogger(DefaultDunningProducer.class);
 	private final IBPartnerBL bPartnerBL = Services.get(IBPartnerBL.class);
 
-	private IDunningContext dunningContext;
+	@Getter private IDunningContext dunningContext;
 
 	private final CompositeDunningAggregator dunningAggregators = new CompositeDunningAggregator();
 
-	private I_C_DunningDoc dunningDoc = null;
-	private I_C_DunningDoc_Line dunningDocLine = null;
+	@Nullable private I_C_DunningDoc dunningDoc = null;
+	@Nullable private I_C_DunningDoc_Line dunningDocLine = null;
 	private final List<I_C_DunningDoc_Line_Source> dunningDocLineSources = new ArrayList<>();
 
 	@Override
-	public void setDunningContext(IDunningContext context)
+	public void setDunningContext(@NonNull final IDunningContext context)
 	{
-		Check.assumeNotNull(context, "context not null");
 		this.dunningContext = context;
 	}
 
-	public IDunningContext getDunningContext()
-	{
-		return dunningContext;
-	}
-
 	@Override
-	public void addCandidate(I_C_Dunning_Candidate candidate)
+	public void addCandidate(final I_C_Dunning_Candidate candidate)
 	{
 		if (dunningDoc != null && dunningAggregators.isNewDunningDoc(candidate))
 		{
@@ -98,10 +92,10 @@ public class DefaultDunningProducer implements IDunningProducer
 
 			//
 			// check for async batch set
-			final I_C_Async_Batch asyncBatch = getDunningContext().getProperty(IDunningProducer.CONTEXT_AsyncBatchDunningDoc);
-			if (asyncBatch != null)
+			final AsyncBatchId asyncBatchId = getDunningContext().getProperty(IDunningProducer.CONTEXT_AsyncBatchIdDunningDoc);
+			if (asyncBatchId != null)
 			{
-				InterfaceWrapperHelper.setDynAttribute(dunningDoc, Async_Constants.C_Async_Batch, asyncBatch);
+				AsyncHelper.setAsyncBatchId(dunningDoc, asyncBatchId);
 			}
 		}
 
@@ -140,7 +134,7 @@ public class DefaultDunningProducer implements IDunningProducer
 			if (contextDunningLevel.getC_DunningLevel_ID() != candidate.getC_DunningLevel_ID())
 			{
 				logger.warn("Candidate {} has dunning level {} but in context we have {}. Using candidate's dunning level",
-						new Object[] { candidate, candidate.getC_DunningLevel(), contextDunningLevel });
+						candidate, candidate.getC_DunningLevel(), contextDunningLevel);
 			}
 
 			doc.setC_DunningLevel_ID(candidate.getC_DunningLevel_ID());
@@ -224,7 +218,7 @@ public class DefaultDunningProducer implements IDunningProducer
 		return source;
 	}
 
-	protected void aggregateDunningDocLine(I_C_DunningDoc_Line dunningDocLine, I_C_Dunning_Candidate candidate)
+	protected void aggregateDunningDocLine(final I_C_DunningDoc_Line dunningDocLine, final I_C_Dunning_Candidate candidate)
 	{
 		final IDunningUtil util = Services.get(IDunningUtil.class);
 
@@ -283,7 +277,7 @@ public class DefaultDunningProducer implements IDunningProducer
 
 	protected void completeDunningDocLine()
 	{
-		for (I_C_DunningDoc_Line_Source source : dunningDocLineSources)
+		for (final I_C_DunningDoc_Line_Source source : dunningDocLineSources)
 		{
 			completeDunningDocLineSource(source);
 		}
@@ -314,7 +308,7 @@ public class DefaultDunningProducer implements IDunningProducer
 	}
 
 	@Override
-	public void addAggregator(IDunningAggregator aggregator)
+	public void addAggregator(final IDunningAggregator aggregator)
 	{
 		dunningAggregators.addAggregator(aggregator);
 	}

--- a/backend/de.metas.dunning/src/main/java/de/metas/dunning/api/impl/DunningBL.java
+++ b/backend/de.metas.dunning/src/main/java/de/metas/dunning/api/impl/DunningBL.java
@@ -227,11 +227,8 @@ public class DunningBL implements IDunningBL
 	}
 
 	@Override
-	public void processCandidates(final IDunningContext context, final IDunningCandidateSource candidates)
+	public void processCandidates(@NonNull final IDunningContext context, @NonNull final IDunningCandidateSource candidates)
 	{
-		Check.assumeNotNull(context, "context not null");
-		Check.assumeNotNull(candidates, "candidates source not null");
-
 		final IDunningConfig config = context.getDunningConfig();
 
 		final IDunningProducer dunningProducer = config.createDunningProducer();

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRImportEnqueuer.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRImportEnqueuer.java
@@ -1,8 +1,8 @@
 package de.metas.payment.esr.dataimporter;
 
+import de.metas.async.AsyncBatchId;
 import de.metas.async.api.IAsyncBatchBL;
 import de.metas.async.api.IWorkPackageQueue;
-import de.metas.async.model.I_C_Async_Batch;
 import de.metas.async.processor.IWorkPackageQueueFactory;
 import de.metas.attachments.AttachmentEntry;
 import de.metas.attachments.AttachmentEntryId;
@@ -23,7 +23,6 @@ import de.metas.util.ILoggable;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -98,7 +97,7 @@ public class ESRImportEnqueuer
 
 	}
 
-	public static final ESRImportEnqueuer newInstance()
+	public static ESRImportEnqueuer newInstance()
 	{
 		return new ESRImportEnqueuer();
 	}
@@ -173,19 +172,19 @@ public class ESRImportEnqueuer
 			final Properties ctx = getCtx();
 
 			// Create Async Batch for tracking
-			final I_C_Async_Batch asyncBatch = asyncBatchBL.newAsyncBatch()
+			final AsyncBatchId asyncBatchId = asyncBatchBL.newAsyncBatch()
 					.setContext(ctx)
 					.setC_Async_Batch_Type(ESRConstants.C_Async_Batch_InternalName)
 					.setAD_PInstance_Creator_ID(getPinstanceId())
 					.setName(getAsyncBatchName())
 					.setDescription(getAsyncBatchDesc())
-					.build();
+					.buildAndEnqueue();
 
 			//
 			final IWorkPackageQueue queue = Services.get(IWorkPackageQueueFactory.class).getQueueForEnqueuing(ctx, LoadESRImportFileWorkpackageProcessor.class);
 			queue
 					.newWorkPackage()
-					.setC_Async_Batch(asyncBatch) // set the async batch in workpackage in order to track it
+					.setC_Async_Batch_ID(asyncBatchId) // set the async batch in workpackage in order to track it
 					.addElement(esrImport)
 					.buildAndEnqueue();
 		}
@@ -231,7 +230,7 @@ public class ESRImportEnqueuer
 			{
 				createImportFileFromSingleAttachment(esrImport, unzippedFile.getData(), unzippedFile.getFilename());
 			}
-			catch (Exception ex)
+			catch (final Exception ex)
 			{
 				errors.add(String.format("Error processing file '%s': %s", unzippedFile.getFilename(), ex.getMessage()));
 			}
@@ -261,7 +260,7 @@ public class ESRImportEnqueuer
 					final ZipFileResource unzippedFile = extractResource(zipStream, zipEntry);
 					unzippedFiles.add(unzippedFile);
 				}
-				catch (Exception e)
+				catch (final Exception e)
 				{
 					// Log error for the problematic file, but continue processing
 					addLog("Failed to extract file '{}': {}", zipEntry.getName(), e.getMessage());
@@ -272,14 +271,14 @@ public class ESRImportEnqueuer
 					{
 						zipStream.closeEntry();
 					}
-					catch (IOException e)
+					catch (final IOException e)
 					{
 						addLog("Failed to close zip entry '{}': {}", zipEntry.getName(), e.getMessage());
 					}
 				}
 			}
 		}
-		catch (IOException e)
+		catch (final IOException e)
 		{
 			throw new AdempiereException("Failed to process ZIP file: " + e.getMessage(), e);
 		}

--- a/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/api/IPrintJobBL.java
+++ b/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/api/IPrintJobBL.java
@@ -25,7 +25,7 @@ package de.metas.printing.api;
 
 import java.util.List;
 
-import de.metas.async.model.I_C_Async_Batch;
+import de.metas.async.AsyncBatchId;
 import de.metas.printing.model.I_C_Print_Job;
 import de.metas.printing.model.I_C_Print_Job_Detail;
 import de.metas.printing.model.I_C_Print_Job_Instructions;
@@ -99,5 +99,5 @@ public interface IPrintJobBL extends ISingletonService
 	/**
 	 * Enqueue print job instructions for async pdf printing
 	 */
-	void enqueuePrintJobInstructions(I_C_Print_Job_Instructions jobInstructions, I_C_Async_Batch asyncBatch);
+	void enqueuePrintJobInstructions(@NonNull I_C_Print_Job_Instructions jobInstructions, AsyncBatchId asyncBatchId);
 }

--- a/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/api/impl/PrintJobBL.java
+++ b/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/api/impl/PrintJobBL.java
@@ -112,7 +112,7 @@ public class PrintJobBL implements IPrintJobBL
 		return maxLinesPerJob;
 	}
 
-	public void setMaxLinesPerJob(int maxLinesPerJob)
+	public void setMaxLinesPerJob(final int maxLinesPerJob)
 	{
 		this.maxLinesPerJob = maxLinesPerJob;
 	}
@@ -122,7 +122,7 @@ public class PrintJobBL implements IPrintJobBL
 	{
 		final PrintingQueueProcessingInfo printingQueueProcessingInfo = source.getProcessingInfo();
 
-		int printJobCount = 0;
+		final int printJobCount = 0;
 		final List<I_C_Print_Job_Instructions> pdfPrintingJobInstructions = new ArrayList<>();
 
 		try
@@ -243,7 +243,7 @@ public class PrintJobBL implements IPrintJobBL
 
 		final Mutable<List<I_C_Print_Job_Instructions>> instructionsMutable = new Mutable<>();
 
-		trxManager.run(ITrx.TRXNAME_ThreadInherited, (TrxRunnable)localTrxName -> instructionsMutable.setValue(createPrintJobInstructionsAndPrintJobs0(source, items, printingQueueProcessingInfo, localTrxName)));
+		trxManager.run(ITrx.TRXNAME_ThreadInherited, localTrxName -> instructionsMutable.setValue(createPrintJobInstructionsAndPrintJobs0(source, items, printingQueueProcessingInfo, localTrxName)));
 
 		if (instructionsMutable.getValue() == null)
 		{
@@ -277,7 +277,7 @@ public class PrintJobBL implements IPrintJobBL
 		ContextForAsyncProcessing printJobContext;
 	}
 
-	private void enqueuePrintJobInstructionsForPDFPrintingIfNeeded(@NonNull final List<I_C_Print_Job_Instructions> printJobInstructions, @NonNull PrintingAsyncBatch printingAsyncBatch)
+	private void enqueuePrintJobInstructionsForPDFPrintingIfNeeded(@NonNull final List<I_C_Print_Job_Instructions> printJobInstructions, @NonNull final PrintingAsyncBatch printingAsyncBatch)
 	{
 		if (printJobInstructions.isEmpty())
 		{
@@ -285,11 +285,12 @@ public class PrintJobBL implements IPrintJobBL
 		}
 
 		final Properties ctx = InterfaceWrapperHelper.getCtx(printJobInstructions.get(0));
-		final I_C_Async_Batch asyncBatch = createAsyncBatchForPDFPrinting(ctx, printingAsyncBatch);
-		printJobInstructions.forEach(pji -> enqueuePrintJobInstructions(pji, asyncBatch));
+		final AsyncBatchId asyncBatchId = createAsyncBatchForPDFPrinting(ctx, printingAsyncBatch);
+		
+		printJobInstructions.forEach(pji -> enqueuePrintJobInstructions(pji, asyncBatchId));
 	}
 
-	private I_C_Async_Batch createAsyncBatchForPDFPrinting(@NonNull final Properties ctx, @NonNull PrintingAsyncBatch printingAsyncBatch)
+	private AsyncBatchId createAsyncBatchForPDFPrinting(@NonNull final Properties ctx, @NonNull final PrintingAsyncBatch printingAsyncBatch)
 	{
 		final String name = Check.isEmpty(printingAsyncBatch.getName(), true) ? "Print to pdf" : printingAsyncBatch.getName();
 		final int printJobCount = printingAsyncBatch.getPrintJobCount();
@@ -303,10 +304,10 @@ public class PrintJobBL implements IPrintJobBL
 				.setParentAsyncBatchId(AsyncBatchId.ofRepoIdOrNull(parentAsyncBatchId))
 				.setCountExpected(printJobCount)
 				.setName(name)
-				.build();
+				.buildAndEnqueue();
 	}
 
-	private PInstanceId getAdPInstanceId(@NonNull PrintingAsyncBatch printingAsyncBatch)
+	private PInstanceId getAdPInstanceId(@NonNull final PrintingAsyncBatch printingAsyncBatch)
 	{
 		final I_C_Async_Batch parentAsyncBatch = getParentAsyncPatchIfExists(printingAsyncBatch.getParentAsyncBatchId());
 		return parentAsyncBatch == null ? printingAsyncBatch.getAdPInstanceId() : PInstanceId.ofRepoIdOrNull(parentAsyncBatch.getAD_PInstance_ID());
@@ -318,14 +319,15 @@ public class PrintJobBL implements IPrintJobBL
 	}
 
 	@Override
-	public void enqueuePrintJobInstructions(final I_C_Print_Job_Instructions jobInstructions, final I_C_Async_Batch asyncBatch)
+	public void enqueuePrintJobInstructions(final I_C_Print_Job_Instructions jobInstructions, 
+											final AsyncBatchId asyncBatchId)
 	{
 		final Properties ctx = InterfaceWrapperHelper.getCtx(jobInstructions);
 
 		final IWorkPackageQueue queue = Services.get(IWorkPackageQueueFactory.class).getQueueForEnqueuing(ctx, PDFDocPrintingWorkpackageProcessor.class);
 		queue
 				.newWorkPackage()
-				.setC_Async_Batch(asyncBatch) // set the async batch in workpackage in order to track it
+				.setC_Async_Batch_ID(asyncBatchId) // set the async batch in workpackage in order to track it
 				.addElement(jobInstructions)
 				.buildAndEnqueue();
 	}

--- a/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/async/spi/impl/PDFDocPrintingWorkpackageProcessor.java
+++ b/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/async/spi/impl/PDFDocPrintingWorkpackageProcessor.java
@@ -1,6 +1,7 @@
 package de.metas.printing.async.spi.impl;
 
-import de.metas.async.Async_Constants;
+import de.metas.async.AsyncBatchId;
+import de.metas.async.AsyncHelper;
 import de.metas.async.api.IQueueDAO;
 import de.metas.async.model.I_C_Async_Batch;
 import de.metas.async.model.I_C_Queue_WorkPackage;
@@ -185,13 +186,12 @@ public class PDFDocPrintingWorkpackageProcessor implements IWorkpackageProcessor
 		pinstance.setIsProcessing(true);
 		InterfaceWrapperHelper.save(pinstance);
 
-		final StringBuffer msg = new StringBuffer();
-		msg.append(Services.get(IMsgBL.class)
-				.getMsg(ctx, PDFPrintJob_Done, new Object[] { index, countExpected, noInvoices }));
+		final String msg = Services.get(IMsgBL.class)
+				.getMsg(ctx, PDFPrintJob_Done, new Object[] { index, countExpected, noInvoices });
 
 		final List<ProcessInfoParameter> piParams = new ArrayList<>();
 		piParams.add(ProcessInfoParameter.ofValueObject(X_C_Print_Job_Instructions.COLUMNNAME_C_Print_Job_Instructions_ID, jobInstructions.getC_Print_Job_Instructions_ID()));
-		piParams.add(ProcessInfoParameter.ofValueObject("Title", msg.toString()));
+		piParams.add(ProcessInfoParameter.ofValueObject("Title", msg));
 		Services.get(IADPInstanceDAO.class).saveParameterToDB(PInstanceId.ofRepoId(pinstance.getAD_PInstance_ID()), piParams);
 
 		final ProcessInfo jasperProcessInfo = ProcessInfo.builder()
@@ -227,7 +227,7 @@ public class PDFDocPrintingWorkpackageProcessor implements IWorkpackageProcessor
 				.recordRef(printPackageRef)
 				.build());
 
-		final I_AD_Archive archive = archiveResult.getArchiveRecord();
+		final I_AD_Archive archive = Check.assumeNotNull(archiveResult.getArchiveRecord(), "archiveResult.getArchiveRecord()!=null for archiveResult={}", archiveResult);
 
 		final de.metas.printing.model.I_AD_Archive directArchive = InterfaceWrapperHelper.create(archive, de.metas.printing.model.I_AD_Archive.class);
 		directArchive.setIsDirectEnqueue(true);
@@ -240,7 +240,7 @@ public class PDFDocPrintingWorkpackageProcessor implements IWorkpackageProcessor
 
 		//
 		// set async batch
-		InterfaceWrapperHelper.setDynAttribute(archive, Async_Constants.C_Async_Batch, asyncBatch);
+		AsyncHelper.setAsyncBatchId(archive, AsyncBatchId.ofRepoId(asyncBatch.getC_Async_Batch_ID()));
 		InterfaceWrapperHelper.save(directArchive);
 
 	}

--- a/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/model/validator/ConcatenatePDFsCommand.java
+++ b/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/model/validator/ConcatenatePDFsCommand.java
@@ -101,26 +101,26 @@ class ConcatenatePDFsCommand
 
 		final I_C_Async_Batch parentAsyncBatchRecord = asyncBatchBL.getAsyncBatchById(printingQueueItemsGeneratedAsyncBatchId);
 
-		final I_C_Async_Batch asyncBatch = asyncBatchBL.newAsyncBatch()
+		final AsyncBatchId asyncBatchId = asyncBatchBL.newAsyncBatch()
 				.setContext(ctx)
 				.setC_Async_Batch_Type(C_Async_Batch_InternalName_AutomaticallyInvoicePdfPrinting)
 				.setName(C_Async_Batch_InternalName_AutomaticallyInvoicePdfPrinting)
 				.setDescription(queryRequest.getQueryName())
 				.setParentAsyncBatchId(printingQueueItemsGeneratedAsyncBatchId)
 				.setOrgId(OrgId.ofRepoId(parentAsyncBatchRecord.getAD_Org_ID()))
-				.build();
+				.buildAndEnqueue();
 
 		workPackageQueueFactory
 				.getQueueForEnqueuing(ctx, PrintingQueuePDFConcatenateWorkpackageProcessor.class)
 				.newWorkPackage()
-				.setC_Async_Batch(asyncBatch)
+				.setC_Async_Batch_ID(asyncBatchId)
 				.addElements(printingQueues)
 				.buildAndEnqueue();
 	}
 
 	private List<PrintingQueueQueryRequest> getPrintingQueueQueryBuilders()
 	{
-		Map<String, String> filtersMap = sysConfigBL.getValuesForPrefix(QUERY_PREFIX, clientAndOrgId);
+		final Map<String, String> filtersMap = sysConfigBL.getValuesForPrefix(QUERY_PREFIX, clientAndOrgId);
 		final Collection<String> keys = filtersMap.keySet();
 
 		final ArrayList<PrintingQueueQueryRequest> queries = new ArrayList<>();

--- a/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/process/C_Invoice_Candidate_EnqueueSelectionForInvoicingAndPDFConcatenating.java
+++ b/backend/de.metas.printing/de.metas.printing.base/src/main/java/de/metas/printing/process/C_Invoice_Candidate_EnqueueSelectionForInvoicingAndPDFConcatenating.java
@@ -83,7 +83,7 @@ public class C_Invoice_Candidate_EnqueueSelectionForInvoicingAndPDFConcatenating
 		final IParams params = getParameterAsIParams();
 		this.invoicingParams = new InvoicingParams(params);
 
-		int selectionCount = createSelection();
+		final int selectionCount = createSelection();
 
 		if (selectionCount <= 0)
 		{
@@ -96,15 +96,13 @@ public class C_Invoice_Candidate_EnqueueSelectionForInvoicingAndPDFConcatenating
 	private AsyncBatchId createAsyncBatch()
 	{
 		// Create Async Batch for tracking
-		final I_C_Async_Batch asyncBatch = asyncBatchBL.newAsyncBatch()
+		return asyncBatchBL.newAsyncBatch()
 				.setContext(getCtx())
 				.setAD_PInstance_Creator_ID(getPinstanceId())
 				.setOrgId(p_OrgId)
 				.setC_Async_Batch_Type(C_Async_Batch_InternalName_InvoiceCandidate_Processing)
 				.setName(C_Async_Batch_InternalName_InvoiceCandidate_Processing)
-				.build();
-
-		return AsyncBatchId.ofRepoId(asyncBatch.getC_Async_Batch_ID());
+				.buildAndEnqueue();
 	}
 
 	@Override

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/async/C_OLCandToOrderEnqueuer.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/async/C_OLCandToOrderEnqueuer.java
@@ -117,7 +117,7 @@ public class C_OLCandToOrderEnqueuer
 	private OlCandEnqueueResult lockAndEnqueueSelection(@NonNull final PInstanceId selectionId, @Nullable final AsyncBatchId asyncBatchId)
 	{
 		final ILock mainLock = lockSelection(selectionId);
-		try (final ILockAutoCloseable l = mainLock.asAutocloseableOnTrxClose(ITrx.TRXNAME_ThreadInherited))
+		try (final ILockAutoCloseable ignored = mainLock.asAutocloseableOnTrxClose(ITrx.TRXNAME_ThreadInherited))
 		{
 			return enqueueSelectionInTrx(mainLock, selectionId, asyncBatchId);
 		}

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/source/OLCandProcessingHelper.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/source/OLCandProcessingHelper.java
@@ -22,6 +22,7 @@
 
 package de.metas.ordercandidate.api.source;
 
+import ch.qos.logback.classic.Level;
 import com.google.common.collect.ImmutableList;
 import de.metas.async.AsyncBatchId;
 import de.metas.common.util.time.SystemTime;
@@ -35,6 +36,8 @@ import de.metas.ordercandidate.api.OLCandAggregation;
 import de.metas.ordercandidate.api.OLCandAggregationColumn;
 import de.metas.ordercandidate.model.I_C_OLCand;
 import de.metas.process.PInstanceId;
+import de.metas.util.ILoggable;
+import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
@@ -150,34 +153,36 @@ public class OLCandProcessingHelper
 			@NonNull final OLCand cand,
 			@Nullable final AsyncBatchId asyncBatchId)
 	{
+		final ILoggable loggable = Loggables.withLogger(logger, Level.DEBUG);
+		
 		if (cand.isProcessed())
 		{
-			logger.debug("Skipping processed C_OLCand: {}", cand);
+			loggable.addLog("Skipping processed C_OLCand: {}", cand);
 			return false;
 		}
 
 		if (cand.isError())
 		{
-			logger.debug("Skipping C_OLCand with errors: {}", cand);
+			loggable.addLog("Skipping C_OLCand with errors: {}", cand);
 			return false;
 		}
 
 		if (cand.getOrderLineGroup() != null && cand.getOrderLineGroup().isGroupingError())
 		{
-			logger.debug("Skipping C_OLCand with grouping errors: {}", cand);
+			loggable.addLog("Skipping C_OLCand with grouping errors: {}", cand);
 			return false;
 		}
 
 		final InputDataSourceId candDataDestinationId = InputDataSourceId.ofRepoIdOrNull(cand.getAD_DataDestination_ID());
 		if (!Objects.equals(candDataDestinationId, processorDataDestinationId))
 		{
-			logger.debug("Skipping C_OLCand with AD_DataDestination_ID={} but {} was expected: {}", candDataDestinationId, processorDataDestinationId, cand);
+			loggable.addLog("Skipping C_OLCand with AD_DataDestination_ID={} but {} was expected: {}", candDataDestinationId, processorDataDestinationId, cand);
 			return false;
 		}
 
 		if (asyncBatchId != null && !cand.isAssignToBatch(asyncBatchId))
 		{
-			logger.debug("Skipping C_OLCand due to missing batch assignment: targetBatchId: {}, candidate: {}", asyncBatchId, cand);
+			loggable.addLog("Skipping C_OLCand due to missing batch assignment: targetBatchId: {}, candidate: {}", asyncBatchId.getRepoId(), cand);
 			return false;
 		}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/RecreateInvoiceEnqueuer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/RecreateInvoiceEnqueuer.java
@@ -22,9 +22,9 @@
 
 package de.metas.invoicecandidate.async.spi.impl;
 
+import de.metas.async.AsyncBatchId;
 import de.metas.async.api.IAsyncBatchBL;
 import de.metas.async.api.IWorkPackageQueue;
-import de.metas.async.model.I_C_Async_Batch;
 import de.metas.async.processor.IWorkPackageQueueFactory;
 import de.metas.process.PInstanceId;
 import de.metas.util.Services;
@@ -43,16 +43,15 @@ public class RecreateInvoiceEnqueuer
 
 	public void enqueueSelection(@NonNull final PInstanceId pInstanceId)
 	{
-		final I_C_Async_Batch asyncBatch = asyncBatchBL.newAsyncBatch()
+		final AsyncBatchId asyncBatchId = asyncBatchBL.newAsyncBatch()
 				.setContext(getCtx())
 				.setC_Async_Batch_Type(C_Async_Batch_InternalName_VoidAndRecreateInvoice)
 				.setName(C_Async_Batch_InternalName_VoidAndRecreateInvoice)
-				.build();
+				.buildAndEnqueue();
 
 		final IWorkPackageQueue queue = workPackageQueueFactory.getQueueForEnqueuing(getCtx(), RecreateInvoiceWorkpackageProcessor.class);
-		queue
-				.newWorkPackage()
-				.setC_Async_Batch(asyncBatch)
+		queue.newWorkPackage()
+				.setC_Async_Batch_ID(asyncBatchId)
 				.parameter(I_AD_PInstance.COLUMNNAME_AD_PInstance_ID, pInstanceId)
 				.buildAndEnqueue();
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/invoicecandidate/C_OrderLine_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/invoicecandidate/C_OrderLine_Handler.java
@@ -109,6 +109,8 @@ public class C_OrderLine_Handler extends AbstractInvoiceCandidateHandler
 	}
 
 	/**
+	 *
+	 *
 	 * @see C_Order_Handler#expandRequest(InvoiceCandidateGenerateRequest)
 	 */
 	@Override

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentInterfaceWrapperHelper.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentInterfaceWrapperHelper.java
@@ -3,6 +3,7 @@ package de.metas.ui.web.window.model;
 import java.util.Properties;
 import java.util.Set;
 
+import lombok.NonNull;
 import org.adempiere.ad.persistence.TableModelLoader;
 import org.adempiere.ad.service.IDeveloperModeBL;
 import org.adempiere.ad.trx.api.ITrx;
@@ -231,7 +232,7 @@ public class DocumentInterfaceWrapperHelper extends AbstractInterfaceWrapperHelp
 	}
 
 	@Override
-	public <T> T getDynAttribute(final Object model, final String attributeName)
+	public <T> T getDynAttribute(final @NonNull Object model, final String attributeName)
 	{
 		return DocumentInterfaceWrapper.getDocument(model).getDynAttribute(attributeName);
 	}


### PR DESCRIPTION
When creating an AsyncBatch-Workpackage, don't store the C_AsyncBatch_ID thread-locally (#20369)

* When creating/enqueuing an AsyncBatch-Workpackage, don't store the C_AsyncBatch_ID thread-locally

We didn't have proper code to unset the ID, and it seems to me that we don't need to do this.

 - Also did a number of trivial code-improvements
 - Also added code to set the threadlocal asyncBatchId with a closable, but commented it out for now, because i can't see where it would be needed. !!Going to remove it within this PR!!

* Further cut down on the threadlocal-magic

---------



(cherry picked from commit ad3dfc2ffa2639656ef54f2de572f180994e4e8a)