### PR TITLE
new dawn uat receivingAndPickingCustomQRCodes

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/JUnitBeansMap.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/JUnitBeansMap.java
@@ -65,8 +65,7 @@ import java.util.stream.Collectors;
 	{
 		assertJUnitMode();
 
-		@SuppressWarnings("unchecked")
-		final Class<T> beanType = (Class<T>)beanImpl.getClass();
+		@SuppressWarnings("unchecked") final Class<T> beanType = (Class<T>)beanImpl.getClass();
 
 		registerJUnitBean(beanType, beanImpl);
 	}
@@ -78,8 +77,15 @@ import java.util.stream.Collectors;
 		assertJUnitMode();
 
 		final ArrayList<Object> beans = map.computeIfAbsent(ClassReference.of(beanType), key -> new ArrayList<>());
-		beans.add(beanImpl);
-		logger.info("JUnit testing: Registered bean {}={}", beanType, beanImpl);
+		if (!beans.contains(beanImpl))
+		{
+			beans.add(beanImpl);
+			logger.info("JUnit testing: Registered bean {}={}", beanType, beanImpl);
+		}
+		else
+		{
+			logger.info("JUnit testing: Skip registering bean because already registered {}={}", beanType, beanImpl);
+		}
 	}
 
 	public synchronized <BT, T extends BT> void registerJUnitBeans(
@@ -109,14 +115,13 @@ import java.util.stream.Collectors;
 		}
 
 		final T beanImpl = castBean(beans.get(0), beanType);
-		logger.info("JUnit testing Returning manually registered bean: {}", beanImpl);
+		logger.debug("JUnit testing Returning manually registered bean: {}", beanImpl);
 		return beanImpl;
 	}
 
-	private static <T> T castBean(final Object beanImpl, final Class<T> beanType)
+	private static <T> T castBean(final Object beanImpl, final Class<T> ignoredBeanType)
 	{
-		@SuppressWarnings("unchecked")
-		final T beanImplCasted = (T)beanImpl;
+		@SuppressWarnings("unchecked") final T beanImplCasted = (T)beanImpl;
 		return beanImplCasted;
 	}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/scannable_code/format/ParsedScannedCode.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/scannable_code/format/ParsedScannedCode.java
@@ -14,10 +14,15 @@ import java.time.LocalDate;
 public class ParsedScannedCode
 {
 	@NonNull ScannedCode scannedCode;
-	
+
 	@Nullable String productNo;
 	@Nullable BigDecimal weightKg;
 	@Nullable String lotNo;
 	@Nullable LocalDate bestBeforeDate;
 	@Nullable LocalDate productionDate;
+
+	public String getAsString()
+	{
+		return scannedCode.getAsString();
+	}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/scannable_code/format/service/ScannableCodeFormatService.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/scannable_code/format/service/ScannableCodeFormatService.java
@@ -1,5 +1,8 @@
 package de.metas.scannable_code.format.service;
 
+import de.metas.i18n.ExplainedOptional;
+import de.metas.scannable_code.ScannedCode;
+import de.metas.scannable_code.format.ParsedScannedCode;
 import de.metas.scannable_code.format.ScannableCodeFormat;
 import de.metas.scannable_code.format.ScannableCodeFormatCreateRequest;
 import de.metas.scannable_code.format.ScannableCodeFormatQuery;
@@ -7,6 +10,7 @@ import de.metas.scannable_code.format.ScannableCodeFormatsCollection;
 import de.metas.scannable_code.format.repository.ScannableCodeFormatRepository;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.compiere.SpringContextHolder;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +19,19 @@ import org.springframework.stereotype.Service;
 public class ScannableCodeFormatService
 {
 	@NonNull private final ScannableCodeFormatRepository repository;
+
+	public static ScannableCodeFormatService newInstanceForUnitTesting()
+	{
+		SpringContextHolder.assertUnitTestMode();
+		return SpringContextHolder.getBeanOrSupply(
+				ScannableCodeFormatService.class,
+				() -> new ScannableCodeFormatService(
+						new ScannableCodeFormatRepository()
+				)
+		);
+	}
+
+	public ExplainedOptional<ParsedScannedCode> parse(@NonNull final ScannedCode scannedCode) {return repository.getAll().parse(scannedCode);}
 
 	public ScannableCodeFormatsCollection getAll() {return repository.getAll();}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/uom/X12DE355.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/uom/X12DE355.java
@@ -13,6 +13,7 @@ import org.adempiere.exceptions.AdempiereException;
 import javax.annotation.Nullable;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
+import java.util.Objects;
 import java.util.Optional;
 
 /*
@@ -166,4 +167,6 @@ public class X12DE355
 
 		return temporalUnit;
 	}
+
+	public static boolean equals(@Nullable final X12DE355 uom1, @Nullable final X12DE355 uom2) {return Objects.equals(uom1, uom2);}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/test/AdempiereTestHelper.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/test/AdempiereTestHelper.java
@@ -1,9 +1,6 @@
 package org.adempiere.test;
 
 import ch.qos.logback.classic.Level;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.base.Stopwatch;
 import de.metas.JsonObjectMapperHolder;
 import de.metas.adempiere.form.IClientUI;
@@ -57,7 +54,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.function.Function;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstanceOutOfTrx;
@@ -191,7 +187,7 @@ public class AdempiereTestHelper
 		CacheMgt.get().reset();
 
 		// Logging
-		LogManager.setLevel(Level.WARN);
+		LogManager.setLevel(Level.INFO); // INFO is a decent level to not flood the test console but to understand what was initialized
 		//noinspection resource
 		Loggables.temporarySetLoggable(Loggables.console(">>> "));
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/mobileui/picking/MobileUI_Picking_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/mobileui/picking/MobileUI_Picking_StepDef.java
@@ -167,7 +167,7 @@ public class MobileUI_Picking_StepDef
 		}
 
 		//
-		final IHUQRCode itemQRCode = row.getAsOptionalString("QRCode").map(HUQRCodesService::toHUQRCode).orElse(null);
+		final IHUQRCode itemQRCode = row.getAsOptionalString("QRCode").map(huQRCodesService::parse).orElse(null);
 		if (itemQRCode != null)
 		{
 			requestBuilder

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHURequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHURequest.java
@@ -14,8 +14,8 @@ import java.math.BigDecimal;
 @Jacksonized
 public class JsonCreateHURequest
 {
-	@NonNull Identifier product;
-	@NonNull Identifier warehouse;
+	@Nullable Identifier product;
+	@Nullable Identifier warehouse;
 	@Nullable BigDecimal qty;
 	@Nullable Identifier packingInstructions;
 }

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHURequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHURequest.java
@@ -2,7 +2,6 @@ package de.metas.frontend_testing.masterdata.hu;
 
 import de.metas.frontend_testing.masterdata.Identifier;
 import lombok.Builder;
-import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHUResponse.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHUResponse.java
@@ -1,9 +1,11 @@
 package de.metas.frontend_testing.masterdata.hu;
 
+import de.metas.product.ProductId;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
+import org.adempiere.warehouse.WarehouseId;
 
 @Value
 @Builder
@@ -12,4 +14,6 @@ public class JsonCreateHUResponse
 {
 	@NonNull String huId;
 	@NonNull String qrCode;
+	@NonNull ProductId productId;
+	@NonNull WarehouseId warehouseId;
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUQueryBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUQueryBuilder.java
@@ -44,6 +44,7 @@ import org.compiere.model.I_M_Attribute;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -105,6 +106,8 @@ public interface IHUQueryBuilder
 
 	/** Retrieves first {@link I_M_HU} */
 	I_M_HU first();
+
+	Optional<HuId> firstId();
 
 	/** Counts how many {@link I_M_HU}s are matched by our criteria */
 	int count();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUQueryBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUQueryBuilder.java
@@ -50,9 +50,9 @@ import java.util.Set;
 
 /**
  * Developer friendly Query Builder which is oriented on Handling Units concerns.
- *
+ * <p>
  * To create a new instance, please use {@link IHandlingUnitsDAO#createHUQueryBuilder()}.
- *
+ * <p>
  * Defaults:
  * <ul>
  * <li>only top level HUs are matched by default
@@ -64,10 +64,6 @@ import java.util.Set;
 @SuppressWarnings("UnusedReturnValue")
 public interface IHUQueryBuilder
 {
-	/**
-	 * @return user readable string about attributes filters
-	 */
-	String getAttributesSummary();
 
 	/** Creates a copy of this object */
 	IHUQueryBuilder copy();
@@ -80,7 +76,7 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Create an {@link IQueryFilter} based on what we set in our builder.
-	 *
+	 * <p>
 	 * NOTE: Using directly {@link IQueryFilter#accept(Object)} won't work in all cases (e.g. when matching attributes because other tables are involved)
 	 *
 	 * @return created query filter
@@ -97,7 +93,7 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Retrieves first {@link I_M_HU}.
-	 *
+	 * <p>
 	 * If there are more HUs an exception will be thrown.
 	 *
 	 * @return HU or <code>null</code>
@@ -114,7 +110,7 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Collects a unique list of models from on of {@link I_M_HU}'s columns.
-	 *
+	 * <p>
 	 * e.g. Collect all business partners from matched HUs
 	 *
 	 * <pre>
@@ -145,7 +141,7 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Filter only those HUs which have any of the given product(s) in their storages.
-	 *
+	 * <p>
 	 * NOTEs:
 	 * <ul>
 	 * <li>given product(s) are appended to the list of previously specified ones</li>
@@ -168,7 +164,7 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Filter only those HUs which are in any of the given warehouse(s).
-	 *
+	 * <p>
 	 * NOTE: given warehouse(s) are appended to the list of previously specified ones
 	 *
 	 * @return this
@@ -177,7 +173,7 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Filter only those HUs which are in any of the given warehouse(s).
-	 *
+	 * <p>
 	 * NOTE: given warehouse(s) are appended to the list of previously specified ones
 	 */
 	IHUQueryBuilder addOnlyInWarehouseId(final WarehouseId warehouseId);
@@ -198,7 +194,7 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Filter only those HUs which are assigned to any of the given bpartner(s).
-	 *
+	 * <p>
 	 * NOTE: given bpartner(s) are appended to the list of previously specified ones.
 	 *
 	 * @param bPartnerId HU's BPartner that can be accepted. If it's <code>null</code> we will search for HU's without BPartner too.
@@ -220,7 +216,7 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Filter only those HUs which are assigned to any of the given bpartner location(s).
-	 *
+	 * <p>
 	 * NOTE: given bpartner location(s) are appended to the list of previously specified ones.
 	 *
 	 * @param bpartnerLocationId HU's BPartner Location that can be accepted. If it's <code>null</code> we will search for HU's without BPartner Location too.
@@ -230,7 +226,7 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Match only top level HUs.
-	 *
+	 * <p>
 	 * It's same as calling {@link #setOnlyTopLevelHUs(boolean)} with <code>true</code>.
 	 *
 	 * @return this
@@ -240,9 +236,9 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Sets if we shall match only top level HUs or not.
-	 *
+	 * <p>
 	 * A HU is considered top level when it does not have any parent.
-	 *
+	 * <p>
 	 * NOTE: in case you are matching only top level HUs, then {@link #setM_HU_Item_Parent_ID(int)} will be ignored
 	 *
 	 * @param onlyTopLevelHUs true if only top level HUs shall be matched; false if any HU shall be matched
@@ -252,7 +248,7 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Sets parent HU Item that our HUs needs to have.
-	 *
+	 * <p>
 	 * In case we are matching only top level HUs, this parameter is ignored.
 	 */
 	IHUQueryBuilder setM_HU_Item_Parent_ID(final int huItemId);
@@ -267,9 +263,9 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Sets HU's HUStatus to be matched.
-	 *
+	 * <p>
 	 * If <code>null</code> then all HU statuses are matched.
-	 *
+	 * <p>
 	 * NOTE: this is a short version for clearing all HU Statuses to be included and then if not null, adding this HUStatus.
 	 */
 	IHUQueryBuilder setHUStatus(String huStatus);
@@ -355,7 +351,7 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Add miscelanous filter to be applied.
-	 *
+	 * <p>
 	 * NOTE: use this method when none of other filters from here applies.
 	 *
 	 * @param filter filter to be applied
@@ -392,9 +388,9 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Ask this builder to throw or to not throw an error if there were no HUs retrieved.
-	 *
+	 * <p>
 	 * Applies only if we call methods like {@link #list()}, {@link #firstOnly()}, {@link #first()} etc.
-	 *
+	 * <p>
 	 * Does not apply to {@link #collect(ModelColumn)}.
 	 *
 	 * @param errorIfNoHUs if true, an exception need to be thrown when there were no HUs retrieved.
@@ -415,7 +411,7 @@ public interface IHUQueryBuilder
 
 	/**
 	 * Adds HUs which shall be selected. No other HUs, beside those ones will be considered.
-	 *
+	 * <p>
 	 * If the given list {@code null} this method will do nothing. If it is empty, no HUs will be considered.
 	 */
 	IHUQueryBuilder addOnlyHUIds(Collection<HuId> onlyHUIds);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHandlingUnitsBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHandlingUnitsBL.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableSet;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.bpartner.service.IBPartnerDAO;
+import de.metas.handlingunits.attribute.storage.IAttributeStorage;
 import de.metas.handlingunits.exceptions.HUException;
 import de.metas.handlingunits.generichumodel.HUType;
 import de.metas.handlingunits.impl.CopyHUsCommand.CopyHUsCommandBuilder;
@@ -284,6 +285,8 @@ public interface IHandlingUnitsBL extends ISingletonService
 	AttributeSetInstanceId createASIFromHUAttributes(@NonNull ProductId productId, @NonNull HuId huId);
 
 	AttributeSetInstanceId createASIFromHUAttributes(@NonNull ProductId productId, @NonNull I_M_HU hu);
+
+	IAttributeStorage getAttributeStorage(I_M_HU hu);
 
 	ImmutableAttributeSet getImmutableAttributeSet(@NonNull I_M_HU hu);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHandlingUnitsDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHandlingUnitsDAO.java
@@ -224,6 +224,7 @@ public interface IHandlingUnitsDAO extends ISingletonService
 
 	HuPackingInstructionsVersionId retrievePICurrentVersionId(final HuPackingInstructionsId piId);
 
+	@NonNull
 	I_M_HU_PI_Version retrievePICurrentVersion(HuPackingInstructionsId piId);
 
 	/**

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/HUAttributeConstants.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/HUAttributeConstants.java
@@ -50,6 +50,8 @@ public final class HUAttributeConstants
 
 	public static final AttributeCode ATTR_Quarantine = AttributeCode.ofString("HU_Quarantine");
 	public static final String ATTR_Quarantine_Value_Quarantine = "quarantine";
+	
+	public static final AttributeCode ATTR_QRCode = AttributeCode.ofString("HU_QRCode");
 
 	public static String sqlBestBeforeDate(final String huIdColumnName)
 	{

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUQueryBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUQueryBuilder.java
@@ -71,6 +71,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -340,8 +341,7 @@ import java.util.Set;
 
 		//
 		// ORDER BY
-		queryBuilder.orderBy()
-				.addColumn(I_M_HU.COLUMN_M_HU_ID); // just to have a predictable order
+		queryBuilder.orderBy(I_M_HU.COLUMN_M_HU_ID); // just to have a predictable order
 
 		return queryBuilder;
 	}
@@ -584,7 +584,7 @@ import java.util.Set;
 			filtersFinal = queryBL.createCompositeQueryFilter(I_M_HU.class)
 					.setJoinOr()
 					.addInArrayFilter(I_M_HU.COLUMNNAME_M_HU_ID, _huIdsToAlwaysInclude);
-			if(!andFilters.isEmpty())
+			if (!andFilters.isEmpty())
 			{
 				filtersFinal.addFilter(andFilters);
 			}
@@ -661,6 +661,13 @@ import java.util.Set;
 		}
 
 		return hu;
+	}
+
+	@Override
+	public Optional<HuId> firstId()
+	{
+		final int huRepoId = createQuery().firstId();
+		return Optional.ofNullable(HuId.ofRepoIdOrNull(huRepoId));
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUQueryBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUQueryBuilder.java
@@ -315,12 +315,6 @@ import java.util.Set;
 	}
 
 	@Override
-	public String getAttributesSummary()
-	{
-		return attributes.getAttributesSummary();
-	}
-
-	@Override
 	public IQueryBuilder<I_M_HU> createQueryBuilder()
 	{
 		//

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HandlingUnitsBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HandlingUnitsBL.java
@@ -53,6 +53,7 @@ import de.metas.handlingunits.IMutableHUContext;
 import de.metas.handlingunits.LUTUCUPair;
 import de.metas.handlingunits.QtyTU;
 import de.metas.handlingunits.allocation.IHUContextProcessor;
+import de.metas.handlingunits.attribute.impl.HUAttributesDAO;
 import de.metas.handlingunits.attribute.storage.IAttributeStorage;
 import de.metas.handlingunits.attribute.storage.IAttributeStorageFactory;
 import de.metas.handlingunits.attribute.storage.IAttributeStorageFactoryService;
@@ -276,7 +277,7 @@ public class HandlingUnitsBL implements IHandlingUnitsBL
 					return null;
 				});
 
-		return destroyed.getValue();
+		return destroyed.getValueNotNull();
 	}
 
 	@Override
@@ -1118,10 +1119,15 @@ public class HandlingUnitsBL implements IHandlingUnitsBL
 		return handlingUnitsRepo.createHUQueryBuilder();
 	}
 
+	private IAttributeStorageFactory newHUAttributeStorageFactory()
+	{
+		return attributeStorageFactoryService.createHUAttributeStorageFactory(getStorageFactory(), HUAttributesDAO.instance);
+	}
+
 	@Override
 	public AttributesKey getAttributesKeyForInventory(@NonNull final I_M_HU hu)
 	{
-		final IAttributeStorageFactory attributeStorageFactory = attributeStorageFactoryService.createHUAttributeStorageFactory();
+		final IAttributeStorageFactory attributeStorageFactory = newHUAttributeStorageFactory();
 		final IAttributeStorage attributeStorage = attributeStorageFactory.getAttributeStorage(hu);
 		return getAttributesKeyForInventory(attributeStorage);
 	}
@@ -1241,9 +1247,15 @@ public class HandlingUnitsBL implements IHandlingUnitsBL
 	}
 
 	@Override
+	public IAttributeStorage getAttributeStorage(final I_M_HU hu)
+	{
+		return newHUAttributeStorageFactory().getAttributeStorage(hu);
+	}
+
+	@Override
 	public ImmutableAttributeSet getImmutableAttributeSet(@NonNull final I_M_HU hu)
 	{
-		return attributeStorageFactoryService.createHUAttributeStorageFactory().getImmutableAttributeSet(hu);
+		return newHUAttributeStorageFactory().getImmutableAttributeSet(hu);
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HandlingUnitsDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HandlingUnitsDAO.java
@@ -727,6 +727,7 @@ public class HandlingUnitsDAO implements IHandlingUnitsDAO
 	}
 
 	@Override
+	@NonNull
 	public I_M_HU_PI_Version retrievePICurrentVersion(@NonNull final HuPackingInstructionsId piId)
 	{
 		final I_M_HU_PI_Version piVersion = retrievePICurrentVersionOrNull(Env.getCtx(), piId, ITrx.TRXNAME_None);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inventory/InventoryService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inventory/InventoryService.java
@@ -8,17 +8,13 @@ import de.metas.document.DocTypeQuery;
 import de.metas.document.IDocTypeDAO;
 import de.metas.document.engine.IDocument;
 import de.metas.document.engine.IDocumentBL;
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.inventory.impl.SyncInventoryQtyToHUsCommand;
 import de.metas.handlingunits.inventory.internaluse.HUInternalUseInventoryCreateRequest;
 import de.metas.handlingunits.inventory.internaluse.HUInternalUseInventoryCreateResponse;
 import de.metas.handlingunits.inventory.internaluse.HUInternalUseInventoryProducer;
 import de.metas.handlingunits.model.I_M_InventoryLine;
-import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.sourcehu.SourceHUsService;
 import de.metas.i18n.AdMessageKey;
 import de.metas.inventory.AggregationType;
@@ -26,7 +22,6 @@ import de.metas.inventory.HUAggregationType;
 import de.metas.inventory.InventoryDocSubType;
 import de.metas.inventory.InventoryId;
 import de.metas.organization.OrgId;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.product.ProductId;
 import de.metas.quantity.QuantitiesUOMNotMatchingExpection;
 import de.metas.quantity.Quantity;
@@ -92,11 +87,7 @@ public class InventoryService
 		return new InventoryService(
 				new InventoryRepository(),
 				SourceHUsService.get(),
-				new HUQRCodesService(
-						new HUQRCodesRepository(),
-						new GlobalQRCodeService(DoNothingMassPrintingService.instance),
-						new QRCodeConfigurationService(new QRCodeConfigurationRepository())
-				)
+				HUQRCodesService.newInstanceForUnitTesting()
 		);
 	}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobStepEvent.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobStepEvent.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import de.metas.common.util.time.SystemTime;
 import de.metas.handlingunits.picking.QtyRejectedReasonCode;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
-import de.metas.handlingunits.qrcodes.model.IHUQRCode;
+import de.metas.scannable_code.ScannedCode;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
@@ -32,7 +32,7 @@ public class PickingJobStepEvent
 
 	//
 	// Common
-	@NonNull IHUQRCode huQRCode;
+	@NonNull ScannedCode qrCode;
 	
 	//
 	// Event Type: PICK

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
@@ -307,7 +307,7 @@ public class PickingJobService implements PickingSlotListener
 						.pickingJobLineId(event.getPickingLineId())
 						.pickingJobStepId(event.getPickingStepId())
 						.pickFromKey(event.getPickFromKey())
-						.pickFromHUQRCode(event.getHuQRCode())
+						.pickFromQRCode(event.getQrCode())
 						.qtyToPickBD(Objects.requireNonNull(event.getQtyPicked()))
 						.isPickWholeTU(event.isPickWholeTU())
 						.checkIfAlreadyPacked(event.isCheckIfAlreadyPacked())

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pporder/api/IPPOrderReceiptHUProducer.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pporder/api/IPPOrderReceiptHUProducer.java
@@ -25,6 +25,7 @@ import java.util.Set;
  * @author metas-dev <dev@metasfresh.com>
  *
  */
+@SuppressWarnings("UnusedReturnValue")
 public interface IPPOrderReceiptHUProducer
 {
 	/**

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/custom/CustomHUQRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/custom/CustomHUQRCode.java
@@ -1,0 +1,51 @@
+package de.metas.handlingunits.qrcodes.custom;
+
+import de.metas.handlingunits.qrcodes.model.IHUQRCode;
+import de.metas.scannable_code.format.ParsedScannedCode;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+@EqualsAndHashCode
+public class CustomHUQRCode implements IHUQRCode
+{
+	@NonNull private final ParsedScannedCode parsedScannedCode;
+
+	private CustomHUQRCode(@NonNull final ParsedScannedCode parsedScannedCode)
+	{
+		this.parsedScannedCode = parsedScannedCode;
+	}
+
+	public static CustomHUQRCode ofParsedScannedCode(@NonNull final ParsedScannedCode parsedScannedCode)
+	{
+		return new CustomHUQRCode(parsedScannedCode);
+	}
+
+	@Override
+	@Deprecated
+	public String toString() {return getAsString();}
+
+	@Override
+	public String getAsString() {return parsedScannedCode.getAsString();}
+
+	@Override
+	public Optional<BigDecimal> getWeightInKg()
+	{
+		return Optional.ofNullable(parsedScannedCode.getWeightKg());
+	}
+
+	@Override
+	public Optional<LocalDate> getBestBeforeDate()
+	{
+		return Optional.ofNullable(parsedScannedCode.getBestBeforeDate());
+	}
+
+	@Override
+	public Optional<String> getLotNumber()
+	{
+		return Optional.ofNullable(parsedScannedCode.getLotNo());
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/ean13/EAN13HUQRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/ean13/EAN13HUQRCode.java
@@ -3,6 +3,7 @@ package de.metas.handlingunits.qrcodes.ean13;
 import de.metas.ean13.EAN13;
 import de.metas.handlingunits.qrcodes.model.IHUQRCode;
 import de.metas.i18n.ExplainedOptional;
+import de.metas.scannable_code.ScannedCode;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,12 @@ public class EAN13HUQRCode implements IHUQRCode
 	}
 
 	@Nullable
+	public static EAN13HUQRCode fromScannedCodeOrNullIfNotHandled(@NonNull final ScannedCode scannedCode)
+	{
+		return fromStringOrNullIfNotHandled(scannedCode.getAsString());
+	}
+
+	@Nullable
 	public static EAN13HUQRCode fromStringOrNullIfNotHandled(@NonNull final String barcode)
 	{
 		return fromString(barcode).orElse(null);
@@ -35,6 +42,15 @@ public class EAN13HUQRCode implements IHUQRCode
 	{
 		return EAN13.fromString(barcode).map(EAN13HUQRCode::ofEAN13);
 	}
+
+	@Override
+	@Deprecated
+	public String toString() {return getAsString();}
+
+	public ScannedCode toScannedCode() {return ScannedCode.ofString(getAsString());}
+
+	@Override
+	public String getAsString() {return ean13.getAsString();}
 
 	@Override
 	public Optional<BigDecimal> getWeightInKg() {return ean13.getWeightInKg();}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/ean13/EAN13HUQRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/ean13/EAN13HUQRCode.java
@@ -7,7 +7,6 @@ import de.metas.scannable_code.ScannedCode;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 
 import javax.annotation.Nullable;
 import java.math.BigDecimal;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/ean13/EAN13HUQRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/ean13/EAN13HUQRCode.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 
 @RequiredArgsConstructor
 @EqualsAndHashCode
-@ToString
 public class EAN13HUQRCode implements IHUQRCode
 {
 	@NonNull private final EAN13 ean13;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/gs1/GS1HUQRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/gs1/GS1HUQRCode.java
@@ -4,30 +4,38 @@ import de.metas.gs1.GS1Elements;
 import de.metas.gs1.GS1Parser;
 import de.metas.gs1.GTIN;
 import de.metas.handlingunits.qrcodes.model.IHUQRCode;
+import de.metas.scannable_code.ScannedCode;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
-import lombok.ToString;
 import org.adempiere.exceptions.AdempiereException;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Optional;
 
 @EqualsAndHashCode
-@ToString
 public class GS1HUQRCode implements IHUQRCode
 {
+	@NonNull private final ScannedCode code;
 	@NonNull private final GS1Elements elements;
 
-	private GS1HUQRCode(@NonNull final GS1Elements elements)
+	private GS1HUQRCode(@NonNull final ScannedCode code, @NonNull final GS1Elements elements)
 	{
+		this.code = code;
 		this.elements = elements;
 	}
 
+	@Nullable
 	public static GS1HUQRCode fromStringOrNullIfNotHandled(@NonNull final String string)
 	{
-		final GS1Elements elements = GS1Parser.parseElementsOrNull(string);
-		return elements != null ? new GS1HUQRCode(elements) : null;
+		return fromScannedCodeOrNullIfNotHandled(ScannedCode.ofString(string));
+	}
+
+	public static GS1HUQRCode fromScannedCodeOrNullIfNotHandled(@NonNull final ScannedCode scannedCode)
+	{
+		final GS1Elements elements = GS1Parser.parseElementsOrNull(scannedCode.getAsString());
+		return elements != null ? new GS1HUQRCode(scannedCode, elements) : null;
 	}
 
 	public static GS1HUQRCode fromString(@NonNull final String string)
@@ -39,6 +47,13 @@ public class GS1HUQRCode implements IHUQRCode
 		}
 		return code;
 	}
+
+	@Override
+	@Deprecated
+	public String toString() {return getAsString();}
+
+	@Override
+	public String getAsString() {return code.getAsString();}
 
 	public Optional<GTIN> getGTIN() {return elements.getGTIN();}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/leich_und_mehl/LMQRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/leich_und_mehl/LMQRCode.java
@@ -75,9 +75,6 @@ public class LMQRCode implements IHUQRCode
 	@Override
 	public Optional<BigDecimal> getWeightInKg() {return Optional.of(weightInKg);}
 
-	@NonNull
-	public BigDecimal getWeightInKgNotNull() {return weightInKg;}
-
 	@Override
 	public Optional<LocalDate> getBestBeforeDate() {return Optional.ofNullable(bestBeforeDate);}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/leich_und_mehl/LMQRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/leich_und_mehl/LMQRCode.java
@@ -43,6 +43,7 @@ import java.util.Optional;
 @Jacksonized // NOTE: we are making it json friendly mainly for snapshot testing
 public class LMQRCode implements IHUQRCode
 {
+	@NonNull GlobalQRCode code;
 	@NonNull BigDecimal weightInKg;
 	@Nullable LocalDate bestBeforeDate;
 	@Nullable String lotNumber;
@@ -63,6 +64,13 @@ public class LMQRCode implements IHUQRCode
 	{
 		return LMQRCodeParser.fromGlobalQRCode(globalQRCode);
 	}
+
+	@Override
+	@Deprecated
+	public String toString() {return getAsString();}
+
+	@Override
+	public String getAsString() {return code.getAsString();}
 
 	@Override
 	public Optional<BigDecimal> getWeightInKg() {return Optional.of(weightInKg);}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/leich_und_mehl/LMQRCodeParser.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/leich_und_mehl/LMQRCodeParser.java
@@ -82,11 +82,12 @@ class LMQRCodeParser
 	private static LMQRCode fromGlobalQRCode_version1(final GlobalQRCode globalQRCode)
 	{
 		// NOTE to dev: keep in sync with huQRCodes.js, parseQRCodePayload_LeichMehl_v1
-		
+
 		try
 		{
 			final List<String> parts = SPLITTER.splitToList(globalQRCode.getPayloadAsJson());
 			return LMQRCode.builder()
+					.code(globalQRCode)
 					.weightInKg(new BigDecimal(parts.get(0)))
 					.bestBeforeDate(parts.size() >= 2 ? LocalDate.parse(parts.get(1), BEST_BEFORE_DATE_FORMAT) : null)
 					.lotNumber(parts.size() >= 3 ? StringUtils.trimBlankToNull(parts.get(2)) : null)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/model/HUQRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/model/HUQRCode.java
@@ -9,6 +9,7 @@ import de.metas.handlingunits.HuPackingInstructionsId;
 import de.metas.handlingunits.attribute.weightable.Weightables;
 import de.metas.handlingunits.qrcodes.model.json.HUQRCodeJsonConverter;
 import de.metas.product.ProductId;
+import de.metas.scannable_code.ScannedCode;
 import de.metas.util.StringUtils;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -47,7 +48,10 @@ public class HUQRCode implements IHUQRCode
 
 	@Override
 	@Deprecated
-	public String toString() {return toGlobalQRCodeString();}
+	public String toString() {return getAsString();}
+
+	@Override
+	public String getAsString() {return toGlobalQRCodeString();}
 
 	@NonNull
 	public static HUQRCode fromGlobalQRCodeJsonString(@NonNull final String qrCodeString)
@@ -69,6 +73,14 @@ public class HUQRCode implements IHUQRCode
 		return HUQRCodeJsonConverter.fromGlobalQRCode(globalQRCode);
 	}
 
+	public static Optional<HUQRCode> parse(@NonNull final ScannedCode code)
+	{
+		final GlobalQRCode globalQRCode = code.toGlobalQRCodeIfMatching().orNullIfError();
+		return globalQRCode != null && isHandled(globalQRCode)
+				? Optional.of(fromGlobalQRCode(globalQRCode))
+				: Optional.empty();
+	}
+
 	@JsonIgnore
 	public JsonDisplayableQRCode toRenderedJson()
 	{
@@ -84,6 +96,8 @@ public class HUQRCode implements IHUQRCode
 	{
 		return HUQRCodeJsonConverter.toGlobalQRCodeJsonString(this);
 	}
+
+	public ScannedCode toScannedCode() {return ScannedCode.ofString(toGlobalQRCodeString());}
 
 	public String toDisplayableQRCode()
 	{

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/model/IHUQRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/model/IHUQRCode.java
@@ -28,6 +28,8 @@ import java.util.Optional;
 
 public interface IHUQRCode
 {
+	String getAsString();
+
 	Optional<BigDecimal> getWeightInKg();
 
 	Optional<LocalDate> getBestBeforeDate();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -11,6 +11,7 @@ import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.attribute.storage.IAttributeStorageFactoryService;
 import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.qrcodes.custom.CustomHUQRCode;
 import de.metas.handlingunits.qrcodes.ean13.EAN13HUQRCode;
 import de.metas.handlingunits.qrcodes.gs1.GS1HUQRCode;
 import de.metas.handlingunits.qrcodes.leich_und_mehl.LMQRCode;
@@ -19,15 +20,20 @@ import de.metas.handlingunits.qrcodes.model.HUQRCodeAssignment;
 import de.metas.handlingunits.qrcodes.model.HUQRCodeUniqueId;
 import de.metas.handlingunits.qrcodes.model.IHUQRCode;
 import de.metas.handlingunits.qrcodes.special.PickOnTheFlyQRCode;
+import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.process.AdProcessId;
 import de.metas.process.PInstanceId;
 import de.metas.product.IProductBL;
 import de.metas.report.PrintCopies;
+import de.metas.scannable_code.ScannedCode;
+import de.metas.scannable_code.format.service.ScannableCodeFormatService;
 import de.metas.util.Services;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.api.IAttributeDAO;
 import org.adempiere.service.ISysConfigBL;
+import org.compiere.SpringContextHolder;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
@@ -39,6 +45,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 @Service
+@RequiredArgsConstructor
 public class HUQRCodesService
 {
 	@NonNull private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
@@ -49,18 +56,23 @@ public class HUQRCodesService
 	@NonNull private final HUQRCodesRepository huQRCodesRepository;
 	@NonNull private final GlobalQRCodeService globalQRCodeService;
 	@NonNull private final QRCodeConfigurationService qrCodeConfigurationService;
+	@NonNull private final ScannableCodeFormatService scannableCodeFormatService;
 
 	@VisibleForTesting
 	static final String SYSCONFIG_GenerateQRCodeIfMissing = "de.metas.handlingunits.qrcodes.GenerateQRCodeIfMissing";
 
-	public HUQRCodesService(
-			final @NonNull HUQRCodesRepository huQRCodesRepository,
-			final @NonNull GlobalQRCodeService globalQRCodeService,
-			final @NonNull QRCodeConfigurationService qrCodeConfigurationService)
+	public static HUQRCodesService newInstanceForUnitTesting()
 	{
-		this.huQRCodesRepository = huQRCodesRepository;
-		this.globalQRCodeService = globalQRCodeService;
-		this.qrCodeConfigurationService = qrCodeConfigurationService;
+		SpringContextHolder.assertUnitTestMode();
+		return SpringContextHolder.getBeanOrSupply(
+				HUQRCodesService.class,
+				() -> new HUQRCodesService(
+						new HUQRCodesRepository(),
+						new GlobalQRCodeService(DoNothingMassPrintingService.instance),
+						QRCodeConfigurationService.newInstanceForUnitTesting(),
+						ScannableCodeFormatService.newInstanceForUnitTesting()
+				)
+		);
 	}
 
 	public List<HUQRCode> generate(final HUQRCodeGenerateRequest request)
@@ -354,9 +366,20 @@ public class HUQRCodesService
 				.collect(ImmutableMap.toImmutableMap(HUQRCodeAssignment::getId, HUQRCodeAssignment::getSingleHUId));
 	}
 
-	public static IHUQRCode toHUQRCode(@NonNull final String jsonString)
+	public IHUQRCode parse(@NonNull final String jsonString)
 	{
-		final GlobalQRCode globalQRCode = GlobalQRCode.parse(jsonString).orNullIfError();
+		return parse(ScannedCode.ofString(jsonString));
+	}
+
+	public IHUQRCode parse(@NonNull final ScannedCode scannedCode)
+	{
+		final PickOnTheFlyQRCode pickOnTheFlyQRCode = PickOnTheFlyQRCode.fromScannedCodeOrNullIfNotHandled(scannedCode);
+		if (pickOnTheFlyQRCode != null)
+		{
+			return pickOnTheFlyQRCode;
+		}
+
+		final GlobalQRCode globalQRCode = scannedCode.toGlobalQRCodeIfMatching().orNullIfError();
 		if (globalQRCode != null)
 		{
 			if (HUQRCode.isHandled(globalQRCode))
@@ -369,24 +392,26 @@ public class HUQRCodesService
 			}
 		}
 
-		final GS1HUQRCode gs1HUQRCode = GS1HUQRCode.fromStringOrNullIfNotHandled(jsonString);
+		final CustomHUQRCode customHUQRCode = scannableCodeFormatService.parse(scannedCode)
+				.map(CustomHUQRCode::ofParsedScannedCode)
+				.orElse(null);
+		if (customHUQRCode != null)
+		{
+			return customHUQRCode;
+		}
+
+		final GS1HUQRCode gs1HUQRCode = GS1HUQRCode.fromScannedCodeOrNullIfNotHandled(scannedCode);
 		if (gs1HUQRCode != null)
 		{
 			return gs1HUQRCode;
 		}
 
-		final EAN13HUQRCode ean13HUQRCode = EAN13HUQRCode.fromStringOrNullIfNotHandled(jsonString);
+		final EAN13HUQRCode ean13HUQRCode = EAN13HUQRCode.fromScannedCodeOrNullIfNotHandled(scannedCode);
 		if (ean13HUQRCode != null)
 		{
 			return ean13HUQRCode;
 		}
 
-		final PickOnTheFlyQRCode pickOnTheFlyQRCode = PickOnTheFlyQRCode.fromStringOrNullIfNotHandled(jsonString);
-		if (pickOnTheFlyQRCode != null)
-		{
-			return pickOnTheFlyQRCode;
-		}
-
-		throw new AdempiereException("QR code is not handled: " + jsonString);
+		throw new AdempiereException("QR code is not handled: " + scannedCode);
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/QRCodeConfigurationService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/QRCodeConfigurationService.java
@@ -36,6 +36,7 @@ import de.metas.product.ProductId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.compiere.SpringContextHolder;
 import org.compiere.model.I_M_Product;
 import org.springframework.stereotype.Service;
 
@@ -46,13 +47,21 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public class QRCodeConfigurationService
 {
-	private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
-	private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
-	private final IProductBL productBL = Services.get(IProductBL.class);
+	@NonNull private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
+	@NonNull private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
+	@NonNull private final IProductBL productBL = Services.get(IProductBL.class);
+	@NonNull private final QRCodeConfigurationRepository repository;
 
-	@NonNull
-	private final QRCodeConfigurationRepository repository;
+	public static QRCodeConfigurationService newInstanceForUnitTesting()
+	{
+		SpringContextHolder.assertUnitTestMode();
+		return SpringContextHolder.getBeanOrSupply(
+				QRCodeConfigurationService.class,
+				() -> new QRCodeConfigurationService(new QRCodeConfigurationRepository())
+		);
+	}
 
+	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
 	public boolean isOneQrCodeForAggregatedHUsEnabledFor(@NonNull final I_M_HU hu)
 	{
 		if (!handlingUnitsBL.isTransportUnitOrAggregate(hu))

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/special/PickOnTheFlyQRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/special/PickOnTheFlyQRCode.java
@@ -2,6 +2,7 @@ package de.metas.handlingunits.qrcodes.special;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import de.metas.handlingunits.qrcodes.model.IHUQRCode;
+import de.metas.scannable_code.ScannedCode;
 import de.metas.util.StringUtils;
 import lombok.NonNull;
 
@@ -18,6 +19,12 @@ public final class PickOnTheFlyQRCode implements IHUQRCode
 	private static final String STRING_VALUE = "PICK_ON_THE_FLY";
 
 	@Nullable
+	public static PickOnTheFlyQRCode fromScannedCodeOrNullIfNotHandled(@NonNull final ScannedCode scannedCode)
+	{
+		return fromStringOrNullIfNotHandled(scannedCode.getAsString());
+	}
+
+	@Nullable
 	public static PickOnTheFlyQRCode fromStringOrNullIfNotHandled(@NonNull final String string)
 	{
 		final String stringNorm = StringUtils.trimBlankToNull(string);
@@ -32,8 +39,11 @@ public final class PickOnTheFlyQRCode implements IHUQRCode
 	}
 
 	@Override
+	@Deprecated
+	public String toString() {return getAsString();}
+
 	@JsonValue
-	public String toString() {return STRING_VALUE;}
+	public String getAsString() {return STRING_VALUE;}
 
 	@Override
 	public Optional<BigDecimal> getWeightInKg() {return Optional.empty();}

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/5759770_HU_QRCode_attribute.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/5759770_HU_QRCode_attribute.sql
@@ -1,0 +1,10 @@
+-- Run mode: SWING_CLIENT
+
+-- 2025-07-03T10:58:15.286Z
+INSERT INTO M_Attribute (AD_Client_ID,AD_Org_ID,AttributeValueType,Created,CreatedBy,Description,IsActive,IsAlwaysUpdateable,IsAttrDocumentRelevant,IsHighVolume,IsInstanceAttribute,IsMandatory,IsPricingRelevant,IsPrintedInDocument,IsReadOnlyValues,IsStorageRelevant,IsTransferWhenNull,M_Attribute_ID,Name,Updated,UpdatedBy,Value,ValueMax,ValueMin) VALUES (0,0,'S',TO_TIMESTAMP('2025-07-03 10:58:15.027000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'QR Code (catch weight) used when this HU was scanned','Y','N','N','N','Y','N','N','N','Y','N','N',540168,'QR Code',TO_TIMESTAMP('2025-07-03 10:58:15.027000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'HU_QRCode',0,0)
+;
+
+-- 2025-07-03T11:00:33.642Z
+INSERT INTO M_HU_PI_Attribute (AD_Client_ID,AD_Org_ID,Created,CreatedBy,HU_TansferStrategy_JavaClass_ID,IsActive,IsDisplayed,IsInstanceAttribute,IsMandatory,IsOnlyIfInProductAttributeSet,IsReadOnly,M_Attribute_ID,M_HU_PI_Attribute_ID,M_HU_PI_Version_ID,PropagationType,SeqNo,Updated,UpdatedBy,UseInASI) VALUES (0,0,TO_TIMESTAMP('2025-07-03 11:00:33.478000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,540026,'Y','Y','Y','N','N','Y',540168,540129,100,'NONE',9130,TO_TIMESTAMP('2025-07-03 11:00:33.478000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N')
+;
+

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/AbstractHUTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/AbstractHUTest.java
@@ -108,8 +108,6 @@ public abstract class AbstractHUTest
 	 */
 	protected I_M_Attribute attr_WeightTareAdjust;
 
-	protected I_M_Attribute attr_AttributeNotFound;
-
 	/**
 	 * See {@link de.metas.handlingunits.HUTestHelper#attr_QualityDiscountPercent}
 	 */

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/AbstractHUTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/AbstractHUTest.java
@@ -9,20 +9,15 @@ import de.metas.document.dimension.InOutLineDimensionFactory;
 import de.metas.document.dimension.OrderLineDimensionFactory;
 import de.metas.document.references.zoom_into.NullCustomizedWindowInfoMapRepository;
 import de.metas.email.MailService;
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.model.I_M_HU_PackingMaterial;
 import de.metas.handlingunits.model.I_M_Locator;
-import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.inoutcandidate.api.IShipmentScheduleUpdater;
 import de.metas.inoutcandidate.api.impl.ShipmentScheduleUpdater;
 import de.metas.inoutcandidate.document.dimension.ReceiptScheduleDimensionFactory;
 import de.metas.notification.INotificationRepository;
 import de.metas.notification.impl.NotificationRepository;
 import de.metas.order.impl.OrderEmailPropagationSysConfigRepository;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.product.ProductId;
 import de.metas.user.UserRepository;
 import de.metas.util.Services;
@@ -142,7 +137,9 @@ public abstract class AbstractHUTest
 		POJOWrapper.setDefaultStrictValues(false);
 	}
 
-	/** HU Test helper */
+	/**
+	 * HU Test helper
+	 */
 	public HUTestHelper helper;
 
 	@BeforeEach
@@ -168,10 +165,7 @@ public abstract class AbstractHUTest
 
 		final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 		SpringContextHolder.registerJUnitBean(new OrderEmailPropagationSysConfigRepository(sysConfigBL));
-
-		final QRCodeConfigurationService qrCodeConfigurationService = new QRCodeConfigurationService(new QRCodeConfigurationRepository());
-		SpringContextHolder.registerJUnitBean(qrCodeConfigurationService);
-		SpringContextHolder.registerJUnitBean(new HUQRCodesService(new HUQRCodesRepository(), new GlobalQRCodeService(DoNothingMassPrintingService.instance), qrCodeConfigurationService));
+		SpringContextHolder.registerJUnitBean(HUQRCodesService.newInstanceForUnitTesting());
 
 		initialize();
 	}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/HUTestHelper.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/HUTestHelper.java
@@ -556,7 +556,7 @@ public class HUTestHelper
 
 	/**
 	 * Setup module interceptors: "de.metas.handlingunits" module - FULL (interceptors, factories, etc), like in production (used by some integration tests).
-	 *
+	 * <p>
 	 * <b>Important:</b> if you do the full monty with interceptors, then you also need to annotate the respective test class like this:
 	 *
 	 * <pre>

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/HUTestHelper.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/HUTestHelper.java
@@ -20,7 +20,6 @@ import de.metas.document.location.IDocumentLocationBL;
 import de.metas.document.location.impl.DocumentLocationBL;
 import de.metas.event.IEventBusFactory;
 import de.metas.event.impl.PlainEventBusFactory;
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.allocation.IAllocationDestination;
 import de.metas.handlingunits.allocation.IAllocationRequest;
 import de.metas.handlingunits.allocation.IAllocationResult;
@@ -83,10 +82,7 @@ import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleRep
 import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleService;
 import de.metas.handlingunits.pporder.source_hu.PPOrderSourceHURepository;
 import de.metas.handlingunits.pporder.source_hu.PPOrderSourceHUService;
-import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.reservation.HUReservationRepository;
 import de.metas.handlingunits.reservation.HUReservationService;
 import de.metas.handlingunits.spi.IHUPackingMaterialCollectorSource;
@@ -104,7 +100,6 @@ import de.metas.invoicecandidate.document.dimension.InvoiceCandidateDimensionFac
 import de.metas.materialtransaction.MTransactionUtil;
 import de.metas.pricing.tax.ProductTaxCategoryRepository;
 import de.metas.pricing.tax.ProductTaxCategoryService;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
 import de.metas.quantity.Capacity;
@@ -461,11 +456,7 @@ public class HUTestHelper
 		SpringContextHolder.registerJUnitBean(new AllocationStrategyFactory(new AllocationStrategySupportingServicesFacade()));
 		SpringContextHolder.registerJUnitBean(new ShipperTransportationRepository());
 		SpringContextHolder.registerJUnitBean(new ProductTaxCategoryService(new ProductTaxCategoryRepository()));
-		final QRCodeConfigurationService qrCodeConfigurationService = new QRCodeConfigurationService(new QRCodeConfigurationRepository());
-		SpringContextHolder.registerJUnitBean(qrCodeConfigurationService);
-		SpringContextHolder.registerJUnitBean(new HUQRCodesService(new HUQRCodesRepository(),
-				new GlobalQRCodeService(DoNothingMassPrintingService.instance),
-				qrCodeConfigurationService));
+		SpringContextHolder.registerJUnitBean(HUQRCodesService.newInstanceForUnitTesting());
 
 		final BPartnerBL bpartnerBL = new BPartnerBL(new UserRepository());
 		SpringContextHolder.registerJUnitBean(IBPartnerBL.class, bpartnerBL);
@@ -586,9 +577,7 @@ public class HUTestHelper
 	{
 		final DDOrderLowLevelDAO ddOrderLowLevelDAO = new DDOrderLowLevelDAO();
 		final HUReservationService huReservationService = new HUReservationService(new HUReservationRepository());
-		final HUQRCodesService huqrCodesService = new HUQRCodesService(new HUQRCodesRepository(),
-				new GlobalQRCodeService(DoNothingMassPrintingService.instance),
-				new QRCodeConfigurationService(new QRCodeConfigurationRepository()));
+		final HUQRCodesService huqrCodesService = HUQRCodesService.newInstanceForUnitTesting();
 		final DDOrderMoveScheduleService ddOrderMoveScheduleService = new DDOrderMoveScheduleService(
 				ddOrderLowLevelDAO,
 				new DDOrderMoveScheduleRepository(),
@@ -598,7 +587,8 @@ public class HUTestHelper
 						new PPOrderIssueScheduleService(
 								new PPOrderIssueScheduleRepository(),
 								new HUQtyService(InventoryService.newInstanceForUnitTesting())
-						)), huqrCodesService);
+						)),
+				huqrCodesService);
 		final DDOrderLowLevelService ddOrderLowLevelService = new DDOrderLowLevelService(ddOrderLowLevelDAO);
 		final DDOrderService ddOrderService = new DDOrderService(ddOrderLowLevelDAO, ddOrderLowLevelService, ddOrderMoveScheduleService);
 		return new de.metas.handlingunits.model.validator.Main(

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/HUTransformServiceReceiptCandidatesTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/HUTransformServiceReceiptCandidatesTests.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import de.metas.bpartner.BPartnerId;
 import de.metas.business.BusinessTestHelper;
 import de.metas.common.util.time.SystemTime;
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.HUIteratorListenerAdapter;
 import de.metas.handlingunits.HUXmlConverter;
 import de.metas.handlingunits.IHandlingUnitsBL;
@@ -25,16 +24,12 @@ import de.metas.handlingunits.model.I_M_HU_Storage;
 import de.metas.handlingunits.model.I_M_ReceiptSchedule;
 import de.metas.handlingunits.model.I_M_ReceiptSchedule_Alloc;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
-import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.receiptschedule.IHUReceiptScheduleDAO;
 import de.metas.handlingunits.storage.IHUItemStorage;
 import de.metas.handlingunits.storage.IHUProductStorage;
 import de.metas.handlingunits.storage.IHUStorageDAO;
 import de.metas.handlingunits.storage.IHUStorageFactory;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.quantity.Quantity;
 import de.metas.util.Check;
 import de.metas.util.Services;
@@ -115,9 +110,7 @@ public class HUTransformServiceReceiptCandidatesTests
 		handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
 		huDocumentFactoryService = Services.get(IHUDocumentFactoryService.class);
 
-		final QRCodeConfigurationService qrCodeConfigurationService = new QRCodeConfigurationService(new QRCodeConfigurationRepository());
-		SpringContextHolder.registerJUnitBean(qrCodeConfigurationService);
-		SpringContextHolder.registerJUnitBean(new HUQRCodesService(new HUQRCodesRepository(), new GlobalQRCodeService(DoNothingMassPrintingService.instance), qrCodeConfigurationService));
+		SpringContextHolder.registerJUnitBean(HUQRCodesService.newInstanceForUnitTesting());
 	}
 
 	private I_M_ReceiptSchedule create_receiptSchedule_for_CU(final I_M_HU cu, final String cuQtyStr)

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/HUTransformServiceReceiptCandidatesTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/HUTransformServiceReceiptCandidatesTests.java
@@ -253,7 +253,7 @@ public class HUTransformServiceReceiptCandidatesTests
 	 * <li><move 1.6kg of the salad to the TU
 	 * </ul>
 	 *
-	 * @task https://github.com/metasfresh/metasfresh-webui/issues/237 Transform CU on existing TU not working
+	 * @implSpec  <a href="https://github.com/metasfresh/metasfresh-webui/issues/237">Transform CU on existing TU not working</a>
 	 */
 	@Test
 	public void test_CUToExistingTU_create_mixed_TU_partialCU()
@@ -418,7 +418,7 @@ public class HUTransformServiceReceiptCandidatesTests
 	}
 
 	/**
-	 * @task https://github.com/metasfresh/metasfresh/issues/1177
+	 * @implSpec  <a href="https://github.com/metasfresh/metasfresh/issues/1177">task</a>
 	 */
 	@Test
 	public void testMultipleActionsIssue1177()

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/HUTransformServiceReservationTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/HUTransformServiceReservationTests.java
@@ -1,7 +1,6 @@
 package de.metas.handlingunits.allocation.transfer;
 
 import com.google.common.collect.ImmutableList;
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.HUTestHelper;
 import de.metas.handlingunits.HUXmlConverter;
 import de.metas.handlingunits.IHandlingUnitsBL;
@@ -10,13 +9,9 @@ import de.metas.handlingunits.allocation.impl.HUProducerDestination;
 import de.metas.handlingunits.allocation.transfer.HUTransformService.HUsToNewCUsRequest;
 import de.metas.handlingunits.allocation.transfer.impl.LUTUProducerDestinationTestSupport;
 import de.metas.handlingunits.model.I_M_HU;
-import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.reservation.HUReservationService;
 import de.metas.handlingunits.util.HUTracerInstance;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.quantity.Quantity;
 import de.metas.util.Services;
 import de.metas.util.collections.CollectionUtils;
@@ -83,9 +78,7 @@ public class HUTransformServiceReservationTests
 		final LUTUProducerDestinationTestSupport data = testsBase.getData();
 		huTransformService = HUTransformService.newInstance(data.helper.getHUContext());
 
-		final QRCodeConfigurationService qrCodeConfigurationService = new QRCodeConfigurationService(new QRCodeConfigurationRepository());
-		SpringContextHolder.registerJUnitBean(qrCodeConfigurationService);
-		SpringContextHolder.registerJUnitBean(new HUQRCodesService(new HUQRCodesRepository(), new GlobalQRCodeService(DoNothingMassPrintingService.instance), qrCodeConfigurationService));
+		SpringContextHolder.registerJUnitBean(HUQRCodesService.newInstanceForUnitTesting());
 	}
 
 	/**

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/HUTransformServiceTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/HUTransformServiceTests.java
@@ -1,7 +1,6 @@
 package de.metas.handlingunits.allocation.transfer;
 
 import com.google.common.collect.ImmutableList;
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.HUXmlConverter;
 import de.metas.handlingunits.IHUStatusBL;
 import de.metas.handlingunits.IHandlingUnitsBL;
@@ -18,13 +17,9 @@ import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.handlingunits.model.X_M_HU;
-import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.storage.EmptyHUListener;
 import de.metas.material.planning.ddorder.DistributionNetworkRepository;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.quantity.Quantity;
 import de.metas.util.Services;
 import de.metas.util.collections.CollectionUtils;
@@ -114,10 +109,7 @@ public class HUTransformServiceTests
 
 		huTransformService = HUTransformService.newInstance(testsBase.getData().helper.getHUContext());
 
-
-		final QRCodeConfigurationService qrCodeConfigurationService = new QRCodeConfigurationService(new QRCodeConfigurationRepository());
-		SpringContextHolder.registerJUnitBean(qrCodeConfigurationService);
-		SpringContextHolder.registerJUnitBean(new HUQRCodesService(new HUQRCodesRepository(), new GlobalQRCodeService(DoNothingMassPrintingService.instance), qrCodeConfigurationService));
+		SpringContextHolder.registerJUnitBean(HUQRCodesService.newInstanceForUnitTesting());
 	}
 
 	/**
@@ -509,7 +501,7 @@ public class HUTransformServiceTests
 	}
 
 	/**
-	 * Similar to {@link #testSplitAggregateTU_To_NewTUs_MaxValue()}, but here the source TU is on a pallet.<br>
+	 * Similar to testSplitAggregateTU_To_NewTUs_MaxValue(), but here the source TU is on a pallet.<br>
 	 * So this time, it shall be taken off the pallet.
 	 */
 	@Theory

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUAssignmentBLTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUAssignmentBLTest.java
@@ -11,7 +11,6 @@ import de.metas.distribution.ddorder.movement.schedule.DDOrderMoveScheduleServic
 import de.metas.distribution.ddordercandidate.DDOrderCandidateService;
 import de.metas.event.IEventBusFactory;
 import de.metas.event.impl.PlainEventBusFactory;
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.HuPackingInstructionsId;
 import de.metas.handlingunits.HuPackingInstructionsVersionId;
@@ -25,10 +24,7 @@ import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleRep
 import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleService;
 import de.metas.handlingunits.pporder.source_hu.PPOrderSourceHURepository;
 import de.metas.handlingunits.pporder.source_hu.PPOrderSourceHUService;
-import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.reservation.HUReservationRepository;
 import de.metas.handlingunits.reservation.HUReservationService;
 import de.metas.inoutcandidate.api.IReceiptScheduleProducerFactory;
@@ -37,7 +33,6 @@ import de.metas.inoutcandidate.filter.GenerateReceiptScheduleForModelAggregateFi
 import de.metas.inoutcandidate.picking_bom.PickingBOMService;
 import de.metas.pricing.tax.ProductTaxCategoryRepository;
 import de.metas.pricing.tax.ProductTaxCategoryService;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.util.Services;
 import org.adempiere.ad.modelvalidator.IModelInterceptorRegistry;
 import org.adempiere.ad.trx.api.ITrx;
@@ -60,7 +55,7 @@ import java.util.stream.Collectors;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HUAssignmentBLTest
 {
@@ -88,9 +83,7 @@ public class HUAssignmentBLTest
 		// Make sure Main handling units interceptor is registered
 		final DDOrderLowLevelDAO ddOrderLowLevelDAO = new DDOrderLowLevelDAO();
 		final HUReservationService huReservationService = new HUReservationService(new HUReservationRepository());
-		final HUQRCodesService huqrCodesService = new HUQRCodesService(new HUQRCodesRepository(),
-							 new GlobalQRCodeService(DoNothingMassPrintingService.instance),
-							 new QRCodeConfigurationService(new QRCodeConfigurationRepository()));
+		final HUQRCodesService huqrCodesService = HUQRCodesService.newInstanceForUnitTesting();
 		final DDOrderMoveScheduleService ddOrderMoveScheduleService = new DDOrderMoveScheduleService(
 				ddOrderLowLevelDAO,
 				new DDOrderMoveScheduleRepository(),

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/inout/impl/DistributeAndMoveReceiptCreatorTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/inout/impl/DistributeAndMoveReceiptCreatorTest.java
@@ -7,7 +7,6 @@ import de.metas.distribution.ddorder.lowlevel.DDOrderLowLevelDAO;
 import de.metas.distribution.ddorder.lowlevel.DDOrderLowLevelService;
 import de.metas.distribution.ddorder.movement.schedule.DDOrderMoveScheduleRepository;
 import de.metas.distribution.ddorder.movement.schedule.DDOrderMoveScheduleService;
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.impl.HUQtyService;
 import de.metas.handlingunits.inout.impl.DistributeAndMoveReceiptCreator.Result;
 import de.metas.handlingunits.inventory.InventoryService;
@@ -16,17 +15,13 @@ import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleRep
 import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleService;
 import de.metas.handlingunits.pporder.source_hu.PPOrderSourceHURepository;
 import de.metas.handlingunits.pporder.source_hu.PPOrderSourceHUService;
-import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.reservation.HUReservationRepository;
 import de.metas.handlingunits.reservation.HUReservationService;
 import de.metas.inout.model.I_M_InOut;
 import de.metas.inout.model.I_M_InOutLine;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
 import de.metas.inoutcandidate.model.X_M_ReceiptSchedule;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.product.IProductActivityProvider;
 import de.metas.product.LotNumberQuarantineRepository;
 import de.metas.product.ProductId;
@@ -40,7 +35,7 @@ import org.junit.Test;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.save;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /*
  * #%L
@@ -91,12 +86,14 @@ public class DistributeAndMoveReceiptCreatorTest
 								ADReferenceService.newMocked(),
 								huReservationService,
 								new PPOrderSourceHUService(new PPOrderSourceHURepository(),
-														   new PPOrderIssueScheduleService(
-																   new PPOrderIssueScheduleRepository(),
-																   new HUQtyService(InventoryService.newInstanceForUnitTesting())
-														   )), new HUQRCodesService(new HUQRCodesRepository(),
-																					new GlobalQRCodeService(DoNothingMassPrintingService.instance),
-																					new QRCodeConfigurationService(new QRCodeConfigurationRepository())))));
+										new PPOrderIssueScheduleService(
+												new PPOrderIssueScheduleRepository(),
+												new HUQtyService(InventoryService.newInstanceForUnitTesting())
+										)),
+								HUQRCodesService.newInstanceForUnitTesting()
+						)
+				)
+		);
 	}
 
 	@Test

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/PickingJobTestHelper.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/PickingJobTestHelper.java
@@ -8,7 +8,6 @@ import de.metas.bpartner.service.impl.BPartnerBL;
 import de.metas.business.BusinessTestHelper;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.common.util.time.SystemTime;
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.handlingunits.HUTestHelper;
 import de.metas.handlingunits.HuId;
@@ -48,8 +47,6 @@ import de.metas.handlingunits.qrcodes.model.HUQRCodeUniqueId;
 import de.metas.handlingunits.qrcodes.model.HUQRCodeUnitType;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.report.labels.HULabelConfigRepository;
 import de.metas.handlingunits.report.labels.HULabelConfigService;
 import de.metas.handlingunits.report.labels.HULabelService;
@@ -66,7 +63,6 @@ import de.metas.organization.OrgId;
 import de.metas.picking.api.PickingConfigRepository;
 import de.metas.picking.api.PickingSlotId;
 import de.metas.picking.model.I_M_Picking_Config_V2;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
@@ -149,11 +145,7 @@ public class PickingJobTestHelper
 
 		final BPartnerBL bpartnerBL = new BPartnerBL(new UserRepository());
 		final PickingJobRepository pickingJobRepository = new PickingJobRepository();
-		final HUQRCodesService huQRCodeService = new HUQRCodesService(
-				huQRCodesRepository,
-				new GlobalQRCodeService(DoNothingMassPrintingService.instance),
-				new QRCodeConfigurationService(new QRCodeConfigurationRepository())
-		);
+		final HUQRCodesService huQRCodeService = HUQRCodesService.newInstanceForUnitTesting();
 		final WorkplaceService workplaceService = new WorkplaceService(new WorkplaceRepository(), new WorkplaceUserAssignRepository());
 		final InventoryService inventoryService = InventoryService.newInstanceForUnitTesting();
 		final MobileUIPickingUserProfileRepository profileRepository = new MobileUIPickingUserProfileRepository();

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/PickingJob_Scenarios_Test.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/PickingJob_Scenarios_Test.java
@@ -18,12 +18,12 @@ import de.metas.handlingunits.picking.job.model.PickingJobStepPickFromKey;
 import de.metas.handlingunits.picking.job.model.PickingJobStepPickedTo;
 import de.metas.handlingunits.picking.job.model.PickingJobStepPickedToHU;
 import de.metas.handlingunits.qrcodes.ean13.EAN13HUQRCode;
-import de.metas.handlingunits.qrcodes.gs1.GS1HUQRCode;
 import de.metas.order.OrderAndLineId;
 import de.metas.picking.api.PickingSlotIdAndCaption;
 import de.metas.product.ProductCategoryId;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
+import de.metas.scannable_code.ScannedCode;
 import de.metas.user.UserId;
 import de.metas.util.collections.CollectionUtils;
 import lombok.NonNull;
@@ -89,7 +89,7 @@ class PickingJob_Scenarios_Test
 				.pickingStepId(stepId)
 				.pickFromKey(PickingJobStepPickFromKey.MAIN)
 				.eventType(PickingJobStepEventType.PICK)
-				.huQRCode(helper.getQRCode(vhu1))
+				.qrCode(helper.getQRCode(vhu1).toScannedCode())
 				.qtyPicked(new BigDecimal("100"))
 				.qtyRejectedReasonCode(null)
 				.build());
@@ -124,7 +124,7 @@ class PickingJob_Scenarios_Test
 				.pickingStepId(stepId)
 				.pickFromKey(PickingJobStepPickFromKey.MAIN)
 				.eventType(PickingJobStepEventType.UNPICK)
-				.huQRCode(helper.getQRCode(vhu1))
+				.qrCode(helper.getQRCode(vhu1).toScannedCode())
 				.build());
 		{
 			System.out.println("After unpick: " + pickingJob);
@@ -171,7 +171,7 @@ class PickingJob_Scenarios_Test
 				.pickingStepId(stepId)
 				.pickFromKey(PickingJobStepPickFromKey.MAIN)
 				.eventType(PickingJobStepEventType.PICK)
-				.huQRCode(vhu1.getQrCode())
+				.qrCode(vhu1.getQrCode().toScannedCode())
 				.qtyPicked(new BigDecimal("100"))
 				.qtyRejectedReasonCode(null)
 				.build());
@@ -199,7 +199,7 @@ class PickingJob_Scenarios_Test
 				.pickingStepId(stepId)
 				.pickFromKey(PickingJobStepPickFromKey.MAIN)
 				.eventType(PickingJobStepEventType.UNPICK)
-				.huQRCode(vhu1.getQrCode())
+				.qrCode(vhu1.getQrCode().toScannedCode())
 				.build());
 		{
 			System.out.println("After unpick: " + pickingJob);
@@ -245,7 +245,8 @@ class PickingJob_Scenarios_Test
 							.salesOrderId(orderAndLineId.getOrderId())
 							.deliveryBPLocationId(helper.shipToBPLocationId)
 							.isAllowPickingAnyHU(false) // we need a plan built
-							.build());
+							.build())
+					.withPickingSlot(PickingSlotIdAndCaption.of(helper.pickingSlotId, "TEST"));
 		}
 
 		@Test
@@ -257,15 +258,13 @@ class PickingJob_Scenarios_Test
 			final PickingJob pickingJob = createPickingJob(productId, "100");
 			System.out.println("Created " + pickingJob);
 			final PickingJobLine line = CollectionUtils.singleElement(pickingJob.getLines());
-			final PickingJobStepId stepId = CollectionUtils.singleElement(line.getSteps().stream().map(PickingJobStep::getId).collect(ImmutableSet.toImmutableSet()));
 
 			assertThatThrownBy(
 					() -> helper.pickingJobService.processStepEvent(pickingJob, PickingJobStepEvent.builder()
 							.pickingLineId(line.getId())
-							.pickingStepId(stepId)
 							.pickFromKey(PickingJobStepPickFromKey.MAIN)
 							.eventType(PickingJobStepEventType.PICK)
-							.huQRCode(GS1HUQRCode.fromString("019731187634181131030075201527080910501"))
+							.qrCode(ScannedCode.ofString("019731187634181131030075201527080910501"))
 							.qtyPicked(new BigDecimal("1"))
 							.qtyRejectedReasonCode(null)
 							.build())
@@ -282,17 +281,15 @@ class PickingJob_Scenarios_Test
 			final PickingJob pickingJob = createPickingJob(productId, "100");
 			System.out.println("Created " + pickingJob);
 			final PickingJobLine line = CollectionUtils.singleElement(pickingJob.getLines());
-			final PickingJobStepId stepId = CollectionUtils.singleElement(line.getSteps().stream().map(PickingJobStep::getId).collect(ImmutableSet.toImmutableSet()));
 
 			createProduct("97311876341811");
 
 			assertThatThrownBy(
 					() -> helper.pickingJobService.processStepEvent(pickingJob, PickingJobStepEvent.builder()
 							.pickingLineId(line.getId())
-							.pickingStepId(stepId)
 							.pickFromKey(PickingJobStepPickFromKey.MAIN)
 							.eventType(PickingJobStepEventType.PICK)
-							.huQRCode(GS1HUQRCode.fromString("019731187634181131030075201527080910501"))
+							.qrCode(ScannedCode.ofString("019731187634181131030075201527080910501"))
 							.qtyPicked(new BigDecimal("1"))
 							.qtyRejectedReasonCode(null)
 							.build())
@@ -351,15 +348,13 @@ class PickingJob_Scenarios_Test
 			final PickingJob pickingJob = createPickingJob(productId, "100");
 			System.out.println("Created " + pickingJob);
 			final PickingJobLine line = CollectionUtils.singleElement(pickingJob.getLines());
-			final PickingJobStepId stepId = CollectionUtils.singleElement(line.getSteps().stream().map(PickingJobStep::getId).collect(ImmutableSet.toImmutableSet()));
 
 			assertThatThrownBy(
 					() -> helper.pickingJobService.processStepEvent(pickingJob, PickingJobStepEvent.builder()
 							.pickingLineId(line.getId())
-							.pickingStepId(stepId)
 							.pickFromKey(PickingJobStepPickFromKey.MAIN)
 							.eventType(PickingJobStepEventType.PICK)
-							.huQRCode(EAN13HUQRCode.fromString("2859414004825").orElseThrow())
+							.qrCode(EAN13HUQRCode.fromString("2859414004825").orElseThrow().toScannedCode())
 							.qtyPicked(new BigDecimal("1"))
 							.qtyRejectedReasonCode(null)
 							.build())
@@ -386,12 +381,11 @@ class PickingJob_Scenarios_Test
 					.pickingStepId(stepId)
 					.pickFromKey(PickingJobStepPickFromKey.MAIN)
 					.eventType(PickingJobStepEventType.PICK)
-					.huQRCode(EAN13HUQRCode.fromString("2859414004825").orElseThrow())
+					.qrCode(EAN13HUQRCode.fromString("2859414004825").orElseThrow().toScannedCode())
 					.qtyPicked(new BigDecimal("1"))
 					.qtyRejectedReasonCode(null)
 					.build());
 		}
-
 
 		@Test
 		void ean13Prefix29Valid()
@@ -401,7 +395,7 @@ class PickingJob_Scenarios_Test
 			product.setM_Product_Category_ID(productCategoryId.getRepoId());
 			product.setEAN13_ProductCode("4888");
 			InterfaceWrapperHelper.save(product);
-			final ProductId productId= ProductId.ofRepoId(product.getM_Product_ID());
+			final ProductId productId = ProductId.ofRepoId(product.getM_Product_ID());
 
 			helper.createVHU(productId, "100");
 
@@ -415,7 +409,7 @@ class PickingJob_Scenarios_Test
 					.pickingStepId(stepId)
 					.pickFromKey(PickingJobStepPickFromKey.MAIN)
 					.eventType(PickingJobStepEventType.PICK)
-					.huQRCode(EAN13HUQRCode.fromString("2948882005745").orElseThrow())
+					.qrCode(EAN13HUQRCode.fromString("2948882005745").orElseThrow().toScannedCode())
 					.qtyPicked(new BigDecimal("1"))
 					.qtyRejectedReasonCode(null)
 					.build());

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
@@ -24,7 +24,6 @@ package de.metas.handlingunits.qrcodes.service;
 
 import com.google.common.collect.ImmutableList;
 import de.metas.business.BusinessTestHelper;
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.HUTestHelper;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHUContext;
@@ -42,7 +41,6 @@ import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.model.HUQRCodeUnitType;
 import de.metas.handlingunits.qrcodes.model.IHUQRCode;
 import de.metas.organization.OrgId;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
 import de.metas.util.Services;
@@ -96,9 +94,7 @@ class HUQRCodesServiceTest
 	void beforeEach()
 	{
 		this.helper = HUTestHelper.newInstanceOutOfTrx();
-		this.huQRCodesService = new HUQRCodesService(new HUQRCodesRepository(),
-				new GlobalQRCodeService(DoNothingMassPrintingService.instance),
-				new QRCodeConfigurationService(new QRCodeConfigurationRepository()));
+		this.huQRCodesService = HUQRCodesService.newInstanceForUnitTesting();
 
 		this.productId = BusinessTestHelper.createProductId("MyProduct", helper.uomEach);
 
@@ -306,7 +302,7 @@ class HUQRCodesServiceTest
 		@Test
 		void gs1()
 		{
-			final IHUQRCode huQRCode = HUQRCodesService.toHUQRCode("0197311876341811310300752015170809");
+			final IHUQRCode huQRCode = HUQRCodesService.newInstanceForUnitTesting().parse("0197311876341811310300752015170809");
 			assertThat(huQRCode).isInstanceOf(GS1HUQRCode.class);
 
 			final GS1HUQRCode gs1 = (GS1HUQRCode)huQRCode;
@@ -318,7 +314,7 @@ class HUQRCodesServiceTest
 		@Test
 		void ean13()
 		{
-			final IHUQRCode huQRCode = HUQRCodesService.toHUQRCode("2859414004825");
+			final IHUQRCode huQRCode = HUQRCodesService.newInstanceForUnitTesting().parse("2859414004825");
 			assertThat(huQRCode).isInstanceOf(EAN13HUQRCode.class);
 
 			final EAN13HUQRCode ean13 = (EAN13HUQRCode)huQRCode;

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/receiptschedule/impl/InOutProducerFromReceiptScheduleHUTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/receiptschedule/impl/InOutProducerFromReceiptScheduleHUTest.java
@@ -32,7 +32,6 @@ import de.metas.distribution.ddorder.lowlevel.DDOrderLowLevelDAO;
 import de.metas.distribution.ddorder.lowlevel.DDOrderLowLevelService;
 import de.metas.distribution.ddorder.movement.schedule.DDOrderMoveScheduleRepository;
 import de.metas.distribution.ddorder.movement.schedule.DDOrderMoveScheduleService;
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.HUTestHelper;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.attribute.storage.IAttributeStorage;
@@ -47,10 +46,7 @@ import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleRep
 import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleService;
 import de.metas.handlingunits.pporder.source_hu.PPOrderSourceHURepository;
 import de.metas.handlingunits.pporder.source_hu.PPOrderSourceHUService;
-import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.receiptschedule.IHUReceiptScheduleBL.CreateReceiptsParameters;
 import de.metas.handlingunits.receiptschedule.IHUToReceiveValidator;
 import de.metas.handlingunits.reservation.HUReservationRepository;
@@ -58,7 +54,6 @@ import de.metas.handlingunits.reservation.HUReservationService;
 import de.metas.inout.model.I_M_InOut;
 import de.metas.inoutcandidate.api.InOutGenerateResult;
 import de.metas.inoutcandidate.api.impl.ReceiptMovementDateRule;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.product.IProductActivityProvider;
 import de.metas.product.LotNumberQuarantineRepository;
 import de.metas.product.ProductId;
@@ -122,12 +117,13 @@ public class InOutProducerFromReceiptScheduleHUTest extends AbstractRSAllocation
 						ADReferenceService.newMocked(),
 						huReservationService,
 						new PPOrderSourceHUService(new PPOrderSourceHURepository(),
-												   new PPOrderIssueScheduleService(
-														   new PPOrderIssueScheduleRepository(),
-														   new HUQtyService(InventoryService.newInstanceForUnitTesting())
-												   )), new HUQRCodesService(new HUQRCodesRepository(),
-																			new GlobalQRCodeService(DoNothingMassPrintingService.instance),
-																			new QRCodeConfigurationService(new QRCodeConfigurationRepository()))));
+								new PPOrderIssueScheduleService(
+										new PPOrderIssueScheduleRepository(),
+										new HUQtyService(InventoryService.newInstanceForUnitTesting())
+								)),
+						HUQRCodesService.newInstanceForUnitTesting()
+				)
+		);
 		SpringContextHolder.registerJUnitBean(new DistributeAndMoveReceiptCreator(lotNumberQuarantineRepository, ddOrderService));
 	}
 

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/receiptschedule/impl/InOutProducerFromReceiptScheduleHUTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/receiptschedule/impl/InOutProducerFromReceiptScheduleHUTest.java
@@ -448,7 +448,7 @@ public class InOutProducerFromReceiptScheduleHUTest extends AbstractRSAllocation
 	}
 
 	/**
-	 * @implNote task http://dewiki908/mediawiki/index.php/09670_Tageslot_Einlagerung_%28100236982974%29
+	 * @implNote <a href="http://dewiki908/mediawiki/index.php/09670_Tageslot_Einlagerung_%28100236982974%29">task</a>
 	 */
 	@Test
 	public void test_HU_LotNumberDate_propagated()

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/HUReservationServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/HUReservationServiceTest.java
@@ -1,20 +1,15 @@
 package de.metas.handlingunits.reservation;
 
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.IHandlingUnitsDAO;
 import de.metas.handlingunits.allocation.transfer.HUTransformService;
 import de.metas.handlingunits.allocation.transfer.impl.LUTUProducerDestinationTestSupport;
 import de.metas.handlingunits.model.I_M_HU;
-import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.storage.IHUProductStorage;
 import de.metas.handlingunits.storage.IHUStorage;
 import de.metas.order.OrderLineId;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
 import de.metas.util.Services;
@@ -87,10 +82,7 @@ public class HUReservationServiceTest
 
 		handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
 		handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
-
-		final QRCodeConfigurationService qrCodeConfigurationService = new QRCodeConfigurationService(new QRCodeConfigurationRepository());
-		SpringContextHolder.registerJUnitBean(qrCodeConfigurationService);
-		SpringContextHolder.registerJUnitBean(new HUQRCodesService(new HUQRCodesRepository(), new GlobalQRCodeService(DoNothingMassPrintingService.instance), qrCodeConfigurationService));
+		SpringContextHolder.registerJUnitBean(HUQRCodesService.newInstanceForUnitTesting());
 	}
 
 	@Test

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/integrationtest/AbstractHUShipmentProcessIntegrationTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/integrationtest/AbstractHUShipmentProcessIntegrationTest.java
@@ -25,7 +25,6 @@ package de.metas.handlingunits.shipmentschedule.integrationtest;
 import ch.qos.logback.classic.Level;
 import com.google.common.collect.ImmutableList;
 import de.metas.contracts.flatrate.interfaces.I_C_DocType;
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.AbstractHUTest;
 import de.metas.handlingunits.HUTestHelper;
 import de.metas.handlingunits.IHUContext;
@@ -41,9 +40,7 @@ import de.metas.handlingunits.model.I_M_HU_PI;
 import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_ShipmentSchedule;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
-import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
 import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.shipmentschedule.api.HUShippingFacade;
 import de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHU;
@@ -62,7 +59,6 @@ import de.metas.inoutcandidate.picking_bom.PickingBOMService;
 import de.metas.logging.LogManager;
 import de.metas.order.DeliveryRule;
 import de.metas.order.inoutcandidate.OrderLineShipmentScheduleHandler;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.shipping.model.I_M_ShipperTransportation;
 import de.metas.shipping.model.ShipperTransportationId;
 import de.metas.user.UserGroupRepository;
@@ -223,10 +219,7 @@ public abstract class AbstractHUShipmentProcessIntegrationTest extends AbstractH
 		// this.huShipmentScheduleDAO = Services.get(IHUShipmentScheduleDAO.class);
 		SpringContextHolder.registerJUnitBean(new ShipperTransportationRepository());
 		SpringContextHolder.registerJUnitBean(new UserGroupRepository());
-
-		final QRCodeConfigurationService qrCodeConfigurationService = new QRCodeConfigurationService(new QRCodeConfigurationRepository());
-		SpringContextHolder.registerJUnitBean(qrCodeConfigurationService);
-		SpringContextHolder.registerJUnitBean(new HUQRCodesService(new HUQRCodesRepository(), new GlobalQRCodeService(DoNothingMassPrintingService.instance), qrCodeConfigurationService));
+		SpringContextHolder.registerJUnitBean(HUQRCodesService.newInstanceForUnitTesting());
 
 		huShipperTransportationBL = Services.get(IHUShipperTransportationBL.class);
 		huPackageDAO = Services.get(IHUPackageDAO.class);

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/integrationtest/AbstractHUShipmentProcessIntegrationTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/integrationtest/AbstractHUShipmentProcessIntegrationTest.java
@@ -41,7 +41,6 @@ import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_ShipmentSchedule;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.shipmentschedule.api.HUShippingFacade;
 import de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHU;
 import de.metas.handlingunits.shipmentschedule.async.GenerateInOutFromHU.BillAssociatedInvoiceCandidates;
@@ -79,7 +78,6 @@ import org.compiere.model.I_M_Warehouse;
 import org.compiere.model.X_AD_User;
 import org.compiere.model.X_C_DocType;
 import org.compiere.util.Env;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
@@ -340,8 +338,7 @@ public abstract class AbstractHUShipmentProcessIntegrationTest extends AbstractH
 		{
 			//
 			// Add our aggregated HU to Shipper Transportation
-			Assert.assertTrue("HU is not eligible for shipper transportation: " + afterAggregation_HU,
-					huShipperTransportationBL.isEligibleForAddingToShipperTransportation(afterAggregation_HU));
+			assertThat(huShipperTransportationBL.isEligibleForAddingToShipperTransportation(afterAggregation_HU)).as("HU is not eligible for shipper transportation: " + afterAggregation_HU).isTrue();
 			huShipperTransportationBL
 					.addHUsToShipperTransportation(
 							ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID()),
@@ -351,7 +348,7 @@ public abstract class AbstractHUShipmentProcessIntegrationTest extends AbstractH
 			//
 			// Make sure M_Package was created and added to shipper transportation
 			final I_M_Package mpackage_AggregatedHU = huPackageDAO.retrievePackage(afterAggregation_HU);
-			Assert.assertNotNull("M_Package not created for Aggregated HU: " + afterAggregation_HU, mpackage_AggregatedHU);
+			assertThat(mpackage_AggregatedHU).as("M_Package not created for Aggregated HU: " + afterAggregation_HU).isNotNull();
 
 			mpackagesForAggregatedHUs.add(mpackage_AggregatedHU);
 		}
@@ -399,8 +396,8 @@ public abstract class AbstractHUShipmentProcessIntegrationTest extends AbstractH
 		//
 		// When matching expectations, sort the candidates so that they have the same indexes as the aggregated HUs
 		//
-		final List<ShipmentScheduleWithHU> candidatesSorted = new ArrayList<>(huShippingFacade.getCandidates());
-		Collections.sort(candidatesSorted, new Comparator<ShipmentScheduleWithHU>()
+		final ArrayList<ShipmentScheduleWithHU> candidatesSorted = new ArrayList<>(huShippingFacade.getCandidates());
+		candidatesSorted.sort(new Comparator<ShipmentScheduleWithHU>()
 		{
 			@Override
 			public int compare(final ShipmentScheduleWithHU schedWithHU1, final ShipmentScheduleWithHU schedWithHU2)

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/trace/HUTransformTracingTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/trace/HUTransformTracingTests.java
@@ -186,9 +186,6 @@ public class HUTransformTracingTests
 		assertThat(RetrieveDbRecordsUtil.queryAll().isEmpty(), is(true));
 	}
 
-	/**
-	 * Performs {@link HUTransformServiceTests#testAggregateCU_To_NewTUs_1Tomato()} and verifies the generated HU-trace records.
-	 */
 	@Test
 	public void testAggregateCU_To_NewTUs_1Tomato()
 	{

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/trace/HUTransformTracingTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/trace/HUTransformTracingTests.java
@@ -1,6 +1,5 @@
 package de.metas.handlingunits.trace;
 
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.allocation.transfer.HUTransformServiceTests;
 import de.metas.handlingunits.allocation.transfer.HUTransformTestsBase;
@@ -8,15 +7,11 @@ import de.metas.handlingunits.allocation.transfer.HUTransformTestsBase.TestHUs;
 import de.metas.handlingunits.inventory.InventoryRepository;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.X_M_HU;
-import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.trace.HUTraceEvent.HUTraceEventBuilder;
 import de.metas.handlingunits.trace.interceptor.HUTraceModuleInterceptor;
 import de.metas.handlingunits.trace.repository.RetrieveDbRecordsUtil;
 import de.metas.organization.OrgId;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.quantity.Quantity;
 import de.metas.util.Services;
 import de.metas.util.StringUtils;
@@ -85,9 +80,7 @@ public class HUTransformTracingTests
 	@Before
 	public void init()
 	{
-		final QRCodeConfigurationService qrCodeConfigurationService = new QRCodeConfigurationService(new QRCodeConfigurationRepository());
-		SpringContextHolder.registerJUnitBean(qrCodeConfigurationService);
-		SpringContextHolder.registerJUnitBean(new HUQRCodesService(new HUQRCodesRepository(), new GlobalQRCodeService(DoNothingMassPrintingService.instance), qrCodeConfigurationService));
+		SpringContextHolder.registerJUnitBean(HUQRCodesService.newInstanceForUnitTesting());
 
 		testsBase = new HUTransformTestsBase();
 
@@ -168,10 +161,10 @@ public class HUTransformTracingTests
 		// when comparing with "common", we needs to keep the ID out
 		final HUTraceEvent tuTraceEventToCompareWith = tuTraceEvents.get(0).toBuilder().huTraceEventId(OptionalInt.empty()).build();
 		assertThat(tuTraceEventToCompareWith,
-				   is(common
-							  .qty(Quantity.of(new BigDecimal("-3"), uomRecord))
-							  .topLevelHuId(HuId.ofRepoId(parentTU.getM_HU_ID()))
-							  .build()));
+				is(common
+						.qty(Quantity.of(new BigDecimal("-3"), uomRecord))
+						.topLevelHuId(HuId.ofRepoId(parentTU.getM_HU_ID()))
+						.build()));
 
 		final HUTraceEventQuery cuTraceQuery = HUTraceEventQuery.builder().topLevelHuId(HuId.ofRepoId(cuToSplit.getM_HU_ID())).build();
 		final List<HUTraceEvent> cuTraceEvents = huTraceRepository.query(cuTraceQuery);
@@ -180,10 +173,10 @@ public class HUTransformTracingTests
 		// when comparing with "common", we needs to keep the ID out
 		final HUTraceEvent cuTraceEventToCompareWith = cuTraceEvents.get(0).toBuilder().huTraceEventId(OptionalInt.empty()).build();
 		assertThat(cuTraceEventToCompareWith,
-				   is(common
-							  .qty(Quantity.of(new BigDecimal("3"), uomRecord))
-							  .topLevelHuId(HuId.ofRepoId(cuToSplit.getM_HU_ID()))
-							  .build()));
+				is(common
+						.qty(Quantity.of(new BigDecimal("3"), uomRecord))
+						.topLevelHuId(HuId.ofRepoId(cuToSplit.getM_HU_ID()))
+						.build()));
 	}
 
 	@Test

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/tourplanning/integrationtest/HU_TourInstance_DeliveryDay_ShipmentSchedule_IntegrationTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/tourplanning/integrationtest/HU_TourInstance_DeliveryDay_ShipmentSchedule_IntegrationTest.java
@@ -28,7 +28,6 @@ import de.metas.distribution.ddorder.lowlevel.DDOrderLowLevelDAO;
 import de.metas.distribution.ddorder.lowlevel.DDOrderLowLevelService;
 import de.metas.distribution.ddorder.movement.schedule.DDOrderMoveScheduleRepository;
 import de.metas.distribution.ddorder.movement.schedule.DDOrderMoveScheduleService;
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.impl.HUQtyService;
 import de.metas.handlingunits.inventory.InventoryService;
 import de.metas.handlingunits.model.I_M_ShipmentSchedule;
@@ -36,16 +35,12 @@ import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleRep
 import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleService;
 import de.metas.handlingunits.pporder.source_hu.PPOrderSourceHURepository;
 import de.metas.handlingunits.pporder.source_hu.PPOrderSourceHUService;
-import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.reservation.HUReservationRepository;
 import de.metas.handlingunits.reservation.HUReservationService;
 import de.metas.handlingunits.tourplanning.model.I_M_DeliveryDay_Alloc;
 import de.metas.handlingunits.tourplanning.spi.impl.HUShipmentScheduleDeliveryDayHandlerTest;
 import de.metas.inoutcandidate.picking_bom.PickingBOMService;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.tourplanning.model.I_M_DeliveryDay;
 import org.adempiere.model.InterfaceWrapperHelper;
 
@@ -60,9 +55,7 @@ public class HU_TourInstance_DeliveryDay_ShipmentSchedule_IntegrationTest extend
 
 		final DDOrderLowLevelDAO ddOrderLowLevelDAO = new DDOrderLowLevelDAO();
 		final HUReservationService huReservationService = new HUReservationService(new HUReservationRepository());
-		final HUQRCodesService huqrCodesService = new HUQRCodesService(new HUQRCodesRepository(),
-																	   new GlobalQRCodeService(DoNothingMassPrintingService.instance),
-																	   new QRCodeConfigurationService(new QRCodeConfigurationRepository()));
+		final HUQRCodesService huqrCodesService = HUQRCodesService.newInstanceForUnitTesting();
 		final DDOrderMoveScheduleService ddOrderMoveScheduleService = new DDOrderMoveScheduleService(
 				ddOrderLowLevelDAO,
 				new DDOrderMoveScheduleRepository(),

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/model/ReceivingTarget.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/model/ReceivingTarget.java
@@ -42,6 +42,20 @@ public class ReceivingTarget
 
 	public static ReceivingTarget ofExistingTU(@NonNull final I_M_HU tu)
 	{
-		return builder().tuId(HuId.ofRepoId(tu.getM_HU_ID())).build();
+		return ofExistingTUId(HuId.ofRepoId(tu.getM_HU_ID()));
 	}
+
+	public static ReceivingTarget ofExistingTUId(@NonNull final HuId tuId)
+	{
+		return builder().tuId(tuId).build();
+	}
+
+	public static ReceivingTarget ofExistingLU(@NonNull final I_M_HU lu, @NonNull final HUPIItemProductId tuPIItemProductId)
+	{
+		return ReceivingTarget.builder()
+				.luId(HuId.ofRepoId(lu.getM_HU_ID()))
+				.tuPIItemProductId(tuPIItemProductId)
+				.build();
+	}
+
 }

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobService.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobService.java
@@ -537,7 +537,7 @@ public class ManufacturingJobService
 							.productionDate(TimeUtil.asLocalDate(receiveFrom.getProductionDate()))
 							.lotNo(receiveFrom.getLotNo())
 							.catchWeight(getTargetCatchWeight(receiveFrom).orElse(null))
-							.isBarcodeScan(receiveFrom.isBarcodeScan())
+							.barcode(receiveFrom.getBarcode())
 							.build())
 					//
 					.build().execute());

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/commands/ReceiveGoodsRequest.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/commands/ReceiveGoodsRequest.java
@@ -46,6 +46,6 @@ public class ReceiveGoodsRequest
 	@Nullable LocalDate productionDate;
 	@Nullable String lotNo;
 	@Nullable Quantity catchWeight;
-	boolean isBarcodeScan;
+	@Nullable String barcode;
 	@Nullable PPOrderBOMLineId coProductBOMLineId;
 }

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/rest_api/json/JsonManufacturingOrderEvent.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/rest_api/json/JsonManufacturingOrderEvent.java
@@ -49,7 +49,7 @@ public class JsonManufacturingOrderEvent
 		@Nullable String lotNo;
 		@Nullable BigDecimal catchWeight;
 		@Nullable String catchWeightUomSymbol;
-		boolean isBarcodeScan;
+		@Nullable String barcode;
 		@Nullable JsonLUReceivingTarget aggregateToLU;
 		@Nullable JsonTUReceivingTarget aggregateToTU;
 

--- a/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/job/service/ManufacturingJobServiceTest.java
+++ b/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/job/service/ManufacturingJobServiceTest.java
@@ -3,21 +3,16 @@ package de.metas.manufacturing.job.service;
 import de.metas.device.accessor.DeviceAccessorsHubFactory;
 import de.metas.device.config.DeviceConfigPoolFactory;
 import de.metas.device.websocket.DeviceWebsocketNamingStrategy;
-import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.handlingunits.impl.HUQtyService;
 import de.metas.handlingunits.inventory.InventoryService;
 import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleRepository;
 import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleService;
 import de.metas.handlingunits.pporder.source_hu.PPOrderSourceHURepository;
 import de.metas.handlingunits.pporder.source_hu.PPOrderSourceHUService;
-import de.metas.handlingunits.qrcodes.service.HUQRCodesRepository;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationRepository;
-import de.metas.handlingunits.qrcodes.service.QRCodeConfigurationService;
 import de.metas.handlingunits.reservation.HUReservationRepository;
 import de.metas.handlingunits.reservation.HUReservationService;
 import de.metas.organization.ClientAndOrgId;
-import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.util.Services;
 import org.adempiere.service.ISysConfigDAO;
 import org.adempiere.test.AdempiereTestHelper;
@@ -47,10 +42,7 @@ class ManufacturingJobServiceTest
 				new PPOrderSourceHUService(new PPOrderSourceHURepository(), ppOrderIssueScheduleService),
 				new DeviceAccessorsHubFactory(new DeviceConfigPoolFactory()),
 				new DeviceWebsocketNamingStrategy("/test/"),
-				new HUQRCodesService(
-						new HUQRCodesRepository(), 
-						new GlobalQRCodeService(DoNothingMassPrintingService.instance),
-						new QRCodeConfigurationService(new QRCodeConfigurationRepository()))
+				HUQRCodesService.newInstanceForUnitTesting()
 		);
 
 		this.sysConfigDAO = Services.get(ISysConfigDAO.class);

--- a/misc/services/mobile-webui/mobile-webui-frontend-testing/tests/spec/picking/picking_catchWeight.spec.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend-testing/tests/spec/picking/picking_catchWeight.spec.js
@@ -296,7 +296,7 @@ test('Custom QR code format', async ({ page }) => {
                     { startPosition: 1, endPosition: 4, type: 'PRODUCT_CODE' },
                     { startPosition: 5, endPosition: 10, type: 'WEIGHT_KG' },
                     { startPosition: 11, endPosition: 18, type: 'LOT' },
-                    { startPosition: 19, endPosition: 24, type: 'IGNORE' },
+                    { startPosition: 19, endPosition: 24, type: 'PRODUCTION_DATE', dateFormat: 'yyMMdd' },
                     { startPosition: 25, endPosition: 30, type: 'BEST_BEFORE_DATE', dateFormat: 'yyMMdd' },
                 ],
             }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/actions/ManufacturingActions.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/actions/ManufacturingActions.js
@@ -98,7 +98,7 @@ export const updateManufacturingReceiptQty = ({
   bestBeforeDate,
   productionDate,
   lotNo,
-  isBarcodeScan,
+  barcode, // i.e. the catch weight QR code
 }) => {
   console.log('updateManufacturingReceiptQty', {
     wfProcessId,
@@ -111,7 +111,7 @@ export const updateManufacturingReceiptQty = ({
     bestBeforeDate,
     productionDate,
     lotNo,
-    isBarcodeScan,
+    barcode,
   });
   return (dispatch, getState) => {
     const { aggregateToLU, aggregateToTU } = getAggregateTarget({
@@ -133,7 +133,7 @@ export const updateManufacturingReceiptQty = ({
         bestBeforeDate,
         productionDate,
         lotNo,
-        isBarcodeScan,
+        barcode,
       },
       pickTo,
     }) //

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
@@ -11,6 +11,7 @@ import { toQRCodeString } from '../utils/qrCode/hu';
 import HUScanner from './huSelector/HUScanner';
 import BarcodeScannerComponent from './BarcodeScannerComponent';
 import { PICK_ON_THE_FLY_QRCODE } from '../containers/activities/picking/PickConfig';
+import { ATTR_isUnique } from '../utils/qrCode/common';
 
 const STATUS_NOT_INITIALIZED = 'NOT_INITIALIZED';
 const STATUS_READ_BARCODE = 'READ_BARCODE';
@@ -151,7 +152,7 @@ const ScanHUAndGetQtyComponent = ({
       scannedBarcode,
     };
 
-    //console.log('handleResolveScannedBarcode', { resolvedBarcodeDataNew, resolvedBarcodeData });
+    console.log('handleResolveScannedBarcode', { resolvedBarcodeDataNew, resolvedBarcodeData });
 
     return resolvedBarcodeDataNew;
   };
@@ -175,7 +176,15 @@ const ScanHUAndGetQtyComponent = ({
 
   const onBarcodeScanned = (resolvedBarcodeDataNew) => {
     setResolvedBarcodeData(resolvedBarcodeDataNew);
-    const askForQty = resolvedBarcodeDataNew.qtyTarget != null || resolvedBarcodeDataNew.qtyMax != null;
+
+    let askForQty;
+    const qrCode = resolvedBarcodeDataNew?.qrCode;
+    if (qrCode && qrCode[ATTR_isUnique] === false) {
+      // user just scanned a non-unique QR code (e.g. EAN13, custom)
+      askForQty = false;
+    } else {
+      askForQty = resolvedBarcodeDataNew.qtyTarget != null || resolvedBarcodeDataNew.qtyMax != null;
+    }
 
     console.log('onBarcodeScanned', { resolvedBarcodeDataNew, resolvedBarcodeData, askForQty });
 
@@ -186,7 +195,7 @@ const ScanHUAndGetQtyComponent = ({
         qty: 0,
         reason: null,
         scannedBarcode: resolvedBarcodeDataNew.scannedBarcode,
-        resolvedBarcodeData,
+        resolvedBarcodeData: resolvedBarcodeDataNew,
       })?.catch?.((error) => toastErrorFromObj(error));
     }
   };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/dialogs/GetQuantityDialog.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/dialogs/GetQuantityDialog.jsx
@@ -180,7 +180,7 @@ const GetQuantityDialog = ({
         lotNo: qrCode.lotNo,
         productNo: qrCode.productNo,
         barcodeType: qrCode.barcodeType,
-        barcode: result.scannedBarcode,
+        barcode: result.scannedBarcode, // i.e. the catch weight QR code
         isDone: false,
       };
       uiTrace.putContext(onQtyChangePayload);

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/receipt/MaterialReceiptLineScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/receipt/MaterialReceiptLineScreen.jsx
@@ -85,7 +85,7 @@ const MaterialReceiptLineScreen = () => {
     bestBeforeDate,
     productionDate,
     lotNo,
-    isBarcodeScan = false,
+    barcode, // i.e. the catch weight QR code
     isDone = true,
   }) => {
     // shall not happen
@@ -107,7 +107,7 @@ const MaterialReceiptLineScreen = () => {
         bestBeforeDate,
         productionDate,
         lotNo,
-        isBarcodeScan,
+        barcode,
       })
     )
       .then(() => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/receipt/PickQuantityButton.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/receipt/PickQuantityButton.jsx
@@ -28,6 +28,7 @@ const PickQuantityButton = ({ qtyTarget, uom, catchWeightUom, caption, isDisable
     productionDate,
     lotNo,
     barcodeType,
+    barcode, // i.e. the catch weight QR code
     isDone = true,
   }) => {
     if (isDone) {
@@ -40,7 +41,8 @@ const PickQuantityButton = ({ qtyTarget, uom, catchWeightUom, caption, isDisable
       bestBeforeDate,
       productionDate,
       lotNo,
-      isBarcodeScan: !!barcodeType,
+      barcode,
+      barcodeType,
       isDone,
     });
   };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickProductsScanScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickProductsScanScreen.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
-import { getActivityById } from '../../../reducers/wfProcesses';
+import { getActivityById, getCustomQRCodeFormats } from '../../../reducers/wfProcesses';
 import { getNextEligibleLineToPick } from '../../../utils/picking';
 import BarcodeScannerComponent from '../../../components/BarcodeScannerComponent';
 import { parseQRCodeString } from '../../../utils/qrCode/hu';
@@ -17,9 +17,11 @@ const PickProductsScanScreen = () => {
   });
 
   const { activity } = useSelector((state) => getPropsFromState({ state, wfProcessId, activityId }), shallowEqual);
+  const customQRCodeFormats = getCustomQRCodeFormats({ activity });
 
   const onBarcodeScanned = ({ scannedBarcode }) => {
-    const qrCode = parseQRCodeString(scannedBarcode);
+    const qrCode = parseQRCodeString({ string: scannedBarcode, customQRCodeFormats });
+    // console.log('onBarcodeScanned', { scannedBarcode, qrCode });
     const line = getNextEligibleLineToPick({ activity, productId: qrCode.productId });
     if (!line) {
       throw 'No matching lines found'; // TODO trl

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/common.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/common.js
@@ -1,6 +1,7 @@
 import { trl } from '../translations';
 
 export const ATTR_barcodeType = 'barcodeType';
+export const ATTR_isUnique = 'isUnique';
 export const ATTR_productId = 'productId';
 export const ATTR_productNo = 'productNo';
 export const ATTR_GTIN = 'GTIN';

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/ean13.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/ean13.js
@@ -3,6 +3,7 @@ import {
   ATTR_barcodeType,
   ATTR_displayable,
   ATTR_isTUToBePickedAsWhole,
+  ATTR_isUnique,
   ATTR_productNo,
   ATTR_weightNet,
   ATTR_weightNetUOM,
@@ -46,6 +47,7 @@ export const parseEAN13CodeString = (barcode) => {
 
     const result = {};
     result[ATTR_barcodeType] = BARCODE_TYPE_EAN13;
+    result[ATTR_isUnique] = false;
     result[ATTR_displayable] = '' + weightInKg + ' kg';
     result[ATTR_productNo] = productNo;
     result[ATTR_weightNet] = weightInKg;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/gs1.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/gs1.js
@@ -5,6 +5,7 @@ import {
   ATTR_displayable,
   ATTR_GTIN,
   ATTR_isTUToBePickedAsWhole,
+  ATTR_isUnique,
   ATTR_lotNo,
   ATTR_weightNet,
   ATTR_weightNetUOM,
@@ -70,6 +71,7 @@ export const parseGS1CodeString = (string) => {
     }
 
     result[ATTR_barcodeType] = BARCODE_TYPE_GS1;
+    result[ATTR_isUnique] = false;
     return { displayable: string, ...result };
   } catch (ex) {
     //console.log('parseQRCodeString_GS1: got error', { ex });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/hu.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/hu.js
@@ -25,6 +25,7 @@ import {
   ATTR_bestBeforeDate,
   ATTR_displayable,
   ATTR_isTUToBePickedAsWhole,
+  ATTR_isUnique,
   ATTR_lotNo,
   ATTR_productId,
   ATTR_productNo,
@@ -272,6 +273,7 @@ const parseQRCodePayload_HU_v1 = (payload) => {
 
   const result = { displayable };
   result[ATTR_barcodeType] = BARCODE_TYPE_HU;
+  result[ATTR_isUnique] = true;
 
   if (payload?.product?.id) {
     // IMPORTANT: convert it to string because all over in our code we assume IDs are strings.
@@ -303,6 +305,7 @@ const LMQ_BEST_BEFORE_DATE_FORMAT = /^(\d{2}).(\d{2}).(\d{4})$/;
 const parseQRCodePayload_LeichMehl_v1 = (payload) => {
   const result = { displayable: payload };
   result[ATTR_barcodeType] = BARCODE_TYPE_LMQ;
+  result[ATTR_isUnique] = false;
 
   const parts = payload.split('#');
   if (parts.length >= 1 && parts[0] != null) {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/parseCustomQRCode.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/parseCustomQRCode.js
@@ -2,6 +2,8 @@ import {
   ATTR_barcodeType,
   ATTR_bestBeforeDate,
   ATTR_displayable,
+  ATTR_isTUToBePickedAsWhole,
+  ATTR_isUnique,
   ATTR_lotNo,
   ATTR_productionDate,
   ATTR_productNo,
@@ -30,6 +32,8 @@ export const parseCustomQRCode = ({ string, format }) => {
   try {
     let result = {
       [ATTR_barcodeType]: BARCODE_TYPE_CUSTOM,
+      [ATTR_isUnique]: false,
+      [ATTR_isTUToBePickedAsWhole]: true,
     };
 
     for (const formatPart of format.parts) {


### PR DESCRIPTION
- **improve CreateHUCommand for frontend testing**
- **when receiving using a catch weight QR code, make sure the HU_QRCode attribuge is set**
- **improve picking_catchWeight.spec.js**
- **X12DE355.equals**
- **ParsedScannedCode.getAsString**
- **HUQueryBuilder.firstId**
- **improve unit testing API**
- **ScannableCodeFormatService.newInstanceForUnitTesting**
- **IHUQueryBuilder.firstId**
- **QR codes service improvements**
- **PickingJobPickCommand: allow any kind of qrCodeto be picked; handle it here**
- **fix cucumbers**
- **QA**
- **QA**
- **fix/adapt unit tests**
- **handle receiving custom QR codes on FE side**
- **QA**
