### PR TITLE
C_Order is now EDI-Enabled effective bill- or receipt-partner is

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/order/IOrderBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/IOrderBL.java
@@ -104,6 +104,9 @@ public interface IOrderBL extends ISingletonService
 	@Nullable
 	BPartnerId getEffectiveBillPartnerId(@NonNull I_C_Order orderRecord);
 
+	@Nullable
+	BPartnerId getEffectiveDropshipPartnerId(@NonNull I_C_Order orderRecord);
+	
 	/**
 	 * @return the order's bill contact <b>but</b> falls back to the "general" contact ({@code C_Order.AD_User_ID}) if possible.
 	 * Be sure to first check with {@link #hasBillToContactId(I_C_Order)}.
@@ -241,8 +244,6 @@ public interface IOrderBL extends ISingletonService
 	 * <li>QtyInvoiced
 	 * </ul>
 	 * from the sums of the order's lines.
-	 *
-	 * @param order task http://dewiki908/mediawiki/index.php/09285_add_deliver_and_invoice_status_to_order_window
 	 */
 	void updateOrderQtySums(I_C_Order order);
 

--- a/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderBL.java
@@ -901,6 +901,17 @@ public class OrderBL implements IOrderBL
 	}
 
 	@Override
+	@Nullable
+	public BPartnerId getEffectiveDropshipPartnerId(@NonNull final I_C_Order orderRecord)
+	{
+		if (orderRecord.isDropShip() && orderRecord.getDropShip_BPartner_ID() > 0)
+		{
+			return BPartnerId.ofRepoId(orderRecord.getDropShip_BPartner_ID());
+		}
+		return BPartnerId.ofRepoIdOrNull(orderRecord.getC_BPartner_ID());
+	}
+
+	@Override
 	@NonNull
 	public BPartnerContactId getBillToContactId(@NonNull final I_C_Order order)
 	{

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvPack_with_normal_UOM.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvPack_with_normal_UOM.feature
@@ -86,6 +86,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed | OPT.C_OrderLine_ID.Identifier |
       | shipmentLine_1_S0316_010  | s_1_S0316_010         | p_1_S0316_010           | 10          | true      | ol_1_S0316_010                |
 
+    # note: sometimes a custom migration-script sets a M_HU_PackagingCode_LU_Fallback_ID for the M_HU_PI_Item_Product with = 101 (No Packing Item)
+    # if such a script was applied, then this step fails
     And after not more than 30s, EDI_Desadv_Pack records are found:
       | EDI_Desadv_Pack_ID.Identifier | IsManual_IPA_SSCC18 | OPT.M_HU_ID.Identifier | OPT.M_HU_PackagingCode_ID.Identifier | OPT.GTIN_PackingMaterial | OPT.SeqNo |
       | p_1_S0316_010                 | true                | null                   | null                                 | null                     | 1         |
@@ -176,6 +178,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed | OPT.C_OrderLine_ID.Identifier |
       | shipmentLine_1_11212023_4 | s_1_11212023_4        | p_1_11212023_4          | 10          | true      | ol_1_11212023_4               |
 
+        # note: sometimes a custom migration-script sets a M_HU_PackagingCode_LU_Fallback_ID for the M_HU_PI_Item_Product with = 101 (No Packing Item)
+    # if such a script was applied, then this step fails
     And after not more than 30s, EDI_Desadv_Pack records are found:
       | EDI_Desadv_Pack_ID | IsManual_IPA_SSCC18 | M_HU_ID | M_HU_PackagingCode_ID | GTIN_PackingMaterial | SeqNo |
       | p_1_11212023_4     | true                | null    | null                  | null                 | 1     |
@@ -272,6 +276,8 @@ Feature: EDI_DesadvPack and EDI_DesadvPack_Item, when the orderline has a normal
       | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed | OPT.C_OrderLine_ID.Identifier |
       | shipmentLine_1_11212023_1 | s_1_11212023_1        | p_1_11212023_1          | 10          | true      | ol_1_11212023_1               |
 
+    # note: sometimes a custom migration-script sets a M_HU_PackagingCode_LU_Fallback_ID for the M_HU_PI_Item_Product with = 101 (No Packing Item)
+    # if such a script was applied, then this step fails
     And after not more than 30s, EDI_Desadv_Pack records are found:
       | EDI_Desadv_Pack_ID | IsManual_IPA_SSCC18 | M_HU_ID | M_HU_PackagingCode_ID | GTIN_PackingMaterial | SeqNo |
       | p_1_11212023_1     | true                | null    | null                  | null                 | 1     |

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/model/validator/C_Order.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/model/validator/C_Order.java
@@ -24,14 +24,13 @@ package de.metas.edi.model.validator;
  * #L%
  */
 
+import de.metas.bpartner.BPartnerId;
 import de.metas.edi.api.IDesadvBL;
 import de.metas.edi.api.IEDIInputDataSourceBL;
 import de.metas.edi.model.I_C_BPartner;
 import de.metas.edi.model.I_C_Order;
 import de.metas.edi.model.I_EDI_Document;
 import de.metas.order.IOrderBL;
-import de.metas.order.location.adapter.OrderDocumentLocationAdapterFactory;
-import de.metas.order.location.adapter.OrderDropShipLocationAdapter;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -47,6 +46,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class C_Order
 {
+	private final IEDIInputDataSourceBL inputDataSourceBL = Services.get(IEDIInputDataSourceBL.class);
+	private final IOrderBL orderBL = Services.get(IOrderBL.class);
+
 	@DocValidate(timings = { ModelValidator.TIMING_BEFORE_REACTIVATE,
 			ModelValidator.TIMING_BEFORE_REVERSEACCRUAL,
 			ModelValidator.TIMING_BEFORE_REVERSECORRECT,
@@ -115,7 +117,7 @@ public class C_Order
 		}
 		else
 		{
-			ediEnabledByInputDataSource = Services.get(IEDIInputDataSourceBL.class).isEDIInputDataSource(order.getAD_InputDataSource_ID());
+			ediEnabledByInputDataSource = inputDataSourceBL.isEDIInputDataSource(order.getAD_InputDataSource_ID());
 		}
 		if (ediEnabledByInputDataSource)
 		{
@@ -123,8 +125,8 @@ public class C_Order
 			return; // no need to look further
 		}
 
-		final int buyerBPartnerId = OrderDocumentLocationAdapterFactory.billLocationAdapter(order).getBill_BPartner_ID();
-		if (buyerBPartnerId > 0)
+		final BPartnerId buyerBPartnerId = orderBL.getEffectiveBillPartnerId(order);
+		if (buyerBPartnerId != null)
 		{
 			final I_C_BPartner buyer = InterfaceWrapperHelper.load(buyerBPartnerId, de.metas.edi.model.I_C_BPartner.class);
 			if (buyer.isEdiInvoicRecipient())
@@ -133,8 +135,8 @@ public class C_Order
 				return;
 			}
 		}
-		final int recipientBPartnerId = OrderDocumentLocationAdapterFactory.deliveryLocationAdapter(order).getDropShip_BPartner_ID();
-		if (recipientBPartnerId > 0)
+		final BPartnerId recipientBPartnerId =  orderBL.getEffectiveDropshipPartnerId(order);
+		if (recipientBPartnerId != null)
 		{
 			final I_C_BPartner recipient = InterfaceWrapperHelper.load(recipientBPartnerId, de.metas.edi.model.I_C_BPartner.class);
 			if (recipient.isEdiDesadvRecipient())
@@ -161,7 +163,7 @@ public class C_Order
 			return;
 		}
 
-		final boolean isEdiEnabled = Services.get(IEDIInputDataSourceBL.class).isEDIInputDataSource(orderInputDataSourceId);
+		final boolean isEdiEnabled = inputDataSourceBL.isEDIInputDataSource(orderInputDataSourceId);
 		if (isEdiEnabled)
 		{
 			order.setIsEdiEnabled(true);

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/model/validator/C_Order_SetEdiEnabledForNewOrderTest.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/model/validator/C_Order_SetEdiEnabledForNewOrderTest.java
@@ -1,0 +1,230 @@
+/*
+ * #%L
+ * de.metas.edi
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.edi.model.validator;
+
+import de.metas.edi.api.IEDIInputDataSourceBL;
+import de.metas.edi.model.I_C_BPartner;
+import de.metas.edi.model.I_C_Order;
+import de.metas.util.Services;
+import lombok.Setter;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class C_Order_SetEdiEnabledForNewOrderTest
+{
+    private C_Order validator;
+    private IEDIInputDataSourceBL mockEdiInputDataSourceBL;
+
+    @BeforeEach
+    void setUp()
+    {
+        AdempiereTestHelper.get().init();
+        validator = new C_Order();
+
+		mockEdiInputDataSourceBL = new MockEDIInputDataSourceBL();
+        Services.registerService(IEDIInputDataSourceBL.class, mockEdiInputDataSourceBL);
+    }
+
+    @Test
+    void setEdiEnabledForNewOrder_whenInputDataSourceIsEDI_shouldSetEdiEnabled()
+    {
+        // given
+        final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+        order.setAD_InputDataSource_ID(123);
+
+        ((MockEDIInputDataSourceBL) mockEdiInputDataSourceBL).setReturnValue(true);
+
+        // when
+        validator.setEdiEnabledForNewOrder(order);
+
+        // then
+        assertThat(order.isEdiEnabled()).isTrue();
+    }
+
+    @Test
+    void setEdiEnabledForNewOrder_whenInputDataSourceIsNotEDI_andBuyerIsEdiInvoiceRecipient_shouldSetEdiEnabled()
+    {
+        // given
+        final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+        order.setAD_InputDataSource_ID(123);
+
+        // Create buyer partner that is EDI invoice recipient
+        final I_C_BPartner buyer = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+        buyer.setC_BPartner_ID(456);
+        buyer.setIsEdiInvoicRecipient(true);
+        InterfaceWrapperHelper.save(buyer);
+
+        // Create order with buyer partner as bill partner
+        order.setC_BPartner_ID(456);
+        order.setBill_BPartner_ID(456);
+
+        ((MockEDIInputDataSourceBL) mockEdiInputDataSourceBL).setReturnValue(false);
+
+        // when
+        validator.setEdiEnabledForNewOrder(order);
+
+        // then
+        assertThat(order.isEdiEnabled()).isTrue();
+    }
+
+    @Test
+    void setEdiEnabledForNewOrder_whenInputDataSourceIsNotEDI_andBuyerIsNotEdiRecipient_andDeliveryPartnerIsEdiDesadvRecipient_shouldSetEdiEnabled()
+    {
+        // given
+        final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+        order.setAD_InputDataSource_ID(123);
+
+        // Create buyer partner that is NOT EDI recipient
+        final I_C_BPartner buyer = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+        buyer.setC_BPartner_ID(456);
+        buyer.setIsEdiInvoicRecipient(false);
+        InterfaceWrapperHelper.save(buyer);
+
+        // Create delivery partner that IS EDI DESADV recipient
+        final I_C_BPartner deliveryPartner = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+        deliveryPartner.setC_BPartner_ID(789);
+        deliveryPartner.setIsEdiDesadvRecipient(true);
+        InterfaceWrapperHelper.save(deliveryPartner);
+
+        // Set up order with both partners
+        order.setC_BPartner_ID(456);
+        order.setBill_BPartner_ID(456);
+        order.setDropShip_BPartner_ID(789);
+
+        ((MockEDIInputDataSourceBL) mockEdiInputDataSourceBL).setReturnValue(false);
+
+        // when
+        validator.setEdiEnabledForNewOrder(order);
+
+        // then
+        assertThat(order.isEdiEnabled()).isTrue();
+    }
+
+    @Test
+    void setEdiEnabledForNewOrder_whenNoEdiCriteriaMet_shouldSetEdiDisabled()
+    {
+        // given
+        final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+        order.setAD_InputDataSource_ID(123);
+
+        // Create buyer partner that is NOT EDI recipient
+        final I_C_BPartner buyer = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+        buyer.setC_BPartner_ID(456);
+        buyer.setIsEdiInvoicRecipient(false);
+        InterfaceWrapperHelper.save(buyer);
+
+        // Create delivery partner that is NOT EDI recipient
+        final I_C_BPartner deliveryPartner = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+        deliveryPartner.setC_BPartner_ID(789);
+        deliveryPartner.setIsEdiDesadvRecipient(false);
+        InterfaceWrapperHelper.save(deliveryPartner);
+
+        // Set up order with both partners
+        order.setC_BPartner_ID(456);
+        order.setBill_BPartner_ID(456);
+        order.setDropShip_BPartner_ID(789);
+
+        ((MockEDIInputDataSourceBL) mockEdiInputDataSourceBL).setReturnValue(false);
+
+        // when
+        validator.setEdiEnabledForNewOrder(order);
+
+        // then
+        assertThat(order.isEdiEnabled()).isFalse();
+    }
+
+    @Test
+    void setEdiEnabledForNewOrder_whenNoInputDataSource_andNoBuyerPartner_shouldSetEdiDisabled()
+    {
+        // given
+        final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+        order.setAD_InputDataSource_ID(0); // No input data source
+        order.setBill_BPartner_ID(0); // No buyer partner
+        order.setDropShip_BPartner_ID(0); // No delivery partner
+
+        // when
+        validator.setEdiEnabledForNewOrder(order);
+
+        // then
+        assertThat(order.isEdiEnabled()).isFalse();
+    }
+
+    @Test
+    void setEdiEnabledForNewOrder_whenNegativeInputDataSourceId_shouldSetEdiDisabled()
+    {
+        // given
+        final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+        order.setAD_InputDataSource_ID(-1); // Negative input data source ID
+        order.setBill_BPartner_ID(0);
+        order.setDropShip_BPartner_ID(0);
+
+        // when
+        validator.setEdiEnabledForNewOrder(order);
+
+        // then
+        assertThat(order.isEdiEnabled()).isFalse();
+    }
+
+    @Test
+    void setEdiEnabledForNewOrder_whenBuyerPartnerIsNull_shouldCheckDeliveryPartner()
+    {
+        // given
+        final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+        order.setAD_InputDataSource_ID(123);
+        order.setBill_BPartner_ID(0); // No buyer partner
+
+        // Create delivery partner that IS EDI DESADV recipient
+        final I_C_BPartner deliveryPartner = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+        deliveryPartner.setC_BPartner_ID(789);
+        deliveryPartner.setIsEdiDesadvRecipient(true);
+        InterfaceWrapperHelper.save(deliveryPartner);
+
+        order.setDropShip_BPartner_ID(789);
+
+        ((MockEDIInputDataSourceBL) mockEdiInputDataSourceBL).setReturnValue(false);
+
+        // when
+        validator.setEdiEnabledForNewOrder(order);
+
+        // then
+        assertThat(order.isEdiEnabled()).isTrue();
+    }
+
+    // // Inner class to help with mocking
+    @Setter
+	private static class MockEDIInputDataSourceBL implements IEDIInputDataSourceBL
+    {
+        private boolean returnValue = false;
+
+        @Override
+        public boolean isEDIInputDataSource(final int inputDataSourceId)
+        {
+            return returnValue;
+        }
+
+	}
+}

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/model/validator/C_Order_SetEdiEnabledForNewOrderTest.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/model/validator/C_Order_SetEdiEnabledForNewOrderTest.java
@@ -36,195 +36,249 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class C_Order_SetEdiEnabledForNewOrderTest
 {
-    private C_Order validator;
-    private IEDIInputDataSourceBL mockEdiInputDataSourceBL;
+	private C_Order validator;
+	private IEDIInputDataSourceBL mockEdiInputDataSourceBL;
 
-    @BeforeEach
-    void setUp()
-    {
-        AdempiereTestHelper.get().init();
-        validator = new C_Order();
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
 
 		mockEdiInputDataSourceBL = new MockEDIInputDataSourceBL();
-        Services.registerService(IEDIInputDataSourceBL.class, mockEdiInputDataSourceBL);
-    }
+		Services.registerService(IEDIInputDataSourceBL.class, mockEdiInputDataSourceBL);
 
-    @Test
-    void setEdiEnabledForNewOrder_whenInputDataSourceIsEDI_shouldSetEdiEnabled()
-    {
-        // given
-        final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
-        order.setAD_InputDataSource_ID(123);
+		validator = new C_Order();
+	}
 
-        ((MockEDIInputDataSourceBL) mockEdiInputDataSourceBL).setReturnValue(true);
+	@Test
+	void setEdiEnabledForNewOrder_whenInputDataSourceIsEDI_shouldSetEdiEnabled()
+	{
+		// given
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setAD_InputDataSource_ID(123);
 
-        // when
-        validator.setEdiEnabledForNewOrder(order);
+		((MockEDIInputDataSourceBL)mockEdiInputDataSourceBL).setReturnValue(true);
 
-        // then
-        assertThat(order.isEdiEnabled()).isTrue();
-    }
+		// when
+		validator.setEdiEnabledForNewOrder(order);
 
-    @Test
-    void setEdiEnabledForNewOrder_whenInputDataSourceIsNotEDI_andBuyerIsEdiInvoiceRecipient_shouldSetEdiEnabled()
-    {
-        // given
-        final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
-        order.setAD_InputDataSource_ID(123);
+		// then
+		assertThat(order.isEdiEnabled()).isTrue();
+	}
 
-        // Create buyer partner that is EDI invoice recipient
-        final I_C_BPartner buyer = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
-        buyer.setC_BPartner_ID(456);
-        buyer.setIsEdiInvoicRecipient(true);
-        InterfaceWrapperHelper.save(buyer);
+	@Test
+	void setEdiEnabledForNewOrder_whenInputDataSourceIsNotEDI_andBuyerIsEdiInvoiceRecipient_shouldSetEdiEnabled()
+	{
+		// given
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setAD_InputDataSource_ID(123);
 
-        // Create order with buyer partner as bill partner
-        order.setC_BPartner_ID(456);
-        order.setBill_BPartner_ID(456);
+		// Create buyer partner that is EDI invoice recipient
+		final I_C_BPartner buyer = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		buyer.setC_BPartner_ID(456);
+		buyer.setIsEdiInvoicRecipient(true);
+		InterfaceWrapperHelper.save(buyer);
 
-        ((MockEDIInputDataSourceBL) mockEdiInputDataSourceBL).setReturnValue(false);
+		// Create order with buyer partner as bill partner
+		order.setC_BPartner_ID(456);
+		order.setBill_BPartner_ID(456);
 
-        // when
-        validator.setEdiEnabledForNewOrder(order);
+		((MockEDIInputDataSourceBL)mockEdiInputDataSourceBL).setReturnValue(false);
 
-        // then
-        assertThat(order.isEdiEnabled()).isTrue();
-    }
+		// when
+		validator.setEdiEnabledForNewOrder(order);
 
-    @Test
-    void setEdiEnabledForNewOrder_whenInputDataSourceIsNotEDI_andBuyerIsNotEdiRecipient_andDeliveryPartnerIsEdiDesadvRecipient_shouldSetEdiEnabled()
-    {
-        // given
-        final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
-        order.setAD_InputDataSource_ID(123);
+		// then
+		assertThat(order.isEdiEnabled()).isTrue();
+	}
 
-        // Create buyer partner that is NOT EDI recipient
-        final I_C_BPartner buyer = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
-        buyer.setC_BPartner_ID(456);
-        buyer.setIsEdiInvoicRecipient(false);
-        InterfaceWrapperHelper.save(buyer);
+	@Test
+	void setEdiEnabledForNewOrder_whenInputDataSourceIsNotEDI_andBuyerIsEdiDesadvRecipient_shouldSetEdiEnabled()
+	{
+		// given
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setAD_InputDataSource_ID(123);
 
-        // Create delivery partner that IS EDI DESADV recipient
-        final I_C_BPartner deliveryPartner = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
-        deliveryPartner.setC_BPartner_ID(789);
-        deliveryPartner.setIsEdiDesadvRecipient(true);
-        InterfaceWrapperHelper.save(deliveryPartner);
+		// Create buyer partner that is EDI invoice recipient
+		final I_C_BPartner buyer = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		buyer.setC_BPartner_ID(456);
+		buyer.setIsEdiDesadvRecipient(true);
 
-        // Set up order with both partners
-        order.setC_BPartner_ID(456);
-        order.setBill_BPartner_ID(456);
-        order.setDropShip_BPartner_ID(789);
+		InterfaceWrapperHelper.save(buyer);
 
-        ((MockEDIInputDataSourceBL) mockEdiInputDataSourceBL).setReturnValue(false);
+		order.setC_BPartner_ID(456);
 
-        // when
-        validator.setEdiEnabledForNewOrder(order);
+		((MockEDIInputDataSourceBL)mockEdiInputDataSourceBL).setReturnValue(false);
 
-        // then
-        assertThat(order.isEdiEnabled()).isTrue();
-    }
+		// when
+		validator.setEdiEnabledForNewOrder(order);
 
-    @Test
-    void setEdiEnabledForNewOrder_whenNoEdiCriteriaMet_shouldSetEdiDisabled()
-    {
-        // given
-        final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
-        order.setAD_InputDataSource_ID(123);
+		// then
+		assertThat(order.isEdiEnabled()).isTrue();
+	}
 
-        // Create buyer partner that is NOT EDI recipient
-        final I_C_BPartner buyer = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
-        buyer.setC_BPartner_ID(456);
-        buyer.setIsEdiInvoicRecipient(false);
-        InterfaceWrapperHelper.save(buyer);
+	@Test
+	void setEdiEnabledForNewOrder_whenInputDataSourceIsNotEDI_andBuyerIsEdiInvoicRecipient_shouldSetEdiEnabled()
+	{
+		// given
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setAD_InputDataSource_ID(123);
 
-        // Create delivery partner that is NOT EDI recipient
-        final I_C_BPartner deliveryPartner = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
-        deliveryPartner.setC_BPartner_ID(789);
-        deliveryPartner.setIsEdiDesadvRecipient(false);
-        InterfaceWrapperHelper.save(deliveryPartner);
+		// Create buyer partner that is EDI invoice recipient
+		final I_C_BPartner buyer = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		buyer.setC_BPartner_ID(456);
+		buyer.setIsEdiInvoicRecipient(true);
 
-        // Set up order with both partners
-        order.setC_BPartner_ID(456);
-        order.setBill_BPartner_ID(456);
-        order.setDropShip_BPartner_ID(789);
+		InterfaceWrapperHelper.save(buyer);
 
-        ((MockEDIInputDataSourceBL) mockEdiInputDataSourceBL).setReturnValue(false);
+		order.setC_BPartner_ID(456);
 
-        // when
-        validator.setEdiEnabledForNewOrder(order);
+		((MockEDIInputDataSourceBL)mockEdiInputDataSourceBL).setReturnValue(false);
 
-        // then
-        assertThat(order.isEdiEnabled()).isFalse();
-    }
+		// when
+		validator.setEdiEnabledForNewOrder(order);
 
-    @Test
-    void setEdiEnabledForNewOrder_whenNoInputDataSource_andNoBuyerPartner_shouldSetEdiDisabled()
-    {
-        // given
-        final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
-        order.setAD_InputDataSource_ID(0); // No input data source
-        order.setBill_BPartner_ID(0); // No buyer partner
-        order.setDropShip_BPartner_ID(0); // No delivery partner
+		// then
+		assertThat(order.isEdiEnabled()).isTrue();
+	}
 
-        // when
-        validator.setEdiEnabledForNewOrder(order);
+	@Test
+	void setEdiEnabledForNewOrder_whenInputDataSourceIsNotEDI_andBuyerIsNotEdiRecipient_andDeliveryPartnerIsEdiDesadvRecipient_shouldSetEdiEnabled()
+	{
+		// given
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setAD_InputDataSource_ID(123);
 
-        // then
-        assertThat(order.isEdiEnabled()).isFalse();
-    }
+		// Create buyer partner that is NOT EDI recipient
+		final I_C_BPartner buyer = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		buyer.setC_BPartner_ID(456);
+		buyer.setIsEdiInvoicRecipient(false);
+		InterfaceWrapperHelper.save(buyer);
 
-    @Test
-    void setEdiEnabledForNewOrder_whenNegativeInputDataSourceId_shouldSetEdiDisabled()
-    {
-        // given
-        final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
-        order.setAD_InputDataSource_ID(-1); // Negative input data source ID
-        order.setBill_BPartner_ID(0);
-        order.setDropShip_BPartner_ID(0);
+		// Create delivery partner that IS EDI DESADV recipient
+		final I_C_BPartner deliveryPartner = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		deliveryPartner.setC_BPartner_ID(789);
+		deliveryPartner.setIsEdiDesadvRecipient(true);
+		InterfaceWrapperHelper.save(deliveryPartner);
 
-        // when
-        validator.setEdiEnabledForNewOrder(order);
+		// Set up order with both partners
+		order.setC_BPartner_ID(456);
+		order.setBill_BPartner_ID(456);
+		order.setIsDropShip(true);
+		order.setDropShip_BPartner_ID(789);
 
-        // then
-        assertThat(order.isEdiEnabled()).isFalse();
-    }
+		((MockEDIInputDataSourceBL)mockEdiInputDataSourceBL).setReturnValue(false);
 
-    @Test
-    void setEdiEnabledForNewOrder_whenBuyerPartnerIsNull_shouldCheckDeliveryPartner()
-    {
-        // given
-        final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
-        order.setAD_InputDataSource_ID(123);
-        order.setBill_BPartner_ID(0); // No buyer partner
+		// when
+		validator.setEdiEnabledForNewOrder(order);
 
-        // Create delivery partner that IS EDI DESADV recipient
-        final I_C_BPartner deliveryPartner = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
-        deliveryPartner.setC_BPartner_ID(789);
-        deliveryPartner.setIsEdiDesadvRecipient(true);
-        InterfaceWrapperHelper.save(deliveryPartner);
+		// then
+		assertThat(order.isEdiEnabled()).isTrue();
+	}
 
-        order.setDropShip_BPartner_ID(789);
+	@Test
+	void setEdiEnabledForNewOrder_whenNoEdiCriteriaMet_shouldSetEdiDisabled()
+	{
+		// given
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setAD_InputDataSource_ID(123);
 
-        ((MockEDIInputDataSourceBL) mockEdiInputDataSourceBL).setReturnValue(false);
+		// Create buyer partner that is NOT EDI recipient
+		final I_C_BPartner buyer = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		buyer.setC_BPartner_ID(456);
+		buyer.setIsEdiInvoicRecipient(false);
+		InterfaceWrapperHelper.save(buyer);
 
-        // when
-        validator.setEdiEnabledForNewOrder(order);
+		// Create delivery partner that is NOT EDI recipient
+		final I_C_BPartner deliveryPartner = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		deliveryPartner.setC_BPartner_ID(789);
+		deliveryPartner.setIsEdiDesadvRecipient(false);
+		InterfaceWrapperHelper.save(deliveryPartner);
 
-        // then
-        assertThat(order.isEdiEnabled()).isTrue();
-    }
+		// Set up order with both partners
+		order.setC_BPartner_ID(456);
+		order.setBill_BPartner_ID(456);
+		order.setIsDropShip(true);
+		order.setDropShip_BPartner_ID(789);
 
-    // // Inner class to help with mocking
-    @Setter
+		((MockEDIInputDataSourceBL)mockEdiInputDataSourceBL).setReturnValue(false);
+
+		// when
+		validator.setEdiEnabledForNewOrder(order);
+
+		// then
+		assertThat(order.isEdiEnabled()).isFalse();
+	}
+
+	@Test
+	void setEdiEnabledForNewOrder_whenNoInputDataSource_andNoBuyerPartner_shouldSetEdiDisabled()
+	{
+		// given
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setAD_InputDataSource_ID(0); // No input data source
+		order.setBill_BPartner_ID(0); // No buyer partner
+		order.setDropShip_BPartner_ID(0); // No delivery partner
+
+		// when
+		validator.setEdiEnabledForNewOrder(order);
+
+		// then
+		assertThat(order.isEdiEnabled()).isFalse();
+	}
+
+	@Test
+	void setEdiEnabledForNewOrder_whenNegativeInputDataSourceId_shouldSetEdiDisabled()
+	{
+		// given
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setAD_InputDataSource_ID(-1); // Negative input data source ID
+		order.setBill_BPartner_ID(0);
+		order.setDropShip_BPartner_ID(0);
+
+		// when
+		validator.setEdiEnabledForNewOrder(order);
+
+		// then
+		assertThat(order.isEdiEnabled()).isFalse();
+	}
+
+	@Test
+	void setEdiEnabledForNewOrder_whenBuyerPartnerIsNull_shouldCheckDeliveryPartner()
+	{
+		// given
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setAD_InputDataSource_ID(123);
+		order.setBill_BPartner_ID(0); // No buyer partner
+
+		// Create delivery partner that IS EDI DESADV recipient
+		final I_C_BPartner deliveryPartner = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		deliveryPartner.setC_BPartner_ID(789);
+		deliveryPartner.setIsEdiDesadvRecipient(true);
+		InterfaceWrapperHelper.save(deliveryPartner);
+
+		order.setIsDropShip(true);
+		order.setDropShip_BPartner_ID(789);
+
+		((MockEDIInputDataSourceBL)mockEdiInputDataSourceBL).setReturnValue(false);
+
+		// when
+		validator.setEdiEnabledForNewOrder(order);
+
+		// then
+		assertThat(order.isEdiEnabled()).isTrue();
+	}
+
+	// // Inner class to help with mocking
+	@Setter
 	private static class MockEDIInputDataSourceBL implements IEDIInputDataSourceBL
-    {
-        private boolean returnValue = false;
+	{
+		private boolean returnValue = false;
 
-        @Override
-        public boolean isEDIInputDataSource(final int inputDataSourceId)
-        {
-            return returnValue;
-        }
+		@Override
+		public boolean isEDIInputDataSource(final int inputDataSourceId)
+		{
+			return returnValue;
+		}
 
 	}
 }

--- a/misc/dev-support/docker/infrastructure/env-files/vampire_textbook_uat.env
+++ b/misc/dev-support/docker/infrastructure/env-files/vampire_textbook_uat.env
@@ -1,7 +1,16 @@
 #
-# docker-compose.yml
+# environment file for docker-compose.yml
 #
 # In docker-compose, this env-file is used via the "--env-file" cmdline parameter
+#
+# If you want to use these variables as environment-variables in the git-bash shell, you can do
+# set -a
+# source <this file>
+# set +a
+#
+# Then you can run the de.metas.cucumber/pom.xml with "mvn test" and use the infrastructure as if you were using this env file in intellij.
+# Note that this is why we have no dots (.) in the variable names
+#
 
 BRANCH_NAME=vampire_textbook_uat
 
@@ -13,6 +22,7 @@ RABBITMQ_USER=guest
 RABBITMQ_PASS=guest
 
 SEARCH_PORT=57570
+DB_DOCKER_IMG=metasfresh/metas-db:5.175-release-5.175
 
 POSTGREST_PORT=57001
 
@@ -24,8 +34,12 @@ PAPERCUT_MGMT_PORT=57408
 #
 # When running the migration-Tool from intellij, we use this env-file via this plugin: https://plugins.jetbrains.com/plugin/7861-envfile/
 
-db.url=jdbc:postgresql://localhost:${DB_PORT}/metasfresh
+db_url=jdbc:postgresql://localhost:${DB_PORT}/metasfresh
 labels=common,vampire_textbook_uat
+
+# TODO: remove
+db.url=${db_url}
+
 
 #
 # For Cucucumber (de.metas.cucumber.InfrastructureSupport)


### PR DESCRIPTION

before, the buyer (C_Order.C_BPartner_ID) always had to be edi-enabled.