### PR TITLE
Fix duplicate Docker push step in CI/CD pipeline

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -227,13 +227,6 @@ jobs:
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
           command: docker push --quiet metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }}
-      - name: push-image metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }}
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: ${{ vars.RETRY_ATTEMPTS }}
-          retry_wait_seconds: ${{ vars.RETRY_DELAY }}
-          timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }}
   #      # only needed for agent/hub
   #      - name: push-maven-dist metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-fixed }}
   #        run: |


### PR DESCRIPTION
## Summary
This PR removes a duplicate Docker push step in the GitHub Actions CI/CD workflow that was causing the `metasfresh/metas-mvn-camel-dist` floating tag to be pushed twice.

## Problem
In `.github/workflows/cicd.yaml`, lines 230-236 were an exact duplicate of lines 223-229, both pushing the same image with the same tag:
```yaml
- name: push-image metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }}
  uses: nick-fields/retry@v3
  ...
  command: docker push --quiet metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }}
```

## Solution
Removed the duplicate push step (lines 230-236).

## Impact
- **Positive**: Reduces pipeline execution time by eliminating redundant Docker registry operations
- **Positive**: Reduces unnecessary network traffic to Docker Hub
- **No Risk**: The image is still pushed once with both floating and fixed tags as intended
- **No Breaking Changes**: All required images are still built and pushed correctly

## Testing
- This is a straightforward deletion of duplicate code
- The workflow will still push both tags (fixed and floating) for the camel-dist image
- No functional change to the pipeline behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)