### PR TITLE
Fix infrastructure scripts to work in both interactive and non-interactive environments

### DIFF
--- a/misc/dev-support/docker/infrastructure/scripts/00_common.sh
+++ b/misc/dev-support/docker/infrastructure/scripts/00_common.sh
@@ -24,6 +24,28 @@
 
 # Common utility functions for infrastructure scripts
 
+# Detect if we need winpty (only in interactive TTY on Windows)
+# Returns "winpty" if needed, empty string otherwise
+get_winpty() {
+    if [ -t 0 ]; then
+        # stdin is a TTY, use winpty
+        echo "winpty"
+    else
+        # stdin is not a TTY (e.g., piped, redirected, or non-interactive), skip winpty
+        echo ""
+    fi
+}
+
+# Get docker exec flags based on TTY availability
+# Returns "-it" if TTY available, "-i" otherwise
+get_docker_exec_flags() {
+    if [ -t 0 ]; then
+        echo "-it"
+    else
+        echo "-i"
+    fi
+}
+
 # Auto-detect BRANCH_NAME from git branch
 auto_detect_branch_name() {
     CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)

--- a/misc/dev-support/docker/infrastructure/scripts/20_convert_db_to_template.sh
+++ b/misc/dev-support/docker/infrastructure/scripts/20_convert_db_to_template.sh
@@ -34,13 +34,15 @@ BRANCH_NAME=$(resolve_branch_name "$1")
 
 set -u
 
-# the winpty is needed to avoid an error when running the script in git bash on windows
+# Detect if winpty is needed (only in interactive TTY on Windows)
+WINPTY=$(get_winpty)
+DOCKER_EXEC_FLAGS=$(get_docker_exec_flags)
 
 echo "Stopping ${BRANCH_NAME}_postgrest"
-winpty docker stop ${BRANCH_NAME}_postgrest
+$WINPTY docker stop ${BRANCH_NAME}_postgrest
 
-winpty docker exec -it ${BRANCH_NAME}_db  psql -U postgres -c "alter database metasfresh rename to metasfresh_template_${BRANCH_NAME};"
-winpty docker exec -it ${BRANCH_NAME}_db  psql -U postgres -c "alter database metasfresh_template_${BRANCH_NAME} is_template true;"
+$WINPTY docker exec $DOCKER_EXEC_FLAGS ${BRANCH_NAME}_db  psql -U postgres -c "alter database metasfresh rename to metasfresh_template_${BRANCH_NAME};"
+$WINPTY docker exec $DOCKER_EXEC_FLAGS ${BRANCH_NAME}_db  psql -U postgres -c "alter database metasfresh_template_${BRANCH_NAME} with is_template true;"
 
 echo "The local database has been converted to a template database."
 echo "You can drop this template database by running "

--- a/misc/dev-support/docker/infrastructure/scripts/21_drop_template.sh
+++ b/misc/dev-support/docker/infrastructure/scripts/21_drop_template.sh
@@ -34,9 +34,11 @@ BRANCH_NAME=$(resolve_branch_name "$1")
 
 set -u
 
-# the winpty is needed to avoid an error when running the script in git bash on windows
+# Detect if winpty is needed (only in interactive TTY on Windows)
+WINPTY=$(get_winpty)
+DOCKER_EXEC_FLAGS=$(get_docker_exec_flags)
 
-winpty docker exec -it ${BRANCH_NAME}_db  psql -U postgres -c "UPDATE pg_database SET datistemplate='false' WHERE datname='metasfresh_template_${BRANCH_NAME}';"
-winpty docker exec -it ${BRANCH_NAME}_db  psql -U postgres -c "drop database if exists metasfresh_template_${BRANCH_NAME};"
+$WINPTY docker exec $DOCKER_EXEC_FLAGS ${BRANCH_NAME}_db  psql -U postgres -c "UPDATE pg_database SET datistemplate='false' WHERE datname='metasfresh_template_${BRANCH_NAME}';"
+$WINPTY docker exec $DOCKER_EXEC_FLAGS ${BRANCH_NAME}_db  psql -U postgres -c "drop database if exists metasfresh_template_${BRANCH_NAME};"
 
 echo "The template-DB metasfresh_template_${BRANCH_NAME} was dropped and can be recreated with 20_convert_db_to_template.sh"

--- a/misc/dev-support/docker/infrastructure/scripts/30_reset_db_to_template.sh
+++ b/misc/dev-support/docker/infrastructure/scripts/30_reset_db_to_template.sh
@@ -34,16 +34,18 @@ BRANCH_NAME=$(resolve_branch_name "$1")
 
 set -u
 
-# the winpty is needed to avoid an error when running the script in git bash on windows
+# Detect if winpty is needed (only in interactive TTY on Windows)
+WINPTY=$(get_winpty)
+DOCKER_EXEC_FLAGS=$(get_docker_exec_flags)
 
 echo "Stopping ${BRANCH_NAME}_postgrest"
-winpty docker stop ${BRANCH_NAME}_postgrest
+$WINPTY docker stop ${BRANCH_NAME}_postgrest
 
-winpty docker exec -it ${BRANCH_NAME}_db  psql -U postgres -c "drop database if exists metasfresh;"
-winpty docker exec -it ${BRANCH_NAME}_db  psql -U postgres -c "create database metasfresh template metasfresh_template_${BRANCH_NAME};"
+$WINPTY docker exec $DOCKER_EXEC_FLAGS ${BRANCH_NAME}_db  psql -U postgres -c "drop database if exists metasfresh;"
+$WINPTY docker exec $DOCKER_EXEC_FLAGS ${BRANCH_NAME}_db  psql -U postgres -c "create database metasfresh template metasfresh_template_${BRANCH_NAME};"
 
 echo "Starting ${BRANCH_NAME}_postgrest again"
-winpty docker start ${BRANCH_NAME}_postgrest
+$WINPTY docker start ${BRANCH_NAME}_postgrest
 
 echo "The local database has been recreated from the template database."
 echo "You can rerun this script to reset the local database to the template database."


### PR DESCRIPTION
## Summary

Infrastructure scripts now intelligently detect TTY availability and adapt their behavior for both interactive (user) and non-interactive (automation) environments.

## Changes

### Added to `00_common.sh`:
- **`get_winpty()`** - Returns `"winpty"` when stdin is a TTY, empty string otherwise
- **`get_docker_exec_flags()`** - Returns `"-it"` for TTY environments, `"-i"` for non-interactive

### Updated scripts:
- **`20_convert_db_to_template.sh`** - Uses dynamic winpty/flags detection
- **`21_drop_template.sh`** - Uses dynamic winpty/flags detection  
- **`30_reset_db_to_template.sh`** - Uses dynamic winpty/flags detection

### Bug fix:
- Fixed SQL syntax in `20_convert_db_to_template.sh` (changed `is_template true` to `with is_template true`)

## Benefits

✅ **Works interactively** - Scripts use `winpty` and `-it` when run in git bash by developers
✅ **Works non-interactively** - Scripts skip `winpty` and use `-i` when run by automation tools (Claude Code, CI/CD)
✅ **No more "stdin is not a tty" errors** when running scripts from Claude Code or other automation
✅ **Maintains backward compatibility** - Interactive usage unchanged

## Test plan

- [x] Tested scripts from git bash (interactive) - works with winpty
- [x] Tested scripts from Claude Code (non-interactive) - works without winpty  
- [x] Verified `./30_reset_db_to_template.sh` completes successfully
- [x] Verified DB template creation and reset workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)