### PR TITLE
mobile IU picking's Quick Pack button - show only when all quantity is available

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/IBPartnerBL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/IBPartnerBL.java
@@ -46,6 +46,7 @@ import org.compiere.model.I_C_BPartner_Location;
 
 import javax.annotation.Nullable;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -186,6 +187,10 @@ public interface IBPartnerBL extends ISingletonService
 	void setPreviousIdIfPossible(@NonNull I_C_BPartner_Location location);
 
 	boolean isInvoiceEmailCcToMember(@NonNull BPartnerId bpartnerId);
+
+	I_C_BPartner_Location getBPartnerLocationByIdEvenInactive(@NonNull BPartnerLocationId bpartnerLocationId);
+
+	List<I_C_BPartner_Location> getBPartnerLocationsByIds(Set<BPartnerLocationId> ids);
 
 	@Value
 	@Builder

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerBL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerBL.java
@@ -951,4 +951,16 @@ public class BPartnerBL implements IBPartnerBL
 		final I_C_BPartner bpartner = getById(bpartnerId);
 		return bpartner.isInvoiceEmailCcToMember();
 	}
+	
+	@Override
+	public I_C_BPartner_Location getBPartnerLocationByIdEvenInactive(@NonNull final BPartnerLocationId bpartnerLocationId)
+	{
+		return bpartnersRepo.getBPartnerLocationByIdEvenInactive(bpartnerLocationId);
+	}
+
+	@Override
+	public List<I_C_BPartner_Location> getBPartnerLocationsByIds(final Set<BPartnerLocationId> bpartnerLocationIds)
+	{
+		return bpartnersRepo.retrieveBPartnerLocationsByIds(bpartnerLocationIds);
+	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/MobileUIPickingUserProfile_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/MobileUIPickingUserProfile_StepDef.java
@@ -23,7 +23,7 @@
 package de.metas.cucumber.stepdefs.picking;
 
 import de.metas.cucumber.stepdefs.DataTableRow;
-import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileRepository;
+import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileService;
 import de.metas.handlingunits.picking.config.mobileui.PickingJobOptions.PickingJobOptionsBuilder;
 import de.metas.handlingunits.picking.job.service.CreateShipmentPolicy;
 import de.metas.logging.LogManager;
@@ -37,14 +37,14 @@ import org.slf4j.Logger;
 public class MobileUIPickingUserProfile_StepDef
 {
 	private static final Logger logger = LogManager.getLogger(MobileUIPickingUserProfile_StepDef.class);
-	private final MobileUIPickingUserProfileRepository repo = SpringContextHolder.instance.getBean(MobileUIPickingUserProfileRepository.class);
+	private final MobileUIPickingUserProfileService profileService = SpringContextHolder.instance.getBean(MobileUIPickingUserProfileService.class);
 
 	@And("set mobile UI picking profile")
 	public void updateProfile(@NonNull final DataTable dataTable)
 	{
 		final DataTableRow row = DataTableRow.singleRow(dataTable);
 
-		repo.update((profile) -> {
+		profileService.update((profile) -> {
 			final PickingJobOptionsBuilder defaultPickingJobOptionsBuilder = profile.getDefaultPickingJobOptions().toBuilder();
 			row.getAsOptionalBoolean("IsAllowPickingAnyHU").ifPresent(defaultPickingJobOptionsBuilder::isAllowPickingAnyHU);
 			row.getAsOptionalString("CreateShipmentPolicy").map(CreateShipmentPolicy::ofCodeOrName).ifPresent(defaultPickingJobOptionsBuilder::createShipmentPolicy);
@@ -55,7 +55,7 @@ public class MobileUIPickingUserProfile_StepDef
 					.defaultPickingJobOptions(defaultPickingJobOptionsBuilder.build())
 					.build();
 		});
-		
-		logger.info("Profile updated: {}", repo.getProfile());
+
+		logger.info("Profile updated: {}", profileService.getProfile());
 	}
 }

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommand.java
@@ -263,7 +263,7 @@ public class CreateMasterdataCommand
 
 		return MobileConfigCommand.builder()
 				.mobileConfigService(services.mobileConfigService)
-				.mobilePickingConfigRepository(services.mobilePickingConfigRepository)
+				.mobilePickingConfigService(services.mobilePickingConfigService)
 				.mobileDistributionConfigRepository(services.mobileDistributionConfigRepository)
 				.mobileManufacturingConfigRepository(services.mobileManufacturingConfigRepository)
 				//

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommandSupportingServices.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommandSupportingServices.java
@@ -5,7 +5,7 @@ import de.metas.distribution.config.MobileUIDistributionConfigRepository;
 import de.metas.distribution.ddorder.DDOrderService;
 import de.metas.frontend_testing.expectations.AssertExpectationsCommandServices;
 import de.metas.handlingunits.inventory.InventoryService;
-import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileRepository;
+import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileService;
 import de.metas.handlingunits.picking.job_schedule.service.PickingJobScheduleService;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
 import de.metas.manufacturing.config.MobileUIManufacturingConfigRepository;
@@ -26,7 +26,7 @@ public class CreateMasterdataCommandSupportingServices
 	@NonNull public final ProductRepository productRepository;
 	@NonNull public final WorkplaceService workplaceService;
 	@NonNull public final MobileConfigService mobileConfigService;
-	@NonNull public final MobileUIPickingUserProfileRepository mobilePickingConfigRepository;
+	@NonNull public final MobileUIPickingUserProfileService mobilePickingConfigService;
 	@NonNull public final MobileUIDistributionConfigRepository mobileDistributionConfigRepository;
 	@NonNull public final MobileUIManufacturingConfigRepository mobileManufacturingConfigRepository;
 	@NonNull public final InventoryService inventoryService;

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigCommand.java
@@ -8,7 +8,7 @@ import de.metas.distribution.config.MobileUIDistributionConfigRepository;
 import de.metas.frontend_testing.masterdata.MasterdataContext;
 import de.metas.handlingunits.picking.config.mobileui.AllowedPickToStructures;
 import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfile;
-import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileRepository;
+import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileService;
 import de.metas.handlingunits.picking.config.mobileui.PickToStructure;
 import de.metas.handlingunits.picking.config.mobileui.PickingCustomerConfig;
 import de.metas.handlingunits.picking.config.mobileui.PickingCustomerConfigsCollection;
@@ -36,7 +36,7 @@ import java.util.List;
 public class MobileConfigCommand
 {
 	@NonNull private final MobileConfigService mobileConfigService;
-	@NonNull private final MobileUIPickingUserProfileRepository mobilePickingConfigRepository;
+	@NonNull private final MobileUIPickingUserProfileService mobilePickingConfigService;
 	@NonNull private final MobileUIDistributionConfigRepository mobileDistributionConfigRepository;
 	@NonNull private final MobileUIManufacturingConfigRepository mobileManufacturingConfigRepository;
 
@@ -83,7 +83,7 @@ public class MobileConfigCommand
 			return null;
 		}
 
-		mobilePickingConfigRepository.update((profile) -> {
+		mobilePickingConfigService.update((profile) -> {
 			final MobileUIPickingUserProfile.MobileUIPickingUserProfileBuilder newProfileBuilder = profile.toBuilder()
 					.defaultPickingJobOptions(updatePickingJobOptions(profile.getDefaultPickingJobOptions(), picking))
 					.customerConfigs(updatePickingCustomers(profile.getCustomerConfigs(), picking.getCustomers()))
@@ -100,7 +100,7 @@ public class MobileConfigCommand
 			return newProfileBuilder.build();
 		});
 
-		final MobileUIPickingUserProfile newProfile = mobilePickingConfigRepository.getProfile(); // reload to make sure we are returning exactly what's in DB
+		final MobileUIPickingUserProfile newProfile = mobilePickingConfigService.getProfile(); // reload to make sure we are returning exactly what's in DB
 
 		// guard against common config errors
 		if (newProfile.getDefaultPickingJobOptions().getAllowedPickToStructures().toAllowedSet().isEmpty())

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileService.java
@@ -4,9 +4,11 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.handlingunits.picking.config.PickingConfigRepositoryV2;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.compiere.Adempiere;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
+import java.util.function.UnaryOperator;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +16,13 @@ public class MobileUIPickingUserProfileService
 {
 	@NonNull private final MobileUIPickingUserProfileRepository profileRepository;
 	@NonNull private final PickingConfigRepositoryV2 pickingConfigRepositoryV2;
+
+	@NonNull
+	public static MobileUIPickingUserProfileService newInstanceForUnitTesting()
+	{
+		Adempiere.assertUnitTestMode();
+		return new MobileUIPickingUserProfileService(new MobileUIPickingUserProfileRepository(), new PickingConfigRepositoryV2());
+	}
 
 	@NonNull
 	public MobileUIPickingUserProfile getProfile()
@@ -38,4 +47,8 @@ public class MobileUIPickingUserProfileService
 		return pickingConfigRepositoryV2.getPickingConfig().isConsiderAttributes();
 	}
 
+	public void update(@NonNull UnaryOperator<MobileUIPickingUserProfile> updater)
+	{
+		profileRepository.update(updater);
+	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJob.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJob.java
@@ -158,6 +158,7 @@ public final class PickingJob implements PickingJobHeaderOrLine
 	@JsonIgnore
 	public boolean isAnonymousPickHUsOnTheFly() {return header.isAnonymousPickHUsOnTheFly();}
 
+	@Nullable
 	public UserId getLockedBy() {return header.getLockedBy();}
 
 	public PickingJob withLockedBy(@Nullable final UserId lockedBy)
@@ -178,6 +179,15 @@ public final class PickingJob implements PickingJobHeaderOrLine
 		if (isProcessed())
 		{
 			throw new AdempiereException(PICKING_JOB_PROCESSED_ERROR_MSG);
+		}
+	}
+
+	public void assertCanBeEditedBy(final UserId userId)
+	{
+		assertNotProcessed();
+		if (!Objects.equals(userId, getLockedBy()))
+		{
+			throw new AdempiereException("Can be edited only by the user who locked the job");
 		}
 	}
 
@@ -554,5 +564,4 @@ public final class PickingJob implements PickingJobHeaderOrLine
 				.filter(Objects::nonNull)
 				.collect(ImmutableSet.toImmutableSet());
 	}
-
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobCandidateProduct.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobCandidateProduct.java
@@ -34,20 +34,7 @@ public class PickingJobCandidateProduct
 			return Optional.empty();
 		}
 
-		final Quantity qtyNotAvailable = qtyToDeliver.subtract(qtyAvailableToPick);
-
-		if (qtyNotAvailable.signum() <= 0)
-		{
-			return Optional.of(QtyAvailableStatus.FULLY_AVAILABLE);
-		}
-		else if (qtyAvailableToPick.signum() > 0)
-		{
-			return Optional.of(QtyAvailableStatus.PARTIALLY_AVAILABLE);
-		}
-		else
-		{
-			return Optional.of(QtyAvailableStatus.NOT_AVAILABLE);
-		}
+		return Optional.of(QtyAvailableStatus.computeOfQtyRequiredAndQtyAvailable(qtyToDeliver, qtyAvailableToPick));
 	}
 }
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobCandidateProducts.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobCandidateProducts.java
@@ -10,7 +10,6 @@ import de.metas.util.OptionalBoolean;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
-import org.adempiere.exceptions.AdempiereException;
 
 import javax.annotation.Nullable;
 import java.util.Iterator;
@@ -82,46 +81,7 @@ public class PickingJobCandidateProducts implements Iterable<PickingJobCandidate
 
 	private Optional<QtyAvailableStatus> computeQtyAvailableStatus()
 	{
-		if (byProductId.isEmpty())
-		{
-			return Optional.empty();
-		}
-
-		boolean hasNotAvailableProducts = false;
-		boolean hasFullyAvailableProducts = false;
-
-		for (final PickingJobCandidateProduct product : byProductId.values())
-		{
-			final QtyAvailableStatus productStatus = product.getQtyAvailableStatus().orElse(null);
-			if (productStatus == null)
-			{
-				return Optional.empty();
-			}
-
-			switch (productStatus)
-			{
-				case NOT_AVAILABLE:
-					hasNotAvailableProducts = true;
-					break;
-				case PARTIALLY_AVAILABLE:
-					return Optional.of(QtyAvailableStatus.PARTIALLY_AVAILABLE);
-				case FULLY_AVAILABLE:
-					hasFullyAvailableProducts = true;
-					break;
-				default:
-					throw new AdempiereException("Unknown QtyAvailableStatus: " + productStatus);
-			}
-		}
-
-		if (hasFullyAvailableProducts)
-		{
-			return hasNotAvailableProducts ? Optional.of(QtyAvailableStatus.PARTIALLY_AVAILABLE) : Optional.of(QtyAvailableStatus.FULLY_AVAILABLE);
-		}
-		else
-		{
-			return Optional.of(QtyAvailableStatus.NOT_AVAILABLE);
-		}
-
+		return QtyAvailableStatus.computeOfLines(byProductId.values(), product -> product.getQtyAvailableStatus().orElse(null));
 	}
 
 	public PickingJobCandidateProducts updatingEachProduct(@NonNull UnaryOperator<PickingJobCandidateProduct> updater)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobLine.java
@@ -32,11 +32,11 @@ import de.metas.gs1.GS1ProductCodes;
 import de.metas.handlingunits.HUPIItemProduct;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.QtyTU;
-import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
 import de.metas.i18n.ITranslatableString;
 import de.metas.order.OrderAndLineId;
 import de.metas.picking.api.PickingSlotId;
 import de.metas.picking.api.PickingSlotIdAndCaption;
+import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
 import de.metas.product.ProductCategoryId;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
@@ -301,4 +301,6 @@ public class PickingJobLine implements PickingJobHeaderOrLine
 	{
 		return withCurrentPickingTarget(currentPickingTarget.withPickingSlot(pickingSlot));
 	}
+
+	public boolean isFullyPicked() {return qtyRemainingToPick.signum() <= 0;}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobLineQtyAvailable.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobLineQtyAvailable.java
@@ -1,0 +1,36 @@
+package de.metas.handlingunits.picking.job.model;
+
+import de.metas.quantity.Quantity;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+import javax.annotation.Nullable;
+
+@Value
+public class PickingJobLineQtyAvailable
+{
+	@NonNull PickingJobLineId lineId;
+	@NonNull Quantity qtyRemainingToPick;
+	@Nullable Quantity qtyAvailableToPick;
+	@NonNull String uomSymbol;
+	@Nullable QtyAvailableStatus status;
+
+	@Builder
+	private PickingJobLineQtyAvailable(
+			@NonNull final PickingJobLineId lineId,
+			@NonNull final Quantity qtyRemainingToPick,
+			@Nullable final Quantity qtyAvailableToPick)
+	{
+		Quantity.getCommonUomIdOfAll(qtyRemainingToPick, qtyAvailableToPick);
+
+		this.lineId = lineId;
+		this.qtyRemainingToPick = qtyRemainingToPick;
+		this.qtyAvailableToPick = qtyAvailableToPick;
+
+		this.uomSymbol = qtyRemainingToPick.getUOMSymbol();
+		this.status = qtyAvailableToPick != null
+				? QtyAvailableStatus.computeOfQtyRequiredAndQtyAvailable(qtyRemainingToPick, qtyAvailableToPick)
+				: null;
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobQtyAvailable.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobQtyAvailable.java
@@ -1,0 +1,26 @@
+package de.metas.handlingunits.picking.job.model;
+
+import com.google.common.collect.ImmutableList;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Singular;
+import lombok.Value;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@Value
+public class PickingJobQtyAvailable
+{
+	@NonNull ImmutableList<PickingJobLineQtyAvailable> lines;
+	@Nullable QtyAvailableStatus status;
+
+	@Builder
+	private PickingJobQtyAvailable(
+			@Nullable @Singular final List<PickingJobLineQtyAvailable> lines)
+	{
+		this.lines = lines != null && !lines.isEmpty() ? ImmutableList.copyOf(lines) : ImmutableList.of();
+		this.status = QtyAvailableStatus.computeOfLines(this.lines, PickingJobLineQtyAvailable::getStatus).orElse(null);
+	}
+}
+

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/QtyAvailableStatus.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/QtyAvailableStatus.java
@@ -1,11 +1,84 @@
 package de.metas.handlingunits.picking.job.model;
 
+import de.metas.quantity.Quantity;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Function;
+
 public enum QtyAvailableStatus
 {
 	NOT_AVAILABLE,
 	PARTIALLY_AVAILABLE,
 	FULLY_AVAILABLE,
 	;
+
+	public static QtyAvailableStatus computeOfQtyRequiredAndQtyAvailable(@NonNull final Quantity qtyRequired, @NonNull final Quantity qtyAvailable)
+	{
+		final Quantity qtyNotAvailable = qtyRequired.subtract(qtyAvailable);
+
+		if (qtyNotAvailable.signum() <= 0)
+		{
+			return QtyAvailableStatus.FULLY_AVAILABLE;
+		}
+		else if (qtyAvailable.signum() > 0)
+		{
+			return QtyAvailableStatus.PARTIALLY_AVAILABLE;
+		}
+		else
+		{
+			return QtyAvailableStatus.NOT_AVAILABLE;
+		}
+	}
+
+	public static <T> Optional<QtyAvailableStatus> computeOfLines(
+			@NonNull final Collection<T> lines,
+			@NonNull final Function<T, QtyAvailableStatus> getStatusFunc)
+	{
+		if (lines.isEmpty())
+		{
+			return Optional.empty();
+		}
+
+		boolean hasNotAvailableProducts = false;
+		boolean hasFullyAvailableProducts = false;
+
+		for (final T line : lines)
+		{
+			@Nullable final QtyAvailableStatus lineStatus = getStatusFunc.apply(line);
+			if (lineStatus == null)
+			{
+				return Optional.empty();
+			}
+
+			switch (lineStatus)
+			{
+				case NOT_AVAILABLE:
+					hasNotAvailableProducts = true;
+					break;
+				case PARTIALLY_AVAILABLE:
+					return Optional.of(QtyAvailableStatus.PARTIALLY_AVAILABLE);
+				case FULLY_AVAILABLE:
+					hasFullyAvailableProducts = true;
+					break;
+				default:
+					throw new AdempiereException("Unknown QtyAvailableStatus: " + lineStatus);
+			}
+		}
+
+		if (hasFullyAvailableProducts)
+		{
+			return hasNotAvailableProducts ? Optional.of(QtyAvailableStatus.PARTIALLY_AVAILABLE) : Optional.of(QtyAvailableStatus.FULLY_AVAILABLE);
+		}
+		else
+		{
+			return Optional.of(QtyAvailableStatus.NOT_AVAILABLE);
+		}
+
+	}
 
 	public boolean isPartialOrFullyAvailable() {return this == PARTIALLY_AVAILABLE || this == FULLY_AVAILABLE;}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/QtyAvailableStatus.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/QtyAvailableStatus.java
@@ -11,6 +11,7 @@ import java.util.function.Function;
 
 public enum QtyAvailableStatus
 {
+	// NOTE: keep in sync with QtyAvailableStatus.js
 	NOT_AVAILABLE,
 	PARTIALLY_AVAILABLE,
 	FULLY_AVAILABLE,

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/DefaultPickingJobLoaderSupportingServices.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/DefaultPickingJobLoaderSupportingServices.java
@@ -6,7 +6,7 @@ import de.metas.handlingunits.HUPIItemProduct;
 import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.HuPackingInstructionsId;
-import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileRepository;
+import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileService;
 import de.metas.handlingunits.picking.config.mobileui.PickingJobOptions;
 import de.metas.handlingunits.picking.job.model.ScheduledPackageable;
 import de.metas.handlingunits.picking.job.model.ScheduledPackageableList;
@@ -61,7 +61,7 @@ public class DefaultPickingJobLoaderSupportingServices implements PickingJobLoad
 	@NonNull private final PickingJobSlotService pickingSlotService;
 	@NonNull private final PickingJobLockService pickingJobLockService;
 	@NonNull private final PickingJobHUService huService;
-	@NonNull private final MobileUIPickingUserProfileRepository profileRepository;
+	@NonNull private final MobileUIPickingUserProfileService profileService;
 
 	private final HashMap<OrderId, String> salesOrderDocumentNosCache = new HashMap<>();
 	private final HashMap<BPartnerId, String> bpartnerNamesCache = new HashMap<>();
@@ -70,7 +70,7 @@ public class DefaultPickingJobLoaderSupportingServices implements PickingJobLoad
 	private final HashMap<LocatorId, String> locatorNamesCache = new HashMap<>();
 
 	@Override
-	public PickingJobOptions getPickingJobOptions(@Nullable final BPartnerId customerId) {return profileRepository.getPickingJobOptions(customerId);}
+	public PickingJobOptions getPickingJobOptions(@Nullable final BPartnerId customerId) {return profileService.getPickingJobOptions(customerId);}
 
 	@Override
 	public void warmUpCachesFrom(@NonNull final ScheduledPackageableList items)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/DefaultPickingJobLoaderSupportingServicesFactory.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/DefaultPickingJobLoaderSupportingServicesFactory.java
@@ -1,6 +1,6 @@
 package de.metas.handlingunits.picking.job.repository;
 
-import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileRepository;
+import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileService;
 import de.metas.handlingunits.picking.job.service.PickingJobLockService;
 import de.metas.handlingunits.picking.job.service.PickingJobSlotService;
 import de.metas.handlingunits.picking.job.service.external.bpartner.PickingJobBPartnerService;
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class DefaultPickingJobLoaderSupportingServicesFactory implements PickingJobLoaderSupportingServicesFactory
 {
+	@NonNull private final MobileUIPickingUserProfileService profileService;
 	@NonNull private final PickingJobSalesOrderService orderService;
 	@NonNull private final PickingJobWarehouseService warehouseService;
 	@NonNull private final PickingJobBPartnerService bpartnerService;
@@ -23,7 +24,6 @@ public class DefaultPickingJobLoaderSupportingServicesFactory implements Picking
 	@NonNull private final PickingJobSlotService pickingSlotService;
 	@NonNull private final PickingJobLockService pickingJobLockService;
 	@NonNull private final PickingJobHUService huService;
-	@NonNull private final MobileUIPickingUserProfileRepository profileRepository;
 
 	@Override
 	public PickingJobLoaderSupportingServices createLoaderSupportingServices()
@@ -36,7 +36,7 @@ public class DefaultPickingJobLoaderSupportingServicesFactory implements Picking
 				.pickingSlotService(pickingSlotService)
 				.pickingJobLockService(pickingJobLockService)
 				.huService(huService)
-				.profileRepository(profileRepository)
+				.profileService(profileService)
 				.build();
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
@@ -24,6 +24,7 @@ import de.metas.handlingunits.picking.job.model.PickingJobCandidate;
 import de.metas.handlingunits.picking.job.model.PickingJobId;
 import de.metas.handlingunits.picking.job.model.PickingJobLine;
 import de.metas.handlingunits.picking.job.model.PickingJobLineId;
+import de.metas.handlingunits.picking.job.model.PickingJobQtyAvailable;
 import de.metas.handlingunits.picking.job.model.PickingJobQuery;
 import de.metas.handlingunits.picking.job.model.PickingJobReference;
 import de.metas.handlingunits.picking.job.model.PickingJobReferenceQuery;
@@ -40,6 +41,7 @@ import de.metas.handlingunits.picking.job.service.commands.PickingJobCreateComma
 import de.metas.handlingunits.picking.job.service.commands.PickingJobCreateRequest;
 import de.metas.handlingunits.picking.job.service.commands.PickingJobReopenCommand;
 import de.metas.handlingunits.picking.job.service.commands.PickingJobUnPickCommand;
+import de.metas.handlingunits.picking.job.service.commands.get_qty_available.PickingJobGetQtyAvailableCommand;
 import de.metas.handlingunits.picking.job.service.commands.pick.PickingJobPickCommand;
 import de.metas.handlingunits.picking.job.service.commands.pick_all.PickingJobPickAllCommand;
 import de.metas.handlingunits.picking.job.service.commands.retrieve.PickingJobCandidateRetrieveCommand;
@@ -61,13 +63,11 @@ import de.metas.picking.qrcode.PickingSlotQRCode;
 import de.metas.product.ProductId;
 import de.metas.user.UserId;
 import de.metas.util.Services;
-import de.metas.workplace.WorkplaceService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.util.Util;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
@@ -97,7 +97,6 @@ public class PickingJobService implements PickingSlotListener
 	@NonNull private final PickingCandidateService pickingCandidateService;
 	@NonNull private final PickingJobLoaderSupportingServicesFactory pickingJobLoaderSupportingServicesFactory;
 	@NonNull private final PickingShipmentService shipmentService;
-	@NonNull private final WorkplaceService workplaceService;
 	@NonNull private final MobileUIPickingUserProfileService configService;
 	@NonNull private final PickingJobScheduleService pickingJobScheduleService;
 	@NonNull private final PickingJobHUService huService;
@@ -132,7 +131,7 @@ public class PickingJobService implements PickingSlotListener
 				.pickingJobSlotService(pickingSlotService)
 				.huService(huService)
 				.loadingSupportServices(pickingJobLoaderSupportingServicesFactory.createLoaderSupportingServices())
-				.workplaceService(workplaceService)
+				.warehouseService(warehouseService)
 				.pickingJobScheduleService(pickingJobScheduleService)
 				//
 				.request(request)
@@ -693,14 +692,27 @@ public class PickingJobService implements PickingSlotListener
 		return pickingSlotService.getPickingSlotsSuggestions(deliveryLocations);
 	}
 
-	public PickingJob pickAll(final PickingJobId pickingJobId, final @NotNull UserId callerId)
+	public PickingJob pickAll(@NonNull final PickingJobId pickingJobId, final @NonNull UserId callerId)
 	{
 		return PickingJobPickAllCommand.builder()
 				.pickingJobService(this)
+				//
 				.pickingJobId(pickingJobId)
 				.callerId(callerId)
-				.build()
-				.execute();
+				//
+				.build().execute();
 	}
 
+	public PickingJobQtyAvailable getQtyAvailable(@NonNull final PickingJobId pickingJobId, final @NonNull UserId callerId)
+	{
+		return PickingJobGetQtyAvailableCommand.builder()
+				.pickingJobService(this)
+				.warehouseService(warehouseService)
+				.huService(huService)
+				//
+				.pickingJobId(pickingJobId)
+				.callerId(callerId)
+				//
+				.build().execute();
+	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobCreateCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobCreateCommand.java
@@ -18,6 +18,7 @@ import de.metas.handlingunits.picking.job.service.PickingJobLockService;
 import de.metas.handlingunits.picking.job.service.PickingJobSlotService;
 import de.metas.handlingunits.picking.job.service.external.hu.PickingJobHUService;
 import de.metas.handlingunits.picking.job.service.external.shipmentschedule.PickingJobShipmentScheduleService;
+import de.metas.handlingunits.picking.job.service.external.warehouse.PickingJobWarehouseService;
 import de.metas.handlingunits.picking.job_schedule.service.PickingJobScheduleService;
 import de.metas.handlingunits.picking.plan.generator.CreatePickingPlanRequest;
 import de.metas.handlingunits.picking.plan.generator.pickFromHUs.PickFromHU;
@@ -40,7 +41,6 @@ import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
 import de.metas.util.Services;
 import de.metas.workplace.Workplace;
-import de.metas.workplace.WorkplaceService;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
@@ -69,7 +69,7 @@ public class PickingJobCreateCommand
 	@NonNull private final PickingCandidateService pickingCandidateService;
 	private final PickingJobLoaderSupportingServices loadingSupportServices;
 	@NonNull private final PickingJobSlotService pickingJobSlotService;
-	@NonNull private final WorkplaceService workplaceService;
+	@NonNull private final PickingJobWarehouseService warehouseService;
 	@NonNull private final PickingJobScheduleService pickingJobScheduleService;
 	@NonNull private final PickingJobHUService huService;
 
@@ -130,7 +130,7 @@ public class PickingJobCreateCommand
 	@NonNull
 	private PickingJob allocatePickingSlotIfPossible(@NonNull final PickingJob pickingJob)
 	{
-		final PickingSlotId pickingSlotId = workplaceService.getWorkplaceByUserId(request.getPickerId())
+		final PickingSlotId pickingSlotId = warehouseService.getWorkplaceByUserId(request.getPickerId())
 				.map(Workplace::getPickingSlotId)
 				.orElse(null);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/get_qty_available/PickingJobGetQtyAvailableCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/get_qty_available/PickingJobGetQtyAvailableCommand.java
@@ -1,0 +1,133 @@
+package de.metas.handlingunits.picking.job.service.commands.get_qty_available;
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableSet;
+import de.metas.handlingunits.picking.job.model.PickingJob;
+import de.metas.handlingunits.picking.job.model.PickingJobId;
+import de.metas.handlingunits.picking.job.model.PickingJobLine;
+import de.metas.handlingunits.picking.job.model.PickingJobLineQtyAvailable;
+import de.metas.handlingunits.picking.job.model.PickingJobQtyAvailable;
+import de.metas.handlingunits.picking.job.service.PickingJobService;
+import de.metas.handlingunits.picking.job.service.external.hu.PickingJobHUService;
+import de.metas.handlingunits.picking.job.service.external.hu.ProductAvailableStocks;
+import de.metas.handlingunits.picking.job.service.external.warehouse.PickingJobWarehouseService;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.user.UserId;
+import de.metas.workplace.Workplace;
+import lombok.Builder;
+import lombok.NonNull;
+
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+public class PickingJobGetQtyAvailableCommand
+{
+	// services
+	@NonNull private final PickingJobService pickingJobService;
+	@NonNull private final PickingJobWarehouseService warehouseService;
+	@NonNull private final PickingJobHUService huService;
+
+	// params
+	@NonNull private final PickingJobId pickingJobId;
+	@NonNull private final UserId callerId;
+
+	// state
+	@NonNull private final Supplier<PickingJob> pickingJobSupplier = Suppliers.memoize(this::retrievePickingJob);
+	@NonNull private final Supplier<ProductAvailableStocks> availableStocksSupplier = Suppliers.memoize(this::computeAvailableStocks);
+
+	@Builder
+	private PickingJobGetQtyAvailableCommand(
+			@NonNull final PickingJobService pickingJobService,
+			@NonNull final PickingJobWarehouseService warehouseService,
+			@NonNull final PickingJobHUService huService,
+			@NonNull final PickingJobId pickingJobId,
+			@NonNull final UserId callerId)
+	{
+		this.pickingJobService = pickingJobService;
+		this.warehouseService = warehouseService;
+		this.huService = huService;
+		this.pickingJobId = pickingJobId;
+		this.callerId = callerId;
+	}
+
+	public PickingJobQtyAvailable execute()
+	{
+		final PickingJobQtyAvailable.PickingJobQtyAvailableBuilder result = PickingJobQtyAvailable.builder();
+
+		final PickingJob pickingJob = getPickingJob();
+		for (PickingJobLine line : pickingJob.getLines())
+		{
+			final Quantity qtyAvailableToPick = allocateLine(line);
+
+			result.line(PickingJobLineQtyAvailable.builder()
+					.lineId(line.getId())
+					.qtyRemainingToPick(line.getQtyRemainingToPick())
+					.qtyAvailableToPick(qtyAvailableToPick)
+					.build());
+		}
+
+		return result.build();
+	}
+
+	private ImmutableSet<ProductId> getProductIdsRemainingToBePicked()
+	{
+		final PickingJob pickingJob = getPickingJob();
+		return pickingJob.streamLines()
+				.filter(line -> !line.isFullyPicked())
+				.map(PickingJobLine::getProductId)
+				.collect(ImmutableSet.toImmutableSet());
+	}
+
+	@NonNull
+	private PickingJob getPickingJob()
+	{
+		return pickingJobSupplier.get();
+	}
+
+	private PickingJob retrievePickingJob()
+	{
+		@NonNull final PickingJob pickingJob = pickingJobService.getById(pickingJobId);
+		pickingJob.assertCanBeEditedBy(callerId);
+		return pickingJob;
+	}
+
+	@Nullable
+	private Quantity allocateLine(PickingJobLine line)
+	{
+		final Quantity qtyRemainingToPick = line.getQtyRemainingToPick();
+		if (line.isFullyPicked())
+		{
+			return qtyRemainingToPick.toZeroIfNegative();
+		}
+
+		final ProductAvailableStocks availableStocks = getAvailableStocks();
+		if (availableStocks == null)
+		{
+			return null; // N/A 
+		}
+
+		return availableStocks.allocateQty(line.getProductId(), qtyRemainingToPick);
+	}
+
+	@Nullable
+	private ProductAvailableStocks getAvailableStocks()
+	{
+		return availableStocksSupplier.get();
+	}
+
+	@Nullable
+	private ProductAvailableStocks computeAvailableStocks()
+	{
+		final Workplace workplace = warehouseService.getWorkplaceByUserId(callerId).orElse(null);
+		if (workplace == null) {return null;}
+
+		final ProductAvailableStocks availableStocks = huService.newAvailableStocksProvider(workplace);
+		if (availableStocks == null) {return null;}
+
+		availableStocks.warmUpByProductIds(getProductIdsRemainingToBePicked());
+
+		return availableStocks;
+	}
+
+}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick_all/PickingJobPickAllCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick_all/PickingJobPickAllCommand.java
@@ -29,7 +29,7 @@ public class PickingJobPickAllCommand
 	private PickingJob executeInTrx()
 	{
 		PickingJob pickingJob = pickingJobService.getById(pickingJobId);
-		pickingJob.assertNotProcessed();
+		pickingJob.assertCanBeEditedBy(callerId);
 
 		PickingJob pickingJobChanged = pickingJob;
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/bpartner/PickingJobBPartnerService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/bpartner/PickingJobBPartnerService.java
@@ -9,9 +9,11 @@ import de.metas.document.location.IDocumentLocationBL;
 import de.metas.document.location.RenderedAddressProvider;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.compiere.model.I_C_BPartner_Location;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -40,6 +42,16 @@ public class PickingJobBPartnerService
 	public Set<DocumentLocation> getDocumentLocations(@NonNull final Set<BPartnerLocationId> bpartnerLocationIds)
 	{
 		return documentLocationBL.getDocumentLocations(bpartnerLocationIds);
+	}
+
+	public I_C_BPartner_Location getBPartnerLocationByIdEvenInactive(final @NonNull BPartnerLocationId id)
+	{
+		return bpartnerBL.getBPartnerLocationByIdEvenInactive(id);
+	}
+
+	public List<I_C_BPartner_Location> getBPartnerLocationsByIds(final Set<BPartnerLocationId> ids)
+	{
+		return bpartnerBL.getBPartnerLocationsByIds(ids);
 	}
 
 	public RenderedAddressProvider newRenderedAddressProvider()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickingJobHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickingJobHUService.java
@@ -48,6 +48,7 @@ import de.metas.quantity.Quantity;
 import de.metas.scannable_code.ScannedCode;
 import de.metas.uom.IUOMConversionBL;
 import de.metas.util.Services;
+import de.metas.workplace.Workplace;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -290,4 +291,20 @@ public class PickingJobHUService
 
 		huReservationService.deleteReservationsByDocumentRefs(reservationDocRefs);
 	}
+
+	@Nullable
+	public ProductAvailableStocks newAvailableStocksProvider(@NonNull final Workplace workplace)
+	{
+		final Set<LocatorId> pickFromLocatorIds = warehouseService.getPickFromLocatorIds(workplace);
+		if (pickFromLocatorIds.isEmpty())
+		{
+			return null;
+		}
+
+		return ProductAvailableStocks.builder()
+				.handlingUnitsBL(handlingUnitsBL)
+				.pickFromLocatorIds(pickFromLocatorIds)
+				.build();
+	}
+
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/ProductAvailableStock.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/ProductAvailableStock.java
@@ -1,4 +1,4 @@
-package de.metas.picking.workflow.lauchers;
+package de.metas.handlingunits.picking.job.service.external.hu;
 
 import de.metas.quantity.MixedQuantity;
 import de.metas.quantity.Quantity;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/ProductAvailableStocks.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/ProductAvailableStocks.java
@@ -13,6 +13,7 @@ import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
 import de.metas.util.Check;
 import de.metas.util.collections.CollectionUtils;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NonNull;
 import org.adempiere.warehouse.LocatorId;
@@ -34,7 +35,7 @@ public class ProductAvailableStocks
 	// State
 	@NonNull private final HashMap<ProductId, ProductAvailableStock> map = new HashMap<>();
 
-	@Builder
+	@Builder(access = AccessLevel.PACKAGE)
 	private ProductAvailableStocks(
 			@NonNull final IHandlingUnitsBL handlingUnitsBL,
 			@NonNull final Set<LocatorId> pickFromLocatorIds)
@@ -63,15 +64,23 @@ public class ProductAvailableStocks
 
 	private PickingJobCandidateProduct allocate(final PickingJobCandidateProduct product)
 	{
-		final ProductId productId = product.getProductId();
 		final Quantity qtyToDeliver = product.getQtyToDeliver();
-		final Quantity qtyAvailableToPick = allocateQty(productId, qtyToDeliver).toZeroIfNegative();
+		if (qtyToDeliver == null)
+		{
+			return product;
+		}
+
+		final ProductId productId = product.getProductId();
+		final Quantity qtyAvailableToPick = allocateQty(productId, qtyToDeliver);
+
 		return product.withQtyAvailableToPick(qtyAvailableToPick);
 	}
 
-	public Quantity allocateQty(final ProductId productId, final Quantity qty)
+	public Quantity allocateQty(@NonNull final ProductId productId, @NonNull final Quantity qtyToDeliver)
 	{
-		return getByProductId(productId).allocateQty(qty);
+		return getByProductId(productId)
+				.allocateQty(qtyToDeliver)
+				.toZeroIfNegative();
 	}
 
 	private ProductAvailableStock getByProductId(final ProductId productId)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/ProductAvailableStocks.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/ProductAvailableStocks.java
@@ -1,4 +1,4 @@
-package de.metas.picking.workflow.lauchers;
+package de.metas.handlingunits.picking.job.service.external.hu;
 
 import com.google.common.collect.ImmutableSet;
 import de.metas.handlingunits.IHandlingUnitsBL;
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-class ProductAvailableStocks
+public class ProductAvailableStocks
 {
 	// Services
 	@NonNull final IHandlingUnitsBL handlingUnitsBL;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/warehouse/PickingJobWarehouseService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/warehouse/PickingJobWarehouseService.java
@@ -1,17 +1,26 @@
 package de.metas.handlingunits.picking.job.service.external.warehouse;
 
 import com.google.common.collect.ImmutableSet;
+import de.metas.user.UserId;
 import de.metas.util.Services;
+import de.metas.workplace.Workplace;
+import de.metas.workplace.WorkplaceService;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.IWarehouseBL;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+import java.util.Set;
+
 @Service
+@RequiredArgsConstructor
 public class PickingJobWarehouseService
 {
 	@NonNull private final IWarehouseBL warehouseBL = Services.get(IWarehouseBL.class);
+	@NonNull private final WorkplaceService workplaceService;
 
 	public String getLocatorNameById(final LocatorId locatorId)
 	{
@@ -21,6 +30,21 @@ public class PickingJobWarehouseService
 	public ImmutableSet<LocatorId> getLocatorIdsOfTheSamePickingGroup(@NonNull final WarehouseId warehouseId)
 	{
 		return warehouseBL.getLocatorIdsOfTheSamePickingGroup(warehouseId);
+	}
+
+	public Optional<Workplace> getWorkplaceByUserId(@NonNull final UserId userId)
+	{
+		return workplaceService.getWorkplaceByUserId(userId);
+	}
+
+	public Optional<WarehouseId> getWarehouseIdByUserId(@NonNull final UserId userId)
+	{
+		return workplaceService.getWarehouseIdByUserId(userId);
+	}
+
+	public Set<LocatorId> getPickFromLocatorIds(final Workplace workplace)
+	{
+		return workplaceService.getPickFromLocatorIds(workplace);
 	}
 
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentService.java
@@ -4,7 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.handlingunits.HuId;
-import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileRepository;
+import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileService;
 import de.metas.handlingunits.picking.job.model.PickingJob;
 import de.metas.handlingunits.picking.job.model.PickingJobLine;
 import de.metas.handlingunits.picking.job.service.CreateShipmentPolicy;
@@ -27,7 +27,7 @@ import static de.metas.handlingunits.shipmentschedule.api.M_ShipmentSchedule_Qua
 @RequiredArgsConstructor
 public class PickingShipmentService
 {
-	@NonNull private final MobileUIPickingUserProfileRepository configRepository;
+	@NonNull private final MobileUIPickingUserProfileService profileService;
 	@NonNull private final IShipmentService shipmentService;
 
 	@VisibleForTesting
@@ -35,7 +35,7 @@ public class PickingShipmentService
 	{
 		Adempiere.assertUnitTestMode();
 		return new PickingShipmentService(
-				new MobileUIPickingUserProfileRepository(),
+				MobileUIPickingUserProfileService.newInstanceForUnitTesting(),
 				ShipmentService.getInstance()
 		);
 	}
@@ -67,7 +67,7 @@ public class PickingShipmentService
 			{
 				final CreateShipmentPolicy createShipmentPolicyEffective = CoalesceUtil.coalesceNotNull(
 						createShipmentPolicyOverride,
-						() -> configRepository.getPickingJobOptions(key.getCustomerId()).getCreateShipmentPolicy()
+						() -> profileService.getPickingJobOptions(key.getCustomerId()).getCreateShipmentPolicy()
 				);
 				if (!createShipmentPolicyEffective.isCreateShipment())
 				{

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/PickingJobTestHelper.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/PickingJobTestHelper.java
@@ -232,7 +232,6 @@ public class PickingJobTestHelper
 				pickingCandidateService,
 				defaultPickingJobLoaderSupportingServicesFactory,
 				PickingShipmentService.newInstanceForUnitTesting(),
-				workplaceService,
 				configService,
 				pickingJobScheduleService,
 				huService

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/PickingJobTestHelper.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/PickingJobTestHelper.java
@@ -131,7 +131,8 @@ public class PickingJobTestHelper
 	private final IBPartnerBL bpartnerBL;
 	private final IOrderBL orderBL;
 	private final PackagingDAO packagingDAO;
-	public final WorkplaceService workplaceService;
+	public final PickingJobWarehouseService warehouseService;
+	private final WorkplaceService workplaceService;
 	private final HUTestHelper huTestHelper;
 	private final HUQRCodesRepository huQRCodesRepository;
 	private final IProductBL productBL;
@@ -176,7 +177,6 @@ public class PickingJobTestHelper
 		final BPartnerBL bpartnerBL = new BPartnerBL(new UserRepository());
 		final PickingJobRepository pickingJobRepository = new PickingJobRepository();
 		final HUQRCodesService huQRCodeService = HUQRCodesService.newInstanceForUnitTesting();
-		this.workplaceService = new WorkplaceService(new WorkplaceRepository(), new WorkplaceUserAssignRepository());
 		final InventoryService inventoryService = InventoryService.newInstanceForUnitTesting();
 		this.configService = MobileUIPickingUserProfileService.newInstanceForUnitTesting();
 		final PickingCandidateService pickingCandidateService = new PickingCandidateService(
@@ -193,7 +193,8 @@ public class PickingJobTestHelper
 		final PickingJobLockService pickingJobLockService = new PickingJobLockService(new InMemoryShipmentScheduleLockRepository());
 		documentLocationBL = DummyDocumentLocationBL.newInstanceForUnitTesting();
 		pickingJobScheduleService = PickingJobScheduleService.newInstanceForUnitTesting();
-		final PickingJobWarehouseService warehouseService = new PickingJobWarehouseService();
+		this.workplaceService = new WorkplaceService(new WorkplaceRepository(), new WorkplaceUserAssignRepository());
+		this.warehouseService = new PickingJobWarehouseService(workplaceService);
 		final HULabelService huLabelService = new HULabelService(
 				new HULabelConfigService(new HULabelConfigRepository()),
 				huQRCodeService

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/PickingJobTestHelper.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/PickingJobTestHelper.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import de.metas.ad_reference.ADReferenceService;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.bpartner.ShipmentAllocationBestBeforePolicy;
-import de.metas.bpartner.service.IBPartnerBL;
 import de.metas.bpartner.service.impl.BPartnerBL;
 import de.metas.business.BusinessTestHelper;
 import de.metas.common.util.CoalesceUtil;
@@ -128,20 +127,20 @@ public class PickingJobTestHelper
 
 	//
 	// Services
-	private final IBPartnerBL bpartnerBL;
-	private final IOrderBL orderBL;
-	private final PackagingDAO packagingDAO;
 	public final PickingJobWarehouseService warehouseService;
-	private final WorkplaceService workplaceService;
-	private final HUTestHelper huTestHelper;
-	private final HUQRCodesRepository huQRCodesRepository;
-	private final IProductBL productBL;
 	public final MobileUIPickingUserProfileService configService;
 	public final PickingJobService pickingJobService;
 	public final HUTracerInstance huTracer;
-	public final DummyDocumentLocationBL documentLocationBL;
 	public final PickingJobScheduleService pickingJobScheduleService;
 	public final PickingJobBPartnerService bpartnerService;
+	public final PickingJobHUService huService;
+	//
+	private final IProductBL productBL;
+	private final IOrderBL orderBL;
+	private final PackagingDAO packagingDAO;
+	private final WorkplaceService workplaceService;
+	private final HUTestHelper huTestHelper;
+	private final HUQRCodesRepository huQRCodesRepository;
 
 	//
 	// Master data
@@ -163,7 +162,6 @@ public class PickingJobTestHelper
 		// because most of the tests are using snapshot testing.
 		POJOLookupMap.setNextIdSupplier(POJONextIdSuppliers.newPerTableSequence());
 
-		bpartnerBL = Services.get(IBPartnerBL.class);
 		orderBL = Services.get(IOrderBL.class);
 		packagingDAO = (PackagingDAO)Services.get(IPackagingDAO.class);
 
@@ -175,6 +173,11 @@ public class PickingJobTestHelper
 		SpringContextHolder.registerJUnitBean(pickingCandidateRepository); // needed for HUPickingSlotBL
 
 		final BPartnerBL bpartnerBL = new BPartnerBL(new UserRepository());
+		this.bpartnerService = new PickingJobBPartnerService(
+				bpartnerBL,
+				DummyDocumentLocationBL.newInstanceForUnitTesting()
+		);
+
 		final PickingJobRepository pickingJobRepository = new PickingJobRepository();
 		final HUQRCodesService huQRCodeService = HUQRCodesService.newInstanceForUnitTesting();
 		final InventoryService inventoryService = InventoryService.newInstanceForUnitTesting();
@@ -191,7 +194,6 @@ public class PickingJobTestHelper
 				PickingSlotService.newInstanceForUnitTesting(),
 				pickingJobRepository);
 		final PickingJobLockService pickingJobLockService = new PickingJobLockService(new InMemoryShipmentScheduleLockRepository());
-		documentLocationBL = DummyDocumentLocationBL.newInstanceForUnitTesting();
 		pickingJobScheduleService = PickingJobScheduleService.newInstanceForUnitTesting();
 		this.workplaceService = new WorkplaceService(new WorkplaceRepository(), new WorkplaceUserAssignRepository());
 		this.warehouseService = new PickingJobWarehouseService(workplaceService);
@@ -200,9 +202,7 @@ public class PickingJobTestHelper
 				huQRCodeService
 		);
 
-		this.bpartnerService = new PickingJobBPartnerService(bpartnerBL, documentLocationBL);
-
-		final PickingJobHUService huService = new PickingJobHUService(
+		this.huService = new PickingJobHUService(
 				configService,
 				warehouseService,
 				huQRCodeService,
@@ -375,7 +375,7 @@ public class PickingJobTestHelper
 		final I_C_Order order = orderBL.getById(OrderId.ofRepoId(sched.getC_Order_ID()));
 
 		final BPartnerLocationId shipToBPLocationId = BPartnerLocationId.ofRepoId(sched.getC_BPartner_ID(), sched.getC_BPartner_Location_ID());
-		final String bpName = bpartnerBL.getBPartnerName(shipToBPLocationId.getBpartnerId());
+		final String bpName = bpartnerService.getBPartnerName(shipToBPLocationId.getBpartnerId());
 
 		final ProductId productId = ProductId.ofRepoId(sched.getM_Product_ID());
 		final UomId uomId = productBL.getStockUOMId(productId);

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/PickingJobTestHelper.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/PickingJobTestHelper.java
@@ -28,9 +28,7 @@ import de.metas.handlingunits.model.I_M_Warehouse;
 import de.metas.handlingunits.model.X_M_HU;
 import de.metas.handlingunits.picking.PickingCandidateRepository;
 import de.metas.handlingunits.picking.PickingCandidateService;
-import de.metas.handlingunits.picking.config.PickingConfigRepositoryV2;
 import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfile;
-import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileRepository;
 import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileService;
 import de.metas.handlingunits.picking.job.model.HUInfo;
 import de.metas.handlingunits.picking.job.repository.DefaultPickingJobLoaderSupportingServicesFactory;
@@ -137,7 +135,6 @@ public class PickingJobTestHelper
 	private final HUTestHelper huTestHelper;
 	private final HUQRCodesRepository huQRCodesRepository;
 	private final IProductBL productBL;
-	public final MobileUIPickingUserProfileRepository configRepository;
 	public final MobileUIPickingUserProfileService configService;
 	public final PickingJobService pickingJobService;
 	public final HUTracerInstance huTracer;
@@ -181,11 +178,7 @@ public class PickingJobTestHelper
 		final HUQRCodesService huQRCodeService = HUQRCodesService.newInstanceForUnitTesting();
 		this.workplaceService = new WorkplaceService(new WorkplaceRepository(), new WorkplaceUserAssignRepository());
 		final InventoryService inventoryService = InventoryService.newInstanceForUnitTesting();
-		this.configRepository = new MobileUIPickingUserProfileRepository();
-		this.configService = new MobileUIPickingUserProfileService(
-				configRepository,
-				new PickingConfigRepositoryV2()
-		);
+		this.configService = MobileUIPickingUserProfileService.newInstanceForUnitTesting();
 		final PickingCandidateService pickingCandidateService = new PickingCandidateService(
 				new PickingConfigRepository(),
 				pickingCandidateRepository,
@@ -206,7 +199,6 @@ public class PickingJobTestHelper
 				huQRCodeService
 		);
 
-
 		this.bpartnerService = new PickingJobBPartnerService(bpartnerBL, documentLocationBL);
 
 		final PickingJobHUService huService = new PickingJobHUService(
@@ -218,14 +210,14 @@ public class PickingJobTestHelper
 				inventoryService);
 
 		final DefaultPickingJobLoaderSupportingServicesFactory defaultPickingJobLoaderSupportingServicesFactory = new DefaultPickingJobLoaderSupportingServicesFactory(
+				configService,
 				new PickingJobSalesOrderService(),
 				warehouseService,
 				bpartnerService,
 				new PickingJobProductService(),
 				pickingJobSlotService,
 				pickingJobLockService,
-				huService,
-				configRepository
+				huService
 		);
 
 		pickingJobService = new PickingJobService(
@@ -309,7 +301,7 @@ public class PickingJobTestHelper
 
 	public void updateMobileProfile(UnaryOperator<MobileUIPickingUserProfile> updater)
 	{
-		configRepository.update(updater);
+		configService.update(updater);
 	}
 
 	public OrderAndLineId createOrderAndLineId(final String documentNo)

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
@@ -28,6 +28,7 @@ import de.metas.common.handlingunits.JsonHUList;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.picking.job.model.LUPickingTarget;
 import de.metas.handlingunits.picking.job.model.PickingJobLineId;
+import de.metas.handlingunits.picking.job.model.PickingJobQtyAvailable;
 import de.metas.handlingunits.picking.job.model.TUPickingTarget;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.model.IHUQRCode;
@@ -39,6 +40,7 @@ import de.metas.picking.rest_api.json.JsonHUInfo;
 import de.metas.picking.rest_api.json.JsonLUPickingTarget;
 import de.metas.picking.rest_api.json.JsonPickingEventsList;
 import de.metas.picking.rest_api.json.JsonPickingJobAvailableTargets;
+import de.metas.picking.rest_api.json.JsonPickingJobQtyAvailable;
 import de.metas.picking.rest_api.json.JsonPickingLineCloseRequest;
 import de.metas.picking.rest_api.json.JsonPickingLineOpenRequest;
 import de.metas.picking.rest_api.json.JsonPickingStepEvent;
@@ -277,5 +279,14 @@ public class PickingRestController
 		assertApplicationAccess();
 		final WFProcessId wfProcessId = WFProcessId.ofString(wfProcessIdStr);
 		return pickingMobileApplication.pickAll(wfProcessId, getLoggedUserId());
+	}
+
+	@GetMapping("/job/{wfProcessId}/qtyAvailable")
+	public JsonPickingJobQtyAvailable getQtyAvailable(@PathVariable("wfProcessId") final String wfProcessIdStr)
+	{
+		assertApplicationAccess();
+		final WFProcessId wfProcessId = WFProcessId.ofString(wfProcessIdStr);
+		final PickingJobQtyAvailable qtyAvailable = pickingMobileApplication.getQtyAvailable(wfProcessId, getLoggedUserId());
+		return JsonPickingJobQtyAvailable.of(qtyAvailable);
 	}
 }

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonPickingJobQtyAvailable.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonPickingJobQtyAvailable.java
@@ -1,0 +1,63 @@
+package de.metas.picking.rest_api.json;
+
+import com.google.common.collect.ImmutableMap;
+import de.metas.handlingunits.picking.job.model.PickingJobLineId;
+import de.metas.handlingunits.picking.job.model.PickingJobLineQtyAvailable;
+import de.metas.handlingunits.picking.job.model.PickingJobQtyAvailable;
+import de.metas.handlingunits.picking.job.model.QtyAvailableStatus;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.util.Map;
+
+@Value
+@Builder
+@Jacksonized
+public class JsonPickingJobQtyAvailable
+{
+	@Nullable QtyAvailableStatus status;
+	@NonNull Map<PickingJobLineId, Line> lines;
+
+	public static JsonPickingJobQtyAvailable of(PickingJobQtyAvailable from)
+	{
+		return builder()
+				.status(from.getStatus())
+				.lines(from.getLines().stream()
+						.map(Line::of)
+						.collect(ImmutableMap.toImmutableMap(Line::getLineId, line -> line)))
+				.build();
+	}
+
+	//
+	//
+	//
+	//
+	//
+
+	@Value
+	@Builder
+	@Jacksonized
+	public static class Line
+	{
+		@NonNull PickingJobLineId lineId;
+		@Nullable QtyAvailableStatus status;
+		@NonNull String uom;
+		@NonNull BigDecimal qtyRemainingToPick;
+		@Nullable BigDecimal qtyAvailableToPick;
+
+		public static Line of(PickingJobLineQtyAvailable from)
+		{
+			return builder()
+					.lineId(from.getLineId())
+					.status(from.getStatus())
+					.uom(from.getUomSymbol())
+					.qtyRemainingToPick(from.getQtyRemainingToPick().toBigDecimal())
+					.qtyAvailableToPick(from.getQtyAvailableToPick() != null ? from.getQtyAvailableToPick().toBigDecimal() : null)
+					.build();
+		}
+	}
+}

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/DisplayValueProvider.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/DisplayValueProvider.java
@@ -27,7 +27,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import de.metas.bpartner.BPartnerLocationId;
-import de.metas.bpartner.service.IBPartnerDAO;
 import de.metas.document.location.RenderedAddressProvider;
 import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfile;
 import de.metas.handlingunits.picking.config.mobileui.PickingJobField;
@@ -37,6 +36,7 @@ import de.metas.handlingunits.picking.job.model.PickingJobCandidate;
 import de.metas.handlingunits.picking.job.model.PickingJobCandidateList;
 import de.metas.handlingunits.picking.job.model.PickingJobReference;
 import de.metas.handlingunits.picking.job.model.PickingJobReferenceList;
+import de.metas.handlingunits.picking.job.service.external.bpartner.PickingJobBPartnerService;
 import de.metas.i18n.ITranslatableString;
 import de.metas.i18n.TranslatableStrings;
 import de.metas.location.AddressDisplaySequence;
@@ -59,8 +59,8 @@ import java.util.Optional;
 
 public class DisplayValueProvider
 {
-	@NonNull private final IBPartnerDAO partnerDAO;
 	@NonNull private final IOrgDAO orgDAO;
+	@NonNull private final PickingJobBPartnerService bpartnerService;
 	@NonNull private final RenderedAddressProvider renderedAddressProvider;
 
 	@NonNull private final MobileUIPickingUserProfile profile;
@@ -69,15 +69,14 @@ public class DisplayValueProvider
 
 	@Builder
 	private DisplayValueProvider(
-			@NonNull final IBPartnerDAO partnerDAO,
 			@NonNull final IOrgDAO orgDAO,
-			@NonNull final RenderedAddressProvider renderedAddressProvider,
+			@NonNull final PickingJobBPartnerService bpartnerService,
 			//
 			@NonNull final MobileUIPickingUserProfile profile)
 	{
-		this.partnerDAO = partnerDAO;
 		this.orgDAO = orgDAO;
-		this.renderedAddressProvider = renderedAddressProvider;
+		this.bpartnerService = bpartnerService;
+		this.renderedAddressProvider = bpartnerService.newRenderedAddressProvider();
 		this.profile = profile;
 	}
 
@@ -121,7 +120,7 @@ public class DisplayValueProvider
 		final ImmutableSet<BPartnerLocationId> deliveryLocationIds = extractDeliveryLocationIds(contexts);
 
 		final ImmutableMap<BPartnerLocationId, I_C_BPartner_Location> locationsById = Maps.uniqueIndex(
-				partnerDAO.retrieveBPartnerLocationsByIds(deliveryLocationIds),
+				bpartnerService.getBPartnerLocationsByIds(deliveryLocationIds),
 				location -> BPartnerLocationId.ofRepoId(location.getC_BPartner_ID(), location.getC_BPartner_Location_ID())
 		);
 
@@ -317,7 +316,7 @@ public class DisplayValueProvider
 
 	private Optional<String> retrieveRuestplatz(final BPartnerLocationId deliveryLocationId)
 	{
-		return extractRuestplatz(partnerDAO.getBPartnerLocationByIdEvenInactive(deliveryLocationId));
+		return extractRuestplatz(bpartnerService.getBPartnerLocationByIdEvenInactive(deliveryLocationId));
 	}
 
 	private static Optional<String> extractRuestplatz(@Nullable final I_C_BPartner_Location location)

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/DisplayValueProviderService.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/DisplayValueProviderService.java
@@ -22,9 +22,8 @@
 
 package de.metas.picking.workflow;
 
-import de.metas.bpartner.service.IBPartnerDAO;
-import de.metas.document.location.IDocumentLocationBL;
 import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfile;
+import de.metas.handlingunits.picking.job.service.external.bpartner.PickingJobBPartnerService;
 import de.metas.organization.IOrgDAO;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -35,16 +34,14 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class DisplayValueProviderService
 {
-	private final IBPartnerDAO partnerDAO = Services.get(IBPartnerDAO.class);
 	private final IOrgDAO orgDAO = Services.get(IOrgDAO.class);
-	private final IDocumentLocationBL documentLocationBL;
+	private final PickingJobBPartnerService bpartnerService;
 
 	public DisplayValueProvider newDisplayValueProvider(@NonNull final MobileUIPickingUserProfile profile)
 	{
 		return DisplayValueProvider.builder()
-				.partnerDAO(partnerDAO)
 				.orgDAO(orgDAO)
-				.renderedAddressProvider(documentLocationBL.newRenderedAddressProvider())
+				.bpartnerService(bpartnerService)
 				//
 				.profile(profile)
 				//

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PickingJobRestService.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PickingJobRestService.java
@@ -37,6 +37,7 @@ import de.metas.handlingunits.picking.job.model.PickingJob;
 import de.metas.handlingunits.picking.job.model.PickingJobCandidate;
 import de.metas.handlingunits.picking.job.model.PickingJobId;
 import de.metas.handlingunits.picking.job.model.PickingJobLineId;
+import de.metas.handlingunits.picking.job.model.PickingJobQtyAvailable;
 import de.metas.handlingunits.picking.job.model.PickingJobQuery;
 import de.metas.handlingunits.picking.job.model.PickingJobReference;
 import de.metas.handlingunits.picking.job.model.PickingJobReferenceQuery;
@@ -52,7 +53,6 @@ import de.metas.user.UserId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
@@ -254,8 +254,13 @@ public class PickingJobRestService
 		return pickingJobService.getPickingSlotsSuggestions(pickingJob);
 	}
 
-	public PickingJob pickAll(final PickingJobId pickingJobId, final @NotNull UserId callerId)
+	public PickingJob pickAll(@NonNull final PickingJobId pickingJobId, final @NonNull UserId callerId)
 	{
 		return pickingJobService.pickAll(pickingJobId, callerId);
+	}
+
+	public PickingJobQtyAvailable getQtyAvailable(@NonNull final PickingJobId pickingJobId, final @NonNull UserId callerId)
+	{
+		return pickingJobService.getQtyAvailable(pickingJobId, callerId);
 	}
 }

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/PickingMobileApplication.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/PickingMobileApplication.java
@@ -31,7 +31,7 @@ import de.metas.document.engine.IDocument;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.picking.QtyRejectedReasonCode;
 import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfile;
-import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileRepository;
+import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileService;
 import de.metas.handlingunits.picking.config.mobileui.PickingJobAggregationType;
 import de.metas.handlingunits.picking.config.mobileui.PickingJobOptions;
 import de.metas.handlingunits.picking.job.model.LUPickingTarget;
@@ -109,21 +109,21 @@ public class PickingMobileApplication implements WorkflowBasedMobileApplication
 	private static final AdMessageKey MSG_Caption_ScanPickingSlot = AdMessageKey.of("mobileui.picking.activity.scanPickingSlot");
 	private static final AdMessageKey MSG_Caption_PickLines = AdMessageKey.of("mobileui.picking.activity.pickLines");
 
+	private final MobileUIPickingUserProfileService profileService;
 	private final PickingJobRestService pickingJobRestService;
 	private final PickingWorkflowLaunchersProvider wfLaunchersProvider;
 	private final DisplayValueProviderService displayValueProviderService;
-	private final MobileUIPickingUserProfileRepository mobileUIPickingUserProfileRepository;
 
 	public PickingMobileApplication(
+			@NonNull final MobileUIPickingUserProfileService profileService,
 			@NonNull final PickingJobRestService pickingJobRestService,
 			@NonNull final PickingWorkflowLaunchersProvider wfLaunchersProvider,
-			@NonNull final MobileUIPickingUserProfileRepository mobileUIPickingUserProfileRepository,
 			@NonNull final DisplayValueProviderService displayValueProviderService)
 	{
 		this.pickingJobRestService = pickingJobRestService;
 		this.wfLaunchersProvider = wfLaunchersProvider;
 		this.displayValueProviderService = displayValueProviderService;
-		this.mobileUIPickingUserProfileRepository = mobileUIPickingUserProfileRepository;
+		this.profileService = profileService;
 	}
 
 	@Override
@@ -132,7 +132,7 @@ public class PickingMobileApplication implements WorkflowBasedMobileApplication
 	@Override
 	public @NonNull MobileApplicationInfo customizeApplicationInfo(@NonNull final MobileApplicationInfo applicationInfo, @NonNull final UserId loggedUserId)
 	{
-		final MobileUIPickingUserProfile profile = mobileUIPickingUserProfileRepository.getProfile();
+		final MobileUIPickingUserProfile profile = profileService.getProfile();
 
 		return applicationInfo.toBuilder()
 				.requiresWorkplace(profile.isActiveWorkplaceRequired())
@@ -192,7 +192,7 @@ public class PickingMobileApplication implements WorkflowBasedMobileApplication
 	{
 		final PickingJob pickingJob = getPickingJob(wfProcess);
 
-		final MobileUIPickingUserProfile profile = mobileUIPickingUserProfileRepository.getProfile();
+		final MobileUIPickingUserProfile profile = profileService.getProfile();
 		final DisplayValueProvider displayValueProvider = displayValueProviderService.newDisplayValueProvider(profile);
 
 		final ImmutableList<WFProcessHeaderProperty> entries = profile.getDetailFieldsInOrder()
@@ -414,7 +414,7 @@ public class PickingMobileApplication implements WorkflowBasedMobileApplication
 
 	private PickingJob processStepEvents(@NonNull final PickingJob pickingJob, @NonNull final Collection<JsonPickingStepEvent> jsonEvents)
 	{
-		final PickingJobOptions pickingJobOptions = mobileUIPickingUserProfileRepository.getPickingJobOptions(pickingJob.getCustomerId());
+		final PickingJobOptions pickingJobOptions = profileService.getPickingJobOptions(pickingJob.getCustomerId());
 
 		final ImmutableList<PickingJobStepEvent> events = jsonEvents.stream()
 				.map(json -> fromJson(json, pickingJob, pickingJobOptions))

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/PickingMobileApplication.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/PickingMobileApplication.java
@@ -38,6 +38,7 @@ import de.metas.handlingunits.picking.job.model.LUPickingTarget;
 import de.metas.handlingunits.picking.job.model.PickingJob;
 import de.metas.handlingunits.picking.job.model.PickingJobId;
 import de.metas.handlingunits.picking.job.model.PickingJobLineId;
+import de.metas.handlingunits.picking.job.model.PickingJobQtyAvailable;
 import de.metas.handlingunits.picking.job.model.PickingJobStepEvent;
 import de.metas.handlingunits.picking.job.model.PickingJobStepEventType;
 import de.metas.handlingunits.picking.job.model.PickingJobStepId;
@@ -627,5 +628,11 @@ public class PickingMobileApplication implements WorkflowBasedMobileApplication
 		final PickingJobId pickingJobId = toPickingJobId(wfProcessId);
 		final PickingJob pickingJob = pickingJobRestService.pickAll(pickingJobId, callerId);
 		return toWFProcess(pickingJob);
+	}
+
+	public PickingJobQtyAvailable getQtyAvailable(final WFProcessId wfProcessId, final @NotNull UserId callerId)
+	{
+		final PickingJobId pickingJobId = toPickingJobId(wfProcessId);
+		return pickingJobRestService.getQtyAvailable(pickingJobId, callerId);
 	}
 }

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/lauchers/PickingWorkflowLaunchersProvider.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/lauchers/PickingWorkflowLaunchersProvider.java
@@ -20,6 +20,7 @@ import de.metas.handlingunits.picking.job.model.facets.PickingJobFacetGroup;
 import de.metas.handlingunits.picking.job.model.facets.PickingJobFacetHandlers;
 import de.metas.handlingunits.picking.job.model.facets.PickingJobFacets;
 import de.metas.handlingunits.picking.job.service.external.bpartner.PickingJobBPartnerService;
+import de.metas.handlingunits.picking.job.service.external.warehouse.PickingJobWarehouseService;
 import de.metas.i18n.AdMessageKey;
 import de.metas.picking.workflow.DisplayValueProvider;
 import de.metas.picking.workflow.DisplayValueProviderService;
@@ -39,7 +40,6 @@ import de.metas.workflow.rest_api.model.WorkflowLauncherIndicator;
 import de.metas.workflow.rest_api.model.WorkflowLaunchersList;
 import de.metas.workflow.rest_api.model.WorkflowLaunchersQuery;
 import de.metas.workplace.Workplace;
-import de.metas.workplace.WorkplaceService;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -69,7 +69,7 @@ public class PickingWorkflowLaunchersProvider
 	@NonNull private final MobileUIPickingUserProfileService configService;
 	@NonNull private final PickingJobBPartnerService bpartnerService;
 	@NonNull private final PickingJobRestService pickingJobRestService;
-	@NonNull private final WorkplaceService workplaceService;
+	@NonNull private final PickingJobWarehouseService warehouseService;
 	@NonNull private final DisplayValueProviderService displayValueProviderService;
 	@NonNull private final ScannedProductCodeResolver scannedProductCodeResolver;
 
@@ -101,7 +101,7 @@ public class PickingWorkflowLaunchersProvider
 	{
 		final MobileUIPickingUserProfile profile = configService.getProfile();
 		final UserId userId = query.getUserId();
-		final Workplace workplace = workplaceService.getWorkplaceByUserId(userId).orElse(null);
+		final Workplace workplace = warehouseService.getWorkplaceByUserId(userId).orElse(null);
 		boolean returnNoResult = false;
 
 		//noinspection RedundantIfStatement
@@ -202,7 +202,7 @@ public class PickingWorkflowLaunchersProvider
 	@Nullable
 	private ProductAvailableStocks createProductsAvailableStocksOrNull(@NonNull final Workplace workplace)
 	{
-		final Set<LocatorId> pickFromLocatorIds = workplaceService.getPickFromLocatorIds(workplace);
+		final Set<LocatorId> pickFromLocatorIds = warehouseService.getPickFromLocatorIds(workplace);
 		if (pickFromLocatorIds.isEmpty())
 		{
 			return null;
@@ -293,7 +293,7 @@ public class PickingWorkflowLaunchersProvider
 				PickingJobQuery.builder()
 						.userId(userId)
 						.onlyCustomerIds(profile.getPickOnlyCustomerIds())
-						.warehouseId(workplaceService.getWarehouseIdByUserId(userId).orElse(null))
+						.warehouseId(warehouseService.getWarehouseIdByUserId(userId).orElse(null))
 						.salesOrderDocumentNo(query.getFilterByDocumentNo())
 						//.facets(activeFacets) // IMPORTANT: don't filter by active facets because we want to collect all facets, not only the active ones
 						.build(),

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/lauchers/PickingWorkflowLaunchersProvider.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/lauchers/PickingWorkflowLaunchersProvider.java
@@ -3,7 +3,6 @@ package de.metas.picking.workflow.lauchers;
 import com.google.common.collect.ImmutableList;
 import de.metas.cache.CCache;
 import de.metas.common.util.time.SystemTime;
-import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfile;
 import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileService;
 import de.metas.handlingunits.picking.config.mobileui.PickingJobFieldType;
@@ -20,6 +19,8 @@ import de.metas.handlingunits.picking.job.model.facets.PickingJobFacetGroup;
 import de.metas.handlingunits.picking.job.model.facets.PickingJobFacetHandlers;
 import de.metas.handlingunits.picking.job.model.facets.PickingJobFacets;
 import de.metas.handlingunits.picking.job.service.external.bpartner.PickingJobBPartnerService;
+import de.metas.handlingunits.picking.job.service.external.hu.PickingJobHUService;
+import de.metas.handlingunits.picking.job.service.external.hu.ProductAvailableStocks;
 import de.metas.handlingunits.picking.job.service.external.warehouse.PickingJobWarehouseService;
 import de.metas.i18n.AdMessageKey;
 import de.metas.picking.workflow.DisplayValueProvider;
@@ -31,7 +32,6 @@ import de.metas.product.ScannedProductCodeResolver;
 import de.metas.rest_workflows.facets.WorkflowLaunchersFacetGroupList;
 import de.metas.rest_workflows.facets.WorkflowLaunchersFacetQuery;
 import de.metas.user.UserId;
-import de.metas.util.Services;
 import de.metas.workflow.rest_api.model.WFProcessId;
 import de.metas.workflow.rest_api.model.WorkflowLauncher;
 import de.metas.workflow.rest_api.model.WorkflowLauncherCaption;
@@ -46,7 +46,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.util.lang.SynchronizedMutable;
-import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
@@ -55,7 +54,6 @@ import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import static de.metas.picking.workflow.handlers.PickingMobileApplication.APPLICATION_ID;
 
@@ -65,11 +63,11 @@ public class PickingWorkflowLaunchersProvider
 {
 	private static final AdMessageKey INVALID_QR_CODE_ERROR_MSG = AdMessageKey.of("mobileui.picking.INVALID_QR_CODE_ERROR_MSG");
 
-	@NonNull private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
 	@NonNull private final MobileUIPickingUserProfileService configService;
 	@NonNull private final PickingJobBPartnerService bpartnerService;
 	@NonNull private final PickingJobRestService pickingJobRestService;
 	@NonNull private final PickingJobWarehouseService warehouseService;
+	@NonNull private final PickingJobHUService huService;
 	@NonNull private final DisplayValueProviderService displayValueProviderService;
 	@NonNull private final ScannedProductCodeResolver scannedProductCodeResolver;
 
@@ -120,7 +118,7 @@ public class PickingWorkflowLaunchersProvider
 			}
 		}
 
-		final ProductAvailableStocks productsAvailableStocks = workplace != null ? createProductsAvailableStocksOrNull(workplace) : null;
+		final ProductAvailableStocks productsAvailableStocks = workplace != null ? huService.newAvailableStocksProvider(workplace) : null;
 
 		final ArrayList<WorkflowLauncher> currentResult = new ArrayList<>();
 
@@ -197,21 +195,6 @@ public class PickingWorkflowLaunchersProvider
 		}
 
 		return toComputedWorkflowLaunchers(query, currentResult);
-	}
-
-	@Nullable
-	private ProductAvailableStocks createProductsAvailableStocksOrNull(@NonNull final Workplace workplace)
-	{
-		final Set<LocatorId> pickFromLocatorIds = warehouseService.getPickFromLocatorIds(workplace);
-		if (pickFromLocatorIds.isEmpty())
-		{
-			return null;
-		}
-
-		return ProductAvailableStocks.builder()
-				.handlingUnitsBL(handlingUnitsBL)
-				.pickFromLocatorIds(pickFromLocatorIds)
-				.build();
 	}
 
 	@NotNull

--- a/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/lauchers/PickingWorkflowLaunchersProviderTest.java
+++ b/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/lauchers/PickingWorkflowLaunchersProviderTest.java
@@ -51,7 +51,7 @@ class PickingWorkflowLaunchersProviderTest
 				helper.configService,
 				helper.bpartnerService,
 				new PickingJobRestService(helper.pickingJobService, helper.configService),
-				helper.workplaceService,
+				helper.warehouseService,
 				new DisplayValueProviderService(helper.documentLocationBL),
 				new ScannedProductCodeResolver(new EDIProductLookupService())
 		);

--- a/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/lauchers/PickingWorkflowLaunchersProviderTest.java
+++ b/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/lauchers/PickingWorkflowLaunchersProviderTest.java
@@ -52,7 +52,8 @@ class PickingWorkflowLaunchersProviderTest
 				helper.bpartnerService,
 				new PickingJobRestService(helper.pickingJobService, helper.configService),
 				helper.warehouseService,
-				new DisplayValueProviderService(helper.documentLocationBL),
+				helper.huService,
+				new DisplayValueProviderService(helper.bpartnerService),
 				new ScannedProductCodeResolver(new EDIProductLookupService())
 		);
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/picking.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/picking.js
@@ -156,3 +156,9 @@ export const getScannedHUQRCodeInfo = ({ qrCode }) => {
     .get(toUrl(`${apiBasePath}/picking/hu/byScannedCode`, { scannedCode: qrCode }))
     .then((response) => unboxAxiosResponse(response));
 };
+
+export const getQtyAvailable = ({ wfProcessId }) => {
+  return axios
+    .get(`${apiBasePath}/picking/job/${wfProcessId}/qtyAvailable`)
+    .then((response) => unboxAxiosResponse(response));
+};

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/constants/QtyAvailableStatus.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/constants/QtyAvailableStatus.js
@@ -1,0 +1,6 @@
+// note to dev: keep in sync with de.metas.handlingunits.picking.job.model.QtyAvailableStatus
+export const QtyAvailableStatus = Object.freeze({
+  NOT_AVAILABLE: 'NOT_AVAILABLE',
+  PARTIALLY_AVAILABLE: 'PARTIALLY_AVAILABLE',
+  FULLY_AVAILABLE: 'FULLY_AVAILABLE',
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickProductsActivity.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickProductsActivity.jsx
@@ -32,13 +32,19 @@ import { updateWFProcess } from '../../../actions/WorkflowActions';
 import { toastErrorFromObj } from '../../../utils/toast';
 import { trl } from '../../../utils/translations';
 import { useApplicationInfoParameters } from '../../../reducers/applications';
+import { usePickingJobQtyAvailable } from './usePickingJobQtyAvailable';
+import { QtyAvailableStatus } from '../../../constants/QtyAvailableStatus';
 
 export const COMPONENTTYPE_PickProducts = 'picking/pickProducts';
 
 const PickProductsActivity = ({ applicationId, wfProcessId, activityId, activity }) => {
   const history = useMobileNavigation();
   const dispatch = useDispatch();
+
   const { allowQuickPackAll } = useApplicationInfoParameters({ applicationId });
+  const qtyAvailable = usePickingJobQtyAvailable({ wfProcessId, enabled: allowQuickPackAll });
+  const isShowQuickPackAllButton = allowQuickPackAll && qtyAvailable?.status === QtyAvailableStatus.FULLY_AVAILABLE;
+
   const { onBarcodeScanned } = usePickProductsScan({ applicationId, wfProcessId, activityId });
 
   const isUserEditable = isUserEditableFunc({ activity });
@@ -117,7 +123,7 @@ const PickProductsActivity = ({ applicationId, wfProcessId, activityId, activity
           );
         })}
 
-      {allowQuickPackAll && (
+      {isShowQuickPackAllButton && (
         <ButtonWithIndicator
           testId={'pickAll-button'}
           caption={trl('activities.picking.pickAll')}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/usePickingJobQtyAvailable.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/usePickingJobQtyAvailable.js
@@ -1,0 +1,12 @@
+import { useQuery } from '../../../hooks/useQuery';
+import { getQtyAvailable } from '../../../api/picking';
+
+export const usePickingJobQtyAvailable = ({ wfProcessId, enabled }) => {
+  const { isPending, data } = useQuery({
+    enabled,
+    queryKey: [wfProcessId],
+    queryFn: () => getQtyAvailable({ wfProcessId }),
+  });
+
+  return enabled && !isPending ? data : null;
+};


### PR DESCRIPTION
- **Replace `MobileUIPickingUserProfileRepository` usage with `MobileUIPickingUserProfileService` globally.**
- **Refactor `WorkplaceService` usage, replacing it with `PickingJobWarehouseService`.**
- **Refactor BPartner and PickingJob services to streamline location handling and dependency management.**
- **Introduce `PickingJobQtyAvailable` and refactor related services to streamline quantity availability handling.**
- **Introduce `QtyAvailableStatus` sync between backend and frontend, and add logic to conditionally display Quick Pack All button.**
