### PR TITLE
Fix bug where *all* M_ShippingPackages were returned although the caller expected just packages with orderlines

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationRepository.java
@@ -18,6 +18,7 @@ import de.metas.sscc18.SSCC18;
 import de.metas.uom.UomId;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.ad.dao.ConstantQueryFilter;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -186,6 +187,12 @@ public class PurchaseOrderToShipperTransportationRepository
 
 	private IQueryBuilder<I_M_ShippingPackage> toShippingPackageQueryBuilder(final @NonNull ShippingPackageQuery query)
 	{
+		if(query.getOrderIds().isEmpty() && query.getOrderLineIds().isEmpty())
+		{
+			return queryBL.createQueryBuilder(I_M_ShippingPackage.class)
+					.filter(ConstantQueryFilter.of(false));
+		}
+
 		final IQueryBuilder<I_M_ShippingPackage> builder = queryBL.createQueryBuilder(I_M_ShippingPackage.class)
 				.addOnlyActiveRecordsFilter();
 

--- a/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationService.java
@@ -60,6 +60,7 @@ import org.springframework.stereotype.Service;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -114,11 +115,6 @@ public class PurchaseOrderToShipperTransportationService
 			Loggables.addLog("Adding purchase order with ID: {} to shipper transportation with ID: {}", purchaseOrderId, shipperTransportationId);
 			addPurchaseOrderToShipperTransportation(purchaseOrderId, shipperTransportationId);
 		}
-	}
-
-	private boolean isOrderNotOnShipperTransportation(@NonNull final OrderId orderId)
-	{
-		return !repo.anyMatch(ShippingPackageQuery.builder().orderId(orderId).build());
 	}
 
 	public void addOrderLinesToShipperTransportation(@NonNull final ShipperTransportationId shipperTransportationId, @NonNull final Collection<OrderAndLineId> orderAndLineIds)
@@ -201,8 +197,10 @@ public class PurchaseOrderToShipperTransportationService
 
 		final Collection<OrderAndLineId> assignedOrderAndLineIds = repo.getBy(ShippingPackageQuery.builder().orderLineIds(orderLineIds).build())
 				.stream()
-				.map(sp -> OrderAndLineId.ofRepoIds(sp.getC_Order_ID(), sp.getC_OrderLine_ID()))
+				.map(sp -> OrderAndLineId.ofRepoIdsOrNull(sp.getC_Order_ID(), sp.getC_OrderLine_ID()))
+				.filter(Objects::nonNull)
 				.collect(Collectors.toSet());
+		
 		return orderAndLineIdToPoMap.keySet()
 				.stream()
 				.filter(olId -> !assignedOrderAndLineIds.contains(olId))

--- a/backend/de.metas.business/src/main/java/de/metas/shipping/ShippingPackageQuery.java
+++ b/backend/de.metas.business/src/main/java/de/metas/shipping/ShippingPackageQuery.java
@@ -35,13 +35,6 @@ import java.util.Collection;
 @Builder
 public class ShippingPackageQuery
 {
-	private static final ShippingPackageQuery ANY = builder().build();
-
 	@NonNull @Singular Collection<OrderId> orderIds;
 	@NonNull @Singular Collection<OrderLineId> orderLineIds;
-
-	public boolean isAny()
-	{
-		return this.equals(ANY);
-	}
 }


### PR DESCRIPTION
Solutions:
- add empty query filter to `toShippingPackageQueryBuilder`.
- filter out packages that don'z have both the orderlineId and orderId set

Also remove
- unused `ANY` constant and `isAny()` method from `ShippingPackageQuery`;
- unused method PurchaseOrderToShipperTransportationService.isOrderNotOnShipperTransportation