### PR TITLE
Fix unique index for `c_bpartner_stats` table

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5778920_c_bpartner_stats_c_bpartner_id_unique.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5778920_c_bpartner_stats_c_bpartner_id_unique.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS c_bpartner_stats_c_bpartner_id_unique
+;
+
+CREATE UNIQUE INDEX c_bpartner_stats_c_bpartner_id_unique ON c_bpartner_stats (c_bpartner_id)
+;


### PR DESCRIPTION
### Summary

This PR addresses the unique index issue for the `c_bpartner_stats` table by removing the `isActive='Y'` where clause, ensuring proper indexing without conditional constraints.

### Changes Made

- Updated the `c_bpartner_stats_c_bpartner_id_unique` index to exclude the restrictive `isActive='Y'`.
