### PR TITLE
mobile ui bugfix: consider isScheduledForWorkplaceOnly when fetching facets

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5778930_PickingProfile_Filter_UQ.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5778930_PickingProfile_Filter_UQ.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS PickingProfile_Filter_UQ
+;
+
+CREATE UNIQUE INDEX PickingProfile_Filter_UQ ON PickingProfile_Filter (mobileui_userprofile_picking_id, filtertype)
+;
+

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/JsonCreateMasterdataRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/JsonCreateMasterdataRequest.java
@@ -18,7 +18,6 @@ import de.metas.frontend_testing.masterdata.user.JsonLoginUserRequest;
 import de.metas.frontend_testing.masterdata.warehouse.JsonWarehouseRequest;
 import de.metas.frontend_testing.masterdata.workplace.JsonWorkplaceRequest;
 import lombok.Builder;
-import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/JsonCreateMasterdataResponse.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/JsonCreateMasterdataResponse.java
@@ -6,7 +6,6 @@ import de.metas.frontend_testing.masterdata.dd_order.JsonDDOrderResponse;
 import de.metas.frontend_testing.masterdata.hu.JsonCreateHUResponse;
 import de.metas.frontend_testing.masterdata.hu.JsonPackingInstructionsResponse;
 import de.metas.frontend_testing.masterdata.huQRCodes.JsonGenerateHUQRCodeResponse;
-import de.metas.frontend_testing.masterdata.inventory.JsonInventoryRequest;
 import de.metas.frontend_testing.masterdata.inventory.JsonInventoryResponse;
 import de.metas.frontend_testing.masterdata.mobile_configuration.JsonMobileConfigResponse;
 import de.metas.frontend_testing.masterdata.picking_slot.JsonPickingSlotCreateResponse;

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/JsonMobileConfigRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/JsonMobileConfigRequest.java
@@ -4,6 +4,7 @@ import de.metas.frontend_testing.masterdata.Identifier;
 import de.metas.handlingunits.picking.config.mobileui.PickAttribute;
 import de.metas.handlingunits.picking.config.mobileui.PickToStructure;
 import de.metas.handlingunits.picking.config.mobileui.PickingJobAggregationType;
+import de.metas.handlingunits.picking.job.model.facets.PickingJobFacetGroup;
 import de.metas.handlingunits.picking.job.service.CreateShipmentPolicy;
 import de.metas.mobile.MobileAuthMethod;
 import lombok.Builder;
@@ -59,6 +60,8 @@ public class JsonMobileConfigRequest
 		@Nullable Boolean allowQuickPackAll;
 
 		@Nullable List<Customer> customers;
+		
+		@Nullable List<PickingJobFacetGroup> filters;
 
 		@Value
 		@Builder

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/JsonMobileConfigResponse.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/JsonMobileConfigResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import de.metas.handlingunits.picking.config.mobileui.PickAttribute;
 import de.metas.handlingunits.picking.config.mobileui.PickToStructure;
 import de.metas.handlingunits.picking.config.mobileui.PickingJobAggregationType;
+import de.metas.handlingunits.picking.job.model.facets.PickingJobFacetGroup;
 import de.metas.handlingunits.picking.job.service.CreateShipmentPolicy;
 import de.metas.mobile.MobileAuthMethod;
 import lombok.Builder;
@@ -11,6 +12,7 @@ import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Set;
 
 @Value
@@ -47,6 +49,8 @@ public class JsonMobileConfigResponse
 		@Nullable Boolean displayPickingSlotSuggestions;
 		@Nullable Boolean activeWorkplaceRequired;
 		@Nullable Boolean considerOnlyJobScheduledToWorkplace;
+
+		@Nullable List<PickingJobFacetGroup> filters;
 	}
 
 	//

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigPickingCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigPickingCommand.java
@@ -11,9 +11,13 @@ import de.metas.handlingunits.picking.config.mobileui.PickAttributesConfig;
 import de.metas.handlingunits.picking.config.mobileui.PickToStructure;
 import de.metas.handlingunits.picking.config.mobileui.PickingCustomerConfig;
 import de.metas.handlingunits.picking.config.mobileui.PickingCustomerConfigsCollection;
+import de.metas.handlingunits.picking.config.mobileui.PickingFilter;
+import de.metas.handlingunits.picking.config.mobileui.PickingFiltersList;
 import de.metas.handlingunits.picking.config.mobileui.PickingJobOptions;
+import de.metas.handlingunits.picking.job.model.facets.PickingJobFacetGroup;
 import de.metas.util.OptionalBoolean;
 import de.metas.util.collections.CollectionUtils;
+import de.metas.util.lang.SeqNoProvider;
 import lombok.Builder;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
@@ -38,6 +42,7 @@ class MobileConfigPickingCommand
 			final MobileUIPickingUserProfile.MobileUIPickingUserProfileBuilder newProfileBuilder = profile.toBuilder()
 					.defaultPickingJobOptions(updatePickingJobOptions(profile.getDefaultPickingJobOptions(), request))
 					.customerConfigs(updatePickingCustomers(profile.getCustomerConfigs(), request.getCustomers()))
+					.filters(toPickingFiltersList(request.getFilters()))
 					.isFilterByBarcode(request.getFilterByQRCode() != null && request.getFilterByQRCode())
 					.isActiveWorkplaceRequired(request.getActiveWorkplaceRequired() != null ? request.getActiveWorkplaceRequired() : false)
 					.isConsiderOnlyJobScheduledToWorkplace(request.getConsiderOnlyJobScheduledToWorkplace() != null ? request.getConsiderOnlyJobScheduledToWorkplace() : false)
@@ -80,6 +85,7 @@ class MobileConfigPickingCommand
 				.displayPickingSlotSuggestions(profile.getDefaultPickingJobOptions().getDisplayPickingSlotSuggestions().toBooleanOrNull())
 				.activeWorkplaceRequired(profile.isActiveWorkplaceRequired())
 				.considerOnlyJobScheduledToWorkplace(profile.isConsiderOnlyJobScheduledToWorkplace())
+				.filters(profile.getFilterGroupsInOrder())
 				.build();
 	}
 
@@ -203,5 +209,24 @@ class MobileConfigPickingCommand
 				.execute();
 
 		return PickingCustomerConfigsCollection.ofCollection(result);
+	}
+
+	private PickingFiltersList toPickingFiltersList(@Nullable final List<PickingJobFacetGroup> filters)
+	{
+		if (filters == null)
+		{
+			return PickingFiltersList.DEFAULT;
+		}
+		else if (filters.isEmpty())
+		{
+			return PickingFiltersList.EMPTY;
+		}
+		else
+		{
+			final SeqNoProvider seqNoProvider = SeqNoProvider.ofInt(10);
+			return filters.stream()
+					.map(filter -> PickingFilter.of(filter, seqNoProvider.getAndIncrement().toInt()))
+					.collect(PickingFiltersList.collect());
+		}
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfile.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfile.java
@@ -55,10 +55,7 @@ public class MobileUIPickingUserProfile
 					.isAllowCompletingPartialPickingJob(true)
 					.isShowLastPickedBestBeforeDateForLines(false)
 					.build())
-			.filters(PickingFiltersList.ofList(ImmutableList.of(
-					PickingFilter.of(PickingJobFacetGroup.CUSTOMER, 10),
-					PickingFilter.of(PickingJobFacetGroup.DELIVERY_DATE, 20)))
-			)
+			.filters(PickingFiltersList.DEFAULT)
 			.fields(ImmutableList.of(
 					PickingJobField.builder()
 							.seqNo(10)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepository.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepository.java
@@ -32,6 +32,7 @@ import de.metas.picking.model.I_PickingProfile_PickingJobConfig;
 import de.metas.util.GuavaCollectors;
 import de.metas.util.OptionalBoolean;
 import de.metas.util.Services;
+import de.metas.util.lang.SeqNoProvider;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -212,49 +213,65 @@ public class MobileUIPickingUserProfileRepository
 
 	private void save(@NonNull final MobileUIPickingUserProfile profile)
 	{
-		//
-		// Header record
-		final MobileUIPickingUserProfileId profileId;
-		{
-			I_MobileUI_UserProfile_Picking profileRecord = retrieveProfileRecord();
-			if (profileRecord == null)
-			{
-				profileRecord = InterfaceWrapperHelper.newInstance(I_MobileUI_UserProfile_Picking.class);
-			}
-			profileRecord.setIsActive(true);
-			profileRecord.setName(profile.getName());
-			profileRecord.setIsAllowAnyCustomer(profile.isAllowPickingAnyCustomer());
-			profileRecord.setIsFilterByBarcode(profile.isFilterByBarcode());
-			profileRecord.setIsActiveWorkplaceRequired(profile.isActiveWorkplaceRequired());
-			profileRecord.setIsConsideredOnlyScheduledJobs(profile.isConsiderOnlyJobScheduledToWorkplace());
-			profileRecord.setIsAllowQuickPackAll(profile.isAllowQuickPackAll());
-			updateRecord(profileRecord, profile.getDefaultPickingJobOptions());
-			InterfaceWrapperHelper.saveRecord(profileRecord);
-			profileId = MobileUIPickingUserProfileId.ofRepoId(profileRecord.getMobileUI_UserProfile_Picking_ID());
-		}
-
-		//
-		// BPartner configs
-		save_BPartnerConfigs(profile, profileId);
+		final MobileUIPickingUserProfileId profileId = save_Header(profile);
+		save_CustomerConfigs(profile.getCustomerConfigs(), profileId);
+		save_Filters(profile.getFilterGroupsInOrder(), profileId);
 	}
 
-	private void save_BPartnerConfigs(final @NonNull MobileUIPickingUserProfile profile, final MobileUIPickingUserProfileId profileId)
+	@NonNull
+	private MobileUIPickingUserProfileId save_Header(final @NotNull MobileUIPickingUserProfile profile)
+	{
+		I_MobileUI_UserProfile_Picking profileRecord = retrieveProfileRecord();
+		if (profileRecord == null)
+		{
+			profileRecord = InterfaceWrapperHelper.newInstance(I_MobileUI_UserProfile_Picking.class);
+		}
+		updateRecord(profileRecord, profile);
+		InterfaceWrapperHelper.saveRecord(profileRecord);
+
+		return MobileUIPickingUserProfileId.ofRepoId(profileRecord.getMobileUI_UserProfile_Picking_ID());
+	}
+
+	private void save_CustomerConfigs(@NonNull final PickingCustomerConfigsCollection customerConfigs, final MobileUIPickingUserProfileId profileId)
 	{
 		final HashMap<BPartnerId, I_MobileUI_UserProfile_Picking_BPartner> profileBPartnerRecords = streamProfileBPartnerRecords(profileId)
 				.collect(GuavaCollectors.toHashMapByKey(MobileUIPickingUserProfileRepository::extractBPartnerId));
-		for (final PickingCustomerConfig bpartnerConfig : profile.getCustomerConfigs())
+		for (final PickingCustomerConfig customerConfig : customerConfigs)
 		{
-			I_MobileUI_UserProfile_Picking_BPartner bpartnerConfigRecord = profileBPartnerRecords.remove(bpartnerConfig.getCustomerId());
+			I_MobileUI_UserProfile_Picking_BPartner bpartnerConfigRecord = profileBPartnerRecords.remove(customerConfig.getCustomerId());
 			if (bpartnerConfigRecord == null)
 			{
 				bpartnerConfigRecord = InterfaceWrapperHelper.newInstance(I_MobileUI_UserProfile_Picking_BPartner.class);
 				bpartnerConfigRecord.setMobileUI_UserProfile_Picking_ID(profileId.getRepoId());
 			}
-			updateRecord(bpartnerConfigRecord, bpartnerConfig);
+			updateRecord(bpartnerConfigRecord, customerConfig);
 			InterfaceWrapperHelper.saveRecord(bpartnerConfigRecord);
 		}
 
 		InterfaceWrapperHelper.deleteAll(profileBPartnerRecords.values());
+	}
+
+	private void save_Filters(@NonNull final ImmutableList<PickingJobFacetGroup> filterGroupsInOrder, final MobileUIPickingUserProfileId profileId)
+	{
+		final HashMap<PickingJobFacetGroup, I_PickingProfile_Filter> filterRecords = streamFilterRecords(profileId)
+				.collect(GuavaCollectors.toHashMapByKey(MobileUIPickingUserProfileRepository::extractPickingJobFacetGroup));
+		final SeqNoProvider seqNoProvider = SeqNoProvider.ofInt(10);
+		for (final PickingJobFacetGroup filterGroup : filterGroupsInOrder)
+		{
+			I_PickingProfile_Filter filterRecord = filterRecords.remove(filterGroup);
+			if (filterRecord == null)
+			{
+				filterRecord = InterfaceWrapperHelper.newInstance(I_PickingProfile_Filter.class);
+				filterRecord.setMobileUI_UserProfile_Picking_ID(profileId.getRepoId());
+			}
+			filterRecord.setIsActive(true);
+			filterRecord.setSeqNo(seqNoProvider.getAndIncrement().toInt());
+			filterRecord.setFilterType(filterGroup.getCode());
+			InterfaceWrapperHelper.saveRecord(filterRecord);
+		}
+
+		InterfaceWrapperHelper.deleteAll(filterRecords.values());
+
 	}
 
 	private static void updateRecord(@NonNull final I_MobileUI_UserProfile_Picking_BPartner record, @NonNull final PickingCustomerConfig from)
@@ -262,6 +279,18 @@ public class MobileUIPickingUserProfileRepository
 		record.setIsActive(true);
 		record.setC_BPartner_ID(from.getCustomerId().getRepoId());
 		record.setMobileUI_UserProfile_Picking_Job_ID(PickingJobOptionsId.toRepoId(from.getPickingJobOptionsId()));
+	}
+
+	private static void updateRecord(final I_MobileUI_UserProfile_Picking record, final @NonNull MobileUIPickingUserProfile from)
+	{
+		record.setIsActive(true);
+		record.setName(from.getName());
+		record.setIsAllowAnyCustomer(from.isAllowPickingAnyCustomer());
+		record.setIsFilterByBarcode(from.isFilterByBarcode());
+		record.setIsActiveWorkplaceRequired(from.isActiveWorkplaceRequired());
+		record.setIsConsideredOnlyScheduledJobs(from.isConsiderOnlyJobScheduledToWorkplace());
+		record.setIsAllowQuickPackAll(from.isAllowQuickPackAll());
+		updateRecord(record, from.getDefaultPickingJobOptions());
 	}
 
 	private static void updateRecord(@NonNull final I_MobileUI_UserProfile_Picking record, @NonNull final PickingJobOptions from)
@@ -286,7 +315,7 @@ public class MobileUIPickingUserProfileRepository
 		record.setPickingLineSortBy(from.getPickingLineSortBy().map(PickingLineSortBy::getCode).orElse(null));
 	}
 
-	private static void updateRecord(final @NotNull I_MobileUI_UserProfile_Picking record, final AllowedPickToStructures from)
+	private static void updateRecord(final @NonNull I_MobileUI_UserProfile_Picking record, final AllowedPickToStructures from)
 	{
 		record.setAllowPickToStructure_LU_TU(from.isStrictlyAllowed(PickToStructure.LU_TU));
 		record.setAllowPickToStructure_TU(from.isStrictlyAllowed(PickToStructure.TU));
@@ -294,7 +323,7 @@ public class MobileUIPickingUserProfileRepository
 		record.setAllowPickToStructure_CU(from.isStrictlyAllowed(PickToStructure.CU));
 	}
 
-	private static void updateRecord(final @NotNull I_MobileUI_UserProfile_Picking record, final PickAttributesConfig from)
+	private static void updateRecord(final @NonNull I_MobileUI_UserProfile_Picking record, final PickAttributesConfig from)
 	{
 		record.setBestBeforeDate(from.isReadAttribute(PickAttribute.BestBeforeDate));
 		record.setLotNumber(from.isReadAttribute(PickAttribute.LotNo));
@@ -303,13 +332,23 @@ public class MobileUIPickingUserProfileRepository
 	@NonNull
 	private PickingFiltersList retrieveFilters(@NonNull final MobileUIPickingUserProfileId profileId)
 	{
+		return streamFilterRecords(profileId)
+				.map(record -> PickingFilter.of(extractPickingJobFacetGroup(record), record.getSeqNo()))
+				.collect(PickingFiltersList.collect());
+	}
+
+	private static @NonNull PickingJobFacetGroup extractPickingJobFacetGroup(final I_PickingProfile_Filter record)
+	{
+		return PickingJobFacetGroup.ofCode(record.getFilterType());
+	}
+
+	private Stream<I_PickingProfile_Filter> streamFilterRecords(final @NonNull MobileUIPickingUserProfileId profileId)
+	{
 		return queryBL.createQueryBuilder(I_PickingProfile_Filter.class)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_PickingProfile_Filter.COLUMNNAME_MobileUI_UserProfile_Picking_ID, profileId)
 				.create()
-				.stream()
-				.map(record -> PickingFilter.of(PickingJobFacetGroup.ofCode(record.getFilterType()), record.getSeqNo()))
-				.collect(PickingFiltersList.collect());
+				.stream();
 	}
 
 	@NonNull

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/PickingFiltersList.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/PickingFiltersList.java
@@ -41,6 +41,11 @@ public class PickingFiltersList
 {
 	public static final PickingFiltersList EMPTY = new PickingFiltersList(ImmutableList.of());
 
+	public static final PickingFiltersList DEFAULT = new PickingFiltersList(ImmutableList.of(
+			PickingFilter.of(PickingJobFacetGroup.CUSTOMER, 10),
+			PickingFilter.of(PickingJobFacetGroup.DELIVERY_DATE, 20)
+	));
+
 	@NonNull @Getter private final ImmutableList<PickingJobFacetGroup> groupsInOrder;
 	@NonNull private final ImmutableMap<PickingJobFacetGroup, PickingFilter> filtersByGroup;
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobQuery.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobQuery.java
@@ -35,6 +35,7 @@ import de.metas.handlingunits.picking.job.model.facets.PickingJobFacetHandlers;
 import de.metas.picking.api.PackageableQuery;
 import de.metas.picking.api.PackageableQuery.PackageableQueryBuilder;
 import de.metas.picking.api.ShipmentScheduleAndJobScheduleIdSet;
+import de.metas.picking.job_schedule.model.PickingJobScheduleQuery;
 import de.metas.product.ResolvedScannedProductCodes;
 import de.metas.user.UserId;
 import de.metas.workplace.WorkplaceId;
@@ -44,6 +45,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Singular;
 import lombok.Value;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.warehouse.WarehouseId;
 
 import javax.annotation.Nullable;
@@ -99,11 +101,6 @@ public class PickingJobQuery
 		return facets != null ? facets.getHandoverLocationIds() : ImmutableSet.of();
 	}
 
-	public PackageableQuery toPackageableQuery()
-	{
-		return toPackageableQueryBuilder().build();
-	}
-
 	public PackageableQueryBuilder toPackageableQueryBuilder()
 	{
 		final PackageableQueryBuilder builder = PackageableQuery.builder()
@@ -146,7 +143,26 @@ public class PickingJobQuery
 		{
 			builder.warehouseId(workplaceWarehouseId);
 		}
+
 		return builder;
+	}
+
+	public PickingJobScheduleQuery toPickingJobScheduleQuery()
+	{
+		if (this.scheduledForWorkplaceId == null)
+		{
+			throw new AdempiereException("Expected query to have scheduledForWorkplaceId set");
+		}
+
+		return PickingJobScheduleQuery.builder()
+				.workplaceId(this.scheduledForWorkplaceId)
+				.excludeJobScheduleIds(this.excludeScheduleIds.getJobScheduleIds())
+				.build();
+	}
+
+	public boolean isScheduledForWorkplaceOnly()
+	{
+		return this.scheduledForWorkplaceId != null;
 	}
 
 	//

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/facets/PickingJobFacetGroup.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/facets/PickingJobFacetGroup.java
@@ -22,6 +22,8 @@
 
 package de.metas.handlingunits.picking.job.model.facets;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import de.metas.ad_reference.ReferenceId;
 import de.metas.rest_workflows.facets.WorkflowLaunchersFacetGroupId;
 import de.metas.util.lang.ReferenceListAwareEnum;
@@ -58,6 +60,7 @@ public enum PickingJobFacetGroup implements ReferenceListAwareEnum
 	}
 
 	@NonNull
+	@JsonCreator
 	public static PickingJobFacetGroup ofCode(@NonNull final String code)
 	{
 		return index.ofCode(code);
@@ -70,4 +73,7 @@ public enum PickingJobFacetGroup implements ReferenceListAwareEnum
 	}
 
 	public static boolean equals(@Nullable PickingJobFacetGroup group1, @Nullable PickingJobFacetGroup group2) {return Objects.equals(group1, group2);}
+
+	@JsonValue
+	public String toJson() {return getCode();}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
@@ -59,6 +59,7 @@ import de.metas.inout.ShipmentScheduleId;
 import de.metas.order.OrderId;
 import de.metas.picking.api.Packageable;
 import de.metas.picking.api.PickingSlotId;
+import de.metas.picking.job_schedule.model.PickingJobScheduleCollection;
 import de.metas.picking.qrcode.PickingSlotQRCode;
 import de.metas.product.ProductId;
 import de.metas.user.UserId;
@@ -232,7 +233,27 @@ public class PickingJobService implements PickingSlotListener
 	@NonNull
 	public Stream<Packageable> streamPackageable(@NonNull final PickingJobQuery query)
 	{
-		return shipmentScheduleService.stream(query.toPackageableQuery());
+		final Set<ShipmentScheduleId> onlyShipmentScheduleIds;
+		if (query.isScheduledForWorkplaceOnly())
+		{
+			final PickingJobScheduleCollection jobSchedules = pickingJobScheduleService.list(query.toPickingJobScheduleQuery());
+			if (jobSchedules.isEmpty())
+			{
+				return Stream.of();
+			}
+
+			onlyShipmentScheduleIds = jobSchedules.getShipmentScheduleIds();
+		}
+		else
+		{
+			onlyShipmentScheduleIds = null;
+		}
+
+		return shipmentScheduleService.stream(
+				query.toPackageableQueryBuilder()
+						.onlyShipmentScheduleIds(onlyShipmentScheduleIds)
+						.build()
+		);
 	}
 
 	public ADRefList getQtyRejectedReasons()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/retrieve/PickingJobCandidateRetrieveCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/retrieve/PickingJobCandidateRetrieveCommand.java
@@ -1,8 +1,6 @@
 package de.metas.handlingunits.picking.job.service.commands.retrieve;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileService;
 import de.metas.handlingunits.picking.config.mobileui.PickingJobAggregationType;
 import de.metas.handlingunits.picking.job.model.PickingJobCandidate;
@@ -14,7 +12,7 @@ import de.metas.handlingunits.picking.job_schedule.service.PickingJobScheduleSer
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.picking.api.Packageable;
 import de.metas.picking.job_schedule.model.PickingJobSchedule;
-import de.metas.picking.job_schedule.model.PickingJobScheduleQuery;
+import de.metas.picking.job_schedule.model.PickingJobScheduleCollection;
 import lombok.Builder;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
@@ -22,6 +20,8 @@ import org.adempiere.exceptions.AdempiereException;
 import javax.annotation.Nullable;
 import java.util.LinkedHashMap;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 @Builder
@@ -39,7 +39,7 @@ public class PickingJobCandidateRetrieveCommand
 
 	//
 	// State
-	@Nullable ImmutableMap<ShipmentScheduleId, PickingJobSchedule> _onlyPickingJobSchedules; // lazy
+	@Nullable private PickingJobScheduleCollection _onlyPickingJobSchedules; // lazy
 	@NonNull private final LinkedHashMap<OrderBasedAggregationKey, OrderBasedAggregation> orderBasedAggregates = new LinkedHashMap<>();
 	@NonNull private final LinkedHashMap<ProductBasedAggregationKey, ProductBasedAggregation> productBasedAggregates = new LinkedHashMap<>();
 	@NonNull private final LinkedHashMap<DeliveryLocationBasedAggregationKey, DeliveryLocationBasedAggregation> deliveryLocationBasedAggregates = new LinkedHashMap<>();
@@ -56,21 +56,35 @@ public class PickingJobCandidateRetrieveCommand
 
 	private Stream<Packageable> streamPackageables()
 	{
-		final ImmutableMap<ShipmentScheduleId, PickingJobSchedule> jobSchedules = getJobSchedules();
-		if (isScheduledForWorkplaceOnly() && jobSchedules.isEmpty())
+		final Set<ShipmentScheduleId> onlyShipmentScheduleIds;
+		if (query.isScheduledForWorkplaceOnly())
 		{
-			return Stream.of();
+			final PickingJobScheduleCollection jobSchedules = getJobSchedules();
+			if (jobSchedules.isEmpty())
+			{
+				return Stream.of();
+			}
+
+			onlyShipmentScheduleIds = jobSchedules.getShipmentScheduleIds();
+		}
+		else
+		{
+			onlyShipmentScheduleIds = null;
 		}
 
-		return shipmentScheduleService.stream(query.toPackageableQueryBuilder().onlyShipmentScheduleIds(jobSchedules.keySet()).build());
+		return shipmentScheduleService.stream(
+				query.toPackageableQueryBuilder()
+						.onlyShipmentScheduleIds(onlyShipmentScheduleIds)
+						.build()
+		);
 	}
 
 	@Nullable
 	private ScheduledPackageable toScheduledPackageable(@NonNull Packageable packageable)
 	{
-		if (isScheduledForWorkplaceOnly())
+		if (query.isScheduledForWorkplaceOnly())
 		{
-			final PickingJobSchedule schedule = getJobScheduleOrNull(packageable.getShipmentScheduleId());
+			final PickingJobSchedule schedule = getJobSchedule(packageable.getShipmentScheduleId()).orElse(null);
 			return schedule != null
 					? ScheduledPackageable.of(packageable, schedule)
 					: null;
@@ -81,40 +95,25 @@ public class PickingJobCandidateRetrieveCommand
 		}
 	}
 
-	@Nullable
-	private PickingJobSchedule getJobScheduleOrNull(ShipmentScheduleId shipmentScheduleId)
+	private Optional<PickingJobSchedule> getJobSchedule(ShipmentScheduleId shipmentScheduleId)
 	{
-		return getJobSchedules().get(shipmentScheduleId);
+		return getJobSchedules().getSingleScheduleByShipmentScheduleId(shipmentScheduleId);
 	}
 
-	private ImmutableMap<ShipmentScheduleId, PickingJobSchedule> getJobSchedules()
+	private PickingJobScheduleCollection getJobSchedules()
 	{
 		if (this._onlyPickingJobSchedules == null)
 		{
-			if (isScheduledForWorkplaceOnly())
-			{
-				this._onlyPickingJobSchedules = Maps.uniqueIndex(
-						pickingJobScheduleService.list(
-								PickingJobScheduleQuery.builder()
-										.workplaceId(query.getScheduledForWorkplaceId())
-										.excludeJobScheduleIds(query.getExcludeScheduleIds().getJobScheduleIds())
-										.build()
-						),
-						PickingJobSchedule::getShipmentScheduleId
-				);
-			}
-			else
-			{
-				this._onlyPickingJobSchedules = ImmutableMap.of();
-			}
+			this._onlyPickingJobSchedules = retrieveJobSchedules();
 		}
-
 		return this._onlyPickingJobSchedules;
 	}
 
-	private boolean isScheduledForWorkplaceOnly()
+	private PickingJobScheduleCollection retrieveJobSchedules()
 	{
-		return query.getScheduledForWorkplaceId() != null;
+		return query.isScheduledForWorkplaceOnly()
+				? pickingJobScheduleService.list(query.toPickingJobScheduleQuery())
+				: PickingJobScheduleCollection.EMPTY;
 	}
 
 	private PickingJobCandidateList aggregate()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job_schedule/service/PickingJobScheduleService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job_schedule/service/PickingJobScheduleService.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimaps;
+import de.metas.handlingunits.picking.job.model.PickingJobQuery;
 import de.metas.handlingunits.picking.job_schedule.service.commands.CreateOrUpdatePickingJobSchedulesCommand;
 import de.metas.handlingunits.picking.job_schedule.service.commands.CreateOrUpdatePickingJobSchedulesRequest;
 import de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleBL;
@@ -100,7 +101,7 @@ public class PickingJobScheduleService
 		shipmentScheduleBL.flagForRecompute(deletedSchedules.getShipmentScheduleIds());
 	}
 
-	public List<PickingJobSchedule> list(@NonNull final PickingJobScheduleQuery query)
+	public PickingJobScheduleCollection list(@NonNull final PickingJobScheduleQuery query)
 	{
 		return pickingJobScheduleRepository.list(query);
 	}

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/lauchers/PickingWorkflowLaunchersProvider.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/lauchers/PickingWorkflowLaunchersProvider.java
@@ -267,6 +267,7 @@ public class PickingWorkflowLaunchersProvider
 	public WorkflowLaunchersFacetGroupList getFacets(@NonNull final WorkflowLaunchersFacetQuery query)
 	{
 		final UserId userId = query.getUserId();
+		final Workplace workplace = warehouseService.getWorkplaceByUserId(userId).orElse(null);
 		final PickingJobQuery.Facets activeFacets = PickingJobFacetHandlers.toPickingJobFacetsQuery(query.getActiveFacetIds());
 
 		final MobileUIPickingUserProfile profile = configService.getProfile();
@@ -279,10 +280,12 @@ public class PickingWorkflowLaunchersProvider
 		final PickingJobFacets pickingFacets = pickingJobRestService.getFacets(
 				PickingJobQuery.builder()
 						.userId(userId)
-						.onlyCustomerIds(profile.getPickOnlyCustomerIds())
-						.warehouseId(warehouseService.getWarehouseIdByUserId(userId).orElse(null))
-						.salesOrderDocumentNo(query.getFilterByDocumentNo())
+						//.excludeScheduleIds()
 						//.facets(activeFacets) // IMPORTANT: don't filter by active facets because we want to collect all facets, not only the active ones
+						.onlyCustomerIds(profile.getPickOnlyCustomerIds())
+						.scheduledForWorkplaceId(profile.isConsiderOnlyJobScheduledToWorkplace() && workplace != null ? workplace.getId() : null)
+						.warehouseId(workplace != null ? workplace.getWarehouseId() : null)
+						.salesOrderDocumentNo(query.getFilterByDocumentNo())
 						.build(),
 				CollectingParameters.builder()
 						.addressProvider(bpartnerService.newRenderedAddressProvider())

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/job_schedule/model/PickingJobScheduleCollection.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/job_schedule/model/PickingJobScheduleCollection.java
@@ -1,7 +1,9 @@
 package de.metas.picking.job_schedule.model;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimaps;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.picking.api.PickingJobScheduleId;
 import de.metas.picking.api.ShipmentScheduleAndJobScheduleIdSet;
@@ -30,11 +32,13 @@ public class PickingJobScheduleCollection implements Iterable<PickingJobSchedule
 
 	@NonNull private final ImmutableList<PickingJobSchedule> list;
 	@NonNull @Getter private final ImmutableSet<PickingJobScheduleId> jobScheduleIds;
+	@NonNull private final ImmutableListMultimap<ShipmentScheduleId, PickingJobSchedule> byShipmentScheduleId;
 
 	private PickingJobScheduleCollection(@NonNull final ImmutableList<PickingJobSchedule> list)
 	{
 		this.list = list;
 		this.jobScheduleIds = list.stream().map(PickingJobSchedule::getId).collect(ImmutableSet.toImmutableSet());
+		this.byShipmentScheduleId = Multimaps.index(list, PickingJobSchedule::getShipmentScheduleId);
 	}
 
 	public static PickingJobScheduleCollection ofCollection(@NonNull final Collection<PickingJobSchedule> list)
@@ -72,16 +76,17 @@ public class PickingJobScheduleCollection implements Iterable<PickingJobSchedule
 
 	public Set<ShipmentScheduleId> getShipmentScheduleIds()
 	{
-		return list.stream()
-				.map(PickingJobSchedule::getShipmentScheduleId)
-				.collect(ImmutableSet.toImmutableSet());
+		return byShipmentScheduleId.keySet();
 	}
 
 	public ShipmentScheduleId getSingleShipmentScheduleId()
 	{
-		return list.stream()
-				.map(PickingJobSchedule::getShipmentScheduleId)
-				.collect(GuavaCollectors.singleElementOrThrow(() -> new AdempiereException("Expected only one shipment schedule").setParameter("list", list)));
+		final Set<ShipmentScheduleId> shipmentScheduleIds = getShipmentScheduleIds();
+		if (shipmentScheduleIds.size() != 1)
+		{
+			throw new AdempiereException("Expected only one shipment schedule").setParameter("list", list);
+		}
+		return shipmentScheduleIds.iterator().next();
 	}
 
 	public ShipmentScheduleAndJobScheduleIdSet toShipmentScheduleAndJobScheduleIdSet()
@@ -101,5 +106,22 @@ public class PickingJobScheduleCollection implements Iterable<PickingJobSchedule
 		return list.stream()
 				.map(PickingJobSchedule::getQtyToPick)
 				.reduce(Quantity::add);
+	}
+
+	public Optional<PickingJobSchedule> getSingleScheduleByShipmentScheduleId(@NonNull ShipmentScheduleId shipmentScheduleId)
+	{
+		final ImmutableList<PickingJobSchedule> schedules = byShipmentScheduleId.get(shipmentScheduleId);
+		if (schedules.isEmpty())
+		{
+			return Optional.empty();
+		}
+		else if (schedules.size() == 1)
+		{
+			return Optional.of(schedules.get(0));
+		}
+		else
+		{
+			throw new AdempiereException("Only one schedule was expected for " + shipmentScheduleId + " but found " + schedules);
+		}
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/job_schedule/repository/PickingJobScheduleRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/job_schedule/repository/PickingJobScheduleRepository.java
@@ -165,9 +165,9 @@ public class PickingJobScheduleRepository
 		return deletedSchedules;
 	}
 
-	public List<PickingJobSchedule> list(@NonNull final PickingJobScheduleQuery query)
+	public PickingJobScheduleCollection list(@NonNull final PickingJobScheduleQuery query)
 	{
-		return stream(query).collect(ImmutableList.toImmutableList());
+		return stream(query).collect(PickingJobScheduleCollection.collect());
 	}
 
 	public Stream<PickingJobSchedule> stream(@NonNull final PickingJobScheduleQuery query)
@@ -177,7 +177,7 @@ public class PickingJobScheduleRepository
 				.map(PickingJobScheduleRepository::fromRecord);
 	}
 
-	public boolean anyMatch (@NonNull final PickingJobScheduleQuery query)
+	public boolean anyMatch(@NonNull final PickingJobScheduleQuery query)
 	{
 		return toSqlQuery(query).anyMatch();
 	}

--- a/e2e/mobile-webui/tests/spec/picking/facets.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/facets.spec.js
@@ -1,0 +1,126 @@
+import { test } from "../../../playwright.config";
+import { Backend } from '../../utils/screens/Backend';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { PickingJobsListScreen } from '../../utils/screens/picking/PickingJobsListScreen';
+import { PickingJobsListFiltersScreen } from '../../utils/screens/picking/PickingJobsListFiltersScreen';
+
+const createMasterdata = async ({ salesOrders }) => {
+    const salesOrdersEffective = {};
+    Object.keys(salesOrders)
+        .forEach(key => salesOrdersEffective[key] = {
+            bpartner: salesOrders[key].bpartner,
+            warehouse: 'wh',
+            datePromised: '2025-03-01T00:00:00.000+02:00',
+            lines: [{
+                product: 'P1',
+                qty: 10,
+                workplace: salesOrders[key].workplace
+            }]
+        });
+
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: {
+                user1: { language: "en_US", workplace: "workplace1" },
+            },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU', 'TU', 'LU_CU', 'CU'],
+                    activeWorkplaceRequired: true,
+                    considerOnlyJobScheduledToWorkplace: true,
+                    allowPickingAnyCustomer: false,
+                    customers: [
+                        { customer: "customer1" },
+                        { customer: "customer2" },
+                        { customer: "customer3" },
+                        { customer: "customer4" },
+                    ],
+                    filters: ['Customer', 'DeliveryDate']
+                }
+            },
+            bpartners: {
+                "customer1": {},
+                "customer2": {},
+                "customer3": {},
+                "customer4": {},
+            },
+            warehouses: { "wh": {} },
+            workplaces: {
+                workplace1: {},
+                workplace2: {},
+            },
+            pickingSlots: { slot1: {} },
+            products: { "P1": { price: 1 } },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', qty: 1000 },
+            },
+            salesOrders: salesOrdersEffective,
+        }
+    })
+}
+
+// noinspection JSUnusedLocalSymbols
+test('Check facets when only scheduled for workplace is enabled', async ({ page }) => {
+    const masterdata = await createMasterdata({
+        salesOrders: {
+            'SO1': { bpartner: 'customer1', workplace: 'workplace1' },
+            'SO2': { bpartner: 'customer2', workplace: 'workplace2' },
+            'SO3': { bpartner: 'customer3', workplace: 'workplace1' },
+            'SO4': { bpartner: 'customer4', workplace: 'workplace2' },
+        }
+    });
+
+    await LoginScreen.login(masterdata.login.user1);
+
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startPickingApplication();
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.clickFilterButton();
+
+    await test.step('Check initial facets', async () => {
+        await PickingJobsListFiltersScreen.expectFacets({
+            groupId: 'Customer',
+            facets: [
+                { facetId: 'Customer_' + masterdata.bpartners.customer1.id, isChecked: false },
+                { facetId: 'Customer_' + masterdata.bpartners.customer3.id, isChecked: false },
+            ]
+        })
+        await PickingJobsListFiltersScreen.expectShowResults({ hitCount: 2 });
+    });
+
+    await test.step('Tick first customer facet', async () => {
+        await PickingJobsListFiltersScreen.clickFacet({ facetId: 'Customer_' + masterdata.bpartners.customer1.id });
+        await PickingJobsListFiltersScreen.expectFacets({
+            groupId: 'Customer',
+            facets: [
+                { facetId: 'Customer_' + masterdata.bpartners.customer1.id, isChecked: true },
+                { facetId: 'Customer_' + masterdata.bpartners.customer3.id, isChecked: false },
+            ]
+        })
+        await PickingJobsListFiltersScreen.expectShowResults({ hitCount: 1 });
+    });
+
+    await test.step('Untick first customer facet', async () => {
+        await PickingJobsListFiltersScreen.clickFacet({ facetId: 'Customer_' + masterdata.bpartners.customer1.id });
+        await PickingJobsListFiltersScreen.expectFacets({
+            groupId: 'Customer',
+            facets: [
+                { facetId: 'Customer_' + masterdata.bpartners.customer1.id, isChecked: false },
+                { facetId: 'Customer_' + masterdata.bpartners.customer3.id, isChecked: false },
+            ]
+        })
+        await PickingJobsListFiltersScreen.expectShowResults({ hitCount: 2 });
+    });
+
+
+    await test.step('Go back and logout', async () => {
+        await PickingJobsListFiltersScreen.goBack();
+        await PickingJobsListScreen.goBack();
+        await ApplicationsListScreen.logout();
+    });
+});

--- a/e2e/mobile-webui/tests/spec/picking/facets.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/facets.spec.js
@@ -11,7 +11,7 @@ const createMasterdata = async ({ salesOrders }) => {
         .forEach(key => salesOrdersEffective[key] = {
             bpartner: salesOrders[key].bpartner,
             warehouse: 'wh',
-            datePromised: '2025-03-01T00:00:00.000+02:00',
+            datePromised: '2025-03-01T05:00:00.000+02:00',
             lines: [{
                 product: 'P1',
                 qty: 10,

--- a/e2e/mobile-webui/tests/spec/picking/facets.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/facets.spec.js
@@ -83,40 +83,31 @@ test('Check facets when only scheduled for workplace is enabled', async ({ page 
     await PickingJobsListScreen.clickFilterButton();
 
     await test.step('Check initial facets', async () => {
-        await PickingJobsListFiltersScreen.expectFacets({
-            groupId: 'Customer',
-            facets: [
-                { facetId: 'Customer_' + masterdata.bpartners.customer1.id, isChecked: false },
-                { facetId: 'Customer_' + masterdata.bpartners.customer3.id, isChecked: false },
-            ]
-        })
+        await PickingJobsListFiltersScreen.expectFacets([
+            { facetId: 'Customer_' + masterdata.bpartners.customer1.id, isChecked: false },
+            { facetId: 'Customer_' + masterdata.bpartners.customer3.id, isChecked: false },
+        ]);
         await PickingJobsListFiltersScreen.expectShowResults({ hitCount: 2 });
     });
 
     await test.step('Tick first customer facet', async () => {
         await PickingJobsListFiltersScreen.clickFacet({ facetId: 'Customer_' + masterdata.bpartners.customer1.id });
-        await PickingJobsListFiltersScreen.expectFacets({
-            groupId: 'Customer',
-            facets: [
-                { facetId: 'Customer_' + masterdata.bpartners.customer1.id, isChecked: true },
-                { facetId: 'Customer_' + masterdata.bpartners.customer3.id, isChecked: false },
-            ]
-        })
+        await PickingJobsListFiltersScreen.expectFacets([
+            { facetId: 'Customer_' + masterdata.bpartners.customer1.id, isChecked: true },
+            { facetId: 'Customer_' + masterdata.bpartners.customer3.id, isChecked: false },
+            { facetId: 'DeliveryDate_2025-03-01', isChecked: false },
+        ]);
         await PickingJobsListFiltersScreen.expectShowResults({ hitCount: 1 });
     });
 
     await test.step('Untick first customer facet', async () => {
         await PickingJobsListFiltersScreen.clickFacet({ facetId: 'Customer_' + masterdata.bpartners.customer1.id });
-        await PickingJobsListFiltersScreen.expectFacets({
-            groupId: 'Customer',
-            facets: [
-                { facetId: 'Customer_' + masterdata.bpartners.customer1.id, isChecked: false },
-                { facetId: 'Customer_' + masterdata.bpartners.customer3.id, isChecked: false },
-            ]
-        })
+        await PickingJobsListFiltersScreen.expectFacets([
+            { facetId: 'Customer_' + masterdata.bpartners.customer1.id, isChecked: false },
+            { facetId: 'Customer_' + masterdata.bpartners.customer3.id, isChecked: false },
+        ]);
         await PickingJobsListFiltersScreen.expectShowResults({ hitCount: 2 });
     });
-
 
     await test.step('Go back and logout', async () => {
         await PickingJobsListFiltersScreen.goBack();

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListFiltersScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListFiltersScreen.js
@@ -1,7 +1,8 @@
 import { test } from "../../../../playwright.config";
-import { page } from "../../common";
+import { ID_BACK_BUTTON, page } from "../../common";
 import { GetDocumentNoDialog } from "../../dialogs/GetDocumentNoDialog";
-import { PickingJobsListScreen as PickingJobListScreen } from './PickingJobsListScreen';
+import { PickingJobsListScreen, PickingJobsListScreen as PickingJobListScreen } from './PickingJobsListScreen';
+import { expect } from '@playwright/test';
 
 const NAME = 'PickingJobsListFiltersScreen';
 /** @returns {import('@playwright/test').Locator} */
@@ -10,6 +11,10 @@ const containerElement = () => page.locator('#WFLaunchersFiltersScreen');
 export const PickingJobsListFiltersScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
         await containerElement().waitFor();
+    }),
+
+    waitLoadingDone: async () => await test.step(`${NAME} - Wait for loading done`, async () => {
+        await page.locator('.loading').waitFor({ state: 'detached' });
     }),
 
     filterByDocumentNo: async (documentNo) => await test.step(`${NAME} - Filter by documentNo ${documentNo}`, async () => {
@@ -22,9 +27,57 @@ export const PickingJobsListFiltersScreen = {
     clickOnlyQtyAvailableButton: async () => await test.step(`${NAME} - Filter by qty available`, async () => {
         await page.locator('#filterByQtyAvailableAtPickFromLocator-button').tap();
     }),
-    
-    clickShowResults: async () => await test.step(`${NAME} - Click Show results`, async () => {
-       await page.locator('#showResults').tap();
-       await PickingJobListScreen.waitForScreen();
+
+    expectFacets: async ({ groupId, facets }) => await test.step(`${NAME} - Expect group ${groupId} to have ${facets.length} facets`, async () => {
+        await PickingJobsListFiltersScreen.waitLoadingDone();
+
+        const groupElement = page.locator(`[data-testid="${groupId}"]`);
+        await expect(groupElement).toBeVisible();
+
+        const buttons = groupElement.locator('button');
+        await expect(buttons).toHaveCount(facets.length);
+
+        for (let i = 0; i < facets.length; i++) {
+            const facet = facets[i];
+            const facetButton = groupElement.locator(`button[data-testid="${facet.facetId}"]`);
+            await expect(facetButton).toBeVisible();
+
+            if (facet?.isChecked != null) {
+                const checkIcon = facetButton.locator('.fa-check');
+                if (facet.isChecked) {
+                    await expect(checkIcon).toHaveCount(1);
+                    await expect(checkIcon).toBeVisible();
+                } else {
+                    await expect(checkIcon).toHaveCount(0);
+                }
+            }
+        }
     }),
+
+    clickFacet: async ({ facetId }) => await test.step(`${NAME} - Click facet ${facetId}`, async () => {
+        const facetButton = page.locator(`button[data-testid="${facetId}"]`);
+        await facetButton.waitFor({ state: 'attached' });
+        await facetButton.tap();
+    }),
+
+    clickShowResults: async () => await test.step(`${NAME} - Click Show results`, async () => {
+        await page.locator('#showResults').tap();
+        await PickingJobListScreen.waitForScreen();
+    }),
+
+    expectShowResults: async ({ hitCount }) => await test.step(`${NAME} - Expect show results`, async () => {
+        await PickingJobsListFiltersScreen.waitLoadingDone();
+        
+        if(hitCount != null)
+        {
+            await expect(page.locator('#showResults')).toHaveAttribute('data-hitcount', String(hitCount));
+        }
+    }),
+
+    goBack: async () => await test.step(`${NAME} - Go back`, async () => {
+        await PickingJobsListFiltersScreen.waitForScreen();
+        await page.locator(ID_BACK_BUTTON).tap();
+        await PickingJobsListScreen.waitForScreen();
+    }),
+
 };

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListFiltersScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListFiltersScreen.js
@@ -28,29 +28,20 @@ export const PickingJobsListFiltersScreen = {
         await page.locator('#filterByQtyAvailableAtPickFromLocator-button').tap();
     }),
 
-    expectFacets: async ({ groupId, facets }) => await test.step(`${NAME} - Expect group ${groupId} to have ${facets.length} facets`, async () => {
+    expectFacets: async (expectationsArray) => await test.step(`${NAME} - Expect to have ${expectationsArray.length} facets`, async () => {
         await PickingJobsListFiltersScreen.waitLoadingDone();
 
-        const groupElement = page.locator(`[data-testid="${groupId}"]`);
-        await expect(groupElement).toBeVisible();
+        const buttons = page.locator('.group').locator('button');
+        await expect(buttons).toHaveCount(expectationsArray.length);
 
-        const buttons = groupElement.locator('button');
-        await expect(buttons).toHaveCount(facets.length);
+        for (let i = 0; i < expectationsArray.length; i++) {
+            let expectation = expectationsArray[i];
 
-        for (let i = 0; i < facets.length; i++) {
-            const facet = facets[i];
-            const facetButton = groupElement.locator(`button[data-testid="${facet.facetId}"]`);
-            await expect(facetButton).toBeVisible();
-
-            if (facet?.isChecked != null) {
-                const checkIcon = facetButton.locator('.fa-check');
-                if (facet.isChecked) {
-                    await expect(checkIcon).toHaveCount(1);
-                    await expect(checkIcon).toBeVisible();
-                } else {
-                    await expect(checkIcon).toHaveCount(0);
-                }
-            }
+            await expectFacet({
+                name: `${i + 1}/${expectationsArray.length} - ${expectation.facetId}`,
+                button: buttons.nth(i),
+                expectation
+            });
         }
     }),
 
@@ -67,9 +58,8 @@ export const PickingJobsListFiltersScreen = {
 
     expectShowResults: async ({ hitCount }) => await test.step(`${NAME} - Expect show results`, async () => {
         await PickingJobsListFiltersScreen.waitLoadingDone();
-        
-        if(hitCount != null)
-        {
+
+        if (hitCount != null) {
             await expect(page.locator('#showResults')).toHaveAttribute('data-hitcount', String(hitCount));
         }
     }),
@@ -81,3 +71,27 @@ export const PickingJobsListFiltersScreen = {
     }),
 
 };
+
+//
+//
+//
+//
+//
+
+const expectFacet = async ({ name, button, expectation }) => await test.step(`Expect facet button ${name}`, async () => {
+    await expect(button).toBeVisible();
+
+    if (expectation.facetId != null) {
+        await expect(button).toHaveAttribute('data-testid', expectation.facetId);
+    }
+
+    if (expectation.isChecked != null) {
+        const checkIcon = button.locator('.fa-check');
+        if (expectation.isChecked) {
+            await expect(checkIcon).toHaveCount(1);
+            await expect(checkIcon).toBeVisible();
+        } else {
+            await expect(checkIcon).toHaveCount(0);
+        }
+    }
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/filters/FacetGroup.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/filters/FacetGroup.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Facet } from './Facet';
 
-export const FacetGroup = ({ caption, facets, onClick }) => {
+export const FacetGroup = ({ groupId, caption, facets, onClick }) => {
   return (
-    <div className="group">
+    <div className="group" data-testid={groupId}>
       <div className="caption">{caption}</div>
       {facets &&
         facets.map((facet) => (
@@ -23,6 +23,7 @@ export const FacetGroup = ({ caption, facets, onClick }) => {
 };
 
 FacetGroup.propTypes = {
+  groupId: PropTypes.string.isRequired,
   caption: PropTypes.string.isRequired,
   facets: PropTypes.array.isRequired,
   onClick: PropTypes.func.isRequired,

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/filters/WFLaunchersFilters.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/filters/WFLaunchersFilters.jsx
@@ -103,7 +103,13 @@ const WFLaunchersFilters = ({ applicationId, onDone }) => {
         />
       )}
       {groups?.map((group) => (
-        <FacetGroup key={group.groupId} caption={group.caption} facets={group.facets} onClick={onFacetClicked} />
+        <FacetGroup
+          key={group.groupId}
+          groupId={group.groupId}
+          caption={group.caption}
+          facets={group.facets}
+          onClick={onFacetClicked}
+        />
       ))}
       {groupsLoading && (
         <div className="loading">


### PR DESCRIPTION
### Summary
This pull request includes key updates to the Picking module's facets handling and filtering logic:

- Refactored facet expectation handling in `PickingJobsListFiltersScreen` and updated related end-to-end (e2e) tests.
- Added support for facet group identification via `groupId` and enhanced e2e tests for facet interactions.
- Introduced filtering by `PickingJobFacetGroup` in `MobileUIPickingUserProfile` and related classes.
- Resolved a bug ensuring `isScheduledForWorkplaceOnly` is considered during facet fetching.
- Added a unique index for `PickingProfile_Filter` to maintain database integrity.


### Additional Notes
These updates improve functionality, reduce potential bugs, and enhance the robustness of filtering mechanisms in the Picking workflows.