### PR TITLE
Fix circular static initialization in Ini class causing NoClassDefFoundError in WSL

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/Ini.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/Ini.java
@@ -19,7 +19,6 @@ package org.compiere.util;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import de.metas.common.util.CoalesceUtil;
-import de.metas.i18n.Language;
 import de.metas.logging.LogManager;
 import de.metas.util.Check;
 import de.metas.util.FileUtil;
@@ -107,7 +106,9 @@ public final class Ini
 	 * Language
 	 */
 	public static final String P_LANGUAGE = "Language";
-	private static final String DEFAULT_LANGUAGE = Language.getName(System.getProperty("user.language") + "_" + System.getProperty("user.country"));
+	// NOTE: we intentionally avoid calling Language.getName() here to prevent circular static initialization
+	// between Ini -> Language -> Env -> Ini which causes NoClassDefFoundError in some environments (e.g. WSL)
+	private static final String DEFAULT_LANGUAGE = System.getProperty("user.language", "en") + "_" + System.getProperty("user.country", "US");
 	/**
 	 * Ini File Name
 	 */


### PR DESCRIPTION
## Summary
- Fixed circular static initialization dependency in `Ini.java` that caused `NoClassDefFoundError` when running tests in WSL
- The `DEFAULT_LANGUAGE` field was calling `Language.getName()` during class loading, which triggered a chain: `Ini` → `Language` → `Env` → `Ini`
- Changed to use raw system properties with safe defaults (`en_US`) instead

## Root Cause
The initialization chain was:
1. `Ini` class loads, initializes `DEFAULT_LANGUAGE` by calling `Language.getName()`
2. `Language.getName()` may call `getLoginLanguage()` as fallback
3. `getLoginLanguage()` calls `Env.getLanguage(Env.getCtx())`
4. `Env.getAD_Language()` calls `Ini.getRunMode()`
5. But `Ini` class is not yet fully initialized → `NoClassDefFoundError`

## Test plan
- [x] Verified build passes in WSL with `mvn_build.sh`
- [x] Tests that were failing (`CacheInterceptorTests`, `FactAcctDAOTest`) now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)