### PR TITLE
Fix HUReportExecutor transaction scope for report visibility

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/report/HUReportExecutor.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/report/HUReportExecutor.java
@@ -204,7 +204,7 @@ public class HUReportExecutor
 				// Execute report in a new transaction
 				.buildAndPrepareExecution()
 				.onErrorThrowException(request.isOnErrorThrowException())
-				.callBefore(processInfo -> DB.createT_Selection(processInfo.getPinstanceId(), HuId.toRepoIds(huIdsToProcess), ITrx.TRXNAME_ThreadInherited))
+				.callBefore(processInfo -> DB.createT_Selection(processInfo.getPinstanceId(), HuId.toRepoIds(huIdsToProcess), ITrx.TRXNAME_None))
 				.executeSync();
 
 		return HUReportExecutorResult.builder()


### PR DESCRIPTION
This pull request resolves an issue where the `HUReportExecutor` failed to create selections outside the transaction scope, causing visibility issues for Jasper Reports. The changes ensure that the selection process occurs correctly and reports are now visible as intended.