### PR TITLE
Adjusted `HULabelPrintCommand` to perform printing operations only after the transaction is fully closed, ensuring no interaction with an already-committed transaction.

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/ITrx.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/ITrx.java
@@ -77,6 +77,8 @@ public interface ITrx
 	 * @return true if transaction active (e.g. not already committed/closed)
 	 */
 	boolean isActive();
+	
+	boolean isCommittedOK();
 
 	/**
 	 * Then this trx obtains a connection, it will check and invoke {@link Connection#setAutoCommit(boolean)} if necessary.

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/ITrxListenerManager.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/ITrxListenerManager.java
@@ -5,6 +5,7 @@ import com.google.common.base.MoreObjects.ToStringHelper;
 import lombok.Getter;
 import lombok.NonNull;
 
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -205,6 +206,13 @@ public interface ITrxListenerManager
 		newEventListener(TrxEventTiming.AFTER_ROLLBACK)
 				.invokeMethodJustOnce(true)
 				.registerHandlingMethod(trx -> runnable.run());
+	}
+
+	default void runAfterClose(@NonNull final Consumer<ITrx> runnable)
+	{
+		newEventListener(TrxEventTiming.AFTER_CLOSE)
+				.invokeMethodJustOnce(true)
+				.registerHandlingMethod(runnable::accept);
 	}
 
 	/**

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/ITrxManager.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/ITrxManager.java
@@ -280,6 +280,8 @@ public interface ITrxManager extends ISingletonService
 	 */
 	void runAfterCommit(final Runnable runnable);
 
+	void runAfterClose(@NonNull Consumer<ITrx> runnable);
+
 	/**
 	 * Commit transaction for given <code>trxName</code>.
 	 *

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/NullTrxPlaceholder.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/NullTrxPlaceholder.java
@@ -82,6 +82,12 @@ public final class NullTrxPlaceholder implements ITrx
 	}
 
 	@Override
+	public boolean isCommittedOK()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public boolean isAutoCommit()
 	{
 		throw new UnsupportedOperationException();

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/impl/AbstractTrx.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/impl/AbstractTrx.java
@@ -22,15 +22,11 @@ package org.adempiere.ad.trx.api.impl;
  * #L%
  */
 
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.util.Date;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
+import de.metas.logging.LogManager;
+import de.metas.util.Check;
+import de.metas.util.Services;
+import lombok.Getter;
+import lombok.NonNull;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.trx.api.ITrxListenerManager;
 import org.adempiere.ad.trx.api.ITrxManager;
@@ -41,12 +37,15 @@ import org.adempiere.util.trxConstraints.api.IOpenTrxBL;
 import org.compiere.util.Util;
 import org.slf4j.Logger;
 
-import de.metas.logging.LogManager;
-import de.metas.util.Check;
-import de.metas.util.Services;
-import lombok.NonNull;
-
 import javax.annotation.Nullable;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Abstract {@link ITrx} implementation which has no dependencies on any native implementation.
@@ -56,8 +55,7 @@ import javax.annotation.Nullable;
  */
 public abstract class AbstractTrx implements ITrx
 {
-	/** Logger */
-	private static final transient Logger log = LogManager.getLogger(AbstractTrx.class);
+	private static final Logger log = LogManager.getLogger(AbstractTrx.class);
 
 	private final ITrxManager trxManager;
 	private final String m_trxName;
@@ -66,6 +64,7 @@ public abstract class AbstractTrx implements ITrx
 	 * set to <code>true</code> by {@link #start()}.
 	 */
 	private boolean m_active = false;
+	@Getter private boolean isCommittedOK = false;
 	private long m_startTime;
 
 	private final boolean autoCommit;
@@ -129,13 +128,13 @@ public abstract class AbstractTrx implements ITrx
 	{
 		if (m_active)
 		{
-			log.warn("Trx in progress " + m_trxName);
+			log.warn("Trx in progress {}", m_trxName);
 			return false;
 		}
 		m_active = true;
 		m_startTime = System.currentTimeMillis();
 		return true;
-	}	// startTrx
+	}
 
 	@Override
 	public Date getStartTime()
@@ -147,7 +146,7 @@ public abstract class AbstractTrx implements ITrx
 	public boolean isActive()
 	{
 		return m_active;
-	}	// isActive
+	}    // isActive
 
 	@Override
 	public boolean isAutoCommit()
@@ -156,9 +155,8 @@ public abstract class AbstractTrx implements ITrx
 	}
 
 	/**
-	 * Returns true if the transaction was just started but no actual actions were performed on this transaction.
-	 *
-	 * NOTE: This method shall be overwritten by actual transaction implementations and it's used for optimizations.
+	 * Returns true if the transaction was just started, but no actual actions were performed on this transaction.
+	 * NOTE: This method shall be overwritten by actual transaction implementations, and it's used for optimizations.
 	 *
 	 * @return true if the transaction was just started
 	 */
@@ -241,13 +239,14 @@ public abstract class AbstractTrx implements ITrx
 		final ITrxListenerManager trxListenerManager = getTrxListenerManager(false);
 
 		boolean success = false;
+		isCommittedOK = false;
 		try
 		{
 			// Fire before-commit listeners
 			trxListenerManager.fireBeforeCommit(this);
 
 			// Actual native commit
-			success = commitNative(throwException);
+			success = this.isCommittedOK = commitNative(throwException);
 			return success;
 		}
 		finally
@@ -256,7 +255,7 @@ public abstract class AbstractTrx implements ITrx
 
 			Services.get(IOpenTrxBL.class).onCommit(this); // metas 02367
 
-			// 04265: If transaction was successfully committed fire listeners
+			// 04265: If transaction was successfully committed, fire listeners
 			if (success)
 			{
 				trxListenerManager.fireAfterCommit(this);
@@ -431,20 +430,18 @@ public abstract class AbstractTrx implements ITrx
 
 		sb.append("]");
 		return sb.toString();
-	}	// toString
+	}    // toString
 
 	/**
 	 * Current {@link ITrxListenerManager}
-	 *
+	 * <p>
 	 * Task 04265
 	 */
 	private ITrxListenerManager trxListenerManager = null;
 
 	/**
 	 * Gets the {@link ITrxListenerManager} associated with this transaction.
-	 *
 	 * If no {@link ITrxListenerManager} was already created and <code>create</code> is true, a new transaction listener manager will be created and returned
-	 *
 	 * Task 04265
 	 */
 	private ITrxListenerManager getTrxListenerManager(final boolean create)
@@ -477,11 +474,11 @@ public abstract class AbstractTrx implements ITrx
 
 	private Map<String, Object> getPropertiesMap()
 	{
-		if(_properties == null)
+		if (_properties == null)
 		{
 			synchronized (this)
 			{
-				if(_properties == null)
+				if (_properties == null)
 				{
 					_properties = new ConcurrentHashMap<>();
 				}
@@ -505,22 +502,20 @@ public abstract class AbstractTrx implements ITrx
 		Check.assumeNotEmpty(name, "name is not empty");
 
 		// Handle null value case
-		if(value == null)
+		if (value == null)
 		{
 			final Map<String, Object> properties = getPropertiesMapOrNull();
-			if(properties == null)
+			if (properties == null)
 			{
 				return null;
 			}
 
-			@SuppressWarnings("unchecked")
-			final T valueOld = (T)properties.remove(name);
+			@SuppressWarnings("unchecked") final T valueOld = (T)properties.remove(name);
 			return valueOld;
 		}
 		else
 		{
-			@SuppressWarnings("unchecked")
-			final T valueOld = (T)getPropertiesMap().put(name, value);
+			@SuppressWarnings("unchecked") final T valueOld = (T)getPropertiesMap().put(name, value);
 			return valueOld;
 		}
 	}
@@ -528,24 +523,21 @@ public abstract class AbstractTrx implements ITrx
 	@Override
 	public final <T> T getProperty(final String name)
 	{
-		@SuppressWarnings("unchecked")
-		final T value = (T)getPropertiesMap().get(name);
+		@SuppressWarnings("unchecked") final T value = (T)getPropertiesMap().get(name);
 		return value;
 	}
 
 	@Override
 	public <T> T getProperty(final String name, final Supplier<T> valueInitializer)
 	{
-		@SuppressWarnings("unchecked")
-		final T value = (T)getPropertiesMap().computeIfAbsent(name, key->valueInitializer.get());
+		@SuppressWarnings("unchecked") final T value = (T)getPropertiesMap().computeIfAbsent(name, key -> valueInitializer.get());
 		return value;
 	}
 
 	@Override
 	public <T> T getProperty(final String name, final Function<ITrx, T> valueInitializer)
 	{
-		@SuppressWarnings("unchecked")
-		final T value = (T)getPropertiesMap().computeIfAbsent(name, key->valueInitializer.apply(this));
+		@SuppressWarnings("unchecked") final T value = (T)getPropertiesMap().computeIfAbsent(name, key -> valueInitializer.apply(this));
 		return value;
 	}
 
@@ -553,18 +545,15 @@ public abstract class AbstractTrx implements ITrx
 	public <T> T setAndGetProperty(@NonNull final String name, @NonNull final Function<T, T> valueRemappingFunction)
 	{
 		final BiFunction<? super String, ? super Object, ?> remappingFunction = (propertyName, oldValue) -> {
-			@SuppressWarnings("unchecked")
-			final T oldValueCasted = (T)oldValue;
+			@SuppressWarnings("unchecked") final T oldValueCasted = (T)oldValue;
 
 			return valueRemappingFunction.apply(oldValueCasted);
 		};
 
-		@SuppressWarnings("unchecked")
-		final T value = (T)getPropertiesMap().compute(name, remappingFunction);
+		@SuppressWarnings("unchecked") final T value = (T)getPropertiesMap().compute(name, remappingFunction);
 		return value;
 
 	}
-
 
 	protected final void setDebugConnectionBackendId(final String debugConnectionBackendId)
 	{

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/impl/AbstractTrxManager.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/trx/api/impl/AbstractTrxManager.java
@@ -74,6 +74,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 /**
  * Abstract {@link ITrxManager} implementation without any dependencies on a native stuff.
@@ -93,7 +94,9 @@ public abstract class AbstractTrxManager implements ITrxManager
 
 	private ITrxNameGenerator trxNameGenerator = DefaultTrxNameGenerator.instance;
 
-	/** Name of the trx currently associated with this thread */
+	/**
+	 * Name of the trx currently associated with this thread
+	 */
 	private final ThreadLocal<String> threadLocalTrx = new ThreadLocal<>();
 	private final ThreadLocal<OnRunnableFail> threadLocalOnRunnableFail = new ThreadLocal<>();
 
@@ -101,7 +104,7 @@ public abstract class AbstractTrxManager implements ITrxManager
 	private boolean debugTrxCloseStacktrace = false;
 	/**
 	 * Debugging: closed transactions list.
-	 *
+	 * <p>
 	 * If not null it will collect transactions which were cloased and removed from {@link #getActiveTransactionsList()}.
 	 */
 	private List<ITrx> debugClosedTransactionsList = null;
@@ -115,7 +118,7 @@ public abstract class AbstractTrxManager implements ITrxManager
 
 	/**
 	 * Creates and returns a transaction for given name.
-	 *
+	 * <p>
 	 * NOTE: implementations of this method shall not register or start the transaction. They only need to create the actual {@link ITrx} object.
 	 *
 	 * @param trxName transaction name; please keep in mind: this is the actual trxName that will be used and not a prefix
@@ -125,7 +128,7 @@ public abstract class AbstractTrxManager implements ITrxManager
 
 	/**
 	 * Creates and registers {@link ITrx} for given transaction name.
-	 *
+	 * <p>
 	 * NOTE: this method assumes that {@link #trxName2trxLock} is already locked.
 	 *
 	 * @return created transaction name
@@ -267,7 +270,7 @@ public abstract class AbstractTrxManager implements ITrxManager
 	{
 		final OnTrxMissingPolicy onTrxMissingPolicy = createNew ? OnTrxMissingPolicy.CreateNew
 				: OnTrxMissingPolicy.ReturnTrxNone // backward compatibility
-		;
+				;
 
 		return get(trxName, onTrxMissingPolicy);
 	}
@@ -359,7 +362,7 @@ public abstract class AbstractTrxManager implements ITrxManager
 		{
 			trxName2trxLock.unlock();
 		}
-	}	// get
+	}    // get
 
 	@Override
 	public boolean remove(final ITrx trx)
@@ -430,7 +433,7 @@ public abstract class AbstractTrxManager implements ITrxManager
 		}
 
 		return trxName;
-	}	// createTrxName
+	}    // createTrxName
 
 	/**
 	 * Create unique Transaction Name
@@ -441,7 +444,7 @@ public abstract class AbstractTrxManager implements ITrxManager
 	{
 		final String prefix = null;
 		return createTrxName(prefix);
-	}	// createTrxName
+	}    // createTrxName
 
 	@Override
 	public <T> T callInNewTrx(@NonNull final Callable<T> callable)
@@ -771,13 +774,13 @@ public abstract class AbstractTrxManager implements ITrxManager
 		catch (final Throwable runException)
 		{
 			final ILoggable loggable = Loggables.withLogger(logger, Level.WARN);
-			if(AdempiereException.isThrowableLoggedInTrxManager(runException))
+			if (AdempiereException.isThrowableLoggedInTrxManager(runException))
 			{
 				loggable.addLog("AbstractTrxManager.call0 - caught {} with message={}",
-								runException.getClass(), runException.getMessage(),
-								runException /* note that some ILoggable implementations can handle this additional parameter; the others can be expected to ignore it */);
+						runException.getClass(), runException.getMessage(),
+						runException /* note that some ILoggable implementations can handle this additional parameter; the others can be expected to ignore it */);
 			}
-			
+
 			// Call custom exception handler to advice us what to do
 			exceptionToThrow = runException;
 			boolean rollback = true;
@@ -968,6 +971,13 @@ public abstract class AbstractTrxManager implements ITrxManager
 	{
 		getCurrentTrxListenerManagerOrAutoCommit()
 				.runAfterCommit(runnable);
+	}
+
+	@Override
+	public void runAfterClose(@NonNull final Consumer<ITrx> runnable)
+	{
+		getCurrentTrxListenerManagerOrAutoCommit()
+				.runAfterClose(runnable);
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/report/labels/HULabelPrintCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/report/labels/HULabelPrintCommand.java
@@ -53,7 +53,7 @@ class HULabelPrintCommand
 
 		trxManager.runAfterClose((trx) ->
 		{
-			if (!trx.isCommittedOK()) {return;}
+			if (trx != null && !trx.isCommittedOK()) {return;}
 			//M_HU_Storage persistence may be delayed by de.metas.handlingunits.storage.impl.SaveOnCommitHUStorageDAO
 			huQRCodesService.generateForExistingHUs(batchToPrintCollector.getHuIds());
 			batchToPrintCollector.forEach(this::printBatchNow);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/report/labels/HULabelPrintCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/report/labels/HULabelPrintCommand.java
@@ -51,8 +51,9 @@ class HULabelPrintCommand
 			return;
 		}
 
-		trxManager.runAfterCommit(() ->
+		trxManager.runAfterClose((trx) ->
 		{
+			if (!trx.isCommittedOK()) {return;}
 			//M_HU_Storage persistence may be delayed by de.metas.handlingunits.storage.impl.SaveOnCommitHUStorageDAO
 			huQRCodesService.generateForExistingHUs(batchToPrintCollector.getHuIds());
 			batchToPrintCollector.forEach(this::printBatchNow);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleEnqueuer.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleEnqueuer.java
@@ -329,7 +329,7 @@ public class ShipmentScheduleEnqueuer
 				// NOTE: when we will add the scheds to workpackages we will move the ICs to another owner and we will also set AutoCleanup=false
 				.setAutoCleanup(true)
 				.setFailIfAlreadyLocked(true)
-				.retryOnFailure(3)
+				.retryOnFailure(10)
 				.setRecordsByFilter(I_M_ShipmentSchedule.class, queryFilters);
 
 		final Set<PickingJobScheduleId> jobScheduleIds = workPackageParameters.getPickingJobScheduleIds();


### PR DESCRIPTION
---

### Description
This pull request introduces the following changes:

- Increased the `retryOnFailure` count in `ShipmentScheduleEnqueuer` from 3 to 10 to improve reliability.
- Added null checks in `HULabelPrintCommand` to ensure the transaction is valid before verifying `isCommittedOK`.
- Adjusted `HULabelPrintCommand` to perform printing operations only after the transaction is fully closed, ensuring no interaction with an already-committed transaction.

