### PR TITLE
Add local CI/CD runner using act

### DIFF
--- a/misc/dev-support/.gitignore
+++ b/misc/dev-support/.gitignore
@@ -1,1 +1,4 @@
 *.log
+
+# Local CI/CD secrets (never commit credentials!)
+local-cicd/.secrets

--- a/misc/dev-support/local-cicd/.actrc
+++ b/misc/dev-support/local-cicd/.actrc
@@ -1,0 +1,17 @@
+# act configuration for running CI/CD locally
+# See: https://nektosact.com/usage/index.html
+
+# Use larger Ubuntu image with more tools pre-installed
+-P ubuntu-latest=ghcr.io/catthehacker/ubuntu:full-latest
+
+# Local artifact storage
+--artifact-server-path=/tmp/act-artifacts
+
+# Set default run number (GitHub Actions increments this automatically)
+--env GITHUB_RUN_NUMBER=1
+
+# Enable verbose container logs
+--container-options --log-driver=json-file
+
+# Reuse containers for faster subsequent runs
+--reuse

--- a/misc/dev-support/local-cicd/.secrets.template
+++ b/misc/dev-support/local-cicd/.secrets.template
@@ -1,0 +1,19 @@
+# Copy this file to .secrets and fill in your credentials
+# NEVER commit .secrets to git!
+
+# Required: Docker Hub token with read/write access to metasfresh organization
+# Get from: https://hub.docker.com/settings/security (Access Tokens)
+DOCKERHUB_METASFRESH_RW_TOKEN=your_dockerhub_token_here
+
+# Required: GitHub Personal Access Token with read:packages scope
+# Get from: https://github.com/settings/tokens (classic token with read:packages)
+METASFRESH_PACKAGES_READ_TOKEN=ghp_your_github_pat_here
+
+# Optional: For email/SMTP tests in Cucumber
+# TEST_SMTP_HOST=
+# TEST_SMTP_FROM=
+# TEST_SMTP_USER=
+# TEST_SMTP_PASSWORD=
+
+# Optional: Testspace integration (test results upload)
+# TESTSPACE_TOKEN=

--- a/misc/dev-support/local-cicd/README.md
+++ b/misc/dev-support/local-cicd/README.md
@@ -1,0 +1,246 @@
+# Local CI/CD with `act`
+
+Run the metasfresh CI/CD pipeline locally using [act](https://github.com/nektos/act) - a tool that runs GitHub Actions workflows on your local Docker host.
+
+## Why Run CI/CD Locally?
+
+- **Debug test failures** without waiting for GitHub Actions
+- **Iterate quickly** on build issues
+- **Reproduce** the exact CI environment locally
+- **Run specific jobs** in isolation (e.g., just JUnit or Cucumber)
+
+## Prerequisites
+
+### 1. Install `act`
+
+```bash
+# Linux
+curl -sfL https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- -b /usr/local/bin
+
+# macOS
+brew install act
+
+# Windows (via Chocolatey)
+choco install act-cli
+```
+
+Verify installation:
+```bash
+act --version
+```
+
+### 2. Docker Requirements
+
+- Docker Engine 20.10+ or Docker Desktop
+- At least **8GB RAM** allocated to Docker
+- At least **50GB free disk space** for images
+- Docker BuildKit enabled (set automatically by the script)
+
+**Configuring Docker Desktop RAM:**
+
+| Platform | Path |
+|----------|------|
+| **Windows** | Settings → Resources → Advanced → Memory slider |
+| **macOS** | Settings → Resources → Advanced → Memory slider |
+| **Linux** | Settings → Resources → Advanced → Memory slider (or edit `~/.docker/daemon.json`) |
+
+In Docker Desktop: Click the gear icon (⚙️) → Resources → Advanced → Set Memory to 8GB or higher → Apply & Restart
+
+### 3. Required Credentials
+
+You need two tokens:
+
+| Token | How to Get | Purpose |
+|-------|------------|---------|
+| Docker Hub | [hub.docker.com/settings/security](https://hub.docker.com/settings/security) → Access Tokens | Push/pull metasfresh images |
+| GitHub PAT | [github.com/settings/tokens](https://github.com/settings/tokens) → Classic token with `read:packages` | Maven dependencies |
+
+## Quick Setup
+
+```bash
+# 1. Copy the secrets template
+cp .secrets.template .secrets
+
+# 2. Edit .secrets and add your tokens
+# DOCKERHUB_METASFRESH_RW_TOKEN=your_dockerhub_token
+# METASFRESH_PACKAGES_READ_TOKEN=ghp_your_github_pat
+
+# 3. Test the setup
+./run-cicd.sh list
+```
+
+## Usage
+
+### List Available Jobs
+
+```bash
+./run-cicd.sh list
+```
+
+### Run Specific Jobs
+
+```bash
+# Build Java/Maven artifacts (20-30 min, 5-10 with cache)
+./run-cicd.sh java
+
+# Build frontend images
+./run-cicd.sh frontend
+
+# Run JUnit tests (20-30 min)
+./run-cicd.sh junit
+
+# Run Cucumber integration tests (30-45 min per profile)
+./run-cicd.sh cucumber
+
+# Run health checks
+./run-cicd.sh health_check
+
+# Run Playwright mobile tests
+./run-cicd.sh mobile_test
+
+# Run Playwright frontend tests
+./run-cicd.sh frontend_test
+```
+
+### Run Full Pipeline
+
+```bash
+./run-cicd.sh full
+```
+
+**Warning**: Full pipeline takes 1.5-2+ hours depending on caching.
+
+### Advanced Options
+
+```bash
+# Verbose output (see container logs)
+./run-cicd.sh junit -v
+
+# Dry run (see what would execute)
+./run-cicd.sh java --dry-run
+
+# Run any job by name
+./run-cicd.sh cucumber-build
+```
+
+## Debugging Test Failures
+
+### 1. Check Artifacts
+
+Test results and logs are saved to `/tmp/act-artifacts/`:
+
+```bash
+ls -la /tmp/act-artifacts/
+```
+
+### 2. Verbose Mode
+
+Run with `-v` for detailed container output:
+
+```bash
+./run-cicd.sh junit -v
+```
+
+### 3. Database Snapshots
+
+The CI/CD workflow creates database snapshots after tests (`docker commit`). You can inspect the test state:
+
+```bash
+# List available database snapshots
+docker images | grep metas-db
+
+# Start a post-test database
+docker run -d -p 15432:5432 \
+    -e PGDATA=/var/lib/postgresql/initdata \
+    --name debug-db \
+    metasfresh/metas-db:5.175-your_branch-postcucumber-profile1
+
+# Connect with psql
+psql -h localhost -p 15432 -U metasfresh -d metasfresh
+
+# Cleanup when done
+docker stop debug-db && docker rm debug-db
+```
+
+### 4. Run Single Cucumber Test
+
+To run a specific Cucumber scenario, you'll need to modify the workflow temporarily or use the matrix parameter:
+
+```bash
+# Run specific Cucumber profile
+act -j cucumber-run --matrix profile:profile1 \
+    --secret-file .secrets
+```
+
+## Estimated Run Times
+
+| Job | Duration | With Cache |
+|-----|----------|------------|
+| `java` | 20-30 min | 5-10 min |
+| `frontend` | 5-10 min | 3-5 min |
+| `junit` | 20-30 min | - |
+| `cucumber` (1 profile) | 30-45 min | - |
+| `cucumber` (all 10) | 5-8 hours | - |
+| `health_check` | 5-10 min | - |
+| Full pipeline | 1.5-2 hours | - |
+
+## Troubleshooting
+
+### "act is not installed"
+
+Follow the installation instructions above.
+
+### "Docker daemon is not running"
+
+Start Docker:
+```bash
+# Linux
+sudo systemctl start docker
+
+# macOS/Windows
+# Start Docker Desktop
+```
+
+### "Secrets file not found"
+
+```bash
+cp .secrets.template .secrets
+# Edit .secrets with your credentials
+```
+
+### Out of disk space
+
+```bash
+# Clean up Docker resources
+docker system prune -a --volumes
+```
+
+### Build cache issues
+
+```bash
+# Force clean build (no cache)
+docker builder prune -a
+./run-cicd.sh java
+```
+
+### Permission denied on secrets
+
+```bash
+chmod 600 .secrets
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `.actrc` | act configuration (runner image, artifact path, etc.) |
+| `.secrets.template` | Template for credentials (copy to `.secrets`) |
+| `.secrets` | Your credentials (gitignored, never commit!) |
+| `run-cicd.sh` | Wrapper script for common commands |
+| `README.md` | This documentation |
+
+## Resources
+
+- [act documentation](https://nektosact.com/)
+- [act GitHub repository](https://github.com/nektos/act)
+- [GitHub Actions workflow syntax](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions)

--- a/misc/dev-support/local-cicd/run-cicd.sh
+++ b/misc/dev-support/local-cicd/run-cicd.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+#
+# run-cicd.sh - Run CI/CD pipeline locally using act
+#
+# Usage:
+#   ./run-cicd.sh list          - List all available jobs
+#   ./run-cicd.sh java          - Build Java/Maven artifacts
+#   ./run-cicd.sh frontend      - Build frontend images
+#   ./run-cicd.sh junit         - Run JUnit tests
+#   ./run-cicd.sh cucumber      - Run Cucumber integration tests
+#   ./run-cicd.sh full          - Run entire pipeline
+#   ./run-cicd.sh <job-name>    - Run any specific job by name
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Check prerequisites
+check_prerequisites() {
+    if ! command -v act &> /dev/null; then
+        log_error "act is not installed. Install it with:"
+        echo "  curl -sfL https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- -b /usr/local/bin"
+        exit 1
+    fi
+
+    if ! command -v docker &> /dev/null; then
+        log_error "docker is not installed or not in PATH"
+        exit 1
+    fi
+
+    if ! docker info &> /dev/null; then
+        log_error "Docker daemon is not running"
+        exit 1
+    fi
+
+    if [ ! -f "$SCRIPT_DIR/.secrets" ]; then
+        log_error "Secrets file not found: $SCRIPT_DIR/.secrets"
+        echo "  Copy .secrets.template to .secrets and fill in your credentials:"
+        echo "  cp $SCRIPT_DIR/.secrets.template $SCRIPT_DIR/.secrets"
+        exit 1
+    fi
+}
+
+# Common act arguments
+ACT_ARGS=(
+    --secret-file "$SCRIPT_DIR/.secrets"
+    -C "$REPO_ROOT"
+    -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:full-latest
+    --artifact-server-path=/tmp/act-artifacts
+    --env GITHUB_RUN_NUMBER=1
+)
+
+show_help() {
+    cat << EOF
+Usage: $0 <command> [options]
+
+Commands:
+  list              List all available jobs in the workflow
+  full              Run the entire CI/CD pipeline
+  java              Build Java/Maven artifacts (metas-mvn-common, backend, camel)
+  frontend          Build frontend and mobile images
+  backend           Build runtime Docker images (api, app, db, etc.)
+  junit             Run JUnit unit tests
+  cucumber          Run Cucumber integration tests (all profiles)
+  cucumber-build    Build the Cucumber test container
+  health_check      Run health checks on all services
+  mobile_test       Run Playwright mobile E2E tests
+  frontend_test     Run Playwright frontend E2E tests
+  <job-name>        Run any specific job by name (use 'list' to see all)
+
+Options:
+  -v, --verbose     Enable verbose output
+  -n, --dry-run     Show what would be run without executing
+  -h, --help        Show this help message
+
+Examples:
+  $0 list                    # See all available jobs
+  $0 junit                   # Run JUnit tests
+  $0 cucumber -v             # Run Cucumber with verbose output
+  $0 java --dry-run          # See what Java build would do
+
+Environment:
+  DOCKER_BUILDKIT=1          Enable BuildKit (recommended, set automatically)
+EOF
+}
+
+# Ensure BuildKit is enabled
+export DOCKER_BUILDKIT=1
+
+# Parse command and options
+COMMAND="${1:-help}"
+shift || true
+
+VERBOSE=""
+DRY_RUN=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -v|--verbose)
+            VERBOSE="-v"
+            shift
+            ;;
+        -n|--dry-run)
+            DRY_RUN="--dryrun"
+            shift
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+case "$COMMAND" in
+    help|-h|--help)
+        show_help
+        exit 0
+        ;;
+    list)
+        log_info "Available jobs in cicd.yaml:"
+        act -l -C "$REPO_ROOT"
+        exit 0
+        ;;
+    full)
+        check_prerequisites
+        log_info "Running full CI/CD pipeline..."
+        log_warn "This may take 1-2 hours depending on caching"
+        act "${ACT_ARGS[@]}" $VERBOSE $DRY_RUN
+        ;;
+    java)
+        check_prerequisites
+        log_info "Building Java/Maven artifacts..."
+        act -j java "${ACT_ARGS[@]}" $VERBOSE $DRY_RUN
+        ;;
+    frontend)
+        check_prerequisites
+        log_info "Building frontend images..."
+        act -j frontend "${ACT_ARGS[@]}" $VERBOSE $DRY_RUN
+        ;;
+    backend)
+        check_prerequisites
+        log_info "Building backend runtime images..."
+        act -j backend "${ACT_ARGS[@]}" $VERBOSE $DRY_RUN
+        ;;
+    junit)
+        check_prerequisites
+        log_info "Running JUnit tests..."
+        act -j junit "${ACT_ARGS[@]}" $VERBOSE $DRY_RUN
+        ;;
+    cucumber)
+        check_prerequisites
+        log_info "Running Cucumber integration tests..."
+        log_warn "This runs all 10 profiles sequentially (may take several hours)"
+        act -j cucumber-run "${ACT_ARGS[@]}" $VERBOSE $DRY_RUN
+        ;;
+    cucumber-build)
+        check_prerequisites
+        log_info "Building Cucumber test container..."
+        act -j cucumber-build "${ACT_ARGS[@]}" $VERBOSE $DRY_RUN
+        ;;
+    health_check)
+        check_prerequisites
+        log_info "Running health checks..."
+        act -j health_check "${ACT_ARGS[@]}" $VERBOSE $DRY_RUN
+        ;;
+    mobile_test)
+        check_prerequisites
+        log_info "Running Playwright mobile tests..."
+        act -j mobile_test "${ACT_ARGS[@]}" $VERBOSE $DRY_RUN
+        ;;
+    frontend_test)
+        check_prerequisites
+        log_info "Running Playwright frontend tests..."
+        act -j frontend_webui_test "${ACT_ARGS[@]}" $VERBOSE $DRY_RUN
+        ;;
+    *)
+        # Try to run it as a job name
+        check_prerequisites
+        log_info "Running job: $COMMAND"
+        act -j "$COMMAND" "${ACT_ARGS[@]}" $VERBOSE $DRY_RUN
+        ;;
+esac
+
+log_info "Done!"
+log_info "Artifacts available at: /tmp/act-artifacts/"


### PR DESCRIPTION
## Summary

- Adds scripts to run the GitHub Actions CI/CD pipeline locally using `act`
- Enables easier debugging of test failures without waiting for GitHub Actions
- Wrapper script with commands for specific jobs (java, junit, cucumber, etc.)

## Files Added

```
misc/dev-support/local-cicd/
├── .actrc              # act configuration
├── .secrets.template   # credentials template
├── run-cicd.sh         # wrapper script
└── README.md           # documentation
```

## Usage

```bash
cd misc/dev-support/local-cicd
cp .secrets.template .secrets
# Edit .secrets with your Docker Hub and GitHub tokens

./run-cicd.sh list       # See available jobs
./run-cicd.sh junit      # Run JUnit tests
./run-cicd.sh cucumber   # Run Cucumber tests
./run-cicd.sh full       # Full pipeline
```

## Test plan

- [x] Tested `./run-cicd.sh list` locally
- [ ] Test running actual jobs with proper credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)