### PR TITLE
Migrate Allure reports to dedicated metasfresh-testreports repository

### DIFF
--- a/.github/workflows/allure-cleanup.yml
+++ b/.github/workflows/allure-cleanup.yml
@@ -23,11 +23,14 @@ jobs:
     name: Cleanup Stale Reports
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout gh-pages branch
+      - name: Checkout testreports gh-pages branch
         uses: actions/checkout@v4
         with:
+          repository: metasfresh/metasfresh-testreports
           ref: gh-pages
           fetch-depth: 0
+          ssh-key: ${{ secrets.TESTREPORTS_DEPLOY_KEY }}
+          persist-credentials: true
 
       - name: Get active branches from repository
         id: active

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1456,11 +1456,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout gh-pages branch
+      - name: Checkout testreports gh-pages branch
         uses: actions/checkout@v4
         with:
+          repository: metasfresh/metasfresh-testreports
           ref: gh-pages
           path: gh-pages-repo
+          ssh-key: ${{ secrets.TESTREPORTS_DEPLOY_KEY }}
+          persist-credentials: true
 
       - name: Setup directory structure
         run: |


### PR DESCRIPTION
## Summary
- Migrate Allure test report publishing from main repo's gh-pages branch to dedicated `metasfresh/metasfresh-testreports` repository
- Reduces main metasfresh repository size significantly
- Updates both `cicd.yaml` (allure_publish job) and `allure-cleanup.yml` (cleanup job)

## Changes
- `cicd.yaml`: Checkout and push reports to `metasfresh/metasfresh-testreports` instead of local gh-pages
- `allure-cleanup.yml`: Point cleanup job to the new repository

## New Report URLs
- Landing page: https://metasfresh.github.io/metasfresh-testreports/
- Reports: Same path structure as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)