### PR TITLE
Fix maven-surefire-plugin version for procurement-webui-backend

### DIFF
--- a/misc/services/procurement-webui/procurement-webui-backend/pom.xml
+++ b/misc/services/procurement-webui/procurement-webui-backend/pom.xml
@@ -211,8 +211,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <!-- Override to 3.5.2 because 3.5.3 requires JUnit 5.12+ but Spring Boot 2.4.1 uses JUnit 5.7.0 -->
-                <version>3.5.2</version>
+                <!-- Override to 3.2.5 because 3.5.x requires JUnit 5.10+ but Spring Boot 2.4.1 uses JUnit 5.7.0 -->
+                <version>3.2.5</version>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
## Summary

- Downgrade maven-surefire-plugin from 3.5.2 to 3.2.5 in `procurement-webui-backend`
- Fixes JUnit version compatibility issue (Surefire 3.5.x requires JUnit 5.10+, but Spring Boot 2.4.1 uses JUnit 5.7.0)

## Problem

The previous version (3.5.2) caused test failures with:
```
NoSuchMethodError: 'java.util.Set org.junit.platform.engine.TestDescriptor.getAncestors()'
```

## Test plan

- [x] Run `mvn test` for procurement-webui-backend module with Java 14+
- [x] Verify tests pass (1 test, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)