### PR TITLE
#3860 Delete legacy C_DocType with removed MMP DocBaseType

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5782980_sys_gh3860_cleanup_legacy_MMP_doctype.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5782980_sys_gh3860_cleanup_legacy_MMP_doctype.sql
@@ -4,7 +4,11 @@
 -- but the C_DocType record was not cleaned up, causing customer repo builds to fail
 -- when loading DocTypes during startup.
 
--- Delete the DocType translations first (FK constraint)
+-- Delete document action access records first (FK constraint)
+DELETE FROM AD_Document_Action_Access
+WHERE C_DocType_ID IN (SELECT C_DocType_ID FROM C_DocType WHERE DocBaseType = 'MMP');
+
+-- Delete the DocType translations (FK constraint)
 DELETE FROM C_DocType_Trl
 WHERE C_DocType_ID IN (SELECT C_DocType_ID FROM C_DocType WHERE DocBaseType = 'MMP');
 

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5782980_sys_gh3860_cleanup_legacy_MMP_doctype.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5782980_sys_gh3860_cleanup_legacy_MMP_doctype.sql
@@ -17,3 +17,6 @@ DELETE FROM C_DocType WHERE DocBaseType = 'MMP';
 
 -- Delete counter DocBaseType mappings that reference MMP
 DELETE FROM C_DocBaseType_Counter WHERE DocBaseType = 'MMP' OR Counter_DocBaseType = 'MMP';
+
+-- Delete period controls for MMP DocBaseType
+DELETE FROM C_PeriodControl WHERE DocBaseType = 'MMP';

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5782980_sys_gh3860_cleanup_legacy_MMP_doctype.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5782980_sys_gh3860_cleanup_legacy_MMP_doctype.sql
@@ -14,3 +14,6 @@ WHERE C_DocType_ID IN (SELECT C_DocType_ID FROM C_DocType WHERE DocBaseType = 'M
 
 -- Delete the DocType record(s)
 DELETE FROM C_DocType WHERE DocBaseType = 'MMP';
+
+-- Delete counter DocBaseType mappings that reference MMP
+DELETE FROM C_DocBaseType_Counter WHERE DocBaseType = 'MMP' OR Counter_DocBaseType = 'MMP';

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5782980_sys_gh3860_cleanup_legacy_MMP_doctype.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5782980_sys_gh3860_cleanup_legacy_MMP_doctype.sql
@@ -1,0 +1,12 @@
+-- #3860 Delete legacy Production DocType that references removed MMP DocBaseType
+-- The MMP (Material Production) DocBaseType was removed in metasfresh
+-- migration 5486280_sys_gh3537-app_cleanup_legacy_production_stuff.sql (2018)
+-- but the C_DocType record was not cleaned up, causing customer repo builds to fail
+-- when loading DocTypes during startup.
+
+-- Delete the DocType translations first (FK constraint)
+DELETE FROM C_DocType_Trl
+WHERE C_DocType_ID IN (SELECT C_DocType_ID FROM C_DocType WHERE DocBaseType = 'MMP');
+
+-- Delete the DocType record(s)
+DELETE FROM C_DocType WHERE DocBaseType = 'MMP';


### PR DESCRIPTION
## Summary
- Delete legacy C_DocType records that reference the removed MMP (Material Production) DocBaseType
- The MMP DocBaseType was removed in 2018 by migration 5486280_sys_gh3537-app_cleanup_legacy_production_stuff.sql
- The C_DocType cleanup was missed, causing customer repo builds (e.g. sp80) to fail during startup

## Root Cause
When metasfresh loads C_DocType records at startup, it tries to convert the DocBaseType code to a `DocBaseType` enum. The MMP code is not in the enum (since it was removed), causing an exception:
```
No DocBaseType found for code: MMP
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)