### PR TITLE
fix: Use unique ports in e2e-tests to avoid conflicts

### DIFF
--- a/docker-builds/e2e-tests/compose.yml
+++ b/docker-builds/e2e-tests/compose.yml
@@ -33,8 +33,8 @@ services:
   rabbitmq:
     image: rabbitmq:3.9.13-management
     ports:
-      - "5672:5672"
-      - "15672:15672"
+      - "14672:5672"
+      - "14673:15672"
     healthcheck:
       test: rabbitmq-diagnostics -q status
       interval: 10s
@@ -53,8 +53,8 @@ services:
   search:
     image: elasticsearch:7.17.8
     ports:
-      - "9200:9200"
-      - "9300:9300"
+      - "14200:9200"
+      - "14300:9300"
     healthcheck:
       test: "curl --fail --silent GET http://localhost:9200/_cluster/health?pretty | grep status | grep -q '\\(green\\|yellow\\)'"
       interval: 10s


### PR DESCRIPTION
## Summary
- Changes e2e-tests compose.yml to use unique ports in the 14xxx range
- RabbitMQ: 14672 (AMQP), 14673 (Management) instead of 5672/15672
- Elasticsearch: 14200 (HTTP), 14300 (Transport) instead of 9200/9300

## Why
Prevents port conflicts when running both mf-docker e2e-tests stack and Local Dev Infrastructure simultaneously.

## Test plan
- [ ] Verify e2e-tests stack starts successfully with new ports
- [ ] Confirm no port conflicts with Local Dev Infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)