### PR TITLE
Fix Product costing when dealing with included tax prices and catch weight

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_InOut.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_InOut.java
@@ -22,7 +22,7 @@ import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderId;
 import de.metas.order.costs.inout.InOutCost;
 import de.metas.organization.OrgId;
-import de.metas.quantity.Quantity;
+import de.metas.quantity.StockQtyAndUOMQty;
 import de.metas.util.collections.CollectionUtils;
 import lombok.Getter;
 import lombok.NonNull;
@@ -64,6 +64,7 @@ class DocLine_InOut extends DocLine<Doc_InOut>
 	@NonNull private final IOrderBL orderBL;
 
 	@NonNull @Getter private final ImmutableList<InOutCost> inoutCosts;
+	@NonNull @Getter private final StockQtyAndUOMQty qtyNominalAndCatchWeight;
 
 	/**
 	 * Outside Processing
@@ -79,8 +80,9 @@ class DocLine_InOut extends DocLine<Doc_InOut>
 		this.orderBL = doc.orderBL;
 		this.inoutCosts = ImmutableList.copyOf(inoutCosts);
 
-		final Quantity qty = doc.inOutBL.getMovementQty(inoutLine);
-		setQty(qty, doc.isSOTrx());
+		final boolean isSOTrx = doc.isSOTrx();
+		this.qtyNominalAndCatchWeight = doc.inOutBL.getStockQtyAndCatchQty(inoutLine).negateIf(isSOTrx);
+		setQty(qtyNominalAndCatchWeight.getStockQty());
 	}
 
 	public InOutLineId getInOutLineId()
@@ -164,7 +166,7 @@ class DocLine_InOut extends DocLine<Doc_InOut>
 					.productId(getProductId())
 					.attributeSetInstanceId(getAttributeSetInstanceId())
 					.documentRef(CostingDocumentRef.ofReceiptLineId(get_ID()))
-					.qty(getQty())
+					.qtyAndCatchWeight(getQtyNominalAndCatchWeight())
 					//.amt(null)
 					.currencyConversionContext(getCurrencyConversionContext(as))
 					.date(getDateAcctAsInstant());
@@ -217,7 +219,7 @@ class DocLine_InOut extends DocLine<Doc_InOut>
 							.productId(getProductId())
 							.attributeSetInstanceId(getAttributeSetInstanceId())
 							.documentRef(CostingDocumentRef.ofShipmentLineId(get_ID()))
-							.qty(getQty())
+							.qtyAndCatchWeight(getQtyNominalAndCatchWeight())
 							.amt(CostAmount.zero(as.getCurrencyId())) // expect to be calculated
 							.currencyConversionContext(getCurrencyConversionContext(as))
 							.date(getDateAcctAsInstant())

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_MatchPO.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_MatchPO.java
@@ -9,7 +9,6 @@ import de.metas.costing.CostingDocumentRef;
 import de.metas.costing.CostingMethod;
 import de.metas.currency.CurrencyConversionContext;
 import de.metas.currency.CurrencyConversionResult;
-import de.metas.currency.CurrencyPrecision;
 import de.metas.currency.ICurrencyBL;
 import de.metas.inout.IInOutBL;
 import de.metas.inout.InOutId;
@@ -20,9 +19,7 @@ import de.metas.order.IOrderLineBL;
 import de.metas.order.OrderLineId;
 import de.metas.organization.LocalDateAndOrgId;
 import de.metas.organization.OrgId;
-import de.metas.product.ProductPrice;
 import de.metas.quantity.Quantity;
-import de.metas.uom.IUOMConversionBL;
 import de.metas.util.Services;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ClientId;
@@ -60,7 +57,6 @@ final class DocLine_MatchPO extends DocLine<Doc_MatchPO>
 {
 	private final ICurrencyBL currencyBL = Services.get(ICurrencyBL.class);
 	private final IOrderLineBL orderLineBL = Services.get(IOrderLineBL.class);
-	private final IUOMConversionBL uomConversionsBL = Services.get(IUOMConversionBL.class);
 
 	private final I_C_OrderLine orderLine;
 	private final I_M_InOutLine _receiptLine;
@@ -99,7 +95,7 @@ final class DocLine_MatchPO extends DocLine<Doc_MatchPO>
 
 	CostAmount getPOCostAmountInAcctCurrency(final AcctSchema acctSchema)
 	{
-		final CostAmount poCostAmt = CostAmount.multiply(getOrderLineCostPriceInStockingUOM(), getQty());
+		final CostAmount poCostAmt = orderLineBL.getCostAmount(getOrderLine(), getQty());
 		return convertToAcctCurrency(poCostAmt, acctSchema);
 	}
 
@@ -116,15 +112,6 @@ final class DocLine_MatchPO extends DocLine<Doc_MatchPO>
 				acctSchema.getCurrencyId());
 
 		return CostAmount.of(poCostConv.getAmount(), acctSchema.getCurrencyId());
-	}
-
-	private ProductPrice getOrderLineCostPriceInStockingUOM()
-	{
-		final I_C_OrderLine orderLine = getOrderLine();
-		final ProductPrice costPrice = orderLineBL.getCostPrice(orderLine);
-
-		final CurrencyPrecision precision = currencyBL.getCostingPrecision(costPrice.getCurrencyId());
-		return uomConversionsBL.convertProductPriceToUom(costPrice, getProductStockingUOMId(), precision);
 	}
 
 	CostAmount getStandardCosts(final AcctSchema acctSchema)
@@ -151,7 +138,7 @@ final class DocLine_MatchPO extends DocLine<Doc_MatchPO>
 	{
 		final I_M_InOut receipt = getReceipt();
 		final Quantity qty = isReturnTrx() ? getQty().negate() : getQty();
-		final CostAmount amt = CostAmount.multiply(getOrderLineCostPriceInStockingUOM(), qty);
+		final CostAmount amt = getPOCostAmountInAcctCurrency(as).negateIf(isReturnTrx());
 
 		// NOTE: there is no need to fail if no cost details were created because:
 		// * not all costing methods are creating cost details for MatchPO

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_InOut.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_InOut.java
@@ -416,7 +416,7 @@ public class Doc_InOut extends Doc<DocLine_InOut>
 				.setDocLine(line)
 				.setAccount(line.getProductAssetAccount(as))
 				.setAmt(roundToStdPrecision(costs), null)
-				.setQty(line.getQty()) // (+) Qty
+				.setQty(line.getQtyNominalAndCatchWeight()) // (+) Qty
 				.bPartnerAndLocationId(line.getBPartnerId(costElement.getId()), line.getBPartnerLocationId(costElement.getId()))
 				.locatorId(line.getM_Locator_ID())
 				.fromLocationOfBPartner(line.getBPartnerLocationId(costElement.getId()))
@@ -436,7 +436,7 @@ public class Doc_InOut extends Doc<DocLine_InOut>
 						? getBPGroupAccount(BPartnerGroupAccountType.NotInvoicedReceipts, as)
 						: getCostElementAccount(as, costElement.getId(), CostElementAccountType.P_CostClearing_Acct))
 				.setAmt(null, roundToStdPrecision(costs))
-				.setQty(line.getQty().negate()) // (-) Qty
+				.setQty(line.getQtyNominalAndCatchWeight().negate()) // (-) Qty
 				.bPartnerAndLocationId(line.getBPartnerId(costElement.getId()), line.getBPartnerLocationId(costElement.getId()))
 				.locatorId(line.getM_Locator_ID())
 				.fromLocationOfBPartner(line.getBPartnerLocationId(costElement.getId()))
@@ -476,7 +476,7 @@ public class Doc_InOut extends Doc<DocLine_InOut>
 				.setDocLine(line)
 				.setAccount(getBPGroupAccount(BPartnerGroupAccountType.NotInvoicedReceipts, as))
 				.setAmt(roundToStdPrecision(costs), null)
-				.setQty(line.getQty().negate())
+				.setQty(line.getQtyNominalAndCatchWeight().negate())
 				.locatorId(line.getM_Locator_ID())
 				.fromLocationOfBPartner(getBPartnerLocationId())
 				.toLocationOfLocator(line.getM_Locator_ID())
@@ -500,7 +500,7 @@ public class Doc_InOut extends Doc<DocLine_InOut>
 				.setDocLine(line)
 				.setAccount(line.getProductAssetAccount(as))
 				.setAmt(null, roundToStdPrecision(costs))
-				.setQty(line.getQty())
+				.setQty(line.getQtyNominalAndCatchWeight())
 				.locatorId(line.getM_Locator_ID())
 				.fromLocationOfBPartner(getBPartnerLocationId())
 				.toLocationOfLocator(line.getM_Locator_ID())

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_MatchInv.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_MatchInv.java
@@ -55,7 +55,7 @@ import de.metas.order.costs.inout.InOutCost;
 import de.metas.organization.InstantAndOrgId;
 import de.metas.organization.OrgId;
 import de.metas.product.IProductBL;
-import de.metas.quantity.Quantity;
+import de.metas.quantity.StockQtyAndUOMQty;
 import de.metas.tax.api.Tax;
 import de.metas.tax.api.TaxId;
 import de.metas.util.Check;
@@ -213,9 +213,9 @@ public class Doc_MatchInv extends Doc<DocLine_MatchInv>
 		return getModel(I_M_MatchInv.class);
 	}
 
-	private Quantity getQty()
+	private StockQtyAndUOMQty getQty()
 	{
-		return docLine.getQty();
+		return getMatchInv().getQty();
 	}
 
 	/**
@@ -463,7 +463,7 @@ public class Doc_MatchInv extends Doc<DocLine_MatchInv>
 		final BigDecimal qtyInvoiced = getQtyInvoiced();
 		if (qtyInvoiced.signum() != 0) // task 08337: guard against division by zero
 		{
-			return getQty().divide(qtyInvoiced, 12, RoundingMode.HALF_UP).toBigDecimal();
+			return getQty().getStockQty().divide(qtyInvoiced, 12, RoundingMode.HALF_UP).toBigDecimal();
 		}
 		else
 		{
@@ -542,7 +542,7 @@ public class Doc_MatchInv extends Doc<DocLine_MatchInv>
 
 		final I_M_InOut receipt = getReceipt();
 		final MovementType movementType = MovementType.ofCode(receipt.getMovementType());
-		final Quantity qtyMatched = getQty().negateIf(movementType.isMaterialReturn());
+		final StockQtyAndUOMQty qtyMatched = getQty().negateIf(movementType.isMaterialReturn());
 
 		final MatchInvType type = matchInv.getType();
 		final Money amtMatched;
@@ -572,7 +572,7 @@ public class Doc_MatchInv extends Doc<DocLine_MatchInv>
 								.attributeSetInstanceId(matchInv.getAsiId())
 								.documentRef(CostingDocumentRef.ofMatchInvoiceId(matchInv.getId()))
 								.costElement(costElement)
-								.qty(qtyMatched)
+								.qtyAndCatchWeight(qtyMatched)
 								.amt(CostAmount.ofMoney(amtMatched))
 								.currencyConversionContext(inOutBL.getCurrencyConversionContext(receipt))
 								.date(getDateAcctAsInstant())

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/FactLineBuilder.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/FactLineBuilder.java
@@ -21,6 +21,7 @@ import de.metas.product.ProductId;
 import de.metas.product.acct.api.ActivityId;
 import de.metas.project.ProjectId;
 import de.metas.quantity.Quantity;
+import de.metas.quantity.StockQtyAndUOMQty;
 import de.metas.tax.api.TaxId;
 import de.metas.util.Check;
 import de.metas.util.StringUtils;
@@ -346,6 +347,11 @@ public final class FactLineBuilder
 		assertNotBuild();
 		this.qty = qty;
 		return this;
+	}
+
+	public FactLineBuilder setQty(@NonNull final StockQtyAndUOMQty qty)
+	{
+		return setQty(qty.getStockQty());
 	}
 
 	public FactLineBuilder setAmtSource(final CurrencyId currencyId, @Nullable final BigDecimal amtSourceDr, @Nullable final BigDecimal amtSourceCr)
@@ -701,7 +707,6 @@ public final class FactLineBuilder
 	{
 		return fromLocationOfLocator(locatorId != null ? locatorId.getRepoId() : -1);
 	}
-
 
 	public FactLineBuilder toLocation(final Optional<LocationId> optionalLocationId)
 	{

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/inout/InOutAndLineId.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/inout/InOutAndLineId.java
@@ -54,13 +54,13 @@ public class InOutAndLineId
 	public static InOutAndLineId ofRepoIdOrNull(final int inOutRepoId, final int inOutLineRepoId)
 	{
 		final InOutId inoutId = InOutId.ofRepoIdOrNull(inOutRepoId);
-		if(inoutId == null)
+		if (inoutId == null)
 		{
 			return null;
 		}
 
 		final InOutLineId inoutLineId = InOutLineId.ofRepoIdOrNull(inOutLineRepoId);
-		if(inoutLineId == null)
+		if (inoutLineId == null)
 		{
 			return null;
 		}
@@ -68,11 +68,11 @@ public class InOutAndLineId
 		return new InOutAndLineId(inoutId, inoutLineId);
 	}
 
-
 	@JsonProperty("inOutId")
-	InOutId inOutId;
+	@NonNull InOutId inOutId;
+
 	@JsonProperty("inOutLineId")
-	InOutLineId inOutLineId;
+	@NonNull InOutLineId inOutLineId;
 
 	@JsonCreator
 	private InOutAndLineId(

--- a/backend/de.metas.business/src/main/java/de/metas/costing/CostDetailCreateRequest.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/CostDetailCreateRequest.java
@@ -7,12 +7,14 @@ import de.metas.currency.CurrencyConversionContext;
 import de.metas.organization.OrgId;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
+import de.metas.quantity.StockQtyAndUOMQty;
 import de.metas.util.Check;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
 import lombok.Value;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.service.ClientId;
 
@@ -61,6 +63,7 @@ public class CostDetailCreateRequest
 	@NonNull CostAmountType amtType;
 	@NonNull CostAmount amt;
 	@NonNull Quantity qty;
+	@Nullable Quantity catchWeight;
 	@Nullable CurrencyConversionContext currencyConversionContext;
 	@NonNull Instant date;
 	@Nullable String description;
@@ -80,6 +83,7 @@ public class CostDetailCreateRequest
 			@Nullable final CostAmountType amtType,
 			@NonNull final CostAmount amt,
 			@NonNull final Quantity qty,
+			@Nullable Quantity catchWeight,
 			@Nullable final CurrencyConversionContext currencyConversionContext,
 			@NonNull final Instant date,
 			@Nullable final String description,
@@ -96,10 +100,27 @@ public class CostDetailCreateRequest
 		this.amtType = amtType != null ? amtType : CostAmountType.MAIN;
 		this.amt = amt;
 		this.qty = qty;
+		this.catchWeight = catchWeight;
 		this.currencyConversionContext = currencyConversionContext;
 		this.date = date;
 		this.description = description;
 		this.explicitCostPrice = explicitCostPrice;
+	}
+
+	public static class CostDetailCreateRequestBuilder
+	{
+		public CostDetailCreateRequestBuilder qtyAndCatchWeight(@NonNull StockQtyAndUOMQty qtyAndCatchWeight)
+		{
+			//noinspection ConstantValue
+			if (this.productId != null && !ProductId.equals(this.productId, qtyAndCatchWeight.getProductId()))
+			{
+				throw new AdempiereException("Invalid productId: " + qtyAndCatchWeight.getProductId() + " != " + this.productId);
+			}
+
+			qty(qtyAndCatchWeight.getStockQty());
+			catchWeight(qtyAndCatchWeight.getUOMQtyOpt().orElse(null));
+			return this;
+		}
 	}
 
 	public AcctSchemaId getAcctSchemaId()
@@ -157,6 +178,12 @@ public class CostDetailCreateRequest
 		}
 
 		return toBuilder().costElement(costElement).build();
+	}
+
+	@NonNull
+	public Quantity getQtyCatchWeightOrNominal()
+	{
+		return catchWeight != null ? catchWeight : qty;
 	}
 
 	public CostDetailCreateRequest withAmount(@NonNull final CostAmount amt)

--- a/backend/de.metas.business/src/main/java/de/metas/costing/methods/AveragePOCostingMethodHandler.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/methods/AveragePOCostingMethodHandler.java
@@ -16,7 +16,6 @@ import de.metas.costing.CurrentCost;
 import de.metas.costing.MoveCostsRequest;
 import de.metas.costing.MoveCostsResult;
 import de.metas.currency.CurrencyConversionContext;
-import de.metas.currency.CurrencyPrecision;
 import de.metas.inout.IInOutBL;
 import de.metas.inout.InOutId;
 import de.metas.inout.InOutLineId;
@@ -28,7 +27,6 @@ import de.metas.money.Money;
 import de.metas.order.IOrderLineBL;
 import de.metas.order.costs.OrderCostService;
 import de.metas.order.costs.inout.InOutCost;
-import de.metas.product.ProductPrice;
 import de.metas.quantity.Quantity;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -103,22 +101,11 @@ public class AveragePOCostingMethodHandler extends CostingMethodHandlerTemplate
 		final MatchInv matchInv = matchInvoiceService.getById(request.getDocumentRef().getId(MatchInvId.class));
 		final CurrentCost currentCost = utils.getCurrentCost(request);
 
-		final CostAmount amtConv = getReceiptAmount(matchInv, request.getQty(), request.getCostElement(), request.getAcctSchemaId(), currentCost.getPrecision());
-
-		return utils.createCostDetailRecordNoCostsChanged(
-				request.withAmount(amtConv),
-				CostDetailPreviousAmounts.of(currentCost));
-	}
-
-	private CostAmount getReceiptAmount(
-			@NonNull final MatchInv matchInv,
-			@NonNull final Quantity receiptQty,
-			@NonNull final CostElement costElement,
-			@NonNull final AcctSchemaId acctSchemaId,
-			@NonNull final CurrencyPrecision precision)
-	{
+		final @NonNull CostElement costElement = request.getCostElement();
+		final @NonNull AcctSchemaId acctSchemaId = request.getAcctSchemaId();
 		final CurrencyConversionContext currencyConversionContext = inoutBL.getCurrencyConversionContext(matchInv.getInOutId());
 
+		final CostAmount amtConv;
 		final MatchInvType type = matchInv.getType();
 		if (type.isMaterial())
 		{
@@ -128,16 +115,16 @@ public class AveragePOCostingMethodHandler extends CostingMethodHandlerTemplate
 					.map(orderLineBL::getOrderLineById)
 					.orElseThrow(() -> new AdempiereException("Cannot determine order line for " + matchInv));
 
-			return getCostAmountInAcctCurrency(orderLine, receiptQty, acctSchemaId, currencyConversionContext);
+			amtConv = getCostAmountInAcctCurrency(orderLine, request.getQtyCatchWeightOrNominal(), acctSchemaId, currencyConversionContext);
 		}
 		else if (type.isCost())
 		{
 			final InOutCost inoutCost = orderCostService.getInOutCostsById(matchInv.getCostPartNotNull().getInoutCostId());
 			Check.assumeEquals(inoutCost.getCostElementId(), costElement.getId(), "Cost Element shall match: {}, {}", inoutCost, costElement);
 
-			final Money receiptAmount = inoutCost.getCostAmountForQty(receiptQty, precision);
+			final Money receiptAmount = inoutCost.getCostAmountForQty(request.getQty(), currentCost.getPrecision());
 
-			return utils.convertToAcctSchemaCurrency(
+			amtConv = utils.convertToAcctSchemaCurrency(
 					CostAmount.ofMoney(receiptAmount),
 					() -> currencyConversionContext,
 					acctSchemaId);
@@ -146,6 +133,10 @@ public class AveragePOCostingMethodHandler extends CostingMethodHandlerTemplate
 		{
 			throw new AdempiereException("Unknown type: " + type);
 		}
+
+		return utils.createCostDetailRecordNoCostsChanged(
+				request.withAmount(amtConv),
+				CostDetailPreviousAmounts.of(currentCost));
 	}
 
 	@Override
@@ -153,15 +144,15 @@ public class AveragePOCostingMethodHandler extends CostingMethodHandlerTemplate
 	{
 		final CurrentCost currentCost = utils.getCurrentCost(request);
 
-		final InOutLineId receipLineId = request.getDocumentRef().getId(InOutLineId.class);
-		final I_M_InOutLine receiptLine = inoutBL.getLineByIdInTrx(receipLineId);
+		final InOutLineId receiptLineId = request.getDocumentRef().getId(InOutLineId.class);
+		final I_M_InOutLine receiptLine = inoutBL.getLineByIdInTrx(receiptLineId);
 		final I_C_OrderLine orderLine = receiptLine.getC_OrderLine();
 		final CostAmount amtConv;
 		if (orderLine != null)
 		{
 			final InOutId receiptId = InOutId.ofRepoId(receiptLine.getM_InOut_ID());
 			final CurrencyConversionContext currencyConversionContext = inoutBL.getCurrencyConversionContext(receiptId);
-			amtConv = getCostAmountInAcctCurrency(orderLine, request.getQty(), request.getAcctSchemaId(), currencyConversionContext);
+			amtConv = getCostAmountInAcctCurrency(orderLine, request.getQtyCatchWeightOrNominal(), request.getAcctSchemaId(), currencyConversionContext);
 		}
 		else
 		{
@@ -413,21 +404,11 @@ public class AveragePOCostingMethodHandler extends CostingMethodHandlerTemplate
 			@NonNull final AcctSchemaId acctSchemaId,
 			@NonNull final CurrencyConversionContext currencyConversionContext)
 	{
-		final CostAmount amt = getCostAmountInSourceCurrency(orderLine, qty);
+		final CostAmount amt = orderLineBL.getCostAmount(orderLine, qty);
 
 		return utils.convertToAcctSchemaCurrency(
 				amt,
 				() -> currencyConversionContext,
 				acctSchemaId);
-	}
-
-	@NonNull
-	private CostAmount getCostAmountInSourceCurrency(@NonNull final I_C_OrderLine orderLine, @NonNull final Quantity qty)
-	{
-		final ProductPrice costPriceConv = utils.convertToUOM(
-				orderLineBL.getCostPrice(orderLine),
-				qty.getUomId());
-
-		return CostAmount.ofProductPrice(costPriceConv).multiply(qty);
 	}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/costing/methods/MovingAverageInvoiceCostingMethodHandler.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/methods/MovingAverageInvoiceCostingMethodHandler.java
@@ -41,7 +41,6 @@ import de.metas.costing.MoveCostsRequest;
 import de.metas.costing.MoveCostsResult;
 import de.metas.costing.ShipmentCosts;
 import de.metas.currency.CurrencyConversionContext;
-import de.metas.currency.CurrencyPrecision;
 import de.metas.inout.IInOutBL;
 import de.metas.inout.InOutId;
 import de.metas.inout.InOutLineId;
@@ -56,7 +55,6 @@ import de.metas.order.IOrderLineBL;
 import de.metas.order.costs.OrderCostService;
 import de.metas.order.costs.inout.InOutCost;
 import de.metas.product.ProductId;
-import de.metas.product.ProductPrice;
 import de.metas.quantity.Quantity;
 import de.metas.uom.UomId;
 import de.metas.util.Services;
@@ -492,35 +490,71 @@ public class MovingAverageInvoiceCostingMethodHandler extends CostingMethodHandl
 		final InvoiceId invoiceId = matchInv.getInvoiceId();
 		final boolean isReversal = invoiceBL.isReversal(invoiceId);
 
-		final Quantity receiptQty = request.getQty().negateIf(isReversal); // i.e. qty matched
-		final CostAmount receiptAmt = getReceiptAmount(matchInv, receiptQty, request.getCostElement(), request.getAcctSchemaId(), currentCost.getPrecision());
+		final Quantity qty = request.getQty().negateIf(isReversal); // i.e. qty matched
+		final @NonNull CostElement costElement = request.getCostElement();
+		final @NonNull AcctSchemaId acctSchemaId = request.getAcctSchemaId();
+		final CurrencyConversionContext currencyConversionContext = inoutBL.getCurrencyConversionContext(matchInv.getInOutId());
+
+		final CostAmount receiptAmt;
+		final MatchInvType type = matchInv.getType();
+		if (type.isMaterial())
+		{
+			Check.assume(costElement.isMaterial(), "Cost Element shall be material: {}", costElement);
+
+			final I_C_OrderLine orderLine = matchInvoiceService.getOrderLineId(matchInv)
+					.map(orderLineBL::getOrderLineById)
+					.orElseThrow(() -> new AdempiereException("Cannot determine order line for " + matchInv));
+
+			receiptAmt = getCostAmountInAcctCurrency(
+					orderLine, 
+					request.getQtyCatchWeightOrNominal().negateIf(isReversal),  
+					acctSchemaId, 
+					currencyConversionContext);
+		}
+		else if (type.isCost())
+		{
+			final InOutCost inoutCost = orderCostService.getInOutCostsById(matchInv.getCostPartNotNull().getInoutCostId());
+			Check.assumeEquals(inoutCost.getCostElementId(), costElement.getId(), "Cost Element shall match: {}, {}", inoutCost, costElement);
+
+			final Money receiptAmount = inoutCost.getCostAmountForQty(qty, currentCost.getPrecision());
+
+			receiptAmt = utils.convertToAcctSchemaCurrency(
+					CostAmount.ofMoney(receiptAmount),
+					() -> currencyConversionContext,
+					acctSchemaId);
+		}
+		else
+		{
+			throw new AdempiereException("Unknown type: " + type);
+		}
+
 		final CostAmount invoicedAmt = request.getAmt().negateIf(isReversal);
 		final CostAmount amtDifference = invoicedAmt.subtract(receiptAmt);
 
 		final CostAmount costAdjustmentAmt;
 		final CostAmount alreadyShippedAmt;
 
-		final Quantity qtyStillInStock = currentCost.getCurrentQty().min(receiptQty);
+		final Quantity qtyStillInStock = currentCost.getCurrentQty().min(qty);
 		if (amtDifference.isZero())
 		{
 			costAdjustmentAmt = CostAmount.zero(currentCost.getCurrencyId());
 			alreadyShippedAmt = CostAmount.zero(currentCost.getCurrencyId());
 		}
-		else if (receiptQty.isZero())
+		else if (qty.isZero())
 		{
 			costAdjustmentAmt = CostAmount.zero(currentCost.getCurrencyId());
 			alreadyShippedAmt = amtDifference;
 		}
-		else if (receiptQty.equalsIgnoreSource(qtyStillInStock))
+		else if (qty.equalsIgnoreSource(qtyStillInStock))
 		{
 			costAdjustmentAmt = amtDifference;
 			alreadyShippedAmt = CostAmount.zero(currentCost.getCurrencyId());
 		}
 		else
 		{
-			final CostAmount priceDifference = amtDifference.isZero() || receiptQty.isZero()
+			final CostAmount priceDifference = amtDifference.isZero() || qty.isZero()
 					? CostAmount.zero(currentCost.getCurrencyId())
-					: amtDifference.divide(receiptQty, currentCost.getPrecision());
+					: amtDifference.divide(qty, currentCost.getPrecision());
 
 			costAdjustmentAmt = priceDifference.multiply(qtyStillInStock);
 			alreadyShippedAmt = amtDifference.subtract(costAdjustmentAmt);
@@ -532,44 +566,6 @@ public class MovingAverageInvoiceCostingMethodHandler extends CostingMethodHandl
 				.alreadyShippedAmt(alreadyShippedAmt)
 				.build()
 				.negateIf(isReversal);
-	}
-
-	private CostAmount getReceiptAmount(
-			@NonNull final MatchInv matchInv,
-			@NonNull final Quantity receiptQty,
-			@NonNull final CostElement costElement,
-			@NonNull final AcctSchemaId acctSchemaId,
-			@NonNull final CurrencyPrecision precision)
-	{
-		final CurrencyConversionContext currencyConversionContext = inoutBL.getCurrencyConversionContext(matchInv.getInOutId());
-
-		final MatchInvType type = matchInv.getType();
-		if (type.isMaterial())
-		{
-			Check.assume(costElement.isMaterial(), "Cost Element shall be material: {}", costElement);
-
-			final I_C_OrderLine orderLine = matchInvoiceService.getOrderLineId(matchInv)
-					.map(orderLineBL::getOrderLineById)
-					.orElseThrow(() -> new AdempiereException("Cannot determine order line for " + matchInv));
-
-			return getCostAmountInAcctCurrency(orderLine, receiptQty, acctSchemaId, currencyConversionContext);
-		}
-		else if (type.isCost())
-		{
-			final InOutCost inoutCost = orderCostService.getInOutCostsById(matchInv.getCostPartNotNull().getInoutCostId());
-			Check.assumeEquals(inoutCost.getCostElementId(), costElement.getId(), "Cost Element shall match: {}, {}", inoutCost, costElement);
-
-			final Money receiptAmount = inoutCost.getCostAmountForQty(receiptQty, precision);
-
-			return utils.convertToAcctSchemaCurrency(
-					CostAmount.ofMoney(receiptAmount),
-					() -> currencyConversionContext,
-					acctSchemaId);
-		}
-		else
-		{
-			throw new AdempiereException("Unknown type: " + type);
-		}
 	}
 
 	@Override
@@ -603,7 +599,7 @@ public class MovingAverageInvoiceCostingMethodHandler extends CostingMethodHandl
 			@NonNull final AcctSchemaId acctSchemaId,
 			@NonNull final CurrencyConversionContext currencyConversionContext)
 	{
-		final CostAmount amt = getCostAmountInSourceCurrency(orderLine, qty);
+		final CostAmount amt = orderLineBL.getCostAmount(orderLine, qty);
 
 		return utils.convertToAcctSchemaCurrency(
 				amt,
@@ -611,13 +607,4 @@ public class MovingAverageInvoiceCostingMethodHandler extends CostingMethodHandl
 				acctSchemaId);
 	}
 
-	@NonNull
-	private CostAmount getCostAmountInSourceCurrency(@NonNull final I_C_OrderLine orderLine, @NonNull final Quantity qty)
-	{
-		final ProductPrice costPriceConv = utils.convertToUOM(
-				orderLineBL.getCostPrice(orderLine),
-				qty.getUomId());
-
-		return CostAmount.ofProductPrice(costPriceConv).multiply(qty);
-	}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/inout/impl/InOutBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/inout/impl/InOutBL.java
@@ -264,7 +264,8 @@ public class InOutBL implements IInOutBL
 	public StockQtyAndUOMQty getStockQtyAndCatchQty(@NonNull final I_M_InOutLine inoutLine)
 	{
 		final UomId catchUomIdOrNull;
-		if (inoutLine.getQtyDeliveredCatch().signum() != 0)
+		final BigDecimal qtyDeliveredCatch = inoutLine.getQtyDeliveredCatch();
+		if (qtyDeliveredCatch.signum() != 0)
 		{
 			catchUomIdOrNull = UomId.ofRepoIdOrNull(inoutLine.getCatch_UOM_ID());
 		}
@@ -278,7 +279,7 @@ public class InOutBL implements IInOutBL
 		return StockQtyAndUOMQtys.create(
 				inoutLine.getMovementQty(),
 				productId,
-				inoutLine.getQtyDeliveredCatch(),
+				qtyDeliveredCatch,
 				catchUomIdOrNull);
 	}
 

--- a/backend/de.metas.business/src/main/java/de/metas/order/IOrderLineBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/IOrderLineBL.java
@@ -23,6 +23,7 @@ package de.metas.order;
  */
 
 import de.metas.bpartner.BPartnerId;
+import de.metas.costing.CostAmount;
 import de.metas.currency.CurrencyPrecision;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.payment.paymentterm.PaymentTermId;
@@ -209,7 +210,7 @@ public interface IOrderLineBL extends ISingletonService
 	 */
 	boolean isAllowedCounterLineCopy(org.compiere.model.I_C_OrderLine fromLine);
 
-	ProductPrice getCostPrice(org.compiere.model.I_C_OrderLine orderLine);
+	CostAmount getCostAmount(@NonNull org.compiere.model.I_C_OrderLine orderLine, @NonNull Quantity qty);
 
 	ProductPrice getPriceActual(org.compiere.model.I_C_OrderLine orderLine);
 

--- a/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderLineBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderLineBL.java
@@ -7,6 +7,7 @@ import de.metas.bpartner.BPartnerLocationId;
 import de.metas.bpartner.service.IBPartnerBL;
 import de.metas.bpartner.service.IBPartnerDAO;
 import de.metas.costing.ChargeId;
+import de.metas.costing.CostAmount;
 import de.metas.costing.impl.ChargeRepository;
 import de.metas.currency.CurrencyPrecision;
 import de.metas.currency.ICurrencyDAO;
@@ -369,7 +370,7 @@ public class OrderLineBL implements IOrderLineBL
 		final Quantity qtyInPriceUOM = orderLine.isManualQtyInPriceUOM()
 				? getQtyEnteredInPriceUOM(orderLine)
 				: convertQtyEnteredToPriceUOM(orderLine);
-		
+
 		updateLineNetAmtFromQtyInPriceUOM(orderLine, qtyInPriceUOM);
 	}
 
@@ -604,7 +605,7 @@ public class OrderLineBL implements IOrderLineBL
 		final BigDecimal qtyItemCapacity = orderLine.getQtyItemCapacity();
 		if (qtyItemCapacity.signum() <= 0 && orderLine.getQtyEntered().signum() != 0)
 		{
-			throw new AdempiereException(TranslatableStrings.constant("Missing QtyItemCapacity for C_ORderLine_ID="+orderLine.getC_OrderLine_ID()))
+			throw new AdempiereException(TranslatableStrings.constant("Missing QtyItemCapacity for C_ORderLine_ID=" + orderLine.getC_OrderLine_ID()))
 					.appendParametersToMessage()
 					.setParameter("C_Order_ID", orderLine.getC_Order_ID())
 					.setParameter("Line", orderLine.getLine())
@@ -760,68 +761,34 @@ public class OrderLineBL implements IOrderLineBL
 	}
 
 	@Override
-	public ProductPrice getCostPrice(final org.compiere.model.I_C_OrderLine orderLine)
+	public CostAmount getCostAmount(@NonNull final org.compiere.model.I_C_OrderLine orderLine, @NonNull final Quantity qty)
 	{
-		final CurrencyId currencyId = CurrencyId.ofRepoId(orderLine.getC_Currency_ID());
-		final ProductId productId = ProductId.ofRepoId(orderLine.getM_Product_ID());
+		// IMPORTANT: the order how we calculate is super important because these amounts are used in accounting 
+		// so we shall also have to match how the invoice net amount is calculated.
+		// i.e. we calculated the amount then we subtract the included tax at the end,
+		// and not subtracting the included tax from the price and then multiplying with the qty because that would introduce a big rounding error
 
-		final BigDecimal poCostPrice = orderLine.getPriceCost();
-		if (poCostPrice != null && poCostPrice.signum() != 0)
+		ProductPrice price = getPriceActual(orderLine);
+		if (!UomId.equals(price.getUomId(), qty.getUomId()))
 		{
-			final UomId productUomId = productBL.getStockUOMId(productId);
-
-			return ProductPrice.builder()
-					.productId(productId)
-					.uomId(productUomId)
-					.money(Money.of(poCostPrice, currencyId))
-					.build();
+			final CurrencyPrecision stdPrecision = currencyDAO.getStdPrecision(price.getCurrencyId());
+			price = uomConversionBL.convertProductPriceToUom(price, qty.getUomId(), stdPrecision);
 		}
 
-		UomId priceUomId = UomId.ofRepoId(orderLine.getPrice_UOM_ID());
-		if (priceUomId == null)
+		CostAmount costAmount = CostAmount.multiply(price, qty);
+
+		//
+		// Subtract included tax if any
+		final TaxId taxId = TaxId.ofRepoIdOrNull(orderLine.getC_Tax_ID());
+		if (taxId != null && isTaxIncluded(orderLine))
 		{
-			priceUomId = UomId.ofRepoId(orderLine.getC_UOM_ID());
+			final Tax tax = taxBL.getTaxById(taxId);
+			final CurrencyPrecision taxPrecision = getTaxPrecision(orderLine);
+			final BigDecimal baseAmt = tax.calculateBaseAmt(costAmount.toBigDecimal(), true, taxPrecision.toInt());
+			costAmount = CostAmount.of(baseAmt, costAmount.getCurrencyId());
 		}
 
-		final BigDecimal priceActual = orderLine.getPriceActual();
-		if (!isTaxIncluded(orderLine))
-		{
-			return ProductPrice.builder()
-					.productId(productId)
-					.uomId(priceUomId)
-					.money(Money.of(priceActual, currencyId))
-					.build();
-		}
-
-		final int taxId = orderLine.getC_Tax_ID();
-		if (taxId <= 0)
-		{
-			// shall not happen
-			return ProductPrice.builder()
-					.productId(productId)
-					.uomId(priceUomId)
-					.money(Money.of(priceActual, currencyId))
-					.build();
-		}
-
-		final MTax tax = MTax.get(Env.getCtx(), taxId);
-		if (tax.isZeroTax())
-		{
-			return ProductPrice.builder()
-					.productId(productId)
-					.uomId(priceUomId)
-					.money(Money.of(priceActual, currencyId))
-					.build();
-		}
-
-		final CurrencyPrecision taxPrecision = getTaxPrecision(orderLine);
-		final BigDecimal taxAmt = taxBL.calculateTaxAmt(tax, priceActual, true/* taxIncluded */, taxPrecision.toInt());
-		final BigDecimal priceActualWithoutTax = priceActual.subtract(taxAmt);
-		return ProductPrice.builder()
-				.productId(productId)
-				.uomId(priceUomId)
-				.money(Money.of(priceActualWithoutTax, currencyId))
-				.build();
+		return costAmount;
 	}
 
 	@Override
@@ -829,12 +796,17 @@ public class OrderLineBL implements IOrderLineBL
 	{
 		final CurrencyId currencyId = CurrencyId.ofRepoId(orderLine.getC_Currency_ID());
 		final ProductId productId = ProductId.ofRepoId(orderLine.getM_Product_ID());
-		final UomId productUomId = productBL.getStockUOMId(productId);
 		final BigDecimal priceActual = orderLine.getPriceActual();
+
+		UomId priceUomId = UomId.ofRepoIdOrNull(orderLine.getPrice_UOM_ID());
+		if (priceUomId == null)
+		{
+			priceUomId = UomId.ofRepoId(orderLine.getC_UOM_ID());
+		}
 
 		return ProductPrice.builder()
 				.productId(productId)
-				.uomId(productUomId)
+				.uomId(priceUomId)
 				.money(Money.of(priceActual, currencyId))
 				.build();
 	}


### PR DESCRIPTION
- **minor QA. Refactor variable usage in `InOutBL`. Replaced inline method call for `getQtyDeliveredCatch` with a local variable to improve readability and reuse. Adjusted references accordingly within `getStockQtyAndCatchQty`.**
- **Minor QA. Add `@NonNull` annotations to `InOutAndLineId` fields**
- **Implement support for `StockQtyAndUOMQty` in costing logic**
