### PR TITLE
Port: Fix record_id parameter naming collision

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/db_alter_function.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/db_alter_function.sql
@@ -1,0 +1,72 @@
+DROP FUNCTION IF EXISTS public.db_alter_function(text, text);
+
+CREATE OR REPLACE FUNCTION public.db_alter_function(
+    p_function_name text,       -- Function name (with schema), e.g. 'de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Sum_Weight'
+    p_function_definition text  -- Full CREATE OR REPLACE FUNCTION statement
+)
+    RETURNS void AS
+$BODY$
+DECLARE
+    i                int;
+    j                int;
+    v                record;
+    viewFullName     text[];
+    viewDef          text[];
+    dropViews        text[];
+    currentViewName  text;
+    command          text;
+BEGIN
+    -- 1. Fetch dependent views and store them
+    i := 0;
+    FOR v IN (SELECT view_schema, view_name, view_def
+              FROM public.db_dependent_views_of_function(p_function_name))
+        LOOP
+            currentViewName := '"' || v.view_schema || '"."' || v.view_name || '"';
+
+            -- Skip if already in the list
+            IF viewFullName @> array [currentViewName] THEN
+                RAISE NOTICE 'skip view % because it was already detected', currentViewName;
+                CONTINUE;
+            END IF;
+
+            i := i + 1;
+            viewFullName[i] := currentViewName;
+            viewDef[i] := v.view_def;
+            RAISE NOTICE 'Found dependent view: %', currentViewName;
+        END LOOP;
+
+    -- 2. Drop dependent views
+    IF i > 0 THEN
+        FOR j IN 1 .. i
+            LOOP
+                RAISE NOTICE 'Dropping view %', viewFullName[j];
+                command := 'DROP VIEW IF EXISTS ' || viewFullName[j];
+                EXECUTE command;
+                dropViews[j] := viewFullName[j];
+            END LOOP;
+    END IF;
+
+    -- 3. Drop and recreate the function
+    RAISE NOTICE 'Dropping function %', p_function_name;
+    EXECUTE 'DROP FUNCTION IF EXISTS ' || p_function_name;
+
+    RAISE NOTICE 'Creating function with new definition';
+    EXECUTE p_function_definition;
+
+    -- 4. Recreate dependent views in reverse order
+    IF i > 0 THEN
+        FOR j IN REVERSE i .. 1
+            LOOP
+                RAISE NOTICE 'Recreating view %', dropViews[j];
+                command := 'CREATE OR REPLACE VIEW ' || dropViews[j] || ' AS ' || viewDef[j];
+                EXECUTE command;
+            END LOOP;
+    END IF;
+
+    RAISE NOTICE 'db_alter_function completed successfully for %', p_function_name;
+END;
+$BODY$
+    LANGUAGE plpgsql VOLATILE;
+
+COMMENT ON FUNCTION public.db_alter_function(text, text)
+    IS 'Safely alters a function by first dropping dependent views, then dropping and recreating the function, and finally recreating the dependent views. Use this when you need to change a function''s parameter names or signature and there are dependent views.';

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/db_dependent_views_of_function.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/db_dependent_views_of_function.sql
@@ -1,0 +1,52 @@
+DROP FUNCTION IF EXISTS public.db_dependent_views_of_function(text);
+
+CREATE OR REPLACE FUNCTION public.db_dependent_views_of_function(IN p_function_name text)
+    RETURNS TABLE
+            (
+                view_schema text,
+                view_name   text,
+                view_def    text
+            )
+AS
+$BODY$
+DECLARE
+    v_function_name text;
+BEGIN
+    -- Strip signature if present (e.g., 'schema.func(int, text)' -> 'schema.func')
+    v_function_name := regexp_replace(p_function_name, '\([^)]*\)$', '');
+
+    RETURN QUERY
+        WITH function_oid AS (
+            -- Find the function OID by name (handles schema.function_name format)
+            SELECT p.oid
+            FROM pg_proc p
+                     JOIN pg_namespace n ON p.pronamespace = n.oid
+            WHERE CASE
+                      WHEN position('.' IN v_function_name) > 0 THEN
+                              n.nspname || '.' || p.proname = lower(v_function_name)
+                      ELSE
+                          p.proname = lower(v_function_name)
+                END
+            LIMIT 1
+        ),
+             dependent_views AS (
+                 -- Find views that depend on this function
+                 SELECT DISTINCT c.relnamespace::regnamespace::text AS view_schema,
+                                 c.relname::text                    AS view_name
+                 FROM pg_depend d
+                          JOIN function_oid f ON d.refobjid = f.oid
+                          JOIN pg_rewrite r ON d.objid = r.oid
+                          JOIN pg_class c ON r.ev_class = c.oid
+                 WHERE d.classid = 'pg_rewrite'::regclass
+                   AND c.relkind = 'v' -- views only
+             )
+        SELECT dv.view_schema,
+               dv.view_name,
+               pg_get_viewdef((dv.view_schema || '.' || dv.view_name)::regclass, true) AS view_def
+        FROM dependent_views dv;
+END;
+$BODY$
+    LANGUAGE plpgsql VOLATILE;
+
+COMMENT ON FUNCTION public.db_dependent_views_of_function(text)
+    IS 'Finds views that directly depend on the given function. Returns schema, name, and definition of each dependent view. Handles both schema.function_name and schema.function_name(args) formats.';

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5784229_sys_add_db_alter_function.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5784229_sys_add_db_alter_function.sql
@@ -1,0 +1,138 @@
+-- Title: Add db_alter_function helper for safely altering functions with dependent views
+-- Description: Creates db_dependent_views_of_function and db_alter_function to handle
+--              function alterations that have dependent views, similar to db_alter_view.
+-- 2026-01-17
+-- Task: Improve migration tooling for function DDL changes
+
+-- ===========================================================================
+-- 1. db_dependent_views_of_function - finds views that depend on a given function
+-- ===========================================================================
+DROP FUNCTION IF EXISTS public.db_dependent_views_of_function(text);
+
+CREATE OR REPLACE FUNCTION public.db_dependent_views_of_function(IN p_function_name text)
+    RETURNS TABLE
+            (
+                view_schema text,
+                view_name   text,
+                view_def    text
+            )
+AS
+$BODY$
+DECLARE
+    v_function_name text;
+BEGIN
+    -- Strip signature if present (e.g., 'schema.func(int, text)' -> 'schema.func')
+    v_function_name := regexp_replace(p_function_name, '\([^)]*\)$', '');
+
+    RETURN QUERY
+        WITH function_oid AS (
+            -- Find the function OID by name (handles schema.function_name format)
+            SELECT p.oid
+            FROM pg_proc p
+                     JOIN pg_namespace n ON p.pronamespace = n.oid
+            WHERE CASE
+                      WHEN position('.' IN v_function_name) > 0 THEN
+                              n.nspname || '.' || p.proname = lower(v_function_name)
+                      ELSE
+                          p.proname = lower(v_function_name)
+                END
+            LIMIT 1
+        ),
+             dependent_views AS (
+                 -- Find views that depend on this function
+                 SELECT DISTINCT c.relnamespace::regnamespace::text AS view_schema,
+                                 c.relname::text                    AS view_name
+                 FROM pg_depend d
+                          JOIN function_oid f ON d.refobjid = f.oid
+                          JOIN pg_rewrite r ON d.objid = r.oid
+                          JOIN pg_class c ON r.ev_class = c.oid
+                 WHERE d.classid = 'pg_rewrite'::regclass
+                   AND c.relkind = 'v' -- views only
+             )
+        SELECT dv.view_schema,
+               dv.view_name,
+               pg_get_viewdef((dv.view_schema || '.' || dv.view_name)::regclass, true) AS view_def
+        FROM dependent_views dv;
+END;
+$BODY$
+    LANGUAGE plpgsql VOLATILE;
+
+COMMENT ON FUNCTION public.db_dependent_views_of_function(text)
+    IS 'Finds views that directly depend on the given function. Returns schema, name, and definition of each dependent view. Handles both schema.function_name and schema.function_name(args) formats.';
+
+
+-- ===========================================================================
+-- 2. db_alter_function - safely alters a function by handling dependent views
+-- ===========================================================================
+DROP FUNCTION IF EXISTS public.db_alter_function(text, text);
+
+CREATE OR REPLACE FUNCTION public.db_alter_function(
+    p_function_name text,       -- Function name (with schema), e.g. 'de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Sum_Weight'
+    p_function_definition text  -- Full CREATE OR REPLACE FUNCTION statement
+)
+    RETURNS void AS
+$BODY$
+DECLARE
+    i                int;
+    j                int;
+    v                record;
+    viewFullName     text[];
+    viewDef          text[];
+    dropViews        text[];
+    currentViewName  text;
+    command          text;
+BEGIN
+    -- 1. Fetch dependent views and store them
+    i := 0;
+    FOR v IN (SELECT view_schema, view_name, view_def
+              FROM public.db_dependent_views_of_function(p_function_name))
+        LOOP
+            currentViewName := '"' || v.view_schema || '"."' || v.view_name || '"';
+
+            -- Skip if already in the list
+            IF viewFullName @> array [currentViewName] THEN
+                RAISE NOTICE 'skip view % because it was already detected', currentViewName;
+                CONTINUE;
+            END IF;
+
+            i := i + 1;
+            viewFullName[i] := currentViewName;
+            viewDef[i] := v.view_def;
+            RAISE NOTICE 'Found dependent view: %', currentViewName;
+        END LOOP;
+
+    -- 2. Drop dependent views
+    IF i > 0 THEN
+        FOR j IN 1 .. i
+            LOOP
+                RAISE NOTICE 'Dropping view %', viewFullName[j];
+                command := 'DROP VIEW IF EXISTS ' || viewFullName[j];
+                EXECUTE command;
+                dropViews[j] := viewFullName[j];
+            END LOOP;
+    END IF;
+
+    -- 3. Drop and recreate the function
+    RAISE NOTICE 'Dropping function %', p_function_name;
+    EXECUTE 'DROP FUNCTION IF EXISTS ' || p_function_name;
+
+    RAISE NOTICE 'Creating function with new definition';
+    EXECUTE p_function_definition;
+
+    -- 4. Recreate dependent views in reverse order
+    IF i > 0 THEN
+        FOR j IN REVERSE i .. 1
+            LOOP
+                RAISE NOTICE 'Recreating view %', dropViews[j];
+                command := 'CREATE OR REPLACE VIEW ' || dropViews[j] || ' AS ' || viewDef[j];
+                EXECUTE command;
+            END LOOP;
+    END IF;
+
+    RAISE NOTICE 'db_alter_function completed successfully for %', p_function_name;
+END;
+$BODY$
+    LANGUAGE plpgsql VOLATILE;
+
+COMMENT ON FUNCTION public.db_alter_function(text, text)
+    IS 'Safely alters a function by first dropping dependent views, then dropping and recreating the function, and finally recreating the dependent views. Use this when you need to change a function''s parameter names or signature and there are dependent views.';

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5784350_sys_fix_orphan_user_references.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5784350_sys_fix_orphan_user_references.sql
@@ -1,0 +1,37 @@
+-- Fix orphan user references (UpdatedBy/CreatedBy pointing to non-existent users)
+-- This fixes CI test failures where business rule triggers fail due to FK constraint
+-- on ad_businessrule_event.triggering_user_id referencing a non-existent user.
+--
+-- The issue: Some records (e.g. C_BPartner 2155894 "metasfresh AG") have UpdatedBy
+-- pointing to user IDs that don't exist in AD_User. When these records are modified,
+-- the BusinessRule trigger tries to create an event with the old UpdatedBy value,
+-- which fails the FK constraint.
+
+-- Fix C_BPartner records where UpdatedBy references non-existent users
+UPDATE C_BPartner bp
+SET UpdatedBy = 100
+WHERE NOT EXISTS (SELECT 1 FROM AD_User u WHERE u.AD_User_ID = bp.UpdatedBy);
+
+UPDATE C_BPartner bp
+SET CreatedBy = 100
+WHERE NOT EXISTS (SELECT 1 FROM AD_User u WHERE u.AD_User_ID = bp.CreatedBy);
+
+-- Fix C_BPartner_Location records
+UPDATE C_BPartner_Location bpl
+SET UpdatedBy = 100
+WHERE NOT EXISTS (SELECT 1 FROM AD_User u WHERE u.AD_User_ID = bpl.UpdatedBy);
+
+UPDATE C_BPartner_Location bpl
+SET CreatedBy = 100
+WHERE NOT EXISTS (SELECT 1 FROM AD_User u WHERE u.AD_User_ID = bpl.CreatedBy);
+
+-- Fix AD_User records (self-referential)
+UPDATE AD_User usr
+SET UpdatedBy = 100
+WHERE UpdatedBy != 0
+  AND NOT EXISTS (SELECT 1 FROM AD_User u WHERE u.AD_User_ID = usr.UpdatedBy);
+
+UPDATE AD_User usr
+SET CreatedBy = 100
+WHERE CreatedBy != 0
+  AND NOT EXISTS (SELECT 1 FROM AD_User u WHERE u.AD_User_ID = usr.CreatedBy);

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Manufacturing_Order_Description.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Manufacturing_Order_Description.sql
@@ -4,7 +4,7 @@ DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Manufacturing_Or
 ;
 
 CREATE
-    OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Manufacturing_Order_Description(IN record_id        NUMERIC,
+    OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Manufacturing_Order_Description(IN p_record_id      NUMERIC,
                                                                                                 IN p_m_attribute_id NUMERIC,
                                                                                                 IN p_ad_language    CHARACTER VARYING(6))
 
@@ -48,7 +48,7 @@ FROM PP_Order pp
          LEFT JOIN C_DocType dt ON pp.C_DocTypeTarget_ID = dt.C_DocType_ID
          LEFT JOIN C_DocType_Trl dtt
                    ON pp.C_DocTypeTarget_ID = dtt.C_DocType_ID AND dtt.AD_Language = p_ad_language
-WHERE pp.PP_Order_ID = record_id
+WHERE pp.PP_Order_ID = p_record_id
 $$
     LANGUAGE SQL
     STABLE

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Manufacturing_Order_Details.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Manufacturing_Order_Details.sql
@@ -1,7 +1,7 @@
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Manufacturing_Order_Details(IN numeric, IN numeric, IN Character Varying)
 ;
 
-CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Manufacturing_Order_Details(IN record_id        numeric,
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Manufacturing_Order_Details(IN p_record_id      numeric,
                                                                                                IN p_m_attribute_id numeric,
                                                                                                IN p_ad_language    character Varying)
 
@@ -37,7 +37,7 @@ FROM PP_Order_BOMLine bomLine
          LEFT OUTER JOIN C_UOM_Trl uomt ON bomLine.C_UOM_ID = uomt.C_UOM_ID AND uomt.AD_Language = p_ad_language
          LEFT JOIN getc_bpartner_product_vendor(p.m_product_id) bpp ON 1 = 1
          LEFT JOIN de_metas_endcustomer_fresh_reports.get_hu_attribute_value_for_pp_order_and_pp_order_bomline(p_m_attribute_id, bomLine.pp_order_id, bomLine.pp_order_bomline_id) AS Attributes ON 1 = 1
-WHERE bomLine.PP_Order_ID = record_id
+WHERE bomLine.PP_Order_ID = p_record_id
   AND bomLine.isActive = 'Y'
   AND bomLine.componenttype != 'BY'
 ORDER BY line

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Purchase_Order_Description.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Purchase_Order_Description.sql
@@ -1,9 +1,9 @@
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Description(IN record_id  numeric,
-                                                                                           IN p_language Character Varying(6))
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Description(IN p_record_id numeric,
+                                                                                           IN p_language  Character Varying(6))
 ;
 
-CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Description(record_id  numeric,
-                                                                                              p_language character varying)
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Description(p_record_id numeric,
+                                                                                              p_language  character varying)
     RETURNS TABLE
             (
                 description   character varying,
@@ -72,7 +72,7 @@ FROM C_Order o
          LEFT OUTER JOIN C_DocType dt ON o.C_DocTypeTarget_ID = dt.C_DocType_ID
          LEFT OUTER JOIN C_DocType_Trl dtt ON o.C_DocTypeTarget_ID = dtt.C_DocType_ID AND dtt.AD_Language = p_language
 
-WHERE o.c_order_id = record_id
+WHERE o.c_order_id = p_record_id
 $$
 ;
 

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Sales_InOut_Description.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Sales_InOut_Description.sql
@@ -1,9 +1,9 @@
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Description(IN record_id  numeric,
-                                                                                        IN p_language Character Varying(6))
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Description(IN p_record_id numeric,
+                                                                                        IN p_language  Character Varying(6))
 ;
 
-CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Description(record_id  numeric,
-                                                                                           p_language character varying)
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Description(p_record_id numeric,
+                                                                                           p_language  character varying)
     RETURNS TABLE
             (
                 description        character varying,
@@ -128,9 +128,9 @@ FROM m_inout io
              JOIN C_Order o ON ol.C_Order_ID = o.C_Order_ID
              LEFT JOIN C_Order offer ON offer.C_Order_ID = o.ref_proposal_id
 
-    WHERE iol.M_InOut_ID = record_id
+    WHERE iol.M_InOut_ID = p_record_id
     GROUP BY o.billtoaddress
     ) o ON TRUE
-WHERE io.m_inout_id = record_id
+WHERE io.m_inout_id = p_record_id
 $$
 ;

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Sales_InOut_Sum_Weight.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Sales_InOut_Sum_Weight.sql
@@ -1,8 +1,8 @@
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Sum_Weight (IN Record_ID     numeric,
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Sum_Weight (IN p_Record_ID   numeric,
                                                                                         IN p_AD_Language Character Varying)
 ;
 
-CREATE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Sum_Weight(IN Record_ID     numeric,
+CREATE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Sum_Weight(IN p_Record_ID   numeric,
                                                                                IN p_AD_Language Character Varying)
     RETURNS TABLE
             (
@@ -23,7 +23,7 @@ FROM M_InOutline iol
          LEFT OUTER JOIN C_UOM uom ON uom.C_UOM_ID = COALESCE(iol.catch_uom_id, (SELECT c_uom_Id FROM C_uom WHERE isactive = 'Y' AND x12de355 = 'KGM'))
          LEFT OUTER JOIN C_UOM_Trl uomt ON uomt.c_UOM_ID = uom.C_UOM_ID AND uomt.AD_Language = p_AD_Language
          INNER JOIN M_Product p ON p.M_Product_ID = iol.M_Product_ID
-WHERE iol.m_inout_id = Record_ID
+WHERE iol.m_inout_id = p_Record_ID
 GROUP BY uomt.UOMSymbol, uom.UOMSymbol, iol.m_inout_id
 
 $$

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Sales_Invoice_Description.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Sales_Invoice_Description.sql
@@ -1,9 +1,9 @@
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.docs_sales_invoice_description(IN record_id  numeric,
-                                                                                          IN p_language Character Varying(6))
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.docs_sales_invoice_description(IN p_record_id numeric,
+                                                                                          IN p_language  Character Varying(6))
 ;
 
-CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.docs_sales_invoice_description(record_id  numeric,
-                                                                                             p_language character varying)
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.docs_sales_invoice_description(p_record_id numeric,
+                                                                                             p_language  character varying)
     RETURNS TABLE
             (
                 description        character varying,
@@ -130,7 +130,7 @@ FROM C_Invoice i
         -- proposal order
              LEFT JOIN C_Order offer ON offer.C_Order_ID = o.ref_proposal_id
 
-    WHERE il.C_Invoice_ID = record_id
+    WHERE il.C_Invoice_ID = p_record_id
     ) o ON TRUE
 
          LEFT JOIN LATERAL
@@ -142,14 +142,14 @@ FROM C_Invoice i
              JOIN M_InOutLine iol ON il.M_InOutLine_ID = iol.M_InOutLine_ID
              JOIN M_InOut io ON iol.M_InOut_ID = io.M_InOut_ID
 
-    WHERE il.C_Invoice_ID = record_id
+    WHERE il.C_Invoice_ID = p_record_id
     ) io ON TRUE
 
     -- warehouse
          LEFT JOIN m_warehouse wh ON i.m_warehouse_id = wh.m_warehouse_id
     -- project
          LEFT JOIN c_project pr ON i.c_project_id = pr.c_project_id
-WHERE i.C_Invoice_ID = record_id
+WHERE i.C_Invoice_ID = p_record_id
 
 $$
 ;

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Sales_OrderCheckup_Root.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Sales_OrderCheckup_Root.sql
@@ -1,6 +1,6 @@
 --DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Root( IN record_id numeric, IN bPartnerId numeric, IN datePromised date );
 
-CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Root(IN record_id    numeric,
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Root(IN p_record_id  numeric,
                                                                                            IN bPartnerId   numeric,
                                                                                            IN p_datePromised date)
   RETURNS TABLE
@@ -23,7 +23,7 @@ FROM report.RV_C_Order_MFGWarehouse_Report_Header r
 WHERE
   CASE
   WHEN record_id IS NOT NULL
-    THEN r.C_Order_MFGWarehouse_Report_ID = record_id
+    THEN r.C_Order_MFGWarehouse_Report_ID = p_record_id
   WHEN bPartnerId IS NOT NULL AND DatePromised :: date IS NOT NULL
     THEN r.C_BPartner_ID = bPartnerId AND r.DatePromised :: date = p_datePromised :: date
   ELSE false -- shall never nappen

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Sales_Order_Description.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/Docs_Sales_Order_Description.sql
@@ -1,8 +1,8 @@
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Description(IN record_id     numeric,
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Description(IN p_record_id   numeric,
                                                                                         IN p_ad_language Character Varying(6))
 ;
 
-CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Description(record_id     numeric,
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Description(p_record_id   numeric,
                                                                                            p_ad_language character varying)
     RETURNS TABLE
             (
@@ -121,7 +121,7 @@ FROM C_Order o
     -- project
          LEFT JOIN c_project pr ON o.c_project_id = pr.c_project_id
 
-WHERE o.C_Order_ID = record_id
+WHERE o.C_Order_ID = p_record_id
 $$
 ;
 

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784230_sys_fix_record_id_parameter_collision.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784230_sys_fix_record_id_parameter_collision.sql
@@ -51,7 +51,7 @@ LANGUAGE sql STABLE;
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Details_Footer(IN record_id numeric);
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Details_Footer(IN p_record_id numeric);
 
-﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Details_Footer(IN p_record_id numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Details_Footer(IN p_record_id numeric);
 
 CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Details_Footer(IN p_record_id numeric)
 RETURNS TABLE 
@@ -88,7 +88,7 @@ LANGUAGE sql STABLE;
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Page_Header(IN record_id numeric, IN ad_language character varying);
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Page_Header(IN p_record_id numeric, IN ad_language character varying);
 
-﻿-- Function: de_metas_endcustomer_fresh_reports.docs_purchase_inout_page_header(numeric, character varying)
+-- Function: de_metas_endcustomer_fresh_reports.docs_purchase_inout_page_header(numeric, character varying)
 
 -- DROP FUNCTION de_metas_endcustomer_fresh_reports.docs_purchase_InOut_Material_Disposal_page_header(numeric, character varying);
 
@@ -134,7 +134,7 @@ $$
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Root(IN record_id numeric);
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Root(IN p_record_id numeric);
 
-﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Root(IN p_record_id numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Root(IN p_record_id numeric);
 
 CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Root(IN p_record_id numeric)
 RETURNS TABLE 
@@ -236,7 +236,7 @@ $$
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_POS_Root(IN record_id numeric, IN ad_table_id numeric);
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_POS_Root(IN p_record_id numeric, IN ad_table_id numeric);
 
-﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_POS_Root(IN p_record_id numeric, IN ad_table_id numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_POS_Root(IN p_record_id numeric, IN ad_table_id numeric);
 
 CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_POS_Root(IN p_record_id numeric, IN ad_table_id numeric)
 RETURNS TABLE 
@@ -310,7 +310,7 @@ LANGUAGE sql STABLE;
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Root(IN p_record_id numeric);
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Root(IN p_p_record_id numeric);
 
-﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Root(IN p_record_id numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Root(IN p_record_id numeric);
 
 CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Root(IN p_record_id numeric)
 RETURNS TABLE 
@@ -401,7 +401,7 @@ LANGUAGE sql STABLE;
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Description(IN record_id numeric, IN AD_Language Character Varying (6);
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6);
 
-﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6));
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6));
 
 CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6))
 RETURNS TABLE 
@@ -463,7 +463,7 @@ LANGUAGE sql STABLE;
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Details_HU(IN record_id numeric, IN AD_Language Character Varying (6);
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Details_HU(IN p_record_id numeric, IN AD_Language Character Varying (6);
 
-﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Details_HU(IN p_record_id numeric, IN AD_Language Character Varying (6));
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Details_HU(IN p_record_id numeric, IN AD_Language Character Varying (6));
 
 CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Details_HU(IN p_record_id numeric, IN AD_Language Character Varying (6))
 RETURNS TABLE 
@@ -526,7 +526,7 @@ LANGUAGE sql STABLE;
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Root(IN record_id numeric);
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Root(IN p_record_id numeric);
 
-﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Root(IN p_record_id numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Root(IN p_record_id numeric);
 
 CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Root(IN p_record_id numeric)
 RETURNS TABLE 
@@ -695,7 +695,7 @@ LANGUAGE sql STABLE
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Customer_Returns_Description(IN record_id numeric, IN AD_Language Character Varying (6);
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Customer_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6);
 
-﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Customer_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6));
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Customer_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6));
 
 CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Customer_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6))
 RETURNS TABLE 

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784230_sys_fix_record_id_parameter_collision.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784230_sys_fix_record_id_parameter_collision.sql
@@ -1,0 +1,972 @@
+-- Migration script: Fix record_id parameter naming collision
+-- Generated for: oasis_sun_hotfix branch
+-- Issue: Parameter name 'record_id' shadows built-in record identifier in PostgreSQL
+-- Fix: Rename parameter from 'record_id' to 'p_record_id'
+-- 2026-01-18
+
+-- Function: Docs_Purchase_InOut_Customs_Root
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Customs_Root(IN record_id numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Customs_Root(IN p_record_id numeric);
+
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Customs_Root(IN p_record_id numeric);
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Customs_Root(IN p_record_id numeric)
+RETURNS TABLE 
+	(
+	ad_org_id numeric,
+	c_orderline_id numeric,
+	c_order_id numeric,
+	HasWeightSnapshot boolean
+	)
+AS
+$$	
+SELECT
+ ol.AD_Org_ID,
+ ol.C_OrderLine_ID,
+ ol.C_Order_ID
+,EXISTS(
+  SELECT 0
+  FROM
+   M_InOut io
+   INNER JOIN M_HU_Assignment thuas ON iol.M_InOutLine_ID = thuas.Record_ID AND ad_table_id = (SELECT Get_Table_ID('M_InOutLine')) AND thuas.isActive = 'Y'
+   -- Get snapshot weight
+   INNER JOIN M_HU_Attribute_Snapshot thuwns ON thuas.M_HU_ID = thuwns.M_HU_ID
+    AND thuwns.M_Attribute_ID = ((SELECT M_Attribute_ID FROM M_Attribute WHERE value = 'WeightNet'))
+    AND thuwns.Snapshot_UUID = io.Snapshot_UUID
+	AND thuwns.isActive = 'Y'
+  WHERE iol.M_InOut_ID = io.M_InOut_ID AND io.isActive = 'Y'
+   
+ ) AS HasWeightSnapshot
+
+FROM C_OrderLine ol
+INNER JOIN M_ReceiptSchedule rs ON rs.C_OrderLine_ID = ol.C_OrderLine_ID AND rs.AD_Table_ID = ( SELECT Get_Table_ID('C_OrderLine') ) AND rs.isActive = 'Y'
+INNER JOIN M_ReceiptSchedule_Alloc rsa ON rs.M_ReceiptSchedule_ID = rsa.M_ReceiptSchedule_ID AND rsa.isActive = 'Y'
+INNER JOIN M_InOutLine iol ON rsa.M_InOutLine_ID = iol.M_InOutLine_ID AND iol.isActive = 'Y'
+WHERE iol.M_InOut_ID = $1
+LIMIT 1
+$$
+LANGUAGE sql STABLE;
+
+-- Function: Docs_Purchase_InOut_Material_Disposal_Details_Footer
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Details_Footer(IN record_id numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Details_Footer(IN p_record_id numeric);
+
+﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Details_Footer(IN p_record_id numeric);
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Details_Footer(IN p_record_id numeric)
+RETURNS TABLE 
+	(
+	iso_code character(3)
+	)
+AS
+$$	
+SELECT
+	c.iso_code
+FROM M_Inventory i
+
+INNER JOIN M_InventoryLine il ON i.M_Inventory_ID = il.M_Inventory_ID AND il.isActive = 'Y'
+INNER JOIN M_InOutLine iol ON il.M_InOutLine_ID = iol.M_InOutLine_ID AND iol.isActive = 'Y'
+INNER JOIN M_InOut io ON iol.M_InOut_ID = io.M_InOut_ID AND io.isActive = 'Y'
+INNER JOIN C_BPartner bp ON io.C_BPartner_ID = bp.C_BPartner_ID AND bp.isActive = 'Y'
+INNER JOIN C_BPartner_Location bpl ON bp.C_BPartner_ID = bpl.C_BPartner_ID AND bpl.isActive = 'Y'
+LEFT JOIN C_Location l ON bpl.C_Location_id = l.C_Location_ID AND l.isActive = 'Y'
+
+LEFT OUTER JOIN M_Pricingsystem ps ON bp.PO_Pricingsystem_ID = ps.M_Pricingsystem_ID AND ps.isActive = 'Y'
+LEFT OUTER JOIN M_PriceList pl ON ps.M_Pricingsystem_ID = pl.M_Pricingsystem_ID AND pl.C_Country_ID = l.C_Country_ID AND pl.isActive = 'Y'
+
+LEFT OUTER JOIN AD_ClientInfo ci ON ci.AD_Client_ID=i.ad_client_id AND ci.isActive = 'Y'
+LEFT OUTER JOIN C_AcctSchema acs ON acs.C_AcctSchema_ID=ci.C_AcctSchema1_ID AND acs.isActive = 'Y'
+LEFT OUTER JOIN C_Currency c ON COALESCE(pl.C_Currency_ID,acs.C_Currency_ID)=c.C_Currency_ID AND c.isActive = 'Y'
+WHERE i.M_Inventory_ID = $1 AND i.isActive = 'Y'
+limit 1
+$$
+LANGUAGE sql STABLE;
+
+
+
+-- Function: Docs_Purchase_InOut_Material_Disposal_Page_Header
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Page_Header(IN record_id numeric, IN ad_language character varying);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Page_Header(IN p_record_id numeric, IN ad_language character varying);
+
+﻿-- Function: de_metas_endcustomer_fresh_reports.docs_purchase_inout_page_header(numeric, character varying)
+
+-- DROP FUNCTION de_metas_endcustomer_fresh_reports.docs_purchase_InOut_Material_Disposal_page_header(numeric, character varying);
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.docs_purchase_InOut_Material_Disposal_page_header(IN p_record_id numeric, IN ad_language character varying)
+  RETURNS TABLE(
+				documentno text, 
+				inventorydate timestamp without time zone, 
+				bp_value character varying, 
+				printname character varying
+				) 
+  AS
+$$
+
+SELECT 
+	i.DocumentNo AS documentNo,
+	i.movementDate as inventorydate,
+	COALESCE(dtt.printName, dt.printName) as printname,
+	bp.Value as BP_Value
+	
+
+FROM M_Inventory i
+
+-- data from inventory
+INNER JOIN C_DocType dt ON i.C_DocType_ID = dt.C_DocType_ID AND dt.isActive = 'Y'
+LEFT OUTER JOIN C_DocType_Trl dtt ON dt.C_DocType_ID = dtt.C_DocType_ID AND dtt.isActive = 'Y' AND dtt.AD_Language = $2
+
+--data from inout
+INNER JOIN M_InventoryLine il ON i.M_Inventory_ID = il.M_Inventory_ID AND il.isActive = 'Y'
+INNER JOIN M_InOutLine iol ON il.M_InOutLine_ID = iol.M_InOutLine_ID AND iol.isActive = 'Y'
+INNER JOIN M_InOut io ON iol.M_InOut_ID = io.M_InOut_ID AND io.isActive = 'Y'
+
+INNER JOIN C_BPartner bp ON io.C_BPartner_ID = bp.C_BPartner_ID AND bp.isActive = 'Y'
+
+WHERE i.M_Inventory_ID = $1 AND i.isActive = 'Y'
+
+ORDER BY bp_value	
+	
+$$
+  LANGUAGE sql STABLE;
+
+
+-- Function: Docs_Purchase_InOut_Material_Disposal_Root
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Root(IN record_id numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Root(IN p_record_id numeric);
+
+﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Root(IN p_record_id numeric);
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Material_Disposal_Root(IN p_record_id numeric)
+RETURNS TABLE 
+	(
+	ad_org_id numeric,
+	m_inout_id integer,
+	displayhu text,
+	DocStatus Character (2)
+	)
+AS
+$$	
+SELECT 
+	i.ad_org_id,
+	MIN(io.M_inOut_ID)::int,
+	CASE
+		WHEN
+		EXISTS(
+			SELECT 0
+			FROM M_InventoryLine il1
+			WHERE m_hu_pi_item_product_id IS NOT NULL AND il1.M_Inventory_ID = $1
+		)
+		THEN 'Y'
+		ELSE 'N'
+	END as displayhu,
+	i.docstatus
+	
+FROM M_Inventory i
+
+
+INNER JOIN M_InventoryLine il ON i.M_Inventory_ID = il.M_Inventory_ID
+INNER JOIN M_InOutLine iol ON il.M_InOutLine_ID = iol.M_InOutLine_ID AND iol.isActive = 'Y'
+INNER JOIN M_InOut io ON iol.M_InOut_ID = io.M_InOut_ID AND io.isActive = 'Y'
+
+
+WHERE i.M_Inventory_ID = $1 AND i.isActive = 'Y'
+
+GROUP BY
+	i.ad_org_id,i.docstatus
+
+$$
+LANGUAGE sql STABLE;
+
+
+-- Function: Docs_Purchase_InOut_Page_Header
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Page_Header(IN record_id numeric, IN ad_language character varying);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Page_Header(IN p_record_id numeric, IN ad_language character varying);
+
+-- Function: de_metas_endcustomer_fresh_reports.docs_purchase_inout_page_header(numeric, character varying)
+
+-- DROP FUNCTION de_metas_endcustomer_fresh_reports.docs_purchase_inout_page_header(numeric, character varying);
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.docs_purchase_inout_page_header(IN p_record_id numeric, IN ad_language character varying)
+  RETURNS TABLE(
+				documentno text, 
+				dateinvoiced timestamp without time zone, 
+				bp_value character varying, 
+				printname character varying
+				) 
+  AS
+$$
+
+SELECT
+	CASE
+		WHEN io.DocNo_hi = io.DocNo_lo THEN io.DocNo_lo
+		ELSE io.DocNo_lo || ' ff.'
+	END AS documentno,
+	io.movementdate AS dateinvoiced,
+	bp.value AS bp_value,
+	COALESCE(dtt.PrintName, dt.PrintName) AS PrintName
+FROM
+	C_OrderLine ol
+	INNER JOIN (
+		SELECT
+			ol.C_Order_ID,
+			MAX(io.movementdate) as movementdate,
+			MIN(io.Documentno) as Docno_lo,
+			MAX(io.Documentno) as Docno_hi,
+			MAX(io.C_DocType_ID) AS C_DocType_ID
+		FROM
+			C_OrderLine ol
+	
+			INNER JOIN M_InOutLine iol ON ol.C_OrderLine_ID = iol.C_OrderLine_ID AND iol.isActive = 'Y'
+			INNER JOIN M_InOut io ON iol.M_InOut_ID = io.M_InOut_ID AND io.isActive = 'Y'
+		WHERE ol.C_OrderLine_ID = $1 AND ol.isActive = 'Y'
+		GROUP BY
+			ol.C_Order_ID
+	) io ON ol.C_Order_ID = io.C_Order_ID
+	INNER JOIN C_Order o ON ol.C_Order_ID = o.C_Order_ID AND o.isActive = 'Y'
+	INNER JOIN C_BPartner bp ON o.C_BPartner_ID = bp.C_BPartner_ID AND bp.isActive = 'Y'
+	LEFT OUTER JOIN C_DocType dt ON io.C_DocType_ID = dt.C_DocType_ID AND dt.isActive = 'Y'
+	LEFT OUTER JOIN C_DocType_Trl dtt ON io.C_DocType_ID = dtt.C_DocType_ID AND dtt.AD_Language = $2 AND dtt.isActive = 'Y'
+WHERE
+	ol.C_OrderLine_ID = $1 AND ol.isActive = 'Y'
+$$
+  LANGUAGE sql STABLE;
+
+
+-- Function: Docs_Purchase_InOut_POS_Root
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_POS_Root(IN record_id numeric, IN ad_table_id numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_POS_Root(IN p_record_id numeric, IN ad_table_id numeric);
+
+﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_POS_Root(IN p_record_id numeric, IN ad_table_id numeric);
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_POS_Root(IN p_record_id numeric, IN ad_table_id numeric)
+RETURNS TABLE 
+	(
+	ad_org_id numeric,
+	c_order_id integer,
+	c_orderline_id integer,
+	displayhu text
+	)
+AS
+$$
+SELECT
+	ol.ad_org_id,
+	ol.C_Order_ID::int,
+	ol.C_OrderLine_ID::int,
+	CASE
+		WHEN
+		EXISTS(
+			SELECT 0
+			FROM c_orderline ol1
+			join c_order o ON ol1.c_order_id = o.c_order_id and o.isactive = 'Y'
+			join m_inout io2 ON o.c_order_id = io2.c_order_id and io2.isactive = 'Y'
+			join m_inoutLine iol2 ON io2.m_inout_id = iol2.m_inout_id and iol2.isactive = 'Y'
+
+			INNER JOIN M_Product p ON iol2.M_Product_ID = p.M_Product_ID AND p.isActive = 'Y'
+			INNER JOIN M_Product_Category pc ON p.M_Product_Category_ID = pc.M_Product_Category_ID AND pc.isActive = 'Y'
+			WHERE pc.M_Product_Category_ID = getSysConfigAsNumeric('PackingMaterialProductCategoryID', iol2.AD_Client_ID, iol2.AD_Org_ID)
+				AND ol.C_OrderLine_ID = ol1.C_OrderLine_ID AND ol1.isActive = 'Y'
+		)
+		THEN 'Y'
+		ELSE 'N'
+	END as displayhu
+FROM
+	C_OrderLine ol
+WHERE
+	ol.C_OrderLine_ID = $1 AND ol.isActive = 'Y' AND get_Table_ID('C_OrderLine') = $2
+
+UNION
+(SELECT
+	ol.ad_org_id,
+	ol.C_Order_ID::int,
+	ol.C_OrderLine_ID::int,
+	CASE
+		WHEN
+		EXISTS(
+			SELECT 0
+			FROM c_orderline ol1
+			join c_order o ON ol1.c_order_id = o.c_order_id and o.isactive = 'Y'
+			join m_inout io2 ON o.c_order_id = io2.c_order_id and io2.isactive = 'Y'
+			join m_inoutLine iol2 ON io2.m_inout_id = iol2.m_inout_id and iol2.isactive = 'Y'
+
+			INNER JOIN M_Product p ON iol2.M_Product_ID = p.M_Product_ID AND p.isActive = 'Y'
+			INNER JOIN M_Product_Category pc ON p.M_Product_Category_ID = pc.M_Product_Category_ID AND pc.isActive = 'Y'
+			WHERE pc.M_Product_Category_ID = getSysConfigAsNumeric('PackingMaterialProductCategoryID', iol2.AD_Client_ID, iol2.AD_Org_ID)
+				AND ol.C_OrderLine_ID = ol1.C_OrderLine_ID AND ol1.isActive = 'Y'
+		)
+		THEN 'Y'
+		ELSE 'N'
+	END as displayhu
+FROM
+M_ReceiptSchedule rs
+JOIN C_OrderLine ol ON rs.C_OrderLine_ID = ol.C_OrderLine_id AND ol.isActive = 'Y'	
+WHERE
+	rs.M_ReceiptSchedule_ID = $1 AND rs.isActive = 'Y' AND get_Table_ID('M_ReceiptSchedule') = $2
+
+)
+$$
+LANGUAGE sql STABLE;
+
+-- Function: Docs_Purchase_InOut_Root
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Root(IN p_record_id numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Root(IN p_p_record_id numeric);
+
+﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Root(IN p_record_id numeric);
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Root(IN p_record_id numeric)
+RETURNS TABLE 
+	(
+	ad_org_id numeric,
+	c_orderline_id integer,
+	displayhu text,
+	c_order_id integer,
+	movementdate date
+	)
+AS
+$$	
+SELECT
+	ol.AD_Org_ID,
+	ol.C_OrderLine_ID::int,
+	CASE
+		WHEN
+		EXISTS(
+			SELECT 0
+			FROM c_orderline ol1
+			join c_order o ON ol1.c_order_id = o.c_order_id and o.isactive = 'Y'
+			join m_inout io2 ON o.c_order_id = io2.c_order_id and io2.isactive = 'Y'
+			join m_inoutLine iol2 ON io2.m_inout_id = iol2.m_inout_id and iol2.isactive = 'Y'
+
+			INNER JOIN M_Product p ON iol2.M_Product_ID = p.M_Product_ID AND p.isActive = 'Y'
+			INNER JOIN M_Product_Category pc ON p.M_Product_Category_ID = pc.M_Product_Category_ID AND pc.isActive = 'Y'
+			WHERE pc.M_Product_Category_ID = getSysConfigAsNumeric('PackingMaterialProductCategoryID', iol2.AD_Client_ID, iol2.AD_Org_ID)
+				AND ol.C_OrderLine_ID = ol1.C_OrderLine_ID AND ol1.isActive = 'Y'
+		)
+		THEN 'Y'
+		ELSE 'N'
+	END as displayhu,
+	ol.C_Order_ID::int,
+	(
+		SELECT	MAX(io.movementdate)::date AS Movementdate
+		FROM	M_ReceiptSchedule rs
+			INNER JOIN M_ReceiptSchedule_Alloc rsa ON rs.M_ReceiptSchedule_ID = rsa.M_ReceiptSchedule_ID
+			INNER JOIN M_InOutLine siol ON rsa.M_InOutLine_ID = siol.M_InOutLine_ID
+			INNER JOIN M_InOut io ON siol.M_InOut_ID = io.M_InOut_ID
+		WHERE 	rs.AD_Table_ID = (SELECT Get_Table_ID( 'C_OrderLine' )) AND ol.C_OrderLine_ID = rs.C_OrderLine_ID
+	) AS MovementDate
+FROM
+	-- All In Out Lines directly linked to the order
+	M_InOutLine iol
+	INNER JOIN M_ReceiptSchedule_Alloc rsa ON rsa.M_InOutLine_ID = iol.M_InOutLine_ID
+	INNER JOIN M_ReceiptSchedule rs ON rs.M_ReceiptSchedule_ID = rsa.M_ReceiptSchedule_ID
+		AND rs.AD_Table_ID = (SELECT Get_Table_ID( 'C_OrderLine' ))
+	INNER JOIN C_OrderLine ol ON rs.C_OrderLine_ID = ol.C_OrderLine_ID
+WHERE
+	iol.M_InOut_ID = p_record_id
+
+UNION
+DISTINCT
+
+SELECT ol.AD_Org_ID,
+       ol.C_OrderLine_ID::int,
+       CASE
+           WHEN
+               EXISTS(SELECT 0
+                      FROM c_orderline ol1
+                               JOIN c_order o ON ol1.c_order_id = o.c_order_id AND o.isactive = 'Y'
+                               JOIN m_inout io2 ON o.c_order_id = io2.c_order_id AND io2.isactive = 'Y'
+                               JOIN m_inoutLine iol2 ON io2.m_inout_id = iol2.m_inout_id AND iol2.isactive = 'Y'
+
+                               INNER JOIN M_Product p ON iol2.M_Product_ID = p.M_Product_ID AND p.isActive = 'Y'
+                               INNER JOIN M_Product_Category pc ON p.M_Product_Category_ID = pc.M_Product_Category_ID AND pc.isActive = 'Y'
+                      WHERE pc.M_Product_Category_ID = getSysConfigAsNumeric('PackingMaterialProductCategoryID', iol2.AD_Client_ID, iol2.AD_Org_ID)
+                        AND ol.C_OrderLine_ID = ol1.C_OrderLine_ID
+                        AND ol1.isActive = 'Y')
+               THEN 'Y'
+               ELSE 'N'
+       END                                             AS displayhu,
+       ol.C_Order_ID::int,
+       (SELECT MAX(io.movementdate)::date AS Movementdate
+        FROM M_InOut io
+                 INNER JOIN M_InOutLine siol ON io.m_inout_id = siol.m_inout_id
+        WHERE ol.C_OrderLine_ID = siol.C_OrderLine_ID) AS MovementDate
+FROM
+    M_InOutLine iol
+        INNER JOIN C_OrderLine ol ON iol.C_OrderLine_ID = ol.C_OrderLine_ID
+WHERE iol.M_InOut_ID = p_record_id
+
+LIMIT 1
+$$
+LANGUAGE sql STABLE;
+
+-- Function: Docs_Purchase_InOut_Vendor_Returns_Description
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Description(IN record_id numeric, IN AD_Language Character Varying (6);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6);
+
+﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6));
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6))
+RETURNS TABLE 
+	(
+	printname character varying(60),
+	io_printname character varying(60),
+	documentno character varying(30),
+	io_documentno text,
+	bp_value character varying(40),
+	movementdate_io timestamp without time zone, 
+	movementdate timestamp without time zone
+	)
+AS
+$$	
+SELECT
+	COALESCE(dtt.printName, dt.printName) as printname,
+	COALESCE(io_dtt.printName, io_dt.printName) as io_printname,
+	io.DocumentNo AS documentNo,
+	CASE
+		WHEN io_origin.DocNo_hi = io_origin.DocNo_lo THEN io_origin.DocNo_lo
+		ELSE io_origin.DocNo_lo || ' ff.'
+	END AS io_documentno,
+	bp.Value as BP_Value,
+	io.movementDate as movementDate,
+	io_origin.movementDate as movementdate_io
+
+FROM M_Inout io --vendor return
+--INNER JOIN M_InOutLine iol ON io.M_Inout_ID = iol.M_Inout_ID
+INNER JOIN C_DocType dt ON io.C_DocType_ID = dt.C_DocType_ID AND dt.isActive = 'Y'
+LEFT OUTER JOIN C_DocType_Trl dtt ON dt.C_DocType_ID = dtt.C_DocType_ID AND dtt.isActive = 'Y' AND dtt.AD_Language = $2
+
+
+--data from original inout
+INNER JOIN (
+	SELECT 
+		iol.M_InOut_ID,
+		MAX(io_origin.movementdate) as movementdate,
+		MIN(io_origin.Documentno) as Docno_lo,
+		MAX(io_origin.Documentno) as Docno_hi,
+		MAX(io_origin.C_DocType_ID) AS C_DocType_ID
+	FROM M_InOutLine iol
+	INNER JOIN M_InOutLine iol_origin ON iol.return_origin_inoutline_id = iol_origin.M_InOutLine_ID AND iol_origin.isActive = 'Y'
+	INNER JOIN M_InOut io_origin ON iol_origin.M_InOut_ID = io_origin.M_InOut_ID AND io_origin.isActive = 'Y'
+	
+	GROUP BY iol.M_InOut_ID
+) io_origin ON io.M_InOut_ID = io_origin.M_InOut_ID
+
+INNER JOIN C_BPartner bp ON io.C_BPartner_ID = bp.C_BPartner_ID AND bp.isActive = 'Y'
+INNER JOIN C_DocType io_dt ON io_origin.C_DocType_ID = io_dt.C_DocType_ID AND io_dt.isActive = 'Y'
+LEFT OUTER JOIN C_DocType_Trl io_dtt ON io_dt.C_DocType_ID = io_dtt.C_DocType_ID AND io_dtt.isActive = 'Y' AND io_dtt.AD_Language = $2
+
+WHERE io.M_InOut_ID = $1
+
+	
+$$
+LANGUAGE sql STABLE;
+
+-- Function: Docs_Purchase_InOut_Vendor_Returns_Details_HU
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Details_HU(IN record_id numeric, IN AD_Language Character Varying (6);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Details_HU(IN p_record_id numeric, IN AD_Language Character Varying (6);
+
+﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Details_HU(IN p_record_id numeric, IN AD_Language Character Varying (6));
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Details_HU(IN p_record_id numeric, IN AD_Language Character Varying (6))
+RETURNS TABLE 
+(
+	Name character varying, 
+	HUQty numeric,
+	MovementQty numeric,
+	UOMSymbol character varying,
+	Description character varying
+)
+AS
+$$	
+
+SELECT 
+	Name, -- product
+	SUM( HUQty ) AS HUQty,
+	SUM( MovementQty ) AS MovementQty,
+	UOMSymbol,
+	iol.Description
+
+FROM
+
+(
+SELECT
+	COALESCE(pt.Name, p.name) AS Name,
+	iol.QtyEnteredTU AS HUQty,
+	iol.MovementQty AS MovementQty,
+	COALESCE(uomt.UOMSymbol, uom.UOMSymbol) AS UOMSymbol,
+	iol.Description
+	
+
+FROM M_Inout io --vendor return
+
+INNER JOIN M_InOutLine iol ON io.M_InOut_ID = iol.M_InOut_ID
+
+INNER JOIN M_Product p ON iol.M_Product_ID = p.M_Product_ID AND p.isActive = 'Y'
+LEFT OUTER JOIN M_Product_Trl pt ON p.M_Product_ID = pt.M_Product_ID AND pt.AD_Language = $2 AND pt.isActive = 'Y'
+INNER JOIN M_Product_Category pc ON p.M_Product_Category_ID = pc.M_Product_Category_ID AND pc.isActive = 'Y'
+LEFT OUTER JOIN C_BPartner bp ON io.C_BPartner_ID =  bp.C_BPartner_ID AND bp.isActive = 'Y'
+LEFT OUTER JOIN C_BPartner_Product bpp ON bp.C_BPartner_ID = bpp.C_BPartner_ID
+				AND p.M_Product_ID = bpp.M_Product_ID AND bpp.isActive = 'Y'
+
+-- Unit of measurement & its translation
+INNER JOIN C_UOM uom			ON iol.C_UOM_ID = uom.C_UOM_ID AND uom.isActive = 'Y'
+LEFT OUTER JOIN C_UOM_Trl uomt			ON iol.C_UOM_ID = uomt.C_UOM_ID AND uomt.AD_Language = $2 AND uomt.isActive = 'Y'
+
+WHERE
+		pc.M_Product_Category_ID = getSysConfigAsNumeric('PackingMaterialProductCategoryID', iol.AD_Client_ID, iol.AD_Org_ID) AND io.M_InOut_ID = $1
+)iol
+
+
+GROUP BY 
+	Name, 
+	UOMSymbol,
+	iol.Description
+$$
+LANGUAGE sql STABLE;
+
+-- Function: Docs_Purchase_InOut_Vendor_Returns_Root
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Root(IN record_id numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Root(IN p_record_id numeric);
+
+﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Root(IN p_record_id numeric);
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Root(IN p_record_id numeric)
+RETURNS TABLE 
+	(
+	ad_org_id numeric,
+	displayhu text,
+	DocStatus Character (2)
+	)
+AS
+$$	
+SELECT
+	io.AD_Org_ID,
+	CASE
+		WHEN
+		EXISTS(
+			SELECT 0
+			FROM M_InOutLine iol1
+			INNER JOIN M_Product p ON iol1.M_Product_ID = p.M_Product_ID AND p.isActive = 'Y'
+			INNER JOIN M_Product_Category pc ON p.M_Product_Category_ID = pc.M_Product_Category_ID AND pc.isActive = 'Y'
+			WHERE pc.M_Product_Category_ID = getSysConfigAsNumeric('PackingMaterialProductCategoryID', iol1.AD_Client_ID, iol1.AD_Org_ID)
+				AND io.M_InOut_ID = iol1.M_InOut_ID AND iol1.isActive = 'Y'
+		)
+		THEN 'Y'
+		ELSE 'N'
+	END as displayhum
+	io.docstatus
+FROM
+	M_InOut io
+WHERE
+	io.M_InOut_ID = $1 AND io.isActive = 'Y'
+$$
+LANGUAGE sql STABLE;
+
+-- Function: Docs_Purchase_Invoice_Root
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Invoice_Root(IN record_id numeric, IN ad_language Character Varying (6);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Invoice_Root(IN p_record_id numeric, IN ad_language Character Varying (6);
+
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Invoice_Root(IN p_record_id numeric, IN ad_language Character Varying (6));
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_Invoice_Root(IN p_record_id numeric, IN ad_language Character Varying (6))
+RETURNS TABLE 
+	(
+	ad_org_id numeric,
+	docstatus character(2),
+	printname character varying(60),
+	displayhu text
+	)
+AS
+$$
+SELECT
+	i.AD_Org_ID,
+	i.DocStatus,
+	dt.PrintName,
+	CASE
+		WHEN
+		EXISTS(
+			SELECT 0
+			FROM C_InvoiceLine il
+			INNER JOIN M_Product p ON il.M_Product_ID = p.M_Product_ID AND p.isActive = 'Y'
+			INNER JOIN M_Product_Category pc ON p.M_Product_Category_ID = pc.M_Product_Category_ID AND pc.isActive = 'Y'
+			WHERE pc.M_Product_Category_ID = getSysConfigAsNumeric('PackingMaterialProductCategoryID', il.AD_Client_ID, il.AD_Org_ID)
+			AND il.C_Invoice_ID = i.C_Invoice_ID AND il.isActive = 'Y'
+		)
+		THEN 'Y'
+		ELSE 'N'
+	END as displayhu
+FROM
+	C_Invoice i
+	INNER JOIN C_DocType dt ON i.C_DocType_ID = dt.C_DocType_ID AND dt.isActive = 'Y'
+	LEFT OUTER JOIN C_DocType_Trl dtt ON i.C_DocType_ID = dtt.C_DocType_ID AND dtt.AD_Language = $2 AND dtt.isActive = 'Y'
+WHERE
+	i.C_Invoice_ID = $1 AND i.isActive = 'Y'
+
+$$
+LANGUAGE sql STABLE;
+
+-- Function: Docs_Purchase_Order_Details_HU
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Details_HU(IN record_id numeric, IN ad_language Character Varying (6);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Details_HU(IN p_record_id numeric, IN ad_language Character Varying (6);
+
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Details_HU(IN p_record_id numeric, IN ad_language Character Varying (6));
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Details_HU(IN p_record_id numeric, IN ad_language Character Varying (6))
+
+RETURNS TABLE
+(
+	qtyordered numeric, 
+	Name character varying,
+	Price numeric, 
+	LineNetAmt numeric,  
+	UOMSymbol character varying(10),
+	Description character varying
+
+)
+AS
+$$
+SELECT
+	ol.QtyOrdered,
+	COALESCE(pt.Name, p.name)		AS Name,
+	ol.PriceEntered			AS Price,
+	ol.LineNetAmt,
+	COALESCE(uom.UOMSymbol, uomt.UOMSymbol)	AS UOMSymbol,
+	ol.Description
+FROM
+	C_OrderLine ol
+	-- Product and its translation
+	LEFT OUTER JOIN M_Product p 			ON ol.M_Product_ID = p.M_Product_ID AND p.isActive = 'Y'
+	LEFT OUTER JOIN M_Product_Trl pt 		ON ol.M_Product_ID = pt.M_Product_ID AND pt.AD_Language = $2 AND pt.isActive = 'Y'
+	LEFT OUTER JOIN M_Product_Category pc 		ON p.M_Product_Category_ID = pc.M_Product_Category_ID AND pc.isActive = 'Y'
+	-- Unit of measurement and its translation
+	LEFT OUTER JOIN C_UOM uom			ON ol.C_UOM_ID = uom.C_UOM_ID
+	LEFT OUTER JOIN C_UOM_Trl uomt			ON ol.C_UOM_ID = uomt.C_UOM_ID AND uomt.AD_Language = $2
+WHERE
+	ol.C_Order_ID = $1 AND ol.isActive = 'Y'
+	AND pc.M_Product_Category_ID = getSysConfigAsNumeric('PackingMaterialProductCategoryID', ol.AD_Client_ID, ol.AD_Org_ID)
+
+$$
+LANGUAGE sql STABLE	
+;
+
+-- Function: Docs_Purchase_Order_Root
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Root(IN record_id numeric, IN ad_language Character Varying (6);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Root(IN p_record_id numeric, IN ad_language Character Varying (6);
+
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Root(IN p_record_id numeric, IN ad_language Character Varying (6));
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Root(IN p_record_id numeric, IN ad_language Character Varying (6))
+RETURNS TABLE 
+	(
+	ad_org_id numeric(10,0),
+	docstatus character(2),
+	printname character varying(60),
+	displayhu text
+	)
+AS
+$$	
+
+SELECT
+	o.AD_Org_ID,
+	o.DocStatus,
+	dt.PrintName,
+	CASE
+		WHEN
+		EXISTS(
+			SELECT 0
+			FROM C_OrderLine ol
+			INNER JOIN M_Product p ON ol.M_Product_ID = p.M_Product_ID AND p.isActive = 'Y'
+			INNER JOIN M_Product_Category pc ON p.M_Product_Category_ID = pc.M_Product_Category_ID AND pc.isActive = 'Y'
+			WHERE pc.M_Product_Category_ID = getSysConfigAsNumeric('PackingMaterialProductCategoryID', ol.AD_Client_ID, ol.AD_Org_ID)
+				AND ol.C_Order_ID = o.C_Order_ID
+		)
+		THEN 'Y'
+		ELSE 'N'
+	END as displayhu
+FROM
+	C_Order o
+	INNER JOIN C_DocType dt ON o.C_DocType_ID = dt.C_DocType_ID AND dt.isActive = 'Y'
+	LEFT OUTER JOIN C_DocType_Trl dtt ON o.C_DocType_ID = dtt.C_DocType_ID AND dtt.AD_Language = $2 AND dtt.isActive = 'Y'
+WHERE
+	o.C_Order_ID = $1 AND o.isActive = 'Y'
+$$	
+LANGUAGE sql STABLE
+;
+
+-- Function: Docs_Sales_InOut_Customer_Returns_Description
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Customer_Returns_Description(IN record_id numeric, IN AD_Language Character Varying (6);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Customer_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6);
+
+﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Customer_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6));
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Customer_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6))
+RETURNS TABLE 
+	(
+	printname character varying(60),
+	documentno character varying(30),
+	bp_value character varying(40),
+	movementdate timestamp without time zone
+	)
+AS
+$$	
+SELECT
+	COALESCE(dtt.printName, dt.printName) as printname,
+	io.DocumentNo AS documentNo,
+	bp.Value as BP_Value,
+	io.movementDate as movementDate
+
+FROM M_Inout io --customer return
+INNER JOIN C_DocType dt ON io.C_DocType_ID = dt.C_DocType_ID AND dt.isActive = 'Y'
+LEFT OUTER JOIN C_DocType_Trl dtt ON dt.C_DocType_ID = dtt.C_DocType_ID AND dtt.isActive = 'Y' AND dtt.AD_Language = $2
+
+
+INNER JOIN C_BPartner bp ON io.C_BPartner_ID = bp.C_BPartner_ID AND bp.isActive = 'Y'
+
+WHERE io.M_InOut_ID = $1
+
+	
+$$
+LANGUAGE sql STABLE;
+
+-- Function: Docs_Sales_Order_Root
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Root(IN record_id numeric, IN ad_language Character Varying (6);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Root(IN p_record_id numeric, IN ad_language Character Varying (6);
+
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Root(IN p_record_id numeric, IN ad_language Character Varying (6));
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Root(IN p_record_id numeric, IN ad_language Character Varying (6))
+RETURNS TABLE 
+	(
+	ad_org_id numeric(10,0),
+	docstatus character(2),
+	printname character varying(60),
+	C_Currency_ID numeric,
+	poreference varchar(60),
+	displayhu text,
+	isoffer character(1),
+	isprepay character(1)
+	)
+AS
+$$	
+
+SELECT
+	o.AD_Org_ID,
+	o.DocStatus,
+	dt.PrintName,
+	o.C_Currency_ID,
+	poreference,
+	CASE
+		WHEN
+		EXISTS(
+			SELECT 0
+			FROM C_OrderLine ol
+			INNER JOIN M_Product p ON ol.M_Product_ID = p.M_Product_ID AND p.isActive = 'Y'
+			INNER JOIN M_Product_Category pc ON p.M_Product_Category_ID = pc.M_Product_Category_ID AND pc.isActive = 'Y'
+			WHERE pc.M_Product_Category_ID = getSysConfigAsNumeric('PackingMaterialProductCategoryID', ol.AD_Client_ID, ol.AD_Org_ID)
+			AND ol.C_Order_ID = o.C_Order_ID AND ol.isActive = 'Y'
+		)
+		THEN 'Y'
+		ELSE 'N'
+	END as displayhu,
+		CASE WHEN dt.docbasetype = 'SOO' AND dt.docsubtype IN ('ON', 'OB')
+		THEN 'Y'
+		ELSE 'N'
+	END AS isoffer,
+	CASE WHEN dt.docbasetype = 'SOO' AND dt.docsubtype ='PR'
+		THEN 'Y'
+		ELSE 'N'
+	END AS isprepay
+FROM
+	C_Order o
+	INNER JOIN C_DocType dt ON o.C_DocTypeTarget_ID = dt.C_DocType_ID AND dt.isActive = 'Y'
+	LEFT OUTER JOIN C_DocType_Trl dtt ON o.C_DocTypeTarget_ID = dtt.C_DocType_ID AND dtt.AD_Language = $2 AND dtt.isActive = 'Y'
+WHERE
+	o.C_Order_ID = $1 AND o.isActive = 'Y'
+$$
+LANGUAGE sql STABLE
+;
+
+
+-- Function: Docs_Sales_OrderCheckup_Description
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Description(IN record_id numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Description(IN p_record_id numeric);
+
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Description(IN p_record_id numeric);
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Description(IN p_record_id numeric)
+RETURNS TABLE 
+	(
+	bpValue character varying(50),
+	order_no character varying(30),
+	reference character varying(40),
+	preparationdate timestamp with time zone,
+	datepromised timestamp with time zone,
+	ReportDocumentTypeName character varying(40),
+	handoverlocation character varying(140),
+    warehousename character varying(60),
+    plantname character varying(60)
+	)
+AS
+$$	
+SELECT
+	r.bpValue,
+	r.document_no as order_no,
+	r.poreference as reference,
+	r.preparationdate as PreparationDate,
+	r.datepromised as DatePromised,
+	r.ReportDocumentTypeName,
+	r.handoverlocation ,
+    r.warehousename,
+    r.plantname
+	
+FROM report.RV_C_Order_MFGWarehouse_Report_Description r
+WHERE
+	r.C_Order_MFGWarehouse_Report_ID = $1
+LIMIT 1
+
+$$
+LANGUAGE sql STABLE;
+
+-- Function: Docs_Sales_OrderCheckup_Details
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Details(IN record_id numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Details(IN p_record_id numeric);
+
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Details(IN p_record_id numeric);
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Details(IN p_record_id numeric)
+RETURNS TABLE 
+	(
+	line numeric,
+	attributes text,
+	prodValue character varying,
+	value character varying,
+	name character varying(255),
+	ean character varying,
+	pricelist numeric,
+	capacity numeric,
+	priceactual numeric,
+	qtyenteredtu numeric,
+	qtyentered numeric,
+	container character varying(60),
+	uomsymbol character varying(10),
+	c_order_mfgwarehouse_report_id numeric,
+	reportdocumenttype character varying(2),
+	C_Order_MFGWarehouse_ReportLine_ID numeric,
+	c_order_id numeric,
+	c_orderline_id numeric,
+	m_warehouse_id numeric,
+	pp_plant_id numeric,
+	c_bpartner_id numeric,
+	datepromised timestamp with time zone,
+	barcode character varying(255)
+	)
+AS
+$$	
+
+SELECT
+	ol.line,
+	att.Attributes,
+	p.value AS prodValue,
+	COALESCE(bpp.ProductNo, p.value) AS Value,
+	p.Name AS Name,
+	COALESCE(bpp.UPC, p.UPC) AS EAN,
+	-- Rounding these columns is important to have them in one group
+	-- Jasper groups by comparing the BigDecimals. In that logic, 1.00 is not the same as 1
+	round(ol.pricelist, 3) AS PriceList,
+	round(ip.qty, 3) AS Capacity,
+	round(ol.Priceactual, 3) AS PriceActual,
+	ol.QtyEnteredTU,
+	ol.QtyEntered,
+	pm.name as Container,
+	uom.UOMSymbol AS UOMSymbol,
+	--
+	-- Filtering columns
+	report.C_Order_MFGWarehouse_Report_ID,
+	report.DocumentType as ReportDocumentType,
+	reportLine.C_Order_MFGWarehouse_ReportLine_ID,
+	o.C_Order_ID,
+	ol.C_OrderLine_ID,
+	report.M_Warehouse_ID,
+	report.PP_Plant_ID,
+	o.C_BPartner_ID,
+	o.DatePromised,
+	reportLine.barcode AS barcode 
+FROM
+	C_Order_MFGWarehouse_Report report
+	INNER JOIN C_Order o on (report.C_Order_ID=o.C_Order_ID) AND o.isActive = 'Y'
+	INNER JOIN C_Order_MFGWarehouse_ReportLine reportLine on (reportLine.C_Order_MFGWarehouse_Report_ID=report.C_Order_MFGWarehouse_Report_ID)
+	INNER JOIN C_OrderLine ol ON (ol.C_OrderLine_ID = reportLine.C_OrderLine_ID) AND ol.isActive = 'Y'
+	--
+	LEFT OUTER JOIN C_BPartner bp ON ol.C_BPartner_ID =  bp.C_BPartner_ID AND bp.isActive = 'Y'
+	LEFT OUTER JOIN M_HU_PI_Item_Product ip ON ol.M_HU_PI_Item_Product_ID = ip.M_HU_PI_Item_Product_ID AND ip.isActive = 'Y'
+	LEFT OUTER JOIN M_HU_PI_Item pii ON ip.M_HU_PI_Item_ID = pii.M_HU_PI_Item_ID AND pii.isActive = 'Y'
+	LEFT OUTER JOIN M_HU_PI_Item pmi ON pmi.M_HU_PI_Version_ID = pii.M_HU_PI_Version_ID  AND pmi.isActive = 'Y'
+		AND pmi.ItemType= 'PM'
+	LEFT OUTER JOIN M_HU_PackingMaterial pm ON pmi.M_HU_PackingMaterial_ID = pm.M_HU_PackingMaterial_ID AND pm.isActive = 'Y'
+	-- Product and its translation
+	LEFT OUTER JOIN M_Product p ON ol.M_Product_ID = p.M_Product_ID AND p.isActive = 'Y'
+
+	LEFT OUTER JOIN C_BPartner_Product bpp ON bp.C_BPartner_ID = bpp.C_BPartner_ID AND bpp.isActive='Y'
+		AND p.M_Product_ID = bpp.M_Product_ID
+	LEFT OUTER JOIN M_Product_Category pc ON p.M_Product_Category_ID = pc.M_Product_Category_ID AND pc.isActive = 'Y'
+	-- Unit of measurement and its translation
+	LEFT OUTER JOIN C_UOM uom ON ol.C_UOM_ID = uom.C_UOM_ID AND uom.isActive = 'Y'
+	-- ADR Attribute
+	LEFT OUTER JOIN	LATERAL(
+		SELECT 	String_agg ( ai_value, ', ' ) AS Attributes, M_AttributeSetInstance_ID
+		FROM 	Report.fresh_Attributes
+		WHERE	at_Value IN ( '1000015', '1000001', '1000002' ) -- Marke (ADR), task 08891: also Herkunft, task 2237: also Label
+			AND M_AttributeSetInstance_ID = ol.M_AttributeSetInstance_ID AND  ol.M_AttributeSetInstance_ID != 0
+		GROUP BY	M_AttributeSetInstance_ID
+	) att ON TRUE
+WHERE
+	1=1
+	AND report.IsActive='Y' and reportLine.IsActive='Y'
+	AND COALESCE(pc.M_Product_Category_ID, -1) != getSysConfigAsNumeric('PackingMaterialProductCategoryID', ol.AD_Client_ID, ol.AD_Org_ID)
+	AND o.IsSOTrx != 'N'
+	AND o.DocStatus = 'CO'
+	AND report.C_Order_MFGWarehouse_Report_ID =  $1
+	
+ORDER BY ol.line
+
+$$
+LANGUAGE sql STABLE;
+
+-- Function: Docs_Sales_OrderCheckup_Root
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Root(2);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Root(2);
+
+--DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Root( IN p_record_id numeric, IN bPartnerId numeric, IN datePromised date );
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Root(IN p_record_id  numeric,
+                                                                                           IN bPartnerId   numeric,
+                                                                                           IN p_datePromised date)
+  RETURNS TABLE
+  (
+    ad_org_id  numeric,
+    docstatus  character(2),
+    printname  character varying(60),
+    c_order_id integer,
+	C_Order_MFGWarehouse_Report_ID integer
+  )
+AS
+$$
+SELECT
+  r.AD_Org_ID,
+  r.DocStatus,
+  r.PrintName,
+  r.C_Order_ID :: int,
+  r.C_Order_MFGWarehouse_Report_ID :: int
+FROM report.RV_C_Order_MFGWarehouse_Report_Header r
+WHERE
+  CASE
+  WHEN record_id IS NOT NULL
+    THEN r.C_Order_MFGWarehouse_Report_ID = p_record_id
+  WHEN bPartnerId IS NOT NULL AND DatePromised :: date IS NOT NULL
+    THEN r.C_BPartner_ID = bPartnerId AND r.DatePromised :: date = p_datePromised :: date
+  ELSE false -- shall never nappen
+  END
+LIMIT 1
+
+$$
+LANGUAGE sql
+STABLE;
+

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784230_sys_fix_record_id_parameter_collision.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784230_sys_fix_record_id_parameter_collision.sql
@@ -90,7 +90,7 @@ DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_M
 
 -- Function: de_metas_endcustomer_fresh_reports.docs_purchase_inout_page_header(numeric, character varying)
 
--- DROP FUNCTION de_metas_endcustomer_fresh_reports.docs_purchase_InOut_Material_Disposal_page_header(numeric, character varying);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.docs_purchase_InOut_Material_Disposal_page_header(numeric, character varying);
 
 CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.docs_purchase_InOut_Material_Disposal_page_header(IN p_record_id numeric, IN ad_language character varying)
   RETURNS TABLE(
@@ -184,7 +184,7 @@ DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_P
 
 -- Function: de_metas_endcustomer_fresh_reports.docs_purchase_inout_page_header(numeric, character varying)
 
--- DROP FUNCTION de_metas_endcustomer_fresh_reports.docs_purchase_inout_page_header(numeric, character varying);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.docs_purchase_inout_page_header(numeric, character varying);
 
 CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.docs_purchase_inout_page_header(IN p_record_id numeric, IN ad_language character varying)
   RETURNS TABLE(
@@ -398,8 +398,8 @@ $$
 LANGUAGE sql STABLE;
 
 -- Function: Docs_Purchase_InOut_Vendor_Returns_Description
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Description(IN record_id numeric, IN AD_Language Character Varying (6);
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Description(IN record_id numeric, IN AD_Language Character Varying (6));
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6));
 
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6));
 
@@ -460,8 +460,8 @@ $$
 LANGUAGE sql STABLE;
 
 -- Function: Docs_Purchase_InOut_Vendor_Returns_Details_HU
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Details_HU(IN record_id numeric, IN AD_Language Character Varying (6);
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Details_HU(IN p_record_id numeric, IN AD_Language Character Varying (6);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Details_HU(IN record_id numeric, IN AD_Language Character Varying (6));
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Details_HU(IN p_record_id numeric, IN AD_Language Character Varying (6));
 
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Vendor_Returns_Details_HU(IN p_record_id numeric, IN AD_Language Character Varying (6));
 
@@ -551,7 +551,7 @@ SELECT
 		)
 		THEN 'Y'
 		ELSE 'N'
-	END as displayhum
+	END as displayhu,
 	io.docstatus
 FROM
 	M_InOut io
@@ -561,8 +561,8 @@ $$
 LANGUAGE sql STABLE;
 
 -- Function: Docs_Purchase_Invoice_Root
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Invoice_Root(IN record_id numeric, IN ad_language Character Varying (6);
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Invoice_Root(IN p_record_id numeric, IN ad_language Character Varying (6);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Invoice_Root(IN record_id numeric, IN ad_language Character Varying (6));
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Invoice_Root(IN p_record_id numeric, IN ad_language Character Varying (6));
 
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Invoice_Root(IN p_record_id numeric, IN ad_language Character Varying (6));
 
@@ -604,8 +604,8 @@ $$
 LANGUAGE sql STABLE;
 
 -- Function: Docs_Purchase_Order_Details_HU
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Details_HU(IN record_id numeric, IN ad_language Character Varying (6);
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Details_HU(IN p_record_id numeric, IN ad_language Character Varying (6);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Details_HU(IN record_id numeric, IN ad_language Character Varying (6));
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Details_HU(IN p_record_id numeric, IN ad_language Character Varying (6));
 
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Details_HU(IN p_record_id numeric, IN ad_language Character Varying (6));
 
@@ -648,8 +648,8 @@ LANGUAGE sql STABLE
 ;
 
 -- Function: Docs_Purchase_Order_Root
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Root(IN record_id numeric, IN ad_language Character Varying (6);
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Root(IN p_record_id numeric, IN ad_language Character Varying (6);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Root(IN record_id numeric, IN ad_language Character Varying (6));
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Root(IN p_record_id numeric, IN ad_language Character Varying (6));
 
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Root(IN p_record_id numeric, IN ad_language Character Varying (6));
 
@@ -692,8 +692,8 @@ LANGUAGE sql STABLE
 ;
 
 -- Function: Docs_Sales_InOut_Customer_Returns_Description
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Customer_Returns_Description(IN record_id numeric, IN AD_Language Character Varying (6);
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Customer_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Customer_Returns_Description(IN record_id numeric, IN AD_Language Character Varying (6));
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Customer_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6));
 
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Customer_Returns_Description(IN p_record_id numeric, IN AD_Language Character Varying (6));
 
@@ -727,8 +727,8 @@ $$
 LANGUAGE sql STABLE;
 
 -- Function: Docs_Sales_Order_Root
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Root(IN record_id numeric, IN ad_language Character Varying (6);
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Root(IN p_record_id numeric, IN ad_language Character Varying (6);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Root(IN record_id numeric, IN ad_language Character Varying (6));
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Root(IN p_record_id numeric, IN ad_language Character Varying (6));
 
 DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Root(IN p_record_id numeric, IN ad_language Character Varying (6));
 
@@ -931,10 +931,10 @@ $$
 LANGUAGE sql STABLE;
 
 -- Function: Docs_Sales_OrderCheckup_Root
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Root(2);
-DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Root(2);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Root(numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Root(numeric, numeric);
 
---DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Root( IN p_record_id numeric, IN bPartnerId numeric, IN datePromised date );
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Root( IN p_record_id numeric, IN bPartnerId numeric, IN datePromised date );
 
 CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_OrderCheckup_Root(IN p_record_id  numeric,
                                                                                            IN bPartnerId   numeric,
@@ -958,7 +958,7 @@ SELECT
 FROM report.RV_C_Order_MFGWarehouse_Report_Header r
 WHERE
   CASE
-  WHEN record_id IS NOT NULL
+  WHEN p_record_id IS NOT NULL
     THEN r.C_Order_MFGWarehouse_Report_ID = p_record_id
   WHEN bPartnerId IS NOT NULL AND DatePromised :: date IS NOT NULL
     THEN r.C_BPartner_ID = bPartnerId AND r.DatePromised :: date = p_datePromised :: date

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784330_sys_fix_Docs_Sales_Order_Details_Footer_subtractdays.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784330_sys_fix_Docs_Sales_Order_Details_Footer_subtractdays.sql
@@ -1,0 +1,86 @@
+-- Title: Fix Docs_Sales_Order_Details_Footer to use subtractdays function
+-- Description: The function was using direct subtraction (o.DateOrdered - DiscountDays) which
+--              requires a custom operator. Replace with subtractdays() function call.
+-- Issue: PG17 migration STEP 5 had a bug - it skipped fixing when custom operators didn't exist
+-- 2026-01-18
+-- Task: Fix Jasper report cucumber test failure
+
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Details_Footer (IN p_Order_ID  numeric,
+                                                                                            IN p_Language Character Varying(6))
+;
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_Order_Details_Footer(IN p_Order_ID  numeric,
+                                                                                              IN p_Language Character Varying(6))
+    RETURNS TABLE
+            (
+                paymentrule       character varying(60),
+                paymentterm       character varying(60),
+                discount1         numeric,
+                discount2         numeric,
+                discount_date1    text,
+                discount_date2    text,
+                cursymbol         character varying(10),
+                documentnote      text,
+                descriptionbottom text,
+                subject           character varying,
+                textsnippet       character varying,
+                Incoterms         character varying,
+                incotermlocation  character varying,
+                additionaltext    text,
+                isoffer           character,
+                taxnote           text
+            )
+AS
+$$
+SELECT COALESCE(reft.name, ref.name)                                        AS paymentrule,
+       COALESCE(ptt.name, pt.name)                                          AS paymentterm,
+       (CASE
+            WHEN pt.DiscountDays > 0 THEN (o.grandtotal + (o.grandtotal * pt.discount / 100))
+        END)                                                                AS discount1,
+       (CASE
+            WHEN pt.DiscountDays2 > 0 THEN (o.grandtotal + (o.grandtotal * pt.discount2 / 100))
+        END)                                                                AS discount2,
+       TO_CHAR(subtractdays(o.DateOrdered, DiscountDays), 'dd.MM.YYYY')     AS discount_date1,
+       TO_CHAR(subtractdays(o.DateOrdered, DiscountDays2), 'dd.MM.YYYY')    AS discount_date2,
+       c.cursymbol,
+       COALESCE(NULLIF(dtt.documentnote, ''),
+                NULLIF(dt.documentnote, ''))                                AS documentnote,
+       o.descriptionbottom,
+       otb.subject,
+       otb.textsnippet,
+       COALESCE(inc_trl.name, inc.name)                                     AS Incoterms,
+       o.incotermlocation,
+       report.getBPartner_CustomDocumentText(o.C_DocTypeTarget_ID, o.c_bpartner_id) AS AdditionalText,
+       CASE
+           WHEN dt.docbasetype = 'SOO' AND dt.docsubtype IN ('ON', 'OB')
+               THEN 'Y'
+               ELSE 'N'
+       END                                                                  AS isoffer,
+       report.TaxNote(p_Order_ID, NULL, p_Language)                         AS taxnote
+FROM C_Order o
+
+         LEFT OUTER JOIN C_PaymentTerm pt ON o.C_PaymentTerm_ID = pt.C_PaymentTerm_ID
+         LEFT OUTER JOIN C_PaymentTerm_Trl ptt
+                         ON o.C_PaymentTerm_ID = ptt.C_PaymentTerm_ID AND ptt.AD_Language = p_Language
+
+         LEFT OUTER JOIN AD_Ref_List ref ON o.PaymentRule = ref.Value AND ref.AD_Reference_ID = (SELECT AD_Reference_ID
+                                                                                                 FROM AD_Reference
+                                                                                                 WHERE name = '_Payment Rule')
+
+         LEFT OUTER JOIN AD_Ref_List_Trl reft
+                         ON reft.AD_Ref_List_ID = ref.AD_Ref_List_ID AND reft.AD_Language = p_Language
+         INNER JOIN C_Currency c ON o.C_Currency_ID = c.C_Currency_ID
+
+-- take out document type notes
+         INNER JOIN C_DocType dt ON o.C_DocTypeTarget_ID = dt.C_DocType_ID
+         LEFT OUTER JOIN C_DocType_Trl dtt
+                         ON o.C_DocTypeTarget_ID = dtt.C_DocType_ID AND dtt.AD_Language = p_Language
+         LEFT OUTER JOIN de_metas_endcustomer_fresh_reports.getOrderTextBoilerPlate(p_Order_ID) otb ON TRUE
+         LEFT OUTER JOIN C_Incoterms inc ON o.c_incoterms_id = inc.c_incoterms_id
+         LEFT OUTER JOIN C_Incoterms_trl inc_trl ON inc.c_incoterms_id = inc_trl.c_incoterms_id AND inc_trl.ad_language = p_Language
+
+WHERE o.C_Order_ID = p_Order_ID
+
+$$
+    LANGUAGE sql STABLE
+;

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784330_sys_fix_Docs_Sales_Order_Details_Footer_subtractdays.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784330_sys_fix_Docs_Sales_Order_Details_Footer_subtractdays.sql
@@ -27,8 +27,7 @@ CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Sales_Order_D
                 Incoterms         character varying,
                 incotermlocation  character varying,
                 additionaltext    text,
-                isoffer           character,
-                taxnote           text
+                isoffer           character
             )
 AS
 $$
@@ -55,8 +54,7 @@ SELECT COALESCE(reft.name, ref.name)                                        AS p
            WHEN dt.docbasetype = 'SOO' AND dt.docsubtype IN ('ON', 'OB')
                THEN 'Y'
                ELSE 'N'
-       END                                                                  AS isoffer,
-       report.TaxNote(p_Order_ID, NULL, p_Language)                         AS taxnote
+       END                                                                  AS isoffer
 FROM C_Order o
 
          LEFT OUTER JOIN C_PaymentTerm pt ON o.C_PaymentTerm_ID = pt.C_PaymentTerm_ID

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784340_sys_fix_Docs_Purchase_Order_Details_Footer_subtractdays.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784340_sys_fix_Docs_Purchase_Order_Details_Footer_subtractdays.sql
@@ -1,0 +1,86 @@
+-- Title: Fix Docs_Purchase_Order_Details_Footer to use subtractdays function
+-- Description: The function was using direct subtraction (o.DateOrdered - DiscountDays) which
+--              requires a custom operator. Replace with subtractdays() function call.
+-- Issue: PG17 migration STEP 6 had a bug - it skipped fixing when custom operators didn't exist
+-- 2026-01-18
+-- Task: Fix Jasper report failures (same issue as Docs_Sales_Order_Details_Footer)
+
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Details_Footer (IN p_Order_ID  numeric,
+                                                                                               IN p_language Character Varying(6))
+;
+
+CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_Order_Details_Footer(IN p_Order_ID  numeric,
+                                                                                                 IN p_language Character Varying(6))
+    RETURNS TABLE
+            (
+                paymentrule       character varying(60),
+                paymentterm       character varying(60),
+                discount1         numeric,
+                discount2         numeric,
+                discount_date1    text,
+                discount_date2    text,
+                cursymbol         character varying(10),
+                Incoterms         character varying,
+                incotermlocation  character varying,
+                descriptionbottom character varying,
+                deliveryrule      character varying,
+                deliveryviarule   character varying,
+                additionaltext    text,
+                taxnote           text
+            )
+AS
+$$
+SELECT COALESCE(reft.name, ref.name)                                          AS paymentrule,
+       CASE
+           WHEN report.IsHiddenReportElement(o.C_DocType_ID, 'Payment_Term') = 'N' THEN
+               REPLACE(REPLACE(REPLACE(COALESCE(ptt.name, pt.name),
+                                       '$datum_netto',
+                                       TO_CHAR(o.dateordered + pt.netdays, 'DD.MM.YYYY')),
+                               '$datum_skonto_1',
+                               TO_CHAR(o.dateordered::date + pt.discountdays, 'DD.MM.YYYY')),
+                       '$datum_skonto_2',
+                       TO_CHAR(o.dateordered::date + pt.discountdays2, 'DD.MM.YYYY'))
+       END                                                                              AS paymentterm,
+       (CASE
+            WHEN pt.DiscountDays > 0
+                THEN (o.grandtotal + (o.grandtotal * pt.discount / 100))
+        END)                                                                  AS discount1,
+       (CASE
+            WHEN pt.DiscountDays2 > 0
+                THEN (o.grandtotal + (o.grandtotal * pt.discount2 / 100))
+        END)                                                                  AS discount2,
+       TO_CHAR(subtractdays(o.DateOrdered, DiscountDays), 'dd.MM.YYYY')                  AS discount_date1,
+       TO_CHAR(subtractdays(o.DateOrdered, DiscountDays2), 'dd.MM.YYYY')                 AS discount_date2,
+       c.cursymbol,
+       COALESCE(inc_trl.name, inc.name)                                       AS Incoterms,
+       o.incotermlocation,
+       o.descriptionbottom,
+       COALESCE(o_dr_trl.name, o_dr.name)                                     AS deliveryrule,
+       CASE
+           WHEN report.IsHiddenReportElement(o.C_DocType_ID, 'Delivery_Via_Rule') = 'N' THEN
+               COALESCE(o_dvr_trl.name, o_dvr.name)
+       END                                                                              AS deliveryviarule,
+       report.getBPartner_CustomDocumentText(o.C_DocTypeTarget_ID, o.c_bpartner_id)       AS AdditionalText,
+       report.TaxNote(p_Order_ID, NULL, p_Language)                                                 AS taxnote
+
+FROM C_Order o
+
+         LEFT OUTER JOIN C_PaymentTerm pt ON o.C_PaymentTerm_ID = pt.C_PaymentTerm_ID
+         LEFT OUTER JOIN C_PaymentTerm_Trl ptt ON o.C_PaymentTerm_ID = ptt.C_PaymentTerm_ID AND ptt.AD_Language = p_Language
+         LEFT OUTER JOIN AD_Ref_List ref ON o.PaymentRule = ref.Value AND ref.AD_Reference_ID = (SELECT AD_Reference_ID
+                                                                                                 FROM AD_Reference
+                                                                                                 WHERE name = '_Payment Rule')
+         LEFT OUTER JOIN AD_Ref_List_Trl reft ON reft.AD_Ref_List_ID = ref.AD_Ref_List_ID AND reft.AD_Language = p_Language
+         INNER JOIN C_Currency c ON o.C_Currency_ID = c.C_Currency_ID
+         LEFT OUTER JOIN C_Incoterms inc ON o.c_incoterms_id = inc.c_incoterms_id
+         LEFT OUTER JOIN C_Incoterms_trl inc_trl ON inc.c_incoterms_id = inc_trl.c_incoterms_id AND inc_trl.ad_language = p_Language
+         LEFT OUTER JOIN AD_Ref_List o_dr ON o_dr.AD_Reference_ID = 151 AND o_dr.value = o.deliveryrule
+         LEFT OUTER JOIN AD_Ref_List_Trl o_dr_trl ON o_dr.ad_ref_list_id = o_dr_trl.ad_ref_list_id AND o_dr_trl.ad_language = p_Language
+         LEFT OUTER JOIN AD_Ref_List o_dvr ON o_dvr.AD_Reference_ID = 152 AND o_dvr.value = o.deliveryviarule
+         LEFT OUTER JOIN AD_Ref_List_Trl o_dvr_trl ON o_dvr.ad_ref_list_id = o_dvr_trl.ad_ref_list_id AND o_dvr_trl.ad_language = p_Language
+
+WHERE o.C_Order_ID = p_Order_ID
+
+$$
+    LANGUAGE sql STABLE
+;

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784340_sys_fix_Docs_Purchase_Order_Details_Footer_subtractdays.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784340_sys_fix_Docs_Purchase_Order_Details_Footer_subtractdays.sql
@@ -25,8 +25,7 @@ CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_Orde
                 descriptionbottom character varying,
                 deliveryrule      character varying,
                 deliveryviarule   character varying,
-                additionaltext    text,
-                taxnote           text
+                additionaltext    text
             )
 AS
 $$
@@ -60,8 +59,7 @@ SELECT COALESCE(reft.name, ref.name)                                          AS
            WHEN report.IsHiddenReportElement(o.C_DocType_ID, 'Delivery_Via_Rule') = 'N' THEN
                COALESCE(o_dvr_trl.name, o_dvr.name)
        END                                                                              AS deliveryviarule,
-       report.getBPartner_CustomDocumentText(o.C_DocTypeTarget_ID, o.c_bpartner_id)       AS AdditionalText,
-       report.TaxNote(p_Order_ID, NULL, p_Language)                                                 AS taxnote
+       report.getBPartner_CustomDocumentText(o.C_DocTypeTarget_ID, o.c_bpartner_id)       AS AdditionalText
 
 FROM C_Order o
 

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784360_sys_fix_Docs_Purchase_InOut_Root_record_id.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5784360_sys_fix_Docs_Purchase_InOut_Root_record_id.sql
@@ -1,7 +1,17 @@
-﻿DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Root(IN record_id numeric);
+-- Title: Fix record_id parameter in Docs_Purchase_InOut_Root
+-- Description: This function was missed in 5784230_sys_fix_record_id_parameter_collision.sql
+--              The DDL file was updated but not the migration script, causing the preloaded
+--              DB image to have the old buggy version with 'record_id' parameter collision.
+--              This causes M_InOut (Material Receipt) reports to return wrong data (first
+--              record's data for all subsequent queries).
+-- Issue: https://github.com/metasfresh/metasfresh/pull/22012
+-- 2026-01-18
+
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Root(IN record_id numeric);
+DROP FUNCTION IF EXISTS de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Root(IN p_record_id numeric);
 
 CREATE OR REPLACE FUNCTION de_metas_endcustomer_fresh_reports.Docs_Purchase_InOut_Root(IN p_record_id numeric)
-RETURNS TABLE 
+RETURNS TABLE
 	(
 	ad_org_id numeric,
 	c_orderline_id integer,
@@ -10,7 +20,7 @@ RETURNS TABLE
 	movementdate date
 	)
 AS
-$$	
+$$
 SELECT
 	ol.AD_Org_ID,
 	ol.C_OrderLine_ID::int,

--- a/misc/dev-support/idea-runConfigurations/WebRestApiApplication - new_dawn_uat.run.xml
+++ b/misc/dev-support/idea-runConfigurations/WebRestApiApplication - new_dawn_uat.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="WebRestApiApplication - new_dawn_uat" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" folderName="new_dawn_uat">
+    <module name="metasfresh-webui-api" />
+    <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="de.metas.ui.web.WebRestApiApplication" />
+    <option name="VM_PARAMETERS" value="-Xmx736M -DPropertyFile=C:\work-metas\metasfresh.properties" />
+    <option name="WORKING_DIRECTORY" value="file://$MODULE_WORKING_DIR$" />
+    <extension name="net.ashald.envfile">
+      <option name="IS_ENABLED" value="true" />
+      <option name="IS_SUBST" value="true" />
+      <option name="IS_PATH_MACRO_SUPPORTED" value="false" />
+      <option name="IS_IGNORE_MISSING_FILES" value="false" />
+      <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
+      <ENTRIES>
+        <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
+        <ENTRY IS_ENABLED="true" PARSER="env" IS_EXECUTABLE="false" PATH="metasfresh/misc/dev-support/docker/infrastructure/env-files/new_dawn_uat.env" />
+      </ENTRIES>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
## Summary

Cherry-pick from new_dawn_uat:
- PR #22016 merge commit (30765969ff6)
- Additional migration 5784360_sys_fix_Docs_Purchase_InOut_Root_record_id.sql

Fixes PostgreSQL function parameter naming collision that caused reports to return wrong data.

🤖 Generated with [Claude Code](https://claude.ai/code)