### PR TITLE
Port R2 test report upload from new_dawn_uat

### DIFF
--- a/.github/actions/upload-to-r2/action.yml
+++ b/.github/actions/upload-to-r2/action.yml
@@ -1,0 +1,81 @@
+name: 'Upload to R2'
+description: 'Upload files to Cloudflare R2 storage for test reports'
+
+inputs:
+  source-dir:
+    description: 'Local directory to upload'
+    required: true
+  r2-path:
+    description: 'Destination path suffix in R2 (e.g., raw/junit-xml/jest/)'
+    required: true
+  branch:
+    description: 'Branch name (sanitized for R2 path)'
+    required: true
+  version:
+    description: 'Build version tag'
+    required: true
+  access-key-id:
+    description: 'R2 access key ID'
+    required: true
+  secret-access-key:
+    description: 'R2 secret access key'
+    required: true
+  endpoint-url:
+    description: 'R2 S3-compatible endpoint URL'
+    required: true
+  bucket-name:
+    description: 'R2 bucket name'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check if source directory exists
+      id: check-source
+      shell: bash
+      run: |
+        if [ -d "${{ inputs.source-dir }}" ] && [ "$(ls -A ${{ inputs.source-dir }} 2>/dev/null)" ]; then
+          echo "has_files=true" >> $GITHUB_OUTPUT
+          echo "Found files to upload in ${{ inputs.source-dir }}"
+          ls -la "${{ inputs.source-dir }}"
+        else
+          echo "has_files=false" >> $GITHUB_OUTPUT
+          echo "::warning::No files found in ${{ inputs.source-dir }} - skipping upload"
+        fi
+
+    - name: Install AWS CLI if needed
+      if: steps.check-source.outputs.has_files == 'true'
+      shell: bash
+      run: |
+        if ! command -v aws &> /dev/null; then
+          echo "Installing AWS CLI..."
+          curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip -q awscliv2.zip
+          sudo ./aws/install
+          rm -rf awscliv2.zip aws/
+          echo "AWS CLI installed"
+        else
+          echo "AWS CLI already available"
+        fi
+
+    - name: Upload to R2
+      if: steps.check-source.outputs.has_files == 'true'
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.secret-access-key }}
+        AWS_DEFAULT_REGION: auto
+      run: |
+        # Configure for 50 concurrent uploads
+        aws configure set default.s3.max_concurrent_requests 50
+
+        # Construct full R2 path
+        R2_FULL_PATH="branches/${{ inputs.branch }}/builds/${{ inputs.version }}/${{ inputs.r2-path }}"
+
+        echo "Uploading to R2: s3://${{ inputs.bucket-name }}/${R2_FULL_PATH}"
+
+        aws s3 sync "${{ inputs.source-dir }}" "s3://${{ inputs.bucket-name }}/${R2_FULL_PATH}" \
+          --endpoint-url "${{ inputs.endpoint-url }}" \
+          --no-progress
+
+        echo "Upload complete: $(du -sh ${{ inputs.source-dir }} | cut -f1) uploaded to ${R2_FULL_PATH}"

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -489,6 +489,18 @@ jobs:
           path: jest/frontend/*.xml
           retention-days: 1
           if-no-files-found: warn
+      - name: upload raw junit xml to R2
+        if: always() && env.ACT != 'true'
+        uses: ./.github/actions/upload-to-r2
+        with:
+          source-dir: jest/frontend
+          r2-path: raw/junit-xml/jest/
+          branch: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          version: ${{ needs.init.outputs.tag-fixed }}
+          access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          endpoint-url: ${{ vars.R2_ENDPOINT_URL }}
+          bucket-name: ${{ vars.R2_BUCKET_NAME }}
       - name: assert success
         run: |
           if [ $(cat jest/frontend/jest.exit-code) != 0 ]; then tail -1000 jest/frontend/jest.log && exit 1; fi     # print frontend log and exit if frontend failed
@@ -1219,6 +1231,30 @@ jobs:
           path: junit/camel/**/*.xml
           retention-days: 1
           if-no-files-found: warn
+      - name: upload raw backend junit xml to R2
+        if: always() && env.ACT != 'true'
+        uses: ./.github/actions/upload-to-r2
+        with:
+          source-dir: junit/backend
+          r2-path: raw/junit-xml/backend/
+          branch: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          version: ${{ needs.init.outputs.tag-fixed }}
+          access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          endpoint-url: ${{ vars.R2_ENDPOINT_URL }}
+          bucket-name: ${{ vars.R2_BUCKET_NAME }}
+      - name: upload raw camel junit xml to R2
+        if: always() && env.ACT != 'true'
+        uses: ./.github/actions/upload-to-r2
+        with:
+          source-dir: junit/camel
+          r2-path: raw/junit-xml/camel/
+          branch: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          version: ${{ needs.init.outputs.tag-fixed }}
+          access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          endpoint-url: ${{ vars.R2_ENDPOINT_URL }}
+          bucket-name: ${{ vars.R2_BUCKET_NAME }}
       - name: assert success
         run: |
           if [ $(cat junit/commons/junit.exit-code) != 0 ] || [ $(cat junit/commons/junit.mvn.exit-code) != 0 ]; then tail -1000 junit/commons/junit.log && exit 1; fi      # print commons log and exit if commons failed
@@ -1472,6 +1508,30 @@ jobs:
           path: cucumber/cucumber-junit-${{ matrix.profile }}.xml
           if-no-files-found: ignore
           retention-days: 1
+      - name: upload raw cucumber allure results to R2
+        if: always() && env.ACT != 'true'
+        uses: ./.github/actions/upload-to-r2
+        with:
+          source-dir: cucumber-allure-results
+          r2-path: raw/allure-results/cucumber-${{ matrix.profile }}/
+          branch: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          version: ${{ needs.init.outputs.tag-fixed }}
+          access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          endpoint-url: ${{ vars.R2_ENDPOINT_URL }}
+          bucket-name: ${{ vars.R2_BUCKET_NAME }}
+      - name: upload raw cucumber junit xml to R2
+        if: always() && env.ACT != 'true'
+        uses: ./.github/actions/upload-to-r2
+        with:
+          source-dir: cucumber
+          r2-path: raw/junit-xml/cucumber-${{ matrix.profile }}/
+          branch: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          version: ${{ needs.init.outputs.tag-fixed }}
+          access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          endpoint-url: ${{ vars.R2_ENDPOINT_URL }}
+          bucket-name: ${{ vars.R2_BUCKET_NAME }}
 
   cucumber-allure-report:
     name: Generate Cucumber Allure Report
@@ -1708,6 +1768,18 @@ jobs:
           path: docker-builds/e2e-tests/playwright-report-mobile/junit/results.xml
           if-no-files-found: ignore
           retention-days: 1
+      - name: upload raw mobile allure results to R2
+        if: always() && env.ACT != 'true'
+        uses: ./.github/actions/upload-to-r2
+        with:
+          source-dir: docker-builds/e2e-tests/allure-results-mobile
+          r2-path: raw/allure-results/mobile-webui/
+          branch: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          version: ${{ needs.init.outputs.tag-fixed }}
+          access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          endpoint-url: ${{ vars.R2_ENDPOINT_URL }}
+          bucket-name: ${{ vars.R2_BUCKET_NAME }}
 
   frontend_webui_test:
     name: frontend webui test
@@ -1788,302 +1860,36 @@ jobs:
           path: docker-builds/e2e-tests/playwright-report-frontend/junit/results.xml
           if-no-files-found: ignore
           retention-days: 1
-
-  test_reports_publish:
-    name: Publish Test Reports to R2
-    runs-on: ubuntu-latest
-    needs: [ init, test-frontend, junit, frontend_webui_test, mobile_test, cucumber-run, cucumber-allure-report ]
-    if: always()  # Run even if tests failed
-    permissions: {}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup directory structure
-        run: |
-          BRANCH_SANITIZED="${{ needs.init.outputs.branch-sanitized-gh-pages }}"
-          BUILD_DIR="reports/branches/${BRANCH_SANITIZED}/builds/${{ needs.init.outputs.tag-fixed }}"
-
-          # Create directory structure for Allure reports
-          mkdir -p "${BUILD_DIR}/allure/frontend-webui"
-          mkdir -p "${BUILD_DIR}/allure/mobile-webui"
-          mkdir -p "${BUILD_DIR}/allure/cucumber"
-
-          # Create directory structure for JUnit HTML reports
-          mkdir -p "${BUILD_DIR}/junit/jest"
-          mkdir -p "${BUILD_DIR}/junit/backend"
-          mkdir -p "${BUILD_DIR}/junit/camel"
-          mkdir -p "${BUILD_DIR}/junit/cucumber"
-
-          echo "Created directory structure for branch: ${BRANCH_SANITIZED}, build: ${{ needs.init.outputs.tag-fixed }}"
-
-      # ===== DOWNLOAD ALLURE REPORTS =====
-      - name: Download Frontend Allure report
-        if: needs.frontend_webui_test.result == 'success' || needs.frontend_webui_test.result == 'failure'
-        uses: actions/download-artifact@v4
+      - name: upload raw frontend allure results to R2
+        if: always() && env.ACT != 'true'
+        uses: ./.github/actions/upload-to-r2
         with:
-          name: allure-report-frontend-webui
-          path: reports/branches/${{ needs.init.outputs.branch-sanitized-gh-pages }}/builds/${{ needs.init.outputs.tag-fixed }}/allure/frontend-webui/
-        continue-on-error: true
+          source-dir: docker-builds/e2e-tests/allure-results
+          r2-path: raw/allure-results/frontend-webui/
+          branch: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          version: ${{ needs.init.outputs.tag-fixed }}
+          access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          endpoint-url: ${{ vars.R2_ENDPOINT_URL }}
+          bucket-name: ${{ vars.R2_BUCKET_NAME }}
 
-      - name: Download Mobile Allure report
-        if: needs.mobile_test.result == 'success' || needs.mobile_test.result == 'failure'
-        uses: actions/download-artifact@v4
-        with:
-          name: allure-report-mobile-webui
-          path: reports/branches/${{ needs.init.outputs.branch-sanitized-gh-pages }}/builds/${{ needs.init.outputs.tag-fixed }}/allure/mobile-webui/
-        continue-on-error: true
-
-      - name: Download Cucumber Allure report
-        if: needs.cucumber-allure-report.result == 'success'
-        uses: actions/download-artifact@v4
-        with:
-          name: allure-report-cucumber
-          path: reports/branches/${{ needs.init.outputs.branch-sanitized-gh-pages }}/builds/${{ needs.init.outputs.tag-fixed }}/allure/cucumber/
-        continue-on-error: true
-
-      # ===== DOWNLOAD JUNIT XML RESULTS =====
-      - name: Download Jest JUnit results
-        if: needs.test-frontend.result == 'success' || needs.test-frontend.result == 'failure'
-        uses: actions/download-artifact@v4
-        with:
-          name: junit-results-jest
-          path: junit-raw/jest/
-        continue-on-error: true
-
-      - name: Download Backend JUnit results
-        if: needs.junit.result == 'success' || needs.junit.result == 'failure'
-        uses: actions/download-artifact@v4
-        with:
-          name: junit-results-backend
-          path: junit-raw/backend/
-        continue-on-error: true
-
-      - name: Download Camel JUnit results
-        if: needs.junit.result == 'success' || needs.junit.result == 'failure'
-        uses: actions/download-artifact@v4
-        with:
-          name: junit-results-camel
-          path: junit-raw/camel/
-        continue-on-error: true
-
-      # ===== GENERATE JUNIT HTML REPORTS =====
-      # Note: Playwright tests use Allure reports (richer visualization) instead of JUnit HTML
-      # Paths account for directory structure preserved by upload-artifact:
-      #   - jest/frontend/*.xml downloaded to junit-raw/jest/ → junit-raw/jest/jest/frontend/*.xml
-      #   - junit/{commons,backend}/**/*.xml downloaded to junit-raw/backend/ → junit-raw/backend/junit/{commons,backend}/**/*.xml
-      #   - junit/camel/**/*.xml downloaded to junit-raw/camel/ → junit-raw/camel/junit/camel/**/*.xml
-      - name: Generate Jest HTML report
-        uses: ./.github/actions/generate-junit-html
-        with:
-          xml-path: junit-raw/jest/**/*.xml
-          output-dir: reports/branches/${{ needs.init.outputs.branch-sanitized-gh-pages }}/builds/${{ needs.init.outputs.tag-fixed }}/junit/jest
-          artifact-name: junit-report-jest
-          history-artifact-name: junit-history-jest
-          report-title: 'Jest (Frontend Unit Tests)'
-        continue-on-error: true
-
-      - name: Generate Backend JUnit HTML report
-        uses: ./.github/actions/generate-junit-html
-        with:
-          xml-path: junit-raw/backend/**/*.xml
-          output-dir: reports/branches/${{ needs.init.outputs.branch-sanitized-gh-pages }}/builds/${{ needs.init.outputs.tag-fixed }}/junit/backend
-          artifact-name: junit-report-backend
-          history-artifact-name: junit-history-backend
-          report-title: 'Backend Unit Tests'
-        continue-on-error: true
-
-      - name: Generate Camel JUnit HTML report
-        uses: ./.github/actions/generate-junit-html
-        with:
-          xml-path: junit-raw/camel/**/*.xml
-          output-dir: reports/branches/${{ needs.init.outputs.branch-sanitized-gh-pages }}/builds/${{ needs.init.outputs.tag-fixed }}/junit/camel
-          artifact-name: junit-report-camel
-          history-artifact-name: junit-history-camel
-          report-title: 'Camel Unit and Integration Tests'
-        continue-on-error: true
-
-      - name: Verify reports exist
-        id: verify_reports
-        run: |
-          BRANCH_SANITIZED="${{ needs.init.outputs.branch-sanitized-gh-pages }}"
-          BUILD_DIR="reports/branches/${BRANCH_SANITIZED}/builds/${{ needs.init.outputs.tag-fixed }}"
-
-          ALLURE_FOUND=0
-          JUNIT_FOUND=0
-
-          # Check Allure reports
-          for report in frontend-webui mobile-webui cucumber; do
-            if [ -f "${BUILD_DIR}/allure/${report}/index.html" ]; then
-              echo "✓ Allure ${report} report found"
-              ALLURE_FOUND=$((ALLURE_FOUND + 1))
-            fi
-          done
-
-          # Check JUnit reports (Playwright uses Allure instead)
-          for report in jest backend camel cucumber; do
-            if [ -f "${BUILD_DIR}/junit/${report}/index.html" ]; then
-              echo "✓ JUnit ${report} report found"
-              JUNIT_FOUND=$((JUNIT_FOUND + 1))
-            fi
-          done
-
-          echo "allure_found=${ALLURE_FOUND}" >> $GITHUB_OUTPUT
-          echo "junit_found=${JUNIT_FOUND}" >> $GITHUB_OUTPUT
-
-          TOTAL=$((ALLURE_FOUND + JUNIT_FOUND))
-          if [ "$TOTAL" -eq 0 ]; then
-            echo "::warning::No reports found to publish - this may be expected if all tests were skipped"
-          else
-            echo "Found ${ALLURE_FOUND} Allure and ${JUNIT_FOUND} JUnit report(s) to publish"
-          fi
-
-      # ===== CLOUDFLARE R2 UPLOAD =====
-      - name: Validate R2 configuration
-        run: |
-          MISSING=""
-          if [ -z "${{ secrets.R2_ACCESS_KEY_ID }}" ]; then MISSING="${MISSING} R2_ACCESS_KEY_ID"; fi
-          if [ -z "${{ secrets.R2_SECRET_ACCESS_KEY }}" ]; then MISSING="${MISSING} R2_SECRET_ACCESS_KEY"; fi
-          if [ -z "${{ vars.R2_ENDPOINT_URL }}" ]; then MISSING="${MISSING} R2_ENDPOINT_URL"; fi
-          if [ -z "${{ vars.R2_BUCKET_NAME }}" ]; then MISSING="${MISSING} R2_BUCKET_NAME"; fi
-          if [ -z "${{ vars.R2_PUBLIC_URL }}" ]; then MISSING="${MISSING} R2_PUBLIC_URL"; fi
-
-          if [ -n "$MISSING" ]; then
-            echo "::error::Missing required R2 configuration:${MISSING}"
-            exit 1
-          fi
-          echo "✓ R2 configuration validated"
-
-      - name: Configure AWS CLI for R2
-        run: |
-          if ! command -v aws &> /dev/null; then
-            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-            unzip -q awscliv2.zip
-            sudo ./aws/install
-          fi
-
-      - name: Sync reports to Cloudflare R2
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-        run: |
-          # Configure AWS CLI for 50 concurrent uploads (default is 10)
-          aws configure set default.s3.max_concurrent_requests 50
-
-          echo "Syncing reports to R2 (50 concurrent uploads)..."
-          aws s3 sync reports/ s3://${{ vars.R2_BUCKET_NAME }}/ \
-            --endpoint-url ${{ vars.R2_ENDPOINT_URL }} \
-            --no-progress
-
-          echo "✓ Reports synced to R2"
-          echo "Total size: $(du -sh reports | cut -f1)"
-
-      # ===== GENERATE AND UPLOAD LANDING PAGE =====
-      - name: Generate landing page
-        uses: ./.github/actions/generate-r2-landing-page
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-        with:
-          r2-endpoint: ${{ vars.R2_ENDPOINT_URL }}
-          r2-bucket: ${{ vars.R2_BUCKET_NAME }}
-          r2-public-url: ${{ vars.R2_PUBLIC_URL }}
-
-      - name: Upload landing page to R2
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-        run: |
-          aws s3 sync landing-page/ s3://${{ vars.R2_BUCKET_NAME }}/ \
-            --endpoint-url ${{ vars.R2_ENDPOINT_URL }} \
-            --no-progress
-          echo "✓ Landing page uploaded"
-
-      - name: Cleanup old builds from R2
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-        run: |
-          BRANCH_SANITIZED="${{ needs.init.outputs.branch-sanitized-gh-pages }}"
-          MAX_BUILDS_PER_BRANCH=10
-
-          echo "Cleaning up old builds for branch: ${BRANCH_SANITIZED}"
-          echo "Keeping only the ${MAX_BUILDS_PER_BRANCH} most recent builds"
-
-          > builds_with_time.txt
-
-          aws s3api list-objects-v2 \
-            --endpoint-url ${{ vars.R2_ENDPOINT_URL }} \
-            --bucket ${{ vars.R2_BUCKET_NAME }} \
-            --prefix "branches/${BRANCH_SANITIZED}/builds/" \
-            --delimiter "/" \
-            --query 'CommonPrefixes[].Prefix' \
-            --output text | tr '\t' '\n' > all_prefixes.txt
-
-          while read -r prefix; do
-            [ -z "$prefix" ] && continue
-            LAST_MODIFIED=$(aws s3api list-objects-v2 \
-              --endpoint-url ${{ vars.R2_ENDPOINT_URL }} \
-              --bucket ${{ vars.R2_BUCKET_NAME }} \
-              --prefix "${prefix}" \
-              --query 'sort_by(Contents, &LastModified)[-1].LastModified' \
-              --output text 2>/dev/null || echo "1970-01-01T00:00:00Z")
-            [ "$LAST_MODIFIED" == "None" ] && LAST_MODIFIED="1970-01-01T00:00:00Z"
-            echo "${LAST_MODIFIED} ${prefix}" >> builds_with_time.txt
-          done < all_prefixes.txt
-
-          sort -r builds_with_time.txt | awk '{print $2}' > all_builds.txt
-
-          BUILD_COUNT=$(wc -l < all_builds.txt | tr -d ' ')
-          echo "Found ${BUILD_COUNT} builds"
-
-          if [ "$BUILD_COUNT" -gt "$MAX_BUILDS_PER_BRANCH" ]; then
-            BUILDS_TO_DELETE=$((BUILD_COUNT - MAX_BUILDS_PER_BRANCH))
-            echo "Deleting ${BUILDS_TO_DELETE} old build(s)"
-
-            tail -n "$BUILDS_TO_DELETE" all_builds.txt | while read -r build_prefix; do
-              [ -z "$build_prefix" ] && continue
-              echo "Deleting: ${build_prefix}"
-              aws s3 rm "s3://${{ vars.R2_BUCKET_NAME }}/${build_prefix}" \
-                --endpoint-url ${{ vars.R2_ENDPOINT_URL }} \
-                --recursive 2>/dev/null || true
-            done
-            echo "CLEANUP_INFO=🧹 Deleted ${BUILDS_TO_DELETE} old build(s), keeping ${MAX_BUILDS_PER_BRANCH} most recent" >> $GITHUB_ENV
-          else
-            echo "No cleanup needed (${BUILD_COUNT} <= ${MAX_BUILDS_PER_BRANCH})"
-            echo "CLEANUP_INFO=🧹 No cleanup needed (${BUILD_COUNT}/${MAX_BUILDS_PER_BRANCH} builds)" >> $GITHUB_ENV
-          fi
-
-      - name: produce-summary
-        run: |
-          BRANCH_SANITIZED="${{ needs.init.outputs.branch-sanitized-gh-pages }}"
-          VERSION="${{ needs.init.outputs.tag-fixed }}"
-          R2_BASE_URL="${{ vars.R2_PUBLIC_URL }}/branches/${BRANCH_SANITIZED}/builds/${VERSION}"
-          LANDING_URL="${{ vars.R2_PUBLIC_URL }}/index.html"
-
-          echo '#### 📊 Test Reports' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo "**[Browse All Reports](${LANDING_URL})**" >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '##### Allure Reports' >> $GITHUB_STEP_SUMMARY
-          echo "| Report | Link |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Frontend WebUI | [View](${R2_BASE_URL}/allure/frontend-webui/index.html) |" >> $GITHUB_STEP_SUMMARY
-          echo "| Mobile WebUI | [View](${R2_BASE_URL}/allure/mobile-webui/index.html) |" >> $GITHUB_STEP_SUMMARY
-          echo "| Cucumber | [View](${R2_BASE_URL}/allure/cucumber/index.html) |" >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '##### JUnit Reports' >> $GITHUB_STEP_SUMMARY
-          echo "| Report | Link |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Jest (Frontend) | [View](${R2_BASE_URL}/junit/jest/index.html) |" >> $GITHUB_STEP_SUMMARY
-          echo "| Backend | [View](${R2_BASE_URL}/junit/backend/index.html) |" >> $GITHUB_STEP_SUMMARY
-          echo "| Camel | [View](${R2_BASE_URL}/junit/camel/index.html) |" >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo "$CLEANUP_INFO" >> $GITHUB_STEP_SUMMARY
-
+  # =============================================================================
+  # NOTE: test_reports_publish job has been removed
+  # =============================================================================
+  # Report generation is now handled by r2-reports-generate.yml workflow which
+  # triggers automatically after this workflow completes (via workflow_run event).
+  #
+  # The new approach follows the Testspace async pattern:
+  # 1. Each test job uploads raw data to R2 inline (fast, ~10-30s per job)
+  # 2. r2-reports-generate.yml triggers after cicd.yaml completes
+  # 3. That workflow generates HTML reports from raw data and uploads to R2
+  # 4. Creates a GitHub Check with report links
+  #
+  # Benefits:
+  # - cicd.yaml workflow completes faster (no waiting for report generation)
+  # - Reports are generated shortly after the workflow completes
+  # - Follows proven Testspace pattern
+  # =============================================================================
 
   cicd-dispatch:
     if: contains(fromJson(vars.CICD_BRANCH_MAP), github.ref_name) == true

--- a/.github/workflows/r2-reports-generate.yml
+++ b/.github/workflows/r2-reports-generate.yml
@@ -1,0 +1,422 @@
+# =============================================================================
+# R2 Test Reports Generator
+# =============================================================================
+#
+# PURPOSE:
+#   Generates HTML test reports from raw test data uploaded during cicd.yaml
+#   and publishes them to Cloudflare R2 storage.
+#
+# TRIGGER:
+#   Automatically triggered when cicd.yaml workflow completes (success or failure)
+#   Can also be manually triggered for re-processing.
+#
+# PATTERN:
+#   Follows the Testspace async pattern:
+#   1. cicd.yaml uploads raw test data (JUnit XML, Allure results) to R2
+#   2. This workflow triggers after cicd.yaml completes
+#   3. Downloads raw data, generates HTML reports, uploads to R2
+#   4. Optionally creates a GitHub Check with report links
+#
+# =============================================================================
+
+name: Generate R2 Test Reports
+
+on:
+  workflow_run:
+    workflows: ["cicd"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch name (sanitized for R2)'
+        required: true
+      version:
+        description: 'Build version tag'
+        required: true
+
+permissions:
+  contents: read
+  checks: write  # For creating GitHub Check
+
+jobs:
+  generate-reports:
+    name: Generate and Publish Reports
+    runs-on: ubuntu-latest
+    # Skip if triggered by workflow_run but cicd was cancelled
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion != 'cancelled'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract build info from triggering workflow
+        id: build-info
+        env:
+          # Use env vars to avoid code injection from untrusted branch names
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_BRANCH: ${{ github.event.inputs.branch }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          if [ "$EVENT_NAME" == "workflow_dispatch" ]; then
+            # Manual trigger - use inputs
+            echo "branch=${INPUT_BRANCH}" >> $GITHUB_OUTPUT
+            echo "version=${INPUT_VERSION}" >> $GITHUB_OUTPUT
+            echo "head_sha=${CURRENT_SHA}" >> $GITHUB_OUTPUT
+          else
+            # workflow_run trigger - extract from event
+            # The branch name needs to be extracted and sanitized
+            RAW_BRANCH="${WORKFLOW_HEAD_BRANCH}"
+            SANITIZED=$(echo "$RAW_BRANCH" | tr '/' '-' | tr '_' '-' | tr -cd 'a-zA-Z0-9.-' | tr '[:upper:]' '[:lower:]' | sed 's/--*/-/g' | sed 's/^-*//' | sed 's/-*$//')
+            echo "branch=${SANITIZED}" >> $GITHUB_OUTPUT
+
+            # Version needs to be constructed from workflow run
+            # Format: {mfversion}-{branch}.{run_number}
+            # We'll need to get this from R2 raw data path or from the triggering workflow
+            echo "Triggering workflow run: ${WORKFLOW_RUN_ID}"
+            echo "head_sha=${WORKFLOW_HEAD_SHA}" >> $GITHUB_OUTPUT
+
+            # For now, we'll list the R2 bucket to find the latest build for this branch
+            echo "needs_version_lookup=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Validate R2 configuration
+        run: |
+          MISSING=""
+          if [ -z "${{ secrets.R2_ACCESS_KEY_ID }}" ]; then MISSING="${MISSING} R2_ACCESS_KEY_ID"; fi
+          if [ -z "${{ secrets.R2_SECRET_ACCESS_KEY }}" ]; then MISSING="${MISSING} R2_SECRET_ACCESS_KEY"; fi
+          if [ -z "${{ vars.R2_ENDPOINT_URL }}" ]; then MISSING="${MISSING} R2_ENDPOINT_URL"; fi
+          if [ -z "${{ vars.R2_BUCKET_NAME }}" ]; then MISSING="${MISSING} R2_BUCKET_NAME"; fi
+          if [ -z "${{ vars.R2_PUBLIC_URL }}" ]; then MISSING="${MISSING} R2_PUBLIC_URL"; fi
+
+          if [ -n "$MISSING" ]; then
+            echo "::error::Missing required R2 configuration:${MISSING}"
+            exit 1
+          fi
+          echo "R2 configuration validated"
+
+      - name: Configure AWS CLI for R2
+        run: |
+          if ! command -v aws &> /dev/null; then
+            curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            unzip -q awscliv2.zip
+            sudo ./aws/install
+            rm -rf awscliv2.zip aws/
+          fi
+          aws configure set default.s3.max_concurrent_requests 50
+
+      - name: Find latest build version for branch
+        id: find-version
+        if: steps.build-info.outputs.needs_version_lookup == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          BRANCH="${{ steps.build-info.outputs.branch }}"
+
+          # List builds for this branch and get the latest one with raw data
+          LATEST_BUILD=$(aws s3api list-objects-v2 \
+            --endpoint-url "${{ vars.R2_ENDPOINT_URL }}" \
+            --bucket "${{ vars.R2_BUCKET_NAME }}" \
+            --prefix "branches/${BRANCH}/builds/" \
+            --delimiter "/" \
+            --query 'CommonPrefixes[].Prefix' \
+            --output text 2>/dev/null | tr '\t' '\n' | sed 's|.*/builds/||' | sed 's|/$||' | sort -V | tail -1)
+
+          if [ -z "$LATEST_BUILD" ]; then
+            echo "::error::No builds found for branch ${BRANCH}"
+            exit 1
+          fi
+
+          echo "Found latest build: ${LATEST_BUILD}"
+          echo "version=${LATEST_BUILD}" >> $GITHUB_OUTPUT
+
+      - name: Set final version
+        id: final-version
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ steps.find-version.outputs.version }}" >> $GITHUB_OUTPUT
+          fi
+          echo "branch=${{ steps.build-info.outputs.branch }}" >> $GITHUB_OUTPUT
+
+      - name: Download raw data from R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          BRANCH="${{ steps.final-version.outputs.branch }}"
+          VERSION="${{ steps.final-version.outputs.version }}"
+          RAW_PATH="branches/${BRANCH}/builds/${VERSION}/raw"
+
+          echo "Downloading raw data from: ${RAW_PATH}"
+          mkdir -p raw-data
+
+          aws s3 sync "s3://${{ vars.R2_BUCKET_NAME }}/${RAW_PATH}/" raw-data/ \
+            --endpoint-url "${{ vars.R2_ENDPOINT_URL }}" \
+            --no-progress || echo "::warning::Some raw data may be missing"
+
+          echo "Downloaded raw data structure:"
+          find raw-data -type f | head -20 || echo "No files found"
+
+      - name: Setup Allure CLI
+        uses: ./.github/actions/setup-allure
+
+      - name: Setup directory structure
+        run: |
+          BRANCH="${{ steps.final-version.outputs.branch }}"
+          VERSION="${{ steps.final-version.outputs.version }}"
+          BUILD_DIR="reports/branches/${BRANCH}/builds/${VERSION}"
+
+          mkdir -p "${BUILD_DIR}/allure/frontend-webui"
+          mkdir -p "${BUILD_DIR}/allure/mobile-webui"
+          mkdir -p "${BUILD_DIR}/allure/cucumber"
+          mkdir -p "${BUILD_DIR}/junit/jest"
+          mkdir -p "${BUILD_DIR}/junit/backend"
+          mkdir -p "${BUILD_DIR}/junit/camel"
+
+          echo "build_dir=${BUILD_DIR}" >> $GITHUB_ENV
+
+      # ===== GENERATE ALLURE REPORTS =====
+      - name: Generate Frontend WebUI Allure report
+        if: always()
+        run: |
+          if [ -d "raw-data/allure-results/frontend-webui" ] && [ "$(ls -A raw-data/allure-results/frontend-webui 2>/dev/null)" ]; then
+            echo "Generating Frontend WebUI Allure report..."
+            allure generate raw-data/allure-results/frontend-webui -o "${build_dir}/allure/frontend-webui" --clean || echo "::warning::Failed to generate frontend-webui report"
+          else
+            echo "::warning::No frontend-webui raw data found"
+          fi
+
+      - name: Generate Mobile WebUI Allure report
+        if: always()
+        run: |
+          if [ -d "raw-data/allure-results/mobile-webui" ] && [ "$(ls -A raw-data/allure-results/mobile-webui 2>/dev/null)" ]; then
+            echo "Generating Mobile WebUI Allure report..."
+            allure generate raw-data/allure-results/mobile-webui -o "${build_dir}/allure/mobile-webui" --clean || echo "::warning::Failed to generate mobile-webui report"
+          else
+            echo "::warning::No mobile-webui raw data found"
+          fi
+
+      - name: Generate Cucumber Allure report
+        if: always()
+        run: |
+          # Cucumber has multiple profiles, merge them
+          CUCUMBER_DIRS=$(find raw-data/allure-results -maxdepth 1 -type d -name 'cucumber-*' 2>/dev/null)
+          if [ -n "$CUCUMBER_DIRS" ]; then
+            echo "Found cucumber result directories: ${CUCUMBER_DIRS}"
+            mkdir -p merged-cucumber-results
+            for dir in $CUCUMBER_DIRS; do
+              if [ -d "$dir" ] && [ "$(ls -A $dir 2>/dev/null)" ]; then
+                cp -r "$dir"/* merged-cucumber-results/ 2>/dev/null || true
+              fi
+            done
+            if [ "$(ls -A merged-cucumber-results 2>/dev/null)" ]; then
+              allure generate merged-cucumber-results -o "${build_dir}/allure/cucumber" --clean || echo "::warning::Failed to generate cucumber report"
+            fi
+          else
+            echo "::warning::No cucumber raw data found"
+          fi
+
+      # ===== GENERATE JUNIT HTML REPORTS =====
+      - name: Generate Jest JUnit HTML report
+        if: always()
+        run: |
+          if [ -d "raw-data/junit-xml/jest" ] && [ "$(find raw-data/junit-xml/jest -name '*.xml' 2>/dev/null | head -1)" ]; then
+            echo "Generating Jest JUnit report..."
+            allure generate raw-data/junit-xml/jest -o "${build_dir}/junit/jest" --clean || echo "::warning::Failed to generate jest report"
+          else
+            echo "::warning::No jest raw data found"
+          fi
+
+      - name: Generate Backend JUnit HTML report
+        if: always()
+        run: |
+          if [ -d "raw-data/junit-xml/backend" ] && [ "$(find raw-data/junit-xml/backend -name '*.xml' 2>/dev/null | head -1)" ]; then
+            echo "Generating Backend JUnit report..."
+            allure generate raw-data/junit-xml/backend -o "${build_dir}/junit/backend" --clean || echo "::warning::Failed to generate backend report"
+          else
+            echo "::warning::No backend raw data found"
+          fi
+
+      - name: Generate Camel JUnit HTML report
+        if: always()
+        run: |
+          if [ -d "raw-data/junit-xml/camel" ] && [ "$(find raw-data/junit-xml/camel -name '*.xml' 2>/dev/null | head -1)" ]; then
+            echo "Generating Camel JUnit report..."
+            allure generate raw-data/junit-xml/camel -o "${build_dir}/junit/camel" --clean || echo "::warning::Failed to generate camel report"
+          else
+            echo "::warning::No camel raw data found"
+          fi
+
+      - name: Verify generated reports
+        id: verify
+        run: |
+          ALLURE_COUNT=0
+          JUNIT_COUNT=0
+
+          for report in frontend-webui mobile-webui cucumber; do
+            if [ -f "${build_dir}/allure/${report}/index.html" ]; then
+              echo "Allure ${report} report generated"
+              ALLURE_COUNT=$((ALLURE_COUNT + 1))
+            fi
+          done
+
+          for report in jest backend camel; do
+            if [ -f "${build_dir}/junit/${report}/index.html" ]; then
+              echo "JUnit ${report} report generated"
+              JUNIT_COUNT=$((JUNIT_COUNT + 1))
+            fi
+          done
+
+          echo "allure_count=${ALLURE_COUNT}" >> $GITHUB_OUTPUT
+          echo "junit_count=${JUNIT_COUNT}" >> $GITHUB_OUTPUT
+          echo "Generated ${ALLURE_COUNT} Allure and ${JUNIT_COUNT} JUnit reports"
+
+      # ===== UPLOAD REPORTS TO R2 =====
+      - name: Upload generated reports to R2
+        if: steps.verify.outputs.allure_count > 0 || steps.verify.outputs.junit_count > 0
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          echo "Uploading reports to R2..."
+          aws s3 sync reports/ "s3://${{ vars.R2_BUCKET_NAME }}/" \
+            --endpoint-url "${{ vars.R2_ENDPOINT_URL }}" \
+            --no-progress
+          echo "Reports uploaded successfully"
+
+      # ===== GENERATE LANDING PAGE =====
+      - name: Generate landing page
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        uses: ./.github/actions/generate-r2-landing-page
+        with:
+          r2-endpoint: ${{ vars.R2_ENDPOINT_URL }}
+          r2-bucket: ${{ vars.R2_BUCKET_NAME }}
+          r2-public-url: ${{ vars.R2_PUBLIC_URL }}
+
+      - name: Upload landing page to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          aws s3 sync landing-page/ "s3://${{ vars.R2_BUCKET_NAME }}/" \
+            --endpoint-url "${{ vars.R2_ENDPOINT_URL }}" \
+            --no-progress
+          echo "Landing page updated"
+
+      # ===== CLEANUP OLD BUILDS =====
+      - name: Cleanup old builds
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          BRANCH="${{ steps.final-version.outputs.branch }}"
+          MAX_BUILDS=5
+
+          # List all builds for this branch
+          BUILDS=$(aws s3api list-objects-v2 \
+            --endpoint-url "${{ vars.R2_ENDPOINT_URL }}" \
+            --bucket "${{ vars.R2_BUCKET_NAME }}" \
+            --prefix "branches/${BRANCH}/builds/" \
+            --delimiter "/" \
+            --query 'CommonPrefixes[].Prefix' \
+            --output text 2>/dev/null | tr '\t' '\n' | sed 's|.*/builds/||' | sed 's|/$||' | sort -V)
+
+          BUILD_COUNT=$(echo "$BUILDS" | grep -c . || echo 0)
+
+          if [ "$BUILD_COUNT" -gt "$MAX_BUILDS" ]; then
+            BUILDS_TO_DELETE=$((BUILD_COUNT - MAX_BUILDS))
+            echo "Found ${BUILD_COUNT} builds, will delete ${BUILDS_TO_DELETE} oldest"
+
+            echo "$BUILDS" | head -n "$BUILDS_TO_DELETE" | while read -r build; do
+              if [ -n "$build" ]; then
+                echo "Deleting old build: ${build}"
+                aws s3 rm "s3://${{ vars.R2_BUCKET_NAME }}/branches/${BRANCH}/builds/${build}/" \
+                  --endpoint-url "${{ vars.R2_ENDPOINT_URL }}" \
+                  --recursive || true
+              fi
+            done
+          else
+            echo "Only ${BUILD_COUNT} builds found, no cleanup needed"
+          fi
+
+      # ===== CREATE GITHUB CHECK =====
+      - name: Create GitHub Check with report links
+        if: github.event_name == 'workflow_run'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = '${{ steps.final-version.outputs.branch }}';
+            const version = '${{ steps.final-version.outputs.version }}';
+            const baseUrl = '${{ vars.R2_PUBLIC_URL }}/branches/' + branch + '/builds/' + version;
+
+            const allureCount = parseInt('${{ steps.verify.outputs.allure_count }}') || 0;
+            const junitCount = parseInt('${{ steps.verify.outputs.junit_count }}') || 0;
+
+            let summary = '## Test Reports Generated\n\n';
+            summary += `**Branch:** ${branch}\n`;
+            summary += `**Build:** ${version}\n\n`;
+
+            if (allureCount > 0) {
+              summary += '### Allure Reports (E2E & Integration)\n';
+              summary += `- [Frontend WebUI](${baseUrl}/allure/frontend-webui/index.html)\n`;
+              summary += `- [Mobile WebUI](${baseUrl}/allure/mobile-webui/index.html)\n`;
+              summary += `- [Cucumber BDD](${baseUrl}/allure/cucumber/index.html)\n\n`;
+            }
+
+            if (junitCount > 0) {
+              summary += '### JUnit Reports (Unit Tests)\n';
+              summary += `- [Jest (Frontend)](${baseUrl}/junit/jest/index.html)\n`;
+              summary += `- [Backend](${baseUrl}/junit/backend/index.html)\n`;
+              summary += `- [Camel](${baseUrl}/junit/camel/index.html)\n\n`;
+            }
+
+            summary += `\n[View All Reports](${baseUrl.replace('/branches/' + branch + '/builds/' + version, '/index.html')})`;
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'R2 Test Reports',
+              head_sha: '${{ steps.build-info.outputs.head_sha }}',
+              status: 'completed',
+              conclusion: 'success',
+              output: {
+                title: 'Test Reports Available',
+                summary: summary
+              }
+            });
+
+      - name: Summary
+        run: |
+          BRANCH="${{ steps.final-version.outputs.branch }}"
+          VERSION="${{ steps.final-version.outputs.version }}"
+          BASE_URL="${{ vars.R2_PUBLIC_URL }}/branches/${BRANCH}/builds/${VERSION}"
+
+          echo "## R2 Test Reports" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:** ${BRANCH}" >> $GITHUB_STEP_SUMMARY
+          echo "**Build:** ${VERSION}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Report Links" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Report Type | Link |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------------|------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Frontend WebUI | [View](${BASE_URL}/allure/frontend-webui/index.html) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Mobile WebUI | [View](${BASE_URL}/allure/mobile-webui/index.html) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Cucumber | [View](${BASE_URL}/allure/cucumber/index.html) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Jest | [View](${BASE_URL}/junit/jest/index.html) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Backend | [View](${BASE_URL}/junit/backend/index.html) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Camel | [View](${BASE_URL}/junit/camel/index.html) |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "[Landing Page](${{ vars.R2_PUBLIC_URL }}/index.html)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Ports the R2 test report upload functionality from `new_dawn_uat` to `intensive_care_release`.

### Changes
- Add `upload-to-r2` composite action for inline raw data uploads
- Add `r2-reports-generate.yml` async workflow for HTML report generation
- Add R2 upload steps to test jobs in `cicd.yaml`:
  - Jest frontend → `raw/junit-xml/jest/`
  - Backend JUnit → `raw/junit-xml/backend/`
  - Camel JUnit → `raw/junit-xml/camel/`
  - Cucumber Allure → `raw/allure-results/cucumber-{profile}/`
  - Cucumber JUnit → `raw/junit-xml/cucumber-{profile}/`
  - Mobile Allure → `raw/allure-results/mobile-webui/`
  - Frontend Allure → `raw/allure-results/frontend-webui/`
- Remove `test_reports_publish` job (replaced by async workflow)

### How it works
1. Each test job uploads raw data to R2 inline (~10-30s per job)
2. `r2-reports-generate.yml` triggers after `cicd.yaml` completes
3. That workflow generates HTML reports and uploads to R2

### Required secrets/vars
- `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` (secrets)
- `R2_ENDPOINT_URL`, `R2_BUCKET_NAME` (vars)

## Test plan
- [ ] CI build passes
- [ ] R2 uploads work (requires R2 secrets configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)