### PR TITLE
Reduce default page length in web UI

### DIFF
--- a/frontend/src/utils/documentListHelper.js
+++ b/frontend/src/utils/documentListHelper.js
@@ -11,7 +11,7 @@ import { getCachedFilter, getEntityRelatedId } from '../reducers/filters';
 import { TIME_REGEX_TEST } from '../constants/Constants';
 import { getCurrentActiveLocale } from './locale';
 
-const DEFAULT_PAGE_LENGTH = 20;
+const DEFAULT_PAGE_LENGTH = 15;
 
 /**
  * @typedef {object} Props Component props


### PR DESCRIPTION
The default page length for the web UI has been reduced from 20 to 15 to improve usability and viewing performance.