### PR TITLE
fix(e2e): make Page Objects resilient to window overrides and Interna…

### DIFF
--- a/e2e/frontend-webui/tests/utils/pages/MaterialReceiptPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/MaterialReceiptPage.js
@@ -66,8 +66,8 @@ export class MaterialReceiptPage {
       // Use keyboard shortcut Alt+N to create new document
       await page.keyboard.press('Alt+N');
 
-      // Wait for navigation to new document
-      await page.waitForURL(/\/window\/184\/\d+/, {
+      // Wait for navigation to new document (flexible pattern for window overrides)
+      await page.waitForURL(/\/window\/\d+\/\d+/, {
         timeout: SLOW_ACTION_TIMEOUT,
       });
 

--- a/e2e/frontend-webui/tests/utils/pages/PurchaseOrderPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/PurchaseOrderPage.js
@@ -800,9 +800,11 @@ export class PurchaseOrderPage {
       const page = getPage();
 
       // Language-independent selector for Vendor Invoice link
-      // Uses data-cy attribute with InternalName from AD_RelationType (C_Order -> C_Invoice POTrx)
-      // This relation links Purchase Order to Vendor Invoice (IsSOTrx='N')
-      const vendorInvoiceLink = page.locator('[data-cy="reference-C_Order_to_C_Invoice_PO"]');
+      // Handle both InternalName format and fallback AD_RelationType_ID format
+      // InternalName: C_Order_to_C_Invoice_PO, Fallback: AD_RelationType_ID-540161
+      const vendorInvoiceLink = page.locator(
+        '[data-cy="reference-C_Order_to_C_Invoice_PO"], [data-cy="reference-AD_RelationType_ID-540161"]'
+      );
 
       let lastError = null;
       let sseReferences = []; // Collect references from SSE responses for debugging
@@ -903,7 +905,7 @@ export class PurchaseOrderPage {
             const subheaderItems = await page.locator('.subheader-item').all();
             console.log(`[DEBUG] Found ${subheaderItems.length} .subheader-item elements`);
 
-            throw new Error('Vendor Invoice link (data-cy="reference-C_Order_to_C_Invoice_PO") not yet visible');
+            throw new Error('Vendor Invoice link (data-cy="reference-C_Order_to_C_Invoice_PO" or "reference-AD_RelationType_ID-540161") not yet visible');
           }
 
           // Link is visible - click it

--- a/e2e/frontend-webui/tests/utils/pages/SalesOrderPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/SalesOrderPage.js
@@ -50,7 +50,8 @@ export class SalesOrderPage {
 
       await page.keyboard.press('Alt+N');
 
-      await page.waitForURL(/\/window\/143\/\d+/, {
+      // Use flexible window ID pattern - custom projects may override window 143
+      await page.waitForURL(/\/window\/\d+\/\d+/, {
         timeout: SLOW_ACTION_TIMEOUT,
       });
 
@@ -375,12 +376,16 @@ export class SalesOrderPage {
       }).catch(() => {});
 
       // Click on Shipment Schedule link using data-cy attribute (language-independent)
-      // This corresponds to the M_ShipmentSchedule reference
-      const link = page.locator('[data-cy="reference-M_ShipmentSchedule"]');
+      // Handle both InternalName format and fallback AD_RelationType_ID format
+      // InternalName: M_ShipmentSchedule, Fallback: AD_RelationType_ID-540170 (C_Order_to_M_ShipmentSchedule)
+      const link = page.locator(
+        '[data-cy="reference-M_ShipmentSchedule"], [data-cy="reference-AD_RelationType_ID-540170"]'
+      );
       await link.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
       await link.click();
 
-      await page.waitForURL(/\/window\/500221/, {
+      // Use flexible window ID pattern - custom projects may override windows
+      await page.waitForURL(/\/window\/\d+/, {
         timeout: SLOW_ACTION_TIMEOUT,
       });
 
@@ -425,12 +430,16 @@ export class SalesOrderPage {
       }).catch(() => {});
 
       // Click on Shipment link using data-cy attribute (language-independent)
-      // Uses InternalName from AD_RelationType (C_Order -> M_InOut SOTrx)
-      const link = page.locator('[data-cy="reference-C_Order_to_M_InOut_SO"]');
+      // Handle both InternalName format and fallback AD_RelationType_ID format
+      // InternalName: C_Order_to_M_InOut_SO, Fallback: AD_RelationType_ID-540159
+      const link = page.locator(
+        '[data-cy="reference-C_Order_to_M_InOut_SO"], [data-cy="reference-AD_RelationType_ID-540159"]'
+      );
       await link.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
       await link.click();
 
-      await page.waitForURL(/\/window\/169/, {
+      // Use flexible window ID pattern - custom projects may override window 169 (M_InOut)
+      await page.waitForURL(/\/window\/\d+/, {
         timeout: SLOW_ACTION_TIMEOUT,
       });
 
@@ -475,13 +484,16 @@ export class SalesOrderPage {
       }).catch(() => {});
 
       // Click on Invoice Candidate link using data-cy attribute (language-independent)
-      // The reference is: reference-C_Invoice_Candidate_Sales (not just C_Invoice_Candidate)
-      const link = page.locator('[data-cy="reference-C_Invoice_Candidate_Sales"]');
+      // Handle both InternalName format and fallback AD_RelationType_ID format
+      // InternalName: C_Invoice_Candidate_Sales, Fallback: AD_RelationType_ID-540119
+      const link = page.locator(
+        '[data-cy="reference-C_Invoice_Candidate_Sales"], [data-cy="reference-AD_RelationType_ID-540119"]'
+      );
       await link.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
       await link.click();
 
-      // Sales IC window is 540092, not 540983 (purchase)
-      await page.waitForURL(/\/window\/540092/, {
+      // Use flexible window ID pattern - custom projects may override windows
+      await page.waitForURL(/\/window\/\d+/, {
         timeout: SLOW_ACTION_TIMEOUT,
       });
 
@@ -607,10 +619,12 @@ export class SalesOrderPage {
         timeout: SLOW_ACTION_TIMEOUT,
       }).catch(() => {});
 
-      // Click on Invoice link
-      // CRITICAL: Uses data-cy with InternalName from AD_RelationType
-      // C_Order_to_C_Invoice_SO = Sales Order -> Customer Invoice relation
-      const invoiceLink = page.locator('[data-cy="reference-C_Order_to_C_Invoice_SO"]').first();
+      // Click on Invoice link using data-cy attribute (language-independent)
+      // Handle both InternalName format and fallback AD_RelationType_ID format
+      // InternalName: C_Order_to_C_Invoice_SO, Fallback: AD_RelationType_ID-540160
+      const invoiceLink = page.locator(
+        '[data-cy="reference-C_Order_to_C_Invoice_SO"], [data-cy="reference-AD_RelationType_ID-540160"]'
+      ).first();
 
       await invoiceLink.waitFor({
         state: 'visible',
@@ -619,7 +633,8 @@ export class SalesOrderPage {
 
       await invoiceLink.click();
 
-      await page.waitForURL(/\/window\/167/, {
+      // Use flexible window ID pattern - custom projects may override window 167 (C_Invoice)
+      await page.waitForURL(/\/window\/\d+/, {
         timeout: SLOW_ACTION_TIMEOUT,
       });
 

--- a/e2e/frontend-webui/tests/utils/pages/VendorInvoicePage.js
+++ b/e2e/frontend-webui/tests/utils/pages/VendorInvoicePage.js
@@ -111,8 +111,8 @@ export class VendorInvoicePage {
       // Double click to open detail view
       await firstRow.dblclick();
 
-      // Wait for navigation to detail view (URL pattern: /window/183/{id})
-      await page.waitForURL(/\/window\/183\/\d+/, {
+      // Wait for navigation to detail view (flexible pattern for window overrides)
+      await page.waitForURL(/\/window\/\d+\/\d+/, {
         timeout: SLOW_ACTION_TIMEOUT,
       });
 
@@ -215,8 +215,8 @@ export class VendorInvoicePage {
       // Double click to open detail view
       await firstRow.dblclick();
 
-      // Wait for navigation to detail view (URL pattern: /window/183/{id})
-      await page.waitForURL(/\/window\/183\/\d+/, {
+      // Wait for navigation to detail view (flexible pattern for window overrides)
+      await page.waitForURL(/\/window\/\d+\/\d+/, {
         timeout: SLOW_ACTION_TIMEOUT,
       });
 
@@ -370,9 +370,9 @@ export class VendorInvoicePage {
       let url = page.url();
 
       // Check if we're on a list view (no document ID in URL)
-      // List view: /window/183?filters...
-      // Detail view: /window/183/12345
-      const isListView = !url.match(/\/window\/183\/\d+/);
+      // List view: /window/{id}?filters...
+      // Detail view: /window/{id}/12345
+      const isListView = !url.match(/\/window\/\d+\/\d+/);
 
       if (isListView) {
         console.log('On list view, opening detail view by double-clicking first row');
@@ -384,8 +384,8 @@ export class VendorInvoicePage {
         // Double-click to open detail view
         await firstRow.dblclick();
 
-        // Wait for navigation to detail view
-        await page.waitForURL(/\/window\/183\/\d+/, { timeout: 15000 });
+        // Wait for navigation to detail view (flexible pattern for window overrides)
+        await page.waitForURL(/\/window\/\d+\/\d+/, { timeout: 15000 });
         await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
 
         // Update URL after navigation
@@ -407,7 +407,7 @@ export class VendorInvoicePage {
         documentNo = await documentNoInput.first().inputValue();
       } catch {
         // Fallback: extract from URL (less reliable but better than nothing)
-        const documentId = url.match(/\/window\/183\/(\d+)/)?.[1];
+        const documentId = url.match(/\/window\/\d+\/(\d+)/)?.[1];
         console.log(`Warning: Could not get DocumentNo from page, using URL document ID: ${documentId}`);
         documentNo = documentId;
       }


### PR DESCRIPTION
…lName fallbacks

Problem:
- E2E tests fail in custom projects (e.g., ms205) because:
  1. Tests use hardcoded data-cy selectors expecting AD_RelationType.InternalName to be set, but migration script wasn't applied
  2. Tests hardcode window IDs in URL assertions, but custom projects may override windows via AD_Window.Overrides_Window_ID

Solution:
- Use flexible selectors that match both InternalName and fallback formats: `[data-cy="reference-C_Order_to_M_InOut_SO"], [data-cy="reference-AD_RelationType_ID-540159"]`
- Use flexible URL patterns `/window/\d+/` instead of hardcoded window IDs

Files changed:
- SalesOrderPage.js: openRelatedShipment, openRelatedShipmentCandidate, openRelatedInvoiceCandidate, openRelatedInvoice, clickNew
- PurchaseOrderPage.js: openRelatedVendorInvoice
- VendorInvoicePage.js: selectFirstInvoice, selectInvoiceByVendor, downloadAndValidatePdf
- MaterialReceiptPage.js: clickNew