### PR TITLE
fix(mergify): use merge queue to ensure CI completes before auto-merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,6 +5,17 @@ merge_protections:
     success_conditions:
       - check-success=testspace-analytics
 
+queue_rules:
+  - name: squash-queue
+    merge_method: squash
+    merge_conditions:
+      - check-success=testspace-analytics
+
+  - name: merge-queue
+    merge_method: merge
+    merge_conditions:
+      - check-success=testspace-analytics
+
 pull_request_rules:
 
   ############
@@ -100,7 +111,6 @@ pull_request_rules:
 
   - name: Automatic squash-merge successful PRs into the respective base-branch
     conditions:
-      - check-success=testspace-analytics
       - label=ops:auto_squash_merge
       - or:
           - or: *ALL_BASE_BRANCHES
@@ -108,12 +118,11 @@ pull_request_rules:
           - "#approved-reviews-by>=1"
           - label=ops:without_review_approval
     actions:
-      merge:
-        method: squash
+      queue:
+        name: squash-queue
 
   - name: Automatic merge commit (not squash) successful PRs
     conditions:
-      - check-success=testspace-analytics
       - label=ops:auto_merge_commit
       - or:
           - or: *ALL_BASE_BRANCHES
@@ -121,6 +130,6 @@ pull_request_rules:
           - "#approved-reviews-by>=1"
           - label=ops:without_review_approval
     actions:
-      merge:
-        method: merge
+      queue:
+        name: merge-queue
 


### PR DESCRIPTION
## Summary
- Add `queue_rules` with `squash-queue` and `merge-queue` definitions
- Update auto-merge rules to use `queue:` action instead of direct `merge:`
- Queue's `merge_conditions` ensure `testspace-analytics` passes before merge

## Problem
The auto-merge rules were merging PRs immediately when commits had inherited check statuses from previous CI runs. Example: PR #22081 was merged 36 seconds after creation, before the new CI build even started, because the commits already had a successful `testspace-analytics` check from the source branch.

## Solution
Using Mergify's merge queue ensures:
1. PR enters queue when labeled (no CI check required to enter)
2. Queue updates/rebases the PR against the target branch
3. This triggers a **fresh CI build**
4. `merge_conditions` waits for the new `testspace-analytics` check
5. Only then does the merge happen

## Test plan
- [ ] Mergify validates the config (check the PR's Checks tab)
- [ ] Test with a porting PR using `ops:auto_merge_commit` label
- [ ] Verify PR waits for CI to complete before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)