### PR TITLE
Fix Dockerfile.mobile: Use archive.debian.org for EOL Debian Buster

### DIFF
--- a/docker-builds/Dockerfile.mobile
+++ b/docker-builds/Dockerfile.mobile
@@ -1,14 +1,20 @@
-FROM node:14 as build
+FROM node:14 AS build
 
 RUN npm install -g webpack webpack-cli
 
-RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
+# Temporarily override apt sources to use archive for EOL distribution
+RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian buster-updates main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y locales && rm -rf /var/lib/apt/lists/* && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
 ENV LANG=de_DE.UTF-8 LANGUAGE=de_DE.UTF-8 LC_MESSAGES=de_DE.UTF-8
 ENV TZ=Europe/Berlin
 
 WORKDIR /app 
 
 COPY misc/services/mobile-webui/mobile-webui-frontend/package.json .
+COPY misc/services/mobile-webui/mobile-webui-frontend/yarn.lock* .
 RUN yarn install
 
 COPY misc/services/mobile-webui/mobile-webui-frontend/ .
@@ -19,7 +25,7 @@ ENV PUBLIC_URL=/
 RUN yarn build
 
 
-FROM nginx:1.21.6 as runtime
+FROM nginx:1.21.6 AS runtime
 
 COPY docker-builds/nginx/default.conf /etc/nginx/conf.d
 


### PR DESCRIPTION
## Summary
- Fix mobile Docker build failure caused by Debian Buster EOL
- Redirect apt sources to archive.debian.org

## Root Cause
The `node:14` image is based on Debian Buster which reached End of Life. Standard Debian repos (`deb.debian.org`) no longer serve Buster packages (returning 404).

## Fix
Redirect apt sources to `archive.debian.org` before running `apt-get update`.

Port of fix from new_dawn_uat PR #21096.

🤖 Generated with [Claude Code](https://claude.ai/code)