### PR TITLE
Disable R2 test report uploads

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -490,7 +490,7 @@ jobs:
           retention-days: 1
           if-no-files-found: warn
       - name: upload raw junit xml to R2
-        if: always() && env.ACT != 'true'
+        if: false  # DISABLED: R2 upload not working - was: always() && env.ACT != 'true'
         uses: ./.github/actions/upload-to-r2
         with:
           source-dir: jest/frontend
@@ -1232,7 +1232,7 @@ jobs:
           retention-days: 1
           if-no-files-found: warn
       - name: upload raw backend junit xml to R2
-        if: always() && env.ACT != 'true'
+        if: false  # DISABLED: R2 upload not working - was: always() && env.ACT != 'true'
         uses: ./.github/actions/upload-to-r2
         with:
           source-dir: junit/backend
@@ -1244,7 +1244,7 @@ jobs:
           endpoint-url: ${{ vars.R2_ENDPOINT_URL }}
           bucket-name: ${{ vars.R2_BUCKET_NAME }}
       - name: upload raw camel junit xml to R2
-        if: always() && env.ACT != 'true'
+        if: false  # DISABLED: R2 upload not working - was: always() && env.ACT != 'true'
         uses: ./.github/actions/upload-to-r2
         with:
           source-dir: junit/camel
@@ -1509,7 +1509,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 1
       - name: upload raw cucumber allure results to R2
-        if: always() && env.ACT != 'true'
+        if: false  # DISABLED: R2 upload not working - was: always() && env.ACT != 'true'
         uses: ./.github/actions/upload-to-r2
         with:
           source-dir: cucumber-allure-results
@@ -1521,7 +1521,7 @@ jobs:
           endpoint-url: ${{ vars.R2_ENDPOINT_URL }}
           bucket-name: ${{ vars.R2_BUCKET_NAME }}
       - name: upload raw cucumber junit xml to R2
-        if: always() && env.ACT != 'true'
+        if: false  # DISABLED: R2 upload not working - was: always() && env.ACT != 'true'
         uses: ./.github/actions/upload-to-r2
         with:
           source-dir: cucumber
@@ -1773,7 +1773,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 1
       - name: upload raw mobile allure results to R2
-        if: always() && env.ACT != 'true'
+        if: false  # DISABLED: R2 upload not working - was: always() && env.ACT != 'true'
         uses: ./.github/actions/upload-to-r2
         with:
           source-dir: docker-builds/e2e-tests/allure-results-mobile
@@ -1869,7 +1869,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 1
       - name: upload raw frontend allure results to R2
-        if: always() && env.ACT != 'true'
+        if: false  # DISABLED: R2 upload not working - was: always() && env.ACT != 'true'
         uses: ./.github/actions/upload-to-r2
         with:
           source-dir: docker-builds/e2e-tests/allure-results

--- a/.github/workflows/r2-cleanup-stale-reports.yml
+++ b/.github/workflows/r2-cleanup-stale-reports.yml
@@ -80,6 +80,8 @@ jobs:
   cleanup:
     name: Clean up stale R2 Allure reports
     runs-on: ubuntu-latest
+    # DISABLED: R2 upload not working
+    if: false
     permissions:
       contents: read
     steps:

--- a/.github/workflows/r2-reports-generate.yml
+++ b/.github/workflows/r2-reports-generate.yml
@@ -42,8 +42,9 @@ jobs:
   generate-reports:
     name: Generate and Publish Reports
     runs-on: ubuntu-latest
-    # Skip if triggered by workflow_run but cicd was cancelled
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion != 'cancelled'
+    # DISABLED: R2 upload not working
+    # Original condition was: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion != 'cancelled'
+    if: false
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Disable all R2 test report upload steps in CI pipeline (not working)
- Disable `r2-reports-generate.yml` workflow
- Disable `r2-cleanup-stale-reports.yml` workflow

## What's preserved
- GitHub Actions artifact uploads (Allure results, Playwright reports)
- Testspace publishing
- Local report generation in CI

## Re-enabling
All disabled steps are marked with `# DISABLED: R2 upload not working` comment. Search for this text to find and re-enable when R2 is fixed.

## Test plan
- [ ] Verify CI pipeline runs without R2-related failures
- [ ] Confirm test artifacts are still uploaded to GitHub Actions

🤖 Generated with [Claude Code](https://claude.ai/code)