### PR TITLE
Fix movement accounting to avoid recreating cost details

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/costing/ICostDetailService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/ICostDetailService.java
@@ -41,6 +41,8 @@ public interface ICostDetailService
 
 	List<CostDetail> getExistingCostDetails(CostDetailCreateRequest request);
 
+	AggregatedCostAmount toAggregatedCostAmount(List<CostDetail> costDetails);
+
 	List<CostDetail> getAllForDocument(CostingDocumentRef documentRef);
 
 	List<CostDetail> getAllForDocumentAndAcctSchemaId(CostingDocumentRef documentRef, AcctSchemaId acctSchemaId);

--- a/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostDetailService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostDetailService.java
@@ -3,6 +3,7 @@ package de.metas.costing.impl;
 import de.metas.acct.api.AcctSchema;
 import de.metas.acct.api.AcctSchemaId;
 import de.metas.acct.api.IAcctSchemaDAO;
+import de.metas.costing.AggregatedCostAmount;
 import de.metas.costing.CostDetail;
 import de.metas.costing.CostDetail.CostDetailBuilder;
 import de.metas.costing.CostDetailCreateRequest;
@@ -24,6 +25,7 @@ import de.metas.costing.MoveCostsRequest;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -128,6 +130,23 @@ public class CostDetailService implements ICostDetailService
 				// .productId(request.getProductId())
 				// .attributeSetInstanceId(request.getAttributeSetInstanceId())
 				.build());
+	}
+
+	@Override
+	public AggregatedCostAmount toAggregatedCostAmount(final List<CostDetail> costDetails)
+	{
+		return costDetails.stream()
+				.map(this::toAggregatedCostAmount)
+				.reduce(AggregatedCostAmount::add)
+				.orElseThrow(() -> new AdempiereException("No cost details"));
+	}
+
+	private AggregatedCostAmount toAggregatedCostAmount(final CostDetail costDetail)
+	{
+		return AggregatedCostAmount.builder()
+				.costSegment(extractCostSegment(costDetail))
+				.amount(costElementRepo.getById(costDetail.getCostElementId()), costDetail.getAmtAndQtyDetailed().getAmt())
+				.build();
 	}
 
 	@Override

--- a/backend/de.metas.business/src/main/java/de/metas/costing/methods/AverageInvoiceCostingMethodHandler.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/methods/AverageInvoiceCostingMethodHandler.java
@@ -108,7 +108,7 @@ public class AverageInvoiceCostingMethodHandler extends CostingMethodHandlerTemp
 	}
 
 	@Override
-	public MoveCostsResult createMovementCosts(@NonNull final MoveCostsRequest request)
+	protected MoveCostsResult createMovementCostsImpl(@NonNull MoveCostsRequest request)
 	{
 		// TODO Auto-generated method stub
 		throw new UnsupportedOperationException();

--- a/backend/de.metas.business/src/main/java/de/metas/costing/methods/AveragePOCostingMethodHandler.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/methods/AveragePOCostingMethodHandler.java
@@ -310,7 +310,7 @@ public class AveragePOCostingMethodHandler extends CostingMethodHandlerTemplate
 	}
 
 	@Override
-	public MoveCostsResult createMovementCosts(@NonNull final MoveCostsRequest request)
+	protected MoveCostsResult createMovementCostsImpl(@NonNull MoveCostsRequest request)
 	{
 		final CostElement costElement = request.getCostElement();
 		if (costElement == null)

--- a/backend/de.metas.business/src/main/java/de/metas/costing/methods/CostingMethodHandlerTemplate.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/methods/CostingMethodHandlerTemplate.java
@@ -8,9 +8,12 @@ import de.metas.costing.CostDetailCreateRequest;
 import de.metas.costing.CostDetailCreateResult;
 import de.metas.costing.CostDetailCreateResultsList;
 import de.metas.costing.CostDetailPreviousAmounts;
+import de.metas.costing.CostDetailQuery;
 import de.metas.costing.CostElement;
 import de.metas.costing.CostingDocumentRef;
 import de.metas.costing.CurrentCost;
+import de.metas.costing.MoveCostsRequest;
+import de.metas.costing.MoveCostsResult;
 import de.metas.currency.CurrencyPrecision;
 import de.metas.i18n.AdMessageKey;
 import de.metas.quantity.Quantity;
@@ -235,6 +238,40 @@ public abstract class CostingMethodHandlerTemplate implements CostingMethodHandl
 	}
 
 	protected abstract CostDetailCreateResult createOutboundCostDefaultImpl(final CostDetailCreateRequest request);
+
+	public final MoveCostsResult createMovementCosts(@NonNull MoveCostsRequest request)
+	{
+		final List<CostDetail> outboundCostDetails = utils.getExistingCostDetails(CostDetailQuery.builder()
+				.acctSchemaId(request.getAcctSchemaId())
+				.costElementId(request.getCostElementId()) // assume request's costing element is set
+				.documentRef(request.getOutboundDocumentRef())
+				.amtType(CostAmountType.MAIN)
+				.build());
+		final List<CostDetail> inboundCostDetails = utils.getExistingCostDetails(CostDetailQuery.builder()
+				.acctSchemaId(request.getAcctSchemaId())
+				.costElementId(request.getCostElementId()) // assume request's costing element is set
+				.documentRef(request.getInboundDocumentRef())
+				.amtType(CostAmountType.MAIN)
+				.build());
+
+		if (!outboundCostDetails.isEmpty() || !inboundCostDetails.isEmpty())
+		{
+			// make sure DateAcct is up-to-date
+			final List<CostDetail> outboundCostDetailsUpdated = utils.updateDateAcct(outboundCostDetails, request.getDate());
+			final List<CostDetail> inboundCostDetailsUpdated = utils.updateDateAcct(inboundCostDetails, request.getDate());
+
+			return MoveCostsResult.builder()
+					.outboundCosts(utils.toAggregatedCostAmount(outboundCostDetailsUpdated))
+					.inboundCosts(utils.toAggregatedCostAmount(inboundCostDetailsUpdated))
+					.build();
+		}
+		else
+		{
+			return createMovementCostsImpl(request);
+		}
+	}
+
+	protected abstract MoveCostsResult createMovementCostsImpl(@NonNull MoveCostsRequest request);
 
 	@Override
 	public CostDetailAdjustment recalculateCostDetailAmountAndUpdateCurrentCost(

--- a/backend/de.metas.business/src/main/java/de/metas/costing/methods/CostingMethodHandlerUtils.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/methods/CostingMethodHandlerUtils.java
@@ -1,9 +1,11 @@
 package de.metas.costing.methods;
 
+import com.google.common.collect.ImmutableList;
 import de.metas.acct.api.AcctSchema;
 import de.metas.acct.api.AcctSchemaId;
 import de.metas.acct.api.IAcctSchemaDAO;
 import de.metas.common.util.CoalesceUtil;
+import de.metas.costing.AggregatedCostAmount;
 import de.metas.costing.CostAmount;
 import de.metas.costing.CostDetail;
 import de.metas.costing.CostDetailCreateRequest;
@@ -166,6 +168,11 @@ public class CostingMethodHandlerUtils
 		return costDetailsService.getExistingCostDetails(request);
 	}
 
+	public List<CostDetail> getExistingCostDetails(@NonNull final CostDetailQuery query)
+	{
+		return costDetailsService.stream(query).collect(ImmutableList.toImmutableList());
+	}
+
 	public CostDetail getSingleCostDetail(@NonNull final CostDetailQuery query)
 	{
 		return costDetailsService.firstOnly(query)
@@ -256,4 +263,10 @@ public class CostingMethodHandlerUtils
 						request.getClientId(),
 						request.getOrgId()));
 	}
+
+	public AggregatedCostAmount toAggregatedCostAmount(final List<CostDetail> costDetails)
+	{
+		return costDetailsService.toAggregatedCostAmount(costDetails);
+	}
+
 }

--- a/backend/de.metas.business/src/main/java/de/metas/costing/methods/LastInvoiceCostingMethodHandler.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/methods/LastInvoiceCostingMethodHandler.java
@@ -104,7 +104,7 @@ public class LastInvoiceCostingMethodHandler extends CostingMethodHandlerTemplat
 	}
 
 	@Override
-	public MoveCostsResult createMovementCosts(@NonNull final MoveCostsRequest request)
+	protected MoveCostsResult createMovementCostsImpl(@NonNull MoveCostsRequest request)
 	{
 		// TODO Auto-generated method stub
 		throw new UnsupportedOperationException();

--- a/backend/de.metas.business/src/main/java/de/metas/costing/methods/LastPOCostingMethodHandler.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/methods/LastPOCostingMethodHandler.java
@@ -110,7 +110,7 @@ public class LastPOCostingMethodHandler extends CostingMethodHandlerTemplate
 	}
 
 	@Override
-	public MoveCostsResult createMovementCosts(@NonNull final MoveCostsRequest request)
+	protected MoveCostsResult createMovementCostsImpl(@NonNull MoveCostsRequest request)
 	{
 		// TODO: do it right! It's copied from de.metas.costing.methods.AveragePOCostingMethodHandler.createMovementCosts
 

--- a/backend/de.metas.business/src/main/java/de/metas/costing/methods/MovingAverageInvoiceCostingMethodHandler.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/methods/MovingAverageInvoiceCostingMethodHandler.java
@@ -390,7 +390,7 @@ public class MovingAverageInvoiceCostingMethodHandler extends CostingMethodHandl
 	}
 
 	@Override
-	public MoveCostsResult createMovementCosts(@NonNull final MoveCostsRequest request)
+	protected MoveCostsResult createMovementCostsImpl(@NonNull MoveCostsRequest request)
 	{
 		final CostElement costElement = request.getCostElement();
 		if (costElement == null)

--- a/backend/de.metas.business/src/main/java/de/metas/costing/methods/StandardCostingMethodHandler.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/methods/StandardCostingMethodHandler.java
@@ -116,7 +116,7 @@ public class StandardCostingMethodHandler extends CostingMethodHandlerTemplate
 	}
 
 	@Override
-	public MoveCostsResult createMovementCosts(@NonNull final MoveCostsRequest request)
+	protected MoveCostsResult createMovementCostsImpl(@NonNull MoveCostsRequest request)
 	{
 		final CostElement costElement = request.getCostElement();
 		if (costElement == null)


### PR DESCRIPTION
---

### Description of the Change

This pull request addresses an issue in the movement accounting process by ensuring cost details are not recreated if they already exist. The aim is to prevent duplicate entries and maintain accurate accounting records.

### Benefits

- Avoids duplicate cost details.
- Improves consistency in movement accounting.

