### PR TITLE
Fix white-screen crash from race condition in tables reducer

### DIFF
--- a/frontend/src/__tests__/reducers/Tables.test.js
+++ b/frontend/src/__tests__/reducers/Tables.test.js
@@ -198,7 +198,6 @@ describe('Tables reducer', () => {
   });
 
   // Regression tests for race condition: actions dispatched before table creation
-  // See: https://github.com/metasfresh/metasfresh/issues/XXXXX
   describe('Race condition handling - actions before table creation', () => {
     it('Should handle SET_ACTIVE_SORT gracefully when table does not exist', () => {
       const nonExistentId = '541851_541851-g';

--- a/frontend/src/__tests__/reducers/Tables.test.js
+++ b/frontend/src/__tests__/reducers/Tables.test.js
@@ -2,8 +2,9 @@ import { merge } from 'merge-anything';
 
 import { deleteTable, updateTableSelection } from '../../actions/TableActions';
 import * as ACTION_TYPES from '../../constants/ActionTypes';
+import { SORT_TAB } from '../../constants/ActionTypes';
 import reducer, {
-  initialState, 
+  initialState,
   initialTableState,
 } from '../../reducers/tables';
 
@@ -194,5 +195,113 @@ describe('Tables reducer', () => {
         length: 1,
       })
     );
+  });
+
+  // Regression tests for race condition: actions dispatched before table creation
+  // See: https://github.com/metasfresh/metasfresh/issues/XXXXX
+  describe('Race condition handling - actions before table creation', () => {
+    it('Should handle SET_ACTIVE_SORT gracefully when table does not exist', () => {
+      const nonExistentId = '541851_541851-g';
+
+      const action = {
+        type: ACTION_TYPES.SET_ACTIVE_SORT,
+        payload: {
+          id: nonExistentId,
+          active: true,
+        },
+      };
+
+      // Should not throw - this was causing white-screen crashes
+      expect(() => {
+        reducer(initialState, action);
+      }).not.toThrow();
+
+      // State should remain unchanged
+      const state = reducer(initialState, action);
+      expect(state).toEqual(initialState);
+      expect(state[nonExistentId]).toBeUndefined();
+    });
+
+    it('Should handle SORT_TAB gracefully when table does not exist', () => {
+      const action = {
+        type: SORT_TAB,
+        scope: 'master',
+        windowId: '541851',
+        docId: '1000001',
+        tabId: 'AD_Tab-999',
+        field: 'M_AttributeSetInstance_ID',
+        asc: true,
+      };
+
+      // Should not throw - this was causing white-screen crashes
+      expect(() => {
+        reducer(initialState, action);
+      }).not.toThrow();
+
+      // State should remain unchanged
+      const state = reducer(initialState, action);
+      expect(state).toEqual(initialState);
+    });
+
+    it('Should still set activeSort when table exists', () => {
+      const id = '143_1000037_AD_Tab-187';
+      const initialStateData = createState({
+        [id]: { ...initialTableState, ...basicData, activeSort: false },
+        length: 1,
+      });
+
+      const action = {
+        type: ACTION_TYPES.SET_ACTIVE_SORT,
+        payload: {
+          id,
+          active: true,
+        },
+      };
+
+      const state = reducer(initialStateData, action);
+      expect(state[id].activeSort).toBe(true);
+    });
+
+    it('Should still set orderBys via SORT_TAB when table exists', () => {
+      const id = '541851_1000001_AD_Tab-999';
+      const initialStateData = createState({
+        [id]: { ...initialTableState, windowId: '541851', docId: '1000001', tabId: 'AD_Tab-999' },
+        length: 1,
+      });
+
+      const action = {
+        type: SORT_TAB,
+        scope: 'master',
+        windowId: '541851',
+        docId: '1000001',
+        tabId: 'AD_Tab-999',
+        field: 'M_AttributeSetInstance_ID',
+        asc: true,
+      };
+
+      const state = reducer(initialStateData, action);
+      expect(state[id].orderBys).toEqual([
+        { fieldName: 'M_AttributeSetInstance_ID', ascending: true },
+      ]);
+    });
+
+    it('Should ignore SORT_TAB for non-master scope even when table does not exist', () => {
+      const action = {
+        type: SORT_TAB,
+        scope: 'included', // Not 'master'
+        windowId: '541851',
+        docId: '1000001',
+        tabId: 'AD_Tab-999',
+        field: 'SomeField',
+        asc: false,
+      };
+
+      expect(() => {
+        reducer(initialState, action);
+      }).not.toThrow();
+
+      const state = reducer(initialState, action);
+      expect(state).toEqual(initialState);
+    });
   });
 });

--- a/frontend/src/reducers/tables.js
+++ b/frontend/src/reducers/tables.js
@@ -443,7 +443,6 @@ const reducer = produce((draftState, action) => {
       const { id, active } = action.payload;
 
       // Guard against race condition where sort action fires before table creation
-      // See: https://github.com/metasfresh/metasfresh/issues/XXXXX
       if (draftState[id]) {
         draftState[id].activeSort = active;
       }

--- a/frontend/src/reducers/tables.js
+++ b/frontend/src/reducers/tables.js
@@ -442,7 +442,11 @@ const reducer = produce((draftState, action) => {
     case types.SET_ACTIVE_SORT: {
       const { id, active } = action.payload;
 
-      draftState[id].activeSort = active;
+      // Guard against race condition where sort action fires before table creation
+      // See: https://github.com/metasfresh/metasfresh/issues/XXXXX
+      if (draftState[id]) {
+        draftState[id].activeSort = active;
+      }
 
       return;
     }
@@ -475,7 +479,10 @@ const reducer = produce((draftState, action) => {
       }
 
       const tableId = getTableId({ windowId, docId, tabId });
-      draftState[tableId].orderBys = [{ fieldName, ascending }];
+      // Guard against race condition where sort action fires before table creation
+      if (draftState[tableId]) {
+        draftState[tableId].orderBys = [{ fieldName, ascending }];
+      }
 
       return;
     }


### PR DESCRIPTION
## Summary

- Fix race condition in Redux tables reducer that caused white-screen crashes
- Add null checks to `SET_ACTIVE_SORT` and `SORT_TAB` action handlers
- Add regression tests to prevent future recurrence

## Problem

When users navigate to a window URL that contains a `sort` parameter (e.g., via bookmarks, shared links, browser back/forward, or session restore), the sort-related Redux actions can fire **before** the `CREATE_TABLE` action completes.

This causes:
1. `TypeError: Cannot set properties of undefined (setting 'activeSort')`
2. Cascading React DOM reconciliation errors (`insertBefore` failures)
3. White screen / app crash

## Root Cause

```javascript
// Before fix - crashes when draftState[id] is undefined
case types.SET_ACTIVE_SORT: {
  draftState[id].activeSort = active;  // ← crash here
}
```

## Solution

Add null checks before accessing table state, following the existing pattern used in `DESELECT_TABLE_ROWS` and `SET_TABLE_NAVIGATION`:

```javascript
// After fix - gracefully handles missing table
case types.SET_ACTIVE_SORT: {
  if (draftState[id]) {
    draftState[id].activeSort = active;
  }
}
```

## Test plan

- [x] Added 5 regression tests for race condition scenarios
- [x] Verified normal sort functionality still works
- [x] All 12 Jest tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)