### PR TITLE
Fix maturity date calculation in PP_Maturing_Candidates_v view When m…

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pporder/api/impl/HUPPOrderBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pporder/api/impl/HUPPOrderBL.java
@@ -12,6 +12,7 @@ import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.IHandlingUnitsDAO;
 import de.metas.handlingunits.allocation.IAllocationSource;
 import de.metas.handlingunits.allocation.impl.GenericAllocationSourceDestination;
+import de.metas.handlingunits.attribute.HUAttributeConstants;
 import de.metas.handlingunits.attribute.IHUAttributesBL;
 import de.metas.handlingunits.impl.DocumentLUTUConfigurationManager;
 import de.metas.handlingunits.impl.IDocumentLUTUConfigurationManager;
@@ -50,6 +51,7 @@ import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.IWarehouseDAO;
 import org.adempiere.warehouse.groups.WarehouseGroupAssignmentType;
+import org.apache.commons.lang3.StringUtils;
 import org.compiere.SpringContextHolder;
 import org.eevolution.api.IPPOrderBL;
 import org.eevolution.api.IPPOrderDAO;
@@ -372,9 +374,12 @@ public class HUPPOrderBL implements IHUPPOrderBL
 
 		final ProductId maturedProductId = ProductId.ofRepoId(ppOrder.getM_Product_ID());
 
-		if (isHUEligibleForMaturing(maturingHU, maturedProductId))
+		if (!isHUEligibleForMaturing(maturingHU, maturedProductId))
 		{
-			throw new AdempiereException("Issue HU is not eligible for maturing !");
+			throw new AdempiereException("Issue HU is not eligible for maturing!")
+					.appendParametersToMessage()
+					.setParameter("maturingHUId", maturingHUId)
+					.setParameter("maturedProductId", maturedProductId);
 		}
 
 		return maturingHU;
@@ -392,10 +397,39 @@ public class HUPPOrderBL implements IHUPPOrderBL
 				.receiveVHU(Quantitys.of(ppOrder.getQtyOrdered(), UomId.ofRepoId(ppOrder.getC_UOM_ID())));
 
 		attributesBL.transferAttributesForSingleProductHUs(huToBeIssued, receivedHu);
-		attributesBL.updateHUAttribute(HuId.ofRepoId(receivedHu.getM_HU_ID()), AttributeConstants.ProductionDate, SystemTime.asTimestamp());
+		final HuId receivedHuId = HuId.ofRepoId(receivedHu.getM_HU_ID());
+		attributesBL.updateHUAttribute(receivedHuId, AttributeConstants.ProductionDate, SystemTime.asTimestamp());
+		// When maturing, the new HU's ProductionDate is set to NOW(), which would reset its calculated age to 0.
+		// To preserve the original aging timeline, we copy the source HU's current Age as AgeOffset.
+		// The AgeOffset is then used in PP_Maturing_Candidate_v to adjust the DateStartSchedule calculation.
+		final String ageString = attributesBL.getHUAttributeValue(huToBeIssued, HUAttributeConstants.ATTR_Age);
+		if (StringUtils.isNumeric(ageString))
+		{
 
-		final HUQRCode huqrCode = huqrCodesService.get().getQRCodeByHuId(HuId.ofRepoId(huToBeIssued.getM_HU_ID()));
-		huqrCodesService.get().assign(huqrCode, ImmutableSet.of(HuId.ofRepoId(receivedHu.getM_HU_ID())));
+			attributesBL.updateHUAttribute(receivedHuId, HUAttributeConstants.ATTR_AgeOffset, ageString);
+		}
+
+		final HUQRCodesService qrCodeService = huqrCodesService.get();
+		final HuId huToBeIssuedId = HuId.ofRepoId(huToBeIssued.getM_HU_ID());
+		final HUQRCode huqrCode = qrCodeService.getQRCodeByHuId(huToBeIssuedId);
+		if (huqrCode != null)
+		{
+			qrCodeService.assign(huqrCode, ImmutableSet.of(receivedHuId));
+			try
+			{
+				qrCodeService.removeAssignment(huqrCode, ImmutableSet.of(huToBeIssuedId));
+			}
+			catch (final Exception e)
+			{
+				// Compensating action: remove the assignment we just made
+				qrCodeService.removeAssignment(huqrCode, ImmutableSet.of(receivedHuId));
+				throw AdempiereException.wrapIfNeeded(e)
+						.appendParametersToMessage()
+						.setParameter("huqrCode", huqrCode.toDisplayableQRCode())
+						.setParameter("sourceHuId", huToBeIssuedId)
+						.setParameter("targetHuId", receivedHuId);
+			}
+		}
 
 		processPlanning(PPOrderPlanningStatus.COMPLETE, ppOrderId);
 	}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesRepository.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesRepository.java
@@ -1,5 +1,6 @@
 package de.metas.handlingunits.qrcodes.service;
 
+import ch.qos.logback.classic.Level;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -12,7 +13,9 @@ import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.model.HUQRCodeAssignment;
 import de.metas.handlingunits.qrcodes.model.HUQRCodeRepoId;
 import de.metas.handlingunits.qrcodes.model.HUQRCodeUniqueId;
+import de.metas.logging.LogManager;
 import de.metas.util.Check;
+import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
@@ -20,6 +23,7 @@ import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.slf4j.Logger;
 import org.springframework.stereotype.Repository;
 
 import javax.annotation.Nullable;
@@ -33,6 +37,8 @@ import java.util.stream.Stream;
 @Repository
 public class HUQRCodesRepository
 {
+	private final Logger logger = LogManager.getLogger(HUQRCodesRepository.class);
+
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 	public Optional<HUQRCodeAssignment> getHUAssignmentByQRCode(@NonNull final HUQRCode huQRCode)
@@ -124,7 +130,8 @@ public class HUQRCodesRepository
 		final I_M_HU_QRCode existingRecord = getByUniqueId(qrCode.getId()).orElse(null);
 		if (existingRecord == null)
 		{
-			//nothing to be done
+			Loggables.withLogger(logger, Level.WARN).addLog("Cannot remove QR code assignment - QR code record not found in database. " +
+					"qrCodeId={}, huIdsToRemove={}", qrCode.getId(), huIdsToRemove);
 			return;
 		}
 
@@ -205,7 +212,7 @@ public class HUQRCodesRepository
 
 		return assignments.stream()
 				.collect(ImmutableSetMultimap.toImmutableSetMultimap(record -> HuId.ofRepoId(record.getM_HU_ID()),
-																	 record -> toHUQRCode(id2QrCode.get(HUQRCodeRepoId.ofRepoId(record.getM_HU_QRCode_ID())))));
+						record -> toHUQRCode(id2QrCode.get(HUQRCodeRepoId.ofRepoId(record.getM_HU_QRCode_ID())))));
 	}
 
 	@NonNull
@@ -259,7 +266,7 @@ public class HUQRCodesRepository
 	{
 		return streamAssignmentForQrIds(huQrCodeIds)
 				.collect(ImmutableSetMultimap.toImmutableSetMultimap(assignment -> HUQRCodeRepoId.ofRepoId(assignment.getM_HU_QRCode_ID()),
-																	 assignment -> HuId.ofRepoId(assignment.getM_HU_ID())));
+						assignment -> HuId.ofRepoId(assignment.getM_HU_ID())));
 	}
 
 	private void createAssignments(@NonNull final I_M_HU_QRCode qrCode, @NonNull final ImmutableSet<HuId> huIds)
@@ -297,7 +304,7 @@ public class HUQRCodesRepository
 				.create()
 				.stream()
 				.collect(ImmutableMap.toImmutableMap(huQrCode -> HUQRCodeRepoId.ofRepoId(huQrCode.getM_HU_QRCode_ID()),
-													 Function.identity()));
+						Function.identity()));
 	}
 
 	@NonNull

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/ddl/views/PP_Maturing_Candidate_v.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/ddl/views/PP_Maturing_Candidate_v.sql
@@ -2,12 +2,12 @@ DROP VIEW IF EXISTS PP_Maturing_Candidates_v
 ;
 
 CREATE OR REPLACE VIEW PP_Maturing_Candidates_v AS
-SELECT hu.m_hu_id                                                 AS PP_Maturing_Candidates_v_ID,
+SELECT hu.m_hu_id                                                                                                                                 AS PP_Maturing_Candidates_v_ID,
        hu.m_hu_id,
        hus.qty,
        hu.hustatus,
        pp.m_product_id,
-       hus.m_product_id as issue_m_product_id,
+       hus.m_product_id                                                                                                                           AS issue_m_product_id,
        hus.c_uom_id,
        w.m_warehouse_id,
        mc.m_maturing_configuration_id,
@@ -15,13 +15,17 @@ SELECT hu.m_hu_id                                                 AS PP_Maturing
        pp.pp_product_planning_id,
        pp.pp_product_bomversions_id,
        pp.m_attributesetinstance_id,
-       hua.valuedate + MAKE_INTERVAL(0, mcl.maturityage::integer) AS DateStartSchedule,
+       -- DateStartSchedule: When this HU should be scheduled for the next maturing step
+       -- Formula: ProductionDate + MaturityAge - AgeOffset
+       -- Note: AgeOffset compensates for previously accumulated age when ProductionDate is reset during maturing
+       hua_ProdDate.valuedate + MAKE_INTERVAL(0, mcl.maturityage::integer) - MAKE_INTERVAL(0, COALESCE(hua_AgeOffset.value::numeric::integer, 0)) AS DateStartSchedule,
        ppoc.pp_order_candidate_id,
        hu.ad_org_id,
        hu.ad_client_id
 FROM m_hu hu
          INNER JOIN m_hu_storage hus ON hu.m_hu_id = hus.m_hu_id
-         INNER JOIN m_hu_attribute hua ON hu.m_hu_id = hua.m_hu_id AND m_attribute_id = (SELECT m_attribute_id FROM m_attribute WHERE VALUE = 'ProductionDate')
+         INNER JOIN m_hu_attribute hua_ProdDate ON hu.m_hu_id = hua_ProdDate.m_hu_id AND hua_ProdDate.m_attribute_id = (SELECT m_attribute_id FROM m_attribute WHERE VALUE = 'ProductionDate')
+         LEFT JOIN m_hu_attribute hua_AgeOffset ON hu.m_hu_id = hua_AgeOffset.m_hu_id AND hua_AgeOffset.m_attribute_id = (SELECT m_attribute_id FROM m_attribute WHERE VALUE = 'AgeOffset')
          INNER JOIN m_locator l ON hu.m_locator_id = l.m_locator_id
          INNER JOIN m_warehouse w ON l.m_warehouse_id = w.m_warehouse_id
          INNER JOIN m_maturing_configuration_line mcl ON hus.m_product_id = mcl.from_product_id AND mcl.isactive = 'Y'
@@ -35,8 +39,9 @@ WHERE hu.isactive = 'Y'
   AND hu.isreserved != 'Y'
   AND hu.locked != 'Y'
   AND hus.qty > 0
+  AND hu.m_hu_item_parent_id IS NULL
   AND (ppoc.pp_order_candidate_id IS NULL
     OR (ppoc.isclosed != 'Y' AND ppoc.processed != 'Y'))
-  AND hua.valuedate IS NOT NULL
+  AND hua_ProdDate.valuedate IS NOT NULL
   AND childHu.m_hu_id IS NULL
 ;

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5786620_PP_Maturing_Candidate_v.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5786620_PP_Maturing_Candidate_v.sql
@@ -1,0 +1,43 @@
+DROP VIEW IF EXISTS PP_Maturing_Candidates_v
+;
+
+SELECT public.db_alter_view('PP_Maturing_Candidates_v','SELECT hu.m_hu_id                                                                                                                                 AS PP_Maturing_Candidates_v_ID,
+       hu.m_hu_id,
+       hus.qty,
+       hu.hustatus,
+       pp.m_product_id,
+       hus.m_product_id                                                                                                                           AS issue_m_product_id,
+       hus.c_uom_id,
+       w.m_warehouse_id,
+       mc.m_maturing_configuration_id,
+       mcl.m_maturing_configuration_line_id,
+       pp.pp_product_planning_id,
+       pp.pp_product_bomversions_id,
+       pp.m_attributesetinstance_id,
+       hua_ProdDate.valuedate + MAKE_INTERVAL(0, mcl.maturityage::integer) - MAKE_INTERVAL(0, COALESCE(hua_AgeOffset.value::numeric::integer, 0)) AS DateStartSchedule,
+       ppoc.pp_order_candidate_id,
+       hu.ad_org_id,
+       hu.ad_client_id
+FROM m_hu hu
+         INNER JOIN m_hu_storage hus ON hu.m_hu_id = hus.m_hu_id
+         INNER JOIN m_hu_attribute hua_ProdDate ON hu.m_hu_id = hua_ProdDate.m_hu_id AND hua_ProdDate.m_attribute_id = (SELECT m_attribute_id FROM m_attribute WHERE VALUE = ''ProductionDate'')
+         LEFT JOIN m_hu_attribute hua_AgeOffset ON hu.m_hu_id = hua_AgeOffset.m_hu_id AND hua_AgeOffset.m_attribute_id = (SELECT m_attribute_id FROM m_attribute WHERE VALUE = ''AgeOffset'')
+         INNER JOIN m_locator l ON hu.m_locator_id = l.m_locator_id
+         INNER JOIN m_warehouse w ON l.m_warehouse_id = w.m_warehouse_id
+         INNER JOIN m_maturing_configuration_line mcl ON hus.m_product_id = mcl.from_product_id AND mcl.isactive = ''Y''
+         INNER JOIN m_maturing_configuration mc ON mcl.m_maturing_configuration_id = mc.m_maturing_configuration_id AND mc.isactive = ''Y''
+         INNER JOIN pp_product_planning pp ON w.m_warehouse_id = pp.m_warehouse_id AND mcl.m_maturing_configuration_line_id = pp.m_maturing_configuration_line_id AND pp.m_product_id = mcl.matured_product_id AND pp.isactive = ''Y'' AND pp.ismatured = ''Y''
+         LEFT JOIN pp_order_candidate ppoc ON hu.m_hu_id = ppoc.issue_hu_id
+         LEFT JOIN m_hu_item hui ON hu.m_hu_id = hui.m_hu_id
+         LEFT JOIN m_hu childHu ON childHu.m_hu_item_parent_id = hui.m_hu_item_id
+WHERE hu.isactive = ''Y''
+  AND hu.hustatus IN (''A'', ''I'')
+  AND hu.isreserved != ''Y''
+  AND hu.locked != ''Y''
+  AND hus.qty > 0
+  AND hu.m_hu_item_parent_id IS NULL
+  AND (ppoc.pp_order_candidate_id IS NULL
+    OR (ppoc.isclosed != ''Y'' AND ppoc.processed != ''Y''))
+  AND hua_ProdDate.valuedate IS NOT NULL
+  AND childHu.m_hu_id IS NULL')
+;


### PR DESCRIPTION
…aturing, copy previous HU's Age as AgeOffset (since ProductionDate=NOW()). Remove qrCode from old HU (to prevent same QR being assigned to multiple HUs) (#22271)

* Fix maturity date calculation in PP_Maturing_Candidates_v view When maturing, copy previous HU's Age as AgeOffset (since ProductionDate=NOW()). Remove qrCode from old HU (to prevent same QR being assigned to multiple HUs)

* Handle nullable `hua_AgeOffset.value` in PP_Maturing_Candidate_v and prevent creating maturing order candidates for non-toplevel-HUs

* Improve handling of HU QR code assignments and enhance maturing process consistency:

- Prevent QR code duplication during assignment by adding compensating actions for errors.
- Replace deprecated `Check` usage with `StringUtils` for better null safety.
- Update `PP_Maturing_Candidates_v` view to:
  - Properly handle nullable or missing `AgeOffset` attributes.
  - Add detailed comments for clarity on maturity date calculation logic.
- Refactor QR code repository with enhanced logging for unresolvable QR code records.