### PR TITLE
gh#28066 Document RAISE NOTICE flow and fix AD_Process field descriptions

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/DB.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/DB.java
@@ -907,6 +907,8 @@ public class DB
 			DB.close(cs);
 		}
 
+		// PostgreSQL RAISE NOTICE messages are delivered as SQLWarnings by the JDBC driver.
+		// Extract them here so callers (e.g. ExecuteUpdateSQL) can log them to AD_PInstance_Log.
 		final List<String> warningMessages = SQLUtil.extractWarningMessages(warning);
 
 		return SQLUpdateResult.builder()

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/SQLUpdateResult.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/SQLUpdateResult.java
@@ -29,11 +29,18 @@ import javax.annotation.Nullable;
 import java.sql.SQLWarning;
 import java.util.List;
 
+/**
+ * Result of a SQL UPDATE/INSERT/DELETE execution, including any {@link SQLWarning} messages.
+ * Warning messages originate from PostgreSQL {@code RAISE NOTICE} statements.
+ *
+ * @see SQLUtil#extractWarningMessages
+ */
 @Builder
 @Value
 public class SQLUpdateResult
 {
 	int returnedValue;
+	/** PostgreSQL RAISE NOTICE messages captured from the JDBC {@link SQLWarning} chain */
 	@Nullable
 	List<String> warningMessages;
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/SQLUtil.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/SQLUtil.java
@@ -32,6 +32,13 @@ import java.util.List;
 @UtilityClass
 public class SQLUtil
 {
+	/**
+	 * Walks the {@link SQLWarning} chain and extracts all messages.
+	 * In PostgreSQL, {@code RAISE NOTICE} messages are delivered as {@link SQLWarning}s,
+	 * so this method is the bridge that captures them for logging to {@code AD_PInstance_Log}.
+	 *
+	 * @see ExecuteUpdateSQL which uses this to capture RAISE NOTICE output from SQL-type AD_Processes
+	 */
 	public List<String> extractWarningMessages(@Nullable SQLWarning warning)
 	{
 		final List<String> warningMessages = new ArrayList<>();

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/SQLValueStringResult.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/SQLValueStringResult.java
@@ -29,6 +29,12 @@ import javax.annotation.Nullable;
 import java.sql.SQLWarning;
 import java.util.List;
 
+/**
+ * Result of a SQL SELECT (single value) execution, including any {@link SQLWarning} messages.
+ * Warning messages originate from PostgreSQL {@code RAISE NOTICE} statements.
+ *
+ * @see SQLUtil#extractWarningMessages
+ */
 @Value
 @Builder
 public class SQLValueStringResult
@@ -36,6 +42,7 @@ public class SQLValueStringResult
 	@Nullable
 	String returnedValue;
 
+	/** PostgreSQL RAISE NOTICE messages captured from the JDBC {@link SQLWarning} chain */
 	@Nullable
 	List<String> warningMessages;
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ExecuteUpdateSQL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ExecuteUpdateSQL.java
@@ -17,6 +17,19 @@ import com.google.common.base.Stopwatch;
 import org.compiere.util.SQLUpdateResult;
 import org.compiere.util.SQLValueStringResult;
 
+/**
+ * Executes SQL statements configured in {@link de.metas.process.ProcessInfo#getSQLStatement()}.
+ * Used by AD_Process records with ProcessType=SQL.
+ *
+ * <h3>RAISE NOTICE support</h3>
+ * PostgreSQL {@code RAISE NOTICE} messages are captured via the JDBC {@link java.sql.SQLWarning} chain:
+ * <ol>
+ *   <li>{@link DB#executeUpdateWithWarningEx} / {@link DB#getSQLValueStringWithWarningEx} execute the SQL</li>
+ *   <li>{@link org.compiere.util.SQLUtil#extractWarningMessages} walks the {@link java.sql.SQLWarning} chain</li>
+ *   <li>If {@code AD_Process.IsLogWarning='Y'}, the warnings are written to {@code AD_PInstance_Log.Warnings}
+ *       via {@link JavaProcess#addLog(java.util.List, String)}</li>
+ * </ol>
+ */
 @Process(requiresCurrentRecordWhenCalledFromGear = false)
 public class ExecuteUpdateSQL extends JavaProcess
 {

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5787790_sys_gh28066_fix_AD_Process_field_descriptions.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5787790_sys_gh28066_fix_AD_Process_field_descriptions.sql
@@ -1,0 +1,70 @@
+-- gh#28066: Fix AD_Process field descriptions (IsLogWarning, SQLStatement)
+--
+-- IsLogWarning (AD_Element_ID=581085):
+--   The existing description incorrectly states that RAISE NOTICE messages are ignored.
+--   In reality, PostgreSQL JDBC maps both RAISE NOTICE and RAISE WARNING to java.sql.SQLWarning,
+--   and ExecuteUpdateSQL captures them all via SQLUtil.extractWarningMessages().
+--
+-- SQLStatement (AD_Element_ID=50028):
+--   Has no description at all. Add one.
+--   Note: also used on AD_MigrationStep, so keep description generic.
+
+-- =====================================================
+-- 1) Fix IsLogWarning (AD_Element_ID=581085)
+-- =====================================================
+
+-- 1a) de_DE
+UPDATE AD_Element_Trl
+SET Name = 'Warnungen protokollieren',
+    Description = 'Wenn aktiv, werden PostgreSQL-Meldungen (RAISE NOTICE / RAISE WARNING) in AD_PInstance_Log gespeichert.',
+    Help = 'Wenn aktiv, werden die von der SQL-Funktion erzeugten PostgreSQL-Meldungen (RAISE NOTICE und RAISE WARNING) als Warnungen in AD_PInstance_Log protokolliert.'
+     || E'\nDie Meldungen werden über die JDBC-SQLWarning-Kette erfasst und in der Spalte "Warnings" gespeichert.'
+     || E'\nEinzelne Warnmeldungen sollten maximal 5000 Zeichen lang sein.',
+    Updated = '2026-02-11 18:30',
+    UpdatedBy = 100
+WHERE AD_Element_ID = 581085 AND AD_Language = 'de_DE';
+
+/* DDL */ SELECT update_ad_element_on_ad_element_trl_update(581085, 'de_DE');
+/* DDL */ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(581085, 'de_DE');
+
+-- 1b) en_US
+UPDATE AD_Element_Trl
+SET Name = 'Log Warning',
+    Description = 'If enabled, PostgreSQL messages (RAISE NOTICE / RAISE WARNING) are logged to AD_PInstance_Log.',
+    Help = 'If enabled, PostgreSQL messages raised by the SQL function (both RAISE NOTICE and RAISE WARNING) are captured via the JDBC SQLWarning chain and stored in the AD_PInstance_Log.Warnings column.'
+     || E'\nA single warning message should contain a maximum of 5000 characters.',
+    Updated = '2026-02-11 18:30',
+    UpdatedBy = 100
+WHERE AD_Element_ID = 581085 AND AD_Language = 'en_US';
+
+/* DDL */ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(581085, 'en_US');
+
+
+-- =====================================================
+-- 2) Add SQLStatement description (AD_Element_ID=50028)
+-- =====================================================
+
+-- 2a) de_DE
+UPDATE AD_Element_Trl
+SET Description = 'SQL-Anweisung die von diesem Prozess ausgeführt wird',
+    Help = 'Die SQL-Anweisung wird von ExecuteUpdateSQL ausgeführt.'
+     || E'\nSie kann Kontext-Variablen enthalten (z.B. @C_BPartner_ID@), die zur Laufzeit aufgelöst werden.'
+     || E'\nBei Nicht-SELECT-Anweisungen werden RAISE NOTICE / RAISE WARNING Meldungen erfasst (siehe "Warnungen protokollieren").',
+    Updated = '2026-02-11 18:30',
+    UpdatedBy = 100
+WHERE AD_Element_ID = 50028 AND AD_Language = 'de_DE';
+
+/* DDL */ SELECT update_ad_element_on_ad_element_trl_update(50028, 'de_DE');
+/* DDL */ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(50028, 'de_DE');
+
+-- 2b) en_US
+UPDATE AD_Element_Trl
+SET Description = 'SQL statement to be executed by this process',
+    Help = 'The SQL statement is executed by ExecuteUpdateSQL.'
+     || E'\nIt may contain context variables (e.g. @C_BPartner_ID@) which are resolved at runtime.'
+     || E'\nFor non-SELECT statements, RAISE NOTICE / RAISE WARNING messages are captured (see "Log Warning" flag).',
+    Updated = '2026-02-11 18:30',
+    UpdatedBy = 100
+WHERE AD_Element_ID = 50028 AND AD_Language = 'en_US';
+
+/* DDL */ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(50028, 'en_US');


### PR DESCRIPTION
## Summary
- Fix incorrect `IsLogWarning` AD_Element description (claimed RAISE NOTICE is ignored; actually both NOTICE and WARNING are captured via JDBC SQLWarning)
- Add missing `SQLStatement` AD_Element description/help (de_DE + en_US)
- Add Javadoc to `ExecuteUpdateSQL`, `SQLUtil`, `SQLUpdateResult`, `SQLValueStringResult`, `DB.java` documenting the RAISE NOTICE → JDBC SQLWarning → AD_PInstance_Log.Warnings flow

## Test plan
- [ ] Verify AD_Process window shows updated field descriptions for "Log Warning" and "SQLStatement"
- [ ] Create a test SQL process with `IsLogWarning=Y` that uses `RAISE NOTICE` and confirm messages appear in AD_PInstance_Log

🤖 Generated with [Claude Code](https://claude.com/claude-code)