### PR TITLE
change Docker compose DB port from 15432 to 14432

### DIFF
--- a/docker-builds/README.md
+++ b/docker-builds/README.md
@@ -91,7 +91,7 @@ junit and cucumber test results will be accumulated under: https://metasfresh.te
 in addition to that, a database image with the post cucumber run state is available for every cucumber run as:<br>
 `metasfresh/metas-db:<tag>-postcucumber`<br>
 <br>
-which can be run like this: ```docker run -it --rm -p 15432:5432 metasfresh/metas-db:<tag>-postcucumber```
+which can be run like this: ```docker run -it --rm -p 14432:5432 metasfresh/metas-db:<tag>-postcucumber```
 
 ### local
 
@@ -108,8 +108,8 @@ execute ```stop.cmd``` to clean up running and/or stopped containers<br>
 <br>
 cucumber results get stored under __docker-builds/cucumber/cucumber_<br>
 in addition to that, a database image with the post cucumber run state is available as: `metasfresh/metas-db:local-postcucumber`<br>
-which can be run like this: ```docker run -it --rm -p 15432:5432 metasfresh/metas-db:local-postcucumber```
-to be accessed under *localhost:15432*<br>
+which can be run like this: ```docker run -it --rm -p 14432:5432 metasfresh/metas-db:local-postcucumber```
+to be accessed under *localhost:14432*<br>
 alternatively the local docker compose run can be adjusted by switching the *dbqualifier* in _docker-builds/compose/.env_ to *postcucumber*<br>
 to run with a database in post cucumber state<br>
 <br>

--- a/docker-builds/compose/compose.yml
+++ b/docker-builds/compose/compose.yml
@@ -10,7 +10,7 @@ services:
         mfversion: $mfversion
         dbqualifier: $dbqualifier
     ports:
-      - "15432:5432"
+      - "14432:5432"
     environment:
       - PGDATA=/var/lib/postgresql/data
     healthcheck:

--- a/docker-builds/cucumber/compose.yml
+++ b/docker-builds/cucumber/compose.yml
@@ -5,7 +5,7 @@ services:
   db:
     image: ${mfregistry:-metasfresh}/metas-db:$mfversion-preloaded
     ports:
-      - "15432:5432"
+      - "14432:5432"
     environment:
       # run the database on the initial data
       # so we can later commit it again to create postcucumber images without doubling the image size

--- a/docker-builds/db/init-preloaded/compose.yml
+++ b/docker-builds/db/init-preloaded/compose.yml
@@ -10,7 +10,7 @@ services:
         mfversion: $mfversion
         dbqualifier: $dbqualifier
     ports:
-      - "15432:5432"
+      - "14432:5432"
     environment:
       # run the database on the initial data
       # so we can later commit it again to create the preloaded db with migrations applied

--- a/docker-builds/mobiletest/compose.yml
+++ b/docker-builds/mobiletest/compose.yml
@@ -5,7 +5,7 @@ services:
   db:
     image: $mfregistry/metas-db:$mfversion-$dbqualifier
     ports:
-      - "15432:5432"
+      - "14432:5432"
     healthcheck:
       test: pg_isready -h localhost -U metasfresh -d metasfresh -t 1
       interval: 10s


### PR DESCRIPTION
## Summary

Changes the published PostgreSQL port from `15432` to `14432` in all Docker compose files to avoid conflicts

**Files changed:**
- `docker-builds/compose/compose.yml`
- `docker-builds/cucumber/compose.yml`
- `docker-builds/db/init-preloaded/compose.yml`
- `docker-builds/mobiletest/compose.yml`
- `docker-builds/README.md`

## Test plan

- [ ] Verify `docker compose up` starts DB on port 14432
- [ ] Verify no other services reference the old port 15432

🤖 Generated with [Claude Code](https://claude.com/claude-code)