### PR TITLE
minor code cleanup: fix typo, method references, distinct() for HU dedup

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/customs/CustomsInvoiceRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/customs/CustomsInvoiceRepository.java
@@ -178,7 +178,7 @@ public class CustomsInvoiceRepository
 				.docTypeId(DocTypeId.ofRepoId(customsInvoicePO.getC_DocType_ID()))
 				.invoiceDate(TimeUtil.asLocalDate(customsInvoicePO.getDateInvoiced()))
 				.docAction(customsInvoicePO.getDocAction())
-				.docStatus(DocStatus.ofNullableCode(customsInvoicePO.getDocStatus()))
+				.docStatus(DocStatus.ofCode(customsInvoicePO.getDocStatus()))
 				.lines(lines)
 				.build();
 	}
@@ -266,14 +266,14 @@ public class CustomsInvoiceRepository
 		saveLineAllocations(line);
 	}
 
-	public CustomsInvoice updateDocActionAndStatus(@NonNull final CustomsInvoice customsInvoice)
+	public void updateDocActionAndStatus(@NonNull final CustomsInvoice customsInvoice)
 	{
 		final I_C_Customs_Invoice customsInvoiceRecord = load(customsInvoice.getId(), I_C_Customs_Invoice.class);
 
 		final String docAction = customsInvoiceRecord.getDocAction();
 		final DocStatus docStatus = DocStatus.ofCode(customsInvoiceRecord.getDocStatus());
 
-		return customsInvoice.toBuilder()
+		customsInvoice.toBuilder()
 				.docAction(docAction)
 				.docStatus(docStatus)
 				.build();
@@ -300,7 +300,7 @@ public class CustomsInvoiceRepository
 	{
 		final HashMap<InOutAndLineId, I_M_InOutLine_To_C_Customs_Invoice_Line> existingRecords = retrieveAllocationRecords(line.getId())
 				.stream()
-				.collect(GuavaCollectors.toHashMapByKey(allocRecord -> extractInOutAndLineId(allocRecord)));
+				.collect(GuavaCollectors.toHashMapByKey(CustomsInvoiceRepository::extractInOutAndLineId));
 
 		for (final CustomsInvoiceLineAlloc alloc : line.getAllocations())
 		{
@@ -362,8 +362,8 @@ public class CustomsInvoiceRepository
 				.create()
 				.stream()
 				.collect(ImmutableListMultimap.toImmutableListMultimap(
-						record -> extractCustomsInvoiceLineId(record),
-						record -> toCustomsInvoiceLineAlloc(record)));
+						CustomsInvoiceRepository::extractCustomsInvoiceLineId,
+						this::toCustomsInvoiceLineAlloc));
 	}
 
 	private CustomsInvoiceLineAlloc toCustomsInvoiceLineAlloc(final I_M_InOutLine_To_C_Customs_Invoice_Line record)

--- a/backend/de.metas.business/src/main/java/de/metas/customs/CustomsInvoiceService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/customs/CustomsInvoiceService.java
@@ -295,11 +295,11 @@ public class CustomsInvoiceService
 			lineQty = Quantitys.of(inoutLineRecord.getMovementQty(), productBL.getStockUOMId(productId));
 		}
 
-		return convertToKillogram(lineQty, productId)
+		return convertToKilogram(lineQty, productId)
 				.orElse(lineQty);
 	}
 
-	private Optional<Quantity> convertToKillogram(final Quantity qty, final ProductId productId)
+	private Optional<Quantity> convertToKilogram(@NonNull final Quantity qty, @NonNull final ProductId productId)
 	{
 		try
 		{

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_InOut.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_InOut.java
@@ -264,6 +264,7 @@ public class M_InOut
 						.anonymousHuPickedOnTheFly(qtyPicked.isAnonymousHuPickedOnTheFly())
 						.huId(HuId.ofRepoId(qtyPicked.getVHU_ID()))
 						.build())
+				.distinct() // one HU might be in multiple qtyPicked records if inouts are completed and reversed multiple times
 				.collect(ImmutableList.toImmutableList());
 
 		final ReopenPickingJobRequest request = ReopenPickingJobRequest.builder()


### PR DESCRIPTION
## Summary

Minor code quality improvements across 3 files:

- **CustomsInvoiceRepository**: use `DocStatus.ofCode()` instead of `ofNullableCode()`, change `updateDocActionAndStatus` to void (caller already ignores return value), replace lambdas with method references
- **CustomsInvoiceService**: fix typo `convertToKillogram` → `convertToKilogram`, add `@NonNull` annotations
- **M_InOut validator**: add `.distinct()` to prevent duplicate HU entries when inouts are completed and reversed multiple times

## Test plan

- [ ] Customs invoice processing still works (complete flow)
- [ ] InOut reversal + re-completion doesn't create duplicate picking job HU entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)