### PR TITLE
Remove unused Language AD_Preference, add Turkish (tr_TR)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/Language.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/Language.java
@@ -107,6 +107,7 @@ public final class Language implements Serializable
 	private static final String AD_Language_ar_TN = "ar_TN";
 	private static final String AD_Language_hu_HU = "hu_HU";
 	private static final String AD_Language_el_GR = "el_GR";
+	private static final String AD_Language_tr_TR = "tr_TR";
 
 	/** System Languages. */
 	private static final CopyOnWriteArrayList<Language> s_languages = new CopyOnWriteArrayList<>(new Language[] {
@@ -220,6 +221,9 @@ public final class Language implements Serializable
 					MediaSize.ISO.A4),
 			new Language("\u0e44\u0e17\u0e22 (TH)",
 					AD_Language_th_TH, new Locale("th", "TH"), Boolean.FALSE, "dd/MM/yyyy",
+					MediaSize.ISO.A4),
+			new Language("T\u00fcrk\u00e7e",
+					AD_Language_tr_TR, new Locale("tr", "TR"), Boolean.FALSE, "dd.MM.yyyy",
 					MediaSize.ISO.A4),
 			new Language("Vi\u1EC7t Nam",
 					AD_Language_vi_VN, new Locale("vi", "VN"), Boolean.FALSE, "dd-MM-yyyy",

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/login/LoginRestController.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/login/LoginRestController.java
@@ -407,7 +407,6 @@ public class LoginRestController
 
 		//
 		// Save user preferences
-		// userPreference.setProperty(UserPreference.P_LANGUAGE, Env.getContext(Env.getCtx(), UserPreference.LANGUAGE_NAME));
 		userPreference.setProperty(UserPreference.P_ROLE, RoleId.toRepoId(loginCtx.getRoleId()));
 		userPreference.setProperty(UserPreference.P_CLIENT, ClientId.toRepoId(loginCtx.getClientId()));
 		userPreference.setProperty(UserPreference.P_ORG, OrgId.toRepoId(loginCtx.getOrgId()));

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/session/UserPreference.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/session/UserPreference.java
@@ -22,7 +22,6 @@
 package de.metas.ui.web.session;
 
 import com.google.common.base.MoreObjects;
-import de.metas.i18n.Language;
 import de.metas.util.Check;
 import de.metas.util.GuavaCollectors;
 import de.metas.util.Services;
@@ -46,10 +45,6 @@ public final class UserPreference implements Serializable
 {
 	private static final long serialVersionUID = -3434473097915381994L;
 
-	/** Language */
-	public static final String P_LANGUAGE = "Language";
-	private static final String DEFAULT_LANGUAGE = Language.getName(System.getProperty("user.language") + "_" + System.getProperty("user.country"));
-
 	/** Role */
 	public static final String P_ROLE = "Role";
 	private static final String DEFAULT_ROLE = "";
@@ -66,9 +61,6 @@ public final class UserPreference implements Serializable
 	/** Auto Commit */
 	public static final String P_AUTO_COMMIT = "AutoCommit";
 	private static final String DEFAULT_AUTO_COMMIT = "Y";
-
-	/** Language Name Context **/
-	public static final String LANGUAGE_NAME = "#LanguageName";
 
 	/** window tab placement **/
 	public static final String P_WINDOW_TAB_PLACEMENT = "WindowTabPlacement";
@@ -88,7 +80,6 @@ public final class UserPreference implements Serializable
 
 	/** Ini Properties */
 	private static final String[] PROPERTIES = new String[] {
-			P_LANGUAGE,
 			P_ROLE,
 			P_CLIENT,
 			P_ORG,
@@ -100,7 +91,6 @@ public final class UserPreference implements Serializable
 			P_MENU_COLLAPSED };
 	/** Ini Property Values */
 	private static final String[] DEFAULT_VALUES = new String[] {
-			DEFAULT_LANGUAGE,
 			DEFAULT_ROLE,
 			DEFAULT_CLIENT,
 			DEFAULT_ORG,


### PR DESCRIPTION
## Summary
- Remove the `Language` AD_Preference from `UserPreference.java` — it was stored on every login but never used for language resolution (`AD_User.AD_Language` is used instead via `Login.loadUserLanguage()`). The commented-out setter in `LoginRestController` confirms it was already defunct.
- Add Turkish (`tr_TR`, "Türkçe") to the static `Language` registry in `Language.java` so it's properly recognized without falling back to the on-the-fly creation path.

## Context
While implementing Turkish translations (#28087), we discovered that users with `AD_User.AD_Language='tr_TR'` still saw German UI because:
1. Turkish was not in `Language.java`'s static registry, causing fallback to base language
2. The `AD_Preference` with `Attribute='Language'` and `Value='English'` was confusingly present but unused, making debugging harder

## Changes
- `UserPreference.java`: Remove `P_LANGUAGE`, `DEFAULT_LANGUAGE`, `LANGUAGE_NAME` constants and their array entries
- `LoginRestController.java`: Remove commented-out `P_LANGUAGE` setter line
- `Language.java`: Add `tr_TR` constant and Turkish language entry (date format: `dd.MM.yyyy`, A4 paper)

## Test plan
- [ ] Login with a user that has `AD_User.AD_Language='tr_TR'` — UI should show Turkish translations
- [ ] Login with existing users — no Language AD_Preference is created anymore
- [ ] Existing Language AD_Preferences are harmless (orphaned, not read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)