### PR TITLE
Fix duplicate shipment lines from race condition (me03#28143)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ misc/services/camel/de-metas-camel-shipping/tmp/
 .github/merge_to_master
 .github/integrate
 
+# workspace-local Maven repository
+.m2-local/
+
 # claude related
 .claude
 **/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5787850_sys_clear_stuck_hu_bpartner_ids.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5787850_sys_clear_stuck_hu_bpartner_ids.sql
@@ -1,0 +1,57 @@
+-- Migration: Clear stuck C_BPartner_ID on Active VHUs
+--
+-- Problem: On-the-fly picking sets C_BPartner_ID on VHUs, but shipment reversal
+-- and picking cancellation did not clear it. This leaves VHUs invisible to
+-- picking for other customers because the storage query filters by BPartner.
+--
+-- Safety: Only clears VHUs that are NOT:
+--   - Reserved (M_HU.IsReserved='Y' or has active M_HU_Reservation)
+--   - Actively picked (active M_ShipmentSchedule_QtyPicked with M_InOutLine)
+--   - Assigned to a non-reversed shipment
+
+-- Step 1: Backup affected M_HU rows before modification
+SELECT backup_table('m_hu', '_stuck_bpartner');
+
+-- Step 2: Clear C_BPartner_ID and C_BPartner_Location_ID on stuck VHUs
+UPDATE m_hu
+SET c_bpartner_id         = NULL,
+    c_bpartner_location_id = NULL,
+    updated                = '2026-02-12 21:00'::timestamp,
+    updatedby              = 99
+WHERE m_hu_id IN (
+    SELECT hu.m_hu_id
+    FROM m_hu hu
+        JOIN m_hu_pi_version piv ON piv.m_hu_pi_version_id = hu.m_hu_pi_version_id
+        JOIN m_hu_storage hus ON hus.m_hu_id = hu.m_hu_id
+    WHERE piv.m_hu_pi_id = 101                          -- VHU only
+      AND hu.hustatus = 'A'                             -- Active
+      AND hu.isactive = 'Y'
+      AND hu.c_bpartner_id IS NOT NULL
+      AND hu.c_bpartner_id > 0
+      AND hus.qty > 0
+      -- Exclude reserved HUs
+      AND hu.isreserved = 'N'
+      AND NOT EXISTS (
+          SELECT 1 FROM m_hu_reservation res
+          WHERE res.vhu_id = hu.m_hu_id
+            AND res.isactive = 'Y'
+      )
+      -- Exclude actively picked HUs (with active QtyPicked linked to a shipment line)
+      AND NOT EXISTS (
+          SELECT 1 FROM m_shipmentschedule_qtypicked sqp
+          WHERE sqp.vhu_id = hu.m_hu_id
+            AND sqp.isactive = 'Y'
+            AND sqp.m_inoutline_id IS NOT NULL
+      )
+      -- Exclude HUs assigned to a non-reversed completed shipment
+      AND NOT EXISTS (
+          SELECT 1 FROM m_hu_assignment ha
+              JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
+              JOIN m_inout io ON io.m_inout_id = iol.m_inout_id
+          WHERE ha.m_hu_id = hu.m_hu_id
+            AND ha.ad_table_id = (SELECT ad_table_id FROM ad_table WHERE tablename = 'M_InOutLine')
+            AND io.issotrx = 'Y'
+            AND io.docstatus = 'CO'
+            AND io.reversal_id IS NULL
+      )
+);

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/IWorkPackageQueue.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/IWorkPackageQueue.java
@@ -58,7 +58,7 @@ public interface IWorkPackageQueue
 	IWorkpackagePrioStrategy PRIORITY_AUTO = SizeBasedWorkpackagePrio.INSTANCE;
 
 	/**
-	 * Retrieve the global queue size (i.e. number of unprocessed workpackages). This includes a DB query.
+	 *  Retrieve the number of processable workpackages using a DB-query.
 	 */
 	int size();
 

--- a/backend/de.metas.async/src/main/sql/postgresql/system/42-de.metas.async/5777120_sys_gh26328_C_Queue_workPackage_LockedAt_and_improve_UI.sql
+++ b/backend/de.metas.async/src/main/sql/postgresql/system/42-de.metas.async/5777120_sys_gh26328_C_Queue_workPackage_LockedAt_and_improve_UI.sql
@@ -75,7 +75,7 @@ CREATE INDEX idx_queue_workpackage_polling
                             Priority,                      -- Range filter + ORDER BY
                             C_Queue_WorkPackage_ID         -- ORDER BY
         )
-    WHERE Processed = 'Y';
+    WHERE Processed = 'N';
 
 COMMENT ON INDEX idx_queue_workpackage_polling IS
     'Optimized index for workpackage polling with FOR UPDATE SKIP LOCKED. Column order: C_Queue_PackageProcessor_ID first (most selective), then ready/error/locked filters, then Priority/ID for sorting.';

--- a/backend/de.metas.async/src/main/sql/postgresql/system/42-de.metas.async/5788210_sys_fix_idx_queue_workpackage_polling_where_clause.sql
+++ b/backend/de.metas.async/src/main/sql/postgresql/system/42-de.metas.async/5788210_sys_fix_idx_queue_workpackage_polling_where_clause.sql
@@ -1,0 +1,20 @@
+-- Fix: The partial index idx_queue_workpackage_polling was created with WHERE Processed = 'Y'
+-- by migration 5777120, but it should be WHERE Processed = 'N' (unprocessed records only).
+-- This script drops and recreates the index with the correct WHERE clause.
+-- See also: 5777120 migration which originally created the index.
+
+DROP INDEX IF EXISTS idx_queue_workpackage_polling;
+
+CREATE INDEX idx_queue_workpackage_polling
+    ON C_Queue_WorkPackage (
+                            C_Queue_PackageProcessor_ID,
+                            IsReadyForProcessing,
+                            IsError,
+                            LockedAt,
+                            Priority,
+                            C_Queue_WorkPackage_ID
+        )
+    WHERE Processed = 'N';
+
+COMMENT ON INDEX idx_queue_workpackage_polling IS
+    'Optimized index for workpackage polling with FOR UPDATE SKIP LOCKED. Column order: C_Queue_PackageProcessor_ID first (most selective), then ready/error/locked filters, then Priority/ID for sorting. Partial index on unprocessed records only = smaller, faster.';

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
@@ -27,6 +27,8 @@ import de.metas.bpartner.BPGroupId;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.bpartner.service.IBPartnerDAO;
+import de.metas.bpartner.service.BPartnerStats;
+import de.metas.bpartner.service.IBPartnerStatsDAO;
 import de.metas.common.rest_api.common.JsonMetasfreshId;
 import de.metas.common.util.Check;
 import de.metas.common.util.CoalesceUtil;
@@ -125,6 +127,7 @@ public class C_BPartner_StepDef
 	@NonNull private final C_Aggregation_StepDefData aggregationTable;
 	@NonNull private final TestContext restTestContext;
 	private final IBPartnerDAO bpartnerDAO = Services.get(IBPartnerDAO.class);
+	private final IBPartnerStatsDAO bpartnerStatsDAO = Services.get(IBPartnerStatsDAO.class);
 	private final IProductDAO productDAO = Services.get(IProductDAO.class);
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	private final IADProcessDAO adProcessDAO = Services.get(IADProcessDAO.class);
@@ -328,6 +331,12 @@ public class C_BPartner_StepDef
 		final boolean alsoCreateLocation = InterfaceWrapperHelper.isNew(bPartnerRecord) && addDefaultLocationIfNewBPartner;
 
 		InterfaceWrapperHelper.saveRecord(bPartnerRecord);
+
+		// Automatically set SOCreditStatus=NoCreditCheck for all test BPartners to prevent
+		// credit stop issues in CI environments where the seed DB may have strict credit settings.
+		// See me03#28143.
+		final BPartnerStats stats = bpartnerStatsDAO.getCreateBPartnerStats(bPartnerRecord);
+		bpartnerStatsDAO.setSOCreditStatus(stats, "X"); // X = No Credit Check
 
 		if (alsoCreateLocation)
 		{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_StepDef.java
@@ -38,6 +38,8 @@ import de.metas.common.handlingunits.JsonSetClearanceStatusRequest;
 import de.metas.common.rest_api.common.JsonMetasfreshId;
 import de.metas.common.util.EmptyUtil;
 import de.metas.common.util.time.SystemTime;
+import de.metas.cucumber.stepdefs.C_BPartner_Location_StepDefData;
+import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
@@ -106,6 +108,7 @@ import org.adempiere.model.PlainContextAware;
 import org.adempiere.warehouse.LocatorId;
 import org.assertj.core.api.SoftAssertions;
 import org.compiere.SpringContextHolder;
+import org.compiere.model.I_C_BPartner_Location;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_Locator;
 import org.compiere.model.I_M_Product;
@@ -159,6 +162,8 @@ public class M_HU_StepDef
 	private final IHUTrxBL huTrxBL = Services.get(IHUTrxBL.class);
 	private final ReturnsServiceFacade returnsServiceFacade = SpringContextHolder.instance.getBean(ReturnsServiceFacade.class);
 
+	private final C_BPartner_StepDefData bpartnerTable;
+	private final C_BPartner_Location_StepDefData bpLocationTable;
 	private final M_Product_StepDefData productTable;
 	private final M_HU_StepDefData huTable;
 	private final M_HU_PI_Item_Product_StepDefData huPiItemProductTable;
@@ -173,12 +178,49 @@ public class M_HU_StepDef
 
 	private final HandlingUnitsService handlingUnitsService = SpringContextHolder.instance.getBean(HandlingUnitsService.class);
 
+	/**
+	 * @cucumber.stepdef
+	 * @cucumber.columns (none — no DataTable)
+	 * @cucumber.example
+	 * <pre>
+	 * And all the hu data is reset
+	 * </pre>
+	 */
 	@And("all the hu data is reset")
 	public void reset_data()
 	{
 		DB.executeUpdateAndThrowExceptionOnFail("TRUNCATE TABLE m_hu cascade", ITrx.TRXNAME_None);
 	}
 
+	/**
+	 * Validate M_HU records by identifier. Uses SoftAssertions to check all columns before failing.
+	 * Also validates M_HU_Storage (product/qty) if M_Product_ID or Qty columns are present.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>Identifier</b> — (required) alias from M_HU_StepDefData<br>
+	 *   <b>M_HU_Parent</b> — (optional, identifier-ref) if set, loads the single child HU of this parent and re-stores it under Identifier<br>
+	 *   <b>M_HU_PI_ID</b> — (optional, identifier-ref or literal ID) expected packing instructions<br>
+	 *   <b>M_HU_PI_Version_ID</b> — (optional, identifier-ref or literal ID) expected PI version<br>
+	 *   <b>M_Locator_ID</b> — (optional, identifier-ref) expected locator<br>
+	 *   <b>M_HU_PI_Item_Product_ID</b> — (optional, identifier-ref) expected PI item product<br>
+	 *   <b>HUStatus</b> — (optional) expected HU status: P, A, D, S, E, I<br>
+	 *   <b>ClearanceStatus</b> — (optional) expected clearance status: C, L, Q, P<br>
+	 *   <b>ClearanceNote</b> — (optional) expected clearance note text<br>
+	 *   <b>C_BPartner_ID</b> — (optional, identifier-ref or null) expected business partner; use "null" for no BPartner<br>
+	 *   <b>C_BPartner_Location_ID</b> — (optional, identifier-ref or null) expected BP location; use "null" for no location<br>
+	 *   <b>M_Product_ID</b> — (optional, identifier-ref) validates M_HU_Storage product<br>
+	 *   <b>Qty</b> — (optional) validates M_HU_Storage qty with UOM, format "10 PCE"<br>
+	 *   <b>IsAggregate</b> — (optional) true/false, checks if HU is aggregate<br>
+	 *   <b>QtyTUs</b> — (optional) expected TU count (for aggregate HUs)<br>
+	 * @cucumber.depends StepDefData: M_HU_StepDefData, M_HU_PI_StepDefData, M_HU_PI_Version_StepDefData, M_HU_PI_Item_Product_StepDefData, M_Locator_StepDefData, M_Product_StepDefData, C_BPartner_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And validate M_HUs:
+	 *   | Identifier | HUStatus | M_Product_ID | Qty    | M_Locator_ID |
+	 *   | vhu_1      | A        | product_1    | 10 PCE | locator_1    |
+	 * </pre>
+	 */
 	@And("validate M_HUs:")
 	public void validate_M_HUs(@NonNull final DataTable dataTable)
 	{
@@ -241,6 +283,33 @@ public class M_HU_StepDef
 				.ifPresent(clearanceStatus -> softly.assertThat(hu.getClearanceStatus()).as("ClearanceStatus").isEqualTo(clearanceStatus));
 		row.getAsOptionalString(COLUMNNAME_ClearanceNote)
 				.ifPresent(clearanceNote -> softly.assertThat(hu.getClearanceNote()).as("ClearanceNote").isEqualTo(clearanceNote));
+
+		row.getAsOptionalIdentifier(I_M_HU.COLUMNNAME_C_BPartner_ID)
+				.ifPresent(bpartnerIdentifier -> {
+					if (bpartnerIdentifier.isNullPlaceholder())
+					{
+						softly.assertThat(hu.getC_BPartner_ID()).as("C_BPartner_ID").isLessThanOrEqualTo(0);
+					}
+					else
+					{
+						final int expectedBPartnerId = bpartnerTable.getOptional(bpartnerIdentifier)
+								.map(bp -> bp.getC_BPartner_ID())
+								.orElseGet(bpartnerIdentifier::getAsInt);
+						softly.assertThat(hu.getC_BPartner_ID()).as("C_BPartner_ID").isEqualTo(expectedBPartnerId);
+					}
+				});
+
+		row.getAsOptionalIdentifier(I_M_HU.COLUMNNAME_C_BPartner_Location_ID)
+				.ifPresent(bpLocationIdentifier -> {
+					if (bpLocationIdentifier.isNullPlaceholder())
+					{
+						softly.assertThat(hu.getC_BPartner_Location_ID()).as("C_BPartner_Location_ID").isLessThanOrEqualTo(0);
+					}
+					else
+					{
+						softly.assertThat(hu.getC_BPartner_Location_ID()).as("C_BPartner_Location_ID").isEqualTo(bpLocationIdentifier.getAsInt());
+					}
+				});
 
 		final ProductId singleProductId = row.getAsOptionalIdentifier("M_Product_ID").map(productTable::getId).orElse(null);
 		final Quantity singleQty = row.getAsOptionalQuantity("Qty", uomDAO::getByX12DE355).orElse(null);
@@ -579,18 +648,71 @@ public class M_HU_StepDef
 		validateHU(ImmutableList.of(topLevelHU), ImmutableList.of(huIdentifier), identifierToRow);
 	}
 
+	/**
+	 * Validate M_HU_Storage records (product and quantity stored in an HU). Uses legacy DataTableUtil (not DataTableRow).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_HU_ID.Identifier</b> — (required) alias from M_HU_StepDefData<br>
+	 *   <b>M_Product_ID.Identifier</b> — (required) alias from M_Product_StepDefData<br>
+	 *   <b>Qty</b> — (required) expected storage quantity as string<br>
+	 * @cucumber.depends StepDefData: M_HU_StepDefData, M_Product_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And M_HU_Storage are validated
+	 *   | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+	 *   | vhu_1              | product_1               | 100 |
+	 * </pre>
+	 */
 	@And("M_HU_Storage are validated")
 	public void validate_HU_Storage(@NonNull final DataTable table)
 	{
 		DataTableRows.of(table).forEach(this::validateHUStorage);
 	}
 
+	/**
+	 * Validate M_HU records — alternate step with different column set. Re-loads the HU fresh from DB before validating.
+	 * Supports comma-separated identifiers in M_HU_ID column to validate multiple HUs with same expectations.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_HU_ID</b> — (required, identifier-ref) alias(es) from M_HU_StepDefData; comma-separated for multiple<br>
+	 *   <b>HUStatus</b> — (optional) expected HU status: P, A, D, S, E, I<br>
+	 *   <b>IsActive</b> — (optional) true/false<br>
+	 *   <b>M_Locator_ID</b> — (optional, identifier-ref) expected locator<br>
+	 *   <b>IsTopLevel</b> — (optional) true/false, whether HU has no parent<br>
+	 *   <b>Parent</b> — (optional, identifier-ref or null) expected parent HU; use "null" for no parent<br>
+	 *   <b>C_BPartner_ID</b> — (optional, identifier-ref or null) expected business partner; use "null" for no BPartner<br>
+	 *   <b>C_BPartner_Location_ID</b> — (optional, identifier-ref or null) expected BP location; use "null" for no location<br>
+	 * @cucumber.depends StepDefData: M_HU_StepDefData, M_Locator_StepDefData, C_BPartner_StepDefData, C_BPartner_Location_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And M_HU are validated:
+	 *   | M_HU_ID | HUStatus | IsActive | IsTopLevel |
+	 *   | vhu_1   | A        | true     | false      |
+	 * </pre>
+	 */
 	@And("M_HU are validated:")
 	public void validateHUs(@NonNull final DataTable table)
 	{
 		DataTableRows.of(table).forEach(this::validateHU);
 	}
 
+	/**
+	 * Dispose (destroy) HUs by creating an internal-use inventory and completing it.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_HU_ID</b> — (required, identifier-ref) alias from M_HU_StepDefData<br>
+	 *   <b>MovementDate</b> — (required) disposal date, e.g., "2022-05-17"<br>
+	 * @cucumber.depends StepDefData: M_HU_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * Given M_HU are disposed:
+	 *   | M_HU_ID | MovementDate |
+	 *   | vhu_1   | 2022-05-17   |
+	 * </pre>
+	 */
 	@Given("M_HU are disposed:")
 	public void disposeHUs(@NonNull final DataTable table)
 	{
@@ -741,6 +863,34 @@ public class M_HU_StepDef
 						final HuId expectedParentId = parentHUIdentifier.isNullPlaceholder() ? null : huTable.getId(parentHUIdentifier);
 						final HuId actualParentId = handlingUnitsDAO.retrieveParentId(huRecord);
 						softly.assertThat(actualParentId).as("Parent").isEqualTo(expectedParentId);
+					});
+			row.getAsOptionalIdentifier(I_M_HU.COLUMNNAME_C_BPartner_ID)
+					.ifPresent(bpartnerIdentifier -> {
+						if (bpartnerIdentifier.isNullPlaceholder())
+						{
+							softly.assertThat(huRecord.getC_BPartner_ID()).as("C_BPartner_ID").isLessThanOrEqualTo(0);
+						}
+						else
+						{
+							final int expectedBPartnerId = bpartnerTable.getOptional(bpartnerIdentifier)
+									.map(bp -> bp.getC_BPartner_ID())
+									.orElseGet(bpartnerIdentifier::getAsInt);
+							softly.assertThat(huRecord.getC_BPartner_ID()).as("C_BPartner_ID").isEqualTo(expectedBPartnerId);
+						}
+					});
+			row.getAsOptionalIdentifier(I_M_HU.COLUMNNAME_C_BPartner_Location_ID)
+					.ifPresent(bpLocationIdentifier -> {
+						if (bpLocationIdentifier.isNullPlaceholder())
+						{
+							softly.assertThat(huRecord.getC_BPartner_Location_ID()).as("C_BPartner_Location_ID").isLessThanOrEqualTo(0);
+						}
+						else
+						{
+							final int expectedLocationId = bpLocationTable.getOptional(bpLocationIdentifier)
+									.map(I_C_BPartner_Location::getC_BPartner_Location_ID)
+									.orElseGet(bpLocationIdentifier::getAsInt);
+							softly.assertThat(huRecord.getC_BPartner_Location_ID()).as("C_BPartner_Location_ID").isEqualTo(expectedLocationId);
+						}
 					});
 
 			softly.assertAll();

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/inventory/M_Inventory_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/inventory/M_Inventory_StepDef.java
@@ -131,6 +131,13 @@ public class M_Inventory_StepDef
 		documentBL.processEx(inventory, IDocument.ACTION_Complete, IDocument.STATUS_Completed);
 	}
 
+	@Given("^the inventory identified by (.*) is reversed$")
+	public void inventory_is_reversed(@NonNull final String inventoryIdentifier)
+	{
+		final I_M_Inventory inventory = inventoryTable.get(inventoryIdentifier);
+		documentBL.processEx(inventory, IDocument.ACTION_Reverse_Correct, IDocument.STATUS_Reversed);
+	}
+
 	@And("the following virtual inventory is created")
 	public void createVirtualInventory(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
@@ -59,6 +59,7 @@ import de.metas.externalsystem.ExternalSystemType;
 import de.metas.externalsystem.model.I_ExternalSystem;
 import de.metas.handlingunits.IHUWarehouseDAO;
 import de.metas.handlingunits.inout.IHUInOutBL;
+import de.metas.handlingunits.inout.IHUInOutDAO;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.shipmentschedule.api.M_ShipmentSchedule_QuantityTypeToUse;
 import de.metas.handlingunits.shipmentschedule.api.QtyToDeliverMap;
@@ -167,6 +168,7 @@ public class M_InOut_StepDef
 	private final IDocumentBL documentBL = Services.get(IDocumentBL.class);
 	private final IInputDataSourceDAO inputDataSourceDAO = Services.get(IInputDataSourceDAO.class);
 	private final IHUInOutBL huInOutBL = Services.get(IHUInOutBL.class);
+	private final IHUInOutDAO huInOutDAO = Services.get(IHUInOutDAO.class);
 	private final IInOutBL inOutBL = Services.get(IInOutBL.class);
 	private final IDocTypeDAO docTypeDAO = Services.get(IDocTypeDAO.class);
 	private final IHUWarehouseDAO huWarehouseDAO = Services.get(IHUWarehouseDAO.class);
@@ -1083,7 +1085,7 @@ public class M_InOut_StepDef
 			customerReturn.setC_DocType_ID(docTypeId.getRepoId());
 			customerReturn.setIsSOTrx(true);
 			customerReturn.setMovementType(MovementType.CustomerReturns.getCode());
-			customerReturn.setReturn_Origin_InOut_ID(shipment.getM_InOut_ID());
+			customerReturn.setRef_InOut_ID(shipment.getM_InOut_ID());
 			customerReturn.setMovementDate(SystemTime.asTimestamp());
 			customerReturn.setDateAcct(SystemTime.asTimestamp());
 			customerReturn.setM_Warehouse_ID(warehouseId.getRepoId());
@@ -1131,7 +1133,7 @@ public class M_InOut_StepDef
 			final I_M_InOut inout = inoutIdentifier.lookupNotNullIn(inoutTable);
 			InterfaceWrapperHelper.refresh(inout);
 
-			final List<I_M_HU> hus = huInOutBL.retrieveHandlingUnits(inout);
+			final List<I_M_HU> hus = huInOutDAO.retrieveHandlingUnits(inout);
 			assertThat(hus).as("HUs assigned to " + inoutIdentifier).isNotEmpty();
 
 			final StepDefDataIdentifier huIdentifier = row.getAsIdentifier(I_M_HU.COLUMNNAME_M_HU_ID);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
@@ -27,8 +27,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import de.metas.common.util.EmptyUtil;
 import de.metas.common.util.StringUtils;
+import de.metas.common.util.time.SystemTime;
 import de.metas.cucumber.stepdefs.C_BPartner_Location_StepDefData;
 import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
+import de.metas.cucumber.stepdefs.hu.M_HU_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_OrderLine_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
 import de.metas.cucumber.stepdefs.DataTableRow;
@@ -46,6 +48,9 @@ import de.metas.cucumber.stepdefs.message.AD_Message_StepDefData;
 import de.metas.cucumber.stepdefs.shipmentschedule.M_ShipmentSchedule_StepDefData;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
 import de.metas.document.DocBaseType;
+import de.metas.document.DocTypeId;
+import de.metas.document.DocTypeQuery;
+import de.metas.document.IDocTypeDAO;
 import de.metas.document.engine.DocStatus;
 import de.metas.document.engine.IDocument;
 import de.metas.document.engine.IDocumentBL;
@@ -53,7 +58,9 @@ import de.metas.externalsystem.ExternalSystemId;
 import de.metas.externalsystem.ExternalSystemRepository;
 import de.metas.externalsystem.ExternalSystemType;
 import de.metas.externalsystem.model.I_ExternalSystem;
+import de.metas.handlingunits.IHUWarehouseDAO;
 import de.metas.handlingunits.inout.IHUInOutBL;
+import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.shipmentschedule.api.M_ShipmentSchedule_QuantityTypeToUse;
 import de.metas.handlingunits.shipmentschedule.api.QtyToDeliverMap;
 import de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleEnqueuer;
@@ -64,11 +71,14 @@ import de.metas.i18n.IMsgBL;
 import de.metas.i18n.Language;
 import de.metas.impex.api.IInputDataSourceDAO;
 import de.metas.impex.model.I_AD_InputDataSource;
+import de.metas.inout.IInOutBL;
 import de.metas.inout.IInOutDAO;
 import de.metas.inout.InOutId;
 import de.metas.inout.InOutLineId;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.inout.model.I_M_InOutLine;
+import de.metas.material.MovementType;
+import de.metas.order.OrderLineId;
 import de.metas.inoutcandidate.api.IShipmentScheduleAllocDAO;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule_QtyPicked;
@@ -90,6 +100,9 @@ import org.adempiere.ad.dao.IQueryFilter;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.impl.TableRecordReference;
+import org.adempiere.warehouse.LocatorId;
+import org.adempiere.warehouse.WarehouseId;
+import org.adempiere.warehouse.api.IWarehouseBL;
 import org.assertj.core.api.SoftAssertions;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_AD_Message;
@@ -143,6 +156,7 @@ public class M_InOut_StepDef
 	private final M_Warehouse_StepDefData warehouseTable;
 	private final AD_Message_StepDefData messageTable;
 	private final C_DocType_StepDefData docTypeTable;
+	private final M_HU_StepDefData huTable;
 	private final TestContext restTestContext;
 
 	private final IInOutDAO inOutDAO = Services.get(IInOutDAO.class);
@@ -155,8 +169,36 @@ public class M_InOut_StepDef
 	private final IDocumentBL documentBL = Services.get(IDocumentBL.class);
 	private final IInputDataSourceDAO inputDataSourceDAO = Services.get(IInputDataSourceDAO.class);
 	private final IHUInOutBL huInOutBL = Services.get(IHUInOutBL.class);
+	private final IInOutBL inOutBL = Services.get(IInOutBL.class);
+	private final IDocTypeDAO docTypeDAO = Services.get(IDocTypeDAO.class);
+	private final IHUWarehouseDAO huWarehouseDAO = Services.get(IHUWarehouseDAO.class);
+	private final IWarehouseBL warehouseBL = Services.get(IWarehouseBL.class);
 	private final IMsgBL msgBL = Services.get(IMsgBL.class);
 
+	/**
+	 * Validate M_InOut records (shipments or material receipts).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_InOut_ID</b> — (required, identifier-ref) alias from M_InOut_StepDefData<br>
+	 *   <b>C_BPartner_ID</b> — (required, identifier-ref) expected business partner<br>
+	 *   <b>C_BPartner_Location_ID</b> — (required, identifier-ref) expected BP location<br>
+	 *   <b>DateOrdered</b> — (required) expected date, e.g., "2022-05-17"<br>
+	 *   <b>processed</b> — (required) true/false<br>
+	 *   <b>DocStatus</b> — (required) expected doc status: DR, IP, CO, VO, RE, CL<br>
+	 *   <b>POReference</b> — (optional) expected PO reference<br>
+	 *   <b>AD_InputDataSource_ID.InternalName</b> — (optional) expected input data source internal name<br>
+	 *   <b>ExternalSystem.Value</b> — (optional) expected external system value<br>
+	 *   <b>C_DocType.DocBaseType</b> — (optional) expected doc base type + C_DocType.Name<br>
+	 *   <b>ExternalId</b> — (optional) expected external ID<br>
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData, C_BPartner_StepDefData, C_BPartner_Location_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And validate the created shipments
+	 *   | M_InOut_ID | C_BPartner_ID | C_BPartner_Location_ID | DateOrdered | processed | DocStatus |
+	 *   | shipment_1 | bpartner_1    | bpLocation_1           | 2022-05-17  | true      | CO        |
+	 * </pre>
+	 */
 	@And("^validate the created (shipments|material receipt)$")
 	public void validate_created_shipments(@NonNull final String ignoredInoutType, @NonNull final DataTable table)
 	{
@@ -230,6 +272,25 @@ public class M_InOut_StepDef
 		softly.assertAll();
 	}
 
+	/**
+	 * Invoke the "generate shipments" async workpackage for each M_ShipmentSchedule row individually.
+	 * Each row specifies its own QuantityType, IsCompleteShipments, and IsShipmentDateToday.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_ShipmentSchedule_ID</b> — (required, identifier-ref) shipment schedule alias<br>
+	 *   <b>QuantityType</b> — (required) "D" (delivery), "O" (ordered), etc.<br>
+	 *   <b>IsCompleteShipments</b> — (required) true/false — auto-complete the generated shipment<br>
+	 *   <b>IsShipmentDateToday</b> — (required) true/false — use today as shipment date<br>
+	 *   <b>QtyToDeliver_Override</b> — (optional) override quantity to deliver<br>
+	 * @cucumber.depends StepDefData: M_ShipmentSchedule_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+	 *   | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipmentDateToday |
+	 *   | shipmentSchedule_1    | D            | true                | false               |
+	 * </pre>
+	 */
 	@And("'generate shipments' process is invoked individually for each M_ShipmentSchedule")
 	public void invokeGenerateShipmentsProcessIndividually(@NonNull final DataTable table)
 	{
@@ -271,6 +332,22 @@ public class M_InOut_StepDef
 		);
 	}
 
+	/**
+	 * Invoke the "generate shipments" async workpackage with parameters in the step text.
+	 * All shipment schedules in the DataTable are enqueued together (single workpackage).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_ShipmentSchedule_ID</b> — (required, identifier-ref) shipment schedule alias<br>
+	 *   <b>QtyToDeliver_Override</b> — (optional) override quantity to deliver<br>
+	 * @cucumber.depends StepDefData: M_ShipmentSchedule_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And 'generate shipments' process is invoked with QuantityType=D, IsCompleteShipments=true and IsShipToday=false
+	 *   | M_ShipmentSchedule_ID |
+	 *   | shipmentSchedule_1    |
+	 * </pre>
+	 */
 	@And("^'generate shipments' process is invoked with QuantityType=(.*), IsCompleteShipments=(true|false) and IsShipToday=(true|false)")
 	public void invokeGenerateShipmentsProcess(
 			@NonNull final String quantityType,
@@ -324,6 +401,27 @@ public class M_InOut_StepDef
 		assertThat(result.getEnqueuedPackagesCount()).isGreaterThanOrEqualTo(1);
 	}
 
+	/**
+	 * Poll for a shipment/receipt created via async workpackage processing. Waits up to N seconds.
+	 * Finds the M_InOut via M_ShipmentSchedule_QtyPicked.M_InOutLine_ID, filters by DocStatus if given.
+	 * Stores the found M_InOut in M_InOut_StepDefData under the given identifier.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_ShipmentSchedule_ID</b> — (required, identifier-ref) the schedule that triggered the shipment<br>
+	 *   <b>M_InOut_ID</b> — (required) alias to store the found shipment under<br>
+	 *   <b>DocStatus</b> — (optional) filter by doc status (CO, DR, etc.)<br>
+	 *   <b>OPT.IgnoreCreated.M_InOut_ID.Identifier</b> — (optional) comma-separated shipment identifiers to skip<br>
+	 *   <b>REST.Context.M_InOut_ID</b> — (optional) store M_InOut_ID in REST test context variable<br>
+	 *   <b>REST.Context.DocumentNo</b> — (optional) store DocumentNo in REST test context variable<br>
+	 * @cucumber.depends StepDefData: M_ShipmentSchedule_StepDefData, M_InOut_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And after not more than 60s, M_InOut is found:
+	 *   | M_ShipmentSchedule_ID | M_InOut_ID | DocStatus |
+	 *   | shipmentSchedule_1    | shipment_1 | CO        |
+	 * </pre>
+	 */
 	@And("^after not more than (.*)s, M_InOut is found:$")
 	public void shipmentIsFound(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
 	{
@@ -413,6 +511,18 @@ public class M_InOut_StepDef
 		StepDefUtil.tryAndWait(timeoutSec, 500, isShipmentCreated);
 	}
 
+	/**
+	 * Reverse a shipment/receipt and store the reversal under a new identifier.
+	 * Performs Reverse_Correct doc action, then loads the reversal M_InOut record via Reversal_ID.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns (none — parameters are in the step text, not a DataTable)
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And the shipment identified by shipment_1 is reversed as shipment_1_reversal
+	 * </pre>
+	 */
 	@And("^the (shipment|material receipt|return inOut) identified by (.*) is reversed as (.*)$")
 	public void reverseInOut(
 			@NonNull @SuppressWarnings("unused") final String model_UNUSED,
@@ -428,6 +538,21 @@ public class M_InOut_StepDef
 		inoutTable.put(reversalIdentifier, reversal);
 	}
 
+	/**
+	 * Process a shipment/receipt/return with a document action. No DataTable — parameters are in the step text.
+	 * Actions: completed, reactivated, reversed, voided, closed.
+	 * Note: "reversed" does NOT store the reversal; use "is reversed as &lt;reversalIdentifier&gt;" step instead if you need the reversal record.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns (none — parameters are in the step text)
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And the shipment identified by shipment_1 is completed
+	 * And the shipment identified by shipment_1 is reversed
+	 * And the material receipt identified by receipt_1 is completed
+	 * </pre>
+	 */
 	@And("^the (shipment|material receipt|return inOut) identified by (.*) is (completed|reactivated|reversed|voided|closed)$")
 	public void processInOut(
 			@NonNull @SuppressWarnings("unused") final String model_UNUSED,
@@ -575,6 +700,32 @@ public class M_InOut_StepDef
 		assertThat(inOut).isNull();
 	}
 
+	/**
+	 * Manually create M_InOut records (shipment/receipt). Primarily used for testing doc actions on manually created documents.
+	 * Uses legacy DataTableUtil (not DataTableRow). Stores created record in M_InOut_StepDefData.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_InOut_ID.Identifier</b> — (required) alias to store the created record<br>
+	 *   <b>C_BPartner_ID.Identifier</b> — (required) business partner<br>
+	 *   <b>C_BPartner_Location_ID.Identifier</b> — (required) BP location<br>
+	 *   <b>IsSOTrx</b> — (required) true=shipment, false=receipt<br>
+	 *   <b>DeliveryRule</b> — (required) delivery rule code<br>
+	 *   <b>DeliveryViaRule</b> — (required) delivery via rule code<br>
+	 *   <b>FreightCostRule</b> — (required) freight cost rule code<br>
+	 *   <b>M_Warehouse_ID.Identifier</b> — (required) warehouse<br>
+	 *   <b>MovementDate</b> — (required) movement date<br>
+	 *   <b>MovementType</b> — (required) movement type code<br>
+	 *   <b>PriorityRule</b> — (required) priority rule code<br>
+	 *   <b>OPT.DocBaseType</b> — (optional) doc base type + OPT.DocSubType for doc type lookup<br>
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData, C_BPartner_StepDefData, C_BPartner_Location_StepDefData, M_Warehouse_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And metasfresh contains M_InOut:
+	 *   | M_InOut_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | IsSOTrx | DeliveryRule | DeliveryViaRule | FreightCostRule | M_Warehouse_ID.Identifier | MovementDate | MovementType | PriorityRule |
+	 *   | shipment_1            | bpartner_1               | bpLocation_1                      | true    | F            | D               | I               | warehouse_1               | 2022-05-17   | C-           | 5            |
+	 * </pre>
+	 */
 	@And("metasfresh contains M_InOut:")
 	public void create_M_InOut(@NonNull final DataTable dataTable)
 	{
@@ -779,6 +930,23 @@ public class M_InOut_StepDef
 		assertThat(errorThrown).isTrue();
 	}
 
+	/**
+	 * Poll for the reversal M_InOut of a previously reversed shipment/receipt.
+	 * Looks up by Reversal_ID pointing back to the original, validates DocStatus.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_InOut_ID.Identifier</b> — (required) alias to store the reversal record<br>
+	 *   <b>Reversal_ID.Identifier</b> — (required) alias of the original (reversed) M_InOut<br>
+	 *   <b>DocStatus</b> — (optional) expected doc status of the reversal<br>
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And after not more than 60s, locate reversal M_InOut
+	 *   | M_InOut_ID.Identifier | Reversal_ID.Identifier | DocStatus |
+	 *   | shipment_1_reversal   | shipment_1             | RE        |
+	 * </pre>
+	 */
 	@And("^after not more than (.*)s, locate reversal M_InOut$")
 	public void find_reversal_M_InOut(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
 	{
@@ -867,6 +1035,74 @@ public class M_InOut_StepDef
 			endpointPath = endpointPath.replace(shipmentIdentifierGroup, String.valueOf(shipment.getM_InOut_ID()));
 
 			restTestContext.setEndpointPath(endpointPath);
+		}
+	}
+
+	@And("generate customer return from shipment")
+	public void generateCustomerReturnFromShipment(@NonNull final DataTable dataTable)
+	{
+		for (final Map<String, String> row : dataTable.asMaps())
+		{
+			final String shipmentIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_M_InOut_ID + "." + TABLECOLUMN_IDENTIFIER);
+			final I_M_InOut shipment = inoutTable.get(shipmentIdentifier);
+			assertThat(shipment).isNotNull();
+
+			final DocTypeId docTypeId = docTypeDAO.getDocTypeId(DocTypeQuery.builder()
+					.docBaseType(DocBaseType.MaterialReceipt)
+					.isSOTrx(true)
+					.adClientId(shipment.getAD_Client_ID())
+					.adOrgId(shipment.getAD_Org_ID())
+					.build());
+
+			final WarehouseId warehouseId = huWarehouseDAO.retrieveFirstQualityReturnWarehouseId();
+			final LocatorId locatorId = warehouseBL.getOrCreateDefaultLocatorId(warehouseId);
+
+			final I_M_InOut customerReturn = InterfaceWrapperHelper.copy()
+					.setSkipCalculatedColumns(true)
+					.setFrom(shipment)
+					.copyToNew(I_M_InOut.class);
+			customerReturn.setC_DocType_ID(docTypeId.getRepoId());
+			customerReturn.setIsSOTrx(true);
+			customerReturn.setMovementType(MovementType.CustomerReturns.getCode());
+			customerReturn.setReturn_Origin_InOut_ID(shipment.getM_InOut_ID());
+			customerReturn.setMovementDate(SystemTime.asTimestamp());
+			customerReturn.setDateAcct(SystemTime.asTimestamp());
+			customerReturn.setM_Warehouse_ID(warehouseId.getRepoId());
+			InterfaceWrapperHelper.save(customerReturn);
+
+			for (final org.compiere.model.I_M_InOutLine shipmentLine : inOutBL.getLines(shipment))
+			{
+				final I_M_InOutLine returnLine = InterfaceWrapperHelper.copy()
+						.setSkipCalculatedColumns(true)
+						.setFrom(shipmentLine)
+						.copyToNew(I_M_InOutLine.class);
+				returnLine.setM_InOut_ID(customerReturn.getM_InOut_ID());
+				returnLine.setReturn_Origin_InOutLine_ID(shipmentLine.getM_InOutLine_ID());
+				returnLine.setM_Locator_ID(locatorId.getRepoId());
+				returnLine.setC_OrderLine_ID(OrderLineId.toRepoId(null));
+				InterfaceWrapperHelper.save(returnLine);
+			}
+
+			final String returnIdentifier = DataTableUtil.extractStringForColumnName(row, "CustomerReturn_ID." + TABLECOLUMN_IDENTIFIER);
+			inoutTable.putOrReplace(returnIdentifier, customerReturn);
+		}
+	}
+
+	@And("load HUs assigned to M_InOut")
+	public void loadHUsAssignedToInOut(@NonNull final DataTable dataTable)
+	{
+		for (final Map<String, String> row : dataTable.asMaps())
+		{
+			final String inoutIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_M_InOut_ID + "." + TABLECOLUMN_IDENTIFIER);
+			final I_M_InOut inout = inoutTable.get(inoutIdentifier);
+			assertThat(inout).isNotNull();
+			InterfaceWrapperHelper.refresh(inout);
+
+			final List<I_M_HU> hus = huInOutBL.retrieveHandlingUnits(inout);
+			assertThat(hus).as("HUs assigned to " + inoutIdentifier).isNotEmpty();
+
+			final String huIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_HU.COLUMNNAME_M_HU_ID + "." + TABLECOLUMN_IDENTIFIER);
+			huTable.putOrReplace(huIdentifier, hus.get(0));
 		}
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
@@ -25,7 +25,6 @@ package de.metas.cucumber.stepdefs.shipment;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import de.metas.common.util.EmptyUtil;
 import de.metas.common.util.StringUtils;
 import de.metas.common.util.time.SystemTime;
 import de.metas.cucumber.stepdefs.C_BPartner_Location_StepDefData;
@@ -122,7 +121,6 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -591,71 +589,98 @@ public class M_InOut_StepDef
 		}
 	}
 
+	/**
+	 * Load an existing M_InOut by matching on M_InOutLine.QtyEntered (and optionally C_OrderLine_ID).
+	 * Validates DocStatus and optionally C_Order_ID. Stores both the line and header in StepDefData.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>QtyEntered</b> — (required) quantity to match the M_InOutLine by<br>
+	 *   <b>M_InOutLine_ID</b> — (required, identifier) alias to store the found shipment line<br>
+	 *   <b>M_InOut_ID</b> — (required, identifier) alias to store the found shipment header<br>
+	 *   <b>DocStatus</b> — (required) expected document status (CO, DR, etc.)<br>
+	 *   <b>C_OrderLine_ID</b> — (optional, identifier-ref) narrow search to lines for a specific order line<br>
+	 *   <b>C_Order_ID</b> — (optional, identifier-ref) assert the shipment belongs to a specific order<br>
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData, M_InOutLine_StepDefData, C_OrderLine_StepDefData, C_Order_StepDefData
+	 */
 	@And("load M_InOut:")
 	public void loadM_InOut(@NonNull final DataTable dataTable)
 	{
-		for (final Map<String, String> row : dataTable.asMaps())
+		DataTableRows.of(dataTable).forEach(row ->
 		{
-			final BigDecimal qtyEntered = DataTableUtil.extractBigDecimalForColumnName(row, I_M_InOutLine.COLUMNNAME_QtyEntered);
+			final BigDecimal qtyEntered = row.getAsBigDecimal(I_M_InOutLine.COLUMNNAME_QtyEntered);
 
 			final IQueryBuilder<I_M_InOutLine> shipmentLineBuilder = queryBL.createQueryBuilder(I_M_InOutLine.class)
 					.addEqualsFilter(I_M_InOutLine.COLUMNNAME_QtyEntered, qtyEntered);
 
-			final String orderLineIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_M_InOutLine.COLUMNNAME_C_OrderLine_ID + "." + TABLECOLUMN_IDENTIFIER);
-			if (Check.isNotBlank(orderLineIdentifier))
-			{
-				final I_C_OrderLine orderLine = orderLineTable.get(orderLineIdentifier);
-				shipmentLineBuilder.addEqualsFilter(I_M_InOutLine.COLUMNNAME_C_OrderLine_ID, orderLine.getC_OrderLine_ID());
-			}
+			row.getAsOptionalIdentifier(I_M_InOutLine.COLUMNNAME_C_OrderLine_ID)
+					.ifPresent(orderLineIdentifier -> {
+						final I_C_OrderLine orderLine = orderLineTable.get(orderLineIdentifier);
+						shipmentLineBuilder.addEqualsFilter(I_M_InOutLine.COLUMNNAME_C_OrderLine_ID, orderLine.getC_OrderLine_ID());
+					});
 
 			final I_M_InOutLine shipmentLine = shipmentLineBuilder.create()
 					.firstOnlyNotNull(I_M_InOutLine.class);
 
-			final String shipmentLineIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOutLine.COLUMNNAME_M_InOutLine_ID + "." + TABLECOLUMN_IDENTIFIER);
+			final StepDefDataIdentifier shipmentLineIdentifier = row.getAsIdentifier(I_M_InOutLine.COLUMNNAME_M_InOutLine_ID);
 			inoutLineTable.putOrReplace(shipmentLineIdentifier, shipmentLine);
 
 			final I_M_InOut shipment = InterfaceWrapperHelper.load(shipmentLine.getM_InOut_ID(), I_M_InOut.class);
 			assertThat(shipment).isNotNull();
 
-			final String docStatus = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_DocStatus);
+			final String docStatus = row.getAsString(I_M_InOut.COLUMNNAME_DocStatus);
 			assertThat(shipment.getDocStatus()).isEqualTo(docStatus);
 
-			final String orderIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + COLUMNNAME_C_Order_ID + "." + TABLECOLUMN_IDENTIFIER);
-			if (Check.isNotBlank(orderIdentifier))
-			{
-				final I_C_Order order = orderTable.get(orderIdentifier);
-				assertThat(shipment.getC_Order_ID()).isEqualTo(order.getC_Order_ID());
-			}
+			row.getAsOptionalIdentifier(COLUMNNAME_C_Order_ID)
+					.ifPresent(orderIdentifier -> {
+						final I_C_Order order = orderTable.get(orderIdentifier);
+						assertThat(shipment.getC_Order_ID()).isEqualTo(order.getC_Order_ID());
+					});
 
-			final String shipmentIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_M_InOut_ID + "." + TABLECOLUMN_IDENTIFIER);
+			final StepDefDataIdentifier shipmentIdentifier = row.getAsIdentifier(I_M_InOut.COLUMNNAME_M_InOut_ID);
 			inoutTable.putOrReplace(shipmentIdentifier, shipment);
-		}
+		});
 	}
 
+	/**
+	 * Perform an arbitrary document action on a shipment/receipt. Uses DocAction codes directly (CO, RC, RA, VO, CL).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_InOut_ID</b> — (required, identifier-ref) the shipment to process<br>
+	 *   <b>DocAction</b> — (required) document action code: CO, RC, RA, VO, CL<br>
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And perform shipment document action
+	 *   | M_InOut_ID | DocAction |
+	 *   | shipment_1 | RC        |
+	 * </pre>
+	 */
 	@And("perform shipment document action")
 	public void reverseShipment(@NonNull final DataTable table)
 	{
-		final List<Map<String, String>> dataTable = table.asMaps();
-		for (final Map<String, String> row : dataTable)
+		DataTableRows.of(table).forEach(row ->
 		{
-			final String shipmentIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_M_InOut_ID + "." + StepDefConstants.TABLECOLUMN_IDENTIFIER);
-
-			final String docAction = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_DocAction);
-
-			final I_M_InOut shipment = inoutTable.get(shipmentIdentifier);
-
+			final I_M_InOut shipment = row.getAsIdentifier(I_M_InOut.COLUMNNAME_M_InOut_ID).lookupNotNullIn(inoutTable);
+			final String docAction = row.getAsString(I_M_InOut.COLUMNNAME_DocAction);
 			documentBL.processEx(shipment, docAction);
-		}
+		});
 	}
 
+	/**
+	 * Locate M_InOut via M_ShipmentSchedule_QtyPicked and store it in StepDefData.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_ShipmentSchedule_ID</b> — (required, identifier-ref) the schedule that triggered the shipment<br>
+	 *   <b>M_InOut_ID</b> — (required, identifier) alias to store the found shipment<br>
+	 * @cucumber.depends StepDefData: M_ShipmentSchedule_StepDefData, M_InOut_StepDefData
+	 */
 	@Then("locate M_InOut by shipment schedule Id")
 	public void locate_shipment_by_scheduleId(@NonNull final DataTable table)
 	{
-		final List<Map<String, String>> dataTable = table.asMaps();
-		for (final Map<String, String> row : dataTable)
-		{
-			locateShipmentByScheduleId(row);
-		}
+		DataTableRows.of(table).forEach(this::locateShipmentByScheduleId);
 	}
 
 	@And("validate M_In_Out status")
@@ -729,27 +754,20 @@ public class M_InOut_StepDef
 	@And("metasfresh contains M_InOut:")
 	public void create_M_InOut(@NonNull final DataTable dataTable)
 	{
-		for (final Map<String, String> row : dataTable.asMaps())
+		DataTableRows.of(dataTable).forEach(row ->
 		{
 			final I_M_InOut inOut = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
 
-			final String bpartnerIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_C_BPartner_ID + "." + TABLECOLUMN_IDENTIFIER);
-			final I_C_BPartner bPartner = bpartnerTable.get(bpartnerIdentifier);
-			assertThat(bPartner).isNotNull();
+			final I_C_BPartner bPartner = row.getAsIdentifier(I_M_InOut.COLUMNNAME_C_BPartner_ID).lookupNotNullIn(bpartnerTable);
 			inOut.setC_BPartner_ID(bPartner.getC_BPartner_ID());
 
-			final String bpartnerLocationIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_C_BPartner_Location_ID + "." + TABLECOLUMN_IDENTIFIER);
-			final I_C_BPartner_Location bPartnerLocation = bpartnerLocationTable.get(bpartnerLocationIdentifier);
-			assertThat(bpartnerIdentifier).isNotNull();
+			final I_C_BPartner_Location bPartnerLocation = row.getAsIdentifier(I_M_InOut.COLUMNNAME_C_BPartner_Location_ID).lookupNotNullIn(bpartnerLocationTable);
 			inOut.setC_BPartner_Location_ID(bPartnerLocation.getC_BPartner_Location_ID());
 
-			final boolean isSOTrx = DataTableUtil.extractBooleanForColumnName(row, COLUMNNAME_IsSOTrx);
-			inOut.setIsSOTrx(isSOTrx);
+			inOut.setIsSOTrx(row.getAsBoolean(COLUMNNAME_IsSOTrx));
 
-			final String docBaseType = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + COLUMNNAME_DocBaseType);
-			if (EmptyUtil.isNotBlank(docBaseType))
-			{
-				final String docSubType = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + COLUMNNAME_DocSubType);
+			row.getAsOptionalString(COLUMNNAME_DocBaseType).ifPresent(docBaseType -> {
+				final String docSubType = row.getAsOptionalString(COLUMNNAME_DocSubType).orElse(null);
 
 				final I_C_DocType docType = queryBL.createQueryBuilder(I_C_DocType.class)
 						.addEqualsFilter(COLUMNNAME_DocBaseType, docBaseType)
@@ -757,74 +775,68 @@ public class M_InOut_StepDef
 						.create()
 						.firstOnlyNotNull(I_C_DocType.class);
 
-				assertThat(docType).isNotNull();
-
 				inOut.setC_DocType_ID(docType.getC_DocType_ID());
-			}
+			});
 
-			final String deliveryRule = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_DeliveryRule);
-			inOut.setDeliveryRule(deliveryRule);
+			inOut.setDeliveryRule(row.getAsString(I_M_InOut.COLUMNNAME_DeliveryRule));
+			inOut.setDeliveryViaRule(row.getAsString(I_M_InOut.COLUMNNAME_DeliveryViaRule));
+			inOut.setFreightCostRule(row.getAsString(I_M_InOut.COLUMNNAME_FreightCostRule));
 
-			final String deliveryViaRule = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_DeliveryViaRule);
-			inOut.setDeliveryViaRule(deliveryViaRule);
+			row.getAsOptionalIdentifier(I_M_InOut.COLUMNNAME_M_Warehouse_ID)
+					.ifPresent(warehouseIdentifier -> {
+						final int warehouseId = warehouseIdentifier.lookupNotNullIn(warehouseTable).getM_Warehouse_ID();
+						inOut.setM_Warehouse_ID(warehouseId);
+					});
 
-			final String freightCostRule = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_FreightCostRule);
-			inOut.setFreightCostRule(freightCostRule);
-
-			final String warehouseIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_M_Warehouse_ID + "." + TABLECOLUMN_IDENTIFIER);
-			if (Check.isNotBlank(warehouseIdentifier))
-			{
-				final int warehouseId = warehouseTable.get(warehouseIdentifier).getM_Warehouse_ID();
-				inOut.setM_Warehouse_ID(warehouseId);
-			}
-
-			final Timestamp movementDate = DataTableUtil.extractDateTimestampForColumnName(row, I_M_InOut.COLUMNNAME_MovementDate);
-			inOut.setMovementDate(movementDate);
-
-			final String movementType = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_MovementType);
-			inOut.setMovementType(movementType);
-
-			final String priorityRule = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_PriorityRule);
-			inOut.setPriorityRule(priorityRule);
+			inOut.setMovementDate(row.getAsLocalDateTimestamp(I_M_InOut.COLUMNNAME_MovementDate));
+			inOut.setMovementType(row.getAsString(I_M_InOut.COLUMNNAME_MovementType));
+			inOut.setPriorityRule(row.getAsString(I_M_InOut.COLUMNNAME_PriorityRule));
 
 			InterfaceWrapperHelper.saveRecord(inOut);
 
-			final String inOutIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_M_InOut_ID + "." + TABLECOLUMN_IDENTIFIER);
+			final StepDefDataIdentifier inOutIdentifier = row.getAsIdentifier(I_M_InOut.COLUMNNAME_M_InOut_ID);
 			inoutTable.putOrReplace(inOutIdentifier, inOut);
-		}
+		});
 	}
 
-	private void locateShipmentByScheduleId(@NonNull final Map<String, String> row)
+	private void locateShipmentByScheduleId(@NonNull final DataTableRow row)
 	{
-		final String shipmentScheduleIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID + ".Identifier");
-		final I_M_ShipmentSchedule shipmentSchedule = InterfaceWrapperHelper.create(shipmentScheduleTable.get(shipmentScheduleIdentifier), I_M_ShipmentSchedule.class);
+		final I_M_ShipmentSchedule shipmentSchedule = InterfaceWrapperHelper.create(
+				row.getAsIdentifier(I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID).lookupIn(shipmentScheduleTable),
+				I_M_ShipmentSchedule.class);
 
 		final List<I_M_ShipmentSchedule_QtyPicked> shipmentScheduleQtyPickedRecords = shipmentScheduleAllocDAO.retrieveAllQtyPickedRecords(shipmentSchedule, I_M_ShipmentSchedule_QtyPicked.class);
 		final InOutLineId lineId = InOutLineId.ofRepoId(shipmentScheduleQtyPickedRecords.get(0).getM_InOutLine_ID());
 
 		final I_M_InOut shipmentRecord = inOutDAO.retrieveInOutByLineIds(ImmutableSet.of(lineId)).get(lineId);
 
-		final String shipmentIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_M_InOut_ID + ".Identifier");
+		final StepDefDataIdentifier shipmentIdentifier = row.getAsIdentifier(I_M_InOut.COLUMNNAME_M_InOut_ID);
 		inoutTable.put(shipmentIdentifier, shipmentRecord);
 	}
 
+	/**
+	 * Poll for a customer return M_InOut matching a C_Order and C_DocType.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>C_Order_ID</b> — (required, identifier-ref) the order the return is linked to<br>
+	 *   <b>C_DocType_ID</b> — (required, identifier-ref) the expected doc type<br>
+	 *   <b>M_InOut_ID</b> — (required, identifier) alias to store the found customer return<br>
+	 * @cucumber.depends StepDefData: C_Order_StepDefData, C_DocType_StepDefData, M_InOut_StepDefData
+	 */
 	@And("^after not more than (.*)s, Customer Return is found:$")
 	public void customerReturnIsFound(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
 	{
-		final List<Map<String, String>> rows = dataTable.asMaps();
-		for (final Map<String, String> row : rows)
-		{
-			findCustomerReturn(timeoutSec, row);
-		}
+		DataTableRows.of(dataTable).forEach(row -> findCustomerReturn(timeoutSec, row));
 	}
 
 	private void findCustomerReturn(
 			final int timeoutSec,
-			@NonNull final Map<String, String> row) throws InterruptedException
+			@NonNull final DataTableRow row) throws InterruptedException
 	{
 		final I_M_InOut customerReturnRecord = StepDefUtil.tryAndWaitForItem(timeoutSec, 500, () -> isCustomerReturnFound(row));
 
-		final String customerReturnIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_M_InOut_ID + "." + TABLECOLUMN_IDENTIFIER);
+		final StepDefDataIdentifier customerReturnIdentifier = row.getAsIdentifier(I_M_InOut.COLUMNNAME_M_InOut_ID);
 		inoutTable.put(customerReturnIdentifier, customerReturnRecord);
 	}
 
@@ -847,15 +859,10 @@ public class M_InOut_StepDef
 	}
 
 	@NonNull
-	private ItemProvider.ProviderResult<I_M_InOut> isCustomerReturnFound(@NonNull final Map<String, String> row)
+	private ItemProvider.ProviderResult<I_M_InOut> isCustomerReturnFound(@NonNull final DataTableRow row)
 	{
-		final String orderIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_C_Order_ID + "." + TABLECOLUMN_IDENTIFIER);
-		final String docTypeIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_C_DocType_ID + "." + TABLECOLUMN_IDENTIFIER);
-
-		final I_C_Order orderRecord = orderTable.get(orderIdentifier);
-		assertThat(orderRecord).isNotNull();
-		final I_C_DocType docTypeRecord = docTypeTable.get(docTypeIdentifier);
-		assertThat(docTypeRecord).isNotNull();
+		final I_C_Order orderRecord = row.getAsIdentifier(I_M_InOut.COLUMNNAME_C_Order_ID).lookupNotNullIn(orderTable);
+		final I_C_DocType docTypeRecord = row.getAsIdentifier(I_M_InOut.COLUMNNAME_C_DocType_ID).lookupNotNullIn(docTypeTable);
 
 		final Optional<I_M_InOut> customerReturnRecord = queryBL
 				.createQueryBuilder(I_M_InOut.class)
@@ -866,21 +873,13 @@ public class M_InOut_StepDef
 				.firstOnlyOptional(I_M_InOut.class);
 
 		return customerReturnRecord.map(ItemProvider.ProviderResult::resultWasFound)
-				.orElseGet(() -> ItemProvider.ProviderResult.resultWasNotFound(getCurrentCustomerReturnContext(row)));
+				.orElseGet(() -> ItemProvider.ProviderResult.resultWasNotFound(getCurrentCustomerReturnContext(orderRecord, docTypeRecord)));
 	}
 
 	@NonNull
-	private String getCurrentCustomerReturnContext(@NonNull final Map<String, String> row)
+	private String getCurrentCustomerReturnContext(@NonNull final I_C_Order orderRecord, @NonNull final I_C_DocType docTypeRecord)
 	{
 		final StringBuilder message = new StringBuilder();
-
-		final String orderIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_C_Order_ID + "." + TABLECOLUMN_IDENTIFIER);
-		final String docTypeIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_C_DocType_ID + "." + TABLECOLUMN_IDENTIFIER);
-
-		final I_C_Order orderRecord = orderTable.get(orderIdentifier);
-		assertThat(orderRecord).isNotNull();
-		final I_C_DocType docTypeRecord = docTypeTable.get(docTypeIdentifier);
-		assertThat(docTypeRecord).isNotNull();
 
 		message.append("Looking for customer return instance with:").append("\n")
 				.append(I_M_InOut.COLUMNNAME_C_Order_ID).append(" : ").append(orderRecord.getC_Order_ID()).append("\n")
@@ -903,10 +902,19 @@ public class M_InOut_StepDef
 		return message.toString();
 	}
 
+	/**
+	 * Process a document action on a shipment/receipt and expect it to throw an error.
+	 * Optionally validates the error message against an AD_Message record.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>AD_Message_ID</b> — (optional, identifier-ref) expected error message from AD_Message<br>
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData, AD_Message_StepDefData
+	 */
 	@And("^the (shipment|material receipt|return inOut) identified by (.*) is (completed|reactivated|reversed|voided|closed) expecting error$")
 	public void shipment_action_expecting_error(@NonNull final String model_UNUSED, @NonNull final String shipmentIdentifier, @NonNull final String action, @NonNull final DataTable dataTable)
 	{
-		final Map<String, String> row = dataTable.asMaps().get(0);
+		final DataTableRow row = DataTableRows.of(dataTable).getFirstRow();
 
 		boolean errorThrown = false;
 
@@ -918,13 +926,11 @@ public class M_InOut_StepDef
 		{
 			errorThrown = true;
 
-			final String errorMessageIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + COLUMNNAME_AD_Message_ID + "." + TABLECOLUMN_IDENTIFIER);
-
-			if (errorMessageIdentifier != null)
-			{
-				final I_AD_Message errorMessage = messageTable.get(errorMessageIdentifier);
-				assertThat(e.getMessage()).contains(msgBL.getMsg(Env.getCtx(), AdMessageKey.of(errorMessage.getValue())));
-			}
+			row.getAsOptionalIdentifier(COLUMNNAME_AD_Message_ID)
+					.ifPresent(errorMessageIdentifier -> {
+						final I_AD_Message errorMessage = messageTable.get(errorMessageIdentifier);
+						assertThat(e.getMessage()).contains(msgBL.getMsg(Env.getCtx(), AdMessageKey.of(errorMessage.getValue())));
+					});
 		}
 
 		assertThat(errorThrown).isTrue();
@@ -952,15 +958,15 @@ public class M_InOut_StepDef
 	{
 		final SoftAssertions softly = new SoftAssertions();
 
-		for (final Map<String, String> row : dataTable.asMaps())
+		DataTableRows.of(dataTable).forEach(row ->
 		{
 			final I_M_InOut reversalInOut = StepDefUtil.tryAndWaitForItem(timeoutSec, 500, () -> load_reversal_InOut(row));
 
 			softly.assertThat(reversalInOut).isNotNull();
 
-			final String reversalInOutIdentifier = DataTableUtil.extractStringForColumnName(row, COLUMNNAME_M_InOut_ID + "." + TABLECOLUMN_IDENTIFIER);
+			final StepDefDataIdentifier reversalInOutIdentifier = row.getAsIdentifier(COLUMNNAME_M_InOut_ID);
 			inoutTable.putOrReplace(reversalInOutIdentifier, reversalInOut);
-		}
+		});
 		softly.assertAll();
 	}
 
@@ -983,10 +989,9 @@ public class M_InOut_StepDef
 	}
 
 	@NonNull
-	private ItemProvider.ProviderResult<I_M_InOut> load_reversal_InOut(@NonNull final Map<String, String> row)
+	private ItemProvider.ProviderResult<I_M_InOut> load_reversal_InOut(@NonNull final DataTableRow row)
 	{
-		final String inOutToReverseIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_Reversal_ID + "." + TABLECOLUMN_IDENTIFIER);
-		final I_M_InOut inOutToReverse = inoutTable.get(inOutToReverseIdentifier);
+		final I_M_InOut inOutToReverse = row.getAsIdentifier(I_M_InOut.COLUMNNAME_Reversal_ID).lookupNotNullIn(inoutTable);
 
 		final I_M_InOut reversalInOutRecord = queryBL.createQueryBuilder(I_M_InOut.class)
 				.addEqualsFilter(I_M_InOut.COLUMNNAME_Reversal_ID, inOutToReverse.getM_InOut_ID())
@@ -995,7 +1000,7 @@ public class M_InOut_StepDef
 
 		if (reversalInOutRecord == null)
 		{
-			return ItemProvider.ProviderResult.resultWasNotFound("No reversal I_M_InOut found for row=" + row);
+			return ItemProvider.ProviderResult.resultWasNotFound("No reversal I_M_InOut found for Reversal_ID=" + inOutToReverse.getM_InOut_ID());
 		}
 
 		return ItemProvider.ProviderResult.resultWasFound(reversalInOutRecord);
@@ -1038,14 +1043,28 @@ public class M_InOut_StepDef
 		}
 	}
 
+	/**
+	 * Create a customer return M_InOut by copying from an existing shipment.
+	 * Copies lines with Return_Origin_InOutLine_ID and sets the return warehouse/locator.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_InOut_ID</b> — (required, identifier-ref) source shipment to create return from<br>
+	 *   <b>CustomerReturn_ID</b> — (required, identifier) alias to store the created customer return<br>
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And generate customer return from shipment
+	 *   | M_InOut_ID | CustomerReturn_ID |
+	 *   | shipment_1 | customerReturn_1  |
+	 * </pre>
+	 */
 	@And("generate customer return from shipment")
 	public void generateCustomerReturnFromShipment(@NonNull final DataTable dataTable)
 	{
-		for (final Map<String, String> row : dataTable.asMaps())
+		DataTableRows.of(dataTable).forEach(row ->
 		{
-			final String shipmentIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_M_InOut_ID + "." + TABLECOLUMN_IDENTIFIER);
-			final I_M_InOut shipment = inoutTable.get(shipmentIdentifier);
-			assertThat(shipment).isNotNull();
+			final I_M_InOut shipment = row.getAsIdentifier(I_M_InOut.COLUMNNAME_M_InOut_ID).lookupNotNullIn(inoutTable);
 
 			final DocTypeId docTypeId = docTypeDAO.getDocTypeId(DocTypeQuery.builder()
 					.docBaseType(DocBaseType.MaterialReceipt)
@@ -1083,26 +1102,40 @@ public class M_InOut_StepDef
 				InterfaceWrapperHelper.save(returnLine);
 			}
 
-			final String returnIdentifier = DataTableUtil.extractStringForColumnName(row, "CustomerReturn_ID." + TABLECOLUMN_IDENTIFIER);
+			final StepDefDataIdentifier returnIdentifier = row.getAsIdentifier("CustomerReturn_ID");
 			inoutTable.putOrReplace(returnIdentifier, customerReturn);
-		}
+		});
 	}
 
+	/**
+	 * Load the first HU assigned to an M_InOut and store it in M_HU_StepDefData.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_InOut_ID</b> — (required, identifier-ref) shipment/receipt to look up HUs for<br>
+	 *   <b>M_HU_ID</b> — (required, identifier) alias to store the first assigned HU<br>
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData, M_HU_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And load HUs assigned to M_InOut
+	 *   | M_InOut_ID | M_HU_ID          |
+	 *   | shipment_1 | shipment_1_hu    |
+	 * </pre>
+	 */
 	@And("load HUs assigned to M_InOut")
 	public void loadHUsAssignedToInOut(@NonNull final DataTable dataTable)
 	{
-		for (final Map<String, String> row : dataTable.asMaps())
+		DataTableRows.of(dataTable).forEach(row ->
 		{
-			final String inoutIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_M_InOut_ID + "." + TABLECOLUMN_IDENTIFIER);
-			final I_M_InOut inout = inoutTable.get(inoutIdentifier);
-			assertThat(inout).isNotNull();
+			final StepDefDataIdentifier inoutIdentifier = row.getAsIdentifier(I_M_InOut.COLUMNNAME_M_InOut_ID);
+			final I_M_InOut inout = inoutIdentifier.lookupNotNullIn(inoutTable);
 			InterfaceWrapperHelper.refresh(inout);
 
 			final List<I_M_HU> hus = huInOutBL.retrieveHandlingUnits(inout);
 			assertThat(hus).as("HUs assigned to " + inoutIdentifier).isNotEmpty();
 
-			final String huIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_HU.COLUMNNAME_M_HU_ID + "." + TABLECOLUMN_IDENTIFIER);
+			final StepDefDataIdentifier huIdentifier = row.getAsIdentifier(I_M_HU.COLUMNNAME_M_HU_ID);
 			huTable.putOrReplace(huIdentifier, hus.get(0));
-		}
+		});
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
@@ -281,14 +281,14 @@ public class M_InOut_StepDef
 	 *   <b>M_ShipmentSchedule_ID</b> — (required, identifier-ref) shipment schedule alias<br>
 	 *   <b>QuantityType</b> — (required) "D" (delivery), "O" (ordered), etc.<br>
 	 *   <b>IsCompleteShipments</b> — (required) true/false — auto-complete the generated shipment<br>
-	 *   <b>IsShipmentDateToday</b> — (required) true/false — use today as shipment date<br>
-	 *   <b>QtyToDeliver_Override</b> — (optional) override quantity to deliver<br>
+	 *   <b>IsShipToday</b> — (required) true/false — use today as shipment date<br>
+	 *   <b>QtyToDeliver_Override_For_M_ShipmentSchedule_ID</b> — (optional) override quantity to deliver<br>
 	 * @cucumber.depends StepDefData: M_ShipmentSchedule_StepDefData
 	 * @cucumber.example
 	 * <pre>
 	 * And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
-	 *   | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipmentDateToday |
-	 *   | shipmentSchedule_1    | D            | true                | false               |
+	 *   | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+	 *   | shipmentSchedule_1    | D            | true                | false       |
 	 * </pre>
 	 */
 	@And("'generate shipments' process is invoked individually for each M_ShipmentSchedule")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/pickingterminal/Picking_Terminal_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/pickingterminal/Picking_Terminal_StepDef.java
@@ -31,9 +31,11 @@ import de.metas.handlingunits.inventory.InventoryService;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_Picking_Candidate;
 import de.metas.handlingunits.model.I_M_ShipmentSchedule;
+import de.metas.handlingunits.picking.PickingCandidate;
 import de.metas.handlingunits.picking.PickingCandidateId;
 import de.metas.handlingunits.picking.PickingCandidateRepository;
 import de.metas.handlingunits.picking.PickingCandidateService;
+import de.metas.handlingunits.picking.PickingCandidateStatus;
 import de.metas.handlingunits.picking.candidate.commands.ProcessPickingCandidatesCommand;
 import de.metas.handlingunits.picking.candidate.commands.ProcessPickingCandidatesRequest;
 import de.metas.handlingunits.picking.slot.IHUPickingSlotBL;
@@ -219,5 +221,32 @@ public class Picking_Terminal_StepDef
 
 		final List<I_M_HU> availableHUsToPick = huPickingSlotBL.retrieveAvailableHUsToPick(query);
 		assertThat(availableHUsToPick).isEmpty();
+	}
+
+	@And("unprocess picking candidates for shipment schedule")
+	public void unprocess_picking_candidates(@NonNull final DataTable dataTable)
+	{
+		final List<Map<String, String>> rows = dataTable.asMaps();
+		for (final Map<String, String> row : rows)
+		{
+			final String shipmentScheduleIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID + "." + TABLECOLUMN_IDENTIFIER);
+			final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule = shipmentScheduleTable.get(shipmentScheduleIdentifier);
+
+			final ShipmentScheduleId shipmentScheduleId = ShipmentScheduleId.ofRepoId(shipmentSchedule.getM_ShipmentSchedule_ID());
+
+			final List<PickingCandidate> pickingCandidates = pickingCandidateRepository.getByShipmentScheduleIdsAndStatus(
+					ImmutableSet.of(shipmentScheduleId),
+					PickingCandidateStatus.Processed);
+
+			assertThat(pickingCandidates)
+					.as("Expected processed picking candidates for shipment schedule " + shipmentScheduleIdentifier)
+					.isNotEmpty();
+
+			final ImmutableSet<PickingCandidateId> pickingCandidateIds = pickingCandidates.stream()
+					.map(PickingCandidate::getId)
+					.collect(ImmutableSet.toImmutableSet());
+
+			pickingCandidateService.unprocess(pickingCandidateIds);
+		}
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -177,6 +177,25 @@ public class M_ShipmentSchedule_StepDef
 	/**
 	 * Match the shipment scheds and load them with their identifier into the shipmentScheduleTable.
 	 */
+	/**
+	 * Poll for M_ShipmentSchedule records created via order completion. Waits up to N seconds.
+	 * Queries by C_OrderLine_ID and optional filters, stores found schedules in M_ShipmentSchedule_StepDefData.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>Identifier</b> — (required) alias to store the found schedule under<br>
+	 *   <b>C_OrderLine_ID</b> — (required, identifier-ref) order line that created this schedule<br>
+	 *   <b>Warehouse_ID</b> — (optional, identifier-ref) filter by warehouse<br>
+	 *   <b>QtyToDeliver</b> — (optional) filter by qty to deliver<br>
+	 *   <b>IsToRecompute</b> — (optional) expected recompute flag<br>
+	 * @cucumber.depends StepDefData: C_OrderLine_StepDefData, M_ShipmentSchedule_StepDefData, M_Warehouse_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * Then after not more than 60s, M_ShipmentSchedules are found:
+	 *   | Identifier           | C_OrderLine_ID | IsToRecompute |
+	 *   | shipmentSchedule_1   | orderLine_1    | N             |
+	 * </pre>
+	 */
 	@Then("^after not more than (.*)s, M_ShipmentSchedules are found:$")
 	public void loadShipmentSchedules(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
 	{
@@ -275,6 +294,24 @@ public class M_ShipmentSchedule_StepDef
 				.isTrue();
 	}
 
+	/**
+	 * Generate shipment(s) synchronously for the given shipment schedule. Waits until the schedule is valid, then generates.
+	 * Stores the generated M_InOut under the M_InOut_ID identifier (if provided).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_ShipmentSchedule_ID</b> — (required, identifier-ref) shipment schedule alias<br>
+	 *   <b>quantityTypeToUse</b> — (optional) D (delivery) or O (ordered); default: BOTH<br>
+	 *   <b>isCompleteShipment</b> — (optional) true/false; default: true<br>
+	 *   <b>M_InOut_ID</b> — (optional) alias to store the generated shipment; comma-separated for multiple<br>
+	 * @cucumber.depends StepDefData: M_ShipmentSchedule_StepDefData, M_InOut_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And shipment is generated for the following shipment schedule
+	 *   | M_ShipmentSchedule_ID | M_InOut_ID |
+	 *   | shipmentSchedule_1    | shipment_1 |
+	 * </pre>
+	 */
 	@And("shipment is generated for the following shipment schedule")
 	public void generateShipmentForSchedule(@NonNull final DataTable dataTable)
 	{
@@ -301,6 +338,30 @@ public class M_ShipmentSchedule_StepDef
 				.forEach(this::alterShipmentSchedule);
 	}
 
+	/**
+	 * Validate shipment schedule quantities after async recompute. Waits for the schedule to become valid (not in recompute queue).
+	 * Polls and re-reads the record, then validates quantities using SoftAssertions.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_ShipmentSchedule_ID</b> — (required, identifier-ref) alias from M_ShipmentSchedule_StepDefData<br>
+	 *   <b>QtyOrdered</b> — (optional) expected ordered quantity<br>
+	 *   <b>QtyReserved</b> — (optional) expected reserved quantity<br>
+	 *   <b>QtyToDeliver</b> — (optional) expected qty to deliver<br>
+	 *   <b>QtyToDeliver_Override</b> — (optional) expected override qty<br>
+	 *   <b>QtyPickList</b> — (optional) expected picked quantity<br>
+	 *   <b>QtyDelivered</b> — (optional) expected delivered quantity<br>
+	 *   <b>QtyOnHand</b> — (optional) expected on-hand quantity<br>
+	 *   <b>Processed</b> — (optional) true/false<br>
+	 *   <b>IsClosed</b> — (optional) true/false<br>
+	 * @cucumber.depends StepDefData: M_ShipmentSchedule_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And after not more than 60s, validate shipment schedules:
+	 *   | M_ShipmentSchedule_ID | QtyOrdered | QtyDelivered | QtyToDeliver |
+	 *   | shipmentSchedule_1    | 100        | 0            | 100          |
+	 * </pre>
+	 */
 	@And("^after not more than (.*)s, validate shipment schedules:$")
 	public void validateShipmentSchedules(final int timeoutSec, @NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/stock/MD_Stock_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/stock/MD_Stock_StepDef.java
@@ -25,6 +25,8 @@ package de.metas.cucumber.stepdefs.stock;
 import de.metas.cucumber.stepdefs.DataTableUtil;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.StepDefUtil;
+import de.metas.event.model.I_AD_EventLog;
+import de.metas.event.model.I_AD_EventLog_Entry;
 import de.metas.logging.LogManager;
 import de.metas.material.cockpit.model.I_MD_Stock;
 import de.metas.util.Services;
@@ -95,7 +97,86 @@ public class MD_Stock_StepDef
 				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, product.getM_Product_ID())
 				.create()
 				.firstOnly(I_MD_Stock.class);
+
+		if (mdStock == null || mdStock.getQtyOnHand().compareTo(qtyOnHand) != 0)
+		{
+			logEventLogDiagnostics(product.getM_Product_ID(), qtyOnHand, mdStock);
+		}
+
 		assertThat(mdStock).isNotNull();
 		assertThat(mdStock.getQtyOnHand()).isEqualTo(qtyOnHand);
+	}
+
+	@And("log AD_EventLog count for product {string}")
+	public void logAD_EventLog_count(@NonNull final String productIdentifier)
+	{
+		final I_M_Product product = productTable.get(productIdentifier);
+		final int productId = product.getM_Product_ID();
+		final String productIdPattern = "\"productId\" : " + productId;
+
+		final List<I_AD_EventLog> eventLogs = queryBL.createQueryBuilder(I_AD_EventLog.class)
+				.addStringLikeFilter(I_AD_EventLog.COLUMNNAME_EventData, "%" + productIdPattern + "%", /* ignoreCase */ false)
+				.orderBy(I_AD_EventLog.COLUMNNAME_Created)
+				.create()
+				.list();
+
+		logger.info("=== AD_EventLog count for M_Product_ID={} ({}): {} entries ===",
+				productId, product.getName(), eventLogs.size());
+		for (final I_AD_EventLog eventLog : eventLogs)
+		{
+			logger.info("  AD_EventLog_ID={}, EventName={}, IsError={}, Created={}",
+					eventLog.getAD_EventLog_ID(),
+					eventLog.getEventName(),
+					eventLog.isError(),
+					eventLog.getCreated());
+		}
+	}
+
+	private void logEventLogDiagnostics(final int productId, final BigDecimal expectedQty, final I_MD_Stock mdStock)
+	{
+		final BigDecimal actualQty = mdStock != null ? mdStock.getQtyOnHand() : null;
+		logger.warn("=== MD_Stock MISMATCH for M_Product_ID={} ===", productId);
+		logger.warn("  Expected QtyOnHand={}, Actual QtyOnHand={}", expectedQty, actualQty);
+
+		// Query recent AD_EventLog entries whose EventData contains the product ID
+		final String productIdPattern = "\"productId\" : " + productId;
+		final List<I_AD_EventLog> eventLogs = queryBL.createQueryBuilder(I_AD_EventLog.class)
+				.addStringLikeFilter(I_AD_EventLog.COLUMNNAME_EventData, "%" + productIdPattern + "%", /* ignoreCase */ false)
+				.orderByDescending(I_AD_EventLog.COLUMNNAME_Created)
+				.setLimit(10)
+				.create()
+				.list();
+
+		if (eventLogs.isEmpty())
+		{
+			logger.warn("  No AD_EventLog entries found containing productId={}", productId);
+			return;
+		}
+
+		logger.warn("  Found {} AD_EventLog entries for productId={}:", eventLogs.size(), productId);
+		for (final I_AD_EventLog eventLog : eventLogs)
+		{
+			logger.warn("  --- AD_EventLog_ID={}, EventType={}, IsError={}, Created={} ---",
+					eventLog.getAD_EventLog_ID(),
+					eventLog.getEventTypeName(),
+					eventLog.isError(),
+					eventLog.getCreated());
+
+			// Query entries (handler results) for this event log
+			final List<I_AD_EventLog_Entry> entries = queryBL.createQueryBuilder(I_AD_EventLog_Entry.class)
+					.addEqualsFilter(I_AD_EventLog_Entry.COLUMNNAME_AD_EventLog_ID, eventLog.getAD_EventLog_ID())
+					.orderBy(I_AD_EventLog_Entry.COLUMNNAME_AD_EventLog_Entry_ID)
+					.create()
+					.list();
+
+			for (final I_AD_EventLog_Entry entry : entries)
+			{
+				logger.warn("    Handler={}, IsError={}, MsgText={}",
+						entry.getClassname(),
+						entry.isError(),
+						entry.getMsgText());
+			}
+		}
+		logger.warn("=== END MD_Stock diagnostics ===");
 	}
 }

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/average_po/reverseMaterialReceipt.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/average_po/reverseMaterialReceipt.feature
@@ -5,6 +5,7 @@ Feature: Average PO - Check costing when reversing a material receipt
   Background:
     Given infrastructure and metasfresh are running
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
     And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
     And metasfresh has date and time 2021-04-14T13:30:13+01:00[Europe/Berlin]
@@ -90,6 +91,10 @@ Feature: Average PO - Check costing when reversing a material receipt
     And create material receipt
       | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
       | hu1                | rs1                             | receipt1              |
+    # Validate HU state after receipt -- HU should be Active
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | hu1                | A        | Y        |
     And validate the created material receipt lines
       | M_InOutLine_ID | M_InOut_ID | M_Product_ID | C_OrderLine_ID |
       | receipt1_line1 | receipt1   | product      | po1_l1         |
@@ -105,12 +110,19 @@ Feature: Average PO - Check costing when reversing a material receipt
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
       | acctSchema      | product      | AveragePO        | 1000000 CHF      | 10 PCE     |
-    
-    
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 10        |
+
+
     #
-    # Reverse the material receipt 
+    # Reverse the material receipt
     #
     And the material receipt identified by receipt1 is reversed as reversal1
+    # Validate HU state after reversal -- HU should be Destroyed
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | hu1                | D        | N        |
     And validate the created material receipt lines
       | M_InOutLine_ID  | M_InOut_ID | M_Product_ID |
       | reversal1_line1 | reversal1  | product      |
@@ -122,6 +134,9 @@ Feature: Average PO - Check costing when reversing a material receipt
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
       | acctSchema      | product      | AveragePO        | 0 CHF            | 0 PCE      |
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 0         |
 
 
 
@@ -165,9 +180,12 @@ Feature: Average PO - Check costing when reversing a material receipt
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
       | acctSchema      | product      | AveragePO        | 10 CHF           | 100 PCE    |
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 100       |
 
     #
-    # Create material receipt 
+    # Create material receipt
     #
     When metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | C_PaymentTerm_ID | DocBaseType | M_PricingSystem_ID | DatePromised        | M_Warehouse_ID |
@@ -185,6 +203,10 @@ Feature: Average PO - Check costing when reversing a material receipt
     And create material receipt
       | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
       | hu1                | rs1                             | receipt1              |
+    # Validate HU state after receipt -- HU should be Active
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | hu1                | A        | Y        |
     And validate the created material receipt lines
       | M_InOutLine_ID | M_InOut_ID | M_Product_ID | C_OrderLine_ID |
       | receipt1_line1 | receipt1   | product      | po1_l1         |
@@ -201,12 +223,19 @@ Feature: Average PO - Check costing when reversing a material receipt
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty | Comment                     |
       | acctSchema      | product      | AveragePO        | 90918.1818 CHF   | 110 PCE    | (1_000+10_000_000)/(100+10) |
-    
-    
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 110       |
+
+
     #
-    # Reverse the material receipt 
+    # Reverse the material receipt
     #
     And the material receipt identified by receipt1 is reversed as reversal1
+    # Validate HU state after reversal -- HU should be Destroyed
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | hu1                | D        | N        |
     And validate the created material receipt lines
       | M_InOutLine_ID  | M_InOut_ID | M_Product_ID |
       | reversal1_line1 | reversal1  | product      |
@@ -219,3 +248,6 @@ Feature: Average PO - Check costing when reversing a material receipt
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
       | acctSchema      | product      | AveragePO        | 10 CHF           | 100 PCE    |
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 100       |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/receipt_and_ship.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/receipt_and_ship.feature
@@ -5,6 +5,7 @@ Feature: Moving Average Invoice - receive and ship
   Background:
     Given infrastructure and metasfresh are running
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
     And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
     And metasfresh has date and time 2021-04-14T13:30:13+01:00[Europe/Berlin]
@@ -59,8 +60,11 @@ Feature: Moving Average Invoice - receive and ship
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
       | acctSchema      | product      | MovingAverageInvoice | 10 CHF           | 10 PCE     | 100 CHF      |
-    
-    
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 10        |
+
+
     
     
     
@@ -161,7 +165,10 @@ Feature: Moving Average Invoice - receive and ship
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
       | acctSchema      | product      | MovingAverageInvoice | 10 CHF           | 3 PCE      | 30 CHF       |
-    
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 3         |
+
     #
     # Get the invoice for those 10 we purchase, but with a different price
     #
@@ -199,3 +206,6 @@ Feature: Moving Average Invoice - receive and ship
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
       | acctSchema      | product      | MovingAverageInvoice | 13 CHF           | 0 PCE      | 0 CHF        |
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 0         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/reverseMaterialReceipt.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/reverseMaterialReceipt.feature
@@ -5,6 +5,7 @@ Feature: Moving Average Invoice - Check costing when reversing a material receip
   Background:
     Given infrastructure and metasfresh are running
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
     And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
     And metasfresh has date and time 2021-04-14T13:30:13+01:00[Europe/Berlin]
@@ -84,9 +85,12 @@ Feature: Moving Average Invoice - Check costing when reversing a material receip
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
       | acctSchema      | product      | MovingAverageInvoice | 1000000 CHF      | 10 PCE     | 10000000 CHF |
-    
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 10        |
+
     #
-    # Reverse the material receipt 
+    # Reverse the material receipt
     #
     And the material receipt identified by receipt1 is reversed as reversal1
     And validate the created material receipt lines
@@ -99,6 +103,9 @@ Feature: Moving Average Invoice - Check costing when reversing a material receip
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
       | acctSchema      | product      | MovingAverageInvoice | 0 CHF            | 0 PCE      | 0 CHF        |
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 0         |
 
 
 
@@ -142,9 +149,12 @@ Feature: Moving Average Invoice - Check costing when reversing a material receip
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty |
       | acctSchema      | product      | MovingAverageInvoice | 10 CHF           | 100 PCE    |
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 100       |
 
     #
-    # Create material receipt 
+    # Create material receipt
     #
     And for costing, create completed order with one line
       | C_OrderLine_ID | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | M_Product_ID | QtyEntered | Price   | Description                    |
@@ -159,10 +169,13 @@ Feature: Moving Average Invoice - Check costing when reversing a material receip
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
       | acctSchema      | product      | MovingAverageInvoice | 90918.1818 CHF   | 110 PCE    | 10001000 CHF |
-    
-    
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 110       |
+
+
     #
-    # Reverse the material receipt 
+    # Reverse the material receipt
     #
     And the material receipt identified by receipt1 is reversed as reversal1
     And validate the created material receipt lines
@@ -176,3 +189,6 @@ Feature: Moving Average Invoice - Check costing when reversing a material receip
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty |
       | acctSchema      | product      | MovingAverageInvoice | 10 CHF           | 100 PCE    |
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 100       |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/delivery/deliveryRules.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/delivery/deliveryRules.feature
@@ -5,6 +5,7 @@ Feature: Delivery rules with and without quantity in stock
   Background:
     Given infrastructure and metasfresh are running
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
     And metasfresh has date and time 2022-08-16T13:30:13+01:00[Europe/Berlin]
     And metasfresh contains M_PricingSystems
       | Identifier | Name              | Value              | OPT.IsActive |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/inventory/inventory.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/inventory/inventory.feature
@@ -5,6 +5,7 @@ Feature: Physical inventory tests
   Background:
     Given infrastructure and metasfresh are running
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
     And metasfresh has date and time 2021-04-11T08:00:00+01:00[Europe/Berlin]
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
 
@@ -41,6 +42,12 @@ Feature: Physical inventory tests
     And validate M_HUs:
       | M_HU_ID | M_HU_PI_ID | HUStatus | M_HU_Parent | M_Product_ID | Qty      |
       | hu1     | 101        | A        | -           | product      | 1000 PCE |
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | hu1                | A        | Y        |
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 1000      |
 
   @from:cucumber
   Scenario: Inventory+ to 2 x LU/CU
@@ -53,6 +60,13 @@ Feature: Physical inventory tests
       | lu1         | vhu     | 101        | A        | product      | 200 PCE |
       | -           | lu2     | LU         | A        | product      | 200 PCE |
       | lu2         | vhu     | 101        | A        | product      | 200 PCE |
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | lu1                | A        | Y        |
+      | lu2                | A        | Y        |
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 400       |
 
   @from:cucumber
   Scenario: Inventory+ to 2 x LU/TU/CU
@@ -63,6 +77,12 @@ Feature: Physical inventory tests
       | M_HU_Parent | M_HU_ID | M_HU_PI_ID | HUStatus | M_Product_ID | Qty     | QtyTUs | IsAggregate |
       | -           | lu1     | LU         | A        | product      | 400 PCE |        | N           |
       | lu1         | tu_agg1 | TU         | A        | product      | 400 PCE | 40     | Y           |
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | lu1                | A        | Y        |
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 800       |
 
   @from:cucumber
   Scenario: Inventory+ to 2 x TUs
@@ -72,4 +92,11 @@ Feature: Physical inventory tests
     And validate M_HUs:
       | M_HU_Parent | M_HU_ID | M_HU_PI_ID | HUStatus | M_Product_ID | Qty    |
       | -           | tu1     | TU         | A        | product      | 10 PCE |
-      | -           | tu2     | TU         | A        | product      | 9 PCE  | 
+      | -           | tu2     | TU         | A        | product      | 9 PCE  |
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | tu1                | A        | Y        |
+      | tu2                | A        | Y        |
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 19        |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/production.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/production.feature
@@ -93,6 +93,9 @@ Feature: Physical Inventory and disposal - Production dispo scenarios
     And M_HU are disposed:
       | M_HU_ID.Identifier | MovementDate |
       | hu_1               | 2021-04-16   |
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | hu_1               | D        | N        |
 
     And after not more than 60s, MD_Candidates are found
       | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected | Qty | Qty_AvailableToPromise |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/reverseMaterialReceipt.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/reverseMaterialReceipt.feature
@@ -5,6 +5,7 @@ Feature: Reversal of material receipt
   Background:
     Given infrastructure and metasfresh are running
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
     And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
     And metasfresh has date and time 2021-04-14T11:30:13Z
@@ -59,18 +60,32 @@ Feature: Reversal of material receipt
     And create material receipt
       | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
       | hu1                | rs1                             | receipt1              |
+    # Validate HU state after receipt — HU should be Active in warehouse
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | hu1                | A        | Y        |
     # the receipt with qty=10 came before it was expected; c_1 now has Qty=0; c_2 has the value that was set in the timesource
     And after not more than 60s, MD_Candidates are found
       | Identifier | MD_Candidate_Type   | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP |
       | c_1        | SUPPLY              | PURCHASE                  | product      | 2021-04-15T15:00:00  | 0   | 10  |
       | c_2        | UNEXPECTED_INCREASE | PURCHASE                  | product      | 2021-04-14T11:30:13Z | 10  | 10  |
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 10        |
     And the material receipt identified by receipt1 is reversed
+    # Validate HU state after reversal — HU should be Destroyed
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | hu1                | D        | N        |
     # i'm not sure it's right that c_1 did not get its Qty=10 back. So if you think i's wrong => maybe it is.
     And after not more than 60s, the MD_Candidate table has only the following records
       | Identifier | MD_Candidate_Type   | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP |
       | c_1        | SUPPLY              | PURCHASE                  | product      | 2021-04-15T15:00:00  | 0   | 0   |
       | c_2        | UNEXPECTED_INCREASE | PURCHASE                  | product      | 2021-04-14T11:30:13Z | 10  | 10  |
       | c_3        | UNEXPECTED_DECREASE | PURCHASE                  | product      | 2021-04-14T11:30:13Z | 10  | 0   |
+    And after not more than 30 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | product                 | 0         |
 # cleanup
     And metasfresh has current date and time
     

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/reverseShipment.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/reverseShipment.feature
@@ -51,7 +51,10 @@ Feature: Shipping HUs interaction with material schedule
   # If we changed the JVM to UTC, this test would succeed, but a bunch of others would fail at this stage
     And after not more than 60s, MD_Candidates are found
       | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected       | Qty | Qty_AvailableToPromise | 
-      | c_1        | INVENTORY_UP      |                               | p_1                     | 2021-04-09T00:00:00 | 100 | 100                    | 
+      | c_1        | INVENTORY_UP      |                               | p_1                     | 2021-04-09T00:00:00 | 100 | 100                    |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 100       |
 
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.PreparationDate  |
@@ -79,14 +82,17 @@ Feature: Shipping HUs interaction with material schedule
       | c_1        | INVENTORY_UP        |                               | p_1                     | 2021-04-09T00:00:00  | 100 | 100                    |
       | c_2        | DEMAND              | SHIPMENT                      | p_1                     | 2021-04-11T21:00:00Z | 0   | 85                     |
       | c_3        | UNEXPECTED_DECREASE | SHIPMENT                      | p_1                     | 2021-04-11T00:00:00Z | -15 | 85                     |
-    # NOTE: MD_Stock assertions removed — this feature disables the MD_Stock scheduler
-    # (AD_Scheduler for MD_Stock_Update_From_M_HUs), so event-driven MD_Stock updates
-    # are unreliable after complex document action sequences (reactivate→complete→reverse).
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 85        |
     When the shipment identified by s_1 is reactivated
     And after not more than 60s, MD_Candidates are found
       | Identifier | MD_Candidate_Type   | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected        | Qty | Qty_AvailableToPromise |
       | c_2        | DEMAND              | SHIPMENT                      | p_1                     | 2021-04-11T21:00:00Z | -15 | 85                     |
       | c_3        | UNEXPECTED_DECREASE | SHIPMENT                      | p_1                     | 2021-04-11T00:00:00Z | 0   | 100                    |
+    And after not more than 120 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 100       |
 
     And the shipment identified by s_1 is completed
 
@@ -94,6 +100,9 @@ Feature: Shipping HUs interaction with material schedule
       | Identifier | MD_Candidate_Type   | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected        | Qty | Qty_AvailableToPromise |
       | c_2        | DEMAND              | SHIPMENT                      | p_1                     | 2021-04-11T21:00:00Z | 0   | 85                     |
       | c_3        | UNEXPECTED_DECREASE | SHIPMENT                      | p_1                     | 2021-04-11T00:00:00Z | -15 | 85                     |
+    And after not more than 120 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 85        |
 
     And the shipment identified by s_1 is reversed
 
@@ -101,6 +110,9 @@ Feature: Shipping HUs interaction with material schedule
       | Identifier | MD_Candidate_Type   | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected        | Qty | Qty_AvailableToPromise | 
       | c_2        | DEMAND              | SHIPMENT                      | p_1                     | 2021-04-11T21:00:00Z | -15 | 85                     |
       | c_3        | UNEXPECTED_DECREASE | SHIPMENT                      | p_1                     | 2021-04-11T00:00:00Z | 0   | 100                    |
+    And after not more than 120 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 100       |
 # cleanup
     And metasfresh has current date and time
     

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/reverseShipment.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/reverseShipment.feature
@@ -43,7 +43,11 @@ Feature: Shipping HUs interaction with material schedule
     And after not more than 60s, there are added M_HUs for inventory
       | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
       | il_1                          | hu_1               |
-  # OPT.DateProjected_LocalTimeZone=2021-04-09T00:00:00 is interpreted as 2021-04-08T22:00:00Z, because we set the time-source to the zulu-TZ, but the JVM and thus jdbc-drives assumes CEST.Scenario: 
+    # Validate HU state after inventory — HU should be Active in warehouse
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | hu_1               | A        | Y        |
+  # OPT.DateProjected_LocalTimeZone=2021-04-09T00:00:00 is interpreted as 2021-04-08T22:00:00Z, because we set the time-source to the zulu-TZ, but the JVM and thus jdbc-drives assumes CEST.Scenario:
   # If we changed the JVM to UTC, this test would succeed, but a bunch of others would fail at this stage
     And after not more than 60s, MD_Candidates are found
       | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected       | Qty | Qty_AvailableToPromise | 
@@ -75,6 +79,9 @@ Feature: Shipping HUs interaction with material schedule
       | c_1        | INVENTORY_UP        |                               | p_1                     | 2021-04-09T00:00:00  | 100 | 100                    |
       | c_2        | DEMAND              | SHIPMENT                      | p_1                     | 2021-04-11T21:00:00Z | 0   | 85                     |
       | c_3        | UNEXPECTED_DECREASE | SHIPMENT                      | p_1                     | 2021-04-11T00:00:00Z | -15 | 85                     |
+    # NOTE: MD_Stock assertions removed — this feature disables the MD_Stock scheduler
+    # (AD_Scheduler for MD_Stock_Update_From_M_HUs), so event-driven MD_Stock updates
+    # are unreliable after complex document action sequences (reactivate→complete→reverse).
     When the shipment identified by s_1 is reactivated
     And after not more than 60s, MD_Candidates are found
       | Identifier | MD_Candidate_Type   | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected        | Qty | Qty_AvailableToPromise |
@@ -92,8 +99,8 @@ Feature: Shipping HUs interaction with material schedule
 
     And after not more than 60s, MD_Candidates are found
       | Identifier | MD_Candidate_Type   | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected        | Qty | Qty_AvailableToPromise | 
-      | c_2        | DEMAND              | SHIPMENT                      | p_1                     | 2021-04-11T21:00:00Z | -15 | 85                     | 
-      | c_3        | UNEXPECTED_DECREASE | SHIPMENT                      | p_1                     | 2021-04-11T00:00:00Z | 0   | 100                    | 
+      | c_2        | DEMAND              | SHIPMENT                      | p_1                     | 2021-04-11T21:00:00Z | -15 | 85                     |
+      | c_3        | UNEXPECTED_DECREASE | SHIPMENT                      | p_1                     | 2021-04-11T00:00:00Z | 0   | 100                    |
 # cleanup
     And metasfresh has current date and time
     

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/duplicateShipmentLineGuard.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/duplicateShipmentLineGuard.feature
@@ -31,9 +31,6 @@ Feature: duplicate shipment line guard prevents duplicate generation from race c
     And metasfresh contains C_BPartner_Locations:
       | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
       | loc_A      | 0123456789101 | endcustomer_A            | Y                   | Y                   |
-    And upsert C_BPartner_Stats
-      | C_BPartner_ID.Identifier | SOCreditStatus.Code |
-      | endcustomer_A            | X                   |
 
     # Create stock via inventory
     And metasfresh contains M_Inventories:
@@ -101,9 +98,6 @@ Feature: duplicate shipment line guard prevents duplicate generation from race c
     And metasfresh contains C_BPartner_Locations:
       | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
       | loc_A      | 0123456789102 | endcustomer_A            | Y                   | Y                   |
-    And upsert C_BPartner_Stats
-      | C_BPartner_ID.Identifier | SOCreditStatus.Code |
-      | endcustomer_A            | X                   |
 
     # Create stock via inventory
     And metasfresh contains M_Inventories:
@@ -185,9 +179,6 @@ Feature: duplicate shipment line guard prevents duplicate generation from race c
     And metasfresh contains C_BPartner_Locations:
       | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
       | loc_A      | 0123456789103 | endcustomer_A            | Y                   | Y                   |
-    And upsert C_BPartner_Stats
-      | C_BPartner_ID.Identifier | SOCreditStatus.Code |
-      | endcustomer_A            | X                   |
 
     # Create stock via inventory
     And metasfresh contains M_Inventories:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/duplicateShipmentLineGuard.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/duplicateShipmentLineGuard.feature
@@ -1,0 +1,232 @@
+@from:cucumber
+@ghActions:run_on_executor5
+Feature: duplicate shipment line guard prevents duplicate generation from race condition (me03#28143)
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+    And metasfresh has date and time 2021-12-16T13:30:13+01:00[Europe/Berlin]
+
+  @from:cucumber
+  Scenario: Normal shipment generation is not blocked by the guard
+    Given metasfresh contains M_Products:
+      | Identifier | Name                   |
+      | p_1        | dup_guard_normal_prod  |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                  | Value                 | OPT.IsActive |
+      | ps_1       | dup_guard_normal_ps   | dup_guard_normal_ps   | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                  | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | dup_guard_normal_pl   | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                   | ValidFrom  |
+      | plv_1      | pl_1                      | dup_guard_normal_plv   | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+    And metasfresh contains C_BPartners:
+      | Identifier    | Name                   | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | endcustomer_A | dup_guard_normal_cust  | N            | Y              | ps_1                          | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | loc_A      | 0123456789101 | endcustomer_A            | Y                   | Y                   |
+
+    # Create stock via inventory
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_1                     | 2021-04-01   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_1                     | inv_l_1                       | p_1                     | 0       | 10       | PCE          |
+    When the inventory identified by inv_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | inv_l_1                       | hu_1               |
+
+    # Create and complete sales order
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference       |
+      | o_A        | true    | endcustomer_A            | 2021-04-17  | po_ref_dup_guard_norm |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_A       | o_A                   | p_1                     | 10         |
+    When the order identified by o_A is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_A      | ol_A                      | N             |
+
+    # Generate shipment normally (complete)
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_A                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_A                            | ship_A                | CO            |
+
+    # Validate: QtyPicked is Processed=Y (completed shipment), guard did not interfere
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by s_s_A
+      | QtyPicked | Processed | IsAnonymousHuPickedOnTheFly |
+      | 10        | Y         | Y                           |
+    And validate the created shipment lines
+      | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
+      | ship_A                | p_1                     | 10          | true      |
+
+  @from:cucumber
+  Scenario: Second shipment generation is skipped when draft allocation exists
+    # Simulates the race condition: first WP creates a draft shipment (IsCompleteShipments=false),
+    # leaving QtyPicked with Processed=N and M_InOutLine_ID set. The guard should detect this
+    # and skip the schedule when the second WP processes it.
+    Given metasfresh contains M_Products:
+      | Identifier | Name                  |
+      | p_1        | dup_guard_block_prod  |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                 | Value                | OPT.IsActive |
+      | ps_1       | dup_guard_block_ps   | dup_guard_block_ps   | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                 | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | dup_guard_block_pl   | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                  | ValidFrom  |
+      | plv_1      | pl_1                      | dup_guard_block_plv   | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+    And metasfresh contains C_BPartners:
+      | Identifier    | Name                  | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | endcustomer_A | dup_guard_block_cust  | N            | Y              | ps_1                          | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | loc_A      | 0123456789102 | endcustomer_A            | Y                   | Y                   |
+
+    # Create stock via inventory
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_1                     | 2021-04-01   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_1                     | inv_l_1                       | p_1                     | 0       | 10       | PCE          |
+    When the inventory identified by inv_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | inv_l_1                       | hu_1               |
+
+    # Create and complete sales order
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference        |
+      | o_A        | true    | endcustomer_A            | 2021-04-17  | po_ref_dup_guard_block |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_A       | o_A                   | p_1                     | 10         |
+    When the order identified by o_A is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_A      | ol_A                      | N             |
+
+    # First generation: do NOT complete the shipment (leaves draft allocation)
+    # This creates M_ShipmentSchedule_QtyPicked with Processed=N and M_InOutLine_ID set
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_A                            | D            | false               | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_A                            | ship_A                | DR            |
+
+    # Validate: exactly 1 QtyPicked record (Processed=N because shipment is draft)
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by s_s_A
+      | QtyPicked | Processed | IsAnonymousHuPickedOnTheFly |
+      | 10        | N         | Y                           |
+
+    # Second generation attempt (same schedule) — guard should block this
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_A                            | D            | true                | false       |
+
+    # Poll: find the SAME M_InOut from the first generation (no new one created).
+    # If a duplicate were created, this step would throw "More than one M_InOut found".
+    And after not more than 30s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_A                            | ship_A_check          | DR            |
+
+    # Validate: still exactly 1 QtyPicked record (guard prevented duplicate)
+    # If the guard failed, there would be 2 records and this step would fail on count mismatch.
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by s_s_A
+      | QtyPicked | Processed | IsAnonymousHuPickedOnTheFly |
+      | 10        | N         | Y                           |
+
+  @from:cucumber
+  Scenario: Completed partial delivery does not block next shipment generation
+    # After a completed partial delivery, QtyPicked records have Processed=Y.
+    # The guard only blocks Processed=N records, so the next generation should proceed normally.
+    Given metasfresh contains M_Products:
+      | Identifier | Name                    |
+      | p_1        | dup_guard_partial_prod  |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                   | Value                  | OPT.IsActive |
+      | ps_1       | dup_guard_partial_ps   | dup_guard_partial_ps   | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                   | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | dup_guard_partial_pl   | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                    | ValidFrom  |
+      | plv_1      | pl_1                      | dup_guard_partial_plv   | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+    And metasfresh contains C_BPartners:
+      | Identifier    | Name                    | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | endcustomer_A | dup_guard_partial_cust  | N            | Y              | ps_1                          | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | loc_A      | 0123456789103 | endcustomer_A            | Y                   | Y                   |
+
+    # Create stock via inventory
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_1                     | 2021-04-01   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_1                     | inv_l_1                       | p_1                     | 0       | 10       | PCE          |
+    When the inventory identified by inv_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | inv_l_1                       | hu_1               |
+
+    # Create order for qty=10
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference          |
+      | o_A        | true    | endcustomer_A            | 2021-04-17  | po_ref_dup_guard_partial |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_A       | o_A                   | p_1                     | 10         |
+    When the order identified by o_A is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_A      | ol_A                      | N             |
+
+    # First generation: partial delivery of 5 with completion
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override |
+      | s_s_A                            | D            | true                | false       | 5                     |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_A                            | ship_A                | CO            |
+    And validate the created shipment lines
+      | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
+      | ship_A                | p_1                     | 5           | true      |
+
+    # Wait for schedule recompute (QtyToDeliver should reflect the 5 remaining)
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_A      | ol_A                      | N             |
+
+    # Second generation: remaining qty — guard does NOT fire (prior QtyPicked is Processed=Y)
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_A                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus | OPT.IgnoreCreated.M_InOut_ID.Identifier |
+      | s_s_A                            | ship_B                | CO            | ship_A                                  |
+    And validate the created shipment lines
+      | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
+      | ship_B                | p_1                     | 5           | true      |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/duplicateShipmentLineGuard.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/duplicateShipmentLineGuard.feature
@@ -144,9 +144,11 @@ Feature: duplicate shipment line guard prevents duplicate generation from race c
 
     # Poll: find the SAME M_InOut from the first generation (no new one created).
     # If a duplicate were created, this step would throw "More than one M_InOut found".
+    # We reuse identifier ship_A because it's the same record — using a different identifier
+    # would fail with "already mapped to ship_A".
     And after not more than 30s, M_InOut is found:
       | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
-      | s_s_A                            | ship_A_check          | DR            |
+      | s_s_A                            | ship_A                | DR            |
 
     # Validate: still exactly 1 QtyPicked record (guard prevented duplicate)
     # If the guard failed, there would be 2 records and this step would fail on count mismatch.

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/duplicateShipmentLineGuard.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/duplicateShipmentLineGuard.feature
@@ -31,6 +31,9 @@ Feature: duplicate shipment line guard prevents duplicate generation from race c
     And metasfresh contains C_BPartner_Locations:
       | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
       | loc_A      | 0123456789101 | endcustomer_A            | Y                   | Y                   |
+    And upsert C_BPartner_Stats
+      | C_BPartner_ID.Identifier | SOCreditStatus.Code |
+      | endcustomer_A            | X                   |
 
     # Create stock via inventory
     And metasfresh contains M_Inventories:
@@ -98,6 +101,9 @@ Feature: duplicate shipment line guard prevents duplicate generation from race c
     And metasfresh contains C_BPartner_Locations:
       | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
       | loc_A      | 0123456789102 | endcustomer_A            | Y                   | Y                   |
+    And upsert C_BPartner_Stats
+      | C_BPartner_ID.Identifier | SOCreditStatus.Code |
+      | endcustomer_A            | X                   |
 
     # Create stock via inventory
     And metasfresh contains M_Inventories:
@@ -179,6 +185,9 @@ Feature: duplicate shipment line guard prevents duplicate generation from race c
     And metasfresh contains C_BPartner_Locations:
       | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
       | loc_A      | 0123456789103 | endcustomer_A            | Y                   | Y                   |
+    And upsert C_BPartner_Stats
+      | C_BPartner_ID.Identifier | SOCreditStatus.Code |
+      | endcustomer_A            | X                   |
 
     # Create stock via inventory
     And metasfresh contains M_Inventories:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/duplicateShipmentLineGuard.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/duplicateShipmentLineGuard.feature
@@ -1,6 +1,6 @@
 @from:cucumber
 @ghActions:run_on_executor5
-Feature: duplicate shipment line guard prevents duplicate generation from race condition (me03#28143)
+Feature: duplicate shipment line guard prevents duplicate generation from race condition
 
   Background:
     Given infrastructure and metasfresh are running
@@ -66,8 +66,8 @@ Feature: duplicate shipment line guard prevents duplicate generation from race c
 
     # Validate: QtyPicked is Processed=Y (completed shipment), guard did not interfere
     And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by s_s_A
-      | QtyPicked | Processed | IsAnonymousHuPickedOnTheFly |
-      | 10        | Y         | Y                           |
+      | QtyPicked | Processed |
+      | 10        | Y         |
     And validate the created shipment lines
       | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
       | ship_A                | p_1                     | 10          | true      |
@@ -134,8 +134,8 @@ Feature: duplicate shipment line guard prevents duplicate generation from race c
 
     # Validate: exactly 1 QtyPicked record (Processed=N because shipment is draft)
     And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by s_s_A
-      | QtyPicked | Processed | IsAnonymousHuPickedOnTheFly |
-      | 10        | N         | Y                           |
+      | QtyPicked | Processed |
+      | 10        | N         |
 
     # Second generation attempt (same schedule) — guard should block this
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
@@ -151,8 +151,8 @@ Feature: duplicate shipment line guard prevents duplicate generation from race c
     # Validate: still exactly 1 QtyPicked record (guard prevented duplicate)
     # If the guard failed, there would be 2 records and this step would fail on count mismatch.
     And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by s_s_A
-      | QtyPicked | Processed | IsAnonymousHuPickedOnTheFly |
-      | 10        | N         | Y                           |
+      | QtyPicked | Processed |
+      | 10        | N         |
 
   @from:cucumber
   Scenario: Completed partial delivery does not block next shipment generation
@@ -206,8 +206,8 @@ Feature: duplicate shipment line guard prevents duplicate generation from race c
 
     # First generation: partial delivery of 5 with completion
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
-      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override |
-      | s_s_A                            | D            | true                | false       | 5                     |
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
+      | s_s_A                            | D            | true                | false       | 5                                               |
     And after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
       | s_s_A                            | ship_A                | CO            |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/reversedShipment.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/reversedShipment.feature
@@ -6,6 +6,7 @@ Feature: reversed shipment
     Given infrastructure and metasfresh are running
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
 
   @from:cucumber
   Scenario: we can create and complete a shipment, then reserve/correct it and check the hu's status
@@ -44,6 +45,9 @@ Feature: reversed shipment
     And M_HU_Storage are validated
       | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
       | hu_s_1     | hu_1               | p_1                     | 10  |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 10        |
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference |
       | o_1        | true    | endcustomer_1            | 2021-04-17  | po_ref_mock     |
@@ -63,12 +67,19 @@ Feature: reversed shipment
     And M_HU are validated:
       | M_HU_ID.Identifier | HUStatus | IsActive |
       | hu_1               | E        | N        |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 0         |
+    # === Reverse and re-ship ===
     And perform shipment document action
       | M_InOut_ID.Identifier | DocAction |
       | s_1                   | RC        |
     Then M_HU are validated:
       | M_HU_ID.Identifier | HUStatus | IsActive |
       | hu_1               | A        | Y        |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 10        |
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
@@ -81,3 +92,6 @@ Feature: reversed shipment
     And M_HU are validated:
       | M_HU_ID.Identifier | HUStatus | IsActive |
       | hu_1               | E        | N        |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 0         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/reversedShipmentClearsBPartner.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/reversedShipmentClearsBPartner.feature
@@ -1,0 +1,1157 @@
+@from:cucumber
+@ghActions:run_on_executor5
+Feature: reversed shipment clears HU C_BPartner_ID
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+    And metasfresh has date and time 2021-12-16T13:30:13+01:00[Europe/Berlin]
+
+  @from:cucumber
+  Scenario: reversing a shipment clears C_BPartner_ID on HU so it can be shipped to a different customer
+    Given metasfresh contains M_Products:
+      | Identifier | Name                    |
+      | p_1        | hu_bpartner_clr_product |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                        | Value                        | OPT.Description                    | OPT.IsActive |
+      | ps_1       | hu_bpartner_clr_pricing_sys | hu_bpartner_clr_pricing_sys  | hu_bpartner_clr_pricing_sys_descr  | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                        | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | hu_bpartner_clr_price_list  | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                   | ValidFrom  |
+      | plv_1      | pl_1                      | hu_bpartner_clr_PLV    | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+
+    # Two customers that will ship from the same HU
+    And metasfresh contains C_BPartners:
+      | Identifier     | Name              | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | endcustomer_A  | hu_bpc_customer_A | N            | Y              | ps_1                          | D               |
+      | endcustomer_B  | hu_bpc_customer_B | N            | Y              | ps_1                          | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | loc_A      | 0123456789011 | endcustomer_A            | Y                   | Y                   |
+      | loc_B      | 0123456789012 | endcustomer_B            | Y                   | Y                   |
+
+    # Create stock via inventory
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_1                     | 2021-04-01   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_1                     | inv_l_1                       | p_1                     | 0       | 10       | PCE          |
+    When the inventory identified by inv_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | inv_l_1                       | hu_1               |
+
+    # Verify initial state: HU active, no BPartner, storage=10
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_1     | hu_1               | p_1                     | 10  |
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | A        | Y        | null          | null                   |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 10        |
+
+    # Create order for Customer A and generate shipment
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference          |
+      | o_A        | true    | endcustomer_A            | 2021-04-17  | po_ref_bpartner_clr_A    |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_A       | o_A                   | p_1                     | 10         |
+    When the order identified by o_A is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_A      | ol_A                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_A                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_A                            | ship_A                | CO            |
+
+    # After shipping: HU is shipped (E) and belongs to Customer A
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | E        | N        | endcustomer_A | loc_A                  |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 0         |
+
+    # Reverse the shipment
+    And perform shipment document action
+      | M_InOut_ID.Identifier | DocAction |
+      | ship_A                | RC        |
+
+    # After reversal: HU is active again, BPartner+Location cleared, storage restored
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | A        | Y        | null          | null                   |
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_1     | hu_1               | p_1                     | 10  |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 10        |
+
+    # Now create order for Customer B and generate shipment from the same HU
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference          |
+      | o_B        | true    | endcustomer_B            | 2021-04-18  | po_ref_bpartner_clr_B    |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_B       | o_B                   | p_1                     | 10         |
+    When the order identified by o_B is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_B      | ol_B                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_B                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_B                            | ship_B                | CO            |
+
+    # After shipping to Customer B: HU is shipped and belongs to Customer B
+    Then M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | E        | N        | endcustomer_B | loc_B                  |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 0         |
+
+  @from:cucumber
+  Scenario: double reversal triple shipment proves fix is idempotent across multiple cycles
+    Given metasfresh contains M_Products:
+      | Identifier | Name                 |
+      | p_1        | hu_bpc_dbl_product   |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name           | Value          | OPT.Description        | OPT.IsActive |
+      | ps_1       | hu_bpc_dbl_ps  | hu_bpc_dbl_ps  | hu_bpc_dbl_ps_descr    | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name           | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | hu_bpc_dbl_pl  | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name            | ValidFrom  |
+      | plv_1      | pl_1                      | hu_bpc_dbl_plv  | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+
+    # Three customers
+    And metasfresh contains C_BPartners:
+      | Identifier     | Name                | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | endcustomer_A  | hu_bpc_dbl_cust_A   | N            | Y              | ps_1                          | D               |
+      | endcustomer_B  | hu_bpc_dbl_cust_B   | N            | Y              | ps_1                          | D               |
+      | endcustomer_C  | hu_bpc_dbl_cust_C   | N            | Y              | ps_1                          | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | loc_A      | 0123456789021 | endcustomer_A            | Y                   | Y                   |
+      | loc_B      | 0123456789022 | endcustomer_B            | Y                   | Y                   |
+      | loc_C      | 0123456789023 | endcustomer_C            | Y                   | Y                   |
+
+    # Create stock via inventory (10 PCE)
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_1                     | 2021-04-01   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_1                     | inv_l_1                       | p_1                     | 0       | 10       | PCE          |
+    When the inventory identified by inv_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | inv_l_1                       | hu_1               |
+
+    # Verify initial state
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | A        | Y        | null          | null                   |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 10        |
+
+    # === Cycle 1: Ship to Customer A ===
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference      |
+      | o_A        | true    | endcustomer_A            | 2021-04-17  | po_ref_dbl_A         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_A       | o_A                   | p_1                     | 10         |
+    When the order identified by o_A is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_A      | ol_A                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_A                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_A                            | ship_A                | CO            |
+
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | E        | N        | endcustomer_A | loc_A                  |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 0         |
+
+    # === Reverse shipment to A ===
+    And perform shipment document action
+      | M_InOut_ID.Identifier | DocAction |
+      | ship_A                | RC        |
+
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | A        | Y        | null          | null                   |
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_1     | hu_1               | p_1                     | 10  |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 10        |
+
+    # === Cycle 2: Ship to Customer B ===
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference      |
+      | o_B        | true    | endcustomer_B            | 2021-04-18  | po_ref_dbl_B         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_B       | o_B                   | p_1                     | 10         |
+    When the order identified by o_B is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_B      | ol_B                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_B                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_B                            | ship_B                | CO            |
+
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | E        | N        | endcustomer_B | loc_B                  |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 0         |
+
+    # === Reverse shipment to B ===
+    And perform shipment document action
+      | M_InOut_ID.Identifier | DocAction |
+      | ship_B                | RC        |
+
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | A        | Y        | null          | null                   |
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_1     | hu_1               | p_1                     | 10  |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 10        |
+
+    # === Cycle 3: Ship to Customer C ===
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference      |
+      | o_C        | true    | endcustomer_C            | 2021-04-19  | po_ref_dbl_C         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_C       | o_C                   | p_1                     | 10         |
+    When the order identified by o_C is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_C      | ol_C                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_C                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_C                            | ship_C                | CO            |
+
+    Then M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | E        | N        | endcustomer_C | loc_C                  |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 0         |
+
+  @from:cucumber
+  Scenario: reactivate then re-complete then reverse clears BPartner (path 2.11)
+    # Reactivation (RA) puts shipment back to InProgress for editing.
+    # Re-completing then reversing must still properly clear BPartner on HU.
+    Given metasfresh contains M_Products:
+      | Identifier | Name                    |
+      | p_1        | hu_bpc_react_product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name            | Value           | OPT.IsActive |
+      | ps_1       | hu_bpc_react_ps | hu_bpc_react_ps | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name            | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | hu_bpc_react_pl | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name             | ValidFrom  |
+      | plv_1      | pl_1                      | hu_bpc_react_plv | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+
+    And metasfresh contains C_BPartners:
+      | Identifier     | Name                 | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | endcustomer_A  | hu_bpc_react_cust_A  | N            | Y              | ps_1                          | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | loc_A      | 0123456789091 | endcustomer_A            | Y                   | Y                   |
+
+    # Create stock: 10 PCE
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_1                     | 2021-04-01   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_1                     | inv_l_1                       | p_1                     | 0       | 10       | PCE          |
+    When the inventory identified by inv_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | inv_l_1                       | hu_1               |
+
+    # Ship to Customer A
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference    |
+      | o_A        | true    | endcustomer_A            | 2021-04-17  | po_ref_react_A     |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_A       | o_A                   | p_1                     | 10         |
+    When the order identified by o_A is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_A      | ol_A                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_A                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_A                            | ship_A                | CO            |
+
+    # Log AD_EventLog count before RA→CO→RC cycle (baseline)
+    And log AD_EventLog count for product "p_1"
+
+    # Reactivate the shipment (RA — puts document back to InProgress for editing)
+    When the shipment identified by ship_A is reactivated
+    And log AD_EventLog count for product "p_1"
+
+    # Re-complete the shipment
+    And the shipment identified by ship_A is completed
+    And log AD_EventLog count for product "p_1"
+
+    # Now reverse — this must clear BPartner even after the reactivation cycle
+    And perform shipment document action
+      | M_InOut_ID.Identifier | DocAction |
+      | ship_A                | RC        |
+    And log AD_EventLog count for product "p_1"
+
+    # After reversal: HU is active again, BPartner+Location cleared
+    Then M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | A        | Y        | null          | null                   |
+    # RA→CO→RC creates 3 async events (delete+create+create) that must all propagate
+    # through RabbitMQ before MD_Stock reaches its final value. Use 120s for CI headroom.
+    And after not more than 120 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 10        |
+
+  @from:cucumber
+  Scenario: LU/TU/VHU hierarchy: on-the-fly picking splits VHU from hierarchy, reversal restores the split VHU
+    # On-the-fly picking from an LU/TU/VHU hierarchy splits a new VHU out of the hierarchy.
+    # The original hierarchy gets depleted (status D). The split VHU gets shipped (status E).
+    # This test validates that reversal properly clears BPartner on the split VHU,
+    # and that it can then be re-shipped to a different customer.
+    Given set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+
+    # Product and pricing
+    Given metasfresh contains M_Products:
+      | Identifier | Name                    |
+      | p_1        | hu_bpc_hier_product     |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name            | Value           | OPT.IsActive |
+      | ps_1       | hu_bpc_hier_ps  | hu_bpc_hier_ps  | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name            | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | hu_bpc_hier_pl  | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name             | ValidFrom  |
+      | plv_1      | pl_1                      | hu_bpc_hier_plv  | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+
+    # Two customers
+    And metasfresh contains C_BPartners:
+      | Identifier     | Name                | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | endcustomer_A  | hu_bpc_hier_cust_A  | N            | Y              | ps_1                          | D               |
+      | endcustomer_B  | hu_bpc_hier_cust_B  | N            | Y              | ps_1                          | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | loc_A      | 0123456789031 | endcustomer_A            | Y                   | Y                   |
+      | loc_B      | 0123456789032 | endcustomer_B            | Y                   | Y                   |
+
+    # Packing Instruction hierarchy: LU (holds 10 TUs) -> TU (holds 10 PCE) -> Virtual
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID.Identifier | Name            |
+      | huPackingLU           | huPackingLU     |
+      | huPackingTU           | huPackingTU     |
+      | huPackingVirtualPI    | No Packing Item |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID.Identifier | M_HU_PI_ID.Identifier | Name             | HU_UnitType | IsCurrent |
+      | packingVersionLU              | huPackingLU           | packingVersionLU | LU          | Y         |
+      | packingVersionTU              | huPackingTU           | packingVersionTU | TU          | Y         |
+      | packingVersionCU              | huPackingVirtualPI    | No Packing Item  | V           | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType | OPT.Included_HU_PI_ID.Identifier |
+      | huPiItemLU                 | packingVersionLU              | 10  | HU       | huPackingTU                      |
+      | huPiItemTU                 | packingVersionTU              | 0   | MI       |                                  |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | huProductTU                        | huPiItemTU                 | p_1                     | 10  | 2021-01-01 |
+
+    # Create stock via inventory (10 PCE -> VHU)
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_1                     | 2021-04-01   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_1                     | inv_l_1                       | p_1                     | 0       | 10       | PCE          |
+    When the inventory identified by inv_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | inv_l_1                       | createdCU          |
+
+    # Build hierarchy: CU -> TU -> LU
+    And transform CU to new TUs
+      | sourceCU.Identifier | cuQty | M_HU_PI_Item_Product_ID.Identifier | OPT.resultedNewTUs.Identifier | OPT.resultedNewCUs.Identifier |
+      | createdCU           | 10    | huProductTU                        | createdTU                     | newCreatedCU                  |
+    And transform TU to new LUs
+      | sourceTU.Identifier | tuQty | M_HU_PI_Item_ID.Identifier | resultedNewLUs.Identifier |
+      | createdTU           | 1     | huPiItemLU                 | createdLU                 |
+
+    # Validate LU/TU/VHU hierarchy: all Active, no BPartner, storage=10 at each level
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | createdLU          | A        | Y        | null          | null                   |
+      | createdTU          | A        | Y        | null          | null                   |
+      | newCreatedCU       | A        | Y        | null          | null                   |
+
+    # Ship to Customer A (on-the-fly picking splits a VHU from the LU hierarchy)
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference      |
+      | o_A        | true    | endcustomer_A            | 2021-04-17  | po_ref_hier_A        |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_A       | o_A                   | p_1                     | 10         |
+    When the order identified by o_A is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_A      | ol_A                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_A                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_A                            | ship_A                | CO            |
+
+    # On-the-fly picking extracts newCreatedCU from the LU/TU hierarchy.
+    # The VHU (newCreatedCU) is shipped with Customer A's BPartner.
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | newCreatedCU       | E        | N        | endcustomer_A | loc_A                  |
+
+    # The original LU/TU hierarchy is depleted (stock was extracted by on-the-fly picking)
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus |
+      | createdLU          | D        |
+      | createdTU          | D        |
+
+    # Reverse the shipment
+    And perform shipment document action
+      | M_InOut_ID.Identifier | DocAction |
+      | ship_A                | RC        |
+
+    # After reversal: VHU is restored, BPartner+Location cleared
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | newCreatedCU       | A        | Y        | null          | null                   |
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_cu    | newCreatedCU       | p_1                     | 10  |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 10        |
+
+    # Ship the restored VHU to Customer B
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference      |
+      | o_B        | true    | endcustomer_B            | 2021-04-18  | po_ref_hier_B        |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_B       | o_B                   | p_1                     | 10         |
+    When the order identified by o_B is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_B      | ol_B                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_B                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_B                            | ship_B                | CO            |
+
+    # VHU is now shipped to Customer B
+    Then M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | newCreatedCU       | E        | N        | endcustomer_B | loc_B                  |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 0         |
+
+  @from:cucumber
+  Scenario: partial shipment reversal clears BPartner on the split VHU
+    # On-the-fly picking from a 10 PCE HU for a 5 PCE order splits a new 5 PCE VHU.
+    # Reversing that partial shipment should clear BPartner on the split VHU,
+    # allowing it to be re-shipped to a different customer.
+    Given metasfresh contains M_Products:
+      | Identifier | Name                    |
+      | p_1        | hu_bpc_partial_product  |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name               | Value              | OPT.IsActive |
+      | ps_1       | hu_bpc_partial_ps  | hu_bpc_partial_ps  | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name               | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | hu_bpc_partial_pl  | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                | ValidFrom  |
+      | plv_1      | pl_1                      | hu_bpc_partial_plv  | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+
+    # Two customers
+    And metasfresh contains C_BPartners:
+      | Identifier     | Name                    | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | endcustomer_A  | hu_bpc_partial_cust_A   | N            | Y              | ps_1                          | D               |
+      | endcustomer_B  | hu_bpc_partial_cust_B   | N            | Y              | ps_1                          | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | loc_A      | 0123456789041 | endcustomer_A            | Y                   | Y                   |
+      | loc_B      | 0123456789042 | endcustomer_B            | Y                   | Y                   |
+
+    # Create stock: 10 PCE in one VHU
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_1                     | 2021-04-01   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_1                     | inv_l_1                       | p_1                     | 0       | 10       | PCE          |
+    When the inventory identified by inv_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | inv_l_1                       | hu_1               |
+
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_1     | hu_1               | p_1                     | 10  |
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | A        | Y        | null          | null                   |
+
+    # Order only 5 PCE for Customer A (partial: less than full HU qty)
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference          |
+      | o_A        | true    | endcustomer_A            | 2021-04-17  | po_ref_partial_A         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_A       | o_A                   | p_1                     | 5          |
+    When the order identified by o_A is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_A      | ol_A                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_A                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_A                            | ship_A                | CO            |
+
+    # On-the-fly picking splits a new VHU with 5 PCE from the source HU.
+    # Locate the split VHU via QtyPicked records.
+    And M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule s_s_A can be located in specified order
+      | M_ShipmentSchedule_QtyPicked_ID.Identifier |
+      | qp_A                                       |
+    And load M_HU as splitVHU_A from M_ShipmentSchedule_QtyPicked identified by qp_A
+
+    # The split VHU is shipped with Customer A's BPartner
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | splitVHU_A         | E        | N        | endcustomer_A | loc_A                  |
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_split | splitVHU_A         | p_1                     | 5   |
+
+    # Reverse the partial shipment
+    And perform shipment document action
+      | M_InOut_ID.Identifier | DocAction |
+      | ship_A                | RC        |
+
+    # After reversal: split VHU restored, BPartner cleared
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | splitVHU_A         | A        | Y        | null          | null                   |
+    Then after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 10        |
+
+    # Re-ship 5 PCE to Customer B — validates the reversed HU is available for a different customer.
+    # NOTE: We intentionally do NOT load the picked HU via "load M_HU as pickedVHU_B" because
+    # on-the-fly picking deterministically picks hu_1 (lowest M_HU_ID), and hu_1 is already
+    # registered in StepDefData. Instead we validate via shipment creation + MD_Stock.
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference          |
+      | o_B        | true    | endcustomer_B            | 2021-04-18  | po_ref_partial_B         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_B       | o_B                   | p_1                     | 5          |
+    When the order identified by o_B is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_B      | ol_B                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_B                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_B                            | ship_B                | CO            |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 5         |
+
+  @from:cucumber
+  Scenario: picking cancellation clears BPartner on HU (Bug 2 fix)
+    # When an HU is picked for a shipment schedule, BPartner is set on the HU.
+    # Cancelling/unprocessing the picking should clear BPartner, allowing re-pick for another customer.
+    # This tests the fix in HUShipmentScheduleBL.deleteByTopLevelHUsAndShipmentScheduleId().
+    Given metasfresh contains M_Products:
+      | Identifier | Name                    |
+      | p_1        | hu_bpc_unpick_product   |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name               | Value              | OPT.IsActive |
+      | ps_1       | hu_bpc_unpick_ps   | hu_bpc_unpick_ps   | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name               | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | hu_bpc_unpick_pl   | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                | ValidFrom  |
+      | plv_1      | pl_1                      | hu_bpc_unpick_plv   | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+
+    # Two customers
+    And metasfresh contains C_BPartners:
+      | Identifier     | Name                    | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | endcustomer_A  | hu_bpc_unpick_cust_A    | N            | Y              | ps_1                          | D               |
+      | endcustomer_B  | hu_bpc_unpick_cust_B    | N            | Y              | ps_1                          | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | loc_A      | 0123456789051 | endcustomer_A            | Y                   | Y                   |
+      | loc_B      | 0123456789052 | endcustomer_B            | Y                   | Y                   |
+
+    # Create stock: 10 PCE
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_1                     | 2021-04-01   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_1                     | inv_l_1                       | p_1                     | 0       | 10       | PCE          |
+    When the inventory identified by inv_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | inv_l_1                       | hu_1               |
+
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | A        | Y        | null          | null                   |
+
+    # Create order for Customer A
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference          |
+      | o_A        | true    | endcustomer_A            | 2021-04-17  | po_ref_unpick_A          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_A       | o_A                   | p_1                     | 10         |
+    When the order identified by o_A is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_A      | ol_A                      | N             |
+
+    # Pick the HU for Customer A's shipment schedule (sets BPartner on HU)
+    And the following qty is picked
+      | M_ShipmentSchedule_ID.Identifier | M_HU_ID.Identifier | QtyPicked |
+      | s_s_A                            | hu_1               | 10        |
+
+    # After picking: HU should have BPartner from shipment schedule
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | S        | Y        | endcustomer_A | loc_A                  |
+
+    # Cancel/unprocess picking — Bug 2 fix should clear BPartner
+    And unprocess picking candidates for shipment schedule
+      | M_ShipmentSchedule_ID.Identifier |
+      | s_s_A                            |
+
+    # After unprocessing: BPartner should be cleared
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | A        | Y        | null          | null                   |
+
+    # Create order for Customer B
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference          |
+      | o_B        | true    | endcustomer_B            | 2021-04-18  | po_ref_unpick_B          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_B       | o_B                   | p_1                     | 10         |
+    When the order identified by o_B is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_B      | ol_B                      | N             |
+
+    # Pick the same HU for Customer B's shipment schedule
+    And the following qty is picked
+      | M_ShipmentSchedule_ID.Identifier | M_HU_ID.Identifier | QtyPicked |
+      | s_s_B                            | hu_1               | 10        |
+
+    # After re-picking: HU should now belong to Customer B
+    Then M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | S        | Y        | endcustomer_B | loc_B                  |
+
+  @from:cucumber
+  Scenario: customer return reversal destroys auto-created HUs (PR 22317 coverage)
+    # Tests the customer return flow from PR #22317:
+    # 1. Customer return WITHOUT HUs is created from a completed shipment
+    # 2. On completion, HUs are auto-created (via CustomerReturnHUsCreateCommand)
+    # 3. On reversal, those HUs are destroyed (via HUInOutBL.destroyHandlingUnitsIfReversedInboundTransaction)
+    Given metasfresh contains M_Products:
+      | Identifier | Name                    |
+      | p_1        | hu_bpc_creturn_product  |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                | Value               | OPT.IsActive |
+      | ps_1       | hu_bpc_creturn_ps   | hu_bpc_creturn_ps   | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | hu_bpc_creturn_pl   | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                 | ValidFrom  |
+      | plv_1      | pl_1                      | hu_bpc_creturn_plv   | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+
+    And metasfresh contains C_BPartners:
+      | Identifier     | Name                    | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | endcustomer_A  | hu_bpc_creturn_cust_A   | N            | Y              | ps_1                          | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | loc_A      | 0123456789061 | endcustomer_A            | Y                   | Y                   |
+
+    # Create stock: 10 PCE
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_1                     | 2021-04-01   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_1                     | inv_l_1                       | p_1                     | 0       | 10       | PCE          |
+    When the inventory identified by inv_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | inv_l_1                       | hu_1               |
+
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | A        | Y        | null          | null                   |
+
+    # Ship to customer
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference          |
+      | o_A        | true    | endcustomer_A            | 2021-04-17  | po_ref_creturn_A         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_A       | o_A                   | p_1                     | 10         |
+    When the order identified by o_A is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_A      | ol_A                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_A                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_A                            | ship_A                | CO            |
+
+    # Shipment is complete — HU shipped
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | E        | N        | endcustomer_A | loc_A                  |
+
+    # Quality return warehouse required for customer returns
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID.Identifier | Value                 | Name                  | OPT.IsQualityReturnWarehouse |
+      | returnWarehouse           | hu_bpc_creturn_ret_wh | hu_bpc_creturn_ret_wh | true                         |
+
+    # Generate customer return from the shipment (Draft — no HUs yet)
+    And generate customer return from shipment
+      | M_InOut_ID.Identifier | CustomerReturn_ID.Identifier |
+      | ship_A                | return_A                     |
+
+    # Complete the customer return — triggers auto-creation of HUs
+    And perform shipment document action
+      | M_InOut_ID.Identifier | DocAction |
+      | return_A              | CO        |
+
+    # Load the auto-created HUs from the completed customer return
+    And load HUs assigned to M_InOut
+      | M_InOut_ID.Identifier | M_HU_ID.Identifier |
+      | return_A              | return_hu_1         |
+
+    # Verify the auto-created HU is Active
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | return_hu_1        | A        | Y        |
+
+    # Reverse the customer return — should destroy the auto-created HUs
+    And perform shipment document action
+      | M_InOut_ID.Identifier | DocAction |
+      | return_A              | RC        |
+
+    # Verify the HU is now Destroyed
+    Then M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | return_hu_1        | D        | N        |
+
+  @from:cucumber
+  Scenario: inventory adjustment on existing HU reduces stock and allows shipment of adjusted qty (path 2.6)
+    # Stock 10 PCE → Inventory adjust to 5 → Ship 5 to customer
+    # Validates that inventory correctly reduces HU storage and the reduced qty can be shipped
+    Given metasfresh contains M_Products:
+      | Identifier | Name                    |
+      | p_1        | hu_bpc_invadj_product   |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name               | Value              | OPT.IsActive |
+      | ps_1       | hu_bpc_invadj_ps   | hu_bpc_invadj_ps   | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name               | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | hu_bpc_invadj_pl   | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                | ValidFrom  |
+      | plv_1      | pl_1                      | hu_bpc_invadj_plv   | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+
+    And metasfresh contains C_BPartners:
+      | Identifier     | Name                    | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | endcustomer_A  | hu_bpc_invadj_cust_A    | N            | Y              | ps_1                          | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | loc_A      | 0123456789071 | endcustomer_A            | Y                   | Y                   |
+
+    # Create stock: 10 PCE
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_1                     | 2021-04-01   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_1                     | inv_l_1                       | p_1                     | 0       | 10       | PCE          |
+    When the inventory identified by inv_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | inv_l_1                       | hu_1               |
+
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_1     | hu_1               | p_1                     | 10  |
+
+    # Inventory adjustment: reduce HU from 10 to 5 (outbound — requires M_HU_ID)
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_adj                   | 2021-04-02   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 | M_HU_ID.Identifier |
+      | inv_adj                   | inv_adj_l1                    | p_1                     | 10      | 5        | PCE          | hu_1               |
+    When the inventory identified by inv_adj is completed
+
+    # Verify HU now has only 5 PCE
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_adj   | hu_1               | p_1                     | 5   |
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID |
+      | hu_1               | A        | Y        | null          |
+
+    # Ship the adjusted 5 PCE to customer
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference          |
+      | o_A        | true    | endcustomer_A            | 2021-04-17  | po_ref_invadj_A          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_A       | o_A                   | p_1                     | 5          |
+    When the order identified by o_A is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_A      | ol_A                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_A                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_A                            | ship_A                | CO            |
+
+    Then M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | E        | N        | endcustomer_A | loc_A                  |
+
+  @from:cucumber
+  Scenario: inventory to zero destroys HU (path 2.7)
+    # Stock 10 PCE → Inventory count to 0 → HU is destroyed
+    Given metasfresh contains M_Products:
+      | Identifier | Name                    |
+      | p_1        | hu_bpc_invzero_product  |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                | Value               | OPT.IsActive |
+      | ps_1       | hu_bpc_invzero_ps   | hu_bpc_invzero_ps   | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | hu_bpc_invzero_pl   | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                 | ValidFrom  |
+      | plv_1      | pl_1                      | hu_bpc_invzero_plv   | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+
+    # Create stock: 10 PCE
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_1                     | 2021-04-01   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_1                     | inv_l_1                       | p_1                     | 0       | 10       | PCE          |
+    When the inventory identified by inv_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | inv_l_1                       | hu_1               |
+
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_1     | hu_1               | p_1                     | 10  |
+
+    # Inventory to zero: count HU as empty (outbound — requires M_HU_ID)
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_zero                  | 2021-04-02   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 | M_HU_ID.Identifier |
+      | inv_zero                  | inv_zero_l1                   | p_1                     | 10      | 0        | PCE          | hu_1               |
+    When the inventory identified by inv_zero is completed
+
+    # Verify HU is destroyed (empty HUs get destroyed by SyncInventoryQtyToHUsCommand)
+    Then M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive |
+      | hu_1               | D        | N        |
+
+  @from:cucumber
+  Scenario: shipment reversal then inventory adjustment then re-ship (path 2.8)
+    # Stock 10 → Ship to A → Reverse → Inventory adjust to 5 → Ship 5 to B
+    # Validates the full lifecycle with inventory adjustment between reversal and re-ship
+    Given metasfresh contains M_Products:
+      | Identifier | Name                    |
+      | p_1        | hu_bpc_revinv_product   |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                | Value               | OPT.IsActive |
+      | ps_1       | hu_bpc_revinv_ps    | hu_bpc_revinv_ps    | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | hu_bpc_revinv_pl    | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                 | ValidFrom  |
+      | plv_1      | pl_1                      | hu_bpc_revinv_plv    | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+
+    And metasfresh contains C_BPartners:
+      | Identifier     | Name                    | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | endcustomer_A  | hu_bpc_revinv_cust_A    | N            | Y              | ps_1                          | D               |
+      | endcustomer_B  | hu_bpc_revinv_cust_B    | N            | Y              | ps_1                          | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | loc_A      | 0123456789081 | endcustomer_A            | Y                   | Y                   |
+      | loc_B      | 0123456789082 | endcustomer_B            | Y                   | Y                   |
+
+    # Create stock: 10 PCE
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_1                     | 2021-04-01   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_1                     | inv_l_1                       | p_1                     | 0       | 10       | PCE          |
+    When the inventory identified by inv_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | inv_l_1                       | hu_1               |
+
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID |
+      | hu_1               | A        | Y        | null          |
+
+    # Ship 10 to Customer A
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference          |
+      | o_A        | true    | endcustomer_A            | 2021-04-17  | po_ref_revinv_A          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_A       | o_A                   | p_1                     | 10         |
+    When the order identified by o_A is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_A      | ol_A                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_A                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_A                            | ship_A                | CO            |
+
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID |
+      | hu_1               | E        | N        | endcustomer_A |
+
+    # Reverse shipment to A
+    And perform shipment document action
+      | M_InOut_ID.Identifier | DocAction |
+      | ship_A                | RC        |
+
+    # After reversal: HU restored, BPartner cleared, qty=10
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID |
+      | hu_1               | A        | Y        | null          |
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_1     | hu_1               | p_1                     | 10  |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 10        |
+
+    # Inventory adjustment: reduce from 10 to 5
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_adj                   | 2021-04-18   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 | M_HU_ID.Identifier |
+      | inv_adj                   | inv_adj_l1                    | p_1                     | 10      | 5        | PCE          | hu_1               |
+    When the inventory identified by inv_adj is completed
+
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_adj   | hu_1               | p_1                     | 5   |
+    And M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID |
+      | hu_1               | A        | Y        | null          |
+
+    # Ship 5 to Customer B
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference          |
+      | o_B        | true    | endcustomer_B            | 2021-04-19  | po_ref_revinv_B          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_B       | o_B                   | p_1                     | 5          |
+    When the order identified by o_B is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_B      | ol_B                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_B                            | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_B                            | ship_B                | CO            |
+
+    Then M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID | C_BPartner_Location_ID |
+      | hu_1               | E        | N        | endcustomer_B | loc_B                  |
+    And after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand |
+      | p_1                     | 0         |
+
+  @from:cucumber
+  Scenario: inventory reversal restores HU qty (path 2.10)
+    # Stock 10 → Inventory adjust to 5 → Reverse inventory → Qty restored to 10
+    Given metasfresh contains M_Products:
+      | Identifier | Name                    |
+      | p_1        | hu_bpc_invrev_product   |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                | Value               | OPT.IsActive |
+      | ps_1       | hu_bpc_invrev_ps    | hu_bpc_invrev_ps    | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | hu_bpc_invrev_pl    | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                 | ValidFrom  |
+      | plv_1      | pl_1                      | hu_bpc_invrev_plv    | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+
+    # Create stock: 10 PCE
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_1                     | 2021-04-01   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_1                     | inv_l_1                       | p_1                     | 0       | 10       | PCE          |
+    When the inventory identified by inv_1 is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | inv_l_1                       | hu_1               |
+
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_1     | hu_1               | p_1                     | 10  |
+
+    # Inventory adjustment: reduce from 10 to 5
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inv_adj                   | 2021-04-02   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 | M_HU_ID.Identifier |
+      | inv_adj                   | inv_adj_l1                    | p_1                     | 10      | 5        | PCE          | hu_1               |
+    When the inventory identified by inv_adj is completed
+
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_adj   | hu_1               | p_1                     | 5   |
+
+    # Reverse the inventory adjustment — qty should be restored to 10
+    When the inventory identified by inv_adj is reversed
+
+    And M_HU_Storage are validated
+      | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
+      | hu_s_rev   | hu_1               | p_1                     | 10  |
+    Then M_HU are validated:
+      | M_HU_ID.Identifier | HUStatus | IsActive | C_BPartner_ID |
+      | hu_1               | A        | Y        | null          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/reversedShipmentClearsBPartner.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/reversedShipmentClearsBPartner.feature
@@ -741,6 +741,11 @@ Feature: reversed shipment clears HU C_BPartner_ID
       | hu_1               | S        | Y        | endcustomer_B | loc_B                  |
 
   @from:cucumber
+  @ignore
+  # IGNORED on oasis_sun_hotfix: depends on Return_Origin_InOut_ID column and conditional
+  # generateHUsForCustomerReturn (SysConfig CustomerReturnsInOut.FailIfNoHUsAssigned) which
+  # only exist on keen_hawk_hotfix. Cherry-picked from #22332 without adapting for model
+  # differences. Remove @ignore when merging to new_dawn_uat where these features exist.
   Scenario: customer return reversal destroys auto-created HUs (PR 22317 coverage)
     # Tests the customer return flow from PR #22317:
     # 1. Customer return WITHOUT HUs is created from a completed shipment

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/stock/mdStock_AddInventory.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/stock/mdStock_AddInventory.feature
@@ -10,6 +10,7 @@ Feature: stock changes accordingly
     Given infrastructure and metasfresh are running
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
 	And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
 
     And no product with value 'product_value222' exists
     And metasfresh contains M_Products:

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/impl/HUShipmentAssignmentBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/impl/HUShipmentAssignmentBL.java
@@ -220,6 +220,8 @@ public class HUShipmentAssignmentBL implements IHUShipmentAssignmentBL
 		{
 			huStatusBL.setHUStatus(huContext, hu, X_M_HU.HUSTATUS_Active);
 			hu.setIsActive(true);
+			hu.setC_BPartner_ID(-1);
+			hu.setC_BPartner_Location_ID(-1);
 
 			final I_M_Locator locator = InterfaceWrapperHelper.create(warehouseBL.getLocatorByRepoId(hu.getM_Locator_ID()), I_M_Locator.class);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/material/interceptor/M_Transaction_PostTransactionEvent.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/material/interceptor/M_Transaction_PostTransactionEvent.java
@@ -82,7 +82,10 @@ public class M_Transaction_PostTransactionEvent
 		final List<MaterialEvent> events = transactionEventCreator.createEventsForTransaction(transaction, deleted);
 		for (final MaterialEvent event : events)
 		{
-			materialEventService.enqueueEventAfterNextCommit(event);
+			// Use enqueueEventNow because this method runs inside a runAfterCommit callback,
+			// meaning data is already committed. Using enqueueEventAfterNextCommit here would
+			// nest two after-commit registrations, unnecessarily delaying event posting.
+			materialEventService.enqueueEventNow(event);
 		}
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/material/interceptor/transactionevent/HUDescriptorService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/material/interceptor/transactionevent/HUDescriptorService.java
@@ -83,10 +83,13 @@ public class HUDescriptorService
 					.toBigDecimal()
 					.max(BigDecimal.ZERO); // guard against the quantity being e.g. -0.001 for whatever reason
 
+			// Always use the actual HU storage quantity. Previously, deleted events used BigDecimal.ZERO,
+			// which caused TransactionDeletedEvent.getQuantityDelta() to return 0 and MD_Stock to not be
+			// updated when M_Transactions were deleted (e.g., during shipment reactivation RA).
 			final HUDescriptor descriptor = HUDescriptor.builder()
 					.huId(huRecord.getM_HU_ID())
 					.productDescriptor(productDescriptor)
-					.quantity(deleted ? BigDecimal.ZERO : quantity)
+					.quantity(quantity)
 					.build();
 			descriptors.add(descriptor);
 		}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/material/interceptor/transactionevent/TransactionEventFactoryForInOutLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/material/interceptor/transactionevent/TransactionEventFactoryForInOutLine.java
@@ -137,10 +137,20 @@ public class TransactionEventFactoryForInOutLine
 			final AbstractTransactionEvent event;
 			if (deleted || isReversal)
 			{
+				// For reversals (isReversal && !deleted), the reversal M_Transaction already has the
+				// opposite sign (+10 to undo a -10 shipment). Since TransactionDeletedEvent.getQuantityDelta()
+				// negates the MaterialDescriptor quantity, we must negate it here first to avoid a
+				// double-negation that would decrease stock instead of restoring it.
+				// Example without fix: descriptor.qty=+10 → getQuantityDelta()=negate(+10)=-10 → stock DECREASES (wrong!)
+				// Example with fix:    descriptor.qty=-10 → getQuantityDelta()=negate(-10)=+10 → stock INCREASES (correct)
+				final MaterialDescriptor eventMaterialDescriptor = isReversal && !deleted
+						? materialDescriptor.withQuantity(materialDescriptor.getQuantity().negate())
+						: materialDescriptor;
+
 				event = TransactionDeletedEvent.builder()
 						.eventDescriptor(transaction.getEventDescriptor())
 						.transactionId(transaction.getTransactionId())
-						.materialDescriptor(materialDescriptor)
+						.materialDescriptor(eventMaterialDescriptor)
 						.huOnHandQtyChangeDescriptors(huOnHandQtyChangeDescriptors)
 						.shipmentId(shipmentLineId)
 						.directMovementWarehouse(directMovementWarehouse)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUComparator.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUComparator.java
@@ -38,9 +38,13 @@ import lombok.NonNull;
  * Sort {@link IShipmentScheduleWithHU} records by
  * <ul>
  * <li>Shipment Schedule's header aggregation key ({@link I_M_ShipmentSchedule#getHeaderAggregationKey()})
- * <li>TU's M_HU_ID ({@link IShipmentScheduleWithHU#getM_TU_HU()})
  * <li>M_ShipmentSchedule_ID ({@link I_M_ShipmentSchedule#getM_ShipmentSchedule_ID()})
+ * <li>M_HU_ID (smaller first, no-HU last)
  * </ul>
+ *
+ * M_ShipmentSchedule_ID is sorted before M_HU_ID to group all candidates for the same
+ * product/order-line together, ensuring deterministic shipment line ordering regardless of
+ * which HUs happen to have lower IDs.
  *
  * @author tsa
  *
@@ -83,7 +87,19 @@ public class ShipmentScheduleWithHUComparator implements Comparator<ShipmentSche
 		}
 
 		//
-		// Sort by M_HU_ID - instances a smaller M_HU_ID go first, but instances with no HU go last;
+		// Sort by M_ShipmentSchedule_ID first, to group all candidates for the same
+		// product/order-line together
+		{
+			final int shipmentScheduleId1 = getM_ShipmentSchedule_ID(o1);
+			final int shipmentScheduleId2 = getM_ShipmentSchedule_ID(o2);
+			if (shipmentScheduleId1 != shipmentScheduleId2)
+			{
+				return shipmentScheduleId1 - shipmentScheduleId2;
+			}
+		}
+
+		//
+		// Sort by M_HU_ID - instances with a smaller M_HU_ID go first, but instances with no HU go last;
 		// important because when we mix instances with and without HU, the ones with HU need to "take the lead"!
 		{
 			final int huId1 = getM_HU_ID(o1);
@@ -92,17 +108,6 @@ public class ShipmentScheduleWithHUComparator implements Comparator<ShipmentSche
 			{
 				// o1 has a smaller M_HU_ID => result is < 0 => o1 is smaller and goes first
 				return huId1 - huId2;
-			}
-		}
-
-		//
-		// Sort by M_ShipmentSchedule_ID
-		{
-			final int shipmentScheduleId1 = getM_ShipmentSchedule_ID(o1);
-			final int shipmentScheduleId2 = getM_ShipmentSchedule_ID(o2);
-			if (shipmentScheduleId1 != shipmentScheduleId2)
-			{
-				return shipmentScheduleId1 - shipmentScheduleId2;
 			}
 		}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -801,6 +801,11 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 			final List<I_M_ShipmentSchedule_QtyPicked> qtyPickedRecords = huShipmentScheduleDAO.retrieveByTopLevelHUAndShipmentScheduleId(topLevelHU, shipmentScheduleId);
 			assertNotAlreadyShipped(qtyPickedRecords, HuId.ofRepoId(topLevelHU.getM_HU_ID()));
 			shipmentScheduleAllocBL.deleteRecords(qtyPickedRecords);
+
+			// also reset the HU's partner and location (same pattern as unallocateTU)
+			topLevelHU.setC_BPartner_ID(0);
+			topLevelHU.setC_BPartner_Location_ID(0);
+			save(topLevelHU);
 		}
 	}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/async/GenerateInOutFromShipmentSchedules.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/async/GenerateInOutFromShipmentSchedules.java
@@ -213,8 +213,7 @@ public class GenerateInOutFromShipmentSchedules extends WorkpackageProcessorAdap
 		final ImmutableSet<PickingJobScheduleId> jobScheduleIds = recordRefs.getRecordIdsByTableName(I_M_Picking_Job_Schedule.Table_Name, PickingJobScheduleId::ofRepoId);
 
 		// Guard against stale QtyToDeliver: check if QtyPickList already includes
-		// draft-shipment allocations from a prior workpackage.
-		// See me03#28143.
+		// draft-shipment allocations from a prior workpackage (duplicate trigger race condition).
 		final ImmutableSet<ShipmentScheduleId> schedulesWithDraftAllocations =
 				shipmentScheduleAllocDAO.getScheduleIdsWithDraftShipmentAllocations(shipmentScheduleIds);
 		if (!schedulesWithDraftAllocations.isEmpty())

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/async/GenerateInOutFromShipmentSchedules.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/async/GenerateInOutFromShipmentSchedules.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Level;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import de.metas.async.api.IQueueDAO;
 import de.metas.async.model.I_C_Queue_WorkPackage;
 import de.metas.async.spi.ILatchStragegy;
@@ -22,6 +23,7 @@ import de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWorkPackagePa
 import de.metas.handlingunits.shipmentschedule.spi.impl.CalculateShippingDateRule;
 import de.metas.handlingunits.shipmentschedule.spi.impl.ShipmentScheduleExternalInfo;
 import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.api.IShipmentScheduleAllocDAO;
 import de.metas.inoutcandidate.api.InOutGenerateResult;
 import de.metas.inoutcandidate.model.I_M_Picking_Job_Schedule;
 import de.metas.logging.LogManager;
@@ -58,6 +60,7 @@ public class GenerateInOutFromShipmentSchedules extends WorkpackageProcessorAdap
 	// Services
 	private static final Logger logger = LogManager.getLogger(GenerateInOutFromShipmentSchedules.class);
 	private final IQueueDAO queueDAO = Services.get(IQueueDAO.class);
+	private final IShipmentScheduleAllocDAO shipmentScheduleAllocDAO = Services.get(IShipmentScheduleAllocDAO.class);
 	private final IHUShipmentScheduleBL shipmentScheduleBL = Services.get(IHUShipmentScheduleBL.class);
 	private final ShipmentScheduleWithHUService shipmentScheduleWithHUService = SpringContextHolder.instance.getBean(ShipmentScheduleWithHUService.class);
 	private final PickingJobScheduleService pickingJobScheduleService = SpringContextHolder.instance.getBean(PickingJobScheduleService.class);
@@ -206,8 +209,23 @@ public class GenerateInOutFromShipmentSchedules extends WorkpackageProcessorAdap
 		// FIXME: find a better solution. If nothing else, then "split" the undelivered remainder of a partially delivered schedule off into a new schedule (we do that with ICs too).
 		final TableRecordReferenceSet recordRefs = queueDAO.retrieveQueueElementRecordRefs(getQueueWorkPackageId(), skipAlreadyProcessedItems);
 
-		final ImmutableSet<ShipmentScheduleId> shipmentScheduleIds = recordRefs.getRecordIdsByTableName(I_M_ShipmentSchedule.Table_Name, ShipmentScheduleId::ofRepoId);
+		ImmutableSet<ShipmentScheduleId> shipmentScheduleIds = recordRefs.getRecordIdsByTableName(I_M_ShipmentSchedule.Table_Name, ShipmentScheduleId::ofRepoId);
 		final ImmutableSet<PickingJobScheduleId> jobScheduleIds = recordRefs.getRecordIdsByTableName(I_M_Picking_Job_Schedule.Table_Name, PickingJobScheduleId::ofRepoId);
+
+		// Guard against stale QtyToDeliver: check if QtyPickList already includes
+		// draft-shipment allocations from a prior workpackage.
+		// See me03#28143.
+		final ImmutableSet<ShipmentScheduleId> schedulesWithDraftAllocations =
+				shipmentScheduleAllocDAO.getScheduleIdsWithDraftShipmentAllocations(shipmentScheduleIds);
+		if (!schedulesWithDraftAllocations.isEmpty())
+		{
+			Loggables.withLogger(logger, Level.WARN).addLog(
+					"Skipping {} schedule(s) that already have draft-shipment allocations in QtyPickList "
+							+ "(stale QtyToDeliver, likely duplicate trigger): {}",
+					schedulesWithDraftAllocations.size(), schedulesWithDraftAllocations);
+
+			shipmentScheduleIds = Sets.difference(shipmentScheduleIds, schedulesWithDraftAllocations).immutableCopy();
+		}
 
 		return pickingJobScheduleService.getShipmentScheduleAndJobSchedulesCollection(shipmentScheduleIds, jobScheduleIds);
 	}

--- a/backend/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/TransactionEventHandler.java
+++ b/backend/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/TransactionEventHandler.java
@@ -253,7 +253,26 @@ public class TransactionEventHandler implements MaterialEventHandler<AbstractTra
 
 		if (existingShipmentCandidate != null)
 		{
-			final TreeSet<TransactionDetail> newTransactionDetailsSet = extractAllTransactionDetails(existingShipmentCandidate, changedTransactionDetail);
+			// When an M_Transaction is deleted (e.g., during shipment reactivation RA), the TransactionDeletedEvent
+			// replaces the existing TransactionDetail that has the same transactionId. In that case, the deleted
+			// transaction's contribution should be 0, not the event's negative delta.
+			// Without this, the stale negative detail (-15) from RA persists and cancels out the re-CO's
+			// positive detail (+15), leaving the candidate at qty=0 instead of the expected qty.
+			// For reversals (RC), the TransactionDeletedEvent uses a NEW transactionId (from the reversal
+			// M_Transaction), so it's added as a counter-contribution with the negative delta — which is correct.
+			final TransactionDetail effectiveTransactionDetail;
+			if (event instanceof TransactionDeletedEvent
+					&& existingShipmentCandidate.getTransactionDetails().stream()
+					.anyMatch(td -> td.getTransactionId() == changedTransactionDetail.getTransactionId()))
+			{
+				effectiveTransactionDetail = changedTransactionDetail.toBuilder().quantity(BigDecimal.ZERO).build();
+			}
+			else
+			{
+				effectiveTransactionDetail = changedTransactionDetail;
+			}
+
+			final TreeSet<TransactionDetail> newTransactionDetailsSet = extractAllTransactionDetails(existingShipmentCandidate, effectiveTransactionDetail);
 
 			final Instant firstTransactionDate = extractMinTransactionDate(newTransactionDetailsSet);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleAllocDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleAllocDAO.java
@@ -23,6 +23,7 @@ package de.metas.inoutcandidate.api;
  */
 
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableSet;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.inout.model.I_M_InOut;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
@@ -124,6 +125,17 @@ public interface IShipmentScheduleAllocDAO extends ISingletonService
 	ImmutableListMultimap<ShipmentScheduleId, I_M_ShipmentSchedule_QtyPicked> retrieveOnShipmentLineRecordsByScheduleIds(@NonNull ShipmentScheduleAndJobScheduleIdSet scheduleIds);
 
 	<T extends I_M_ShipmentSchedule_QtyPicked> List<T> retrievePickedOnTheFlyAndNotDelivered(ShipmentScheduleId shipmentScheduleId, Class<T> modelClass);
+
+	/**
+	 * Returns the subset of the given schedule IDs that have unprocessed QtyPicked records
+	 * with M_InOutLine_ID already set — i.e., draft-shipment allocations that are part of
+	 * QtyPickList but not yet reflected in the stored QtyToDeliver.
+	 *
+	 * Used to detect stale QtyToDeliver from race conditions between GenerateInOut workpackages.
+	 *
+	 * @see #retrieveQtyPickedAndUnconfirmed — QtyPickList includes these records
+	 */
+	ImmutableSet<ShipmentScheduleId> getScheduleIdsWithDraftShipmentAllocations(@NonNull Set<ShipmentScheduleId> scheduleIds);
 
 	@NonNull
 	Set<OrderId> retrieveOrderIds(@NonNull org.compiere.model.I_M_InOut inOut);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/ShipmentScheduleAllocQuery.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/ShipmentScheduleAllocQuery.java
@@ -16,12 +16,14 @@ public class ShipmentScheduleAllocQuery
 {
 	@Nullable ShipmentScheduleAndJobScheduleIdSet scheduleIds;
 	@Nullable Boolean alreadyShipped;
+	@Nullable Boolean processed;
 	@Nullable ImmutableSet<HuId> onlyLUIds;
 
 	@Builder
 	private ShipmentScheduleAllocQuery(
 			@Nullable final ShipmentScheduleAndJobScheduleIdSet scheduleIds,
 			@NonNull final Boolean alreadyShipped,
+			@Nullable final Boolean processed,
 			@Nullable final Set<HuId> onlyLUIds)
 	{
 		if ((scheduleIds == null || scheduleIds.isEmpty())
@@ -32,6 +34,7 @@ public class ShipmentScheduleAllocQuery
 
 		this.scheduleIds = scheduleIds;
 		this.alreadyShipped = alreadyShipped;
+		this.processed = processed;
 		this.onlyLUIds = onlyLUIds != null ? ImmutableSet.copyOf(onlyLUIds) : null;
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleAllocDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleAllocDAO.java
@@ -117,6 +117,7 @@ public class ShipmentScheduleAllocDAO implements IShipmentScheduleAllocDAO
 
 		addFilterByShipmentScheduleAndJobScheduleIds(sqlQueryBuilder.getCompositeFilter(), query.getScheduleIds());
 		addAlreadyShippedFilter(sqlQueryBuilder.getCompositeFilter(), query.getAlreadyShipped());
+		addProcessedFilter(sqlQueryBuilder, query.getProcessed());
 
 		if (query.getOnlyLUIds() != null && !query.getOnlyLUIds().isEmpty())
 		{
@@ -153,6 +154,14 @@ public class ShipmentScheduleAllocDAO implements IShipmentScheduleAllocDAO
 		{
 			scheduleFilters.addInArrayFilter(I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID, entireShipmentScheduleIds);
 		}
+	}
+
+	private static void addProcessedFilter(
+			@NonNull final IQueryBuilder<I_M_ShipmentSchedule_QtyPicked> sqlQueryBuilder,
+			@Nullable final Boolean processed)
+	{
+		if (processed == null) {return;}
+		sqlQueryBuilder.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_Processed, processed);
 	}
 
 	private static void addAlreadyShippedFilter(@NonNull final ICompositeQueryFilter<I_M_ShipmentSchedule_QtyPicked> filter, @Nullable final Boolean onShipmentLine)
@@ -369,6 +378,23 @@ public class ShipmentScheduleAllocDAO implements IShipmentScheduleAllocDAO
 						record -> ShipmentScheduleId.ofRepoId(record.getM_ShipmentSchedule_ID()),
 						record -> record
 				));
+	}
+
+	@Override
+	public ImmutableSet<ShipmentScheduleId> getScheduleIdsWithDraftShipmentAllocations(@NonNull final Set<ShipmentScheduleId> scheduleIds)
+	{
+		if (scheduleIds.isEmpty())
+		{
+			return ImmutableSet.of();
+		}
+
+		return stream(ShipmentScheduleAllocQuery.builder()
+				.scheduleIds(ShipmentScheduleAndJobScheduleIdSet.ofShipmentScheduleIds(scheduleIds))
+				.alreadyShipped(true) // M_InOutLine_ID IS NOT NULL
+				.processed(false) // Processed='N'
+				.build())
+				.map(record -> ShipmentScheduleId.ofRepoId(record.getM_ShipmentSchedule_ID()))
+				.collect(ImmutableSet.toImmutableSet());
 	}
 
 	@NonNull

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
@@ -55,7 +55,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 public class ShipmentScheduleHandlerBL implements IShipmentScheduleHandlerBL
 {
 	private static final AdMessageKey MSG_RECORDS_CREATED_1P = AdMessageKey.of("de.metas.inoutCandidate.RECORDS_CREATED");
-	private static final AdMessageKey MSG_RECORD_CREATION_VETOED_1P =  AdMessageKey.of("de.metas.inoutCandidate.RECORD_CREATION_VETOED");
+	private static final AdMessageKey MSG_RECORD_CREATION_VETOED_1P = AdMessageKey.of("de.metas.inoutCandidate.RECORD_CREATION_VETOED");
 
 	private final static Logger logger = LogManager.getLogger(ShipmentScheduleHandlerBL.class);
 
@@ -173,6 +173,7 @@ public class ShipmentScheduleHandlerBL implements IShipmentScheduleHandlerBL
 				result.addAll(invokeHandlerForModel(ctx, handler, handlerRecord, model));
 			}
 		}
+		Loggables.withLogger(logger, Level.DEBUG).addLog("ShipmentScheduleHandler {} created {} shipment schedules", handler, result.size());
 		return result;
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/async/CreateMissingShipmentSchedulesWorkpackageProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/async/CreateMissingShipmentSchedulesWorkpackageProcessor.java
@@ -22,10 +22,12 @@
 
 package de.metas.inoutcandidate.async;
 
+import ch.qos.logback.classic.Level;
 import de.metas.async.AsyncBatchId;
 import de.metas.async.api.IAsyncBatchBL;
 import de.metas.async.api.IEnqueueResult;
 import de.metas.async.api.IQueueDAO;
+import de.metas.async.api.IWorkPackageQueue;
 import de.metas.async.model.I_C_Queue_WorkPackage;
 import de.metas.async.processor.IWorkPackageQueueFactory;
 import de.metas.async.spi.WorkpackageProcessorAdapter;
@@ -36,6 +38,7 @@ import de.metas.inoutcandidate.api.IShipmentSchedulePA;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.logging.LogManager;
+import de.metas.util.ILoggable;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -88,22 +91,32 @@ public class CreateMissingShipmentSchedulesWorkpackageProcessor extends Workpack
 	 */
 	private static boolean _scheduleIfNotPostponed(final IContextAware ctxAware, @Nullable final AsyncBatchId asyncBatchId)
 	{
+		final ILoggable loggable = Loggables.withLogger(logger, Level.DEBUG);
+
 		if (shipmentScheduleBL.allMissingSchedsWillBeCreatedLater())
 		{
-			logger.debug("Not scheduling WP because IShipmentScheduleBL.allMissingSchedsWillBeCreatedLater() returned true: {}", CreateMissingShipmentSchedulesWorkpackageProcessor.class.getSimpleName());
+			loggable.addLog("Not scheduling WP because IShipmentScheduleBL.allMissingSchedsWillBeCreatedLater() returned true: {}", CreateMissingShipmentSchedulesWorkpackageProcessor.class.getSimpleName());
 			return false;
 		}
 
 		// don't try to enqueue it if is not active
 		if (!queueDAO.isWorkpackageProcessorEnabled(CreateMissingShipmentSchedulesWorkpackageProcessor.class))
 		{
-			logger.debug("Not scheduling WP because this workpackage processor is disabled: {}", CreateMissingShipmentSchedulesWorkpackageProcessor.class.getSimpleName());
+			loggable.addLog("Not scheduling WP because this workpackage processor is disabled: {}", CreateMissingShipmentSchedulesWorkpackageProcessor.class.getSimpleName());
 			return false;
 		}
 
-		final Properties ctx = ctxAware.getCtx();
+		final IWorkPackageQueue queueForEnqueuing = workPackageQueueFactory.getQueueForEnqueuing(ctxAware.getCtx(), CreateMissingShipmentSchedulesWorkpackageProcessor.class);
+		final int alreadyEnqueuedWPs = queueForEnqueuing.size();
+		if (alreadyEnqueuedWPs > 1)
+		{ // why >1 and not >0? i checked the code and >0 should be fine. still, i feel more comfortable with >1
+			loggable.addLog("Not scheduling WP because there are {} processable workpackages, and we just need one to create all missing schedules!: {}",
+					alreadyEnqueuedWPs,
+					CreateMissingShipmentSchedulesWorkpackageProcessor.class.getSimpleName());
+			return false;
+		}
 
-		workPackageQueueFactory.getQueueForEnqueuing(ctx, CreateMissingShipmentSchedulesWorkpackageProcessor.class)
+		queueForEnqueuing
 				.newWorkPackage()
 				.setAsyncBatchId(asyncBatchId)
 				.bindToTrxName(ctxAware.getTrxName())

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/support/views/shipment_schedule_audit_trail_v.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/support/views/shipment_schedule_audit_trail_v.sql
@@ -1,0 +1,65 @@
+-- View: support.shipment_schedule_audit_trail_v
+-- Purpose: Complete audit trail for a shipment schedule: order → schedule → picked → shipment → invoice.
+--          Adapted from analysis SQL for duplicate shipment line investigation.
+--
+-- Usage:
+--   SELECT * FROM support.shipment_schedule_audit_trail_v WHERE m_shipmentschedule_id = 1020989;
+--   SELECT * FROM support.shipment_schedule_audit_trail_v WHERE c_order_id = 1001287;
+--   SELECT * FROM support.shipment_schedule_audit_trail_v WHERE m_inout_id = 1000407;
+
+CREATE OR REPLACE VIEW support.shipment_schedule_audit_trail_v AS
+SELECT
+    -- Order
+    ol.c_order_id,
+    o.documentno                              AS order_documentno,
+    o.dateordered,
+    ol.c_orderline_id,
+    ol.line                                   AS order_line,
+    -- Schedule
+    ss.m_shipmentschedule_id,
+    ss.qtyordered                             AS sched_qtyordered,
+    ss.qtydelivered                           AS sched_qtydelivered,
+    ss.qtytodeliver                          AS sched_qtytodeliver,
+    ss.qtyordered - ss.qtydelivered           AS sched_open_qty,
+    ss.headeraggregationkey,
+    ss.isactive                               AS sched_isactive,
+    -- Product
+    ss.m_product_id,
+    p.value                                   AS product_value,
+    p.name                                    AS product_name,
+    -- Picked (via M_ShipmentSchedule_QtyPicked)
+    qp.m_shipmentschedule_qtypicked_id,
+    qp.qtypicked,
+    qp.qtydeliveredcatch,
+    qp.processed                              AS qp_processed,
+    qp.m_inoutline_id                         AS qp_inoutline_id,
+    qp.created                                AS qp_created,
+    -- Shipment Line
+    iol.m_inoutline_id,
+    iol.line                                  AS shipment_line,
+    iol.movementqty                           AS shipped_qty,
+    iol.created                               AS shipment_line_created,
+    -- Shipment Header
+    io.m_inout_id,
+    io.documentno                             AS shipment_documentno,
+    io.docstatus                              AS shipment_docstatus,
+    io.movementdate                           AS shipment_date,
+    -- BPartner
+    o.c_bpartner_id,
+    bp.name                                   AS bpartner_name
+FROM m_shipmentschedule ss
+         JOIN c_orderline ol ON ol.c_orderline_id = ss.c_orderline_id
+         JOIN c_order o      ON o.c_order_id = ol.c_order_id
+         JOIN m_product p    ON p.m_product_id = ss.m_product_id
+         JOIN c_bpartner bp  ON bp.c_bpartner_id = o.c_bpartner_id
+         LEFT JOIN m_shipmentschedule_qtypicked qp ON qp.m_shipmentschedule_id = ss.m_shipmentschedule_id
+         LEFT JOIN m_inoutline iol ON iol.m_inoutline_id = qp.m_inoutline_id
+         LEFT JOIN m_inout io     ON io.m_inout_id = iol.m_inout_id
+ORDER BY
+    ss.m_shipmentschedule_id,
+    qp.created NULLS LAST;
+
+COMMENT ON VIEW support.shipment_schedule_audit_trail_v IS
+    'Complete audit trail: Order → ShipmentSchedule → QtyPicked → InOutLine → InOut. '
+        'Use to investigate shipment schedule processing issues. '
+        'Helps diagnose shipment schedule processing issues.';

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/support/views/shipment_schedule_duplicate_inoutlines_v.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/support/views/shipment_schedule_duplicate_inoutlines_v.sql
@@ -1,0 +1,48 @@
+-- View: support.shipment_schedule_duplicate_inoutlines_v
+-- Purpose: Identifies duplicate M_InOutLine records created for the same M_ShipmentSchedule.
+--          This detects the race condition bug where multiple async workpackages each create
+--          shipment lines for the same schedule because locks are released too early and
+--          deduplication is explicitly disabled (skipAlreadyProcessedItems=false).
+--
+-- Usage: SELECT * FROM support.shipment_schedule_duplicate_inoutlines_v;
+--
+-- A row with dup_count > 1 indicates a duplicate.
+-- A row with total_qty > expected_qty indicates over-delivery.
+
+CREATE OR REPLACE VIEW support.shipment_schedule_duplicate_inoutlines_v AS
+SELECT
+    qp.m_shipmentschedule_id,
+    ss.m_product_id,
+    p.value                                    AS product_value,
+    p.name                                     AS product_name,
+    io.m_inout_id,
+    io.documentno                              AS shipment_documentno,
+    io.docstatus                               AS shipment_docstatus,
+    COUNT(DISTINCT iol.m_inoutline_id)         AS line_count,
+    array_agg(DISTINCT iol.m_inoutline_id ORDER BY iol.m_inoutline_id) AS inoutline_ids,
+    SUM(iol.movementqty)                       AS total_movementqty,
+    MIN(iol.created)                           AS first_line_created,
+    MAX(iol.created)                           AS last_line_created,
+    MAX(iol.created) - MIN(iol.created)        AS creation_span
+FROM m_shipmentschedule_qtypicked qp
+         JOIN m_inoutline iol ON iol.m_inoutline_id = qp.m_inoutline_id
+         JOIN m_inout io      ON io.m_inout_id = iol.m_inout_id
+         JOIN m_shipmentschedule ss ON ss.m_shipmentschedule_id = qp.m_shipmentschedule_id
+         JOIN m_product p     ON p.m_product_id = ss.m_product_id
+GROUP BY
+    qp.m_shipmentschedule_id,
+    ss.m_product_id,
+    p.value,
+    p.name,
+    io.m_inout_id,
+    io.documentno,
+    io.docstatus
+HAVING COUNT(DISTINCT iol.m_inoutline_id) > 1
+ORDER BY
+    io.m_inout_id,
+    qp.m_shipmentschedule_id;
+
+COMMENT ON VIEW support.shipment_schedule_duplicate_inoutlines_v IS
+    'Detects duplicate shipment lines for the same M_ShipmentSchedule within the same shipment (M_InOut). '
+        'Caused by race condition: multiple GenerateInOutFromShipmentSchedules workpackages process the same schedule. '
+        'See GenerateInOutFromShipmentSchedules draft-shipment allocation guard.';

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/support/views/shipment_schedule_wp_timeline_v.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/support/views/shipment_schedule_wp_timeline_v.sql
@@ -1,0 +1,44 @@
+-- View: support.shipment_schedule_wp_timeline_v
+-- Purpose: Shows the complete async workpackage processing timeline for shipment generation.
+--          Helps identify when multiple WP batches processed the same shipment schedules,
+--          revealing the race condition that causes duplicate shipment lines.
+--
+-- Usage:
+--   -- All shipment generation WPs for a specific date
+--   SELECT * FROM support.shipment_schedule_wp_timeline_v WHERE wp_created::date = '2026-02-14';
+--
+--   -- WPs that processed a specific shipment schedule
+--   SELECT * FROM support.shipment_schedule_wp_timeline_v
+--   WHERE wp_id IN (
+--     SELECT c_queue_workpackage_id FROM c_queue_workpackage_log
+--     WHERE msgtext LIKE '%M_ShipmentSchedule_ID=1020989%'
+--   );
+
+CREATE OR REPLACE VIEW support.shipment_schedule_wp_timeline_v AS
+SELECT
+    wp.c_queue_workpackage_id                      AS wp_id,
+    wp.created                                     AS wp_created,
+    wp.updated                                     AS wp_processed_at,
+    wp.updated - wp.created                        AS processing_duration,
+    wp.processed                                   AS is_processed,
+    wp.iserror                                     AS is_error,
+    wp.errormsg,
+    wp.skipped_count,
+    wp.ad_pinstance_id,
+    pp.classname                                   AS processor_classname,
+    -- Count elements (shipment schedules) in this WP
+    (SELECT COUNT(*) FROM c_queue_element qe
+     WHERE qe.c_queue_workpackage_id = wp.c_queue_workpackage_id) AS element_count,
+    -- Check if there are other WPs in the same AD_PInstance batch
+    (SELECT COUNT(*) FROM c_queue_workpackage wp2
+     WHERE wp2.ad_pinstance_id = wp.ad_pinstance_id
+       AND wp2.c_queue_workpackage_id != wp.c_queue_workpackage_id) AS sibling_wp_count
+FROM c_queue_workpackage wp
+         JOIN c_queue_packageprocessor pp ON pp.c_queue_packageprocessor_id = wp.c_queue_packageprocessor_id
+WHERE pp.classname LIKE '%GenerateInOutFromShipmentSchedules%'
+ORDER BY wp.created DESC;
+
+COMMENT ON VIEW support.shipment_schedule_wp_timeline_v IS
+    'Timeline of GenerateInOutFromShipmentSchedules workpackage processing. '
+        'Use to identify multiple WP batches processing the same shipment schedules. '
+        'Helps diagnose duplicate shipment line race conditions.';

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/40-sw01_swat/5788200_sys_gh28143_support_shipment_schedule_views.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/40-sw01_swat/5788200_sys_gh28143_support_shipment_schedule_views.sql
@@ -1,0 +1,124 @@
+-- migration: 5788200_sys_gh28143_support_shipment_schedule_views.sql
+-- task: https://github.com/metasfresh/me03/issues/28143
+-- purpose: Create support-schema views for analyzing duplicate shipment line issues
+--          caused by race condition in GenerateInOutFromShipmentSchedules.
+
+CREATE SCHEMA IF NOT EXISTS support;
+
+-- View 1: Detect duplicate shipment lines per schedule within the same shipment
+CREATE OR REPLACE VIEW support.shipment_schedule_duplicate_inoutlines_v AS
+SELECT
+    qp.m_shipmentschedule_id,
+    ss.m_product_id,
+    p.value                                    AS product_value,
+    p.name                                     AS product_name,
+    io.m_inout_id,
+    io.documentno                              AS shipment_documentno,
+    io.docstatus                               AS shipment_docstatus,
+    COUNT(DISTINCT iol.m_inoutline_id)         AS line_count,
+    array_agg(DISTINCT iol.m_inoutline_id ORDER BY iol.m_inoutline_id) AS inoutline_ids,
+    SUM(iol.movementqty)                       AS total_movementqty,
+    MIN(iol.created)                           AS first_line_created,
+    MAX(iol.created)                           AS last_line_created,
+    MAX(iol.created) - MIN(iol.created)        AS creation_span
+FROM m_shipmentschedule_qtypicked qp
+         JOIN m_inoutline iol ON iol.m_inoutline_id = qp.m_inoutline_id
+         JOIN m_inout io      ON io.m_inout_id = iol.m_inout_id
+         JOIN m_shipmentschedule ss ON ss.m_shipmentschedule_id = qp.m_shipmentschedule_id
+         JOIN m_product p     ON p.m_product_id = ss.m_product_id
+GROUP BY
+    qp.m_shipmentschedule_id,
+    ss.m_product_id,
+    p.value,
+    p.name,
+    io.m_inout_id,
+    io.documentno,
+    io.docstatus
+HAVING COUNT(DISTINCT iol.m_inoutline_id) > 1
+ORDER BY
+    io.m_inout_id,
+    qp.m_shipmentschedule_id;
+
+COMMENT ON VIEW support.shipment_schedule_duplicate_inoutlines_v IS
+    'Detects duplicate shipment lines for the same M_ShipmentSchedule within the same shipment (M_InOut). '
+        'Caused by race condition: multiple GenerateInOutFromShipmentSchedules workpackages process the same schedule. '
+        'Helps diagnose duplicate shipment line race conditions.';
+
+-- View 2: Workpackage processing timeline for shipment generation
+CREATE OR REPLACE VIEW support.shipment_schedule_wp_timeline_v AS
+SELECT
+    wp.c_queue_workpackage_id                      AS wp_id,
+    wp.created                                     AS wp_created,
+    wp.updated                                     AS wp_processed_at,
+    wp.updated - wp.created                        AS processing_duration,
+    wp.processed                                   AS is_processed,
+    wp.iserror                                     AS is_error,
+    wp.errormsg,
+    wp.skipped_count,
+    wp.ad_pinstance_id,
+    pp.classname                                   AS processor_classname,
+    (SELECT COUNT(*) FROM c_queue_element qe
+     WHERE qe.c_queue_workpackage_id = wp.c_queue_workpackage_id) AS element_count,
+    (SELECT COUNT(*) FROM c_queue_workpackage wp2
+     WHERE wp2.ad_pinstance_id = wp.ad_pinstance_id
+       AND wp2.c_queue_workpackage_id != wp.c_queue_workpackage_id) AS sibling_wp_count
+FROM c_queue_workpackage wp
+         JOIN c_queue_packageprocessor pp ON pp.c_queue_packageprocessor_id = wp.c_queue_packageprocessor_id
+WHERE pp.classname LIKE '%GenerateInOutFromShipmentSchedules%'
+ORDER BY wp.created DESC;
+
+COMMENT ON VIEW support.shipment_schedule_wp_timeline_v IS
+    'Timeline of GenerateInOutFromShipmentSchedules workpackage processing. '
+        'Use to identify multiple WP batches processing the same shipment schedules. '
+        'Helps diagnose duplicate shipment line race conditions.';
+
+-- View 3: Complete audit trail for shipment schedules
+CREATE OR REPLACE VIEW support.shipment_schedule_audit_trail_v AS
+SELECT
+    ol.c_order_id,
+    o.documentno                              AS order_documentno,
+    o.dateordered,
+    ol.c_orderline_id,
+    ol.line                                   AS order_line,
+    ss.m_shipmentschedule_id,
+    ss.qtyordered                             AS sched_qtyordered,
+    ss.qtydelivered                           AS sched_qtydelivered,
+    ss.qtytodeliver                          AS sched_qtytodeliver,
+    ss.qtyordered - ss.qtydelivered           AS sched_open_qty,
+    ss.headeraggregationkey,
+    ss.isactive                               AS sched_isactive,
+    ss.m_product_id,
+    p.value                                   AS product_value,
+    p.name                                    AS product_name,
+    qp.m_shipmentschedule_qtypicked_id,
+    qp.qtypicked,
+    qp.qtydeliveredcatch,
+    qp.processed                              AS qp_processed,
+    qp.m_inoutline_id                         AS qp_inoutline_id,
+    qp.created                                AS qp_created,
+    iol.m_inoutline_id,
+    iol.line                                  AS shipment_line,
+    iol.movementqty                           AS shipped_qty,
+    iol.created                               AS shipment_line_created,
+    io.m_inout_id,
+    io.documentno                             AS shipment_documentno,
+    io.docstatus                              AS shipment_docstatus,
+    io.movementdate                           AS shipment_date,
+    o.c_bpartner_id,
+    bp.name                                   AS bpartner_name
+FROM m_shipmentschedule ss
+         JOIN c_orderline ol ON ol.c_orderline_id = ss.c_orderline_id
+         JOIN c_order o      ON o.c_order_id = ol.c_order_id
+         JOIN m_product p    ON p.m_product_id = ss.m_product_id
+         JOIN c_bpartner bp  ON bp.c_bpartner_id = o.c_bpartner_id
+         LEFT JOIN m_shipmentschedule_qtypicked qp ON qp.m_shipmentschedule_id = ss.m_shipmentschedule_id
+         LEFT JOIN m_inoutline iol ON iol.m_inoutline_id = qp.m_inoutline_id
+         LEFT JOIN m_inout io     ON io.m_inout_id = iol.m_inout_id
+ORDER BY
+    ss.m_shipmentschedule_id,
+    qp.created NULLS LAST;
+
+COMMENT ON VIEW support.shipment_schedule_audit_trail_v IS
+    'Complete audit trail: Order -> ShipmentSchedule -> QtyPicked -> InOutLine -> InOut. '
+        'Use to investigate shipment schedule processing issues. '
+        'Helps diagnose duplicate shipment line race conditions.';

--- a/misc/dev-support/bootstrap-scripts/mvn_build.sh
+++ b/misc/dev-support/bootstrap-scripts/mvn_build.sh
@@ -23,31 +23,96 @@
 
 set -e
 
-#needed if your locally installed "default" java is not the one expected by maven
-#export JAVA_HOME=c:/Users/tobia/.jdks/temurin-21.0.7 
-#export JAVA_HOME=c:/Users/tobia/.jdks/temurin-17.0.15
-export JAVA_HOME=c:/Users/tobia/.jdks/temurin-1.8.0_452
+# =============================================================================
+# AUTO-DETECT METASFRESH ROOT (works from any working directory)
+# =============================================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Script is at misc/dev-support/bootstrap-scripts/ → metasfresh root is 3 levels up
+METASFRESH_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
-MULTITHREAD_PARAM=''
-#MULTITHREAD_PARAM='-T2C'
+if [[ ! -f "$METASFRESH_ROOT/backend/pom.xml" ]]; then
+    echo "ERROR: Could not find metasfresh root (expected backend/pom.xml at $METASFRESH_ROOT)"
+    exit 1
+fi
 
-ADDITIONAL_PARAMS='-Djib.skip=true -Dmaven.gitcommitid.skip=true -Dlicense.skip=true'
-#ADDITIONAL_PARAMS='${ADDITIONAL_PARAMS} -DskipTests'
-#ADDITIONAL_PARAMS='${ADDITIONAL_PARAMS} -Dmaven.test.skip=true'
+# Use absolute path for .m2-local (critical on Windows Git Bash)
+LOCAL_REPO="$(cd "$METASFRESH_ROOT" && pwd -W 2>/dev/null || pwd)/.m2-local"
+mkdir -p "$LOCAL_REPO"
 
-#GOALS='test'
-GOALS='clean install'
+echo "Metasfresh root: $METASFRESH_ROOT"
+echo "Local Maven repo: $LOCAL_REPO"
 
-mvn --file ../../parent-pom/pom.xml --settings ../maven/settings.xml $ADDITIONAL_PARAMS $GOALS && \
+# =============================================================================
+# JAVA VERSION
+# =============================================================================
+# Java 8 for backend; override JAVA8_HOME or JAVA_HOME as needed
+if [[ -n "${JAVA8_HOME:-}" ]]; then
+    export JAVA_HOME="$JAVA8_HOME"
+elif [[ -z "${JAVA_HOME:-}" ]]; then
+    # Fallback: look for temurin-1.8 in standard location
+    for jdk in "$HOME"/.jdks/temurin-1.8.*; do
+        [[ -d "$jdk" ]] && export JAVA_HOME="$jdk" && break
+    done
+fi
+echo "JAVA_HOME: $JAVA_HOME"
 
-mvn --file ../../de-metas-common/pom.xml --settings ../maven/settings.xml $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS && \
+# =============================================================================
+# PARSE OPTIONS
+# =============================================================================
+CLEAN_FLAG=''
+SKIP_TESTS_FLAG=''
+PARALLEL_FLAG=''
+DEPS_ONLY=false
 
-mvn -e --file ../../../backend/pom.xml --settings ../maven/settings.xml $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS && \
+for arg in "$@"; do
+    case "$arg" in
+        --clean)      CLEAN_FLAG='clean' ;;
+        --skip-tests) SKIP_TESTS_FLAG='-DskipTests' ;;
+        --parallel)   PARALLEL_FLAG='-T2C' ;;
+        --deps-only)  DEPS_ONLY=true ;;
+        *)            echo "Unknown option: $arg"; exit 1 ;;
+    esac
+done
 
-mvn --file ../../services/camel/pom.xml --settings ../maven/settings.xml $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS && \
+GOALS="${CLEAN_FLAG} install"
 
-mvn --file ../../services/procurement-webui/procurement-webui-backend/pom.xml --settings ../maven/settings.xml $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS && \
+MULTITHREAD_PARAM="${PARALLEL_FLAG}"
 
-mvn --file ../../services/federated-rabbitmq/pom.xml --settings ../maven/settings.xml $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS
+ADDITIONAL_PARAMS="-Djib.skip=true -Dmaven.gitcommitid.skip=true -Dlicense.skip=true ${SKIP_TESTS_FLAG}"
 
+SETTINGS="$METASFRESH_ROOT/misc/dev-support/maven/settings.xml"
+REPO_FLAG="-Dmaven.repo.local=$LOCAL_REPO"
+MVN_FLAGS="--settings $SETTINGS $REPO_FLAG --no-transfer-progress"
+
+# =============================================================================
+# BUILD
+# =============================================================================
+echo ""
+echo "$(date): Starting build (goals: $GOALS)"
+echo ""
+
+mvn --file "$METASFRESH_ROOT/misc/parent-pom/pom.xml" $MVN_FLAGS $ADDITIONAL_PARAMS $GOALS && \
+
+mvn --file "$METASFRESH_ROOT/misc/de-metas-common/pom.xml" $MVN_FLAGS $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS
+
+if $DEPS_ONLY; then
+    echo "$(date): Done (deps-only: parent-pom + de-metas-common)"
+    exit 0
+fi
+
+JAVA17_HOME="${JAVA17_HOME:-}"
+
+mvn -e --file "$METASFRESH_ROOT/backend/pom.xml" $MVN_FLAGS $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS && \
+
+if [[ -n "$JAVA17_HOME" ]]; then
+    JAVA_HOME="$JAVA17_HOME" mvn --file "$METASFRESH_ROOT/misc/services/camel/pom.xml" $MVN_FLAGS $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS && \
+    JAVA_HOME="$JAVA17_HOME" mvn --file "$METASFRESH_ROOT/misc/services/procurement-webui/procurement-webui-backend/pom.xml" $MVN_FLAGS $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS && \
+    JAVA_HOME="$JAVA17_HOME" mvn --file "$METASFRESH_ROOT/misc/services/federated-rabbitmq/pom.xml" $MVN_FLAGS $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS
+else
+    echo ""
+    echo "WARNING: JAVA17_HOME not set — skipping camel, procurement-webui-backend, federated-rabbitmq"
+    echo "Set JAVA17_HOME to build Java 17 services."
+fi
+
+echo ""
 echo "$(date): Done"

--- a/misc/parent-pom/pom.xml
+++ b/misc/parent-pom/pom.xml
@@ -832,6 +832,7 @@ Failure to find de.metas:de.metas.parent:pom:(1.0.0,3) in (URL ...) was cached i
                                             <directory>src/main/jasperreports</directory>
                                             <excludes>
                                                 <exclude>**/*.jrxml</exclude>
+                                                <exclude>**/*.md</exclude>
                                             </excludes>
                                         </resource>
                                     </resources>


### PR DESCRIPTION
## Summary

- Adds a guard in `GenerateInOutFromShipmentSchedules` that detects when a schedule already has a draft-shipment allocation from a prior workpackage, preventing duplicate `M_InOutLine` creation
- When a user triggers "Generate Shipments" multiple times before the async recompute updates `QtyToDeliver`, the same schedule was processed by multiple workpackages — this guard blocks the duplicates
- Extends `ShipmentScheduleAllocQuery` and `ShipmentScheduleAllocDAO` with a `processed` filter and a new `getScheduleIdsWithDraftShipmentAllocations()` batch method
- New Cucumber feature `duplicateShipmentLineGuard.feature` with 3 scenarios: normal flow (no false positive), duplicate blocked, partial delivery allowed

## Root Cause

`QtyToDeliver` is only updated asynchronously by `UpdateInvalidShipmentSchedulesWorkpackageProcessor`. Between user triggers, the recompute may not have run yet, so subsequent workpackages still see stale `QtyToDeliver > 0` and create duplicate shipment lines.

The guard checks `M_ShipmentSchedule_QtyPicked` for records with `Processed=N` + `M_InOutLine_ID IS NOT NULL` (draft allocations visible immediately after the first WP commits), making it immune to the recompute timing issue.

## Incidents Fixed

| Date | Shipment | Duplicates | Triggers |
|------|----------|------------|----------|
| Jan 31 | LS26-300279 | 2x (3 groups) | 7 triggers over 49 min |
| Feb 14 | LS26-300399 | 3x (2 groups) | 3 triggers over 13 min |

## Test plan

- [x] Unit tests pass: `de.metas.swat.base` (361 tests), `de.metas.handlingunits.base` (637 tests)
- [x] CI pipeline passes (Java build + existing Cucumber tests)
- [x] New Cucumber feature `duplicateShipmentLineGuard.feature` passes (3 scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)