### PR TITLE
gh#28014: fix Intrastat view — exclude zero-value packaging, dynamic country

### DIFF
--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788010_sys_gh28014_Intrastat_exclude_packaging_without_tariff.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788010_sys_gh28014_Intrastat_exclude_packaging_without_tariff.sql
@@ -1,3 +1,14 @@
+-- gh#28014: Two fixes for the Intrastat export view M_InOut_V:
+--
+-- 1) Exclude packaging materials without customs tariff (e.g. EUR pallets added as regular
+--    shipment lines with ispackagingmaterial='N'). These have no CN8 code and zero invoice
+--    value, causing RTIC validation errors. Lines with a missing tariff but non-zero value
+--    are intentionally kept so the gap is visible, prompting the user to assign the CN8 code.
+--
+-- 2) Replace hardcoded country codes with dynamic lookup via the org's business partner
+--    location (AD_OrgInfo.OrgBP_Location_ID). Fallback chain: warehouse country first
+--    (physical dispatch location), org country as fallback if warehouse location is incomplete.
+
 DROP VIEW IF EXISTS de_metas_endcustomer_fresh_reports.M_InOut_V;
 
 CREATE OR REPLACE VIEW de_metas_endcustomer_fresh_reports.M_InOut_V AS


### PR DESCRIPTION
## Summary
- **Exclude zero-value packaging lines** from the Intrastat export view `M_InOut_V`. Lines with no customs tariff (`M_CustomsTariff_ID IS NULL`) AND zero invoice value (`linenetamt = 0`) are filtered out — these are typically EUR pallets added as regular shipment lines. Lines with missing tariff but non-zero value are intentionally kept so the gap is visible, prompting the user to assign the CN8 code.
- **Replace hardcoded country codes** (`'DE'`/`'AT'`) with a dynamic lookup via the org's business partner location (`AD_OrgInfo.OrgBP_Location_ID → C_BPartner_Location → C_Location → C_Country`). Fallback chain: warehouse country first (physical dispatch location), org country as fallback if warehouse location is incomplete.

## Test plan
- [x] Run `SELECT * FROM report.Intrastat_Export(org_id, year_id, 'Export', 'period') LIMIT 10` and verify rows are returned
- [x] Verify EU-Palette / zero-value packaging lines are excluded
- [x] Verify `deliveredFromCountry` matches the org's actual country (derived dynamically, not hardcoded)
- [x] Verify products with missing tariff but non-zero value still appear (gap is visible for the user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)