### PR TITLE
gh#28014: port Intrastat view fix to science_vessel_release

### DIFF
--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788010_sys_gh28014_Intrastat_exclude_packaging_without_tariff.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788010_sys_gh28014_Intrastat_exclude_packaging_without_tariff.sql
@@ -1,3 +1,14 @@
+-- gh#28014: Two fixes for the Intrastat export view M_InOut_V:
+--
+-- 1) Exclude packaging materials without customs tariff (e.g. EUR pallets added as regular
+--    shipment lines with ispackagingmaterial='N'). These have no CN8 code and zero invoice
+--    value, causing RTIC validation errors. Lines with a missing tariff but non-zero value
+--    are intentionally kept so the gap is visible, prompting the user to assign the CN8 code.
+--
+-- 2) Replace hardcoded country codes with dynamic lookup via the org's business partner
+--    location (AD_OrgInfo.OrgBP_Location_ID). Fallback chain: warehouse country first
+--    (physical dispatch location), org country as fallback if warehouse location is incomplete.
+
 DROP VIEW IF EXISTS de_metas_endcustomer_fresh_reports.M_InOut_V;
 
 CREATE OR REPLACE VIEW de_metas_endcustomer_fresh_reports.M_InOut_V AS
@@ -14,7 +25,11 @@ select commoditynumber,
        C_Period_ID,
        Period,
        AD_Org_ID,
-       OrgName
+       OrgName,
+       CustomsTariff,
+       weight,
+       vataxid,
+       c_year_id
 from (
          select cn.value        as commoditynumber,
                 p.Name          as productName,
@@ -57,7 +72,11 @@ from (
                 C_Period_ID,
                 per.name        as Period,
                 io.AD_Org_ID,
-                o.Name          as OrgName
+                o.Name          as OrgName,
+                ct.value           AS CustomsTariff,
+                iow.catchweight    AS weight,
+                bp.vataxid,
+                per.c_year_id
          from M_InOut io
                   join AD_Org o on io.ad_org_id = o.ad_org_id
                   -- Org's country via AD_OrgInfo → OrgBP_Location → C_Location → C_Country
@@ -74,6 +93,7 @@ from (
                   join m_product p on p.m_product_id = iol.m_product_id
                   left join m_commoditynumber cn on cn.m_commoditynumber_id = p.m_commoditynumber_id
                   left join C_country pco on pco.c_country_id = p.rawmaterialorigin_id
+                  JOIN c_bpartner bp ON bp.c_bpartner_id = io.c_bpartner_id
                   join c_bpartner_location bpl on bpl.c_bpartner_location_id = io.c_bpartner_location_id
                   join c_location l on l.c_location_id = bpl.c_location_id
                   join C_country co on co.c_country_id = l.c_country_id
@@ -88,6 +108,9 @@ from (
                   LEFT OUTER JOIN C_UOM uom_iol ON uom_iol.C_UOM_ID = iol.C_UOM_ID
 
                   JOIN C_Period per on i.dateinvoiced >= per.startdate and i.dateinvoiced <= per.enddate
+
+                  LEFT OUTER JOIN M_CustomsTariff ct ON ct.M_CustomsTariff_ID = p.M_CustomsTariff_ID
+                  LEFT OUTER JOIN de_metas_endcustomer_fresh_reports.Docs_Sales_InOut_Sum_Weight(io.m_inout_id, 'de_DE') AS iow ON TRUE
 
          where io.issotrx = 'Y'
            and io.isactive = 'Y'
@@ -114,5 +137,9 @@ group by commoditynumber,
          C_Period_ID,
          Period,
          AD_Org_ID,
-         OrgName
+         OrgName,
+         CustomsTariff,
+         weight,
+         vataxid,
+         c_year_id
 order by deliveryCountry, commoditynumber;


### PR DESCRIPTION
## Summary
Cherry-pick of #22371 from `keen_hawk_hotfix` to `science_vessel_release`.

- Exclude shipment lines with no customs tariff AND zero invoice value (e.g. EUR pallets added as regular lines)
- Replace hardcoded country codes with dynamic lookup via org's business partner location (AD_OrgInfo → OrgBP_Location_ID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)