### PR TITLE
Update dockerfiles to maven:3.9.6-eclipse-temurin-17 to prevent cgroup docker runtime errors

### DIFF
--- a/docker-builds/Dockerfile.backend
+++ b/docker-builds/Dockerfile.backend
@@ -1,14 +1,14 @@
 ARG REFNAME=local
-FROM metasfresh/metas-mvn-common:$REFNAME as common
+FROM metasfresh/metas-mvn-common:$REFNAME AS common
 
-FROM alpine as poms
+FROM alpine AS poms
 
 WORKDIR /backend
 COPY backend . 
 RUN find . -type f ! -name "pom.xml" -exec rm -r {} \;
 
 
-FROM maven:3.8.4-eclipse-temurin-17 as build
+FROM maven:3.9.6-eclipse-temurin-17 AS build
 
 WORKDIR /backend
 

--- a/docker-builds/Dockerfile.camel
+++ b/docker-builds/Dockerfile.camel
@@ -1,7 +1,7 @@
 ARG REFNAME=local
-FROM metasfresh/metas-mvn-common:$REFNAME as common
+FROM metasfresh/metas-mvn-common:$REFNAME AS common
 
-FROM maven:3.8.4-eclipse-temurin-17 as build
+FROM maven:3.9.6-eclipse-temurin-17 AS build
 
 COPY --from=common /root/.m2 /root/.m2/
 

--- a/docker-builds/Dockerfile.camel.junit
+++ b/docker-builds/Dockerfile.camel.junit
@@ -2,7 +2,7 @@ ARG REFNAME=local
 ARG REGISTRY=
 FROM ${REGISTRY}metasfresh/metas-mvn-camel:$REFNAME AS camel
 
-FROM maven:3.8.4-eclipse-temurin-17 AS junit
+FROM maven:3.9.6-eclipse-temurin-17 AS junit
 
 RUN apt-get update && apt-get install -y locales mmv && rm -rf /var/lib/apt/lists/* && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
 ENV LANG=de_DE.UTF-8 LANGUAGE=de_DE.UTF-8 LC_MESSAGES=de_DE.UTF-8

--- a/docker-builds/Dockerfile.common
+++ b/docker-builds/Dockerfile.common
@@ -1,4 +1,4 @@
-FROM maven:3.8.4-eclipse-temurin-17
+FROM maven:3.9.6-eclipse-temurin-17
 
 WORKDIR /parent
 COPY misc/parent-pom .

--- a/docker-builds/Dockerfile.cucumber
+++ b/docker-builds/Dockerfile.cucumber
@@ -1,5 +1,5 @@
 ARG REFNAME=local
-FROM metasfresh/metas-mvn-backend:$REFNAME as backend
+FROM metasfresh/metas-mvn-backend:$REFNAME AS backend
 
 FROM maven:3.9.6-eclipse-temurin-17
 

--- a/docker-builds/Dockerfile.cucumber
+++ b/docker-builds/Dockerfile.cucumber
@@ -1,7 +1,7 @@
 ARG REFNAME=local
 FROM metasfresh/metas-mvn-backend:$REFNAME as backend
 
-FROM maven:3.8.4-eclipse-temurin-17
+FROM maven:3.9.6-eclipse-temurin-17
 
 RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
 ENV LANG=de_DE.UTF-8 LANGUAGE=de_DE.UTF-8 LC_MESSAGES=de_DE.UTF-8

--- a/docker-builds/Dockerfile.junit
+++ b/docker-builds/Dockerfile.junit
@@ -3,7 +3,7 @@ ARG REGISTRY=
 FROM ${REGISTRY}metasfresh/metas-mvn-common:$REFNAME AS common
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
-FROM maven:3.8.4-eclipse-temurin-17 AS junit
+FROM maven:3.9.6-eclipse-temurin-17 AS junit
 
 ARG SKIP_MIGRATION_SCRIPTS_TEST=false
 

--- a/docker-builds/Dockerfile.procurement.backend
+++ b/docker-builds/Dockerfile.procurement.backend
@@ -1,7 +1,7 @@
 ARG REFNAME=local
-FROM metasfresh/metas-mvn-common:$REFNAME as common
+FROM metasfresh/metas-mvn-common:$REFNAME AS common
 
-FROM maven:3.8.4-eclipse-temurin-17 as build
+FROM maven:3.9.6-eclipse-temurin-17 AS build
 
 COPY --from=common /root/.m2 /root/.m2/
 


### PR DESCRIPTION
Fix for `Caused by: java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null`