### PR TITLE
gh#28014: ascending period dropdown + lookup page length

### DIFF
--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788030_sys_gh28014_C_Period_Ordered_Asc_reference.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788030_sys_gh28014_C_Period_Ordered_Asc_reference.sql
@@ -18,8 +18,26 @@ INSERT INTO AD_Reference (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive,
                           Created, CreatedBy, Updated, UpdatedBy,
                           Name, Description, ValidationType, EntityType, IsOrderByValue)
 VALUES (542051, 0, 0, 'Y',
-        now(), 100, now(), 100,
+        TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'), 100, TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'), 100,
         'C_Period Ordered (asc)', 'C_Period ordered by StartDate ascending — use when year is already filtered', 'T', 'de.metas.fresh', 'N');
+
+-- Step 1b: Create AD_Reference_Trl rows for all active system languages
+INSERT INTO AD_Reference_Trl (AD_Language, AD_Reference_ID, Description, Help, Name,
+                              IsTranslated, AD_Client_ID, AD_Org_ID,
+                              Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Reference_ID, t.Description, t.Help, t.Name,
+       'N', t.AD_Client_ID, t.AD_Org_ID,
+       t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Reference t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND l.IsBaseLanguage = 'N'
+  AND t.AD_Reference_ID = 542051
+  AND NOT EXISTS (
+      SELECT 1 FROM AD_Reference_Trl tt
+      WHERE tt.AD_Language = l.AD_Language
+        AND tt.AD_Reference_ID = t.AD_Reference_ID
+  );
 
 -- Step 2: Create the AD_Ref_Table (same as 540658 but with ascending order)
 INSERT INTO AD_Ref_Table (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive,
@@ -27,7 +45,7 @@ INSERT INTO AD_Ref_Table (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive,
                           AD_Table_ID, AD_Key, AD_Display, OrderByClause, WhereClause,
                           IsValueDisplayed, EntityType)
 VALUES (542051, 0, 0, 'Y',
-        now(), 100, now(), 100,
+        TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'), 100, TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'), 100,
         145, 837, null, 'C_Period.StartDate', null,
         'N', 'de.metas.fresh');
 
@@ -35,7 +53,7 @@ VALUES (542051, 0, 0, 'Y',
 -- from 540658 (desc) to 542051 (asc)
 UPDATE AD_Process_Para pp
 SET AD_Reference_Value_ID = 542051,
-    Updated               = now(),
+    Updated               = TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'),
     UpdatedBy             = 100
 WHERE pp.AD_Reference_Value_ID = 540658
   AND pp.IsActive = 'Y'

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788030_sys_gh28014_C_Period_Ordered_Asc_reference.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788030_sys_gh28014_C_Period_Ordered_Asc_reference.sql
@@ -1,0 +1,48 @@
+-- gh#28014: Create ascending-order pendant of "C_Period Ordered" (540658)
+--
+-- Reference 540658 ("C_Period Ordered") sorts descending (most recent first),
+-- which makes sense for open-ended lookups (accounting reports without year filter).
+--
+-- But for processes that already have a C_Year_ID parameter pre-filtering to a single
+-- year's 12 periods, descending order is confusing — users expect Jan → Dec.
+-- Additionally, with the default WebUI lookup page size of 10, the last 2 months
+-- (typically Jan + Feb) get cut off and hidden behind "Es gibt weitere Ergebnisse".
+--
+-- This migration:
+-- 1) Creates reference 542051 "C_Period Ordered (asc)" with ascending StartDate order
+-- 2) Switches all process parameters that have a sibling C_Year_ID parameter
+--    from 540658 (desc) to 542051 (asc)
+
+-- Step 1: Create the new AD_Reference
+INSERT INTO AD_Reference (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                          Created, CreatedBy, Updated, UpdatedBy,
+                          Name, Description, ValidationType, EntityType, IsOrderByValue)
+VALUES (542051, 0, 0, 'Y',
+        now(), 100, now(), 100,
+        'C_Period Ordered (asc)', 'C_Period ordered by StartDate ascending — use when year is already filtered', 'T', 'de.metas.fresh', 'N');
+
+-- Step 2: Create the AD_Ref_Table (same as 540658 but with ascending order)
+INSERT INTO AD_Ref_Table (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                          Created, CreatedBy, Updated, UpdatedBy,
+                          AD_Table_ID, AD_Key, AD_Display, OrderByClause, WhereClause,
+                          IsValueDisplayed, EntityType)
+VALUES (542051, 0, 0, 'Y',
+        now(), 100, now(), 100,
+        145, 837, null, 'C_Period.StartDate', null,
+        'N', 'de.metas.fresh');
+
+-- Step 3: Switch process parameters that have a sibling C_Year_ID parameter
+-- from 540658 (desc) to 542051 (asc)
+UPDATE AD_Process_Para pp
+SET AD_Reference_Value_ID = 542051,
+    Updated               = now(),
+    UpdatedBy             = 100
+WHERE pp.AD_Reference_Value_ID = 540658
+  AND pp.IsActive = 'Y'
+  AND EXISTS (
+    SELECT 1
+    FROM AD_Process_Para sibling
+    WHERE sibling.AD_Process_ID = pp.AD_Process_ID
+      AND sibling.ColumnName = 'C_Year_ID'
+      AND sibling.IsActive = 'Y'
+  );

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788040_sys_gh28014_webui_lookup_pageLength.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788040_sys_gh28014_webui_lookup_pageLength.sql
@@ -10,7 +10,7 @@ INSERT INTO AD_SysConfig (AD_SysConfig_ID, AD_Client_ID, AD_Org_ID, IsActive,
                           Name, Value,
                           Description, EntityType, ConfigurationLevel)
 SELECT nextval('ad_sysconfig_seq'), 0, 0, 'Y',
-       now(), 100, now(), 100,
+       TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'), 100, TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'), 100,
        'webui.lookup.pageLength', '15',
        'Max items returned per lookup/typeahead request. Must be at least 12 to show all periods of a year without truncation.',
        'de.metas.fresh', 'S'

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788040_sys_gh28014_webui_lookup_pageLength.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788040_sys_gh28014_webui_lookup_pageLength.sql
@@ -1,0 +1,21 @@
+-- gh#28014: Set WebUI lookup page length to 15
+--
+-- The hardcoded default is 10, which cuts off results in any lookup with more than 10 matches.
+-- Most notably, period dropdowns filtered by year have 12 entries (Jan–Dec), so the last 2
+-- are hidden behind "Es gibt weitere Ergebnisse". The value should be at least 12 to
+-- accommodate our usual 12 periods per year; we use 15 to leave a small buffer.
+
+INSERT INTO AD_SysConfig (AD_SysConfig_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                          Created, CreatedBy, Updated, UpdatedBy,
+                          Name, Value,
+                          Description, EntityType, ConfigurationLevel)
+SELECT nextval('ad_sysconfig_seq'), 0, 0, 'Y',
+       now(), 100, now(), 100,
+       'webui.lookup.pageLength', '15',
+       'Max items returned per lookup/typeahead request. Must be at least 12 to show all periods of a year without truncation.',
+       'de.metas.fresh', 'S'
+WHERE NOT EXISTS (
+    SELECT 1 FROM AD_SysConfig
+    WHERE Name = 'webui.lookup.pageLength'
+      AND IsActive = 'Y'
+);


### PR DESCRIPTION
## Summary

- **New AD_Reference 542051** "C_Period Ordered (asc)" — ascending `StartDate` order, pendant of 540658 (desc). Switched for all 15 process parameters (11 processes) that have a sibling `C_Year_ID` parameter, so periods show Jan→Dec when year is already filtered. Processes without year filter keep descending (most-recent-first).
- **AD_SysConfig `webui.lookup.pageLength` = 15** (hardcoded default was 10). Must be at least 12 to show all 12 periods of a year without the "Es gibt weitere Ergebnisse" truncation message.

## Affected processes (switched to ascending)

Artikelstatistik, Artikelstatistik (Excel), Dump Berechnungsrevision, Dump Hierarchiebaum, Einkaufsstatistik, Forecast Report, Forecast Report by Period, INTRASTAT RTIC Datei (AT), Kostenstellenwechsel, Statistik nach Mengen, Statistik nach Mengen Gesamt, Umsatzreport, Verkauf-Einkauf-Rückverfolgung (Excel)

## Test plan

- [ ] Open any year-filtered process (e.g. Intrastat, Umsatzreport), select a year, open the period dropdown → should show Jan–Dec in chronological order, all 12 visible
- [ ] Open a process without year filter (e.g. Buchführungs-Details, Probesaldo) → period dropdown should still show most-recent-first (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)