### PR TITLE
me03#28131 add PaymentRule javadoc and AD_Ref_List descriptions

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/payment/PaymentRule.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/payment/PaymentRule.java
@@ -34,21 +34,65 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Optional;
 
+/**
+ * Defines how a document (order, invoice) will be paid.
+ * Corresponds to AD_Reference_ID=195 ({@code _Payment Rule}).
+ *
+ * <h2>Downstream behavior</h2>
+ * <p>
+ * PaymentRule propagates: {@code C_OLCand -> C_Order -> C_Invoice_Candidate -> C_Invoice}.
+ * OLCands with different PaymentRules always produce separate orders
+ * (hard-coded split in {@code OLCandProcessingHelper.isOrderSplit()}).
+ * </p>
+ *
+ * <h3>PaySelection / SEPA export eligibility</h3>
+ * <p>
+ * {@link PaySelectionUpdater#buildSelectSQL_InvoiceMatchRequirement()} uses a hardcoded SQL WHERE
+ * that only includes certain PaymentRules in payment proposals:
+ * </p>
+ * <ul>
+ *   <li>Vendor invoices (IsSOTrx=N): {@code PaymentRule IN ('T','P')} &rarr; {@link #DirectDeposit}, {@link #OnCredit}</li>
+ *   <li>Customer invoices (IsSOTrx=Y, non-credit-memo): {@code PaymentRule = 'D'} &rarr; {@link #DirectDebit}</li>
+ *   <li>Customer credit memos (IsSOTrx=Y, DocBaseType=ARC): {@code PaymentRule IN ('T','P')} &rarr; {@link #DirectDeposit}, {@link #OnCredit}</li>
+ * </ul>
+ * <p>
+ * All other PaymentRules (including {@link #CreditCardExtern}, {@link #PayPalExtern}, {@link #Cash}, etc.)
+ * are <b>excluded</b> from payment proposals and SEPA export.
+ * Invoices with these rules must be allocated via the Payment Allocation view (WebUI),
+ * the REST API ({@code POST /api/v2/invoices/payment}), or Remittance Advice.
+ * </p>
+ *
+ * @see de.metas.banking.payment.impl.PaySelectionUpdater
+ * @see de.metas.ordercandidate.api.impl.OLCandProcessingHelper#isOrderSplit
+ */
 public enum PaymentRule implements ReferenceListAwareEnum
 {
-	Cash(X_C_Order.PAYMENTRULE_Cash), // B
-	CreditCard(X_C_Order.PAYMENTRULE_CreditCard), // K
-	DirectDeposit(X_C_Order.PAYMENTRULE_DirectDeposit), // T
-	Check(X_C_Order.PAYMENTRULE_Check), // S
-	OnCredit(X_C_Order.PAYMENTRULE_OnCredit), // P
-	DirectDebit(X_C_Order.PAYMENTRULE_DirectDebit), // D
-	Mixed(X_C_Order.PAYMENTRULE_Mixed), // M
-	PayPal(X_C_Order.PAYMENTRULE_PayPal), // L
-	PayPalExtern(X_C_Order.PAYMENTRULE_PayPalExtern), // V
-	CreditCardExtern(X_C_Order.PAYMENTRULE_KreditkarteExtern), // U
-	InstantBankTransfer(X_C_Order.PAYMENTRULE_Sofortueberweisung), // R
-	Reimbursement(X_C_Order.PAYMENTRULE_Reimbursement), // E
-	Settlement(X_C_Order.PAYMENTRULE_Settlement) // F
+	/** Code {@code B}. Immediate cash payment. Not included in PaySelection. */
+	Cash(X_C_Order.PAYMENTRULE_Cash),
+	/** Code {@code K}. Internal credit card payment. Not included in PaySelection. */
+	CreditCard(X_C_Order.PAYMENTRULE_CreditCard),
+	/** Code {@code T}. Bank transfer to vendor. Included in PaySelection (vendor invoices + customer credit memos). SEPA credit transfer. */
+	DirectDeposit(X_C_Order.PAYMENTRULE_DirectDeposit),
+	/** Code {@code S}. Payment by check. Not included in PaySelection. */
+	Check(X_C_Order.PAYMENTRULE_Check),
+	/** Code {@code P}. Payment on account per payment terms (Auf Ziel). Included in PaySelection (vendor invoices + customer credit memos). SEPA credit transfer. System default. */
+	OnCredit(X_C_Order.PAYMENTRULE_OnCredit),
+	/** Code {@code D}. SEPA direct debit from customer account. Included in PaySelection for customer invoices (IsSOTrx=Y). */
+	DirectDebit(X_C_Order.PAYMENTRULE_DirectDebit),
+	/** Code {@code M}. Multiple payment methods combined. Not included in PaySelection. */
+	Mixed(X_C_Order.PAYMENTRULE_Mixed),
+	/** Code {@code L}. PayPal payment. Not included in PaySelection. */
+	PayPal(X_C_Order.PAYMENTRULE_PayPal),
+	/** Code {@code V}. Externally processed PayPal payment. Not included in PaySelection. Allocate via WebUI, REST API, or Remittance Advice. */
+	PayPalExtern(X_C_Order.PAYMENTRULE_PayPalExtern),
+	/** Code {@code U}. Externally processed credit card payment (e.g. Stripe, Adyen). Not included in PaySelection. Allocate via WebUI, REST API, or Remittance Advice. */
+	CreditCardExtern(X_C_Order.PAYMENTRULE_KreditkarteExtern),
+	/** Code {@code R}. Instant bank transfer (e.g. Klarna Sofortüberweisung). Not included in PaySelection. */
+	InstantBankTransfer(X_C_Order.PAYMENTRULE_Sofortueberweisung),
+	/** Code {@code E}. Reimbursement/refund. Not included in PaySelection. */
+	Reimbursement(X_C_Order.PAYMENTRULE_Reimbursement),
+	/** Code {@code F}. Settlement/compensation between business partners. Not included in PaySelection. */
+	Settlement(X_C_Order.PAYMENTRULE_Settlement),
 	;
 
 	@Getter

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5789130_sys_me03_28131_PaymentRule_descriptions.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5789130_sys_me03_28131_PaymentRule_descriptions.sql
@@ -1,0 +1,82 @@
+-- Reference: _Payment Rule (AD_Reference_ID=195)
+-- Add descriptions to all PaymentRule ref-list entries explaining downstream behavior
+-- (PaySelection eligibility, SEPA export, allocation paths)
+-- https://github.com/metasfresh/me03/issues/28131
+
+-- B = Cash (Bar)
+-- AD_Ref_List_ID=332
+UPDATE AD_Ref_List SET Description='Sofortige Barzahlung. Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=332;
+UPDATE AD_Ref_List_Trl SET Description='Sofortige Barzahlung. Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=332 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Description='Immediate cash payment. Not included in payment proposals (PaySelection).', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=332 AND AD_Language='en_US';
+
+-- D = DirectDebit (Bankeinzug / SEPA-Lastschrift)
+-- AD_Ref_List_ID=652
+UPDATE AD_Ref_List SET Description='SEPA-Lastschrift vom Kundenkonto. In Zahlungsvorschlägen für Kundenrechnungen (IsSOTrx=Y) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=652;
+UPDATE AD_Ref_List_Trl SET Description='SEPA-Lastschrift vom Kundenkonto. In Zahlungsvorschlägen für Kundenrechnungen (IsSOTrx=Y) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=652 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Description='SEPA direct debit from customer account. Included in payment proposals for sales invoices (IsSOTrx=Y).', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=652 AND AD_Language='en_US';
+
+-- E = Reimbursement (Rückerstattung)
+-- AD_Ref_List_ID=543787
+UPDATE AD_Ref_List SET Description='Rückerstattung/Erstattung. Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543787;
+UPDATE AD_Ref_List_Trl SET Description='Rückerstattung/Erstattung. Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543787 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Description='Reimbursement/refund. Not included in payment proposals (PaySelection).', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543787 AND AD_Language='en_US';
+
+-- F = Settlement (Verrechnung)
+-- AD_Ref_List_ID=543788
+UPDATE AD_Ref_List SET Description='Verrechnung/Aufrechnung zwischen Geschäftspartnern. Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543788;
+UPDATE AD_Ref_List_Trl SET Description='Verrechnung/Aufrechnung zwischen Geschäftspartnern. Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543788 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Description='Settlement/compensation between business partners. Not included in payment proposals (PaySelection).', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543788 AND AD_Language='en_US';
+
+-- K = CreditCard (Kreditkarte intern) — currently inactive
+-- AD_Ref_List_ID=333
+UPDATE AD_Ref_List SET Description='Interne Kreditkartenzahlung. Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=333;
+UPDATE AD_Ref_List_Trl SET Description='Interne Kreditkartenzahlung. Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=333 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Description='Internal credit card payment. Not included in payment proposals (PaySelection).', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=333 AND AD_Language='en_US';
+
+-- L = PayPal
+-- AD_Ref_List_ID=541987
+UPDATE AD_Ref_List SET Description='PayPal-Zahlung. Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=541987;
+UPDATE AD_Ref_List_Trl SET Description='PayPal-Zahlung. Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=541987 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Description='PayPal payment. Not included in payment proposals (PaySelection).', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=541987 AND AD_Language='en_US';
+
+-- M = Mixed — currently inactive
+-- AD_Ref_List_ID=52000
+UPDATE AD_Ref_List SET Description='Mehrere Zahlungsarten kombiniert. Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=52000;
+UPDATE AD_Ref_List_Trl SET Description='Mehrere Zahlungsarten kombiniert. Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=52000 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Description='Multiple payment methods combined. Not included in payment proposals (PaySelection).', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=52000 AND AD_Language='en_US';
+
+-- P = OnCredit (Auf Ziel)
+-- AD_Ref_List_ID=337
+UPDATE AD_Ref_List SET Description='Zahlung auf Ziel gemäss Zahlungsbedingungen. In Zahlungsvorschlägen (PaySelection) enthalten: Kreditorenrechnungen und Debitorengutschriften. SEPA-Überweisungsdatei wird erstellt.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=337;
+UPDATE AD_Ref_List_Trl SET Description='Zahlung auf Ziel gemäss Zahlungsbedingungen. In Zahlungsvorschlägen (PaySelection) enthalten: Kreditorenrechnungen und Debitorengutschriften. SEPA-Überweisungsdatei wird erstellt.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=337 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Description='Payment on account per payment terms. Included in payment proposals (PaySelection): vendor invoices and customer credit memos. SEPA credit transfer file is generated.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=337 AND AD_Language='en_US';
+
+-- R = InstantBankTransfer (Sofortüberweisung) — currently inactive
+-- AD_Ref_List_ID=543127
+UPDATE AD_Ref_List SET Description='Sofortüberweisung (z.B. Klarna). Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543127;
+UPDATE AD_Ref_List_Trl SET Description='Sofortüberweisung (z.B. Klarna). Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543127 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Description='Instant bank transfer (e.g. Klarna). Not included in payment proposals (PaySelection).', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543127 AND AD_Language='en_US';
+
+-- S = Check (Scheck) — currently inactive
+-- AD_Ref_List_ID=335
+UPDATE AD_Ref_List SET Description='Zahlung per Scheck. Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=335;
+UPDATE AD_Ref_List_Trl SET Description='Zahlung per Scheck. Nicht in Zahlungsvorschlägen (PaySelection) enthalten.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=335 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Description='Payment by check. Not included in payment proposals (PaySelection).', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=335 AND AD_Language='en_US';
+
+-- T = DirectDeposit (Überweisung)
+-- AD_Ref_List_ID=334
+UPDATE AD_Ref_List SET Description='Banküberweisung an Lieferant/Geschäftspartner. In Zahlungsvorschlägen (PaySelection) enthalten: Kreditorenrechnungen und Debitorengutschriften. SEPA-Überweisungsdatei wird erstellt.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=334;
+UPDATE AD_Ref_List_Trl SET Description='Banküberweisung an Lieferant/Geschäftspartner. In Zahlungsvorschlägen (PaySelection) enthalten: Kreditorenrechnungen und Debitorengutschriften. SEPA-Überweisungsdatei wird erstellt.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=334 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Description='Bank transfer to vendor/business partner. Included in payment proposals (PaySelection): vendor invoices and customer credit memos. SEPA credit transfer file is generated.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=334 AND AD_Language='en_US';
+
+-- U = CreditCardExtern (Kreditkarte Extern) — currently inactive
+-- AD_Ref_List_ID=543126
+UPDATE AD_Ref_List SET Description='Extern abgewickelte Kreditkartenzahlung (z.B. Stripe, Adyen). Nicht in Zahlungsvorschlägen (PaySelection) enthalten, da Zahlung bereits extern erfolgt ist. Zuordnung über Zahlung-Zuordnung (WebUI), REST-API oder Avis.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543126;
+UPDATE AD_Ref_List_Trl SET Description='Extern abgewickelte Kreditkartenzahlung (z.B. Stripe, Adyen). Nicht in Zahlungsvorschlägen (PaySelection) enthalten, da Zahlung bereits extern erfolgt ist. Zuordnung über Zahlung-Zuordnung (WebUI), REST-API oder Avis.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543126 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Description='Externally processed credit card payment (e.g. Stripe, Adyen). Not included in payment proposals (PaySelection) since payment is already handled externally. Allocate via Payment Allocation (WebUI), REST API, or Remittance Advice.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543126 AND AD_Language='en_US';
+
+-- V = PayPalExtern (PayPal Extern) — currently inactive
+-- AD_Ref_List_ID=543125
+UPDATE AD_Ref_List SET Description='Extern abgewickelte PayPal-Zahlung. Nicht in Zahlungsvorschlägen (PaySelection) enthalten, da Zahlung bereits extern erfolgt ist. Zuordnung über Zahlung-Zuordnung (WebUI), REST-API oder Avis.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543125;
+UPDATE AD_Ref_List_Trl SET Description='Extern abgewickelte PayPal-Zahlung. Nicht in Zahlungsvorschlägen (PaySelection) enthalten, da Zahlung bereits extern erfolgt ist. Zuordnung über Zahlung-Zuordnung (WebUI), REST-API oder Avis.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543125 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Description='Externally processed PayPal payment. Not included in payment proposals (PaySelection) since payment is already handled externally. Allocate via Payment Allocation (WebUI), REST API, or Remittance Advice.', Updated='2026-02-20 12:00', UpdatedBy=100 WHERE AD_Ref_List_ID=543125 AND AD_Language='en_US';


### PR DESCRIPTION
## Summary
- Add comprehensive javadoc to `de.metas.payment.PaymentRule` enum documenting downstream behavior (PaySelection eligibility, SEPA export, OLCand order splitting)
- Add descriptions to all 13 `AD_Ref_List` entries for `_Payment Rule` (AD_Reference_ID=195) in both `de_DE` and `en_US`
- Each description explains whether the PaymentRule is included in PaySelection and, if not, how to allocate invoices instead

## Context
All PaymentRule ref-list descriptions were previously NULL. The enum had no javadoc explaining the critical downstream differences between values — particularly the hardcoded PaySelection filter in `PaySelectionUpdater.buildSelectSQL_InvoiceMatchRequirement()` that only includes `P` (OnCredit), `T` (DirectDeposit), and `D` (DirectDebit).

## Test plan
- [ ] Verify migration script applies cleanly
- [ ] Check PaymentRule descriptions are visible in WebUI dropdowns (tooltips)
- [ ] Confirm javadoc renders correctly in IDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)