### PR TITLE
#26729 TU mode: resolve from LUTU Configuration and PI Item Product

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/pp_order/JsonPPOrderRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/pp_order/JsonPPOrderRequest.java
@@ -22,6 +22,7 @@ public class JsonPPOrderRequest
 	@NonNull ZonedDateTime datePromised;
 	@Nullable Identifier salesOrderLine;
 	@Nullable Identifier lutuConfigurationTU;
+	@Nullable Identifier piItemProduct;
 
 	@Nullable Map<String, Line> lines;
 

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/pp_order/JsonPPOrderRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/pp_order/JsonPPOrderRequest.java
@@ -21,6 +21,7 @@ public class JsonPPOrderRequest
 	@NonNull BigDecimal qty;
 	@NonNull ZonedDateTime datePromised;
 	@Nullable Identifier salesOrderLine;
+	@Nullable Identifier lutuConfigurationTU;
 
 	@Nullable Map<String, Line> lines;
 

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/pp_order/PPOrderCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/pp_order/PPOrderCommand.java
@@ -2,16 +2,23 @@ package de.metas.frontend_testing.masterdata.pp_order;
 
 import de.metas.frontend_testing.masterdata.Identifier;
 import de.metas.frontend_testing.masterdata.MasterdataContext;
+import de.metas.handlingunits.HUPIItemProductId;
+import de.metas.handlingunits.IHUPIItemProductDAO;
+import de.metas.handlingunits.allocation.ILUTUConfigurationFactory;
+import de.metas.handlingunits.model.I_M_HU_LUTU_Configuration;
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.order.OrderLineId;
 import de.metas.organization.ClientAndOrgId;
 import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
+import de.metas.uom.UomId;
 import de.metas.util.Services;
 import de.metas.util.StringUtils;
 import lombok.Builder;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.warehouse.WarehouseId;
 import org.eevolution.api.IPPOrderBL;
 import org.eevolution.api.PPOrderBOMLineId;
@@ -63,12 +70,39 @@ public class PPOrderCommand
 
 		final PPOrderId ppOrderId = PPOrderId.ofRepoId(ppOrder.getPP_Order_ID());
 		context.putIdentifier(identifier, ppOrderId);
-		
+
+		if (request.getLutuConfigurationTU() != null)
+		{
+			setLUTUConfiguration(ppOrder, productId, quantity.getUomId());
+		}
+
 		checkBOMLines(ppOrderId);
 
 		return JsonPPOrderResponse.builder()
 				.documentNo(ppOrder.getDocumentNo())
 				.build();
+	}
+
+	private void setLUTUConfiguration(
+			@NonNull final I_PP_Order ppOrder,
+			@NonNull final ProductId productId,
+			@NonNull final UomId uomId)
+	{
+		final HUPIItemProductId tuPIItemProductId = context.getId(request.getLutuConfigurationTU(), HUPIItemProductId.class);
+		final I_M_HU_PI_Item_Product tuPIItemProduct = Services.get(IHUPIItemProductDAO.class).getRecordById(tuPIItemProductId);
+
+		final ILUTUConfigurationFactory lutuConfigurationFactory = Services.get(ILUTUConfigurationFactory.class);
+		final I_M_HU_LUTU_Configuration lutuConfiguration = lutuConfigurationFactory.createLUTUConfiguration(
+				tuPIItemProduct,
+				productId,
+				uomId,
+				null,
+				true);
+		lutuConfigurationFactory.save(lutuConfiguration);
+
+		final de.metas.handlingunits.model.I_PP_Order huPPOrder = InterfaceWrapperHelper.create(ppOrder, de.metas.handlingunits.model.I_PP_Order.class);
+		huPPOrder.setM_HU_LUTU_Configuration(lutuConfiguration);
+		InterfaceWrapperHelper.save(huPPOrder);
 	}
 
 	private void checkBOMLines(final PPOrderId ppOrderId)

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/pp_order/PPOrderCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/pp_order/PPOrderCommand.java
@@ -76,6 +76,11 @@ public class PPOrderCommand
 			setLUTUConfiguration(ppOrder, productId, quantity.getUomId());
 		}
 
+		if (request.getPiItemProduct() != null)
+		{
+			setPIItemProduct(ppOrder);
+		}
+
 		checkBOMLines(ppOrderId);
 
 		return JsonPPOrderResponse.builder()
@@ -103,6 +108,13 @@ public class PPOrderCommand
 		final de.metas.handlingunits.model.I_PP_Order huPPOrder = InterfaceWrapperHelper.create(ppOrder, de.metas.handlingunits.model.I_PP_Order.class);
 		huPPOrder.setM_HU_LUTU_Configuration(lutuConfiguration);
 		InterfaceWrapperHelper.save(huPPOrder);
+	}
+
+	private void setPIItemProduct(@NonNull final I_PP_Order ppOrder)
+	{
+		final HUPIItemProductId piItemProductId = context.getId(request.getPiItemProduct(), HUPIItemProductId.class);
+		ppOrder.setM_HU_PI_Item_Product_ID(piItemProductId.getRepoId());
+		InterfaceWrapperHelper.save(ppOrder);
 	}
 
 	private void checkBOMLines(final PPOrderId ppOrderId)

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/pporder/api/impl/PPOrderDocumentLUTUConfigurationHandlerTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/pporder/api/impl/PPOrderDocumentLUTUConfigurationHandlerTest.java
@@ -22,6 +22,7 @@ import de.metas.handlingunits.model.I_PP_Order;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
 import de.metas.product.ProductId;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /*
@@ -120,67 +121,112 @@ public class PPOrderDocumentLUTUConfigurationHandlerTest
 		assertThat(lutuConfiguration.getQtyCUsPerTU()).isEqualByComparingTo(ZERO);
 	}
 
-	@Test
-	public void getM_HU_PI_Item_Product_from_LUTUConfiguration()
+	@Nested
+	class GetM_HU_PI_Item_Product
 	{
-		// Create a second TU definition: 5 CUs per TU (different from the default 10 CUs per TU)
-		final I_M_HU_PI piTU2 = huTestHelper.createHUDefinition("TU2", X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit);
-		final I_M_HU_PI_Item piTU2_Item = huTestHelper.createHU_PI_Item_Material(piTU2);
-		final I_M_HU_PI_Item_Product piTU2_Item_Product = huTestHelper.assignProduct(piTU2_Item, productId, new BigDecimal("5"), productUOM);
+		private I_M_HU_PI_Item_Product piTU2_Item_Product;
 
-		// Create a PP_Order linked to the first PI Item Product (10 CUs/TU) via order line
-		final I_PP_Order ppOrder = createPPOrder(piTU_Item_Product, TEN);
+		@BeforeEach
+		void createSecondTU()
+		{
+			// Create a second TU definition: 5 CUs per TU (different from the default 10 CUs per TU)
+			final I_M_HU_PI piTU2 = huTestHelper.createHUDefinition("TU2", X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit);
+			final I_M_HU_PI_Item piTU2_Item = huTestHelper.createHU_PI_Item_Material(piTU2);
+			piTU2_Item_Product = huTestHelper.assignProduct(piTU2_Item, productId, new BigDecimal("5"), productUOM);
+		}
 
-		// Create an LUTU Configuration pointing to the second PI Item Product (5 CUs/TU)
-		final I_M_HU_LUTU_Configuration lutuConfig = newInstance(I_M_HU_LUTU_Configuration.class);
-		lutuConfig.setM_HU_PI_Item_Product_ID(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
-		save(lutuConfig);
+		@Test
+		void from_LUTUConfiguration()
+		{
+			// Create a PP_Order linked to the first PI Item Product (10 CUs/TU) via order line
+			final I_PP_Order ppOrder = createPPOrder(piTU_Item_Product, TEN);
 
-		// Set the LUTU Configuration on the PP_Order
-		ppOrder.setM_HU_LUTU_Configuration(lutuConfig);
-		save(ppOrder);
+			// Create an LUTU Configuration pointing to the second PI Item Product (5 CUs/TU)
+			final I_M_HU_LUTU_Configuration lutuConfig = newInstance(I_M_HU_LUTU_Configuration.class);
+			lutuConfig.setM_HU_PI_Item_Product_ID(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
+			save(lutuConfig);
 
-		// invoke the method under test
-		final I_M_HU_PI_Item_Product result = PPOrderDocumentLUTUConfigurationHandler.instance
-				.getM_HU_PI_Item_Product(ppOrder);
+			// Set the LUTU Configuration on the PP_Order
+			ppOrder.setM_HU_LUTU_Configuration(lutuConfig);
+			save(ppOrder);
 
-		// Expect: LUTU Configuration's PI Item Product wins over the order line's
-		assertThat(result.getM_HU_PI_Item_Product_ID())
-				.as("LUTU Configuration's PI Item Product should take priority over order line's")
-				.isEqualTo(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
-	}
+			// invoke the method under test
+			final I_M_HU_PI_Item_Product result = PPOrderDocumentLUTUConfigurationHandler.instance
+					.getM_HU_PI_Item_Product(ppOrder);
 
-	@Test
-	public void getM_HU_PI_Item_Product_from_LUTUConfiguration_noOrderLine()
-	{
-		// Create a TU definition: 5 CUs per TU
-		final I_M_HU_PI piTU2 = huTestHelper.createHUDefinition("TU2", X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit);
-		final I_M_HU_PI_Item piTU2_Item = huTestHelper.createHU_PI_Item_Material(piTU2);
-		final I_M_HU_PI_Item_Product piTU2_Item_Product = huTestHelper.assignProduct(piTU2_Item, productId, new BigDecimal("5"), productUOM);
+			// Expect: LUTU Configuration's PI Item Product wins over the order line's
+			assertThat(result.getM_HU_PI_Item_Product_ID())
+					.as("LUTU Configuration's PI Item Product should take priority over order line's")
+					.isEqualTo(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
+		}
 
-		// Create a PP_Order WITHOUT an order line
-		final I_PP_Order ppOrder = newInstance(I_PP_Order.class);
-		ppOrder.setM_Product_ID(productId.getRepoId());
-		ppOrder.setC_UOM_ID(productUOM.getC_UOM_ID());
-		ppOrder.setQtyOrdered(TEN);
-		save(ppOrder);
+		@Test
+		void from_LUTUConfiguration_noOrderLine()
+		{
+			// Create a PP_Order WITHOUT an order line
+			final I_PP_Order ppOrder = newInstance(I_PP_Order.class);
+			ppOrder.setM_Product_ID(productId.getRepoId());
+			ppOrder.setC_UOM_ID(productUOM.getC_UOM_ID());
+			ppOrder.setQtyOrdered(TEN);
+			save(ppOrder);
 
-		// Create an LUTU Configuration pointing to the PI Item Product
-		final I_M_HU_LUTU_Configuration lutuConfig = newInstance(I_M_HU_LUTU_Configuration.class);
-		lutuConfig.setM_HU_PI_Item_Product_ID(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
-		save(lutuConfig);
+			// Create an LUTU Configuration pointing to the PI Item Product
+			final I_M_HU_LUTU_Configuration lutuConfig = newInstance(I_M_HU_LUTU_Configuration.class);
+			lutuConfig.setM_HU_PI_Item_Product_ID(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
+			save(lutuConfig);
 
-		// Set the LUTU Configuration on the PP_Order
-		ppOrder.setM_HU_LUTU_Configuration(lutuConfig);
-		save(ppOrder);
+			// Set the LUTU Configuration on the PP_Order
+			ppOrder.setM_HU_LUTU_Configuration(lutuConfig);
+			save(ppOrder);
 
-		// invoke the method under test
-		final I_M_HU_PI_Item_Product result = PPOrderDocumentLUTUConfigurationHandler.instance
-				.getM_HU_PI_Item_Product(ppOrder);
+			// invoke the method under test
+			final I_M_HU_PI_Item_Product result = PPOrderDocumentLUTUConfigurationHandler.instance
+					.getM_HU_PI_Item_Product(ppOrder);
 
-		// Expect: LUTU Configuration's PI Item Product is returned
-		assertThat(result.getM_HU_PI_Item_Product_ID())
-				.isEqualTo(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
+			// Expect: LUTU Configuration's PI Item Product is returned
+			assertThat(result.getM_HU_PI_Item_Product_ID())
+					.isEqualTo(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
+		}
+
+		@Test
+		void from_PPOrder_PIItemProduct_noOrderLine()
+		{
+			// Create a PP_Order WITHOUT an order line, but with M_HU_PI_Item_Product_ID set
+			final I_PP_Order ppOrder = newInstance(I_PP_Order.class);
+			ppOrder.setM_Product_ID(productId.getRepoId());
+			ppOrder.setC_UOM_ID(productUOM.getC_UOM_ID());
+			ppOrder.setQtyOrdered(TEN);
+			ppOrder.setM_HU_PI_Item_Product_ID(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
+			save(ppOrder);
+
+			// invoke the method under test
+			final I_M_HU_PI_Item_Product result = PPOrderDocumentLUTUConfigurationHandler.instance
+					.getM_HU_PI_Item_Product(ppOrder);
+
+			// Expect: PP_Order's M_HU_PI_Item_Product_ID is returned
+			assertThat(result.getM_HU_PI_Item_Product_ID())
+					.isEqualTo(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
+		}
+
+		@Test
+		void from_PPOrder_PIItemProduct_winsOverOrderLine()
+		{
+			// Create a PP_Order linked to the first PI Item Product (10 CUs/TU) via order line
+			final I_PP_Order ppOrder = createPPOrder(piTU_Item_Product, TEN);
+
+			// Set M_HU_PI_Item_Product_ID on PP_Order to the second PI Item Product (5 CUs/TU)
+			ppOrder.setM_HU_PI_Item_Product_ID(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
+			save(ppOrder);
+
+			// invoke the method under test
+			final I_M_HU_PI_Item_Product result = PPOrderDocumentLUTUConfigurationHandler.instance
+					.getM_HU_PI_Item_Product(ppOrder);
+
+			// Expect: PP_Order's M_HU_PI_Item_Product_ID wins over order line's
+			assertThat(result.getM_HU_PI_Item_Product_ID())
+					.as("PP_Order.M_HU_PI_Item_Product_ID should take priority over order line's")
+					.isEqualTo(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
+		}
 	}
 
 	private I_PP_Order createPPOrder(final I_M_HU_PI_Item_Product piTU_Item_Product, final BigDecimal qtyOrdered)

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/pporder/api/impl/PPOrderDocumentLUTUConfigurationHandlerTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/pporder/api/impl/PPOrderDocumentLUTUConfigurationHandlerTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.Test;
 public class PPOrderDocumentLUTUConfigurationHandlerTest
 {
 	private static final BigDecimal THREE = new BigDecimal("3");
+	private HUTestHelper huTestHelper;
 	private I_C_UOM productUOM;
 	private ProductId productId;
 	private I_M_HU_PI_Item_Product piTU_Item_Product;
@@ -59,7 +60,7 @@ public class PPOrderDocumentLUTUConfigurationHandlerTest
 	{
 		AdempiereTestHelper.get().init();
 
-		final HUTestHelper huTestHelper = new HUTestHelper();
+		huTestHelper = new HUTestHelper();
 
 		productId = huTestHelper.pTomatoProductId;
 		productUOM = huTestHelper.uomEach;
@@ -117,6 +118,69 @@ public class PPOrderDocumentLUTUConfigurationHandlerTest
 
 		assertThat(lutuConfiguration.isInfiniteQtyCU()).isTrue();
 		assertThat(lutuConfiguration.getQtyCUsPerTU()).isEqualByComparingTo(ZERO);
+	}
+
+	@Test
+	public void getM_HU_PI_Item_Product_from_LUTUConfiguration()
+	{
+		// Create a second TU definition: 5 CUs per TU (different from the default 10 CUs per TU)
+		final I_M_HU_PI piTU2 = huTestHelper.createHUDefinition("TU2", X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit);
+		final I_M_HU_PI_Item piTU2_Item = huTestHelper.createHU_PI_Item_Material(piTU2);
+		final I_M_HU_PI_Item_Product piTU2_Item_Product = huTestHelper.assignProduct(piTU2_Item, productId, new BigDecimal("5"), productUOM);
+
+		// Create a PP_Order linked to the first PI Item Product (10 CUs/TU) via order line
+		final I_PP_Order ppOrder = createPPOrder(piTU_Item_Product, TEN);
+
+		// Create an LUTU Configuration pointing to the second PI Item Product (5 CUs/TU)
+		final I_M_HU_LUTU_Configuration lutuConfig = newInstance(I_M_HU_LUTU_Configuration.class);
+		lutuConfig.setM_HU_PI_Item_Product_ID(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
+		save(lutuConfig);
+
+		// Set the LUTU Configuration on the PP_Order
+		ppOrder.setM_HU_LUTU_Configuration(lutuConfig);
+		save(ppOrder);
+
+		// invoke the method under test
+		final I_M_HU_PI_Item_Product result = PPOrderDocumentLUTUConfigurationHandler.instance
+				.getM_HU_PI_Item_Product(ppOrder);
+
+		// Expect: LUTU Configuration's PI Item Product wins over the order line's
+		assertThat(result.getM_HU_PI_Item_Product_ID())
+				.as("LUTU Configuration's PI Item Product should take priority over order line's")
+				.isEqualTo(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
+	}
+
+	@Test
+	public void getM_HU_PI_Item_Product_from_LUTUConfiguration_noOrderLine()
+	{
+		// Create a TU definition: 5 CUs per TU
+		final I_M_HU_PI piTU2 = huTestHelper.createHUDefinition("TU2", X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit);
+		final I_M_HU_PI_Item piTU2_Item = huTestHelper.createHU_PI_Item_Material(piTU2);
+		final I_M_HU_PI_Item_Product piTU2_Item_Product = huTestHelper.assignProduct(piTU2_Item, productId, new BigDecimal("5"), productUOM);
+
+		// Create a PP_Order WITHOUT an order line
+		final I_PP_Order ppOrder = newInstance(I_PP_Order.class);
+		ppOrder.setM_Product_ID(productId.getRepoId());
+		ppOrder.setC_UOM_ID(productUOM.getC_UOM_ID());
+		ppOrder.setQtyOrdered(TEN);
+		save(ppOrder);
+
+		// Create an LUTU Configuration pointing to the PI Item Product
+		final I_M_HU_LUTU_Configuration lutuConfig = newInstance(I_M_HU_LUTU_Configuration.class);
+		lutuConfig.setM_HU_PI_Item_Product_ID(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
+		save(lutuConfig);
+
+		// Set the LUTU Configuration on the PP_Order
+		ppOrder.setM_HU_LUTU_Configuration(lutuConfig);
+		save(ppOrder);
+
+		// invoke the method under test
+		final I_M_HU_PI_Item_Product result = PPOrderDocumentLUTUConfigurationHandler.instance
+				.getM_HU_PI_Item_Product(ppOrder);
+
+		// Expect: LUTU Configuration's PI Item Product is returned
+		assertThat(result.getM_HU_PI_Item_Product_ID())
+				.isEqualTo(piTU2_Item_Product.getM_HU_PI_Item_Product_ID());
 	}
 
 	private I_PP_Order createPPOrder(final I_M_HU_PI_Item_Product piTU_Item_Product, final BigDecimal qtyOrdered)

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/commands/create_job/ManufacturingJobCreateCommand.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/commands/create_job/ManufacturingJobCreateCommand.java
@@ -2,6 +2,8 @@ package de.metas.manufacturing.job.service.commands.create_job;
 
 import com.google.common.collect.ArrayListMultimap;
 import de.metas.handlingunits.HUPIItemProductId;
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.handlingunits.model.I_PP_Order;
 import de.metas.handlingunits.pporder.api.IHUPPOrderBL;
 import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueSchedule;
 import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleCreateRequest;
@@ -16,8 +18,6 @@ import de.metas.manufacturing.issue.plan.PPOrderIssuePlanStep;
 import de.metas.manufacturing.job.model.ManufacturingJob;
 import de.metas.manufacturing.job.service.ManufacturingJobLoaderAndSaver;
 import de.metas.manufacturing.job.service.ManufacturingJobLoaderAndSaverSupportingServices;
-import de.metas.order.OrderLineId;
-import de.metas.product.ProductId;
 import de.metas.user.UserId;
 import de.metas.util.GuavaCollectors;
 import de.metas.util.lang.SeqNoProvider;
@@ -29,8 +29,6 @@ import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.service.ClientId;
 import org.eevolution.api.PPOrderBOMLineId;
 import org.eevolution.api.PPOrderId;
-import org.eevolution.model.I_PP_Order;
-
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -134,23 +132,11 @@ public class ManufacturingJobCreateCommand
 	@Nullable
 	private HUPIItemProductId suggestReceivingTUPIItemProductId()
 	{
-		// Try from order line's packing instructions
-		HUPIItemProductId tuPIItemProductId = null;
-		final OrderLineId orderLineId = OrderLineId.ofRepoIdOrNull(ppOrder.getC_OrderLine_ID());
-		if (orderLineId != null)
-		{
-			tuPIItemProductId = loadingSupportServices.getSalesOrderTUPIItemProductId(orderLineId).orElse(null);
-		}
+		final I_M_HU_PI_Item_Product pip = ppOrderBL.createReceiptLUTUConfigurationManager(ppOrder)
+				.getM_HU_PI_Item_Product();
 
-		// Fallback: default for product
-		if (tuPIItemProductId == null)
-		{
-			tuPIItemProductId = this.loadingSupportServices.getDefaultTUPIItemProductId(
-					ProductId.ofRepoId(ppOrder.getM_Product_ID()),
-					ppOrder.getDateStartSchedule().toInstant()
-			).orElse(null);
-		}
-		return tuPIItemProductId;
+		final HUPIItemProductId id = HUPIItemProductId.ofRepoId(pip.getM_HU_PI_Item_Product_ID());
+		return id.isVirtualHU() ? null : id;
 	}
 
 	private void setResponsible()

--- a/e2e/mobile-webui/tests/spec/manufacturing/receiving_tu_mode_lutu_config.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/receiving_tu_mode_lutu_config.spec.js
@@ -1,0 +1,121 @@
+import { Backend } from '../../utils/screens/Backend';
+import { test } from '../../../playwright.config';
+import { allure } from 'allure-playwright';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/ManufacturingJobsListScreen';
+import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
+import { MaterialReceiptLineScreen } from '../../utils/screens/manufacturing/receipt/MaterialReceiptLineScreen';
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: {
+                user: { language: "en_US" },
+            },
+            mobileConfig: {
+                manufacturing: {
+                    receiveUnitType: 'TU',
+                },
+            },
+            bpartners: {
+                "BP1": {},
+            },
+            warehouses: {
+                "wh": {},
+            },
+            products: {
+                "COMP1": {},
+                "COMP2": {},
+                "BOM": {
+                    prices: [{ price: 1 }],
+                    bom: {
+                        lines: [
+                            { product: 'COMP1', qty: 1 },
+                            { product: 'COMP2', qty: 2 },
+                        ]
+                    }
+                },
+            },
+            packingInstructions: {
+                "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "BOM", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU_COMP1": { product: 'COMP1', warehouse: 'wh', qty: 100 },
+                "HU_COMP2": { product: 'COMP2', warehouse: 'wh', qty: 200 },
+            },
+            // No sales order — the PP_Order uses lutuConfigurationTU to set LUTU configuration directly
+            manufacturingOrders: {
+                "PP1": {
+                    warehouse: 'wh',
+                    product: 'BOM',
+                    qty: 80,
+                    lutuConfigurationTU: 'TU',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                }
+            },
+        }
+    });
+}
+
+// noinspection JSUnusedLocalSymbols
+test('Receive in TU mode via LUTU configuration to a new TU target', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0160: Manufacturing Execution');
+    allure.tag('F8030: MobileUI Manufacturing');
+    allure.tag('F8030');
+    allure.story('Receive main products in TU mode via LUTU configuration');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('mfg');
+    await ManufacturingJobsListScreen.waitForScreen();
+    const { jobId } = await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+
+    // In TU mode, the receive button should show quantities in TUs:
+    // 80 CUs / 4 CUs per TU = 20 TUs
+    await ManufacturingJobScreen.expectReceiveButton({
+        index: 1,
+        qtyToReceive: '20 TU',
+        qtyReceived: '0 TU',
+    });
+
+    // Receive 5 TUs to a new TU target
+    await ManufacturingJobScreen.clickReceiveButton({ index: 1 });
+    await MaterialReceiptLineScreen.selectNewTUTarget({ tuPIItemProductTestId: masterdata.packingInstructions.PI.tuPIItemProductTestId });
+    await MaterialReceiptLineScreen.expectHeaderProperty({ caption: 'Qty to Receive Target', value: '20 TU' });
+    await MaterialReceiptLineScreen.expectHeaderProperty({ caption: 'Qty to Receive', value: '20 TU' });
+    await MaterialReceiptLineScreen.expectHeaderProperty({ caption: 'Qty Received', value: '0 TU' });
+    await MaterialReceiptLineScreen.receiveQty({
+        expectQtyEntered: '20',
+        qtyEntered: '5',
+    });
+
+    // Verify partial receive in TU mode
+    await ManufacturingJobScreen.expectReceiveButton({
+        index: 1,
+        qtyToReceive: '20 TU',
+        qtyReceived: '5 TU',
+    });
+
+    await ManufacturingJobScreen.complete();
+
+    // Backend validation: 5 TUs × 4 CUs/TU = 20 CUs
+    await Backend.expect({
+        manufacturings: {
+            [jobId]: {
+                receivedHUs: [
+                    { tu: 'tu1', qty: '4 PCE' },
+                    { tu: 'tu2', qty: '4 PCE' },
+                    { tu: 'tu3', qty: '4 PCE' },
+                    { tu: 'tu4', qty: '4 PCE' },
+                    { tu: 'tu5', qty: '4 PCE' },
+                ]
+            }
+        },
+    });
+});

--- a/e2e/mobile-webui/tests/spec/manufacturing/receiving_tu_mode_pi_item_product.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/receiving_tu_mode_pi_item_product.spec.js
@@ -1,0 +1,121 @@
+import { Backend } from '../../utils/screens/Backend';
+import { test } from '../../../playwright.config';
+import { allure } from 'allure-playwright';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/ManufacturingJobsListScreen';
+import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
+import { MaterialReceiptLineScreen } from '../../utils/screens/manufacturing/receipt/MaterialReceiptLineScreen';
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: {
+                user: { language: "en_US" },
+            },
+            mobileConfig: {
+                manufacturing: {
+                    receiveUnitType: 'TU',
+                },
+            },
+            bpartners: {
+                "BP1": {},
+            },
+            warehouses: {
+                "wh": {},
+            },
+            products: {
+                "COMP1": {},
+                "COMP2": {},
+                "BOM": {
+                    prices: [{ price: 1 }],
+                    bom: {
+                        lines: [
+                            { product: 'COMP1', qty: 1 },
+                            { product: 'COMP2', qty: 2 },
+                        ]
+                    }
+                },
+            },
+            packingInstructions: {
+                "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "BOM", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU_COMP1": { product: 'COMP1', warehouse: 'wh', qty: 100 },
+                "HU_COMP2": { product: 'COMP2', warehouse: 'wh', qty: 200 },
+            },
+            // No sales order — the PP_Order uses piItemProduct to set M_HU_PI_Item_Product_ID directly
+            manufacturingOrders: {
+                "PP1": {
+                    warehouse: 'wh',
+                    product: 'BOM',
+                    qty: 80,
+                    piItemProduct: 'TU',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                }
+            },
+        }
+    });
+}
+
+// noinspection JSUnusedLocalSymbols
+test('Receive in TU mode via PP_Order M_HU_PI_Item_Product to a new TU target', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0160: Manufacturing Execution');
+    allure.tag('F8030: MobileUI Manufacturing');
+    allure.tag('F8030');
+    allure.story('Receive main products in TU mode via PP_Order PI Item Product');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('mfg');
+    await ManufacturingJobsListScreen.waitForScreen();
+    const { jobId } = await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+
+    // In TU mode, the receive button should show quantities in TUs:
+    // 80 CUs / 4 CUs per TU = 20 TUs
+    await ManufacturingJobScreen.expectReceiveButton({
+        index: 1,
+        qtyToReceive: '20 TU',
+        qtyReceived: '0 TU',
+    });
+
+    // Receive 5 TUs to a new TU target
+    await ManufacturingJobScreen.clickReceiveButton({ index: 1 });
+    await MaterialReceiptLineScreen.selectNewTUTarget({ tuPIItemProductTestId: masterdata.packingInstructions.PI.tuPIItemProductTestId });
+    await MaterialReceiptLineScreen.expectHeaderProperty({ caption: 'Qty to Receive Target', value: '20 TU' });
+    await MaterialReceiptLineScreen.expectHeaderProperty({ caption: 'Qty to Receive', value: '20 TU' });
+    await MaterialReceiptLineScreen.expectHeaderProperty({ caption: 'Qty Received', value: '0 TU' });
+    await MaterialReceiptLineScreen.receiveQty({
+        expectQtyEntered: '20',
+        qtyEntered: '5',
+    });
+
+    // Verify partial receive in TU mode
+    await ManufacturingJobScreen.expectReceiveButton({
+        index: 1,
+        qtyToReceive: '20 TU',
+        qtyReceived: '5 TU',
+    });
+
+    await ManufacturingJobScreen.complete();
+
+    // Backend validation: 5 TUs × 4 CUs/TU = 20 CUs
+    await Backend.expect({
+        manufacturings: {
+            [jobId]: {
+                receivedHUs: [
+                    { tu: 'tu1', qty: '4 PCE' },
+                    { tu: 'tu2', qty: '4 PCE' },
+                    { tu: 'tu3', qty: '4 PCE' },
+                    { tu: 'tu4', qty: '4 PCE' },
+                    { tu: 'tu5', qty: '4 PCE' },
+                ]
+            }
+        },
+    });
+});


### PR DESCRIPTION
## Summary

- Delegate `suggestReceivingTUPIItemProductId()` to `PPOrderDocumentLUTUConfigurationHandler` which checks `PP_Order.M_HU_LUTU_Configuration` first, then `PP_Order.M_HU_PI_Item_Product_ID`, then falls back to sales order line
- Add E2E masterdata support for `lutuConfigurationTU` and `piItemProduct` on manufacturing orders (sets LUTU config / PI Item Product directly on PP_Order)
- Add two new E2E tests verifying TU mode works via each path (without a sales order)

## Test plan

- [x] E2E `receiving_tu_mode_lutu_config.spec.js` — TU mode via `PP_Order.M_HU_LUTU_Configuration` (passing)
- [x] E2E `receiving_tu_mode_pi_item_product.spec.js` — TU mode via `PP_Order.M_HU_PI_Item_Product_ID` (passing)
- [x] Existing `receiving_tu_mode.spec.js` — TU mode via sales order line (unchanged)
- [ ] Unit test `PPOrderDocumentLUTUConfigurationHandlerTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)