### PR TITLE
gh#28337: Bank fee WriteOffType on C_AllocationLine

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -565,10 +565,10 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 			final BankAccountId bankAccountId = BankAccountId.ofRepoIdOrNull(payment.getC_BP_BankAccount_ID());
 			if (bankAccountId != null)
 			{
-				final Optional<Account> acct = getAccountProvider().getBankAccountAccountIfSet(acctSchemaId, bankAccountId, BankAccountAcctType.PayBankFee_Acct);
-				if (acct.isPresent())
+				final Account acct = getAccountProvider().getBankAccountAccountIfSet(acctSchemaId, bankAccountId, BankAccountAcctType.PayBankFee_Acct).orElse(null);
+				if (acct != null)
 				{
-					return acct;
+					return Optional.of(acct);
 				}
 			}
 		}

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -42,6 +42,7 @@ import de.metas.payment.api.IPaymentBL;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import de.metas.util.StringUtils;
+import lombok.Getter;
 import lombok.NonNull;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.DBException;
@@ -151,8 +152,7 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 	private final BigDecimal m_OverUnderAmt;
 	private final BigDecimal m_PaymentWriteOffAmt;
 
-	@NonNull
-	private final WriteOffType writeOffType;
+	@NonNull @Getter private final WriteOffType writeOffType;
 
 	/**
 	 * String Representation
@@ -549,12 +549,6 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 		}
 
 		return getAccountProvider().getBankAccountAccountIfSet(acctSchemaId, bankAccountId, BankAccountAcctType.Payment_WriteOff_Acct);
-	}
-
-	@NonNull
-	public WriteOffType getWriteOffType()
-	{
-		return writeOffType;
 	}
 
 	public boolean isBankFeeWriteOff()

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -564,19 +564,23 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 
 	public Optional<Account> getBankFeeAccount(final AcctSchemaId acctSchemaId)
 	{
+		// Try payment's bank account first
 		final I_C_Payment payment = getC_Payment();
-		if (payment == null)
+		if (payment != null)
 		{
-			return Optional.empty();
+			final BankAccountId bankAccountId = BankAccountId.ofRepoIdOrNull(payment.getC_BP_BankAccount_ID());
+			if (bankAccountId != null)
+			{
+				final Optional<Account> acct = getAccountProvider().getBankAccountAccountIfSet(acctSchemaId, bankAccountId, BankAccountAcctType.PayBankFee_Acct);
+				if (acct.isPresent())
+				{
+					return acct;
+				}
+			}
 		}
 
-		final BankAccountId bankAccountId = BankAccountId.ofRepoIdOrNull(payment.getC_BP_BankAccount_ID());
-		if (bankAccountId == null)
-		{
-			return Optional.empty();
-		}
-
-		return getAccountProvider().getBankAccountAccountIfSet(acctSchemaId, bankAccountId, BankAccountAcctType.PayBankFee_Acct);
+		// Fallback: schema default
+		return getAccountProvider().getAcctSchemaDefaultPayBankFeeAccount(acctSchemaId);
 	}
 
 	public final CurrencyConversionContext getInvoiceCurrencyConversionCtx()

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -22,6 +22,7 @@ import de.metas.acct.accounts.BPartnerVendorAccountType;
 import de.metas.acct.accounts.CashAccountType;
 import de.metas.acct.api.AcctSchema;
 import de.metas.acct.api.AcctSchemaId;
+import de.metas.allocation.api.WriteOffType;
 import de.metas.banking.BankAccountId;
 import de.metas.banking.accounting.BankAccountAcctType;
 import de.metas.bpartner.BPartnerId;
@@ -122,6 +123,8 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 		m_WriteOffAmt = Money.of(line.getWriteOffAmt(), doc.getCurrencyId());
 		m_OverUnderAmt = line.getOverUnderAmt();
 		m_PaymentWriteOffAmt = line.getPaymentWriteOffAmt();
+
+		this.writeOffType = WriteOffType.ofNullableCodeOrWriteOff(line.getWriteOffType());
 	}    // DocLine_Allocation
 
 	private final int m_C_Invoice_ID;
@@ -147,6 +150,9 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 	private final Money m_WriteOffAmt;
 	private final BigDecimal m_OverUnderAmt;
 	private final BigDecimal m_PaymentWriteOffAmt;
+
+	@NonNull
+	private final WriteOffType writeOffType;
 
 	/**
 	 * String Representation
@@ -543,6 +549,34 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 		}
 
 		return getAccountProvider().getBankAccountAccountIfSet(acctSchemaId, bankAccountId, BankAccountAcctType.Payment_WriteOff_Acct);
+	}
+
+	@NonNull
+	public WriteOffType getWriteOffType()
+	{
+		return writeOffType;
+	}
+
+	public boolean isBankFeeWriteOff()
+	{
+		return writeOffType.isBankFee();
+	}
+
+	public Optional<Account> getBankFeeAccount(final AcctSchemaId acctSchemaId)
+	{
+		final I_C_Payment payment = getC_Payment();
+		if (payment == null)
+		{
+			return Optional.empty();
+		}
+
+		final BankAccountId bankAccountId = BankAccountId.ofRepoIdOrNull(payment.getC_BP_BankAccount_ID());
+		if (bankAccountId == null)
+		{
+			return Optional.empty();
+		}
+
+		return getAccountProvider().getBankAccountAccountIfSet(acctSchemaId, bankAccountId, BankAccountAcctType.PayBankFee_Acct);
 	}
 
 	public final CurrencyConversionContext getInvoiceCurrencyConversionCtx()

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -764,9 +764,25 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		}
 
 		final AcctSchema as = fact.getAcctSchema();
+
+		// Determine account based on WriteOffType: bank fee uses PayBankFee_Acct, standard write-off uses WriteOff_Acct
+		final Account writeOffAcct;
+		if (line.isBankFeeWriteOff())
+		{
+			writeOffAcct = line.getBankFeeAccount(as.getId())
+					.orElseThrow(() -> newPostingException()
+							.setDocLine(line)
+							.setAcctSchema(as)
+							.setDetailMessage("PayBankFee_Acct not configured for the payment's bank account"));
+		}
+		else
+		{
+			writeOffAcct = getBPGroupAccount(BPartnerGroupAccountType.WriteOff, as);
+		}
+
 		final FactLineBuilder factLineBuilder = fact.createLine()
 				.setDocLine(line)
-				.setAccount(getBPGroupAccount(BPartnerGroupAccountType.WriteOff, as))
+				.setAccount(writeOffAcct)
 				.setCurrencyId(getCurrencyId())
 				.orgId(line.getPaymentOrgId())
 				.bPartnerAndLocationId(line.getPaymentBPartnerId(), line.getPaymentBPartnerLocationId())
@@ -1091,7 +1107,16 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		//
 		// Get discount and write off amounts to be corrected
 		final Money discountAmt = taxCorrectionType.isDiscount() ? line.getDiscountAmt() : line.getDiscountAmt().toZero();
-		final Money writeOffAmt = taxCorrectionType.isWriteOff() ? line.getWriteOffAmt() : line.getWriteOffAmt().toZero();
+		// Bank fees are VAT-neutral — skip tax correction regardless of schema's TaxCorrectionType
+		final Money writeOffAmt;
+		if (line.isBankFeeWriteOff())
+		{
+			writeOffAmt = line.getWriteOffAmt().toZero();
+		}
+		else
+		{
+			writeOffAmt = taxCorrectionType.isWriteOff() ? line.getWriteOffAmt() : line.getWriteOffAmt().toZero();
+		}
 		if (discountAmt.signum() == 0 && writeOffAmt.signum() == 0)
 		{
 			// no amounts => nothing to do

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/accounts/AccountProvider.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/accounts/AccountProvider.java
@@ -167,6 +167,12 @@ public class AccountProvider
 	}
 
 	@NonNull
+	public Optional<Account> getAcctSchemaDefaultPayBankFeeAccount(@NonNull final AcctSchemaId acctSchemaId)
+	{
+		return bankAccountAcctRepository.getAcctSchemaDefaultPayBankFeeAccount(acctSchemaId);
+	}
+
+	@NonNull
 	public Account getCashAccount(
 			@NonNull final AcctSchemaId ignoredAcctSchemaId,
 			final int ignoredCashBookId,

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_AcctSchema_Default.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_AcctSchema_Default.java
@@ -1648,6 +1648,29 @@ public interface I_C_AcctSchema_Default
     public static final String COLUMNNAME_PayDiscount_Rev_Acct = "PayDiscount_Rev_Acct";
 
 	/**
+	 * Set Bank Fee Account.
+	 *
+	 * <br>Type: Account
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	public void setPayBankFee_Acct (int PayBankFee_Acct);
+
+	/**
+	 * Get Bank Fee Account.
+	 *
+	 * <br>Type: Account
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	public int getPayBankFee_Acct();
+
+    /** Column definition for PayBankFee_Acct */
+    public static final org.adempiere.model.ModelColumn<I_C_AcctSchema_Default, org.compiere.model.I_C_ValidCombination> COLUMN_PayBankFee_Acct = new org.adempiere.model.ModelColumn<>(I_C_AcctSchema_Default.class, "PayBankFee_Acct", org.compiere.model.I_C_ValidCombination.class);
+    /** Column name PayBankFee_Acct */
+    public static final String COLUMNNAME_PayBankFee_Acct = "PayBankFee_Acct";
+
+	/**
 	 * Set Project Asset.
 	 * Project Asset Account
 	 *

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_AllocationLine.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_AllocationLine.java
@@ -527,4 +527,27 @@ public interface I_C_AllocationLine
     public static final org.adempiere.model.ModelColumn<I_C_AllocationLine, Object> COLUMN_WriteOffAmt = new org.adempiere.model.ModelColumn<I_C_AllocationLine, Object>(I_C_AllocationLine.class, "WriteOffAmt", null);
     /** Column name WriteOffAmt */
     public static final String COLUMNNAME_WriteOffAmt = "WriteOffAmt";
+
+	/**
+	 * Set Write-Off Type.
+	 * Discriminates standard write-off (WO) from bank fee (BF)
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	public void setWriteOffType (String WriteOffType);
+
+	/**
+	 * Get Write-Off Type.
+	 * Discriminates standard write-off (WO) from bank fee (BF)
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	public String getWriteOffType();
+
+    /** Column name WriteOffType */
+    public static final String COLUMNNAME_WriteOffType = "WriteOffType";
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_AcctSchema_Default.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_AcctSchema_Default.java
@@ -1892,9 +1892,28 @@ public class X_C_AcctSchema_Default extends org.compiere.model.PO implements I_C
 		@return Konto für erhaltene Skonti
 	  */
 	@Override
-	public int getPayDiscount_Rev_Acct () 
+	public int getPayDiscount_Rev_Acct ()
 	{
 		Integer ii = (Integer)get_Value(COLUMNNAME_PayDiscount_Rev_Acct);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Bank Fee Account.
+		@param PayBankFee_Acct Bank Fee Account	  */
+	@Override
+	public void setPayBankFee_Acct (int PayBankFee_Acct)
+	{
+		set_Value (COLUMNNAME_PayBankFee_Acct, Integer.valueOf(PayBankFee_Acct));
+	}
+
+	/** Get Bank Fee Account.
+		@return Bank Fee Account	  */
+	@Override
+	public int getPayBankFee_Acct ()
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_PayBankFee_Acct);
 		if (ii == null)
 			 return 0;
 		return ii.intValue();

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_AllocationLine.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_AllocationLine.java
@@ -438,7 +438,7 @@ public class X_C_AllocationLine extends org.compiere.model.PO implements I_C_All
 	}
 
 	/** Set Abschreiben.
-		@param WriteOffAmt 
+		@param WriteOffAmt
 		Amount to write-off
 	  */
 	@Override
@@ -451,11 +451,30 @@ public class X_C_AllocationLine extends org.compiere.model.PO implements I_C_All
 		@return Amount to write-off
 	  */
 	@Override
-	public java.math.BigDecimal getWriteOffAmt () 
+	public java.math.BigDecimal getWriteOffAmt ()
 	{
 		BigDecimal bd = (BigDecimal)get_Value(COLUMNNAME_WriteOffAmt);
 		if (bd == null)
 			 return BigDecimal.ZERO;
 		return bd;
+	}
+
+	/** Set Write-Off Type.
+		@param WriteOffType
+		Discriminates standard write-off (WO) from bank fee (BF)
+	  */
+	@Override
+	public void setWriteOffType (String WriteOffType)
+	{
+		set_Value (COLUMNNAME_WriteOffType, WriteOffType);
+	}
+
+	/** Get Write-Off Type.
+		@return Discriminates standard write-off (WO) from bank fee (BF)
+	  */
+	@Override
+	public String getWriteOffType ()
+	{
+		return (String)get_Value(COLUMNNAME_WriteOffType);
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_AllocationLine.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_AllocationLine.java
@@ -459,6 +459,11 @@ public class X_C_AllocationLine extends org.compiere.model.PO implements I_C_All
 		return bd;
 	}
 
+	/** WriteOffType AD_Reference_ID=542053 */
+	public static final String WRITEOFFTYPE_StandardWriteOff = "WO";
+	/** WriteOffType AD_Reference_ID=542053 */
+	public static final String WRITEOFFTYPE_BankFee = "BF";
+
 	/** Set Write-Off Type.
 		@param WriteOffType
 		Discriminates standard write-off (WO) from bank fee (BF)

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/acct/api/AcctSchemaDefaultAccounts.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/acct/api/AcctSchemaDefaultAccounts.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 
+import javax.annotation.Nullable;
+
 /*
  * #%L
  * de.metas.adempiere.adempiere.base
@@ -40,4 +42,7 @@ public class AcctSchemaDefaultAccounts
 	Account unrealizedGainAcct;
 	@NonNull
 	Account unrealizedLossAcct;
+
+	@Nullable
+	Account payBankFeeAcct;
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/acct/api/AcctSchemaDefaultAccounts.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/acct/api/AcctSchemaDefaultAccounts.java
@@ -33,16 +33,11 @@ import javax.annotation.Nullable;
 @Builder
 public class AcctSchemaDefaultAccounts
 {
-	@NonNull
-	Account realizedGainAcct;
-	@NonNull
-	Account realizedLossAcct;
+	@NonNull Account realizedGainAcct;
+	@NonNull Account realizedLossAcct;
 
-	@NonNull
-	Account unrealizedGainAcct;
-	@NonNull
-	Account unrealizedLossAcct;
+	@NonNull Account unrealizedGainAcct;
+	@NonNull Account unrealizedLossAcct;
 
-	@Nullable
-	Account payBankFeeAcct;
+	@Nullable Account payBankFeeAcct;
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/acct/api/impl/AcctSchemaDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/acct/api/impl/AcctSchemaDAO.java
@@ -386,6 +386,7 @@ public class AcctSchemaDAO implements IAcctSchemaDAO
 				.realizedLossAcct(Account.of(AccountId.ofRepoId(record.getRealizedLoss_Acct()), I_C_AcctSchema_Default.COLUMNNAME_RealizedLoss_Acct))
 				.unrealizedGainAcct(Account.of(AccountId.ofRepoId(record.getUnrealizedGain_Acct()), I_C_AcctSchema_Default.COLUMNNAME_UnrealizedGain_Acct))
 				.unrealizedLossAcct(Account.of(AccountId.ofRepoId(record.getUnrealizedLoss_Acct()), I_C_AcctSchema_Default.COLUMNNAME_UnrealizedLoss_Acct))
+				.payBankFeeAcct(record.getPayBankFee_Acct() > 0 ? Account.of(AccountId.ofRepoId(record.getPayBankFee_Acct()), I_C_AcctSchema_Default.COLUMNNAME_PayBankFee_Acct) : null)
 				.build();
 	}
 

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789810_sys_gh28337_C_AllocationLine_WriteOffType.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789810_sys_gh28337_C_AllocationLine_WriteOffType.sql
@@ -26,12 +26,12 @@ INSERT INTO AD_Column (AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created,
                        AD_Table_ID, AD_Element_ID, AD_Reference_ID, AD_Reference_Value_ID,
                        ColumnName, Name, Description,
                        FieldLength, IsMandatory, IsUpdateable, DefaultValue,
-                       EntityType, IsSelectionColumn, SeqNo, PersonalDataCategory)
+                       EntityType, IsSelectionColumn, SeqNo, PersonalDataCategory, Version)
 VALUES (592061, 0, 0, 'Y', TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100,
         390, 584561, 17, 542053,
         'WriteOffType', 'Write-Off Type', 'Discriminates standard write-off (WO) from bank fee (BF)',
         2, 'Y', 'Y', 'WO',
-        'D', 'N', 0, 'NP');
+        'D', 'N', 0, 'NP', 0);
 
 -- 6. DDL: Add column to C_AllocationLine
 SELECT db_alter_table('C_AllocationLine', 'ALTER TABLE C_AllocationLine ADD COLUMN IF NOT EXISTS WriteOffType VARCHAR(2) DEFAULT ''WO'' NOT NULL');

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789810_sys_gh28337_C_AllocationLine_WriteOffType.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789810_sys_gh28337_C_AllocationLine_WriteOffType.sql
@@ -1,0 +1,40 @@
+-- gh#28337: Add WriteOffType discriminator to C_AllocationLine
+-- Distinguishes standard write-off (WO) from bank fee (BF) for posting purposes.
+
+-- 1. AD_Reference (List type) for WriteOffType
+INSERT INTO AD_Reference (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Name, Description, ValidationType, EntityType, IsOrderByValue)
+VALUES (542053, 0, 0, 'Y', TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100,
+        'C_AllocationLine WriteOffType', 'Discriminator for write-off amounts on allocation lines', 'L', 'de.metas.allocation', 'N');
+
+-- 2. AD_Ref_List: WO = Standard Write-Off
+INSERT INTO AD_Ref_List (AD_Ref_List_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Value, Name, AD_Reference_ID, EntityType)
+VALUES (544125, 0, 0, 'Y', TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100,
+        'WO', 'Standard Write-Off', 542053, 'de.metas.allocation');
+
+-- 3. AD_Ref_List: BF = Bank Fee
+INSERT INTO AD_Ref_List (AD_Ref_List_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Value, Name, AD_Reference_ID, EntityType)
+VALUES (544126, 0, 0, 'Y', TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100,
+        'BF', 'Bank Fee', 542053, 'de.metas.allocation');
+
+-- 4. AD_Element for WriteOffType
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, ColumnName, Name, PrintName, EntityType)
+VALUES (584561, 0, 0, 'Y', TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100,
+        'WriteOffType', 'Write-Off Type', 'Write-Off Type', 'de.metas.allocation');
+
+-- 5. AD_Column on C_AllocationLine (AD_Table_ID=390)
+INSERT INTO AD_Column (AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                       AD_Table_ID, AD_Element_ID, AD_Reference_ID, AD_Reference_Value_ID,
+                       ColumnName, Name, Description,
+                       FieldLength, IsMandatory, IsUpdateable, DefaultValue,
+                       EntityType, IsSelectionColumn, SeqNo, PersonalDataCategory)
+VALUES (592061, 0, 0, 'Y', TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100,
+        390, 584561, 17, 542053,
+        'WriteOffType', 'Write-Off Type', 'Discriminates standard write-off (WO) from bank fee (BF)',
+        2, 'Y', 'Y', 'WO',
+        'de.metas.allocation', 'N', 0, 'NP');
+
+-- 6. DDL: Add column to C_AllocationLine
+SELECT db_alter_table('C_AllocationLine', 'ALTER TABLE C_AllocationLine ADD COLUMN IF NOT EXISTS WriteOffType VARCHAR(2) DEFAULT ''WO'' NOT NULL');
+
+-- 7. Backfill existing rows (safety net — DEFAULT should handle this, but explicit is better)
+UPDATE C_AllocationLine SET WriteOffType = 'WO' WHERE WriteOffType IS NULL;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789810_sys_gh28337_C_AllocationLine_WriteOffType.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789810_sys_gh28337_C_AllocationLine_WriteOffType.sql
@@ -4,22 +4,22 @@
 -- 1. AD_Reference (List type) for WriteOffType
 INSERT INTO AD_Reference (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Name, Description, ValidationType, EntityType, IsOrderByValue)
 VALUES (542053, 0, 0, 'Y', TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100,
-        'C_AllocationLine WriteOffType', 'Discriminator for write-off amounts on allocation lines', 'L', 'de.metas.allocation', 'N');
+        'C_AllocationLine WriteOffType', 'Discriminator for write-off amounts on allocation lines', 'L', 'D', 'N');
 
 -- 2. AD_Ref_List: WO = Standard Write-Off
 INSERT INTO AD_Ref_List (AD_Ref_List_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Value, Name, AD_Reference_ID, EntityType)
 VALUES (544125, 0, 0, 'Y', TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100,
-        'WO', 'Standard Write-Off', 542053, 'de.metas.allocation');
+        'WO', 'Standard Write-Off', 542053, 'D');
 
 -- 3. AD_Ref_List: BF = Bank Fee
 INSERT INTO AD_Ref_List (AD_Ref_List_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Value, Name, AD_Reference_ID, EntityType)
 VALUES (544126, 0, 0, 'Y', TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100,
-        'BF', 'Bank Fee', 542053, 'de.metas.allocation');
+        'BF', 'Bank Fee', 542053, 'D');
 
 -- 4. AD_Element for WriteOffType
 INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, ColumnName, Name, PrintName, EntityType)
 VALUES (584561, 0, 0, 'Y', TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI'), 100,
-        'WriteOffType', 'Write-Off Type', 'Write-Off Type', 'de.metas.allocation');
+        'WriteOffType', 'Write-Off Type', 'Write-Off Type', 'D');
 
 -- 5. AD_Column on C_AllocationLine (AD_Table_ID=390)
 INSERT INTO AD_Column (AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
@@ -31,7 +31,7 @@ VALUES (592061, 0, 0, 'Y', TO_TIMESTAMP('2026-02-23 10:00','YYYY-MM-DD HH24:MI')
         390, 584561, 17, 542053,
         'WriteOffType', 'Write-Off Type', 'Discriminates standard write-off (WO) from bank fee (BF)',
         2, 'Y', 'Y', 'WO',
-        'de.metas.allocation', 'N', 0, 'NP');
+        'D', 'N', 0, 'NP');
 
 -- 6. DDL: Add column to C_AllocationLine
 SELECT db_alter_table('C_AllocationLine', 'ALTER TABLE C_AllocationLine ADD COLUMN IF NOT EXISTS WriteOffType VARCHAR(2) DEFAULT ''WO'' NOT NULL');

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789960_sys_gh28337_C_AllocationLine_WriteOffType_translations.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789960_sys_gh28337_C_AllocationLine_WriteOffType_translations.sql
@@ -40,9 +40,6 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y')
   AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
 ;
 
--- Sync element translations to all dependent objects (AD_Column_Trl, AD_Field_Trl, etc.)
-SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584561);
-
 -- 5. AD_Column_Trl (ID=592061, "WriteOffType" on C_AllocationLine)
 INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
 SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
@@ -51,5 +48,34 @@ WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=592061
 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
 ;
 
--- Sync AD_Column translations from AD_Element
+-- 6. Set German translations (de_DE, de_CH)
+-- AD_Reference base record: Name is already in English ("C_AllocationLine WriteOffType") — that's fine, it's a technical name
+-- AD_Ref_List: set German names
+UPDATE AD_Ref_List SET Name='Standardabschreibung', Updated=TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy=99 WHERE AD_Ref_List_ID=544125;
+UPDATE AD_Ref_List SET Name='Bankgebühr', Updated=TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy=99 WHERE AD_Ref_List_ID=544126;
+
+UPDATE AD_Ref_List_Trl SET Name='Standardabschreibung', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy=99
+WHERE AD_Ref_List_ID=544125 AND AD_Language IN ('de_DE','de_CH');
+UPDATE AD_Ref_List_Trl SET Name='Bankgebühr', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy=99
+WHERE AD_Ref_List_ID=544126 AND AD_Language IN ('de_DE','de_CH');
+
+-- AD_Ref_List: set English translations
+UPDATE AD_Ref_List_Trl SET Name='Standard Write-Off', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy=99
+WHERE AD_Ref_List_ID=544125 AND AD_Language='en_US';
+UPDATE AD_Ref_List_Trl SET Name='Bank Fee', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy=99
+WHERE AD_Ref_List_ID=544126 AND AD_Language='en_US';
+
+-- AD_Element: set German base (Name, PrintName)
+UPDATE AD_Element SET Name='Abschreibungsart', PrintName='Abschreibungsart', Updated=TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy=99
+WHERE AD_Element_ID=584561;
+
+UPDATE AD_Element_Trl SET Name='Abschreibungsart', PrintName='Abschreibungsart', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy=99
+WHERE AD_Element_ID=584561 AND AD_Language IN ('de_DE','de_CH');
+
+-- AD_Element: set English translation
+UPDATE AD_Element_Trl SET Name='Write-Off Type', PrintName='Write-Off Type', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy=99
+WHERE AD_Element_ID=584561 AND AD_Language='en_US';
+
+-- 7. Propagate all translations
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584561);
 SELECT update_Column_Translation_From_AD_Element(584561);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789960_sys_gh28337_C_AllocationLine_WriteOffType_translations.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789960_sys_gh28337_C_AllocationLine_WriteOffType_translations.sql
@@ -40,7 +40,15 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y')
   AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
 ;
 
--- 5. Set German translations (de_DE, de_CH)
+-- 5. AD_Column_Trl (ID=592061, "WriteOffType") — skeleton rows for each system language
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=592061
+AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 6. Set German translations (de_DE, de_CH)
 -- AD_Reference base record: Name is already in English ("C_AllocationLine WriteOffType") — that's fine, it's a technical name
 -- AD_Ref_List: set German names
 UPDATE AD_Ref_List SET Name='Standardabschreibung', Updated=TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy=99 WHERE AD_Ref_List_ID=544125;
@@ -68,6 +76,6 @@ WHERE AD_Element_ID=584561 AND AD_Language IN ('de_DE','de_CH');
 UPDATE AD_Element_Trl SET Name='Write-Off Type', PrintName='Write-Off Type', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy=99
 WHERE AD_Element_ID=584561 AND AD_Language='en_US';
 
--- 6. Propagate all translations (syncs to AD_Column_Trl, AD_Field_Trl, etc.)
+-- 7. Propagate translations from AD_Element_Trl into AD_Column_Trl, AD_Field_Trl, etc.
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584561);
 SELECT update_Column_Translation_From_AD_Element(584561);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789960_sys_gh28337_C_AllocationLine_WriteOffType_translations.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789960_sys_gh28337_C_AllocationLine_WriteOffType_translations.sql
@@ -1,0 +1,55 @@
+-- gh#28337: Add translations for WriteOffType discriminator on C_AllocationLine
+-- This is a follow-up to 5789810_sys_gh28337_C_AllocationLine_WriteOffType.sql
+
+-- 1. AD_Reference_Trl (ID=542053, "C_AllocationLine WriteOffType")
+INSERT INTO AD_Reference_Trl (AD_Language,AD_Reference_ID, Help,Name,Description, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Reference_ID, t.Help,t.Name,t.Description, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Reference t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Reference_ID=542053
+AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
+;
+
+-- 2. AD_Ref_List_Trl (ID=544125, "WO" = "Standard Write-Off")
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Name,Description, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Name,t.Description, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Ref_List_ID=544125
+AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+-- 3. AD_Ref_List_Trl (ID=544126, "BF" = "Bank Fee")
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Name,Description, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Name,t.Description, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Ref_List_ID=544126
+AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+-- 4. AD_Element_Trl (ID=584561, "WriteOffType")
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID,
+                            CommitWarning, Description, Help, Name, PO_Description, PO_Help, PO_Name, PO_PrintName, PrintName,
+                            WEBUI_NameBrowse, WEBUI_NameNew, WEBUI_NameNewBreadcrumb,
+                            IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID,
+       t.CommitWarning, t.Description, t.Help, t.Name, t.PO_Description, t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName,
+       t.WEBUI_NameBrowse, t.WEBUI_NameNew, t.WEBUI_NameNewBreadcrumb,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y')
+  AND t.AD_Element_ID=584561
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- Sync element translations to all dependent objects (AD_Column_Trl, AD_Field_Trl, etc.)
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584561);
+
+-- 5. AD_Column_Trl (ID=592061, "WriteOffType" on C_AllocationLine)
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=592061
+AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Sync AD_Column translations from AD_Element
+SELECT update_Column_Translation_From_AD_Element(584561);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789960_sys_gh28337_C_AllocationLine_WriteOffType_translations.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789960_sys_gh28337_C_AllocationLine_WriteOffType_translations.sql
@@ -40,15 +40,7 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y')
   AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
 ;
 
--- 5. AD_Column_Trl (ID=592061, "WriteOffType" on C_AllocationLine)
-INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
-SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
-FROM AD_Language l, AD_Column t
-WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=592061
-AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
-;
-
--- 6. Set German translations (de_DE, de_CH)
+-- 5. Set German translations (de_DE, de_CH)
 -- AD_Reference base record: Name is already in English ("C_AllocationLine WriteOffType") — that's fine, it's a technical name
 -- AD_Ref_List: set German names
 UPDATE AD_Ref_List SET Name='Standardabschreibung', Updated=TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy=99 WHERE AD_Ref_List_ID=544125;
@@ -76,6 +68,6 @@ WHERE AD_Element_ID=584561 AND AD_Language IN ('de_DE','de_CH');
 UPDATE AD_Element_Trl SET Name='Write-Off Type', PrintName='Write-Off Type', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy=99
 WHERE AD_Element_ID=584561 AND AD_Language='en_US';
 
--- 7. Propagate all translations
+-- 6. Propagate all translations (syncs to AD_Column_Trl, AD_Field_Trl, etc.)
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584561);
 SELECT update_Column_Translation_From_AD_Element(584561);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789980_sys_gh28337_C_AllocationLine_WriteOffType_field.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789980_sys_gh28337_C_AllocationLine_WriteOffType_field.sql
@@ -1,0 +1,53 @@
+-- gh#28337: Add WriteOffType field to C_AllocationLine tabs and make it visible in UI
+-- Tabs: 349 (Zuordnungs-Position), 684 (Zuordnung/Invoice), 685 (Zuordnung/PurchaseInvoice), 686 (Zuordnungen/Payment)
+
+-- 1. AD_Field on tab 349 (Zuordnungs-Position, window 205 "Zuordnung aufheben")
+INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                      AD_Tab_ID, AD_Column_ID, Name, IsDisplayed, IsReadOnly, IsSameLine, SeqNo, EntityType)
+VALUES (774697, 0, 0, 'Y', TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99,
+        349, 592061, 'Abschreibungsart', 'Y', 'Y', 'N', 170, 'D');
+
+-- 2. AD_Field on tab 684 (Zuordnung, window 167 "Rechnung")
+INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                      AD_Tab_ID, AD_Column_ID, Name, IsDisplayed, IsReadOnly, IsSameLine, SeqNo, EntityType)
+VALUES (774698, 0, 0, 'Y', TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99,
+        684, 592061, 'Abschreibungsart', 'Y', 'Y', 'N', 130, 'D');
+
+-- 3. AD_Field on tab 685 (Zuordnung, window 183 "Eingangsrechnung")
+INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                      AD_Tab_ID, AD_Column_ID, Name, IsDisplayed, IsReadOnly, IsSameLine, SeqNo, EntityType)
+VALUES (774699, 0, 0, 'Y', TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99,
+        685, 592061, 'Abschreibungsart', 'Y', 'Y', 'N', 130, 'D');
+
+-- 4. AD_Field on tab 686 (Zuordnungen, window 195 "Zahlung")
+INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                      AD_Tab_ID, AD_Column_ID, Name, IsDisplayed, IsReadOnly, IsSameLine, SeqNo, EntityType)
+VALUES (774700, 0, 0, 'Y', TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99,
+        686, 592061, 'Abschreibungsart', 'Y', 'Y', 'N', 120, 'D');
+
+-- 5. AD_UI_Element on tab 349 (UI group 540098, max seqno was 150 → use 160)
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                           AD_UI_ElementGroup_ID, AD_Field_ID, Name, SeqNo, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, EntityType, WidgetSize)
+VALUES (648396, 0, 0, 'Y', TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99,
+        540098, 774697, 'Abschreibungsart', 160, 'Y', 'Y', 'N', 'D', 'S');
+
+-- 6. AD_UI_Element on tab 686 (UI group 540062, max seqno was 120 → use 130)
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                           AD_UI_ElementGroup_ID, AD_Field_ID, Name, SeqNo, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, EntityType, WidgetSize)
+VALUES (648397, 0, 0, 'Y', TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99,
+        540062, 774700, 'Abschreibungsart', 130, 'Y', 'Y', 'N', 'D', 'S');
+
+-- Note: Tabs 684 and 685 have UI element groups (540026, 540222) with max_seqno=0 (no existing UI elements).
+-- Adding UI elements there since the field is relevant for users to see the write-off type.
+
+-- 7. AD_UI_Element on tab 684 (UI group 540026, no existing elements → use 10)
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                           AD_UI_ElementGroup_ID, AD_Field_ID, Name, SeqNo, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, EntityType, WidgetSize)
+VALUES (648398, 0, 0, 'Y', TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99,
+        540026, 774698, 'Abschreibungsart', 10, 'Y', 'Y', 'N', 'D', 'S');
+
+-- 8. AD_UI_Element on tab 685 (UI group 540222, no existing elements → use 10)
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                           AD_UI_ElementGroup_ID, AD_Field_ID, Name, SeqNo, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, EntityType, WidgetSize)
+VALUES (648399, 0, 0, 'Y', TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99,
+        540222, 774699, 'Abschreibungsart', 10, 'Y', 'Y', 'N', 'D', 'S');

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789980_sys_gh28337_C_AllocationLine_WriteOffType_field.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789980_sys_gh28337_C_AllocationLine_WriteOffType_field.sql
@@ -51,3 +51,32 @@ INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, 
                            AD_UI_ElementGroup_ID, AD_Field_ID, Name, SeqNo, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, EntityType, WidgetSize)
 VALUES (648399, 0, 0, 'Y', TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99,
         540222, 774699, 'Abschreibungsart', 10, 'Y', 'Y', 'N', 'D', 'S');
+
+-- 9. AD_Field_Trl — skeleton rows for each new field (one per system language)
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Name,Description,Help, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Name,t.Description,t.Help, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Field_ID=774697
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Name,Description,Help, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Name,t.Description,t.Help, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Field_ID=774698
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Name,Description,Help, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Name,t.Description,t.Help, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Field_ID=774699
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Name,Description,Help, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Name,t.Description,t.Help, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Field_ID=774700
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 10. Propagate translations from AD_Element_Trl into the new AD_Field_Trl rows
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584561);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789980_sys_gh28337_C_AllocationLine_WriteOffType_field.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789980_sys_gh28337_C_AllocationLine_WriteOffType_field.sql
@@ -26,31 +26,39 @@ VALUES (774700, 0, 0, 'Y', TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI')
         686, 592061, 'Abschreibungsart', 'Y', 'Y', 'N', 120, 'D');
 
 -- 5. AD_UI_Element on tab 349 (UI group 540098, max seqno was 150 → use 160)
-INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
-                           AD_UI_ElementGroup_ID, AD_Field_ID, Name, SeqNo, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, EntityType, WidgetSize)
-VALUES (648396, 0, 0, 'Y', TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99,
-        540098, 774697, 'Abschreibungsart', 160, 'Y', 'Y', 'N', 'D', 'S');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+                           Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774697, 0, 349, 540098, 648396, 'F',
+        TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, 'Y', 'N', 'Y', 'Y', 'N',
+        'Abschreibungsart', 160, 160, 0, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99);
 
 -- 6. AD_UI_Element on tab 686 (UI group 540062, max seqno was 120 → use 130)
-INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
-                           AD_UI_ElementGroup_ID, AD_Field_ID, Name, SeqNo, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, EntityType, WidgetSize)
-VALUES (648397, 0, 0, 'Y', TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99,
-        540062, 774700, 'Abschreibungsart', 130, 'Y', 'Y', 'N', 'D', 'S');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+                           Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774700, 0, 686, 540062, 648397, 'F',
+        TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, 'Y', 'N', 'Y', 'Y', 'N',
+        'Abschreibungsart', 130, 130, 0, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99);
 
 -- Note: Tabs 684 and 685 have UI element groups (540026, 540222) with max_seqno=0 (no existing UI elements).
 -- Adding UI elements there since the field is relevant for users to see the write-off type.
 
 -- 7. AD_UI_Element on tab 684 (UI group 540026, no existing elements → use 10)
-INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
-                           AD_UI_ElementGroup_ID, AD_Field_ID, Name, SeqNo, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, EntityType, WidgetSize)
-VALUES (648398, 0, 0, 'Y', TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99,
-        540026, 774698, 'Abschreibungsart', 10, 'Y', 'Y', 'N', 'D', 'S');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+                           Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774698, 0, 684, 540026, 648398, 'F',
+        TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, 'Y', 'N', 'Y', 'Y', 'N',
+        'Abschreibungsart', 10, 10, 0, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99);
 
 -- 8. AD_UI_Element on tab 685 (UI group 540222, no existing elements → use 10)
-INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
-                           AD_UI_ElementGroup_ID, AD_Field_ID, Name, SeqNo, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, EntityType, WidgetSize)
-VALUES (648399, 0, 0, 'Y', TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99,
-        540222, 774699, 'Abschreibungsart', 10, 'Y', 'Y', 'N', 'D', 'S');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+                           Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774699, 0, 685, 540222, 648399, 'F',
+        TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99, 'Y', 'N', 'Y', 'Y', 'N',
+        'Abschreibungsart', 10, 10, 0, TO_TIMESTAMP('2026-02-24 08:00','YYYY-MM-DD HH24:MI'), 99);
 
 -- 9. AD_Field_Trl — skeleton rows for each new field (one per system language)
 INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Name,Description,Help, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5790000_sys_gh28337_C_AllocationLine_WriteOffType_check_constraint.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5790000_sys_gh28337_C_AllocationLine_WriteOffType_check_constraint.sql
@@ -1,0 +1,3 @@
+-- gh#28337: Add check constraint for WriteOffType column on C_AllocationLine
+ALTER TABLE C_AllocationLine DROP CONSTRAINT IF EXISTS WriteOffType_Check;
+ALTER TABLE C_AllocationLine ADD CONSTRAINT WriteOffType_Check CHECK (WriteOffType IN ('WO', 'BF'));

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/service/AllocationLineCandidate.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/service/AllocationLineCandidate.java
@@ -1,5 +1,6 @@
 package de.metas.banking.payment.paymentallocation.service;
 
+import de.metas.allocation.api.WriteOffType;
 import de.metas.bpartner.BPartnerId;
 import de.metas.invoice.invoiceProcessingServiceCompany.InvoiceProcessingFeeCalculation;
 import de.metas.money.CurrencyId;
@@ -54,6 +55,9 @@ public class AllocationLineCandidate
 	Money paymentOverUnderAmt;
 	InvoiceProcessingFeeCalculation invoiceProcessingFeeCalculation;
 
+	@NonNull
+	WriteOffType writeOffType;
+
 	/**
 	 *  This is about the paymentTerm invoice discount when used as payment. (i.e. CreditMemo or PurchaseInvoice allocated against a SalesInvoice)
 	 */
@@ -79,7 +83,8 @@ public class AllocationLineCandidate
 			@Nullable final Money payableOverUnderAmt,
 			@Nullable final Money paymentOverUnderAmt,
 			@Nullable final InvoiceProcessingFeeCalculation invoiceProcessingFeeCalculation,
-			@Nullable final Money payAmtDiscountInInvoiceCurrency)
+			@Nullable final Money payAmtDiscountInInvoiceCurrency,
+			@Nullable final WriteOffType writeOffType)
 	{
 		if (!orgId.isRegular())
 		{
@@ -125,7 +130,8 @@ public class AllocationLineCandidate
 		this.payableOverUnderAmt = payableOverUnderAmt != null ? payableOverUnderAmt : Money.zero(amounts.getCurrencyId());
 		this.paymentOverUnderAmt = paymentOverUnderAmt != null ? paymentOverUnderAmt : Money.zero(amounts.getCurrencyId());
 		this.invoiceProcessingFeeCalculation = invoiceProcessingFeeCalculation;
-		this.payAmtDiscountInInvoiceCurrency = payAmtDiscountInInvoiceCurrency != null ? payAmtDiscountInInvoiceCurrency : Money.zero(amounts.getCurrencyId()); 
+		this.payAmtDiscountInInvoiceCurrency = payAmtDiscountInInvoiceCurrency != null ? payAmtDiscountInInvoiceCurrency : Money.zero(amounts.getCurrencyId());
+		this.writeOffType = writeOffType != null ? writeOffType : WriteOffType.WriteOff;
 	}
 
 	public static class AllocationLineCandidateBuilder
@@ -134,6 +140,7 @@ public class AllocationLineCandidate
 		{
 			payableDocumentRef(payableDocument.getReference());
 			payableDocumentIsCreditMemo(payableDocument.isCreditMemo());
+			writeOffType(payableDocument.getWriteOffType());
 			return this;
 		}
 	}

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/service/AllocationLineCandidate.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/service/AllocationLineCandidate.java
@@ -55,8 +55,7 @@ public class AllocationLineCandidate
 	Money paymentOverUnderAmt;
 	InvoiceProcessingFeeCalculation invoiceProcessingFeeCalculation;
 
-	@NonNull
-	WriteOffType writeOffType;
+	@NonNull WriteOffType writeOffType;
 
 	/**
 	 *  This is about the paymentTerm invoice discount when used as payment. (i.e. CreditMemo or PurchaseInvoice allocated against a SalesInvoice)

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/service/AllocationLineCandidateSaver.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/service/AllocationLineCandidateSaver.java
@@ -6,6 +6,7 @@ import de.metas.allocation.api.C_AllocationHdr_Builder;
 import de.metas.allocation.api.IAllocationBL;
 import de.metas.allocation.api.IAllocationDAO;
 import de.metas.allocation.api.PaymentAllocationId;
+import de.metas.allocation.api.WriteOffType;
 import de.metas.banking.payment.paymentallocation.service.AllocationLineCandidate.AllocationLineCandidateType;
 import de.metas.invoice.InvoiceId;
 import de.metas.money.Money;
@@ -141,6 +142,7 @@ final class AllocationLineCandidateSaver
 				.discountAmt(discountAmt.toBigDecimal())
 				.writeOffAmt(writeOffAmt.toBigDecimal())
 				.overUnderAmt(candidate.getPayableOverUnderAmt().toBigDecimal())
+				.writeOffType(candidate.getWriteOffType())
 				//
 				.invoiceId(extractInvoiceId(candidate.getPayableDocumentRef()))
 				.paymentId(extractPaymentId(candidate.getPaymentDocumentRef()));
@@ -175,6 +177,7 @@ final class AllocationLineCandidateSaver
 				.discountAmt(discountAmt.toBigDecimal())
 				.writeOffAmt(writeOffAmt.toBigDecimal())
 				.overUnderAmt(candidate.getPayableOverUnderAmt().toBigDecimal())
+				.writeOffType(candidate.getWriteOffType())
 				//
 				.invoiceId(extractInvoiceId(candidate.getPayableDocumentRef()));
 
@@ -225,6 +228,7 @@ final class AllocationLineCandidateSaver
 				.discountAmt(discountAmt.negate().toBigDecimal())
 				.writeOffAmt(writeOffAmt.negate().toBigDecimal())
 				.overUnderAmt(candidate.getPayableOverUnderAmt().toBigDecimal())
+				.writeOffType(candidate.getWriteOffType())
 				//
 				.invoiceId(extractInvoiceId(candidate.getPayableDocumentRef()));
 
@@ -267,6 +271,7 @@ final class AllocationLineCandidateSaver
 				.discountAmt(discountAmt.toBigDecimal())
 				.writeOffAmt(writeOffAmt.toBigDecimal())
 				.overUnderAmt(candidate.getPayableOverUnderAmt().toBigDecimal())
+				.writeOffType(candidate.getWriteOffType())
 				//
 				.invoiceId(extractInvoiceId(candidate.getPayableDocumentRef()));
 

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/service/PayableDocument.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/service/PayableDocument.java
@@ -23,6 +23,7 @@
 package de.metas.banking.payment.paymentallocation.service;
 
 import com.google.common.annotations.VisibleForTesting;
+import de.metas.allocation.api.WriteOffType;
 import de.metas.bpartner.BPartnerId;
 import de.metas.invoice.InvoiceId;
 import de.metas.invoice.invoiceProcessingServiceCompany.InvoiceProcessingFeeCalculation;
@@ -112,6 +113,9 @@ public class PayableDocument
 	@Getter
 	private final CurrencyConversionTypeId currencyConversionTypeId;
 
+	@Getter
+	private final WriteOffType writeOffType;
+
 	@Builder
 	private PayableDocument(
 			@Nullable final InvoiceId invoiceId,
@@ -127,7 +131,8 @@ public class PayableDocument
 			@Nullable final InvoiceProcessingFeeCalculation invoiceProcessingFeeCalculation,
 			@NonNull final ClientAndOrgId clientAndOrgId,
 			@NonNull final LocalDate date,
-			@Nullable final CurrencyConversionTypeId currencyConversionTypeId
+			@Nullable final CurrencyConversionTypeId currencyConversionTypeId,
+			@Nullable final WriteOffType writeOffType
 	)
 	{
 		final OrgId orgId = clientAndOrgId.getOrgId();
@@ -180,6 +185,7 @@ public class PayableDocument
 		this.clientAndOrgId = clientAndOrgId;
 		this.date = date;
 		this.currencyConversionTypeId = currencyConversionTypeId;
+		this.writeOffType = writeOffType != null ? writeOffType : WriteOffType.WriteOff;
 	}
 
 	public CurrencyId getCurrencyId()

--- a/backend/de.metas.business/src/main/java/de/metas/allocation/api/C_AllocationLine_Builder.java
+++ b/backend/de.metas.business/src/main/java/de/metas/allocation/api/C_AllocationLine_Builder.java
@@ -131,10 +131,7 @@ public class C_AllocationLine_Builder
 
 	public C_AllocationLine_Builder writeOffType(@Nullable final WriteOffType writeOffType)
 	{
-		if (writeOffType != null)
-		{
-			allocLine.setWriteOffType(writeOffType.getCode());
-		}
+		allocLine.setWriteOffType(writeOffType != null ? writeOffType.getCode() : null);
 		return this;
 	}
 

--- a/backend/de.metas.business/src/main/java/de/metas/allocation/api/C_AllocationLine_Builder.java
+++ b/backend/de.metas.business/src/main/java/de/metas/allocation/api/C_AllocationLine_Builder.java
@@ -129,6 +129,15 @@ public class C_AllocationLine_Builder
 		return this;
 	}
 
+	public C_AllocationLine_Builder writeOffType(@Nullable final WriteOffType writeOffType)
+	{
+		if (writeOffType != null)
+		{
+			allocLine.setWriteOffType(writeOffType.getCode());
+		}
+		return this;
+	}
+
 	public final C_AllocationLine_Builder skipIfAllAmountsAreZero()
 	{
 		this.skipIfAllAmountsAreZero = true;

--- a/backend/de.metas.business/src/main/java/de/metas/allocation/api/WriteOffType.java
+++ b/backend/de.metas.business/src/main/java/de/metas/allocation/api/WriteOffType.java
@@ -1,5 +1,7 @@
 package de.metas.allocation.api;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import de.metas.util.lang.ReferenceListAwareEnum;
 import de.metas.util.lang.ReferenceListAwareEnums;
 import de.metas.util.lang.ReferenceListAwareEnums.ValuesIndex;
@@ -21,6 +23,7 @@ public enum WriteOffType implements ReferenceListAwareEnum
 
 	@NonNull private final String code;
 
+	@JsonCreator
 	public static WriteOffType ofCode(@NonNull final String code) {return index.ofCode(code);}
 
 	@Nullable
@@ -32,6 +35,9 @@ public enum WriteOffType implements ReferenceListAwareEnum
 		final WriteOffType result = ofNullableCode(code);
 		return result != null ? result : WriteOff;
 	}
+
+	@JsonValue
+	public String toJson() {return code;}
 
 	public boolean isBankFee() {return this == BankFee;}
 

--- a/backend/de.metas.business/src/main/java/de/metas/allocation/api/WriteOffType.java
+++ b/backend/de.metas.business/src/main/java/de/metas/allocation/api/WriteOffType.java
@@ -17,6 +17,8 @@ public enum WriteOffType implements ReferenceListAwareEnum
 	WriteOff(X_C_AllocationLine.WRITEOFFTYPE_StandardWriteOff),
 	BankFee(X_C_AllocationLine.WRITEOFFTYPE_BankFee);
 
+	private static final ValuesIndex<WriteOffType> index = ReferenceListAwareEnums.index(values());
+
 	@NonNull private final String code;
 
 	public static WriteOffType ofCode(@NonNull final String code) {return index.ofCode(code);}
@@ -34,6 +36,4 @@ public enum WriteOffType implements ReferenceListAwareEnum
 	public boolean isBankFee() {return this == BankFee;}
 
 	public boolean isWriteOff() {return this == WriteOff;}
-
-	private static final ValuesIndex<WriteOffType> index = ReferenceListAwareEnums.index(values());
 }

--- a/backend/de.metas.business/src/main/java/de/metas/allocation/api/WriteOffType.java
+++ b/backend/de.metas.business/src/main/java/de/metas/allocation/api/WriteOffType.java
@@ -5,18 +5,19 @@ import de.metas.util.lang.ReferenceListAwareEnums;
 import de.metas.util.lang.ReferenceListAwareEnums.ValuesIndex;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.compiere.model.X_C_AllocationLine;
 
 import javax.annotation.Nullable;
 
+@RequiredArgsConstructor
+@Getter
 public enum WriteOffType implements ReferenceListAwareEnum
 {
-	WriteOff("WO"),
-	BankFee("BF");
+	WriteOff(X_C_AllocationLine.WRITEOFFTYPE_StandardWriteOff),
+	BankFee(X_C_AllocationLine.WRITEOFFTYPE_BankFee);
 
-	@Getter
-	private final String code;
-
-	WriteOffType(@NonNull final String code) {this.code = code;}
+	@NonNull private final String code;
 
 	public static WriteOffType ofCode(@NonNull final String code) {return index.ofCode(code);}
 

--- a/backend/de.metas.business/src/main/java/de/metas/allocation/api/WriteOffType.java
+++ b/backend/de.metas.business/src/main/java/de/metas/allocation/api/WriteOffType.java
@@ -1,0 +1,38 @@
+package de.metas.allocation.api;
+
+import de.metas.util.lang.ReferenceListAwareEnum;
+import de.metas.util.lang.ReferenceListAwareEnums;
+import de.metas.util.lang.ReferenceListAwareEnums.ValuesIndex;
+import lombok.Getter;
+import lombok.NonNull;
+
+import javax.annotation.Nullable;
+
+public enum WriteOffType implements ReferenceListAwareEnum
+{
+	WriteOff("WO"),
+	BankFee("BF");
+
+	@Getter
+	private final String code;
+
+	WriteOffType(@NonNull final String code) {this.code = code;}
+
+	public static WriteOffType ofCode(@NonNull final String code) {return index.ofCode(code);}
+
+	@Nullable
+	public static WriteOffType ofNullableCode(@Nullable final String code) {return index.ofNullableCode(code);}
+
+	@NonNull
+	public static WriteOffType ofNullableCodeOrWriteOff(@Nullable final String code)
+	{
+		final WriteOffType result = ofNullableCode(code);
+		return result != null ? result : WriteOff;
+	}
+
+	public boolean isBankFee() {return this == BankFee;}
+
+	public boolean isWriteOff() {return this == WriteOff;}
+
+	private static final ValuesIndex<WriteOffType> index = ReferenceListAwareEnums.index(values());
+}

--- a/backend/de.metas.business/src/main/java/de/metas/banking/accounting/BankAccountAcctRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/banking/accounting/BankAccountAcctRepository.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Maps;
 import de.metas.acct.Account;
 import de.metas.acct.api.AccountId;
 import de.metas.acct.api.AcctSchemaId;
+import de.metas.acct.api.IAcctSchemaDAO;
 import de.metas.banking.BankAccountId;
 import de.metas.cache.CCache;
 import de.metas.util.Services;
@@ -159,11 +160,7 @@ public class BankAccountAcctRepository
 	@NonNull
 	public Optional<Account> getAcctSchemaDefaultPayBankFeeAccount(@NonNull final AcctSchemaId acctSchemaId)
 	{
-		final I_C_AcctSchema_Default schemaDefault = queryBL.createQueryBuilderOutOfTrx(I_C_AcctSchema_Default.class)
-				.addEqualsFilter(I_C_AcctSchema_Default.COLUMN_C_AcctSchema_ID, acctSchemaId)
-				.create()
-				.firstOnly(I_C_AcctSchema_Default.class);
-
+		final I_C_AcctSchema_Default schemaDefault = Services.get(IAcctSchemaDAO.class).retrieveAcctSchemaDefaultsRecordOrNull(acctSchemaId);
 		if (schemaDefault == null)
 		{
 			return Optional.empty();

--- a/backend/de.metas.business/src/main/java/de/metas/banking/accounting/BankAccountAcctRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/banking/accounting/BankAccountAcctRepository.java
@@ -14,12 +14,14 @@ import lombok.ToString;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_AcctSchema_Default;
 import org.compiere.model.I_C_BP_BankAccount_Acct;
 import org.compiere.util.DB;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 /*
  * #%L
@@ -152,6 +154,28 @@ public class BankAccountAcctRepository
 				sql,
 				new Object[] { acctSchemaId },
 				ITrx.TRXNAME_ThreadInherited);
+	}
+
+	@NonNull
+	public Optional<Account> getAcctSchemaDefaultPayBankFeeAccount(@NonNull final AcctSchemaId acctSchemaId)
+	{
+		final I_C_AcctSchema_Default schemaDefault = queryBL.createQueryBuilderOutOfTrx(I_C_AcctSchema_Default.class)
+				.addEqualsFilter(I_C_AcctSchema_Default.COLUMN_C_AcctSchema_ID, acctSchemaId)
+				.create()
+				.firstOnly(I_C_AcctSchema_Default.class);
+
+		if (schemaDefault == null)
+		{
+			return Optional.empty();
+		}
+
+		final Integer payBankFeeAcctId = InterfaceWrapperHelper.getValueOrNull(schemaDefault, I_C_BP_BankAccount_Acct.COLUMNNAME_PayBankFee_Acct);
+		if (payBankFeeAcctId == null || payBankFeeAcctId <= 0)
+		{
+			return Optional.empty();
+		}
+
+		return Optional.of(Account.of(AccountId.ofRepoId(payBankFeeAcctId), BankAccountAcctType.PayBankFee_Acct));
 	}
 
 	//

--- a/backend/de.metas.business/src/main/java/de/metas/banking/accounting/BankAccountAcctRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/banking/accounting/BankAccountAcctRepository.java
@@ -5,8 +5,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import de.metas.acct.Account;
 import de.metas.acct.api.AccountId;
+import de.metas.acct.api.AcctSchema;
 import de.metas.acct.api.AcctSchemaId;
-import de.metas.acct.api.IAcctSchemaDAO;
+import de.metas.acct.api.IAcctSchemaBL;
 import de.metas.banking.BankAccountId;
 import de.metas.cache.CCache;
 import de.metas.util.Services;
@@ -15,7 +16,6 @@ import lombok.ToString;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_AcctSchema_Default;
 import org.compiere.model.I_C_BP_BankAccount_Acct;
 import org.compiere.util.DB;
@@ -50,6 +50,7 @@ import java.util.Optional;
 public class BankAccountAcctRepository
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	@NonNull private final IAcctSchemaBL acctSchemaBL = Services.get(IAcctSchemaBL.class);
 	private final CCache<BankAccountId, BPBankAccountAcctBySchemasMap> cache = CCache.<BankAccountId, BPBankAccountAcctBySchemasMap>builder()
 			.tableName(I_C_BP_BankAccount_Acct.Table_Name)
 			.cacheMapType(CCache.CacheMapType.LRU)
@@ -160,19 +161,8 @@ public class BankAccountAcctRepository
 	@NonNull
 	public Optional<Account> getAcctSchemaDefaultPayBankFeeAccount(@NonNull final AcctSchemaId acctSchemaId)
 	{
-		final I_C_AcctSchema_Default schemaDefault = Services.get(IAcctSchemaDAO.class).retrieveAcctSchemaDefaultsRecordOrNull(acctSchemaId);
-		if (schemaDefault == null)
-		{
-			return Optional.empty();
-		}
-
-		final Integer payBankFeeAcctId = InterfaceWrapperHelper.getValueOrNull(schemaDefault, I_C_BP_BankAccount_Acct.COLUMNNAME_PayBankFee_Acct);
-		if (payBankFeeAcctId == null || payBankFeeAcctId <= 0)
-		{
-			return Optional.empty();
-		}
-
-		return Optional.of(Account.of(AccountId.ofRepoId(payBankFeeAcctId), BankAccountAcctType.PayBankFee_Acct));
+		final AcctSchema acctSchema = acctSchemaBL.getById(acctSchemaId);
+		return Optional.ofNullable(acctSchema.getDefaultAccounts().getPayBankFeeAcct());
 	}
 
 	//

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationHdr_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationHdr_StepDef.java
@@ -3,6 +3,7 @@ package de.metas.cucumber.stepdefs.allocation;
 import de.metas.allocation.api.C_AllocationHdr_Builder;
 import de.metas.allocation.api.C_AllocationLine_Builder;
 import de.metas.allocation.api.IAllocationBL;
+import de.metas.allocation.api.WriteOffType;
 import de.metas.common.util.time.SystemTime;
 import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
 import de.metas.cucumber.stepdefs.DataTableRow;
@@ -108,6 +109,10 @@ public class C_AllocationHdr_StepDef
 			{
 				lineBuilder.overUnderAmt(overUnderAmt.toBigDecimal());
 			}
+
+			row.getAsOptionalString("WriteOffType")
+					.map(WriteOffType::ofCode)
+					.ifPresent(lineBuilder::writeOffType);
 
 			row.getAsOptionalIdentifier("C_BPartner_ID")
 					.map(bpartnerTable::getId)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationHdr_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationHdr_StepDef.java
@@ -3,6 +3,7 @@ package de.metas.cucumber.stepdefs.allocation;
 import de.metas.allocation.api.C_AllocationHdr_Builder;
 import de.metas.allocation.api.C_AllocationLine_Builder;
 import de.metas.allocation.api.IAllocationBL;
+import de.metas.allocation.api.IAllocationDAO;
 import de.metas.allocation.api.PaymentAllocationId;
 import de.metas.allocation.api.WriteOffType;
 import de.metas.common.util.time.SystemTime;
@@ -25,7 +26,6 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_AllocationHdr;
 import org.compiere.model.I_C_AllocationLine;
@@ -37,6 +37,7 @@ import java.util.List;
 public class C_AllocationHdr_StepDef
 {
 	@NonNull private final IAllocationBL allocationBL = Services.get(IAllocationBL.class);
+	@NonNull private final IAllocationDAO allocationDAO = Services.get(IAllocationDAO.class);
 	@NonNull private final IDocumentBL documentBL = Services.get(IDocumentBL.class);
 	@NonNull private final ITrxManager trxManager = Services.get(ITrxManager.class);
 	@NonNull private final MoneyService moneyService = SpringContextHolder.instance.getBean(MoneyService.class);
@@ -114,8 +115,7 @@ public class C_AllocationHdr_StepDef
 				lineBuilder.overUnderAmt(overUnderAmt.toBigDecimal());
 			}
 
-			row.getAsOptionalString("WriteOffType")
-					.map(WriteOffType::ofCode)
+			row.getAsOptionalEnum("WriteOffType", WriteOffType.class)
 					.ifPresent(lineBuilder::writeOffType);
 
 			row.getAsOptionalIdentifier("C_BPartner_ID")
@@ -145,7 +145,7 @@ public class C_AllocationHdr_StepDef
 		final int reversalId = allocationHdr.getReversal_ID();
 		if (reversalId > 0)
 		{
-			final I_C_AllocationHdr reversal = InterfaceWrapperHelper.load(reversalId, I_C_AllocationHdr.class);
+			final I_C_AllocationHdr reversal = allocationDAO.getById(PaymentAllocationId.ofRepoId(reversalId));
 			final StepDefDataIdentifier reversalIdentifier = StepDefDataIdentifier.ofString(allocationIdentifierStr + ".reversed");
 			allocationTable.putOrReplace(reversalIdentifier, reversal);
 		}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationHdr_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationHdr_StepDef.java
@@ -3,6 +3,7 @@ package de.metas.cucumber.stepdefs.allocation;
 import de.metas.allocation.api.C_AllocationHdr_Builder;
 import de.metas.allocation.api.C_AllocationLine_Builder;
 import de.metas.allocation.api.IAllocationBL;
+import de.metas.allocation.api.PaymentAllocationId;
 import de.metas.allocation.api.WriteOffType;
 import de.metas.common.util.time.SystemTime;
 import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
@@ -11,6 +12,8 @@ import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.payment.C_Payment_StepDefData;
+import de.metas.document.engine.IDocument;
+import de.metas.document.engine.IDocumentBL;
 import de.metas.money.CurrencyId;
 import de.metas.money.Money;
 import de.metas.money.MoneyService;
@@ -34,6 +37,7 @@ import java.util.List;
 public class C_AllocationHdr_StepDef
 {
 	@NonNull private final IAllocationBL allocationBL = Services.get(IAllocationBL.class);
+	@NonNull private final IDocumentBL documentBL = Services.get(IDocumentBL.class);
 	@NonNull private final ITrxManager trxManager = Services.get(ITrxManager.class);
 	@NonNull private final MoneyService moneyService = SpringContextHolder.instance.getBean(MoneyService.class);
 	@NonNull private final C_BPartner_StepDefData bpartnerTable;
@@ -127,5 +131,23 @@ public class C_AllocationHdr_StepDef
 
 		final I_C_AllocationHdr allocationHdr = builder.createAndComplete();
 		allocationTable.putOrReplaceIfSameId(identifier, allocationHdr);
+	}
+
+	@And("^the allocation identified by (.*) is reversed$")
+	public void reverseAllocation(@NonNull final String allocationIdentifierStr)
+	{
+		final StepDefDataIdentifier allocationIdentifier = StepDefDataIdentifier.ofString(allocationIdentifierStr);
+		final I_C_AllocationHdr allocationHdr = allocationTable.get(allocationIdentifier);
+
+		allocationHdr.setDocAction(IDocument.ACTION_Reverse_Correct);
+		documentBL.processEx(allocationHdr, IDocument.ACTION_Reverse_Correct, IDocument.STATUS_Reversed);
+
+		final int reversalId = allocationHdr.getReversal_ID();
+		if (reversalId > 0)
+		{
+			final I_C_AllocationHdr reversal = InterfaceWrapperHelper.load(reversalId, I_C_AllocationHdr.class);
+			final StepDefDataIdentifier reversalIdentifier = StepDefDataIdentifier.ofString(allocationIdentifierStr + ".reversed");
+			allocationTable.putOrReplace(reversalIdentifier, reversal);
+		}
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationHdr_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationHdr_StepDef.java
@@ -142,10 +142,10 @@ public class C_AllocationHdr_StepDef
 		allocationHdr.setDocAction(IDocument.ACTION_Reverse_Correct);
 		documentBL.processEx(allocationHdr, IDocument.ACTION_Reverse_Correct, IDocument.STATUS_Reversed);
 
-		final int reversalId = allocationHdr.getReversal_ID();
-		if (reversalId > 0)
+		final PaymentAllocationId reversalId = PaymentAllocationId.ofRepoIdOrNull(allocationHdr.getReversal_ID());
+		if (reversalId != null)
 		{
-			final I_C_AllocationHdr reversal = allocationDAO.getById(PaymentAllocationId.ofRepoId(reversalId));
+			final I_C_AllocationHdr reversal = allocationDAO.getById(reversalId);
 			final StepDefDataIdentifier reversalIdentifier = StepDefDataIdentifier.ofString(allocationIdentifierStr + ".reversed");
 			allocationTable.putOrReplace(reversalIdentifier, reversal);
 		}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationLine_StepDef.java
@@ -139,7 +139,7 @@ public class C_AllocationLine_StepDef
 		row.getAsOptionalBigDecimal(I_C_AllocationLine.COLUMNNAME_OverUnderAmt)
 				.ifPresent(amount -> softly.assertThat(allocationLine.getOverUnderAmt()).as("OverUnderAmt").isEqualByComparingTo(amount));
 		row.getAsOptionalString(I_C_AllocationLine.COLUMNNAME_WriteOffType)
-				.ifPresent(wot -> softly.assertThat(allocationLine.getWriteOffType()).as("WriteOffType").isEqualTo(wot));
+				.ifPresent(writeOffType -> softly.assertThat(allocationLine.getWriteOffType()).as("WriteOffType").isEqualTo(writeOffType));
 
 		softly.assertAll();
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationLine_StepDef.java
@@ -138,6 +138,8 @@ public class C_AllocationLine_StepDef
 				.ifPresent(amount -> softly.assertThat(allocationLine.getWriteOffAmt()).as("WriteOffAmt").isEqualByComparingTo(amount));
 		row.getAsOptionalBigDecimal(I_C_AllocationLine.COLUMNNAME_OverUnderAmt)
 				.ifPresent(amount -> softly.assertThat(allocationLine.getOverUnderAmt()).as("OverUnderAmt").isEqualByComparingTo(amount));
+		row.getAsOptionalString(I_C_AllocationLine.COLUMNNAME_WriteOffType)
+				.ifPresent(wot -> softly.assertThat(allocationLine.getWriteOffType()).as("WriteOffType").isEqualTo(wot));
 
 		softly.assertAll();
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation_BankFee.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation_BankFee.feature
@@ -324,3 +324,9 @@ Feature: payment allocation - bank fee posting
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID              |
       | PayBankFee_Acct       | -0.20 EUR   |             |          | alloc_bf_140.reversed  |
       | C_Receivable_Acct     |             | -0.20 EUR   |          | alloc_bf_140.reversed  |
+
+    # Verify that after allocation + reversal, account balances are zero
+    And Fact_Acct records balances for documents alloc_bf_140,alloc_bf_140.reversed are matching
+      | AccountConceptualName | SourceBalance |
+      | PayBankFee_Acct       | 0 EUR         |
+      | C_Receivable_Acct     | 0 EUR         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation_BankFee.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation_BankFee.feature
@@ -1,0 +1,326 @@
+@from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00700_Invoicing
+@F00700
+@ghActions:run_on_executor5
+Feature: payment allocation - bank fee posting
+## gh#28337: Bank Fee in Payment Allocation
+## Validates that allocation with WriteOffType=BF posts to PayBankFee_Acct
+## and does NOT trigger VAT tax correction (unlike standard WriteOff).
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And documents are accounted immediately
+
+    And metasfresh contains M_PricingSystems
+      | Identifier    |
+      | pricingSystem |
+
+    And metasfresh contains M_PriceLists
+      | Identifier     | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | salesPriceList | pricingSystem      | DE           | EUR           | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | salesPLV   | salesPriceList |
+
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsCustomer | IsVendor | M_PricingSystem_ID |
+      | customer1  | Y          | N        | pricingSystem      |
+
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier          | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | bpartner_location_1 | customer1     | Y               | Y               |
+
+    And metasfresh contains organization bank accounts
+      | Identifier      | C_Currency_ID |
+      | org_EUR_account | EUR           |
+
+
+# ############################################################################################################################################
+# Scenario 1: Single invoice — bank fee — correct posting to PayBankFee_Acct, NO VAT tax correction
+# ############################################################################################################################################
+  @Id:S0465_BF_100
+  @from:cucumber
+  Scenario: single sales invoice - bank fee - posting to PayBankFee_Acct without VAT correction
+
+    Given metasfresh contains M_Products:
+      | Identifier     |
+      | product_bf_100 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID   | PriceStd | C_UOM_ID |
+      | salesPLV               | product_bf_100 | 5.00     | PCE      |
+
+    And metasfresh contains C_Invoice:
+      | Identifier  | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | inv_bf_100  | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | Identifier   | C_Invoice_ID | M_Product_ID   | QtyInvoiced | C_Tax_ID |
+      | invl_bf_100  | inv_bf_100   | product_bf_100 | 1 PCE       | tax1     |
+    And the invoice identified by inv_bf_100 is completed
+
+    # Payment = 5.75 EUR, invoice grand total = 5.95 EUR (5.00 net + 0.95 VAT at 19%)
+    # Residual = 0.20 EUR to be covered by bank fee
+    And metasfresh contains C_Payment
+      | Identifier     | C_BPartner_ID | PayAmt     | IsReceipt | C_BP_BankAccount_ID |
+      | payment_bf_100 | customer1     | 5.75 EUR   | true      | org_EUR_account     |
+    And the payment identified by payment_bf_100 is completed
+
+    And allocate payments to invoices
+      | C_Invoice_ID | C_Payment_ID   |
+      | inv_bf_100   | payment_bf_100 |
+
+    Then validate created invoices
+      | C_Invoice_ID | C_BPartner_ID | C_BPartner_Location_ID | processed | DocStatus | IsPaid | OpenAmt | IsPartiallyPaid |
+      | inv_bf_100   | customer1     | bpartner_location_1    | true      | CO        | false  | 0.20    | true            |
+    And validate C_AllocationLines
+      | C_Invoice_ID | C_Payment_ID   | Amount | OverUnderAmt | C_AllocationHdr_ID |
+      | inv_bf_100   | payment_bf_100 | 5.75   | 0.20         | alloc_bf_1         |
+
+    # Now apply bank fee to clear the residual
+    And create and complete manual payment allocations
+      | C_AllocationHdr_ID | C_Invoice_ID | Amount | WriteOffAmt | WriteOffType |
+      | alloc_bf_2         | inv_bf_100   | 0 EUR  | 0.20 EUR    | BF           |
+
+    Then validate created invoices
+      | C_Invoice_ID | C_BPartner_ID | C_BPartner_Location_ID | processed | DocStatus | IsPaid | IsPartiallyPaid |
+      | inv_bf_100   | customer1     | bpartner_location_1    | true      | CO        | true   | false           |
+    And validate payments
+      | C_Payment_ID   | IsAllocated |
+      | payment_bf_100 | true        |
+    And validate C_AllocationLines
+      | C_Invoice_ID | Amount | WriteOffAmt | WriteOffType | C_AllocationHdr_ID |
+      | inv_bf_100   | 0      | 0.20        | BF           | alloc_bf_2         |
+
+    # KEY ASSERTION: posting goes to PayBankFee_Acct, NOT WriteOff_Acct
+    # KEY ASSERTION: NO T_Due_Acct tax correction lines (unlike standard write-off)
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID  |
+      | PayBankFee_Acct       | 0.20 EUR    |             |          | alloc_bf_2 |
+      | C_Receivable_Acct     |             | 0.20 EUR    |          | alloc_bf_2 |
+
+
+# ############################################################################################################################################
+# Scenario 2: Bank fee vs standard write-off — tax correction difference
+# Same residual amount, but applied as WRITEOFF → should produce T_Due_Acct tax correction lines
+# This scenario documents the behavioral difference between BF and WO
+# ############################################################################################################################################
+  @Id:S0465_BF_110
+  @from:cucumber
+  Scenario: standard write-off produces VAT tax correction (comparison baseline for bank fee)
+
+    Given metasfresh contains M_Products:
+      | Identifier     |
+      | product_bf_110 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID   | PriceStd | C_UOM_ID |
+      | salesPLV               | product_bf_110 | 5.00     | PCE      |
+
+    And metasfresh contains C_Invoice:
+      | Identifier  | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | inv_bf_110  | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | Identifier   | C_Invoice_ID | M_Product_ID   | QtyInvoiced | C_Tax_ID |
+      | invl_bf_110  | inv_bf_110   | product_bf_110 | 1 PCE       | tax1     |
+    And the invoice identified by inv_bf_110 is completed
+
+    And metasfresh contains C_Payment
+      | Identifier     | C_BPartner_ID | PayAmt     | IsReceipt | C_BP_BankAccount_ID |
+      | payment_bf_110 | customer1     | 5.75 EUR   | true      | org_EUR_account     |
+    And the payment identified by payment_bf_110 is completed
+
+    And allocate payments to invoices
+      | C_Invoice_ID | C_Payment_ID   |
+      | inv_bf_110   | payment_bf_110 |
+
+    # Apply as standard WRITEOFF (not bank fee)
+    And create and complete manual payment allocations
+      | C_AllocationHdr_ID | C_Invoice_ID | Amount | WriteOffAmt | WriteOffType |
+      | alloc_bf_110       | inv_bf_110   | 0 EUR  | 0.20 EUR    | WO           |
+
+    Then validate C_AllocationLines
+      | C_Invoice_ID | Amount | WriteOffAmt | WriteOffType | C_AllocationHdr_ID |
+      | inv_bf_110   | 0      | 0.20        | WO           | alloc_bf_110       |
+
+    # CONTRAST: standard write-off DOES produce T_Due_Acct tax correction lines
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID    |
+      | WriteOff_Acct         | 0.20 EUR    |             |          | alloc_bf_110 |
+      | C_Receivable_Acct     |             | 0.20 EUR    |          | alloc_bf_110 |
+      | T_Due_Acct            | 0.03 EUR    |             | tax1     | alloc_bf_110 |
+      | WriteOff_Acct         |             | 0.03 EUR    | tax1     | alloc_bf_110 |
+
+
+# ############################################################################################################################################
+# Scenario 3: Discount + bank fee on the same allocation
+# Discount has VAT correction, bank fee does not
+# ############################################################################################################################################
+  @Id:S0465_BF_120
+  @from:cucumber
+  Scenario: discount with VAT correction + bank fee without VAT correction on same allocation
+
+    Given metasfresh contains M_Products:
+      | Identifier     |
+      | product_bf_120 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID   | PriceStd | C_UOM_ID |
+      | salesPLV               | product_bf_120 | 100.00   | PCE      |
+
+    And metasfresh contains C_Invoice:
+      | Identifier  | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | inv_bf_120  | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | Identifier   | C_Invoice_ID | M_Product_ID   | QtyInvoiced | C_Tax_ID |
+      | invl_bf_120  | inv_bf_120   | product_bf_120 | 1 PCE       | tax1     |
+    And the invoice identified by inv_bf_120 is completed
+
+    # Invoice grand total = 119.00 EUR (100.00 net + 19.00 VAT)
+    # Payment = 106.00 EUR
+    # Discount = 3.00 EUR (early payment discount — gets VAT correction)
+    # Bank fee = 10.00 EUR (bank-deducted — no VAT correction)
+    And metasfresh contains C_Payment
+      | Identifier     | C_BPartner_ID | PayAmt      | IsReceipt | C_BP_BankAccount_ID |
+      | payment_bf_120 | customer1     | 106.00 EUR  | true      | org_EUR_account     |
+    And the payment identified by payment_bf_120 is completed
+
+    And create and complete manual payment allocations
+      | C_AllocationHdr_ID | C_Invoice_ID | C_Payment_ID   | Amount     | DiscountAmt | WriteOffAmt | WriteOffType |
+      | alloc_bf_120       | inv_bf_120   | payment_bf_120 | 106.00 EUR | 3.00 EUR    | 10.00 EUR   | BF           |
+
+    Then validate created invoices
+      | C_Invoice_ID | C_BPartner_ID | C_BPartner_Location_ID | processed | DocStatus | IsPaid | IsPartiallyPaid |
+      | inv_bf_120   | customer1     | bpartner_location_1    | true      | CO        | true   | false           |
+
+    # Posting for the allocation:
+    # - Payment portion: DR B_UnallocatedCash_Acct 106.00, CR C_Receivable_Acct 106.00
+    # - Discount portion: DR PayDiscount_Exp_Acct 3.00, CR C_Receivable_Acct 3.00
+    #   + VAT correction for discount: DR T_Due_Acct, CR PayDiscount_Exp_Acct
+    # - Bank fee portion: DR PayBankFee_Acct 10.00, CR C_Receivable_Acct 10.00
+    #   NO VAT correction for bank fee
+    And Fact_Acct records are matching
+      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID    |
+      | B_UnallocatedCash_Acct | 106.00 EUR  |             |          | alloc_bf_120 |
+      | PayBankFee_Acct        | 10.00 EUR   |             |          | alloc_bf_120 |
+      | C_Receivable_Acct      |             | 119.00 EUR  |          | alloc_bf_120 |
+      | *                      |             |             |          | alloc_bf_120 |
+
+
+# ############################################################################################################################################
+# Scenario 4: Multi-invoice — bank fee on last invoice
+# ############################################################################################################################################
+  @Id:S0465_BF_130
+  @from:cucumber
+  Scenario: multiple sales invoices - bank fee on last invoice - all fully cleared
+
+    Given metasfresh contains M_Products:
+      | Identifier     |
+      | product_bf_130 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID   | PriceStd | C_UOM_ID |
+      | salesPLV               | product_bf_130 | 5.00     | PCE      |
+
+    And metasfresh contains C_Invoice:
+      | Identifier    | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | inv_bf_130_1  | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+      | inv_bf_130_2  | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | Identifier     | C_Invoice_ID  | M_Product_ID   | QtyInvoiced | C_Tax_ID |
+      | invl_bf_130_1  | inv_bf_130_1  | product_bf_130 | 1 PCE       | tax1     |
+      | invl_bf_130_2  | inv_bf_130_2  | product_bf_130 | 1 PCE       | tax1     |
+    And the invoice identified by inv_bf_130_1 is completed
+    And the invoice identified by inv_bf_130_2 is completed
+
+    # Two invoices of 5.95 EUR each = 11.90 EUR total
+    # Payment = 11.70 EUR → 0.20 EUR short
+    And metasfresh contains C_Payment
+      | Identifier     | C_BPartner_ID | PayAmt      | IsReceipt | C_BP_BankAccount_ID |
+      | payment_bf_130 | customer1     | 11.70 EUR   | true      | org_EUR_account     |
+    And the payment identified by payment_bf_130 is completed
+
+    And allocate payments to invoices
+      | C_Invoice_ID  | C_Payment_ID   |
+      | inv_bf_130_1  | payment_bf_130 |
+      | inv_bf_130_2  |                |
+
+    Then validate created invoices
+      | C_Invoice_ID  | C_BPartner_ID | C_BPartner_Location_ID | processed | DocStatus | IsPaid | OpenAmt | IsPartiallyPaid |
+      | inv_bf_130_1  | customer1     | bpartner_location_1    | true      | CO        | true   |         | false           |
+      | inv_bf_130_2  | customer1     | bpartner_location_1    | true      | CO        | false  | 0.20    | true            |
+
+    # Apply bank fee to clear the residual on the second invoice
+    And create and complete manual payment allocations
+      | C_AllocationHdr_ID | C_Invoice_ID | Amount | WriteOffAmt | WriteOffType |
+      | alloc_bf_130       | inv_bf_130_2 | 0 EUR  | 0.20 EUR    | BF           |
+
+    Then validate created invoices
+      | C_Invoice_ID  | C_BPartner_ID | C_BPartner_Location_ID | processed | DocStatus | IsPaid | IsPartiallyPaid |
+      | inv_bf_130_2  | customer1     | bpartner_location_1    | true      | CO        | true   | false           |
+    And validate payments
+      | C_Payment_ID   | IsAllocated |
+      | payment_bf_130 | true        |
+    And validate C_AllocationLines
+      | C_Invoice_ID  | Amount | WriteOffAmt | WriteOffType | C_AllocationHdr_ID |
+      | inv_bf_130_2  | 0      | 0.20        | BF           | alloc_bf_130       |
+
+    # Bank fee posting: PayBankFee_Acct, NO tax correction
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID    |
+      | PayBankFee_Acct       | 0.20 EUR    |             |          | alloc_bf_130 |
+      | C_Receivable_Acct     |             | 0.20 EUR    |          | alloc_bf_130 |
+
+
+# ############################################################################################################################################
+# Scenario 5: Reversal — bank fee allocation reversed, AR reopened, PayBankFee_Acct reversed
+# ############################################################################################################################################
+  @Id:S0465_BF_140
+  @from:cucumber
+  Scenario: reverse allocation with bank fee - posting correctly reversed
+
+    Given metasfresh contains M_Products:
+      | Identifier     |
+      | product_bf_140 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID   | PriceStd | C_UOM_ID |
+      | salesPLV               | product_bf_140 | 5.00     | PCE      |
+
+    And metasfresh contains C_Invoice:
+      | Identifier  | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | inv_bf_140  | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | Identifier   | C_Invoice_ID | M_Product_ID   | QtyInvoiced | C_Tax_ID |
+      | invl_bf_140  | inv_bf_140   | product_bf_140 | 1 PCE       | tax1     |
+    And the invoice identified by inv_bf_140 is completed
+
+    And metasfresh contains C_Payment
+      | Identifier     | C_BPartner_ID | PayAmt     | IsReceipt | C_BP_BankAccount_ID |
+      | payment_bf_140 | customer1     | 5.75 EUR   | true      | org_EUR_account     |
+    And the payment identified by payment_bf_140 is completed
+
+    And allocate payments to invoices
+      | C_Invoice_ID | C_Payment_ID   |
+      | inv_bf_140   | payment_bf_140 |
+
+    And create and complete manual payment allocations
+      | C_AllocationHdr_ID | C_Invoice_ID | Amount | WriteOffAmt | WriteOffType |
+      | alloc_bf_140       | inv_bf_140   | 0 EUR  | 0.20 EUR    | BF           |
+
+    Then validate created invoices
+      | C_Invoice_ID | C_BPartner_ID | C_BPartner_Location_ID | processed | DocStatus | IsPaid | IsPartiallyPaid |
+      | inv_bf_140   | customer1     | bpartner_location_1    | true      | CO        | true   | false           |
+    And validate C_AllocationLines
+      | C_Invoice_ID | Amount | WriteOffAmt | WriteOffType | C_AllocationHdr_ID |
+      | inv_bf_140   | 0      | 0.20        | BF           | alloc_bf_140       |
+
+    # Now reverse the bank fee allocation
+    And the allocation identified by alloc_bf_140 is reversed
+
+    Then validate created invoices
+      | C_Invoice_ID | C_BPartner_ID | C_BPartner_Location_ID | processed | DocStatus | IsPaid | OpenAmt | IsPartiallyPaid |
+      | inv_bf_140   | customer1     | bpartner_location_1    | true      | CO        | false  | 0.20    | true            |
+
+    # Reversal posting must mirror the original: DR C_Receivable, CR PayBankFee_Acct
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID              |
+      | PayBankFee_Acct       |             | 0.20 EUR    |          | alloc_bf_140.reversed  |
+      | C_Receivable_Acct     | 0.20 EUR    |             |          | alloc_bf_140.reversed  |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation_BankFee.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation_BankFee.feature
@@ -319,8 +319,8 @@ Feature: payment allocation - bank fee posting
       | C_Invoice_ID | C_BPartner_ID | C_BPartner_Location_ID | processed | DocStatus | IsPaid | OpenAmt | IsPartiallyPaid |
       | inv_bf_140   | customer1     | bpartner_location_1    | true      | CO        | false  | 0.20    | true            |
 
-    # Reversal posting must mirror the original: DR C_Receivable, CR PayBankFee_Acct
+    # Reversal posting negates amounts on the same side (ADempiere convention)
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID              |
-      | PayBankFee_Acct       |             | 0.20 EUR    |          | alloc_bf_140.reversed  |
-      | C_Receivable_Acct     | 0.20 EUR    |             |          | alloc_bf_140.reversed  |
+      | PayBankFee_Acct       | -0.20 EUR   |             |          | alloc_bf_140.reversed  |
+      | C_Receivable_Acct     |             | -0.20 EUR   |          | alloc_bf_140.reversed  |

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/payment_allocation/process/PaymentsViewAllocateCommand.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/payment_allocation/process/PaymentsViewAllocateCommand.java
@@ -25,6 +25,7 @@ package de.metas.ui.web.payment_allocation.process;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import de.metas.allocation.api.WriteOffType;
 import de.metas.banking.payment.paymentallocation.service.AllocationAmounts;
 import de.metas.banking.payment.paymentallocation.service.PayableDocument;
 import de.metas.banking.payment.paymentallocation.service.PaymentAllocationBuilder;
@@ -188,7 +189,14 @@ public class PaymentsViewAllocateCommand
 				? moneyService.toMoney(invoiceProcessingFeeCalculation.getFeeAmountIncludingTax())
 				: Money.zero(currencyId);
 
-		final Money payAmt = openAmt.subtract(discountAmt).subtract(invoiceProcessingFee);
+		// Bank fee: mapped into writeOffAmt with WriteOffType=BF
+		@Nullable final Amount bankFeeAmtRaw = row.getBankFeeAmt();
+		final Money bankFeeAmt = bankFeeAmtRaw != null && !bankFeeAmtRaw.isZero()
+				? moneyService.toMoney(bankFeeAmtRaw)
+				: Money.zero(currencyId);
+		final WriteOffType writeOffType = bankFeeAmt.signum() != 0 ? WriteOffType.BankFee : WriteOffType.WriteOff;
+
+		final Money payAmt = openAmt.subtract(discountAmt).subtract(invoiceProcessingFee).subtract(bankFeeAmt);
 
 		final SOTrx soTrx = row.getDocBaseType().getSoTrx();
 
@@ -202,6 +210,7 @@ public class PaymentsViewAllocateCommand
 				.amountsToAllocate(AllocationAmounts.builder()
 										   .payAmt(payAmt)
 										   .discountAmt(discountAmt)
+										   .writeOffAmt(bankFeeAmt)
 										   .invoiceProcessingFee(invoiceProcessingFee)
 										   .build()
 										   .convertToRealAmounts(row.getInvoiceAmtMultiplier()))
@@ -209,6 +218,7 @@ public class PaymentsViewAllocateCommand
 				.date(row.getDateInvoiced())
 				.clientAndOrgId(row.getClientAndOrgId())
 				.currencyConversionTypeId(row.getCurrencyConversionTypeId())
+				.writeOffType(writeOffType)
 				.build();
 	}
 


### PR DESCRIPTION
## Summary

- Adds `WriteOffType` column to `C_AllocationLine` (`WO` = standard write-off, `BF` = bank fee)
- Bank fees entered in the WebUI Payment Allocation modal now persist through the allocation pipeline
- Bank fees post to `PayBankFee_Acct` (existing account from bank account setup) instead of `WriteOff_Acct`
- Bank fees skip VAT tax correction (unlike standard write-offs)
- Reversals work automatically — `PO.copyValues()` preserves `WriteOffType`

## Changes

| Layer | Files | What |
|-------|-------|------|
| **Migration** | `5789810_sys_gh28337_...WriteOffType.sql` | AD_Reference, AD_Ref_List (WO/BF), AD_Element, AD_Column, DDL |
| **Model** | `I_C_AllocationLine`, `X_C_AllocationLine` | Getter/setter for WriteOffType |
| **Enum** | `WriteOffType.java` (new) | `ReferenceListAwareEnum` with WO/BF values |
| **Builder** | `C_AllocationLine_Builder` | `writeOffType()` method |
| **Allocation** | `PayableDocument`, `AllocationLineCandidate`, `AllocationLineCandidateSaver` | Propagate writeOffType through pipeline |
| **WebUI** | `PaymentsViewAllocateCommand` | Read `bankFeeAmt` from InvoiceRow, map to writeOff + BF type |
| **Posting** | `DocLine_Allocation`, `Doc_AllocationHdr` | Branch account + skip tax correction for BF |
| **Cucumber** | `C_AllocationHdr_StepDef`, `C_AllocationLine_StepDef`, `invoicePaymentAllocation_BankFee.feature` | 5 test scenarios |

## Test plan

- [ ] Compile all affected modules (de.metas.business, de.metas.banking.base, de.metas.ui.web.base, de.metas.acct.base, de.metas.cucumber)
- [ ] Run existing `PaymentAllocationBuilderTest` and `AllocationAmountsTest` — no regressions
- [ ] Run cucumber feature `invoicePaymentAllocation_BankFee.feature` (5 scenarios: bank fee posting, standard write-off comparison, discount+bankfee combo, multi-invoice, reversal)
- [ ] Verify `PayBankFee_Acct` is configured on test bank account before running

🤖 Generated with [Claude Code](https://claude.com/claude-code)