### PR TITLE
#28126 Material Cockpit V2 - Increment 1 (Read-Only)

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/MaterialCockpitV2Filters.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/MaterialCockpitV2Filters.java
@@ -1,0 +1,176 @@
+package de.metas.ui.web.material.cockpit.v2;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.ui.web.document.filter.DocumentFilter;
+import de.metas.ui.web.document.filter.DocumentFilterDescriptor;
+import de.metas.ui.web.document.filter.DocumentFilterList;
+import de.metas.ui.web.document.filter.DocumentFilterParam.Operator;
+import de.metas.ui.web.document.filter.DocumentFilterParamDescriptor;
+import de.metas.ui.web.document.filter.provider.DocumentFilterDescriptorsProvider;
+import de.metas.ui.web.document.filter.provider.ImmutableDocumentFilterDescriptorsProvider;
+import de.metas.ui.web.view.CreateViewRequest;
+import de.metas.ui.web.window.descriptor.DocumentFieldWidgetType;
+import lombok.NonNull;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class MaterialCockpitV2Filters
+{
+	private static final String FILTER_ID_Product = "Product";
+	private static final String FILTER_ID_Warehouse = "Warehouse";
+	private static final String FILTER_ID_SupplyType = "SupplyType";
+
+	private static final String PARAM_ProductValue = "ProductValue";
+	private static final String PARAM_M_Warehouse_ID = "M_Warehouse_ID";
+	private static final String PARAM_SupplyType = "SupplyType";
+
+	public DocumentFilterDescriptorsProvider getFilterDescriptors()
+	{
+		return ImmutableDocumentFilterDescriptorsProvider.of(
+				createProductFilterDescriptor(),
+				createWarehouseFilterDescriptor(),
+				createSupplyTypeFilterDescriptor());
+	}
+
+	public DocumentFilterList extractDocumentFilters(@NonNull final CreateViewRequest request)
+	{
+		return request.getFilters();
+	}
+
+	private static DocumentFilterDescriptor createProductFilterDescriptor()
+	{
+		return DocumentFilterDescriptor.builder()
+				.setFilterId(FILTER_ID_Product)
+				.setFrequentUsed(true)
+				.addParameter(DocumentFilterParamDescriptor.builder()
+						.setFieldName(PARAM_ProductValue)
+						.setDisplayName("Product")
+						.setWidgetType(DocumentFieldWidgetType.Text)
+						.build())
+				.build();
+	}
+
+	private static DocumentFilterDescriptor createWarehouseFilterDescriptor()
+	{
+		return DocumentFilterDescriptor.builder()
+				.setFilterId(FILTER_ID_Warehouse)
+				.setFrequentUsed(true)
+				.addParameter(DocumentFilterParamDescriptor.builder()
+						.setFieldName(PARAM_M_Warehouse_ID)
+						.setDisplayName("Warehouse")
+						.setWidgetType(DocumentFieldWidgetType.Integer)
+						.build())
+				.build();
+	}
+
+	private static DocumentFilterDescriptor createSupplyTypeFilterDescriptor()
+	{
+		return DocumentFilterDescriptor.builder()
+				.setFilterId(FILTER_ID_SupplyType)
+				.setFrequentUsed(true)
+				.addParameter(DocumentFilterParamDescriptor.builder()
+						.setFieldName(PARAM_SupplyType)
+						.setDisplayName("Supply Type")
+						.setWidgetType(DocumentFieldWidgetType.Text)
+						.build())
+				.build();
+	}
+
+	/**
+	 * Convert the frontend filter parameters to SQL WHERE clause parts.
+	 *
+	 * @return SQL WHERE clause and parameters
+	 */
+	public SqlWhereClause toSqlWhereClause(@NonNull final DocumentFilterList filters)
+	{
+		final StringBuilder whereClause = new StringBuilder();
+		final List<Object> sqlParams = new ArrayList<>();
+
+		for (final DocumentFilter filter : filters.toList())
+		{
+			final String filterId = filter.getFilterId();
+			switch (filterId)
+			{
+				case FILTER_ID_Product:
+				{
+					final String productValue = filter.getParameterValueAsString(PARAM_ProductValue, null);
+					if (productValue != null && !productValue.isEmpty())
+					{
+						if (whereClause.length() > 0)
+						{
+							whereClause.append(" AND ");
+						}
+						whereClause.append("(UPPER(v.ProductValue) LIKE UPPER(?) OR UPPER(v.ProductName) LIKE UPPER(?))");
+						sqlParams.add("%" + productValue + "%");
+						sqlParams.add("%" + productValue + "%");
+					}
+					break;
+				}
+				case FILTER_ID_Warehouse:
+				{
+					final int warehouseId = filter.getParameterValueAsInt(PARAM_M_Warehouse_ID, -1);
+					if (warehouseId > 0)
+					{
+						if (whereClause.length() > 0)
+						{
+							whereClause.append(" AND ");
+						}
+						whereClause.append("v.M_Warehouse_ID = ?");
+						sqlParams.add(warehouseId);
+					}
+					break;
+				}
+				case FILTER_ID_SupplyType:
+				{
+					final String supplyType = filter.getParameterValueAsString(PARAM_SupplyType, null);
+					if (supplyType != null && !supplyType.isEmpty())
+					{
+						if (whereClause.length() > 0)
+						{
+							whereClause.append(" AND ");
+						}
+						whereClause.append("v.SupplyType = ?");
+						sqlParams.add(supplyType);
+					}
+					break;
+				}
+				default:
+					// ignore unknown filters
+					break;
+			}
+		}
+
+		return new SqlWhereClause(whereClause.toString(), sqlParams);
+	}
+
+	public static class SqlWhereClause
+	{
+		private final String sql;
+		private final List<Object> params;
+
+		public SqlWhereClause(@NonNull final String sql, @NonNull final List<Object> params)
+		{
+			this.sql = sql;
+			this.params = ImmutableList.copyOf(params);
+		}
+
+		public String getSql()
+		{
+			return sql;
+		}
+
+		public List<Object> getParams()
+		{
+			return params;
+		}
+
+		public boolean isEmpty()
+		{
+			return sql.isEmpty();
+		}
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/MaterialCockpitV2Row.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/MaterialCockpitV2Row.java
@@ -1,0 +1,218 @@
+package de.metas.ui.web.material.cockpit.v2;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import de.metas.ui.web.view.IViewRow;
+import de.metas.ui.web.view.IViewRowType;
+import de.metas.ui.web.view.ViewRow.DefaultRowType;
+import de.metas.ui.web.view.ViewRowFieldNameAndJsonValues;
+import de.metas.ui.web.view.ViewRowFieldNameAndJsonValuesHolder;
+import de.metas.ui.web.view.descriptor.annotation.ViewColumn;
+import de.metas.ui.web.view.descriptor.annotation.ViewColumn.ViewColumnLayout;
+import de.metas.ui.web.view.json.JSONViewDataType;
+import de.metas.ui.web.window.datatypes.DocumentId;
+import de.metas.ui.web.window.datatypes.DocumentPath;
+import de.metas.ui.web.window.datatypes.LookupValue;
+import de.metas.ui.web.window.descriptor.DocumentFieldWidgetType;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Set;
+
+@ToString
+@EqualsAndHashCode(of = "documentId")
+public class MaterialCockpitV2Row implements IViewRow
+{
+	@Getter
+	private final DocumentId documentId;
+	private final DocumentPath documentPath;
+
+	@ViewColumn(widgetType = DocumentFieldWidgetType.Text,
+			captionKey = "ProductValue",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 10) })
+	private final String productValue;
+
+	@ViewColumn(widgetType = DocumentFieldWidgetType.Text,
+			captionKey = "ProductName",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 20) })
+	private final String productName;
+
+	@ViewColumn(fieldName = "M_Product_Category_ID",
+			widgetType = DocumentFieldWidgetType.Lookup,
+			captionKey = "M_Product_Category_ID",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 30) })
+	private final LookupValue productCategory;
+
+	@ViewColumn(fieldName = "M_Warehouse_ID",
+			widgetType = DocumentFieldWidgetType.Lookup,
+			captionKey = "M_Warehouse_ID",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 40) })
+	private final LookupValue warehouse;
+
+	@ViewColumn(fieldName = "SupplyType",
+			widgetType = DocumentFieldWidgetType.Text,
+			captionKey = "SupplyType",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 50) })
+	private final String supplyType;
+
+	@ViewColumn(fieldName = "C_BPartner_Vendor_ID",
+			widgetType = DocumentFieldWidgetType.Lookup,
+			captionKey = "C_BPartner_Vendor_ID",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 60) })
+	private final LookupValue vendor;
+
+	@ViewColumn(fieldName = "DatePromised",
+			widgetType = DocumentFieldWidgetType.Date,
+			captionKey = "DatePromised",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 70) })
+	private final java.util.Date datePromised;
+
+	@ViewColumn(fieldName = "QtyOnHand",
+			widgetType = DocumentFieldWidgetType.Quantity,
+			captionKey = "QtyOnHand",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 80) })
+	private final BigDecimal qtyOnHand;
+
+	@ViewColumn(fieldName = "QtyTU",
+			widgetType = DocumentFieldWidgetType.Quantity,
+			captionKey = "QtyTU",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 90) })
+	private final BigDecimal qtyTU;
+
+	@ViewColumn(fieldName = "QtyLU",
+			widgetType = DocumentFieldWidgetType.Quantity,
+			captionKey = "QtyLU",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 100) })
+	private final BigDecimal qtyLU;
+
+	@ViewColumn(fieldName = "WeightNet",
+			widgetType = DocumentFieldWidgetType.Quantity,
+			captionKey = "WeightNet",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 110) })
+	private final BigDecimal weightNet;
+
+	@ViewColumn(fieldName = "LastCostPrice",
+			widgetType = DocumentFieldWidgetType.CostPrice,
+			captionKey = "LastCostPrice",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 120) })
+	private final BigDecimal lastCostPrice;
+
+	@ViewColumn(fieldName = "C_UOM_ID",
+			widgetType = DocumentFieldWidgetType.Lookup,
+			captionKey = "C_UOM_ID",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 130) })
+	private final LookupValue uom;
+
+	// Customer-specific columns (from SE203_MaterialCockpit_V)
+	@ViewColumn(fieldName = "Kaliber",
+			widgetType = DocumentFieldWidgetType.Text,
+			captionKey = "Kaliber",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 140) })
+	@Nullable
+	private final String kaliber;
+
+	@ViewColumn(fieldName = "Herkunft",
+			widgetType = DocumentFieldWidgetType.Text,
+			captionKey = "Herkunft",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 150) })
+	@Nullable
+	private final String herkunft;
+
+	@ViewColumn(fieldName = "Marke",
+			widgetType = DocumentFieldWidgetType.Text,
+			captionKey = "Marke",
+			layouts = { @ViewColumnLayout(when = JSONViewDataType.grid, seqNo = 160) })
+	@Nullable
+	private final String marke;
+
+	private final ViewRowFieldNameAndJsonValuesHolder<MaterialCockpitV2Row> values = ViewRowFieldNameAndJsonValuesHolder.newInstance(MaterialCockpitV2Row.class);
+
+	@Builder
+	private MaterialCockpitV2Row(
+			@NonNull final DocumentId documentId,
+			@NonNull final String productValue,
+			@NonNull final String productName,
+			@Nullable final LookupValue productCategory,
+			@Nullable final LookupValue warehouse,
+			@NonNull final String supplyType,
+			@Nullable final LookupValue vendor,
+			@Nullable final java.util.Date datePromised,
+			@Nullable final BigDecimal qtyOnHand,
+			@Nullable final BigDecimal qtyTU,
+			@Nullable final BigDecimal qtyLU,
+			@Nullable final BigDecimal weightNet,
+			@Nullable final BigDecimal lastCostPrice,
+			@Nullable final LookupValue uom,
+			@Nullable final String kaliber,
+			@Nullable final String herkunft,
+			@Nullable final String marke)
+	{
+		this.documentId = documentId;
+		this.documentPath = DocumentPath.rootDocumentPath(MaterialCockpitV2Util.WINDOWID_MaterialCockpitV2, documentId);
+		this.productValue = productValue;
+		this.productName = productName;
+		this.productCategory = productCategory;
+		this.warehouse = warehouse;
+		this.supplyType = supplyType;
+		this.vendor = vendor;
+		this.datePromised = datePromised;
+		this.qtyOnHand = qtyOnHand;
+		this.qtyTU = qtyTU;
+		this.qtyLU = qtyLU;
+		this.weightNet = weightNet;
+		this.lastCostPrice = lastCostPrice;
+		this.uom = uom;
+		this.kaliber = kaliber;
+		this.herkunft = herkunft;
+		this.marke = marke;
+	}
+
+	@Override
+	public DocumentId getId()
+	{
+		return documentId;
+	}
+
+	@Override
+	public IViewRowType getType()
+	{
+		return DefaultRowType.Row;
+	}
+
+	@Override
+	public boolean isProcessed()
+	{
+		return true; // read-only view
+	}
+
+	@Override
+	public DocumentPath getDocumentPath()
+	{
+		return documentPath;
+	}
+
+	@Override
+	public ImmutableSet<String> getFieldNames()
+	{
+		return values.getFieldNames();
+	}
+
+	@Override
+	public ViewRowFieldNameAndJsonValues getFieldNameAndJsonValues()
+	{
+		return values.get(this);
+	}
+
+	@Override
+	public List<? extends IViewRow> getIncludedRows()
+	{
+		return ImmutableList.of();
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/MaterialCockpitV2RowsData.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/MaterialCockpitV2RowsData.java
@@ -1,0 +1,125 @@
+package de.metas.ui.web.material.cockpit.v2;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import de.metas.ui.web.view.template.IRowsData;
+import de.metas.ui.web.window.datatypes.DocumentId;
+import de.metas.ui.web.window.datatypes.DocumentIdsSelection;
+import de.metas.ui.web.window.datatypes.LookupValue;
+import de.metas.ui.web.window.datatypes.LookupValue.IntegerLookupValue;
+import lombok.NonNull;
+import org.adempiere.util.lang.impl.TableRecordReferenceSet;
+import org.compiere.util.DB;
+import org.compiere.util.DisplayType;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class MaterialCockpitV2RowsData implements IRowsData<MaterialCockpitV2Row>
+{
+	private final String sql;
+	private final List<Object> sqlParams;
+	private ImmutableMap<DocumentId, MaterialCockpitV2Row> rows;
+
+	public MaterialCockpitV2RowsData(@NonNull final String sql, @NonNull final List<Object> sqlParams)
+	{
+		this.sql = sql;
+		this.sqlParams = ImmutableList.copyOf(sqlParams);
+		this.rows = loadRows();
+	}
+
+	@Override
+	public Map<DocumentId, MaterialCockpitV2Row> getDocumentId2TopLevelRows()
+	{
+		return rows;
+	}
+
+	@Override
+	public DocumentIdsSelection getDocumentIdsToInvalidate(@NonNull final TableRecordReferenceSet recordRefs)
+	{
+		// For a SQL view, any change invalidates everything
+		return DocumentIdsSelection.ALL;
+	}
+
+	@Override
+	public void invalidateAll()
+	{
+		rows = loadRows();
+	}
+
+	private ImmutableMap<DocumentId, MaterialCockpitV2Row> loadRows()
+	{
+		final List<MaterialCockpitV2Row> rowsList = DB.retrieveRows(sql, sqlParams, MaterialCockpitV2RowsData::toRow);
+
+		final ImmutableMap.Builder<DocumentId, MaterialCockpitV2Row> builder = ImmutableMap.builder();
+		for (final MaterialCockpitV2Row row : rowsList)
+		{
+			builder.put(row.getId(), row);
+		}
+		return builder.build();
+	}
+
+	@NonNull
+	private static MaterialCockpitV2Row toRow(@NonNull final ResultSet rs) throws SQLException
+	{
+		final int viewId = rs.getInt("QtyDemand_QtySupply_V_ID");
+		final DocumentId documentId = DocumentId.of(viewId);
+
+		final int productId = rs.getInt("M_Product_ID");
+		final int productCategoryId = rs.getInt("M_Product_Category_ID");
+		final int warehouseId = rs.getInt("M_Warehouse_ID");
+		final int uomId = rs.getInt("C_UOM_ID");
+		final int vendorId = rs.getInt("C_BPartner_Vendor_ID");
+
+		return MaterialCockpitV2Row.builder()
+				.documentId(documentId)
+				.productValue(rs.getString("ProductValue"))
+				.productName(rs.getString("ProductName"))
+				.productCategory(toLookupValueOrNull(productCategoryId, "M_Product_Category"))
+				.warehouse(toLookupValueOrNull(warehouseId, "M_Warehouse"))
+				.supplyType(rs.getString("SupplyType"))
+				.vendor(toLookupValueOrNull(vendorId, "C_BPartner"))
+				.datePromised(rs.getTimestamp("DatePromised"))
+				.qtyOnHand(rs.getBigDecimal("QtyOnHand"))
+				.qtyTU(rs.getBigDecimal("QtyTU"))
+				.qtyLU(rs.getBigDecimal("QtyLU"))
+				.weightNet(rs.getBigDecimal("WeightNet"))
+				.lastCostPrice(rs.getBigDecimal("LastCostPrice"))
+				.uom(toLookupValueOrNull(uomId, "C_UOM"))
+				.kaliber(getStringOrNull(rs, "Kaliber"))
+				.herkunft(getStringOrNull(rs, "Herkunft"))
+				.marke(getStringOrNull(rs, "Marke"))
+				.build();
+	}
+
+	@Nullable
+	private static LookupValue toLookupValueOrNull(final int id, @NonNull final String tableName)
+	{
+		if (id <= 0)
+		{
+			return null;
+		}
+		// Use simple lookup; the WebUI will resolve display names
+		return IntegerLookupValue.of(id, tableName + "#" + id);
+	}
+
+	@Nullable
+	private static String getStringOrNull(@NonNull final ResultSet rs, @NonNull final String columnName)
+	{
+		try
+		{
+			return rs.getString(columnName);
+		}
+		catch (final SQLException e)
+		{
+			// Column not present in this view variant (e.g. base view has no customer columns)
+			return null;
+		}
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/MaterialCockpitV2Util.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/MaterialCockpitV2Util.java
@@ -1,0 +1,15 @@
+package de.metas.ui.web.material.cockpit.v2;
+
+import de.metas.ui.web.window.datatypes.WindowId;
+
+public final class MaterialCockpitV2Util
+{
+	public static final String WINDOWID_MaterialCockpitV2_String = "541963";
+	public static final WindowId WINDOWID_MaterialCockpitV2 = WindowId.fromJson(WINDOWID_MaterialCockpitV2_String);
+
+	public static final String VIEW_TABLE_NAME = "QtyDemand_QtySupply_V";
+
+	private MaterialCockpitV2Util()
+	{
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/MaterialCockpitV2View.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/MaterialCockpitV2View.java
@@ -1,0 +1,71 @@
+package de.metas.ui.web.material.cockpit.v2;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.i18n.ITranslatableString;
+import de.metas.process.RelatedProcessDescriptor;
+import de.metas.ui.web.document.filter.DocumentFilterList;
+import de.metas.ui.web.document.filter.provider.DocumentFilterDescriptorsProvider;
+import de.metas.ui.web.view.IView;
+import de.metas.ui.web.view.ViewId;
+import de.metas.ui.web.view.template.AbstractCustomView;
+import de.metas.ui.web.view.template.IRowsData;
+import de.metas.ui.web.window.datatypes.DocumentId;
+import de.metas.ui.web.window.model.DocumentQueryOrderBy;
+import de.metas.ui.web.window.model.DocumentQueryOrderByList;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Singular;
+
+import java.util.List;
+
+public class MaterialCockpitV2View extends AbstractCustomView<MaterialCockpitV2Row>
+{
+	private final DocumentFilterList filters;
+	private final List<RelatedProcessDescriptor> relatedProcessDescriptors;
+
+	@Builder
+	private MaterialCockpitV2View(
+			@NonNull final ViewId viewId,
+			@NonNull final ITranslatableString description,
+			@NonNull final IRowsData<MaterialCockpitV2Row> rowsData,
+			@NonNull final DocumentFilterList filters,
+			@NonNull final DocumentFilterDescriptorsProvider filterDescriptors,
+			@Singular final List<RelatedProcessDescriptor> relatedProcessDescriptors)
+	{
+		super(viewId, description, rowsData, filterDescriptors);
+		this.filters = filters;
+		this.relatedProcessDescriptors = ImmutableList.copyOf(relatedProcessDescriptors);
+	}
+
+	public static MaterialCockpitV2View cast(final IView view)
+	{
+		return (MaterialCockpitV2View)view;
+	}
+
+	@Override
+	public String getTableNameOrNull(final DocumentId documentId)
+	{
+		return MaterialCockpitV2Util.VIEW_TABLE_NAME;
+	}
+
+	@Override
+	public DocumentFilterList getFilters()
+	{
+		return filters;
+	}
+
+	@Override
+	public DocumentQueryOrderByList getDefaultOrderBys()
+	{
+		return DocumentQueryOrderByList.ofList(
+				ImmutableList.of(
+						DocumentQueryOrderBy.byFieldName("ProductValue"),
+						DocumentQueryOrderBy.byFieldName("M_Warehouse_ID")));
+	}
+
+	@Override
+	public List<RelatedProcessDescriptor> getAdditionalRelatedProcessDescriptors()
+	{
+		return relatedProcessDescriptors;
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/MaterialCockpitV2ViewFactory.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/MaterialCockpitV2ViewFactory.java
@@ -1,0 +1,101 @@
+package de.metas.ui.web.material.cockpit.v2;
+
+import de.metas.i18n.TranslatableStrings;
+import de.metas.ui.web.document.filter.DocumentFilterList;
+import de.metas.ui.web.document.filter.provider.DocumentFilterDescriptorsProvider;
+import de.metas.ui.web.view.CreateViewRequest;
+import de.metas.ui.web.view.IViewFactory;
+import de.metas.ui.web.view.ViewFactory;
+import de.metas.ui.web.view.ViewId;
+import de.metas.ui.web.view.ViewProfileId;
+import de.metas.ui.web.view.descriptor.ViewLayout;
+import de.metas.ui.web.view.json.JSONViewDataType;
+import de.metas.ui.web.window.datatypes.WindowId;
+import de.metas.ui.web.window.descriptor.factory.standard.DefaultDocumentDescriptorFactory;
+import de.metas.util.Check;
+import lombok.NonNull;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+@ViewFactory(windowId = MaterialCockpitV2Util.WINDOWID_MaterialCockpitV2_String,
+		viewTypes = { JSONViewDataType.grid, JSONViewDataType.includedView })
+public class MaterialCockpitV2ViewFactory implements IViewFactory
+{
+	private final MaterialCockpitV2Filters materialCockpitV2Filters;
+
+	public MaterialCockpitV2ViewFactory(
+			@NonNull final MaterialCockpitV2Filters materialCockpitV2Filters,
+			@NonNull final DefaultDocumentDescriptorFactory defaultDocumentDescriptorFactory)
+	{
+		this.materialCockpitV2Filters = materialCockpitV2Filters;
+		defaultDocumentDescriptorFactory.addUnsupportedWindowId(MaterialCockpitV2Util.WINDOWID_MaterialCockpitV2);
+	}
+
+	@Override
+	public MaterialCockpitV2View createView(@NonNull final CreateViewRequest request)
+	{
+		assertWindowId(request);
+
+		final DocumentFilterDescriptorsProvider filterDescriptors = materialCockpitV2Filters.getFilterDescriptors();
+		final DocumentFilterList filters = materialCockpitV2Filters.extractDocumentFilters(request);
+
+		final MaterialCockpitV2RowsData rowsData = createRowsData(filters);
+
+		return MaterialCockpitV2View.builder()
+				.viewId(request.getViewId())
+				.description(TranslatableStrings.empty())
+				.filters(filters)
+				.filterDescriptors(filterDescriptors)
+				.rowsData(rowsData)
+				.build();
+	}
+
+	private void assertWindowId(@NonNull final CreateViewRequest request)
+	{
+		final ViewId viewId = request.getViewId();
+		final WindowId windowId = viewId.getWindowId();
+
+		Check.errorUnless(MaterialCockpitV2Util.WINDOWID_MaterialCockpitV2.equals(windowId),
+				"Expected WindowId={}, but got {}; request={}",
+				MaterialCockpitV2Util.WINDOWID_MaterialCockpitV2, windowId, request);
+	}
+
+	private MaterialCockpitV2RowsData createRowsData(@NonNull final DocumentFilterList filters)
+	{
+		final List<Object> sqlParams = new ArrayList<>();
+		final StringBuilder sql = new StringBuilder();
+		sql.append("SELECT * FROM ").append(MaterialCockpitV2Util.VIEW_TABLE_NAME).append(" v");
+
+		final MaterialCockpitV2Filters.SqlWhereClause whereClause = materialCockpitV2Filters.toSqlWhereClause(filters);
+		if (!whereClause.isEmpty())
+		{
+			sql.append(" WHERE ").append(whereClause.getSql());
+			sqlParams.addAll(whereClause.getParams());
+		}
+
+		sql.append(" ORDER BY v.ProductValue, v.M_Warehouse_ID");
+
+		return new MaterialCockpitV2RowsData(sql.toString(), sqlParams);
+	}
+
+	@Override
+	public ViewLayout getViewLayout(
+			@NonNull final WindowId windowId,
+			@NonNull final JSONViewDataType viewDataType,
+			@Nullable final ViewProfileId profileId)
+	{
+		Check.errorUnless(MaterialCockpitV2Util.WINDOWID_MaterialCockpitV2.equals(windowId),
+				"Expected WindowId={}, but got {}",
+				MaterialCockpitV2Util.WINDOWID_MaterialCockpitV2, windowId);
+
+		return ViewLayout.builder()
+				.setWindowId(windowId)
+				.setHasTreeSupport(false)
+				.setAllowOpeningRowDetails(false)
+				.addElementsFromViewRowClass(MaterialCockpitV2Row.class, viewDataType)
+				.setFilters(materialCockpitV2Filters.getFilterDescriptors().getAll())
+				.build();
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/process/C_OrderLine_OpenMaterialCockpit.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/process/C_OrderLine_OpenMaterialCockpit.java
@@ -1,0 +1,76 @@
+package de.metas.ui.web.material.cockpit.v2.process;
+
+import de.metas.process.IProcessPrecondition;
+import de.metas.process.JavaProcess;
+import de.metas.process.ProcessExecutionResult.ViewOpenTarget;
+import de.metas.process.ProcessExecutionResult.WebuiViewToOpen;
+import de.metas.process.ProcessPreconditionsResolution;
+import de.metas.process.RunOutOfTrx;
+import de.metas.ui.web.document.filter.DocumentFilter;
+import de.metas.ui.web.document.filter.DocumentFilterParam;
+import de.metas.ui.web.material.cockpit.v2.MaterialCockpitV2Util;
+import de.metas.ui.web.view.CreateViewRequest;
+import de.metas.ui.web.view.IView;
+import de.metas.ui.web.view.IViewsRepository;
+import org.compiere.model.I_C_OrderLine;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class C_OrderLine_OpenMaterialCockpit extends JavaProcess implements IProcessPrecondition
+{
+	@Autowired
+	private transient IViewsRepository viewsRepo;
+
+	@Override
+	public ProcessPreconditionsResolution checkPreconditionsApplicable(final IProcessPreconditionsContext context)
+	{
+		if (context.getSelectedIncludedRecords().isEmpty()
+				&& context.getSingleSelectedRecordIdOrNull() == null)
+		{
+			return ProcessPreconditionsResolution.rejectBecauseNoSelection();
+		}
+		return ProcessPreconditionsResolution.accept();
+	}
+
+	@Override
+	@RunOutOfTrx
+	protected String doIt() throws Exception
+	{
+		final I_C_OrderLine orderLine = getRecord(I_C_OrderLine.class);
+
+		final int productId = orderLine.getM_Product_ID();
+		final int warehouseId = orderLine.getM_Warehouse_ID();
+
+		final DocumentFilter.DocumentFilterBuilder filterBuilder = DocumentFilter.builder()
+				.setFilterId("SOLineContext");
+
+		if (productId > 0)
+		{
+			filterBuilder.addParameter(DocumentFilterParam.builder()
+					.setFieldName("ProductValue")
+					.setValue(orderLine.getM_Product().getValue())
+					.build());
+		}
+
+		if (warehouseId > 0)
+		{
+			filterBuilder.addParameter(DocumentFilterParam.builder()
+					.setFieldName("M_Warehouse_ID")
+					.setValue(warehouseId)
+					.build());
+		}
+
+		final CreateViewRequest viewRequest = CreateViewRequest
+				.builder(MaterialCockpitV2Util.WINDOWID_MaterialCockpitV2)
+				.addStickyFilters(filterBuilder.build())
+				.build();
+
+		final IView view = viewsRepo.createView(viewRequest);
+
+		getResult().setWebuiViewToOpen(WebuiViewToOpen.builder()
+				.viewId(view.getViewId().getViewId())
+				.target(ViewOpenTarget.ModalOverlay)
+				.build());
+
+		return MSG_OK;
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/ddl/functions/after_migration_M_MaterialCockpit_rebuild.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/ddl/functions/after_migration_M_MaterialCockpit_rebuild.sql
@@ -1,0 +1,59 @@
+CREATE OR REPLACE FUNCTION after_migration_M_MaterialCockpit_rebuild()
+    RETURNS void
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    v_source_view   TEXT;
+    v_count         INTEGER;
+    v_missing_cols  TEXT;
+BEGIN
+    --
+    -- Step 1: Find customer/override views matching '%_MaterialCockpit_V' excluding the base view
+    --
+    SELECT COUNT(*), MAX(viewname)
+    INTO v_count, v_source_view
+    FROM pg_views
+    WHERE viewname LIKE '%_materialcockpit_v'
+      AND viewname <> 'm_materialcockpit_base_v'
+      AND viewname <> 'qtydemand_qtysupply_v';
+
+    --
+    -- Step 2: Decide which source view to use
+    --
+    IF v_count = 0 THEN
+        v_source_view := 'm_materialcockpit_base_v';
+        RAISE NOTICE 'after_migration_M_MaterialCockpit_rebuild: No customer override found. Using base view: %', v_source_view;
+    ELSIF v_count = 1 THEN
+        RAISE NOTICE 'after_migration_M_MaterialCockpit_rebuild: Found customer override: %', v_source_view;
+    ELSE
+        RAISE EXCEPTION 'after_migration_M_MaterialCockpit_rebuild: Found % customer override views matching %%_MaterialCockpit_V. Expected at most 1.', v_count;
+    END IF;
+
+    --
+    -- Step 3: Validate that the chosen source has all required base columns
+    --
+    SELECT string_agg(bc.column_name, ', ')
+    INTO v_missing_cols
+    FROM information_schema.columns bc
+    WHERE bc.table_name = 'm_materialcockpit_base_v'
+      AND bc.table_schema = 'public'
+      AND NOT EXISTS (SELECT 1
+                      FROM information_schema.columns sc
+                      WHERE sc.table_name = v_source_view
+                        AND sc.table_schema = 'public'
+                        AND sc.column_name = bc.column_name);
+
+    IF v_missing_cols IS NOT NULL AND v_source_view <> 'm_materialcockpit_base_v' THEN
+        RAISE EXCEPTION 'after_migration_M_MaterialCockpit_rebuild: Source view "%" is missing base columns: %', v_source_view, v_missing_cols;
+    END IF;
+
+    --
+    -- Step 4: Recreate the API view QtyDemand_QtySupply_V
+    --
+    EXECUTE 'DROP VIEW IF EXISTS QtyDemand_QtySupply_V';
+    EXECUTE 'CREATE OR REPLACE VIEW QtyDemand_QtySupply_V AS SELECT * FROM ' || v_source_view;
+
+    RAISE NOTICE 'after_migration_M_MaterialCockpit_rebuild: Successfully created QtyDemand_QtySupply_V from %', v_source_view;
+END;
+$$;

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/ddl/views/M_MaterialCockpit_Base_V.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/ddl/views/M_MaterialCockpit_Base_V.sql
@@ -1,0 +1,77 @@
+DROP VIEW IF EXISTS M_MaterialCockpit_Base_V;
+
+CREATE OR REPLACE VIEW M_MaterialCockpit_Base_V AS
+
+--
+-- On-hand stock from md_stock (pre-computed from HU data)
+--
+SELECT s.ad_client_id,
+       s.ad_org_id,
+       s.m_product_id,
+       p.m_product_category_id,
+       p.value                                                                           AS ProductValue,
+       p.name                                                                            AS ProductName,
+       p.c_uom_id,
+       s.m_warehouse_id,
+       s.attributeskey                                                                   AS AttributesKey,
+       'OH'::varchar(2)                                                                  AS SupplyType,
+       NULL::numeric(10, 0)                                                              AS C_BPartner_Vendor_ID,
+       now()::timestamp without time zone                                                AS DatePromised,
+       s.qtyonhand                                                                       AS QtyOnHand,
+       0::numeric                                                                        AS QtyTU,
+       0::numeric                                                                        AS QtyLU,
+       COALESCE(s.qtyonhand * NULLIF(p.weight, 0), 0)                                   AS WeightNet,
+       getLastCostPrice(p.m_product_id)                                                  AS LastCostPrice,
+       ABS((('x' || SUBSTR(MD5(CONCAT_WS('#',
+                                          'OH',
+                                          s.ad_client_id::text,
+                                          s.ad_org_id::text,
+                                          s.m_product_id::text,
+                                          COALESCE(s.attributeskey, '')::text,
+                                          COALESCE(s.m_warehouse_id, 0)::text)), 1, 10))::bit(32)::int)) AS QtyDemand_QtySupply_V_ID
+FROM md_stock s
+         INNER JOIN m_product p ON s.m_product_id = p.m_product_id
+WHERE s.isactive = 'Y'
+  AND COALESCE(s.qtyonhand, 0) <> 0
+
+UNION ALL
+
+--
+-- Planned supply from M_ReceiptSchedule (open receipts)
+--
+SELECT rs.ad_client_id,
+       rs.ad_org_id,
+       rs.m_product_id,
+       p.m_product_category_id,
+       p.value                                                                            AS ProductValue,
+       p.name                                                                             AS ProductName,
+       p.c_uom_id,
+       rs.m_warehouse_id,
+       generateasistorageattributeskey(rs.m_attributesetinstance_id)                      AS AttributesKey,
+       'PS'::varchar(2)                                                                   AS SupplyType,
+       rs.c_bpartner_id                                                                   AS C_BPartner_Vendor_ID,
+       rs.datepromised::timestamp without time zone                                       AS DatePromised,
+       SUM(uomconvert(rs.m_product_id, rs.c_uom_id, p.c_uom_id, rs.qtytomove))          AS QtyOnHand,
+       0::numeric                                                                         AS QtyTU,
+       0::numeric                                                                         AS QtyLU,
+       COALESCE(SUM(uomconvert(rs.m_product_id, rs.c_uom_id, p.c_uom_id, rs.qtytomove) * NULLIF(p.weight, 0)), 0) AS WeightNet,
+       getLastCostPrice(p.m_product_id)                                                   AS LastCostPrice,
+       ABS((('x' || SUBSTR(MD5(CONCAT_WS('#',
+                                          'PS',
+                                          rs.ad_client_id::text,
+                                          rs.ad_org_id::text,
+                                          rs.m_product_id::text,
+                                          COALESCE(generateasistorageattributeskey(rs.m_attributesetinstance_id), '')::text,
+                                          COALESCE(rs.m_warehouse_id, 0)::text,
+                                          COALESCE(rs.c_bpartner_id, 0)::text,
+                                          COALESCE(rs.datepromised::text, ''))), 1, 10))::bit(32)::int)) AS QtyDemand_QtySupply_V_ID
+FROM m_receiptschedule rs
+         INNER JOIN m_product p ON rs.m_product_id = p.m_product_id
+WHERE rs.processed = 'N'
+  AND rs.isactive = 'Y'
+  AND COALESCE(rs.qtytomove, 0) <> 0
+GROUP BY rs.ad_client_id, rs.ad_org_id, rs.m_product_id, p.m_product_category_id,
+         p.value, p.name, p.c_uom_id, rs.m_warehouse_id,
+         generateasistorageattributeskey(rs.m_attributesetinstance_id),
+         rs.c_bpartner_id, rs.datepromised, p.weight, p.m_product_id
+;

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5789800_sys_M_MaterialCockpit_Base_V_and_rebuild.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5789800_sys_M_MaterialCockpit_Base_V_and_rebuild.sql
@@ -1,0 +1,141 @@
+-- Migration: Create M_MaterialCockpit_Base_V and the rebuild function
+-- Part of: Material Cockpit V2 (Increment 1) -- me03#27512, se203#252
+
+--
+-- 1. Create the base view
+--
+DROP VIEW IF EXISTS M_MaterialCockpit_Base_V;
+
+CREATE OR REPLACE VIEW M_MaterialCockpit_Base_V AS
+
+-- On-hand stock from md_stock
+SELECT s.ad_client_id,
+       s.ad_org_id,
+       s.m_product_id,
+       p.m_product_category_id,
+       p.value                                                                           AS ProductValue,
+       p.name                                                                            AS ProductName,
+       p.c_uom_id,
+       s.m_warehouse_id,
+       s.attributeskey                                                                   AS AttributesKey,
+       'OH'::varchar(2)                                                                  AS SupplyType,
+       NULL::numeric(10, 0)                                                              AS C_BPartner_Vendor_ID,
+       now()::timestamp without time zone                                                AS DatePromised,
+       s.qtyonhand                                                                       AS QtyOnHand,
+       0::numeric                                                                        AS QtyTU,
+       0::numeric                                                                        AS QtyLU,
+       COALESCE(s.qtyonhand * NULLIF(p.weight, 0), 0)                                   AS WeightNet,
+       getLastCostPrice(p.m_product_id)                                                  AS LastCostPrice,
+       ABS((('x' || SUBSTR(MD5(CONCAT_WS('#',
+                                          'OH',
+                                          s.ad_client_id::text,
+                                          s.ad_org_id::text,
+                                          s.m_product_id::text,
+                                          COALESCE(s.attributeskey, '')::text,
+                                          COALESCE(s.m_warehouse_id, 0)::text)), 1, 10))::bit(32)::int)) AS QtyDemand_QtySupply_V_ID
+FROM md_stock s
+         INNER JOIN m_product p ON s.m_product_id = p.m_product_id
+WHERE s.isactive = 'Y'
+  AND COALESCE(s.qtyonhand, 0) <> 0
+
+UNION ALL
+
+-- Planned supply from M_ReceiptSchedule
+SELECT rs.ad_client_id,
+       rs.ad_org_id,
+       rs.m_product_id,
+       p.m_product_category_id,
+       p.value                                                                            AS ProductValue,
+       p.name                                                                             AS ProductName,
+       p.c_uom_id,
+       rs.m_warehouse_id,
+       generateasistorageattributeskey(rs.m_attributesetinstance_id)                      AS AttributesKey,
+       'PS'::varchar(2)                                                                   AS SupplyType,
+       rs.c_bpartner_id                                                                   AS C_BPartner_Vendor_ID,
+       rs.datepromised::timestamp without time zone                                       AS DatePromised,
+       SUM(uomconvert(rs.m_product_id, rs.c_uom_id, p.c_uom_id, rs.qtytomove))          AS QtyOnHand,
+       0::numeric                                                                         AS QtyTU,
+       0::numeric                                                                         AS QtyLU,
+       COALESCE(SUM(uomconvert(rs.m_product_id, rs.c_uom_id, p.c_uom_id, rs.qtytomove) * NULLIF(p.weight, 0)), 0) AS WeightNet,
+       getLastCostPrice(p.m_product_id)                                                   AS LastCostPrice,
+       ABS((('x' || SUBSTR(MD5(CONCAT_WS('#',
+                                          'PS',
+                                          rs.ad_client_id::text,
+                                          rs.ad_org_id::text,
+                                          rs.m_product_id::text,
+                                          COALESCE(generateasistorageattributeskey(rs.m_attributesetinstance_id), '')::text,
+                                          COALESCE(rs.m_warehouse_id, 0)::text,
+                                          COALESCE(rs.c_bpartner_id, 0)::text,
+                                          COALESCE(rs.datepromised::text, ''))), 1, 10))::bit(32)::int)) AS QtyDemand_QtySupply_V_ID
+FROM m_receiptschedule rs
+         INNER JOIN m_product p ON rs.m_product_id = p.m_product_id
+WHERE rs.processed = 'N'
+  AND rs.isactive = 'Y'
+  AND COALESCE(rs.qtytomove, 0) <> 0
+GROUP BY rs.ad_client_id, rs.ad_org_id, rs.m_product_id, p.m_product_category_id,
+         p.value, p.name, p.c_uom_id, rs.m_warehouse_id,
+         generateasistorageattributeskey(rs.m_attributesetinstance_id),
+         rs.c_bpartner_id, rs.datepromised, p.weight, p.m_product_id
+;
+
+
+--
+-- 2. Create the rebuild function
+--
+CREATE OR REPLACE FUNCTION after_migration_M_MaterialCockpit_rebuild()
+    RETURNS void
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    v_source_view   TEXT;
+    v_count         INTEGER;
+    v_missing_cols  TEXT;
+BEGIN
+    -- Step 1: Find customer/override views matching '%_MaterialCockpit_V' excluding the base view
+    SELECT COUNT(*), MAX(viewname)
+    INTO v_count, v_source_view
+    FROM pg_views
+    WHERE viewname LIKE '%_materialcockpit_v'
+      AND viewname <> 'm_materialcockpit_base_v'
+      AND viewname <> 'qtydemand_qtysupply_v';
+
+    -- Step 2: Decide which source view to use
+    IF v_count = 0 THEN
+        v_source_view := 'm_materialcockpit_base_v';
+        RAISE NOTICE 'after_migration_M_MaterialCockpit_rebuild: No customer override found. Using base view: %', v_source_view;
+    ELSIF v_count = 1 THEN
+        RAISE NOTICE 'after_migration_M_MaterialCockpit_rebuild: Found customer override: %', v_source_view;
+    ELSE
+        RAISE EXCEPTION 'after_migration_M_MaterialCockpit_rebuild: Found % customer override views matching %%_MaterialCockpit_V. Expected at most 1.', v_count;
+    END IF;
+
+    -- Step 3: Validate that the chosen source has all required base columns
+    SELECT string_agg(bc.column_name, ', ')
+    INTO v_missing_cols
+    FROM information_schema.columns bc
+    WHERE bc.table_name = 'm_materialcockpit_base_v'
+      AND bc.table_schema = 'public'
+      AND NOT EXISTS (SELECT 1
+                      FROM information_schema.columns sc
+                      WHERE sc.table_name = v_source_view
+                        AND sc.table_schema = 'public'
+                        AND sc.column_name = bc.column_name);
+
+    IF v_missing_cols IS NOT NULL AND v_source_view <> 'm_materialcockpit_base_v' THEN
+        RAISE EXCEPTION 'after_migration_M_MaterialCockpit_rebuild: Source view "%" is missing base columns: %', v_source_view, v_missing_cols;
+    END IF;
+
+    -- Step 4: Recreate the API view QtyDemand_QtySupply_V
+    EXECUTE 'DROP VIEW IF EXISTS QtyDemand_QtySupply_V';
+    EXECUTE 'CREATE OR REPLACE VIEW QtyDemand_QtySupply_V AS SELECT * FROM ' || v_source_view;
+
+    RAISE NOTICE 'after_migration_M_MaterialCockpit_rebuild: Successfully created QtyDemand_QtySupply_V from %', v_source_view;
+END;
+$$;
+
+
+--
+-- 3. Call the rebuild function
+--
+SELECT after_migration_M_MaterialCockpit_rebuild();

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5789810_sys_QtyDemand_QtySupply_V_AD_Columns.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5789810_sys_QtyDemand_QtySupply_V_AD_Columns.sql
@@ -1,0 +1,327 @@
+-- Migration: Add new AD_Column entries for M_MaterialCockpit_Base_V columns
+-- Part of: Material Cockpit V2 (Increment 1) -- me03#27512, se203#252
+-- Table: QtyDemand_QtySupply_V (AD_Table_ID=542218)
+--
+-- New columns: SupplyType, C_BPartner_Vendor_ID, DatePromised, QtyOnHand, QtyTU, QtyLU, WeightNet
+-- Note: AD_Column_IDs and AD_Element_IDs below need to be verified/allocated from the ID server before merge.
+
+
+-- AD_Element: SupplyType
+-- 2026-02-23
+INSERT INTO AD_Element (AD_Client_ID, AD_Element_ID, AD_Org_ID, ColumnName, Created, CreatedBy, EntityType,
+                        IsActive, Name, PrintName, Updated, UpdatedBy)
+VALUES (0, 584200, 0, 'SupplyType',
+        TO_TIMESTAMP('2026-02-23 12:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100, 'D',
+        'Y', 'Supply Type', 'Supply Type',
+        TO_TIMESTAMP('2026-02-23 12:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, CommitWarning, Description, Help, Name, PO_Description,
+                            PO_Help, PO_Name, PO_PrintName, PrintName, WEBUI_NameBrowse, WEBUI_NameNew,
+                            WEBUI_NameNewBreadcrumb, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby,
+                            Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language,
+       t.AD_Element_ID,
+       t.CommitWarning,
+       t.Description,
+       t.Help,
+       t.Name,
+       t.PO_Description,
+       t.PO_Help,
+       t.PO_Name,
+       t.PO_PrintName,
+       t.PrintName,
+       t.WEBUI_NameBrowse,
+       t.WEBUI_NameNew,
+       t.WEBUI_NameNewBreadcrumb,
+       'N',
+       t.AD_Client_ID,
+       t.AD_Org_ID,
+       t.Created,
+       t.Createdby,
+       t.Updated,
+       t.UpdatedBy,
+       'Y'
+FROM AD_Language l,
+     AD_Element t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Element_ID = 584200
+  AND NOT EXISTS (SELECT 1
+                  FROM AD_Element_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language
+                    AND tt.AD_Element_ID = t.AD_Element_ID)
+;
+
+-- Update German translation for SupplyType
+UPDATE AD_Element_Trl
+SET Name      = 'Versorgungstyp',
+    PrintName = 'Versorgungstyp'
+WHERE AD_Element_ID = 584200
+  AND AD_Language = 'de_DE'
+;
+
+-- AD_Column: QtyDemand_QtySupply_V.SupplyType
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, EntityType, FieldLength,
+                       IsActive, IsAllowLogging, IsAlwaysUpdateable, IsEncrypted, IsIdentifier, IsKey,
+                       IsMandatory, IsParent, IsSelectionColumn, IsTranslated, IsUpdateable, Name,
+                       Updated, UpdatedBy, Version)
+VALUES (0, 591500, 584200, 0, 10, 542218,
+        'SupplyType',
+        TO_TIMESTAMP('2026-02-23 12:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100, 'D', 2,
+        'Y', 'Y', 'N', 'N', 'N', 'N',
+        'N', 'N', 'Y', 'N', 'N', 'Supply Type',
+        TO_TIMESTAMP('2026-02-23 12:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100, 0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created,
+                           Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby,
+       t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l,
+     AD_Column t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 591500
+  AND NOT EXISTS (SELECT 1
+                  FROM AD_Column_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language
+                    AND tt.AD_Column_ID = t.AD_Column_ID)
+;
+
+SELECT update_Column_Translation_From_AD_Element(584200);
+
+
+-- AD_Column: QtyDemand_QtySupply_V.C_BPartner_Vendor_ID
+-- Reuse existing AD_Element for C_BPartner_ID (Element_ID=187) with different column name
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FieldLength,
+                       IsActive, IsAllowLogging, IsAlwaysUpdateable, IsEncrypted, IsIdentifier, IsKey,
+                       IsMandatory, IsParent, IsSelectionColumn, IsTranslated, IsUpdateable, Name,
+                       Updated, UpdatedBy, Version)
+VALUES (0, 591501, 187, 0, 30, 542218,
+        'C_BPartner_Vendor_ID',
+        TO_TIMESTAMP('2026-02-23 12:00:01', 'YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'D', 10,
+        'Y', 'Y', 'N', 'N', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N', 'Vendor',
+        TO_TIMESTAMP('2026-02-23 12:00:01', 'YYYY-MM-DD HH24:MI:SS'), 100, 0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created,
+                           Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby,
+       t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l,
+     AD_Column t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 591501
+  AND NOT EXISTS (SELECT 1
+                  FROM AD_Column_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language
+                    AND tt.AD_Column_ID = t.AD_Column_ID)
+;
+
+
+-- AD_Column: QtyDemand_QtySupply_V.DatePromised
+-- Reuse existing AD_Element for DatePromised (Element_ID=269)
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, EntityType, FieldLength,
+                       IsActive, IsAllowLogging, IsAlwaysUpdateable, IsEncrypted, IsIdentifier, IsKey,
+                       IsMandatory, IsParent, IsSelectionColumn, IsTranslated, IsUpdateable, Name,
+                       Updated, UpdatedBy, Version)
+VALUES (0, 591502, 269, 0, 16, 542218,
+        'DatePromised',
+        TO_TIMESTAMP('2026-02-23 12:00:02', 'YYYY-MM-DD HH24:MI:SS'), 100, 'D', 7,
+        'Y', 'Y', 'N', 'N', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N', 'Date Promised',
+        TO_TIMESTAMP('2026-02-23 12:00:02', 'YYYY-MM-DD HH24:MI:SS'), 100, 0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created,
+                           Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby,
+       t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l,
+     AD_Column t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 591502
+  AND NOT EXISTS (SELECT 1
+                  FROM AD_Column_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language
+                    AND tt.AD_Column_ID = t.AD_Column_ID)
+;
+
+SELECT update_Column_Translation_From_AD_Element(269);
+
+
+-- AD_Element: QtyOnHand (reuse existing Element_ID=530)
+-- AD_Column: QtyDemand_QtySupply_V.QtyOnHand
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, EntityType, FieldLength,
+                       IsActive, IsAllowLogging, IsAlwaysUpdateable, IsEncrypted, IsIdentifier, IsKey,
+                       IsMandatory, IsParent, IsSelectionColumn, IsTranslated, IsUpdateable, Name,
+                       Updated, UpdatedBy, Version)
+VALUES (0, 591503, 530, 0, 29, 542218,
+        'QtyOnHand',
+        TO_TIMESTAMP('2026-02-23 12:00:03', 'YYYY-MM-DD HH24:MI:SS'), 100, 'D', 10,
+        'Y', 'Y', 'N', 'N', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N', 'Qty On Hand',
+        TO_TIMESTAMP('2026-02-23 12:00:03', 'YYYY-MM-DD HH24:MI:SS'), 100, 0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created,
+                           Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby,
+       t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l,
+     AD_Column t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 591503
+  AND NOT EXISTS (SELECT 1
+                  FROM AD_Column_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language
+                    AND tt.AD_Column_ID = t.AD_Column_ID)
+;
+
+SELECT update_Column_Translation_From_AD_Element(530);
+
+
+-- AD_Element: QtyTU
+INSERT INTO AD_Element (AD_Client_ID, AD_Element_ID, AD_Org_ID, ColumnName, Created, CreatedBy, EntityType,
+                        IsActive, Name, PrintName, Updated, UpdatedBy)
+VALUES (0, 584201, 0, 'QtyTU',
+        TO_TIMESTAMP('2026-02-23 12:00:04', 'YYYY-MM-DD HH24:MI:SS'), 100, 'D',
+        'Y', 'Qty TU', 'Qty TU',
+        TO_TIMESTAMP('2026-02-23 12:00:04', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, CommitWarning, Description, Help, Name, PO_Description,
+                            PO_Help, PO_Name, PO_PrintName, PrintName, WEBUI_NameBrowse, WEBUI_NameNew,
+                            WEBUI_NameNewBreadcrumb, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby,
+                            Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning, t.Description, t.Help, t.Name, t.PO_Description,
+       t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName, t.WEBUI_NameBrowse, t.WEBUI_NameNew,
+       t.WEBUI_NameNewBreadcrumb, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby,
+       t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Element_ID = 584201
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID)
+;
+
+UPDATE AD_Element_Trl SET Name = 'Menge TU', PrintName = 'Menge TU' WHERE AD_Element_ID = 584201 AND AD_Language = 'de_DE';
+
+-- AD_Column: QtyDemand_QtySupply_V.QtyTU
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, EntityType, FieldLength,
+                       IsActive, IsAllowLogging, IsAlwaysUpdateable, IsEncrypted, IsIdentifier, IsKey,
+                       IsMandatory, IsParent, IsSelectionColumn, IsTranslated, IsUpdateable, Name,
+                       Updated, UpdatedBy, Version)
+VALUES (0, 591504, 584201, 0, 29, 542218,
+        'QtyTU',
+        TO_TIMESTAMP('2026-02-23 12:00:04', 'YYYY-MM-DD HH24:MI:SS'), 100, 'D', 10,
+        'Y', 'Y', 'N', 'N', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N', 'Qty TU',
+        TO_TIMESTAMP('2026-02-23 12:00:04', 'YYYY-MM-DD HH24:MI:SS'), 100, 0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created,
+                           Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby,
+       t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 591504
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID)
+;
+
+SELECT update_Column_Translation_From_AD_Element(584201);
+
+
+-- AD_Element: QtyLU
+INSERT INTO AD_Element (AD_Client_ID, AD_Element_ID, AD_Org_ID, ColumnName, Created, CreatedBy, EntityType,
+                        IsActive, Name, PrintName, Updated, UpdatedBy)
+VALUES (0, 584202, 0, 'QtyLU',
+        TO_TIMESTAMP('2026-02-23 12:00:05', 'YYYY-MM-DD HH24:MI:SS'), 100, 'D',
+        'Y', 'Qty LU', 'Qty LU',
+        TO_TIMESTAMP('2026-02-23 12:00:05', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, CommitWarning, Description, Help, Name, PO_Description,
+                            PO_Help, PO_Name, PO_PrintName, PrintName, WEBUI_NameBrowse, WEBUI_NameNew,
+                            WEBUI_NameNewBreadcrumb, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby,
+                            Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning, t.Description, t.Help, t.Name, t.PO_Description,
+       t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName, t.WEBUI_NameBrowse, t.WEBUI_NameNew,
+       t.WEBUI_NameNewBreadcrumb, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby,
+       t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Element_ID = 584202
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID)
+;
+
+UPDATE AD_Element_Trl SET Name = 'Menge LU', PrintName = 'Menge LU' WHERE AD_Element_ID = 584202 AND AD_Language = 'de_DE';
+
+-- AD_Column: QtyDemand_QtySupply_V.QtyLU
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, EntityType, FieldLength,
+                       IsActive, IsAllowLogging, IsAlwaysUpdateable, IsEncrypted, IsIdentifier, IsKey,
+                       IsMandatory, IsParent, IsSelectionColumn, IsTranslated, IsUpdateable, Name,
+                       Updated, UpdatedBy, Version)
+VALUES (0, 591505, 584202, 0, 29, 542218,
+        'QtyLU',
+        TO_TIMESTAMP('2026-02-23 12:00:05', 'YYYY-MM-DD HH24:MI:SS'), 100, 'D', 10,
+        'Y', 'Y', 'N', 'N', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N', 'Qty LU',
+        TO_TIMESTAMP('2026-02-23 12:00:05', 'YYYY-MM-DD HH24:MI:SS'), 100, 0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created,
+                           Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby,
+       t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 591505
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID)
+;
+
+SELECT update_Column_Translation_From_AD_Element(584202);
+
+
+-- AD_Column: QtyDemand_QtySupply_V.WeightNet
+-- Reuse existing AD_Element for Weight (Element_ID=629)
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, EntityType, FieldLength,
+                       IsActive, IsAllowLogging, IsAlwaysUpdateable, IsEncrypted, IsIdentifier, IsKey,
+                       IsMandatory, IsParent, IsSelectionColumn, IsTranslated, IsUpdateable, Name,
+                       Updated, UpdatedBy, Version)
+VALUES (0, 591506, 629, 0, 29, 542218,
+        'WeightNet',
+        TO_TIMESTAMP('2026-02-23 12:00:06', 'YYYY-MM-DD HH24:MI:SS'), 100, 'D', 10,
+        'Y', 'Y', 'N', 'N', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N', 'Net Weight',
+        TO_TIMESTAMP('2026-02-23 12:00:06', 'YYYY-MM-DD HH24:MI:SS'), 100, 0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created,
+                           Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby,
+       t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 591506
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID)
+;
+
+SELECT update_Column_Translation_From_AD_Element(629);


### PR DESCRIPTION
## Summary

- Add **Material Cockpit V2** read-only view (window 541963) with SQL-based data loading
- Base view `M_MaterialCockpit_Base_V` aggregates demand/supply quantities from order lines, forecast lines, and DD order lines
- Java view implementation with product, warehouse, and supply-type filters
- Process `C_OrderLine_OpenMaterialCockpit` to open cockpit from a sales order line

## Details

**SQL:**
- `M_MaterialCockpit_Base_V` — base view with demand/supply aggregation
- `after_migration_M_MaterialCockpit_rebuild()` — rebuilds the materialized `QtyDemand_QtySupply_V` table

**Java (package `de.metas.ui.web.material.cockpit.v2`):**
- `MaterialCockpitV2ViewFactory` / `MaterialCockpitV2View` — view factory and view
- `MaterialCockpitV2Row` / `MaterialCockpitV2RowsData` — row model and SQL loader
- `MaterialCockpitV2Filters` — product, warehouse, supply-type filters

**Note:** AD IDs are placeholders needing ID server allocation before merge.

## Test plan

- [ ] Verify `M_MaterialCockpit_Base_V` view creates correctly
- [ ] Open Material Cockpit V2 window — data loads from `QtyDemand_QtySupply_V`
- [ ] Filters (product, warehouse, supply type) work correctly
- [ ] Open cockpit from sales order line via process

Relates to: https://github.com/metasfresh/me03/issues/28126

🤖 Generated with [Claude Code](https://claude.com/claude-code)