### PR TITLE
Fix keyboard shortcuts not working in modals (ALT+ENTER, etc.)

### DIFF
--- a/frontend/src/components/keyshortcuts/ShortcutProvider.js
+++ b/frontend/src/components/keyshortcuts/ShortcutProvider.js
@@ -80,6 +80,22 @@ class ShortcutProvider extends Component {
   keySequence = [];
   fired = {};
 
+  // Stable references for hotkeys and keymap.
+  // Initialized in UNSAFE_componentWillMount from Redux props,
+  // then kept as the single source of truth for subscribe/unsubscribe/handleKeyDown.
+  // This prevents the bug where Redux UPDATE_HOTKEYS creates a new object
+  // via spread operator, causing subscribed handlers to be silently lost.
+  _hotkeys = null;
+  _keymap = null;
+
+  _getHotkeys() {
+    return this._hotkeys || this.props.hotkeys;
+  }
+
+  _getKeymap() {
+    return this._keymap || this.props.keymap;
+  }
+
   getChildContext() {
     return {
       shortcuts: {
@@ -90,9 +106,37 @@ class ShortcutProvider extends Component {
   }
 
   UNSAFE_componentWillMount() {
+    // Capture stable references from Redux props.
+    // These objects will be mutated by subscribe/unsubscribe
+    // and read by handleKeyDown — always the same reference.
+    if (this.props) {
+      this._hotkeys = this.props.hotkeys;
+      this._keymap = this.props.keymap;
+    }
+
     document.addEventListener('keydown', this.handleKeyDown);
     document.addEventListener('keyup', this.handleKeyUp);
     window.addEventListener('blur', this.handleBlur);
+  }
+
+  componentDidUpdate(prevProps) {
+    // When Redux creates new hotkeys/keymap objects (e.g., via UPDATE_HOTKEYS),
+    // merge new entries into our stable references instead of adopting the new objects.
+    if (prevProps.hotkeys !== this.props.hotkeys && this._hotkeys) {
+      const reduxHotkeys = this.props.hotkeys;
+      Object.keys(reduxHotkeys).forEach((key) => {
+        if (!(key in this._hotkeys)) {
+          this._hotkeys[key] = reduxHotkeys[key];
+        }
+      });
+    }
+
+    if (prevProps.keymap !== this.props.keymap && this._keymap) {
+      const reduxKeymap = this.props.keymap;
+      Object.keys(reduxKeymap).forEach((key) => {
+        this._keymap[key] = reduxKeymap[key];
+      });
+    }
   }
 
   componentWillUnmount() {
@@ -127,7 +171,7 @@ class ShortcutProvider extends Component {
     }
 
     const { fired } = this;
-    const { hotkeys } = this.props;
+    const hotkeys = this._getHotkeys();
     let { keySequence } = this;
 
     if (event.altKey === true) {
@@ -203,9 +247,10 @@ class ShortcutProvider extends Component {
   };
 
   subscribe = (name, handler) => {
-    const { hotkeys, keymap } = this.props;
+    const hotkeys = this._getHotkeys();
+    const keymap = this._getKeymap();
 
-    if (!(name in this.props.keymap)) {
+    if (!(name in keymap)) {
       // eslint-disable-next-line no-console
       console.warn(`There are no hotkeys defined for "${name}".`);
 
@@ -217,15 +262,19 @@ class ShortcutProvider extends Component {
     }
 
     const key = keymap[name].toUpperCase();
+    if (!hotkeys[key]) {
+      hotkeys[key] = [];
+    }
     const bucket = hotkeys[key];
 
     hotkeys[key] = [handler, ...bucket];
   };
 
   unsubscribe = (name, handler) => {
-    const { hotkeys, keymap } = this.props;
+    const hotkeys = this._getHotkeys();
+    const keymap = this._getKeymap();
 
-    if (!(name in this.props.keymap)) {
+    if (!(name in keymap)) {
       // eslint-disable-next-line no-console
       console.warn(`There are no hotkeys defined for "${name}".`);
 
@@ -238,6 +287,9 @@ class ShortcutProvider extends Component {
 
     const key = keymap[name].toUpperCase();
     const bucket = hotkeys[key];
+    if (!bucket) {
+      return;
+    }
     let found = false;
 
     hotkeys[key] = bucket.filter((_handler) => {


### PR DESCRIPTION
## Summary

- **Fix keyboard shortcuts (ALT+ENTER, Escape, ALT+P) not working in modals** on `inner_silence_hotfix`
- Root cause: `ShortcutProvider.subscribe()` mutated the Redux `hotkeys` object directly. When `TableFilterContextShortcuts` dispatched `UPDATE_HOTKEYS`, the reducer created a **new object** via spread operator (`{ ...state.hotkeys, ...payload }`), causing all subscribed handlers to be silently lost — they remained on the old object while `handleKeyDown` read from the new one.
- Fix: maintain stable instance references (`_hotkeys`, `_keymap`) initialized from Redux props on mount, merged with updates in `componentDidUpdate`. Handlers always operate on the same object reference.

### Root Cause Detail

1. `App.js` dispatches `initHotkeys(hotkeys)` → creates initial hotkeys in Redux
2. `ShortcutProvider` gets `hotkeys` from Redux via `mapStateToProps`
3. `Shortcut` components call `subscribe()` which mutates `this.props.hotkeys[key]`
4. **Bug trigger**: `TableFilterContextShortcuts.componentDidMount()` dispatches `updateHotkeys()` → reducer uses `{ ...state.hotkeys, ...payload }` → **NEW object** in Redux → `ShortcutProvider` gets new props → `handleKeyDown` reads from new object (empty handlers)

### Why not port PR #21630 (the full refactoring)?

On `new_dawn_uat`, this was fixed by a 34-file refactoring that rewrote the entire keyboard shortcut system from Redux-connected class components to React hooks with Context API. Porting that to a hotfix branch is too invasive. This PR applies the minimal fix (~57 lines added) that addresses the specific root cause.

## Test plan

- [ ] All 65 frontend test suites pass (343 tests pass, 0 failures)
- [ ] `yarn lint` produces 0 errors (21 pre-existing warnings)
- [ ] Open any window with a table (e.g., Business Partner), open a modal → ALT+ENTER should work
- [ ] Test after logout/login cycle — shortcuts should still work
- [ ] Test ESR Import process (AD_Process_ID=584646) — ALT+ENTER should confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)