### PR TITLE
Fix C_Flatrate_Term.MasterEndDate not always set (#1630)

### DIFF
--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
@@ -1143,6 +1143,17 @@ public class FlatrateBL implements IFlatrateBL
 		}
 		while (X_C_Flatrate_Transition.EXTENSIONTYPE_ExtendAll.equals(nextTransition.getExtensionType()) && nextTransition.getC_Flatrate_Conditions_Next_ID() > 0);
 
+		// Also collect predecessor contracts (those before the initial contract in the chain)
+		// so their MasterEndDate is updated as well.
+		final List<I_C_Flatrate_Term> predecessors = new ArrayList<>();
+		I_C_Flatrate_Term predecessor = flatrateDAO.retrieveAncestorFlatrateTerm(request.getContract());
+		while (predecessor != null)
+		{
+			predecessors.add(0, predecessor);
+			predecessor = flatrateDAO.retrieveAncestorFlatrateTerm(predecessor);
+		}
+		contracts.addAll(predecessors);
+
 		updateMasterEndDateIfNeeded(contracts, request.getContract());
 	}
 

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
@@ -139,12 +139,11 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.save;
@@ -1106,7 +1105,8 @@ public class FlatrateBL implements IFlatrateBL
 		seenFlatrateCondition.put(currentConditions.getC_Flatrate_Conditions_ID(), currentConditions.getName());
 
 		ContractExtendingRequest currentRequest = request;
-		I_C_Flatrate_Transition nextTransition = null;
+		I_C_Flatrate_Transition nextTransition;
+		// order is irrelevant; updateMasterEndDateIfNeeded sorts by EndDate
 		final List<I_C_Flatrate_Term> contracts = new ArrayList<>();
 
 		contracts.add(currentRequest.getContract());
@@ -1152,19 +1152,19 @@ public class FlatrateBL implements IFlatrateBL
 		final List<I_C_Flatrate_Term> predecessors = new ArrayList<>();
 		// Use term IDs (not conditions IDs) for cycle detection: the same conditions template may
 		// legitimately be reused across multiple terms, so conditions-ID tracking causes false positives.
-		final Set<FlatrateTermId> seenPredecessorTermIds = new HashSet<>();
-		seenPredecessorTermIds.add(FlatrateTermId.ofRepoId(request.getContract().getC_Flatrate_Term_ID()));
+		final Map<FlatrateTermId, String> seenPredecessorTermIds = new HashMap<>();
+		seenPredecessorTermIds.put(FlatrateTermId.ofRepoId(request.getContract().getC_Flatrate_Term_ID()), request.getContract().getC_Flatrate_Conditions().getName());
 		I_C_Flatrate_Term predecessor = flatrateDAO.retrieveAncestorFlatrateTerm(request.getContract());
 		while (predecessor != null)
 		{
 			// infinite loop detection: guard against cycles in the term chain
-			if (seenPredecessorTermIds.contains(FlatrateTermId.ofRepoId(predecessor.getC_Flatrate_Term_ID())))
+			if (seenPredecessorTermIds.containsKey(FlatrateTermId.ofRepoId(predecessor.getC_Flatrate_Term_ID())))
 			{
 				final I_C_Flatrate_Conditions predecessorConditions = predecessor.getC_Flatrate_Conditions();
 				Check.assumeNotNull(predecessorConditions, "C_Flatrate_Conditions shall not be null!");
-				throw new AdempiereException(MSG_INFINITE_LOOP, predecessorConditions.getName(), seenPredecessorTermIds);
+				throw new AdempiereException(MSG_INFINITE_LOOP, predecessorConditions.getName(), seenPredecessorTermIds.values());
 			}
-			seenPredecessorTermIds.add(FlatrateTermId.ofRepoId(predecessor.getC_Flatrate_Term_ID()));
+			seenPredecessorTermIds.put(FlatrateTermId.ofRepoId(predecessor.getC_Flatrate_Term_ID()), predecessor.getC_Flatrate_Conditions().getName());
 
 			predecessors.add(0, predecessor);
 			predecessor = flatrateDAO.retrieveAncestorFlatrateTerm(predecessor);

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
@@ -1144,11 +1144,34 @@ public class FlatrateBL implements IFlatrateBL
 		while (X_C_Flatrate_Transition.EXTENSIONTYPE_ExtendAll.equals(nextTransition.getExtensionType()) && nextTransition.getC_Flatrate_Conditions_Next_ID() > 0);
 
 		// Also collect predecessor contracts (those before the initial contract in the chain)
-		// so their MasterEndDate is updated as well.
+		// so their MasterEndDate is updated as well. Walk back only as long as the predecessor's
+		// transition is ExtendAll (mirroring the forward loop's while-condition).
 		final List<I_C_Flatrate_Term> predecessors = new ArrayList<>();
+		final Map<Integer, String> seenPredecessorConditions = new LinkedHashMap<>();
+		seenPredecessorConditions.put(
+				request.getContract().getC_Flatrate_Conditions_ID(),
+				request.getContract().getC_Flatrate_Conditions().getName());
 		I_C_Flatrate_Term predecessor = flatrateDAO.retrieveAncestorFlatrateTerm(request.getContract());
 		while (predecessor != null)
 		{
+			final I_C_Flatrate_Conditions predecessorConditions = predecessor.getC_Flatrate_Conditions();
+			Check.assumeNotNull(predecessorConditions, "C_Flatrate_Conditions shall not be null!");
+			final I_C_Flatrate_Transition predecessorTransition = predecessorConditions.getC_Flatrate_Transition();
+			Check.assumeNotNull(predecessorTransition, "C_Flatrate_Transition shall not be null!");
+
+			if (!X_C_Flatrate_Transition.EXTENSIONTYPE_ExtendAll.equals(predecessorTransition.getExtensionType())
+					|| predecessorTransition.getC_Flatrate_Conditions_Next_ID() <= 0)
+			{
+				break;
+			}
+
+			// infinite loop detection (same guard as forward loop)
+			if (seenPredecessorConditions.containsKey(predecessorConditions.getC_Flatrate_Conditions_ID()))
+			{
+				throw new AdempiereException(MSG_INFINITE_LOOP, predecessorConditions.getName(), seenPredecessorConditions.values());
+			}
+			seenPredecessorConditions.put(predecessorConditions.getC_Flatrate_Conditions_ID(), predecessorConditions.getName());
+
 			predecessors.add(0, predecessor);
 			predecessor = flatrateDAO.retrieveAncestorFlatrateTerm(predecessor);
 		}

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
@@ -238,11 +238,11 @@ public class FlatrateBL implements IFlatrateBL
 									X_C_Flatrate_DataEntry.DOCSTATUS_Completed);
 					final ITranslatableString uomName = uomDAO.getName(UomId.ofRepoId(invoicingEntry.getC_UOM_ID()));
 					return msgBL.getMsg(ctx,
-							FlatrateBL.MSG_FLATRATEBL_INVOICING_ENTRY_NOT_CO_3P,
-							new Object[] {
-									invoicingEntry.getC_Period().getName(),
-									uomName,
-									competed.translate(Env.getAD_Language()) });
+										FlatrateBL.MSG_FLATRATEBL_INVOICING_ENTRY_NOT_CO_3P,
+										new Object[] {
+												invoicingEntry.getC_Period().getName(),
+												uomName,
+												competed.translate(Env.getAD_Language()) });
 				}
 			}
 
@@ -273,9 +273,9 @@ public class FlatrateBL implements IFlatrateBL
 				{
 					final Properties ctx = InterfaceWrapperHelper.getCtx(dataEntry);
 					return msgBL.getMsg(ctx,
-							FlatrateBL.MSG_FLATRATEBL_INVOICE_CANDIDATE_TO_RECOMPUTE_1P,
-							new Object[] {
-									sb.toString() });
+										FlatrateBL.MSG_FLATRATEBL_INVOICE_CANDIDATE_TO_RECOMPUTE_1P,
+										new Object[] {
+												sb.toString() });
 				}
 
 				//
@@ -299,13 +299,13 @@ public class FlatrateBL implements IFlatrateBL
 				{
 					final Properties ctx = InterfaceWrapperHelper.getCtx(dataEntry);
 					return msgBL.getMsg(ctx,
-							FlatrateBL.MSG_FLATRATEBL_INVOICE_CANDIDATE_QTY_TO_INVOICE_1P,
-							new Object[] {
-									sb.toString() });
+										FlatrateBL.MSG_FLATRATEBL_INVOICE_CANDIDATE_QTY_TO_INVOICE_1P,
+										new Object[] {
+												sb.toString() });
 				}
 			}
 			Check.assume(X_C_Flatrate_DataEntry.TYPE_Invoicing_PeriodBased.equals(dataEntry.getType()),
-					dataEntry + "has type=" + X_C_Flatrate_DataEntry.TYPE_Invoicing_PeriodBased);
+						 dataEntry + "has type=" + X_C_Flatrate_DataEntry.TYPE_Invoicing_PeriodBased);
 			qtyToInvoice = dataEntry.getQty_Reported();
 		}
 
@@ -342,7 +342,7 @@ public class FlatrateBL implements IFlatrateBL
 
 					// C_Flatrate_DataEntry_ID and QtyCleared have already been set by InvoiceCandidateValidator
 					Check.assume(alloc.getC_Flatrate_DataEntry_ID() == dataEntry.getC_Flatrate_DataEntry_ID(),
-							alloc + " sould have C_Flatrate_DataEntry_ID=" + dataEntry.getC_Flatrate_DataEntry_ID() + " but has " + alloc.getC_Flatrate_DataEntry_ID());
+								 alloc + " sould have C_Flatrate_DataEntry_ID=" + dataEntry.getC_Flatrate_DataEntry_ID() + " but has " + alloc.getC_Flatrate_DataEntry_ID());
 
 					// update the allocation record
 					alloc.setC_Invoice_Candidate_ID(newCand.getC_Invoice_Candidate_ID());
@@ -360,9 +360,9 @@ public class FlatrateBL implements IFlatrateBL
 		Check.assume(!dataEntry.isSimulation(), dataEntry + " has IsSimulation='N'");
 
 		Check.assume(X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee.equals(fc.getType_Conditions())
-						|| X_C_Flatrate_Conditions.TYPE_CONDITIONS_Refundable.equals(fc.getType_Conditions()),
-				fc + " has Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee
-						+ " or " + X_C_Flatrate_Conditions.TYPE_CONDITIONS_Refundable);
+							 || X_C_Flatrate_Conditions.TYPE_CONDITIONS_Refundable.equals(fc.getType_Conditions()),
+					 fc + " has Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee
+							 + " or " + X_C_Flatrate_Conditions.TYPE_CONDITIONS_Refundable);
 
 		final Properties ctx = InterfaceWrapperHelper.getCtx(fc);
 		final String trxName = InterfaceWrapperHelper.getTrxName(fc);
@@ -400,7 +400,7 @@ public class FlatrateBL implements IFlatrateBL
 
 			final int productId = fc.getM_Product_Flatrate_ID();
 			Check.assume(productId > 0,
-					fc + " with Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee + " has no M_Product_Flatrate");
+						 fc + " with Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee + " has no M_Product_Flatrate");
 
 			final I_C_Invoice_Candidate newIc = createCand(ctx, term, dataEntry, productId, priceActual, trxName);
 			result.add(newIc);
@@ -553,7 +553,7 @@ public class FlatrateBL implements IFlatrateBL
 		{
 			final ProductId productId = ProductId.ofRepoIdOrNull(dataEntry.getM_Product_DataEntry_ID());
 			Check.assume(productId != null,
-					dataEntry + " has no M_Product_DataEntry, despite " + fc + "has Type_Conditions=" + fc.getType_Conditions());
+						 dataEntry + " has no M_Product_DataEntry, despite " + fc + "has Type_Conditions=" + fc.getType_Conditions());
 
 			productIdForIc = productId.getRepoId();
 
@@ -567,7 +567,7 @@ public class FlatrateBL implements IFlatrateBL
 		else
 		{
 			Check.assume(X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee.equals(fc.getType_Conditions()),
-					fc + " has Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee);
+						 fc + " has Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee);
 
 			if (X_C_Flatrate_DataEntry.TYPE_Invoicing_PeriodBased.equals(dataEntry.getType()))
 			{
@@ -576,11 +576,11 @@ public class FlatrateBL implements IFlatrateBL
 			else
 			{
 				Check.assume(X_C_Flatrate_DataEntry.TYPE_Correction_PeriodBased.equals(dataEntry.getType()),
-						"dataEntry has type " + X_C_Flatrate_DataEntry.TYPE_Correction_PeriodBased);
+							 "dataEntry has type " + X_C_Flatrate_DataEntry.TYPE_Correction_PeriodBased);
 				productIdForIc = fc.getM_Product_Correction_ID();
 			}
 			Check.assume(productIdForIc > 0,
-					fc + " with Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee + " has no M_Product_Flatrate");
+						 fc + " with Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee + " has no M_Product_Flatrate");
 
 			priceActual = dataEntry.getFlatrateAmt();
 		}
@@ -759,7 +759,7 @@ public class FlatrateBL implements IFlatrateBL
 						else
 						{
 							final String msg = msgBL.getMsg(ctx, "FlatrateBL_InvoicingEntry_Not_Invoiced",
-									new Object[] { periodOfTerm.getName(), uom.getName() });
+															new Object[] { periodOfTerm.getName(), uom.getName() });
 							errors.add(msg);
 							result = null;
 						}
@@ -767,7 +767,7 @@ public class FlatrateBL implements IFlatrateBL
 					else
 					{
 						final String msg = msgBL.getMsg(ctx, "PrepareClosing_InvoicingEntry_Not_CO",
-								new Object[] { uom.getName(), periodOfTerm.getName() });
+														new Object[] { uom.getName(), periodOfTerm.getName() });
 						errors.add(msg);
 						result = null;
 					}
@@ -848,10 +848,10 @@ public class FlatrateBL implements IFlatrateBL
 		}
 
 		final String msg = msgBL.getMsg(ctx, FlatrateBL.MSG_DATA_ENTRY_CREATE_HOLDING_FEE_3P,
-				new Object[] {
-						counter,
-						flatrateTerm.getStartDate(),
-						flatrateTerm.getEndDate() });
+										new Object[] {
+												counter,
+												flatrateTerm.getStartDate(),
+												flatrateTerm.getEndDate() });
 		Loggables.withLogger(logger, Level.INFO).addLog(msg);
 	}
 
@@ -897,11 +897,11 @@ public class FlatrateBL implements IFlatrateBL
 		final Lookup columnLookup = poInfo.getColumnLookup(ctx, poInfo.getColumnIndex(I_C_Flatrate_Term.COLUMNNAME_UOMType));
 
 		final String msg = msgBL.getMsg(ctx, FlatrateBL.MSG_DATA_ENTRY_CREATE_FLAT_FEE_4P,
-				new Object[] {
-						counter,
-						flatrateTerm.getStartDate(),
-						flatrateTerm.getEndDate(),
-						columnLookup.getDisplay(flatrateTerm.getUOMType()) });
+										new Object[] {
+												counter,
+												flatrateTerm.getStartDate(),
+												flatrateTerm.getEndDate(),
+												columnLookup.getDisplay(flatrateTerm.getUOMType()) });
 		Loggables.withLogger(logger, Level.INFO).addLog(msg);
 	}
 
@@ -932,7 +932,7 @@ public class FlatrateBL implements IFlatrateBL
 		else
 		{
 			Check.assume(X_C_Flatrate_DataEntry.TYPE_Correction_PeriodBased.equals(dataEntry.getType()),
-					dataEntry + " has Type=" + X_C_Flatrate_DataEntry.TYPE_Correction_PeriodBased);
+						 dataEntry + " has Type=" + X_C_Flatrate_DataEntry.TYPE_Correction_PeriodBased);
 
 			actualQtyOfUnits = dataEntry.getQty_Reported().subtract(dataEntry.getQty_Planned());
 			correctionWithoutActualQty = !conditions.isCorrectionAmtAtClosing();
@@ -1050,9 +1050,9 @@ public class FlatrateBL implements IFlatrateBL
 					else
 					{
 						Check.assume(X_C_Flatrate_Conditions.TYPE_CLEARING_Exceeding.equals(conditions.getType_Clearing()),
-								conditions + " has either Type_Clearing '" + X_C_Flatrate_Conditions.TYPE_CLEARING_Exceeding + "' or '"
-										+ X_C_Flatrate_Conditions.TYPE_CLEARING_Complete
-										+ "'");
+									 conditions + " has either Type_Clearing '" + X_C_Flatrate_Conditions.TYPE_CLEARING_Exceeding + "' or '"
+											 + X_C_Flatrate_Conditions.TYPE_CLEARING_Complete
+											 + "'");
 						effectiveDiffPercent = diffPercent.subtract(percentSubtrahent);
 					}
 
@@ -1060,7 +1060,7 @@ public class FlatrateBL implements IFlatrateBL
 					// (X_C_Flatrate_Conditions.CLEARINGAMTBASEON_Pauschalenpreis.equals(conditions.getClearingAmtBaseOn()))
 					// {
 					Check.assume(X_C_Flatrate_Conditions.CLEARINGAMTBASEON_FlatrateAmount.equals(conditions.getClearingAmtBaseOn()),
-							conditions + " has ClearingAmtBaseOn='" + X_C_Flatrate_Conditions.CLEARINGAMTBASEON_FlatrateAmount + "'");
+								 conditions + " has ClearingAmtBaseOn='" + X_C_Flatrate_Conditions.CLEARINGAMTBASEON_FlatrateAmount + "'");
 
 					amtCorrection = flatrateAmt
 							.multiply(effectiveDiffPercent.divide(Env.ONEHUNDRED, scale * 2, RoundingMode.HALF_UP))
@@ -1116,7 +1116,7 @@ public class FlatrateBL implements IFlatrateBL
 
 			final I_C_Flatrate_Term currentTerm = currentRequest.getContract();
 			currentTerm.setAD_PInstance_EndOfTerm_ID(PInstanceId.toRepoId(currentRequest.getAD_PInstance_ID()));
-			save(currentTerm);
+				save(currentTerm);
 			if (currentTerm.getC_FlatrateTerm_Next_ID() <= 0)
 			{
 				// https://github.com/metasfresh/metasfresh/issues/4022 avoid NPE if currentTerm was actually *not* extended by extendContractIfRequired
@@ -1178,7 +1178,7 @@ public class FlatrateBL implements IFlatrateBL
 	 * Update <code>masterenddate</code> for all contracts in the chain.
 	 * MasterEndDate is the EndDate of the last term in the chain.
 	 */
-	private void updateMasterEndDateIfNeeded(final List<I_C_Flatrate_Term> contracts)
+	private void updateMasterEndDateIfNeeded(@NonNull final List<I_C_Flatrate_Term> contracts)
 	{
 		if (contracts.isEmpty())
 		{
@@ -1218,8 +1218,8 @@ public class FlatrateBL implements IFlatrateBL
 
 			// the conditions were set via de.metas.flatrate.modelvalidator.C_Flatrate_Term.copyFromConditions(term)
 			Check.errorUnless(currentTerm.getType_Conditions().equals(nextTerm.getType_Conditions()),
-					"currentTerm has Type_Conditions={} while nextTerm has Type_Conditions={}; currentTerm={}",
-					currentTerm.getType_Conditions(), nextTerm.getType_Conditions(), currentTerm);
+							  "currentTerm has Type_Conditions={} while nextTerm has Type_Conditions={}; currentTerm={}",
+							  currentTerm.getType_Conditions(), nextTerm.getType_Conditions(), currentTerm);
 
 			currentTerm.setC_FlatrateTerm_Next_ID(nextTerm.getC_Flatrate_Term_ID());
 			save(currentTerm);
@@ -1297,7 +1297,7 @@ public class FlatrateBL implements IFlatrateBL
 		final Timestamp nextTermStartDate = context.getNextTermStartDate();
 
 		Check.errorIf(currentTerm.getC_FlatrateTerm_Next_ID() > 0,
-				"{} has C_FlatrateTerm_Next_ID = {} (should be <= 0)", currentTerm, currentTerm.getC_FlatrateTerm_Next_ID());
+					  "{} has C_FlatrateTerm_Next_ID = {} (should be <= 0)", currentTerm, currentTerm.getC_FlatrateTerm_Next_ID());
 
 		final I_C_Flatrate_Conditions conditions = currentTerm.getC_Flatrate_Conditions();
 		final I_C_Flatrate_Transition currentTransition = conditions.getC_Flatrate_Transition();
@@ -1324,7 +1324,7 @@ public class FlatrateBL implements IFlatrateBL
 		ContractDocumentLocationAdapterFactory
 				.billLocationAdapter(nextTerm)
 				.setFrom(ContractLocationHelper.extractBillToLocationId(currentTerm),
-						billContactId);
+						 billContactId);
 
 		final BPartnerContactId dropshipContactId = BPartnerContactId.ofRepoIdOrNull(currentTerm.getDropShip_BPartner_ID(), currentTerm.getDropShip_User_ID());
 
@@ -1458,7 +1458,7 @@ public class FlatrateBL implements IFlatrateBL
 			{
 				// make sure that durationUnit==month and duration==(n times 12); note that we have a model interceptor which enforces this.
 				Check.errorUnless(X_C_Flatrate_Transition.TERMDURATIONUNIT_MonatE.equals(transition.getTermDurationUnit()),
-						"The term duration unit is not suitable for a term that ends with calendar year");
+								  "The term duration unit is not suitable for a term that ends with calendar year");
 				Check.errorUnless(transition.getTermDuration() % 12 == 0, "Term duration not suitable for a term that ends with calendar year");
 
 				termDuration = transition.getTermDuration() / 12;
@@ -1671,8 +1671,8 @@ public class FlatrateBL implements IFlatrateBL
 		}
 
 		final I_C_BPartner_Location billPartnerLocation = bPartnerDAO.retrieveBillToLocation(ctx, bPartner.getC_BPartner_ID(),
-				true,            // alsoTryBPartnerRelation
-				trxName);
+																							 true,            // alsoTryBPartnerRelation
+																							 trxName);
 
 		if (billPartnerLocation == null)
 		{
@@ -1691,13 +1691,13 @@ public class FlatrateBL implements IFlatrateBL
 		else
 		{
 			if (!flatrateDAO.retrieveTerms(ctx,
-					OrgId.ofRepoId(bPartner.getAD_Org_ID()),
-					bPartner.getC_BPartner_ID(),
-					null,
-					productAndCategoryId.getProductCategoryId().getRepoId(),
-					productAndCategoryId.getProductId().getRepoId(),
-					-1,
-					trxName).isEmpty())
+										   OrgId.ofRepoId(bPartner.getAD_Org_ID()),
+										   bPartner.getC_BPartner_ID(),
+										   null,
+										   productAndCategoryId.getProductCategoryId().getRepoId(),
+										   productAndCategoryId.getProductId().getRepoId(),
+										   -1,
+										   trxName).isEmpty())
 			{
 				notCreatedReason.append(" already has a term;");
 				dontCreateTerm = true;
@@ -1718,8 +1718,8 @@ public class FlatrateBL implements IFlatrateBL
 		newTerm.setEndDate(startDate); // will be updated later
 
 		final BPartnerLocationAndCaptureId billToLocationId = BPartnerLocationAndCaptureId.ofRepoIdOrNull(billPartnerLocation.getC_BPartner_ID(),// note that in case of bPartner relations, this might be a different partner than 'bPartner'.
-				billPartnerLocation.getC_BPartner_Location_ID(),
-				billPartnerLocation.getC_Location_ID());
+																										  billPartnerLocation.getC_BPartner_Location_ID(),
+																										  billPartnerLocation.getC_Location_ID());
 		ContractDocumentLocationAdapterFactory.billLocationAdapter(newTerm)
 				.setFrom(billToLocationId);
 
@@ -1734,8 +1734,8 @@ public class FlatrateBL implements IFlatrateBL
 		if (shipToLocationRecord != null)
 		{
 			final BPartnerLocationAndCaptureId shipToLocationId = BPartnerLocationAndCaptureId.ofRepoIdOrNull(shipToLocationRecord.getC_BPartner_ID(),
-					shipToLocationRecord.getC_BPartner_Location_ID(),
-					shipToLocationRecord.getC_Location_ID());
+																											  shipToLocationRecord.getC_BPartner_Location_ID(),
+																											  shipToLocationRecord.getC_Location_ID());
 
 			ContractDocumentLocationAdapterFactory.dropShipLocationAdapter(newTerm)
 					.setFrom(shipToLocationId);
@@ -1864,7 +1864,7 @@ public class FlatrateBL implements IFlatrateBL
 			// Only consider terms with the same org.
 			// C_Flatrate_Term has access-level=Org, so there is no term with Org=*
 			// Also note that when finding a term for an invoice-candidate, that IC's org is used as a matching criterion
-			if (term.getAD_Org_ID() != newTerm.getAD_Org_ID())
+			if(term.getAD_Org_ID() != newTerm.getAD_Org_ID())
 			{
 				continue;
 			}

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
@@ -139,10 +139,12 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.save;
@@ -1144,27 +1146,25 @@ public class FlatrateBL implements IFlatrateBL
 		while (X_C_Flatrate_Transition.EXTENSIONTYPE_ExtendAll.equals(nextTransition.getExtensionType()) && nextTransition.getC_Flatrate_Conditions_Next_ID() > 0);
 
 		// Also collect predecessor contracts (those before the initial contract in the chain)
-		// so their MasterEndDate is updated as well. Walk back only as long as the predecessor's
-		// transition is ExtendAll (mirroring the forward loop's while-condition).
+		// so their MasterEndDate is updated as well.
+		// MasterEndDate must reflect the last EndDate for every term in the chain, regardless of
+		// transition type, so we walk all the way back to the root.
 		final List<I_C_Flatrate_Term> predecessors = new ArrayList<>();
-		final Map<Integer, String> seenPredecessorConditions = new LinkedHashMap<>();
-		seenPredecessorConditions.put(
-				request.getContract().getC_Flatrate_Conditions_ID(),
-				request.getContract().getC_Flatrate_Conditions().getName());
+		// Use term IDs (not conditions IDs) for cycle detection: the same conditions template may
+		// legitimately be reused across multiple terms, so conditions-ID tracking causes false positives.
+		final Set<FlatrateTermId> seenPredecessorTermIds = new HashSet<>();
+		seenPredecessorTermIds.add(FlatrateTermId.ofRepoId(request.getContract().getC_Flatrate_Term_ID()));
 		I_C_Flatrate_Term predecessor = flatrateDAO.retrieveAncestorFlatrateTerm(request.getContract());
 		while (predecessor != null)
 		{
-			final I_C_Flatrate_Conditions predecessorConditions = predecessor.getC_Flatrate_Conditions();
-			Check.assumeNotNull(predecessorConditions, "C_Flatrate_Conditions shall not be null!");
-			final I_C_Flatrate_Transition predecessorTransition = predecessorConditions.getC_Flatrate_Transition();
-			Check.assumeNotNull(predecessorTransition, "C_Flatrate_Transition shall not be null!");
-
-			// infinite loop detection (same guard as forward loop)
-			if (seenPredecessorConditions.containsKey(predecessorConditions.getC_Flatrate_Conditions_ID()))
+			// infinite loop detection: guard against cycles in the term chain
+			if (seenPredecessorTermIds.contains(FlatrateTermId.ofRepoId(predecessor.getC_Flatrate_Term_ID())))
 			{
-				throw new AdempiereException(MSG_INFINITE_LOOP, predecessorConditions.getName(), seenPredecessorConditions.values());
+				final I_C_Flatrate_Conditions predecessorConditions = predecessor.getC_Flatrate_Conditions();
+				Check.assumeNotNull(predecessorConditions, "C_Flatrate_Conditions shall not be null!");
+				throw new AdempiereException(MSG_INFINITE_LOOP, predecessorConditions.getName(), seenPredecessorTermIds);
 			}
-			seenPredecessorConditions.put(predecessorConditions.getC_Flatrate_Conditions_ID(), predecessorConditions.getName());
+			seenPredecessorTermIds.add(FlatrateTermId.ofRepoId(predecessor.getC_Flatrate_Term_ID()));
 
 			predecessors.add(0, predecessor);
 			predecessor = flatrateDAO.retrieveAncestorFlatrateTerm(predecessor);
@@ -1180,6 +1180,11 @@ public class FlatrateBL implements IFlatrateBL
 	 */
 	private void updateMasterEndDateIfNeeded(final List<I_C_Flatrate_Term> contracts)
 	{
+		if (contracts.isEmpty())
+		{
+			return;
+		}
+
 		final Timestamp endDate = contracts.stream()
 				.sorted(Comparator.comparing(I_C_Flatrate_Term::getEndDate).reversed())
 				.findFirst()

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
@@ -237,11 +237,11 @@ public class FlatrateBL implements IFlatrateBL
 									X_C_Flatrate_DataEntry.DOCSTATUS_Completed);
 					final ITranslatableString uomName = uomDAO.getName(UomId.ofRepoId(invoicingEntry.getC_UOM_ID()));
 					return msgBL.getMsg(ctx,
-										FlatrateBL.MSG_FLATRATEBL_INVOICING_ENTRY_NOT_CO_3P,
-										new Object[] {
-												invoicingEntry.getC_Period().getName(),
-												uomName,
-												competed.translate(Env.getAD_Language()) });
+							FlatrateBL.MSG_FLATRATEBL_INVOICING_ENTRY_NOT_CO_3P,
+							new Object[] {
+									invoicingEntry.getC_Period().getName(),
+									uomName,
+									competed.translate(Env.getAD_Language()) });
 				}
 			}
 
@@ -272,9 +272,9 @@ public class FlatrateBL implements IFlatrateBL
 				{
 					final Properties ctx = InterfaceWrapperHelper.getCtx(dataEntry);
 					return msgBL.getMsg(ctx,
-										FlatrateBL.MSG_FLATRATEBL_INVOICE_CANDIDATE_TO_RECOMPUTE_1P,
-										new Object[] {
-												sb.toString() });
+							FlatrateBL.MSG_FLATRATEBL_INVOICE_CANDIDATE_TO_RECOMPUTE_1P,
+							new Object[] {
+									sb.toString() });
 				}
 
 				//
@@ -298,13 +298,13 @@ public class FlatrateBL implements IFlatrateBL
 				{
 					final Properties ctx = InterfaceWrapperHelper.getCtx(dataEntry);
 					return msgBL.getMsg(ctx,
-										FlatrateBL.MSG_FLATRATEBL_INVOICE_CANDIDATE_QTY_TO_INVOICE_1P,
-										new Object[] {
-												sb.toString() });
+							FlatrateBL.MSG_FLATRATEBL_INVOICE_CANDIDATE_QTY_TO_INVOICE_1P,
+							new Object[] {
+									sb.toString() });
 				}
 			}
 			Check.assume(X_C_Flatrate_DataEntry.TYPE_Invoicing_PeriodBased.equals(dataEntry.getType()),
-						 dataEntry + "has type=" + X_C_Flatrate_DataEntry.TYPE_Invoicing_PeriodBased);
+					dataEntry + "has type=" + X_C_Flatrate_DataEntry.TYPE_Invoicing_PeriodBased);
 			qtyToInvoice = dataEntry.getQty_Reported();
 		}
 
@@ -341,7 +341,7 @@ public class FlatrateBL implements IFlatrateBL
 
 					// C_Flatrate_DataEntry_ID and QtyCleared have already been set by InvoiceCandidateValidator
 					Check.assume(alloc.getC_Flatrate_DataEntry_ID() == dataEntry.getC_Flatrate_DataEntry_ID(),
-								 alloc + " sould have C_Flatrate_DataEntry_ID=" + dataEntry.getC_Flatrate_DataEntry_ID() + " but has " + alloc.getC_Flatrate_DataEntry_ID());
+							alloc + " sould have C_Flatrate_DataEntry_ID=" + dataEntry.getC_Flatrate_DataEntry_ID() + " but has " + alloc.getC_Flatrate_DataEntry_ID());
 
 					// update the allocation record
 					alloc.setC_Invoice_Candidate_ID(newCand.getC_Invoice_Candidate_ID());
@@ -359,9 +359,9 @@ public class FlatrateBL implements IFlatrateBL
 		Check.assume(!dataEntry.isSimulation(), dataEntry + " has IsSimulation='N'");
 
 		Check.assume(X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee.equals(fc.getType_Conditions())
-							 || X_C_Flatrate_Conditions.TYPE_CONDITIONS_Refundable.equals(fc.getType_Conditions()),
-					 fc + " has Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee
-							 + " or " + X_C_Flatrate_Conditions.TYPE_CONDITIONS_Refundable);
+						|| X_C_Flatrate_Conditions.TYPE_CONDITIONS_Refundable.equals(fc.getType_Conditions()),
+				fc + " has Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee
+						+ " or " + X_C_Flatrate_Conditions.TYPE_CONDITIONS_Refundable);
 
 		final Properties ctx = InterfaceWrapperHelper.getCtx(fc);
 		final String trxName = InterfaceWrapperHelper.getTrxName(fc);
@@ -399,7 +399,7 @@ public class FlatrateBL implements IFlatrateBL
 
 			final int productId = fc.getM_Product_Flatrate_ID();
 			Check.assume(productId > 0,
-						 fc + " with Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee + " has no M_Product_Flatrate");
+					fc + " with Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee + " has no M_Product_Flatrate");
 
 			final I_C_Invoice_Candidate newIc = createCand(ctx, term, dataEntry, productId, priceActual, trxName);
 			result.add(newIc);
@@ -552,7 +552,7 @@ public class FlatrateBL implements IFlatrateBL
 		{
 			final ProductId productId = ProductId.ofRepoIdOrNull(dataEntry.getM_Product_DataEntry_ID());
 			Check.assume(productId != null,
-						 dataEntry + " has no M_Product_DataEntry, despite " + fc + "has Type_Conditions=" + fc.getType_Conditions());
+					dataEntry + " has no M_Product_DataEntry, despite " + fc + "has Type_Conditions=" + fc.getType_Conditions());
 
 			productIdForIc = productId.getRepoId();
 
@@ -566,7 +566,7 @@ public class FlatrateBL implements IFlatrateBL
 		else
 		{
 			Check.assume(X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee.equals(fc.getType_Conditions()),
-						 fc + " has Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee);
+					fc + " has Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee);
 
 			if (X_C_Flatrate_DataEntry.TYPE_Invoicing_PeriodBased.equals(dataEntry.getType()))
 			{
@@ -575,11 +575,11 @@ public class FlatrateBL implements IFlatrateBL
 			else
 			{
 				Check.assume(X_C_Flatrate_DataEntry.TYPE_Correction_PeriodBased.equals(dataEntry.getType()),
-							 "dataEntry has type " + X_C_Flatrate_DataEntry.TYPE_Correction_PeriodBased);
+						"dataEntry has type " + X_C_Flatrate_DataEntry.TYPE_Correction_PeriodBased);
 				productIdForIc = fc.getM_Product_Correction_ID();
 			}
 			Check.assume(productIdForIc > 0,
-						 fc + " with Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee + " has no M_Product_Flatrate");
+					fc + " with Type_Conditions=" + X_C_Flatrate_Conditions.TYPE_CONDITIONS_FlatFee + " has no M_Product_Flatrate");
 
 			priceActual = dataEntry.getFlatrateAmt();
 		}
@@ -758,7 +758,7 @@ public class FlatrateBL implements IFlatrateBL
 						else
 						{
 							final String msg = msgBL.getMsg(ctx, "FlatrateBL_InvoicingEntry_Not_Invoiced",
-															new Object[] { periodOfTerm.getName(), uom.getName() });
+									new Object[] { periodOfTerm.getName(), uom.getName() });
 							errors.add(msg);
 							result = null;
 						}
@@ -766,7 +766,7 @@ public class FlatrateBL implements IFlatrateBL
 					else
 					{
 						final String msg = msgBL.getMsg(ctx, "PrepareClosing_InvoicingEntry_Not_CO",
-														new Object[] { uom.getName(), periodOfTerm.getName() });
+								new Object[] { uom.getName(), periodOfTerm.getName() });
 						errors.add(msg);
 						result = null;
 					}
@@ -847,10 +847,10 @@ public class FlatrateBL implements IFlatrateBL
 		}
 
 		final String msg = msgBL.getMsg(ctx, FlatrateBL.MSG_DATA_ENTRY_CREATE_HOLDING_FEE_3P,
-										new Object[] {
-												counter,
-												flatrateTerm.getStartDate(),
-												flatrateTerm.getEndDate() });
+				new Object[] {
+						counter,
+						flatrateTerm.getStartDate(),
+						flatrateTerm.getEndDate() });
 		Loggables.withLogger(logger, Level.INFO).addLog(msg);
 	}
 
@@ -896,11 +896,11 @@ public class FlatrateBL implements IFlatrateBL
 		final Lookup columnLookup = poInfo.getColumnLookup(ctx, poInfo.getColumnIndex(I_C_Flatrate_Term.COLUMNNAME_UOMType));
 
 		final String msg = msgBL.getMsg(ctx, FlatrateBL.MSG_DATA_ENTRY_CREATE_FLAT_FEE_4P,
-										new Object[] {
-												counter,
-												flatrateTerm.getStartDate(),
-												flatrateTerm.getEndDate(),
-												columnLookup.getDisplay(flatrateTerm.getUOMType()) });
+				new Object[] {
+						counter,
+						flatrateTerm.getStartDate(),
+						flatrateTerm.getEndDate(),
+						columnLookup.getDisplay(flatrateTerm.getUOMType()) });
 		Loggables.withLogger(logger, Level.INFO).addLog(msg);
 	}
 
@@ -931,7 +931,7 @@ public class FlatrateBL implements IFlatrateBL
 		else
 		{
 			Check.assume(X_C_Flatrate_DataEntry.TYPE_Correction_PeriodBased.equals(dataEntry.getType()),
-						 dataEntry + " has Type=" + X_C_Flatrate_DataEntry.TYPE_Correction_PeriodBased);
+					dataEntry + " has Type=" + X_C_Flatrate_DataEntry.TYPE_Correction_PeriodBased);
 
 			actualQtyOfUnits = dataEntry.getQty_Reported().subtract(dataEntry.getQty_Planned());
 			correctionWithoutActualQty = !conditions.isCorrectionAmtAtClosing();
@@ -1049,9 +1049,9 @@ public class FlatrateBL implements IFlatrateBL
 					else
 					{
 						Check.assume(X_C_Flatrate_Conditions.TYPE_CLEARING_Exceeding.equals(conditions.getType_Clearing()),
-									 conditions + " has either Type_Clearing '" + X_C_Flatrate_Conditions.TYPE_CLEARING_Exceeding + "' or '"
-											 + X_C_Flatrate_Conditions.TYPE_CLEARING_Complete
-											 + "'");
+								conditions + " has either Type_Clearing '" + X_C_Flatrate_Conditions.TYPE_CLEARING_Exceeding + "' or '"
+										+ X_C_Flatrate_Conditions.TYPE_CLEARING_Complete
+										+ "'");
 						effectiveDiffPercent = diffPercent.subtract(percentSubtrahent);
 					}
 
@@ -1059,7 +1059,7 @@ public class FlatrateBL implements IFlatrateBL
 					// (X_C_Flatrate_Conditions.CLEARINGAMTBASEON_Pauschalenpreis.equals(conditions.getClearingAmtBaseOn()))
 					// {
 					Check.assume(X_C_Flatrate_Conditions.CLEARINGAMTBASEON_FlatrateAmount.equals(conditions.getClearingAmtBaseOn()),
-								 conditions + " has ClearingAmtBaseOn='" + X_C_Flatrate_Conditions.CLEARINGAMTBASEON_FlatrateAmount + "'");
+							conditions + " has ClearingAmtBaseOn='" + X_C_Flatrate_Conditions.CLEARINGAMTBASEON_FlatrateAmount + "'");
 
 					amtCorrection = flatrateAmt
 							.multiply(effectiveDiffPercent.divide(Env.ONEHUNDRED, scale * 2, RoundingMode.HALF_UP))
@@ -1114,7 +1114,7 @@ public class FlatrateBL implements IFlatrateBL
 
 			final I_C_Flatrate_Term currentTerm = currentRequest.getContract();
 			currentTerm.setAD_PInstance_EndOfTerm_ID(PInstanceId.toRepoId(currentRequest.getAD_PInstance_ID()));
-				save(currentTerm);
+			save(currentTerm);
 			if (currentTerm.getC_FlatrateTerm_Next_ID() <= 0)
 			{
 				// https://github.com/metasfresh/metasfresh/issues/4022 avoid NPE if currentTerm was actually *not* extended by extendContractIfRequired
@@ -1159,12 +1159,6 @@ public class FlatrateBL implements IFlatrateBL
 			final I_C_Flatrate_Transition predecessorTransition = predecessorConditions.getC_Flatrate_Transition();
 			Check.assumeNotNull(predecessorTransition, "C_Flatrate_Transition shall not be null!");
 
-			if (!X_C_Flatrate_Transition.EXTENSIONTYPE_ExtendAll.equals(predecessorTransition.getExtensionType())
-					|| predecessorTransition.getC_Flatrate_Conditions_Next_ID() <= 0)
-			{
-				break;
-			}
-
 			// infinite loop detection (same guard as forward loop)
 			if (seenPredecessorConditions.containsKey(predecessorConditions.getC_Flatrate_Conditions_ID()))
 			{
@@ -1177,14 +1171,14 @@ public class FlatrateBL implements IFlatrateBL
 		}
 		contracts.addAll(predecessors);
 
-		updateMasterEndDateIfNeeded(contracts, request.getContract());
+		updateMasterEndDateIfNeeded(contracts);
 	}
 
 	/**
 	 * Update <code>masterenddate</code> for all contracts in the chain.
 	 * MasterEndDate is the EndDate of the last term in the chain.
 	 */
-	private void updateMasterEndDateIfNeeded(final List<I_C_Flatrate_Term> contracts, final I_C_Flatrate_Term initialContract)
+	private void updateMasterEndDateIfNeeded(final List<I_C_Flatrate_Term> contracts)
 	{
 		final Timestamp endDate = contracts.stream()
 				.sorted(Comparator.comparing(I_C_Flatrate_Term::getEndDate).reversed())
@@ -1193,8 +1187,11 @@ public class FlatrateBL implements IFlatrateBL
 				.orElse(null);
 
 		contracts.forEach(contract -> {
-			contract.setMasterEndDate(endDate);
-			save(contract);
+			if (contract.getMasterEndDate() == null || !contract.getMasterEndDate().equals(endDate))
+			{
+				contract.setMasterEndDate(endDate);
+				save(contract);
+			}
 		});
 	}
 
@@ -1216,8 +1213,8 @@ public class FlatrateBL implements IFlatrateBL
 
 			// the conditions were set via de.metas.flatrate.modelvalidator.C_Flatrate_Term.copyFromConditions(term)
 			Check.errorUnless(currentTerm.getType_Conditions().equals(nextTerm.getType_Conditions()),
-							  "currentTerm has Type_Conditions={} while nextTerm has Type_Conditions={}; currentTerm={}",
-							  currentTerm.getType_Conditions(), nextTerm.getType_Conditions(), currentTerm);
+					"currentTerm has Type_Conditions={} while nextTerm has Type_Conditions={}; currentTerm={}",
+					currentTerm.getType_Conditions(), nextTerm.getType_Conditions(), currentTerm);
 
 			currentTerm.setC_FlatrateTerm_Next_ID(nextTerm.getC_Flatrate_Term_ID());
 			save(currentTerm);
@@ -1295,7 +1292,7 @@ public class FlatrateBL implements IFlatrateBL
 		final Timestamp nextTermStartDate = context.getNextTermStartDate();
 
 		Check.errorIf(currentTerm.getC_FlatrateTerm_Next_ID() > 0,
-					  "{} has C_FlatrateTerm_Next_ID = {} (should be <= 0)", currentTerm, currentTerm.getC_FlatrateTerm_Next_ID());
+				"{} has C_FlatrateTerm_Next_ID = {} (should be <= 0)", currentTerm, currentTerm.getC_FlatrateTerm_Next_ID());
 
 		final I_C_Flatrate_Conditions conditions = currentTerm.getC_Flatrate_Conditions();
 		final I_C_Flatrate_Transition currentTransition = conditions.getC_Flatrate_Transition();
@@ -1322,7 +1319,7 @@ public class FlatrateBL implements IFlatrateBL
 		ContractDocumentLocationAdapterFactory
 				.billLocationAdapter(nextTerm)
 				.setFrom(ContractLocationHelper.extractBillToLocationId(currentTerm),
-						 billContactId);
+						billContactId);
 
 		final BPartnerContactId dropshipContactId = BPartnerContactId.ofRepoIdOrNull(currentTerm.getDropShip_BPartner_ID(), currentTerm.getDropShip_User_ID());
 
@@ -1456,7 +1453,7 @@ public class FlatrateBL implements IFlatrateBL
 			{
 				// make sure that durationUnit==month and duration==(n times 12); note that we have a model interceptor which enforces this.
 				Check.errorUnless(X_C_Flatrate_Transition.TERMDURATIONUNIT_MonatE.equals(transition.getTermDurationUnit()),
-								  "The term duration unit is not suitable for a term that ends with calendar year");
+						"The term duration unit is not suitable for a term that ends with calendar year");
 				Check.errorUnless(transition.getTermDuration() % 12 == 0, "Term duration not suitable for a term that ends with calendar year");
 
 				termDuration = transition.getTermDuration() / 12;
@@ -1669,8 +1666,8 @@ public class FlatrateBL implements IFlatrateBL
 		}
 
 		final I_C_BPartner_Location billPartnerLocation = bPartnerDAO.retrieveBillToLocation(ctx, bPartner.getC_BPartner_ID(),
-																							 true,            // alsoTryBPartnerRelation
-																							 trxName);
+				true,            // alsoTryBPartnerRelation
+				trxName);
 
 		if (billPartnerLocation == null)
 		{
@@ -1689,13 +1686,13 @@ public class FlatrateBL implements IFlatrateBL
 		else
 		{
 			if (!flatrateDAO.retrieveTerms(ctx,
-										   OrgId.ofRepoId(bPartner.getAD_Org_ID()),
-										   bPartner.getC_BPartner_ID(),
-										   null,
-										   productAndCategoryId.getProductCategoryId().getRepoId(),
-										   productAndCategoryId.getProductId().getRepoId(),
-										   -1,
-										   trxName).isEmpty())
+					OrgId.ofRepoId(bPartner.getAD_Org_ID()),
+					bPartner.getC_BPartner_ID(),
+					null,
+					productAndCategoryId.getProductCategoryId().getRepoId(),
+					productAndCategoryId.getProductId().getRepoId(),
+					-1,
+					trxName).isEmpty())
 			{
 				notCreatedReason.append(" already has a term;");
 				dontCreateTerm = true;
@@ -1716,8 +1713,8 @@ public class FlatrateBL implements IFlatrateBL
 		newTerm.setEndDate(startDate); // will be updated later
 
 		final BPartnerLocationAndCaptureId billToLocationId = BPartnerLocationAndCaptureId.ofRepoIdOrNull(billPartnerLocation.getC_BPartner_ID(),// note that in case of bPartner relations, this might be a different partner than 'bPartner'.
-																										  billPartnerLocation.getC_BPartner_Location_ID(),
-																										  billPartnerLocation.getC_Location_ID());
+				billPartnerLocation.getC_BPartner_Location_ID(),
+				billPartnerLocation.getC_Location_ID());
 		ContractDocumentLocationAdapterFactory.billLocationAdapter(newTerm)
 				.setFrom(billToLocationId);
 
@@ -1732,8 +1729,8 @@ public class FlatrateBL implements IFlatrateBL
 		if (shipToLocationRecord != null)
 		{
 			final BPartnerLocationAndCaptureId shipToLocationId = BPartnerLocationAndCaptureId.ofRepoIdOrNull(shipToLocationRecord.getC_BPartner_ID(),
-																											  shipToLocationRecord.getC_BPartner_Location_ID(),
-																											  shipToLocationRecord.getC_Location_ID());
+					shipToLocationRecord.getC_BPartner_Location_ID(),
+					shipToLocationRecord.getC_Location_ID());
 
 			ContractDocumentLocationAdapterFactory.dropShipLocationAdapter(newTerm)
 					.setFrom(shipToLocationId);
@@ -1862,7 +1859,7 @@ public class FlatrateBL implements IFlatrateBL
 			// Only consider terms with the same org.
 			// C_Flatrate_Term has access-level=Org, so there is no term with Org=*
 			// Also note that when finding a term for an invoice-candidate, that IC's org is used as a matching criterion
-			if(term.getAD_Org_ID() != newTerm.getAD_Org_ID())
+			if (term.getAD_Org_ID() != newTerm.getAD_Org_ID())
 			{
 				continue;
 			}

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/impl/FlatrateBL.java
@@ -1147,25 +1147,21 @@ public class FlatrateBL implements IFlatrateBL
 	}
 
 	/**
-	 * Update <code>masterenddate</code> only for contract of which we know the entire period
+	 * Update <code>masterenddate</code> for all contracts in the chain.
+	 * MasterEndDate is the EndDate of the last term in the chain.
 	 */
 	private void updateMasterEndDateIfNeeded(final List<I_C_Flatrate_Term> contracts, final I_C_Flatrate_Term initialContract)
 	{
-		final I_C_Flatrate_Conditions initialConditions = initialContract.getC_Flatrate_Conditions();
-		final I_C_Flatrate_Transition initialTransition = initialConditions.getC_Flatrate_Transition();
-		if (X_C_Flatrate_Transition.EXTENSIONTYPE_ExtendAll.equals(initialTransition.getExtensionType()))
-		{
-			final Timestamp endDate = contracts.stream()
-					.sorted(Comparator.comparing(I_C_Flatrate_Term::getEndDate).reversed())
-					.findFirst()
-					.map(I_C_Flatrate_Term::getEndDate)
-					.orElse(null);
+		final Timestamp endDate = contracts.stream()
+				.sorted(Comparator.comparing(I_C_Flatrate_Term::getEndDate).reversed())
+				.findFirst()
+				.map(I_C_Flatrate_Term::getEndDate)
+				.orElse(null);
 
-			contracts.forEach(contract -> {
-				contract.setMasterEndDate(endDate);
-				save(contract);
-			});
-		}
+		contracts.forEach(contract -> {
+			contract.setMasterEndDate(endDate);
+			save(contract);
+		});
 	}
 
 	private void extendContractAndNotifyUserIfRequired(final @NonNull ContractExtendingRequest request)

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/interceptor/C_Flatrate_Term.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/interceptor/C_Flatrate_Term.java
@@ -555,7 +555,7 @@ public class C_Flatrate_Term
 	private void setMasterEndDate(final I_C_Flatrate_Term term)
 	{
 		Timestamp masterEndDate = null;
-		if (InterfaceWrapperHelper.isNew(term) && !term.isAutoRenew())
+		if (InterfaceWrapperHelper.isNew(term))
 		{
 			masterEndDate = term.getEndDate();
 		}

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/interceptor/C_Flatrate_Term.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/interceptor/C_Flatrate_Term.java
@@ -555,7 +555,7 @@ public class C_Flatrate_Term
 	private void setMasterEndDate(final I_C_Flatrate_Term term)
 	{
 		Timestamp masterEndDate = null;
-		if (InterfaceWrapperHelper.isNew(term))
+		if (InterfaceWrapperHelper.isNew(term) && !term.isAutoRenew())
 		{
 			masterEndDate = term.getEndDate();
 		}

--- a/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/ExtendContractTest.java
+++ b/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/ExtendContractTest.java
@@ -253,9 +253,10 @@ public class ExtendContractTest extends AbstractFlatrateTermTest
 		// Assert: all three terms must share MasterEndDate = C.EndDate
 		final Timestamp expectedMasterEndDate = TimeUtil.addDays(TimeUtil.addYears(startDate, 3), -1);
 		assertThat(termAReloaded.getMasterEndDate()).as("termA.MasterEndDate").isEqualTo(expectedMasterEndDate);
-		// term B already contain the correct data, since it was used to create C via  de.metas.contracts.IFlatrateBL.extendContractAndNotifyUser
+		// term B already contains the correct data, since it was used to create C via  de.metas.contracts.IFlatrateBL.extendContractAndNotifyUser
 		assertThat(termB.getMasterEndDate()).as("termB.MasterEndDate").isEqualTo(expectedMasterEndDate);
 		assertThat(termC.getMasterEndDate()).as("termC.MasterEndDate").isEqualTo(expectedMasterEndDate);
+		assertThat(termC.getEndDate()).as("termC.MasterEndDate").isEqualTo(expectedMasterEndDate);
 	}
 
 	private void assertFlatrateTerm(@NonNull final I_C_Flatrate_Term currentflatrateTerm)

--- a/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/ExtendContractTest.java
+++ b/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/ExtendContractTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class ExtendContractTest extends AbstractFlatrateTermTest
 {
 	final private static Timestamp startDate = TimeUtil.parseTimestamp("2017-09-10");
+	private final IFlatrateBL flatrateBL = Services.get(IFlatrateBL.class);
 
 	@BeforeEach
 	public void before()
@@ -56,7 +57,7 @@ public class ExtendContractTest extends AbstractFlatrateTermTest
 				.nextTermStartDate(null)
 				.build();
 
-		Services.get(IFlatrateBL.class).extendContractAndNotifyUser(context);
+		flatrateBL.extendContractAndNotifyUser(context);
 
 		assertFlatrateTerm(contract);
 		assertPartnerData(contract);
@@ -75,7 +76,7 @@ public class ExtendContractTest extends AbstractFlatrateTermTest
 				.nextTermStartDate(null)
 				.build();
 
-		Services.get(IFlatrateBL.class).extendContractAndNotifyUser(context);
+		flatrateBL.extendContractAndNotifyUser(context);
 
 		assertFlatrateTerm(contract);
 		assertPartnerData(contract);
@@ -94,7 +95,7 @@ public class ExtendContractTest extends AbstractFlatrateTermTest
 				.nextTermStartDate(null)
 				.build();
 
-		Services.get(IFlatrateBL.class).extendContractAndNotifyUser(context);
+		flatrateBL.extendContractAndNotifyUser(context);
 
 		I_C_Flatrate_Term curentContract = contract;
 		do
@@ -132,7 +133,7 @@ public class ExtendContractTest extends AbstractFlatrateTermTest
 				.build();
 
 		assertThatThrownBy(() -> {
-			Services.get(IFlatrateBL.class).extendContractAndNotifyUser(context);
+			flatrateBL.extendContractAndNotifyUser(context);
 		}).isInstanceOf(AdempiereException.class)
 				.hasMessageContaining(FlatrateBL.MSG_INFINITE_LOOP.toAD_Message());
 	}
@@ -228,7 +229,7 @@ public class ExtendContractTest extends AbstractFlatrateTermTest
 				.forceComplete(true)
 				.nextTermStartDate(null)
 				.build();
-		Services.get(IFlatrateBL.class).extendContractAndNotifyUser(extendA);
+		flatrateBL.extendContractAndNotifyUser(extendA);
 
 		final I_C_Flatrate_Term termB = InterfaceWrapperHelper.load(termA.getC_FlatrateTerm_Next_ID(), I_C_Flatrate_Term.class);
 		assertThat(termB).isNotNull();
@@ -241,7 +242,7 @@ public class ExtendContractTest extends AbstractFlatrateTermTest
 				.forceComplete(true)
 				.nextTermStartDate(null)
 				.build();
-		Services.get(IFlatrateBL.class).extendContractAndNotifyUser(extendB);
+		flatrateBL.extendContractAndNotifyUser(extendB);
 
 		final I_C_Flatrate_Term termC = InterfaceWrapperHelper.load(termB.getC_FlatrateTerm_Next_ID(), I_C_Flatrate_Term.class);
 		assertThat(termC).isNotNull();
@@ -252,6 +253,7 @@ public class ExtendContractTest extends AbstractFlatrateTermTest
 		// Assert: all three terms must share MasterEndDate = C.EndDate
 		final Timestamp expectedMasterEndDate = TimeUtil.addDays(TimeUtil.addYears(startDate, 3), -1);
 		assertThat(termAReloaded.getMasterEndDate()).as("termA.MasterEndDate").isEqualTo(expectedMasterEndDate);
+		// term B already contain the correct data, since it was used to create C via  de.metas.contracts.IFlatrateBL.extendContractAndNotifyUser
 		assertThat(termB.getMasterEndDate()).as("termB.MasterEndDate").isEqualTo(expectedMasterEndDate);
 		assertThat(termC.getMasterEndDate()).as("termC.MasterEndDate").isEqualTo(expectedMasterEndDate);
 	}

--- a/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/ExtendContractTest.java
+++ b/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/ExtendContractTest.java
@@ -210,6 +210,52 @@ public class ExtendContractTest extends AbstractFlatrateTermTest
 				startDate);
 	}
 
+	/**
+	 * Verifies that extending a middle term of an existing chain (A → B, then extend B to create C)
+	 * causes all three terms (A, B, C) to receive MasterEndDate = C.EndDate.
+	 * This exercises the predecessor-walking logic in FlatrateBL.extendContractAndNotifyUser().
+	 */
+	@Test
+	public void extendFromMiddleOfChain_allTermsGetMasterEndDateUpdated_test()
+	{
+		// Setup: create term A and extend it once to get B (chain: A → B)
+		final I_C_Flatrate_Term termA = prepareContractForTest(X_C_Flatrate_Transition.EXTENSIONTYPE_ExtendOne);
+
+		final ContractExtendingRequest extendA = ContractExtendingRequest.builder()
+				.AD_PInstance_ID(PInstanceId.ofRepoId(1))
+				.contract(termA)
+				.forceExtend(true)
+				.forceComplete(true)
+				.nextTermStartDate(null)
+				.build();
+		Services.get(IFlatrateBL.class).extendContractAndNotifyUser(extendA);
+
+		final I_C_Flatrate_Term termB = InterfaceWrapperHelper.load(termA.getC_FlatrateTerm_Next_ID(), I_C_Flatrate_Term.class);
+		assertThat(termB).isNotNull();
+
+		// Act: extend B to create C (chain becomes A → B → C)
+		final ContractExtendingRequest extendB = ContractExtendingRequest.builder()
+				.AD_PInstance_ID(PInstanceId.ofRepoId(2))
+				.contract(termB)
+				.forceExtend(true)
+				.forceComplete(true)
+				.nextTermStartDate(null)
+				.build();
+		Services.get(IFlatrateBL.class).extendContractAndNotifyUser(extendB);
+
+		final I_C_Flatrate_Term termC = InterfaceWrapperHelper.load(termB.getC_FlatrateTerm_Next_ID(), I_C_Flatrate_Term.class);
+		assertThat(termC).isNotNull();
+
+		// Reload termA: the predecessor update saves a DAO-fetched copy, so the original reference is stale.
+		final I_C_Flatrate_Term termAReloaded = InterfaceWrapperHelper.load(termA.getC_Flatrate_Term_ID(), I_C_Flatrate_Term.class);
+
+		// Assert: all three terms must share MasterEndDate = C.EndDate
+		final Timestamp expectedMasterEndDate = TimeUtil.addDays(TimeUtil.addYears(startDate, 3), -1);
+		assertThat(termAReloaded.getMasterEndDate()).as("termA.MasterEndDate").isEqualTo(expectedMasterEndDate);
+		assertThat(termB.getMasterEndDate()).as("termB.MasterEndDate").isEqualTo(expectedMasterEndDate);
+		assertThat(termC.getMasterEndDate()).as("termC.MasterEndDate").isEqualTo(expectedMasterEndDate);
+	}
+
 	private void assertFlatrateTerm(@NonNull final I_C_Flatrate_Term currentflatrateTerm)
 	{
 		final I_C_Flatrate_Term nextflatrateTerm = currentflatrateTerm.getC_FlatrateTerm_Next();

--- a/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/ExtendContractTest.java
+++ b/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/ExtendContractTest.java
@@ -1,25 +1,6 @@
 package de.metas.contracts.impl;
 
-import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
-import static org.adempiere.model.InterfaceWrapperHelper.save;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.List;
-
 import de.metas.bpartner.service.impl.BPartnerBL;
-import de.metas.location.impl.DummyDocumentLocationBL;
-import de.metas.pricing.PricingSystemId;
-import de.metas.user.UserRepository;
-import org.adempiere.ad.modelvalidator.IModelInterceptorRegistry;
-import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.model.InterfaceWrapperHelper;
-import org.compiere.util.TimeUtil;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import de.metas.contracts.IFlatrateBL;
 import de.metas.contracts.IFlatrateBL.ContractExtendingRequest;
 import de.metas.contracts.impl.FlatrateTermDataFactory.ProductAndPricingSystem;
@@ -31,9 +12,26 @@ import de.metas.contracts.model.X_C_Flatrate_Conditions;
 import de.metas.contracts.model.X_C_Flatrate_Transition;
 import de.metas.contracts.order.ContractOrderService;
 import de.metas.contracts.order.model.I_C_Order;
+import de.metas.location.impl.DummyDocumentLocationBL;
 import de.metas.process.PInstanceId;
+import de.metas.user.UserRepository;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.ad.modelvalidator.IModelInterceptorRegistry;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.util.TimeUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.save;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ExtendContractTest extends AbstractFlatrateTermTest
 {
@@ -42,7 +40,7 @@ public class ExtendContractTest extends AbstractFlatrateTermTest
 	@BeforeEach
 	public void before()
 	{
-		Services.get(IModelInterceptorRegistry.class).addModelInterceptor(new C_Flatrate_Term(new ContractOrderService(),new DummyDocumentLocationBL(new BPartnerBL(new UserRepository()))));
+		Services.get(IModelInterceptorRegistry.class).addModelInterceptor(new C_Flatrate_Term(new ContractOrderService(), new DummyDocumentLocationBL(new BPartnerBL(new UserRepository()))));
 	}
 
 	@Test
@@ -226,20 +224,12 @@ public class ExtendContractTest extends AbstractFlatrateTermTest
 		assertThat(currentflatrateTerm.getMasterEndDate()).isEqualTo(nextflatrateTerm.getMasterEndDate());
 		assertThat(nextflatrateTerm.getMasterStartDate()).isNotNull();
 		assertThat(currentflatrateTerm.isAutoRenew()).isEqualTo(nextflatrateTerm.isAutoRenew());
-		if (currentflatrateTerm.isAutoRenew())
-		{
-			assertThat(currentflatrateTerm.getMasterEndDate()).isNull();
-			assertThat(nextflatrateTerm.getMasterEndDate()).isNull();
-		}
-		else
-		{
-			assertThat(currentflatrateTerm.getMasterEndDate()).isNotNull();
-			assertThat(nextflatrateTerm.getMasterEndDate()).isNotNull();
+		assertThat(currentflatrateTerm.getMasterEndDate()).isNotNull();
+		assertThat(nextflatrateTerm.getMasterEndDate()).isNotNull();
 
-			final Timestamp expectedMasterEndDate = TimeUtil.addDays(TimeUtil.addYears(startDate, 2), -1);
-			assertThat(currentflatrateTerm.getMasterEndDate()).isEqualTo(expectedMasterEndDate);
-			assertThat(nextflatrateTerm.getMasterEndDate()).isEqualTo(expectedMasterEndDate);
-		}
+		final Timestamp expectedMasterEndDate = TimeUtil.addDays(TimeUtil.addYears(startDate, 2), -1);
+		assertThat(currentflatrateTerm.getMasterEndDate()).isEqualTo(expectedMasterEndDate);
+		assertThat(nextflatrateTerm.getMasterEndDate()).isEqualTo(expectedMasterEndDate);
 
 		final I_C_Order order = InterfaceWrapperHelper.create(currentflatrateTerm.getC_OrderLine_Term().getC_Order(), I_C_Order.class);
 		assertThat(order.getContractStatus()).isEqualTo(I_C_Order.CONTRACTSTATUS_Active);

--- a/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/ExtendContractTest.java
+++ b/backend/de.metas.contracts/src/test/java/de/metas/contracts/impl/ExtendContractTest.java
@@ -256,7 +256,7 @@ public class ExtendContractTest extends AbstractFlatrateTermTest
 		// term B already contains the correct data, since it was used to create C via  de.metas.contracts.IFlatrateBL.extendContractAndNotifyUser
 		assertThat(termB.getMasterEndDate()).as("termB.MasterEndDate").isEqualTo(expectedMasterEndDate);
 		assertThat(termC.getMasterEndDate()).as("termC.MasterEndDate").isEqualTo(expectedMasterEndDate);
-		assertThat(termC.getEndDate()).as("termC.MasterEndDate").isEqualTo(expectedMasterEndDate);
+		assertThat(termC.getEndDate()).as("termC.EndDate").isEqualTo(expectedMasterEndDate);
 	}
 
 	private void assertFlatrateTerm(@NonNull final I_C_Flatrate_Term currentflatrateTerm)


### PR DESCRIPTION
## Summary

- **Interceptor fix**: Removed `!isAutoRenew()` guard from `C_Flatrate_Term.setMasterEndDate()` so all new terms (including auto-renew) get `MasterEndDate = EndDate` on creation
- **FlatrateBL fix**: Removed `ExtendAll`-only restriction from `updateMasterEndDateIfNeeded()` so MasterEndDate is propagated through the chain for all extension types

### Root cause

Two issues caused `MasterEndDate` to remain NULL for auto-renew contracts:

1. The interceptor only set `MasterEndDate = EndDate` for new **non-auto-renew** terms. Auto-renew terms got `null`, and when the next term in the chain was linked, it read `null` from the next term too (chicken-and-egg).

2. `updateMasterEndDateIfNeeded()` (which correctly walks the whole chain and sets the last EndDate) only executed for `EXTENSIONTYPE_ExtendAll`. Regular single-extension auto-renew contracts never hit this code path.

### Data impact

On the customer DB: 16,532 out of 116,008 completed terms have `MasterEndDate = NULL`. All are auto-renew with a next term set. A companion migration script in yo98 fixes the existing data.

## Test plan

- [ ] Create a new auto-renew contract and verify `MasterEndDate` is set to `EndDate`
- [ ] Extend the contract and verify all terms in the chain have `MasterEndDate` = last term's `EndDate`
- [ ] Create a non-auto-renew contract and verify `MasterEndDate` still works correctly
- [ ] Test ExtendAll contracts still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)