### PR TITLE
Fix stale closure in Shortcut component causing modal shortcuts to fail

### DIFF
--- a/frontend/src/components/keyshortcuts/Shortcut.js
+++ b/frontend/src/components/keyshortcuts/Shortcut.js
@@ -22,11 +22,16 @@ class Shortcut extends PureComponent {
     subscribe(name, handler);
   }
 
-  /**
-   * @method componentWillUnmount
-   * @summary ToDo: Describe the method
-   * @todo Write the documentation
-   */
+  componentDidUpdate(prevProps) {
+    if (prevProps.handler !== this.props.handler) {
+      const { unsubscribe, subscribe } = this.context.shortcuts;
+
+      unsubscribe(this.name, this.handler);
+      this.handler = this.props.handler;
+      subscribe(this.name, this.handler);
+    }
+  }
+
   componentWillUnmount() {
     const { unsubscribe } = this.context.shortcuts;
     const { name, handler } = this;


### PR DESCRIPTION
## Summary

- Fix stale closure bug in `Shortcut` component (`frontend/src/components/keyshortcuts/Shortcut.js`)
- Add `componentDidUpdate` to re-subscribe handlers when the `handler` prop changes
- This fixes ALT+ENTER (and other keyboard shortcuts) not working in modals like Allocate Payments

**Root cause:** `ModalContextShortcuts` is a functional component that creates new handler closures on every render. `Shortcut` (a PureComponent) only subscribed the handler in `UNSAFE_componentWillMount` and never re-subscribed when the prop changed. On first render `done` is `undefined`, so the stale closure captured `undefined` — later re-renders brought the real `done` function but the old closure stayed in the hotkeys bucket.

**Note:** This is the follow-up fix to PR #22436 (stable references in ShortcutProvider). That PR fixed Redux `UPDATE_HOTKEYS` replacing the hotkeys object; this PR fixes the separate stale closure issue in the `Shortcut` subscriber component.

## Test plan

- [x] Existing 343 frontend unit tests pass
- [ ] Open any modal with keyboard shortcut support (e.g., Business Partner → Allocate Payments)
- [ ] Press ALT+ENTER → modal should close with "Done" action
- [ ] Press ESC → modal should close with "Cancel" action
- [ ] Verify shortcuts still work in non-modal contexts (document views, lists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)