### PR TITLE
Fix - `VAT-ID` may not be displayed as part of the address (#21969)

### DIFF
--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/docs/generics/report_bp_org_block_left.jrxml
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/docs/generics/report_bp_org_block_left.jrxml
@@ -94,7 +94,7 @@ FROM 	de_metas_endcustomer_fresh_reports.Docs_Generics_BPartner_Report( $P{org_i
 				<textElement>
 					<font fontName="Arial" size="11" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{addressblock} + (($F{vataxid}!=null) ? $F{vataxid} :"")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{addressblock}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement x="0" y="0" width="400" height="12" uuid="4b99bcc1-d46f-4b92-ba33-860c86089c6a"/>


### PR DESCRIPTION
https://github.com/metasfresh/metasfresh/pull/21969