### PR TITLE
Set `IsRefreshViewOnChangeEvents` to true for the Wareneingangsdisposition tab to ensure view refresh on change events.

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5790400_refresh_MRC_on_events.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5790400_refresh_MRC_on_events.sql
@@ -1,0 +1,8 @@
+-- Run mode: SWING_CLIENT
+
+-- Tab: Wareneingangsdisposition(540196,de.metas.inoutcandidate) -> Wareneingangsdisposition
+-- Table: M_ReceiptSchedule
+-- 2026-02-25T14:28:03.329Z
+UPDATE AD_Tab SET IsRefreshViewOnChangeEvents='Y',Updated=TO_TIMESTAMP('2026-02-25 14:28:03.329000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Tab_ID=540526
+;
+


### PR DESCRIPTION
Refresh Material Receipt Candidate window after a row is closed/opened, so that the view filter criteria is respected at all times.