### PR TITLE
Merge: inner_silence_hotfix → inner_silence_uat

### DIFF
--- a/frontend/src/components/keyshortcuts/Shortcut.js
+++ b/frontend/src/components/keyshortcuts/Shortcut.js
@@ -22,11 +22,16 @@ class Shortcut extends PureComponent {
     subscribe(name, handler);
   }
 
-  /**
-   * @method componentWillUnmount
-   * @summary ToDo: Describe the method
-   * @todo Write the documentation
-   */
+  componentDidUpdate(prevProps) {
+    if (prevProps.handler !== this.props.handler) {
+      const { unsubscribe, subscribe } = this.context.shortcuts;
+
+      unsubscribe(this.name, this.handler);
+      this.handler = this.props.handler;
+      subscribe(this.name, this.handler);
+    }
+  }
+
   componentWillUnmount() {
     const { unsubscribe } = this.context.shortcuts;
     const { name, handler } = this;


### PR DESCRIPTION
Forward merge of `inner_silence_hotfix` into `inner_silence_uat`.

Includes:
- #22446 — Fix stale closure in Shortcut component causing modal shortcuts to fail

Part of patch port for me03#27082.