### PR TITLE
hilfe() diagnostic: add navigation & process event tracking

### DIFF
--- a/frontend/src/actions/ProcessActions.js
+++ b/frontend/src/actions/ProcessActions.js
@@ -56,7 +56,10 @@ export const handleProcessResponse = ({
           processId,
           pinstanceId,
           actionType: action.type,
-          action,
+          windowId: action.windowId,
+          viewId: action.viewId,
+          documentId: action.documentId,
+          targetTab: action.targetTab,
         });
 
         switch (action.type) {

--- a/frontend/src/actions/ProcessActions.js
+++ b/frontend/src/actions/ProcessActions.js
@@ -29,6 +29,7 @@ import {
   getProcessLayout,
   startProcess,
 } from '../api/process';
+import { logDiagEvent } from '../utils/diagnostics';
 
 export const handleProcessResponse = ({
   response,
@@ -51,6 +52,13 @@ export const handleProcessResponse = ({
       let keepProcessModal = false;
 
       if (action) {
+        logDiagEvent('processAction', {
+          processId,
+          pinstanceId,
+          actionType: action.type,
+          action,
+        });
+
         switch (action.type) {
           case 'openCalendar': {
             await dispatch(closeModal());

--- a/frontend/src/components/header/RedirectHandler.js
+++ b/frontend/src/components/header/RedirectHandler.js
@@ -13,6 +13,7 @@ import { useLocation } from 'react-router';
 import { isObject } from 'lodash/lang';
 import { trl } from '../../utils/locale';
 import { markMasterDataAsChanged } from '../../actions/WindowActions';
+import { logDiagEvent } from '../../utils/diagnostics';
 
 const isCypress = () => navigator.userAgent.includes('Cypress');
 
@@ -56,6 +57,15 @@ const RedirectHandler = () => {
   // Handle programmatic redirects
   useEffect(() => {
     if (targetUrl) {
+      const resolvedUrl = isObject(targetUrl) ? targetUrl.url : targetUrl;
+      logDiagEvent('redirect', {
+        reason: 'targetUrl',
+        targetUrl: resolvedUrl,
+        setWindowLocation: isObject(targetUrl)
+          ? !!targetUrl.setWindowLocation
+          : false,
+      });
+
       // dispatch(clearMasterData());
       dispatch(markMasterDataAsChanged());
 
@@ -79,6 +89,11 @@ const RedirectHandler = () => {
     if (currentPath !== previousPath) {
       sessionStorage.setItem(KEY_PreviousPath, currentPath);
       if (isWarnOnPageUnload && !confirmDiscardChanges()) {
+        logDiagEvent('redirect', {
+          reason: 'revertToPrevious',
+          previousPath,
+          currentPath,
+        });
         history.push(previousPath); // Revert back to previous page
       }
     }
@@ -89,10 +104,24 @@ const RedirectHandler = () => {
   useEffect(() => {
     if (attemptedUrl) {
       if (isDocumentNotSaved) {
-        confirmDiscardChanges()
-          ? dispatch(confirmRedirect())
-          : dispatch(cancelRedirect());
+        if (confirmDiscardChanges()) {
+          logDiagEvent('redirect', {
+            reason: 'attemptedUrl_confirmed',
+            attemptedUrl,
+          });
+          dispatch(confirmRedirect());
+        } else {
+          logDiagEvent('redirect', {
+            reason: 'attemptedUrl_cancelled',
+            attemptedUrl,
+          });
+          dispatch(cancelRedirect());
+        }
       } else {
+        logDiagEvent('redirect', {
+          reason: 'attemptedUrl_autoConfirmed',
+          attemptedUrl,
+        });
         dispatch(confirmRedirect());
       }
     }

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
 import './utils/diagnostics'; // White screen diagnostic logging - type hilfe() in console
+import { logDiagEvent } from './utils/diagnostics';
 import App from './containers/App';
 import { ProvideAuth } from './hooks/useAuth';
 import { historyDoubleBackOnPopstate } from './utils';
@@ -44,5 +45,6 @@ ReactDOM.render(
 // to deal with this case we added a `popstate` listener that will go to the correct page in history skipping
 // the case when the URL and the view are the same when the back button is pressed
 window.addEventListener('popstate', () => {
+  logDiagEvent('popstate', { href: document.location.href });
   historyDoubleBackOnPopstate(store);
 });

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -45,6 +45,6 @@ ReactDOM.render(
 // to deal with this case we added a `popstate` listener that will go to the correct page in history skipping
 // the case when the URL and the view are the same when the back button is pressed
 window.addEventListener('popstate', () => {
-  logDiagEvent('popstate', { href: document.location.href });
+  logDiagEvent('popstate', {});
   historyDoubleBackOnPopstate(store);
 });

--- a/frontend/src/services/History.js
+++ b/frontend/src/services/History.js
@@ -14,17 +14,26 @@ const wrappedHistory = qhistory(
   queryString.parse
 );
 
-// Wrap push/replace to log all route changes for diagnostics
+// Wrap push/replace to log programmatic route changes for diagnostics
+// (direct window.location changes are not captured here)
 const originalPush = wrappedHistory.push.bind(wrappedHistory);
 const originalReplace = wrappedHistory.replace.bind(wrappedHistory);
 
 wrappedHistory.push = (...args) => {
-  logDiagEvent('navigation', { action: 'push', to: args[0] });
+  try {
+    logDiagEvent('navigation', { action: 'push', to: args[0] });
+  } catch (e) {
+    // Never let diagnostic logging break navigation
+  }
   return originalPush(...args);
 };
 
 wrappedHistory.replace = (...args) => {
-  logDiagEvent('navigation', { action: 'replace', to: args[0] });
+  try {
+    logDiagEvent('navigation', { action: 'replace', to: args[0] });
+  } catch (e) {
+    // Never let diagnostic logging break navigation
+  }
   return originalReplace(...args);
 };
 

--- a/frontend/src/services/History.js
+++ b/frontend/src/services/History.js
@@ -1,10 +1,31 @@
 import qhistory from 'qhistory';
 import queryString from 'query-string';
 import { createBrowserHistory, createMemoryHistory } from 'history';
+import { logDiagEvent } from '../utils/diagnostics';
 
 const isTest = process.env.NODE_ENV === 'test';
 const history = isTest
   ? createMemoryHistory({ initialEntries: ['/'] })
   : createBrowserHistory();
 
-export default qhistory(history, queryString.stringify, queryString.parse);
+const wrappedHistory = qhistory(
+  history,
+  queryString.stringify,
+  queryString.parse
+);
+
+// Wrap push/replace to log all route changes for diagnostics
+const originalPush = wrappedHistory.push.bind(wrappedHistory);
+const originalReplace = wrappedHistory.replace.bind(wrappedHistory);
+
+wrappedHistory.push = (...args) => {
+  logDiagEvent('navigation', { action: 'push', to: args[0] });
+  return originalPush(...args);
+};
+
+wrappedHistory.replace = (...args) => {
+  logDiagEvent('navigation', { action: 'replace', to: args[0] });
+  return originalReplace(...args);
+};
+
+export default wrappedHistory;

--- a/frontend/src/utils/diagnostics.js
+++ b/frontend/src/utils/diagnostics.js
@@ -18,18 +18,23 @@ const MAX_EVENTS = 200;
 const events = [];
 
 /**
- * Log a diagnostic event (navigation, process action, redirect, etc.).
+ * Log a diagnostic event (navigation, processAction, redirect, popstate).
  * Other modules import this to record events for the hilfe() report.
+ * Wrapped in try-catch so diagnostic logging never breaks the application.
  */
 export function logDiagEvent(type, data) {
-  events.push({
-    timestamp: new Date().toISOString(),
-    type,
-    url: window.location.href,
-    ...data,
-  });
-  if (events.length > MAX_EVENTS) {
-    events.shift();
+  try {
+    events.push({
+      timestamp: new Date().toISOString(),
+      type,
+      url: window.location.href,
+      ...data,
+    });
+    if (events.length > MAX_EVENTS) {
+      events.shift();
+    }
+  } catch (e) {
+    // Diagnostic logging must never break the application
   }
 }
 
@@ -69,35 +74,64 @@ window.addEventListener('unhandledrejection', (event) => {
  * Customer types hilfe() in browser console.
  */
 window.hilfe = () => {
-  const report = {
-    exportTime: new Date().toISOString(),
-    // eslint-disable-next-line no-undef
-    buildHash: typeof COMMIT_HASH !== 'undefined' ? COMMIT_HASH : 'unknown',
-    browserInfo: {
-      userAgent: navigator.userAgent,
-      language: navigator.language,
-      url: window.location.href,
-      screen: `${window.screen.width}x${window.screen.height}`,
-      window: `${window.innerWidth}x${window.innerHeight}`,
-    },
-    errors: errors,
-    events: events,
-  };
+  try {
+    const report = {
+      exportTime: new Date().toISOString(),
+      // eslint-disable-next-line no-undef
+      buildHash: typeof COMMIT_HASH !== 'undefined' ? COMMIT_HASH : 'unknown',
+      browserInfo: {
+        userAgent: navigator.userAgent,
+        language: navigator.language,
+        url: window.location.href,
+        screen: `${window.screen.width}x${window.screen.height}`,
+        window: `${window.innerWidth}x${window.innerHeight}`,
+      },
+      errors: errors,
+      events: events,
+    };
 
-  const blob = new Blob([JSON.stringify(report, null, 2)], {
-    type: 'application/json',
-  });
-  const link = document.createElement('a');
-  link.href = URL.createObjectURL(blob);
-  link.download = `metasfresh-diagnose-${Date.now()}.json`;
-  link.click();
-  URL.revokeObjectURL(link.href);
+    let jsonString;
+    try {
+      jsonString = JSON.stringify(report, null, 2);
+    } catch (e) {
+      // Fallback: handle circular references gracefully
+      const seen = new WeakSet();
+      jsonString = JSON.stringify(
+        report,
+        (key, value) => {
+          if (typeof value === 'object' && value !== null) {
+            if (seen.has(value)) return '[Circular]';
+            seen.add(value);
+          }
+          return value;
+        },
+        2
+      );
+    }
 
-  // eslint-disable-next-line no-console
-  console.info(
-    '%cDiagnose-Datei wurde heruntergeladen. Bitte senden Sie diese Datei an den Support.',
-    'color: green; font-weight: bold;'
-  );
+    const blob = new Blob([jsonString], {
+      type: 'application/json',
+    });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = `metasfresh-diagnose-${Date.now()}.json`;
+    link.click();
+    URL.revokeObjectURL(link.href);
+
+    // eslint-disable-next-line no-console
+    console.info(
+      '%cDiagnose-Datei wurde heruntergeladen. Bitte senden Sie diese Datei an den Support.',
+      'color: green; font-weight: bold;'
+    );
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(
+      '%cFehler beim Erstellen der Diagnose-Datei. Bitte machen Sie einen Screenshot dieser Fehlermeldung und senden Sie ihn an den Support.',
+      'color: red; font-weight: bold;'
+    );
+    // eslint-disable-next-line no-console
+    console.error(e);
+  }
 };
 
 // Show hint in console on page load

--- a/frontend/src/utils/diagnostics.js
+++ b/frontend/src/utils/diagnostics.js
@@ -1,17 +1,37 @@
 /**
  * Diagnostic error logging for white screen issues.
  *
- * Captures JavaScript errors and unhandled promise rejections.
+ * Captures JavaScript errors, unhandled promise rejections,
+ * navigation events, and process actions.
  * Customer can type hilfe() in browser console to download a diagnostic report.
  *
  * Usage:
  *   1. Import this file in index.jsx: import './utils/diagnostics';
  *   2. When white screen occurs, customer opens console (F12) and types: hilfe()
- *   3. A JSON file is downloaded containing error logs and browser info
+ *   3. A JSON file is downloaded containing error logs, navigation events, and browser info
  */
 
 const MAX_ENTRIES = 100;
 const errors = [];
+
+const MAX_EVENTS = 200;
+const events = [];
+
+/**
+ * Log a diagnostic event (navigation, process action, redirect, etc.).
+ * Other modules import this to record events for the hilfe() report.
+ */
+export function logDiagEvent(type, data) {
+  events.push({
+    timestamp: new Date().toISOString(),
+    type,
+    url: window.location.href,
+    ...data,
+  });
+  if (events.length > MAX_EVENTS) {
+    events.shift();
+  }
+}
 
 // Capture JavaScript errors
 window.onerror = (message, source, lineno, colno, error) => {
@@ -61,6 +81,7 @@ window.hilfe = () => {
       window: `${window.innerWidth}x${window.innerHeight}`,
     },
     errors: errors,
+    events: events,
   };
 
   const blob = new Blob([JSON.stringify(report, null, 2)], {

--- a/frontend/support-docs/hilfe-diagnose-funktion.md
+++ b/frontend/support-docs/hilfe-diagnose-funktion.md
@@ -109,8 +109,10 @@ Die **events**-Liste zeichnet auf, welche Seitenwechsel und Aktionen in der Anwe
       "timestamp": "2026-01-16T14:30:15.456Z",
       "type": "processAction",
       "processId": "WEBUI_Shipment_Schedule",
+      "pinstanceId": "12345",
       "actionType": "openView",
-      "action": { "type": "openView", "windowId": "540674", "viewId": "..." },
+      "windowId": "540674",
+      "viewId": "540674-aabbcc",
       "url": "http://localhost/window/143/1000000"
     }
   ]
@@ -119,7 +121,7 @@ Die **events**-Liste zeichnet auf, welche Seitenwechsel und Aktionen in der Anwe
 
 ## Datenschutz
 
-Die Diagnosedatei enthält **keine** persönlichen Daten, Passwörter oder Geschäftsdaten. Es werden ausschließlich technische Informationen über den Browser, aufgetretene Fehler und Navigations-/Prozessereignisse erfasst. Die Ereignisse enthalten nur URL-Pfade und Prozess-IDs, keine Dokumentinhalte.
+Die Diagnosedatei enthält **keine** persönlichen Daten, Passwörter oder Geschäftsdaten. Es werden ausschließlich technische Informationen über den Browser, aufgetretene Fehler und Navigations-/Prozessereignisse erfasst. Die Ereignisse enthalten URL-Pfade, Prozess-IDs und Fenster-/Ansichts-Kennungen — keine Dokumentinhalte oder Geschäftsdaten.
 
 ## Häufige Fragen
 

--- a/frontend/support-docs/hilfe-diagnose-funktion.md
+++ b/frontend/support-docs/hilfe-diagnose-funktion.md
@@ -63,6 +63,16 @@ Die Datei enthält technische Informationen zur Fehleranalyse:
 | **buildHash** | Version der Anwendung |
 | **browserInfo** | Browser, Sprache, Bildschirmgröße |
 | **errors** | Liste der aufgetretenen JavaScript-Fehler |
+| **events** | Protokoll der Navigations- und Prozessereignisse (bis zu 200 Einträge) |
+
+Die **events**-Liste zeichnet auf, welche Seitenwechsel und Aktionen in der Anwendung stattgefunden haben. Dies hilft dem Support insbesondere bei der Analyse von unerwarteten Weiterleitungen oder Seitenwechseln.
+
+| Ereignistyp | Beschreibung |
+|-------------|--------------|
+| **navigation** | Jede URL-Änderung (Seitenwechsel) |
+| **processAction** | Ergebnis einer Prozessausführung (z.B. Beleg öffnen, Ansicht öffnen) |
+| **redirect** | Weiterleitung durch die Anwendung (z.B. automatische Umleitung, Verwerfen-Dialog) |
+| **popstate** | Browser Vor-/Zurück-Navigation |
 
 ### Beispiel einer Diagnosedatei
 
@@ -86,13 +96,30 @@ Die Datei enthält technische Informationen zur Fehleranalyse:
       "lineno": 12345,
       "stack": "Error: Cannot read property..."
     }
+  ],
+  "events": [
+    {
+      "timestamp": "2026-01-16T14:30:01.123Z",
+      "type": "navigation",
+      "action": "push",
+      "to": "/window/143/1000000",
+      "url": "http://localhost/window/143"
+    },
+    {
+      "timestamp": "2026-01-16T14:30:15.456Z",
+      "type": "processAction",
+      "processId": "WEBUI_Shipment_Schedule",
+      "actionType": "openView",
+      "action": { "type": "openView", "windowId": "540674", "viewId": "..." },
+      "url": "http://localhost/window/143/1000000"
+    }
   ]
 }
 ```
 
 ## Datenschutz
 
-Die Diagnosedatei enthält **keine** persönlichen Daten, Passwörter oder Geschäftsdaten. Es werden ausschließlich technische Informationen über den Browser und aufgetretene Fehler erfasst.
+Die Diagnosedatei enthält **keine** persönlichen Daten, Passwörter oder Geschäftsdaten. Es werden ausschließlich technische Informationen über den Browser, aufgetretene Fehler und Navigations-/Prozessereignisse erfasst. Die Ereignisse enthalten nur URL-Pfade und Prozess-IDs, keine Dokumentinhalte.
 
 ## Häufige Fragen
 
@@ -102,7 +129,7 @@ Stellen Sie sicher, dass Sie die Konsole im richtigen Browser-Tab geöffnet habe
 
 ### Es werden keine Fehler in der Datei angezeigt?
 
-Wenn keine Fehler erfasst wurden, ist das Feld "errors" leer. In diesem Fall beschreiben Sie bitte das Problem so genau wie möglich in Ihrem Support-Ticket.
+Wenn keine Fehler erfasst wurden, ist das Feld "errors" leer. Auch in diesem Fall enthält die Datei wertvolle Informationen im "events"-Bereich, der alle Seitenwechsel und Aktionen protokolliert. Bitte senden Sie die Datei trotzdem an den Support und beschreiben Sie das Problem so genau wie möglich in Ihrem Support-Ticket.
 
 ### Wo finde ich die heruntergeladene Datei?
 

--- a/frontend/support-docs/hilfe-diagnostic-function-en.md
+++ b/frontend/support-docs/hilfe-diagnostic-function-en.md
@@ -111,8 +111,10 @@ The **events** list records which page changes and actions took place in the app
       "timestamp": "2026-01-16T14:30:15.456Z",
       "type": "processAction",
       "processId": "WEBUI_Shipment_Schedule",
+      "pinstanceId": "12345",
       "actionType": "openView",
-      "action": { "type": "openView", "windowId": "540674", "viewId": "..." },
+      "windowId": "540674",
+      "viewId": "540674-aabbcc",
       "url": "http://localhost/window/143/1000000"
     }
   ]
@@ -121,7 +123,7 @@ The **events** list records which page changes and actions took place in the app
 
 ## Privacy
 
-The diagnostic file does **not** contain any personal data, passwords, or business data. Only technical information about the browser, occurred errors, and navigation/process events is captured. The events contain only URL paths and process IDs, not document contents.
+The diagnostic file does **not** contain any personal data, passwords, or business data. Only technical information about the browser, occurred errors, and navigation/process events is captured. The events contain URL paths, process IDs, and window/view identifiers — no document contents or business data.
 
 ## FAQ
 

--- a/frontend/support-docs/hilfe-diagnostic-function-en.md
+++ b/frontend/support-docs/hilfe-diagnostic-function-en.md
@@ -65,6 +65,16 @@ The file contains technical information for troubleshooting:
 | **buildHash** | Application version identifier |
 | **browserInfo** | Browser type, language, screen size |
 | **errors** | List of captured JavaScript errors |
+| **events** | Log of navigation and process events (up to 200 entries) |
+
+The **events** list records which page changes and actions took place in the application. This is especially helpful for support when analyzing unexpected redirects or page changes.
+
+| Event Type | Description |
+|------------|-------------|
+| **navigation** | Every URL change (page navigation) |
+| **processAction** | Result of a process execution (e.g., open document, open view) |
+| **redirect** | Application-triggered redirect (e.g., automatic redirection, discard-changes dialog) |
+| **popstate** | Browser back/forward navigation |
 
 ### Example Diagnostic File
 
@@ -88,13 +98,30 @@ The file contains technical information for troubleshooting:
       "lineno": 12345,
       "stack": "Error: Cannot read property..."
     }
+  ],
+  "events": [
+    {
+      "timestamp": "2026-01-16T14:30:01.123Z",
+      "type": "navigation",
+      "action": "push",
+      "to": "/window/143/1000000",
+      "url": "http://localhost/window/143"
+    },
+    {
+      "timestamp": "2026-01-16T14:30:15.456Z",
+      "type": "processAction",
+      "processId": "WEBUI_Shipment_Schedule",
+      "actionType": "openView",
+      "action": { "type": "openView", "windowId": "540674", "viewId": "..." },
+      "url": "http://localhost/window/143/1000000"
+    }
   ]
 }
 ```
 
 ## Privacy
 
-The diagnostic file does **not** contain any personal data, passwords, or business data. Only technical information about the browser and occurred errors is captured.
+The diagnostic file does **not** contain any personal data, passwords, or business data. Only technical information about the browser, occurred errors, and navigation/process events is captured. The events contain only URL paths and process IDs, not document contents.
 
 ## FAQ
 
@@ -104,7 +131,7 @@ Make sure you have the console open in the correct browser tab (where metasfresh
 
 ### No errors are shown in the file?
 
-If no errors were captured, the "errors" field will be empty. In this case, please describe the problem as detailed as possible in your support ticket.
+If no errors were captured, the "errors" field will be empty. Even in this case, the file contains valuable information in the "events" section, which logs all page changes and actions. Please still send the file to support and describe the problem as detailed as possible in your support ticket.
 
 ### Where can I find the downloaded file?
 


### PR DESCRIPTION
## Summary

- Enhance `hilfe()` diagnostic function to capture navigation events, process action responses, redirect events, and browser back/forward (popstate) in a new `events` ring buffer (max 200 entries)
- This provides a full trail of URL changes and their sources, helping diagnose involuntary redirects
- Update DE/EN support documentation with the new events section, updated privacy notice, and improved FAQ

## Changes

| File | What |
|------|------|
| `diagnostics.js` | New `events[]` buffer + exported `logDiagEvent()` |
| `History.js` | Wrap `push`/`replace` to log all route changes |
| `ProcessActions.js` | Log process response actions (openDocument, openView, etc.) |
| `RedirectHandler.js` | Log targetUrl, revert-to-previous, and attemptedUrl events |
| `index.jsx` | Log popstate (browser back/forward) events |
| `hilfe-diagnose-funktion.md` | Updated DE docs with events section |
| `hilfe-diagnostic-function-en.md` | Updated EN docs with events section |

## Test plan

- [ ] `yarn lint` passes (0 errors)
- [ ] `yarn test` passes (all 62 suites, 2 snapshots)
- [ ] Navigate between windows, run `hilfe()` in console — report contains `events` array with navigation entries
- [ ] Run a process that opens a document — `processAction` event appears in report
- [ ] Use browser back/forward — `popstate` event appears in report