### PR TITLE
fix PP_Product_Planning IsCreatePlan / IsDocComplete for auto-PO creation from purchase candidates

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_Product_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_Product_StepDef.java
@@ -28,11 +28,13 @@ import de.metas.gs1.GTIN;
 import de.metas.gs1.ean13.EAN13;
 import de.metas.product.ProductId;
 import de.metas.product.ProductRepository;
+import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_BPartner;
@@ -156,35 +158,50 @@ public class C_BPartner_Product_StepDef
 
 	private void createBPartnerProduct(@NonNull final DataTableRow tableRow)
 	{
-		final I_C_BPartner_Product bPartnerProductRecord = InterfaceWrapperHelper.newInstance(I_C_BPartner_Product.class);
-		bPartnerProductRecord.setAD_Org_ID(StepDefConstants.ORG_ID.getRepoId());
-		bPartnerProductRecord.setUsedForCustomer(true);
-		bPartnerProductRecord.setShelfLifeMinDays(0);
-		bPartnerProductRecord.setShelfLifeMinPct(0);
-
 		final ProductId productId = tableRow.getAsIdentifier(COLUMNNAME_M_Product_ID).lookupNotNullIdIn(productTable);
-		bPartnerProductRecord.setM_Product_ID(productId.getRepoId());
 
 		final StepDefDataIdentifier bpartnerIdentifier = tableRow.getAsIdentifier(COLUMNNAME_C_BPartner_ID);
 		final BPartnerId bpartnerId = bPartnerTable.getIdOptional(bpartnerIdentifier)
 				.orElseGet(() -> bpartnerIdentifier.getAsId(BPartnerId.class));
 
-		bPartnerProductRecord.setC_BPartner_ID(bpartnerId.getRepoId());
+		// Reuse existing record if one already exists for the same bpartner+product (idempotent)
+		final I_C_BPartner_Product bPartnerProductRecord = Services.get(IQueryBL.class)
+				.createQueryBuilder(I_C_BPartner_Product.class)
+				.addEqualsFilter(COLUMNNAME_C_BPartner_ID, bpartnerId)
+				.addEqualsFilter(COLUMNNAME_M_Product_ID, productId)
+				.create()
+				.firstOnlyOrNull(I_C_BPartner_Product.class);
 
-		bPartnerProductRecord.setUsedForVendor(tableRow.getAsOptionalBoolean(COLUMNNAME_UsedForVendor).orElse(true));
-		bPartnerProductRecord.setIsCurrentVendor(tableRow.getAsOptionalBoolean(COLUMNNAME_IsCurrentVendor).orElse(true));
-		bPartnerProductRecord.setIsExcludedFromSale(tableRow.getAsOptionalBoolean(COLUMNNAME_IsExcludedFromSale).orElse(false));
-		tableRow.getAsOptionalString(COLUMNNAME_ExclusionFromSaleReason).ifPresent(bPartnerProductRecord::setExclusionFromSaleReason);
-		bPartnerProductRecord.setIsExcludedFromPurchase(tableRow.getAsOptionalBoolean(COLUMNNAME_IsExcludedFromPurchase).orElse(false));
-		tableRow.getAsOptionalString(COLUMNNAME_ExclusionFromPurchaseReason).ifPresent(bPartnerProductRecord::setExclusionFromPurchaseReason);
-		tableRow.getAsOptionalString(COLUMNNAME_ProductNo).ifPresent(bPartnerProductRecord::setProductNo);
-		tableRow.getAsOptionalString(COLUMNNAME_GTIN).ifPresent(bPartnerProductRecord::setGTIN);
-		tableRow.getAsOptionalString(COLUMNNAME_EAN_CU).ifPresent(bPartnerProductRecord::setEAN_CU);
-		tableRow.getAsOptionalString(COLUMNNAME_UPC).ifPresent(bPartnerProductRecord::setUPC);
+		final I_C_BPartner_Product record;
+		if (bPartnerProductRecord != null)
+		{
+			record = bPartnerProductRecord;
+		}
+		else
+		{
+			record = InterfaceWrapperHelper.newInstance(I_C_BPartner_Product.class);
+			record.setAD_Org_ID(StepDefConstants.ORG_ID.getRepoId());
+			record.setM_Product_ID(productId.getRepoId());
+			record.setC_BPartner_ID(bpartnerId.getRepoId());
+			record.setShelfLifeMinDays(0);
+			record.setShelfLifeMinPct(0);
+		}
 
-		saveRecord(bPartnerProductRecord);
+		record.setUsedForCustomer(true);
+		record.setUsedForVendor(tableRow.getAsOptionalBoolean(COLUMNNAME_UsedForVendor).orElse(true));
+		record.setIsCurrentVendor(tableRow.getAsOptionalBoolean(COLUMNNAME_IsCurrentVendor).orElse(true));
+		record.setIsExcludedFromSale(tableRow.getAsOptionalBoolean(COLUMNNAME_IsExcludedFromSale).orElse(false));
+		tableRow.getAsOptionalString(COLUMNNAME_ExclusionFromSaleReason).ifPresent(record::setExclusionFromSaleReason);
+		record.setIsExcludedFromPurchase(tableRow.getAsOptionalBoolean(COLUMNNAME_IsExcludedFromPurchase).orElse(false));
+		tableRow.getAsOptionalString(COLUMNNAME_ExclusionFromPurchaseReason).ifPresent(record::setExclusionFromPurchaseReason);
+		tableRow.getAsOptionalString(COLUMNNAME_ProductNo).ifPresent(record::setProductNo);
+		tableRow.getAsOptionalString(COLUMNNAME_GTIN).ifPresent(record::setGTIN);
+		tableRow.getAsOptionalString(COLUMNNAME_EAN_CU).ifPresent(record::setEAN_CU);
+		tableRow.getAsOptionalString(COLUMNNAME_UPC).ifPresent(record::setUPC);
+
+		saveRecord(record);
 
 		tableRow.getAsOptionalIdentifier(COLUMNNAME_C_BPartner_Product_ID)
-				.ifPresent(i -> bpartnerProductTable.putOrReplace(i, ProductRepository.fromRecord(bPartnerProductRecord)));
+				.ifPresent(i -> bpartnerProductTable.putOrReplace(i, ProductRepository.fromRecord(record)));
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
@@ -731,7 +731,7 @@ public class C_Order_StepDef
 
 		row.getAsOptionalString(COLUMNNAME_DocBaseType)
 				.ifPresent(docBaseType -> {
-					final int docTypeRepoId = order.getC_DocType_ID() > 0 ? order.getC_DocType_ID() : order.getC_DocTypeTarget_ID();
+					final int docTypeRepoId = CoalesceUtil.firstGreaterThanZero(order.getC_DocType_ID(), order.getC_DocTypeTarget_ID());
 					final I_C_DocType docType = docTypeDAO.getById(DocTypeId.ofRepoId(docTypeRepoId));
 					softly.assertThat(docType.getDocBaseType()).as("DocBaseType for Identifier=%s", identifierStr).isEqualTo(docBaseType);
 				});

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
@@ -731,7 +731,8 @@ public class C_Order_StepDef
 
 		row.getAsOptionalString(COLUMNNAME_DocBaseType)
 				.ifPresent(docBaseType -> {
-					final I_C_DocType docType = docTypeDAO.getById(DocTypeId.ofRepoId(order.getC_DocType_ID()));
+					final int docTypeRepoId = order.getC_DocType_ID() > 0 ? order.getC_DocType_ID() : order.getC_DocTypeTarget_ID();
+					final I_C_DocType docType = docTypeDAO.getById(DocTypeId.ofRepoId(docTypeRepoId));
 					softly.assertThat(docType.getDocBaseType()).as("DocBaseType for Identifier=%s", identifierStr).isEqualTo(docBaseType);
 				});
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/productplanning/PP_Product_Planning_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/productplanning/PP_Product_Planning_StepDef.java
@@ -86,18 +86,34 @@ public class PP_Product_Planning_StepDef
 
 	private static final ResourceId DEFAULT_PLANT_ID = ResourceId.ofRepoId(540006);
 
+	/**
+	 * Creates or updates a {@code PP_Product_Planning} record for each row via {@link IProductPlanningDAO#save(ProductPlanning)}.
+	 * Matches an existing planning by org/warehouse/plant/product; creates a new one if none is found.
+	 * Key columns: {@code M_Product_ID}, {@code IsCreatePlan} (controls auto-enqueue of C_Order generation),
+	 * {@code IsDocComplete} (controls whether the auto-generated C_Order is completed), {@code IsPurchased},
+	 * {@code IsManufactured}, {@code IsAttributeDependant}, {@code PP_Product_BOMVersions_ID},
+	 * {@code DD_NetworkDistribution_ID}, {@code M_Warehouse_ID}, {@code S_Resource_ID}.
+	 */
 	@Given("metasfresh contains PP_Product_Plannings")
 	public void createOrUpdate(@NonNull final DataTable dataTable)
 	{
 		DataTableRows.of(dataTable).forEach(row -> createOrUpdate(row));
 	}
 
+	/**
+	 * Updates an existing {@code PP_Product_Planning} record. Throws {@link org.adempiere.exceptions.AdempiereException}
+	 * if no matching planning is found; use {@code metasfresh contains PP_Product_Plannings} if upsert behaviour is needed.
+	 */
 	@Given("update existing PP_Product_Plannings")
 	public void updateExisting(@NonNull final DataTable dataTable)
 	{
 		DataTableRows.of(dataTable).forEach(this::updateExisting);
 	}
 
+	/**
+	 * Internal implementation used by both {@link #updateExisting(DataTable)} and {@link #createOrUpdate(DataTableRow)}.
+	 * Delegates to {@link IProductPlanningDAO#save(ProductPlanning)} after applying the data table row values to the builder.
+	 */
 	public void updateExisting(@NonNull final DataTableRow row)
 	{
 		final ProductPlanning productPlanning = getExistingProductPlanning(row).orElseThrow(() -> new AdempiereException("No product planning found for " + row));

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/purchasecandidate/C_PurchaseCandidate_Alloc_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/purchasecandidate/C_PurchaseCandidate_Alloc_StepDef.java
@@ -60,6 +60,13 @@ public class C_PurchaseCandidate_Alloc_StepDef
 		this.orderLineTable = orderLineTable;
 	}
 
+	/**
+	 * Polls (up to {@code timeoutSec} seconds) until a {@code C_PurchaseCandidate_Alloc} record is found
+	 * for each of the given {@code C_PurchaseCandidate} identifiers. The alloc record links a purchase
+	 * candidate to the purchase order line ({@code C_PurchaseCandidate_Alloc.C_OrderLinePO_ID}) created
+	 * when the async PO generation work package is processed. Stores each found alloc record under the
+	 * row's alloc identifier for use in subsequent load steps.
+	 */
 	@And("^after not more than (.*)s, C_PurchaseCandidate_Alloc are found$")
 	public void findC_PurchaseCandidate_Alloc(
 			final int timeoutSec,
@@ -69,6 +76,39 @@ public class C_PurchaseCandidate_Alloc_StepDef
 				.forEach(tableRow -> findC_PurchaseCandidate_Alloc_ByCandidateId(timeoutSec, tableRow));
 	}
 
+	/**
+	 * Asserts that no {@code C_PurchaseCandidate_Alloc} records exist for the given purchase candidates.
+	 * Use this after draining the async queue (e.g. "wait until de.metas.material rabbitMQ queue is empty")
+	 * to confirm that no C_Order was auto-generated (e.g. when {@code PP_Product_Planning.IsCreatePlan=N}).
+	 */
+	@And("no C_PurchaseCandidate_Alloc are found for:")
+	public void assertNoC_PurchaseCandidate_Alloc(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable)
+				.forEach(this::assertNoPurchaseCandidateAlloc);
+	}
+
+	private void assertNoPurchaseCandidateAlloc(@NonNull final DataTableRow tableRow)
+	{
+		final I_C_PurchaseCandidate purchaseCandidateRecord = tableRow.getAsIdentifier(I_C_PurchaseCandidate.COLUMNNAME_C_PurchaseCandidate_ID).lookupNotNullIn(purchaseCandidateTable);
+
+		final long count = queryBL.createQueryBuilder(I_C_PurchaseCandidate_Alloc.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_C_PurchaseCandidate_Alloc.COLUMNNAME_C_PurchaseCandidate_ID, purchaseCandidateRecord.getC_PurchaseCandidate_ID())
+				.create()
+				.count();
+
+		assertThat(count)
+				.as("Expected no C_PurchaseCandidate_Alloc for C_PurchaseCandidate_ID=%s", purchaseCandidateRecord.getC_PurchaseCandidate_ID())
+				.isEqualTo(0);
+	}
+
+	/**
+	 * Loads the purchase order line ({@code C_OrderLine}) that was linked via
+	 * {@code C_PurchaseCandidate_Alloc.C_OrderLinePO_ID} and stores it under the given identifier.
+	 * Prerequisite: the alloc record must have been found and stored by a prior
+	 * "C_PurchaseCandidate_Alloc are found" step.
+	 */
 	@And("load C_OrderLines from C_PurchaseCandidate_Alloc")
 	public void loadC_OrderLines(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/purchasecandidate/C_PurchaseCandidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/purchasecandidate/C_PurchaseCandidate_StepDef.java
@@ -85,6 +85,10 @@ public class C_PurchaseCandidate_StepDef
 		this.orderTable = orderTable;
 	}
 
+	/**
+	 * Asserts that no {@code C_PurchaseCandidate} record exists for the given order line identifier.
+	 * Fails immediately if any candidate is found (no polling).
+	 */
 	@And("^no C_PurchaseCandidate found for orderLine (.*)$")
 	public void validate_no_C_PurchaseCandidate_found(@NonNull final String orderLineIdentifier)
 	{
@@ -101,6 +105,10 @@ public class C_PurchaseCandidate_StepDef
 		}
 	}
 
+	/**
+	 * Polls (up to {@code timeoutSec} seconds) until a {@code C_PurchaseCandidate} matching the given order line and optional quantity appears.
+	 * Stores the found record under the row's identifier for use in later validation steps.
+	 */
 	@And("^after not more than (.*)s, C_PurchaseCandidate found for orderLine (.*)$")
 	public void validate_C_PurchaseCandidate_found_for_OrderLine(
 			final int timeoutSec,
@@ -117,6 +125,14 @@ public class C_PurchaseCandidate_StepDef
 		});
 	}
 
+	/**
+	 * Enqueues the specified {@code C_PurchaseCandidate} records for asynchronous purchase order generation via
+	 * {@link C_PurchaseCandidates_GeneratePurchaseOrders}. The generated work packages are processed by the
+	 * async processor and result in {@code C_Order} (purchase) records and {@code C_PurchaseCandidate_Alloc} links.
+	 * <p>
+	 * Note: since {@code PP_Product_Planning.IsCreatePlan=Y} now triggers auto-enqueue, this manual step is only
+	 * needed when the auto-enqueue path is not active (e.g. for testing the UI workflow explicitly).
+	 */
 	@And("the following C_PurchaseCandidates are enqueued for generating C_Orders")
 	public void enqueueC_PurchaseCandidates(@NonNull final DataTable dataTable)
 	{
@@ -135,6 +151,11 @@ public class C_PurchaseCandidate_StepDef
 		return PurchaseCandidateId.ofRepoId(purchaseCandidateRecord.getC_PurchaseCandidate_ID());
 	}
 
+	/**
+	 * Polls (up to {@code timeoutSec} seconds, checking every 500 ms) until a {@code C_PurchaseCandidate}
+	 * matching the given {@code C_OrderSO_ID}, {@code C_OrderLineSO_ID}, and {@code M_Product_ID} appears.
+	 * Stores each found record under its row identifier for use in later validation steps.
+	 */
 	@And("^after not more than (.*)s, C_PurchaseCandidates are found$")
 	public void find_purchase_candidates(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
 	{
@@ -142,6 +163,11 @@ public class C_PurchaseCandidate_StepDef
 				.forEach(row -> findPurchaseCandidate(timeoutSec, row));
 	}
 
+	/**
+	 * Synchronously validates the state of previously-found {@code C_PurchaseCandidate} records.
+	 * Supported optional columns: {@code OPT.QtyToPurchase}.
+	 * The candidate must have been stored via a prior "C_PurchaseCandidates are found" step.
+	 */
 	@And("C_PurchaseCandidates are validated")
 	public void validate_purchase_candidates(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/materialDispo_purchaseOrder_autoCreateFromProductPlanning.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/materialDispo_purchaseOrder_autoCreateFromProductPlanning.feature
@@ -1,0 +1,239 @@
+@from:cucumber
+@allure.label.epic:E0155_Material_Disposition
+@allure.label.feature:F5100
+@ghActions:run_on_executor6
+Feature: PP_Product_Planning.IsCreatePlan / IsDocComplete automatically create/complete purchase orders from material disposition
+## F5100: Material Disposition
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2021-04-11T08:00:00+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+
+    And load M_AttributeSet:
+      | M_AttributeSet_ID.Identifier   | Name               |
+      | attributeSet_convenienceSalate | Convenience Salate |
+    And load M_Product_Category:
+      | M_Product_Category_ID.Identifier | Name     | Value    |
+      | standard_category                | Standard | Standard |
+    And update M_Product_Category:
+      | M_Product_Category_ID.Identifier | OPT.M_AttributeSet_ID.Identifier |
+      | standard_category                | attributeSet_convenienceSalate   |
+
+  @from:cucumber
+  @allure.label.epic:E0155_Material_Disposition
+  @allure.label.feature:F5100
+  @Id:S0265_10
+  Scenario: IsCreatePlan=Y and IsDocComplete=Y — completing a sales order auto-creates and auto-completes a purchase order
+    Given metasfresh contains M_Products:
+      | Identifier | Name                        | OPT.M_Product_Category_ID.Identifier | OPT.IsSold | OPT.IsPurchased |
+      | p_1        | product_autoCreatePO_S10    | standard_category                    | Y          | Y               |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                               | Value                               | OPT.Description                           | OPT.IsActive |
+      | ps_1       | pricing_system_autoCreatePO_S10    | pricing_system_val_autoCreatePO_S10 | pricing_system_desc_autoCreatePO_S10      | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                              | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | s_price_list_autoCreatePO_S10     | null            | true  | false         | 2              | true         |
+      | pl_2       | ps_1                          | DE                        | EUR                 | p_price_list_autoCreatePO_S10     | null            | false | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                              | ValidFrom  |
+      | plv_1      | pl_1                      | s_PLV_autoCreatePO_S10            | 2021-04-01 |
+      | plv_2      | pl_2                      | p_PLV_autoCreatePO_S10            | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+      | pp_2       | plv_2                             | p_1                     | 10.0     | PCE               | Normal                        |
+    And metasfresh contains M_DiscountSchemas:
+      | Identifier | Name                        | DiscountType | ValidFrom  |
+      | ds_1       | discount_schema_autoCreatePO_S10 | F           | 2021-04-01 |
+    And metasfresh contains M_DiscountSchemaBreaks:
+      | Identifier | M_DiscountSchema_ID.Identifier | M_Product_ID.Identifier | Base_PricingSystem_ID.Identifier | SeqNo | OPT.IsBPartnerFlatDiscount | OPT.PriceBase | OPT.BreakValue | OPT.BreakDiscount |
+      | dsb_1      | ds_1                           | p_1                     | ps_1                             | 10    | Y                          | P             | 10             | 0                 |
+    And metasfresh contains PP_Product_Plannings
+      | Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan | OPT.IsDocComplete | OPT.IsPurchased |
+      | ppln_1     | p_1                     |                                          | true         | true              | Y               |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier    | Name                        | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.PO_DiscountSchema_ID.Identifier |
+      | endcustomer_1 | EndCustomer_autoCreatePO_S10 | N            | Y              | ps_1                          |                                     |
+      | endvendor_1   | EndVendor_autoCreatePO_S10   | Y            | N              | ps_1                          | ds_1                                |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier             | GLN           | C_BPartner_ID.Identifier | OPT.Name                     | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | endvendor_location_1   | 2411250100000 | endvendor_1              | EndVendor_autoCreatePO_S10   | Y                   | Y                   |
+      | endcustomer_location_1 | 2411250100001 | endcustomer_1            | EndCustomer_autoCreatePO_S10 | Y                   | Y                   |
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID.Identifier | M_Product_ID.Identifier |
+      | endvendor_1              | p_1                     |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.PreparationDate  |
+      | o_1        | true    | endcustomer_1            | 2021-04-17  | 2021-04-16T21:00:00Z |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_1       | o_1                   | p_1                     | 5          |
+    When the order identified by o_1 is completed
+
+    Then after not more than 60s, C_PurchaseCandidates are found
+      | Identifier | C_OrderSO_ID.Identifier | C_OrderLineSO_ID.Identifier | M_Product_ID.Identifier |
+      | pc_1       | o_1                     | ol_1                        | p_1                     |
+
+    And after not more than 60s, C_PurchaseCandidate_Alloc are found
+      | C_PurchaseCandidate_ID.Identifier | C_PurchaseCandidate_Alloc_ID.Identifier |
+      | pc_1                              | pca_1                                   |
+
+    And load C_OrderLines from C_PurchaseCandidate_Alloc
+      | C_OrderLinePO_ID.Identifier | C_PurchaseCandidate_Alloc_ID.Identifier |
+      | pol_1                       | pca_1                                   |
+
+    And load C_Order from C_OrderLine
+      | C_Order_ID.Identifier | C_OrderLine_ID.Identifier |
+      | po_1                  | pol_1                     |
+
+    Then validate the created orders
+      | C_Order_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | DeliveryRule | DeliveryViaRule | processed | DocStatus |
+      | po_1                  | endvendor_1              | endvendor_location_1              | 2021-04-16  | POO         | EUR          | F            | P               | true      | CO        |
+
+    And validate C_OrderLine:
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
+      | pol_1                     | po_1                  | 2021-04-16      | p_1                     | 5          | 0            | 0           | 10    | 0        | EUR          | true      |
+
+
+  @from:cucumber
+  @allure.label.epic:E0155_Material_Disposition
+  @allure.label.feature:F5100
+  @Id:S0265_20
+  Scenario: IsCreatePlan=Y and IsDocComplete=N — completing a sales order auto-creates a draft purchase order (not completed)
+    Given metasfresh contains M_Products:
+      | Identifier | Name                        | OPT.M_Product_Category_ID.Identifier | OPT.IsSold | OPT.IsPurchased |
+      | p_1        | product_autoCreatePO_S20    | standard_category                    | Y          | Y               |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                               | Value                               | OPT.Description                           | OPT.IsActive |
+      | ps_1       | pricing_system_autoCreatePO_S20    | pricing_system_val_autoCreatePO_S20 | pricing_system_desc_autoCreatePO_S20      | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                              | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | s_price_list_autoCreatePO_S20     | null            | true  | false         | 2              | true         |
+      | pl_2       | ps_1                          | DE                        | EUR                 | p_price_list_autoCreatePO_S20     | null            | false | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                              | ValidFrom  |
+      | plv_1      | pl_1                      | s_PLV_autoCreatePO_S20            | 2021-04-01 |
+      | plv_2      | pl_2                      | p_PLV_autoCreatePO_S20            | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+      | pp_2       | plv_2                             | p_1                     | 10.0     | PCE               | Normal                        |
+    And metasfresh contains M_DiscountSchemas:
+      | Identifier | Name                        | DiscountType | ValidFrom  |
+      | ds_1       | discount_schema_autoCreatePO_S20 | F           | 2021-04-01 |
+    And metasfresh contains M_DiscountSchemaBreaks:
+      | Identifier | M_DiscountSchema_ID.Identifier | M_Product_ID.Identifier | Base_PricingSystem_ID.Identifier | SeqNo | OPT.IsBPartnerFlatDiscount | OPT.PriceBase | OPT.BreakValue | OPT.BreakDiscount |
+      | dsb_1      | ds_1                           | p_1                     | ps_1                             | 10    | Y                          | P             | 10             | 0                 |
+    And metasfresh contains PP_Product_Plannings
+      | Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan | OPT.IsDocComplete | OPT.IsPurchased |
+      | ppln_1     | p_1                     |                                          | true         | false             | Y               |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier    | Name                        | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.PO_DiscountSchema_ID.Identifier |
+      | endcustomer_1 | EndCustomer_autoCreatePO_S20 | N            | Y              | ps_1                          |                                     |
+      | endvendor_1   | EndVendor_autoCreatePO_S20   | Y            | N              | ps_1                          | ds_1                                |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier             | GLN           | C_BPartner_ID.Identifier | OPT.Name                     | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | endvendor_location_1   | 2411250100002 | endvendor_1              | EndVendor_autoCreatePO_S20   | Y                   | Y                   |
+      | endcustomer_location_1 | 2411250100003 | endcustomer_1            | EndCustomer_autoCreatePO_S20 | Y                   | Y                   |
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID.Identifier | M_Product_ID.Identifier |
+      | endvendor_1              | p_1                     |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.PreparationDate  |
+      | o_1        | true    | endcustomer_1            | 2021-04-17  | 2021-04-16T21:00:00Z |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_1       | o_1                   | p_1                     | 5          |
+    When the order identified by o_1 is completed
+
+    Then after not more than 60s, C_PurchaseCandidates are found
+      | Identifier | C_OrderSO_ID.Identifier | C_OrderLineSO_ID.Identifier | M_Product_ID.Identifier |
+      | pc_1       | o_1                     | ol_1                        | p_1                     |
+
+    And after not more than 60s, C_PurchaseCandidate_Alloc are found
+      | C_PurchaseCandidate_ID.Identifier | C_PurchaseCandidate_Alloc_ID.Identifier |
+      | pc_1                              | pca_1                                   |
+
+    And load C_OrderLines from C_PurchaseCandidate_Alloc
+      | C_OrderLinePO_ID.Identifier | C_PurchaseCandidate_Alloc_ID.Identifier |
+      | pol_1                       | pca_1                                   |
+
+    And load C_Order from C_OrderLine
+      | C_Order_ID.Identifier | C_OrderLine_ID.Identifier |
+      | po_1                  | pol_1                     |
+
+    Then validate the created orders
+      | C_Order_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | DeliveryRule | DeliveryViaRule | processed | DocStatus |
+      | po_1                  | endvendor_1              | endvendor_location_1              | 2021-04-16  | POO         | EUR          | F            | P               | false     | DR        |
+
+    And validate C_OrderLine:
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
+      | pol_1                     | po_1                  | 2021-04-16      | p_1                     | 5          | 0            | 0           | 10    | 0        | EUR          | false     |
+
+
+  @from:cucumber
+  @allure.label.epic:E0155_Material_Disposition
+  @allure.label.feature:F5100
+  @Id:S0265_30
+  Scenario: IsCreatePlan=N — completing a sales order creates a purchase candidate but does NOT auto-create a purchase order
+    Given metasfresh contains M_Products:
+      | Identifier | Name                        | OPT.M_Product_Category_ID.Identifier | OPT.IsSold | OPT.IsPurchased |
+      | p_1        | product_autoCreatePO_S30    | standard_category                    | Y          | Y               |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                               | Value                               | OPT.Description                           | OPT.IsActive |
+      | ps_1       | pricing_system_autoCreatePO_S30    | pricing_system_val_autoCreatePO_S30 | pricing_system_desc_autoCreatePO_S30      | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                              | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_1       | ps_1                          | DE                        | EUR                 | s_price_list_autoCreatePO_S30     | null            | true  | false         | 2              | true         |
+      | pl_2       | ps_1                          | DE                        | EUR                 | p_price_list_autoCreatePO_S30     | null            | false | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                              | ValidFrom  |
+      | plv_1      | pl_1                      | s_PLV_autoCreatePO_S30            | 2021-04-01 |
+      | plv_2      | pl_2                      | p_PLV_autoCreatePO_S30            | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
+      | pp_2       | plv_2                             | p_1                     | 10.0     | PCE               | Normal                        |
+    And metasfresh contains M_DiscountSchemas:
+      | Identifier | Name                        | DiscountType | ValidFrom  |
+      | ds_1       | discount_schema_autoCreatePO_S30 | F           | 2021-04-01 |
+    And metasfresh contains M_DiscountSchemaBreaks:
+      | Identifier | M_DiscountSchema_ID.Identifier | M_Product_ID.Identifier | Base_PricingSystem_ID.Identifier | SeqNo | OPT.IsBPartnerFlatDiscount | OPT.PriceBase | OPT.BreakValue | OPT.BreakDiscount |
+      | dsb_1      | ds_1                           | p_1                     | ps_1                             | 10    | Y                          | P             | 10             | 0                 |
+    And metasfresh contains PP_Product_Plannings
+      | Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan | OPT.IsPurchased |
+      | ppln_1     | p_1                     |                                          | false        | Y               |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier    | Name                        | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.PO_DiscountSchema_ID.Identifier |
+      | endcustomer_1 | EndCustomer_autoCreatePO_S30 | N            | Y              | ps_1                          |                                     |
+      | endvendor_1   | EndVendor_autoCreatePO_S30   | Y            | N              | ps_1                          | ds_1                                |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier             | GLN           | C_BPartner_ID.Identifier | OPT.Name                     | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | endvendor_location_1   | 2411250100004 | endvendor_1              | EndVendor_autoCreatePO_S30   | Y                   | Y                   |
+      | endcustomer_location_1 | 2411250100005 | endcustomer_1            | EndCustomer_autoCreatePO_S30 | Y                   | Y                   |
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID.Identifier | M_Product_ID.Identifier |
+      | endvendor_1              | p_1                     |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.PreparationDate  |
+      | o_1        | true    | endcustomer_1            | 2021-04-17  | 2021-04-16T21:00:00Z |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_1       | o_1                   | p_1                     | 5          |
+    When the order identified by o_1 is completed
+
+    Then after not more than 60s, C_PurchaseCandidates are found
+      | Identifier | C_OrderSO_ID.Identifier | C_OrderLineSO_ID.Identifier | M_Product_ID.Identifier |
+      | pc_1       | o_1                     | ol_1                        | p_1                     |
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And no C_PurchaseCandidate_Alloc are found for:
+      | C_PurchaseCandidate_ID.Identifier |
+      | pc_1                              |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/materialDispo_purchaseOrder_autoCreateFromProductPlanning.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/materialDispo_purchaseOrder_autoCreateFromProductPlanning.feature
@@ -98,6 +98,22 @@ Feature: PP_Product_Planning.IsCreatePlan / IsDocComplete automatically create/c
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
       | pol_1                     | po_1                  | 2021-04-16      | p_1                     | 5          | 0            | 0           | 10    | 0        | EUR          | true      |
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected        | Qty | Qty_AvailableToPromise |
+      | c_1        | DEMAND            | SHIPMENT                      | p_1                     | 2021-04-16T21:00:00Z | -5  | -5                     |
+      | c_2        | SUPPLY            | PURCHASE                      | p_1                     | 2021-04-16T21:00:00Z | 5   | 0                      |
+
+    And after not more than 90s, metasfresh has this MD_Cockpit data
+      | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
+      | cp_1       | p_1                     | 2021-04-16  | 5                               | 5                       | 5                       | 5                            | 0                             | 0                              | 0                              | 0                          | 5                                  |
+
+    And after not more than 60s, metasfresh has this MD_Cockpit_DocumentDetail data
+      | MD_Cockpit_DocumentDetail_ID.Identifier | MD_Cockpit_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyOrdered | OPT.QtyReserved |
+      | cp_dd_1                                 | cp_1                     | ol_1                      | 5              | 5               |
+      | cp_dd_2                                 | cp_1                     | pol_1                     | 5              | 5               |
+
 
   @from:cucumber
   @allure.label.epic:E0155_Material_Disposition
@@ -175,6 +191,21 @@ Feature: PP_Product_Planning.IsCreatePlan / IsDocComplete automatically create/c
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
       | pol_1                     | po_1                  | 2021-04-16      | p_1                     | 5          | 0            | 0           | 10    | 0        | EUR          | false     |
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected        | Qty | Qty_AvailableToPromise |
+      | c_1        | DEMAND            | SHIPMENT                      | p_1                     | 2021-04-16T21:00:00Z | -5  | -5                     |
+      | c_2        | SUPPLY            | PURCHASE                      | p_1                     | 2021-04-16T21:00:00Z | 5   | 0                      |
+
+    And after not more than 90s, metasfresh has this MD_Cockpit data
+      | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
+      | cp_1       | p_1                     | 2021-04-16  | 5                               | 5                       | 5                       | 5                            | 0                             | 0                              | 0                              | 0                          | 0                                  |
+
+    And after not more than 60s, metasfresh has this MD_Cockpit_DocumentDetail data
+      | MD_Cockpit_DocumentDetail_ID.Identifier | MD_Cockpit_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyOrdered | OPT.QtyReserved |
+      | cp_dd_1                                 | cp_1                     | ol_1                      | 5              | 5               |
+
 
   @from:cucumber
   @allure.label.epic:E0155_Material_Disposition
@@ -237,3 +268,16 @@ Feature: PP_Product_Planning.IsCreatePlan / IsDocComplete automatically create/c
     And no C_PurchaseCandidate_Alloc are found for:
       | C_PurchaseCandidate_ID.Identifier |
       | pc_1                              |
+
+    And after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected        | Qty | Qty_AvailableToPromise |
+      | c_1        | DEMAND            | SHIPMENT                      | p_1                     | 2021-04-16T21:00:00Z | -5  | -5                     |
+      | c_2        | SUPPLY            | PURCHASE                      | p_1                     | 2021-04-16T21:00:00Z | 5   | 0                      |
+
+    And after not more than 90s, metasfresh has this MD_Cockpit data
+      | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
+      | cp_1       | p_1                     | 2021-04-16  | 5                               | 5                       | 5                       | 5                            | 0                             | 0                              | 0                              | 0                          | 0                                  |
+
+    And after not more than 60s, metasfresh has this MD_Cockpit_DocumentDetail data
+      | MD_Cockpit_DocumentDetail_ID.Identifier | MD_Cockpit_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyOrdered | OPT.QtyReserved |
+      | cp_dd_1                                 | cp_1                     | ol_1                      | 5              | 5               |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/materialDispo_purchaseOrder_autoCreateFromProductPlanning.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/materialDispo_purchaseOrder_autoCreateFromProductPlanning.feature
@@ -200,7 +200,7 @@ Feature: PP_Product_Planning.IsCreatePlan / IsDocComplete automatically create/c
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
-      | cp_1       | p_1                     | 2021-04-16  | 5                               | 5                       | 5                       | 5                            | 0                             | 0                              | 0                              | 0                          | 0                                  |
+      | cp_1       | p_1                     | 2021-04-16  | 5                               | 5                       | 0                       | 5                            | -5                            | 5                              | 0                              | 0                          | 0                                  |
 
     And after not more than 60s, metasfresh has this MD_Cockpit_DocumentDetail data
       | MD_Cockpit_DocumentDetail_ID.Identifier | MD_Cockpit_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyOrdered | OPT.QtyReserved |
@@ -276,7 +276,7 @@ Feature: PP_Product_Planning.IsCreatePlan / IsDocComplete automatically create/c
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
-      | cp_1       | p_1                     | 2021-04-16  | 5                               | 5                       | 5                       | 5                            | 0                             | 0                              | 0                              | 0                          | 0                                  |
+      | cp_1       | p_1                     | 2021-04-16  | 5                               | 5                       | 0                       | 5                            | -5                            | 5                              | 0                              | 0                          | 0                                  |
 
     And after not more than 60s, metasfresh has this MD_Cockpit_DocumentDetail data
       | MD_Cockpit_DocumentDetail_ID.Identifier | MD_Cockpit_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyOrdered | OPT.QtyReserved |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/supplyRequiredQtyViaPurchase.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/supplyRequiredQtyViaPurchase.feature
@@ -58,8 +58,8 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
       | dsb_1      | ds_1                           | p_1                     | ps_1                             | 10    | Y                          | P             | 10             | 0                 |
 
     And metasfresh contains PP_Product_Plannings
-      | Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan | OPT.IsPurchased |
-      | ppln_1     | p_1                     |                                          | true         | Y               |
+      | Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan | OPT.IsDocComplete | OPT.IsPurchased |
+      | ppln_1     | p_1                     |                                          | true         | true              | Y               |
     And metasfresh contains C_BPartners without locations:
       | Identifier    | Name                   | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.PO_DiscountSchema_ID.Identifier |
       | endcustomer_1 | EndCustomer_01042022_1 | N            | Y              | ps_1                          |                                     |
@@ -136,10 +136,6 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
       | MD_Cockpit_DocumentDetail_ID.Identifier | MD_Cockpit_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyOrdered | OPT.QtyReserved |
       | cp_dd_1                                 | cp_1                     | ol_1                      | 10             | 10              |
 
-    And the following C_PurchaseCandidates are enqueued for generating C_Orders
-      | C_PurchaseCandidate_ID.Identifier |
-      | pc_1                              |
-
     And after not more than 60s, C_PurchaseCandidate_Alloc are found
       | C_PurchaseCandidate_ID.Identifier | C_PurchaseCandidate_Alloc_ID.Identifier |
       | pc_1                              | pca_1                                   |
@@ -208,8 +204,8 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
       | dsb_1      | ds_1                           | p_1                     | ps_1                             | 10    | Y                          | P             | 10             | 0                 |
 
     And metasfresh contains PP_Product_Plannings
-      | Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan | OPT.IsPurchased |
-      | ppln_1     | p_1                     |                                          | true         | Y               |
+      | Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan | OPT.IsDocComplete | OPT.IsPurchased |
+      | ppln_1     | p_1                     |                                          | true         | true              | Y               |
     And metasfresh contains C_BPartners without locations:
       | Identifier    | Name                   | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.PO_DiscountSchema_ID.Identifier |
       | endcustomer_1 | EndCustomer_01042022_2 | N            | Y              | ps_1                          |                                     |
@@ -290,10 +286,6 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
     And after not more than 60s, metasfresh has this MD_Cockpit_DocumentDetail data
       | MD_Cockpit_DocumentDetail_ID.Identifier | MD_Cockpit_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyOrdered | OPT.QtyReserved |
       | cp_dd_1                                 | cp_1                     | ol_1                      | 10             | 10              |
-
-    And the following C_PurchaseCandidates are enqueued for generating C_Orders
-      | C_PurchaseCandidate_ID.Identifier |
-      | pc_1                              |
 
     And after not more than 60s, C_PurchaseCandidate_Alloc are found
       | C_PurchaseCandidate_ID.Identifier | C_PurchaseCandidate_Alloc_ID.Identifier |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/supplyRequiredQtyViaPurchase.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/supplyRequiredQtyViaPurchase.feature
@@ -126,16 +126,6 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
       | c_3        | DEMAND            | SHIPMENT                      | p_1                     | 2021-04-16T21:00:00Z | -10 | -10                    |                                 |
       | c_4        | SUPPLY            | PURCHASE                      | p_1                     | 2021-04-16T21:00:00Z | 10  | 0                      |                                 |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
-
-    And after not more than 90s, metasfresh has this MD_Cockpit data
-      | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
-      | cp_1       | p_1                     | 2021-04-16  |                              | 10                              | 10                      | 0                       | 10                           | -10                           | 10                             | 0                              | 0                          | 0                                  |
-
-    And after not more than 60s, metasfresh has this MD_Cockpit_DocumentDetail data
-      | MD_Cockpit_DocumentDetail_ID.Identifier | MD_Cockpit_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyOrdered | OPT.QtyReserved |
-      | cp_dd_1                                 | cp_1                     | ol_1                      | 10             | 10              |
-
     And after not more than 60s, C_PurchaseCandidate_Alloc are found
       | C_PurchaseCandidate_ID.Identifier | C_PurchaseCandidate_Alloc_ID.Identifier |
       | pc_1                              | pca_1                                   |
@@ -276,16 +266,6 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
       | c_3        | INVENTORY_DOWN    |                               | p_1                     | 2021-04-16T21:00:00Z | -10 | 5                      |                                 |
       | c_4        | DEMAND            | SHIPMENT                      | p_1                     | 2021-04-16T21:00:00Z | -10 | -5                     |                                 |
       | c_5        | SUPPLY            | PURCHASE                      | p_1                     | 2021-04-16T21:00:00Z | 5   | 0                      |                                 |
-
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
-
-    And after not more than 90s, metasfresh has this MD_Cockpit data
-      | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
-      | cp_1       | p_1                     | 2021-04-16  |                              | 10                              | 10                      | 0                       | 5                            | -10                           | 5                              | 0                              | 0                          | 0                                  |
-
-    And after not more than 60s, metasfresh has this MD_Cockpit_DocumentDetail data
-      | MD_Cockpit_DocumentDetail_ID.Identifier | MD_Cockpit_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyOrdered | OPT.QtyReserved |
-      | cp_dd_1                                 | cp_1                     | ol_1                      | 10             | 10              |
 
     And after not more than 60s, C_PurchaseCandidate_Alloc are found
       | C_PurchaseCandidate_ID.Identifier | C_PurchaseCandidate_Alloc_ID.Identifier |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/supplyRequiredQtyViaPurchase.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/supplyRequiredQtyViaPurchase.feature
@@ -33,18 +33,18 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
   No stock available at demand time, supplied via purchased
     Given metasfresh contains M_Products:
       | Identifier | Name               | OPT.M_Product_Category_ID.Identifier | OPT.IsSold | OPT.IsPurchased |
-      | p_1        | product_01042022_1 | standard_category                    | Y          | Y               |
+      | p_1        | product_supRqPo_1 | standard_category                    | Y          | Y               |
     And metasfresh contains M_PricingSystems
       | Identifier | Name                           | Value                           | OPT.Description                       | OPT.IsActive |
-      | ps_1       | pricing_system_name_01042022_1 | pricing_system_value_01042022_1 | pricing_system_description_01042022_1 | true         |
+      | ps_1       | pricing_system_name_supRqPo_1 | pricing_system_value_supRqPo_1 | pricing_system_description_supRqPo_1 | true         |
     And metasfresh contains M_PriceLists
       | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                         | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
-      | pl_1       | ps_1                          | DE                        | EUR                 | s_price_list_name_01042022_1 | null            | true  | false         | 2              | true         |
-      | pl_2       | ps_1                          | DE                        | EUR                 | p_price_list_name_01042022_1 | null            | false | false         | 2              | true         |
+      | pl_1       | ps_1                          | DE                        | EUR                 | s_price_list_name_supRqPo_1 | null            | true  | false         | 2              | true         |
+      | pl_2       | ps_1                          | DE                        | EUR                 | p_price_list_name_supRqPo_1 | null            | false | false         | 2              | true         |
     And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID.Identifier | Name                           | ValidFrom  |
-      | plv_1      | pl_1                      | s_trackedProduct-PLV01042022_1 | 2021-04-01 |
-      | plv_2      | pl_2                      | p_trackedProduct-PLV01042022_1 | 2021-04-01 |
+      | plv_1      | pl_1                      | s_trackedProduct-PLVsupRqPo_1 | 2021-04-01 |
+      | plv_2      | pl_2                      | p_trackedProduct-PLVsupRqPo_1 | 2021-04-01 |
     And metasfresh contains M_ProductPrices
       | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
       | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
@@ -52,7 +52,7 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
 
     And metasfresh contains M_DiscountSchemas:
       | Identifier | Name              | DiscountType | ValidFrom  |
-      | ds_1       | discount_schema_1 | F            | 2021-04-01 |
+      | ds_1       | discount_schema_supRqPo_1 | F            | 2021-04-01 |
     And metasfresh contains M_DiscountSchemaBreaks:
       | Identifier | M_DiscountSchema_ID.Identifier | M_Product_ID.Identifier | Base_PricingSystem_ID.Identifier | SeqNo | OPT.IsBPartnerFlatDiscount | OPT.PriceBase | OPT.BreakValue | OPT.BreakDiscount |
       | dsb_1      | ds_1                           | p_1                     | ps_1                             | 10    | Y                          | P             | 10             | 0                 |
@@ -62,12 +62,12 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
       | ppln_1     | p_1                     |                                          | true         | true              | Y               |
     And metasfresh contains C_BPartners without locations:
       | Identifier    | Name                   | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.PO_DiscountSchema_ID.Identifier |
-      | endcustomer_1 | EndCustomer_01042022_1 | N            | Y              | ps_1                          |                                     |
-      | endvendor_1   | EndVendor_01042022_1   | Y            | N              | ps_1                          | ds_1                                |
+      | endcustomer_1 | EndCustomer_supRqPo_1 | N            | Y              | ps_1                          |                                     |
+      | endvendor_1   | EndVendor_supRqPo_1   | Y            | N              | ps_1                          | ds_1                                |
     And metasfresh contains C_BPartner_Locations:
       | Identifier             | GLN           | C_BPartner_ID.Identifier | OPT.Name             | OPT.IsShipToDefault | OPT.IsBillToDefault |
-      | endvendor_location_1   | 2311202200000 | endvendor_1              | EndVendor_01042022_1 | Y                   | Y                   |
-      | endcustomer_location_1 | 2311202200001 | endcustomer_1            | EndVendor_01042022_1 | Y                   | Y                   |
+      | endvendor_location_1   | 2311202200000 | endvendor_1              | EndVendor_supRqPo_1 | Y                   | Y                   |
+      | endcustomer_location_1 | 2311202200001 | endcustomer_1            | EndVendor_supRqPo_1 | Y                   | Y                   |
     And metasfresh contains C_BPartner_Product
       | C_BPartner_ID.Identifier | M_Product_ID.Identifier |
       | endvendor_1              | p_1                     |
@@ -179,18 +179,18 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
   Partial stock available at demand time, supplied via purchased
     Given metasfresh contains M_Products:
       | Identifier | Name               | OPT.M_Product_Category_ID.Identifier | OPT.IsSold | OPT.IsPurchased |
-      | p_1        | product_01042022_2 | standard_category                    | Y          | Y               |
+      | p_1        | product_supRqPo_2 | standard_category                    | Y          | Y               |
     And metasfresh contains M_PricingSystems
       | Identifier | Name                           | Value                           | OPT.Description                       | OPT.IsActive |
-      | ps_1       | pricing_system_name_01042022_2 | pricing_system_value_01042022_2 | pricing_system_description_01042022_2 | true         |
+      | ps_1       | pricing_system_name_supRqPo_2 | pricing_system_value_supRqPo_2 | pricing_system_description_supRqPo_2 | true         |
     And metasfresh contains M_PriceLists
       | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                         | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
-      | pl_1       | ps_1                          | DE                        | EUR                 | s_price_list_name_01042022_2 | null            | true  | false         | 2              | true         |
-      | pl_2       | ps_1                          | DE                        | EUR                 | p_price_list_name_01042022_2 | null            | false | false         | 2              | true         |
+      | pl_1       | ps_1                          | DE                        | EUR                 | s_price_list_name_supRqPo_2 | null            | true  | false         | 2              | true         |
+      | pl_2       | ps_1                          | DE                        | EUR                 | p_price_list_name_supRqPo_2 | null            | false | false         | 2              | true         |
     And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID.Identifier | Name                           | ValidFrom  |
-      | plv_1      | pl_1                      | s_trackedProduct-PLV01042022_2 | 2021-04-01 |
-      | plv_2      | pl_2                      | p_trackedProduct-PLV01042022_2 | 2021-04-01 |
+      | plv_1      | pl_1                      | s_trackedProduct-PLVsupRqPo_2 | 2021-04-01 |
+      | plv_2      | pl_2                      | p_trackedProduct-PLVsupRqPo_2 | 2021-04-01 |
     And metasfresh contains M_ProductPrices
       | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
       | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
@@ -198,7 +198,7 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
 
     And metasfresh contains M_DiscountSchemas:
       | Identifier | Name                       | DiscountType | ValidFrom  |
-      | ds_1       | discount_schema_01042022_2 | F            | 2021-04-01 |
+      | ds_1       | discount_schema_supRqPo_2 | F            | 2021-04-01 |
     And metasfresh contains M_DiscountSchemaBreaks:
       | Identifier | M_DiscountSchema_ID.Identifier | M_Product_ID.Identifier | Base_PricingSystem_ID.Identifier | SeqNo | OPT.IsBPartnerFlatDiscount | OPT.PriceBase | OPT.BreakValue | OPT.BreakDiscount |
       | dsb_1      | ds_1                           | p_1                     | ps_1                             | 10    | Y                          | P             | 10             | 0                 |
@@ -208,12 +208,12 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
       | ppln_1     | p_1                     |                                          | true         | true              | Y               |
     And metasfresh contains C_BPartners without locations:
       | Identifier    | Name                   | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.PO_DiscountSchema_ID.Identifier |
-      | endcustomer_1 | EndCustomer_01042022_2 | N            | Y              | ps_1                          |                                     |
-      | endvendor_1   | EndVendor_01042022_2   | Y            | N              | ps_1                          | ds_1                                |
+      | endcustomer_1 | EndCustomer_supRqPo_2 | N            | Y              | ps_1                          |                                     |
+      | endvendor_1   | EndVendor_supRqPo_2   | Y            | N              | ps_1                          | ds_1                                |
     And metasfresh contains C_BPartner_Locations:
       | Identifier             | GLN           | C_BPartner_ID.Identifier | OPT.Name             | OPT.IsShipToDefault | OPT.IsBillToDefault |
-      | endvendor_location_1   | 2311202200002 | endvendor_1              | EndVendor_01042022_2 | Y                   | Y                   |
-      | endcustomer_location_1 | 2311202200003 | endcustomer_1            | EndVendor_01042022_2 | Y                   | Y                   |
+      | endvendor_location_1   | 2311202200002 | endvendor_1              | EndVendor_supRqPo_2 | Y                   | Y                   |
+      | endcustomer_location_1 | 2311202200003 | endcustomer_1            | EndVendor_supRqPo_2 | Y                   | Y                   |
     And metasfresh contains C_BPartner_Product
       | C_BPartner_ID.Identifier | M_Product_ID.Identifier |
       | endvendor_1              | p_1                     |
@@ -328,18 +328,18 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
   Stock available at demand time, no supply needed
     Given metasfresh contains M_Products:
       | Identifier | Name               | OPT.M_Product_Category_ID.Identifier | OPT.IsSold | OPT.IsPurchased |
-      | p_1        | product_01042022_3 | standard_category                    | Y          | Y               |
+      | p_1        | product_supRqPo_3 | standard_category                    | Y          | Y               |
     And metasfresh contains M_PricingSystems
       | Identifier | Name                           | Value                           | OPT.Description                       | OPT.IsActive |
-      | ps_1       | pricing_system_name_01042022_3 | pricing_system_value_01042022_3 | pricing_system_description_01042022_3 | true         |
+      | ps_1       | pricing_system_name_supRqPo_3 | pricing_system_value_supRqPo_3 | pricing_system_description_supRqPo_3 | true         |
     And metasfresh contains M_PriceLists
       | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                         | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
-      | pl_1       | ps_1                          | DE                        | EUR                 | s_price_list_name_01042022_3 | null            | true  | false         | 2              | true         |
-      | pl_2       | ps_1                          | DE                        | EUR                 | p_price_list_name_01042022_3 | null            | false | false         | 2              | true         |
+      | pl_1       | ps_1                          | DE                        | EUR                 | s_price_list_name_supRqPo_3 | null            | true  | false         | 2              | true         |
+      | pl_2       | ps_1                          | DE                        | EUR                 | p_price_list_name_supRqPo_3 | null            | false | false         | 2              | true         |
     And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID.Identifier | Name                           | ValidFrom  |
-      | plv_1      | pl_1                      | s_trackedProduct-PLV01042022_3 | 2021-04-01 |
-      | plv_2      | pl_2                      | p_trackedProduct-PLV01042022_3 | 2021-04-01 |
+      | plv_1      | pl_1                      | s_trackedProduct-PLVsupRqPo_3 | 2021-04-01 |
+      | plv_2      | pl_2                      | p_trackedProduct-PLVsupRqPo_3 | 2021-04-01 |
     And metasfresh contains M_ProductPrices
       | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
       | pp_1       | plv_1                             | p_1                     | 10.0     | PCE               | Normal                        |
@@ -347,7 +347,7 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
 
     And metasfresh contains M_DiscountSchemas:
       | Identifier | Name                       | DiscountType | ValidFrom  |
-      | ds_1       | discount_schema_01042022_3 | F            | 2021-04-01 |
+      | ds_1       | discount_schema_supRqPo_3 | F            | 2021-04-01 |
     And metasfresh contains M_DiscountSchemaBreaks:
       | Identifier | M_DiscountSchema_ID.Identifier | M_Product_ID.Identifier | Base_PricingSystem_ID.Identifier | SeqNo | OPT.IsBPartnerFlatDiscount | OPT.PriceBase | OPT.BreakValue | OPT.BreakDiscount |
       | dsb_1      | ds_1                           | p_1                     | ps_1                             | 10    | Y                          | P             | 10             | 0                 |
@@ -357,8 +357,8 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
       | ppln_1     | p_1                     |                                          | true         | Y               |
     And metasfresh contains C_BPartners:
       | Identifier    | Name                   | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.PO_DiscountSchema_ID.Identifier |
-      | endcustomer_1 | EndCustomer_01042022_3 | N            | Y              | ps_1                          |                                     |
-      | endvendor_1   | EndVendor_01042022_3   | Y            | N              | ps_1                          | ds_1                                |
+      | endcustomer_1 | EndCustomer_supRqPo_3 | N            | Y              | ps_1                          |                                     |
+      | endvendor_1   | EndVendor_supRqPo_3   | Y            | N              | ps_1                          | ds_1                                |
     And metasfresh contains C_BPartner_Product
       | C_BPartner_ID.Identifier | M_Product_ID.Identifier |
       | endvendor_1              | p_1                     |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderProjectToSO.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderProjectToSO.feature
@@ -46,8 +46,8 @@ Feature: Purchase order project is automatically created when PO is completed
       | dsb_1      | ds_1                | p_1          | ps_1                  | 10    | Y                      | P         | 10         | 0             |
 
     And metasfresh contains PP_Product_Plannings
-      | Identifier | M_Product_ID | IsCreatePlan | IsPurchased |
-      | ppln_1     | p_1          | true         | Y           |
+      | Identifier | M_Product_ID | IsCreatePlan | OPT.IsDocComplete | IsPurchased |
+      | ppln_1     | p_1          | true         | true              | Y           |
     And metasfresh contains C_BPartners without locations:
       | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID | PO_DiscountSchema_ID |
       | customer_1 | N        | Y          | ps_1               |                      |
@@ -76,10 +76,6 @@ Feature: Purchase order project is automatically created when PO is completed
       | pc_1                   | 10            |
 
     And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
-
-    And the following C_PurchaseCandidates are enqueued for generating C_Orders
-      | C_PurchaseCandidate_ID |
-      | pc_1                   |
 
     And after not more than 60s, C_PurchaseCandidate_Alloc are found
       | C_PurchaseCandidate_ID | C_PurchaseCandidate_Alloc_ID |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/simulation/purchaseSimulation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/simulation/purchaseSimulation.feature
@@ -74,8 +74,8 @@ Feature: create purchase simulation
 @allure.label.feature:F00106
   Scenario: Create Sales Order. Create C_PurchaseCandidate. Create C_Order for it. Reactivate and reduce qty. C_PurchaseCandidate is not adjusted.
     When update existing PP_Product_Plannings
-      | Identifier | IsCreatePlan |
-      | ppln_1     | true         |
+      | Identifier | IsCreatePlan | OPT.IsDocComplete |
+      | ppln_1     | true         | true              |
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | PreparationDate      |
       | o_1        | true    | customer_1    | 2021-04-04  | 2021-04-04T00:00:00Z |
@@ -91,10 +91,6 @@ Feature: create purchase simulation
       | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | Qty_AvailableToPromise | C_Purchase_Candidate_ID |
       | c_1        | DEMAND            | SHIPMENT                  | p_1          | 2021-04-04T00:00:00Z | 100 | -100                   |                         |
       | c_2        | SUPPLY            | PURCHASE                  | p_1          | 2021-04-04T00:00:00Z | 100 | 0                      | pc_1                    |
-
-    And the following C_PurchaseCandidates are enqueued for generating C_Orders
-      | C_PurchaseCandidate_ID |
-      | pc_1                   |
 
     And after not more than 60s, C_PurchaseCandidate_Alloc are found
       | C_PurchaseCandidate_ID | C_PurchaseCandidate_Alloc_ID |

--- a/backend/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/purchasecandidate/PurchaseCandidateAdvisedHandler.java
+++ b/backend/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/purchasecandidate/PurchaseCandidateAdvisedHandler.java
@@ -128,15 +128,14 @@ public final class PurchaseCandidateAdvisedHandler
 				.build();
 
 		final MaterialDispoGroupId groupId = candidateChangeHandler.onCandidateNewOrChange(supplyCandidate).getGroupId().orElse(null);
-		if (event.isDirectlyCreatePurchaseCandidate())
+		if (groupId == null)
 		{
-			if (groupId == null)
-			{
-				throw new AdempiereException("No groupId");
-			}
-			
-			// the group contains just one item, i.e. the supplyCandidate, but for the same of generic-ness we use that same interface that's also used for production and distribution
-			requestMaterialOrderService.requestMaterialOrderForCandidates(groupId, event.getEventDescriptor());
+			throw new AdempiereException("No groupId");
 		}
+
+		// the group contains just one item, i.e. the supplyCandidate, but for the sake of generic-ness we use that same interface that's also used for production and distribution
+		// Always request a purchase candidate — whether to also auto-create/complete a C_Order is controlled by PP_Product_Planning.IsCreatePlan and IsDocComplete,
+		// and is handled downstream in PurchaseCandidateRequestedHandler.
+		requestMaterialOrderService.requestMaterialOrderForCandidates(groupId, event.getEventDescriptor());
 	}
 }

--- a/backend/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/purchasecandidate/PurchaseCandidateAdvisedHandler.java
+++ b/backend/de.metas.material/dispo-service/src/main/java/de/metas/material/dispo/service/event/handler/purchasecandidate/PurchaseCandidateAdvisedHandler.java
@@ -17,8 +17,8 @@ import de.metas.material.event.MaterialEventHandler;
 import de.metas.material.event.commons.SupplyRequiredDescriptor;
 import de.metas.material.event.pporder.MaterialDispoGroupId;
 import de.metas.material.event.purchase.PurchaseCandidateAdvisedEvent;
+import de.metas.util.Check;
 import lombok.NonNull;
-import org.adempiere.exceptions.AdempiereException;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -127,11 +127,9 @@ public final class PurchaseCandidateAdvisedHandler
 				.simulated(supplyRequiredDescriptor.isSimulated())
 				.build();
 
-		final MaterialDispoGroupId groupId = candidateChangeHandler.onCandidateNewOrChange(supplyCandidate).getGroupId().orElse(null);
-		if (groupId == null)
-		{
-			throw new AdempiereException("No groupId");
-		}
+		final MaterialDispoGroupId groupId = Check.assumeNotNull(
+				candidateChangeHandler.onCandidateNewOrChange(supplyCandidate).getGroupId().orElse(null),
+				"onCandidateNewOrChange should always return a groupId for supplyCandidate={}", supplyCandidate);
 
 		// the group contains just one item, i.e. the supplyCandidate, but for the sake of generic-ness we use that same interface that's also used for production and distribution
 		// Always request a purchase candidate — whether to also auto-create/complete a C_Order is controlled by PP_Product_Planning.IsCreatePlan and IsDocComplete,

--- a/backend/de.metas.material/event/src/main/java/de/metas/material/event/purchase/PurchaseCandidateAdvisedEvent.java
+++ b/backend/de.metas.material/event/src/main/java/de/metas/material/event/purchase/PurchaseCandidateAdvisedEvent.java
@@ -46,6 +46,14 @@ public class PurchaseCandidateAdvisedEvent implements MaterialEvent
 
 	int productPlanningId;
 
+	/**
+	 * @deprecated This field is no longer used to gate purchase candidate creation.
+	 * All advised events now unconditionally create a {@code C_PurchaseCandidate}.
+	 * Whether to auto-create/complete a {@code C_Order} is controlled by
+	 * {@code PP_Product_Planning.IsCreatePlan} and {@code IsDocComplete} downstream.
+	 * Kept in the constructor for backward JSON deserialization compatibility during rolling deploys.
+	 */
+	@Deprecated
 	boolean directlyCreatePurchaseCandidate;
 
 	int vendorId;

--- a/backend/de.metas.material/event/src/main/java/de/metas/material/event/purchase/PurchaseCandidateAdvisedEvent.java
+++ b/backend/de.metas.material/event/src/main/java/de/metas/material/event/purchase/PurchaseCandidateAdvisedEvent.java
@@ -46,16 +46,6 @@ public class PurchaseCandidateAdvisedEvent implements MaterialEvent
 
 	int productPlanningId;
 
-	/**
-	 * @deprecated This field is no longer used to gate purchase candidate creation.
-	 * All advised events now unconditionally create a {@code C_PurchaseCandidate}.
-	 * Whether to auto-create/complete a {@code C_Order} is controlled by
-	 * {@code PP_Product_Planning.IsCreatePlan} and {@code IsDocComplete} downstream.
-	 * Kept in the constructor for backward JSON deserialization compatibility during rolling deploys.
-	 */
-	@Deprecated
-	boolean directlyCreatePurchaseCandidate;
-
 	int vendorId;
 
 	@Builder
@@ -64,14 +54,12 @@ public class PurchaseCandidateAdvisedEvent implements MaterialEvent
 			@JsonProperty("eventDescriptor") @NonNull final EventDescriptor eventDescriptor,
 			@JsonProperty("supplyRequiredDescriptor") @NonNull final SupplyRequiredDescriptor supplyRequiredDescriptor,
 			@JsonProperty("productPlanningId") final int productPlanningId,
-			@JsonProperty("directlyCreatePurchaseCandidate") final boolean directlyCreatePurchaseCandidate,
 			@JsonProperty("vendorId") final int vendorId)
 	{
 		this.eventDescriptor = eventDescriptor;
 		this.supplyRequiredDescriptor = supplyRequiredDescriptor;
 		this.productPlanningId = Check.assumeGreaterThanZero(productPlanningId, "productPlanningId");
 		this.vendorId = vendorId;
-		this.directlyCreatePurchaseCandidate = directlyCreatePurchaseCandidate;
 	}
 
 	@Override

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/async/C_PurchaseCandidates_GeneratePurchaseOrders.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/async/C_PurchaseCandidates_GeneratePurchaseOrders.java
@@ -62,13 +62,17 @@ import static org.adempiere.model.InterfaceWrapperHelper.loadByIds;
 /**
  * Aggregates enqueued {@link PurchaseCandidate}s and generates purchase orders.
  * <p>
- * Also, {@link #enqueue(Collection)} method is used to enqueue purchase candidates.
+ * Use {@link #enqueue(Collection)}, {@link #enqueue(Collection, DocTypeId)}, or
+ * {@link #enqueue(Collection, DocTypeId, boolean)} to enqueue purchase candidates.
+ * The {@code isCompleteDoc} flag (default {@code true}) controls whether the generated
+ * {@code C_Order} is immediately completed (DocStatus=CO) or left as a draft (DocStatus=DR).
  *
  * @author metas-dev <dev@metasfresh.com>
  */
 public class C_PurchaseCandidates_GeneratePurchaseOrders extends WorkpackageProcessorAdapter
 {
 	public static final String DOC_TYPE_ID = "C_Doctype_Target_ID";
+	public static final String IS_COMPLETE_DOC = "IsCompleteDoc";
 	private final PurchaseCandidateRepository purchaseCandidateRepo = SpringContextHolder.instance.getBean(PurchaseCandidateRepository.class);
 	private final VendorGatewayInvokerFactory vendorGatewayInvokerFactory = SpringContextHolder.instance.getBean(VendorGatewayInvokerFactory.class);
 
@@ -78,6 +82,21 @@ public class C_PurchaseCandidates_GeneratePurchaseOrders extends WorkpackageProc
 	}
 
 	public static void enqueue(@NonNull final Collection<PurchaseCandidateId> purchaseCandidateIds, @Nullable final DocTypeId docTypeId)
+	{
+		enqueue(purchaseCandidateIds, docTypeId, /* isCompleteDoc= */ true);
+	}
+
+	/**
+	 * Enqueues the given purchase candidates for asynchronous purchase order generation.
+	 *
+	 * @param isCompleteDoc if {@code true}, the generated C_Order will be completed (DocStatus=CO);
+	 *                      if {@code false}, only a draft C_Order is created (DocStatus=DR).
+	 *                      Maps to {@code PP_Product_Planning.IsDocComplete}.
+	 */
+	public static void enqueue(
+			@NonNull final Collection<PurchaseCandidateId> purchaseCandidateIds,
+			@Nullable final DocTypeId docTypeId,
+			final boolean isCompleteDoc)
 	{
 		final Multimap<Integer, I_C_PurchaseCandidate> vendorId2purchaseCandidate = //
 				loadByIds(PurchaseCandidateId.toIntSet(purchaseCandidateIds), I_C_PurchaseCandidate.class)
@@ -110,6 +129,7 @@ public class C_PurchaseCandidates_GeneratePurchaseOrders extends WorkpackageProc
 					.addElements(candidateRecordReferences)
 					.setUserInChargeId(Env.getLoggedUserIdIfExists().orElse(null))
 					.parameter(DOC_TYPE_ID, docTypeId)
+					.parameter(IS_COMPLETE_DOC, isCompleteDoc)
 					.buildAndEnqueue();
 		}
 	}
@@ -119,8 +139,10 @@ public class C_PurchaseCandidates_GeneratePurchaseOrders extends WorkpackageProc
 	{
 		final BigDecimal docTypeRepoId = getParameters().getParameterAsBigDecimal(DOC_TYPE_ID);
 		final DocTypeId docTypeId = DocTypeId.ofRepoIdOrNull(docTypeRepoId != null ? docTypeRepoId.intValue() : 0);
+		// Default true for backward compatibility: work packages enqueued via the UI (before this parameter existed) should still complete the order
+		final boolean isCompleteDoc = getParameters().getParameterAsBoolean(IS_COMPLETE_DOC, true);
 		final PurchaseOrderFromItemsAggregator purchaseOrderFromItemsAggregator = //
-				PurchaseOrderFromItemsAggregator.newInstance(docTypeId);
+				PurchaseOrderFromItemsAggregator.newInstance(docTypeId, isCompleteDoc);
 
 		PurchaseCandidateToOrderWorkflow.builder()
 				.purchaseCandidateRepo(purchaseCandidateRepo)

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/event/PurchaseCandidateAdvisedEventCreator.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/event/PurchaseCandidateAdvisedEventCreator.java
@@ -90,7 +90,6 @@ public class PurchaseCandidateAdvisedEventCreator implements SupplyRequiredAdvis
 		final PurchaseCandidateAdvisedEvent event = PurchaseCandidateAdvisedEvent.builder()
 				.eventDescriptor(supplyRequiredDescriptor.newEventDescriptor())
 				.supplyRequiredDescriptor(supplyRequiredDescriptor)
-				.directlyCreatePurchaseCandidate(true) // deprecated field; always true — PO creation is now gated by PP_Product_Planning.IsCreatePlan in PurchaseCandidateRequestedHandler
 				.productPlanningId(ProductPlanningId.toRepoId(productPlanning.getId()))
 				.vendorId(defaultVendorProductInfo.get().getVendorId().getRepoId())
 				.build();

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/event/PurchaseCandidateAdvisedEventCreator.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/event/PurchaseCandidateAdvisedEventCreator.java
@@ -90,7 +90,7 @@ public class PurchaseCandidateAdvisedEventCreator implements SupplyRequiredAdvis
 		final PurchaseCandidateAdvisedEvent event = PurchaseCandidateAdvisedEvent.builder()
 				.eventDescriptor(supplyRequiredDescriptor.newEventDescriptor())
 				.supplyRequiredDescriptor(supplyRequiredDescriptor)
-				.directlyCreatePurchaseCandidate(productPlanning.isCreatePlan())
+				.directlyCreatePurchaseCandidate(true) // deprecated field; always true — PO creation is now gated by PP_Product_Planning.IsCreatePlan in PurchaseCandidateRequestedHandler
 				.productPlanningId(ProductPlanningId.toRepoId(productPlanning.getId()))
 				.vendorId(defaultVendorProductInfo.get().getVendorId().getRepoId())
 				.build();

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/event/PurchaseCandidateRequestedHandler.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/event/PurchaseCandidateRequestedHandler.java
@@ -33,7 +33,9 @@ import de.metas.material.event.commons.MaterialDescriptor;
 import de.metas.material.event.purchase.PurchaseCandidateCreatedEvent;
 import de.metas.material.event.purchase.PurchaseCandidateRequestedEvent;
 import de.metas.material.planning.IProductPlanningDAO;
+import de.metas.material.planning.ProductPlanning;
 import de.metas.material.planning.ProductPlanningId;
+import de.metas.purchasecandidate.async.C_PurchaseCandidates_GeneratePurchaseOrders;
 import de.metas.mforecast.impl.ForecastLineId;
 import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderId;
@@ -170,6 +172,20 @@ public class PurchaseCandidateRequestedHandler implements MaterialEventHandler<P
 					newPurchaseCandidate.getVendorId(),
 					newPurchaseCandidateId);
 			postMaterialEventService.enqueueEventAfterNextCommit(purchaseCandidateCreatedEvent);
+
+			// If PP_Product_Planning.IsCreatePlan=Y, auto-enqueue the candidate for C_Order generation.
+			// IsDocComplete controls whether the generated C_Order is also completed (CO) or left as draft (DR).
+			if (!requestedEvent.isSimulated() && requestedEvent.getProductPlanningId() != null)
+			{
+				final ProductPlanning productPlanning = productPlanningDAO.getById(requestedEvent.getProductPlanningId());
+				if (productPlanning.isCreatePlan())
+				{
+					C_PurchaseCandidates_GeneratePurchaseOrders.enqueue(
+							ImmutableList.of(newPurchaseCandidateId),
+							/* docTypeId= */ null,
+							productPlanning.isDocComplete());
+				}
+			}
 		}
 		finally
 		{

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemFactory.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemFactory.java
@@ -141,26 +141,40 @@ import java.util.Set;
 
 	public I_C_Order createAndComplete()
 	{
-		final I_C_Order order = orderFactory.createAndComplete();
+		return create(true);
+	}
 
-		purchaseItem2OrderLine
-				.forEach(this::updatePurchaseCandidateFromOrderLineBuilder);
+	/**
+	 * Creates a purchase order from the accumulated candidates.
+	 *
+	 * @param complete if {@code true}, the C_Order is created and immediately completed (DocStatus=CO);
+	 *                 if {@code false}, only a draft order is created (DocStatus=DR).
+	 *                 Corresponds to {@code PP_Product_Planning.IsDocComplete}.
+	 */
+	public I_C_Order create(final boolean complete)
+	{
+		final I_C_Order order = complete
+				? orderFactory.createAndComplete()
+				: orderFactory.createDraft();
 
-		final Set<UserId> userIdsToNotify = getUserIdsToNotify();
-		if (userIdsToNotify.isEmpty())
+		purchaseItem2OrderLine.forEach(this::updatePurchaseCandidateFromOrderLineBuilder);
+
+		if (complete)
 		{
-			return order;
+			final Set<UserId> userIdsToNotify = getUserIdsToNotify();
+			if (!userIdsToNotify.isEmpty())
+			{
+				final ADMessageAndParams adMessageAndParams = createMessageAndParamsOrNull(order);
+
+				final NotificationRequest request = NotificationRequest.builder()
+						.order(order)
+						.recipientUserIds(userIdsToNotify)
+						.adMessageAndParams(adMessageAndParams)
+						.build();
+
+				userNotifications.notifyOrderCompleted(request);
+			}
 		}
-
-		final ADMessageAndParams adMessageAndParams = createMessageAndParamsOrNull(order);
-
-		final NotificationRequest request = NotificationRequest.builder()
-				.order(order)
-				.recipientUserIds(userIdsToNotify)
-				.adMessageAndParams(adMessageAndParams)
-				.build();
-
-		userNotifications.notifyOrderCompleted(request);
 
 		return order;
 	}

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemsAggregator.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemsAggregator.java
@@ -36,7 +36,10 @@ import java.util.List;
  */
 
 /**
- * Aggregates {@link PurchaseOrderItem}s and creates completed purchase orders ({@link I_C_Order}).
+ * Aggregates {@link PurchaseOrderItem}s and creates purchase orders ({@link I_C_Order}).
+ * Whether the order is completed (DocStatus=CO) or left as a draft (DocStatus=DR)
+ * is controlled by the {@code isCompleteDoc} flag set at construction time via
+ * {@link #newInstance(DocTypeId, boolean)}.
  *
  * @author metas-dev <dev@metasfresh.com>
  */
@@ -53,8 +56,14 @@ public class PurchaseOrderFromItemsAggregator
 		return new PurchaseOrderFromItemsAggregator(docType);
 	}
 
+	public static PurchaseOrderFromItemsAggregator newInstance(@Nullable final DocTypeId docType, final boolean isCompleteDoc)
+	{
+		return new PurchaseOrderFromItemsAggregator(docType, isCompleteDoc);
+	}
+
 	private final OrderUserNotifications userNotifications = OrderUserNotifications.newInstance();
 	private final DocTypeId docType;
+	private final boolean isCompleteDoc;
 
 	private final List<I_C_Order> createdPurchaseOrders = new ArrayList<>();
 
@@ -67,8 +76,15 @@ public class PurchaseOrderFromItemsAggregator
 	@VisibleForTesting
 	PurchaseOrderFromItemsAggregator(@Nullable final DocTypeId docType)
 	{
+		this(docType, true);
+	}
+
+	@VisibleForTesting
+	PurchaseOrderFromItemsAggregator(@Nullable final DocTypeId docType, final boolean isCompleteDoc)
+	{
 		setItemAggregationKeyBuilder(PurchaseOrderAggregationKey::fromPurchaseOrderItem);
 		this.docType = docType;
+		this.isCompleteDoc = isCompleteDoc;
 	}
 
 	@Override
@@ -88,7 +104,7 @@ public class PurchaseOrderFromItemsAggregator
 	@Override
 	protected void closeGroup(@NonNull final PurchaseOrderFromItemFactory orderFactory)
 	{
-		final I_C_Order newPurchaseOrder = orderFactory.createAndComplete();
+		final I_C_Order newPurchaseOrder = orderFactory.create(isCompleteDoc);
 		createdPurchaseOrders.add(newPurchaseOrder);
 	}
 


### PR DESCRIPTION
Previously IsCreatePlan=N suppressed C_PurchaseCandidate creation entirely, IsCreatePlan=Y created the candidate but never auto-generated a C_Order, and IsDocComplete was not used in the purchase order path at all.

Changes:
- Always create C_PurchaseCandidate regardless of IsCreatePlan (decouples candidate creation from order auto-creation)
- PurchaseCandidateRequestedHandler now auto-enqueues for PO generation when IsCreatePlan=Y, passing IsDocComplete to control draft vs. completed C_Order
- C_PurchaseCandidates_GeneratePurchaseOrders: added IS_COMPLETE_DOC workpackage parameter; new enqueue(ids, docTypeId, isCompleteDoc) overload; all existing callers default to isCompleteDoc=true for backward compatibility
- PurchaseOrderFromItemsAggregator/Factory: added isCompleteDoc field and create(boolean) to conditionally call createAndComplete() vs createDraft()
- Updated supplyRequiredQtyViaPurchase.feature: added IsDocComplete=Y, removed now-redundant manual enqueue steps
- Added new materialDispo_purchaseOrder_autoCreateFromProductPlanning.feature with 3 scenarios covering IsCreatePlan=N/Y and IsDocComplete=N/Y
- Added assertNoC_PurchaseCandidate_Alloc step definition
- Added JavaDoc to 10 step definition methods