### PR TITLE
Fix QR scanning on Zebra MC3300x scanners (DataWedge IME)

### DIFF
--- a/e2e/mobile-webui/tests/spec/picking/barcodeScannerModes.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/barcodeScannerModes.spec.js
@@ -1,0 +1,123 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { BarcodeScannerComponent } from "../../utils/components/BarcodeScannerComponent";
+import { GetQuantityDialog } from "../../utils/screens/picking/GetQuantityDialog";
+import { PickingSlotScanScreen } from "../../utils/screens/picking/PickingSlotScanScreen";
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: { "P1": { prices: [{ price: 1 }] } },
+            packingInstructions: {
+                "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "P1", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' }
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 12, piItemProduct: 'TU' }]
+                }
+            },
+        }
+    });
+};
+
+test.describe('Barcode Scanner Input Modes', () => {
+
+    // noinspection JSUnusedLocalSymbols
+    test('scan barcode via keyboard events', async ({ page }) => {
+        allure.epic('E0105: Picking');
+        allure.tag('F00230: MobileUI Picking');
+        allure.tag('F00230');
+        allure.story('Barcode scanner keyboard input mode');
+        allure.severity('critical');
+
+        const masterdata = await createMasterdata();
+
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('picking');
+        await PickingJobsListScreen.waitForScreen();
+        await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+        await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+
+        await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+        await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '0 TU' });
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.qrCode,
+            isScanDirectly: true,
+            expectQtyEntered: '3',
+        });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU' });
+
+        await PickingJobScreen.complete();
+    });
+
+    // noinspection JSUnusedLocalSymbols
+    test('scan barcode via IME text injection', async ({ page }) => {
+        allure.epic('E0105: Picking');
+        allure.tag('F00230: MobileUI Picking');
+        allure.tag('F00230');
+        allure.story('Barcode scanner IME input mode (Zebra DataWedge)');
+        allure.severity('critical');
+
+        const masterdata = await createMasterdata();
+
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('picking');
+        await PickingJobsListScreen.waitForScreen();
+        await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+        await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+
+        // Scan picking slot via IME
+        await test.step('Scan picking slot via IME', async () => {
+            await PickingJobScreen.clickPickingSlotButton();
+            await PickingSlotScanScreen.waitForScreen();
+            await BarcodeScannerComponent.typeViaIME(masterdata.pickingSlots.slot1.qrCode);
+            await PickingJobScreen.waitForScreen();
+            await PickingJobScreen.expectPickingSlotButtonGreen();
+        });
+
+        await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '0 TU' });
+
+        // Scan HU via IME
+        await test.step('Pick HU via IME', async () => {
+            await BarcodeScannerComponent.typeViaIME(masterdata.handlingUnits.HU1.qrCode);
+            await GetQuantityDialog.fillAndPressDone({ expectQtyEntered: '3' });
+            await PickingJobScreen.waitForScreen();
+        });
+
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU' });
+
+        await PickingJobScreen.complete();
+    });
+
+});

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -71,10 +71,22 @@ export const BarcodeScannerComponent = {
             selector += `[data-testid="${testId}"]`;
         }
 
-        // Simulate DataWedge IME text injection: sets value + fires input/change events, no keydown events
-        await page.locator(selector).fill(scannedCode);
+        // Simulate DataWedge IME text injection: sets value + fires input/change events, no keydown events.
+        // Uses evaluate() because the input may be type="hidden" (when isShowInputText=false),
+        // and Playwright's fill() requires visible elements. DataWedge injects via InputConnection
+        // regardless of visibility.
+        await page.evaluate(({ selector, value }) => {
+            const el = document.querySelector(selector);
+            const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+            nativeInputValueSetter.call(el, value);
+            el.dispatchEvent(new Event('input', { bubbles: true }));
+            el.dispatchEvent(new Event('change', { bubbles: true }));
+        }, { selector, value: scannedCode });
         // DataWedge appends Enter after text injection to trigger submission
-        await page.keyboard.press('Enter');
+        await page.evaluate((selector) => {
+            const el = document.querySelector(selector);
+            el.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', bubbles: true }));
+        }, selector);
     }),
 
     waitForInputFieldToGetEmpty: async () => await test.step(`${NAME} - Wait for input field to get empty`, async () => {

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -45,6 +45,38 @@ export const BarcodeScannerComponent = {
         }, scannedCode);
     }),
 
+    typeViaIME: async (params) => await test.step(`${NAME} - Type scanned code via IME`, async () => {
+        let scannedCode;
+        let testId;
+        if (typeof params === 'string') {
+            scannedCode = params;
+            testId = undefined;
+        } else if (params && typeof params === 'object') {
+            scannedCode = params.scannedCode;
+            testId = params.testId;
+        } else {
+            throw new Error("Invalid argument provided to the 'typeViaIME' function. Must be a string or an object with { scannedCode }.");
+        }
+
+        if (!scannedCode) {
+            throw new Error("Invalid scannedCode provided. Must not be empty.");
+        }
+
+        console.log('Scanning scanned code via IME:\n' + scannedCode);
+
+        await BarcodeScannerComponent.waitToAttach({ testId });
+
+        let selector = '#input-text';
+        if (testId) {
+            selector += `[data-testid="${testId}"]`;
+        }
+
+        // Simulate DataWedge IME text injection: sets value + fires input/change events, no keydown events
+        await page.locator(selector).fill(scannedCode);
+        // DataWedge appends Enter after text injection to trigger submission
+        await page.keyboard.press('Enter');
+    }),
+
     waitForInputFieldToGetEmpty: async () => await test.step(`${NAME} - Wait for input field to get empty`, async () => {
         await expect(page.locator('#input-text')).toHaveValue('');
     }),

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
@@ -121,9 +121,7 @@ const BarcodeScannerComponent = ({
       if (isShowVideo) {
         videoRef?.current?.scrollIntoView({ behaviour: 'smooth', block: 'center', inline: 'end' });
       }
-      if (!isInputTextReadonly) {
-        inputTextRef?.current?.focus();
-      }
+      inputTextRef?.current?.focus();
     } /* no deps, call it on each render */
   );
 
@@ -222,8 +220,6 @@ const BarcodeScannerComponent = ({
   );
 
   const handleInputTextChanged = (e) => {
-    if (isInputTextReadonly) return;
-
     const scannedBarcode = e.target.value;
 
     if (
@@ -240,8 +236,6 @@ const BarcodeScannerComponent = ({
   }, [textChangedDebounceMillis]);
 
   const handleInputTextKeyPress = (e) => {
-    if (isInputTextReadonly) return;
-
     if (e.key === 'Enter') {
       const scannedBarcode = e.target.value;
 
@@ -271,7 +265,7 @@ const BarcodeScannerComponent = ({
           className="input-text"
           type={isShowInputText ? 'text' : 'hidden'}
           placeholder={inputPlaceholderText || trl('components.BarcodeScannerComponent.scanTextPlaceholder')}
-          readOnly={isInputTextReadonly}
+          inputMode={isInputTextReadonly ? 'none' : undefined}
           onFocus={handleInputTextFocus}
           onBlur={handleInputTextBlur}
           onChange={handleInputTextChangedDebounced}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
@@ -33,8 +33,12 @@ export const useKeyboardBarcodeReader = ({
         }
       }
 
-      // Ignore key events with Ctrl, Alt or Meta modifiers
-      if (event.ctrlKey || event.altKey || event.metaKey) {
+      // Ignore key events with Ctrl or Meta modifiers
+      if (event.ctrlKey || event.metaKey) {
+        return;
+      }
+      // Allow altKey for printable characters (Zebra MC3300x firmware sets altKey=true on scanner keystrokes)
+      if (event.altKey && event.key.length !== 1) {
         return;
       }
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
@@ -62,6 +62,11 @@ export const useKeyboardBarcodeReader = ({
         if (now - lastKeyTimeRef.current < rateMs) {
           bufferRef.current += event.key;
           onReadInProgress?.(bufferRef.current);
+          // Prevent the browser from also inserting the character into a focused input.
+          // The hook handles value updates via onReadInProgress. Without this, the character
+          // would be inserted twice: once by onReadInProgress and once by the browser's default action.
+          // (Before the readOnly→inputMode="none" change, readOnly prevented browser insertion.)
+          event.preventDefault();
         }
         //
         // Type rate dropped => send the collected string if any


### PR DESCRIPTION
## Summary

- Replace `readOnly` with `inputMode="none"` on barcode scanner input field to keep Chrome's InputConnection alive for Zebra DataWedge IME text injection
- Remove readonly guards from `onChange`/`onKeyUp` handlers so IME-injected text is processed
- Always focus the input field (required for InputConnection, safe with `inputMode="none"`)
- Relax `altKey` filter in `useKeyboardBarcodeReader` for Zebra MC3300x firmware that sets `altKey=true` on all scanner keystrokes
- Add `typeViaIME()` E2E test utility and barcode scanner input mode regression tests

## Test plan

- [ ] Run new E2E test: `npx playwright test tests/spec/picking/barcodeScannerModes.spec.js`
- [ ] Run picking regression: `npx playwright test tests/spec/picking/` (23+ existing tests)
- [ ] Verify on Zebra MC3300x device: QR scan via DataWedge IME populates the field and triggers scan processing
- [ ] Verify virtual keyboard does NOT appear on mobile when input field has focus