### PR TITLE
Fix M_MaterialCockpit_rebuild: use db_alter_view for dependent views

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/ddl/functions/M_MaterialCockpit_rebuild.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/ddl/functions/M_MaterialCockpit_rebuild.sql
@@ -49,10 +49,10 @@ BEGIN
     END IF;
 
     --
-    -- Step 4: Recreate the API view QtyDemand_QtySupply_V
+    -- Step 4: Recreate the API view QtyDemand_QtySupply_V using db_alter_view
+    -- (handles dependent views like rv_purchasecockpit automatically)
     --
-    EXECUTE 'DROP VIEW IF EXISTS QtyDemand_QtySupply_V';
-    EXECUTE 'CREATE OR REPLACE VIEW QtyDemand_QtySupply_V AS SELECT * FROM ' || v_source_view;
+    PERFORM db_alter_view('QtyDemand_QtySupply_V', 'SELECT * FROM ' || v_source_view);
 
     RAISE NOTICE 'M_MaterialCockpit_rebuild: Successfully created QtyDemand_QtySupply_V from %', v_source_view;
 END;

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5789800_sys_M_MaterialCockpit_Base_V_and_rebuild.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5789800_sys_M_MaterialCockpit_Base_V_and_rebuild.sql
@@ -129,9 +129,9 @@ BEGIN
         RAISE EXCEPTION 'after_migration_M_MaterialCockpit_rebuild: Source view "%" is missing base columns: %', v_source_view, v_missing_cols;
     END IF;
 
-    -- Step 4: Recreate the API view QtyDemand_QtySupply_V
-    EXECUTE 'DROP VIEW IF EXISTS QtyDemand_QtySupply_V';
-    EXECUTE 'CREATE OR REPLACE VIEW QtyDemand_QtySupply_V AS SELECT * FROM ' || v_source_view;
+    -- Step 4: Recreate the API view QtyDemand_QtySupply_V using db_alter_view
+    -- (handles dependent views like rv_purchasecockpit automatically)
+    PERFORM db_alter_view('QtyDemand_QtySupply_V', 'SELECT * FROM ' || v_source_view);
 
     RAISE NOTICE 'after_migration_M_MaterialCockpit_rebuild: Successfully created QtyDemand_QtySupply_V from %', v_source_view;
 END;

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5790200_sys_M_MaterialCockpit_rebuild.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5790200_sys_M_MaterialCockpit_rebuild.sql
@@ -52,10 +52,10 @@ BEGIN
     END IF;
 
     --
-    -- Step 4: Recreate the API view QtyDemand_QtySupply_V
+    -- Step 4: Recreate the API view QtyDemand_QtySupply_V using db_alter_view
+    -- (handles dependent views like rv_purchasecockpit automatically)
     --
-    EXECUTE 'DROP VIEW IF EXISTS QtyDemand_QtySupply_V';
-    EXECUTE 'CREATE OR REPLACE VIEW QtyDemand_QtySupply_V AS SELECT * FROM ' || v_source_view;
+    PERFORM db_alter_view('QtyDemand_QtySupply_V', 'SELECT * FROM ' || v_source_view);
 
     RAISE NOTICE 'M_MaterialCockpit_rebuild: Successfully created QtyDemand_QtySupply_V from %', v_source_view;
 END;


### PR DESCRIPTION
## Summary

- The `M_MaterialCockpit_rebuild()` function used `DROP VIEW` + `CREATE VIEW` for `QtyDemand_QtySupply_V`, which fails when dependent views exist (e.g., `rv_purchasecockpit` on dt204)
- Replace with `db_alter_view()` which automatically drops and recreates dependent views in the correct order
- Fix applied to: migration script `5789800` (blocker), `5790200` (standalone function), and DDL reference file

## Context

CI failure

Error: `cannot drop view qtydemand_qtysupply_v because other objects depend on it` / `view rv_purchasecockpit depends on view qtydemand_qtysupply_v`

This is an edit of already-integrated scripts, which is normally forbidden. However, `5789800` is a **blocker script** — it fails and prevents ALL subsequent migration scripts from running (due to `ON_ERROR_STOP=1`). A follow-up script cannot fix it because it never gets to execute. This falls under the documented exception for blocker scripts.

## Test plan

- [ ] CI `db-apply-migrations` passes on this PR (no `rv_purchasecockpit` on base image, but validates syntax)
- [ ] After merge, re-trigger dt204 CI build — should pass (has `rv_purchasecockpit` depending on `QtyDemand_QtySupply_V`)