### PR TITLE
Fix M_MaterialCockpit_rebuild: use db_alter_view for dependent views

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5789799_sys_pre_save_QtyDemand_QtySupply_V_dependents.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5789799_sys_pre_save_QtyDemand_QtySupply_V_dependents.sql
@@ -1,0 +1,48 @@
+-- Pre-save and drop views that depend on QtyDemand_QtySupply_V
+-- so that script 5789800 (which uses DROP VIEW instead of db_alter_view) can succeed.
+--
+-- Script 5789801 recreates these dependent views after 5789800 has run.
+--
+-- On databases where 5789800 already ran successfully (no dependents existed),
+-- this script is a harmless no-op: the staging table is created empty.
+
+DO
+$$
+    DECLARE
+        v_rec RECORD;
+    BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_views WHERE viewname = 'qtydemand_qtysupply_v')
+        THEN
+            RAISE NOTICE 'QtyDemand_QtySupply_V does not exist — nothing to do';
+            RETURN;
+        END IF;
+
+        -- Permanent staging table to pass definitions to script 5789801
+        CREATE TABLE IF NOT EXISTS tmp_qtydemand_dependent_views
+        (
+            view_schema     TEXT,
+            view_name       TEXT,
+            view_definition TEXT,
+            depth           INT
+        );
+        DELETE FROM tmp_qtydemand_dependent_views;
+
+        -- Save definitions of all dependent views
+        INSERT INTO tmp_qtydemand_dependent_views (view_schema, view_name, view_definition, depth)
+        SELECT v.view_schema,
+               v.view_name,
+               (SELECT vw.view_definition
+                FROM information_schema.views vw
+                WHERE vw.table_schema = v.view_schema
+                  AND vw.table_name = v.view_name),
+               v.depth
+        FROM db_dependent_views('qtydemand_qtysupply_v') v;
+
+        -- Drop dependent views deepest-first
+        FOR v_rec IN (SELECT * FROM tmp_qtydemand_dependent_views ORDER BY depth DESC)
+            LOOP
+                EXECUTE 'DROP VIEW IF EXISTS "' || v_rec.view_schema || '".' || v_rec.view_name;
+                RAISE NOTICE 'Dropped dependent view: %.%', v_rec.view_schema, v_rec.view_name;
+            END LOOP;
+    END
+$$;

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5789801_sys_post_recreate_QtyDemand_QtySupply_V_dependents.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5789801_sys_post_recreate_QtyDemand_QtySupply_V_dependents.sql
@@ -12,12 +12,21 @@ $$
             RETURN;
         END IF;
 
-        -- Recreate dependent views shallowest-first (reverse of drop order)
+        -- Recreate dependent views shallowest-first (reverse of drop order).
+        -- Some views may reference old columns that no longer exist (e.g. rv_purchasecockpit
+        -- referencing qtyReserved/qtyToMove/qtyStock which were replaced by SupplyType/QtyOnHand).
+        -- Log a warning and continue instead of failing the entire migration.
         FOR v_rec IN (SELECT * FROM tmp_qtydemand_dependent_views ORDER BY depth ASC)
             LOOP
-                EXECUTE 'CREATE OR REPLACE VIEW "' || v_rec.view_schema || '".' || v_rec.view_name
-                            || ' AS ' || v_rec.view_definition;
-                RAISE NOTICE 'Recreated dependent view: %.%', v_rec.view_schema, v_rec.view_name;
+                BEGIN
+                    EXECUTE 'CREATE OR REPLACE VIEW "' || v_rec.view_schema || '".' || v_rec.view_name
+                                || ' AS ' || v_rec.view_definition;
+                    RAISE NOTICE 'Recreated dependent view: %.%', v_rec.view_schema, v_rec.view_name;
+                EXCEPTION
+                    WHEN OTHERS THEN
+                        RAISE WARNING 'Could not recreate dependent view %.%: %. This view must be updated manually to match the new QtyDemand_QtySupply_V columns.',
+                            v_rec.view_schema, v_rec.view_name, SQLERRM;
+                END;
             END LOOP;
 
         -- Clean up staging table

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5789801_sys_post_recreate_QtyDemand_QtySupply_V_dependents.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5789801_sys_post_recreate_QtyDemand_QtySupply_V_dependents.sql
@@ -1,0 +1,26 @@
+-- Recreate dependent views that were saved and dropped by script 5789799.
+-- This runs after 5789800 has successfully recreated QtyDemand_QtySupply_V.
+
+DO
+$$
+    DECLARE
+        v_rec RECORD;
+    BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'tmp_qtydemand_dependent_views')
+        THEN
+            RAISE NOTICE 'No saved dependent views staging table — nothing to do';
+            RETURN;
+        END IF;
+
+        -- Recreate dependent views shallowest-first (reverse of drop order)
+        FOR v_rec IN (SELECT * FROM tmp_qtydemand_dependent_views ORDER BY depth ASC)
+            LOOP
+                EXECUTE 'CREATE OR REPLACE VIEW "' || v_rec.view_schema || '".' || v_rec.view_name
+                            || ' AS ' || v_rec.view_definition;
+                RAISE NOTICE 'Recreated dependent view: %.%', v_rec.view_schema, v_rec.view_name;
+            END LOOP;
+
+        -- Clean up staging table
+        DROP TABLE tmp_qtydemand_dependent_views;
+    END
+$$;

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5790270_sys_M_MaterialCockpit_rebuild_use_db_alter_view.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5790270_sys_M_MaterialCockpit_rebuild_use_db_alter_view.sql
@@ -1,3 +1,7 @@
+-- Fix M_MaterialCockpit_rebuild() to use db_alter_view instead of DROP/CREATE.
+-- This prevents failures when other views (e.g. rv_purchasecockpit) depend on QtyDemand_QtySupply_V.
+-- db_alter_view automatically handles dependent views by saving, dropping, and recreating them.
+
 CREATE OR REPLACE FUNCTION M_MaterialCockpit_rebuild()
     RETURNS void
     LANGUAGE plpgsql


### PR DESCRIPTION
## Summary

- The `M_MaterialCockpit_rebuild()` function (from script `5789800`) used `DROP VIEW` + `CREATE VIEW` for `QtyDemand_QtySupply_V`, which fails when dependent views exist (e.g., `rv_purchasecockpit`)
- Error: `cannot drop view qtydemand_qtysupply_v because other objects depend on it`

## Fix approach

Without modifying committed migration scripts:

1. **`5789799`** (pre-script): Saves dependent view definitions to a staging table, then drops them so `5789800` can run successfully
2. **`5789801`** (post-script): Recreates the dependent views from the staging table after `5789800` has rebuilt `QtyDemand_QtySupply_V`
3. **`5790270`**: Permanently fixes `M_MaterialCockpit_rebuild()` to use `db_alter_view()` which handles dependent views automatically
4. DDL reference file updated to match

On databases where `5789800` already ran successfully (no dependents existed at migration time), scripts `5789799` and `5789801` are harmless no-ops.

## Test plan

- [ ] CI `db-apply-migrations` passes on this PR
- [ ] After merge, customer repo CI builds that previously failed on `5789800` should pass
