### PR TITLE
Add Playwright E2E regression tests for keyboard shortcuts

### DIFF
--- a/e2e/frontend-webui/.env.example
+++ b/e2e/frontend-webui/.env.example
@@ -1,0 +1,2 @@
+# Frontend base URL (default: http://localhost:3000)
+FRONTEND_BASE_URL=http://localhost:3000

--- a/e2e/frontend-webui/.gitignore
+++ b/e2e/frontend-webui/.gitignore
@@ -1,0 +1,25 @@
+# Playwright
+node_modules/
+test-results/
+playwright-report/
+playwright-frontend-report*/
+playwright-frontend-report.zip
+blob-report/
+playwright/.cache/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Credentials (sensitive)
+credentials/
+
+# Allure reports
+allure-results/
+allure-report/

--- a/e2e/frontend-webui/README.md
+++ b/e2e/frontend-webui/README.md
@@ -1,0 +1,78 @@
+# Frontend WebUI — Playwright E2E Tests
+
+Playwright end-to-end regression tests for the metasfresh WebUI frontend.
+
+## CI Status
+
+**These tests are NOT executed in CI.** The CI pipeline (`cicd.yaml`) does not include a job for Playwright E2E tests — only Jest unit tests run automatically. These tests must be run locally before merging shortcut-related or UI-interaction changes.
+
+## Prerequisites
+
+- Node.js 18+
+- A running metasfresh stack: frontend (port 3000) + WebAPI backend (port 8080)
+- Chromium (installed via Playwright)
+
+## Setup
+
+```bash
+cd e2e/frontend-webui/
+
+# Install dependencies
+npm install
+
+# Install Playwright browsers
+npx playwright install chromium
+
+# Copy and edit environment config
+cp .env.example .env
+# Edit .env if your frontend runs on a different port
+```
+
+## Running Tests
+
+```bash
+# Run all tests (headless)
+FRONTEND_BASE_URL=http://localhost:3000 npx playwright test
+
+# Run with visible browser
+npx playwright test --headed
+
+# Run a specific test file
+npx playwright test tests/spec/keyboard-shortcuts.spec.js
+
+# Run a specific test by name
+npx playwright test --grep="PageDown"
+```
+
+## Test Suites
+
+### keyboard-shortcuts.spec.js
+
+9 regression tests for the keyboard shortcut infrastructure (`ShortcutProvider` + `Shortcut` components). Covers:
+
+| # | Test | Shortcut |
+|---|------|----------|
+| 1 | ALT+E opens Advanced Edit, ALT+ENTER confirms | `Alt+E` then `Alt+Enter` |
+| 2 | ALT+E opens Advanced Edit, Escape cancels | `Alt+E` then `Escape` |
+| 3 | Shortcuts work after re-open (no stale handlers) | Re-mount cycle |
+| 4 | ALT+1 opens SubHeader/Actions menu | `Alt+1` |
+| 5 | ALT+3 opens Inbox | `Alt+3` |
+| 6 | ALT+4 opens User dropdown | `Alt+4` |
+| 7 | Escape closes each menu after opening | `Escape` |
+| 8 | Shortcuts survive UPDATE_HOTKEYS (table filter regression) | `Alt+E` after filter |
+| 9 | PageDown/PageUp pagination | `PageDown` / `PageUp` |
+
+## Test Results
+
+- **Videos**: Recorded automatically in `test-results/` (gitignored)
+- **Screenshots**: Captured on failure
+- **Allure reports**: Generated in `allure-results/` (gitignored)
+
+## Configuration
+
+| File | Purpose |
+|------|---------|
+| `playwright.config.js` | Test runner config (timeouts, reporters, browser args) |
+| `.env` / `.env.example` | `FRONTEND_BASE_URL` setting |
+| `tests/utils/common.js` | Shared timeout constants, error detection |
+| `tests/utils/components/ErrorToast.js` | Toast notification detection |

--- a/e2e/frontend-webui/package.json
+++ b/e2e/frontend-webui/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@metasfresh/e2e-frontend-webui",
+  "version": "1.0.0",
+  "description": "Playwright E2E tests for metasfresh frontend web UI",
+  "main": "index.js",
+  "license": "GPL-2.0",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "test:debug": "playwright test --debug",
+    "test:report": "playwright show-report playwright-report/html",
+    "allure:generate": "npx allure generate allure-results --clean -o allure-report",
+    "allure:open": "npx allure open allure-report",
+    "allure:serve": "npx allure serve allure-results"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.1",
+    "allure-playwright": "^3.4.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/e2e/frontend-webui/playwright.config.js
+++ b/e2e/frontend-webui/playwright.config.js
@@ -1,0 +1,115 @@
+import { defineConfig, devices } from '@playwright/test';
+import * as os from 'node:os';
+
+export default defineConfig({
+  testDir: './tests',
+  workers: 1, // Sequential execution for test data isolation
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  timeout: 60000, // 1 minute per test (reduced for faster validation)
+
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'playwright-report/html', open: 'never' }],
+    ['junit', { outputFile: 'playwright-report/junit/results.xml' }],
+    // Allure reporter for rich, stakeholder-friendly reports
+    [
+      'allure-playwright',
+      {
+        resultsDir: 'allure-results',
+        detail: true,
+        suiteTitle: true,
+        // Link templates for clickable references in reports
+        links: {
+          issue: {
+            nameTemplate: 'GitHub Issue #%s',
+            urlTemplate: 'https://github.com/metasfresh/metasfresh/issues/%s',
+          },
+          tms: {
+            nameTemplate: 'Feature %s',
+            urlTemplate: 'https://docs.google.com/spreadsheets/d/1HYDaiNZVseCg4WtIaxJQ-LLclNl7vkHXp6WsMEaKK9A/edit#gid=1284833774&range=A%s',
+          },
+          epic: {
+            nameTemplate: 'Epic %s',
+            urlTemplate: 'https://docs.google.com/spreadsheets/d/1HYDaiNZVseCg4WtIaxJQ-LLclNl7vkHXp6WsMEaKK9A/edit#gid=0&range=A%s',
+          },
+        },
+        // Categorize failures for easier analysis
+        categories: [
+          {
+            name: 'Language-specific failures',
+            messageRegex: '.*language.*|.*translation.*|.*locale.*',
+            matchedStatuses: ['failed', 'broken'],
+          },
+          {
+            name: 'Timing/Timeout issues',
+            messageRegex: '.*timeout.*|.*timed out.*|.*waiting.*',
+            matchedStatuses: ['failed', 'broken'],
+          },
+          {
+            name: 'Backend API errors',
+            messageRegex: '.*Backend API error.*|.*500.*|.*503.*|.*ECONNREFUSED.*',
+            matchedStatuses: ['failed', 'broken'],
+          },
+          {
+            name: 'PDF validation failures',
+            messageRegex: '.*PDF.*|.*pdf.*',
+            matchedStatuses: ['failed'],
+          },
+        ],
+        // Environment info displayed in report
+        environmentInfo: {
+          os_platform: os.platform(),
+          os_release: os.release(),
+          node_version: process.version,
+          test_environment: process.env.CI ? 'CI' : 'Local',
+          frontend_url: process.env.FRONTEND_BASE_URL || 'http://localhost:3000',
+        },
+      },
+    ],
+  ],
+
+  use: {
+    baseURL: process.env.FRONTEND_BASE_URL || 'http://localhost:3000',
+    trace: 'on',
+    video: 'on',
+    screenshot: 'only-on-failure',
+    viewport: { width: 1920, height: 1080 },
+    // Record all network traffic to HAR files
+    recordHar: { path: 'playwright-report/network/', mode: 'minimal' },
+  },
+
+  projects: [
+    {
+      name: 'Desktop Chrome',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: [
+            '--no-sandbox', // Avoids sandboxing issues inside Docker
+            '--unsafely-treat-insecure-origin-as-secure=http://webapi-test:8080', // Treats it as a secure origin
+            '--disable-features=StrictOriginPolicy,HttpsOnlyMode,BlockInsecurePrivateNetworkRequests', // Disables HSTS enforcement
+            '--disable-site-isolation-trials', // Helps disable security sandboxing
+            '--disable-web-security', // Disables web security (CORS, mixed content, etc.)
+            '--ignore-certificate-errors', // Ignores SSL certificate errors
+            '--allow-insecure-localhost', // Allows HTTP on local addresses
+            '--allow-running-insecure-content', // Allows mixed content (HTTP on HTTPS)
+          ],
+        },
+      },
+    },
+  ],
+});
+
+// Test context shared across test steps
+export const testContext = {};
+
+// Custom test fixture to manage page and context
+export const test = require('@playwright/test').test.extend({
+  page: async ({ page }, use) => {
+    global.currentPage = page;
+    Object.keys(testContext).forEach((key) => delete testContext[key]);
+    await use(page);
+  },
+});

--- a/e2e/frontend-webui/tests/spec/keyboard-shortcuts.spec.js
+++ b/e2e/frontend-webui/tests/spec/keyboard-shortcuts.spec.js
@@ -1,0 +1,235 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { SLOW_ACTION_TIMEOUT, FAST_ACTION_TIMEOUT } from '../utils/common';
+
+const LOGIN_USERNAME = 'metasfresh';
+const LOGIN_PASSWORD = 'metasfresh';
+
+// Organisation window — always present in any metasfresh DB
+const WINDOW_URL = '/window/110';
+
+/**
+ * Login and navigate to the Organisation window.
+ * Handles role selection if prompted.
+ */
+async function loginAndNavigate(page) {
+  await page.goto('/logout', { waitUntil: 'load' });
+  await page.goto('/', { waitUntil: 'load' });
+
+  // Wait for login form to appear
+  await page
+    .locator('.login-container')
+    .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+  // Fill username
+  await page.locator('input[name="username"]').fill(LOGIN_USERNAME);
+  // Fill password
+  await page.locator('input[name="password"]').fill(LOGIN_PASSWORD);
+  // Click login
+  await page.locator('.login-container .btn-meta-success').click();
+
+  // Handle role selection if it appears (click the first available role submit button)
+  try {
+    const roleSubmitBtn = page.locator(
+      '.login-container .btn-meta-success:visible'
+    );
+    await roleSubmitBtn.waitFor({
+      state: 'visible',
+      timeout: FAST_ACTION_TIMEOUT,
+    });
+    await roleSubmitBtn.click();
+  } catch {
+    // No role selection needed — login completed directly
+  }
+
+  // Wait for dashboard to load
+  await page
+    .locator('.dashboard')
+    .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+  // Navigate to Organisation window
+  await page.goto(WINDOW_URL, { waitUntil: 'load' });
+
+  // Wait for window content to load (the document list or single document view)
+  await page
+    .locator('.document-list-wrapper, .header-breadcrumb')
+    .first()
+    .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+}
+
+/**
+ * Navigate to a single document view by opening the first record.
+ * Navigates directly via double-click then waits for URL to contain a record ID.
+ */
+async function navigateToSingleDocument(page) {
+  // We should be on the list view — double-click the first row to open it
+  const firstRow = page
+    .locator('.table-flex-wrapper tr.row-selected, .table-flex-wrapper .row-0')
+    .first();
+  await firstRow.waitFor({
+    state: 'visible',
+    timeout: FAST_ACTION_TIMEOUT,
+  });
+  await firstRow.dblclick();
+
+  // Wait for navigation to a single record URL (e.g., /window/110/1000000)
+  await page.waitForURL(/\/window\/\d+\/\d+/, {
+    timeout: SLOW_ACTION_TIMEOUT,
+  });
+
+  // Wait for the document to render (form fields visible)
+  await page
+    .locator('.window-wrapper, .row-selected .form-group')
+    .first()
+    .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+  // Brief pause to let React register shortcut handlers after navigation
+  await page.waitForTimeout(1000);
+
+  // Click on the document area to ensure keyboard focus
+  await page.locator('.window-wrapper').first().click();
+}
+
+test.describe('Keyboard Shortcuts — Regression Tests (me03#27082)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAndNavigate(page);
+  });
+
+  test('ALT+E opens Advanced Edit, ALT+ENTER confirms (closes) it', async ({
+    page,
+  }) => {
+    await navigateToSingleDocument(page);
+
+    // Press ALT+E to open Advanced Edit overlay
+    await page.keyboard.press('Alt+e');
+
+    // Verify the modal overlay appeared
+    const modal = page.locator('.panel-modal');
+    await modal.waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
+    expect(await modal.isVisible()).toBe(true);
+
+    // Verify the screen freeze overlay is present
+    const screenFreeze = page.locator('.screen-freeze');
+    expect(await screenFreeze.first().isVisible()).toBe(true);
+
+    // Press ALT+ENTER to confirm (DONE) and close the modal
+    await page.keyboard.press('Alt+Enter');
+
+    // Verify the modal is closed
+    await modal.waitFor({ state: 'hidden', timeout: FAST_ACTION_TIMEOUT });
+    expect(await modal.isVisible()).toBe(false);
+  });
+
+  test('ALT+E opens Advanced Edit, Escape cancels (closes) it', async ({
+    page,
+  }) => {
+    await navigateToSingleDocument(page);
+
+    // Press ALT+E to open Advanced Edit overlay
+    await page.keyboard.press('Alt+e');
+
+    // Verify the modal opened
+    const modal = page.locator('.panel-modal');
+    await modal.waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
+    expect(await modal.isVisible()).toBe(true);
+
+    // Press Escape to cancel and close the modal
+    await page.keyboard.press('Escape');
+
+    // Verify the modal is closed
+    await modal.waitFor({ state: 'hidden', timeout: FAST_ACTION_TIMEOUT });
+    expect(await modal.isVisible()).toBe(false);
+  });
+
+  test('Shortcuts work after re-open (no stale handlers)', async ({
+    page,
+  }) => {
+    await navigateToSingleDocument(page);
+
+    const modal = page.locator('.panel-modal');
+
+    // First cycle: Open with ALT+E, close with Escape
+    await page.keyboard.press('Alt+e');
+    await modal.waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
+    await page.keyboard.press('Escape');
+    await modal.waitFor({ state: 'hidden', timeout: FAST_ACTION_TIMEOUT });
+
+    // Brief pause to let React unmount/remount shortcut handlers
+    await page.waitForTimeout(500);
+
+    // Second cycle: Open with ALT+E, close with ALT+ENTER
+    await page.keyboard.press('Alt+e');
+    await modal.waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
+
+    await page.keyboard.press('Alt+Enter');
+    await modal.waitFor({ state: 'hidden', timeout: FAST_ACTION_TIMEOUT });
+    expect(await modal.isVisible()).toBe(false);
+  });
+
+  test('ALT+1 opens SubHeader/Actions menu', async ({ page }) => {
+    // Press ALT+1 to open SubHeader
+    await page.keyboard.press('Alt+1');
+
+    // Verify the subheader opened
+    const subheader = page.locator('.subheader-container.subheader-open');
+    await subheader.waitFor({
+      state: 'visible',
+      timeout: FAST_ACTION_TIMEOUT,
+    });
+    expect(await subheader.isVisible()).toBe(true);
+  });
+
+  test('ALT+3 opens Inbox', async ({ page }) => {
+    // Press ALT+3 to open Inbox
+    await page.keyboard.press('Alt+3');
+
+    // The .inbox div inside .js-inbox-wrapper only renders when open=true
+    const inbox = page.locator('.js-inbox-wrapper .inbox');
+    await inbox.waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
+    expect(await inbox.isVisible()).toBe(true);
+  });
+
+  test('ALT+4 opens User dropdown', async ({ page }) => {
+    // Press ALT+4 to open User dropdown
+    await page.keyboard.press('Alt+4');
+
+    // Verify the user dropdown list appeared
+    const dropdown = page.locator('.user-dropdown-list');
+    await dropdown.waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
+    expect(await dropdown.isVisible()).toBe(true);
+  });
+
+  test('Escape closes each menu after opening', async ({ page }) => {
+    // --- ALT+1 → Escape ---
+    await page.keyboard.press('Alt+1');
+    const subheader = page.locator('.subheader-container.subheader-open');
+    await subheader.waitFor({
+      state: 'visible',
+      timeout: FAST_ACTION_TIMEOUT,
+    });
+    await page.keyboard.press('Escape');
+    await subheader.waitFor({ state: 'hidden', timeout: FAST_ACTION_TIMEOUT });
+
+    // Brief pause between shortcuts
+    await page.waitForTimeout(300);
+
+    // --- ALT+3 → click outside to close ---
+    // Note: Inbox uses onClickOutside handler, not Escape key
+    await page.keyboard.press('Alt+3');
+    const inbox = page.locator('.js-inbox-wrapper .inbox');
+    await inbox.waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
+    // Click on the document list area (outside the inbox) to close it
+    await page.locator('.document-list-wrapper, .header-breadcrumb').first().click();
+    await inbox.waitFor({ state: 'hidden', timeout: FAST_ACTION_TIMEOUT });
+
+    // Brief pause between shortcuts
+    await page.waitForTimeout(300);
+
+    // --- ALT+4 → Escape ---
+    await page.keyboard.press('Alt+4');
+    const dropdown = page.locator('.user-dropdown-list');
+    await dropdown.waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
+    await page.keyboard.press('Escape');
+    await dropdown.waitFor({ state: 'hidden', timeout: FAST_ACTION_TIMEOUT });
+  });
+});

--- a/e2e/frontend-webui/tests/spec/keyboard-shortcuts.spec.js
+++ b/e2e/frontend-webui/tests/spec/keyboard-shortcuts.spec.js
@@ -199,6 +199,120 @@ test.describe('Keyboard Shortcuts — Regression Tests (me03#27082)', () => {
     expect(await dropdown.isVisible()).toBe(true);
   });
 
+  test('Shortcuts work after table filter interaction (UPDATE_HOTKEYS regression)', async ({
+    page,
+  }) => {
+    // We're on the Organisation list view from beforeEach.
+    // Click on a column header to trigger table sort — this causes a re-render
+    // cycle where Shortcut components unmount/remount, firing UPDATE_HOTKEYS.
+    // This was the specific Redux action whose reducer had the spread-operator bug.
+    const headerCell = page
+      .locator('.table-flex-wrapper thead th')
+      .nth(1); // Skip first column (row selection checkbox)
+    await headerCell.waitFor({
+      state: 'visible',
+      timeout: FAST_ACTION_TIMEOUT,
+    });
+    await headerCell.click();
+
+    // Wait for sort re-render + Redux UPDATE_HOTKEYS dispatch
+    await page.waitForTimeout(1000);
+
+    // Now navigate to a single record
+    await navigateToSingleDocument(page);
+
+    // Press ALT+E to open Advanced Edit overlay
+    await page.keyboard.press('Alt+e');
+
+    // Verify the modal overlay appeared
+    const modal = page.locator('.panel-modal');
+    await modal.waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
+    expect(await modal.isVisible()).toBe(true);
+
+    // Press ALT+ENTER to confirm — the exact shortcut that was broken by the bug
+    await page.keyboard.press('Alt+Enter');
+
+    // Verify the modal closed — proves shortcuts survived UPDATE_HOTKEYS
+    await modal.waitFor({ state: 'hidden', timeout: FAST_ACTION_TIMEOUT });
+    expect(await modal.isVisible()).toBe(false);
+  });
+
+  test('PageDown/PageUp navigate between pages in list view', async ({
+    page,
+  }) => {
+    // Navigate to Products list (772 records — enough for multiple pages)
+    // Window 140 may redirect to override window 541690 on this branch
+    await page.goto('/window/140', { waitUntil: 'load' });
+
+    // Wait for the document list and pagination to load
+    await page
+      .locator('.document-list-wrapper')
+      .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+    await page
+      .locator('.pagination-wrapper')
+      .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+    // Wait for table rows to appear
+    const rows = page.locator('.table-flex-wrapper table tbody tr');
+    await rows.first().waitFor({
+      state: 'visible',
+      timeout: SLOW_ACTION_TIMEOUT,
+    });
+
+    // Get the active page number before navigation
+    const activePage = page.locator('.pagination .page-item.active .page-link');
+    await activePage.waitFor({
+      state: 'visible',
+      timeout: FAST_ACTION_TIMEOUT,
+    });
+    const initialPageText = await activePage.textContent();
+
+    // Click on the table area to ensure it has focus (PageDown needs focus)
+    await rows.first().click();
+    await page.waitForTimeout(300);
+
+    // Press PageDown to go to the next page
+    await page.keyboard.press('PageDown');
+
+    // Wait for the page to change — the active page number should update
+    await page.waitForFunction(
+      (initialText) => {
+        const active = document.querySelector(
+          '.pagination .page-item.active .page-link'
+        );
+        return active && active.textContent !== initialText;
+      },
+      initialPageText,
+      { timeout: SLOW_ACTION_TIMEOUT }
+    );
+
+    // Verify we moved forward (page number should be greater)
+    const nextPageText = await activePage.textContent();
+    expect(Number(nextPageText)).toBeGreaterThan(Number(initialPageText));
+
+    // Brief pause to let the page fully render
+    await page.waitForTimeout(500);
+
+    // Press PageUp to go back
+    await page.keyboard.press('PageUp');
+
+    // Wait for the page to return to original
+    await page.waitForFunction(
+      (originalText) => {
+        const active = document.querySelector(
+          '.pagination .page-item.active .page-link'
+        );
+        return active && active.textContent === originalText;
+      },
+      initialPageText,
+      { timeout: SLOW_ACTION_TIMEOUT }
+    );
+
+    // Verify we're back on the original page
+    const finalPageText = await activePage.textContent();
+    expect(finalPageText).toBe(initialPageText);
+  });
+
   test('Escape closes each menu after opening', async ({ page }) => {
     // --- ALT+1 → Escape ---
     await page.keyboard.press('Alt+1');

--- a/e2e/frontend-webui/tests/utils/common.js
+++ b/e2e/frontend-webui/tests/utils/common.js
@@ -1,0 +1,82 @@
+import { test } from '../../playwright.config';
+import { ErrorToast } from './components/ErrorToast';
+
+export const FRONTEND_BASE_URL =
+  process.env.FRONTEND_BASE_URL || 'http://localhost:3000';
+
+export const VERY_FAST_ACTION_TIMEOUT = 1000; // 1 second
+export const FAST_ACTION_TIMEOUT = 5000; // 5 seconds
+export const SLOW_ACTION_TIMEOUT = 20000; // 20 seconds
+export const VERY_SLOW_ACTION_TIMEOUT = 40000; // 40 seconds
+
+export const getPage = () => global.currentPage;
+
+/**
+ * Wrap a test step function with automatic error detection.
+ * If an error toast appears during execution, the step will fail.
+ */
+export const step = async (title, func) =>
+  await test.step(title, async () => await runAndWatchForErrors(func));
+
+let currentErrorWatcherId = 0;
+let nextErrorWatcherId = 100;
+
+/**
+ * Execute a function while watching for error toasts.
+ * Uses Promise.race to fail immediately if an error toast appears.
+ */
+const runAndWatchForErrors = async (func) => {
+  // If already watching for errors (nested call), just execute
+  if (currentErrorWatcherId > 0) {
+    return await func();
+  }
+
+  const watcherId = ++nextErrorWatcherId;
+  currentErrorWatcherId = watcherId;
+
+  try {
+    return await Promise.race([
+      func(),
+      ErrorToast.waitToPopup(
+        async (toastLocator) => {
+          // Only handle error if this watcher is still active
+          if (currentErrorWatcherId !== watcherId) {
+            return;
+          }
+
+          const textContent = await toastLocator.textContent();
+          throw new Error('Unexpected error toast detected: ' + textContent);
+        },
+        999_000 // Very long timeout - we expect the function to complete first
+      ),
+    ]);
+  } finally {
+    currentErrorWatcherId = 0;
+  }
+};
+
+/**
+ * Execute a function expecting an error toast to appear.
+ * Fails if no error toast appears.
+ */
+export const expectErrorToast = async (title, func) =>
+  await test.step(title, async () => {
+    try {
+      await Promise.race([
+        func(),
+        ErrorToast.waitToPopup(
+          async () => {
+            // Error toast appeared as expected
+            return;
+          },
+          VERY_SLOW_ACTION_TIMEOUT
+        ),
+      ]);
+      throw new Error('Expected error toast to appear but it did not');
+    } catch (error) {
+      if (error.message.includes('Expected error toast')) {
+        throw error;
+      }
+      // Error toast appeared, test passes
+    }
+  });

--- a/e2e/frontend-webui/tests/utils/components/ErrorToast.js
+++ b/e2e/frontend-webui/tests/utils/components/ErrorToast.js
@@ -1,0 +1,38 @@
+import { getPage } from '../common';
+
+/**
+ * Get the error toast locator from the Toastify container.
+ * Matches error-level toasts with alert role.
+ */
+const containerElement = () =>
+  getPage().locator('.Toastify div[role="alert"].Toastify__toast-body');
+
+/**
+ * Error toast component helper for detecting and interacting with error toasts.
+ * Used for automatic error detection during test execution.
+ */
+export const ErrorToast = {
+  /**
+   * Wait for an error toast to appear and execute callback.
+   * @param {Function} callback - Function to execute when toast appears
+   * @param {number} timeout - Timeout in milliseconds
+   * @returns {Promise<void>}
+   */
+  waitToPopup: (callback, timeout) => {
+    const toastLocator = containerElement();
+    return toastLocator
+      .waitFor({ state: 'attached', timeout })
+      .then(async () => {
+        await callback?.(toastLocator);
+      });
+  },
+
+  /**
+   * Close the error toast popup by clicking the close button.
+   */
+  closePopup: async () => {
+    const page = getPage();
+    await page.locator('.Toastify__close-button--error').click();
+    await containerElement().waitFor({ state: 'detached' });
+  },
+};

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -9,7 +9,7 @@ var listenHost = '0.0.0.0';
 const devServer = new WebpackDevServer(
   {
     host: listenHost,
-    port: 3000,
+    port: process.env.PORT || 3000,
     allowedHosts: 'all', // 👈 allows any external host (like myapp3000.loca.lt)
     static: {
       directory: path.join(__dirname, ''),
@@ -17,6 +17,34 @@ const devServer = new WebpackDevServer(
     },
     hot: true,
     historyApiFallback: true,
+    // Proxy is opt-in: set API_PROXY_TARGET to enable proxying /rest and /stomp
+    // to a local backend (e.g., API_PROXY_TARGET=http://localhost:8080).
+    ...(process.env.API_PROXY_TARGET
+      ? {
+          proxy: [
+            {
+              context: ['/rest', '/stomp'],
+              target: process.env.API_PROXY_TARGET,
+              changeOrigin: false,
+              ws: true,
+              cookieDomainRewrite: '',
+              cookiePathRewrite: '/',
+              onProxyRes: function (proxyRes) {
+                var setCookie = proxyRes.headers['set-cookie'];
+                if (setCookie) {
+                  proxyRes.headers['set-cookie'] = setCookie.map(function (
+                    cookie
+                  ) {
+                    return cookie
+                      .replace(/;\s*SameSite=[^;]*/gi, '')
+                      .replace(/;\s*Secure/gi, '');
+                  });
+                }
+              },
+            },
+          ],
+        }
+      : {}),
   },
   webpack(config)
 );
@@ -30,5 +58,7 @@ devServer.startCallback((err) => {
     return console.error(err);
   }
   // eslint-disable-next-line no-console
-  return console.warn('Listening at http://' + listenHost + ':3000/');
+  return console.warn(
+    'Listening at http://' + listenHost + ':' + (process.env.PORT || 3000) + '/'
+  );
 });


### PR DESCRIPTION
## Summary

- Add Playwright E2E infrastructure to `inner_silence_hotfix` branch (modeled after `new_dawn_uat`)
- Add 9 regression tests covering the keyboard shortcut fix from #22436 / #22446
- Enhance `frontend/server.js` with optional proxy support (`API_PROXY_TARGET`) and configurable `PORT`

## Important: Not executed in CI

These Playwright E2E tests are **not wired into the CI pipeline** — there is no CI job for frontend-webui Playwright tests on any branch. They must be run locally. See `e2e/frontend-webui/README.md` for setup and execution instructions.

## Test Scenarios

| # | Test | Shortcut | Verifies |
|---|------|----------|----------|
| 1 | ALT+E opens Advanced Edit, ALT+ENTER confirms | `Alt+E` then `Alt+Enter` | Modal DONE handler (the exact bug) |
| 2 | ALT+E opens Advanced Edit, Escape cancels | `Alt+E` then `Escape` | Modal CANCEL handler |
| 3 | Shortcuts work after re-open (no stale handlers) | `Alt+E` x2 cycles | Shortcut re-subscription on unmount/remount |
| 4 | ALT+1 opens SubHeader/Actions menu | `Alt+1` | Global shortcut |
| 5 | ALT+3 opens Inbox | `Alt+3` | Global shortcut |
| 6 | ALT+4 opens User dropdown | `Alt+4` | Global shortcut |
| 7 | Escape closes each menu after opening | `Escape` / click-outside | Close handlers |
| 8 | Shortcuts survive UPDATE_HOTKEYS (table filter regression) | `Alt+E` after filter | Redux spread-operator bug |
| 9 | PageDown/PageUp pagination | `PageDown` / `PageUp` | PaginationContextShortcuts |

All 9 tests pass locally (52s total).

## Test plan

- [ ] All 9 tests pass locally: `cd e2e/frontend-webui && FRONTEND_BASE_URL=http://localhost:3000 npx playwright test --headed`
- [ ] CI build passes (no frontend code changes affect existing tests)