### PR TITLE
M_ShippingPackage.Note: set IsAlwaysUpdateable

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5790770_sys_M_ShippingPackage_Note_IsAlwaysUpdateable.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5790770_sys_M_ShippingPackage_Note_IsAlwaysUpdateable.sql
@@ -1,0 +1,1 @@
+UPDATE AD_Column Set isalwaysupdateable='Y', updatedby=100, updated='2026-02-27 10:53' where ad_Column_id=551102;


### PR DESCRIPTION
## Summary
- Set `IsAlwaysUpdateable='Y'` on `AD_Column_ID=551102` (`M_ShippingPackage.Note`) so the Note field can be edited even after the record is processed

## Test plan
- [x] Verify the Note field on M_ShippingPackage can be edited after processing