### PR TITLE
Improve ESR QR scanner UX: auto-start webcam and auto-resolve

### DIFF
--- a/frontend/src/components/widget/BarcodeScanner/BarcodeScannerWidget.js
+++ b/frontend/src/components/widget/BarcodeScanner/BarcodeScannerWidget.js
@@ -41,7 +41,7 @@ function addBarcodeScanner(WrappedComponent) {
           ? props.layout.barcodeScannerType
           : null;
 
-      const scanning = barcodeScannerType && currentDevice.type === 'mobile';
+      const scanning = !!barcodeScannerType;
 
       this.state = {
         barcodeScannerType: barcodeScannerType,

--- a/frontend/src/components/widget/RawWidget.js
+++ b/frontend/src/components/widget/RawWidget.js
@@ -509,8 +509,9 @@ export class RawWidget extends PureComponent {
    * @param {string} qrCode
    */
   onDetectedQR = (qrCode) => {
-    const { widgetField, handleChange } = this.props;
+    const { widgetField, handleChange, handlePatch } = this.props;
     handleChange(widgetField, qrCode);
+    handlePatch(widgetField, qrCode);
   };
 
   render() {
@@ -683,7 +684,12 @@ export class RawWidget extends PureComponent {
         </div>
         {/* this is a special case for displaying the scan button on the right side of the field */}
         {this.isScanQRbuttonPanel() && (
-          <BarcodeScannerBtn postDetectionExec={this.onDetectedQR} />
+          <BarcodeScannerBtn
+            postDetectionExec={this.onDetectedQR}
+            layout={{
+              barcodeScannerType: this.props.barcodeScannerType,
+            }}
+          />
         )}
       </div>
     );


### PR DESCRIPTION
## Summary

- When a process parameter field has `barcodeScannerType='qrCode'` (e.g., the ESR import process on vendor invoices), the webcam scanner now **activates immediately** when the dialog opens. Previously, the user had to Tab to the scan button and press Enter to start the camera.
- After a QR code is scanned, the value is **automatically patched** to the backend, triggering the `onParameterChanged` callout which resolves BPartner, bank account, and amount — no manual Tab/blur required.

### Changes

- `BarcodeScannerWidget.js`: Remove mobile-only restriction for auto-start scanning — scanner activates on any device when `barcodeScannerType` is configured
- `RawWidget.js`: Pass `layout` prop (with `barcodeScannerType`) to `BarcodeScannerBtn` so the HOC knows the scanner type; call `handlePatch` after QR detection in addition to `handleChange`

## Test plan

- [ ] Open a completed vendor invoice (Kreditoren Rechnung)
- [ ] Start the "ESR einlesen" (QR Code) process
- [ ] Verify webcam activates automatically when dialog opens
- [ ] Scan a Swiss QR-bill code
- [ ] Verify BPartner, bank account, and amount fields are populated automatically without manual Tab
- [ ] Click "Start" to confirm the payment request is created
- [ ] Verify existing mobile QR scanning still works
- [ ] Verify Jest tests pass (`yarn test` — 65 suites, 343 tests)