### PR TITLE
Fix REMADV overUnderAmt using inconsistent multipliers for debit positions

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/remittanceadvice/RemittanceAdviceService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/remittanceadvice/RemittanceAdviceService.java
@@ -35,7 +35,6 @@ import de.metas.document.IDocTypeDAO;
 import de.metas.invoice.InvoiceAmtMultiplier;
 import de.metas.invoice.InvoiceDocBaseType;
 import de.metas.invoice.InvoiceId;
-import de.metas.invoice.service.IInvoiceBL;
 import de.metas.invoice.service.IInvoiceDAO;
 import de.metas.logging.LogManager;
 import de.metas.money.CurrencyId;
@@ -70,7 +69,6 @@ public class RemittanceAdviceService
 	private final MoneyService moneyService;
 	private final ICurrencyBL currencyConversionBL = Services.get(ICurrencyBL.class);
 	private final IDocTypeDAO docTypeDAO = Services.get(IDocTypeDAO.class);
-	private final IInvoiceBL invoiceBL = Services.get(IInvoiceBL.class);
 	private final IInvoiceDAO invoiceDAO = Services.get(IInvoiceDAO.class);
 	private final ICurrencyDAO currencyDAO = Services.get(ICurrencyDAO.class);
 
@@ -172,10 +170,13 @@ public class RemittanceAdviceService
 			@NonNull final RemittanceAdvice remittanceAdvice,
 			@NonNull final RemittanceAdviceLine remittanceAdviceLine)
 	{
-		final InvoiceAmtMultiplier invoiceAmtMultiplier = invoiceBL.getInvoiceAmtMultiplier(invoice);
+		// Use the REMADV line's externalInvoiceDocBaseType multiplier for BOTH amounts
+		// so that overUnderAmt correctly reflects the numeric difference.
+		// The actual invoice doc type mismatch is handled by isInvoiceDocTypeValid.
+		final InvoiceAmtMultiplier lineMultiplier = InvoiceAmtMultiplier.nonAdjustedFor(remittanceAdviceLine.getExternalInvoiceDocBaseType());
 
 		final Amount invoiceAmt = getInvoiceAmountInRemAdvCurrency(remittanceAdvice.getRemittedAmountCurrencyId(), invoice);
-		final Amount invoiceAmtAdjusted = invoiceAmtMultiplier.convertToRealValue(invoiceAmt);
+		final Amount invoiceAmtAdjusted = lineMultiplier.convertToRealValue(invoiceAmt);
 
 		final Amount remittedAmountAdjusted = remittanceAdviceLine.getRemittedAmountAdjusted();
 

--- a/backend/de.metas.business/src/test/java/de/metas/remittanceadvice/RemittanceAdviceServiceTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/remittanceadvice/RemittanceAdviceServiceTest.java
@@ -65,6 +65,8 @@ import java.util.Map;
 
 import static de.metas.invoice.InvoiceDocBaseType.CustomerInvoice;
 import static de.metas.invoice.InvoiceDocBaseType.VendorCreditMemo;
+import static de.metas.invoice.InvoiceDocBaseType.VendorInvoice;
+import static de.metas.invoice.InvoiceDocBaseType.CustomerCreditMemo;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -195,9 +197,9 @@ public class RemittanceAdviceServiceTest
 
 		final I_C_Invoice invoice;
 
-		final Money invoiceGrandTotal = openAmt
-				.negateIf(type.isCreditMemo())
-				.negateIf(!type.isSales());
+		// In production, GrandTotal is always stored as positive.
+		// The sign is determined by the doc type at read-time via InvoiceAmtMultiplier.
+		final Money invoiceGrandTotal = openAmt;
 
 		final LocalDate invoicedDateToUse = invoicedDate != null
 				? invoicedDate
@@ -414,7 +416,96 @@ public class RemittanceAdviceServiceTest
 		assertThat(remittanceAdviceLine.isServiceFeeResolved()).isFalse();
 
 		// ..because the amounts are the same, but the doctype doesn't match our invoice
-		assertThat(remittanceAdviceLine.isInvoiceDocTypeValid()).isFalse(); 
+		assertThat(remittanceAdviceLine.isInvoiceDocTypeValid()).isFalse();
+	}
+
+	@Test
+	public void testResolveRemittanceAdviceLineWithVendorInvoice_MatchingDocType()
+	{
+		//given - debit REMADV line (API) linked to a matching Vendor Invoice (API)
+		final I_C_Invoice invoice = invoice().type(VendorInvoice).open(BigDecimal.valueOf(100)).currency(euroCurrencyId).build();
+		final RemittanceAdvice remittanceAdvice = remittance().build();
+		final RemittanceAdviceLine remittanceAdviceLine = remittanceLine()
+				.invoiceId(invoice.getC_Invoice_ID())
+				.invoiceDocBaseType(VendorInvoice)
+				.remittanceAmt(new BigDecimal(100))
+				.build();
+
+		//when
+		remittanceAdviceService.resolveRemittanceAdviceLine(remittanceAdvice, remittanceAdviceLine);
+
+		//then
+		assertThat(remittanceAdviceLine.isInvoiceResolved()).isTrue();
+		assertThat(remittanceAdviceLine.isAmountValid()).isTrue();
+		assertThat(remittanceAdviceLine.isInvoiceDocTypeValid()).isTrue();
+		assertThat(remittanceAdviceLine.getOverUnderAmtInREMADVCurrency()).isEqualTo(Amount.zero(CurrencyCode.EUR));
+	}
+
+	@Test
+	public void testResolveRemittanceAdviceLineWithVendorInvoice_DocTypeMismatch_AmountsMatch()
+	{
+		//given - debit REMADV line (API) linked to a Customer Invoice (ARI) with same amount
+		// This is the scenario from gh#28443: customer manually creates wrong invoice type for a debit REMADV line
+		final I_C_Invoice invoice = invoice().type(CustomerInvoice).open(BigDecimal.valueOf(100)).currency(euroCurrencyId).build();
+		final RemittanceAdvice remittanceAdvice = remittance().build();
+		final RemittanceAdviceLine remittanceAdviceLine = remittanceLine()
+				.invoiceId(invoice.getC_Invoice_ID())
+				.invoiceDocBaseType(VendorInvoice)
+				.remittanceAmt(new BigDecimal(100))
+				.build();
+
+		//when
+		remittanceAdviceService.resolveRemittanceAdviceLine(remittanceAdvice, remittanceAdviceLine);
+
+		//then - amounts should be valid (numerically equal), but doc type should be flagged as mismatched
+		assertThat(remittanceAdviceLine.isInvoiceResolved()).isTrue();
+		assertThat(remittanceAdviceLine.isAmountValid()).as("amounts match numerically, overUnder should be zero").isTrue();
+		assertThat(remittanceAdviceLine.isInvoiceDocTypeValid()).as("API != ARI").isFalse();
+		assertThat(remittanceAdviceLine.getOverUnderAmtInREMADVCurrency()).isEqualTo(Amount.zero(CurrencyCode.EUR));
+	}
+
+	@Test
+	public void testResolveRemittanceAdviceLineWithCustomerCreditMemo_MatchingDocType()
+	{
+		//given - REMADV line (ARC) linked to a Customer Credit Memo (ARC)
+		final I_C_Invoice invoice = invoice().type(CustomerCreditMemo).open(BigDecimal.valueOf(100)).currency(euroCurrencyId).build();
+		final RemittanceAdvice remittanceAdvice = remittance().build();
+		final RemittanceAdviceLine remittanceAdviceLine = remittanceLine()
+				.invoiceId(invoice.getC_Invoice_ID())
+				.invoiceDocBaseType(CustomerCreditMemo)
+				.remittanceAmt(new BigDecimal(100))
+				.build();
+
+		//when
+		remittanceAdviceService.resolveRemittanceAdviceLine(remittanceAdvice, remittanceAdviceLine);
+
+		//then
+		assertThat(remittanceAdviceLine.isInvoiceResolved()).isTrue();
+		assertThat(remittanceAdviceLine.isAmountValid()).isTrue();
+		assertThat(remittanceAdviceLine.isInvoiceDocTypeValid()).isTrue();
+		assertThat(remittanceAdviceLine.getOverUnderAmtInREMADVCurrency()).isEqualTo(Amount.zero(CurrencyCode.EUR));
+	}
+
+	@Test
+	public void testResolveRemittanceAdviceLineWithVendorCreditMemo_MatchingDocType()
+	{
+		//given - REMADV line (APC) linked to a Vendor Credit Memo (APC)
+		final I_C_Invoice invoice = invoice().type(VendorCreditMemo).open(BigDecimal.valueOf(100)).currency(euroCurrencyId).build();
+		final RemittanceAdvice remittanceAdvice = remittance().build();
+		final RemittanceAdviceLine remittanceAdviceLine = remittanceLine()
+				.invoiceId(invoice.getC_Invoice_ID())
+				.invoiceDocBaseType(VendorCreditMemo)
+				.remittanceAmt(new BigDecimal(100))
+				.build();
+
+		//when
+		remittanceAdviceService.resolveRemittanceAdviceLine(remittanceAdvice, remittanceAdviceLine);
+
+		//then
+		assertThat(remittanceAdviceLine.isInvoiceResolved()).isTrue();
+		assertThat(remittanceAdviceLine.isAmountValid()).isTrue();
+		assertThat(remittanceAdviceLine.isInvoiceDocTypeValid()).isTrue();
+		assertThat(remittanceAdviceLine.getOverUnderAmtInREMADVCurrency()).isEqualTo(Amount.zero(CurrencyCode.EUR));
 	}
 
 }


### PR DESCRIPTION
## Summary

- Fixed `RemittanceAdviceService.buildInvoiceDetailsForRemittanceLine()` to use the REMADV line's `externalInvoiceDocBaseType` multiplier for **both** the remitted amount and the invoice amount when computing `overUnderAmt`
- Previously the invoice amount used the actual invoice's doc type multiplier, causing wrong `overUnderAmt` when doc types differ (e.g., REMADV line expects API but actual invoice is ARI)
- The doc type mismatch is separately validated by `isInvoiceDocTypeValid`

## Test plan

- [x] Existing 6 tests continue to pass (no regressions)
- [x] New test: VendorInvoice (API) with matching doc type → `overUnderAmt=0`, all flags valid
- [x] New test: VendorInvoice (API) with doc type mismatch (actual=ARI) → `overUnderAmt=0`, `isInvoiceDocTypeValid=false`
- [x] New test: CustomerCreditMemo (ARC) with matching doc type → `overUnderAmt=0`, all flags valid
- [x] New test: VendorCreditMemo (APC) with matching doc type → `overUnderAmt=0`, all flags valid