### PR TITLE
gh#3948 User Import: do not assign sys admin role by default

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/security/RoleId.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/security/RoleId.java
@@ -49,6 +49,24 @@ public class RoleId implements RepoIdAware
 		return Check.assumeNotNull(roleId, "Unable to create a roleId for repoId={}", repoId);
 	}
 
+	/**
+	 * Returns a {@link RoleId} for the given repo ID, or {@code null} if the ID is negative.
+	 *
+	 * <p><b>CAUTION</b>: {@code ofRepoIdOrNull(0)} returns {@link #SYSTEM} (System Administrator), NOT {@code null}.
+	 * When reading nullable FK columns from model records, {@code getAD_Role_ID()} returns {@code 0} for SQL NULL
+	 * (Java int default), which this method interprets as System Administrator.
+	 * Use {@link org.adempiere.model.InterfaceWrapperHelper#getValueOrNull} to distinguish NULL from explicit 0.
+	 *
+	 * <p>Affected columns (where ID=0 is a valid value) —
+	 * see {@code POWrapper._ColumnNamesWithFirstValidIdZERO}:
+	 * AD_Client_ID, AD_Org_ID, Record_ID, C_DocType_ID, Node_ID, AD_User_ID, AD_Role_ID,
+	 * M_AttributeSet_ID, M_AttributeSetInstance_ID, AD_System_ID, GL_Category_ID.
+	 *
+	 * <p>This pitfall applies only to {@code Integer} and {@code BigDecimal} returning getters.
+	 * All other model getter types return {@code null} for SQL NULL values.
+	 *
+	 * @see org.adempiere.model.InterfaceWrapperHelper#getValueOrNull
+	 */
 	public static RoleId ofRepoIdOrNull(final int repoId)
 	{
 		if (repoId == SYSTEM.getRepoId())

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/user/impexp/ADUserImportProcess.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/user/impexp/ADUserImportProcess.java
@@ -218,7 +218,11 @@ public class ADUserImportProcess extends SimpleImportProcessTemplate<I_I_User>
 
 		//
 		// Assign Role
-		final RoleId roleId = RoleId.ofRepoIdOrNull(importRecord.getAD_Role_ID());
+		// NOTE: we must use getValueOrNull because getAD_Role_ID() returns 0 for NULL,
+		// and RoleId.ofRepoIdOrNull(0) returns SYSTEM (System Administrator) instead of null.
+		// See https://github.com/metasfresh/mf15/issues/3948
+		final Integer roleRepoId = InterfaceWrapperHelper.getValueOrNull(importRecord, I_I_User.COLUMNNAME_AD_Role_ID);
+		final RoleId roleId = roleRepoId != null ? RoleId.ofRepoIdOrNull(roleRepoId) : null;
 
 		if (roleId != null)
 		{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/importorder/I_User_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/importorder/I_User_StepDef.java
@@ -1,0 +1,86 @@
+package de.metas.cucumber.stepdefs.importorder;
+
+import de.metas.cucumber.stepdefs.StepDefConstants;
+import de.metas.util.Services;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.trx.api.ITrx;
+import org.compiere.model.I_AD_User;
+import org.compiere.model.I_AD_User_Roles;
+import org.compiere.util.DB;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Step definitions for I_User (user import) staging table and role assignment validation.
+ */
+@RequiredArgsConstructor
+public class I_User_StepDef
+{
+	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@Given("all I_User staging records are deleted")
+	public void all_I_User_staging_records_are_deleted()
+	{
+		DB.executeUpdateAndThrowExceptionOnFail(
+				"DELETE FROM I_User WHERE AD_Client_ID=" + StepDefConstants.CLIENT_ID.getRepoId(),
+				ITrx.TRXNAME_None);
+	}
+
+	@Then("the imported AD_User with login {string} has no role assignments")
+	public void the_imported_AD_User_with_login_has_no_role_assignments(@NonNull final String login)
+	{
+		final I_AD_User user = lookupImportedUserByLogin(login);
+
+		final long roleCount = queryBL.createQueryBuilderOutOfTrx(I_AD_User_Roles.class)
+				.addEqualsFilter(I_AD_User_Roles.COLUMNNAME_AD_User_ID, user.getAD_User_ID())
+				.addOnlyActiveRecordsFilter()
+				.create()
+				.count();
+
+		assertThat(roleCount)
+				.as("Expected no role assignments for user with login '%s' (AD_User_ID=%s)", login, user.getAD_User_ID())
+				.isZero();
+	}
+
+	@Then("the imported AD_User with login {string} has role {string}")
+	public void the_imported_AD_User_with_login_has_role(@NonNull final String login, @NonNull final String roleName)
+	{
+		final I_AD_User user = lookupImportedUserByLogin(login);
+
+		final boolean hasRole = queryBL.createQueryBuilderOutOfTrx(I_AD_User_Roles.class)
+				.addEqualsFilter(I_AD_User_Roles.COLUMNNAME_AD_User_ID, user.getAD_User_ID())
+				.addOnlyActiveRecordsFilter()
+				.create()
+				.stream()
+				.anyMatch(userRole -> {
+					final String assignedRoleName = DB.getSQLValueStringEx(
+							ITrx.TRXNAME_None,
+							"SELECT Name FROM AD_Role WHERE AD_Role_ID=?",
+							userRole.getAD_Role_ID());
+					return roleName.equals(assignedRoleName);
+				});
+
+		assertThat(hasRole)
+				.as("Expected user with login '%s' (AD_User_ID=%s) to have role '%s'", login, user.getAD_User_ID(), roleName)
+				.isTrue();
+	}
+
+	private I_AD_User lookupImportedUserByLogin(@NonNull final String login)
+	{
+		final I_AD_User user = queryBL.createQueryBuilderOutOfTrx(I_AD_User.class)
+				.addEqualsFilter(I_AD_User.COLUMNNAME_Login, login)
+				.addEqualsFilter(I_AD_User.COLUMNNAME_AD_Client_ID, StepDefConstants.CLIENT_ID)
+				.create()
+				.firstOnly(I_AD_User.class);
+
+		assertThat(user)
+				.as("Expected to find an imported AD_User with login '%s'", login)
+				.isNotNull();
+
+		return user;
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/user/importUser_csv_role_assignment.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/user/importUser_csv_role_assignment.feature
@@ -1,0 +1,51 @@
+@from:cucumber
+@ghActions:run_on_executor5
+Feature: User Import via CSV — role assignment
+  Validates that user import does NOT assign the System Administrator role
+  when the role column is left empty in the import CSV.
+  See https://github.com/metasfresh/mf15/issues/3948
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-05-17T13:30:13+01:00[Europe/Berlin]
+    And all I_User staging records are deleted
+
+  @from:cucumber
+  Scenario: CSV import without role column does not assign any role
+    Given metasfresh contains C_BPartners:
+      | Identifier | Value           | Name              | IsCustomer |
+      | bp_noRole  | test_bp_noRole1 | BP Import NoRole  | Y          |
+    And AD_ImpFormat "UserNoRole" for table "I_User" with columns:
+      | ColumnName | DataType |
+      | BPValue    | S        |
+      | Firstname  | S        |
+      | Lastname   | S        |
+      | Login      | S        |
+      | EMail      | S        |
+    And C_DataImport config "UserNoRole" using AD_ImpFormat "UserNoRole"
+    When the following CSV is imported via data import config "UserNoRole":
+      """
+      test_bp_noRole1,John,NoRole,john_norole_test,john_norole@test.com
+      """
+    Then the imported AD_User with login 'john_norole_test' has no role assignments
+
+  @from:cucumber
+  Scenario: CSV import with explicit role assigns the correct role
+    Given metasfresh contains C_BPartners:
+      | Identifier  | Value             | Name               | IsCustomer |
+      | bp_withRole | test_bp_withRole1 | BP Import WithRole | Y          |
+    And AD_ImpFormat "UserWithRole" for table "I_User" with columns:
+      | ColumnName | DataType |
+      | BPValue    | S        |
+      | Firstname  | S        |
+      | Lastname   | S        |
+      | Login      | S        |
+      | EMail      | S        |
+      | RoleName   | S        |
+    And C_DataImport config "UserWithRole" using AD_ImpFormat "UserWithRole"
+    When the following CSV is imported via data import config "UserWithRole":
+      """
+      test_bp_withRole1,Jane,WithRole,jane_withrole_test,jane_withrole@test.com,WebUI
+      """
+    Then the imported AD_User with login 'jane_withrole_test' has role 'WebUI'


### PR DESCRIPTION
## Summary

- **Fix**: `ADUserImportProcess` assigned the System Administrator role (ID=0) to every imported user when the role column was left empty in the CSV, because `RoleId.ofRepoIdOrNull(0)` returns `SYSTEM` (not null). Now uses `InterfaceWrapperHelper.getValueOrNull()` to distinguish NULL (no role) from 0 (explicit System Admin).
- **Tests**: Added 2 cucumber integration tests using the full CSV import pipeline to verify role assignment behavior.

## Test plan

- [x] Cucumber: import without role column → no `AD_User_Roles` created
- [x] Cucumber: import with `RoleName=WebUI` → correct role assigned
- [ ] CI green