### PR TITLE
SAP GLJournal: copy description from base line to generated tax line

### DIFF
--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/gljournal_sap/SAPGLJournal.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/gljournal_sap/SAPGLJournal.java
@@ -233,6 +233,7 @@ public class SAPGLJournal
 				.taxId(taxId)
 				.orgId(baseLine.getOrgId())
 				.dimension(baseLine.getDimension())
+				.description(baseLine.getDescription())
 				.isTaxIncluded(false) // tax can't be included for generated tax lines
 				.build();
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/SAP_GLJournalLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/SAP_GLJournalLine_StepDef.java
@@ -115,14 +115,14 @@ public class SAP_GLJournalLine_StepDef
 			glJournalLine.setAmount(amount);
 			glJournalLine.setAmtAcct(amount);  // same amount, as same currency is used
 
-			// M_SectionCode_ID.Identifier
-			final String sectionCodeIdentifier = DataTableUtil.extractStringForColumnName(tableRow, COLUMNNAME_M_SectionCode_ID + "." + TABLECOLUMN_IDENTIFIER);
-			assertThat(sectionCodeIdentifier).isNotBlank();
-
-			final I_M_SectionCode sectionCode = sectionCodeTable.get(sectionCodeIdentifier);
-			assertThat(sectionCode).isNotNull();
-
-			glJournalLine.setM_SectionCode(sectionCode);
+			// OPT.M_SectionCode_ID.Identifier
+			final String sectionCodeIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + COLUMNNAME_M_SectionCode_ID + "." + TABLECOLUMN_IDENTIFIER);
+			if (EmptyUtil.isNotBlank(sectionCodeIdentifier))
+			{
+				final I_M_SectionCode sectionCode = sectionCodeTable.get(sectionCodeIdentifier);
+				assertThat(sectionCode).isNotNull();
+				glJournalLine.setM_SectionCode(sectionCode);
+			}
 
 			// OPT.C_Tax_ID.Identifier
 			final String taxIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + COLUMNNAME_C_Tax_ID + "." + TABLECOLUMN_IDENTIFIER);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/SAP_GLJournalLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/SAP_GLJournalLine_StepDef.java
@@ -119,8 +119,7 @@ public class SAP_GLJournalLine_StepDef
 
 		// IsTaxIncluded
 		row.getAsOptionalBoolean(COLUMNNAME_IsTaxIncluded)
-				.ifTrue(() -> glJournalLine.setIsTaxIncluded(true))
-				.ifFalse(() -> glJournalLine.setIsTaxIncluded(false));
+				.ifPresent(glJournalLine::setIsTaxIncluded);
 
 		// Description
 		row.getAsOptionalString(COLUMNNAME_Description)
@@ -184,6 +183,8 @@ public class SAP_GLJournalLine_StepDef
 				assertThat(generatedLine.getDescription()).isNullOrEmpty();
 			}
 		});
+
+		glJournalLineTable.putOrReplace(row.getAsIdentifier(), generatedLine);
 	}
 
 	@Given("base tax line updated:")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/SAP_GLJournalLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/SAP_GLJournalLine_StepDef.java
@@ -26,7 +26,6 @@ import de.metas.acct.gljournal_sap.SAPGLJournalId;
 import de.metas.acct.gljournal_sap.service.SAPGLJournalLoaderAndSaver;
 import de.metas.acct.model.I_SAP_GLJournal;
 import de.metas.acct.model.I_SAP_GLJournalLine;
-import de.metas.common.util.EmptyUtil;
 import de.metas.cucumber.stepdefs.sectioncode.M_SectionCode_StepDefData;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Given;
@@ -37,7 +36,6 @@ import org.compiere.model.I_M_SectionCode;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_Amount;
 import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_C_Tax_ID;
@@ -47,12 +45,11 @@ import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_IsTaxIncluded;
 import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_Line;
 import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_M_SectionCode_ID;
 import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_Parent_ID;
+import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_PostingSign;
 import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_SAP_GLJournal_ID;
-import static de.metas.cucumber.stepdefs.StepDefConstants.TABLECOLUMN_IDENTIFIER;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.*;
-import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_PostingSign;
 
 public class SAP_GLJournalLine_StepDef
 {
@@ -76,112 +73,89 @@ public class SAP_GLJournalLine_StepDef
 	@Given("metasfresh contains SAP_GLJournalLines:")
 	public void metasfresh_contains_sap_gl_journal_lines(@NonNull final DataTable dataTable)
 	{
-		final List<Map<String, String>> tableRows = dataTable.asMaps(String.class, String.class);
-		for (final Map<String, String> tableRow : tableRows)
+		for (final DataTableRow row : DataTableRow.toRows(dataTable))
 		{
-			final I_SAP_GLJournalLine glJournalLine = newInstance(I_SAP_GLJournalLine.class);
-
-			glJournalLine.setAD_Org_ID(StepDefConstants.ORG_ID.getRepoId());
-
-			// Line
-			final Integer line = DataTableUtil.extractIntForColumnName(tableRow, COLUMNNAME_Line);
-			assertThat(line).isNotNull();
-
-			glJournalLine.setLine(line);
-
-			// SAP_GLJournal_ID.Identifier
-			final String sapGlJournalIdentifier = DataTableUtil.extractStringForColumnName(tableRow, COLUMNNAME_SAP_GLJournal_ID + "." + TABLECOLUMN_IDENTIFIER);
-			assertThat(sapGlJournalIdentifier).isNotBlank();
-
-			final I_SAP_GLJournal header = glJournalTable.get(sapGlJournalIdentifier);
-			glJournalLine.setSAP_GLJournal(header);
-
-			// PostingSign
-			final String postingSign = DataTableUtil.extractStringForColumnName(tableRow, COLUMNNAME_PostingSign);
-			assertThat(postingSign).isNotBlank();
-
-			glJournalLine.setPostingSign(postingSign);
-
-			// C_ValidCombination_ID
-			final String c_ValidCombination_ID = DataTableUtil.extractStringForColumnName(tableRow, COLUMNNAME_C_ValidCombination_ID);
-			assertThat(c_ValidCombination_ID).isNotBlank();
-
-			glJournalLine.setC_ValidCombination_ID(Integer.valueOf(c_ValidCombination_ID));
-
-			// Amount
-			final BigDecimal amount = DataTableUtil.extractBigDecimalForColumnName(tableRow, COLUMNNAME_Amount);
-			assertThat(amount).isNotNull();
-
-			glJournalLine.setAmount(amount);
-			glJournalLine.setAmtAcct(amount);  // same amount, as same currency is used
-
-			// OPT.M_SectionCode_ID.Identifier
-			final String sectionCodeIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + COLUMNNAME_M_SectionCode_ID + "." + TABLECOLUMN_IDENTIFIER);
-			if (EmptyUtil.isNotBlank(sectionCodeIdentifier))
-			{
-				final I_M_SectionCode sectionCode = sectionCodeTable.get(sectionCodeIdentifier);
-				assertThat(sectionCode).isNotNull();
-				glJournalLine.setM_SectionCode(sectionCode);
-			}
-
-			// OPT.C_Tax_ID.Identifier
-			final String taxIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + COLUMNNAME_C_Tax_ID + "." + TABLECOLUMN_IDENTIFIER);
-			if (EmptyUtil.isNotBlank(taxIdentifier))
-			{
-				final I_C_Tax tax = taxTable.get(taxIdentifier);
-				assertThat(tax).isNotNull();
-				glJournalLine.setC_Tax_ID(tax.getC_Tax_ID());
-			}
-
-			// OPT.IsTaxIncluded
-			final boolean isTaxIncluded = DataTableUtil.extractBooleanForColumnName(tableRow, "OPT." + COLUMNNAME_IsTaxIncluded);
-			glJournalLine.setIsTaxIncluded(isTaxIncluded);
-
-			// OPT.Description
-			final String description = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + COLUMNNAME_Description);
-			if (EmptyUtil.isNotBlank(description))
-			{
-				glJournalLine.setDescription(description);
-			}
-
-			// OPT.Parent_ID
-			final String parentIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + COLUMNNAME_Parent_ID);
-			if (EmptyUtil.isNotBlank(parentIdentifier))
-			{
-				final I_SAP_GLJournalLine parent = glJournalLineTable.get(parentIdentifier);
-				assertThat(parent).isNotNull();
-
-				glJournalLine.setParent(parent);
-			}
-
-			saveRecord(glJournalLine);
-
-			glJournalLineTable.putOrReplace(DataTableUtil.extractRecordIdentifier(tableRow, I_SAP_GLJournalLine.COLUMNNAME_SAP_GLJournalLine_ID), glJournalLine);
+			createGLJournalLine(row);
 		}
+	}
+
+	private void createGLJournalLine(@NonNull final DataTableRow row)
+	{
+		final I_SAP_GLJournalLine glJournalLine = newInstance(I_SAP_GLJournalLine.class);
+
+		glJournalLine.setAD_Org_ID(StepDefConstants.ORG_ID.getRepoId());
+
+		// Line
+		glJournalLine.setLine(row.getAsInt(COLUMNNAME_Line));
+
+		// SAP_GLJournal_ID
+		final I_SAP_GLJournal header = glJournalTable.get(row.getAsIdentifier(COLUMNNAME_SAP_GLJournal_ID));
+		glJournalLine.setSAP_GLJournal(header);
+
+		// PostingSign
+		glJournalLine.setPostingSign(row.getAsString(COLUMNNAME_PostingSign));
+
+		// C_ValidCombination_ID
+		glJournalLine.setC_ValidCombination_ID(row.getAsInt(COLUMNNAME_C_ValidCombination_ID));
+
+		// Amount
+		final BigDecimal amount = row.getAsBigDecimal(COLUMNNAME_Amount);
+		glJournalLine.setAmount(amount);
+		glJournalLine.setAmtAcct(amount);  // same amount, as same currency is used
+
+		// M_SectionCode_ID
+		row.getAsOptionalIdentifier(COLUMNNAME_M_SectionCode_ID).ifPresent(sectionCodeIdentifier -> {
+			final I_M_SectionCode sectionCode = sectionCodeTable.get(sectionCodeIdentifier);
+			assertThat(sectionCode).isNotNull();
+			glJournalLine.setM_SectionCode(sectionCode);
+		});
+
+		// C_Tax_ID
+		row.getAsOptionalIdentifier(COLUMNNAME_C_Tax_ID).ifPresent(taxIdentifier -> {
+			final I_C_Tax tax = taxTable.get(taxIdentifier);
+			assertThat(tax).isNotNull();
+			glJournalLine.setC_Tax_ID(tax.getC_Tax_ID());
+		});
+
+		// IsTaxIncluded
+		row.getAsOptionalBoolean(COLUMNNAME_IsTaxIncluded)
+				.ifTrue(() -> glJournalLine.setIsTaxIncluded(true))
+				.ifFalse(() -> glJournalLine.setIsTaxIncluded(false));
+
+		// Description
+		row.getAsOptionalString(COLUMNNAME_Description)
+				.ifPresent(glJournalLine::setDescription);
+
+		// Parent_ID
+		row.getAsOptionalIdentifier(COLUMNNAME_Parent_ID).ifPresent(parentIdentifier -> {
+			final I_SAP_GLJournalLine parent = glJournalLineTable.get(parentIdentifier);
+			assertThat(parent).isNotNull();
+			glJournalLine.setParent(parent);
+		});
+
+		saveRecord(glJournalLine);
+
+		glJournalLineTable.putOrReplace(row.getAsIdentifier(), glJournalLine);
 	}
 
 	@Given("validate generated lines:")
 	public void validate_tax_lines(@NonNull final DataTable dataTable)
 	{
-		final Map<String, String> row = dataTable.asMaps().get(0);
+		final DataTableRow row = DataTableRow.singleRow(dataTable);
 
-		final I_SAP_GLJournal header = extractHeader(row);
+		final I_SAP_GLJournal header = glJournalTable.get(row.getAsIdentifier(COLUMNNAME_SAP_GLJournal_ID));
 		assertThat(header).as("Record not found").isNotNull();
 
 		// Amount
-		final BigDecimal amount = DataTableUtil.extractBigDecimalForColumnName(row, COLUMNNAME_Amount);
-		assertThat(amount).as("Please provide a valid amount").isNotNull();
+		final BigDecimal amount = row.getAsBigDecimal(COLUMNNAME_Amount);
 
 		// ParentID
-		final String parentLineIdentifier = DataTableUtil.extractStringForColumnName(row, "OPT." + COLUMNNAME_Parent_ID);
-		assertThat(parentLineIdentifier).as("%s is mandatory in this context", COLUMNNAME_Parent_ID).isNotBlank();
-
-		// PostingSign
-		final String postingSign = DataTableUtil.extractStringForColumnName(row, COLUMNNAME_PostingSign);
-		assertThat(postingSign).as("%s is mandatory in this context", COLUMNNAME_PostingSign).isNotBlank();
-
+		final StepDefDataIdentifier parentLineIdentifier = row.getAsIdentifier(COLUMNNAME_Parent_ID);
 		final I_SAP_GLJournalLine parentLine = glJournalLineTable.get(parentLineIdentifier);
 		assertThat(parentLine).as("No record found").isNotNull();
+
+		// PostingSign
+		final String postingSign = row.getAsString(COLUMNNAME_PostingSign);
 
 		// validate
 		final SAPGLJournalLoaderAndSaver loaderAndSaver = new SAPGLJournalLoaderAndSaver();
@@ -199,34 +173,33 @@ public class SAP_GLJournalLine_StepDef
 		assertThat(generatedLine.getPostingSign()).isEqualTo(postingSign);
 		assertThat(generatedLine.getAmount()).isEqualByComparingTo(amount);
 
-		// OPT.Description
-		final String expectedDescription = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + COLUMNNAME_Description);
-		if (EmptyUtil.isNotBlank(expectedDescription))
-		{
-			assertThat(generatedLine.getDescription()).isEqualTo(expectedDescription);
-		}
-		else if (expectedDescription != null) // column present but blank → assert no description
-		{
-			assertThat(generatedLine.getDescription()).isNullOrEmpty();
-		}
+		// Description
+		row.getAsOptionalString(COLUMNNAME_Description).ifPresent(expectedDescription -> {
+			if (!expectedDescription.isEmpty())
+			{
+				assertThat(generatedLine.getDescription()).isEqualTo(expectedDescription);
+			}
+			else
+			{
+				assertThat(generatedLine.getDescription()).isNullOrEmpty();
+			}
+		});
 	}
 
 	@Given("base tax line updated:")
 	public void base_tax_line_updated(@NonNull final DataTable dataTable)
 	{
-		final Map<String, String> row = dataTable.asMaps().get(0);
+		final DataTableRow row = DataTableRow.singleRow(dataTable);
 
-		final I_SAP_GLJournal header = extractHeader(row);
+		final I_SAP_GLJournal header = glJournalTable.get(row.getAsIdentifier(COLUMNNAME_SAP_GLJournal_ID));
 		assertThat(header).as("Record not found").isNotNull();
 
 		// PostingSign
-		final String postingSign = DataTableUtil.extractStringForColumnName(row, COLUMNNAME_PostingSign);
-		assertThat(postingSign).as("%s is mandatory in this context", COLUMNNAME_PostingSign).isNotBlank();
+		final String postingSign = row.getAsString(COLUMNNAME_PostingSign);
 
-		final BigDecimal amount = DataTableUtil.extractBigDecimalForColumnName(row, COLUMNNAME_Amount);
-		assertThat(amount).as("Please provide a valid amount").isNotNull();
+		final BigDecimal amount = row.getAsBigDecimal(COLUMNNAME_Amount);
 
-		final boolean isTaxIncluded = DataTableUtil.extractBooleanForColumnName(row, "OPT." + COLUMNNAME_IsTaxIncluded);
+		final boolean isTaxIncluded = row.getAsOptionalBoolean(COLUMNNAME_IsTaxIncluded).toBooleanOrNull();
 
 		//
 		// validate
@@ -245,14 +218,4 @@ public class SAP_GLJournalLine_StepDef
 		assertThat(baseLine.getAmount()).isEqualByComparingTo(amount);
 		assertThat(baseLine.isTaxIncluded()).isEqualTo(isTaxIncluded);
 	}
-
-	private I_SAP_GLJournal extractHeader(@NonNull final Map<String, String> row)
-	{
-		final String headerIdentifier = DataTableUtil.extractStringForColumnName(row, COLUMNNAME_SAP_GLJournal_ID + "." + TABLECOLUMN_IDENTIFIER);
-
-		assertThat(headerIdentifier).as("%s is mandatory in this context", COLUMNNAME_SAP_GLJournal_ID).isNotBlank();
-
-		return glJournalTable.get(headerIdentifier);
-	}
-
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/SAP_GLJournalLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/SAP_GLJournalLine_StepDef.java
@@ -126,12 +126,12 @@ public class SAP_GLJournalLine_StepDef
 
 			// OPT.C_Tax_ID.Identifier
 			final String taxIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + COLUMNNAME_C_Tax_ID + "." + TABLECOLUMN_IDENTIFIER);
-			assertThat(taxIdentifier).isNotBlank();
-
-			final I_C_Tax tax = taxTable.get(taxIdentifier);
-			assertThat(tax).isNotNull();
-
-			glJournalLine.setC_Tax_ID(tax.getC_Tax_ID());
+			if (EmptyUtil.isNotBlank(taxIdentifier))
+			{
+				final I_C_Tax tax = taxTable.get(taxIdentifier);
+				assertThat(tax).isNotNull();
+				glJournalLine.setC_Tax_ID(tax.getC_Tax_ID());
+			}
 
 			// OPT.IsTaxIncluded
 			final boolean isTaxIncluded = DataTableUtil.extractBooleanForColumnName(tableRow, "OPT." + COLUMNNAME_IsTaxIncluded);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/SAP_GLJournalLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/SAP_GLJournalLine_StepDef.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_Amount;
 import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_C_Tax_ID;
 import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_C_ValidCombination_ID;
+import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_Description;
 import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_IsTaxIncluded;
 import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_Line;
 import static de.metas.acct.model.I_SAP_GLJournalLine.COLUMNNAME_M_SectionCode_ID;
@@ -136,6 +137,13 @@ public class SAP_GLJournalLine_StepDef
 			final boolean isTaxIncluded = DataTableUtil.extractBooleanForColumnName(tableRow, "OPT." + COLUMNNAME_IsTaxIncluded);
 			glJournalLine.setIsTaxIncluded(isTaxIncluded);
 
+			// OPT.Description
+			final String description = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + COLUMNNAME_Description);
+			if (EmptyUtil.isNotBlank(description))
+			{
+				glJournalLine.setDescription(description);
+			}
+
 			// OPT.Parent_ID
 			final String parentIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + COLUMNNAME_Parent_ID);
 			if (EmptyUtil.isNotBlank(parentIdentifier))
@@ -190,6 +198,17 @@ public class SAP_GLJournalLine_StepDef
 		assertThat(generatedLine).as("No generated line").isNotNull();
 		assertThat(generatedLine.getPostingSign()).isEqualTo(postingSign);
 		assertThat(generatedLine.getAmount()).isEqualByComparingTo(amount);
+
+		// OPT.Description
+		final String expectedDescription = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + COLUMNNAME_Description);
+		if (EmptyUtil.isNotBlank(expectedDescription))
+		{
+			assertThat(generatedLine.getDescription()).isEqualTo(expectedDescription);
+		}
+		else if (expectedDescription != null) // column present but blank → assert no description
+		{
+			assertThat(generatedLine.getDescription()).isNullOrEmpty();
+		}
 	}
 
 	@Given("base tax line updated:")

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/sap_gljournal/copyDescriptionToTaxLine.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/sap_gljournal/copyDescriptionToTaxLine.feature
@@ -12,8 +12,8 @@ Feature: SAP GL Journal - copy description from base line to generated tax line
       | acctSchema_desc            | metas fresh UN/34 CHF |
 
     And metasfresh contains C_Tax
-      | Identifier    | C_TaxCategory_ID.InternalName | Name               | ValidFrom  | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
-      | tax_desc_copy | Normal                        | TaxName_desc_copy  | 2023-02-01 | 7.7  | DE                       | DE                        |
+      | Identifier    | C_TaxCategory_ID.InternalName | Name              | ValidFrom  | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
+      | tax_desc_copy | Normal                        | TaxName_desc_copy | 2023-02-01 | 7.7  | DE                       | DE                        |
 
   @from:cucumber
   @Id:S0320_300
@@ -26,16 +26,16 @@ Feature: SAP GL Journal - copy description from base line to generated tax line
       | sap_gljournal_S0320_300 | sap_gljournal_S0320_300 | GLJ         | A           | DR        | 2023-02-10 | 2023-02-10 | acctSchema_desc            | 114                 | 1000001        |
 
     And metasfresh contains SAP_GLJournalLines:
-      | Identifier                     | Line | SAP_GLJournal_ID.Identifier | PostingSign | C_ValidCombination_ID | Amount | OPT.C_Tax_ID.Identifier | OPT.IsTaxIncluded | OPT.Description    |
-      | sap_gljournalLine_S0320_300_10 | 10   | sap_gljournal_S0320_300     | C           | 1000343               | 100    | tax_desc_copy           | false             | Office supplies Q1 |
+      | Identifier                     | Line | SAP_GLJournal_ID               | PostingSign | C_ValidCombination_ID | Amount | C_Tax_ID      | IsTaxIncluded | Description        |
+      | sap_gljournalLine_S0320_300_10 | 10   | sap_gljournal_S0320_300        | C           | 1000343               | 100    | tax_desc_copy | false         | Office supplies Q1 |
 
     When regenerate tax lines:
       | SAP_GLJournal_ID.Identifier |
       | sap_gljournal_S0320_300     |
 
     Then validate generated lines:
-      | Identifier                     | SAP_GLJournal_ID.Identifier | PostingSign | Amount | OPT.Parent_ID                  | OPT.Description    |
-      | sap_gljournalLine_S0320_300_20 | sap_gljournal_S0320_300     | C           | 7.7    | sap_gljournalLine_S0320_300_10 | Office supplies Q1 |
+      | Identifier                     | SAP_GLJournal_ID               | PostingSign | Amount | Parent_ID                      | Description        |
+      | sap_gljournalLine_S0320_300_20 | sap_gljournal_S0320_300        | C           | 7.7    | sap_gljournalLine_S0320_300_10 | Office supplies Q1 |
 
   @from:cucumber
   @Id:S0320_400
@@ -48,13 +48,13 @@ Feature: SAP GL Journal - copy description from base line to generated tax line
       | sap_gljournal_S0320_400 | sap_gljournal_S0320_400 | GLJ         | A           | DR        | 2023-02-10 | 2023-02-10 | acctSchema_desc            | 114                 | 1000001        |
 
     And metasfresh contains SAP_GLJournalLines:
-      | Identifier                     | Line | SAP_GLJournal_ID.Identifier | PostingSign | C_ValidCombination_ID | Amount | OPT.C_Tax_ID.Identifier | OPT.IsTaxIncluded |
-      | sap_gljournalLine_S0320_400_10 | 10   | sap_gljournal_S0320_400     | C           | 1000343               | 100    | tax_desc_copy           | false             |
+      | Identifier                     | Line | SAP_GLJournal_ID               | PostingSign | C_ValidCombination_ID | Amount | C_Tax_ID      | IsTaxIncluded |
+      | sap_gljournalLine_S0320_400_10 | 10   | sap_gljournal_S0320_400        | C           | 1000343               | 100    | tax_desc_copy | false         |
 
     When regenerate tax lines:
       | SAP_GLJournal_ID.Identifier |
       | sap_gljournal_S0320_400     |
 
     Then validate generated lines:
-      | Identifier                     | SAP_GLJournal_ID.Identifier | PostingSign | Amount | OPT.Parent_ID                  | OPT.Description |
-      | sap_gljournalLine_S0320_400_20 | sap_gljournal_S0320_400     | C           | 7.7    | sap_gljournalLine_S0320_400_10 |                 |
+      | Identifier                     | SAP_GLJournal_ID               | PostingSign | Amount | Parent_ID                      | Description |
+      | sap_gljournalLine_S0320_400_20 | sap_gljournal_S0320_400        | C           | 7.7    | sap_gljournalLine_S0320_400_10 |             |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/sap_gljournal/copyDescriptionToTaxLine.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/sap_gljournal/copyDescriptionToTaxLine.feature
@@ -15,10 +15,6 @@ Feature: SAP GL Journal - copy description from base line to generated tax line
       | Identifier    | C_TaxCategory_ID.InternalName | Name               | ValidFrom  | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
       | tax_desc_copy | Normal                        | TaxName_desc_copy  | 2023-02-01 | 7.7  | DE                       | DE                        |
 
-    And metasfresh contains M_SectionCode:
-      | M_SectionCode_ID.Identifier | Value            |
-      | section_desc_copy           | testSection_desc |
-
   @from:cucumber
   @Id:S0320_300
   Scenario: Generated tax line inherits description from base line
@@ -30,8 +26,8 @@ Feature: SAP GL Journal - copy description from base line to generated tax line
       | sap_gljournal_S0320_300 | sap_gljournal_S0320_300 | GLJ         | A           | DR        | 2023-02-10 | 2023-02-10 | acctSchema_desc            | 114                 | 1000001        |
 
     And metasfresh contains SAP_GLJournalLines:
-      | Identifier                     | Line | SAP_GLJournal_ID.Identifier | PostingSign | C_ValidCombination_ID | Amount | M_SectionCode_ID.Identifier | OPT.C_Tax_ID.Identifier | OPT.IsTaxIncluded | OPT.Description    |
-      | sap_gljournalLine_S0320_300_10 | 10   | sap_gljournal_S0320_300     | C           | 1000343               | 100    | section_desc_copy           | tax_desc_copy           | false             | Office supplies Q1 |
+      | Identifier                     | Line | SAP_GLJournal_ID.Identifier | PostingSign | C_ValidCombination_ID | Amount | OPT.C_Tax_ID.Identifier | OPT.IsTaxIncluded | OPT.Description    |
+      | sap_gljournalLine_S0320_300_10 | 10   | sap_gljournal_S0320_300     | C           | 1000343               | 100    | tax_desc_copy           | false             | Office supplies Q1 |
 
     When regenerate tax lines:
       | SAP_GLJournal_ID.Identifier |
@@ -52,8 +48,8 @@ Feature: SAP GL Journal - copy description from base line to generated tax line
       | sap_gljournal_S0320_400 | sap_gljournal_S0320_400 | GLJ         | A           | DR        | 2023-02-10 | 2023-02-10 | acctSchema_desc            | 114                 | 1000001        |
 
     And metasfresh contains SAP_GLJournalLines:
-      | Identifier                     | Line | SAP_GLJournal_ID.Identifier | PostingSign | C_ValidCombination_ID | Amount | M_SectionCode_ID.Identifier | OPT.C_Tax_ID.Identifier | OPT.IsTaxIncluded |
-      | sap_gljournalLine_S0320_400_10 | 10   | sap_gljournal_S0320_400     | C           | 1000343               | 100    | section_desc_copy           | tax_desc_copy           | false             |
+      | Identifier                     | Line | SAP_GLJournal_ID.Identifier | PostingSign | C_ValidCombination_ID | Amount | OPT.C_Tax_ID.Identifier | OPT.IsTaxIncluded |
+      | sap_gljournalLine_S0320_400_10 | 10   | sap_gljournal_S0320_400     | C           | 1000343               | 100    | tax_desc_copy           | false             |
 
     When regenerate tax lines:
       | SAP_GLJournal_ID.Identifier |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/sap_gljournal/copyDescriptionToTaxLine.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/sap_gljournal/copyDescriptionToTaxLine.feature
@@ -18,8 +18,8 @@ Feature: SAP GL Journal - copy description from base line to generated tax line
   @from:cucumber
   @Id:S0320_300
   Scenario: Generated tax line inherits description from base line
-  - Base line has a description
-  - After generating tax lines, the tax line should have the same description as its base line
+    - Base line has a description
+    - After generating tax lines, the tax line should have the same description as its base line
 
     Given metasfresh contains SAP_GLJournal:
       | Identifier              | Description             | DocBaseType | PostingType | DocStatus | DateDoc    | DateAcct   | C_AcctSchema_ID.Identifier | C_ConversionType_ID | GL_Category_ID |
@@ -40,8 +40,8 @@ Feature: SAP GL Journal - copy description from base line to generated tax line
   @from:cucumber
   @Id:S0320_400
   Scenario: Generated tax line has no description when base line has no description
-  - Base line has no description
-  - After generating tax lines, the tax line should also have no description
+    - Base line has no description
+    - After generating tax lines, the tax line should also have no description
 
     Given metasfresh contains SAP_GLJournal:
       | Identifier              | Description             | DocBaseType | PostingType | DocStatus | DateDoc    | DateAcct   | C_AcctSchema_ID.Identifier | C_ConversionType_ID | GL_Category_ID |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/sap_gljournal/copyDescriptionToTaxLine.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/sap_gljournal/copyDescriptionToTaxLine.feature
@@ -1,0 +1,64 @@
+@from:cucumber
+Feature: SAP GL Journal - copy description from base line to generated tax line
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2023-04-16T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+
+    And load C_AcctSchema:
+      | C_AcctSchema_ID.Identifier | OPT.Name              |
+      | acctSchema_desc            | metas fresh UN/34 CHF |
+
+    And metasfresh contains C_Tax
+      | Identifier    | C_TaxCategory_ID.InternalName | Name               | ValidFrom  | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
+      | tax_desc_copy | Normal                        | TaxName_desc_copy  | 2023-02-01 | 7.7  | DE                       | DE                        |
+
+    And metasfresh contains M_SectionCode:
+      | M_SectionCode_ID.Identifier | Value            |
+      | section_desc_copy           | testSection_desc |
+
+  @from:cucumber
+  @Id:S0320_300
+  Scenario: Generated tax line inherits description from base line
+  - Base line has a description
+  - After generating tax lines, the tax line should have the same description as its base line
+
+    Given metasfresh contains SAP_GLJournal:
+      | Identifier              | Description             | DocBaseType | PostingType | DocStatus | DateDoc    | DateAcct   | C_AcctSchema_ID.Identifier | C_ConversionType_ID | GL_Category_ID |
+      | sap_gljournal_S0320_300 | sap_gljournal_S0320_300 | GLJ         | A           | DR        | 2023-02-10 | 2023-02-10 | acctSchema_desc            | 114                 | 1000001        |
+
+    And metasfresh contains SAP_GLJournalLines:
+      | Identifier                     | Line | SAP_GLJournal_ID.Identifier | PostingSign | C_ValidCombination_ID | Amount | M_SectionCode_ID.Identifier | OPT.C_Tax_ID.Identifier | OPT.IsTaxIncluded | OPT.Description    |
+      | sap_gljournalLine_S0320_300_10 | 10   | sap_gljournal_S0320_300     | C           | 1000343               | 100    | section_desc_copy           | tax_desc_copy           | false             | Office supplies Q1 |
+
+    When regenerate tax lines:
+      | SAP_GLJournal_ID.Identifier |
+      | sap_gljournal_S0320_300     |
+
+    Then validate generated lines:
+      | Identifier                     | SAP_GLJournal_ID.Identifier | PostingSign | Amount | OPT.Parent_ID                  | OPT.Description    |
+      | sap_gljournalLine_S0320_300_20 | sap_gljournal_S0320_300     | C           | 7.7    | sap_gljournalLine_S0320_300_10 | Office supplies Q1 |
+
+  @from:cucumber
+  @Id:S0320_400
+  Scenario: Generated tax line has no description when base line has no description
+  - Base line has no description
+  - After generating tax lines, the tax line should also have no description
+
+    Given metasfresh contains SAP_GLJournal:
+      | Identifier              | Description             | DocBaseType | PostingType | DocStatus | DateDoc    | DateAcct   | C_AcctSchema_ID.Identifier | C_ConversionType_ID | GL_Category_ID |
+      | sap_gljournal_S0320_400 | sap_gljournal_S0320_400 | GLJ         | A           | DR        | 2023-02-10 | 2023-02-10 | acctSchema_desc            | 114                 | 1000001        |
+
+    And metasfresh contains SAP_GLJournalLines:
+      | Identifier                     | Line | SAP_GLJournal_ID.Identifier | PostingSign | C_ValidCombination_ID | Amount | M_SectionCode_ID.Identifier | OPT.C_Tax_ID.Identifier | OPT.IsTaxIncluded |
+      | sap_gljournalLine_S0320_400_10 | 10   | sap_gljournal_S0320_400     | C           | 1000343               | 100    | section_desc_copy           | tax_desc_copy           | false             |
+
+    When regenerate tax lines:
+      | SAP_GLJournal_ID.Identifier |
+      | sap_gljournal_S0320_400     |
+
+    Then validate generated lines:
+      | Identifier                     | SAP_GLJournal_ID.Identifier | PostingSign | Amount | OPT.Parent_ID                  | OPT.Description |
+      | sap_gljournalLine_S0320_400_20 | sap_gljournal_S0320_400     | C           | 7.7    | sap_gljournalLine_S0320_400_10 |                 |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/sap_gljournal/regenerateTaxLines.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/sap_gljournal/regenerateTaxLines.feature
@@ -30,20 +30,20 @@ Feature: Regenerate tax lines for SAP GL Journal
       | sap_gljournal_S0320_100 | sap_gljournal_S0320_100 | GLJ         | A           | DR        | 2023-02-10 | 2023-02-10 | acctSchema_1               | 114                 | 1000001        |
 
     And metasfresh contains SAP_GLJournalLines:
-      | Identifier                     | Line | SAP_GLJournal_ID.Identifier | PostingSign | C_ValidCombination_ID | Amount | AmtAcct | OPT.M_SectionCode_ID.Identifier | OPT.C_Tax_ID.Identifier | OPT.IsTaxIncluded |
-      | sap_gljournalLine_S0320_100_10 | 10   | sap_gljournal_S0320_100     | C           | 1000343               | 107.7  | 107.7   | testSection_S0320               | tax_S0320               | true              |
+      | Identifier                     | Line | SAP_GLJournal_ID               | PostingSign | C_ValidCombination_ID | Amount | AmtAcct | M_SectionCode_ID  | C_Tax_ID  | IsTaxIncluded |
+      | sap_gljournalLine_S0320_100_10 | 10   | sap_gljournal_S0320_100        | C           | 1000343               | 107.7  | 107.7   | testSection_S0320 | tax_S0320 | true          |
 
     When regenerate tax lines:
       | SAP_GLJournal_ID.Identifier |
       | sap_gljournal_S0320_100     |
 
     Then validate generated lines:
-      | Identifier                     | SAP_GLJournal_ID.Identifier | PostingSign | Amount | OPT.Parent_ID                  |
-      | sap_gljournalLine_S0320_100_20 | sap_gljournal_S0320_100     | C           | 7.7    | sap_gljournalLine_S0320_100_10 |
+      | Identifier                     | SAP_GLJournal_ID               | PostingSign | Amount | Parent_ID                      |
+      | sap_gljournalLine_S0320_100_20 | sap_gljournal_S0320_100        | C           | 7.7    | sap_gljournalLine_S0320_100_10 |
 
     And base tax line updated:
-      | Identifier                     | SAP_GLJournal_ID.Identifier | PostingSign | Amount | OPT.IsTaxIncluded |
-      | sap_gljournalLine_S0320_100_10 | sap_gljournal_S0320_100     | C           | 100    | false             |
+      | Identifier                     | SAP_GLJournal_ID               | PostingSign | Amount | IsTaxIncluded |
+      | sap_gljournalLine_S0320_100_10 | sap_gljournal_S0320_100        | C           | 100    | false         |
 
 
   @from:cucumber
@@ -57,17 +57,17 @@ Feature: Regenerate tax lines for SAP GL Journal
       | sap_gljournal_S0320_200 | sap_gljournal_S0320_200_test | GLJ         | A           | DR        | 2023-02-10 | 2023-02-10 | acctSchema_1               | 114                 | 1000001        |
 
     And metasfresh contains SAP_GLJournalLines:
-      | Identifier                     | Line | SAP_GLJournal_ID.Identifier | PostingSign | C_ValidCombination_ID | Amount | OPT.M_SectionCode_ID.Identifier | OPT.C_Tax_ID.Identifier | OPT.IsTaxIncluded |
-      | sap_gljournalLine_S0320_200_10 | 10   | sap_gljournal_S0320_200     | C           | 1000343               | 100    | testSection_S0320               | tax_S0320               | false             |
+      | Identifier                     | Line | SAP_GLJournal_ID               | PostingSign | C_ValidCombination_ID | Amount | M_SectionCode_ID  | C_Tax_ID  | IsTaxIncluded |
+      | sap_gljournalLine_S0320_200_10 | 10   | sap_gljournal_S0320_200        | C           | 1000343               | 100    | testSection_S0320 | tax_S0320 | false         |
 
     When regenerate tax lines:
       | SAP_GLJournal_ID.Identifier |
       | sap_gljournal_S0320_200     |
 
     Then validate generated lines:
-      | Identifier                     | SAP_GLJournal_ID.Identifier | PostingSign | Amount | OPT.Parent_ID                  |
-      | sap_gljournalLine_S0320_200_20 | sap_gljournal_S0320_200     | C           | 7.7    | sap_gljournalLine_S0320_200_10 |
+      | Identifier                     | SAP_GLJournal_ID               | PostingSign | Amount | Parent_ID                      |
+      | sap_gljournalLine_S0320_200_20 | sap_gljournal_S0320_200        | C           | 7.7    | sap_gljournalLine_S0320_200_10 |
 
     And base tax line updated:
-      | Identifier                     | SAP_GLJournal_ID.Identifier | PostingSign | Amount | OPT.IsTaxIncluded |
-      | sap_gljournalLine_S0320_200_10 | sap_gljournal_S0320_200     | C           | 100    | false             |
+      | Identifier                     | SAP_GLJournal_ID               | PostingSign | Amount | IsTaxIncluded |
+      | sap_gljournalLine_S0320_200_10 | sap_gljournal_S0320_200        | C           | 100    | false         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/sap_gljournal/regenerateTaxLines.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/sap_gljournal/regenerateTaxLines.feature
@@ -30,8 +30,8 @@ Feature: Regenerate tax lines for SAP GL Journal
       | sap_gljournal_S0320_100 | sap_gljournal_S0320_100 | GLJ         | A           | DR        | 2023-02-10 | 2023-02-10 | acctSchema_1               | 114                 | 1000001        |
 
     And metasfresh contains SAP_GLJournalLines:
-      | Identifier                     | Line | SAP_GLJournal_ID.Identifier | PostingSign | C_ValidCombination_ID | Amount | AmtAcct | M_SectionCode_ID.Identifier | OPT.C_Tax_ID.Identifier | OPT.IsTaxIncluded |
-      | sap_gljournalLine_S0320_100_10 | 10   | sap_gljournal_S0320_100     | C           | 1000343               | 107.7  | 107.7   | testSection_S0320           | tax_S0320               | true              |
+      | Identifier                     | Line | SAP_GLJournal_ID.Identifier | PostingSign | C_ValidCombination_ID | Amount | AmtAcct | OPT.M_SectionCode_ID.Identifier | OPT.C_Tax_ID.Identifier | OPT.IsTaxIncluded |
+      | sap_gljournalLine_S0320_100_10 | 10   | sap_gljournal_S0320_100     | C           | 1000343               | 107.7  | 107.7   | testSection_S0320               | tax_S0320               | true              |
 
     When regenerate tax lines:
       | SAP_GLJournal_ID.Identifier |
@@ -57,8 +57,8 @@ Feature: Regenerate tax lines for SAP GL Journal
       | sap_gljournal_S0320_200 | sap_gljournal_S0320_200_test | GLJ         | A           | DR        | 2023-02-10 | 2023-02-10 | acctSchema_1               | 114                 | 1000001        |
 
     And metasfresh contains SAP_GLJournalLines:
-      | Identifier                     | Line | SAP_GLJournal_ID.Identifier | PostingSign | C_ValidCombination_ID | Amount | M_SectionCode_ID.Identifier | OPT.C_Tax_ID.Identifier | OPT.IsTaxIncluded |
-      | sap_gljournalLine_S0320_200_10 | 10   | sap_gljournal_S0320_200     | C           | 1000343               | 100    | testSection_S0320           | tax_S0320               | false             |
+      | Identifier                     | Line | SAP_GLJournal_ID.Identifier | PostingSign | C_ValidCombination_ID | Amount | OPT.M_SectionCode_ID.Identifier | OPT.C_Tax_ID.Identifier | OPT.IsTaxIncluded |
+      | sap_gljournalLine_S0320_200_10 | 10   | sap_gljournal_S0320_200     | C           | 1000343               | 100    | testSection_S0320               | tax_S0320               | false             |
 
     When regenerate tax lines:
       | SAP_GLJournal_ID.Identifier |


### PR DESCRIPTION
## Summary
- When generating tax lines via `SAP_GLJournal_GenerateTaxLines`, the description field from the base line is now copied to the generated tax line
- Previously, generated tax lines always had `description=null` regardless of the base line's description

## Changes
- `SAPGLJournal.createTaxLine()`: Added `.description(baseLine.getDescription())` to the tax line builder
- `SAP_GLJournalLine_StepDef`: Extended to support `OPT.Description` column in both line creation and validation steps
- New cucumber feature file `copyDescriptionToTaxLine.feature` with 2 scenarios:
  - S0320_300: Tax line inherits description from base line
  - S0320_400: Tax line has no description when base line has no description

## Test plan
- [ ] CI green (compilation + existing cucumber tests)
- [ ] New cucumber scenarios S0320_300 and S0320_400 pass
- [ ] Existing regenerateTaxLines scenarios (S0320_100, S0320_200) still pass