### PR TITLE
#26915 DESADV: merge compensation group sub-articles into main article packing

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_OrderLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_OrderLine_StepDef.java
@@ -60,6 +60,7 @@ import org.adempiere.mm.attributes.keys.AttributesKeys;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_DocType;
 import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_Order_CompensationGroup;
 import org.compiere.model.I_C_OrderLine;
 import org.compiere.model.I_C_TaxCategory;
 import org.compiere.model.I_C_UOM;
@@ -106,6 +107,7 @@ public class C_OrderLine_StepDef
 	private final @NonNull C_Tax_StepDefData taxTable;
 	private final @NonNull M_Warehouse_StepDefData warehouseTable;
 	private final @NonNull IdentifierIds_StepDefData identifierIdsTable;
+	private final @NonNull C_Order_CompensationGroup_StepDefData compGroupTable;
 
 	@Given("metasfresh contains C_OrderLines:")
 	public void metasfresh_contains_c_order_lines(@NonNull final DataTable dataTable)
@@ -199,6 +201,12 @@ public class C_OrderLine_StepDef
 
 					tableRow.getAsOptionalString(I_C_OrderLine.COLUMNNAME_Description)
 							.ifPresent(orderLine::setDescription);
+
+					tableRow.getAsOptionalIdentifier(I_C_OrderLine.COLUMNNAME_C_Order_CompensationGroup_ID)
+							.ifPresent(compGroupIdentifier -> {
+								final I_C_Order_CompensationGroup compGroup = compGroupTable.get(compGroupIdentifier);
+								orderLine.setC_Order_CompensationGroup_ID(compGroup.getC_Order_CompensationGroup_ID());
+							});
 
 					saveRecord(orderLine);
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Order_CompensationGroup_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Order_CompensationGroup_StepDef.java
@@ -1,0 +1,36 @@
+package de.metas.cucumber.stepdefs;
+
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_Order_CompensationGroup;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+
+@RequiredArgsConstructor
+public class C_Order_CompensationGroup_StepDef
+{
+	private final @NonNull C_Order_CompensationGroup_StepDefData compGroupTable;
+	private final @NonNull C_Order_StepDefData orderTable;
+
+	@Given("metasfresh contains C_Order_CompensationGroups:")
+	public void createCompensationGroups(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_C_Order orderRecord = row.getAsIdentifier(I_C_Order_CompensationGroup.COLUMNNAME_C_Order_ID)
+					.lookupNotNullIn(orderTable);
+
+			final I_C_Order_CompensationGroup record = newInstance(I_C_Order_CompensationGroup.class);
+			record.setAD_Org_ID(orderRecord.getAD_Org_ID());
+			record.setC_Order_ID(orderRecord.getC_Order_ID());
+			record.setName(row.getAsString(I_C_Order_CompensationGroup.COLUMNNAME_Name));
+
+			saveRecord(record);
+
+			compGroupTable.putOrReplace(row.getAsIdentifier(), record);
+		});
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Order_CompensationGroup_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Order_CompensationGroup_StepDef.java
@@ -10,12 +10,34 @@ import org.compiere.model.I_C_Order_CompensationGroup;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 
+/**
+ * Step definitions for creating {@link I_C_Order_CompensationGroup} records.
+ * Compensation groups link order lines that belong to the same "Mischkarton" (mixed carton).
+ * The DESADV export uses these groups to merge sub-article pack items into the main article's packing.
+ */
 @RequiredArgsConstructor
 public class C_Order_CompensationGroup_StepDef
 {
 	private final @NonNull C_Order_CompensationGroup_StepDefData compGroupTable;
 	private final @NonNull C_Order_StepDefData orderTable;
 
+	/**
+	 * Creates {@link I_C_Order_CompensationGroup} records.
+	 * <p>
+	 * DataTable columns:
+	 * <ul>
+	 *     <li>{@code Identifier} (required) — identifier for later reference</li>
+	 *     <li>{@code C_Order_ID} (required) — identifier of the parent order</li>
+	 *     <li>{@code Name} (required) — name of the compensation group (e.g., "Mischkarton")</li>
+	 * </ul>
+	 * <p>
+	 * Example usage in feature file:
+	 * <pre>
+	 * Given metasfresh contains C_Order_CompensationGroups:
+	 *   | Identifier | C_Order_ID | Name        |
+	 *   | cg_1       | o_1        | Mischkarton |
+	 * </pre>
+	 */
 	@Given("metasfresh contains C_Order_CompensationGroups:")
 	public void createCompensationGroups(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Order_CompensationGroup_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Order_CompensationGroup_StepDef.java
@@ -1,3 +1,25 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
 package de.metas.cucumber.stepdefs;
 
 import io.cucumber.datatable.DataTable;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Order_CompensationGroup_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Order_CompensationGroup_StepDefData.java
@@ -1,3 +1,25 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
 package de.metas.cucumber.stepdefs;
 
 import org.compiere.model.I_C_Order_CompensationGroup;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Order_CompensationGroup_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Order_CompensationGroup_StepDefData.java
@@ -1,0 +1,11 @@
+package de.metas.cucumber.stepdefs;
+
+import org.compiere.model.I_C_Order_CompensationGroup;
+
+public class C_Order_CompensationGroup_StepDefData extends StepDefData<I_C_Order_CompensationGroup>
+{
+	public C_Order_CompensationGroup_StepDefData()
+	{
+		super(I_C_Order_CompensationGroup.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Order_CompensationGroup_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Order_CompensationGroup_StepDefData.java
@@ -2,6 +2,7 @@ package de.metas.cucumber.stepdefs;
 
 import org.compiere.model.I_C_Order_CompensationGroup;
 
+/** StepDefData holder for {@link I_C_Order_CompensationGroup} records, auto-discovered by PicoContainer. */
 public class C_Order_CompensationGroup_StepDefData extends StepDefData<I_C_Order_CompensationGroup>
 {
 	public C_Order_CompensationGroup_StepDefData()

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
@@ -14,12 +14,44 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Step definitions for verifying DESADV JSON export results,
+ * specifically compensation group (Mischkarton) merging behavior.
+ * <p>
+ * Uses the last REST API response from {@link TestContext} to inspect
+ * the PostgREST JSON output of {@code get_desadv_packs_json_fn}.
+ */
 @RequiredArgsConstructor
 public class EDI_Desadv_JSON_Export_StepDef
 {
 	private final @NonNull TestContext testContext;
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
+	/**
+	 * Verifies that the DESADV JSON export correctly merges compensation group sub-articles
+	 * into the main article's packing entry.
+	 * <p>
+	 * Inspects the {@code Packings[].LineItems[]} in the last API response and counts:
+	 * <ul>
+	 *     <li>Total packings (should be reduced after merging)</li>
+	 *     <li>Main articles ({@code IsSubArticle=false}): must have {@code MainArticleLine=null}</li>
+	 *     <li>Sub-articles ({@code IsSubArticle=true}): must have {@code MainArticleLine > 0}</li>
+	 * </ul>
+	 * <p>
+	 * DataTable columns:
+	 * <ul>
+	 *     <li>{@code PackingCount} (required) — expected number of packing entries after merging</li>
+	 *     <li>{@code MainArticleCount} (required) — expected number of main article line items</li>
+	 *     <li>{@code SubArticleCount} (required) — expected number of sub-article line items</li>
+	 * </ul>
+	 * <p>
+	 * Example usage:
+	 * <pre>
+	 * Then verify DESADV JSON export has compensation group packing:
+	 *   | PackingCount | MainArticleCount | SubArticleCount |
+	 *   | 1            | 1                | 2               |
+	 * </pre>
+	 */
 	@Then("verify DESADV JSON export has compensation group packing:")
 	public void verifyCompensationGroupPacking(@NonNull final DataTable dataTable) throws Exception
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
@@ -1,0 +1,85 @@
+package de.metas.cucumber.stepdefs.edi;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.context.TestContext;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Then;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RequiredArgsConstructor
+public class EDI_Desadv_JSON_Export_StepDef
+{
+	private final @NonNull TestContext testContext;
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Then("verify DESADV JSON export has compensation group packing:")
+	public void verifyCompensationGroupPacking(@NonNull final DataTable dataTable) throws Exception
+	{
+		final String responseBody = testContext.getApiResponseBodyAsString();
+		final JsonNode root = objectMapper.readTree(responseBody);
+		final JsonNode packings = root.path("metasfresh_DESADV").path("Packings");
+
+		assertThat(packings.isArray()).as("Packings should be an array").isTrue();
+
+		DataTableRows.of(dataTable).forEach(row -> {
+			final int expectedPackingCount = row.getAsInt("PackingCount");
+			assertThat(packings.size())
+					.as("Expected %d packings after compensation group merging", expectedPackingCount)
+					.isEqualTo(expectedPackingCount);
+
+			final int expectedMainArticles = row.getAsInt("MainArticleCount");
+			final int expectedSubArticles = row.getAsInt("SubArticleCount");
+
+			int actualMainArticles = 0;
+			int actualSubArticles = 0;
+			final List<Integer> subArticleMainLines = new ArrayList<>();
+
+			for (final JsonNode packing : packings)
+			{
+				final JsonNode lineItems = packing.path("LineItems");
+				assertThat(lineItems.isArray()).as("LineItems should be an array").isTrue();
+
+				for (final JsonNode item : lineItems)
+				{
+					final boolean isSubArticle = item.path("IsSubArticle").asBoolean(false);
+					if (isSubArticle)
+					{
+						actualSubArticles++;
+						final JsonNode mainArticleLine = item.path("MainArticleLine");
+						assertThat(mainArticleLine.isNull()).as("SubArticle should have MainArticleLine set").isFalse();
+						subArticleMainLines.add(mainArticleLine.asInt());
+					}
+					else
+					{
+						actualMainArticles++;
+						final JsonNode mainArticleLine = item.path("MainArticleLine");
+						assertThat(mainArticleLine.isNull() || mainArticleLine.isValueNode() && mainArticleLine.asText().equals("null"))
+								.as("Non-sub-article should have MainArticleLine=null")
+								.isTrue();
+					}
+				}
+			}
+
+			assertThat(actualMainArticles)
+					.as("Expected %d main article line items", expectedMainArticles)
+					.isEqualTo(expectedMainArticles);
+			assertThat(actualSubArticles)
+					.as("Expected %d sub-article line items", expectedSubArticles)
+					.isEqualTo(expectedSubArticles);
+
+			// Verify all sub-articles reference a valid main line
+			for (final Integer mainLine : subArticleMainLines)
+			{
+				assertThat(mainLine).as("MainArticleLine should be > 0").isGreaterThan(0);
+			}
+		});
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
@@ -1,3 +1,25 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
 package de.metas.cucumber.stepdefs.edi;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -93,7 +115,7 @@ public class EDI_Desadv_JSON_Export_StepDef
 					{
 						actualMainArticles++;
 						final JsonNode mainArticleLine = item.path("MainArticleLine");
-						assertThat(mainArticleLine.isNull() || mainArticleLine.isValueNode() && mainArticleLine.asText().equals("null"))
+						assertThat(mainArticleLine.isNull())
 								.as("Non-sub-article should have MainArticleLine=null")
 								.isTrue();
 					}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
@@ -244,7 +244,9 @@ Feature: EDI DESADV export via postgREST
             "GTIN_TU_PackingMaterial": "bPartnerProductGTIN",
             "QtyCUsPerLU_InInvoiceUOM": 100,
             "QtyCUsPerTU_InInvoiceUOM": 10,
-            "M_HU_PackagingCode_TU_Text": "ISO1"
+            "M_HU_PackagingCode_TU_Text": "CART",
+            "IsSubArticle": false,
+            "MainArticleLine": null
           }
         ],
         "IPA_SSCC18": "012345670010000005",
@@ -271,3 +273,164 @@ Feature: EDI DESADV export via postgREST
     And after not more than 1s, M_InOut records have the following export status
       | M_InOut_ID | EDI_ExportStatus |
       | s_1        | S                |
+
+  @Id:S0468_020
+  @from:cucumber
+  Scenario: DESADV export merges compensation group sub-articles into main article pack
+
+    # Three products: main article (Mischkarton) and two sub-articles
+    Given metasfresh contains M_Products:
+      | Identifier    | Value                     | Name                     |
+      | mainProduct   | compGroupMainProductValue | Mischkarton 4000g        |
+      | subProduct1   | compGroupSubProduct1Value | Tofu geräuchert 200g     |
+      | subProduct2   | compGroupSubProduct2Value | Tofu Natur 300g          |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_Product_ID | C_BPartner_ID | M_Product_ID | OPT.GTIN         |
+      | bp_main               | customer1     | mainProduct  | mainProductGTIN   |
+      | bp_sub1               | customer1     | subProduct1  | subProduct1GTIN   |
+      | bp_sub2               | customer1     | subProduct2  | subProduct2GTIN   |
+    And metasfresh contains M_HU_PackingMaterial:
+      | M_HU_PackingMaterial_ID | M_Product_ID | Name            |
+      | pm_main                 | mainProduct  | pmMainProduct   |
+      | pm_sub1                 | subProduct1  | pmSubProduct1   |
+      | pm_sub2                 | subProduct2  | pmSubProduct2   |
+    And load M_HU_PackagingCode:
+      | M_HU_PackagingCode_ID | PackagingCode | HU_UnitType |
+      | huPkgCodeLU           | ISO1          | LU          |
+      | huPkgCodeTU           | CART          | TU          |
+
+    # HU PI setup for main product
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID        |
+      | huPILU_main       |
+      | huPITU_main       |
+      | huPIVirtual_main  |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID       | HU_UnitType | IsCurrent | M_HU_PackagingCode_ID |
+      | huPIVerLU_main     | huPILU_main      | LU          | Y         |                       |
+      | huPIVerTU_main     | huPITU_main      | TU          | Y         | huPkgCodeTU           |
+      | huPIVerCU_main     | huPIVirtual_main | V           | Y         |                       |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID | M_HU_PackingMaterial_ID |
+      | huPiItemLU_main            | huPIVerLU_main     | 10  | HU       | huPITU_main       |                         |
+      | huPiItemTU_main            | huPIVerTU_main     | 0   | PM       |                    | pm_main                 |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID  | M_Product_ID | Qty | ValidFrom  | M_HU_PackagingCode_LU_Fallback_ID | GTIN_LU_PackingMaterial_Fallback |
+      | huPiProd_main           | huPiItemTU_main  | mainProduct  | 10  | 2025-01-01 | huPkgCodeLU                       | mainLuGTIN                       |
+
+    # HU PI setup for sub-product 1
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID        |
+      | huPILU_sub1       |
+      | huPITU_sub1       |
+      | huPIVirtual_sub1  |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID        | HU_UnitType | IsCurrent | M_HU_PackagingCode_ID |
+      | huPIVerLU_sub1     | huPILU_sub1       | LU          | Y         |                       |
+      | huPIVerTU_sub1     | huPITU_sub1       | TU          | Y         | huPkgCodeTU           |
+      | huPIVerCU_sub1     | huPIVirtual_sub1  | V           | Y         |                       |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID | M_HU_PackingMaterial_ID |
+      | huPiItemLU_sub1            | huPIVerLU_sub1     | 10  | HU       | huPITU_sub1       |                         |
+      | huPiItemTU_sub1            | huPIVerTU_sub1     | 0   | PM       |                    | pm_sub1                 |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID  | M_Product_ID | Qty | ValidFrom  | M_HU_PackagingCode_LU_Fallback_ID | GTIN_LU_PackingMaterial_Fallback |
+      | huPiProd_sub1           | huPiItemTU_sub1  | subProduct1  | 10  | 2025-01-01 | huPkgCodeLU                       | sub1LuGTIN                       |
+
+    # HU PI setup for sub-product 2
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID        |
+      | huPILU_sub2       |
+      | huPITU_sub2       |
+      | huPIVirtual_sub2  |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID        | HU_UnitType | IsCurrent | M_HU_PackagingCode_ID |
+      | huPIVerLU_sub2     | huPILU_sub2       | LU          | Y         |                       |
+      | huPIVerTU_sub2     | huPITU_sub2       | TU          | Y         | huPkgCodeTU           |
+      | huPIVerCU_sub2     | huPIVirtual_sub2  | V           | Y         |                       |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID | M_HU_PackingMaterial_ID |
+      | huPiItemLU_sub2            | huPIVerLU_sub2     | 10  | HU       | huPITU_sub2       |                         |
+      | huPiItemTU_sub2            | huPIVerTU_sub2     | 0   | PM       |                    | pm_sub2                 |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID  | M_Product_ID | Qty | ValidFrom  | M_HU_PackagingCode_LU_Fallback_ID | GTIN_LU_PackingMaterial_Fallback |
+      | huPiProd_sub2           | huPiItemTU_sub2  | subProduct2  | 10  | 2025-01-01 | huPkgCodeLU                       | sub2LuGTIN                       |
+
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | salesPLV               | mainProduct  | 10.00    | PCE      |
+      | salesPLV               | subProduct1  | 3.00     | PCE      |
+      | salesPLV               | subProduct2  | 4.00     | PCE      |
+
+    # Create order with 3 lines in one compensation group
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | OPT.POReference    |
+      | o_cg       | true    | customer1     | 2025-04-17  | 2025-04-18Z  | compGroupReference |
+    And metasfresh contains C_Order_CompensationGroups:
+      | Identifier | C_Order_ID | Name        |
+      | cg_1       | o_cg       | Mischkarton |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID | C_Order_CompensationGroup_ID |
+      | ol_main    | o_cg       | mainProduct  | 10         | huPiProd_main           | cg_1                         |
+      | ol_sub1    | o_cg       | subProduct1  | 10         | huPiProd_sub1           | cg_1                         |
+      | ol_sub2    | o_cg       | subProduct2  | 10         | huPiProd_sub2           | cg_1                         |
+
+    And the order identified by o_cg is completed
+    And store order-values in TestContext
+      | C_Order_ID | Column     | REST.Context     |
+      | o_cg       | DocumentNo | o_cg_DocumentNo  |
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ss_main    | ol_main        | N             |
+      | ss_sub1    | ol_sub1        | N             |
+      | ss_sub2    | ol_sub2        | N             |
+
+    And setup the SSCC18 code generator with GS1ManufacturerCode 1234567, GS1ExtensionDigit 0 and next sequence number always=1000000.
+
+    And 'generate shipments' process is invoked with QuantityType=D, IsCompleteShipments=true and IsShipToday=false
+      | M_ShipmentSchedule_ID.Identifier |
+      | ss_main                          |
+      | ss_sub1                          |
+      | ss_sub2                          |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | REST.Context.M_InOut_ID | REST.Context.DocumentNo     |
+      | ss_main                          | s_cg                  | shipment_cg_ID          | shipment_cg_DocumentNo      |
+
+    And reset the SSCC18 code generator's next sequence number back to its actual sequence.
+
+    And EDI_Desadv is found:
+      | EDI_Desadv_ID.Identifier | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_ExportStatus | REST.Context |
+      | d_cg                     | customer1                | o_cg                  | P                | d_cg         |
+
+    And the following API_Audit_Config records are created:
+      | Identifier | SeqNo | OPT.Method | OPT.PathPrefix   | IsForceProcessedAsync | IsSynchronousAuditLoggingEnabled | IsWrapApiResponse |
+      | c_cg       | 10    | GET        | api/v2/processes | N                     | Y                                | N                 |
+    And add HTTP headers
+      | Key          | Value                          |
+      | Content-Type | application/json;charset=UTF-8 |
+      | accept       | application/json;charset=UTF-8 |
+
+    When a 'POST' request with the below payload and headers from context is sent to the metasfresh REST-API 'api/v2/processes/M_InOut_EDI_Export_JSON/invoke' and fulfills with '200' status code
+    """
+{
+    "processParameters": [
+    {
+      "name": "M_InOut_ID",
+      "value": "@shipment_cg_ID@"
+    }
+  ]
+}
+    """
+    # The compensation group merging should produce 1 pack (from originally 3):
+    # the main article's pack absorbs the sub-article packs.
+    # Result: 1 main article LineItem (IsSubArticle=false) + 2 sub-article LineItems (IsSubArticle=true with MainArticleLine)
+    Then verify DESADV JSON export has compensation group packing:
+      | PackingCount | MainArticleCount | SubArticleCount |
+      | 1            | 1                | 2               |
+
+    And after not more than 1s, M_InOut records have the following export status
+      | M_InOut_ID | EDI_ExportStatus |
+      | s_cg       | S                |

--- a/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/desadv_json/get_desadv_packs_json_fn.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/desadv_json/get_desadv_packs_json_fn.sql
@@ -73,34 +73,25 @@ BEGIN
              WHERE ep.edi_desadv_id = p_edi_desadv_id
                AND ep.isactive = 'Y'
          ),
-         pack_batched AS (
-             -- Assign batch numbers within each comp group:
-             -- each main-article pack starts a new batch; sub-article packs inherit
-             SELECT pwr.*,
-                    CASE
-                        WHEN comp_group_id IS NOT NULL THEN
-                            SUM(CASE WHEN is_main_article THEN 1 ELSE 0 END)
-                                OVER (PARTITION BY comp_group_id ORDER BY seqno)
-                        ELSE NULL
-                        END AS batch_no
-             FROM pack_with_role pwr
-         ),
          main_packs AS (
-             -- Identify the main pack in each (comp_group, batch)
-             SELECT comp_group_id, batch_no, edi_desadv_pack_id AS main_pack_id
-             FROM pack_batched
+             -- Identify the main pack per compensation group
+             -- (the pack containing the main article item, i.e. lowest order_line).
+             -- Uses DISTINCT ON to pick one main pack per group regardless of seqno ordering.
+             SELECT DISTINCT ON (comp_group_id)
+                 comp_group_id, edi_desadv_pack_id AS main_pack_id
+             FROM pack_with_role
              WHERE is_main_article
+             ORDER BY comp_group_id, seqno
          ),
          items_assigned AS (
-             -- Sub-article items are reassigned to the main pack in their batch
-             SELECT pb.*,
+             -- Sub-article items are reassigned to the main pack in their compensation group
+             SELECT pwr.*,
                     CASE
-                        WHEN pb.is_sub_article THEN mp.main_pack_id
-                        ELSE pb.edi_desadv_pack_id
+                        WHEN pwr.is_sub_article THEN mp.main_pack_id
+                        ELSE pwr.edi_desadv_pack_id
                         END AS effective_pack_id
-             FROM pack_batched pb
-                      LEFT JOIN main_packs mp
-                                ON mp.comp_group_id = pb.comp_group_id AND mp.batch_no = pb.batch_no
+             FROM pack_with_role pwr
+                      LEFT JOIN main_packs mp ON mp.comp_group_id = pwr.comp_group_id
          ),
          pack_header AS (
              -- Use the main pack's header info (SSCC, packaging code) for each effective_pack_id

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5785000_sys_gh26915_desadv_compensation_group_packs.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5785000_sys_gh26915_desadv_compensation_group_packs.sql
@@ -1,7 +1,12 @@
--- Function for desadv packs
--- Handles compensation group sub-articles: sub-article pack items are merged
--- into the main article's pack, adding IsSubArticle and MainArticleLine to each LineItem.
--- Packs NOT in a compensation group are output as before (backward-compatible).
+-- gh#26915: DESADV Mischkarton - merge sub-article packs into main article packs
+-- Sub-articles in compensation groups are now nested within the main article's pack,
+-- adding IsSubArticle and MainArticleLine fields to each LineItem.
+-- Backward compatible: packs NOT in a compensation group are unchanged.
+--
+-- Also inlines the edi_desadv_line_object_v logic in the LATERAL join,
+-- using pack_item.m_inoutline_id to disambiguate orderline/order context
+-- (avoids row multiplication when a desadv line is linked to multiple orders).
+
 CREATE OR REPLACE FUNCTION "de.metas.edi".get_desadv_packs_json_fn(p_edi_desadv_id NUMERIC)
     RETURNS JSONB
 AS

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5785000_sys_gh26915_desadv_compensation_group_packs.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5785000_sys_gh26915_desadv_compensation_group_packs.sql
@@ -1,3 +1,25 @@
+/*
+ * #%L
+ * de.metas.edi
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
 -- gh#26915: DESADV Mischkarton - merge sub-article packs into main article packs
 -- Sub-articles in compensation groups are now nested within the main article's pack,
 -- adding IsSubArticle and MainArticleLine fields to each LineItem.
@@ -78,34 +100,25 @@ BEGIN
              WHERE ep.edi_desadv_id = p_edi_desadv_id
                AND ep.isactive = 'Y'
          ),
-         pack_batched AS (
-             -- Assign batch numbers within each comp group:
-             -- each main-article pack starts a new batch; sub-article packs inherit
-             SELECT pwr.*,
-                    CASE
-                        WHEN comp_group_id IS NOT NULL THEN
-                            SUM(CASE WHEN is_main_article THEN 1 ELSE 0 END)
-                                OVER (PARTITION BY comp_group_id ORDER BY seqno)
-                        ELSE NULL
-                        END AS batch_no
-             FROM pack_with_role pwr
-         ),
          main_packs AS (
-             -- Identify the main pack in each (comp_group, batch)
-             SELECT comp_group_id, batch_no, edi_desadv_pack_id AS main_pack_id
-             FROM pack_batched
+             -- Identify the main pack per compensation group
+             -- (the pack containing the main article item, i.e. lowest order_line).
+             -- Uses DISTINCT ON to pick one main pack per group regardless of seqno ordering.
+             SELECT DISTINCT ON (comp_group_id)
+                 comp_group_id, edi_desadv_pack_id AS main_pack_id
+             FROM pack_with_role
              WHERE is_main_article
+             ORDER BY comp_group_id, seqno
          ),
          items_assigned AS (
-             -- Sub-article items are reassigned to the main pack in their batch
-             SELECT pb.*,
+             -- Sub-article items are reassigned to the main pack in their compensation group
+             SELECT pwr.*,
                     CASE
-                        WHEN pb.is_sub_article THEN mp.main_pack_id
-                        ELSE pb.edi_desadv_pack_id
+                        WHEN pwr.is_sub_article THEN mp.main_pack_id
+                        ELSE pwr.edi_desadv_pack_id
                         END AS effective_pack_id
-             FROM pack_batched pb
-                      LEFT JOIN main_packs mp
-                                ON mp.comp_group_id = pb.comp_group_id AND mp.batch_no = pb.batch_no
+             FROM pack_with_role pwr
+                      LEFT JOIN main_packs mp ON mp.comp_group_id = pwr.comp_group_id
          ),
          pack_header AS (
              -- Use the main pack's header info (SSCC, packaging code) for each effective_pack_id


### PR DESCRIPTION
## Summary

- When order lines share a `C_Order_CompensationGroup` (Mischkarton), the DESADV JSON export now merges sub-article pack items into the main article's packing entry instead of outputting them as separate packings with their own SSCC numbers
- Rewrites `get_desadv_packs_json_fn` to detect compensation groups via `m_inoutline → c_orderline → c_order_compensationgroup_id` and adds `IsSubArticle` / `MainArticleLine` JSON fields
- Adds Cucumber test coverage: existing scenario updated with new fields, new scenario validates compensation group merging (3 products → 1 pack with 1 main + 2 sub-articles)

## Test plan

- [x] Cucumber S0468_010 (standard DESADV export) — green locally
- [x] Cucumber S0468_020 (compensation group merging) — green locally
- [ ] CI build passes