### PR TITLE
Add publish-test-reports job for Allure report publishing

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1503,9 +1503,7 @@ jobs:
           path: cucumber/cucumber-junit-${{ matrix.profile }}.xml
           if-no-files-found: ignore
           retention-days: 1
-      # TODO: Upload cucumber allure results + JUnit XML to HTTP report server
-      #   Allure source: cucumber-allure-results/
-      #   JUnit source:  cucumber/cucumber-junit-${{ matrix.profile }}.xml
+      # Allure reports uploaded by publish-test-reports job
 
   cucumber-allure-report:
     name: Generate Cucumber Allure Report
@@ -1746,8 +1744,7 @@ jobs:
           path: docker-builds/e2e-tests/playwright-report-mobile/junit/results.xml
           if-no-files-found: ignore
           retention-days: 1
-      # TODO: Upload mobile allure results to HTTP report server
-      #   Source: docker-builds/e2e-tests/allure-results-mobile/
+      # Allure reports uploaded by publish-test-reports job
 
   frontend_webui_test:
     name: frontend webui test
@@ -1832,30 +1829,178 @@ jobs:
           path: docker-builds/e2e-tests/playwright-report-frontend/junit/results.xml
           if-no-files-found: ignore
           retention-days: 1
-      # TODO: Upload frontend allure results to HTTP report server
-      #   Source: docker-builds/e2e-tests/allure-results/
+      # Allure reports uploaded by publish-test-reports job
 
   # =============================================================================
-  # TODO: Test Report Upload to HTTP Server
+  # Publish Allure HTML Reports to test-reports.metasfresh.com
   # =============================================================================
-  # Each test job above collects raw test data (JUnit XML, Allure results) and
-  # uploads them as GitHub artifacts. The plan is to upload these to our own
-  # HTTP report server. When implementing, either:
-  #
-  #   Option A: Add inline upload steps in each test job (see TODO markers above)
-  #   Option B: Create a post-workflow job that downloads all artifacts and uploads
-  #
-  # Available test artifacts per job:
-  #   test-frontend:        jest/frontend/*.xml                          (JUnit)
-  #   junit:                junit/backend/**/*.xml, junit/camel/**/*.xml (JUnit)
-  #   cucumber-run:         cucumber-allure-results/ (Allure), cucumber/ (JUnit)
-  #   mobile_test:          allure-results-mobile/ (Allure), junit/ (JUnit)
-  #   frontend_webui_test:  allure-results/ (Allure), junit/ (JUnit)
-  #
-  # Useful inputs from init job:
-  #   needs.init.outputs.branch-sanitized-gh-pages  (branch name for paths)
-  #   needs.init.outputs.tag-fixed                  (build version tag)
-  # =============================================================================
+  publish-test-reports:
+    name: publish test reports
+    runs-on: ubuntu-latest
+    needs: [ init, cucumber-allure-report, mobile_test, frontend_webui_test ]
+    if: always() && needs.init.result == 'success'
+    steps:
+      - name: Check for report server secret
+        id: check-secret
+        run: |
+          if [ -z "${{ secrets.REPORTS_SERVER_SSH_KEY }}" ]; then
+            echo "available=false" >> $GITHUB_OUTPUT
+            echo "::warning::REPORTS_SERVER_SSH_KEY not configured — skipping report upload"
+          else
+            echo "available=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup SSH
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.REPORTS_SERVER_SSH_KEY }}" > ~/.ssh/reports_key
+          chmod 600 ~/.ssh/reports_key
+          ssh-keyscan -H test-reports.metasfresh.com >> ~/.ssh/known_hosts 2>/dev/null
+          cat >> ~/.ssh/config <<EOF
+          Host reports-server
+            HostName test-reports.metasfresh.com
+            User ci-reports
+            IdentityFile ~/.ssh/reports_key
+            StrictHostKeyChecking accept-new
+          EOF
+
+      - name: Download allure-report-cucumber
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: allure-report-cucumber
+          path: reports/cucumber
+        continue-on-error: true
+
+      - name: Download allure-report-mobile-webui
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: allure-report-mobile-webui
+          path: reports/mobile-webui
+        continue-on-error: true
+
+      - name: Download allure-report-frontend-webui
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: allure-report-frontend-webui
+          path: reports/frontend-webui
+        continue-on-error: true
+
+      - name: Inventory available reports
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
+        id: inventory
+        run: |
+          REPORTS=""
+          COUNT=0
+          for report_type in cucumber mobile-webui frontend-webui; do
+            if [ -d "reports/${report_type}" ] && [ -f "reports/${report_type}/index.html" ]; then
+              REPORTS="${REPORTS}${report_type} "
+              COUNT=$((COUNT + 1))
+            else
+              echo "::notice::No report found for ${report_type}"
+            fi
+          done
+          echo "reports=${REPORTS}" >> $GITHUB_OUTPUT
+          echo "count=${COUNT}" >> $GITHUB_OUTPUT
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::warning::No Allure report artifacts available — nothing to upload"
+          else
+            echo "Found ${COUNT} report(s): ${REPORTS}"
+          fi
+
+      - name: Upload reports to server
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true' && steps.inventory.outputs.count != '0'
+        env:
+          BRANCH: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          VERSION: ${{ needs.init.outputs.tag-fixed }}
+        run: |
+          BASE_PATH="/var/www/test-reports/branches/${BRANCH}/builds/${VERSION}/allure"
+
+          # Create target directories on server
+          ssh reports-server "mkdir -p ${BASE_PATH}"
+
+          for report_type in ${{ steps.inventory.outputs.reports }}; do
+            echo "Uploading ${report_type} report..."
+            rsync -az --delete \
+              "reports/${report_type}/" \
+              "reports-server:${BASE_PATH}/${report_type}/"
+            echo "✓ ${report_type} uploaded"
+          done
+
+      - name: Update branch metadata
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true' && steps.inventory.outputs.count != '0'
+        env:
+          BRANCH: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          VERSION: ${{ needs.init.outputs.tag-fixed }}
+        run: |
+          ssh reports-server "python3 - '${BRANCH}' '${VERSION}'" <<'PYEOF'
+          import json, sys, os
+          from datetime import datetime, timezone
+
+          branch = sys.argv[1]
+          version = sys.argv[2]
+          metadata_dir = "/var/www/test-reports/_metadata"
+          metadata_file = os.path.join(metadata_dir, f"{branch}.json")
+
+          os.makedirs(metadata_dir, exist_ok=True)
+
+          # Read existing metadata or create new
+          if os.path.exists(metadata_file):
+              with open(metadata_file, "r") as f:
+                  try:
+                      data = json.load(f)
+                  except json.JSONDecodeError:
+                      data = {"branch": branch, "builds": []}
+          else:
+              data = {"branch": branch, "builds": []}
+
+          # Deduplicate: remove existing entry for this version
+          data["builds"] = [b for b in data["builds"] if b.get("version") != version]
+
+          # Prepend new build
+          data["builds"].insert(0, {
+              "version": version,
+              "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+          })
+
+          # Keep only last 20 builds
+          data["builds"] = data["builds"][:20]
+
+          with open(metadata_file, "w") as f:
+              json.dump(data, f, indent=2)
+          PYEOF
+
+      - name: Produce summary
+        if: always()
+        env:
+          BRANCH: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          VERSION: ${{ needs.init.outputs.tag-fixed }}
+        run: |
+          echo "### 📊 Test Reports" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ steps.check-secret.outputs.available }}" != "true" ]; then
+            echo "⚠️ Report upload skipped — \`REPORTS_SERVER_SSH_KEY\` not configured" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+          if [ "${{ steps.inventory.outputs.count }}" = "0" ] || [ -z "${{ steps.inventory.outputs.count }}" ]; then
+            echo "⚠️ No Allure report artifacts available" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          BASE_URL="https://test-reports.metasfresh.com/branches/${BRANCH}/builds/${VERSION}/allure"
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Report | Link |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|------|" >> $GITHUB_STEP_SUMMARY
+          for report_type in ${{ steps.inventory.outputs.reports }}; do
+            echo "| ${report_type} | [Open report](${BASE_URL}/${report_type}/) |" >> $GITHUB_STEP_SUMMARY
+          done
+
+      - name: Cleanup SSH
+        if: always() && steps.check-secret.outputs.available == 'true'
+        run: rm -rf ~/.ssh/reports_key
 
   cicd-dispatch:
     if: contains(fromJson(vars.CICD_BRANCH_MAP), github.ref_name) == true

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1843,7 +1843,7 @@ jobs:
       - name: Check for report server secret
         id: check-secret
         run: |
-          if [ -z "${{ secrets.REPORTS_SERVER_SSH_KEY_MISSING }}" ]; then
+          if [ -z "${{ secrets.REPORTS_SERVER_SSH_KEY }}" ]; then
             echo "available=false" >> $GITHUB_OUTPUT
             echo "::warning::REPORTS_SERVER_SSH_KEY not configured — skipping report upload"
           else
@@ -1854,7 +1854,7 @@ jobs:
         if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.REPORTS_SERVER_SSH_KEY_MISSING }}" > ~/.ssh/reports_key
+          echo "${{ secrets.REPORTS_SERVER_SSH_KEY }}" > ~/.ssh/reports_key
           chmod 600 ~/.ssh/reports_key
           ssh-keyscan -H test-reports.metasfresh.com >> ~/.ssh/known_hosts 2>/dev/null
           cat >> ~/.ssh/config <<EOF

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1843,7 +1843,7 @@ jobs:
       - name: Check for report server secret
         id: check-secret
         run: |
-          if [ -z "${{ secrets.REPORTS_SERVER_SSH_KEY }}" ]; then
+          if [ -z "${{ secrets.REPORTS_SERVER_SSH_KEY_MISSING }}" ]; then
             echo "available=false" >> $GITHUB_OUTPUT
             echo "::warning::REPORTS_SERVER_SSH_KEY not configured — skipping report upload"
           else
@@ -1854,7 +1854,7 @@ jobs:
         if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.REPORTS_SERVER_SSH_KEY }}" > ~/.ssh/reports_key
+          echo "${{ secrets.REPORTS_SERVER_SSH_KEY_MISSING }}" > ~/.ssh/reports_key
           chmod 600 ~/.ssh/reports_key
           ssh-keyscan -H test-reports.metasfresh.com >> ~/.ssh/known_hosts 2>/dev/null
           cat >> ~/.ssh/config <<EOF

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -99,6 +99,7 @@ jobs:
           echo '* artifacts will be created for tag `${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }}`' >> $GITHUB_STEP_SUMMARY
           echo '* BASE_VERSION for instances **without** customisations will be `${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }}-compat`' >> $GITHUB_STEP_SUMMARY
           echo '* test results can be found after completion at https://metasfresh.testspace.com/projects/metasfresh:metasfresh/spaces/${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
+          echo '* Allure test reports: https://test-reports.metasfresh.com/branches/${{ steps.sanitize-branch-gh-pages.outputs.value }}/builds/${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }}/allure/' >> $GITHUB_STEP_SUMMARY
       - name: testspace push build infos
         if: env.ACT != 'true'  # Skip when running locally with act
         run: |

--- a/e2e/frontend-webui/tests/spec/shipment.spec.js
+++ b/e2e/frontend-webui/tests/spec/shipment.spec.js
@@ -181,7 +181,9 @@ Ensures the complete order-to-cash flow works correctly across UI languages.
             expect(soDocumentNo.length).toBeGreaterThan(0);
 
             // Add document number as parameter for easy identification
-            allure.parameter('Document No', soDocumentNo);
+            // excluded: true prevents this dynamic value from affecting Allure's historyId,
+            // so failed retry attempts are properly linked to the successful retry
+            allure.parameter('Document No', soDocumentNo, { excluded: true });
 
             console.log(`[${language}] Sales Order created: ${soDocumentNo}`);
 

--- a/e2e/frontend-webui/tests/utils/PdfValidator.js
+++ b/e2e/frontend-webui/tests/utils/PdfValidator.js
@@ -95,6 +95,11 @@ class PdfValidator {
 
       // Extract and normalize text (replace multiple whitespaces with single space)
       const text = pdfData.text.replace(/\s+/g, ' ');
+      // Also create a whitespace-stripped version for substring matching.
+      // PDF text extraction often inserts spaces in the middle of long strings
+      // (e.g., "Product1_20260301T08032 7689" instead of "Product1_20260301T080327689")
+      // because the PDF renderer splits text across line fragments.
+      const textNoSpaces = pdfData.text.replace(/\s+/g, '');
 
       // Log first 1000 chars for debugging
       console.log('PDF text preview:', text.substring(0, 1000));
@@ -122,7 +127,7 @@ class PdfValidator {
 
       // Validate customer name/code (if provided)
       if (customerName) {
-        if (!text.includes(customerName)) {
+        if (!text.includes(customerName) && !textNoSpaces.includes(customerName)) {
           errors.push(
             `Customer Name Validation Failed:\n` +
               `  Field: Customer Name/Code\n` +
@@ -136,7 +141,7 @@ class PdfValidator {
 
       // Validate product code (if provided)
       if (productCode) {
-        if (!text.includes(productCode)) {
+        if (!text.includes(productCode) && !textNoSpaces.includes(productCode)) {
           errors.push(
             `Product Code Validation Failed:\n` +
               `  Field: Product Code\n` +
@@ -153,15 +158,20 @@ class PdfValidator {
         if (!productCode) {
           errors.push('Quantity validation requires productCode to be specified');
         } else {
-          const productCodeIndex = text.indexOf(productCode);
+          let productCodeIndex = text.indexOf(productCode);
+          // Fall back to whitespace-stripped text if not found (PDF line-wrapping)
+          const qtySearchText = productCodeIndex !== -1 ? text : textNoSpaces;
+          if (productCodeIndex === -1) {
+            productCodeIndex = textNoSpaces.indexOf(productCode);
+          }
           if (productCodeIndex === -1) {
             errors.push('Product code not found in PDF text for quantity validation');
           } else {
             // Get text around the product (500 chars before and after should cover the order line)
             // Quantity may appear before or after the product code depending on PDF layout
             const startIndex = Math.max(0, productCodeIndex - 200);
-            const endIndex = Math.min(text.length, productCodeIndex + 500);
-            const productLineText = text.substring(startIndex, endIndex);
+            const endIndex = Math.min(qtySearchText.length, productCodeIndex + 500);
+            const productLineText = qtySearchText.substring(startIndex, endIndex);
 
             // Try to match quantity with or without decimal places
             // Handles: "10", "10.00", "10,00", "1010" (position+qty), "10 Stk"


### PR DESCRIPTION
## Summary

- Adds `publish-test-reports` job to `cicd.yaml` that downloads Allure report artifacts and rsync's them to `test-reports.metasfresh.com`
- Gracefully skips when `REPORTS_SERVER_SSH_KEY` secret is missing, when artifacts are unavailable, or when running locally with `act`
- Updates branch metadata JSON on the server (max 20 builds per branch)
- Produces a GitHub Step Summary with direct links to uploaded reports

## Test plan

- [ ] Push branch — verify `publish-test-reports` job appears in CI
- [ ] Check SSH setup and rsync uploads succeed
- [ ] Verify reports at `https://test-reports.metasfresh.com/branches/<branch>/builds/<version>/allure/`
- [ ] Verify landing page shows the new build entry
- [ ] Verify graceful skip when secret is missing (fork or customer repo without org secret)