### PR TITLE
Add auto-port workflow for automatic hotfix→release→uat chain porting

### DIFF
--- a/.github/workflows/auto-port.yml
+++ b/.github/workflows/auto-port.yml
@@ -1,0 +1,145 @@
+name: Auto-port to new_dawn_uat chain
+
+on:
+  push:
+    branches:
+      - '*_hotfix'
+      - '*_release'
+
+env:
+  # Groups to ALWAYS exclude (independent branch lines, never port to new_dawn_uat)
+  FORCE_EXCLUDE: "inner_silence temporary_test202412"
+  # Groups to ALWAYS include (have _uat on remote but should still port to new_dawn_uat)
+  FORCE_INCLUDE: "science_vessel"
+
+jobs:
+  auto-port:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine target branch
+        id: target
+        run: |
+          BRANCH="${GITHUB_REF_NAME}"
+
+          # Extract group name and suffix
+          if [[ "$BRANCH" =~ ^(.+)_(hotfix|release)$ ]]; then
+            GROUP="${BASH_REMATCH[1]}"
+            SUFFIX="${BASH_REMATCH[2]}"
+          else
+            echo "Branch $BRANCH doesn't match *_hotfix or *_release pattern"
+            exit 0
+          fi
+
+          echo "group=$GROUP" >> "$GITHUB_OUTPUT"
+          echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
+
+          # Check force-exclude
+          if echo " $FORCE_EXCLUDE " | grep -q " $GROUP "; then
+            echo "Group $GROUP is force-excluded, skipping"
+            exit 0
+          fi
+
+          # Check force-include flag
+          FORCE_INCLUDED=false
+          if echo " $FORCE_INCLUDE " | grep -q " $GROUP "; then
+            FORCE_INCLUDED=true
+          fi
+
+          # Dynamic UAT detection (skip groups with their own _uat)
+          if [[ "$FORCE_INCLUDED" != "true" ]]; then
+            if git ls-remote --exit-code --heads origin "${GROUP}_uat" &>/dev/null; then
+              echo "Group $GROUP has its own _uat branch, skipping"
+              exit 0
+            fi
+          fi
+
+          # Determine target
+          if [[ "$SUFFIX" == "release" ]]; then
+            TARGET="new_dawn_uat"
+          elif [[ "$SUFFIX" == "hotfix" ]]; then
+            if git ls-remote --exit-code --heads origin "${GROUP}_release" &>/dev/null; then
+              TARGET="${GROUP}_release"
+            else
+              TARGET="new_dawn_uat"
+            fi
+          fi
+
+          echo "source=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "Porting: $BRANCH → $TARGET"
+
+      - name: Check for existing merge PR
+        id: check
+        if: steps.target.outputs.target != ''
+        run: |
+          SOURCE="${{ steps.target.outputs.source }}"
+          TARGET="${{ steps.target.outputs.target }}"
+          MERGE_BRANCH="merge/${SOURCE}-to-${TARGET}"
+
+          EXISTING=$(gh pr list \
+            --base "$TARGET" \
+            --head "$MERGE_BRANCH" \
+            --state open \
+            --json number --jq '.[0].number // empty')
+
+          echo "merge_branch=$MERGE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "existing_pr=$EXISTING" >> "$GITHUB_OUTPUT"
+
+          if [[ -n "$EXISTING" ]]; then
+            echo "PR #$EXISTING already exists, will update merge branch"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create or update merge branch and PR
+        if: steps.target.outputs.target != ''
+        run: |
+          SOURCE="${{ steps.target.outputs.source }}"
+          TARGET="${{ steps.target.outputs.target }}"
+          MERGE_BRANCH="${{ steps.check.outputs.merge_branch }}"
+          EXISTING_PR="${{ steps.check.outputs.existing_pr }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if [[ -n "$EXISTING_PR" ]]; then
+            # Update existing merge branch: reset to target, re-merge source
+            git checkout "origin/$TARGET" -b "$MERGE_BRANCH"
+            if git merge "origin/$SOURCE" --no-edit; then
+              git push --force-with-lease origin "$MERGE_BRANCH"
+              echo "Updated merge branch for existing PR #$EXISTING_PR"
+            else
+              git merge --abort
+              echo "::error::Merge conflict updating $MERGE_BRANCH. Manual resolution needed."
+              exit 1
+            fi
+          else
+            # Create new merge branch: start from target, merge source
+            git checkout "origin/$TARGET" -b "$MERGE_BRANCH"
+            if git merge "origin/$SOURCE" --no-edit; then
+              git push origin "$MERGE_BRANCH"
+
+              PR_BODY="Automatic merge of \`${SOURCE}\` into \`${TARGET}\`."
+              PR_BODY="${PR_BODY}"$'\n\n'"Created by the auto-port workflow."
+
+              gh pr create \
+                --base "$TARGET" \
+                --head "$MERGE_BRANCH" \
+                --title "merge/${SOURCE}-to-${TARGET}" \
+                --label "ops:auto_merge_commit" \
+                --label "ops:without_review_approval" \
+                --label "ops:auto_ported" \
+                --body "$PR_BODY"
+              echo "Created merge PR: $MERGE_BRANCH → $TARGET"
+            else
+              git merge --abort
+              echo "::error::Merge conflict: $SOURCE → $TARGET. Manual resolution needed."
+              exit 1
+            fi
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-port.yml
+++ b/.github/workflows/auto-port.yml
@@ -6,11 +6,19 @@ on:
       - '*_hotfix'
       - '*_release'
 
+permissions:
+  contents: write      # git push of merge branch
+  pull-requests: write # gh pr create + gh pr list
+
 env:
   # Groups to ALWAYS exclude (independent branch lines, never port to new_dawn_uat)
   FORCE_EXCLUDE: "inner_silence temporary_test202412"
   # Groups to ALWAYS include (have _uat on remote but should still port to new_dawn_uat)
   FORCE_INCLUDE: "science_vessel"
+
+  # NOTE: For auto-merge to work, the target branch must be listed in .mergify.yml
+  # under *ALL_BASE_BRANCHES (UAT, HOTFIX, or RELEASE lists). If you onboard a new
+  # group with a _release branch, add it to PROJECT_BRANCHES_RELEASE in .mergify.yml.
 
 jobs:
   auto-port:
@@ -30,7 +38,8 @@ jobs:
             GROUP="${BASH_REMATCH[1]}"
             SUFFIX="${BASH_REMATCH[2]}"
           else
-            echo "Branch $BRANCH doesn't match *_hotfix or *_release pattern"
+            echo "::notice::Branch $BRANCH doesn't match *_hotfix or *_release pattern, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -39,7 +48,8 @@ jobs:
 
           # Check force-exclude
           if echo " $FORCE_EXCLUDE " | grep -q " $GROUP "; then
-            echo "Group $GROUP is force-excluded, skipping"
+            echo "::notice::Group $GROUP is force-excluded, skipping auto-port"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -52,7 +62,8 @@ jobs:
           # Dynamic UAT detection (skip groups with their own _uat)
           if [[ "$FORCE_INCLUDED" != "true" ]]; then
             if git ls-remote --exit-code --heads origin "${GROUP}_uat" &>/dev/null; then
-              echo "Group $GROUP has its own _uat branch, skipping"
+              echo "::notice::Group $GROUP has its own _uat branch, skipping auto-port"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           fi
@@ -74,7 +85,7 @@ jobs:
 
       - name: Check for existing merge PR
         id: check
-        if: steps.target.outputs.target != ''
+        if: steps.target.outputs.skip != 'true' && steps.target.outputs.target != ''
         run: |
           SOURCE="${{ steps.target.outputs.source }}"
           TARGET="${{ steps.target.outputs.target }}"
@@ -96,7 +107,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create or update merge branch and PR
-        if: steps.target.outputs.target != ''
+        if: steps.target.outputs.skip != 'true' && steps.target.outputs.target != ''
         run: |
           SOURCE="${{ steps.target.outputs.source }}"
           TARGET="${{ steps.target.outputs.target }}"
@@ -107,7 +118,10 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           if [[ -n "$EXISTING_PR" ]]; then
-            # Update existing merge branch: reset to target, re-merge source
+            # Fetch current remote state of merge branch for force-with-lease protection
+            git fetch origin "$MERGE_BRANCH" || true
+
+            # Update existing merge branch: start from target, merge source
             git checkout "origin/$TARGET" -b "$MERGE_BRANCH"
             if git merge "origin/$SOURCE" --no-edit; then
               git push --force-with-lease origin "$MERGE_BRANCH"
@@ -122,6 +136,9 @@ jobs:
             git checkout "origin/$TARGET" -b "$MERGE_BRANCH"
             if git merge "origin/$SOURCE" --no-edit; then
               git push origin "$MERGE_BRANCH"
+
+              # Ensure labels exist
+              gh label create "ops:auto_ported" --color "0075ca" --description "PR auto-created by auto-port workflow" 2>/dev/null || true
 
               PR_BODY="Automatic merge of \`${SOURCE}\` into \`${TARGET}\`."
               PR_BODY="${PR_BODY}"$'\n\n'"Created by the auto-port workflow."

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,16 @@
+# =============================================================================
+# ops:* Label Reference
+# =============================================================================
+# ops:auto_squash_merge      — Auto-merge using squash method after CI passes.
+#                               Requires review approval OR ops:without_review_approval.
+# ops:auto_merge_commit      — Auto-merge using merge commit method after CI passes.
+#                               Requires review approval OR ops:without_review_approval.
+# ops:without_review_approval — Skip the review approval requirement for auto-merge.
+#                               Must be combined with ops:auto_squash_merge or ops:auto_merge_commit.
+# ops:auto_ported            — Informational: PR was auto-created by auto-port.yml workflow.
+# ops:no_auto_port           — (reserved for future use)
+# =============================================================================
+
 merge_protections:
   - name: default
     if:
@@ -104,6 +117,7 @@ pull_request_rules:
               - base=soft_panda_release
               - base=vampire_textbook_release
               - base=science_vessel_release
+              - base=memorable_shiny_release
 
     actions:
       label:

--- a/.testspace.yml
+++ b/.testspace.yml
@@ -58,6 +58,8 @@ release:
   - science_vessel_uat
   - science_vessel_hotfix
   - science_vessel_release
+  - memorable_shiny_hotfix
+  - memorable_shiny_release
   - secondary_opinion_uat
   - secondary_opinion_hotfix
   - tenacious_d_uat


### PR DESCRIPTION
## Summary

- **New workflow** `.github/workflows/auto-port.yml` — automatically creates merge PRs when commits land on `*_hotfix` or `*_release` branches, propagating fixes through the chain to `new_dawn_uat`
- Uses **dynamic branch detection** (naming conventions + `_uat` existence check) instead of a static branch map — zero maintenance when adding/removing branch groups
- Mergify auto-merges the created PRs after CI passes using existing `ops:auto_merge_commit` + `ops:without_review_approval` label rules
- Adds `memorable_shiny_release` to `.mergify.yml` and `.testspace.yml`
- Documents all `ops:*` labels in `.mergify.yml`

### How it works

```
Push to keen_hawk_hotfix
  → auto-port.yml triggers
  → Detects keen_hawk_release exists → creates merge PR hotfix→release
    → Mergify auto-merges after CI
      → Push to keen_hawk_release triggers auto-port again
      → *_release always targets new_dawn_uat → creates merge PR release→uat
        → Mergify auto-merges after CI
```

### Override lists (env vars in workflow)
- `FORCE_EXCLUDE`: Groups that are never ported (e.g., `inner_silence`, `temporary_test202412`)
- `FORCE_INCLUDE`: Groups that are always ported even if they have their own `_uat` (e.g., `science_vessel`)

### Safety
- Idempotent: skips if merge PR already exists (updates branch if it does)
- No circular loops: `new_dawn_uat` doesn't match `*_hotfix`/`*_release`
- Merge conflicts: workflow errors out, no broken PR created
- Existing CI/Mergify untouched

## Test plan

- [ ] GH Actions validates workflow syntax on push
- [ ] Mergify validates `.mergify.yml` changes
- [ ] Post-merge: push to a `*_hotfix` branch → verify auto-port creates merge PR with correct labels
- [ ] Verify chain propagation: merge to `*_release` triggers second auto-port to `new_dawn_uat`
- [ ] Verify exclusion: push to `inner_silence_hotfix` → workflow exits early
- [ ] Verify dynamic detection: push to branch with own `_uat` → skipped