### PR TITLE
Auto-port: add labels to existing merge PRs

### DIFF
--- a/.github/workflows/auto-port.yml
+++ b/.github/workflows/auto-port.yml
@@ -125,7 +125,14 @@ jobs:
             git checkout "origin/$TARGET" -b "$MERGE_BRANCH"
             if git merge "origin/$SOURCE" --no-edit; then
               git push --force-with-lease origin "$MERGE_BRANCH"
-              echo "Updated merge branch for existing PR #$EXISTING_PR"
+
+              # Ensure auto-merge labels are present (may be missing on pre-existing manual PRs)
+              gh label create "ops:auto_ported" --color "0075ca" --description "PR auto-created by auto-port workflow" 2>/dev/null || true
+              gh pr edit "$EXISTING_PR" \
+                --add-label "ops:auto_merge_commit" \
+                --add-label "ops:without_review_approval" \
+                --add-label "ops:auto_ported"
+              echo "Updated merge branch and labels for existing PR #$EXISTING_PR"
             else
               git merge --abort
               echo "::error::Merge conflict updating $MERGE_BRANCH. Manual resolution needed."

--- a/.github/workflows/auto-port.yml
+++ b/.github/workflows/auto-port.yml
@@ -1,0 +1,145 @@
+name: Auto-port to new_dawn_uat chain
+
+on:
+  push:
+    branches:
+      - '*_hotfix'
+      - '*_release'
+
+env:
+  # Groups to ALWAYS exclude (independent branch lines, never port to new_dawn_uat)
+  FORCE_EXCLUDE: "inner_silence temporary_test202412"
+  # Groups to ALWAYS include (have _uat on remote but should still port to new_dawn_uat)
+  FORCE_INCLUDE: "science_vessel"
+
+jobs:
+  auto-port:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine target branch
+        id: target
+        run: |
+          BRANCH="${GITHUB_REF_NAME}"
+
+          # Extract group name and suffix
+          if [[ "$BRANCH" =~ ^(.+)_(hotfix|release)$ ]]; then
+            GROUP="${BASH_REMATCH[1]}"
+            SUFFIX="${BASH_REMATCH[2]}"
+          else
+            echo "Branch $BRANCH doesn't match *_hotfix or *_release pattern"
+            exit 0
+          fi
+
+          echo "group=$GROUP" >> "$GITHUB_OUTPUT"
+          echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
+
+          # Check force-exclude
+          if echo " $FORCE_EXCLUDE " | grep -q " $GROUP "; then
+            echo "Group $GROUP is force-excluded, skipping"
+            exit 0
+          fi
+
+          # Check force-include flag
+          FORCE_INCLUDED=false
+          if echo " $FORCE_INCLUDE " | grep -q " $GROUP "; then
+            FORCE_INCLUDED=true
+          fi
+
+          # Dynamic UAT detection (skip groups with their own _uat)
+          if [[ "$FORCE_INCLUDED" != "true" ]]; then
+            if git ls-remote --exit-code --heads origin "${GROUP}_uat" &>/dev/null; then
+              echo "Group $GROUP has its own _uat branch, skipping"
+              exit 0
+            fi
+          fi
+
+          # Determine target
+          if [[ "$SUFFIX" == "release" ]]; then
+            TARGET="new_dawn_uat"
+          elif [[ "$SUFFIX" == "hotfix" ]]; then
+            if git ls-remote --exit-code --heads origin "${GROUP}_release" &>/dev/null; then
+              TARGET="${GROUP}_release"
+            else
+              TARGET="new_dawn_uat"
+            fi
+          fi
+
+          echo "source=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "Porting: $BRANCH → $TARGET"
+
+      - name: Check for existing merge PR
+        id: check
+        if: steps.target.outputs.target != ''
+        run: |
+          SOURCE="${{ steps.target.outputs.source }}"
+          TARGET="${{ steps.target.outputs.target }}"
+          MERGE_BRANCH="merge/${SOURCE}-to-${TARGET}"
+
+          EXISTING=$(gh pr list \
+            --base "$TARGET" \
+            --head "$MERGE_BRANCH" \
+            --state open \
+            --json number --jq '.[0].number // empty')
+
+          echo "merge_branch=$MERGE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "existing_pr=$EXISTING" >> "$GITHUB_OUTPUT"
+
+          if [[ -n "$EXISTING" ]]; then
+            echo "PR #$EXISTING already exists, will update merge branch"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create or update merge branch and PR
+        if: steps.target.outputs.target != ''
+        run: |
+          SOURCE="${{ steps.target.outputs.source }}"
+          TARGET="${{ steps.target.outputs.target }}"
+          MERGE_BRANCH="${{ steps.check.outputs.merge_branch }}"
+          EXISTING_PR="${{ steps.check.outputs.existing_pr }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if [[ -n "$EXISTING_PR" ]]; then
+            # Update existing merge branch: reset to target, re-merge source
+            git checkout "origin/$TARGET" -b "$MERGE_BRANCH"
+            if git merge "origin/$SOURCE" --no-edit; then
+              git push --force-with-lease origin "$MERGE_BRANCH"
+              echo "Updated merge branch for existing PR #$EXISTING_PR"
+            else
+              git merge --abort
+              echo "::error::Merge conflict updating $MERGE_BRANCH. Manual resolution needed."
+              exit 1
+            fi
+          else
+            # Create new merge branch: start from target, merge source
+            git checkout "origin/$TARGET" -b "$MERGE_BRANCH"
+            if git merge "origin/$SOURCE" --no-edit; then
+              git push origin "$MERGE_BRANCH"
+
+              PR_BODY="Automatic merge of \`${SOURCE}\` into \`${TARGET}\`."
+              PR_BODY="${PR_BODY}"$'\n\n'"Created by the auto-port workflow."
+
+              gh pr create \
+                --base "$TARGET" \
+                --head "$MERGE_BRANCH" \
+                --title "merge/${SOURCE}-to-${TARGET}" \
+                --label "ops:auto_merge_commit" \
+                --label "ops:without_review_approval" \
+                --label "ops:auto_ported" \
+                --body "$PR_BODY"
+              echo "Created merge PR: $MERGE_BRANCH → $TARGET"
+            else
+              git merge --abort
+              echo "::error::Merge conflict: $SOURCE → $TARGET. Manual resolution needed."
+              exit 1
+            fi
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-port.yml
+++ b/.github/workflows/auto-port.yml
@@ -6,11 +6,19 @@ on:
       - '*_hotfix'
       - '*_release'
 
+permissions:
+  contents: write      # git push of merge branch
+  pull-requests: write # gh pr create + gh pr list
+
 env:
   # Groups to ALWAYS exclude (independent branch lines, never port to new_dawn_uat)
   FORCE_EXCLUDE: "inner_silence temporary_test202412"
   # Groups to ALWAYS include (have _uat on remote but should still port to new_dawn_uat)
   FORCE_INCLUDE: "science_vessel"
+
+  # NOTE: For auto-merge to work, the target branch must be listed in .mergify.yml
+  # under *ALL_BASE_BRANCHES (UAT, HOTFIX, or RELEASE lists). If you onboard a new
+  # group with a _release branch, add it to PROJECT_BRANCHES_RELEASE in .mergify.yml.
 
 jobs:
   auto-port:
@@ -30,7 +38,8 @@ jobs:
             GROUP="${BASH_REMATCH[1]}"
             SUFFIX="${BASH_REMATCH[2]}"
           else
-            echo "Branch $BRANCH doesn't match *_hotfix or *_release pattern"
+            echo "::notice::Branch $BRANCH doesn't match *_hotfix or *_release pattern, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -39,7 +48,8 @@ jobs:
 
           # Check force-exclude
           if echo " $FORCE_EXCLUDE " | grep -q " $GROUP "; then
-            echo "Group $GROUP is force-excluded, skipping"
+            echo "::notice::Group $GROUP is force-excluded, skipping auto-port"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -52,7 +62,8 @@ jobs:
           # Dynamic UAT detection (skip groups with their own _uat)
           if [[ "$FORCE_INCLUDED" != "true" ]]; then
             if git ls-remote --exit-code --heads origin "${GROUP}_uat" &>/dev/null; then
-              echo "Group $GROUP has its own _uat branch, skipping"
+              echo "::notice::Group $GROUP has its own _uat branch, skipping auto-port"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           fi
@@ -74,7 +85,7 @@ jobs:
 
       - name: Check for existing merge PR
         id: check
-        if: steps.target.outputs.target != ''
+        if: steps.target.outputs.skip != 'true' && steps.target.outputs.target != ''
         run: |
           SOURCE="${{ steps.target.outputs.source }}"
           TARGET="${{ steps.target.outputs.target }}"
@@ -96,7 +107,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create or update merge branch and PR
-        if: steps.target.outputs.target != ''
+        if: steps.target.outputs.skip != 'true' && steps.target.outputs.target != ''
         run: |
           SOURCE="${{ steps.target.outputs.source }}"
           TARGET="${{ steps.target.outputs.target }}"
@@ -107,7 +118,10 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           if [[ -n "$EXISTING_PR" ]]; then
-            # Update existing merge branch: reset to target, re-merge source
+            # Fetch current remote state of merge branch for force-with-lease protection
+            git fetch origin "$MERGE_BRANCH" || true
+
+            # Update existing merge branch: start from target, merge source
             git checkout "origin/$TARGET" -b "$MERGE_BRANCH"
             if git merge "origin/$SOURCE" --no-edit; then
               git push --force-with-lease origin "$MERGE_BRANCH"
@@ -122,6 +136,9 @@ jobs:
             git checkout "origin/$TARGET" -b "$MERGE_BRANCH"
             if git merge "origin/$SOURCE" --no-edit; then
               git push origin "$MERGE_BRANCH"
+
+              # Ensure labels exist
+              gh label create "ops:auto_ported" --color "0075ca" --description "PR auto-created by auto-port workflow" 2>/dev/null || true
 
               PR_BODY="Automatic merge of \`${SOURCE}\` into \`${TARGET}\`."
               PR_BODY="${PR_BODY}"$'\n\n'"Created by the auto-port workflow."

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,16 @@
+# =============================================================================
+# ops:* Label Reference
+# =============================================================================
+# ops:auto_squash_merge      — Auto-merge using squash method after CI passes.
+#                               Requires review approval OR ops:without_review_approval.
+# ops:auto_merge_commit      — Auto-merge using merge commit method after CI passes.
+#                               Requires review approval OR ops:without_review_approval.
+# ops:without_review_approval — Skip the review approval requirement for auto-merge.
+#                               Must be combined with ops:auto_squash_merge or ops:auto_merge_commit.
+# ops:auto_ported            — Informational: PR was auto-created by auto-port.yml workflow.
+# ops:no_auto_port           — (reserved for future use)
+# =============================================================================
+
 merge_protections:
   - name: default
     if:
@@ -104,6 +117,7 @@ pull_request_rules:
               - base=soft_panda_release
               - base=vampire_textbook_release
               - base=science_vessel_release
+              - base=memorable_shiny_release
 
     actions:
       label:

--- a/.testspace.yml
+++ b/.testspace.yml
@@ -58,6 +58,8 @@ release:
   - science_vessel_uat
   - science_vessel_hotfix
   - science_vessel_release
+  - memorable_shiny_hotfix
+  - memorable_shiny_release
   - secondary_opinion_uat
   - secondary_opinion_hotfix
   - tenacious_d_uat


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/metasfresh/metasfresh/pull/22505.

When the auto-port workflow finds an existing merge PR (e.g., a manually created `merge/keen_hawk_hotfix-to-keen_hawk_release` like https://github.com/metasfresh/metasfresh/pull/22385), it updates the merge branch but previously did not add the auto-merge labels. This meant Mergify would not auto-merge pre-existing manual merge PRs, breaking the chain.

Now the update path also calls `gh pr edit` to ensure `ops:auto_merge_commit`, `ops:without_review_approval`, and `ops:auto_ported` labels are present.

## Test plan

- [ ] PR #22459 merges to `keen_hawk_hotfix` → auto-port finds existing PR #22385 → updates branch AND adds labels → Mergify auto-merges