### PR TITLE
Auto-port: add labels to existing merge PRs

### DIFF
--- a/.github/workflows/auto-port.yml
+++ b/.github/workflows/auto-port.yml
@@ -125,7 +125,14 @@ jobs:
             git checkout "origin/$TARGET" -b "$MERGE_BRANCH"
             if git merge "origin/$SOURCE" --no-edit; then
               git push --force-with-lease origin "$MERGE_BRANCH"
-              echo "Updated merge branch for existing PR #$EXISTING_PR"
+
+              # Ensure auto-merge labels are present (may be missing on pre-existing manual PRs)
+              gh label create "ops:auto_ported" --color "0075ca" --description "PR auto-created by auto-port workflow" 2>/dev/null || true
+              gh pr edit "$EXISTING_PR" \
+                --add-label "ops:auto_merge_commit" \
+                --add-label "ops:without_review_approval" \
+                --add-label "ops:auto_ported"
+              echo "Updated merge branch and labels for existing PR #$EXISTING_PR"
             else
               git merge --abort
               echo "::error::Merge conflict updating $MERGE_BRANCH. Manual resolution needed."


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/metasfresh/metasfresh/pull/22505.

When the auto-port workflow finds an existing merge PR (e.g., the manually created https://github.com/metasfresh/metasfresh/pull/22385 for `merge/keen_hawk_hotfix-to-keen_hawk_release`), it updates the merge branch but previously did not add the auto-merge labels. This meant Mergify would not auto-merge pre-existing manual merge PRs, breaking the chain.

Now the update path also calls `gh pr edit` to ensure `ops:auto_merge_commit`, `ops:without_review_approval`, and `ops:auto_ported` labels are present.

Replaces https://github.com/metasfresh/metasfresh/pull/22507 (closed, stale branch).

## Test plan

- [ ] PR #22459 merges to `keen_hawk_hotfix` → auto-port finds existing PR #22385 → updates branch AND adds labels → Mergify auto-merges