### PR TITLE
Auto-port: fix trigger (use PR merge event instead of push)

### DIFF
--- a/.github/workflows/auto-port.yml
+++ b/.github/workflows/auto-port.yml
@@ -1,7 +1,10 @@
 name: Auto-port to new_dawn_uat chain
 
+# Trigger on PR merge (not push) because pushes by GitHub Apps (Mergify)
+# don't trigger push-based workflows due to GitHub's anti-recursion protection.
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - '*_hotfix'
       - '*_release'
@@ -22,6 +25,8 @@ env:
 
 jobs:
   auto-port:
+    # Only run when the PR was actually merged (not just closed)
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +36,8 @@ jobs:
       - name: Determine target branch
         id: target
         run: |
-          BRANCH="${GITHUB_REF_NAME}"
+          BRANCH="${{ github.event.pull_request.base.ref }}"
+          echo "Triggered by PR merge into $BRANCH"
 
           # Extract group name and suffix
           if [[ "$BRANCH" =~ ^(.+)_(hotfix|release)$ ]]; then


### PR DESCRIPTION
## Summary

Fixes the auto-port workflow that was introduced in https://github.com/metasfresh/metasfresh/pull/22505.

**Problem**: Pushes by GitHub Apps (like Mergify) don't trigger `push`-based workflows due to GitHub's anti-recursion protection. When Mergify merged https://github.com/metasfresh/metasfresh/pull/22459 into `keen_hawk_hotfix`, the auto-port workflow did NOT fire.

**Fix**: Change trigger from `on: push` to `on: pull_request: types: [closed]` with a `merged == true` guard. PR merge events fire regardless of who performed the merge (human, Mergify, or any GitHub App).

Also:
- Uses `github.event.pull_request.base.ref` instead of `GITHUB_REF_NAME` (correct for PR event context)
- Adds labels to pre-existing merge PRs (from https://github.com/metasfresh/metasfresh/pull/22508)

## Test plan

- [ ] Merge any PR into a `*_hotfix` branch → verify auto-port workflow triggers
- [ ] Verify chain: hotfix→release merge PR created → Mergify auto-merges → release→uat PR created