### PR TITLE
Add Merge Gate CI job + update Mergify conditions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1306,3 +1306,85 @@ jobs:
           CICD_DISPATCH_WORKFLOW_FILE: ${{ fromJson(vars.CICD_DISPATCH_CONFIG).workflow_file }}
         run: |
           gh workflow run "${CICD_DISPATCH_WORKFLOW_FILE}" --repo "${CICD_DISPATCH_REPO}" -f "cicd_run_id=${CICD_RUN_ID}" -f "tag_fixed=${TAG_FIXED}"
+
+  # ===========================================================================
+  # Merge Gate — single check for Mergify merge conditions
+  # ===========================================================================
+  # Aggregates results from ALL build and test jobs into one check named
+  # "Merge Gate". Mergify uses `check-success=Merge Gate` to decide whether
+  # a PR can be merged.
+  #
+  # Every job listed in `needs` MUST finish with result 'success'.
+  # Skipped, cancelled, or failed jobs cause the gate to fail.
+  # This prevents "false green" builds where tests were skipped.
+  # ===========================================================================
+  merge-gate:
+    name: Merge Gate
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      # Build jobs
+      - init
+      - java
+      - frontend
+      - backend
+      - preloaded-db
+      - procurement
+      - compatibility-images
+      - cucumber-build
+      # Test jobs
+      - test-frontend
+      - junit
+      - cucumber-run
+      - health_check
+      - mobile_test
+    steps:
+      - name: Evaluate all job results
+        run: |
+          echo "## Merge Gate" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Status | Job | Result |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|-----|--------|" >> $GITHUB_STEP_SUMMARY
+
+          ALL_OK=true
+
+          check_job() {
+            local name="$1"
+            local result="$2"
+            if [[ "$result" == "success" ]]; then
+              echo "| :white_check_mark: | $name | $result |" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "| :x: | $name | **$result** |" >> $GITHUB_STEP_SUMMARY
+              ALL_OK=false
+            fi
+          }
+
+          # Build jobs
+          check_job "init"               "${{ needs.init.result }}"
+          check_job "java"               "${{ needs.java.result }}"
+          check_job "frontend"           "${{ needs.frontend.result }}"
+          check_job "backend"            "${{ needs.backend.result }}"
+          check_job "preloaded-db"       "${{ needs.preloaded-db.result }}"
+          check_job "procurement"        "${{ needs.procurement.result }}"
+          check_job "compatibility-images" "${{ needs.compatibility-images.result }}"
+          check_job "cucumber-build"     "${{ needs.cucumber-build.result }}"
+
+          # Test jobs
+          check_job "test-frontend"      "${{ needs.test-frontend.result }}"
+          check_job "junit"              "${{ needs.junit.result }}"
+          check_job "cucumber-run"       "${{ needs.cucumber-run.result }}"
+          check_job "health_check"       "${{ needs.health_check.result }}"
+          check_job "mobile_test"        "${{ needs.mobile_test.result }}"
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "$ALL_OK" != "true" ]]; then
+            echo ":x: **Merge gate FAILED** — one or more required jobs did not succeed." >> $GITHUB_STEP_SUMMARY
+            echo ""
+            echo "FAILED: One or more required jobs did not succeed"
+            exit 1
+          fi
+
+          echo ":white_check_mark: **Merge gate PASSED** — all 13 required jobs succeeded." >> $GITHUB_STEP_SUMMARY
+          echo ""
+          echo "PASSED: All 13 required jobs succeeded"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,11 +1,15 @@
 merge_protections:
   - name: default
     if:
-      - check-success=testspace-analytics
-      - check-success=continuous-integration/jenkins/branch
+      - or:
+          - check-success=Merge Gate
+          - check-success=testspace-analytics
+          - check-success=continuous-integration/jenkins/branch
     success_conditions:
-      - check-success=testspace-analytics
-      - check-success=continuous-integration/jenkins/branch
+      - or:
+          - check-success=Merge Gate
+          - check-success=testspace-analytics
+          - check-success=continuous-integration/jenkins/branch
 
 pull_request_rules:
 
@@ -98,8 +102,10 @@ pull_request_rules:
 
   - name: Automatic squash-merge successful PRs into the respective base-branch
     conditions:
-      - check-success=testspace-analytics
-      - check-success=continuous-integration/jenkins/branch
+      - or:
+          - check-success=Merge Gate
+          - check-success=testspace-analytics
+          - check-success=continuous-integration/jenkins/branch
       - label=ops:auto_squash_merge
       - or:
           - or: *ALL_BASE_BRANCHES
@@ -112,8 +118,10 @@ pull_request_rules:
 
   - name: Automatic merge commit (not squash) successful PRs
     conditions:
-      - check-success=testspace-analytics
-      - check-success=continuous-integration/jenkins/branch
+      - or:
+          - check-success=Merge Gate
+          - check-success=testspace-analytics
+          - check-success=continuous-integration/jenkins/branch
       - label=ops:auto_merge_commit
       - or:
           - or: *ALL_BASE_BRANCHES


### PR DESCRIPTION
## Summary

Backport of the Merge Gate from `new_dawn_uat` to the keen_hawk branch line.

- Add a **Merge Gate** job to `cicd.yaml` that aggregates all 13 build and test job results into a single check
- Update `.mergify.yml` to accept `Merge Gate` as an alternative to `testspace-analytics` / `continuous-integration/jenkins/branch`
- Adapted for keen_hawk's cicd.yaml structure (uses `preloaded-db` instead of `db-images`/`db-apply-migrations`, no `frontend_webui_test`)

### Purpose

Unblocks auto-port chain: once this merges to `keen_hawk_hotfix` and propagates to `keen_hawk_release`, the stalled merge PR #22385 can pass through Mergify's merge queue using the Merge Gate check.

## Test plan

- [ ] CI runs and the `Merge Gate` check appears
- [ ] After merge to keen_hawk_hotfix, auto-port creates PR to keen_hawk_release
- [ ] PR #22385 can be re-queued with the Merge Gate check