### PR TITLE
E2E test: quick input multiple matches keep dropdown open

### DIFF
--- a/e2e/frontend-webui/TEST-COVERAGE.md
+++ b/e2e/frontend-webui/TEST-COVERAGE.md
@@ -304,7 +304,40 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 9. Invoice Reversal (Reverse-Correct)
+### 9. Quick Input Multiple Matches
+**File**: `tests/spec/quick-input-multiple-matches.spec.js`
+**Status**: New (untested)
+**Duration**: ~20 seconds per test per language
+
+**Features Tested**:
+- F00100: Sales Order
+
+**Epic**: E0100: Sales
+
+**Tests**:
+1. **Multiple matches keep dropdown open** - Type shared prefix matching 2 products -> Enter -> dropdown stays open with 2 options -> click to select manually -> verify order line created
+2. **Single match auto-selects and advances (regression)** - Type full unique product code -> Enter -> auto-selects and advances focus -> fill qty -> verify order line created
+
+**Key Validations**:
+- Multiple typeahead matches: Enter does NOT auto-select, dropdown stays open
+- Product input retains typed text when multiple matches exist
+- Manual click-to-select from open dropdown works
+- Single match: Enter auto-selects via handleAutoSelectAndAdvance
+- Qty field interactable after product selection
+
+**Components Tested**:
+- Sales Order window (143)
+- Order Lines tab (batch entry / quick input)
+- Lookup widget: resolveItems() multiple-match path (RawLookup.js)
+- Lookup widget: resolveItems() single-match path (regression)
+
+**Code Path Coverage**:
+- `resolveItems(items)` where `items.length > 1` -> keep dropdown open (Test 1)
+- `resolveItems(items)` where `items.length === 1` -> `handleAutoSelectAndAdvance` (Test 2)
+
+---
+
+### 10. Invoice Reversal (Reverse-Correct)
 **File**: `tests/spec/invoice-reversal.spec.js`
 **Status**: ✅ Passing (English, German)
 **Duration**: ~70 seconds per language
@@ -343,7 +376,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 10. Business Partner Creation
+### 11. Business Partner Creation
 **File**: `tests/spec/business-partner-create.spec.js`
 **Status**: ✅ Passing (English, German)
 **Duration**: ~14 seconds per language
@@ -376,7 +409,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 11. Menu Navigation & Window Search
+### 12. Menu Navigation & Window Search
 **File**: `tests/spec/menu-navigation.spec.js`
 **Status**: ✅ Passing (English, German)
 **Duration**: ~15 seconds per language
@@ -409,7 +442,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 12. Bookmark Star (SubHeader)
+### 13. Bookmark Star (SubHeader)
 **File**: `tests/spec/bookmark-star.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~8 seconds
@@ -440,7 +473,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 13. Document References (Alt+6) - Complete O2C and P2P
+### 14. Document References (Alt+6) - Complete O2C and P2P
 **File**: `tests/spec/document-references.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~2.8 minutes (both tests)
@@ -482,7 +515,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 14. Zoom-Into (Right-Click Context Menu)
+### 15. Zoom-Into (Right-Click Context Menu)
 **File**: `tests/spec/zoom-into.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~30 seconds
@@ -512,7 +545,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 15. Keyboard Shortcuts
+### 16. Keyboard Shortcuts
 **File**: `tests/spec/keyboard-shortcuts.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~24 seconds
@@ -546,7 +579,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 16. Grid Filtering & Column Sorting
+### 17. Grid Filtering & Column Sorting
 **File**: `tests/spec/grid-filtering.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~20 seconds
@@ -572,7 +605,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 17. Document Clone (Alt+W)
+### 18. Document Clone (Alt+W)
 **File**: `tests/spec/document-clone.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~22 seconds
@@ -592,7 +625,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 18. SubHeader Actions & Change Log
+### 19. SubHeader Actions & Change Log
 **File**: `tests/spec/subheader-actions.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~36 seconds
@@ -612,7 +645,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 19. Included Tabs & Batch Entry
+### 20. Included Tabs & Batch Entry
 **File**: `tests/spec/included-tabs.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~32 seconds
@@ -630,7 +663,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 20. List View Actions (Row Selection, Alt+B, Alt+A)
+### 21. List View Actions (Row Selection, Alt+B, Alt+A)
 **File**: `tests/spec/list-view-actions.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~15 seconds
@@ -651,7 +684,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 21. Navigation Menu (Alt+2)
+### 22. Navigation Menu (Alt+2)
 **File**: `tests/spec/navigation-menu.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~8 seconds
@@ -675,7 +708,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 22. User/Avatar Menu (Alt+4)
+### 23. User/Avatar Menu (Alt+4)
 **File**: `tests/spec/user-menu.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~7 seconds
@@ -694,7 +727,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 23. Comments Panel (Alt+T)
+### 24. Comments Panel (Alt+T)
 **File**: `tests/spec/comments-panel.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~18 seconds
@@ -713,7 +746,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 24. Email & Letter Dialogs (Alt+K, Alt+R)
+### 25. Email & Letter Dialogs (Alt+K, Alt+R)
 **File**: `tests/spec/email-letter-dialog.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~22 seconds
@@ -732,7 +765,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 25. Edit Mode Toggle (Alt+O)
+### 26. Edit Mode Toggle (Alt+O)
 **File**: `tests/spec/edit-mode-toggle.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~22 seconds
@@ -749,7 +782,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 26. Sidebar Panels (Alt+5, Alt+6, Alt+7)
+### 27. Sidebar Panels (Alt+5, Alt+6, Alt+7)
 **File**: `tests/spec/sidebar-panels.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~20 seconds
@@ -767,7 +800,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 27. Document Delete (Alt+D)
+### 28. Document Delete (Alt+D)
 **File**: `tests/spec/document-delete.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~22 seconds
@@ -785,7 +818,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 28. Quick Actions
+### 29. Quick Actions
 **File**: `tests/spec/quick-actions.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~20 seconds
@@ -803,7 +836,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 29. Date Widget
+### 30. Date Widget
 **File**: `tests/spec/date-widget.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~17 seconds
@@ -822,7 +855,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 30. Print Dialog (Alt+P)
+### 31. Print Dialog (Alt+P)
 **File**: `tests/spec/print-dialog.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~18 seconds
@@ -840,7 +873,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 31. Lookup Widget (Autocomplete)
+### 32. Lookup Widget (Autocomplete)
 **File**: `tests/spec/lookup-widget.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~15 seconds
@@ -860,7 +893,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 32. Inline Grid Edit (F2)
+### 33. Inline Grid Edit (F2)
 **File**: `tests/spec/inline-edit.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~25 seconds
@@ -880,7 +913,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 33. Record Navigation
+### 34. Record Navigation
 **File**: `tests/spec/record-navigation.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~15 seconds
@@ -898,7 +931,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
-### 34. Notifications & Inbox
+### 35. Notifications & Inbox
 **File**: `tests/spec/notifications.spec.js`
 **Status**: ✅ Passing
 **Duration**: ~7 seconds
@@ -946,6 +979,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ### Inline Test Helpers
 - **quick-input.spec.js** uses inline helpers (`createMasterdata`, `setupOrderWithBatchEntry`, `typeProductAndWaitForDropdown`, `expectOrderLineInGrid`) instead of a dedicated Page Object, since the test-specific batch entry interactions (Enter-key vs mouse-click, grid row counting) are specialized and not reusable across other test suites.
+- **quick-input-multiple-matches.spec.js** uses the same inline helper pattern (`createMasterdataWithSharedPrefix`, `setupOrderWithBatchEntry`, `typeProductAndWaitForDropdown`, `expectOrderLineInGrid`) for testing the multiple-match typeahead scenario.
 
 ### Test Data Strategy
 - All test data created via Backend API
@@ -990,8 +1024,8 @@ Areas **NOT yet covered** by E2E tests:
 
 ## Test Quality Metrics
 
-- **Total test specs**: 34 files
-- **Total test cases**: 46+ (34 specs, many with en_US + de_DE; quick-input has 5 tests × 2 languages)
+- **Total test specs**: 35 files
+- **Total test cases**: 50+ (35 specs, many with en_US + de_DE; quick-input has 5 tests × 2 languages; quick-input-multiple-matches has 2 tests × 2 languages)
 - **Language coverage**: en_US, de_DE
 - **Success rate**: 100% passing
 - **Average execution time**: ~20 seconds per test

--- a/e2e/frontend-webui/tests/spec/quick-input-multiple-matches.spec.js
+++ b/e2e/frontend-webui/tests/spec/quick-input-multiple-matches.spec.js
@@ -1,0 +1,404 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { LoginPage } from '../utils/pages/LoginPage';
+import { DashboardPage } from '../utils/pages/DashboardPage';
+import { SalesOrderPage } from '../utils/pages/SalesOrderPage';
+import { SLOW_ACTION_TIMEOUT } from '../utils/common';
+import { SALES_ORDER_WINDOW_ID } from '../utils/WindowIds';
+import { waitForTabAllowsNew } from '../utils/WebAPIValidation';
+
+/**
+ * Quick Input Multiple Matches E2E test suite.
+ *
+ * Features tested:
+ * - F00100: Sales Order
+ *
+ * Tests:
+ * 1. Multiple matches keep dropdown open (user must pick manually)
+ * 2. Single match auto-selects and advances focus (regression)
+ *
+ * Covers resolveItems() in RawLookup.js:
+ * - items.length > 1 => keep dropdown open, do NOT auto-select
+ * - items.length === 1 => auto-select via handleAutoSelectAndAdvance
+ */
+
+// ============================================================================
+// Shared helpers (inline, same pattern as quick-input.spec.js)
+// ============================================================================
+
+/**
+ * Create masterdata with two products sharing a unique prefix so typeahead
+ * matches both when the prefix is typed.
+ */
+async function createMasterdataWithSharedPrefix(language) {
+  const sharedPrefix = `QIMM_${Date.now()}`;
+
+  return {
+    sharedPrefix,
+    masterdata: await Backend.createMasterdata({
+      request: {
+        login: {
+          user: {
+            language,
+            firstname: 'QI',
+            lastname: 'Multi',
+          },
+        },
+        bpartners: {
+          CUSTOMER1: {
+            isVendor: false,
+            isCustomer: true,
+            isSoPriceList: true,
+            name: 'Customer',
+          },
+        },
+        products: {
+          ProductA: {
+            name: `${sharedPrefix}_A`,
+            type: 'Item',
+            prices: [{ price: 10.0, currencyCode: 'EUR' }],
+          },
+          ProductB: {
+            name: `${sharedPrefix}_B`,
+            type: 'Item',
+            prices: [{ price: 20.0, currencyCode: 'EUR' }],
+          },
+        },
+      },
+    }),
+  };
+}
+
+/**
+ * Login -> Create Sales Order -> Select Customer -> Go to Order Line tab -> Open batch entry.
+ * Returns { recordId, batchEntryButton }.
+ */
+async function setupOrderWithBatchEntry(page, masterdata, language) {
+  await LoginPage.goto();
+  await LoginPage.login(masterdata.login.user);
+  await DashboardPage.expectVisible();
+
+  await SalesOrderPage.goto();
+  await SalesOrderPage.clickNew();
+
+  const recordId = await SalesOrderPage.selectCustomer(
+    masterdata.bpartners.CUSTOMER1.bpartnerCode
+  );
+  console.log(`[${language}] Sales Order ${recordId} created`);
+
+  await SalesOrderPage.goToOrderLineTab();
+
+  await waitForTabAllowsNew(SALES_ORDER_WINDOW_ID, recordId, 'AD_Tab-187', {
+    maxRetries: 15,
+    retryDelayMs: 1000,
+  });
+
+  const batchEntryButton = page.getByTestId('batch-entry-toggle');
+  await batchEntryButton.scrollIntoViewIfNeeded();
+  await batchEntryButton.waitFor({
+    state: 'visible',
+    timeout: SLOW_ACTION_TIMEOUT,
+  });
+  await batchEntryButton.click();
+
+  await page.locator('.quick-input-container').waitFor({
+    state: 'visible',
+    timeout: SLOW_ACTION_TIMEOUT,
+  });
+
+  return { recordId, batchEntryButton };
+}
+
+/**
+ * Type a product query in the quick input product field and wait for dropdown.
+ * Returns the product input locator.
+ */
+async function typeProductAndWaitForDropdown(page, query) {
+  const productInput = page.locator(
+    '#lookup_M_Product_ID input.input-field'
+  );
+  await productInput.waitFor({
+    state: 'visible',
+    timeout: SLOW_ACTION_TIMEOUT,
+  });
+  await productInput.click();
+
+  await page
+    .locator('#lookup_M_Product_ID .rotating, #lookup_M_Product_ID .spinner')
+    .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+    .catch(() => {});
+
+  await page.waitForTimeout(300);
+
+  await productInput.fill(query);
+
+  // Wait for typeahead debounce + search
+  await page.waitForTimeout(500);
+
+  await page
+    .locator('#lookup_M_Product_ID .rotating, #lookup_M_Product_ID .spinner')
+    .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+    .catch(() => {});
+
+  // Wait for dropdown to populate
+  await page.waitForTimeout(300);
+
+  return productInput;
+}
+
+/**
+ * Verify grid row count in the order lines tab (after closing batch entry).
+ */
+async function expectOrderLineInGrid(page, expectedRowCount) {
+  const gridRows = page.locator('.table-flex-wrapper table tbody tr');
+  await gridRows.first().waitFor({
+    state: 'visible',
+    timeout: SLOW_ACTION_TIMEOUT,
+  });
+
+  if (expectedRowCount) {
+    await expect(gridRows).toHaveCount(expectedRowCount, {
+      timeout: SLOW_ACTION_TIMEOUT,
+    });
+  }
+}
+
+// ============================================================================
+// Test cases
+// ============================================================================
+
+const testCases = [
+  { language: 'en_US', label: 'English' },
+  { language: 'de_DE', label: 'German' },
+];
+
+testCases.forEach(({ language, label }) => {
+  test.describe(`Quick Input Multiple Matches (${label})`, () => {
+    // ------------------------------------------------------------------
+    // TEST 1: Multiple matches keep dropdown open
+    // When typing a shared prefix that matches 2+ products, pressing
+    // Enter should NOT auto-select. The dropdown stays open so the
+    // user can pick the correct product manually.
+    // ------------------------------------------------------------------
+    test(`Multiple matches keep dropdown open (${label})`, async ({
+      page,
+    }) => {
+      allure.epic('E0100: Sales');
+      allure.tag('F00100: Sales Order');
+      allure.story('Quick Input: multiple matches keep dropdown open');
+      allure.severity('normal');
+      allure.parameter('Language', language);
+      allure.tag(language);
+
+      allure.description(`
+## F00100: Sales Order - Multiple matches keep dropdown open
+
+### Test Scenario
+When typing a prefix that matches multiple products, pressing Enter should
+NOT auto-select a product. The dropdown stays open with all matches visible,
+allowing the user to pick the correct one.
+
+1. Create 2 products with shared prefix (QIMM_timestamp_A, QIMM_timestamp_B)
+2. Open batch entry, type the shared prefix
+3. Wait for dropdown to show 2+ options
+4. Press Enter
+5. Assert: dropdown still visible with 2+ options
+6. Assert: product field still contains typed prefix (not replaced)
+7. Click first option to select
+8. Assert: product is selected, Qty field becomes interactable
+
+### Code Path
+RawLookup.resolveAndSelectOnEnter -> resolveItems(items) where items.length > 1
+-> keeps dropdown open (does NOT call handleAutoSelectAndAdvance)
+
+### Beep Testing
+SysConfig beepOnInvalidProduct defaults to N. The E2E framework has no SysConfig
+setter API. Beep assertion skipped. See e2e/frontend-webui/CLAUDE.md:359-383
+for Web Audio API spy pattern if SysConfig support is added to the test API.
+      `);
+
+      test.setTimeout(120000);
+
+      const { sharedPrefix, masterdata } =
+        await createMasterdataWithSharedPrefix(language);
+      allure.attachment(
+        'Test Data',
+        JSON.stringify(masterdata, null, 2),
+        'application/json'
+      );
+
+      console.log(
+        `[${language}] Created 2 products with shared prefix: ${sharedPrefix}`
+      );
+
+      const { batchEntryButton } = await setupOrderWithBatchEntry(
+        page,
+        masterdata,
+        language
+      );
+
+      // Type the shared prefix - should match both products
+      const productInput = await typeProductAndWaitForDropdown(
+        page,
+        sharedPrefix
+      );
+
+      // Verify dropdown shows 2+ options before pressing Enter
+      const dropdownOptions = page.locator('.input-dropdown-list-option');
+      await expect(dropdownOptions).toHaveCount(2, {
+        timeout: SLOW_ACTION_TIMEOUT,
+      });
+      console.log(
+        `[${language}] Dropdown shows 2 options for prefix "${sharedPrefix}"`
+      );
+
+      // KEY ACTION: Press Enter with multiple matches
+      await page.keyboard.press('Enter');
+      await page.waitForTimeout(1000);
+
+      // ASSERT: Dropdown is still visible with 2+ options (not auto-selected)
+      const dropdownAfterEnter = page.locator('.input-dropdown-list-option');
+      const optionCountAfterEnter = await dropdownAfterEnter.count();
+      expect(optionCountAfterEnter).toBeGreaterThanOrEqual(2);
+      console.log(
+        `[${language}] After Enter: dropdown still shows ${optionCountAfterEnter} options`
+      );
+
+      // ASSERT: Product input still contains the typed prefix (not replaced by a resolved product)
+      const inputValueAfterEnter = await productInput.inputValue();
+      expect(inputValueAfterEnter).toContain(sharedPrefix);
+      console.log(
+        `[${language}] After Enter: product field still shows "${inputValueAfterEnter}"`
+      );
+
+      // Now click the first dropdown option to select it
+      await dropdownAfterEnter.first().click();
+      await page.waitForTimeout(1000);
+
+      // ASSERT: Product was resolved (input value changed from prefix to full product name)
+      const resolvedValue = await productInput.inputValue();
+      expect(resolvedValue).toBeTruthy();
+      console.log(
+        `[${language}] After click: product resolved to "${resolvedValue}"`
+      );
+
+      // ASSERT: Qty field is interactable (product was accepted)
+      const quantityInput = page
+        .locator('.quick-input-container')
+        .getByRole('spinbutton');
+      await quantityInput.click();
+      await quantityInput.fill('5');
+
+      // Submit line
+      await page.keyboard.press('Enter');
+      await page.waitForTimeout(2000);
+
+      // Close batch entry and verify line was created
+      await batchEntryButton.click();
+      await page.waitForTimeout(500);
+      await expectOrderLineInGrid(page, 1);
+
+      console.log(
+        `[${language}] Multiple matches test passed - dropdown stayed open, manual selection worked`
+      );
+    });
+
+    // ------------------------------------------------------------------
+    // TEST 2: Single match auto-selects and advances (regression)
+    // When typing the full unique product name, pressing Enter should
+    // auto-select and advance focus - confirming the single-match path
+    // still works correctly alongside the multiple-match path.
+    // ------------------------------------------------------------------
+    test(`Single match auto-selects and advances focus (${label})`, async ({
+      page,
+    }) => {
+      allure.epic('E0100: Sales');
+      allure.tag('F00100: Sales Order');
+      allure.story(
+        'Quick Input: single match auto-selects (regression)'
+      );
+      allure.severity('normal');
+      allure.parameter('Language', language);
+      allure.tag(language);
+
+      allure.description(`
+## F00100: Sales Order - Single match auto-selects (regression)
+
+### Test Scenario
+Typing the full unique product name and pressing Enter should auto-select
+the product and advance focus. This confirms the single-match path
+(items.length === 1) still works after adding the multiple-match handling.
+
+1. Create 2 products with shared prefix
+2. Open batch entry, type the FULL name of ProductA (prefix + "_A")
+3. Press Enter
+4. Assert: product auto-selected (input shows resolved product name)
+5. Fill qty, submit, verify order line created
+
+### Code Path
+RawLookup.resolveAndSelectOnEnter -> resolveItems(items) where items.length === 1
+-> handleAutoSelectAndAdvance -> focusNextFieldInForm
+      `);
+
+      test.setTimeout(120000);
+
+      const { masterdata } =
+        await createMasterdataWithSharedPrefix(language);
+      allure.attachment(
+        'Test Data',
+        JSON.stringify(masterdata, null, 2),
+        'application/json'
+      );
+
+      const productACode = masterdata.products.ProductA.productCode;
+      console.log(
+        `[${language}] Will type full product code: ${productACode}`
+      );
+
+      const { batchEntryButton } = await setupOrderWithBatchEntry(
+        page,
+        masterdata,
+        language
+      );
+
+      // Type the full unique product code (should match exactly 1 product)
+      const productInput = await typeProductAndWaitForDropdown(
+        page,
+        productACode
+      );
+
+      // KEY ACTION: Press Enter with single match
+      await page.keyboard.press('Enter');
+      await page.waitForTimeout(1000);
+
+      // ASSERT: Product was auto-selected (input changed from code to resolved name)
+      const resolvedValue = await productInput.inputValue();
+      expect(resolvedValue).toBeTruthy();
+      console.log(
+        `[${language}] Single match: product resolved to "${resolvedValue}"`
+      );
+
+      // Fill quantity (click explicitly - toBeFocused unreliable in headless)
+      const quantityInput = page
+        .locator('.quick-input-container')
+        .getByRole('spinbutton');
+      await quantityInput.click();
+      await quantityInput.fill('3');
+
+      // Submit line
+      await page.keyboard.press('Enter');
+      await page.waitForTimeout(2000);
+
+      // Close batch entry and verify line was created
+      await batchEntryButton.click();
+      await page.waitForTimeout(500);
+      await expectOrderLineInGrid(page, 1);
+
+      console.log(
+        `[${language}] Single match regression test passed - auto-select worked`
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add E2E test for `resolveItems()` multiple-match behavior: when typeahead returns 2+ products, dropdown stays open for manual selection (no auto-select)
- Regression test: single match still auto-selects and advances focus
- Both scenarios run in en_US and de_DE
- Update TEST-COVERAGE.md with new test entry (#9)

## Test plan

- [ ] CI passes (frontend webui test shards 1/3, 2/3, 3/3)
- [ ] New test `quick-input-multiple-matches.spec.js` runs in all 3 E2E shards without failures