### PR TITLE
Fix idempotent sysconfig migration for beepOnInvalidProduct

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5790270_sys_webui_frontend_quickinput_beepOnInvalidProduct.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5790270_sys_webui_frontend_quickinput_beepOnInvalidProduct.sql
@@ -2,4 +2,5 @@
 INSERT INTO AD_SysConfig (AD_SysConfig_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Name, Value, ConfigurationLevel, EntityType, Description)
 VALUES (541795, 0, 0, 'Y', TO_TIMESTAMP('2026-02-26', 'YYYY-MM-DD'), 100, TO_TIMESTAMP('2026-02-26', 'YYYY-MM-DD'), 100,
        'webui.frontend.quickinput.beepOnInvalidProduct', 'N', 'S', 'de.metas.ui.web',
-       'When Y, play an audible beep when an invalid product is entered in quick input. Default: N.');
+       'When Y, play an audible beep when an invalid product is entered in quick input. Default: N.')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- Add `ON CONFLICT DO NOTHING` to the `beepOnInvalidProduct` AD_SysConfig migration script
- Prevents duplicate key violation on customer DB images that already contain the row from a prior build

## Test plan
- [ ] Verify customer repo CI builds pass after merge