### PR TITLE
M_ReceiptSchedule: close instead of delete on PO reactivation/void

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/receiptschedule/M_ReceiptSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/receiptschedule/M_ReceiptSchedule_StepDef.java
@@ -180,6 +180,12 @@ public class M_ReceiptSchedule_StepDef
 		final boolean processed = DataTableUtil.extractBooleanForColumnNameOr(row, "OPT." + I_M_ReceiptSchedule.COLUMNNAME_Processed, false);
 		softly.assertThat(receiptSchedule.isProcessed()).isEqualTo(processed);
 
+		final Boolean isClosed = DataTableUtil.extractBooleanForColumnNameOrNull(row, "OPT." + I_M_ReceiptSchedule.COLUMNNAME_IsClosed);
+		if (isClosed != null)
+		{
+			softly.assertThat(receiptSchedule.isIsClosed()).as("IsClosed").isEqualTo(isClosed);
+		}
+
 		row.getAsOptionalString(COLUMNNAME_ExternalHeaderId)
 						.ifPresent(externalHeaderId -> softly.assertThat(receiptSchedule.getExternalHeaderId()).as(COLUMNNAME_ExternalHeaderId).isEqualTo(externalHeaderId));
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/receiptschedule/M_ReceiptSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/receiptschedule/M_ReceiptSchedule_StepDef.java
@@ -180,11 +180,8 @@ public class M_ReceiptSchedule_StepDef
 		final boolean processed = DataTableUtil.extractBooleanForColumnNameOr(row, "OPT." + I_M_ReceiptSchedule.COLUMNNAME_Processed, false);
 		softly.assertThat(receiptSchedule.isProcessed()).isEqualTo(processed);
 
-		final Boolean isClosed = DataTableUtil.extractBooleanForColumnNameOrNull(row, "OPT." + I_M_ReceiptSchedule.COLUMNNAME_IsClosed);
-		if (isClosed != null)
-		{
-			softly.assertThat(receiptSchedule.isIsClosed()).as("IsClosed").isEqualTo(isClosed);
-		}
+		row.getAsOptionalBoolean(I_M_ReceiptSchedule.COLUMNNAME_IsClosed)
+				.ifPresent(isClosed -> softly.assertThat(receiptSchedule.isIsClosed()).as("IsClosed").isEqualTo(isClosed));
 
 		row.getAsOptionalString(COLUMNNAME_ExternalHeaderId)
 						.ifPresent(externalHeaderId -> softly.assertThat(receiptSchedule.getExternalHeaderId()).as(COLUMNNAME_ExternalHeaderId).isEqualTo(externalHeaderId));

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderQty.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderQty.feature
@@ -479,6 +479,7 @@ Feature: Purchase order
     And set sys config boolean value false for sys config PO_AllowReactivationIfReceiptsCreated
 
   @from:cucumber
+  @Id:S0156_600
   @allure.label.epic:E0140_Purchasing
   @allure.label.feature:F00600_Purchase_Order
   @F00600

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderQty.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderQty.feature
@@ -477,3 +477,39 @@ Feature: Purchase order
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | OPT.QtyReserved |
       | orderLine_PO_12192025     | order_PO_12192025     | product_PO_17062022     | 50         | 10           | 0           | 10    | 0        | EUR          | true      | 40              |
     And set sys config boolean value false for sys config PO_AllowReactivationIfReceiptsCreated
+
+  @from:cucumber
+  @allure.label.epic:E0140_Purchasing
+  @allure.label.feature:F00600_Purchase_Order
+  @F00600
+  Scenario: Reactivate PO preserves receipt schedules (closed, not deleted); re-complete reopens them
+    Given metasfresh contains C_Orders:
+      | Identifier               | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.DocBaseType | OPT.M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.DeliveryRule | OPT.DeliveryViaRule |
+      | order_PO_rs_close_reopen | N       | supplier_PO              | 2022-06-10  | POO             | ps_PO                             | supplierLocation_PO                   | F                | S                   |
+    And metasfresh contains C_OrderLines:
+      | Identifier                   | C_Order_ID.Identifier    | M_Product_ID.Identifier | QtyEntered |
+      | orderLine_PO_rs_close_reopen | order_PO_rs_close_reopen | product_PO_17062022     | 10         |
+
+    # 1. Complete the PO
+    And the order identified by order_PO_rs_close_reopen is completed
+
+    # 2. Validate M_ReceiptSchedule created: IsClosed=false, Processed=false
+    And after not more than 30s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier    | C_OrderLine_ID.Identifier    | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.Processed | OPT.IsClosed |
+      | rs_PO_close_reopen              | order_PO_rs_close_reopen | orderLine_PO_rs_close_reopen | supplier_PO              | supplierLocation_PO               | product_PO_17062022     | 10         | warehouseStd              | false         | false        |
+
+    # 3. Reactivate the PO
+    When the order identified by order_PO_rs_close_reopen is reactivated
+
+    # 4. Validate M_ReceiptSchedule STILL EXISTS and is closed: IsClosed=true, Processed=true
+    And after not more than 30s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier    | C_OrderLine_ID.Identifier    | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.Processed | OPT.IsClosed |
+      | rs_PO_close_reopen              | order_PO_rs_close_reopen | orderLine_PO_rs_close_reopen | supplier_PO              | supplierLocation_PO               | product_PO_17062022     | 10         | warehouseStd              | true          | true         |
+
+    # 5. Re-complete the PO
+    And the order identified by order_PO_rs_close_reopen is completed
+
+    # 6. Validate M_ReceiptSchedule reopened: IsClosed=false, Processed=false
+    And after not more than 30s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier    | C_OrderLine_ID.Identifier    | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.Processed | OPT.IsClosed |
+      | rs_PO_close_reopen              | order_PO_rs_close_reopen | orderLine_PO_rs_close_reopen | supplier_PO              | supplierLocation_PO               | product_PO_17062022     | 10         | warehouseStd              | false         | false        |

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/view/eventhandler/ReceiptScheduleEventHandler.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/view/eventhandler/ReceiptScheduleEventHandler.java
@@ -109,7 +109,7 @@ public class ReceiptScheduleEventHandler
 			@NonNull final MainDataRecordIdentifier identifier,
 			@NonNull final ZoneId timeZone)
 	{
-		logger.warn("*** cockpit ReceiptScheduleEventHandler: event={}, receiptScheduleId={}"
+		logger.debug("ReceiptScheduleEventHandler: event={}, receiptScheduleId={}"
 						+ " | orderedQtyDelta={}, reservedQtyDelta={}"
 						+ " | materialDescriptor.qty={}, reservedQty={}"
 						+ " | identifier={}",

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/view/eventhandler/ReceiptScheduleEventHandler.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/view/eventhandler/ReceiptScheduleEventHandler.java
@@ -109,7 +109,19 @@ public class ReceiptScheduleEventHandler
 			@NonNull final MainDataRecordIdentifier identifier,
 			@NonNull final ZoneId timeZone)
 	{
-		if ((event instanceof ReceiptScheduleUpdatedEvent) 
+		logger.warn("*** cockpit ReceiptScheduleEventHandler: event={}, receiptScheduleId={}"
+						+ " | orderedQtyDelta={}, reservedQtyDelta={}"
+						+ " | materialDescriptor.qty={}, reservedQty={}"
+						+ " | identifier={}",
+				event.getClass().getSimpleName(),
+				event.getReceiptScheduleId(),
+				event.getOrderedQuantityDelta(),
+				event.getReservedQuantityDelta(),
+				event.getMaterialDescriptor().getQuantity(),
+				event.getReservedQuantity(),
+				identifier);
+
+		if ((event instanceof ReceiptScheduleUpdatedEvent)
 				&& event.getOrderedQuantityDelta().signum() == 0
 				&& event.getReservedQuantityDelta().signum() == 0)
 		{

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/view/mainrecord/MainDataRequestHandler.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/view/mainrecord/MainDataRequestHandler.java
@@ -52,7 +52,9 @@ public class MainDataRequestHandler
 		synchronized (MainDataRequestHandler.class)
 		{
 			final I_MD_Cockpit dataRecord = retrieveOrCreateDataRecord(dataUpdateRequest.getIdentifier());
+
 			updateDataRecordWithRequestQtys(dataRecord, dataUpdateRequest);
+
 			saveRecord(dataRecord);
 		}
 	}

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/interceptor/M_ReceiptSchedule_PostMaterialEvent.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/interceptor/M_ReceiptSchedule_PostMaterialEvent.java
@@ -104,31 +104,25 @@ public class M_ReceiptSchedule_PostMaterialEvent
 			@NonNull final I_M_ReceiptSchedule schedule,
 			@NonNull final ModelChangeType timing)
 	{
-		final I_M_ReceiptSchedule oldSchedule = InterfaceWrapperHelper.createOld(schedule, I_M_ReceiptSchedule.class);
-		logger.warn("*** createAndFireEvent M_ReceiptSchedule_ID={}, timing={}"
-						+ " | IsClosed: {}→{}, Processed: {}→{}, IsActive: {}→{}"
-						+ " | QtyOrdered: {}→{}, QtyToMove: {}→{}, QtyMoved: {}→{}"
-						+ " | ASI_ID: {}→{}",
-				schedule.getM_ReceiptSchedule_ID(), timing,
-				oldSchedule.isIsClosed(), schedule.isIsClosed(),
-				oldSchedule.isProcessed(), schedule.isProcessed(),
-				oldSchedule.isActive(), schedule.isActive(),
-				oldSchedule.getQtyOrdered(), schedule.getQtyOrdered(),
-				oldSchedule.getQtyToMove(), schedule.getQtyToMove(),
-				oldSchedule.getQtyMoved(), schedule.getQtyMoved(),
-				oldSchedule.getM_AttributeSetInstance_ID(), schedule.getM_AttributeSetInstance_ID());
-
 		final AbstractReceiptScheduleEvent event = createReceiptScheduleEvent(schedule, timing);
 
-		logger.warn("*** Enqueuing event: {} | M_ReceiptSchedule_ID={}"
-						+ " | orderedQtyDelta={}, reservedQtyDelta={}"
-						+ " | event.materialDescriptor.storageAttributesKey={}, event.materialDescriptor.quantity={}",
-				event.getClass().getSimpleName(),
-				schedule.getM_ReceiptSchedule_ID(),
-				event.getOrderedQuantityDelta(),
-				event.getReservedQuantityDelta(),
-				event.getMaterialDescriptor().getStorageAttributesKey(),
-				event.getMaterialDescriptor().getQuantity());
+		if (logger.isDebugEnabled())
+		{
+			final I_M_ReceiptSchedule oldSchedule = InterfaceWrapperHelper.createOld(schedule, I_M_ReceiptSchedule.class);
+			logger.debug("createAndFireEvent M_ReceiptSchedule_ID={}, timing={}"
+							+ " | IsClosed: {}>{}, Processed: {}>{}, IsActive: {}>{}"
+							+ " | QtyOrdered: {}>{}, QtyToMove: {}>{}"
+							+ " | event={}, orderedQtyDelta={}, reservedQtyDelta={}",
+					schedule.getM_ReceiptSchedule_ID(), timing,
+					oldSchedule.isIsClosed(), schedule.isIsClosed(),
+					oldSchedule.isProcessed(), schedule.isProcessed(),
+					oldSchedule.isActive(), schedule.isActive(),
+					oldSchedule.getQtyOrdered(), schedule.getQtyOrdered(),
+					oldSchedule.getQtyToMove(), schedule.getQtyToMove(),
+					event.getClass().getSimpleName(),
+					event.getOrderedQuantityDelta(),
+					event.getReservedQuantityDelta());
+		}
 
 		postMaterialEventService.enqueueEventAfterNextCommit(event);
 	}

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/interceptor/M_ReceiptSchedule_PostMaterialEvent.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/interceptor/M_ReceiptSchedule_PostMaterialEvent.java
@@ -93,6 +93,7 @@ public class M_ReceiptSchedule_PostMaterialEvent
 			I_M_ReceiptSchedule.COLUMNNAME_M_AttributeSetInstance_ID,
 			I_M_ReceiptSchedule.COLUMNNAME_MovementDate, // this is the actual order's datePromised
 			I_M_ReceiptSchedule.COLUMNNAME_IsActive, /* IsActive=N shall be threaded like a deletion */
+			I_M_ReceiptSchedule.COLUMNNAME_IsClosed, /* IsClosed=Y shall be treated like a deletion (lowers supply to already-received qty) */
 			I_M_ReceiptSchedule.COLUMNNAME_Processed,
 			I_M_ReceiptSchedule.COLUMNNAME_QtyOrderedOverUnder})
 	public void createAndFireEvent(
@@ -109,19 +110,45 @@ public class M_ReceiptSchedule_PostMaterialEvent
 			@NonNull final I_M_ReceiptSchedule receiptSchedule,
 			@NonNull final ModelChangeType timing)
 	{
-		final boolean created = timing.isNew() || ModelChangeUtil.isJustActivated(receiptSchedule);
+		final boolean created = timing.isNew()
+				|| ModelChangeUtil.isJustActivated(receiptSchedule)
+				|| isJustReopened(receiptSchedule);
 		if (created)
 		{
 			return createCreatedEvent(receiptSchedule);
 		}
 
-		final boolean deleted = timing.isDelete() || ModelChangeUtil.isJustDeactivated(receiptSchedule);
+		final boolean deleted = timing.isDelete()
+				|| ModelChangeUtil.isJustDeactivated(receiptSchedule)
+				|| isJustClosed(receiptSchedule);
 		if (deleted)
 		{
 			return createDeletedEvent(receiptSchedule);
 		}
 
 		return createUpdatedEvent(receiptSchedule);
+	}
+
+	/** IsClosed changed from false to true — treat as deletion from material dispo perspective (lowers supply to already-received qty). */
+	private static boolean isJustClosed(@NonNull final I_M_ReceiptSchedule receiptSchedule)
+	{
+		if (!receiptSchedule.isIsClosed())
+		{
+			return false;
+		}
+		final I_M_ReceiptSchedule old = InterfaceWrapperHelper.createOld(receiptSchedule, I_M_ReceiptSchedule.class);
+		return !old.isIsClosed();
+	}
+
+	/** IsClosed changed from true to false — treat as creation from material dispo perspective (restores supply). */
+	private static boolean isJustReopened(@NonNull final I_M_ReceiptSchedule receiptSchedule)
+	{
+		if (receiptSchedule.isIsClosed())
+		{
+			return false;
+		}
+		final I_M_ReceiptSchedule old = InterfaceWrapperHelper.createOld(receiptSchedule, I_M_ReceiptSchedule.class);
+		return old.isIsClosed();
 	}
 
 	private AbstractReceiptScheduleEvent createCreatedEvent(

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/interceptor/M_ReceiptSchedule_PostMaterialEvent.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/interceptor/M_ReceiptSchedule_PostMaterialEvent.java
@@ -123,7 +123,13 @@ public class M_ReceiptSchedule_PostMaterialEvent
 				|| isJustClosed(receiptSchedule);
 		if (deleted)
 		{
-			return createDeletedEvent(receiptSchedule);
+			// When the receipt schedule is just closed, the M_ReceiptSchedule interceptor
+			// may have already zeroed QtyToMove (because Processed=true triggers recalculation).
+			// Use the OLD values so the event deltas correctly reverse the cockpit quantities.
+			final I_M_ReceiptSchedule scheduleForEvent = isJustClosed(receiptSchedule)
+					? InterfaceWrapperHelper.createOld(receiptSchedule, I_M_ReceiptSchedule.class)
+					: receiptSchedule;
+			return createDeletedEvent(scheduleForEvent);
 		}
 
 		return createUpdatedEvent(receiptSchedule);

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/interceptor/M_ReceiptSchedule_PostMaterialEvent.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/interceptor/M_ReceiptSchedule_PostMaterialEvent.java
@@ -29,6 +29,8 @@ import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.ModelValidator;
 import org.compiere.util.TimeUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
@@ -61,6 +63,8 @@ import java.util.Objects;
 @Component
 public class M_ReceiptSchedule_PostMaterialEvent
 {
+	private static final Logger logger = LoggerFactory.getLogger(M_ReceiptSchedule_PostMaterialEvent.class);
+
 	private final PostMaterialEventService postMaterialEventService;
 	private final ModelProductDescriptorExtractor productDescriptorFactory;
 	private final PurchaseCandidateRepository purchaseCandidateRepository;
@@ -100,7 +104,31 @@ public class M_ReceiptSchedule_PostMaterialEvent
 			@NonNull final I_M_ReceiptSchedule schedule,
 			@NonNull final ModelChangeType timing)
 	{
+		final I_M_ReceiptSchedule oldSchedule = InterfaceWrapperHelper.createOld(schedule, I_M_ReceiptSchedule.class);
+		logger.warn("*** createAndFireEvent M_ReceiptSchedule_ID={}, timing={}"
+						+ " | IsClosed: {}→{}, Processed: {}→{}, IsActive: {}→{}"
+						+ " | QtyOrdered: {}→{}, QtyToMove: {}→{}, QtyMoved: {}→{}"
+						+ " | ASI_ID: {}→{}",
+				schedule.getM_ReceiptSchedule_ID(), timing,
+				oldSchedule.isIsClosed(), schedule.isIsClosed(),
+				oldSchedule.isProcessed(), schedule.isProcessed(),
+				oldSchedule.isActive(), schedule.isActive(),
+				oldSchedule.getQtyOrdered(), schedule.getQtyOrdered(),
+				oldSchedule.getQtyToMove(), schedule.getQtyToMove(),
+				oldSchedule.getQtyMoved(), schedule.getQtyMoved(),
+				oldSchedule.getM_AttributeSetInstance_ID(), schedule.getM_AttributeSetInstance_ID());
+
 		final AbstractReceiptScheduleEvent event = createReceiptScheduleEvent(schedule, timing);
+
+		logger.warn("*** Enqueuing event: {} | M_ReceiptSchedule_ID={}"
+						+ " | orderedQtyDelta={}, reservedQtyDelta={}"
+						+ " | event.materialDescriptor.storageAttributesKey={}, event.materialDescriptor.quantity={}",
+				event.getClass().getSimpleName(),
+				schedule.getM_ReceiptSchedule_ID(),
+				event.getOrderedQuantityDelta(),
+				event.getReservedQuantityDelta(),
+				event.getMaterialDescriptor().getStorageAttributesKey(),
+				event.getMaterialDescriptor().getQuantity());
 
 		postMaterialEventService.enqueueEventAfterNextCommit(event);
 	}

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/interceptor/M_ReceiptSchedule_PostMaterialEvent.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/interceptor/M_ReceiptSchedule_PostMaterialEvent.java
@@ -140,15 +140,16 @@ public class M_ReceiptSchedule_PostMaterialEvent
 			return createCreatedEvent(receiptSchedule);
 		}
 
+		final boolean justClosed = isJustClosed(receiptSchedule);
 		final boolean deleted = timing.isDelete()
 				|| ModelChangeUtil.isJustDeactivated(receiptSchedule)
-				|| isJustClosed(receiptSchedule);
+				|| justClosed;
 		if (deleted)
 		{
 			// When the receipt schedule is just closed, the M_ReceiptSchedule interceptor
 			// may have already zeroed QtyToMove (because Processed=true triggers recalculation).
 			// Use the OLD values so the event deltas correctly reverse the cockpit quantities.
-			final I_M_ReceiptSchedule scheduleForEvent = isJustClosed(receiptSchedule)
+			final I_M_ReceiptSchedule scheduleForEvent = justClosed
 					? InterfaceWrapperHelper.createOld(receiptSchedule, I_M_ReceiptSchedule.class)
 					: receiptSchedule;
 			return createDeletedEvent(scheduleForEvent);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/I_M_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/I_M_ReceiptSchedule.java
@@ -1731,6 +1731,27 @@ public interface I_M_ReceiptSchedule
 	String COLUMNNAME_Processed = "Processed";
 
 	/**
+	 * Set Closed.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsClosed (boolean IsClosed);
+
+	/**
+	 * Get Closed.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isIsClosed();
+
+	ModelColumn<I_M_ReceiptSchedule, Object> COLUMN_IsClosed = new ModelColumn<>(I_M_ReceiptSchedule.class, "IsClosed", null);
+	String COLUMNNAME_IsClosed = "IsClosed";
+
+	/**
 	 * Set Packaging capacity.
 	 * Capacity in the respective product's unit of measuerement
 	 *

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/X_M_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/X_M_ReceiptSchedule.java
@@ -1159,9 +1159,21 @@ public class X_M_ReceiptSchedule extends org.compiere.model.PO implements I_M_Re
 	}
 
 	@Override
-	public boolean isProcessed() 
+	public boolean isProcessed()
 	{
 		return get_ValueAsBoolean(COLUMNNAME_Processed);
+	}
+
+	@Override
+	public void setIsClosed (final boolean IsClosed)
+	{
+		set_Value (COLUMNNAME_IsClosed, IsClosed);
+	}
+
+	@Override
+	public boolean isIsClosed()
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsClosed);
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IReceiptScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IReceiptScheduleBL.java
@@ -42,6 +42,7 @@ import org.adempiere.util.agg.key.IAggregationKeyBuilder;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.I_C_BPartner_Location;
+import org.compiere.model.I_C_Order;
 import org.compiere.model.I_M_AttributeSetInstance;
 import org.compiere.model.I_M_Warehouse;
 
@@ -239,4 +240,16 @@ public interface IReceiptScheduleBL extends ISingletonService
 	List<ReceiptScheduleId> retainLUQtySchedules(List<ReceiptScheduleId> receiptSchedules);
 
 	int updateDatePromisedOverrideAndPOReference(@NonNull PInstanceId pinstanceId, @Nullable LocalDateTime datePromisedOverride, @Nullable String poReference);
+
+	/**
+	 * Reopen all closed receipt schedules belonging to the given order's lines,
+	 * syncing QtyOrdered and ASI from the order line in a single save.
+	 */
+	void reopenReceiptSchedulesForOrder(@NonNull I_C_Order order);
+
+	/**
+	 * Close all open receipt schedules belonging to the given order's lines.
+	 * Used on PO reactivation/void to preserve user modifications.
+	 */
+	void closeReceiptSchedulesForOrder(@NonNull I_C_Order order);
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IReceiptScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IReceiptScheduleBL.java
@@ -204,9 +204,9 @@ public interface IReceiptScheduleBL extends ISingletonService
 	I_M_ReceiptSchedule_Alloc reverseAllocation(I_M_ReceiptSchedule_Alloc rsa);
 
 	/**
-	 * Close receipt schedule line and mark it as processed.
+	 * Close receipt schedule line by setting {@code IsClosed=Y} and {@code Processed=Y}.
 	 * <p>
-	 * Call the {@link IReceiptScheduleListener}s' beforeClose method, then set the schedule to <code>Processed=Y</code>, then save the given <code>receiptSchedule</code>, then call the listeners' afterClose() methods and finally save the record again.
+	 * Call the {@link IReceiptScheduleListener}s' beforeClose method, then set the schedule to <code>IsClosed=Y, Processed=Y</code>, then save the given <code>receiptSchedule</code>, then call the listeners' afterClose() methods and finally save the record again.
 	 * <p>
 	 * The saving prior to <code>afterClose()</code> is done because the listeners might also retrieve the same <code>receiptSchedule</code> data record from the DB and might also change and save it.
 	 * See {@link C_OrderLine_ReceiptSchedule} for an example.
@@ -216,12 +216,13 @@ public interface IReceiptScheduleBL extends ISingletonService
 	void close(I_M_ReceiptSchedule receiptSchedule);
 
 	/**
-	 * Re-open a closed receipt schedule line. Similar to {@link #close(I_M_ReceiptSchedule)}. Also, we save the given <code>receiptSchedule</code> twice for similar reasons.
+	 * Re-open a closed receipt schedule line by setting {@code IsClosed=N} and {@code Processed=N}.
+	 * Similar to {@link #close(I_M_ReceiptSchedule)}. Also, we save the given <code>receiptSchedule</code> twice for similar reasons.
 	 */
 	void reopen(I_M_ReceiptSchedule receiptSchedule);
 
 	/**
-	 * Checks if given receipt schedule is closed (i.e. {@link I_M_ReceiptSchedule#isProcessed()}).
+	 * Checks if given receipt schedule is closed (i.e. {@link I_M_ReceiptSchedule#isIsClosed()}).
 	 *
 	 * @return true if receipt schedule is closed
 	 */

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
@@ -31,6 +31,8 @@ import de.metas.document.location.adapter.IDocumentLocationAdapter;
 import de.metas.i18n.AdMessageKey;
 import de.metas.inout.IInOutBL;
 import de.metas.inout.model.I_M_InOutLine;
+import de.metas.interfaces.I_C_OrderLine;
+import de.metas.invoicecandidate.api.IInvoiceCandBL;
 import de.metas.inoutcandidate.ReceiptScheduleId;
 import de.metas.inoutcandidate.api.ApplyReceiptScheduleChangesRequest;
 import de.metas.inoutcandidate.api.IInOutProducer;
@@ -47,7 +49,10 @@ import de.metas.inoutcandidate.spi.IReceiptScheduleListener;
 import de.metas.inoutcandidate.spi.impl.CompositeReceiptScheduleListener;
 import de.metas.interfaces.I_C_BPartner;
 import de.metas.logging.LogManager;
+import de.metas.order.IOrderBL;
+import de.metas.order.IOrderDAO;
 import de.metas.order.OrderId;
+import de.metas.order.OrderLineId;
 import de.metas.process.PInstanceId;
 import de.metas.product.ProductId;
 import de.metas.quantity.StockQtyAndUOMQty;
@@ -108,6 +113,9 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 	private final IAttributeSetInstanceBL attributeSetInstanceBL = Services.get(IAttributeSetInstanceBL.class);
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	private final IOrderBL orderBL = Services.get(IOrderBL.class);
+	private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
+	private final IInvoiceCandBL invoiceCandBL = Services.get(IInvoiceCandBL.class);
 
 	@Override
 	public void addReceiptScheduleListener(final IReceiptScheduleListener listener)
@@ -632,6 +640,83 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 	public List<ReceiptScheduleId> retainLUQtySchedules(@NonNull final List<ReceiptScheduleId> receiptSchedules)
 	{
 		return receiptScheduleDAO.retainLUQtySchedules(receiptSchedules);
+	}
+
+	@Override
+	public void reopenReceiptSchedulesForOrder(@NonNull final I_C_Order order)
+	{
+		final List<I_C_OrderLine> orderLines = orderDAO.retrieveOrderLines(order);
+		for (final I_C_OrderLine orderLine : orderLines)
+		{
+			final I_M_ReceiptSchedule receiptSchedule = receiptScheduleDAO.retrieveForRecord(orderLine);
+
+			if (receiptSchedule == null || !isClosed(receiptSchedule))
+			{
+				continue;
+			}
+
+			// Reopen the order line BEFORE the receipt schedule.
+			// During save, the M_ReceiptSchedule interceptor fires propagateQtysToOrderLine
+			// which loads the order line from DB and triggers C_OrderLine.updateQtyReserved.
+			// IsDeliveryClosed must already be false at that point, otherwise QtyReserved is
+			// temporarily set to 0 and downstream interceptors (C_Order.updateReserved) may
+			// pick up the stale value.
+			orderBL.reopenLine(orderLine);
+
+			// IMPORTANT: We bypass IReceiptScheduleBL.reopen() intentionally to combine reopen +
+			// QtyOrdered + ASI sync into ONE save. This produces exactly one ReceiptScheduleCreatedEvent
+			// with the final (possibly updated) quantities and the correct storageAttributesKey.
+			// Calling reopen() + save() would produce two events: CreatedEvent(old qty) + UpdatedEvent(delta).
+			//
+			// No InterfaceWrapperHelper.refresh() needed: the receipt schedule was just loaded from DB
+			// via receiptScheduleDAO.retrieveForRecord, so it already has the latest state.
+			//
+			// Bypassed listener callbacks:
+			// - onBeforeReopen: currently no-op in all known implementations
+			//   (OrderLineReceiptScheduleListener, HUReceiptScheduleListener use the default adapter)
+			//   WARNING: If a future IReceiptScheduleListener overrides onBeforeReopen with real logic,
+			//   this method MUST be updated to call it explicitly.
+			// - onAfterReopen: manually replicated below (reopenLine + openDeliveryInvoiceCandidates)
+			receiptSchedule.setIsClosed(false);
+			receiptSchedule.setProcessed(false);
+			receiptSchedule.setQtyOrdered(orderLine.getQtyOrdered());
+			attributeSetInstanceBL.cloneOrCreateASI(receiptSchedule, orderLine);
+
+			logger.debug("reopenReceiptSchedulesForOrder: saving M_ReceiptSchedule_ID={} | IsClosed={}, Processed={}, QtyOrdered={}, ASI_ID={}",
+					receiptSchedule.getM_ReceiptSchedule_ID(),
+					receiptSchedule.isIsClosed(), receiptSchedule.isProcessed(), receiptSchedule.getQtyOrdered(),
+					receiptSchedule.getM_AttributeSetInstance_ID());
+
+			InterfaceWrapperHelper.save(receiptSchedule);
+
+			// Fire the side effects that ReceiptScheduleBL.reopen()'s onAfterReopen listener would have done.
+			// orderBL.reopenLine(orderLine) was already called above.
+			invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
+		}
+	}
+
+	@Override
+	public void closeReceiptSchedulesForOrder(@NonNull final I_C_Order order)
+	{
+		final List<I_C_OrderLine> orderLines = orderDAO.retrieveOrderLines(order);
+		for (final I_C_OrderLine orderLine : orderLines)
+		{
+			final I_M_ReceiptSchedule receiptSchedule = receiptScheduleDAO.retrieveForRecord(orderLine);
+
+			if (receiptSchedule == null || isClosed(receiptSchedule))
+			{
+				continue;
+			}
+
+			close(receiptSchedule);
+
+			// close() fires the OrderLineReceiptScheduleListener which calls closeLine(),
+			// setting IsDeliveryClosed=true on the order line (via the receipt schedule's FK-cached PO).
+			// During PO reactivation/void the receipt schedule is only "parked" — the order line
+			// itself must stay open for editing. Undo the closeLine side-effect.
+			InterfaceWrapperHelper.refresh(orderLine);
+			orderBL.reopenLine(orderLine);
+		}
 	}
 
 	private static class ReceiptScheduleDocumentLocationAdapter implements IDocumentLocationAdapter

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
@@ -518,12 +518,14 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 		// Mark the receipt schedule as not closed
 		receiptSchedule.setIsClosed(false);
 		receiptSchedule.setProcessed(false);
+
 		InterfaceWrapperHelper.save(receiptSchedule);
 
 		// this is already called by a model validator when the receipt schedule is saved
 		// Services.get(IReceiptScheduleQtysBL.class).onReceiptScheduleChanged(receiptSchedule);
 
 		listeners.onAfterReopen(receiptSchedule);
+
 		InterfaceWrapperHelper.save(receiptSchedule);
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
@@ -513,7 +513,7 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 		}
 
 		listeners.onBeforeReopen(receiptSchedule);
-		InterfaceWrapperHelper.refresh(receiptSchedule); // because
+		InterfaceWrapperHelper.refresh(receiptSchedule); // reload from DB because listeners may have changed the record
 
 		// Mark the receipt schedule as not closed
 		receiptSchedule.setIsClosed(false);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
@@ -482,7 +482,7 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 	@Override
 	public void close(@NonNull final I_M_ReceiptSchedule rs)
 	{
-		// Make sure receipt schedule was not already processed
+		// Make sure receipt schedule was not already closed
 		if (isClosed(rs))
 		{
 			throw new AdempiereException("@Closed@=@Y@ (" + rs + ")");
@@ -490,7 +490,8 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 
 		listeners.onBeforeClose(rs);
 
-		// Mark the receipt schedule as closed (i.e. processed)
+		// Mark the receipt schedule as closed
+		rs.setIsClosed(true);
 		rs.setProcessed(true);
 		InterfaceWrapperHelper.save(rs);
 
@@ -498,14 +499,14 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 		// Services.get(IReceiptScheduleQtysBL.class).onReceiptScheduleChanged(receiptSchedule);
 
 		listeners.onAfterClose(rs);
-		InterfaceWrapperHelper.save(rs); // see javadoc on why we same two times
+		InterfaceWrapperHelper.save(rs); // see javadoc on why we save two times
 	}
 
 	@Override
 	public void reopen(@NonNull final I_M_ReceiptSchedule receiptSchedule)
 	{
 		//
-		// Make sure receipt schedule is closed/processed
+		// Make sure receipt schedule is closed
 		if (!isClosed(receiptSchedule))
 		{
 			throw new AdempiereException("@Closed@=@N@ (" + receiptSchedule + ")");
@@ -514,7 +515,8 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 		listeners.onBeforeReopen(receiptSchedule);
 		InterfaceWrapperHelper.refresh(receiptSchedule); // because
 
-		// Mark the receipt schedule as not closed (i.e. not processed)
+		// Mark the receipt schedule as not closed
+		receiptSchedule.setIsClosed(false);
 		receiptSchedule.setProcessed(false);
 		InterfaceWrapperHelper.save(receiptSchedule);
 
@@ -528,7 +530,7 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 	@Override
 	public boolean isClosed(@NonNull final I_M_ReceiptSchedule receiptSchedule)
 	{
-		return receiptSchedule.isProcessed();
+		return receiptSchedule.isIsClosed();
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
@@ -315,6 +315,7 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 				.createQueryBuilder(I_M_ReceiptSchedule.class, ctx, ITrx.TRXNAME_None)
 				.filter(userSelectionFilter)
 				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_Processed, false)
+				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_IsClosed, false)
 				.addOnlyActiveRecordsFilter()
 				.addOnlyContextClient();
 
@@ -329,6 +330,7 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_Order_ID, orderId)
 				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_Processed, false)
+				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_IsClosed, false)
 				.addInArrayFilter(I_M_ReceiptSchedule.COLUMNNAME_ExportStatus, APIExportStatus.EXPORTED_STATES)
 				.create()
 				.anyMatch();

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
@@ -314,6 +314,8 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 		final IQueryBuilder<I_M_ReceiptSchedule> queryBuilder = queryBL
 				.createQueryBuilder(I_M_ReceiptSchedule.class, ctx, ITrx.TRXNAME_None)
 				.filter(userSelectionFilter)
+				// NOTE: IsClosed=Y always implies Processed=Y (see ReceiptScheduleBL.close/reopen).
+				// Both filters are kept for clarity and as a safety net.
 				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_Processed, false)
 				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_IsClosed, false)
 				.addOnlyActiveRecordsFilter()
@@ -329,6 +331,8 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 				.createQueryBuilder(I_M_ReceiptSchedule.class)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_Order_ID, orderId)
+				// NOTE: IsClosed=Y always implies Processed=Y (see ReceiptScheduleBL.close/reopen).
+				// Both filters are kept for clarity and as a safety net.
 				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_Processed, false)
 				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_IsClosed, false)
 				.addInArrayFilter(I_M_ReceiptSchedule.COLUMNNAME_ExportStatus, APIExportStatus.EXPORTED_STATES)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
@@ -30,8 +30,10 @@ import de.metas.inoutcandidate.api.IReceiptScheduleProducerFactory;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
 import de.metas.inoutcandidate.spi.IReceiptScheduleProducer;
 import de.metas.interfaces.I_C_OrderLine;
+import de.metas.invoicecandidate.api.IInvoiceCandBL;
 import de.metas.order.IOrderBL;
 import de.metas.order.IOrderDAO;
+import de.metas.order.OrderLineId;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import org.adempiere.ad.modelvalidator.annotations.DocValidate;
@@ -74,6 +76,11 @@ public class C_Order_ReceiptSchedule
 	 * On COMPLETE: first reopen any previously closed receipt schedules, then create new ones for order lines that don't have one yet.
 	 * <p>
 	 * Declaration order matters: reopenReceiptSchedules runs before createReceiptSchedules.
+	 * <p>
+	 * We reopen the receipt schedule and sync QtyOrdered in a SINGLE save to produce
+	 * exactly one ReceiptScheduleCreatedEvent with the final quantities. Two separate saves
+	 * would produce CreatedEvent(old qty) + UpdatedEvent(delta), and those two events
+	 * would need to sum correctly in the cockpit — fragile and error-prone.
 	 */
 	@DocValidate(timings = { ModelValidator.TIMING_AFTER_COMPLETE })
 	public void reopenReceiptSchedules(final I_C_Order order)
@@ -87,6 +94,7 @@ public class C_Order_ReceiptSchedule
 		final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
 		final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
 		final IReceiptScheduleBL receiptScheduleBL = Services.get(IReceiptScheduleBL.class);
+		final IInvoiceCandBL invoiceCandBL = Services.get(IInvoiceCandBL.class);
 
 		final List<I_C_OrderLine> orderLines = orderDAO.retrieveOrderLines(order);
 		for (final I_C_OrderLine orderLine : orderLines)
@@ -99,20 +107,31 @@ public class C_Order_ReceiptSchedule
 			}
 
 			// Reopen the order line BEFORE the receipt schedule.
-			// During reopen(), the M_ReceiptSchedule interceptor fires propagateQtysToOrderLine
+			// During save, the M_ReceiptSchedule interceptor fires propagateQtysToOrderLine
 			// which loads the order line from DB and triggers C_OrderLine.updateQtyReserved.
 			// IsDeliveryClosed must already be false at that point, otherwise QtyReserved is
 			// temporarily set to 0 and downstream interceptors (C_Order.updateReserved) may
 			// pick up the stale value.
 			orderBL.reopenLine(orderLine);
 
-			receiptScheduleBL.reopen(receiptSchedule);
-
-			// Immediately sync QtyOrdered from the order line because the user may have
-			// changed it during reactivation. The async producer will update all other
-			// fields later, but QtyOrdered must be correct now for material disposition.
+			// Combine reopen + QtyOrdered + ASI sync into ONE save so that the interceptor fires
+			// a single ReceiptScheduleCreatedEvent with the final (possibly updated) quantities
+			// and the correct storageAttributesKey (derived from the ASI).
+			receiptSchedule.setIsClosed(false);
+			receiptSchedule.setProcessed(false);
 			receiptSchedule.setQtyOrdered(orderLine.getQtyOrdered());
+			receiptSchedule.setM_AttributeSetInstance_ID(orderLine.getM_AttributeSetInstance_ID());
+
+			logger.debug("reopenReceiptSchedules: saving M_ReceiptSchedule_ID={} | IsClosed={}, Processed={}, QtyOrdered={}, ASI_ID={}",
+					receiptSchedule.getM_ReceiptSchedule_ID(),
+					receiptSchedule.isIsClosed(), receiptSchedule.isProcessed(), receiptSchedule.getQtyOrdered(),
+					receiptSchedule.getM_AttributeSetInstance_ID());
+
 			InterfaceWrapperHelper.save(receiptSchedule);
+
+			// Fire the side effects that ReceiptScheduleBL.reopen()'s onAfterReopen listener would have done.
+			// orderBL.reopenLine(orderLine) was already called above.
+			invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
 		}
 	}
 
@@ -127,8 +146,6 @@ public class C_Order_ReceiptSchedule
 		// services
 		final IReceiptScheduleProducerFactory receiptScheduleProducerFactory = Services.get(IReceiptScheduleProducerFactory.class);
 		final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
-		final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
-		final IReceiptScheduleBL receiptScheduleBL = Services.get(IReceiptScheduleBL.class);
 
 		//
 		// Generate receipt schedules from this order.
@@ -141,32 +158,16 @@ public class C_Order_ReceiptSchedule
 		final IReceiptScheduleProducer receiptScheduleProducer = receiptScheduleProducerFactory.createProducer(I_C_OrderLine.Table_Name, createReceiptSchedulesAsync);
 
 		// Iterate order lines and call the producer for each of them.
+		// NOTE: we intentionally do NOT skip order lines that already have a reopened receipt schedule.
+		// The async workpackage will find the existing schedule and run the update path, which
+		// synchronises M_AttributeSetInstance_ID (via cloneOrCreateASI) and other fields from the
+		// order line. If the ASI hasn't changed, the storageAttributesKey stays the same and the
+		// resulting ReceiptScheduleUpdatedEvent has zero deltas (no-op). If the ASI DID change
+		// (e.g. user changed it during reactivation), the event correctly moves cockpit quantities
+		// from the old to the new storageAttributesKey bucket.
 		final List<I_C_OrderLine> orderLines = orderDAO.retrieveOrderLines(order);
 		for (final I_C_OrderLine orderLine : orderLines)
 		{
-			// Skip order lines that already have an active, non-closed receipt schedule.
-			// These were reopened by reopenReceiptSchedules() (which runs before this method).
-			// Running the async workpackage on them would trigger cloneOrCreateASI() in the producer,
-			// which may change the M_AttributeSetInstance_ID and shift cockpit quantities
-			// to a different storageAttributesKey.
-			final I_M_ReceiptSchedule existingSchedule = receiptScheduleDAO.retrieveForRecord(orderLine);
-			if (existingSchedule != null && existingSchedule.isActive() && !receiptScheduleBL.isClosed(existingSchedule))
-			{
-				logger.warn("*** createReceiptSchedules: SKIPPING workpackage for C_OrderLine_ID={}"
-								+ " | existing M_ReceiptSchedule_ID={}, IsActive={}, IsClosed={}, ASI_ID={}",
-						orderLine.getC_OrderLine_ID(),
-						existingSchedule.getM_ReceiptSchedule_ID(),
-						existingSchedule.isActive(),
-						existingSchedule.isIsClosed(),
-						existingSchedule.getM_AttributeSetInstance_ID());
-				continue;
-			}
-
-			logger.warn("*** createReceiptSchedules: CREATING workpackage for C_OrderLine_ID={}"
-							+ " | existingSchedule={}",
-					orderLine.getC_OrderLine_ID(),
-					existingSchedule == null ? "null" : "RS_ID=" + existingSchedule.getM_ReceiptSchedule_ID()
-							+ " IsActive=" + existingSchedule.isActive() + " IsClosed=" + existingSchedule.isIsClosed());
 			final List<I_M_ReceiptSchedule> previousSchedules = Collections.emptyList();
 			receiptScheduleProducer.createOrUpdateReceiptSchedules(orderLine, previousSchedules);
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
@@ -23,6 +23,7 @@ package de.metas.inoutcandidate.modelvalidator;
  */
 
 import de.metas.document.exception.DocumentActionException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import de.metas.i18n.AdMessageKey;
 import de.metas.inoutcandidate.api.IReceiptScheduleBL;
 import de.metas.inoutcandidate.api.IReceiptScheduleDAO;
@@ -94,6 +95,12 @@ public class C_Order_ReceiptSchedule
 			}
 
 			receiptScheduleBL.reopen(receiptSchedule);
+
+			// Immediately sync QtyOrdered from the order line because the user may have
+			// changed it during reactivation. The async producer will update all other
+			// fields later, but QtyOrdered must be correct now for material disposition.
+			receiptSchedule.setQtyOrdered(orderLine.getQtyOrdered());
+			InterfaceWrapperHelper.save(receiptSchedule);
 		}
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
@@ -124,6 +124,8 @@ public class C_Order_ReceiptSchedule
 		// services
 		final IReceiptScheduleProducerFactory receiptScheduleProducerFactory = Services.get(IReceiptScheduleProducerFactory.class);
 		final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
+		final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
+		final IReceiptScheduleBL receiptScheduleBL = Services.get(IReceiptScheduleBL.class);
 
 		//
 		// Generate receipt schedules from this order.
@@ -139,6 +141,17 @@ public class C_Order_ReceiptSchedule
 		final List<I_C_OrderLine> orderLines = orderDAO.retrieveOrderLines(order);
 		for (final I_C_OrderLine orderLine : orderLines)
 		{
+			// Skip order lines that already have an active, non-closed receipt schedule.
+			// These were reopened by reopenReceiptSchedules() (which runs before this method).
+			// Running the async workpackage on them would trigger cloneOrCreateASI() in the producer,
+			// which may change the M_AttributeSetInstance_ID and shift cockpit quantities
+			// to a different storageAttributesKey.
+			final I_M_ReceiptSchedule existingSchedule = receiptScheduleDAO.retrieveForRecord(orderLine);
+			if (existingSchedule != null && existingSchedule.isActive() && !receiptScheduleBL.isClosed(existingSchedule))
+			{
+				continue;
+			}
+
 			final List<I_M_ReceiptSchedule> previousSchedules = Collections.emptyList();
 			receiptScheduleProducer.createOrUpdateReceiptSchedules(orderLine, previousSchedules);
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
@@ -41,6 +41,8 @@ import org.adempiere.service.ISysConfigBL;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_M_InOut;
 import org.compiere.model.ModelValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
@@ -48,6 +50,7 @@ import java.util.List;
 @Validator(I_C_Order.class)
 public class C_Order_ReceiptSchedule
 {
+	private static final Logger logger = LoggerFactory.getLogger(C_Order_ReceiptSchedule.class);
 	private static final AdMessageKey ERR_NoReactivationIfReceiptsCreated = AdMessageKey.of("ERR_NoReactivationIfReceiptsCreated");
 	private static final AdMessageKey ERR_NoReactivationIfProcessedReceiptSchedules = AdMessageKey.of("ERR_NoReactivationIfProcessedReceiptSchedules");
 	private static final AdMessageKey ERR_NoVoidIfProcessedReceiptSchedules = AdMessageKey.of("ERR_NoVoidIfProcessedReceiptSchedules");
@@ -149,9 +152,21 @@ public class C_Order_ReceiptSchedule
 			final I_M_ReceiptSchedule existingSchedule = receiptScheduleDAO.retrieveForRecord(orderLine);
 			if (existingSchedule != null && existingSchedule.isActive() && !receiptScheduleBL.isClosed(existingSchedule))
 			{
+				logger.warn("*** createReceiptSchedules: SKIPPING workpackage for C_OrderLine_ID={}"
+								+ " | existing M_ReceiptSchedule_ID={}, IsActive={}, IsClosed={}, ASI_ID={}",
+						orderLine.getC_OrderLine_ID(),
+						existingSchedule.getM_ReceiptSchedule_ID(),
+						existingSchedule.isActive(),
+						existingSchedule.isIsClosed(),
+						existingSchedule.getM_AttributeSetInstance_ID());
 				continue;
 			}
 
+			logger.warn("*** createReceiptSchedules: CREATING workpackage for C_OrderLine_ID={}"
+							+ " | existingSchedule={}",
+					orderLine.getC_OrderLine_ID(),
+					existingSchedule == null ? "null" : "RS_ID=" + existingSchedule.getM_ReceiptSchedule_ID()
+							+ " IsActive=" + existingSchedule.isActive() + " IsClosed=" + existingSchedule.isIsClosed());
 			final List<I_M_ReceiptSchedule> previousSchedules = Collections.emptyList();
 			receiptScheduleProducer.createOrUpdateReceiptSchedules(orderLine, previousSchedules);
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
@@ -80,6 +80,7 @@ public class C_Order_ReceiptSchedule
 			return;
 		}
 
+		final IOrderBL orderBL = Services.get(IOrderBL.class);
 		final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
 		final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
 		final IReceiptScheduleBL receiptScheduleBL = Services.get(IReceiptScheduleBL.class);
@@ -93,6 +94,14 @@ public class C_Order_ReceiptSchedule
 			{
 				continue;
 			}
+
+			// Reopen the order line BEFORE the receipt schedule.
+			// During reopen(), the M_ReceiptSchedule interceptor fires propagateQtysToOrderLine
+			// which loads the order line from DB and triggers C_OrderLine.updateQtyReserved.
+			// IsDeliveryClosed must already be false at that point, otherwise QtyReserved is
+			// temporarily set to 0 and downstream interceptors (C_Order.updateReserved) may
+			// pick up the stale value.
+			orderBL.reopenLine(orderLine);
 
 			receiptScheduleBL.reopen(receiptSchedule);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
@@ -66,6 +66,37 @@ public class C_Order_ReceiptSchedule
 				&& !orderBL.isMediated(order);
 	}
 
+	/**
+	 * On COMPLETE: first reopen any previously closed receipt schedules, then create new ones for order lines that don't have one yet.
+	 * <p>
+	 * Declaration order matters: reopenReceiptSchedules runs before createReceiptSchedules.
+	 */
+	@DocValidate(timings = { ModelValidator.TIMING_AFTER_COMPLETE })
+	public void reopenReceiptSchedules(final I_C_Order order)
+	{
+		if (!isEligibleForReceiptSchedule(order))
+		{
+			return;
+		}
+
+		final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
+		final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
+		final IReceiptScheduleBL receiptScheduleBL = Services.get(IReceiptScheduleBL.class);
+
+		final List<I_C_OrderLine> orderLines = orderDAO.retrieveOrderLines(order);
+		for (final I_C_OrderLine orderLine : orderLines)
+		{
+			final I_M_ReceiptSchedule receiptSchedule = receiptScheduleDAO.retrieveForRecord(orderLine);
+
+			if (receiptSchedule == null || !receiptScheduleBL.isClosed(receiptSchedule))
+			{
+				continue;
+			}
+
+			receiptScheduleBL.reopen(receiptSchedule);
+		}
+	}
+
 	@DocValidate(timings = { ModelValidator.TIMING_AFTER_COMPLETE })
 	public void createReceiptSchedules(final I_C_Order order)
 	{
@@ -97,20 +128,34 @@ public class C_Order_ReceiptSchedule
 		}
 	}
 
-	@DocValidate(timings = { ModelValidator.TIMING_AFTER_REACTIVATE,
-			ModelValidator.TIMING_AFTER_VOID })
-	public void inactivateReceiptSchedules(final I_C_Order order)
+	/**
+	 * On REACTIVATE and VOID: close receipt schedules instead of deleting them.
+	 * This preserves user modifications (delivery dates, override columns, transport orders).
+	 */
+	@DocValidate(timings = { ModelValidator.TIMING_AFTER_REACTIVATE, ModelValidator.TIMING_AFTER_VOID })
+	public void closeReceiptSchedulesOnReactivateOrVoid(final I_C_Order order)
 	{
 		if (!isEligibleForReceiptSchedule(order))
 		{
 			return;
 		}
 
-		// NOTE: we are doing the inactivation synchronously because we need to have it done right away
-		final IReceiptScheduleProducer producer = Services.get(IReceiptScheduleProducerFactory.class)
-				.createProducer(I_C_Order.Table_Name, false);
+		final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
+		final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
+		final IReceiptScheduleBL receiptScheduleBL = Services.get(IReceiptScheduleBL.class);
 
-		producer.inactivateReceiptSchedules(order);
+		final List<I_C_OrderLine> orderLines = orderDAO.retrieveOrderLines(order);
+		for (final I_C_OrderLine orderLine : orderLines)
+		{
+			final I_M_ReceiptSchedule receiptSchedule = receiptScheduleDAO.retrieveForRecord(orderLine);
+
+			if (receiptSchedule == null || receiptScheduleBL.isClosed(receiptSchedule))
+			{
+				continue;
+			}
+
+			receiptScheduleBL.close(receiptSchedule);
+		}
 	}
 
 	/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
@@ -23,7 +23,6 @@ package de.metas.inoutcandidate.modelvalidator;
  */
 
 import de.metas.document.exception.DocumentActionException;
-import org.adempiere.model.InterfaceWrapperHelper;
 import de.metas.i18n.AdMessageKey;
 import de.metas.inoutcandidate.api.IReceiptScheduleBL;
 import de.metas.inoutcandidate.api.IReceiptScheduleDAO;
@@ -37,6 +36,7 @@ import de.metas.util.Check;
 import de.metas.util.Services;
 import org.adempiere.ad.modelvalidator.annotations.DocValidate;
 import org.adempiere.ad.modelvalidator.annotations.Validator;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ISysConfigBL;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_M_InOut;
@@ -256,8 +256,9 @@ public class C_Order_ReceiptSchedule
 		{
 			final I_M_ReceiptSchedule receiptSchedule = receiptScheduleDAO.retrieveForRecord(orderLine);
 
-			// Throw exception if at least one processed receipt schedule is linked to a line of this order
-			if (receiptSchedule != null && receiptSchedule.isProcessed())
+			// Return true only for schedules processed from REAL receipt activity,
+			// not schedules that are merely "parked" (IsClosed=Y) due to PO reactivation/void.
+			if (receiptSchedule != null && receiptSchedule.isProcessed() && !receiptSchedule.isIsClosed())
 			{
 				return true;
 			}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
@@ -156,6 +156,7 @@ public class C_Order_ReceiptSchedule
 			return;
 		}
 
+		final IOrderBL orderBL = Services.get(IOrderBL.class);
 		final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
 		final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
 		final IReceiptScheduleBL receiptScheduleBL = Services.get(IReceiptScheduleBL.class);
@@ -171,6 +172,13 @@ public class C_Order_ReceiptSchedule
 			}
 
 			receiptScheduleBL.close(receiptSchedule);
+
+			// close() fires the OrderLineReceiptScheduleListener which calls closeLine(),
+			// setting IsDeliveryClosed=true on the order line (via the receipt schedule's FK-cached PO).
+			// During PO reactivation/void the receipt schedule is only "parked" — the order line
+			// itself must stay open for editing. Undo the closeLine side-effect.
+			InterfaceWrapperHelper.refresh(orderLine);
+			orderBL.reopenLine(orderLine);
 		}
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
@@ -36,6 +36,7 @@ import de.metas.order.IOrderDAO;
 import de.metas.order.OrderLineId;
 import de.metas.util.Check;
 import de.metas.util.Services;
+import org.adempiere.mm.attributes.api.IAttributeSetInstanceBL;
 import org.adempiere.ad.modelvalidator.annotations.DocValidate;
 import org.adempiere.ad.modelvalidator.annotations.Validator;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -95,6 +96,7 @@ public class C_Order_ReceiptSchedule
 		final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
 		final IReceiptScheduleBL receiptScheduleBL = Services.get(IReceiptScheduleBL.class);
 		final IInvoiceCandBL invoiceCandBL = Services.get(IInvoiceCandBL.class);
+		final IAttributeSetInstanceBL attributeSetInstanceBL = Services.get(IAttributeSetInstanceBL.class);
 
 		final List<I_C_OrderLine> orderLines = orderDAO.retrieveOrderLines(order);
 		for (final I_C_OrderLine orderLine : orderLines)
@@ -126,7 +128,7 @@ public class C_Order_ReceiptSchedule
 			receiptSchedule.setIsClosed(false);
 			receiptSchedule.setProcessed(false);
 			receiptSchedule.setQtyOrdered(orderLine.getQtyOrdered());
-			receiptSchedule.setM_AttributeSetInstance_ID(orderLine.getM_AttributeSetInstance_ID());
+			attributeSetInstanceBL.cloneOrCreateASI(receiptSchedule, orderLine);
 
 			logger.debug("reopenReceiptSchedules: saving M_ReceiptSchedule_ID={} | IsClosed={}, Processed={}, QtyOrdered={}, ASI_ID={}",
 					receiptSchedule.getM_ReceiptSchedule_ID(),

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
@@ -114,9 +114,15 @@ public class C_Order_ReceiptSchedule
 			// pick up the stale value.
 			orderBL.reopenLine(orderLine);
 
-			// Combine reopen + QtyOrdered + ASI sync into ONE save so that the interceptor fires
-			// a single ReceiptScheduleCreatedEvent with the final (possibly updated) quantities
-			// and the correct storageAttributesKey (derived from the ASI).
+			// IMPORTANT: We bypass IReceiptScheduleBL.reopen() intentionally to combine reopen +
+			// QtyOrdered + ASI sync into ONE save. This produces exactly one ReceiptScheduleCreatedEvent
+			// with the final (possibly updated) quantities and the correct storageAttributesKey.
+			// Calling reopen() + save() would produce two events: CreatedEvent(old qty) + UpdatedEvent(delta).
+			//
+			// Bypassed listener callbacks:
+			// - onBeforeReopen: currently no-op in all known implementations
+			//   (OrderLineReceiptScheduleListener, HUReceiptScheduleListener use the default adapter)
+			// - onAfterReopen: manually replicated below (reopenLine + openDeliveryInvoiceCandidates)
 			receiptSchedule.setIsClosed(false);
 			receiptSchedule.setProcessed(false);
 			receiptSchedule.setQtyOrdered(orderLine.getQtyOrdered());

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ReceiptSchedule.java
@@ -30,22 +30,16 @@ import de.metas.inoutcandidate.api.IReceiptScheduleProducerFactory;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
 import de.metas.inoutcandidate.spi.IReceiptScheduleProducer;
 import de.metas.interfaces.I_C_OrderLine;
-import de.metas.invoicecandidate.api.IInvoiceCandBL;
 import de.metas.order.IOrderBL;
 import de.metas.order.IOrderDAO;
-import de.metas.order.OrderLineId;
 import de.metas.util.Check;
 import de.metas.util.Services;
-import org.adempiere.mm.attributes.api.IAttributeSetInstanceBL;
 import org.adempiere.ad.modelvalidator.annotations.DocValidate;
 import org.adempiere.ad.modelvalidator.annotations.Validator;
-import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ISysConfigBL;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_M_InOut;
 import org.compiere.model.ModelValidator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
@@ -53,11 +47,14 @@ import java.util.List;
 @Validator(I_C_Order.class)
 public class C_Order_ReceiptSchedule
 {
-	private static final Logger logger = LoggerFactory.getLogger(C_Order_ReceiptSchedule.class);
 	private static final AdMessageKey ERR_NoReactivationIfReceiptsCreated = AdMessageKey.of("ERR_NoReactivationIfReceiptsCreated");
 	private static final AdMessageKey ERR_NoReactivationIfProcessedReceiptSchedules = AdMessageKey.of("ERR_NoReactivationIfProcessedReceiptSchedules");
 	private static final AdMessageKey ERR_NoVoidIfProcessedReceiptSchedules = AdMessageKey.of("ERR_NoVoidIfProcessedReceiptSchedules");
 	private static final String SYSCONFIG_PO_ALLOW_REACTIVATION_IF_RECEIPTS_CREATED = "PO_AllowReactivationIfReceiptsCreated";
+
+	private final IReceiptScheduleBL receiptScheduleBL = Services.get(IReceiptScheduleBL.class);
+	private final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
+	private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 
 	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
@@ -74,14 +71,14 @@ public class C_Order_ReceiptSchedule
 	}
 
 	/**
-	 * On COMPLETE: first reopen any previously closed receipt schedules, then create new ones for order lines that don't have one yet.
+	 * On COMPLETE: first reopen any previously closed receipt schedules, then create new ones
+	 * for order lines that don't have one yet.
 	 * <p>
-	 * Declaration order matters: reopenReceiptSchedules runs before createReceiptSchedules.
-	 * <p>
-	 * We reopen the receipt schedule and sync QtyOrdered in a SINGLE save to produce
-	 * exactly one ReceiptScheduleCreatedEvent with the final quantities. Two separate saves
-	 * would produce CreatedEvent(old qty) + UpdatedEvent(delta), and those two events
-	 * would need to sum correctly in the cockpit — fragile and error-prone.
+	 * Declaration order matters: reopenReceiptSchedules must run before createReceiptSchedules
+	 * so that reopened schedules already have their final QtyOrdered and ASI when
+	 * createReceiptSchedules fires the async workpackage (which reads these fields).
+	 * The reopen combines IsClosed + QtyOrdered + ASI into a single save to produce exactly one
+	 * ReceiptScheduleCreatedEvent with the correct storageAttributesKey.
 	 */
 	@DocValidate(timings = { ModelValidator.TIMING_AFTER_COMPLETE })
 	public void reopenReceiptSchedules(final I_C_Order order)
@@ -91,56 +88,7 @@ public class C_Order_ReceiptSchedule
 			return;
 		}
 
-		final IOrderBL orderBL = Services.get(IOrderBL.class);
-		final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
-		final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
-		final IReceiptScheduleBL receiptScheduleBL = Services.get(IReceiptScheduleBL.class);
-		final IInvoiceCandBL invoiceCandBL = Services.get(IInvoiceCandBL.class);
-		final IAttributeSetInstanceBL attributeSetInstanceBL = Services.get(IAttributeSetInstanceBL.class);
-
-		final List<I_C_OrderLine> orderLines = orderDAO.retrieveOrderLines(order);
-		for (final I_C_OrderLine orderLine : orderLines)
-		{
-			final I_M_ReceiptSchedule receiptSchedule = receiptScheduleDAO.retrieveForRecord(orderLine);
-
-			if (receiptSchedule == null || !receiptScheduleBL.isClosed(receiptSchedule))
-			{
-				continue;
-			}
-
-			// Reopen the order line BEFORE the receipt schedule.
-			// During save, the M_ReceiptSchedule interceptor fires propagateQtysToOrderLine
-			// which loads the order line from DB and triggers C_OrderLine.updateQtyReserved.
-			// IsDeliveryClosed must already be false at that point, otherwise QtyReserved is
-			// temporarily set to 0 and downstream interceptors (C_Order.updateReserved) may
-			// pick up the stale value.
-			orderBL.reopenLine(orderLine);
-
-			// IMPORTANT: We bypass IReceiptScheduleBL.reopen() intentionally to combine reopen +
-			// QtyOrdered + ASI sync into ONE save. This produces exactly one ReceiptScheduleCreatedEvent
-			// with the final (possibly updated) quantities and the correct storageAttributesKey.
-			// Calling reopen() + save() would produce two events: CreatedEvent(old qty) + UpdatedEvent(delta).
-			//
-			// Bypassed listener callbacks:
-			// - onBeforeReopen: currently no-op in all known implementations
-			//   (OrderLineReceiptScheduleListener, HUReceiptScheduleListener use the default adapter)
-			// - onAfterReopen: manually replicated below (reopenLine + openDeliveryInvoiceCandidates)
-			receiptSchedule.setIsClosed(false);
-			receiptSchedule.setProcessed(false);
-			receiptSchedule.setQtyOrdered(orderLine.getQtyOrdered());
-			attributeSetInstanceBL.cloneOrCreateASI(receiptSchedule, orderLine);
-
-			logger.debug("reopenReceiptSchedules: saving M_ReceiptSchedule_ID={} | IsClosed={}, Processed={}, QtyOrdered={}, ASI_ID={}",
-					receiptSchedule.getM_ReceiptSchedule_ID(),
-					receiptSchedule.isIsClosed(), receiptSchedule.isProcessed(), receiptSchedule.getQtyOrdered(),
-					receiptSchedule.getM_AttributeSetInstance_ID());
-
-			InterfaceWrapperHelper.save(receiptSchedule);
-
-			// Fire the side effects that ReceiptScheduleBL.reopen()'s onAfterReopen listener would have done.
-			// orderBL.reopenLine(orderLine) was already called above.
-			invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
-		}
+		receiptScheduleBL.reopenReceiptSchedulesForOrder(order);
 	}
 
 	@DocValidate(timings = { ModelValidator.TIMING_AFTER_COMPLETE })
@@ -153,7 +101,6 @@ public class C_Order_ReceiptSchedule
 
 		// services
 		final IReceiptScheduleProducerFactory receiptScheduleProducerFactory = Services.get(IReceiptScheduleProducerFactory.class);
-		final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
 
 		//
 		// Generate receipt schedules from this order.
@@ -193,30 +140,7 @@ public class C_Order_ReceiptSchedule
 			return;
 		}
 
-		final IOrderBL orderBL = Services.get(IOrderBL.class);
-		final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
-		final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
-		final IReceiptScheduleBL receiptScheduleBL = Services.get(IReceiptScheduleBL.class);
-
-		final List<I_C_OrderLine> orderLines = orderDAO.retrieveOrderLines(order);
-		for (final I_C_OrderLine orderLine : orderLines)
-		{
-			final I_M_ReceiptSchedule receiptSchedule = receiptScheduleDAO.retrieveForRecord(orderLine);
-
-			if (receiptSchedule == null || receiptScheduleBL.isClosed(receiptSchedule))
-			{
-				continue;
-			}
-
-			receiptScheduleBL.close(receiptSchedule);
-
-			// close() fires the OrderLineReceiptScheduleListener which calls closeLine(),
-			// setting IsDeliveryClosed=true on the order line (via the receipt schedule's FK-cached PO).
-			// During PO reactivation/void the receipt schedule is only "parked" — the order line
-			// itself must stay open for editing. Undo the closeLine side-effect.
-			InterfaceWrapperHelper.refresh(orderLine);
-			orderBL.reopenLine(orderLine);
-		}
+		receiptScheduleBL.closeReceiptSchedulesForOrder(order);
 	}
 
 	/**
@@ -244,7 +168,7 @@ public class C_Order_ReceiptSchedule
 
 	private boolean hasReceipts(final I_C_Order order)
 	{
-		final List<I_M_InOut> inouts = Services.get(IOrderDAO.class).retrieveInOutsForMatchingOrderLines(order);
+		final List<I_M_InOut> inouts = orderDAO.retrieveInOutsForMatchingOrderLines(order);
 
 		return !inouts.isEmpty();
 	}
@@ -284,10 +208,6 @@ public class C_Order_ReceiptSchedule
 
 	public boolean hasProcessedReceiptSchedules(final I_C_Order order)
 	{
-		// services
-		final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
-		final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
-
 		final List<I_C_OrderLine> orderLines = orderDAO.retrieveOrderLines(order);
 		for (final I_C_OrderLine orderLine : orderLines)
 		{
@@ -311,11 +231,6 @@ public class C_Order_ReceiptSchedule
 		{
 			return;
 		}
-
-		// services
-		final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
-		final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
-		final IReceiptScheduleBL receiptScheduleBL = Services.get(IReceiptScheduleBL.class);
 
 		final List<I_C_OrderLine> orderLines = orderDAO.retrieveOrderLines(order);
 		for (final I_C_OrderLine orderLine : orderLines)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ShipmentSchedule.java
@@ -38,7 +38,7 @@ public class C_Order_ShipmentSchedule
 	private final IInOutBL inOutBL = Services.get(IInOutBL.class);
 	private final @NonNull AdMessageKey ERR_NoReactivationIfNotVoidedNotReversedShipments = AdMessageKey.of("ERR_NoReactivationIfNotVoidedNotReversedShipments");
 
-	@DocValidate(timings = { ModelValidator.TIMING_AFTER_REACTIVATE, ModelValidator.TIMING_AFTER_VOID })
+	@DocValidate(timings = ModelValidator.TIMING_AFTER_REACTIVATE)
 	public void closeExistingScheds(@NonNull final I_C_Order orderRecord)
 	{
 		if (!isEligibleForShipmentSchedule(orderRecord))

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ShipmentSchedule.java
@@ -38,7 +38,7 @@ public class C_Order_ShipmentSchedule
 	private final IInOutBL inOutBL = Services.get(IInOutBL.class);
 	private final @NonNull AdMessageKey ERR_NoReactivationIfNotVoidedNotReversedShipments = AdMessageKey.of("ERR_NoReactivationIfNotVoidedNotReversedShipments");
 
-	@DocValidate(timings = ModelValidator.TIMING_AFTER_REACTIVATE)
+	@DocValidate(timings = { ModelValidator.TIMING_AFTER_REACTIVATE, ModelValidator.TIMING_AFTER_VOID })
 	public void closeExistingScheds(@NonNull final I_C_Order orderRecord)
 	{
 		if (!isEligibleForShipmentSchedule(orderRecord))

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ReceiptSchedule.java
@@ -60,6 +60,7 @@ public class M_ReceiptSchedule
 			ModelValidator.TYPE_BEFORE_CHANGE
 	}, ifColumnsChanged = {
 			I_M_ReceiptSchedule.COLUMNNAME_Processed, // on line close we want to recalculate Qty Over/Under Delivery
+			I_M_ReceiptSchedule.COLUMNNAME_IsClosed, // on line close/reopen we want to recalculate Qty Over/Under Delivery
 
 			// https://github.com/metasfresh/metasfresh/issues/315:
 			// call: onReceiptScheduleChanged if *any* for the "input" columns changed
@@ -150,7 +151,7 @@ public class M_ReceiptSchedule
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE })
 	public void updateHeaderAggregationKey(final I_M_ReceiptSchedule sched)
 	{
-		if (sched.isProcessed())
+		if (sched.isProcessed() || sched.isIsClosed())
 		{
 			return;
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ReceiptSchedule.java
@@ -151,7 +151,9 @@ public class M_ReceiptSchedule
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE })
 	public void updateHeaderAggregationKey(final I_M_ReceiptSchedule sched)
 	{
-		if (sched.isProcessed() || sched.isIsClosed())
+		// IsClosed=true always implies Processed=true (see ReceiptScheduleBL.close/reopen),
+		// so checking isProcessed() alone is sufficient.
+		if (sched.isProcessed())
 		{
 			return;
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ReceiptSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ReceiptSchedule.java
@@ -151,9 +151,7 @@ public class M_ReceiptSchedule
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE })
 	public void updateHeaderAggregationKey(final I_M_ReceiptSchedule sched)
 	{
-		// IsClosed=true always implies Processed=true (see ReceiptScheduleBL.close/reopen),
-		// so checking isProcessed() alone is sufficient.
-		if (sched.isProcessed())
+		if (sched.isProcessed() || sched.isIsClosed())
 		{
 			return;
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleProducer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleProducer.java
@@ -117,12 +117,19 @@ public class OrderLineReceiptScheduleProducer extends AbstractReceiptSchedulePro
 
 			receiptSchedule = InterfaceWrapperHelper.newInstance(I_M_ReceiptSchedule.class, line);
 		}
+		else if (receiptScheduleBL.isClosed(receiptSchedule))
+		{
+			// Don't update a closed receipt schedule (e.g., closed due to PO reactivation/void).
+			// It will be properly reopened when the order is re-completed (via reopenReceiptSchedules).
+			// Updating it here would change the M_AttributeSetInstance_ID (via cloneOrCreateASI),
+			// causing cockpit quantities to shift to a different storageAttributesKey bucket.
+			return null;
+		}
 
 		final Properties ctx = InterfaceWrapperHelper.getCtx(receiptSchedule);
 
 		receiptSchedule.setAD_Org_ID(line.getAD_Org_ID());
 		receiptSchedule.setIsActive(true); // make sure it's active
-		receiptSchedule.setIsClosed(false); // make sure it's not closed (belt-and-suspenders for reopen-on-complete path)
 
 		//
 		// Source Document Line link

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleProducer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleProducer.java
@@ -122,6 +122,7 @@ public class OrderLineReceiptScheduleProducer extends AbstractReceiptSchedulePro
 
 		receiptSchedule.setAD_Org_ID(line.getAD_Org_ID());
 		receiptSchedule.setIsActive(true); // make sure it's active
+		receiptSchedule.setIsClosed(false); // make sure it's not closed (belt-and-suspenders for reopen-on-complete path)
 
 		//
 		// Source Document Line link

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5790990_sys_M_ReceiptSchedule_add_IsClosed.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5790990_sys_M_ReceiptSchedule_add_IsClosed.sql
@@ -38,6 +38,8 @@ INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_El
 VALUES (0,774763,0,540526,648454,540134,'F',TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','N','Y','N','N','Geschlossen',50,0,TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100)
 ;
 
--- Propagate element translations to the new AD_Field_Trl rows
+-- Propagate element translations to the new AD_Column_Trl and AD_Field_Trl rows
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(2723)
+;
+SELECT update_Column_Translation_From_AD_Element(2723)
 ;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5790990_sys_M_ReceiptSchedule_add_IsClosed.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5790990_sys_M_ReceiptSchedule_add_IsClosed.sql
@@ -1,0 +1,39 @@
+-- M_ReceiptSchedule: add IsClosed column (mirrors M_ShipmentSchedule.IsClosed)
+-- When a purchase order is reactivated, receipt schedules should be closed (IsClosed=Y)
+-- rather than hard-deleted, preserving user modifications.
+
+-- AD_Column for M_ReceiptSchedule.IsClosed
+-- AD_Column_ID=592114, AD_Table_ID=540524 (M_ReceiptSchedule), AD_Element_ID=2723 (IsClosed)
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,AllowZoomTo,ColumnName,Created,CreatedBy,DDL_NoForeignKey,DefaultValue,Description,EntityType,FieldLength,Help,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsSelectionColumn,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,Name,PersonalDataCategory,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592114,2723,0,20,540524,'N','IsClosed',TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'N','N','','de.metas.inoutcandidate',1,'','Y','N','Y','N','N','N','N','N','N','N','N','N','N','N','Y','N','N','N','N','N','Y','N','Geschlossen','NP',0,0,TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Column_ID=592114
+AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- DDL: add the physical column
+/* DDL */ SELECT public.db_alter_table('m_receiptschedule','ALTER TABLE public.M_ReceiptSchedule ADD COLUMN IsClosed CHAR(1) DEFAULT ''N'' CHECK (IsClosed IN (''Y'',''N'')) NOT NULL')
+;
+
+-- AD_Field for M_ReceiptSchedule main tab (AD_Tab_ID=540526)
+-- AD_Field_ID=774763, placed in org group (AD_UI_ElementGroup_ID=540134), after Processed (SeqNo=40) at SeqNo=50
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,Help,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy)
+VALUES (0,592114,774763,0,540526,0,TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'',0,'de.metas.inoutcandidate','',0,'Y','Y','Y','N','N','N','N','N','Y','N','Geschlossen',570,640,0,1,1,TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Field_ID=774763
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- AD_UI_Element to display the field in WebUI
+-- AD_UI_Element_ID=648454, placed in org group (AD_UI_ElementGroup_ID=540134), after Processed at SeqNo=50
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_Element_ID,AD_UI_ElementGroup_ID,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,774763,0,540526,648454,540134,TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','N','Y','N','N','Geschlossen',50,0,TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5790990_sys_M_ReceiptSchedule_add_IsClosed.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5790990_sys_M_ReceiptSchedule_add_IsClosed.sql
@@ -34,6 +34,10 @@ AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language
 
 -- AD_UI_Element to display the field in WebUI
 -- AD_UI_Element_ID=648454, placed in org group (AD_UI_ElementGroup_ID=540134), after Processed at SeqNo=50
-INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_Element_ID,AD_UI_ElementGroup_ID,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNo_SideList,Updated,UpdatedBy)
-VALUES (0,774763,0,540526,648454,540134,TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','N','Y','N','N','Geschlossen',50,0,TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_Element_ID,AD_UI_ElementGroup_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,774763,0,540526,648454,540134,'F',TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','N','Y','N','N','Geschlossen',50,0,TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- Propagate element translations to the new AD_Field_Trl rows
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(2723)
 ;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5790990_sys_M_ReceiptSchedule_add_IsClosed.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5790990_sys_M_ReceiptSchedule_add_IsClosed.sql
@@ -8,10 +8,10 @@ INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Refe
 VALUES (0,592114,2723,0,20,540524,'N','IsClosed',TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'N','N','','de.metas.inoutcandidate',1,'','Y','N','Y','N','N','N','N','N','N','N','N','N','N','N','Y','N','N','N','N','N','Y','N','Geschlossen','NP',0,0,TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,0)
 ;
 
-INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
-SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
 FROM AD_Language l, AD_Column t
-WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Column_ID=592114
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=592114
 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
 ;
 
@@ -25,10 +25,10 @@ INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,
 VALUES (0,592114,774763,0,540526,0,TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'',0,'de.metas.inoutcandidate','',0,'Y','Y','Y','N','N','N','N','N','Y','N','Geschlossen',570,640,0,1,1,TO_TIMESTAMP('2026-03-02 12:00:00','YYYY-MM-DD HH24:MI:SS'),100)
 ;
 
-INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
-SELECT l.AD_Language,t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
 FROM AD_Language l, AD_Field t
-WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Field_ID=774763
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=774763
 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
 ;
 

--- a/docker-builds/e2e-tests/compose.yml
+++ b/docker-builds/e2e-tests/compose.yml
@@ -124,7 +124,7 @@ services:
       start_period: 60s
       retries: 30
     environment:
-      - "JAVA_TOOL_OPTIONS=-Xmx512M -XX:+HeapDumpOnOutOfMemoryError -Dde.metas.adempiere.report.jasper.JRServerServlet=http://app:8282/adempiereJasper/ReportServlet -Dde.metas.adempiere.report.barcode.BarcodeServlet=http://app:8282/adempiereJasper/BarcodeServlet"
+      - "JAVA_TOOL_OPTIONS=-Xmx512M -XX:+HeapDumpOnOutOfMemoryError -Dde.metas.adempiere.report.jasper.JRServerServlet=http://app:8282/adempiereJasper/ReportServlet -Dde.metas.adempiere.report.barcode.BarcodeServlet=http://app:8282/adempiereJasper/BarcodeServlet -DPO_AllowReactivationIfReceiptsCreated=Y"
       - "SPRING_RABBITMQ_HOST=rabbitmq"
       - "SPRING_RABBITMQ_PORT=5672"
       - "SPRING_RABBITMQ_USERNAME=metasfresh"

--- a/e2e/frontend-webui/TEST-COVERAGE.md
+++ b/e2e/frontend-webui/TEST-COVERAGE.md
@@ -872,6 +872,29 @@ npm run test:report
 
 ---
 
+### 34. PO Reactivation — Receipt Schedule Close/Reopen (`po-reactivation-receipt-schedule.spec.js`)
+
+**Features Tested**:
+- F00600: Purchase Order
+- F65010: Material Receipt Candidates
+
+**Epic**: E0140: Purchasing / E0160: Material Receipt
+
+**Workflow**:
+1. Create PO with 1 order line and complete it
+2. Navigate to receipt schedule via Related Documents — verify IsClosed=false (via WebAPI)
+3. Navigate back to PO — create material receipt via HU-Editor workflow
+4. Reactivate PO (requires `PO_AllowReactivationIfReceiptsCreated=Y` sysconfig)
+5. Verify receipt schedule is closed (IsClosed=true), same record ID (not recreated)
+6. Re-complete PO
+7. Verify receipt schedule is reopened (IsClosed=false), same record ID
+
+**Precondition**: `PO_AllowReactivationIfReceiptsCreated=Y` must be set as JVM property on webapi service.
+
+**Components Tested**: PurchaseOrderPage (reactivate), ReceiptCandidatesPage (createReceipt), WebAPI field validation (getFieldData)
+
+---
+
 ## Test Architecture
 
 ### Page Objects

--- a/e2e/frontend-webui/tests/spec/po-reactivation-receipt-schedule.spec.js
+++ b/e2e/frontend-webui/tests/spec/po-reactivation-receipt-schedule.spec.js
@@ -1,0 +1,253 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { LoginPage } from '../utils/pages/LoginPage';
+import { DashboardPage } from '../utils/pages/DashboardPage';
+import { PurchaseOrderPage } from '../utils/pages/PurchaseOrderPage';
+import { ReceiptCandidatesPage } from '../utils/pages/ReceiptCandidatesPage';
+import { getPage, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../utils/common';
+import { RECEIPT_CANDIDATES_WINDOW_ID } from '../utils/WindowIds';
+import { getFieldData } from '../utils/WebAPIValidation';
+
+/**
+ * PO Reactivation with Receipt Schedule E2E test suite.
+ *
+ * Features tested:
+ * - F00600: Purchase Order (Epic: Purchasing)
+ * - F65010: Material Receipt Candidates (Epic: Material Receipt)
+ *
+ * Tests the receipt schedule close/reopen behavior on PO reactivation:
+ * 1. Create PO with 1 line -> Complete
+ * 2. Verify receipt schedule exists and is open (IsClosed unchecked)
+ * 3. Create actual material receipt
+ * 4. Reactivate PO (requires PO_AllowReactivationIfReceiptsCreated=Y)
+ * 5. Verify receipt schedule is closed (IsClosed checked), NOT deleted
+ * 6. Re-complete PO
+ * 7. Verify receipt schedule is reopened (IsClosed unchecked)
+ *
+ * Precondition: PO_AllowReactivationIfReceiptsCreated=Y sysconfig must be set.
+ * For E2E Docker stack: added as -D JVM property in compose.yml JAVA_TOOL_OPTIONS.
+ */
+
+const testCases = [
+  { language: 'en_US', label: 'English' },
+  { language: 'de_DE', label: 'German' },
+];
+
+/**
+ * Extract the record ID from the current page URL for a given window ID.
+ * @param {import('@playwright/test').Page} page
+ * @param {number} windowId
+ * @returns {string|null}
+ */
+function extractRecordIdFromUrl(page, windowId) {
+  const url = page.url();
+  const match = url.match(new RegExp(`/window/${windowId}/(\\d+)`));
+  return match ? match[1] : null;
+}
+
+testCases.forEach(({ language, label }) => {
+  test.describe(`PO Reactivation — Receipt Schedule Close/Reopen (${label})`, () => {
+    test.setTimeout(240000);
+
+    test(`PO reactivation preserves receipt schedule after material receipt (${label} UI)`, async ({ page }) => {
+      // === ALLURE METADATA ===
+      allure.epic('E0140: Purchasing');
+      allure.tag('F00600: Purchase Order');
+      allure.tag('F65010: Material Receipt Candidates');
+      allure.story('PO reactivation closes receipt schedules instead of deleting them');
+      allure.severity('critical');
+      allure.parameter('Language', language);
+      allure.tag(language);
+
+      allure.description(`
+## PO Reactivation — Receipt Schedule Close/Reopen
+
+### Test Scenario
+Validates that reactivating a Purchase Order closes receipt schedules instead of deleting them,
+and re-completing the PO reopens them.
+
+1. **Create PO** with 1 order line
+2. **Verify receipt schedule** is open (IsClosed=N)
+3. **Create material receipt** via HU-Editor workflow
+4. **Reactivate PO** (requires sysconfig PO_AllowReactivationIfReceiptsCreated=Y)
+5. **Verify receipt schedule** is closed (IsClosed=Y), same record ID (not recreated)
+6. **Re-complete PO**
+7. **Verify receipt schedule** is reopened (IsClosed=N), same record ID
+      `);
+
+      // =====================================================
+      // Step 1: Create test data
+      // =====================================================
+      const masterdata = await Backend.createMasterdata({
+        request: {
+          login: {
+            user: {
+              language,
+            },
+          },
+          bpartners: {
+            VENDOR1: {
+              isVendor: true,
+              isCustomer: false,
+              isSoPriceList: false,
+            },
+          },
+          products: {
+            Product1: {
+              name: `Test Product for PO Reactivation (${language})`,
+              type: 'Item',
+              prices: [
+                {
+                  price: 10.0,
+                  currencyCode: 'EUR',
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      // =====================================================
+      // Step 2: Login and create Purchase Order
+      // =====================================================
+      await LoginPage.goto();
+      await LoginPage.login(masterdata.login.user);
+      await DashboardPage.expectVisible();
+
+      await PurchaseOrderPage.goto();
+      await PurchaseOrderPage.clickNew();
+      await PurchaseOrderPage.selectBusinessPartner(masterdata.bpartners.VENDOR1.bpartnerCode);
+      await PurchaseOrderPage.goToOrderLineTab();
+      await PurchaseOrderPage.addOrderLine({
+        product: masterdata.products.Product1.productCode,
+        quantity: '10',
+      });
+      await PurchaseOrderPage.complete();
+
+      const poDocumentNo = await PurchaseOrderPage.getDocumentNo();
+      const poUrl = page.url();
+      console.log(`[${language}] PO created and completed: ${poDocumentNo}`);
+
+      // =====================================================
+      // Step 3: Verify receipt schedule exists and is open
+      // =====================================================
+      await PurchaseOrderPage.openRelatedReceiptCandidate();
+
+      // Double-click first row to open detail view
+      const listRow = page.locator('.table-row, [class*="table-row"]').first();
+      await listRow.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await listRow.dblclick();
+
+      // Wait for detail view
+      await page.waitForURL(new RegExp(`/window/${RECEIPT_CANDIDATES_WINDOW_ID}/\\d+`), {
+        timeout: SLOW_ACTION_TIMEOUT,
+      });
+      await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+
+      // Extract receipt schedule record ID
+      const rsRecordId = extractRecordIdFromUrl(page, RECEIPT_CANDIDATES_WINDOW_ID);
+      expect(rsRecordId).toBeTruthy();
+      console.log(`[${language}] Receipt Schedule record ID: ${rsRecordId}`);
+
+      // Verify IsClosed is false via WebAPI
+      const isClosedField = await getFieldData(RECEIPT_CANDIDATES_WINDOW_ID, rsRecordId, 'IsClosed');
+      expect(isClosedField.value).toBe(false);
+      console.log(`[${language}] Receipt Schedule IsClosed=${isClosedField.value} (expected: false)`);
+
+      // =====================================================
+      // Step 4: Navigate back to PO and create material receipt
+      // =====================================================
+      await page.goto(poUrl);
+      await page.waitForURL(/\/window\/181\/\d+/, { timeout: SLOW_ACTION_TIMEOUT });
+      await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+      await page.waitForTimeout(1000);
+
+      await PurchaseOrderPage.openRelatedReceiptCandidate();
+      await ReceiptCandidatesPage.expectQuickActionsVisible();
+      await ReceiptCandidatesPage.createReceipt();
+
+      console.log(`[${language}] Material Receipt created`);
+
+      // =====================================================
+      // Step 5: Navigate back to PO and reactivate
+      // =====================================================
+      await page.goto(poUrl);
+      await page.waitForURL(/\/window\/181\/\d+/, { timeout: SLOW_ACTION_TIMEOUT });
+      await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+      await page.waitForTimeout(1000);
+
+      await PurchaseOrderPage.reactivate();
+      console.log(`[${language}] PO reactivated`);
+
+      // =====================================================
+      // Step 6: Verify receipt schedule is closed (not deleted)
+      // =====================================================
+      await PurchaseOrderPage.openRelatedReceiptCandidate();
+
+      // Double-click first row to open detail view
+      const listRow2 = page.locator('.table-row, [class*="table-row"]').first();
+      await listRow2.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await listRow2.dblclick();
+
+      await page.waitForURL(new RegExp(`/window/${RECEIPT_CANDIDATES_WINDOW_ID}/\\d+`), {
+        timeout: SLOW_ACTION_TIMEOUT,
+      });
+      await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+
+      // Verify SAME record ID (schedule was preserved, not recreated)
+      const rsRecordId2 = extractRecordIdFromUrl(page, RECEIPT_CANDIDATES_WINDOW_ID);
+      expect(rsRecordId2).toBe(rsRecordId);
+      console.log(`[${language}] Same receipt schedule preserved: ${rsRecordId2} === ${rsRecordId}`);
+
+      // Verify IsClosed is true via WebAPI
+      const isClosedField2 = await getFieldData(RECEIPT_CANDIDATES_WINDOW_ID, rsRecordId2, 'IsClosed');
+      expect(isClosedField2.value).toBe(true);
+      console.log(`[${language}] Receipt Schedule IsClosed=${isClosedField2.value} (expected: true)`);
+
+      // =====================================================
+      // Step 7: Navigate back to PO and re-complete
+      // =====================================================
+      await page.goto(poUrl);
+      await page.waitForURL(/\/window\/181\/\d+/, { timeout: SLOW_ACTION_TIMEOUT });
+      await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+      await page.waitForTimeout(1000);
+
+      await PurchaseOrderPage.complete();
+      console.log(`[${language}] PO re-completed`);
+
+      // =====================================================
+      // Step 8: Verify receipt schedule is reopened
+      // =====================================================
+      await PurchaseOrderPage.openRelatedReceiptCandidate();
+
+      // Double-click first row to open detail view
+      const listRow3 = page.locator('.table-row, [class*="table-row"]').first();
+      await listRow3.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await listRow3.dblclick();
+
+      await page.waitForURL(new RegExp(`/window/${RECEIPT_CANDIDATES_WINDOW_ID}/\\d+`), {
+        timeout: SLOW_ACTION_TIMEOUT,
+      });
+      await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+
+      // Verify SAME record ID
+      const rsRecordId3 = extractRecordIdFromUrl(page, RECEIPT_CANDIDATES_WINDOW_ID);
+      expect(rsRecordId3).toBe(rsRecordId);
+      console.log(`[${language}] Same receipt schedule preserved: ${rsRecordId3} === ${rsRecordId}`);
+
+      // Verify IsClosed is false (reopened) via WebAPI
+      const isClosedField3 = await getFieldData(RECEIPT_CANDIDATES_WINDOW_ID, rsRecordId3, 'IsClosed');
+      expect(isClosedField3.value).toBe(false);
+      console.log(`[${language}] Receipt Schedule IsClosed=${isClosedField3.value} (expected: false)`);
+
+      console.log(`[${language}] ===================================`);
+      console.log(`[${language}] PO Reactivation Receipt Schedule Test PASSED`);
+      console.log(`[${language}] PO: ${poDocumentNo}`);
+      console.log(`[${language}] Receipt Schedule ID: ${rsRecordId}`);
+      console.log(`[${language}] Cycle: open -> closed -> reopened (same record preserved)`);
+      console.log(`[${language}] ===================================`);
+    });
+  });
+});

--- a/e2e/frontend-webui/tests/spec/po-reactivation-receipt-schedule.spec.js
+++ b/e2e/frontend-webui/tests/spec/po-reactivation-receipt-schedule.spec.js
@@ -184,27 +184,11 @@ and re-completing the PO reopens them.
       // =====================================================
       // Step 6: Verify receipt schedule is closed (not deleted)
       // =====================================================
-      await PurchaseOrderPage.openRelatedReceiptCandidate();
-
-      // Double-click first row to open detail view
-      const listRow2 = page.locator('.table-row, [class*="table-row"]').first();
-      await listRow2.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-      await listRow2.dblclick();
-
-      await page.waitForURL(new RegExp(`/window/${RECEIPT_CANDIDATES_WINDOW_ID}/\\d+`), {
-        timeout: SLOW_ACTION_TIMEOUT,
-      });
-      await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
-
-      // Verify SAME record ID (schedule was preserved, not recreated)
-      const rsRecordId2 = extractRecordIdFromUrl(page, RECEIPT_CANDIDATES_WINDOW_ID);
-      expect(rsRecordId2).toBe(rsRecordId);
-      console.log(`[${language}] Same receipt schedule preserved: ${rsRecordId2} === ${rsRecordId}`);
-
-      // Verify IsClosed is true via WebAPI
-      const isClosedField2 = await getFieldData(RECEIPT_CANDIDATES_WINDOW_ID, rsRecordId2, 'IsClosed');
+      // Use WebAPI directly — the closed receipt schedule (Processed=true) is hidden by
+      // the default "Filter by: Not Processed" filter in the list view, so we verify via API.
+      const isClosedField2 = await getFieldData(RECEIPT_CANDIDATES_WINDOW_ID, rsRecordId, 'IsClosed');
       expect(isClosedField2.value).toBe(true);
-      console.log(`[${language}] Receipt Schedule IsClosed=${isClosedField2.value} (expected: true)`);
+      console.log(`[${language}] Receipt Schedule ${rsRecordId} IsClosed=${isClosedField2.value} (expected: true)`);
 
       // =====================================================
       // Step 7: Navigate back to PO and re-complete
@@ -220,27 +204,10 @@ and re-completing the PO reopens them.
       // =====================================================
       // Step 8: Verify receipt schedule is reopened
       // =====================================================
-      await PurchaseOrderPage.openRelatedReceiptCandidate();
-
-      // Double-click first row to open detail view
-      const listRow3 = page.locator('.table-row, [class*="table-row"]').first();
-      await listRow3.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-      await listRow3.dblclick();
-
-      await page.waitForURL(new RegExp(`/window/${RECEIPT_CANDIDATES_WINDOW_ID}/\\d+`), {
-        timeout: SLOW_ACTION_TIMEOUT,
-      });
-      await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
-
-      // Verify SAME record ID
-      const rsRecordId3 = extractRecordIdFromUrl(page, RECEIPT_CANDIDATES_WINDOW_ID);
-      expect(rsRecordId3).toBe(rsRecordId);
-      console.log(`[${language}] Same receipt schedule preserved: ${rsRecordId3} === ${rsRecordId}`);
-
-      // Verify IsClosed is false (reopened) via WebAPI
-      const isClosedField3 = await getFieldData(RECEIPT_CANDIDATES_WINDOW_ID, rsRecordId3, 'IsClosed');
+      // Use WebAPI directly to verify the same receipt schedule was reopened.
+      const isClosedField3 = await getFieldData(RECEIPT_CANDIDATES_WINDOW_ID, rsRecordId, 'IsClosed');
       expect(isClosedField3.value).toBe(false);
-      console.log(`[${language}] Receipt Schedule IsClosed=${isClosedField3.value} (expected: false)`);
+      console.log(`[${language}] Receipt Schedule ${rsRecordId} IsClosed=${isClosedField3.value} (expected: false)`);
 
       console.log(`[${language}] ===================================`);
       console.log(`[${language}] PO Reactivation Receipt Schedule Test PASSED`);

--- a/e2e/frontend-webui/tests/utils/pages/PurchaseOrderPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/PurchaseOrderPage.js
@@ -510,6 +510,68 @@ export class PurchaseOrderPage {
   }
 
   /**
+   * Reactivate the purchase order using the document action.
+   * Follows the same pattern as complete() but clicks status-RE instead of status-CO.
+   *
+   * @param {Object} options - Configuration options
+   * @param {number} options.maxAttempts - Maximum retry attempts (default: 3)
+   */
+  static async reactivate({ maxAttempts = 3 } = {}) {
+    return await test.step('PurchaseOrderPage - Reactivate order', async () => {
+      const page = getPage();
+
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const reOption = page.getByTestId('status-RE');
+
+        // Check if dropdown is already open from a previous failed attempt
+        const isAlreadyOpen = await reOption.isVisible().catch(() => false);
+        if (!isAlreadyOpen) {
+          await page.getByTestId('status-button').click();
+          await page.waitForTimeout(500);
+        }
+
+        // Language-independent: check if Reactivate action is available
+        const reVisible = await reOption
+          .waitFor({ state: 'visible', timeout: 5000 })
+          .then(() => true)
+          .catch(() => false);
+
+        if (!reVisible) {
+          console.log('Reactivate action (status-RE) not available');
+          await page.keyboard.press('Escape');
+          throw new Error('Reactivate action not available — is PO_AllowReactivationIfReceiptsCreated=Y set?');
+        }
+
+        console.log(`Reactivate attempt ${attempt}/${maxAttempts}`);
+
+        await reOption.click();
+        await page.waitForTimeout(3000);
+
+        await page
+          .locator('.rotating, .indicator-pending')
+          .waitFor({ state: 'detached', timeout: VERY_SLOW_ACTION_TIMEOUT })
+          .catch(() => {});
+
+        // Verification: open dropdown and check if CO is now available (document back to Drafted)
+        await page.getByTestId('status-button').click();
+        await page.waitForTimeout(500);
+        const hasCO = await page.getByTestId('status-CO').isVisible().catch(() => false);
+        await page.keyboard.press('Escape');
+
+        if (hasCO) {
+          console.log(`Order reactivated successfully on attempt ${attempt}`);
+          return;
+        }
+
+        console.log(`Order still does not show CO action after attempt ${attempt}, retrying...`);
+        await page.waitForTimeout(2000);
+      }
+
+      throw new Error(`Failed to reactivate order after ${maxAttempts} attempts`);
+    });
+  }
+
+  /**
    * Open the related Material Receipt (M_InOut) for the current purchase order using Alt+6.
    *
    * Use this method after creating a material receipt via Receipt Candidates workflow.


### PR DESCRIPTION
## Summary

- On PO reactivation/void, receipt schedules are now **soft-closed** (`IsClosed=Y, Processed=Y`) instead of hard-deleted. On re-complete, closed schedules are **reopened** before new ones are created. This preserves user modifications (delivery dates, override columns, transport orders).
- Adds `IsClosed` column to `M_ReceiptSchedule` (mirrors `M_ShipmentSchedule.IsClosed`) with full AD metadata (AD_Column, AD_Field, AD_UI_Element).
- Fixes missing VOID handler on `M_ShipmentSchedule`: shipment schedules are now also closed when a sales order is voided (previously only handled on reactivate).
- Adds Cucumber scenario validating the close-on-reactivate / reopen-on-recomplete cycle.

## Test plan

- [ ] Existing `@Id:S0156_200` (close/reopen receipt schedule) passes
- [ ] Existing PO reactivation scenarios in `purchaseOrderQty.feature` pass
- [ ] New scenario: reactivate PO → receipt schedule closed (not deleted) → re-complete → reopened
- [ ] Void PO → receipt schedule closed, NOT deleted
- [ ] Void SO → shipment schedule closed, NOT left open