### PR TITLE
cicd: make all Testspace push steps non-fatal

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -102,6 +102,7 @@ jobs:
           echo '* Allure test reports: https://test-reports.metasfresh.com/branches/${{ steps.sanitize-branch-gh-pages.outputs.value }}/builds/${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }}/allure/' >> $GITHUB_STEP_SUMMARY
       - name: testspace push build infos
         if: env.ACT != 'true'  # Skip when running locally with act
+        continue-on-error: true  # Testspace may not have a space for this branch (e.g. merge-queue branches)
         run: |
           touch github_run.txt
           echo ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} >> github_run.txt
@@ -479,6 +480,7 @@ jobs:
           docker run --rm --volume "$(pwd)/jest:/reports" metas-frontend:test                                       # extracting test results from docker image
       - name: publish results to testspace
         if: env.ACT != 'true'  # Skip when running locally with act
+        continue-on-error: true  # Testspace may not have a space for this branch
         run: |
           find jest -type d -links 2 -exec testspace [{}]{}/*.xml \;                                                # upload all jest xml's to testspace
           testspace "[jest/frontend]jest/frontend/jest.log{$(cat jest/frontend/jest.exit-code):webui jest tests}"   # upload webui log with exit code
@@ -1227,6 +1229,7 @@ jobs:
           docker run --rm --volume "$(pwd)/junit:/reports" metasfresh/metas-junit:${{ needs.init.outputs.tag-fixed }}-j14       # extracting java14 test results from docker image
       - name: push-results to testspace
         if: env.ACT != 'true'  # Skip when running locally with act
+        continue-on-error: true  # Testspace may not have a space for this branch
         run: |
           find junit -type d -links 2 -exec testspace [{}]{}/*.xml \;                                                           # upload all junit xml's to testspace
           testspace "[junit/commons]junit/commons/junit.log{$(awk '{ sum += $1 } END { print sum }' junit/commons/junit.exit-code junit/commons/junit.mvn.exit-code):java 8 commons junit tests}"     # upload commons log with combined exit code
@@ -1373,6 +1376,7 @@ jobs:
           cat cucumber.log | grep -q "BUILD SUCCESS" && echo "$?" > cucumber.mvn.exit-code || echo "$?" > cucumber.mvn.exit-code
       - name: push-results to testspace
         if: env.ACT != 'true'  # Skip when running locally with act
+        continue-on-error: true  # Testspace may not have a space for this branch
         run: |
           testspace "[cucumber/${{ matrix.profile }}]cucumber/**/*.xml"
           testspace "[cucumber/${{ matrix.profile }}]cucumber/*.html"
@@ -1693,6 +1697,7 @@ jobs:
           docker compose --profile mobile down
       - name: push-results to testspace
         if: env.ACT != 'true'  # Skip when running locally with act
+        continue-on-error: true  # Testspace may not have a space for this branch
         working-directory: docker-builds/e2e-tests/
         run: |
           # Move test-results temporarily to avoid Testspace uploading large attachment files
@@ -1791,6 +1796,7 @@ jobs:
           docker compose --profile frontend down
       - name: push-results to testspace
         if: env.ACT != 'true'  # Skip when running locally with act
+        continue-on-error: true  # Testspace may not have a space for this branch
         working-directory: docker-builds/e2e-tests/
         run: |
           # Move test-results temporarily to avoid Testspace uploading large attachment files


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to all 6 Testspace upload steps in `cicd.yaml`
- Testspace fails with HTTP 404 on branches without a configured space (e.g. Mergify `merge-queue/*` branches), which kills the `init` job and cascades to fail the **entire** pipeline
- With this fix, Testspace upload failures are logged but don't block the build

## Affected steps

| Job | Step | Line |
|-----|------|------|
| init | testspace push build infos | ~103 |
| test (frontend) | publish results to testspace | ~481 |
| test (java) | push-results to testspace | ~1230 |
| test (cucumber) | push-results to testspace | ~1377 |
| mobile test | push-results to testspace | ~1698 |
| frontend webui test | push-results to testspace | ~1797 |

## Test plan

- [ ] Verify Mergify merge-queue builds no longer fail on Testspace 404
- [ ] Verify regular branch builds still upload to Testspace (step succeeds)