### PR TITLE
Add configurable enterRequiresSingleMatch for quick input

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5790280_sys_webui_frontend_quickinput_enterRequiresSingleMatch.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5790280_sys_webui_frontend_quickinput_enterRequiresSingleMatch.sql
@@ -1,0 +1,13 @@
+-- 2026-03-03T00:00:00
+-- webui.frontend.quickinput.enterRequiresSingleMatch
+-- When Y: Enter in quick input only auto-selects when exactly 1 product matches; beeps on multiple matches.
+-- When N (default): Enter selects the first/highlighted item even with multiple matches; no beep.
+
+INSERT INTO AD_SysConfig (AD_SysConfig_ID, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive, Name, Value, Description, ConfigurationLevel, EntityType)
+VALUES (541795, 0, 0, '2026-03-03', 100, '2026-03-03', 100, 'Y',
+        'webui.frontend.quickinput.enterRequiresSingleMatch',
+        'N',
+        'Quick input: when Y, Enter only auto-selects with exactly 1 match and beeps on multiple. When N, Enter selects the first/highlighted item even with multiple matches.',
+        'S',
+        'de.metas.ui.web.base')
+ON CONFLICT DO NOTHING;

--- a/frontend/src/components/widget/Lookup/RawLookup.js
+++ b/frontend/src/components/widget/Lookup/RawLookup.js
@@ -429,14 +429,24 @@ export class RawLookup extends Component {
    * @method resolveItems
    * @summary Given the typeahead results, auto-select if exactly one match,
    * beep if no match, or beep and keep dropdown open if multiple matches.
+   *
+   * When `enterRequiresSingleMatch` is false (sysconfig N), multiple matches
+   * will select the currently highlighted item (or the first one) instead of
+   * keeping the dropdown open.
    */
   resolveItems = (items) => {
     if (items.length === 1) {
       this.handleAutoSelectAndAdvance(items[0]);
     } else if (items.length > 1) {
-      // Multiple matches: beep and keep dropdown open so user can pick
-      if (this.props.beepOnInvalidProduct) {
-        playBeep();
+      if (!this.props.enterRequiresSingleMatch) {
+        // Select the highlighted item (arrow-key navigated) or the first one
+        const selected = this.state.selected || items[0];
+        this.handleAutoSelectAndAdvance(selected);
+      } else {
+        // Default: beep and keep dropdown open so user can pick
+        if (this.props.beepOnInvalidProduct) {
+          playBeep();
+        }
       }
     } else {
       // No match
@@ -946,6 +956,11 @@ const mapStateToProps = (state) => ({
     'quickinput.beepOnInvalidProduct',
     false
   ),
+  enterRequiresSingleMatch: getSettingFromStateAsBoolean(
+    state,
+    'webui.frontend.quickinput.enterRequiresSingleMatch',
+    false
+  ),
 });
 
 RawLookup.propTypes = {
@@ -1004,6 +1019,7 @@ RawLookup.propTypes = {
     boundingRect: PropTypes.object,
   }),
   beepOnInvalidProduct: PropTypes.bool,
+  enterRequiresSingleMatch: PropTypes.bool,
 };
 
 export default connect(mapStateToProps, null, null, { forwardRef: true })(


### PR DESCRIPTION
## Summary

- New sysconfig `webui.frontend.quickinput.enterRequiresSingleMatch` (default `N`)
- When `N`: Enter in quick input selects the first/highlighted item even with multiple matches
- When `Y`: Enter beeps and keeps dropdown open when multiple items match (user must pick manually)
- Frontend reads the sysconfig via `getSettingFromStateAsBoolean` in `RawLookup.js`

## Test plan

- [ ] Default behavior (`N`): type a prefix matching multiple products, press Enter → first/highlighted item is selected and focus advances to Qty
- [ ] With sysconfig `Y`: type a prefix matching multiple products, press Enter → dropdown stays open, beep plays (if `beepOnInvalidProduct` also `Y`)
- [ ] Single match: always auto-selects regardless of sysconfig
- [ ] No match: beeps only when `beepOnInvalidProduct` is `Y`
- [ ] Arrow-key navigation + Enter with sysconfig `N`: selects the navigated-to item