### PR TITLE
Mergify: use only Merge Gate, remove testspace-analytics fallback

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,35 +11,31 @@
 # ops:no_auto_port           — (reserved for future use)
 # =============================================================================
 
-# Transition: "Merge Gate" is the new CI gate (added in cicd.yaml).
-# Branches that already have it use "Merge Gate"; older branches fall back
-# to "testspace-analytics". Once all active branches carry the gate job,
-# remove the testspace-analytics fallback.
+# "Merge Gate" is the CI gate — a workflow_run-based commit status set by
+# merge-gate.yaml after each cicd completion. It maps the cicd workflow
+# conclusion to success/failure. Since it runs from the default branch,
+# it fires for ALL branches automatically.
+#
+# testspace-analytics fallback removed: it could succeed even when tests
+# failed (it only checks upload, not test results), allowing broken PRs
+# to merge.
 merge_protections:
   - name: default
     if:
-      - or:
-          - check-success=Merge Gate
-          - check-success=testspace-analytics
+      - check-success=Merge Gate
     success_conditions:
-      - or:
-          - check-success=Merge Gate
-          - check-success=testspace-analytics
+      - check-success=Merge Gate
 
 queue_rules:
   - name: squash-queue
     merge_method: squash
     merge_conditions:
-      - or:
-          - check-success=Merge Gate
-          - check-success=testspace-analytics
+      - check-success=Merge Gate
 
   - name: merge-queue
     merge_method: merge
     merge_conditions:
-      - or:
-          - check-success=Merge Gate
-          - check-success=testspace-analytics
+      - check-success=Merge Gate
 
 pull_request_rules:
 


### PR DESCRIPTION
## Summary

- Remove `testspace-analytics` from Mergify queue merge conditions and merge protections
- Only `Merge Gate` (commit status set by `merge-gate.yaml`) is now used

## Why

The `OR` condition between `Merge Gate` and `testspace-analytics` allowed PRs to merge even when tests failed:

| Check | Result | Mergify decision |
|-------|--------|-----------------|
| Merge Gate | failure (cicd failed due to test) | - |
| testspace-analytics | success (upload worked) | **Merge** (OR satisfied) |

`testspace-analytics` only checks that test results were uploaded to Testspace — it does not verify that the tests passed. With the OR fallback, any PR whose results were uploaded would merge regardless of test outcomes.

## After this change

Any test failure (including flaky) blocks the merge queue. Only a fully green cicd workflow produces a `Merge Gate: success` status.