### PR TITLE
auto-port: use PAT for push to trigger cicd workflow

### DIFF
--- a/.github/workflows/auto-port.yml
+++ b/.github/workflows/auto-port.yml
@@ -11,6 +11,12 @@
 # Previous approach (pull_request: closed) failed because the workflow file
 # must exist on the PR's base branch, which it never did for non-default
 # branches.
+#
+# PAT requirement: CICD_TRIGGER_DISPATCH secret (PAT) is used for git push.
+# Pushes authenticated with GITHUB_TOKEN are blocked by GitHub's anti-
+# recursion protection and will NOT trigger the cicd workflow on the merge
+# branch. Without cicd, the Merge Gate check never appears, and Mergify
+# cannot auto-merge the PR.
 # ===========================================================================
 
 name: Auto-port to new_dawn_uat chain
@@ -46,6 +52,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # CRITICAL: Use a PAT instead of GITHUB_TOKEN for checkout.
+          # This makes `git push` authenticate with the PAT, which allows
+          # the push to trigger the cicd workflow on the merge branch.
+          # GITHUB_TOKEN pushes are blocked by GitHub's anti-recursion
+          # protection and will NOT trigger downstream workflows.
+          # Falls back to GITHUB_TOKEN if PAT is not configured (but cicd
+          # won't trigger, so Merge Gate won't appear and auto-merge won't work).
+          token: ${{ secrets.CICD_TRIGGER_DISPATCH || github.token }}
+
+      - name: Check push token
+        run: |
+          if [[ -z "${{ secrets.CICD_TRIGGER_DISPATCH }}" ]]; then
+            echo "::warning::CICD_TRIGGER_DISPATCH secret not configured — push will NOT trigger cicd workflow. Auto-merge will not work."
+          else
+            echo "PAT configured — push will trigger cicd workflow"
+          fi
 
       - name: Determine target branch
         id: target


### PR DESCRIPTION
## Summary

- Auto-port merge branches never got a cicd run because `GITHUB_TOKEN` pushes are blocked by GitHub's anti-recursion protection
- Fix: use `CICD_TRIGGER_DISPATCH` PAT for `actions/checkout`, making `git push` authenticate with the PAT
- PAT-authenticated pushes trigger downstream workflows (cicd → Merge Gate → Mergify auto-merge)
- Falls back to `GITHUB_TOKEN` with a warning if the secret is not configured

## Test plan

- [ ] Merge this PR
- [ ] Wait for next auto-port trigger (push to any `*_hotfix` or `*_release` branch)
- [ ] Verify the auto-port merge branch gets a cicd run
- [ ] Verify Merge Gate appears on the auto-port PR
- [ ] Verify Mergify auto-merges the PR after green CI