### PR TITLE
auto-port: dispatch cicd explicitly after push

### DIFF
--- a/.github/workflows/auto-port.yml
+++ b/.github/workflows/auto-port.yml
@@ -12,11 +12,14 @@
 # must exist on the PR's base branch, which it never did for non-default
 # branches.
 #
-# PAT requirement: CICD_TRIGGER_DISPATCH secret (PAT) is used for git push.
-# Pushes authenticated with GITHUB_TOKEN are blocked by GitHub's anti-
-# recursion protection and will NOT trigger the cicd workflow on the merge
-# branch. Without cicd, the Merge Gate check never appears, and Mergify
-# cannot auto-merge the PR.
+# cicd trigger: GITHUB_TOKEN pushes are blocked by GitHub's anti-recursion
+# protection and will NOT trigger the cicd workflow on the merge branch.
+# Without cicd, the Merge Gate check never appears, and Mergify cannot
+# auto-merge the PR. To work around this, after pushing the merge branch
+# we explicitly dispatch the cicd workflow via `gh workflow run` using the
+# CICD_TRIGGER_DISPATCH PAT. We cannot use the PAT for the push itself
+# because it lacks the `workflows` permission needed to push workflow file
+# changes (common in *_release → new_dawn_uat merges).
 # ===========================================================================
 
 name: Auto-port to new_dawn_uat chain
@@ -52,22 +55,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # CRITICAL: Use a PAT instead of GITHUB_TOKEN for checkout.
-          # This makes `git push` authenticate with the PAT, which allows
-          # the push to trigger the cicd workflow on the merge branch.
-          # GITHUB_TOKEN pushes are blocked by GitHub's anti-recursion
-          # protection and will NOT trigger downstream workflows.
-          # Falls back to GITHUB_TOKEN if PAT is not configured (but cicd
-          # won't trigger, so Merge Gate won't appear and auto-merge won't work).
-          token: ${{ secrets.CICD_TRIGGER_DISPATCH || github.token }}
-
-      - name: Check push token
-        run: |
-          if [[ -z "${{ secrets.CICD_TRIGGER_DISPATCH }}" ]]; then
-            echo "::warning::CICD_TRIGGER_DISPATCH secret not configured — push will NOT trigger cicd workflow. Auto-merge will not work."
-          else
-            echo "PAT configured — push will trigger cicd workflow"
-          fi
 
       - name: Determine target branch
         id: target
@@ -351,3 +338,24 @@ jobs:
               exit 1
             fi
           fi
+
+      # ---------------------------------------------------------------
+      # GITHUB_TOKEN pushes do NOT trigger downstream workflows (GitHub
+      # anti-recursion). Explicitly dispatch cicd so that the merge
+      # branch gets built, Merge Gate appears, and Mergify can auto-merge.
+      # We cannot use the PAT for the push itself because it lacks the
+      # `workflows` permission needed to push workflow file changes.
+      # ---------------------------------------------------------------
+      - name: Dispatch cicd for merge branch
+        if: success() && steps.target.outputs.skip != 'true' && steps.target.outputs.target != ''
+        env:
+          DISPATCH_TOKEN: ${{ secrets.CICD_TRIGGER_DISPATCH }}
+          MERGE_BRANCH: ${{ steps.check.outputs.merge_branch }}
+        run: |
+          if [[ -z "$DISPATCH_TOKEN" ]]; then
+            echo "::warning::CICD_TRIGGER_DISPATCH not configured — cannot dispatch cicd. Merge Gate will not appear and auto-merge will not work."
+            exit 0
+          fi
+          echo "Dispatching cicd workflow for: $MERGE_BRANCH"
+          GH_TOKEN="$DISPATCH_TOKEN" gh workflow run cicd.yaml --ref "$MERGE_BRANCH"
+          echo "cicd dispatched for $MERGE_BRANCH"

--- a/.github/workflows/auto-port.yml
+++ b/.github/workflows/auto-port.yml
@@ -11,6 +11,12 @@
 # Previous approach (pull_request: closed) failed because the workflow file
 # must exist on the PR's base branch, which it never did for non-default
 # branches.
+#
+# PAT requirement: CICD_TRIGGER_DISPATCH secret (PAT) is used for git push.
+# Pushes authenticated with GITHUB_TOKEN are blocked by GitHub's anti-
+# recursion protection and will NOT trigger the cicd workflow on the merge
+# branch. Without cicd, the Merge Gate check never appears, and Mergify
+# cannot auto-merge the PR.
 # ===========================================================================
 
 name: Auto-port to new_dawn_uat chain
@@ -46,6 +52,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # CRITICAL: Use a PAT instead of GITHUB_TOKEN for checkout.
+          # This makes `git push` authenticate with the PAT, which allows
+          # the push to trigger the cicd workflow on the merge branch.
+          # GITHUB_TOKEN pushes are blocked by GitHub's anti-recursion
+          # protection and will NOT trigger downstream workflows.
+          # Falls back to GITHUB_TOKEN if PAT is not configured (but cicd
+          # won't trigger, so Merge Gate won't appear and auto-merge won't work).
+          token: ${{ secrets.CICD_TRIGGER_DISPATCH || github.token }}
+
+      - name: Check push token
+        run: |
+          if [[ -z "${{ secrets.CICD_TRIGGER_DISPATCH }}" ]]; then
+            echo "::warning::CICD_TRIGGER_DISPATCH secret not configured — push will NOT trigger cicd workflow. Auto-merge will not work."
+          else
+            echo "PAT configured — push will trigger cicd workflow"
+          fi
 
       - name: Determine target branch
         id: target


### PR DESCRIPTION
## Summary

Fixes the auto-port cicd trigger issue. The previous approach (PR #22567, using PAT for checkout/push) failed because `CICD_TRIGGER_DISPATCH` lacks the `workflows` permission — pushes that include workflow file changes are rejected.

**New approach**:
1. Push with `GITHUB_TOKEN` (has implicit `workflows` permission, can push any files)
2. After push, explicitly dispatch cicd via `gh workflow run cicd.yaml --ref $MERGE_BRANCH` using `CICD_TRIGGER_DISPATCH` PAT

This ensures the merge branch gets a cicd run → Merge Gate check appears → Mergify can auto-merge.

## Test plan

- [ ] Merge this PR
- [ ] Re-run the auto-port workflow for a `_hotfix` or `_release` branch
- [ ] Verify cicd is dispatched and runs on the merge branch
- [ ] Verify Merge Gate appears on the auto-port PR