### PR TITLE
gh#28487: add new columns to Package Licensing Product Report

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/packagelicensing/PackageLicensingProductReport_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/packagelicensing/PackageLicensingProductReport_StepDef.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
  * directly covers the actual business logic without needing to parse Excel output.
  *
  * @see <a href="https://github.com/metasfresh/metasfresh/issues/28225">gh#28225</a>
+ * @see <a href="https://github.com/metasfresh/metasfresh/issues/28487">gh#28487</a>
  */
 @RequiredArgsConstructor
 public class PackageLicensingProductReport_StepDef
@@ -64,6 +65,7 @@ public class PackageLicensingProductReport_StepDef
 	 *   <li>{@code SmallPackagingWeight} (optional) — sets M_Product.SmallPackagingWeight</li>
 	 *   <li>{@code OuterPackagingMaterialName} (optional) — creates M_PackageLicensing_MaterialGroup and links via M_Product_OuterPackagingMaterial</li>
 	 *   <li>{@code OuterPackagingWeight} (optional) — sets M_Product.OuterPackagingWeight</li>
+	 *   <li>{@code ProductCategoryName} (optional) — creates M_Product_Category and assigns it to the product</li>
 	 * </ul>
 	 */
 	@And("package licensing test data is set up:")
@@ -113,6 +115,15 @@ public class PackageLicensingProductReport_StepDef
 		{
 			DB.executeUpdateAndThrowExceptionOnFail(
 					"UPDATE M_Product SET OuterPackagingWeight=" + outerPackagingWeight + " WHERE M_Product_ID=" + productId,
+					ITrx.TRXNAME_None);
+		}
+
+		final String productCategoryName = row.getAsOptionalString("ProductCategoryName").orElse(null);
+		if (productCategoryName != null && !productCategoryName.isEmpty())
+		{
+			final int categoryId = insertProductCategory(productCategoryName);
+			DB.executeUpdateAndThrowExceptionOnFail(
+					"UPDATE M_Product SET M_Product_Category_ID=" + categoryId + " WHERE M_Product_ID=" + productId,
 					ITrx.TRXNAME_None);
 		}
 	}
@@ -174,6 +185,122 @@ public class PackageLicensingProductReport_StepDef
 				ITrx.TRXNAME_None);
 	}
 
+	private int insertProductCategory(@NonNull final String name)
+	{
+		final int id = DB.getSQLValueEx(ITrx.TRXNAME_None, "SELECT nextval('M_PRODUCT_CATEGORY_SEQ')");
+		DB.executeUpdateAndThrowExceptionOnFail(
+				"INSERT INTO M_Product_Category "
+						+ "(M_Product_Category_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Value, Name, IsDefault, IsSelfService, PlannedMargin, MMPolicy) "
+						+ "VALUES (" + id + ", " + Env.getAD_Client_ID(Env.getCtx()) + ", " + Env.getAD_Org_ID(Env.getCtx()) + ", 'Y', now(), 100, now(), 100, "
+						+ sqlQuote(name) + ", " + sqlQuote(name) + ", 'N', 'N', 0, 'F')",
+				ITrx.TRXNAME_None);
+		return id;
+	}
+
+	/**
+	 * Sets up M_HU_PI_Item_Product records for packaging instruction factor testing.
+	 *
+	 * <pre>
+	 * | M_Product_ID.Identifier | Qty | IsDefaultForProduct |
+	 * | p_1                     | 12  | Y                   |
+	 * </pre>
+	 */
+	@And("package licensing packaging instruction test data is set up:")
+	public void setupPackagingInstructionTestData(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::setupPackagingInstructionForProduct);
+	}
+
+	private void setupPackagingInstructionForProduct(@NonNull final DataTableRow row)
+	{
+		final I_M_Product product = productTable.get(row.getAsIdentifier("M_Product_ID"));
+		final int productId = product.getM_Product_ID();
+		final BigDecimal qty = row.getAsBigDecimal("Qty");
+		final String isDefault = row.getAsOptionalString("IsDefaultForProduct").orElse("N");
+
+		final int piItemId = DB.getSQLValueEx(ITrx.TRXNAME_None,
+				"SELECT M_HU_PI_Item_ID FROM M_HU_PI_Item WHERE IsActive='Y' ORDER BY M_HU_PI_Item_ID LIMIT 1");
+
+		final int id = DB.getSQLValueEx(ITrx.TRXNAME_None, "SELECT nextval('M_HU_PI_ITEM_PRODUCT_SEQ')");
+		DB.executeUpdateAndThrowExceptionOnFail(
+				"INSERT INTO M_HU_PI_Item_Product "
+						+ "(M_HU_PI_Item_Product_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, "
+						+ "M_HU_PI_Item_ID, M_Product_ID, Qty, IsDefaultForProduct, IsInfiniteCapacity, IsAllowAnyProduct, ValidFrom, IsOrderInTUOMWhenMatched) "
+						+ "VALUES (" + id + ", " + Env.getAD_Client_ID(Env.getCtx()) + ", " + Env.getAD_Org_ID(Env.getCtx()) + ", 'Y', now(), 100, now(), 100, "
+						+ piItemId + ", " + productId + ", " + qty + ", " + sqlQuote(isDefault) + ", 'N', 'N', '1970-01-01', 'N')",
+				ITrx.TRXNAME_None);
+	}
+
+	/**
+	 * Sets up M_InOut + M_InOutLine records for delivered quantity testing.
+	 * Creates a completed customer shipment (MovementType='C-', DocStatus='CO') with the given movement quantity.
+	 *
+	 * <pre>
+	 * | M_Product_ID.Identifier | MovementQty |
+	 * | p_1                     | 100         |
+	 * </pre>
+	 */
+	@And("package licensing shipment test data is set up:")
+	public void setupShipmentTestData(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::setupShipmentForProduct);
+	}
+
+	private void setupShipmentForProduct(@NonNull final DataTableRow row)
+	{
+		final I_M_Product product = productTable.get(row.getAsIdentifier("M_Product_ID"));
+		final int productId = product.getM_Product_ID();
+		final BigDecimal movementQty = row.getAsBigDecimal("MovementQty");
+
+		final int clientId = Env.getAD_Client_ID(Env.getCtx());
+		final int orgId = Env.getAD_Org_ID(Env.getCtx());
+
+		// Look up required FK references from existing data
+		final int docTypeId = DB.getSQLValueEx(ITrx.TRXNAME_None,
+				"SELECT C_DocType_ID FROM C_DocType WHERE DocBaseType='MMS' AND IsActive='Y' AND AD_Client_ID=" + clientId + " ORDER BY C_DocType_ID LIMIT 1");
+		final int bPartnerId = DB.getSQLValueEx(ITrx.TRXNAME_None,
+				"SELECT C_BPartner_ID FROM C_BPartner WHERE IsActive='Y' AND AD_Client_ID=" + clientId + " ORDER BY C_BPartner_ID LIMIT 1");
+		final int bPartnerLocationId = DB.getSQLValueEx(ITrx.TRXNAME_None,
+				"SELECT C_BPartner_Location_ID FROM C_BPartner_Location WHERE C_BPartner_ID=" + bPartnerId + " AND IsActive='Y' LIMIT 1");
+		final int warehouseId = DB.getSQLValueEx(ITrx.TRXNAME_None,
+				"SELECT M_Warehouse_ID FROM M_Warehouse WHERE IsActive='Y' AND AD_Client_ID=" + clientId + " ORDER BY M_Warehouse_ID LIMIT 1");
+		final int uomId = DB.getSQLValueEx(ITrx.TRXNAME_None,
+				"SELECT C_UOM_ID FROM C_UOM WHERE IsActive='Y' ORDER BY C_UOM_ID LIMIT 1");
+
+		// Insert M_InOut (completed customer shipment)
+		final int inOutId = DB.getSQLValueEx(ITrx.TRXNAME_None, "SELECT nextval('M_INOUT_SEQ')");
+		final String documentNo = "PLR-TEST-" + inOutId;
+		DB.executeUpdateAndThrowExceptionOnFail(
+				"INSERT INTO M_InOut "
+						+ "(M_InOut_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, "
+						+ "IsSOTrx, DocumentNo, DocAction, DocStatus, Posted, Processed, C_DocType_ID, IsPrinted, "
+						+ "MovementType, MovementDate, DateAcct, C_BPartner_ID, C_BPartner_Location_ID, M_Warehouse_ID, "
+						+ "DeliveryRule, FreightCostRule, DeliveryViaRule, PriorityRule, SendEMail, "
+						+ "IsInTransit, IsApproved, IsInDispute, IsUseBPartnerAddress, "
+						+ "EDI_ExportStatus, IsEdiEnabled, IsManual, IsInOutApprovedForInvoicing, IsExportedToCustomsInvoice, IsFillUpSpareParts) "
+						+ "VALUES (" + inOutId + ", " + clientId + ", " + orgId + ", 'Y', now(), 100, now(), 100, "
+						+ "'Y', " + sqlQuote(documentNo) + ", 'CO', 'CO', 'N', 'Y', " + docTypeId + ", 'N', "
+						+ "'C-', CURRENT_DATE, CURRENT_DATE, " + bPartnerId + ", " + bPartnerLocationId + ", " + warehouseId + ", "
+						+ "'A', 'I', 'P', '5', 'N', "
+						+ "'N', 'Y', 'N', 'N', "
+						+ "'P', 'N', 'N', 'N', 'N', 'N')",
+				ITrx.TRXNAME_None);
+
+		// Insert M_InOutLine
+		final int inOutLineId = DB.getSQLValueEx(ITrx.TRXNAME_None, "SELECT nextval('M_INOUTLINE_SEQ')");
+		DB.executeUpdateAndThrowExceptionOnFail(
+				"INSERT INTO M_InOutLine "
+						+ "(M_InOutLine_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, "
+						+ "Line, M_InOut_ID, M_Product_ID, C_UOM_ID, MovementQty, QtyEntered, IsInvoiced, IsDescription, "
+						+ "Processed, IsIndividualDescription, IsInDispute, QualityDiscountPercent, "
+						+ "IsPackagingMaterial, IsManualPackingMaterial, IsHUPrepared, IsWarrantyCase) "
+						+ "VALUES (" + inOutLineId + ", " + clientId + ", " + orgId + ", 'Y', now(), 100, now(), 100, "
+						+ "10, " + inOutId + ", " + productId + ", " + uomId + ", " + movementQty + ", " + movementQty + ", 'N', 'N', "
+						+ "'Y', 'N', 'N', 0, "
+						+ "'N', 'N', 'N', 'N')",
+				ITrx.TRXNAME_None);
+	}
+
 	@When("the Package Licensing Product Report is executed without country filter")
 	public void executeReportWithoutCountryFilter() throws SQLException
 	{
@@ -209,11 +336,14 @@ public class PackageLicensingProductReport_StepDef
 					final Map<String, String> row = new LinkedHashMap<>();
 					row.put("ProductNo", rs.getString("ProductNo"));
 					row.put("ProductName", rs.getString("ProductName"));
-					row.put("ProductGroup", rs.getString("ProductGroup"));
+					row.put("ProductCategory", rs.getString("ProductCategory"));
+					row.put("MaterialType", rs.getString("MaterialType"));
 					row.put("SmallPackagingMaterial", rs.getString("SmallPackagingMaterial"));
 					row.put("SmallPackagingWeight", bigDecimalToString(rs.getBigDecimal("SmallPackagingWeight")));
 					row.put("OverpackMaterial", rs.getString("OverpackMaterial"));
 					row.put("OverpackWeight", bigDecimalToString(rs.getBigDecimal("OverpackWeight")));
+					row.put("PackagingInstructionFactor", bigDecimalToString(rs.getBigDecimal("PackagingInstructionFactor")));
+					row.put("DeliveredQtyLast12Months", bigDecimalToString(rs.getBigDecimal("DeliveredQtyLast12Months")));
 					reportResults.add(row);
 				}
 			}
@@ -233,20 +363,23 @@ public class PackageLicensingProductReport_StepDef
 	/**
 	 * Verifies the report results contain exactly the expected rows (matched by ProductName).
 	 * Empty cells in the expected table assert that the actual value is null/empty.
+	 * Columns not present in the expected table are not checked.
 	 *
 	 * <pre>
-	 * | ProductName     | ProductGroup | SmallPackagingMaterial | SmallPackagingWeight | OverpackMaterial | OverpackWeight |
-	 * | PLR Test Prod 1 | Lebensmittel | Glas                   | 0.150                | Kunststoffe      | 0.030          |
-	 * | PLR Test Prod 2 |              |                        | 0.200                |                  |                |
+	 * | ProductName     | MaterialType | ProductCategory   | SmallPackagingMaterial | SmallPackagingWeight | OverpackMaterial | OverpackWeight | PackagingInstructionFactor | DeliveredQtyLast12Months |
+	 * | PLR Test Prod 1 | Lebensmittel | Test Category     | Glas                   | 0.150                | Kunststoffe      | 0.030          | 12                         | 100                      |
 	 * </pre>
 	 *
 	 * <ul>
 	 *   <li>{@code ProductName} — required; used to match actual report rows</li>
-	 *   <li>{@code ProductGroup} (optional) — expected M_PackageLicensing_ProductGroup name; empty = assert null</li>
+	 *   <li>{@code MaterialType} (optional) — expected comma-separated product group names; empty = assert null</li>
+	 *   <li>{@code ProductCategory} (optional) — expected product category name; empty = assert null</li>
 	 *   <li>{@code SmallPackagingMaterial} (optional) — expected small packaging material name; empty = assert null</li>
 	 *   <li>{@code SmallPackagingWeight} (optional) — expected weight as decimal; empty = assert null</li>
 	 *   <li>{@code OverpackMaterial} (optional) — expected outer packaging material name; empty = assert null</li>
 	 *   <li>{@code OverpackWeight} (optional) — expected weight as decimal; empty = assert null</li>
+	 *   <li>{@code PackagingInstructionFactor} (optional) — expected PI quantity; empty = assert null</li>
+	 *   <li>{@code DeliveredQtyLast12Months} (optional) — expected delivered quantity; empty = assert null</li>
 	 * </ul>
 	 *
 	 * Also asserts that no row multiplication occurred (exactly one result row per expected product).
@@ -284,11 +417,14 @@ public class PackageLicensingProductReport_StepDef
 				continue;
 			}
 
-			assertOptionalColumn(softly, expectedRow, actualRow, "ProductGroup");
-			assertOptionalColumn(softly, expectedRow, actualRow, "SmallPackagingMaterial");
-			assertOptionalBigDecimalColumn(softly, expectedRow, actualRow, "SmallPackagingWeight");
-			assertOptionalColumn(softly, expectedRow, actualRow, "OverpackMaterial");
-			assertOptionalBigDecimalColumn(softly, expectedRow, actualRow, "OverpackWeight");
+			assertOptionalColumnIfPresent(softly, expectedRow, actualRow, "MaterialType");
+			assertOptionalColumnIfPresent(softly, expectedRow, actualRow, "ProductCategory");
+			assertOptionalColumnIfPresent(softly, expectedRow, actualRow, "SmallPackagingMaterial");
+			assertOptionalBigDecimalColumnIfPresent(softly, expectedRow, actualRow, "SmallPackagingWeight");
+			assertOptionalColumnIfPresent(softly, expectedRow, actualRow, "OverpackMaterial");
+			assertOptionalBigDecimalColumnIfPresent(softly, expectedRow, actualRow, "OverpackWeight");
+			assertOptionalBigDecimalColumnIfPresent(softly, expectedRow, actualRow, "PackagingInstructionFactor");
+			assertOptionalBigDecimalColumnIfPresent(softly, expectedRow, actualRow, "DeliveredQtyLast12Months");
 		}
 
 		softly.assertThat(matchingResults)
@@ -298,12 +434,17 @@ public class PackageLicensingProductReport_StepDef
 		softly.assertAll();
 	}
 
-	private static void assertOptionalColumn(
+	private static void assertOptionalColumnIfPresent(
 			@NonNull final SoftAssertions softly,
 			@NonNull final Map<String, String> expectedRow,
 			@NonNull final Map<String, String> actualRow,
 			@NonNull final String columnName)
 	{
+		if (!expectedRow.containsKey(columnName))
+		{
+			return; // column not in expected table, skip
+		}
+
 		final String expectedValue = expectedRow.get(columnName);
 		if (expectedValue != null && !expectedValue.isEmpty())
 		{
@@ -319,12 +460,17 @@ public class PackageLicensingProductReport_StepDef
 		}
 	}
 
-	private static void assertOptionalBigDecimalColumn(
+	private static void assertOptionalBigDecimalColumnIfPresent(
 			@NonNull final SoftAssertions softly,
 			@NonNull final Map<String, String> expectedRow,
 			@NonNull final Map<String, String> actualRow,
 			@NonNull final String columnName)
 	{
+		if (!expectedRow.containsKey(columnName))
+		{
+			return; // column not in expected table, skip
+		}
+
 		final String expectedValue = expectedRow.get(columnName);
 		if (expectedValue != null && !expectedValue.isEmpty())
 		{

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/packagelicensing/packageLicensingProductReport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/packagelicensing/packageLicensingProductReport.feature
@@ -1,6 +1,6 @@
 @from:cucumber
 @ghActions:run_on_executor5
-Feature: Package Licensing Product Report (gh#28225)
+Feature: Package Licensing Product Report (gh#28225, gh#28487)
   Verifies that the SQL function report.Package_Licensing_Product_Report()
   returns the correct product master data for packaging licensing.
 
@@ -19,7 +19,7 @@ Feature: Package Licensing Product Report (gh#28225)
       | p_plr_2                 | 101          | Tiernahrung      | PPK                        | 0.200                |                            |                      |
     When the Package Licensing Product Report is executed without country filter
     Then the Package Licensing Product Report result contains:
-      | ProductName     | ProductGroup | SmallPackagingMaterial | SmallPackagingWeight | OverpackMaterial | OverpackWeight |
+      | ProductName     | MaterialType | SmallPackagingMaterial | SmallPackagingWeight | OverpackMaterial | OverpackWeight |
       | PLR Test Prod 1 | Lebensmittel | Glas                   | 0.150                | Kunststoffe      | 0.030          |
       | PLR Test Prod 2 | Tiernahrung  | PPK                    | 0.200                |                  |                |
 
@@ -35,6 +35,25 @@ Feature: Package Licensing Product Report (gh#28225)
       | p_plr_4                 | 108          | Lebensmittel AT  | Glas AT                    | 0.100                | Kunststoffe AT             | 0.020                |
     When the Package Licensing Product Report is executed with C_Country_ID 101
     Then the Package Licensing Product Report result contains:
-      | ProductName     | ProductGroup    | SmallPackagingMaterial | SmallPackagingWeight | OverpackMaterial | OverpackWeight |
+      | ProductName     | MaterialType    | SmallPackagingMaterial | SmallPackagingWeight | OverpackMaterial | OverpackWeight |
       | PLR Test Prod 3 | Lebensmittel DE | Glas DE                | 0.100                | Kunststoffe DE   | 0.020          |
       | PLR Test Prod 4 |                 |                        | 0.100                |                  | 0.020          |
+
+  @Id:S28487_10
+  Scenario: S28487_10 - Report returns new columns (ProductCategory, MaterialType, PackagingInstructionFactor, DeliveredQtyLast12Months)
+    Given metasfresh contains M_Products:
+      | Identifier | Name            |
+      | p_plr_5    | PLR Test Prod 5 |
+    And package licensing test data is set up:
+      | M_Product_ID.Identifier | C_Country_ID | ProductGroupName | ProductCategoryName | SmallPackagingMaterialName | SmallPackagingWeight | OuterPackagingMaterialName | OuterPackagingWeight |
+      | p_plr_5                 | 101          | Lebensmittel     | PLR Test Category   | Glas                       | 0.150                | Kunststoffe                | 0.030                |
+    And package licensing packaging instruction test data is set up:
+      | M_Product_ID.Identifier | Qty | IsDefaultForProduct |
+      | p_plr_5                 | 12  | Y                   |
+    And package licensing shipment test data is set up:
+      | M_Product_ID.Identifier | MovementQty |
+      | p_plr_5                 | 100         |
+    When the Package Licensing Product Report is executed without country filter
+    Then the Package Licensing Product Report result contains:
+      | ProductName     | MaterialType | ProductCategory   | SmallPackagingMaterial | SmallPackagingWeight | OverpackMaterial | OverpackWeight | PackagingInstructionFactor | DeliveredQtyLast12Months |
+      | PLR Test Prod 5 | Lebensmittel | PLR Test Category | Glas                   | 0.150                | Kunststoffe      | 0.030          | 12                         | 100                      |

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5791510_sys_gh28487_Package_Licensing_Product_Report_Update.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5791510_sys_gh28487_Package_Licensing_Product_Report_Update.sql
@@ -1,0 +1,107 @@
+-- Run mode: SWING_CLIENT
+
+DROP FUNCTION IF EXISTS report.Package_Licensing_Product_Report(numeric);
+
+CREATE OR REPLACE FUNCTION report.Package_Licensing_Product_Report(p_C_Country_ID numeric DEFAULT NULL)
+    RETURNS TABLE
+            (
+                ProductNo                  varchar,
+                ProductName                varchar,
+                ProductCategory            varchar,
+                MaterialType               varchar,
+                SmallPackagingMaterial      varchar,
+                SmallPackagingWeight        numeric,
+                OverpackMaterial            varchar,
+                OverpackWeight              numeric,
+                PackagingInstructionFactor  numeric,
+                DeliveredQtyLast12Months    numeric
+            )
+    LANGUAGE sql
+    STABLE
+AS
+$$
+SELECT p.Value                AS ProductNo,
+       p.Name                 AS ProductName,
+
+       -- NEW: Product category
+       pc.Name                AS ProductCategory,
+
+       -- NEW: MaterialType (replaces ProductGroup; comma-separated when multiple)
+       (SELECT string_agg(pp.Name, ', ' ORDER BY pp.Name)
+        FROM M_Product_PackageLicensing_ProductGroup pppg
+                 JOIN M_PackageLicensing_ProductGroup pp
+                      ON pp.M_PackageLicensing_ProductGroup_ID = pppg.M_PackageLicensing_ProductGroup_ID
+                          AND pp.IsActive = 'Y'
+                          AND (p_C_Country_ID IS NULL OR pp.C_Country_ID = p_C_Country_ID)
+        WHERE pppg.M_Product_ID = p.M_Product_ID
+          AND pppg.IsActive = 'Y'
+       )                      AS MaterialType,
+
+       -- Small packaging material (refactored to subquery)
+       (SELECT mg.Name
+        FROM M_Product_SmallPackagingMaterial pspm
+                 JOIN M_PackageLicensing_MaterialGroup mg
+                      ON mg.M_PackageLicensing_MaterialGroup_ID = pspm.M_PackageLicensing_MaterialGroup_ID
+                          AND mg.IsActive = 'Y'
+                          AND (p_C_Country_ID IS NULL OR mg.C_Country_ID = p_C_Country_ID)
+        WHERE pspm.M_Product_ID = p.M_Product_ID
+          AND pspm.IsActive = 'Y'
+        LIMIT 1
+       )                      AS SmallPackagingMaterial,
+
+       p.SmallPackagingWeight AS SmallPackagingWeight,
+
+       -- Outer packaging material (refactored to subquery)
+       (SELECT mg.Name
+        FROM M_Product_OuterPackagingMaterial popm
+                 JOIN M_PackageLicensing_MaterialGroup mg
+                      ON mg.M_PackageLicensing_MaterialGroup_ID = popm.M_PackageLicensing_MaterialGroup_ID
+                          AND mg.IsActive = 'Y'
+                          AND (p_C_Country_ID IS NULL OR mg.C_Country_ID = p_C_Country_ID)
+        WHERE popm.M_Product_ID = p.M_Product_ID
+          AND popm.IsActive = 'Y'
+        LIMIT 1
+       )                      AS OverpackMaterial,
+
+       p.OuterPackagingWeight AS OverpackWeight,
+
+       -- NEW: Packaging instruction factor (default PI preferred)
+       (SELECT piip.Qty
+        FROM M_HU_PI_Item_Product piip
+        WHERE piip.M_Product_ID = p.M_Product_ID
+          AND piip.IsActive = 'Y'
+        ORDER BY piip.IsDefaultForProduct DESC, piip.Created DESC
+        LIMIT 1
+       )                      AS PackagingInstructionFactor,
+
+       -- NEW: Delivered quantity in last 12 months (completed customer shipments)
+       (SELECT COALESCE(SUM(iol.MovementQty), 0)
+        FROM M_InOutLine iol
+                 JOIN M_InOut io ON io.M_InOut_ID = iol.M_InOut_ID
+        WHERE iol.M_Product_ID = p.M_Product_ID
+          AND io.IsActive = 'Y'
+          AND io.DocStatus IN ('CO', 'CL')
+          AND io.MovementType = 'C-'
+          AND io.MovementDate >= (CURRENT_DATE - INTERVAL '12 months')
+       )                      AS DeliveredQtyLast12Months
+
+FROM M_Product p
+
+         -- Product category
+         LEFT JOIN M_Product_Category pc ON pc.M_Product_Category_ID = p.M_Product_Category_ID
+
+WHERE p.IsActive = 'Y'
+  AND (EXISTS (SELECT 1
+               FROM M_Product_PackageLicensing_ProductGroup pppg
+               WHERE pppg.M_Product_ID = p.M_Product_ID AND pppg.IsActive = 'Y')
+    OR EXISTS (SELECT 1
+               FROM M_Product_SmallPackagingMaterial pspm
+               WHERE pspm.M_Product_ID = p.M_Product_ID AND pspm.IsActive = 'Y')
+    OR EXISTS (SELECT 1
+               FROM M_Product_OuterPackagingMaterial popm
+               WHERE popm.M_Product_ID = p.M_Product_ID AND popm.IsActive = 'Y'))
+
+ORDER BY p.Value, p.Name;
+$$;
+
+COMMENT ON FUNCTION report.Package_Licensing_Product_Report(numeric) IS 'gh#28487: Updated product master data export for packaging licensing. Added ProductCategory, MaterialType (replaces ProductGroup), PackagingInstructionFactor, and DeliveredQtyLast12Months. Refactored to subqueries to avoid row multiplication.';


### PR DESCRIPTION
## Summary
- Adds 4 new columns to `report.Package_Licensing_Product_Report()`: `ProductCategory`, `MaterialType` (replaces `ProductGroup` with `string_agg`), `PackagingInstructionFactor`, and `DeliveredQtyLast12Months`
- Refactors existing LEFT JOINs to correlated subqueries to eliminate row multiplication when a product has multiple packaging attributes
- Updates Cucumber tests: renames `ProductGroup` to `MaterialType` in existing scenarios, adds new scenario `S28487_10` covering all new columns

## Test plan
- [ ] CI passes (Cucumber tests on executor5)
- [ ] Manual SQL verification: `SELECT * FROM report.Package_Licensing_Product_Report(NULL) LIMIT 20`
- [ ] Verify Excel export via WebUI process still works