### PR TITLE
Add M_ShipmentSchedule.CloseReason to track why schedules are closed

### DIFF
--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/shipping/JsonShipmentService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/shipping/JsonShipmentService.java
@@ -47,6 +47,7 @@ import de.metas.handlingunits.shipmentschedule.api.M_ShipmentSchedule_QuantityTy
 import de.metas.handlingunits.shipmentschedule.api.QtyToDeliverMap;
 import de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleEnqueuer;
 import de.metas.handlingunits.shipmentschedule.api.ShipmentService;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.handlingunits.shipmentschedule.api.ShippingInfoCache;
 import de.metas.handlingunits.shipmentschedule.spi.impl.ShipmentScheduleExternalInfo;
 import de.metas.inout.IInOutDAO;
@@ -223,7 +224,7 @@ public class JsonShipmentService
 			if (request.getCloseShipmentSchedule())
 			{
 				loggable.addLog("processShipmentSchedules - start closing shipmentSchedules");
-				shipmentScheduleBL.closeShipmentSchedules(generateShipmentRequest.getScheduleIds().getShipmentScheduleIds());
+				shipmentScheduleBL.closeShipmentSchedules(generateShipmentRequest.getScheduleIds().getShipmentScheduleIds(), ShipmentScheduleCloseReason.ShipmentProcessed);
 				loggable.addLog("processShipmentSchedules - finished closing shipmentSchedules");
 			}
 		}

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/warehouse/WarehouseService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/warehouse/WarehouseService.java
@@ -45,6 +45,7 @@ import de.metas.inout.ShipmentScheduleId;
 import de.metas.inoutcandidate.ShipmentSchedule;
 import de.metas.inoutcandidate.ShipmentScheduleRepository;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.inoutcandidate.invalidation.segments.ImmutableShipmentScheduleSegment;
 import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleSegments;
 import de.metas.inventory.HUAggregationType;
@@ -240,7 +241,7 @@ public class WarehouseService
 		final List<ShipmentScheduleId> closedShipmentScheduleIds = shipmentScheduleRepository.streamFromSegment(shipmentScheduleSegment)
 				.filter(shipmentSchedule -> !shipmentSchedule.isProcessed())
 				.map(ShipmentSchedule::getId)
-				.peek(shipmentScheduleBL::closeShipmentSchedule)
+				.peek(id -> shipmentScheduleBL.closeShipmentSchedule(id, ShipmentScheduleCloseReason.OutOfStock))
 				.collect(ImmutableList.toImmutableList());
 
 		Loggables.addLog("WarehouseService.closeShipmentSchedules: Just closed from warehouse: {} the following shipmentSchedules: {}",

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/spi/impl/FlatrateTermInvoiceCandidateListener.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/spi/impl/FlatrateTermInvoiceCandidateListener.java
@@ -4,6 +4,7 @@ import de.metas.contracts.model.I_C_Flatrate_Term;
 import de.metas.contracts.model.I_C_SubscriptionProgress;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.invoicecandidate.spi.IInvoiceCandidateListener;
 import de.metas.util.Services;
@@ -52,7 +53,7 @@ public class FlatrateTermInvoiceCandidateListener implements IInvoiceCandidateLi
 				.create()
 				.list(I_M_ShipmentSchedule.class);
 
-		shipmentSchedules.forEach(shipmentSchedule -> Services.get(IShipmentScheduleBL.class).closeShipmentSchedule(shipmentSchedule));
+		shipmentSchedules.forEach(shipmentSchedule -> Services.get(IShipmentScheduleBL.class).closeShipmentSchedule(shipmentSchedule, ShipmentScheduleCloseReason.FlatrateTerm));
 	}
 
 }

--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/subscription/impl/subscriptioncommands/InsertPause.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/subscription/impl/subscriptioncommands/InsertPause.java
@@ -10,6 +10,7 @@ import de.metas.contracts.model.X_C_SubscriptionProgress;
 import de.metas.contracts.subscription.impl.SubscriptionService;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -115,7 +116,7 @@ public class InsertPause
 
 			if (sp.getM_ShipmentSchedule_ID() > 0)
 			{
-				Services.get(IShipmentScheduleBL.class).closeShipmentSchedule(ShipmentScheduleId.ofRepoId(sp.getM_ShipmentSchedule_ID()));
+				Services.get(IShipmentScheduleBL.class).closeShipmentSchedule(ShipmentScheduleId.ofRepoId(sp.getM_ShipmentSchedule_ID()), ShipmentScheduleCloseReason.ContractPause);
 			}
 
 			final boolean notYetDone = !Objects.equals(sp.getStatus(), X_C_SubscriptionProgress.STATUS_Done);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -92,6 +92,7 @@ import lombok.Value;
 import org.adempiere.ad.dao.ICompositeQueryUpdater;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.mm.attributes.keys.AttributesKeys;
@@ -546,15 +547,29 @@ public class M_ShipmentSchedule_StepDef
 		validateNoShipmentScheduleCreatedForOrder(orderId);
 	}
 
-	@And("^the M_ShipmentSchedule identified by (.*) is (closed|reactivated)$")
-	public void M_ShipmentSchedule_action(@NonNull final String shipmentScheduleIdentifier, @NonNull final String action)
+	/**
+	 * Close or reopen a shipment schedule.
+	 * When closing, an optional close reason can be provided (e.g., "closed with reason Manual").
+	 * When no reason is provided, calls the no-reason overload (backward compatible).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * When the M_ShipmentSchedule identified by sched_1 is closed
+	 * When the M_ShipmentSchedule identified by sched_1 is closed with reason Manual
+	 * When the M_ShipmentSchedule identified by sched_1 is reactivated
+	 * </pre>
+	 */
+	@And("^the M_ShipmentSchedule identified by (.*) is (closed|reactivated)(?: with reason (.*))?$")
+	public void M_ShipmentSchedule_action(@NonNull final String shipmentScheduleIdentifier, @NonNull final String action, @Nullable final String closeReasonCode)
 	{
 		final I_M_ShipmentSchedule schedule = shipmentScheduleTable.get(shipmentScheduleIdentifier);
 
 		switch (StepDefDocAction.valueOf(action))
 		{
 			case closed:
-				shipmentScheduleBL.closeShipmentSchedule(schedule);
+				final ShipmentScheduleCloseReason closeReason = ShipmentScheduleCloseReason.ofNullableCode(closeReasonCode);
+				shipmentScheduleBL.closeShipmentSchedule(schedule, closeReason);
 				break;
 			case reactivated:
 				shipmentScheduleBL.openShipmentSchedule(schedule);
@@ -757,8 +772,22 @@ public class M_ShipmentSchedule_StepDef
 
 		if (isClosed != null)
 		{
-			assertThat(shipmentSchedule.isClosed()).as("IsClosed for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(isClosed);
+			softly.assertThat(shipmentSchedule.isClosed()).as("IsClosed for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(isClosed);
 		}
+
+		final String closeReasonCode = DataTableUtil.extractStringOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_CloseReason);
+		if (closeReasonCode != null)
+		{
+			if (Check.isBlank(closeReasonCode))
+			{
+				softly.assertThat(shipmentSchedule.getCloseReason()).as("CloseReason for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isNull();
+			}
+			else
+			{
+				softly.assertThat(shipmentSchedule.getCloseReason()).as("CloseReason for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(closeReasonCode);
+			}
+		}
+
 		if (isProcessed != null)
 		{
 			softly.assertThat(shipmentSchedule.isProcessed()).as("Processed for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(isProcessed);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentScheduleCloseReason.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentScheduleCloseReason.feature
@@ -1,0 +1,102 @@
+@from:cucumber
+@ghActions:run_on_executor3
+Feature: Shipment schedule CloseReason tracks why a schedule was closed
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-05-17T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+
+    And metasfresh contains M_Products:
+      | Identifier      |
+      | product_closeRsn |
+    And metasfresh contains M_PricingSystems
+      | Identifier  |
+      | ps_closeRsn |
+    And metasfresh contains M_PriceLists
+      | Identifier  | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name        | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_closeRsn | ps_closeRsn                   | DE                        | EUR                 | pl_closeRsn | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier   | M_PriceList_ID.Identifier | Name         | ValidFrom  |
+      | plv_closeRsn | pl_closeRsn               | plv_closeRsn | 2022-03-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier  | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_closeRsn | plv_closeRsn                      | product_closeRsn        | 10.0     | PCE               | Normal                        |
+    And metasfresh contains C_BPartners:
+      | Identifier   | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | bp_closeRsn  | Y              | ps_closeRsn                   |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier      | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | bpLoc_closeRsn  | 2705501234567 | bp_closeRsn              | Y                   | Y                   |
+
+
+  @from:cucumber
+  @Id:S27550_100
+  Scenario: Order reactivation sets CloseReason=OR on the shipment schedule
+    Given metasfresh contains C_Orders:
+      | Identifier       | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.DeliveryRule |
+      | order_cr100      | true    | bp_closeRsn              | 2022-05-17  | ps_closeRsn                       | bpLoc_closeRsn                        | F                |
+    And metasfresh contains C_OrderLines:
+      | Identifier       | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine_cr100  | order_cr100           | product_closeRsn        | 10         |
+    When the order identified by order_cr100 is completed
+    Then after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier  | C_OrderLine_ID.Identifier | IsToRecompute |
+      | sched_cr100 | orderLine_cr100           | N             |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.IsClosed | OPT.CloseReason |
+      | sched_cr100                      | false        |                 |
+
+    # Reactivate the order => schedule should be closed with reason OR (OrderReactivated)
+    When the order identified by order_cr100 is reactivated
+    Then after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.IsClosed | OPT.CloseReason  |
+      | sched_cr100                      | true         | OR               |
+
+
+  @from:cucumber
+  @Id:S27550_200
+  Scenario: Manual close sets CloseReason=MA on the shipment schedule
+    Given metasfresh contains C_Orders:
+      | Identifier       | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.DeliveryRule |
+      | order_cr200      | true    | bp_closeRsn              | 2022-05-17  | ps_closeRsn                       | bpLoc_closeRsn                        | F                |
+    And metasfresh contains C_OrderLines:
+      | Identifier       | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine_cr200  | order_cr200           | product_closeRsn        | 10         |
+    When the order identified by order_cr200 is completed
+    Then after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier  | C_OrderLine_ID.Identifier | IsToRecompute |
+      | sched_cr200 | orderLine_cr200           | N             |
+
+    # Manually close the schedule => CloseReason=MA
+    When the M_ShipmentSchedule identified by sched_cr200 is closed with reason MA
+    Then after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.IsClosed | OPT.CloseReason |
+      | sched_cr200                      | true         | MA              |
+
+
+  @from:cucumber
+  @Id:S27550_300
+  Scenario: Reopen clears CloseReason to null
+    Given metasfresh contains C_Orders:
+      | Identifier       | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.DeliveryRule |
+      | order_cr300      | true    | bp_closeRsn              | 2022-05-17  | ps_closeRsn                       | bpLoc_closeRsn                        | F                |
+    And metasfresh contains C_OrderLines:
+      | Identifier       | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine_cr300  | order_cr300           | product_closeRsn        | 10         |
+    When the order identified by order_cr300 is completed
+    Then after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier  | C_OrderLine_ID.Identifier | IsToRecompute |
+      | sched_cr300 | orderLine_cr300           | N             |
+
+    # Close with reason, then reopen => CloseReason should be null
+    When the M_ShipmentSchedule identified by sched_cr300 is closed with reason MA
+    Then after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.IsClosed | OPT.CloseReason |
+      | sched_cr300                      | true         | MA              |
+
+    When the M_ShipmentSchedule identified by sched_cr300 is reactivated
+    Then after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.IsClosed | OPT.CloseReason |
+      | sched_cr300                      | false        |                 |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/candidate/commands/ProcessPickingCandidatesCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/candidate/commands/ProcessPickingCandidatesCommand.java
@@ -24,6 +24,7 @@ import de.metas.handlingunits.pporder.api.IssueCandidateGeneratedBy;
 import de.metas.handlingunits.shipmentschedule.api.AddQtyPickedRequest;
 import de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleBL;
 import de.metas.handlingunits.util.CatchWeightHelper;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.invoicecandidate.api.IInvoiceCandBL;
@@ -269,7 +270,7 @@ public class ProcessPickingCandidatesCommand
 			return;
 		}
 
-		huShipmentScheduleBL.closeShipmentSchedule(shipmentSchedule);
+		huShipmentScheduleBL.closeShipmentSchedule(shipmentSchedule, ShipmentScheduleCloseReason.PickingRejected);
 
 		//
 		// Close related invoices candidates too

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentService.java
@@ -11,6 +11,7 @@ import de.metas.handlingunits.picking.job.service.CreateShipmentPolicy;
 import de.metas.handlingunits.shipmentschedule.api.GenerateShipmentsForSchedulesRequest;
 import de.metas.handlingunits.shipmentschedule.api.IShipmentService;
 import de.metas.handlingunits.shipmentschedule.api.ShipmentService;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.compiere.Adempiere;
@@ -106,6 +107,7 @@ public class PickingShipmentService
 				.onTheFlyPickToPackingInstructions(true)
 				.isCompleteShipment(createShipmentPolicy.isCreateAndCompleteShipment())
 				.isCloseShipmentSchedules(createShipmentPolicy.isCloseShipmentSchedules())
+				.closeReason(ShipmentScheduleCloseReason.ShipmentProcessed)
 				// since we are not going to immediately create invoices, we want to move on and to not wait for shipments
 				.waitForShipments(false)
 				.build());

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/GenerateShipmentsForSchedulesRequest.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/GenerateShipmentsForSchedulesRequest.java
@@ -25,6 +25,7 @@ package de.metas.handlingunits.shipmentschedule.api;
 import com.google.common.collect.ImmutableSet;
 import de.metas.handlingunits.HuId;
 import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.picking.api.ShipmentScheduleAndJobScheduleIdSet;
 import lombok.Builder;
 import lombok.NonNull;
@@ -49,6 +50,7 @@ public class GenerateShipmentsForSchedulesRequest
 
 	@NonNull Boolean isCompleteShipment;
 	boolean isCloseShipmentSchedules;
+	@Nullable ShipmentScheduleCloseReason closeReason;
 
 	@Nullable Boolean isShipDateToday;
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/GenerateShipmentsRequest.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/GenerateShipmentsRequest.java
@@ -30,6 +30,7 @@ import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.shipmentschedule.spi.impl.ShipmentScheduleExternalInfo;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.inoutcandidate.ShipmentSchedule;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.picking.api.ShipmentScheduleAndJobScheduleIdSet;
 import lombok.Builder;
 import lombok.NonNull;
@@ -61,6 +62,7 @@ public class GenerateShipmentsRequest
 
 	@NonNull Boolean isCompleteShipment;
 	boolean isCloseShipmentSchedules;
+	@Nullable ShipmentScheduleCloseReason closeReason;
 
 	@Nullable Boolean isShipDateToday;
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleBL.java
@@ -13,6 +13,7 @@ import de.metas.inout.ShipmentScheduleId;
 import de.metas.inout.model.I_M_InOut;
 import de.metas.inoutcandidate.api.ShipmentScheduleLoadingCache;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.quantity.Quantity;
 import de.metas.util.ISingletonService;
 import lombok.NonNull;
@@ -40,7 +41,11 @@ public interface IHUShipmentScheduleBL extends ISingletonService
 
 	void closeShipmentSchedule(I_M_ShipmentSchedule shipmentSchedule);
 
+	void closeShipmentSchedule(I_M_ShipmentSchedule shipmentSchedule, @Nullable ShipmentScheduleCloseReason reason);
+
 	void closeShipmentSchedules(Set<ShipmentScheduleId> shipmentScheduleIds);
+
+	void closeShipmentSchedules(Set<ShipmentScheduleId> shipmentScheduleIds, @Nullable ShipmentScheduleCloseReason reason);
 
 	/**
 	 * Add QtyPicked to the current QtyPicked of given shipment schedule.

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleEnqueuer.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleEnqueuer.java
@@ -39,6 +39,7 @@ import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.IMsgBL;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.inoutcandidate.model.I_M_Picking_Job_Schedule;
 import de.metas.lock.api.ILock;
 import de.metas.lock.api.ILockAutoCloseable;
@@ -229,6 +230,7 @@ public class ShipmentScheduleEnqueuer
 							.setParameter(ShipmentScheduleWorkPackageParameters.PARAM_IsOnTheFlyPickToPackingInstructions, workPackageParameters.isOnTheFlyPickToPackingInstructions())
 							.setParameter(ShipmentScheduleWorkPackageParameters.PARAM_IsCompleteShipments, workPackageParameters.isCompleteShipments())
 							.setParameter(ShipmentScheduleWorkPackageParameters.PARAM_IsCloseShipmentSchedules, workPackageParameters.isCloseShipmentSchedules())
+							.setParameter(ShipmentScheduleWorkPackageParameters.PARAM_CloseReason, ShipmentScheduleCloseReason.toCodeOrNull(workPackageParameters.getCloseReason()))
 							.setParameter(ShipmentScheduleWorkPackageParameters.PARAM_IsShipmentDateToday, workPackageParameters.isShipmentDateToday());
 
 					// Create a new locker which will grab the locked shipment candidates from 'mainLock'

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWorkPackageParameters.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWorkPackageParameters.java
@@ -28,6 +28,7 @@ import de.metas.async.AsyncBatchId;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.model.I_M_ShipmentSchedule;
 import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.picking.api.PickingJobScheduleId;
 import de.metas.picking.api.ShipmentScheduleAndJobScheduleIdSet;
 import de.metas.process.PInstanceId;
@@ -52,6 +53,7 @@ public class ShipmentScheduleWorkPackageParameters
 	public static final String PARAM_IsOnTheFlyPickToPackingInstructions = "IsOnTheFlyPickToPackingInstructions";
 	public static final String PARAM_IsCompleteShipments = "IsCompleteShipments";
 	public static final String PARAM_IsCloseShipmentSchedules = "IsCloseShipmentSchedules";
+	public static final String PARAM_CloseReason = "CloseReason";
 	public static final String PARAM_IsShipmentDateToday = "IsShipToday";
 	public static final String PARAM_PREFIX_AdvisedShipmentDocumentNo = "Advised_ShipmentDocumentNo_For_M_ShipmentSchedule_ID_"; // (param name can have 255 chars)
 	public static final String PARAM_QtyToDeliver_Override = "QtyToDeliver_Override_For_M_ShipmentSchedule_ID";
@@ -76,6 +78,7 @@ public class ShipmentScheduleWorkPackageParameters
 
 	boolean completeShipments;
 	boolean isCloseShipmentSchedules;
+	@Nullable ShipmentScheduleCloseReason closeReason;
 	boolean isShipmentDateToday;
 
 	/**

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentService.java
@@ -156,6 +156,7 @@ public class ShipmentService implements IShipmentService
 				.isShipDateToday(request.getIsShipDateToday())
 				.isCompleteShipment(request.getIsCompleteShipment())
 				.isCloseShipmentSchedules(request.isCloseShipmentSchedules())
+				.closeReason(request.getCloseReason())
 				.waitForShipments(request.isWaitForShipments());
 
 		groupSchedulesByAsyncBatch(allScheduleIds)
@@ -339,6 +340,7 @@ public class ShipmentService implements IShipmentService
 				.onTheFlyPickToPackingInstructions(request.isOnTheFlyPickToPackingInstructions())
 				.completeShipments(request.getIsCompleteShipment())
 				.isCloseShipmentSchedules(request.isCloseShipmentSchedules())
+				.closeReason(request.getCloseReason())
 				.isShipmentDateToday(Boolean.TRUE.equals(request.getIsShipDateToday()))
 				.advisedShipmentDocumentNos(request.extractShipmentDocumentNos())
 				.qtysToDeliverOverride(request.getScheduleToQuantityToDeliverOverride())

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -51,6 +51,7 @@ import de.metas.inoutcandidate.api.IShipmentScheduleEffectiveBL;
 import de.metas.inoutcandidate.api.IShipmentSchedulePA;
 import de.metas.inoutcandidate.api.InOutGenerateResult;
 import de.metas.inoutcandidate.api.ShipmentScheduleLoadingCache;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.inoutcandidate.api.impl.HUShipmentScheduleHeaderAggregationKeyBuilder;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
 import de.metas.logging.LogManager;
@@ -781,9 +782,21 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 	}
 
 	@Override
+	public void closeShipmentSchedule(final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule, @Nullable final ShipmentScheduleCloseReason reason)
+	{
+		shipmentScheduleBL.closeShipmentSchedule(shipmentSchedule, reason);
+	}
+
+	@Override
 	public void closeShipmentSchedules(final Set<ShipmentScheduleId> shipmentScheduleIds)
 	{
 		shipmentScheduleBL.closeShipmentSchedules(shipmentScheduleIds);
+	}
+
+	@Override
+	public void closeShipmentSchedules(final Set<ShipmentScheduleId> shipmentScheduleIds, @Nullable final ShipmentScheduleCloseReason reason)
+	{
+		shipmentScheduleBL.closeShipmentSchedules(shipmentScheduleIds, reason);
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/async/GenerateInOutFromShipmentSchedules.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/async/GenerateInOutFromShipmentSchedules.java
@@ -26,6 +26,7 @@ import de.metas.inout.ShipmentScheduleId;
 import de.metas.inoutcandidate.api.IShipmentScheduleAllocDAO;
 import de.metas.inoutcandidate.api.InOutGenerateResult;
 import de.metas.inoutcandidate.model.I_M_Picking_Job_Schedule;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.logging.LogManager;
 import de.metas.picking.api.PickingJobScheduleId;
 import de.metas.util.Loggables;
@@ -248,7 +249,9 @@ public class GenerateInOutFromShipmentSchedules extends WorkpackageProcessorAdap
 		shipmentScheduleIdsToClose.addAll(schedules.getShipmentScheduleIdsWithoutJobSchedules());
 		shipmentScheduleIdsToClose.addAll(pickingJobScheduleService.getShipmentScheduleIdsWithAllJobSchedulesProcessedOrMissing(schedules.getShipmentScheduleIdsWithJobSchedules()));
 
-		shipmentScheduleBL.closeShipmentSchedules(shipmentScheduleIdsToClose);
+		final ShipmentScheduleCloseReason closeReason = ShipmentScheduleCloseReason.ofNullableCode(
+				getParameters().getParameterAsString(ShipmentScheduleWorkPackageParameters.PARAM_CloseReason));
+		shipmentScheduleBL.closeShipmentSchedules(shipmentScheduleIdsToClose, closeReason);
 	}
 
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/I_M_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/I_M_ShipmentSchedule.java
@@ -470,6 +470,27 @@ public interface I_M_ShipmentSchedule
 	String COLUMNNAME_Catch_UOM_ID = "Catch_UOM_ID";
 
 	/**
+	 * Set Close Reason.
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setCloseReason (@Nullable java.lang.String CloseReason);
+
+	/**
+	 * Get Close Reason.
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	@Nullable java.lang.String getCloseReason();
+
+	ModelColumn<I_M_ShipmentSchedule, Object> COLUMN_CloseReason = new ModelColumn<>(I_M_ShipmentSchedule.class, "CloseReason", null);
+	String COLUMNNAME_CloseReason = "CloseReason";
+
+	/**
 	 * Set Business Partner.
 	 *
 	 * <br>Type: Search

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/X_M_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/X_M_ShipmentSchedule.java
@@ -346,9 +346,39 @@ public class X_M_ShipmentSchedule extends org.compiere.model.PO implements I_M_S
 	}
 
 	@Override
-	public int getCatch_UOM_ID() 
+	public int getCatch_UOM_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_Catch_UOM_ID);
+	}
+
+	/** Manual = Manual */
+	public static final String CLOSEREASON_Manual = "Manual";
+	/** OrderReactivated = OrderReactivated */
+	public static final String CLOSEREASON_OrderReactivated = "OrderReactivated";
+	/** PartiallyShipped = PartiallyShipped */
+	public static final String CLOSEREASON_PartiallyShipped = "PartiallyShipped";
+	/** InvoiceCandidateClosed = InvoiceCandidateClosed */
+	public static final String CLOSEREASON_InvoiceCandidateClosed = "InvoiceCandidateClosed";
+	/** FlatrateTerm = FlatrateTerm */
+	public static final String CLOSEREASON_FlatrateTerm = "FlatrateTerm";
+	/** ContractPause = ContractPause */
+	public static final String CLOSEREASON_ContractPause = "ContractPause";
+	/** ShipmentProcessed = ShipmentProcessed */
+	public static final String CLOSEREASON_ShipmentProcessed = "ShipmentProcessed";
+	/** PickingRejected = PickingRejected */
+	public static final String CLOSEREASON_PickingRejected = "PickingRejected";
+	/** OutOfStock = OutOfStock */
+	public static final String CLOSEREASON_OutOfStock = "OutOfStock";
+	@Override
+	public void setCloseReason (final @Nullable java.lang.String CloseReason)
+	{
+		set_Value (COLUMNNAME_CloseReason, CloseReason);
+	}
+
+	@Override
+	public java.lang.String getCloseReason()
+	{
+		return get_ValueAsString(COLUMNNAME_CloseReason);
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/X_M_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/X_M_ShipmentSchedule.java
@@ -351,24 +351,24 @@ public class X_M_ShipmentSchedule extends org.compiere.model.PO implements I_M_S
 		return get_ValueAsInt(COLUMNNAME_Catch_UOM_ID);
 	}
 
-	/** Manual = Manual */
-	public static final String CLOSEREASON_Manual = "Manual";
-	/** OrderReactivated = OrderReactivated */
-	public static final String CLOSEREASON_OrderReactivated = "OrderReactivated";
-	/** PartiallyShipped = PartiallyShipped */
-	public static final String CLOSEREASON_PartiallyShipped = "PartiallyShipped";
-	/** InvoiceCandidateClosed = InvoiceCandidateClosed */
-	public static final String CLOSEREASON_InvoiceCandidateClosed = "InvoiceCandidateClosed";
-	/** FlatrateTerm = FlatrateTerm */
-	public static final String CLOSEREASON_FlatrateTerm = "FlatrateTerm";
-	/** ContractPause = ContractPause */
-	public static final String CLOSEREASON_ContractPause = "ContractPause";
-	/** ShipmentProcessed = ShipmentProcessed */
-	public static final String CLOSEREASON_ShipmentProcessed = "ShipmentProcessed";
-	/** PickingRejected = PickingRejected */
-	public static final String CLOSEREASON_PickingRejected = "PickingRejected";
-	/** OutOfStock = OutOfStock */
-	public static final String CLOSEREASON_OutOfStock = "OutOfStock";
+	/** Manual = MA */
+	public static final String CLOSEREASON_Manual = "MA";
+	/** OrderReactivated = OR */
+	public static final String CLOSEREASON_OrderReactivated = "OR";
+	/** PartiallyShipped = PS */
+	public static final String CLOSEREASON_PartiallyShipped = "PS";
+	/** InvoiceCandidateClosed = IC */
+	public static final String CLOSEREASON_InvoiceCandidateClosed = "IC";
+	/** FlatrateTerm = FT */
+	public static final String CLOSEREASON_FlatrateTerm = "FT";
+	/** ContractPause = CP */
+	public static final String CLOSEREASON_ContractPause = "CP";
+	/** ShipmentProcessed = SP */
+	public static final String CLOSEREASON_ShipmentProcessed = "SP";
+	/** PickingRejected = PR */
+	public static final String CLOSEREASON_PickingRejected = "PR";
+	/** OutOfStock = OS */
+	public static final String CLOSEREASON_OutOfStock = "OS";
 	@Override
 	public void setCloseReason (final @Nullable java.lang.String CloseReason)
 	{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleBL.java
@@ -32,6 +32,7 @@ import de.metas.inoutcandidate.api.impl.ShipmentScheduleHeaderAggregationKeyBuil
 import de.metas.inoutcandidate.async.CreateMissingShipmentSchedulesWorkpackageProcessor;
 import de.metas.inoutcandidate.exportaudit.APIExportStatus;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
 import de.metas.process.PInstanceId;
@@ -49,6 +50,7 @@ import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_InOut;
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nullable;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Map;
@@ -114,9 +116,15 @@ public interface IShipmentScheduleBL extends ISingletonService
 	 */
 	void closeShipmentSchedule(I_M_ShipmentSchedule schedule);
 
+	void closeShipmentSchedule(I_M_ShipmentSchedule schedule, @Nullable ShipmentScheduleCloseReason reason);
+
 	void closeShipmentSchedule(ShipmentScheduleId shipmentScheduleId);
 
+	void closeShipmentSchedule(ShipmentScheduleId shipmentScheduleId, @Nullable ShipmentScheduleCloseReason reason);
+
 	void closeShipmentSchedules(@NonNull Set<ShipmentScheduleId> shipmentScheduleIds);
+
+	void closeShipmentSchedules(@NonNull Set<ShipmentScheduleId> shipmentScheduleIds, @Nullable ShipmentScheduleCloseReason reason);
 
 	/**
 	 * Reopen the closed shipment schedule given as parameter
@@ -124,6 +132,8 @@ public interface IShipmentScheduleBL extends ISingletonService
 	void openShipmentSchedule(I_M_ShipmentSchedule shipmentScheduleRecord);
 
 	void closeShipmentSchedulesFor(ImmutableList<TableRecordReference> orderLineRecordRefs);
+
+	void closeShipmentSchedulesFor(ImmutableList<TableRecordReference> orderLineRecordRefs, @Nullable ShipmentScheduleCloseReason reason);
 
 	void openShipmentSchedulesFor(ImmutableList<TableRecordReference> recordRefs);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
@@ -32,6 +32,7 @@ import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
 import de.metas.inoutcandidate.location.ShipmentScheduleLocationsUpdater;
 import de.metas.inoutcandidate.location.adapter.ShipmentScheduleDocumentLocationAdapterFactory;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.lang.SOTrx;
 import de.metas.lock.api.ILockManager;
 import de.metas.logging.LogManager;
@@ -101,6 +102,8 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.Nullable;
 
 import static org.adempiere.model.InterfaceWrapperHelper.createOld;
 import static org.adempiere.model.InterfaceWrapperHelper.isNull;
@@ -317,6 +320,13 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 	@Override
 	public void closeShipmentSchedule(@NonNull final I_M_ShipmentSchedule scheduleRecord)
 	{
+		closeShipmentSchedule(scheduleRecord, null);
+	}
+
+	@Override
+	public void closeShipmentSchedule(@NonNull final I_M_ShipmentSchedule scheduleRecord, @Nullable final ShipmentScheduleCloseReason reason)
+	{
+		scheduleRecord.setCloseReason(ShipmentScheduleCloseReason.toCodeOrNull(reason));
 		scheduleRecord.setIsClosed(true);
 		save(scheduleRecord);
 	}
@@ -324,13 +334,24 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 	@Override
 	public void closeShipmentSchedule(@NonNull final ShipmentScheduleId shipmentScheduleId)
 	{
-		final I_M_ShipmentSchedule shipmentSchedule = shipmentSchedulePA.getById(shipmentScheduleId);
+		closeShipmentSchedule(shipmentScheduleId, null);
+	}
 
-		closeShipmentSchedule(shipmentSchedule);
+	@Override
+	public void closeShipmentSchedule(@NonNull final ShipmentScheduleId shipmentScheduleId, @Nullable final ShipmentScheduleCloseReason reason)
+	{
+		final I_M_ShipmentSchedule shipmentSchedule = shipmentSchedulePA.getById(shipmentScheduleId);
+		closeShipmentSchedule(shipmentSchedule, reason);
 	}
 
 	@Override
 	public void closeShipmentSchedules(@NonNull final Set<ShipmentScheduleId> shipmentScheduleIds)
+	{
+		closeShipmentSchedules(shipmentScheduleIds, null);
+	}
+
+	@Override
+	public void closeShipmentSchedules(@NonNull final Set<ShipmentScheduleId> shipmentScheduleIds, @Nullable final ShipmentScheduleCloseReason reason)
 	{
 		if (shipmentScheduleIds.isEmpty())
 		{
@@ -338,7 +359,7 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 		}
 
 		final Collection<I_M_ShipmentSchedule> shipmentSchedules = shipmentSchedulePA.getByIds(shipmentScheduleIds).values();
-		shipmentSchedules.forEach(this::closeShipmentSchedule);
+		shipmentSchedules.forEach(sched -> closeShipmentSchedule(sched, reason));
 	}
 
 	@Override
@@ -346,6 +367,7 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 	{
 		Check.errorUnless(shipmentScheduleRecord.isClosed(), "The given shipmentSchedule is not closed; shipmentSchedule={}", shipmentScheduleRecord);
 
+		shipmentScheduleRecord.setCloseReason(null);
 		shipmentScheduleRecord.setIsClosed(false);
 		save(shipmentScheduleRecord);
 
@@ -645,6 +667,12 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 	@Override
 	public void closeShipmentSchedulesFor(@NonNull final ImmutableList<TableRecordReference> recordRefs)
 	{
+		closeShipmentSchedulesFor(recordRefs, null);
+	}
+
+	@Override
+	public void closeShipmentSchedulesFor(@NonNull final ImmutableList<TableRecordReference> recordRefs, @Nullable final ShipmentScheduleCloseReason reason)
+	{
 		final ImmutableList<I_M_ShipmentSchedule> records = shipmentSchedulePA.getByReferences(recordRefs);
 		for (final I_M_ShipmentSchedule record : records)
 		{
@@ -658,7 +686,7 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 						MSG_SHIPMENT_SCHEDULE_ALREADY_PROCESSED, record.getM_ShipmentSchedule_ID())
 						.markAsUserValidationError();
 			}
-			closeShipmentSchedule(record);
+			closeShipmentSchedule(record, reason);
 		}
 	}
 
@@ -716,7 +744,7 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 						{
 							logger.debug("inoutLine.MovementQty={} is < shipmentSchedule.qtyOrdered={}; -> closing shipment schedule",
 									iolrecord.getMovementQty(), shipmentScheduleRecord.getQtyOrdered());
-							closeShipmentSchedule(shipmentScheduleRecord);
+							closeShipmentSchedule(shipmentScheduleRecord, ShipmentScheduleCloseReason.PartiallyShipped);
 						}
 						else
 						{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleQtysHelper.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleQtysHelper.java
@@ -1,6 +1,8 @@
 package de.metas.inoutcandidate.api.impl;
 
 import com.google.common.annotations.VisibleForTesting;
+import de.metas.ad_reference.ADReferenceService;
+import de.metas.ad_reference.ReferenceId;
 import de.metas.i18n.IMsgBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleAllocDAO;
 import de.metas.inoutcandidate.api.IShipmentScheduleEffectiveBL;
@@ -50,6 +52,8 @@ import java.math.BigDecimal;
 
 	@VisibleForTesting
 	static final String MSG_ClosedStatus = "ShipmentSchedule_Closed_Status";
+
+	private static final ReferenceId CLOSEREASON_AD_Reference_ID = ReferenceId.ofRepoId(542061);
 
 	private static final Logger logger = LogManager.getLogger(ShipmentScheduleQtysHelper.class);
 
@@ -117,7 +121,8 @@ import java.math.BigDecimal;
 			final String closedMsg = Services.get(IMsgBL.class).getMsg(Env.getCtx(), MSG_ClosedStatus);
 			if (closeReason != null)
 			{
-				statusMessages.append(closedMsg).append(" (").append(closeReason.getCode()).append(")").append("\n");
+				final String closeReasonLabel = ADReferenceService.get().retrieveListNameTrl(Env.getCtx(), CLOSEREASON_AD_Reference_ID, closeReason.getCode());
+				statusMessages.append(closedMsg).append(" (").append(closeReasonLabel).append(")").append("\n");
 			}
 			else
 			{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleQtysHelper.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleQtysHelper.java
@@ -6,6 +6,7 @@ import de.metas.inoutcandidate.api.IShipmentScheduleAllocDAO;
 import de.metas.inoutcandidate.api.IShipmentScheduleEffectiveBL;
 import de.metas.inoutcandidate.api.OlAndSched;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.logging.LogManager;
 import de.metas.order.DeliveryRule;
 import de.metas.util.Services;
@@ -112,7 +113,16 @@ import java.math.BigDecimal;
 		}
 		if (sched.isClosed())
 		{
-			statusMessages.append(Services.get(IMsgBL.class).getMsg(Env.getCtx(), MSG_ClosedStatus) + "\n");
+			final ShipmentScheduleCloseReason closeReason = ShipmentScheduleCloseReason.ofNullableCode(sched.getCloseReason());
+			final String closedMsg = Services.get(IMsgBL.class).getMsg(Env.getCtx(), MSG_ClosedStatus);
+			if (closeReason != null)
+			{
+				statusMessages.append(closedMsg).append(" (").append(closeReason.getCode()).append(")").append("\n");
+			}
+			else
+			{
+				statusMessages.append(closedMsg).append("\n");
+			}
 		}
 		logger.debug("isClosed={}; isDeliveryStop={}; -> set QtyToDeliver to zero", sched.isClosed(), sched.isDeliveryStop());
 		sched.setQtyToDeliver(BigDecimal.ZERO);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/model/ShipmentScheduleCloseReason.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/model/ShipmentScheduleCloseReason.java
@@ -1,0 +1,57 @@
+package de.metas.inoutcandidate.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import de.metas.util.lang.ReferenceListAwareEnum;
+import de.metas.util.lang.ReferenceListAwareEnums;
+import de.metas.util.lang.ReferenceListAwareEnums.ValuesIndex;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import javax.annotation.Nullable;
+
+@RequiredArgsConstructor
+@Getter
+public enum ShipmentScheduleCloseReason implements ReferenceListAwareEnum
+{
+	Manual(X_M_ShipmentSchedule.CLOSEREASON_Manual),
+	OrderReactivated(X_M_ShipmentSchedule.CLOSEREASON_OrderReactivated),
+	PartiallyShipped(X_M_ShipmentSchedule.CLOSEREASON_PartiallyShipped),
+	InvoiceCandidateClosed(X_M_ShipmentSchedule.CLOSEREASON_InvoiceCandidateClosed),
+	FlatrateTerm(X_M_ShipmentSchedule.CLOSEREASON_FlatrateTerm),
+	ContractPause(X_M_ShipmentSchedule.CLOSEREASON_ContractPause),
+	ShipmentProcessed(X_M_ShipmentSchedule.CLOSEREASON_ShipmentProcessed),
+	PickingRejected(X_M_ShipmentSchedule.CLOSEREASON_PickingRejected),
+	OutOfStock(X_M_ShipmentSchedule.CLOSEREASON_OutOfStock),
+	;
+
+	@NonNull private static final ValuesIndex<ShipmentScheduleCloseReason> index = ReferenceListAwareEnums.index(values());
+
+	@NonNull private final String code;
+
+	@JsonCreator
+	@NonNull
+	public static ShipmentScheduleCloseReason ofCode(@NonNull final String code)
+	{
+		return index.ofCode(code);
+	}
+
+	@Nullable
+	public static ShipmentScheduleCloseReason ofNullableCode(@Nullable final String code)
+	{
+		return code != null ? ofCode(code) : null;
+	}
+
+	@Nullable
+	public static String toCodeOrNull(@Nullable final ShipmentScheduleCloseReason reason)
+	{
+		return reason != null ? reason.getCode() : null;
+	}
+
+	@JsonValue
+	public String toJson()
+	{
+		return code;
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order_ShipmentSchedule.java
@@ -8,6 +8,7 @@ import de.metas.inout.ShipmentScheduleId;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.api.IShipmentSchedulePA;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateRepository;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.order.IOrderDAO;
 import de.metas.order.OrderAndLineId;
@@ -50,7 +51,7 @@ public class C_Order_ShipmentSchedule
 				.map(orderLineId -> TableRecordReference.of(I_C_OrderLine.Table_Name, orderLineId))
 				.collect(ImmutableList.toImmutableList());
 
-		shipmentScheduleBL.closeShipmentSchedulesFor(orderLineRecordRefs);
+		shipmentScheduleBL.closeShipmentSchedulesFor(orderLineRecordRefs, ShipmentScheduleCloseReason.OrderReactivated);
 	}
 
 	@DocValidate(timings = ModelValidator.TIMING_AFTER_COMPLETE)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedules.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedules.java
@@ -33,6 +33,7 @@ import org.adempiere.exceptions.AdempiereException;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.api.IShipmentSchedulePA;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.process.JavaProcess;
 import de.metas.util.Services;
 
@@ -63,7 +64,7 @@ public class M_ShipmentSchedule_CloseShipmentSchedules extends JavaProcess
 		{
 			final I_M_ShipmentSchedule schedule = schedulesToUpdateIterator.next();
 
-			shipmentScheduleBL.closeShipmentSchedule(schedule);
+			shipmentScheduleBL.closeShipmentSchedule(schedule, ShipmentScheduleCloseReason.Manual);
 		}
 
 		return MSG_OK;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/OrderAndInOutInvoiceCandidateListener.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/OrderAndInOutInvoiceCandidateListener.java
@@ -4,6 +4,7 @@ import de.metas.inoutcandidate.api.IReceiptScheduleBL;
 import de.metas.inoutcandidate.api.IReceiptScheduleDAO;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.api.IShipmentSchedulePA;
+import de.metas.inoutcandidate.model.ShipmentScheduleCloseReason;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.invoicecandidate.spi.IInvoiceCandidateListener;
 import de.metas.util.Services;
@@ -38,7 +39,7 @@ public final class OrderAndInOutInvoiceCandidateListener implements IInvoiceCand
 		shipmentSchedulesRepo.retrieveForInvoiceCandidate(candidate)
 				.stream()
 				.filter(shipmentSchedule -> !shipmentSchedule.isClosed())
-				.forEach(shipmentSchedulesService::closeShipmentSchedule);
+				.forEach(shipmentSchedule -> shipmentSchedulesService.closeShipmentSchedule(shipmentSchedule, ShipmentScheduleCloseReason.InvoiceCandidateClosed));
 	}
 
 	private void closeReceiptCandidates(final I_C_Invoice_Candidate candidate)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5791000_M_ShipmentSchedule_CloseReason.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5791000_M_ShipmentSchedule_CloseReason.sql
@@ -1,0 +1,290 @@
+-- 2026-03-02
+-- https://github.com/metasfresh/me03/issues/27550
+-- M_ShipmentSchedule.CloseReason: tracks why a shipment schedule was closed
+
+-- 1) AD_Element: CloseReason
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,584599,0,'CloseReason',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Schlussgrund','Schlussgrund',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=584599
+AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Schlussgrund', PrintName='Schlussgrund', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=584599 AND AD_Language IN ('de_DE', 'de_CH')
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Close Reason', PrintName='Close Reason', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=584599 AND AD_Language='en_US'
+;
+
+-- 2) AD_Reference (List): M_ShipmentSchedule_CloseReason
+INSERT INTO AD_Reference (AD_Client_ID,AD_Org_ID,AD_Reference_ID,Created,CreatedBy,EntityType,IsActive,IsOrderByValue,Name,Updated,UpdatedBy,ValidationType)
+VALUES (0,0,542061,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','N','M_ShipmentSchedule_CloseReason',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'L')
+;
+
+INSERT INTO AD_Reference_Trl (AD_Language,AD_Reference_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Reference_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Reference t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Reference_ID=542061
+AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
+;
+
+-- 3) AD_Ref_List values (9 reasons)
+-- 3a) Manual
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,542061,544135,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Manuell',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Manual','Manual')
+;
+
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Ref_List_ID=544135
+AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544135 AND AD_Language IN ('de_DE', 'de_CH')
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Manual', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544135 AND AD_Language='en_US'
+;
+
+-- 3b) OrderReactivated
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,542061,544136,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Bestellung reaktiviert',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'OrderReactivated','OrderReactivated')
+;
+
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Ref_List_ID=544136
+AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544136 AND AD_Language IN ('de_DE', 'de_CH')
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Order Reactivated', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544136 AND AD_Language='en_US'
+;
+
+-- 3c) PartiallyShipped
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,542061,544137,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Teilweise geliefert',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'PartiallyShipped','PartiallyShipped')
+;
+
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Ref_List_ID=544137
+AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544137 AND AD_Language IN ('de_DE', 'de_CH')
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Partially Shipped', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544137 AND AD_Language='en_US'
+;
+
+-- 3d) InvoiceCandidateClosed
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,542061,544138,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Rechnungskandidat geschlossen',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'InvoiceCandidateClosed','InvoiceCandidateClosed')
+;
+
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Ref_List_ID=544138
+AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544138 AND AD_Language IN ('de_DE', 'de_CH')
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Invoice Candidate Closed', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544138 AND AD_Language='en_US'
+;
+
+-- 3e) FlatrateTerm
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,542061,544139,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Pauschalvertrag',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'FlatrateTerm','FlatrateTerm')
+;
+
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Ref_List_ID=544139
+AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544139 AND AD_Language IN ('de_DE', 'de_CH')
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Flatrate Term', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544139 AND AD_Language='en_US'
+;
+
+-- 3f) ContractPause
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,542061,544140,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Vertragspause',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'ContractPause','ContractPause')
+;
+
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Ref_List_ID=544140
+AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544140 AND AD_Language IN ('de_DE', 'de_CH')
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Contract Pause', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544140 AND AD_Language='en_US'
+;
+
+-- 3g) ShipmentProcessed
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,542061,544141,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Lieferung verarbeitet',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'ShipmentProcessed','ShipmentProcessed')
+;
+
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Ref_List_ID=544141
+AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544141 AND AD_Language IN ('de_DE', 'de_CH')
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Shipment Processed', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544141 AND AD_Language='en_US'
+;
+
+-- 3h) PickingRejected
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,542061,544142,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Kommissionierung abgelehnt',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'PickingRejected','PickingRejected')
+;
+
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Ref_List_ID=544142
+AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544142 AND AD_Language IN ('de_DE', 'de_CH')
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Picking Rejected', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544142 AND AD_Language='en_US'
+;
+
+-- 3i) OutOfStock
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,542061,544143,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Nicht auf Lager',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'OutOfStock','OutOfStock')
+;
+
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Ref_List_ID=544143
+AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544143 AND AD_Language IN ('de_DE', 'de_CH')
+;
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Out of Stock', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544143 AND AD_Language='en_US'
+;
+
+-- 4) AD_Column on M_ShipmentSchedule (AD_Table_ID=500221)
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,
+    ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FacetFilterSeqNo,FieldLength,
+    IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,
+    IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsFacetFilter,IsForceIncludeInGeneratedModel,
+    IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,
+    IsRangeFilter,IsSelectionColumn,IsShowFilterIncrementButtons,IsStaleable,IsSyncDatabase,IsTranslated,
+    IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,PersonalDataCategory,SelectionColumnSeqNo,SeqNo,
+    Updated,UpdatedBy,Version)
+VALUES (0,592115,584599,0,17,542061,500221,
+    'CloseReason',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.inoutcandidate',0,40,
+    'Y','N','Y','N','N','N',
+    'N','N','N','N','N','N',
+    'N','N','N','N','N','N','N',
+    'N','N','N','N','N','N',
+    'Y','N',0,'Schlussgrund','NP',0,0,
+    TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=592115
+AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+/* DDL */ SELECT update_Column_Translation_From_AD_Element(584599)
+;
+
+-- 5) DDL: add column to table (using db_alter_table wrapper)
+/* DDL */ SELECT public.db_alter_table('M_ShipmentSchedule','ALTER TABLE public.M_ShipmentSchedule ADD COLUMN CloseReason VARCHAR(40)')
+;
+
+-- 6) Check constraint for List reference column
+/* DDL */ SELECT public.db_alter_table('M_ShipmentSchedule',
+    $$ADD CONSTRAINT CloseReason_Check CHECK (CloseReason IS NULL OR CloseReason IN ('Manual','OrderReactivated','PartiallyShipped','InvoiceCandidateClosed','FlatrateTerm','ContractPause','ShipmentProcessed','PickingRejected','OutOfStock'))$$)
+;
+
+-- 7) AD_Field on tab 500221
+INSERT INTO AD_Field (AD_Tab_ID,IsDisplayed,DisplayLength,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,IsActive,
+    Created,CreatedBy,IsReadOnly,Updated,UpdatedBy,AD_Field_ID,AD_Column_ID,Name,AD_Org_ID,EntityType)
+VALUES (500221,'Y',40,'N','N','N','N',0,'Y',
+    TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Y',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,774764,592115,'Schlussgrund',0,'de.metas.inoutcandidate')
+;
+
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Help,Name,Description, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Help,t.Name,t.Description, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Field_ID=774764
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584599)
+;
+
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=774764
+;
+
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(774764)
+;
+
+-- 8) AD_UI_Element: between IsClosed (SeqNo=50) and Status (SeqNo=60), read-only
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,
+    AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,
+    Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,774764,0,500221,540972,648455,
+    'F',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','N','N',
+    'Schlussgrund',55,0,0,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 9) Final propagation: re-run after all AD_Field_Trl rows exist
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584599)
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5791000_M_ShipmentSchedule_CloseReason.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5791000_M_ShipmentSchedule_CloseReason.sql
@@ -37,7 +37,7 @@ AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Lang
 -- 3) AD_Ref_List values (9 reasons)
 -- 3a) Manual
 INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
-VALUES (0,0,542061,544135,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Manuell',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Manual','Manual')
+VALUES (0,0,542061,544135,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Manuell',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'MA','MA')
 ;
 
 INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
@@ -57,7 +57,7 @@ WHERE AD_Ref_List_ID=544135 AND AD_Language='en_US'
 
 -- 3b) OrderReactivated
 INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
-VALUES (0,0,542061,544136,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Bestellung reaktiviert',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'OrderReactivated','OrderReactivated')
+VALUES (0,0,542061,544136,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Bestellung reaktiviert',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'OR','OR')
 ;
 
 INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
@@ -77,7 +77,7 @@ WHERE AD_Ref_List_ID=544136 AND AD_Language='en_US'
 
 -- 3c) PartiallyShipped
 INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
-VALUES (0,0,542061,544137,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Teilweise geliefert',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'PartiallyShipped','PartiallyShipped')
+VALUES (0,0,542061,544137,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Teilweise geliefert',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'PS','PS')
 ;
 
 INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
@@ -97,7 +97,7 @@ WHERE AD_Ref_List_ID=544137 AND AD_Language='en_US'
 
 -- 3d) InvoiceCandidateClosed
 INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
-VALUES (0,0,542061,544138,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Rechnungskandidat geschlossen',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'InvoiceCandidateClosed','InvoiceCandidateClosed')
+VALUES (0,0,542061,544138,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Rechnungskandidat geschlossen',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'IC','IC')
 ;
 
 INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
@@ -117,7 +117,7 @@ WHERE AD_Ref_List_ID=544138 AND AD_Language='en_US'
 
 -- 3e) FlatrateTerm
 INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
-VALUES (0,0,542061,544139,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Pauschalvertrag',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'FlatrateTerm','FlatrateTerm')
+VALUES (0,0,542061,544139,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Pauschalvertrag',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'FT','FT')
 ;
 
 INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
@@ -137,7 +137,7 @@ WHERE AD_Ref_List_ID=544139 AND AD_Language='en_US'
 
 -- 3f) ContractPause
 INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
-VALUES (0,0,542061,544140,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Vertragspause',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'ContractPause','ContractPause')
+VALUES (0,0,542061,544140,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Vertragspause',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'CP','CP')
 ;
 
 INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
@@ -157,7 +157,7 @@ WHERE AD_Ref_List_ID=544140 AND AD_Language='en_US'
 
 -- 3g) ShipmentProcessed
 INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
-VALUES (0,0,542061,544141,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Lieferung verarbeitet',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'ShipmentProcessed','ShipmentProcessed')
+VALUES (0,0,542061,544141,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Lieferung verarbeitet',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'SP','SP')
 ;
 
 INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
@@ -177,7 +177,7 @@ WHERE AD_Ref_List_ID=544141 AND AD_Language='en_US'
 
 -- 3h) PickingRejected
 INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
-VALUES (0,0,542061,544142,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Kommissionierung abgelehnt',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'PickingRejected','PickingRejected')
+VALUES (0,0,542061,544142,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Kommissionierung abgelehnt',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'PR','PR')
 ;
 
 INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
@@ -197,7 +197,7 @@ WHERE AD_Ref_List_ID=544142 AND AD_Language='en_US'
 
 -- 3i) OutOfStock
 INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName)
-VALUES (0,0,542061,544143,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Nicht auf Lager',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'OutOfStock','OutOfStock')
+VALUES (0,0,542061,544143,TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Nicht auf Lager',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'OS','OS')
 ;
 
 INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
@@ -225,7 +225,7 @@ INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Refe
     IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,PersonalDataCategory,SelectionColumnSeqNo,SeqNo,
     Updated,UpdatedBy,Version)
 VALUES (0,592115,584599,0,17,542061,500221,
-    'CloseReason',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.inoutcandidate',0,40,
+    'CloseReason',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.inoutcandidate',0,2,
     'Y','N','Y','N','N','N',
     'N','N','N','N','N','N',
     'N','N','N','N','N','N','N',
@@ -245,18 +245,18 @@ AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Languag
 ;
 
 -- 5) DDL: add column to table (using db_alter_table wrapper)
-/* DDL */ SELECT public.db_alter_table('M_ShipmentSchedule','ALTER TABLE public.M_ShipmentSchedule ADD COLUMN CloseReason VARCHAR(40)')
+/* DDL */ SELECT public.db_alter_table('M_ShipmentSchedule','ALTER TABLE public.M_ShipmentSchedule ADD COLUMN CloseReason VARCHAR(2)')
 ;
 
 -- 6) Check constraint for List reference column
 /* DDL */ SELECT public.db_alter_table('M_ShipmentSchedule',
-    $$ALTER TABLE public.M_ShipmentSchedule ADD CONSTRAINT CloseReason_Check CHECK (CloseReason IS NULL OR CloseReason IN ('Manual','OrderReactivated','PartiallyShipped','InvoiceCandidateClosed','FlatrateTerm','ContractPause','ShipmentProcessed','PickingRejected','OutOfStock'))$$)
+    $$ALTER TABLE public.M_ShipmentSchedule ADD CONSTRAINT CloseReason_Check CHECK (CloseReason IS NULL OR CloseReason IN ('MA','OR','PS','IC','FT','CP','SP','PR','OS'))$$)
 ;
 
 -- 7) AD_Field on tab 500221
 INSERT INTO AD_Field (AD_Tab_ID,IsDisplayed,DisplayLength,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,IsActive,
     Created,CreatedBy,IsReadOnly,Updated,UpdatedBy,AD_Field_ID,AD_Column_ID,Name,AD_Org_ID,EntityType)
-VALUES (500221,'Y',40,'N','N','N','N',0,'Y',
+VALUES (500221,'Y',2,'N','N','N','N',0,'Y',
     TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Y',TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,774764,592115,'Schlussgrund',0,'de.metas.inoutcandidate')
 ;
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5791000_M_ShipmentSchedule_CloseReason.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5791000_M_ShipmentSchedule_CloseReason.sql
@@ -250,7 +250,7 @@ AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Languag
 
 -- 6) Check constraint for List reference column
 /* DDL */ SELECT public.db_alter_table('M_ShipmentSchedule',
-    $$ADD CONSTRAINT CloseReason_Check CHECK (CloseReason IS NULL OR CloseReason IN ('Manual','OrderReactivated','PartiallyShipped','InvoiceCandidateClosed','FlatrateTerm','ContractPause','ShipmentProcessed','PickingRejected','OutOfStock'))$$)
+    $$ALTER TABLE public.M_ShipmentSchedule ADD CONSTRAINT CloseReason_Check CHECK (CloseReason IS NULL OR CloseReason IN ('Manual','OrderReactivated','PartiallyShipped','InvoiceCandidateClosed','FlatrateTerm','ContractPause','ShipmentProcessed','PickingRejected','OutOfStock'))$$)
 ;
 
 -- 7) AD_Field on tab 500221

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5791000_M_ShipmentSchedule_CloseReason.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5791000_M_ShipmentSchedule_CloseReason.sql
@@ -47,7 +47,7 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t
 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
 ;
 
-UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Manuell', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Ref_List_ID=544135 AND AD_Language IN ('de_DE', 'de_CH')
 ;
 
@@ -67,7 +67,7 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t
 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
 ;
 
-UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Bestellung reaktiviert', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Ref_List_ID=544136 AND AD_Language IN ('de_DE', 'de_CH')
 ;
 
@@ -87,7 +87,7 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t
 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
 ;
 
-UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Teilweise geliefert', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Ref_List_ID=544137 AND AD_Language IN ('de_DE', 'de_CH')
 ;
 
@@ -107,7 +107,7 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t
 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
 ;
 
-UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Rechnungskandidat geschlossen', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Ref_List_ID=544138 AND AD_Language IN ('de_DE', 'de_CH')
 ;
 
@@ -127,7 +127,7 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t
 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
 ;
 
-UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Pauschalvertrag', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Ref_List_ID=544139 AND AD_Language IN ('de_DE', 'de_CH')
 ;
 
@@ -147,7 +147,7 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t
 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
 ;
 
-UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Vertragspause', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Ref_List_ID=544140 AND AD_Language IN ('de_DE', 'de_CH')
 ;
 
@@ -167,7 +167,7 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t
 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
 ;
 
-UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Lieferung verarbeitet', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Ref_List_ID=544141 AND AD_Language IN ('de_DE', 'de_CH')
 ;
 
@@ -187,7 +187,7 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t
 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
 ;
 
-UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Kommissionierung abgelehnt', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Ref_List_ID=544142 AND AD_Language IN ('de_DE', 'de_CH')
 ;
 
@@ -207,7 +207,7 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t
 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
 ;
 
-UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Nicht auf Lager', Updated=TO_TIMESTAMP('2026-03-02 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Ref_List_ID=544143 AND AD_Language IN ('de_DE', 'de_CH')
 ;
 


### PR DESCRIPTION
## Summary
- Adds a `CloseReason` list column on `M_ShipmentSchedule` with 9 values using short 2-char codes (MA, OR, PS, IC, FT, CP, SP, PR, OS) to minimize disk space on this high-volume table
- All close callers now pass a semantic reason; reason is cleared on reopen
- Status text displays the translated close reason label in parentheses (e.g., "Lieferdispo-Datensatz geschlossen (Bestellung reaktiviert)")
- New `ShipmentScheduleCloseReason` enum (ReferenceListAwareEnum) + full AD metadata migration (AD_Reference, AD_Ref_List with DE/EN translations, AD_Column VARCHAR(2), AD_Field read-only, AD_UI_Element SeqNo 55)
- Backward compatible: existing closed records without a CloseReason continue to show the generic status text
- 3 Cucumber integration tests covering order reactivation, manual close, and reopen

## Close Reason Values

| Code | German | English |
|------|--------|---------|
| `MA` | Manuell | Manual |
| `OR` | Bestellung reaktiviert | Order Reactivated |
| `PS` | Teilweise geliefert | Partially Shipped |
| `IC` | Rechnungskandidat geschlossen | Invoice Candidate Closed |
| `FT` | Pauschalvertrag | Flatrate Term |
| `CP` | Vertragspause | Contract Pause |
| `SP` | Lieferung verarbeitet | Shipment Processed |
| `PR` | Kommissionierung abgelehnt | Picking Rejected |
| `OS` | Nicht auf Lager | Out of Stock |

## Test plan
- [ ] Reactivate a completed sales order → verify shipment schedule shows `IsClosed=Y`, `CloseReason=OR`, status text includes "(Bestellung reaktiviert)"
- [ ] Manually close a shipment schedule via process → verify `CloseReason=MA`
- [ ] Reopen a closed shipment schedule → verify `CloseReason` is cleared to NULL
- [ ] Verify CloseReason field is visible and read-only in Shipment Schedule window (between IsClosed and Status)
- [ ] Existing closed records without CloseReason → generic "Lieferdispo-Datensatz geschlossen" without parenthetical reason (backward compat)
- [ ] Check German and English UI for correct translated labels in the Status text
- [ ] Cucumber tests pass: `shipmentScheduleCloseReason.feature` (S27550_100, S27550_200, S27550_300)