### PR TITLE
Propagate packing item, TU qty, and ASI from SO to purchase candidate and PO

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5791950_sys_C_PurchaseCandidate_HU_columns.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5791950_sys_C_PurchaseCandidate_HU_columns.sql
@@ -1,0 +1,11 @@
+-- C_PurchaseCandidate: add M_HU_PI_Item_Product_ID and QtyEnteredTU columns
+-- to transfer packing instructions and TU quantities from SO line to purchase candidate and PO.
+
+-- Column: M_HU_PI_Item_Product_ID
+ALTER TABLE C_PurchaseCandidate ADD COLUMN IF NOT EXISTS M_HU_PI_Item_Product_ID NUMERIC(10);
+
+ALTER TABLE C_PurchaseCandidate ADD CONSTRAINT IF NOT EXISTS mhupiitemproduct_cpurchasecandidate
+    FOREIGN KEY (M_HU_PI_Item_Product_ID) REFERENCES M_HU_PI_Item_Product(M_HU_PI_Item_Product_ID);
+
+-- Column: QtyEnteredTU
+ALTER TABLE C_PurchaseCandidate ADD COLUMN IF NOT EXISTS QtyEnteredTU NUMERIC;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5791950_sys_C_PurchaseCandidate_HU_columns.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5791950_sys_C_PurchaseCandidate_HU_columns.sql
@@ -1,16 +1,91 @@
--- C_PurchaseCandidate: add M_HU_PI_Item_Product_ID and QtyEnteredTU columns
--- to transfer packing instructions and TU quantities from SO line to purchase candidate and PO.
+-- Run mode: SWING_CLIENT
 
--- Column: M_HU_PI_Item_Product_ID
-ALTER TABLE C_PurchaseCandidate ADD COLUMN IF NOT EXISTS M_HU_PI_Item_Product_ID NUMERIC(10);
+-- Column: C_PurchaseCandidate.M_HU_PI_Item_Product_ID
+-- 2026-03-05T15:17:31.440Z
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID, CloningStrategy, ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo, FieldLength, IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule, IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted,
+                       IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn, IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent, IsRestAPICustomColumn, IsSelectionColumn, IsShowFilterInactiveValues, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable, IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence,
+                       MaxFacetsToFetch, Name, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592169, 542132, 0, 19, 540861, 'XX', 'M_HU_PI_Item_Product_ID', TO_TIMESTAMP('2026-03-05 15:17:31.169000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'N', 'de.metas.purchasecandidate', 0, 10, 'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'Y', 'N', 0,
+        'Packvorschrift', 0, 0, TO_TIMESTAMP('2026-03-05 15:17:31.169000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 0)
+;
 
-DO $$
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'mhupiitemproduct_cpurchasecandidate') THEN
-        ALTER TABLE C_PurchaseCandidate ADD CONSTRAINT mhupiitemproduct_cpurchasecandidate
-            FOREIGN KEY (M_HU_PI_Item_Product_ID) REFERENCES M_HU_PI_Item_Product(M_HU_PI_Item_Product_ID);
-    END IF;
-END $$;
+-- 2026-03-05T15:17:31.446Z
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language,
+       t.AD_Column_ID,
+       t.Name,
+       'N',
+       t.AD_Client_ID,
+       t.AD_Org_ID,
+       t.Created,
+       t.Createdby,
+       t.Updated,
+       t.UpdatedBy,
+       'Y'
+FROM AD_Language l,
+     AD_Column t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592169
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID)
+;
 
--- Column: QtyEnteredTU
-ALTER TABLE C_PurchaseCandidate ADD COLUMN IF NOT EXISTS QtyEnteredTU NUMERIC;
+-- 2026-03-05T15:17:31.470Z
+/* DDL */
+
+SELECT update_Column_Translation_From_AD_Element(542132)
+;
+
+-- 2026-03-05T15:18:28.366Z
+/* DDL */
+
+SELECT public.db_alter_table('C_PurchaseCandidate', 'ALTER TABLE public.C_PurchaseCandidate ADD COLUMN M_HU_PI_Item_Product_ID NUMERIC(10)')
+;
+
+-- 2026-03-05T15:18:28.481Z
+ALTER TABLE C_PurchaseCandidate
+    ADD CONSTRAINT MHUPIItemProduct_CPurchaseCandidate FOREIGN KEY (M_HU_PI_Item_Product_ID) REFERENCES public.M_HU_PI_Item_Product DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Column: C_PurchaseCandidate.QtyEnteredTU
+-- 2026-03-05T15:19:09.629Z
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID, CloningStrategy, ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo, FieldLength, IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule, IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted,
+                       IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn, IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent, IsRestAPICustomColumn, IsSelectionColumn, IsShowFilterInactiveValues, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable, IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence,
+                       MaxFacetsToFetch, Name, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592170, 542397, 0, 29, 540861, 'XX', 'QtyEnteredTU', TO_TIMESTAMP('2026-03-05 15:19:09.484000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'N', 'de.metas.purchasecandidate', 0, 10, 'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'Y', 'N', 0, 'Menge TU', 0,
+        0, TO_TIMESTAMP('2026-03-05 15:19:09.484000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 0)
+;
+
+-- 2026-03-05T15:19:09.631Z
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language,
+       t.AD_Column_ID,
+       t.Name,
+       'N',
+       t.AD_Client_ID,
+       t.AD_Org_ID,
+       t.Created,
+       t.Createdby,
+       t.Updated,
+       t.UpdatedBy,
+       'Y'
+FROM AD_Language l,
+     AD_Column t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592170
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID)
+;
+
+-- 2026-03-05T15:19:09.723Z
+/* DDL */
+
+SELECT update_Column_Translation_From_AD_Element(542397)
+;
+
+-- 2026-03-05T15:19:11.572Z
+/* DDL */
+
+SELECT public.db_alter_table('C_PurchaseCandidate', 'ALTER TABLE public.C_PurchaseCandidate ADD COLUMN QtyEnteredTU NUMERIC')
+;
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5791950_sys_C_PurchaseCandidate_HU_columns.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5791950_sys_C_PurchaseCandidate_HU_columns.sql
@@ -89,3 +89,171 @@ SELECT update_Column_Translation_From_AD_Element(542397)
 SELECT public.db_alter_table('C_PurchaseCandidate', 'ALTER TABLE public.C_PurchaseCandidate ADD COLUMN QtyEnteredTU NUMERIC')
 ;
 
+-- Field: Bestelldisposition(540375,de.metas.purchasecandidate) -> Bestelldisposition(540894,de.metas.purchasecandidate) -> Packvorschrift
+-- Column: C_PurchaseCandidate.M_HU_PI_Item_Product_ID
+-- 2026-03-05T15:33:10.369Z
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength, Created, CreatedBy, DisplayLength, EntityType, FacetFilterSeqNo, IncludedTabHeight, IsActive, IsDisplayed, IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsHideGridColumnIfEmpty, IsOverrideFilterDefaultValue, IsReadOnly, IsSameLine, MaxFacetsToFetch, Name, SelectionColumnSeqNo, SeqNo,
+                      SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592169, 774827, 0, 540894, 0, TO_TIMESTAMP('2026-03-05 15:33:10.160000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 0, 'U', 0, 0, 'Y', 'Y', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 0, 'Packvorschrift', 0, 0, 380, 0, 1, 1, TO_TIMESTAMP('2026-03-05 15:33:10.160000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100)
+;
+
+-- 2026-03-05T15:33:10.375Z
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language,
+       t.AD_Field_ID,
+       t.Description,
+       t.Help,
+       t.Name,
+       'N',
+       t.AD_Client_ID,
+       t.AD_Org_ID,
+       t.Created,
+       t.Createdby,
+       t.Updated,
+       t.UpdatedBy,
+       'Y'
+FROM AD_Language l,
+     AD_Field t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Field_ID = 774827
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID)
+;
+
+-- 2026-03-05T15:33:10.400Z
+/* DDL */
+
+SELECT update_FieldTranslation_From_AD_Name_Element(542132)
+;
+
+-- 2026-03-05T15:33:10.412Z
+DELETE
+FROM AD_Element_Link
+WHERE AD_Field_ID = 774827
+;
+
+-- 2026-03-05T15:33:10.414Z
+/* DDL */
+
+SELECT AD_Element_Link_Create_Missing_Field(774827)
+;
+
+-- Field: Bestelldisposition(540375,de.metas.purchasecandidate) -> Bestelldisposition(540894,de.metas.purchasecandidate) -> Menge TU
+-- Column: C_PurchaseCandidate.QtyEnteredTU
+-- 2026-03-05T15:33:16.280Z
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength, Created, CreatedBy, DisplayLength, EntityType, FacetFilterSeqNo, IncludedTabHeight, IsActive, IsDisplayed, IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsHideGridColumnIfEmpty, IsOverrideFilterDefaultValue, IsReadOnly, IsSameLine, MaxFacetsToFetch, Name, SelectionColumnSeqNo, SeqNo,
+                      SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592170, 774828, 0, 540894, 0, TO_TIMESTAMP('2026-03-05 15:33:16.162000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 0, 'U', 0, 0, 'Y', 'Y', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 0, 'Menge TU', 0, 0, 390, 0, 1, 1, TO_TIMESTAMP('2026-03-05 15:33:16.162000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100)
+;
+
+-- 2026-03-05T15:33:16.282Z
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language,
+       t.AD_Field_ID,
+       t.Description,
+       t.Help,
+       t.Name,
+       'N',
+       t.AD_Client_ID,
+       t.AD_Org_ID,
+       t.Created,
+       t.Createdby,
+       t.Updated,
+       t.UpdatedBy,
+       'Y'
+FROM AD_Language l,
+     AD_Field t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Field_ID = 774828
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID)
+;
+
+-- 2026-03-05T15:33:16.283Z
+/* DDL */
+
+SELECT update_FieldTranslation_From_AD_Name_Element(542397)
+;
+
+-- 2026-03-05T15:33:16.286Z
+DELETE
+FROM AD_Element_Link
+WHERE AD_Field_ID = 774828
+;
+
+-- 2026-03-05T15:33:16.287Z
+/* DDL */
+
+SELECT AD_Element_Link_Create_Missing_Field(774828)
+;
+
+-- UI Element: Bestelldisposition(540375,de.metas.purchasecandidate) -> Bestelldisposition(540894,de.metas.purchasecandidate) -> main -> 10 -> default.Abweichende Lieferadresse
+-- Column: C_PurchaseCandidate.IsDropShip
+-- 2026-03-05T15:34:05.914Z
+UPDATE AD_UI_Element
+SET SeqNo=70, Updated=TO_TIMESTAMP('2026-03-05 15:34:05.914000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_UI_Element_ID = 648472
+;
+
+-- UI Element: Bestelldisposition(540375,de.metas.purchasecandidate) -> Bestelldisposition(540894,de.metas.purchasecandidate) -> main -> 10 -> default.Lieferempfänger
+-- Column: C_PurchaseCandidate.DropShip_BPartner_ID
+-- 2026-03-05T15:34:10.096Z
+UPDATE AD_UI_Element
+SET SeqNo=80, Updated=TO_TIMESTAMP('2026-03-05 15:34:10.096000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_UI_Element_ID = 648473
+;
+
+-- UI Element: Bestelldisposition(540375,de.metas.purchasecandidate) -> Bestelldisposition(540894,de.metas.purchasecandidate) -> main -> 10 -> default.Menge TU
+-- Column: C_PurchaseCandidate.QtyEnteredTU
+-- 2026-03-05T15:34:31.407Z
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774828, 0, 540894, 541247, 648474, 'F', TO_TIMESTAMP('2026-03-05 15:34:31.270000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'Y', 'N', 'N', 'Y', 'N', 'N', 'N', 0, 'Menge TU', 90, 0, 0, TO_TIMESTAMP('2026-03-05 15:34:31.270000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100)
+;
+
+-- UI Element: Bestelldisposition(540375,de.metas.purchasecandidate) -> Bestelldisposition(540894,de.metas.purchasecandidate) -> main -> 10 -> default.Packvorschrift
+-- Column: C_PurchaseCandidate.M_HU_PI_Item_Product_ID
+-- 2026-03-05T15:34:46.890Z
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774827, 0, 540894, 541247, 648475, 'F', TO_TIMESTAMP('2026-03-05 15:34:46.772000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'Y', 'N', 'N', 'Y', 'N', 'N', 'N', 0, 'Packvorschrift', 100, 0, 0, TO_TIMESTAMP('2026-03-05 15:34:46.772000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100)
+;
+
+-- Field: Bestelldisposition(540375,de.metas.purchasecandidate) -> Bestelldisposition(540894,de.metas.purchasecandidate) -> Menge TU
+-- Column: C_PurchaseCandidate.QtyEnteredTU
+-- 2026-03-05T15:35:33.536Z
+UPDATE AD_Field
+SET DisplayLogic='@QtyEnteredTU/0@>0', Updated=TO_TIMESTAMP('2026-03-05 15:35:33.536000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Field_ID = 774828
+;
+
+-- Field: Bestelldisposition(540375,de.metas.purchasecandidate) -> Bestelldisposition(540894,de.metas.purchasecandidate) -> Packvorschrift
+-- Column: C_PurchaseCandidate.M_HU_PI_Item_Product_ID
+-- 2026-03-05T15:35:59.799Z
+UPDATE AD_Field
+SET DisplayLogic='@M_HU_PI_Item_Product_ID/-1@>0', Updated=TO_TIMESTAMP('2026-03-05 15:35:59.799000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Field_ID = 774827
+;
+
+-- UI Element: Bestelldisposition(540375,de.metas.purchasecandidate) -> Bestelldisposition(540894,de.metas.purchasecandidate) -> main -> 10 -> default.Lager
+-- Column: C_PurchaseCandidate.M_WarehousePO_ID
+-- 2026-03-05T15:36:45.134Z
+UPDATE AD_UI_Element
+SET SeqNo=60, Updated=TO_TIMESTAMP('2026-03-05 15:36:45.134000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_UI_Element_ID = 549340
+;
+
+-- UI Element: Bestelldisposition(540375,de.metas.purchasecandidate) -> Bestelldisposition(540894,de.metas.purchasecandidate) -> main -> 10 -> default.Menge TU
+-- Column: C_PurchaseCandidate.QtyEnteredTU
+-- 2026-03-05T15:36:48.066Z
+UPDATE AD_UI_Element
+SET SeqNo=40, Updated=TO_TIMESTAMP('2026-03-05 15:36:48.066000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_UI_Element_ID = 648474
+;
+
+-- UI Element: Bestelldisposition(540375,de.metas.purchasecandidate) -> Bestelldisposition(540894,de.metas.purchasecandidate) -> main -> 10 -> default.Packvorschrift
+-- Column: C_PurchaseCandidate.M_HU_PI_Item_Product_ID
+-- 2026-03-05T15:38:58.058Z
+UPDATE AD_UI_Element
+SET SeqNo=50, Updated=TO_TIMESTAMP('2026-03-05 15:38:58.057000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_UI_Element_ID = 648475
+;
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5791950_sys_C_PurchaseCandidate_HU_columns.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5791950_sys_C_PurchaseCandidate_HU_columns.sql
@@ -4,8 +4,13 @@
 -- Column: M_HU_PI_Item_Product_ID
 ALTER TABLE C_PurchaseCandidate ADD COLUMN IF NOT EXISTS M_HU_PI_Item_Product_ID NUMERIC(10);
 
-ALTER TABLE C_PurchaseCandidate ADD CONSTRAINT IF NOT EXISTS mhupiitemproduct_cpurchasecandidate
-    FOREIGN KEY (M_HU_PI_Item_Product_ID) REFERENCES M_HU_PI_Item_Product(M_HU_PI_Item_Product_ID);
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'mhupiitemproduct_cpurchasecandidate') THEN
+        ALTER TABLE C_PurchaseCandidate ADD CONSTRAINT mhupiitemproduct_cpurchasecandidate
+            FOREIGN KEY (M_HU_PI_Item_Product_ID) REFERENCES M_HU_PI_Item_Product(M_HU_PI_Item_Product_ID);
+    END IF;
+END $$;
 
 -- Column: QtyEnteredTU
 ALTER TABLE C_PurchaseCandidate ADD COLUMN IF NOT EXISTS QtyEnteredTU NUMERIC;

--- a/backend/de.metas.business/src/main/java/de/metas/order/OrderLineBuilder.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/OrderLineBuilder.java
@@ -79,6 +79,7 @@ public class OrderLineBuilder
 	@Nullable private BigDecimal manualPrice;
 	@Nullable private UomId priceUomId;
 	private BigDecimal manualDiscount;
+	@Nullable private BigDecimal qtyEnteredTU;
 
 	@Nullable
 	private String description;
@@ -143,6 +144,11 @@ public class OrderLineBuilder
 		if (!Check.isBlank(description))
 		{
 			orderLine.setDescription(description);
+		}
+
+		if (qtyEnteredTU != null)
+		{
+			orderLine.setQtyEnteredTU(qtyEnteredTU);
 		}
 
 		orderLine.setIsHideWhenPrinting(hideWhenPrinting);
@@ -271,6 +277,13 @@ public class OrderLineBuilder
 	{
 		assertNotBuilt();
 		this.manualDiscount = manualDiscount;
+		return this;
+	}
+
+	public OrderLineBuilder qtyEnteredTU(@Nullable final BigDecimal qtyEnteredTU)
+	{
+		assertNotBuilt();
+		this.qtyEnteredTU = qtyEnteredTU;
 		return this;
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
@@ -656,6 +656,12 @@ public class C_OrderLine_StepDef
 			softly.assertThat(huPiItemProduct.getM_HU_PI_Item_Product_ID()).isEqualTo(orderLineHU.getM_HU_PI_Item_Product_ID());
 		}
 
+		row.getAsOptionalBigDecimal(de.metas.handlingunits.model.I_C_OrderLine.COLUMNNAME_QtyEnteredTU)
+				.ifPresent(qtyEnteredTU -> {
+					final de.metas.handlingunits.model.I_C_OrderLine orderLineHU = InterfaceWrapperHelper.load(orderLine.getC_OrderLine_ID(), de.metas.handlingunits.model.I_C_OrderLine.class);
+					softly.assertThat(orderLineHU.getQtyEnteredTU()).as("QtyEnteredTU").isEqualByComparingTo(qtyEnteredTU);
+				});
+
 		final BigDecimal qtyReserved = DataTableUtil.extractBigDecimalOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_QtyReserved);
 		if (qtyReserved != null)
 		{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/purchasecandidate/C_PurchaseCandidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/purchasecandidate/C_PurchaseCandidate_StepDef.java
@@ -31,9 +31,11 @@ import de.metas.cucumber.stepdefs.IdentifierIds_StepDefData;
 import de.metas.cucumber.stepdefs.ItemProvider;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.StepDefUtil;
+import de.metas.cucumber.stepdefs.hu.M_HU_PI_Item_Product_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_OrderLine_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
 import de.metas.cucumber.stepdefs.purchasecandidate.v2.CreatePurchaseCandidate_StepDef;
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.logging.LogManager;
 import de.metas.order.OrderLineId;
 import de.metas.purchasecandidate.PurchaseCandidateId;
@@ -74,6 +76,7 @@ public class C_PurchaseCandidate_StepDef
 	private final C_Order_StepDefData orderTable;
 	private final C_BPartner_StepDefData bpartnerTable;
 	private final C_BPartner_Location_StepDefData bpartnerLocationTable;
+	private final M_HU_PI_Item_Product_StepDefData huPiItemProductTable;
 
 	public C_PurchaseCandidate_StepDef(
 			@NonNull final IdentifierIds_StepDefData identifierIdsTable,
@@ -82,7 +85,8 @@ public class C_PurchaseCandidate_StepDef
 			@NonNull final M_Product_StepDefData productTable,
 			@NonNull final C_Order_StepDefData orderTable,
 			@NonNull final C_BPartner_StepDefData bpartnerTable,
-			@NonNull final C_BPartner_Location_StepDefData bpartnerLocationTable)
+			@NonNull final C_BPartner_Location_StepDefData bpartnerLocationTable,
+			@NonNull final M_HU_PI_Item_Product_StepDefData huPiItemProductTable)
 	{
 		this.identifierIdsTable = identifierIdsTable;
 		this.purchaseCandidateTable = purchaseCandidateTable;
@@ -91,6 +95,7 @@ public class C_PurchaseCandidate_StepDef
 		this.orderTable = orderTable;
 		this.bpartnerTable = bpartnerTable;
 		this.bpartnerLocationTable = bpartnerLocationTable;
+		this.huPiItemProductTable = huPiItemProductTable;
 	}
 
 	/**
@@ -304,6 +309,17 @@ public class C_PurchaseCandidate_StepDef
 				.ifPresent(locationId -> assertThat(purchaseCandidateRecord.getDropShip_Location_ID())
 						.as("DropShip_Location_ID")
 						.isEqualTo(locationId.getRepoId()));
+
+		row.getAsOptionalIdentifier(I_C_PurchaseCandidate.COLUMNNAME_M_HU_PI_Item_Product_ID)
+				.map(huPiItemProductTable::get)
+				.ifPresent(huPiItemProduct -> assertThat(purchaseCandidateRecord.getM_HU_PI_Item_Product_ID())
+						.as("M_HU_PI_Item_Product_ID")
+						.isEqualTo(huPiItemProduct.getM_HU_PI_Item_Product_ID()));
+
+		row.getAsOptionalBigDecimal(I_C_PurchaseCandidate.COLUMNNAME_QtyEnteredTU)
+				.ifPresent(qtyEnteredTU -> assertThat(purchaseCandidateRecord.getQtyEnteredTU())
+						.as("QtyEnteredTU")
+						.isEqualByComparingTo(qtyEnteredTU));
 	}
 
 	private void findPurchaseCandidate(final int timeoutSec, @NonNull final DataTableRow row) throws InterruptedException

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseCandidatePackingAndAttributes.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseCandidatePackingAndAttributes.feature
@@ -9,6 +9,14 @@ Feature: Packing items, TU quantities, and attributes propagated from SO to Purc
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
     And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
 
+    And load M_Product:
+      | Identifier | OPT.M_Product_ID |
+      | ifco_6410  | 2001343          |
+
+    And update M_Product:
+      | Identifier | IsActive |
+      | ifco_6410  | Y        |
+
     And load M_AttributeSet:
       | Identifier                     | Name               |
       | attributeSet_convenienceSalate | Convenience Salate |
@@ -28,7 +36,7 @@ Feature: Packing items, TU quantities, and attributes propagated from SO to Purc
     # Set up HU packing (TU)
     And load M_HU_PI:
       | M_HU_PI_ID.Identifier | M_HU_PI_ID |
-      | huPI_pk1              | 1000006     |
+      | huPI_pk1              | 1000006    |
     And load M_HU_PI_Version:
       | M_HU_PI_Version_ID.Identifier | M_HU_PI_Version_ID |
       | huPIV_pk1                     | 2002669            |
@@ -65,12 +73,14 @@ Feature: Packing items, TU quantities, and attributes propagated from SO to Purc
       | plv_pk1p   | pl_pk1p        |
     And metasfresh contains M_ProductPrices
       | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | pp_pk1s    | plv_pk1s               | p_pk1        | 10.0     | PCE               | Normal                        |
+      | pp_pk1s    | plv_pk1s               | p_pk1        | 20.0     | PCE               | Normal                        |
       | pp_pk1p    | plv_pk1p               | p_pk1        | 10.0     | PCE               | Normal                        |
+      | ifco_6410s | plv_pk1s               | ifco_6410    | 0.3      | PCE               | Normal                        |
+      | ifco_6410p | plv_pk1p               | ifco_6410    | 0.1      | PCE               | Normal                        |
 
     And metasfresh contains M_DiscountSchemas:
-      | Identifier | Name                   | DiscountType | ValidFrom  |
-      | ds_pk1     | ds_purchCandPacking_1  | F            | 2021-04-01 |
+      | Identifier | Name                  | DiscountType | ValidFrom  |
+      | ds_pk1     | ds_purchCandPacking_1 | F            | 2021-04-01 |
     And metasfresh contains M_DiscountSchemaBreaks:
       | Identifier | M_DiscountSchema_ID | M_Product_ID | Base_PricingSystem_ID | SeqNo | IsBPartnerFlatDiscount | PriceBase | BreakValue | BreakDiscount |
       | dsb_pk1    | ds_pk1              | p_pk1        | ps_pk1                | 10    | Y                      | P         | 10         | 0             |
@@ -136,4 +146,4 @@ Feature: Packing items, TU quantities, and attributes propagated from SO to Purc
       | po_pk1     | vendor_pk1    | POO         | CO        |
     And validate C_OrderLine:
       | C_OrderLine_ID.Identifier | OPT.M_HU_PI_Item_Product_ID.Identifier | OPT.QtyEnteredTU |
-      | pol_pk1                   | huPiItemProd_pk1                        | 3                |
+      | pol_pk1                   | huPiItemProd_pk1                       | 3                |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseCandidatePackingAndAttributes.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseCandidatePackingAndAttributes.feature
@@ -1,0 +1,139 @@
+@from:cucumber
+@ghActions:run_on_executor6
+Feature: Packing items, TU quantities, and attributes propagated from SO to Purchase Candidate and Purchase Order
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2021-04-11T08:00:00+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+
+    And load M_AttributeSet:
+      | Identifier                     | Name               |
+      | attributeSet_convenienceSalate | Convenience Salate |
+    And load M_Product_Category:
+      | Identifier        | Name     | Value    |
+      | standard_category | Standard | Standard |
+    And update M_Product_Category:
+      | Identifier        | M_AttributeSet_ID              |
+      | standard_category | attributeSet_convenienceSalate |
+
+  @from:cucumber
+  Scenario: SO with packing item and TU qty creates purchase candidate and PO with same packing and TU qty
+    Given metasfresh contains M_Products:
+      | Identifier | M_Product_Category_ID | IsSold | IsPurchased |
+      | p_pk1      | standard_category     | Y      | Y           |
+
+    # Set up HU packing (TU)
+    And load M_HU_PI:
+      | M_HU_PI_ID.Identifier | M_HU_PI_ID |
+      | huPI_pk1              | 1000006     |
+    And load M_HU_PI_Version:
+      | M_HU_PI_Version_ID.Identifier | M_HU_PI_Version_ID |
+      | huPIV_pk1                     | 2002669            |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType |
+      | huPiItem_pk1               | huPIV_pk1                     | 0   | MI       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | huPiItemProd_pk1                   | huPiItem_pk1               | p_pk1                   | 10  | 2021-01-01 |
+
+    # Set up an ASI to put on the SO line
+    And metasfresh contains M_AttributeSetInstance with identifier "asi_pk1":
+    """
+    {
+      "attributeInstances":[
+        {
+          "attributeCode":"1000002",
+          "valueStr":"Bio"
+        }
+      ]
+    }
+    """
+
+    And metasfresh contains M_PricingSystems
+      | Identifier | IsActive |
+      | ps_pk1     | true     |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx | IsTaxIncluded | PricePrecision | IsActive |
+      | pl_pk1s    | ps_pk1             | DE                    | EUR                 | true  | false         | 2              | true     |
+      | pl_pk1p    | ps_pk1             | DE                    | EUR                 | false | false         | 2              | true     |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_pk1s   | pl_pk1s        |
+      | plv_pk1p   | pl_pk1p        |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_pk1s    | plv_pk1s               | p_pk1        | 10.0     | PCE               | Normal                        |
+      | pp_pk1p    | plv_pk1p               | p_pk1        | 10.0     | PCE               | Normal                        |
+
+    And metasfresh contains M_DiscountSchemas:
+      | Identifier | Name                   | DiscountType | ValidFrom  |
+      | ds_pk1     | ds_purchCandPacking_1  | F            | 2021-04-01 |
+    And metasfresh contains M_DiscountSchemaBreaks:
+      | Identifier | M_DiscountSchema_ID | M_Product_ID | Base_PricingSystem_ID | SeqNo | IsBPartnerFlatDiscount | PriceBase | BreakValue | BreakDiscount |
+      | dsb_pk1    | ds_pk1              | p_pk1        | ps_pk1                | 10    | Y                      | P         | 10         | 0             |
+
+    And metasfresh contains PP_Product_Plannings
+      | Identifier | M_Product_ID | IsCreatePlan | IsPurchased | IsDocComplete |
+      | ppln_pk1   | p_pk1        | true         | Y           | true          |
+
+    # Customer
+    And metasfresh contains C_BPartners without locations:
+      | Identifier   | IsVendor | IsCustomer | M_PricingSystem_ID |
+      | customer_pk1 | N        | Y          | ps_pk1             |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier       | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | customer_pk1_loc | customer_pk1  | Y               | Y               |
+
+    # Vendor
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID | PO_DiscountSchema_ID |
+      | vendor_pk1 | Y        | N          | ps_pk1             | ds_pk1               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier     | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | vendor_pk1_loc | vendor_pk1    | Y               | Y               |
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID |
+      | vendor_pk1    | p_pk1        |
+
+    # Create SO with packing item, TU qty, and ASI on the order line
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | PreparationDate      |
+      | so_pk1     | true    | customer_pk1  | 2021-04-17  | 2021-04-16T21:00:00Z |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID | QtyEnteredTU | M_AttributeSetInstance_ID |
+      | sol_pk1    | so_pk1     | p_pk1        | 30         | huPiItemProd_pk1        | 3            | asi_pk1                   |
+    When the order identified by so_pk1 is completed
+
+    # Verify purchase candidate has packing item, TU qty, and ASI
+    And after not more than 60s, C_PurchaseCandidates are found
+      | Identifier | C_OrderSO_ID | C_OrderLineSO_ID | M_Product_ID |
+      | pc_pk1     | so_pk1       | sol_pk1          | p_pk1        |
+    And C_PurchaseCandidates are validated
+      | C_PurchaseCandidate_ID | QtyToPurchase | M_HU_PI_Item_Product_ID | QtyEnteredTU |
+      | pc_pk1                 | 30            | huPiItemProd_pk1        | 3            |
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # Verify PO was auto-generated
+    And after not more than 60s, C_PurchaseCandidate_Alloc are found
+      | C_PurchaseCandidate_ID | C_PurchaseCandidate_Alloc_ID |
+      | pc_pk1                 | pca_pk1                      |
+
+    And load C_OrderLines from C_PurchaseCandidate_Alloc
+      | C_OrderLinePO_ID | C_PurchaseCandidate_Alloc_ID |
+      | pol_pk1          | pca_pk1                      |
+
+    And load C_Order from C_OrderLine
+      | C_Order_ID | C_OrderLine_ID |
+      | po_pk1     | pol_pk1        |
+
+    # Verify PO line has packing item and TU qty
+    Then validate the created orders
+      | C_Order_ID | C_BPartner_ID | DocBaseType | DocStatus |
+      | po_pk1     | vendor_pk1    | POO         | CO        |
+    And validate C_OrderLine:
+      | C_OrderLine_ID.Identifier | OPT.M_HU_PI_Item_Product_ID.Identifier | OPT.QtyEnteredTU |
+      | pol_pk1                   | huPiItemProd_pk1                        | 3                |

--- a/backend/de.metas.purchasecandidate.base/src/main/java-gen/de/metas/purchasecandidate/model/I_C_PurchaseCandidate.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java-gen/de/metas/purchasecandidate/model/I_C_PurchaseCandidate.java
@@ -796,6 +796,48 @@ public interface I_C_PurchaseCandidate
 	String COLUMNNAME_M_ForecastLine_ID = "M_ForecastLine_ID";
 
 	/**
+	 * Set Packing Item.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setM_HU_PI_Item_Product_ID (int M_HU_PI_Item_Product_ID);
+
+	/**
+	 * Get Packing Item.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getM_HU_PI_Item_Product_ID();
+
+	ModelColumn<I_C_PurchaseCandidate, Object> COLUMN_M_HU_PI_Item_Product_ID = new ModelColumn<>(I_C_PurchaseCandidate.class, "M_HU_PI_Item_Product_ID", Object.class);
+	String COLUMNNAME_M_HU_PI_Item_Product_ID = "M_HU_PI_Item_Product_ID";
+
+	/**
+	 * Set Qty TU.
+	 *
+	 * <br>Type: Quantity
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setQtyEnteredTU (@Nullable BigDecimal QtyEnteredTU);
+
+	/**
+	 * Get Qty TU.
+	 *
+	 * <br>Type: Quantity
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	@Nullable BigDecimal getQtyEnteredTU();
+
+	ModelColumn<I_C_PurchaseCandidate, Object> COLUMN_QtyEnteredTU = new ModelColumn<>(I_C_PurchaseCandidate.class, "QtyEnteredTU", Object.class);
+	String COLUMNNAME_QtyEnteredTU = "QtyEnteredTU";
+
+	/**
 	 * Set Product.
 	 * Product, Service, Item
 	 *

--- a/backend/de.metas.purchasecandidate.base/src/main/java-gen/de/metas/purchasecandidate/model/X_C_PurchaseCandidate.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java-gen/de/metas/purchasecandidate/model/X_C_PurchaseCandidate.java
@@ -538,6 +538,34 @@ public class X_C_PurchaseCandidate extends org.compiere.model.PO implements I_C_
 	}
 
 	@Override
+	public void setM_HU_PI_Item_Product_ID(final int M_HU_PI_Item_Product_ID)
+	{
+		if (M_HU_PI_Item_Product_ID < 1)
+			set_Value(COLUMNNAME_M_HU_PI_Item_Product_ID, null);
+		else
+			set_Value(COLUMNNAME_M_HU_PI_Item_Product_ID, M_HU_PI_Item_Product_ID);
+	}
+
+	@Override
+	public int getM_HU_PI_Item_Product_ID()
+	{
+		return get_ValueAsInt(COLUMNNAME_M_HU_PI_Item_Product_ID);
+	}
+
+	@Override
+	public void setQtyEnteredTU(@Nullable final BigDecimal QtyEnteredTU)
+	{
+		set_Value(COLUMNNAME_QtyEnteredTU, QtyEnteredTU);
+	}
+
+	@Override
+	@Nullable
+	public BigDecimal getQtyEnteredTU()
+	{
+		return get_ValueAsBigDecimal(COLUMNNAME_QtyEnteredTU);
+	}
+
+	@Override
 	public void setM_Product_ID(final int M_Product_ID)
 	{
 		if (M_Product_ID < 1)

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/PurchaseCandidate.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/PurchaseCandidate.java
@@ -6,6 +6,7 @@ import de.metas.bpartner.BPartnerLocationId;
 import de.metas.document.dimension.Dimension;
 import de.metas.error.AdIssueId;
 import de.metas.externalsystem.ExternalSystemId;
+import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.mforecast.impl.ForecastLineId;
 import de.metas.money.CurrencyId;
 import de.metas.order.OrderAndLineId;
@@ -185,6 +186,8 @@ public class PurchaseCandidate
 			@Nullable final TaxCategoryId taxCategoryId,
 			@Nullable final CurrencyId currencyId,
 			final boolean simulated,
+			@Nullable final HUPIItemProductId huPIItemProductId,
+			@Nullable final BigDecimal qtyEnteredTU,
 			final boolean isDropShip,
 			@Nullable final BPartnerId dropShipBPartnerId,
 			@Nullable final BPartnerLocationId dropShipLocationId,
@@ -216,6 +219,8 @@ public class PurchaseCandidate
 				.poReference(poReference)
 				.source(source)
 				.externalPurchaseOrderUrl(externalPurchaseOrderUrl)
+				.huPIItemProductId(huPIItemProductId)
+				.qtyEnteredTU(qtyEnteredTU)
 				.isDropShip(isDropShip)
 				.dropShipBPartnerId(dropShipBPartnerId)
 				.dropShipLocationId(dropShipLocationId)
@@ -457,6 +462,16 @@ public class PurchaseCandidate
 	public @Nullable UserId getDropShipUserId()
 	{
 		return getImmutableFields().getDropShipUserId();
+	}
+
+	public @Nullable HUPIItemProductId getHuPIItemProductId()
+	{
+		return getImmutableFields().getHuPIItemProductId();
+	}
+
+	public @Nullable BigDecimal getQtyEnteredTU()
+	{
+		return getImmutableFields().getQtyEnteredTU();
 	}
 
 	public boolean hasChanges()

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/PurchaseCandidateImmutableFields.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/PurchaseCandidateImmutableFields.java
@@ -4,6 +4,7 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.document.dimension.Dimension;
 import de.metas.externalsystem.ExternalSystemId;
+import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.mforecast.impl.ForecastLineId;
 import de.metas.order.OrderAndLineId;
 import de.metas.organization.OrgId;
@@ -17,6 +18,7 @@ import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.warehouse.WarehouseId;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 
 /*
  * #%L
@@ -92,6 +94,12 @@ class PurchaseCandidateImmutableFields
 
 	@Nullable
 	String externalPurchaseOrderUrl;
+
+	@Nullable
+	HUPIItemProductId huPIItemProductId;
+
+	@Nullable
+	BigDecimal qtyEnteredTU;
 
 	boolean isDropShip;
 

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/PurchaseCandidateRepository.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/PurchaseCandidateRepository.java
@@ -13,6 +13,7 @@ import de.metas.document.dimension.DimensionService;
 import de.metas.externalsystem.ExternalSystemId;
 import de.metas.externalsystem.ExternalSystemIdWithExternalIds;
 import de.metas.externalsystem.ExternalSystemRepository;
+import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.user.UserId;
 import de.metas.lock.api.ILockAutoCloseable;
 import de.metas.lock.api.ILockManager;
@@ -415,6 +416,9 @@ public class PurchaseCandidateRepository
 		record.setDropShip_Location_ID(BPartnerLocationId.toRepoId(purchaseCandidate.getDropShipLocationId()));
 		record.setDropShip_User_ID(UserId.toRepoId(purchaseCandidate.getDropShipUserId()));
 
+		record.setM_HU_PI_Item_Product_ID(HUPIItemProductId.toRepoId(purchaseCandidate.getHuPIItemProductId()));
+		record.setQtyEnteredTU(purchaseCandidate.getQtyEnteredTU());
+
 		record.setIsSimulated(purchaseCandidate.isSimulated());
 
 		if (purchaseCandidate.isSimulated())
@@ -530,6 +534,9 @@ public class PurchaseCandidateRepository
 				.dropShipBPartnerId(BPartnerId.ofRepoIdOrNull(record.getDropShip_BPartner_ID()))
 				.dropShipLocationId(BPartnerLocationId.ofRepoIdOrNull(BPartnerId.ofRepoIdOrNull(record.getDropShip_BPartner_ID()), record.getDropShip_Location_ID() > 0 ? record.getDropShip_Location_ID() : null))
 				.dropShipUserId(UserId.ofRepoIdOrNull(record.getDropShip_User_ID()))
+				//
+				.huPIItemProductId(HUPIItemProductId.ofRepoIdOrNull(record.getM_HU_PI_Item_Product_ID()))
+				.qtyEnteredTU(record.getQtyEnteredTU())
 				//
 				.build();
 

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/event/PurchaseCandidateRequestedHandler.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/event/PurchaseCandidateRequestedHandler.java
@@ -28,6 +28,7 @@ import de.metas.Profiles;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.document.dimension.Dimension;
+import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.material.event.MaterialEventHandler;
 import de.metas.material.event.PostMaterialEventService;
 import de.metas.material.event.commons.MaterialDescriptor;
@@ -62,7 +63,10 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
+import org.adempiere.mm.attributes.api.IAttributeSetInstanceBL;
 import org.compiere.util.TimeUtil;
+
+import java.math.BigDecimal;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -84,6 +88,7 @@ public class PurchaseCandidateRequestedHandler implements MaterialEventHandler<P
 	private final IPurchaseCandidateBL purchaseCandidateBL = Services.get(IPurchaseCandidateBL.class);
 	private final IProductPlanningDAO productPlanningDAO = Services.get(IProductPlanningDAO.class);
 	private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
+	private final IAttributeSetInstanceBL attributeSetInstanceBL = Services.get(IAttributeSetInstanceBL.class);
 
 	@Override
 	public Collection<Class<? extends PurchaseCandidateRequestedEvent>> getHandledEventType()
@@ -123,11 +128,14 @@ public class PurchaseCandidateRequestedHandler implements MaterialEventHandler<P
 				.userElementString7(event.getUserElementString7())
 				.build();
 
-		// Extract dropship info from the sales order, if present
+		// Extract dropship info, packing info, and ASI from the sales order/line, if present
 		boolean isDropShip = false;
 		BPartnerId dropShipBPartnerId = null;
 		BPartnerLocationId dropShipLocationId = null;
 		UserId dropShipUserId = null;
+		HUPIItemProductId huPIItemProductId = null;
+		BigDecimal qtyEnteredTU = null;
+		AttributeSetInstanceId copiedAsiId = null;
 		if (orderAndLineIdOrNull != null)
 		{
 			final org.compiere.model.I_C_Order salesOrder = orderDAO.getById(orderAndLineIdOrNull.getOrderId());
@@ -148,6 +156,18 @@ public class PurchaseCandidateRequestedHandler implements MaterialEventHandler<P
 					dropShipUserId = UserId.ofRepoIdOrNull(salesOrder.getAD_User_ID());
 				}
 			}
+
+			// Extract packing item, TU qty, and ASI from the sales order line
+			final de.metas.interfaces.I_C_OrderLine salesOrderLine = orderDAO.getOrderLineById(orderAndLineIdOrNull.getOrderLineId(), de.metas.interfaces.I_C_OrderLine.class);
+			huPIItemProductId = HUPIItemProductId.ofRepoIdOrNull(salesOrderLine.getM_HU_PI_Item_Product_ID());
+			qtyEnteredTU = salesOrderLine.getQtyEnteredTU();
+
+			// Copy ASI from the order line (create a new ASI instance rather than sharing the same ID)
+			final AttributeSetInstanceId orderLineAsiId = AttributeSetInstanceId.ofRepoIdOrNone(salesOrderLine.getM_AttributeSetInstance_ID());
+			if (orderLineAsiId.isRegular())
+			{
+				copiedAsiId = attributeSetInstanceBL.copy(orderLineAsiId);
+			}
 		}
 
 		final ZonedDateTime datePromised = TimeUtil.asZonedDateTime(materialDescriptor.getDate());
@@ -163,7 +183,7 @@ public class PurchaseCandidateRequestedHandler implements MaterialEventHandler<P
 				.orgId(orgId)
 				.processed(false)
 				.productId(product.getId())
-				.attributeSetInstanceId(AttributeSetInstanceId.ofRepoId(materialDescriptor.getAttributeSetInstanceId()))
+				.attributeSetInstanceId(copiedAsiId != null ? copiedAsiId : AttributeSetInstanceId.ofRepoId(materialDescriptor.getAttributeSetInstanceId()))
 				// .profitInfo(profitInfo)
 				// .purchaseItem(purchaseItem) purchase items are only returned by the vendor gateway
 				.qtyToPurchase(Quantitys.of(materialDescriptor.getQuantity(), product.getUomId()))
@@ -172,6 +192,8 @@ public class PurchaseCandidateRequestedHandler implements MaterialEventHandler<P
 				.warehouseId(materialDescriptor.getWarehouseId())
 				.forecastLineId(ForecastLineId.ofRepoIdOrNull(event.getForecastId(), event.getForecastLineId()))
 				.simulated(event.isSimulated())
+				.huPIItemProductId(huPIItemProductId)
+				.qtyEnteredTU(qtyEnteredTU)
 				.isDropShip(isDropShip)
 				.dropShipBPartnerId(dropShipBPartnerId)
 				.dropShipLocationId(dropShipLocationId)

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemFactory.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemFactory.java
@@ -134,6 +134,9 @@ import java.util.Set;
 
 		orderLineBuilder.addQty(purchaseOrderItem.getPurchasedQty());
 
+		orderLineBuilder.piItemProductId(purchaseOrderItem.getHuPIItemProductId());
+		orderLineBuilder.asiId(purchaseOrderItem.getAttributeSetInstanceId());
+		orderLineBuilder.qtyEnteredTU(purchaseOrderItem.getQtyEnteredTU());
 		orderLineBuilder.setDimension(purchaseOrderItem.getDimension());
 		if (purchaseOrderItem.getDiscount() != null)
 		{

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/purchaseordercreation/remotepurchaseitem/PurchaseOrderItem.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/purchaseordercreation/remotepurchaseitem/PurchaseOrderItem.java
@@ -4,6 +4,7 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.document.dimension.Dimension;
 import de.metas.externalsystem.ExternalSystemId;
+import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.mforecast.impl.ForecastLineId;
 import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderId;
@@ -13,6 +14,7 @@ import de.metas.user.UserId;
 import de.metas.purchasecandidate.PurchaseCandidate;
 import de.metas.purchasecandidate.PurchaseCandidateId;
 import de.metas.purchasecandidate.purchaseordercreation.remoteorder.NullVendorGatewayInvoker;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import de.metas.quantity.Quantity;
 import de.metas.uom.UomId;
 import de.metas.util.Check;
@@ -314,5 +316,22 @@ public class PurchaseOrderItem implements PurchaseItem
 	public UserId getDropShipUserId()
 	{
 		return purchaseCandidate.getDropShipUserId();
+	}
+
+	@Nullable
+	public HUPIItemProductId getHuPIItemProductId()
+	{
+		return purchaseCandidate.getHuPIItemProductId();
+	}
+
+	public AttributeSetInstanceId getAttributeSetInstanceId()
+	{
+		return purchaseCandidate.getAttributeSetInstanceId();
+	}
+
+	@Nullable
+	public BigDecimal getQtyEnteredTU()
+	{
+		return purchaseCandidate.getQtyEnteredTU();
 	}
 }


### PR DESCRIPTION
## Summary

- When purchase candidates are auto-created from sales orders (via material disposition + PP_Product_Planning), **M_HU_PI_Item_Product_ID** (packing item), **QtyEnteredTU** (TU quantity), and **M_AttributeSetInstance_ID** (attributes) are now transferred from the SO line through the purchase candidate to the purchase order line.
- ASI is properly copied (not shared) using `IAttributeSetInstanceBL.copy()` so that modifications to one don't affect the other.
- New migration script adds `M_HU_PI_Item_Product_ID` and `QtyEnteredTU` columns to `C_PurchaseCandidate`.

## Test plan

- [ ] Cucumber test `purchaseCandidatePackingAndAttributes.feature` validates the full SO → Purchase Candidate → PO propagation
- [ ] Existing `purchaseCandidateDropShip.feature` should still pass (no regression)
- [ ] Migration script `5791950` applies cleanly