### PR TITLE
Implement partial vendor returns from receipt window

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5791960_sys_M_InOut_GenerateVendorReturn.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5791960_sys_M_InOut_GenerateVendorReturn.sql
@@ -1,0 +1,42 @@
+-- Migration: Register M_InOut_GenerateVendorReturn process
+-- Purpose: Generate vendor return from completed material receipt (me03#28144)
+
+--
+-- 1. AD_Process: M_InOut_GenerateVendorReturn
+--
+INSERT INTO AD_Process (AccessLevel,AD_Client_ID,AD_Org_ID,AD_Process_ID,AllowProcessReRun,Classname,CopyFromProcess,Created,CreatedBy,EntityType,IsActive,IsApplySecuritySettings,IsBetaFunctionality,IsDirectPrint,IsFormatExcelFile,IsLogWarning,IsNotifyUserAfterExecution,IsOneInstanceOnly,IsReport,IsTranslateExcelHeaders,IsUpdateExportDate,IsUseBPartnerLanguage,LockWaitTimeout,Name,PostgrestResponseFormat,RefreshAllAfterExecution,ShowHelp,SpreadsheetFormat,Type,Updated,UpdatedBy,Value)
+VALUES ('3',0,0,585591,'Y','de.metas.ui.web.shipment.process.M_InOut_GenerateVendorReturn','N',TO_TIMESTAMP('2026-03-04 22:00','YYYY-MM-DD HH24:MI'),100,'D','Y','N','N','N','Y','N','N','N','N','Y','N','Y',0,'Lieferantenrücklieferung erstellen','json','N','N','xls','Java',TO_TIMESTAMP('2026-03-04 22:00','YYYY-MM-DD HH24:MI'),100,'M_InOut_GenerateVendorReturn');
+
+--
+-- 2. AD_Process_Trl
+--
+INSERT INTO AD_Process_Trl (AD_Language,AD_Process_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Process t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_ID=585591
+  AND NOT EXISTS (SELECT 1 FROM AD_Process_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_ID=t.AD_Process_ID);
+
+-- Set English translation
+UPDATE AD_Process_Trl SET Name='Generate Vendor Return', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-04 22:00','YYYY-MM-DD HH24:MI'), UpdatedBy=100
+WHERE AD_Process_ID=585591 AND AD_Language='en_US';
+
+--
+-- 3. AD_Table_Process: Link process to M_InOut table (AD_Table_ID=319)
+--    WEBUI_DocumentAction='Y' so it appears in the document actions menu on receipts
+--
+INSERT INTO AD_Table_Process (AD_Client_ID,AD_Org_ID,AD_Process_ID,AD_Table_ID,AD_Table_Process_ID,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy,WEBUI_DocumentAction,WEBUI_IncludedTabTopAction,WEBUI_ViewAction,WEBUI_ViewQuickAction,WEBUI_ViewQuickAction_Default)
+VALUES (0,0,585591,319,541629,TO_TIMESTAMP('2026-03-04 22:00','YYYY-MM-DD HH24:MI'),100,'D','Y',TO_TIMESTAMP('2026-03-04 22:00','YYYY-MM-DD HH24:MI'),100,'Y','N','N','N','N');
+
+--
+-- 4. AD_Field: Add Return_Origin_InOut_ID field on Vendor Return window header tab (AD_Tab_ID=53276)
+--    AD_Column_ID=591915 (Return_Origin_InOut_ID on M_InOut)
+--    Display as read-only so users can see the linked receipt
+--
+INSERT INTO AD_Field (AD_Client_ID,AD_Org_ID,AD_Field_ID,AD_Tab_ID,AD_Column_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SortNo,Updated,UpdatedBy)
+VALUES (0,0,774826,53276,591915,TO_TIMESTAMP('2026-03-04 22:00','YYYY-MM-DD HH24:MI'),100,'D','Y','Y','Y','N','N','N','Y','N','Ursprüngliche Lieferung',390,0,TO_TIMESTAMP('2026-03-04 22:00','YYYY-MM-DD HH24:MI'),100);
+
+--
+-- 5. AD_SysConfig: VendorReturnsInOut.FailIfNoHUsAssigned (default Y)
+--
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value)
+VALUES (0,0,541796,'S',TO_TIMESTAMP('2026-03-04 22:00','YYYY-MM-DD HH24:MI'),100,'D','Y','VendorReturnsInOut.FailIfNoHUsAssigned',TO_TIMESTAMP('2026-03-04 22:00','YYYY-MM-DD HH24:MI'),100,'Y');

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5791960_sys_M_InOut_GenerateVendorReturn.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5791960_sys_M_InOut_GenerateVendorReturn.sql
@@ -35,6 +35,17 @@ VALUES (0,0,585591,319,541629,TO_TIMESTAMP('2026-03-04 22:00','YYYY-MM-DD HH24:M
 INSERT INTO AD_Field (AD_Client_ID,AD_Org_ID,AD_Field_ID,AD_Tab_ID,AD_Column_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SortNo,Updated,UpdatedBy)
 VALUES (0,0,774826,53276,591915,TO_TIMESTAMP('2026-03-04 22:00','YYYY-MM-DD HH24:MI'),100,'D','Y','Y','Y','N','N','N','Y','N','Ursprüngliche Lieferung',390,0,TO_TIMESTAMP('2026-03-04 22:00','YYYY-MM-DD HH24:MI'),100);
 
+-- AD_Field_Trl for Return_Origin_InOut_ID field
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=774826
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+
+-- English translation for the field
+UPDATE AD_Field_Trl SET Name='Original Delivery', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-03-04 22:00','YYYY-MM-DD HH24:MI'), UpdatedBy=100
+WHERE AD_Field_ID=774826 AND AD_Language='en_US';
+
 --
 -- 5. AD_SysConfig: VendorReturnsInOut.FailIfNoHUsAssigned (default Y)
 --

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUAssignmentBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUAssignmentBL.java
@@ -23,6 +23,7 @@ package de.metas.handlingunits.impl;
  */
 
 import com.google.common.collect.ImmutableSetMultimap;
+import de.metas.common.util.CoalesceUtil;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHUAssignmentBL;
 import de.metas.handlingunits.IHUAssignmentBuilder;
@@ -42,12 +43,16 @@ import org.adempiere.util.lang.impl.TableRecordReferenceSet;
 import org.compiere.util.Env;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+
+import static org.compiere.model.I_M_InOutLine.COLUMNNAME_MovementQty;
+import static org.compiere.model.I_M_InOutLine.COLUMNNAME_QtyEntered;
 
 public class HUAssignmentBL implements IHUAssignmentBL
 {
@@ -87,7 +92,7 @@ public class HUAssignmentBL implements IHUAssignmentBL
 	@Override
 	public void assignHUs(
 			@NonNull final Object model,
-			@NonNull final Collection<I_M_HU> huList, 
+			@NonNull final Collection<I_M_HU> huList,
 			@Nullable final String trxName)
 	{
 		if (huList.isEmpty())
@@ -101,7 +106,7 @@ public class HUAssignmentBL implements IHUAssignmentBL
 	@Override
 	public I_M_HU_Assignment assignHU(
 			@NonNull final Object model,
-			@NonNull final I_M_HU hu, 
+			@NonNull final I_M_HU hu,
 			@Nullable final String trxName)
 	{
 		return assignHU0(model, hu, IsTransferPackingMaterials_DoNotChange, trxName);
@@ -110,7 +115,7 @@ public class HUAssignmentBL implements IHUAssignmentBL
 	@Override
 	public I_M_HU_Assignment assignHU(
 			@NonNull final Object model,
-			@NonNull final I_M_HU hu, 
+			@NonNull final I_M_HU hu,
 			final boolean isTransferPackingMaterials,
 			@Nullable final String trxName)
 	{
@@ -177,6 +182,12 @@ public class HUAssignmentBL implements IHUAssignmentBL
 		final boolean isNewAssignment = builder.isNewAssignment();
 		final boolean isActiveOld = builder.isActive();
 
+		final BigDecimal qty = getQtyOrNull(model);
+		if (qty != null)
+		{
+			builder.setQty(qty);
+		}
+
 		//
 		// Update Assignment fields and save it
 		updateHUAssignmentAndSave(builder, model, hu, isTransferPackingMaterials);
@@ -215,6 +226,17 @@ public class HUAssignmentBL implements IHUAssignmentBL
 			final IReference<Object> modelRef = ImmutableReference.valueOf(model);
 			listeners.onHUUnassigned(huRef, modelRef, trxName);
 		}
+	}
+
+	/**
+	 * Attempts to retrieve the quantity value from the given model object specified by certain column names.
+	 * If the value is not available, returns {@code null}.
+	 */
+	@Nullable
+	private BigDecimal getQtyOrNull(final Object model)
+	{
+		return CoalesceUtil.coalesceSuppliers(() -> InterfaceWrapperHelper.getValueAsBigDecimalOrNull(model, COLUMNNAME_QtyEntered),
+				() -> InterfaceWrapperHelper.getValueAsBigDecimalOrNull(model, COLUMNNAME_MovementQty));
 	}
 
 	/**

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/vendor/VendorReturnFromReceiptHUHandler.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/vendor/VendorReturnFromReceiptHUHandler.java
@@ -9,6 +9,7 @@ import de.metas.handlingunits.inout.IHUInOutBL;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_Assignment;
 import de.metas.handlingunits.model.I_M_InOutLine;
+import de.metas.handlingunits.model.X_M_HU;
 import de.metas.handlingunits.snapshot.IHUSnapshotDAO;
 import de.metas.handlingunits.snapshot.ISnapshotProducer;
 import de.metas.handlingunits.storage.IHUProductStorage;
@@ -26,6 +27,7 @@ import org.adempiere.service.ISysConfigBL;
 import org.adempiere.util.lang.IContextAware;
 import org.compiere.model.I_M_InOut;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -99,9 +101,11 @@ public class VendorReturnFromReceiptHUHandler
 			// Assign split HUs to the return line
 			huAssignmentBL.assignHUs(returnLine, splitHUs, org.compiere.util.Trx.TRXNAME_ThreadInherited);
 
-			// Queue for snapshot and collection
+			// Mark new HUs as Shipped and queue for snapshot
 			for (final I_M_HU hu : splitHUs)
 			{
+				hu.setHUStatus(X_M_HU.HUSTATUS_Shipped);
+				InterfaceWrapperHelper.save(hu);
 				snapshotProducer.addModel(hu);
 			}
 			allSplitHUs.addAll(splitHUs);
@@ -209,7 +213,7 @@ public class VendorReturnFromReceiptHUHandler
 			}
 
 			// Navigate to the VHU level if this is a TU
-			final I_M_HU cuHU = findCUForProduct(sourceHU, productId, storageFactory);
+			final I_M_HU cuHU = findCUForProductOrNull(sourceHU, productId, storageFactory);
 			if (cuHU == null)
 			{
 				continue;
@@ -229,9 +233,18 @@ public class VendorReturnFromReceiptHUHandler
 			final Quantity splitQuantity = Quantity.of(splitQty, productStorage.getC_UOM());
 
 			final List<I_M_HU> splitResult = huTransformService.cuToNewCU(cuHU, splitQuantity);
+
 			allSplitHUs.addAll(splitResult);
 
 			remainingQty = remainingQty.subtract(splitQty);
+
+			// Check if the source HU was fully consumed and mark it as Destroyed
+			final IHUStorage updatedStorage = storageFactory.getStorage(cuHU);
+			if (updatedStorage.isEmpty())
+			{
+				cuHU.setHUStatus(X_M_HU.HUSTATUS_Destroyed);
+				InterfaceWrapperHelper.save(cuHU);
+			}
 		}
 
 		if (remainingQty.signum() > 0 && !isPickAvailableHUsOnTheFly())
@@ -243,7 +256,8 @@ public class VendorReturnFromReceiptHUHandler
 		return allSplitHUs;
 	}
 
-	private I_M_HU findCUForProduct(
+	@Nullable
+	private I_M_HU findCUForProductOrNull(
 			@NonNull final I_M_HU hu,
 			@NonNull final ProductId productId,
 			@NonNull final IHUStorageFactory storageFactory)
@@ -279,7 +293,7 @@ public class VendorReturnFromReceiptHUHandler
 					}
 				}
 				// Recurse for nested TUs
-				final I_M_HU found = findCUForProduct(childHU, productId, storageFactory);
+				final I_M_HU found = findCUForProductOrNull(childHU, productId, storageFactory);
 				if (found != null)
 				{
 					return found;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/vendor/VendorReturnFromReceiptHUHandler.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/vendor/VendorReturnFromReceiptHUHandler.java
@@ -1,0 +1,303 @@
+package de.metas.handlingunits.inout.returns.vendor;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.handlingunits.IHUAssignmentBL;
+import de.metas.handlingunits.IHUAssignmentDAO;
+import de.metas.handlingunits.IHandlingUnitsBL;
+import de.metas.handlingunits.allocation.transfer.HUTransformService;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.I_M_HU_Assignment;
+import de.metas.handlingunits.model.I_M_InOutLine;
+import de.metas.handlingunits.snapshot.IHUSnapshotDAO;
+import de.metas.handlingunits.snapshot.ISnapshotProducer;
+import de.metas.handlingunits.storage.IHUProductStorage;
+import de.metas.handlingunits.storage.IHUStorage;
+import de.metas.handlingunits.storage.IHUStorageFactory;
+import de.metas.inout.InOutLineId;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.util.Services;
+import lombok.Builder;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ISysConfigBL;
+import org.adempiere.util.lang.IContextAware;
+import org.compiere.model.I_M_InOut;
+import org.compiere.model.I_M_InOutLine;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Handles HU split/transform when a vendor return document (created by {@code M_InOut_GenerateVendorReturn}) is completed.
+ * <p>
+ * For each vendor return line that has a {@code Return_Origin_InOutLine_ID}:
+ * 1. Finds the receipt HUs assigned to the origin receipt line
+ * 2. Splits the return quantity from those HUs using {@link HUTransformService}
+ * 3. Assigns the split-off HUs to the vendor return
+ * 4. Creates HU snapshots for reversal support
+ */
+@Builder
+public class VendorReturnFromReceiptHUHandler
+{
+	private static final String SYSCONFIG_PickAvailableHUsOnTheFly = "de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PickAvailableHUsOnTheFly";
+	private static final String SYSCONFIG_VendorReturnsInOut_FailIfNoHUsAssigned = "VendorReturnsInOut.FailIfNoHUsAssigned";
+
+	@NonNull private final I_M_InOut vendorReturn;
+
+	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+	private final IHUAssignmentDAO huAssignmentDAO = Services.get(IHUAssignmentDAO.class);
+	private final IHUAssignmentBL huAssignmentBL = Services.get(IHUAssignmentBL.class);
+	private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
+	private final IHUSnapshotDAO huSnapshotDAO = Services.get(IHUSnapshotDAO.class);
+
+	public void execute()
+	{
+		final de.metas.handlingunits.model.I_M_InOut huVendorReturn = InterfaceWrapperHelper.create(vendorReturn, de.metas.handlingunits.model.I_M_InOut.class);
+
+		final IContextAware context = InterfaceWrapperHelper.getContextAware(vendorReturn);
+		final ISnapshotProducer<I_M_HU> snapshotProducer = huSnapshotDAO.createSnapshot().setContext(context);
+		final List<I_M_HU> allSplitHUs = new ArrayList<>();
+
+		final List<I_M_InOutLine> returnLines = InterfaceWrapperHelper.createList(
+				Services.get(de.metas.inout.IInOutBL.class).getLines(vendorReturn),
+				I_M_InOutLine.class);
+
+		for (final I_M_InOutLine returnLine : returnLines)
+		{
+			if (returnLine.isDescription() || returnLine.isPackagingMaterial())
+			{
+				continue;
+			}
+
+			final int originInOutLineId = returnLine.getReturn_Origin_InOutLine_ID();
+			if (originInOutLineId <= 0)
+			{
+				continue;
+			}
+
+			final BigDecimal returnQty = returnLine.getQtyEntered();
+			if (returnQty == null || returnQty.signum() <= 0)
+			{
+				continue;
+			}
+
+			final List<I_M_HU> splitHUs = splitHUsForReturnLine(returnLine, originInOutLineId, returnQty);
+			if (splitHUs.isEmpty())
+			{
+				continue;
+			}
+
+			// Assign split HUs to the return line
+			huAssignmentBL.assignHUs(returnLine, splitHUs, org.compiere.util.Trx.TRXNAME_ThreadInherited);
+
+			// Queue for snapshot and collection
+			for (final I_M_HU hu : splitHUs)
+			{
+				snapshotProducer.addModel(hu);
+			}
+			allSplitHUs.addAll(splitHUs);
+		}
+
+		if (allSplitHUs.isEmpty())
+		{
+			if (isFailIfNoHUsAssigned())
+			{
+				throw new AdempiereException("No HUs could be split for vendor return. Check receipt HU assignments.");
+			}
+			return;
+		}
+
+		// Also assign all HUs to the header
+		final de.metas.handlingunits.inout.IHUInOutBL huInOutBL = Services.get(de.metas.handlingunits.inout.IHUInOutBL.class);
+		huInOutBL.setAssignedHandlingUnits(vendorReturn, allSplitHUs);
+
+		// Create snapshots and store the UUID
+		snapshotProducer.createSnapshots();
+		huVendorReturn.setSnapshot_UUID(snapshotProducer.getSnapshotId());
+		InterfaceWrapperHelper.save(huVendorReturn);
+	}
+
+	private List<I_M_HU> splitHUsForReturnLine(
+			@NonNull final I_M_InOutLine returnLine,
+			final int originInOutLineId,
+			@NonNull final BigDecimal returnQty)
+	{
+		// 1. Find HUs assigned to the origin receipt line
+		final List<I_M_HU_Assignment> assignments = huAssignmentDAO.retrieveHUAssignmentsForModel(
+				InterfaceWrapperHelper.getCtx(returnLine),
+				org.compiere.model.I_M_InOutLine.Table_ID,
+				originInOutLineId,
+				org.compiere.util.Trx.TRXNAME_ThreadInherited);
+
+		if (assignments.isEmpty())
+		{
+			if (isPickAvailableHUsOnTheFly())
+			{
+				// Customer doesn't care about HUs — skip HU handling for this line
+				// Stock will be adjusted via M_Transaction
+				return ImmutableList.of();
+			}
+			else
+			{
+				throw new AdempiereException("No HUs assigned to origin receipt line (M_InOutLine_ID=" + originInOutLineId + "). "
+						+ "Cannot process vendor return. Please check receipt HU assignments.");
+			}
+		}
+
+		// 2. Collect unique HUs from assignments (use VHU if available, else top-level)
+		final List<I_M_HU> sourceHUs = new ArrayList<>();
+		for (final I_M_HU_Assignment assignment : assignments)
+		{
+			final I_M_HU hu;
+			if (assignment.getVHU_ID() > 0)
+			{
+				hu = InterfaceWrapperHelper.load(assignment.getVHU_ID(), I_M_HU.class);
+			}
+			else if (assignment.getM_TU_HU_ID() > 0)
+			{
+				hu = InterfaceWrapperHelper.load(assignment.getM_TU_HU_ID(), I_M_HU.class);
+			}
+			else
+			{
+				hu = assignment.getM_HU();
+			}
+
+			if (hu != null && hu.isActive())
+			{
+				sourceHUs.add(hu);
+			}
+		}
+
+		if (sourceHUs.isEmpty())
+		{
+			if (isPickAvailableHUsOnTheFly())
+			{
+				return ImmutableList.of();
+			}
+			else
+			{
+				throw new AdempiereException("No active HUs found for origin receipt line (M_InOutLine_ID=" + originInOutLineId + ").");
+			}
+		}
+
+		// 3. Split the return quantity from the source HUs
+		return splitQuantityFromHUs(sourceHUs, returnLine, returnQty);
+	}
+
+	private List<I_M_HU> splitQuantityFromHUs(
+			@NonNull final List<I_M_HU> sourceHUs,
+			@NonNull final I_M_InOutLine returnLine,
+			@NonNull final BigDecimal returnQty)
+	{
+		final ProductId productId = ProductId.ofRepoId(returnLine.getM_Product_ID());
+		final HUTransformService huTransformService = HUTransformService.newInstance();
+		final List<I_M_HU> allSplitHUs = new ArrayList<>();
+		BigDecimal remainingQty = returnQty;
+
+		for (final I_M_HU sourceHU : sourceHUs)
+		{
+			if (remainingQty.signum() <= 0)
+			{
+				break;
+			}
+
+			// Navigate to the VHU level if this is a TU
+			final I_M_HU cuHU = findCUForProduct(sourceHU, productId);
+			if (cuHU == null)
+			{
+				continue;
+			}
+
+			// Determine how much we can split from this HU
+			final IHUStorageFactory storageFactory = handlingUnitsBL
+					.createMutableHUContext(InterfaceWrapperHelper.getContextAware(returnLine))
+					.getHUStorageFactory();
+			final IHUStorage huStorage = storageFactory.getStorage(cuHU);
+			final IHUProductStorage productStorage = huStorage.getProductStorageOrNull(productId);
+			if (productStorage == null || productStorage.getQty().signum() <= 0)
+			{
+				continue;
+			}
+
+			final BigDecimal availableQty = productStorage.getQty();
+			final BigDecimal splitQty = remainingQty.min(availableQty);
+
+			final Quantity splitQuantity = Quantity.of(splitQty, productStorage.getC_UOM());
+
+			final List<I_M_HU> splitResult = huTransformService.cuToNewCU(cuHU, splitQuantity);
+			allSplitHUs.addAll(splitResult);
+
+			remainingQty = remainingQty.subtract(splitQty);
+		}
+
+		if (remainingQty.signum() > 0 && !isPickAvailableHUsOnTheFly())
+		{
+			throw new AdempiereException("Insufficient HU stock for return quantity. "
+					+ "Remaining qty=" + remainingQty + " for product " + productId);
+		}
+
+		return allSplitHUs;
+	}
+
+	private I_M_HU findCUForProduct(@NonNull final I_M_HU hu, @NonNull final ProductId productId)
+	{
+		// If it's already a VHU (CU), return it directly
+		if (handlingUnitsBL.isVirtual(hu))
+		{
+			return hu;
+		}
+
+		// If it's an aggregate HU, it can be used directly with cuToNewCU
+		if (handlingUnitsBL.isAggregateHU(hu))
+		{
+			return hu;
+		}
+
+		// If it's a TU, find the VHU inside
+		final IHUStorageFactory storageFactory = handlingUnitsBL
+				.createMutableHUContext(InterfaceWrapperHelper.getContextAware(hu))
+				.getHUStorageFactory();
+
+		// Try to get product storage directly from this HU level
+		final IHUStorage huStorage = storageFactory.getStorage(hu);
+		final IHUProductStorage productStorage = huStorage.getProductStorageOrNull(productId);
+		if (productStorage != null && productStorage.getQty().signum() > 0)
+		{
+			// This HU has the product — find the VHU child that holds it
+			final List<I_M_HU> childHUs = handlingUnitsBL.retrieveIncludedHUs(hu);
+			for (final I_M_HU childHU : childHUs)
+			{
+				if (handlingUnitsBL.isVirtual(childHU))
+				{
+					final IHUStorage childStorage = storageFactory.getStorage(childHU);
+					final IHUProductStorage childProductStorage = childStorage.getProductStorageOrNull(productId);
+					if (childProductStorage != null && childProductStorage.getQty().signum() > 0)
+					{
+						return childHU;
+					}
+				}
+				// Recurse for nested TUs
+				final I_M_HU found = findCUForProduct(childHU, productId);
+				if (found != null)
+				{
+					return found;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private boolean isPickAvailableHUsOnTheFly()
+	{
+		return sysConfigBL.getBooleanValue(SYSCONFIG_PickAvailableHUsOnTheFly, true);
+	}
+
+	private boolean isFailIfNoHUsAssigned()
+	{
+		return sysConfigBL.getBooleanValue(SYSCONFIG_VendorReturnsInOut_FailIfNoHUsAssigned, true);
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/vendor/VendorReturnFromReceiptHUHandler.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/vendor/VendorReturnFromReceiptHUHandler.java
@@ -132,11 +132,8 @@ public class VendorReturnFromReceiptHUHandler
 			@NonNull final IHUStorageFactory storageFactory)
 	{
 		// 1. Find HUs assigned to the origin receipt line
-		final List<I_M_HU_Assignment> assignments = huAssignmentDAO.retrieveHUAssignmentsForModel(
-				InterfaceWrapperHelper.getCtx(returnLine),
-				org.compiere.model.I_M_InOutLine.Table_ID,
-				originInOutLineId,
-				org.compiere.util.Trx.TRXNAME_ThreadInherited);
+		final org.compiere.model.I_M_InOutLine originLine = InterfaceWrapperHelper.load(originInOutLineId, org.compiere.model.I_M_InOutLine.class);
+		final List<I_M_HU_Assignment> assignments = huAssignmentDAO.retrieveTopLevelHUAssignmentsForModel(originLine);
 
 		if (assignments.isEmpty())
 		{

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/vendor/VendorReturnFromReceiptHUHandler.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/vendor/VendorReturnFromReceiptHUHandler.java
@@ -5,6 +5,7 @@ import de.metas.handlingunits.IHUAssignmentBL;
 import de.metas.handlingunits.IHUAssignmentDAO;
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.allocation.transfer.HUTransformService;
+import de.metas.handlingunits.inout.IHUInOutBL;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_Assignment;
 import de.metas.handlingunits.model.I_M_InOutLine;
@@ -13,7 +14,7 @@ import de.metas.handlingunits.snapshot.ISnapshotProducer;
 import de.metas.handlingunits.storage.IHUProductStorage;
 import de.metas.handlingunits.storage.IHUStorage;
 import de.metas.handlingunits.storage.IHUStorageFactory;
-import de.metas.inout.InOutLineId;
+import de.metas.inout.IInOutBL;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
 import de.metas.util.Services;
@@ -24,7 +25,6 @@ import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ISysConfigBL;
 import org.adempiere.util.lang.IContextAware;
 import org.compiere.model.I_M_InOut;
-import org.compiere.model.I_M_InOutLine;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -48,10 +48,12 @@ public class VendorReturnFromReceiptHUHandler
 	@NonNull private final I_M_InOut vendorReturn;
 
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+	private final IInOutBL inOutBL = Services.get(IInOutBL.class);
 	private final IHUAssignmentDAO huAssignmentDAO = Services.get(IHUAssignmentDAO.class);
 	private final IHUAssignmentBL huAssignmentBL = Services.get(IHUAssignmentBL.class);
 	private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
 	private final IHUSnapshotDAO huSnapshotDAO = Services.get(IHUSnapshotDAO.class);
+	private final IHUInOutBL huInOutBL = Services.get(IHUInOutBL.class);
 
 	public void execute()
 	{
@@ -62,8 +64,12 @@ public class VendorReturnFromReceiptHUHandler
 		final List<I_M_HU> allSplitHUs = new ArrayList<>();
 
 		final List<I_M_InOutLine> returnLines = InterfaceWrapperHelper.createList(
-				Services.get(de.metas.inout.IInOutBL.class).getLines(vendorReturn),
+				inOutBL.getLines(vendorReturn),
 				I_M_InOutLine.class);
+
+		final IHUStorageFactory storageFactory = handlingUnitsBL
+				.createMutableHUContext(context)
+				.getHUStorageFactory();
 
 		for (final I_M_InOutLine returnLine : returnLines)
 		{
@@ -84,7 +90,7 @@ public class VendorReturnFromReceiptHUHandler
 				continue;
 			}
 
-			final List<I_M_HU> splitHUs = splitHUsForReturnLine(returnLine, originInOutLineId, returnQty);
+			final List<I_M_HU> splitHUs = splitHUsForReturnLine(returnLine, originInOutLineId, returnQty, storageFactory);
 			if (splitHUs.isEmpty())
 			{
 				continue;
@@ -111,7 +117,6 @@ public class VendorReturnFromReceiptHUHandler
 		}
 
 		// Also assign all HUs to the header
-		final de.metas.handlingunits.inout.IHUInOutBL huInOutBL = Services.get(de.metas.handlingunits.inout.IHUInOutBL.class);
 		huInOutBL.setAssignedHandlingUnits(vendorReturn, allSplitHUs);
 
 		// Create snapshots and store the UUID
@@ -123,7 +128,8 @@ public class VendorReturnFromReceiptHUHandler
 	private List<I_M_HU> splitHUsForReturnLine(
 			@NonNull final I_M_InOutLine returnLine,
 			final int originInOutLineId,
-			@NonNull final BigDecimal returnQty)
+			@NonNull final BigDecimal returnQty,
+			@NonNull final IHUStorageFactory storageFactory)
 	{
 		// 1. Find HUs assigned to the origin receipt line
 		final List<I_M_HU_Assignment> assignments = huAssignmentDAO.retrieveHUAssignmentsForModel(
@@ -184,13 +190,14 @@ public class VendorReturnFromReceiptHUHandler
 		}
 
 		// 3. Split the return quantity from the source HUs
-		return splitQuantityFromHUs(sourceHUs, returnLine, returnQty);
+		return splitQuantityFromHUs(sourceHUs, returnLine, returnQty, storageFactory);
 	}
 
 	private List<I_M_HU> splitQuantityFromHUs(
 			@NonNull final List<I_M_HU> sourceHUs,
 			@NonNull final I_M_InOutLine returnLine,
-			@NonNull final BigDecimal returnQty)
+			@NonNull final BigDecimal returnQty,
+			@NonNull final IHUStorageFactory storageFactory)
 	{
 		final ProductId productId = ProductId.ofRepoId(returnLine.getM_Product_ID());
 		final HUTransformService huTransformService = HUTransformService.newInstance();
@@ -205,16 +212,13 @@ public class VendorReturnFromReceiptHUHandler
 			}
 
 			// Navigate to the VHU level if this is a TU
-			final I_M_HU cuHU = findCUForProduct(sourceHU, productId);
+			final I_M_HU cuHU = findCUForProduct(sourceHU, productId, storageFactory);
 			if (cuHU == null)
 			{
 				continue;
 			}
 
 			// Determine how much we can split from this HU
-			final IHUStorageFactory storageFactory = handlingUnitsBL
-					.createMutableHUContext(InterfaceWrapperHelper.getContextAware(returnLine))
-					.getHUStorageFactory();
 			final IHUStorage huStorage = storageFactory.getStorage(cuHU);
 			final IHUProductStorage productStorage = huStorage.getProductStorageOrNull(productId);
 			if (productStorage == null || productStorage.getQty().signum() <= 0)
@@ -222,7 +226,7 @@ public class VendorReturnFromReceiptHUHandler
 				continue;
 			}
 
-			final BigDecimal availableQty = productStorage.getQty();
+			final BigDecimal availableQty = productStorage.getQty().toBigDecimal();
 			final BigDecimal splitQty = remainingQty.min(availableQty);
 
 			final Quantity splitQuantity = Quantity.of(splitQty, productStorage.getC_UOM());
@@ -242,7 +246,10 @@ public class VendorReturnFromReceiptHUHandler
 		return allSplitHUs;
 	}
 
-	private I_M_HU findCUForProduct(@NonNull final I_M_HU hu, @NonNull final ProductId productId)
+	private I_M_HU findCUForProduct(
+			@NonNull final I_M_HU hu,
+			@NonNull final ProductId productId,
+			@NonNull final IHUStorageFactory storageFactory)
 	{
 		// If it's already a VHU (CU), return it directly
 		if (handlingUnitsBL.isVirtual(hu))
@@ -257,11 +264,6 @@ public class VendorReturnFromReceiptHUHandler
 		}
 
 		// If it's a TU, find the VHU inside
-		final IHUStorageFactory storageFactory = handlingUnitsBL
-				.createMutableHUContext(InterfaceWrapperHelper.getContextAware(hu))
-				.getHUStorageFactory();
-
-		// Try to get product storage directly from this HU level
 		final IHUStorage huStorage = storageFactory.getStorage(hu);
 		final IHUProductStorage productStorage = huStorage.getProductStorageOrNull(productId);
 		if (productStorage != null && productStorage.getQty().signum() > 0)
@@ -280,7 +282,7 @@ public class VendorReturnFromReceiptHUHandler
 					}
 				}
 				// Recurse for nested TUs
-				final I_M_HU found = findCUForProduct(childHU, productId);
+				final I_M_HU found = findCUForProduct(childHU, productId, storageFactory);
 				if (found != null)
 				{
 					return found;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_InOut.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_InOut.java
@@ -37,6 +37,7 @@ import de.metas.handlingunits.inout.IHUShipmentAssignmentBL;
 import de.metas.handlingunits.inout.impl.MInOutHUDocumentFactory;
 import de.metas.handlingunits.inout.impl.ReceiptInOutLineHUAssignmentListener;
 import de.metas.handlingunits.inout.returns.ReturnsServiceFacade;
+import de.metas.handlingunits.inout.returns.vendor.VendorReturnFromReceiptHUHandler;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_InOutLine;
 import de.metas.handlingunits.model.I_M_ShipmentSchedule_QtyPicked;
@@ -375,6 +376,51 @@ public class M_InOut
 	private boolean isCustomerReturnsInOut_FailIfNoHUsAssigned()
 	{
 		return sysConfigBL.getBooleanValue(SYSCONFIG_CustomerReturnsInOut_FailIfNoHUsAssigned, true);
+	}
+
+	/**
+	 * On vendor return completion (created by {@code M_InOut_GenerateVendorReturn}):
+	 * split/transform receipt HUs to correctly separate the returned quantities.
+	 * <p>
+	 * Only applies to vendor returns that have a {@code Return_Origin_InOut_ID}
+	 * (i.e., created from a receipt by the new process). Does NOT affect existing
+	 * HU-based vendor return or empties return flows.
+	 */
+	@DocValidate(timings = { ModelValidator.TIMING_BEFORE_COMPLETE })
+	public void handleVendorReturnFromReceipt(final I_M_InOut vendorReturn)
+	{
+		if (!returnsServiceFacade.isVendorReturn(vendorReturn))
+		{
+			return;
+		}
+
+		if (returnsServiceFacade.isReversal(vendorReturn))
+		{
+			return;
+		}
+
+		if (returnsServiceFacade.isEmptiesReturn(vendorReturn))
+		{
+			return;
+		}
+
+		// Only handle vendor returns created from receipts (by M_InOut_GenerateVendorReturn)
+		if (vendorReturn.getReturn_Origin_InOut_ID() <= 0)
+		{
+			return;
+		}
+
+		// Skip if HUs are already assigned (e.g., from the existing HU-based vendor return flow)
+		final List<I_M_HU> existingHUs = huInOutBL.retrieveHandlingUnits(vendorReturn);
+		if (!existingHUs.isEmpty())
+		{
+			return;
+		}
+
+		VendorReturnFromReceiptHUHandler.builder()
+				.vendorReturn(vendorReturn)
+				.build()
+				.execute();
 	}
 
 	@DocValidate(timings = ModelValidator.TIMING_AFTER_REVERSECORRECT)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/shipment/process/M_InOut_GenerateVendorReturn.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/shipment/process/M_InOut_GenerateVendorReturn.java
@@ -1,0 +1,146 @@
+package de.metas.ui.web.shipment.process;
+
+import de.metas.common.util.time.SystemTime;
+import de.metas.document.DocBaseType;
+import de.metas.document.DocSubType;
+import de.metas.document.DocTypeId;
+import de.metas.document.DocTypeQuery;
+import de.metas.document.IDocTypeDAO;
+import de.metas.document.engine.DocStatus;
+import de.metas.inout.IInOutBL;
+import de.metas.inout.InOutId;
+import de.metas.inout.model.I_M_InOutLine;
+import de.metas.material.MovementType;
+import de.metas.order.OrderLineId;
+import de.metas.process.IProcessPrecondition;
+import de.metas.process.IProcessPreconditionsContext;
+import de.metas.process.JavaProcess;
+import de.metas.process.ProcessExecutionResult.RecordsToOpen;
+import de.metas.process.ProcessExecutionResult.RecordsToOpen.OpenTarget;
+import de.metas.process.ProcessPreconditionsResolution;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.adempiere.warehouse.LocatorId;
+import org.adempiere.warehouse.WarehouseId;
+import org.adempiere.warehouse.api.IWarehouseBL;
+import org.compiere.model.I_M_InOut;
+
+/**
+ * Process to generate a vendor return document from a completed material receipt.
+ * <p>
+ * Creates a new vendor return (M_InOut with MovementType=V-) in Draft status,
+ * copying all lines from the receipt. The user can then adjust quantities
+ * and delete lines before completing the return.
+ * <p>
+ * Analogous to {@link M_InOut_GenerateCustomerReturn} but for the purchase side.
+ */
+public class M_InOut_GenerateVendorReturn extends JavaProcess implements IProcessPrecondition
+{
+	private static final String VENDOR_RETURN_WINDOW_ID = "53098";
+
+	private final IInOutBL inoutBL = Services.get(IInOutBL.class);
+	private final IDocTypeDAO docTypeDAO = Services.get(IDocTypeDAO.class);
+	private final IWarehouseBL warehouseBL = Services.get(IWarehouseBL.class);
+
+	@Override
+	public ProcessPreconditionsResolution checkPreconditionsApplicable(final @NonNull IProcessPreconditionsContext context)
+	{
+		if (!context.isSingleSelection())
+		{
+			return ProcessPreconditionsResolution.rejectBecauseNotSingleSelection().toInternal();
+		}
+
+		final InOutId receiptId = context.getSingleSelectedRecordId(InOutId.class);
+		final I_M_InOut receipt = inoutBL.getById(receiptId);
+
+		final MovementType movementType = MovementType.ofCode(receipt.getMovementType());
+		if (movementType != MovementType.VendorReceipts)
+		{
+			return ProcessPreconditionsResolution.rejectWithInternalReason("Not a vendor receipt");
+		}
+
+		final DocStatus docStatus = DocStatus.ofCode(receipt.getDocStatus());
+		if (!docStatus.isCompletedOrClosed())
+		{
+			return ProcessPreconditionsResolution.rejectWithInternalReason("Receipt is not completed or closed");
+		}
+
+		return ProcessPreconditionsResolution.accept();
+	}
+
+	@Override
+	protected String doIt()
+	{
+		final I_M_InOut receipt = inoutBL.getById(getReceiptId());
+
+		final MovementType movementType = MovementType.ofCode(receipt.getMovementType());
+		if (movementType != MovementType.VendorReceipts)
+		{
+			throw new AdempiereException("Not a vendor receipt");
+		}
+
+		final DocStatus docStatus = DocStatus.ofCode(receipt.getDocStatus());
+		if (!docStatus.isCompletedOrClosed())
+		{
+			throw new AdempiereException("Receipt is not completed or closed");
+		}
+
+		// Find the vendor return doc type: DocBaseType=MMS (Shipment), isSOTrx=false, DocSubType=NONE
+		final DocTypeId docTypeId = docTypeDAO.getDocTypeId(DocTypeQuery.builder()
+				.docBaseType(DocBaseType.Shipment)
+				.docSubType(DocSubType.NONE)
+				.isSOTrx(false)
+				.adClientId(receipt.getAD_Client_ID())
+				.adOrgId(receipt.getAD_Org_ID())
+				.build());
+
+		// Use the same warehouse as the receipt (not the quality return warehouse)
+		final WarehouseId warehouseId = WarehouseId.ofRepoId(receipt.getM_Warehouse_ID());
+		final LocatorId locatorId = warehouseBL.getOrCreateDefaultLocatorId(warehouseId);
+
+		// Create vendor return header by copying the receipt
+		final I_M_InOut vendorReturn = InterfaceWrapperHelper.copy()
+				.setSkipCalculatedColumns(true)
+				.setFrom(receipt)
+				.copyToNew(I_M_InOut.class);
+		vendorReturn.setC_DocType_ID(docTypeId.getRepoId());
+		vendorReturn.setIsSOTrx(false);
+		vendorReturn.setMovementType(MovementType.VendorReturns.getCode());
+		vendorReturn.setReturn_Origin_InOut_ID(receipt.getM_InOut_ID());
+		vendorReturn.setMovementDate(SystemTime.asTimestamp());
+		vendorReturn.setDateAcct(SystemTime.asTimestamp());
+		vendorReturn.setM_Warehouse_ID(warehouseId.getRepoId());
+		InterfaceWrapperHelper.save(vendorReturn);
+
+		// Copy all lines (including packing material lines) from the receipt
+		for (final org.compiere.model.I_M_InOutLine receiptLine : inoutBL.getLines(receipt))
+		{
+			final I_M_InOutLine returnLine = InterfaceWrapperHelper.copy()
+					.setSkipCalculatedColumns(true)
+					.setFrom(receiptLine)
+					.copyToNew(I_M_InOutLine.class);
+			returnLine.setM_InOut_ID(vendorReturn.getM_InOut_ID());
+			returnLine.setReturn_Origin_InOutLine_ID(receiptLine.getM_InOutLine_ID());
+			returnLine.setM_Locator_ID(locatorId.getRepoId());
+			returnLine.setC_OrderLine_ID(OrderLineId.toRepoId(null));
+			InterfaceWrapperHelper.save(returnLine);
+		}
+
+		// Open the created vendor return in the Vendor Returns window (AD_Window_ID=53098)
+		getResult().setRecordToOpen(RecordsToOpen.builder()
+				.record(TableRecordReference.of(vendorReturn))
+				.adWindowId(VENDOR_RETURN_WINDOW_ID)
+				.target(OpenTarget.SingleDocument)
+				.build());
+
+		return MSG_OK;
+	}
+
+	private InOutId getReceiptId()
+	{
+		return InOutId.ofRepoId(getRecord_ID());
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/shipment/process/M_InOut_GenerateVendorReturn.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/shipment/process/M_InOut_GenerateVendorReturn.java
@@ -48,7 +48,7 @@ public class M_InOut_GenerateVendorReturn extends JavaProcess implements IProces
 	{
 		if (!context.isSingleSelection())
 		{
-			return ProcessPreconditionsResolution.rejectBecauseNotSingleSelection().toInternal();
+			return ProcessPreconditionsResolution.rejectBecauseNotSingleSelection();
 		}
 
 		final InOutId receiptId = context.getSingleSelectedRecordId(InOutId.class);

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/shipment/process/M_InOut_GenerateVendorReturn.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/shipment/process/M_InOut_GenerateVendorReturn.java
@@ -39,8 +39,6 @@ import org.compiere.model.I_M_InOut;
  */
 public class M_InOut_GenerateVendorReturn extends JavaProcess implements IProcessPrecondition
 {
-	private static final String VENDOR_RETURN_WINDOW_ID = "53098";
-
 	private final IInOutBL inoutBL = Services.get(IInOutBL.class);
 	private final IDocTypeDAO docTypeDAO = Services.get(IDocTypeDAO.class);
 	private final IWarehouseBL warehouseBL = Services.get(IWarehouseBL.class);
@@ -129,10 +127,9 @@ public class M_InOut_GenerateVendorReturn extends JavaProcess implements IProces
 			InterfaceWrapperHelper.save(returnLine);
 		}
 
-		// Open the created vendor return in the Vendor Returns window (AD_Window_ID=53098)
+		// Open the created vendor return — let the framework resolve the correct window via zoom targets
 		getResult().setRecordToOpen(RecordsToOpen.builder()
 				.record(TableRecordReference.of(vendorReturn))
-				.adWindowId(VENDOR_RETURN_WINDOW_ID)
 				.target(OpenTarget.SingleDocument)
 				.build());
 

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5793510_fix_vendor_return_relations.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5793510_fix_vendor_return_relations.sql
@@ -225,3 +225,26 @@ SET ReadOnlyLogic='', Updated=TO_TIMESTAMP('2026-03-10 14:22:56.036000', 'YYYY-M
 WHERE AD_Column_ID = 12868
 ;
 
+-- UI Element: Lieferantenrücklieferung(53098,D) -> Lieferantenrücklieferung(53276,D) -> advanced edit -> 10 -> advanced edit.Ursprüngliche Lieferung
+-- Column: M_InOut.Return_Origin_InOut_ID
+-- 2026-03-10T14:44:52.419Z
+DELETE
+FROM AD_UI_Element
+WHERE AD_UI_Element_ID = 648541
+;
+
+-- UI Element: Lieferantenrücklieferung(53098,D) -> Lieferantenrücklieferung(53276,D) -> main -> 10 -> default.Ursprüngliche Wareneingänge
+-- Column: M_InOut.Return_Origin_InOut_ID
+-- 2026-03-10T14:45:35.414Z
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774826, 0, 53276, 540744, 648543, 'F', TO_TIMESTAMP('2026-03-10 14:45:35.175000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'Y', 'N', 'N', 'Y', 'N', 'N', 'N', 0, 'Ursprüngliche Wareneingänge', 30, 0, 0, TO_TIMESTAMP('2026-03-10 14:45:35.175000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100)
+;
+
+-- Tab: Lieferantenrücklieferung(53098,D) -> Handling Unit Assignment
+-- Table: M_HU_Assignment
+-- 2026-03-10T14:48:29.762Z
+UPDATE AD_Tab
+SET TabLevel=1, Updated=TO_TIMESTAMP('2026-03-10 14:48:29.761000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Tab_ID = 540794
+;
+

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5793510_fix_vendor_return_relations.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5793510_fix_vendor_return_relations.sql
@@ -1,0 +1,227 @@
+-- Run mode: SWING_CLIENT
+
+-- UI Element: Lieferantenrücklieferung(53098,D) -> Positionen(53277,D) -> main -> 10 -> default.Return_Origin_InOutLine_ID
+-- Column: M_InOutLine.Return_Origin_InOutLine_ID
+-- 2026-03-10T11:17:41.236Z
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, Description, IsActive, IsAdvancedField, IsAllowFiltering, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 558145, 0, 53277, 540105, 648540, 'F', TO_TIMESTAMP('2026-03-10 11:17:41.080000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'Original receipt line containing the products that are returned.', 'Y', 'N', 'N', 'Y', 'N', 'N', 'N', 0, 'Return_Origin_InOutLine_ID', 95, 0, 0,
+        TO_TIMESTAMP('2026-03-10 11:17:41.080000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100)
+;
+
+-- UI Element: Lieferantenrücklieferung(53098,D) -> Lieferantenrücklieferung(53276,D) -> advanced edit -> 10 -> advanced edit.Ursprüngliche Lieferung
+-- Column: M_InOut.Return_Origin_InOut_ID
+-- 2026-03-10T11:19:51.418Z
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774826, 0, 53276, 540104, 648541, 'F', TO_TIMESTAMP('2026-03-10 11:19:51.298000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'Y', 'Y', 'N', 'Y', 'N', 'N', 'N', 0, 'Ursprüngliche Lieferung', 360, 0, 0, TO_TIMESTAMP('2026-03-10 11:19:51.298000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100)
+;
+
+-- Name: M_InOut PO
+-- 2026-03-10T11:22:05.373Z
+INSERT INTO AD_Reference (AD_Client_ID, AD_Org_ID, AD_Reference_ID, Created, CreatedBy, EntityType, IsActive, IsOrderByValue, Name, Updated, UpdatedBy, ValidationType)
+VALUES (0, 0, 542075, TO_TIMESTAMP('2026-03-10 11:22:05.217000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'D', 'Y', 'N', 'M_InOut PO', TO_TIMESTAMP('2026-03-10 11:22:05.217000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'T')
+;
+
+-- 2026-03-10T11:22:05.376Z
+INSERT INTO AD_Reference_Trl (AD_Language, AD_Reference_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language,
+       t.AD_Reference_ID,
+       t.Description,
+       t.Help,
+       t.Name,
+       'N',
+       t.AD_Client_ID,
+       t.AD_Org_ID,
+       t.Created,
+       t.Createdby,
+       t.Updated,
+       t.UpdatedBy,
+       'Y'
+FROM AD_Language l,
+     AD_Reference t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Reference_ID = 542075
+  AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Reference_ID = t.AD_Reference_ID)
+;
+
+-- Reference: M_InOut PO
+-- Table: M_InOut
+-- Key: M_InOut.M_InOut_ID
+-- 2026-03-10T11:22:46.433Z
+INSERT INTO AD_Ref_Table (AD_Client_ID, AD_Key, AD_Org_ID, AD_Reference_ID, AD_Table_ID, AD_Window_ID, Created, CreatedBy, EntityType, IsActive, IsValueDisplayed, ShowInactiveValues, Updated, UpdatedBy, WhereClause)
+VALUES (0, 3521, 0, 542075, 319, 184, TO_TIMESTAMP('2026-03-10 11:22:46.423000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'D', 'Y', 'N', 'N', TO_TIMESTAMP('2026-03-10 11:22:46.423000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'IsSOTrx=''N''')
+;
+
+-- Column: M_InOut.Return_Origin_InOut_ID
+-- 2026-03-10T11:23:14.760Z
+UPDATE AD_Column
+SET AD_Reference_Value_ID=542075, IsExcludeFromZoomTargets='Y', Updated=TO_TIMESTAMP('2026-03-10 11:23:14.760000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Column_ID = 591915
+;
+
+-- 2026-03-10T11:27:58.427Z
+INSERT INTO AD_Element (AD_Client_ID, AD_Element_ID, AD_Org_ID, Created, CreatedBy, EntityType, IsActive, Name, PrintName, Updated, UpdatedBy)
+VALUES (0, 584649, 0, TO_TIMESTAMP('2026-03-10 11:27:58.307000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'D', 'Y', 'Ursprüngliche Wareneingänge', 'Ursprüngliche Wareneingänge', TO_TIMESTAMP('2026-03-10 11:27:58.307000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100)
+;
+
+-- 2026-03-10T11:27:58.431Z
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, CommitWarning, Description, Help, Name, PO_Description, PO_Help, PO_Name, PO_PrintName, PrintName, WEBUI_NameBrowse, WEBUI_NameNew, WEBUI_NameNewBreadcrumb, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language,
+       t.AD_Element_ID,
+       t.CommitWarning,
+       t.Description,
+       t.Help,
+       t.Name,
+       t.PO_Description,
+       t.PO_Help,
+       t.PO_Name,
+       t.PO_PrintName,
+       t.PrintName,
+       t.WEBUI_NameBrowse,
+       t.WEBUI_NameNew,
+       t.WEBUI_NameNewBreadcrumb,
+       'N',
+       t.AD_Client_ID,
+       t.AD_Org_ID,
+       t.Created,
+       t.Createdby,
+       t.Updated,
+       t.UpdatedBy,
+       'Y'
+FROM AD_Language l,
+     AD_Element t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Element_ID = 584649
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID)
+;
+
+-- Element: null
+-- 2026-03-10T11:28:15.622Z
+UPDATE AD_Element_Trl
+SET IsTranslated='Y', Name='Original Receipt', PrintName='Original Receipt Wareneingänge', Updated=TO_TIMESTAMP('2026-03-10 11:28:15.622000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Element_ID = 584649
+  AND AD_Language = 'en_US'
+;
+
+-- 2026-03-10T11:28:15.623Z
+UPDATE AD_Element base
+SET Name=trl.Name, PrintName=trl.PrintName, Updated=trl.Updated, UpdatedBy=trl.UpdatedBy
+FROM AD_Element_Trl trl
+WHERE trl.AD_Element_ID = base.AD_Element_ID
+  AND trl.AD_Language = 'en_US'
+  AND trl.AD_Language = getBaseLanguage()
+;
+
+-- 2026-03-10T11:28:15.896Z
+/* DDL */
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584649, 'en_US')
+;
+
+-- Field: Lieferantenrücklieferung(53098,D) -> Lieferantenrücklieferung(53276,D) -> Ursprüngliche Wareneingänge
+-- Column: M_InOut.Return_Origin_InOut_ID
+-- 2026-03-10T11:28:51.263Z
+UPDATE AD_Field
+SET AD_Name_ID=584649, Description=NULL, Help=NULL, Name='Ursprüngliche Wareneingänge', Updated=TO_TIMESTAMP('2026-03-10 11:28:51.263000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Field_ID = 774826
+;
+
+-- 2026-03-10T11:28:51.264Z
+UPDATE AD_Field_Trl trl
+SET Name='Ursprüngliche Wareneingänge'
+WHERE AD_Field_ID = 774826
+  AND AD_Language = 'de_DE'
+;
+
+-- 2026-03-10T11:28:51.266Z
+/* DDL */
+
+SELECT update_FieldTranslation_From_AD_Name_Element(584649)
+;
+
+-- 2026-03-10T11:28:51.277Z
+DELETE
+FROM AD_Element_Link
+WHERE AD_Field_ID = 774826
+;
+
+-- 2026-03-10T11:28:51.280Z
+/* DDL */
+
+SELECT AD_Element_Link_Create_Missing_Field(774826)
+;
+
+-- Name: Shipment -> Customer Return
+-- Source Reference: M_InOut SO
+-- Target Reference: Customer Return target for Shipment
+-- 2026-03-10T11:51:35.788Z
+UPDATE AD_RelationType
+SET AD_Reference_Source_ID=540299, Updated=TO_TIMESTAMP('2026-03-10 11:51:35.788000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_RelationType_ID = 540489
+;
+
+-- Name: Vendor Return target for Shipment
+-- 2026-03-10T11:52:13.965Z
+INSERT INTO AD_Reference (AD_Client_ID, AD_Org_ID, AD_Reference_ID, Created, CreatedBy, EntityType, IsActive, IsOrderByValue, Name, Updated, UpdatedBy, ValidationType)
+VALUES (0, 0, 542076, TO_TIMESTAMP('2026-03-10 11:52:13.840000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'D', 'Y', 'N', 'Vendor Return target for Shipment', TO_TIMESTAMP('2026-03-10 11:52:13.840000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'T')
+;
+
+-- 2026-03-10T11:52:13.969Z
+INSERT INTO AD_Reference_Trl (AD_Language, AD_Reference_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language,
+       t.AD_Reference_ID,
+       t.Description,
+       t.Help,
+       t.Name,
+       'N',
+       t.AD_Client_ID,
+       t.AD_Org_ID,
+       t.Created,
+       t.Createdby,
+       t.Updated,
+       t.UpdatedBy,
+       'Y'
+FROM AD_Language l,
+     AD_Reference t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Reference_ID = 542076
+  AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Reference_ID = t.AD_Reference_ID)
+;
+
+-- Reference: Vendor Return target for Shipment
+-- Table: M_InOut
+-- Key: M_InOut.M_InOut_ID
+-- 2026-03-10T11:53:33.458Z
+INSERT INTO AD_Ref_Table (AD_Client_ID, AD_Key, AD_Org_ID, AD_Reference_ID, AD_Table_ID, AD_Window_ID, Created, CreatedBy, EntityType, IsActive, IsValueDisplayed, ShowInactiveValues, Updated, UpdatedBy, WhereClause)
+VALUES (0, 3521, 0, 542076, 319, 53098, TO_TIMESTAMP('2026-03-10 11:53:33.453000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'D', 'Y', 'N', 'N', TO_TIMESTAMP('2026-03-10 11:53:33.453000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'M_InOut.Return_Origin_InOut_ID = @M_InOut_ID/-1@')
+;
+
+-- Reference: Customer Return target for Shipment
+-- Table: M_InOut
+-- Key: M_InOut.M_InOut_ID
+-- 2026-03-10T11:53:49.628Z
+UPDATE AD_Ref_Table
+SET AD_Window_ID=53097, Updated=TO_TIMESTAMP('2026-03-10 11:53:49.628000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Reference_ID = 542049
+;
+
+-- Name: Shipment -> Vendor Return
+-- Source Reference: M_InOut PO
+-- Target Reference: Vendor Return target for Shipment
+-- 2026-03-10T11:55:58.113Z
+INSERT INTO AD_RelationType (AD_Client_ID, AD_Org_ID, AD_Reference_Source_ID, AD_Reference_Target_ID, AD_RelationType_ID, Created, CreatedBy, EntityType, IsActive, IsTableRecordIdTarget, Name, Updated, UpdatedBy)
+VALUES (0, 0, 542075, 542076, 540494, TO_TIMESTAMP('2026-03-10 11:55:57.988000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, 'de.metas.swat', 'Y', 'N', 'Shipment -> Vendor Return', TO_TIMESTAMP('2026-03-10 11:55:57.988000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100)
+;
+
+
+-- From `@IsPackagingMaterial@=N & @IsManualPackingMaterial@=N & @IsManual@ = N`
+-- Without this, it will not be possible to create partial vendor returns
+-- Column: M_InOutLine.QtyEntered
+-- 2026-03-10T14:22:56.036Z
+UPDATE AD_Column
+SET ReadOnlyLogic='', Updated=TO_TIMESTAMP('2026-03-10 14:22:56.036000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Column_ID = 12868
+;
+


### PR DESCRIPTION
## Summary
- New process `M_InOut_GenerateVendorReturn` creates vendor return documents from completed material receipts
- HU handler `VendorReturnFromReceiptHUHandler` splits receipt HUs to match return quantities using `HUTransformService.cuToNewCU()`
- Supports `PickAvailableHUsOnTheFly` mode for customers who don't manage HUs directly
- Migration script registers AD_Process, AD_Table_Process, AD_Field (Return_Origin_InOut_ID on vendor return window), and AD_SysConfig

## Test plan
- [ ] Process appears as action on completed vendor receipts (MovementType=V+)
- [ ] Process does NOT appear on shipments, customer returns, or non-completed receipts
- [ ] Generated vendor return has correct DocType (Shipment, isSOTrx=false), MovementType=V-, and Return_Origin_InOut_ID
- [ ] All receipt lines (including packing material) are copied to the return
- [ ] Completing the vendor return splits HUs from the receipt and assigns them
- [ ] With PickAvailableHUsOnTheFly=Y, completion succeeds even without HU assignments
- [ ] Reversing the vendor return restores HU snapshots