### PR TITLE
Cucumber suite for Zoom-To and Related Documents

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/references/zoom_into/RecordWindowFinder.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/references/zoom_into/RecordWindowFinder.java
@@ -81,7 +81,7 @@ public class RecordWindowFinder
 
 	public static RecordWindowFinder newInstance(final String tableName, final SOTrx soTrx)
 	{
-		return new RecordWindowFinder(tableName, soTrx, null);
+		return new RecordWindowFinder(tableName, soTrx, getCustomizedWindowInfoMapRepository());
 	}
 
 	public static Optional<AdWindowId> findAdWindowId(final TableRecordReference record)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ReferenceFieldInfo.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ReferenceFieldInfo.java
@@ -17,9 +17,4 @@ public class ReferenceFieldInfo
 
 	@Nullable AdWindowId resolvedWindowId;
 	@Nullable String resolvedWindowName;
-
-	boolean hasIsSOTrxColumn;
-
-	@Nullable AdWindowId defaultSOWindowId;
-	@Nullable AdWindowId defaultPOWindowId;
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ReferenceFieldInfo.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ReferenceFieldInfo.java
@@ -1,0 +1,25 @@
+package de.metas.cucumber.stepdefs.zoom_into;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import org.adempiere.ad.element.api.AdWindowId;
+
+import javax.annotation.Nullable;
+
+@Value
+@Builder
+public class ReferenceFieldInfo
+{
+	@NonNull String sourceTableName;
+	@NonNull String sourceColumnName;
+	@NonNull String targetTableName;
+
+	@Nullable AdWindowId resolvedWindowId;
+	@Nullable String resolvedWindowName;
+
+	boolean hasIsSOTrxColumn;
+
+	@Nullable AdWindowId defaultSOWindowId;
+	@Nullable AdWindowId defaultPOWindowId;
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/RelatedDocuments_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/RelatedDocuments_StepDef.java
@@ -1,0 +1,133 @@
+package de.metas.cucumber.stepdefs.zoom_into;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
+import de.metas.document.references.related_documents.IZoomSource;
+import de.metas.document.references.related_documents.POZoomSource;
+import de.metas.document.references.related_documents.RelatedDocumentsCandidateGroup;
+import de.metas.document.references.related_documents.RelatedDocumentsFactory;
+import de.metas.document.references.related_documents.RelatedDocumentsPermissions;
+import de.metas.document.references.related_documents.RelatedDocumentsPermissionsFactory;
+import de.metas.i18n.ITranslatableString;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.element.api.AdWindowId;
+import org.adempiere.ad.window.api.IADWindowDAO;
+import org.assertj.core.api.SoftAssertions;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.MTable;
+import org.compiere.model.PO;
+import org.compiere.util.Env;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RequiredArgsConstructor
+public class RelatedDocuments_StepDef
+{
+	@NonNull private final ZoomIntoTestHelper helper;
+	@NonNull private final C_Order_StepDefData orderTable;
+
+	@NonNull private final RelatedDocumentsFactory relatedDocumentsFactory = SpringContextHolder.instance.getBean(RelatedDocumentsFactory.class);
+	@NonNull private final IADWindowDAO windowDAO = Services.get(IADWindowDAO.class);
+
+	private ImmutableList<RelatedDocumentsCandidateGroup> lastCandidateGroups;
+
+	@Then("the following source tables have at least the listed related document targets:")
+	public void source_tables_have_minimum_related_document_targets(@NonNull final DataTable dataTable)
+	{
+		final SoftAssertions softly = new SoftAssertions();
+
+		DataTableRows.of(dataTable).forEach(row -> {
+			final String sourceTable = row.getAsString("SourceTable");
+			final int minTargetCount = row.getAsInt("MinTargetCount");
+
+			final ImmutableList<RelatedDocumentsCandidateGroup> candidates = getCandidateGroupsForTable(sourceTable);
+
+			softly.assertThat(candidates.size())
+					.as("Related document candidate groups for source table " + sourceTable)
+					.isGreaterThanOrEqualTo(minTargetCount);
+		});
+
+		softly.assertAll();
+	}
+
+	@Then("related documents for source table {string} include targets:")
+	public void related_documents_include_targets(@NonNull final String sourceTable, @NonNull final DataTable dataTable)
+	{
+		final ImmutableList<RelatedDocumentsCandidateGroup> candidates = getCandidateGroupsForTable(sourceTable);
+
+		final Set<String> targetWindowNames = candidates.stream()
+				.map(group -> getWindowName(group.getTargetWindowId()))
+				.collect(Collectors.toSet());
+
+		final SoftAssertions softly = new SoftAssertions();
+
+		DataTableRows.of(dataTable).forEach(row -> {
+			final String expectedTargetWindowName = row.getAsString("TargetWindowName");
+
+			softly.assertThat(targetWindowNames)
+					.as("Related document target windows for source table " + sourceTable + " should include " + expectedTargetWindowName)
+					.contains(expectedTargetWindowName);
+		});
+
+		softly.assertAll();
+	}
+
+	@When("related documents are retrieved for the C_Order identified by {string}")
+	public void related_documents_retrieved_for_order(@NonNull final String orderIdentifier)
+	{
+		final I_C_Order order = orderTable.get(orderIdentifier);
+		lastCandidateGroups = helper.getRelatedDocumentsCandidates(order);
+	}
+
+	@Then("the related documents include at least {int} candidate groups")
+	public void related_documents_include_at_least_n_groups(final int minCount)
+	{
+		assertThat(lastCandidateGroups)
+				.as("Related documents candidate groups")
+				.isNotNull();
+
+		assertThat(lastCandidateGroups.size())
+				.as("Number of related document candidate groups")
+				.isGreaterThanOrEqualTo(minCount);
+	}
+
+	@Then("the related documents include a candidate group targeting window {string}")
+	public void related_documents_include_candidate_group_targeting_window(@NonNull final String expectedWindowName)
+	{
+		assertThat(lastCandidateGroups)
+				.as("Related documents candidate groups should not be null")
+				.isNotNull();
+
+		final Set<String> windowNames = lastCandidateGroups.stream()
+				.map(group -> getWindowName(group.getTargetWindowId()))
+				.collect(Collectors.toSet());
+
+		assertThat(windowNames)
+				.as("Related document target window names should include " + expectedWindowName)
+				.contains(expectedWindowName);
+	}
+
+	private ImmutableList<RelatedDocumentsCandidateGroup> getCandidateGroupsForTable(@NonNull final String tableName)
+	{
+		final PO po = MTable.get(Env.getCtx(), tableName).getPO(0, null);
+		final IZoomSource zoomSource = POZoomSource.of(po);
+		final RelatedDocumentsPermissions permissions = RelatedDocumentsPermissionsFactory.allowAll();
+		return relatedDocumentsFactory.getRelatedDocumentsCandidates(zoomSource, permissions);
+	}
+
+	private String getWindowName(@NonNull final AdWindowId windowId)
+	{
+		final ITranslatableString name = windowDAO.retrieveWindowName(windowId);
+		return name != null ? name.getDefaultValue() : "UNKNOWN(ID=" + windowId.getRepoId() + ")";
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/RelatedDocuments_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/RelatedDocuments_StepDef.java
@@ -3,23 +3,14 @@ package de.metas.cucumber.stepdefs.zoom_into;
 import com.google.common.collect.ImmutableList;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
-import de.metas.document.references.related_documents.IZoomSource;
-import de.metas.document.references.related_documents.POZoomSource;
 import de.metas.document.references.related_documents.RelatedDocumentsCandidateGroup;
-import de.metas.document.references.related_documents.RelatedDocumentsFactory;
-import de.metas.document.references.related_documents.RelatedDocumentsPermissions;
-import de.metas.document.references.related_documents.RelatedDocumentsPermissionsFactory;
-import de.metas.i18n.ITranslatableString;
-import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.element.api.AdWindowId;
-import org.adempiere.ad.window.api.IADWindowDAO;
 import org.assertj.core.api.SoftAssertions;
-import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_Order;
 import org.adempiere.ad.persistence.TableModelLoader;
 import org.compiere.model.PO;
@@ -34,9 +25,6 @@ public class RelatedDocuments_StepDef
 {
 	@NonNull private final ZoomIntoTestHelper helper;
 	@NonNull private final C_Order_StepDefData orderTable;
-
-	@NonNull private final RelatedDocumentsFactory relatedDocumentsFactory = SpringContextHolder.instance.getBean(RelatedDocumentsFactory.class);
-	@NonNull private final IADWindowDAO windowDAO = Services.get(IADWindowDAO.class);
 
 	private ImmutableList<RelatedDocumentsCandidateGroup> lastCandidateGroups;
 
@@ -119,14 +107,12 @@ public class RelatedDocuments_StepDef
 	private ImmutableList<RelatedDocumentsCandidateGroup> getCandidateGroupsForTable(@NonNull final String tableName)
 	{
 		final PO po = TableModelLoader.instance.newPO(tableName);
-		final IZoomSource zoomSource = POZoomSource.of(po);
-		final RelatedDocumentsPermissions permissions = RelatedDocumentsPermissionsFactory.allowAll();
-		return relatedDocumentsFactory.getRelatedDocumentsCandidates(zoomSource, permissions);
+		return helper.getRelatedDocumentsCandidates(po);
 	}
 
 	private String getWindowName(@NonNull final AdWindowId windowId)
 	{
-		final ITranslatableString name = windowDAO.retrieveWindowName(windowId);
-		return name != null ? name.translate("en_US") : "UNKNOWN(ID=" + windowId.getRepoId() + ")";
+		final String name = helper.getWindowName(windowId);
+		return name != null ? name : "UNKNOWN(ID=" + windowId.getRepoId() + ")";
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/RelatedDocuments_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/RelatedDocuments_StepDef.java
@@ -21,9 +21,8 @@ import org.adempiere.ad.window.api.IADWindowDAO;
 import org.assertj.core.api.SoftAssertions;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_Order;
-import org.compiere.model.MTable;
+import org.adempiere.ad.persistence.TableModelLoader;
 import org.compiere.model.PO;
-import org.compiere.util.Env;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -119,7 +118,7 @@ public class RelatedDocuments_StepDef
 
 	private ImmutableList<RelatedDocumentsCandidateGroup> getCandidateGroupsForTable(@NonNull final String tableName)
 	{
-		final PO po = MTable.get(Env.getCtx(), tableName).getPO(0, null);
+		final PO po = TableModelLoader.instance.newPO(tableName);
 		final IZoomSource zoomSource = POZoomSource.of(po);
 		final RelatedDocumentsPermissions permissions = RelatedDocumentsPermissionsFactory.allowAll();
 		return relatedDocumentsFactory.getRelatedDocumentsCandidates(zoomSource, permissions);
@@ -128,6 +127,6 @@ public class RelatedDocuments_StepDef
 	private String getWindowName(@NonNull final AdWindowId windowId)
 	{
 		final ITranslatableString name = windowDAO.retrieveWindowName(windowId);
-		return name != null ? name.getDefaultValue() : "UNKNOWN(ID=" + windowId.getRepoId() + ")";
+		return name != null ? name.translate("en_US") : "UNKNOWN(ID=" + windowId.getRepoId() + ")";
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/RelatedDocuments_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/RelatedDocuments_StepDef.java
@@ -28,6 +28,13 @@ public class RelatedDocuments_StepDef
 
 	private ImmutableList<RelatedDocumentsCandidateGroup> lastCandidateGroups;
 
+	/**
+	 * For each source table listed in the DataTable, resolves related document candidate groups
+	 * and asserts the count meets the given minimum.
+	 * Uses soft assertions so all rows are validated before failing.
+	 *
+	 * @param dataTable columns: {@code SourceTable} (AD table name), {@code MinTargetCount} (minimum expected groups)
+	 */
 	@Then("the following source tables have at least the listed related document targets:")
 	public void source_tables_have_minimum_related_document_targets(@NonNull final DataTable dataTable)
 	{
@@ -47,6 +54,13 @@ public class RelatedDocuments_StepDef
 		softly.assertAll();
 	}
 
+	/**
+	 * Resolves related document candidate groups for the given source table and asserts that
+	 * the target windows include each window name listed in the DataTable.
+	 *
+	 * @param sourceTable the AD table name (e.g. "C_Order")
+	 * @param dataTable single-column table with header {@code TargetWindowName}; expected window names in en_US
+	 */
 	@Then("related documents for source table {string} include targets:")
 	public void related_documents_include_targets(@NonNull final String sourceTable, @NonNull final DataTable dataTable)
 	{
@@ -69,6 +83,12 @@ public class RelatedDocuments_StepDef
 		softly.assertAll();
 	}
 
+	/**
+	 * Retrieves related document candidate groups for a specific C_Order record.
+	 * Stores the result in {@code lastCandidateGroups} for assertion by subsequent {@code @Then} steps.
+	 *
+	 * @param orderIdentifier the StepDefData identifier of the C_Order
+	 */
 	@When("related documents are retrieved for the C_Order identified by {string}")
 	public void related_documents_retrieved_for_order(@NonNull final String orderIdentifier)
 	{
@@ -76,18 +96,27 @@ public class RelatedDocuments_StepDef
 		lastCandidateGroups = helper.getRelatedDocumentsCandidates(order);
 	}
 
+	/**
+	 * Asserts that the number of related document candidate groups retrieved by the preceding
+	 * {@code related documents are retrieved} step is at least the given minimum count.
+	 *
+	 * @param minCount the minimum number of candidate groups expected
+	 */
 	@Then("the related documents include at least {int} candidate groups")
 	public void related_documents_include_at_least_n_groups(final int minCount)
 	{
 		assertThat(lastCandidateGroups)
 				.as("Related documents candidate groups")
-				.isNotNull();
-
-		assertThat(lastCandidateGroups.size())
-				.as("Number of related document candidate groups")
-				.isGreaterThanOrEqualTo(minCount);
+				.isNotNull()
+				.hasSizeGreaterThanOrEqualTo(minCount);
 	}
 
+	/**
+	 * Asserts that the related document candidate groups include at least one group
+	 * whose target window matches the given expected window name.
+	 *
+	 * @param expectedWindowName the expected target window name in en_US (e.g. "Invoice (Customer)")
+	 */
 	@Then("the related documents include a candidate group targeting window {string}")
 	public void related_documents_include_candidate_group_targeting_window(@NonNull final String expectedWindowName)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ZoomIntoTestHelper.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ZoomIntoTestHelper.java
@@ -49,7 +49,7 @@ public class ZoomIntoTestHelper
 	public String getWindowName(@NonNull final AdWindowId windowId)
 	{
 		final ITranslatableString name = windowDAO.retrieveWindowName(windowId);
-		return name != null ? name.getDefaultValue() : null;
+		return name != null ? name.translate("en_US") : null;
 	}
 
 	public ImmutableList<String> findTablesWithMissingZoomIntoWindows(@NonNull final ImmutableSet<String> excludedTables)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ZoomIntoTestHelper.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ZoomIntoTestHelper.java
@@ -1,0 +1,90 @@
+package de.metas.cucumber.stepdefs.zoom_into;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import de.metas.document.references.related_documents.IZoomSource;
+import de.metas.document.references.related_documents.POZoomSource;
+import de.metas.document.references.related_documents.RelatedDocumentsCandidateGroup;
+import de.metas.document.references.related_documents.RelatedDocumentsFactory;
+import de.metas.document.references.related_documents.RelatedDocumentsPermissions;
+import de.metas.document.references.related_documents.RelatedDocumentsPermissionsFactory;
+import de.metas.document.references.zoom_into.RecordWindowFinder;
+import de.metas.i18n.ITranslatableString;
+import de.metas.lang.SOTrx;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.element.api.AdWindowId;
+import org.adempiere.ad.window.api.IADWindowDAO;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.PO;
+import org.compiere.util.DB;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+public class ZoomIntoTestHelper
+{
+	@NonNull private final IADWindowDAO windowDAO = Services.get(IADWindowDAO.class);
+	@NonNull private final RelatedDocumentsFactory relatedDocumentsFactory = SpringContextHolder.instance.getBean(RelatedDocumentsFactory.class);
+
+	public Optional<AdWindowId> resolveZoomIntoWindow(@NonNull final String tableName)
+	{
+		return RecordWindowFinder.findAdWindowId(tableName);
+	}
+
+	public Optional<AdWindowId> resolveZoomIntoWindow(@NonNull final String tableName, @NonNull final SOTrx soTrx)
+	{
+		return RecordWindowFinder.newInstance(tableName, soTrx).findAdWindowId();
+	}
+
+	public Optional<AdWindowId> resolveZoomIntoWindowForRecord(@NonNull final String tableName, final int recordId)
+	{
+		return RecordWindowFinder.newInstance(tableName, recordId)
+				.checkRecordPresentInWindow()
+				.findAdWindowId();
+	}
+
+	@Nullable
+	public String getWindowName(@NonNull final AdWindowId windowId)
+	{
+		final ITranslatableString name = windowDAO.retrieveWindowName(windowId);
+		return name != null ? name.getDefaultValue() : null;
+	}
+
+	public ImmutableList<String> findTablesWithMissingZoomIntoWindows(@NonNull final ImmutableSet<String> excludedTables)
+	{
+		final ImmutableList<String> allTableNames = retrieveAllTableNamesFromView();
+		final ImmutableList.Builder<String> failedTables = ImmutableList.builder();
+
+		for (final String tableName : allTableNames)
+		{
+			if (excludedTables.contains(tableName))
+			{
+				continue;
+			}
+
+			final Optional<AdWindowId> windowId = resolveZoomIntoWindow(tableName);
+			if (!windowId.isPresent())
+			{
+				failedTables.add(tableName);
+			}
+		}
+
+		return failedTables.build();
+	}
+
+	private ImmutableList<String> retrieveAllTableNamesFromView()
+	{
+		final String sql = "SELECT DISTINCT TableName FROM ad_table_windows_v ORDER BY TableName";
+		return DB.retrieveRowsOutOfTrx(sql, null, rs -> rs.getString("TableName"));
+	}
+
+	public ImmutableList<RelatedDocumentsCandidateGroup> getRelatedDocumentsCandidates(@NonNull final Object record)
+	{
+		final PO po = InterfaceWrapperHelper.getPO(record);
+		final IZoomSource zoomSource = POZoomSource.of(po);
+		final RelatedDocumentsPermissions permissions = RelatedDocumentsPermissionsFactory.allowAll();
+		return relatedDocumentsFactory.getRelatedDocumentsCandidates(zoomSource, permissions);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ZoomIntoTestHelper.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ZoomIntoTestHelper.java
@@ -17,8 +17,12 @@ import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.ad.window.api.IADWindowDAO;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.SpringContextHolder;
+import org.compiere.model.MQuery;
 import org.compiere.model.PO;
+import org.compiere.model.POInfo;
+import org.compiere.model.POInfoColumn;
 import org.compiere.util.DB;
+import org.compiere.util.DisplayType;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
@@ -86,5 +90,156 @@ public class ZoomIntoTestHelper
 		final IZoomSource zoomSource = POZoomSource.of(po);
 		final RelatedDocumentsPermissions permissions = RelatedDocumentsPermissionsFactory.allowAll();
 		return relatedDocumentsFactory.getRelatedDocumentsCandidates(zoomSource, permissions);
+	}
+
+	@Nullable
+	private String resolveTargetTableName(@NonNull final POInfoColumn column)
+	{
+		final int displayType = column.getDisplayType();
+		if (displayType == DisplayType.Table || displayType == DisplayType.Search)
+		{
+			final String referencedTable = column.getReferencedTableNameOrNull();
+			if (referencedTable != null)
+			{
+				return referencedTable;
+			}
+			// Fallback: derive table name from column name (same as TableDir logic)
+			return MQuery.getZoomTableName(column.getColumnName());
+		}
+		else if (displayType == DisplayType.TableDir)
+		{
+			return MQuery.getZoomTableName(column.getColumnName());
+		}
+		return null;
+	}
+
+	public ImmutableList<ReferenceFieldInfo> scanReferenceFieldsForTable(
+			@NonNull final String tableName,
+			@NonNull final ImmutableSet<String> excludedColumns)
+	{
+		final POInfo poInfo = POInfo.getPOInfoNotNull(tableName);
+		final ImmutableList.Builder<ReferenceFieldInfo> results = ImmutableList.builder();
+
+		for (int i = 0; i < poInfo.getColumnCount(); i++)
+		{
+			final POInfoColumn column = poInfo.getColumn(i);
+			if (column == null)
+			{
+				continue;
+			}
+
+			final int displayType = column.getDisplayType();
+			if (displayType != DisplayType.Table && displayType != DisplayType.TableDir && displayType != DisplayType.Search)
+			{
+				continue;
+			}
+
+			final String columnName = column.getColumnName();
+			if (excludedColumns.contains(columnName))
+			{
+				continue;
+			}
+
+			final String targetTableName = resolveTargetTableName(column);
+			if (targetTableName == null)
+			{
+				results.add(ReferenceFieldInfo.builder()
+						.sourceTableName(tableName)
+						.sourceColumnName(columnName)
+						.targetTableName("UNRESOLVED")
+						.build());
+				continue;
+			}
+
+			final Optional<AdWindowId> windowId = RecordWindowFinder.findAdWindowId(targetTableName);
+			final String windowName = windowId.map(this::getWindowName).orElse(null);
+
+			results.add(ReferenceFieldInfo.builder()
+					.sourceTableName(tableName)
+					.sourceColumnName(columnName)
+					.targetTableName(targetTableName)
+					.resolvedWindowId(windowId.orElse(null))
+					.resolvedWindowName(windowName)
+					.build());
+		}
+
+		return results.build();
+	}
+
+	public ImmutableList<ReferenceFieldInfo> verifyZoomToForRecord(
+			@NonNull final PO record,
+			@NonNull final ImmutableSet<String> excludedColumns)
+	{
+		final String tableName = record.get_TableName();
+		final POInfo poInfo = POInfo.getPOInfoNotNull(tableName);
+		final ImmutableList.Builder<ReferenceFieldInfo> results = ImmutableList.builder();
+
+		for (int i = 0; i < poInfo.getColumnCount(); i++)
+		{
+			final POInfoColumn column = poInfo.getColumn(i);
+			if (column == null)
+			{
+				continue;
+			}
+
+			final int displayType = column.getDisplayType();
+			if (displayType != DisplayType.Table && displayType != DisplayType.TableDir && displayType != DisplayType.Search)
+			{
+				continue;
+			}
+
+			final String columnName = column.getColumnName();
+			if (excludedColumns.contains(columnName))
+			{
+				continue;
+			}
+
+			final Object value = record.get_Value(columnName);
+			if (value == null)
+			{
+				continue; // skip null FK values
+			}
+
+			final int recordId;
+			if (value instanceof Number)
+			{
+				recordId = ((Number)value).intValue();
+			}
+			else
+			{
+				continue; // not a numeric FK
+			}
+
+			if (recordId <= 0)
+			{
+				continue; // skip non-positive IDs
+			}
+
+			final String targetTableName = resolveTargetTableName(column);
+			if (targetTableName == null)
+			{
+				results.add(ReferenceFieldInfo.builder()
+						.sourceTableName(tableName)
+						.sourceColumnName(columnName)
+						.targetTableName("UNRESOLVED")
+						.build());
+				continue;
+			}
+
+			final Optional<AdWindowId> windowId = RecordWindowFinder.newInstance(targetTableName, recordId)
+					.checkRecordPresentInWindow()
+					.findAdWindowId();
+			final String windowName = windowId.map(this::getWindowName).orElse(null);
+
+			results.add(ReferenceFieldInfo.builder()
+					.sourceTableName(tableName)
+					.sourceColumnName(columnName)
+					.targetTableName(targetTableName)
+					.resolvedWindowId(windowId.orElse(null))
+					.resolvedWindowName(windowName)
+					.build());
+		}
+
+		return results.build();
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ZoomInto_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ZoomInto_StepDef.java
@@ -4,11 +4,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
 import de.metas.cucumber.stepdefs.DataTableRows;
-
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
 import de.metas.lang.SOTrx;
 import io.cucumber.datatable.DataTable;
-import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import lombok.NonNull;
@@ -32,10 +30,18 @@ public class ZoomInto_StepDef
 	@NonNull private final C_Order_StepDefData orderTable;
 	@NonNull private final C_BPartner_StepDefData bpartnerTable;
 
-	private List<String> tablesWithMissingWindows;
+	private List<String> tablesWithMissingWindows = ImmutableList.of();
 	private AdWindowId lastResolvedWindowId;
 	private ImmutableList<ReferenceFieldInfo> lastFieldScanResults;
 
+	/**
+	 * Iterates every table listed in the {@code ad_table_windows_v} view and attempts to resolve
+	 * a zoom-into window via {@link de.metas.document.references.zoom_into.RecordWindowFinder}.
+	 * Tables listed in the DataTable are excluded from the check.
+	 * Stores the list of tables that failed to resolve in {@code tablesWithMissingWindows}.
+	 *
+	 * @param dataTable single-column table with header {@code TableName}; tables to skip
+	 */
 	@When("RecordWindowFinder is asked to resolve a window for each table listed in ad_table_windows_v, excluding:")
 	public void resolve_window_for_each_table_excluding(@NonNull final DataTable dataTable)
 	{
@@ -47,6 +53,10 @@ public class ZoomInto_StepDef
 		tablesWithMissingWindows = helper.findTablesWithMissingZoomIntoWindows(excludedTables);
 	}
 
+	/**
+	 * Asserts that no tables were left unresolved by the preceding
+	 * {@code RecordWindowFinder is asked to resolve a window for each table} step.
+	 */
 	@Then("every table in ad_table_windows_v resolves to a non-null window")
 	public void every_table_resolves_to_non_null_window()
 	{
@@ -55,7 +65,15 @@ public class ZoomInto_StepDef
 				.isEmpty();
 	}
 
-	@Given("zoom-into for the following tables resolves to the expected windows by SOTrx:")
+	/**
+	 * For each row in the DataTable, resolves a zoom-into window for the given table and SOTrx
+	 * direction, then asserts the resolved window name matches the expected value.
+	 * Uses soft assertions so all rows are validated before failing.
+	 *
+	 * @param dataTable columns: {@code TableName} (AD table name), {@code IsSOTrx} (true/false),
+	 *                  {@code ExpectedWindowName} (expected window name in en_US)
+	 */
+	@Then("zoom-into for the following tables resolves to the expected windows by SOTrx:")
 	public void zoom_into_resolves_to_expected_windows(@NonNull final DataTable dataTable)
 	{
 		final SoftAssertions softly = new SoftAssertions();
@@ -82,6 +100,13 @@ public class ZoomInto_StepDef
 		softly.assertAll();
 	}
 
+	/**
+	 * Resolves the zoom-into window for a specific C_Order record using
+	 * {@link de.metas.document.references.zoom_into.RecordWindowFinder#newInstance(String, int)}.
+	 * Stores the resolved {@link AdWindowId} in {@code lastResolvedWindowId}.
+	 *
+	 * @param orderIdentifier the StepDefData identifier of the C_Order to look up
+	 */
 	@When("RecordWindowFinder resolves zoom-into for the C_Order identified by {string}")
 	public void resolve_zoom_into_for_order(@NonNull final String orderIdentifier)
 	{
@@ -93,6 +118,12 @@ public class ZoomInto_StepDef
 		lastResolvedWindowId = windowId.orElse(null);
 	}
 
+	/**
+	 * Asserts that the window resolved by the preceding {@code RecordWindowFinder resolves zoom-into}
+	 * step matches the given expected window name.
+	 *
+	 * @param expectedWindowName the expected window name in en_US (e.g. "Sales Order")
+	 */
 	@Then("the resolved window is {string}")
 	public void the_resolved_window_is(@NonNull final String expectedWindowName)
 	{
@@ -106,8 +137,17 @@ public class ZoomInto_StepDef
 				.isEqualTo(expectedWindowName);
 	}
 
-	// --- Phase 2: Field-level reference scan steps ---
+	// --- Field-level reference scan steps ---
 
+	/**
+	 * Scans all reference fields (Table, TableDir, Search display types) of the given table
+	 * and resolves the zoom-to window for each target table via RecordWindowFinder.
+	 * Columns listed in the DataTable are excluded from the scan.
+	 * Results are stored in {@code lastFieldScanResults} for assertion by a subsequent {@code @Then} step.
+	 *
+	 * @param tableName the AD table name to scan (e.g. "C_Order")
+	 * @param dataTable single-column table with header {@code ColumnName}; columns to skip
+	 */
 	@When("all reference fields of table {string} are scanned for zoom-to targets, excluding columns:")
 	public void scan_reference_fields_with_exclusions(@NonNull final String tableName, @NonNull final DataTable dataTable)
 	{
@@ -119,12 +159,22 @@ public class ZoomInto_StepDef
 		lastFieldScanResults = helper.scanReferenceFieldsForTable(tableName, excludedColumns);
 	}
 
+	/**
+	 * Scans all reference fields of the given table without any exclusions.
+	 * Results are stored in {@code lastFieldScanResults}.
+	 *
+	 * @param tableName the AD table name to scan (e.g. "C_Order")
+	 */
 	@When("all reference fields of table {string} are scanned for zoom-to targets")
 	public void scan_reference_fields(@NonNull final String tableName)
 	{
 		lastFieldScanResults = helper.scanReferenceFieldsForTable(tableName, ImmutableSet.of());
 	}
 
+	/**
+	 * Asserts that every {@link ReferenceFieldInfo} in {@code lastFieldScanResults} has a
+	 * non-null {@code resolvedWindowId}. Uses soft assertions to report all failures at once.
+	 */
 	@Then("every reference field resolves to a valid zoom-to window")
 	public void every_reference_field_resolves_to_window()
 	{
@@ -143,8 +193,15 @@ public class ZoomInto_StepDef
 		softly.assertAll();
 	}
 
-	// --- Phase 2: Record-level verification steps ---
+	// --- Record-level verification steps ---
 
+	/**
+	 * For the C_Order identified by the given StepDefData identifier, iterates all non-null FK
+	 * reference fields and verifies each resolves to a zoom-to window with the target record
+	 * present. No columns are excluded. Results stored in {@code lastFieldScanResults}.
+	 *
+	 * @param orderIdentifier the StepDefData identifier of the C_Order
+	 */
 	@When("all reference fields of the C_Order identified by {string} are verified for zoom-to")
 	public void verify_zoom_to_for_order(@NonNull final String orderIdentifier)
 	{
@@ -153,6 +210,12 @@ public class ZoomInto_StepDef
 		lastFieldScanResults = helper.verifyZoomToForRecord(po, ImmutableSet.of());
 	}
 
+	/**
+	 * Same as {@link #verify_zoom_to_for_order} but excludes the columns listed in the DataTable.
+	 *
+	 * @param orderIdentifier the StepDefData identifier of the C_Order
+	 * @param dataTable single-column table with header {@code ColumnName}; columns to skip
+	 */
 	@When("all reference fields of the C_Order identified by {string} are verified for zoom-to, excluding columns:")
 	public void verify_zoom_to_for_order_with_exclusions(@NonNull final String orderIdentifier, @NonNull final DataTable dataTable)
 	{
@@ -166,6 +229,13 @@ public class ZoomInto_StepDef
 		lastFieldScanResults = helper.verifyZoomToForRecord(po, excludedColumns);
 	}
 
+	/**
+	 * For the C_BPartner identified by the given StepDefData identifier, iterates all non-null FK
+	 * reference fields and verifies each resolves to a zoom-to window with the target record
+	 * present. No columns are excluded. Results stored in {@code lastFieldScanResults}.
+	 *
+	 * @param bpartnerIdentifier the StepDefData identifier of the C_BPartner
+	 */
 	@When("all reference fields of the C_BPartner identified by {string} are verified for zoom-to")
 	public void verify_zoom_to_for_bpartner(@NonNull final String bpartnerIdentifier)
 	{
@@ -174,6 +244,12 @@ public class ZoomInto_StepDef
 		lastFieldScanResults = helper.verifyZoomToForRecord(po, ImmutableSet.of());
 	}
 
+	/**
+	 * Same as {@link #verify_zoom_to_for_bpartner} but excludes the columns listed in the DataTable.
+	 *
+	 * @param bpartnerIdentifier the StepDefData identifier of the C_BPartner
+	 * @param dataTable single-column table with header {@code ColumnName}; columns to skip
+	 */
 	@When("all reference fields of the C_BPartner identified by {string} are verified for zoom-to, excluding columns:")
 	public void verify_zoom_to_for_bpartner_with_exclusions(@NonNull final String bpartnerIdentifier, @NonNull final DataTable dataTable)
 	{
@@ -187,6 +263,13 @@ public class ZoomInto_StepDef
 		lastFieldScanResults = helper.verifyZoomToForRecord(po, excludedColumns);
 	}
 
+	/**
+	 * Asserts that every {@link ReferenceFieldInfo} in {@code lastFieldScanResults} from a
+	 * record-level verification has a non-null {@code resolvedWindowId}. This confirms that
+	 * RecordWindowFinder can resolve a window for each non-null FK value on the record,
+	 * with the target record present in the window.
+	 * Uses soft assertions to report all failures at once.
+	 */
 	@Then("every non-null reference field resolves to a valid zoom-to window for the record")
 	public void every_non_null_reference_field_resolves_to_window()
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ZoomInto_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ZoomInto_StepDef.java
@@ -1,0 +1,100 @@
+package de.metas.cucumber.stepdefs.zoom_into;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
+import de.metas.lang.SOTrx;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.element.api.AdWindowId;
+import org.assertj.core.api.SoftAssertions;
+import org.compiere.model.I_C_Order;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RequiredArgsConstructor
+public class ZoomInto_StepDef
+{
+	@NonNull private final ZoomIntoTestHelper helper;
+	@NonNull private final C_Order_StepDefData orderTable;
+
+	private List<String> tablesWithMissingWindows;
+	private AdWindowId lastResolvedWindowId;
+
+	@When("RecordWindowFinder is asked to resolve a window for each table listed in ad_table_windows_v, excluding:")
+	public void resolve_window_for_each_table_excluding(@NonNull final DataTable dataTable)
+	{
+		final ImmutableSet<String> excludedTables = DataTableRows.of(dataTable)
+				.stream()
+				.map(row -> row.getAsString("TableName"))
+				.collect(ImmutableSet.toImmutableSet());
+
+		tablesWithMissingWindows = helper.findTablesWithMissingZoomIntoWindows(excludedTables);
+	}
+
+	@Then("every table in ad_table_windows_v resolves to a non-null window")
+	public void every_table_resolves_to_non_null_window()
+	{
+		assertThat(tablesWithMissingWindows)
+				.as("Tables in ad_table_windows_v that failed to resolve to a window via RecordWindowFinder")
+				.isEmpty();
+	}
+
+	@Given("zoom-into for the following tables resolves to the expected windows by SOTrx:")
+	public void zoom_into_resolves_to_expected_windows(@NonNull final DataTable dataTable)
+	{
+		final SoftAssertions softly = new SoftAssertions();
+
+		DataTableRows.of(dataTable).forEach(row -> {
+			final String tableName = row.getAsString("TableName");
+			final SOTrx soTrx = SOTrx.ofBoolean(row.getAsBoolean("IsSOTrx"));
+			final String expectedWindowName = row.getAsString("ExpectedWindowName");
+
+			final Optional<AdWindowId> windowId = helper.resolveZoomIntoWindow(tableName, soTrx);
+
+			softly.assertThat(windowId)
+					.as("Window for table=" + tableName + ", IsSOTrx=" + soTrx)
+					.isPresent();
+
+			windowId.ifPresent(id -> {
+				final String actualWindowName = helper.getWindowName(id);
+				softly.assertThat(actualWindowName)
+						.as("Window name for table=" + tableName + ", IsSOTrx=" + soTrx)
+						.isEqualTo(expectedWindowName);
+			});
+		});
+
+		softly.assertAll();
+	}
+
+	@When("RecordWindowFinder resolves zoom-into for the C_Order identified by {string}")
+	public void resolve_zoom_into_for_order(@NonNull final String orderIdentifier)
+	{
+		final I_C_Order order = orderTable.get(orderIdentifier);
+		final Optional<AdWindowId> windowId = helper.resolveZoomIntoWindowForRecord(
+				I_C_Order.Table_Name,
+				order.getC_Order_ID());
+
+		lastResolvedWindowId = windowId.orElse(null);
+	}
+
+	@Then("the resolved window is {string}")
+	public void the_resolved_window_is(@NonNull final String expectedWindowName)
+	{
+		assertThat(lastResolvedWindowId)
+				.as("Resolved window ID should not be null")
+				.isNotNull();
+
+		final String actualWindowName = helper.getWindowName(lastResolvedWindowId);
+		assertThat(actualWindowName)
+				.as("Resolved window name")
+				.isEqualTo(expectedWindowName);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ZoomInto_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ZoomInto_StepDef.java
@@ -1,7 +1,10 @@
 package de.metas.cucumber.stepdefs.zoom_into;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
 import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
 import de.metas.lang.SOTrx;
 import io.cucumber.datatable.DataTable;
@@ -11,8 +14,11 @@ import io.cucumber.java.en.When;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.element.api.AdWindowId;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.assertj.core.api.SoftAssertions;
+import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_Order;
+import org.compiere.model.PO;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,9 +30,11 @@ public class ZoomInto_StepDef
 {
 	@NonNull private final ZoomIntoTestHelper helper;
 	@NonNull private final C_Order_StepDefData orderTable;
+	@NonNull private final C_BPartner_StepDefData bpartnerTable;
 
 	private List<String> tablesWithMissingWindows;
 	private AdWindowId lastResolvedWindowId;
+	private ImmutableList<ReferenceFieldInfo> lastFieldScanResults;
 
 	@When("RecordWindowFinder is asked to resolve a window for each table listed in ad_table_windows_v, excluding:")
 	public void resolve_window_for_each_table_excluding(@NonNull final DataTable dataTable)
@@ -96,5 +104,104 @@ public class ZoomInto_StepDef
 		assertThat(actualWindowName)
 				.as("Resolved window name")
 				.isEqualTo(expectedWindowName);
+	}
+
+	// --- Phase 2: Field-level reference scan steps ---
+
+	@When("all reference fields of table {string} are scanned for zoom-to targets, excluding columns:")
+	public void scan_reference_fields_with_exclusions(@NonNull final String tableName, @NonNull final DataTable dataTable)
+	{
+		final ImmutableSet<String> excludedColumns = DataTableRows.of(dataTable)
+				.stream()
+				.map(row -> row.getAsString("ColumnName"))
+				.collect(ImmutableSet.toImmutableSet());
+
+		lastFieldScanResults = helper.scanReferenceFieldsForTable(tableName, excludedColumns);
+	}
+
+	@When("all reference fields of table {string} are scanned for zoom-to targets")
+	public void scan_reference_fields(@NonNull final String tableName)
+	{
+		lastFieldScanResults = helper.scanReferenceFieldsForTable(tableName, ImmutableSet.of());
+	}
+
+	@Then("every reference field resolves to a valid zoom-to window")
+	public void every_reference_field_resolves_to_window()
+	{
+		assertThat(lastFieldScanResults)
+				.as("Field scan results should not be null")
+				.isNotNull();
+
+		final SoftAssertions softly = new SoftAssertions();
+		for (final ReferenceFieldInfo info : lastFieldScanResults)
+		{
+			softly.assertThat(info.getResolvedWindowId())
+					.as("Zoom-to window for " + info.getSourceTableName() + "." + info.getSourceColumnName()
+							+ " -> " + info.getTargetTableName())
+					.isNotNull();
+		}
+		softly.assertAll();
+	}
+
+	// --- Phase 2: Record-level verification steps ---
+
+	@When("all reference fields of the C_Order identified by {string} are verified for zoom-to")
+	public void verify_zoom_to_for_order(@NonNull final String orderIdentifier)
+	{
+		final I_C_Order order = orderTable.get(orderIdentifier);
+		final PO po = InterfaceWrapperHelper.getPO(order);
+		lastFieldScanResults = helper.verifyZoomToForRecord(po, ImmutableSet.of());
+	}
+
+	@When("all reference fields of the C_Order identified by {string} are verified for zoom-to, excluding columns:")
+	public void verify_zoom_to_for_order_with_exclusions(@NonNull final String orderIdentifier, @NonNull final DataTable dataTable)
+	{
+		final ImmutableSet<String> excludedColumns = DataTableRows.of(dataTable)
+				.stream()
+				.map(row -> row.getAsString("ColumnName"))
+				.collect(ImmutableSet.toImmutableSet());
+
+		final I_C_Order order = orderTable.get(orderIdentifier);
+		final PO po = InterfaceWrapperHelper.getPO(order);
+		lastFieldScanResults = helper.verifyZoomToForRecord(po, excludedColumns);
+	}
+
+	@When("all reference fields of the C_BPartner identified by {string} are verified for zoom-to")
+	public void verify_zoom_to_for_bpartner(@NonNull final String bpartnerIdentifier)
+	{
+		final I_C_BPartner bpartner = bpartnerTable.get(bpartnerIdentifier);
+		final PO po = InterfaceWrapperHelper.getPO(bpartner);
+		lastFieldScanResults = helper.verifyZoomToForRecord(po, ImmutableSet.of());
+	}
+
+	@When("all reference fields of the C_BPartner identified by {string} are verified for zoom-to, excluding columns:")
+	public void verify_zoom_to_for_bpartner_with_exclusions(@NonNull final String bpartnerIdentifier, @NonNull final DataTable dataTable)
+	{
+		final ImmutableSet<String> excludedColumns = DataTableRows.of(dataTable)
+				.stream()
+				.map(row -> row.getAsString("ColumnName"))
+				.collect(ImmutableSet.toImmutableSet());
+
+		final I_C_BPartner bpartner = bpartnerTable.get(bpartnerIdentifier);
+		final PO po = InterfaceWrapperHelper.getPO(bpartner);
+		lastFieldScanResults = helper.verifyZoomToForRecord(po, excludedColumns);
+	}
+
+	@Then("every non-null reference field resolves to a valid zoom-to window for the record")
+	public void every_non_null_reference_field_resolves_to_window()
+	{
+		assertThat(lastFieldScanResults)
+				.as("Record verification results should not be null")
+				.isNotNull();
+
+		final SoftAssertions softly = new SoftAssertions();
+		for (final ReferenceFieldInfo info : lastFieldScanResults)
+		{
+			softly.assertThat(info.getResolvedWindowId())
+					.as("Zoom-to window for record field " + info.getSourceTableName() + "." + info.getSourceColumnName()
+							+ " -> " + info.getTargetTableName())
+					.isNotNull();
+		}
+		softly.assertAll();
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ZoomInto_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/zoom_into/ZoomInto_StepDef.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
 import de.metas.cucumber.stepdefs.DataTableRows;
-import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
 import de.metas.lang.SOTrx;
 import io.cucumber.datatable.DataTable;

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/relatedDocuments_metadata_scan.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/relatedDocuments_metadata_scan.feature
@@ -1,0 +1,24 @@
+@from:cucumber
+@ghActions:run_on_executor6
+Feature: Related Documents metadata scan
+  Verify that key source tables have related documents configured
+  and that expected target windows are present in the candidate list.
+
+  Background:
+    Given infrastructure and metasfresh are running
+
+  @from:cucumber
+  Scenario: Key source tables have minimum related document targets
+    Then the following source tables have at least the listed related document targets:
+      | SourceTable | MinTargetCount |
+      | C_Order     | 3              |
+      | C_Invoice   | 2              |
+      | M_InOut     | 2              |
+      | C_BPartner  | 2              |
+
+  @from:cucumber
+  Scenario: C_Order related documents include expected target windows
+    Then related documents for source table "C_Order" include targets:
+      | TargetWindowName                   |
+      | Sales Invoice (Customer)           |
+      | Shipment                           |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/relatedDocuments_metadata_scan.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/relatedDocuments_metadata_scan.feature
@@ -20,5 +20,5 @@ Feature: Related Documents metadata scan
   Scenario: C_Order related documents include expected target windows
     Then related documents for source table "C_Order" include targets:
       | TargetWindowName                   |
-      | Sales Invoice (Customer)           |
-      | Shipment                           |
+      | Invoice (Customer)           |
+      | Shipment (Customer)                           |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/relatedDocuments_metadata_scan.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/relatedDocuments_metadata_scan.feature
@@ -19,6 +19,6 @@ Feature: Related Documents metadata scan
   @from:cucumber
   Scenario: C_Order related documents include expected target windows
     Then related documents for source table "C_Order" include targets:
-      | TargetWindowName                   |
-      | Invoice (Customer)           |
-      | Shipment (Customer)                           |
+      | TargetWindowName    |
+      | Invoice (Customer)  |
+      | Shipment (Customer) |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/relatedDocuments_soTrx_routing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/relatedDocuments_soTrx_routing.feature
@@ -11,26 +11,44 @@ Feature: Related Documents SOTrx routing
 
   @from:cucumber
   Scenario: Sales Order has expected related document candidates
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name              | Value             |
+      | ps_soRel   | ps_soRel_pricing  | ps_soRel_pricing  |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_soRel   | ps_soRel           | DE                    | EUR                 | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID | Name       | ValidFrom  |
+      | plv_soRel  | pl_soRel       | plv_soRel  | 2021-04-01 |
     Given metasfresh contains C_BPartners:
-      | Identifier     | IsCustomer | IsVendor |
-      | bpartner_soRel | Y          | N        |
+      | Identifier     | IsCustomer | IsVendor | M_PricingSystem_ID |
+      | bpartner_soRel | Y          | N        | ps_soRel           |
     And metasfresh contains C_Orders:
-      | Identifier    | IsSOTrx | C_BPartner_ID  | DocBaseType |
-      | order_so_rel  | true    | bpartner_soRel | SOO         |
+      | Identifier    | IsSOTrx | C_BPartner_ID  | DocBaseType | DateOrdered |
+      | order_so_rel  | true    | bpartner_soRel | SOO         | 2022-06-15  |
     When related documents are retrieved for the C_Order identified by "order_so_rel"
     Then the related documents include at least 3 candidate groups
-    And the related documents include a candidate group targeting window "Sales Invoice (Customer)"
-    And the related documents include a candidate group targeting window "Shipment"
+    And the related documents include a candidate group targeting window "Invoice (Customer)"
+    And the related documents include a candidate group targeting window "Shipment (Customer)"
 
   @from:cucumber
   Scenario: Purchase Order has expected related document candidates
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name              | Value             |
+      | ps_poRel   | ps_poRel_pricing  | ps_poRel_pricing  |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_poRel   | ps_poRel           | DE                    | EUR                 | false | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID | Name       | ValidFrom  |
+      | plv_poRel  | pl_poRel       | plv_poRel  | 2021-04-01 |
     Given metasfresh contains C_BPartners:
-      | Identifier     | IsCustomer | IsVendor |
-      | bpartner_poRel | N          | Y        |
+      | Identifier     | IsCustomer | IsVendor | M_PricingSystem_ID |
+      | bpartner_poRel | N          | Y        | ps_poRel           |
     And metasfresh contains C_Orders:
-      | Identifier    | IsSOTrx | C_BPartner_ID  | DocBaseType |
-      | order_po_rel  | false   | bpartner_poRel | POO         |
+      | Identifier    | IsSOTrx | C_BPartner_ID  | DocBaseType | DateOrdered |
+      | order_po_rel  | false   | bpartner_poRel | POO         | 2022-06-15  |
     When related documents are retrieved for the C_Order identified by "order_po_rel"
     Then the related documents include at least 3 candidate groups
-    And the related documents include a candidate group targeting window "Vendor Invoice (Vendor)"
+    And the related documents include a candidate group targeting window "Invoice (Vendor)"
     And the related documents include a candidate group targeting window "Material Receipt"

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/relatedDocuments_soTrx_routing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/relatedDocuments_soTrx_routing.feature
@@ -20,7 +20,7 @@ Feature: Related Documents SOTrx routing
     And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID | Name       | ValidFrom  |
       | plv_soRel  | pl_soRel       | plv_soRel  | 2021-04-01 |
-    Given metasfresh contains C_BPartners:
+    And metasfresh contains C_BPartners:
       | Identifier     | IsCustomer | IsVendor | M_PricingSystem_ID |
       | bpartner_soRel | Y          | N        | ps_soRel           |
     And metasfresh contains C_Orders:
@@ -42,7 +42,7 @@ Feature: Related Documents SOTrx routing
     And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID | Name       | ValidFrom  |
       | plv_poRel  | pl_poRel       | plv_poRel  | 2021-04-01 |
-    Given metasfresh contains C_BPartners:
+    And metasfresh contains C_BPartners:
       | Identifier     | IsCustomer | IsVendor | M_PricingSystem_ID |
       | bpartner_poRel | N          | Y        | ps_poRel           |
     And metasfresh contains C_Orders:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/relatedDocuments_soTrx_routing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/relatedDocuments_soTrx_routing.feature
@@ -11,7 +11,7 @@ Feature: Related Documents SOTrx routing
 
   @from:cucumber
   Scenario: Sales Order has expected related document candidates
-    And metasfresh contains M_PricingSystems
+    Given metasfresh contains M_PricingSystems
       | Identifier | Name              | Value             |
       | ps_soRel   | ps_soRel_pricing  | ps_soRel_pricing  |
     And metasfresh contains M_PriceLists
@@ -33,7 +33,7 @@ Feature: Related Documents SOTrx routing
 
   @from:cucumber
   Scenario: Purchase Order has expected related document candidates
-    And metasfresh contains M_PricingSystems
+    Given metasfresh contains M_PricingSystems
       | Identifier | Name              | Value             |
       | ps_poRel   | ps_poRel_pricing  | ps_poRel_pricing  |
     And metasfresh contains M_PriceLists

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/relatedDocuments_soTrx_routing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/relatedDocuments_soTrx_routing.feature
@@ -1,0 +1,36 @@
+@from:cucumber
+@ghActions:run_on_executor6
+Feature: Related Documents SOTrx routing
+  Verify that related documents resolve correctly for Sales and Purchase orders,
+  including the presence of expected candidate groups.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-06-15T13:30:00+01:00[Europe/Berlin]
+
+  @from:cucumber
+  Scenario: Sales Order has expected related document candidates
+    Given metasfresh contains C_BPartners:
+      | Identifier     | IsCustomer | IsVendor |
+      | bpartner_soRel | Y          | N        |
+    And metasfresh contains C_Orders:
+      | Identifier    | IsSOTrx | C_BPartner_ID  | DocBaseType |
+      | order_so_rel  | true    | bpartner_soRel | SOO         |
+    When related documents are retrieved for the C_Order identified by "order_so_rel"
+    Then the related documents include at least 3 candidate groups
+    And the related documents include a candidate group targeting window "Sales Invoice (Customer)"
+    And the related documents include a candidate group targeting window "Shipment"
+
+  @from:cucumber
+  Scenario: Purchase Order has expected related document candidates
+    Given metasfresh contains C_BPartners:
+      | Identifier     | IsCustomer | IsVendor |
+      | bpartner_poRel | N          | Y        |
+    And metasfresh contains C_Orders:
+      | Identifier    | IsSOTrx | C_BPartner_ID  | DocBaseType |
+      | order_po_rel  | false   | bpartner_poRel | POO         |
+    When related documents are retrieved for the C_Order identified by "order_po_rel"
+    Then the related documents include at least 3 candidate groups
+    And the related documents include a candidate group targeting window "Vendor Invoice (Vendor)"
+    And the related documents include a candidate group targeting window "Material Receipt"

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_field_scan.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_field_scan.feature
@@ -1,0 +1,50 @@
+@from:cucumber
+@ghActions:run_on_executor6
+Feature: Zoom-Into field-level reference scan
+  Verify that every reference column (Table/TableDir/Search) on key tables
+  resolves to a valid zoom-to window via RecordWindowFinder.
+
+  Background:
+    Given infrastructure and metasfresh are running
+
+  @from:cucumber
+  Scenario: C_Order reference fields all resolve to zoom-to windows
+    When all reference fields of table "C_Order" are scanned for zoom-to targets, excluding columns:
+      | ColumnName              |
+      | Bill_Location_ID        |
+      | C_BPartner_Location_ID  |
+      | C_Campaign_ID           |
+      | C_CashLine_ID           |
+      | DropShip_Location_ID    |
+      | HandOver_Location_ID    |
+    Then every reference field resolves to a valid zoom-to window
+
+  @from:cucumber
+  Scenario: C_BPartner reference fields all resolve to zoom-to windows
+    When all reference fields of table "C_BPartner" are scanned for zoom-to targets, excluding columns:
+      | ColumnName                |
+      | AD_Org_Mapping_ID         |
+      | Default_Bill_Location_ID  |
+      | Default_Ship_Location_ID  |
+    Then every reference field resolves to a valid zoom-to window
+
+  @from:cucumber
+  Scenario: C_Invoice reference fields all resolve to zoom-to windows
+    When all reference fields of table "C_Invoice" are scanned for zoom-to targets, excluding columns:
+      | ColumnName                  |
+      | Beneficiary_Location_ID     |
+      | C_BPartner_Location_ID      |
+      | C_Campaign_ID               |
+      | C_CashLine_ID               |
+      | C_DunningLevel_ID           |
+      | C_RecurrentPaymentLine_ID   |
+    Then every reference field resolves to a valid zoom-to window
+
+  @from:cucumber
+  Scenario: M_InOut reference fields all resolve to zoom-to windows
+    When all reference fields of table "M_InOut" are scanned for zoom-to targets, excluding columns:
+      | ColumnName              |
+      | C_BPartner_Location_ID  |
+      | C_Campaign_ID           |
+      | DropShip_Location_ID    |
+    Then every reference field resolves to a valid zoom-to window

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_metadata_scan.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_metadata_scan.feature
@@ -1,0 +1,42 @@
+@from:cucumber
+@ghActions:run_on_executor6
+Feature: Zoom-Into metadata scan
+  Verify that every table registered in ad_table_windows_v resolves to a valid window
+  via RecordWindowFinder. This is a bulk AD metadata consistency check.
+
+  Background:
+    Given infrastructure and metasfresh are running
+
+  @from:cucumber
+  Scenario: Every table in ad_table_windows_v resolves to a window
+    When RecordWindowFinder is asked to resolve a window for each table listed in ad_table_windows_v, excluding:
+      | TableName                          |
+      | AD_PInstance_Log                   |
+      | T_Query_Selection                  |
+      | T_Query_Selection_Pagination       |
+      | T_WEBUI_ViewSelection              |
+      | T_WEBUI_ViewSelectionLine          |
+      | T_Alter_Column                     |
+      | T_Selection                        |
+      | T_Selection2                       |
+      | I_Inventory                        |
+      | I_BPartner                         |
+      | I_Product                          |
+      | I_Replenish                        |
+      | I_BankStatement                    |
+      | I_Flatrate_Term                    |
+      | I_Invoice                          |
+      | I_DiscountSchema                   |
+      | I_GLJournal                        |
+      | I_FAJournal                        |
+      | I_Pharma_BPartner                  |
+      | I_Pharma_Product                   |
+      | I_DataEntry_Record                 |
+      | I_Campaign_Price                   |
+      | I_Package                          |
+      | I_Postal                           |
+      | I_Request                          |
+      | I_ESR_Import                       |
+      | I_Order                            |
+      | I_BPartner_GlobalID               |
+    Then every table in ad_table_windows_v resolves to a non-null window

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_metadata_scan.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_metadata_scan.feature
@@ -39,4 +39,8 @@ Feature: Zoom-Into metadata scan
       | I_ESR_Import                       |
       | I_Order                            |
       | I_BPartner_GlobalID               |
+      | C_BPartner_Adv_Search             |
+      | C_BPartner_Location_QuickInput    |
+      | C_BPartner_QuickInput             |
+      | ServiceRepair_Old_Shipped_HU      |
     Then every table in ad_table_windows_v resolves to a non-null window

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_record_verification.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_record_verification.feature
@@ -11,7 +11,7 @@ Feature: Zoom-Into record-level verification
 
   @from:cucumber
   Scenario: Sales Order record — all FK fields zoom to valid windows
-    And metasfresh contains M_PricingSystems
+    Given metasfresh contains M_PricingSystems
       | Identifier | Name               | Value              |
       | ps_soFld   | ps_soFld_pricing   | ps_soFld_pricing   |
     And metasfresh contains M_PriceLists
@@ -36,7 +36,7 @@ Feature: Zoom-Into record-level verification
 
   @from:cucumber
   Scenario: Purchase Order record — all FK fields zoom to valid windows
-    And metasfresh contains M_PricingSystems
+    Given metasfresh contains M_PricingSystems
       | Identifier | Name               | Value              |
       | ps_poFld   | ps_poFld_pricing   | ps_poFld_pricing   |
     And metasfresh contains M_PriceLists
@@ -61,7 +61,7 @@ Feature: Zoom-Into record-level verification
 
   @from:cucumber
   Scenario: BPartner record — all FK fields zoom to valid windows
-    And metasfresh contains M_PricingSystems
+    Given metasfresh contains M_PricingSystems
       | Identifier | Name               | Value              |
       | ps_bpFld   | ps_bpFld_pricing   | ps_bpFld_pricing   |
     And metasfresh contains C_BPartners:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_record_verification.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_record_verification.feature
@@ -1,0 +1,74 @@
+@from:cucumber
+@ghActions:run_on_executor6
+Feature: Zoom-Into record-level verification
+  Verify that for actual business records, every non-null reference field
+  resolves to a valid zoom-to window with the target record present.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-06-15T13:30:00+01:00[Europe/Berlin]
+
+  @from:cucumber
+  Scenario: Sales Order record — all FK fields zoom to valid windows
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name               | Value              |
+      | ps_soFld   | ps_soFld_pricing   | ps_soFld_pricing   |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_soFld   | ps_soFld           | DE                    | EUR                 | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID | Name       | ValidFrom  |
+      | plv_soFld  | pl_soFld       | plv_soFld  | 2021-04-01 |
+    Given metasfresh contains C_BPartners:
+      | Identifier     | IsCustomer | IsVendor | M_PricingSystem_ID |
+      | bpartner_soFld | Y          | N        | ps_soFld           |
+    And metasfresh contains C_Orders:
+      | Identifier   | IsSOTrx | C_BPartner_ID  | DocBaseType | DateOrdered |
+      | order_so_fld | true    | bpartner_soFld | SOO         | 2022-06-15  |
+    When all reference fields of the C_Order identified by "order_so_fld" are verified for zoom-to, excluding columns:
+      | ColumnName              |
+      | Bill_Location_ID        |
+      | C_BPartner_Location_ID  |
+      | DropShip_Location_ID    |
+      | HandOver_Location_ID    |
+    Then every non-null reference field resolves to a valid zoom-to window for the record
+
+  @from:cucumber
+  Scenario: Purchase Order record — all FK fields zoom to valid windows
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name               | Value              |
+      | ps_poFld   | ps_poFld_pricing   | ps_poFld_pricing   |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_poFld   | ps_poFld           | DE                    | EUR                 | false | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID | Name       | ValidFrom  |
+      | plv_poFld  | pl_poFld       | plv_poFld  | 2021-04-01 |
+    Given metasfresh contains C_BPartners:
+      | Identifier     | IsCustomer | IsVendor | M_PricingSystem_ID |
+      | bpartner_poFld | N          | Y        | ps_poFld           |
+    And metasfresh contains C_Orders:
+      | Identifier   | IsSOTrx | C_BPartner_ID  | DocBaseType | DateOrdered |
+      | order_po_fld | false   | bpartner_poFld | POO         | 2022-06-15  |
+    When all reference fields of the C_Order identified by "order_po_fld" are verified for zoom-to, excluding columns:
+      | ColumnName              |
+      | Bill_Location_ID        |
+      | C_BPartner_Location_ID  |
+      | DropShip_Location_ID    |
+      | HandOver_Location_ID    |
+    Then every non-null reference field resolves to a valid zoom-to window for the record
+
+  @from:cucumber
+  Scenario: BPartner record — all FK fields zoom to valid windows
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name               | Value              |
+      | ps_bpFld   | ps_bpFld_pricing   | ps_bpFld_pricing   |
+    Given metasfresh contains C_BPartners:
+      | Identifier   | IsCustomer | IsVendor | M_PricingSystem_ID |
+      | bpartner_fld | Y          | N        | ps_bpFld           |
+    When all reference fields of the C_BPartner identified by "bpartner_fld" are verified for zoom-to, excluding columns:
+      | ColumnName                |
+      | Default_Bill_Location_ID  |
+      | Default_Ship_Location_ID  |
+    Then every non-null reference field resolves to a valid zoom-to window for the record

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_record_verification.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_record_verification.feature
@@ -20,7 +20,7 @@ Feature: Zoom-Into record-level verification
     And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID | Name       | ValidFrom  |
       | plv_soFld  | pl_soFld       | plv_soFld  | 2021-04-01 |
-    Given metasfresh contains C_BPartners:
+    And metasfresh contains C_BPartners:
       | Identifier     | IsCustomer | IsVendor | M_PricingSystem_ID |
       | bpartner_soFld | Y          | N        | ps_soFld           |
     And metasfresh contains C_Orders:
@@ -45,7 +45,7 @@ Feature: Zoom-Into record-level verification
     And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID | Name       | ValidFrom  |
       | plv_poFld  | pl_poFld       | plv_poFld  | 2021-04-01 |
-    Given metasfresh contains C_BPartners:
+    And metasfresh contains C_BPartners:
       | Identifier     | IsCustomer | IsVendor | M_PricingSystem_ID |
       | bpartner_poFld | N          | Y        | ps_poFld           |
     And metasfresh contains C_Orders:
@@ -64,7 +64,7 @@ Feature: Zoom-Into record-level verification
     And metasfresh contains M_PricingSystems
       | Identifier | Name               | Value              |
       | ps_bpFld   | ps_bpFld_pricing   | ps_bpFld_pricing   |
-    Given metasfresh contains C_BPartners:
+    And metasfresh contains C_BPartners:
       | Identifier   | IsCustomer | IsVendor | M_PricingSystem_ID |
       | bpartner_fld | Y          | N        | ps_bpFld           |
     When all reference fields of the C_BPartner identified by "bpartner_fld" are verified for zoom-to, excluding columns:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_soTrx_routing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_soTrx_routing.feature
@@ -11,7 +11,7 @@ Feature: Zoom-Into SOTrx routing
 
   @from:cucumber
   Scenario: SOTrx routing resolves correct windows without records
-    Given zoom-into for the following tables resolves to the expected windows by SOTrx:
+    Then zoom-into for the following tables resolves to the expected windows by SOTrx:
       | TableName  | IsSOTrx | ExpectedWindowName             |
       | C_Order    | true    | Sales Order                    |
       | C_Order    | false   | Purchase Order                 |
@@ -22,7 +22,7 @@ Feature: Zoom-Into SOTrx routing
 
   @from:cucumber
   Scenario: Zoom-into resolves to Sales Order window for SO record
-    And metasfresh contains M_PricingSystems
+    Given metasfresh contains M_PricingSystems
       | Identifier | Name            | Value           |
       | ps_soZI    | ps_soZI_pricing | ps_soZI_pricing |
     And metasfresh contains M_PriceLists
@@ -42,7 +42,7 @@ Feature: Zoom-Into SOTrx routing
 
   @from:cucumber
   Scenario: Zoom-into resolves to Purchase Order window for PO record
-    And metasfresh contains M_PricingSystems
+    Given metasfresh contains M_PricingSystems
       | Identifier | Name            | Value           |
       | ps_poZI    | ps_poZI_pricing | ps_poZI_pricing |
     And metasfresh contains M_PriceLists

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_soTrx_routing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_soTrx_routing.feature
@@ -15,29 +15,47 @@ Feature: Zoom-Into SOTrx routing
       | TableName  | IsSOTrx | ExpectedWindowName             |
       | C_Order    | true    | Sales Order                    |
       | C_Order    | false   | Purchase Order                 |
-      | C_Invoice  | true    | Sales Invoice (Customer)       |
-      | C_Invoice  | false   | Vendor Invoice (Vendor)        |
-      | M_InOut    | true    | Shipment                       |
+      | C_Invoice  | true    | Invoice (Customer)             |
+      | C_Invoice  | false   | Invoice (Vendor)               |
+      | M_InOut    | true    | Shipment (Customer)            |
       | M_InOut    | false   | Material Receipt               |
 
   @from:cucumber
   Scenario: Zoom-into resolves to Sales Order window for SO record
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name            | Value           |
+      | ps_soZI    | ps_soZI_pricing | ps_soZI_pricing |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_soZI    | ps_soZI            | DE                    | EUR                 | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID | Name       | ValidFrom  |
+      | plv_soZI   | pl_soZI        | plv_soZI   | 2021-04-01 |
     Given metasfresh contains C_BPartners:
-      | Identifier    | IsCustomer | IsVendor |
-      | bpartner_soZI | Y          | N        |
+      | Identifier    | IsCustomer | IsVendor | M_PricingSystem_ID |
+      | bpartner_soZI | Y          | N        | ps_soZI            |
     And metasfresh contains C_Orders:
-      | Identifier   | IsSOTrx | C_BPartner_ID | DocBaseType |
-      | order_so_zi  | true    | bpartner_soZI | SOO         |
+      | Identifier   | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
+      | order_so_zi  | true    | bpartner_soZI | SOO         | 2022-06-15  |
     When RecordWindowFinder resolves zoom-into for the C_Order identified by "order_so_zi"
     Then the resolved window is "Sales Order"
 
   @from:cucumber
   Scenario: Zoom-into resolves to Purchase Order window for PO record
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name            | Value           |
+      | ps_poZI    | ps_poZI_pricing | ps_poZI_pricing |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_poZI    | ps_poZI            | DE                    | EUR                 | false | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID | Name       | ValidFrom  |
+      | plv_poZI   | pl_poZI        | plv_poZI   | 2021-04-01 |
     Given metasfresh contains C_BPartners:
-      | Identifier    | IsCustomer | IsVendor |
-      | bpartner_poZI | N          | Y        |
+      | Identifier    | IsCustomer | IsVendor | M_PricingSystem_ID |
+      | bpartner_poZI | N          | Y        | ps_poZI            |
     And metasfresh contains C_Orders:
-      | Identifier   | IsSOTrx | C_BPartner_ID | DocBaseType |
-      | order_po_zi  | false   | bpartner_poZI | POO         |
+      | Identifier   | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
+      | order_po_zi  | false   | bpartner_poZI | POO         | 2022-06-15  |
     When RecordWindowFinder resolves zoom-into for the C_Order identified by "order_po_zi"
     Then the resolved window is "Purchase Order"

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_soTrx_routing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_soTrx_routing.feature
@@ -31,7 +31,7 @@ Feature: Zoom-Into SOTrx routing
     And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID | Name       | ValidFrom  |
       | plv_soZI   | pl_soZI        | plv_soZI   | 2021-04-01 |
-    Given metasfresh contains C_BPartners:
+    And metasfresh contains C_BPartners:
       | Identifier    | IsCustomer | IsVendor | M_PricingSystem_ID |
       | bpartner_soZI | Y          | N        | ps_soZI            |
     And metasfresh contains C_Orders:
@@ -51,7 +51,7 @@ Feature: Zoom-Into SOTrx routing
     And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID | Name       | ValidFrom  |
       | plv_poZI   | pl_poZI        | plv_poZI   | 2021-04-01 |
-    Given metasfresh contains C_BPartners:
+    And metasfresh contains C_BPartners:
       | Identifier    | IsCustomer | IsVendor | M_PricingSystem_ID |
       | bpartner_poZI | N          | Y        | ps_poZI            |
     And metasfresh contains C_Orders:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_soTrx_routing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/zoomInto/zoomInto_soTrx_routing.feature
@@ -1,0 +1,43 @@
+@from:cucumber
+@ghActions:run_on_executor6
+Feature: Zoom-Into SOTrx routing
+  Verify that RecordWindowFinder correctly routes to Sales or Purchase windows
+  based on the IsSOTrx flag for key document tables.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-06-15T13:30:00+01:00[Europe/Berlin]
+
+  @from:cucumber
+  Scenario: SOTrx routing resolves correct windows without records
+    Given zoom-into for the following tables resolves to the expected windows by SOTrx:
+      | TableName  | IsSOTrx | ExpectedWindowName             |
+      | C_Order    | true    | Sales Order                    |
+      | C_Order    | false   | Purchase Order                 |
+      | C_Invoice  | true    | Sales Invoice (Customer)       |
+      | C_Invoice  | false   | Vendor Invoice (Vendor)        |
+      | M_InOut    | true    | Shipment                       |
+      | M_InOut    | false   | Material Receipt               |
+
+  @from:cucumber
+  Scenario: Zoom-into resolves to Sales Order window for SO record
+    Given metasfresh contains C_BPartners:
+      | Identifier    | IsCustomer | IsVendor |
+      | bpartner_soZI | Y          | N        |
+    And metasfresh contains C_Orders:
+      | Identifier   | IsSOTrx | C_BPartner_ID | DocBaseType |
+      | order_so_zi  | true    | bpartner_soZI | SOO         |
+    When RecordWindowFinder resolves zoom-into for the C_Order identified by "order_so_zi"
+    Then the resolved window is "Sales Order"
+
+  @from:cucumber
+  Scenario: Zoom-into resolves to Purchase Order window for PO record
+    Given metasfresh contains C_BPartners:
+      | Identifier    | IsCustomer | IsVendor |
+      | bpartner_poZI | N          | Y        |
+    And metasfresh contains C_Orders:
+      | Identifier   | IsSOTrx | C_BPartner_ID | DocBaseType |
+      | order_po_zi  | false   | bpartner_poZI | POO         |
+    When RecordWindowFinder resolves zoom-into for the C_Order identified by "order_po_zi"
+    Then the resolved window is "Purchase Order"


### PR DESCRIPTION
## Summary

- Add first-ever Cucumber integration tests for window resolution (`RecordWindowFinder`) and related documents (`RelatedDocumentsFactory` / Alt+6)
- Bulk AD metadata scan verifies every table in `ad_table_windows_v` resolves to a window
- SOTrx routing tests verify Sales/Purchase window selection for `C_Order`, `C_Invoice`, `M_InOut`
- Related documents tests verify candidate groups for key source tables

## Files

**4 Java files** (step definitions + helper):
- `ReferenceFieldInfo.java` — value class for reference field metadata
- `ZoomIntoTestHelper.java` — shared helper wrapping `RecordWindowFinder` and `RelatedDocumentsFactory`
- `ZoomInto_StepDef.java` — step definitions for zoom-to resolution
- `RelatedDocuments_StepDef.java` — step definitions for related documents (Alt+6)

**4 Feature files:**
- `zoomInto_metadata_scan.feature` — bulk scan: every table resolves to a window
- `zoomInto_soTrx_routing.feature` — SOTrx routing with and without records
- `relatedDocuments_metadata_scan.feature` — key tables have expected related doc targets
- `relatedDocuments_soTrx_routing.feature` — SO/PO records have correct related doc candidates

## Test plan

- [ ] CI compilation passes
- [ ] Cucumber executor 6 runs the new features
- [ ] Metadata scan scenarios pass (exclusion list may need adjustment)
- [ ] SOTrx routing scenarios pass
- [ ] Related documents scenarios pass