### PR TITLE
DESADV JSON export: filter packs by shipment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,24 @@ misc/services/camel/de-metas-camel-shipping/tmp/
 # github related
 .github/merge_to_master
 .github/integrate
+
+# workspace-local Maven repository
+.m2-local/
+
+# claude related
+.claude
+**/CLAUDE.md
+**/CLAUDE.md.backup
+.mcp.json
+**/claude-docs
+
+.m2-local
+
+# dev-mode artifacts extracted from CI images
+.dev-artifacts/
+
+# Local CI/CD output logs
+act_output_*.txt
+nul
+
+/mcp-scripts/**/*

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_StepDef.java
@@ -169,6 +169,26 @@ public class EDI_Desadv_StepDef
 		DataTableRows.of(table).forEach(row -> validateExportStatus(timeoutSec, row));
 	}
 
+	/**
+	 * Asserts that all given M_InOut records point to the same {@code EDI_Desadv_ID}.
+	 * This is used to verify the test precondition that multiple shipments share
+	 * a single DESADV (e.g. because they originate from orders with the same POReference + BPartner).
+	 * <p>
+	 * Each record must have a non-zero {@code EDI_Desadv_ID}, and all must match.
+	 * <p>
+	 * DataTable columns:
+	 * <ul>
+	 *     <li>{@code M_InOut_ID} (required) — identifier of an M_InOut record from {@link M_InOut_StepDefData}</li>
+	 * </ul>
+	 * <p>
+	 * Example usage:
+	 * <pre>
+	 * Then M_InOut records share the same EDI_Desadv:
+	 *   | M_InOut_ID |
+	 *   | s_1        |
+	 *   | s_2        |
+	 * </pre>
+	 */
 	@Then("M_InOut records share the same EDI_Desadv:")
 	public void assertShipmentsShareSameDesadv(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_StepDef.java
@@ -33,8 +33,10 @@ import de.metas.cucumber.stepdefs.DataTableUtil;
 import de.metas.cucumber.stepdefs.StepDefConstants;
 import de.metas.cucumber.stepdefs.StepDefUtil;
 import de.metas.cucumber.stepdefs.context.TestContext;
+import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
 import de.metas.edi.api.EDIDesadvQuery;
 import de.metas.edi.api.IDesadvDAO;
+import de.metas.edi.model.I_M_InOut;
 import de.metas.edi.process.export.enqueue.DesadvEnqueuer;
 import de.metas.edi.process.export.enqueue.EnqueueDesadvRequest;
 import de.metas.edi.process.export.enqueue.EnqueueDesadvResult;
@@ -90,6 +92,7 @@ public class EDI_Desadv_StepDef
 	private final @NonNull C_BPartner_StepDefData bpartnerTable;
 	private final @NonNull C_Order_StepDefData orderTable;
 	private final @NonNull EDI_Exp_Desadv_StepDefData ediExpDesadvTable;
+	private final @NonNull M_InOut_StepDefData inoutTable;
 	private final @NonNull TestContext restTestContext;
 
 	@Given("metasfresh is configured for One-DESADV-Per-ORDERS")
@@ -164,6 +167,34 @@ public class EDI_Desadv_StepDef
 	public void validate_export_status(final int timeoutSec, @NonNull final DataTable table) throws InterruptedException
 	{
 		DataTableRows.of(table).forEach(row -> validateExportStatus(timeoutSec, row));
+	}
+
+	@Then("M_InOut records share the same EDI_Desadv:")
+	public void assertShipmentsShareSameDesadv(@NonNull final DataTable dataTable)
+	{
+		final List<DataTableRow> rows = DataTableRows.of(dataTable).toList();
+		assertThat(rows).as("Need at least 2 M_InOut records to compare").hasSizeGreaterThanOrEqualTo(2);
+
+		int firstDesadvId = -1;
+		for (final DataTableRow row : rows)
+		{
+			final org.compiere.model.I_M_InOut inoutRecord = row.getAsIdentifier(org.compiere.model.I_M_InOut.COLUMNNAME_M_InOut_ID).lookupNotNullIn(inoutTable);
+			final I_M_InOut ediInout = InterfaceWrapperHelper.create(inoutRecord, I_M_InOut.class);
+			InterfaceWrapperHelper.refresh(ediInout);
+			final int desadvId = ediInout.getEDI_Desadv_ID();
+			assertThat(desadvId).as("M_InOut %s should have EDI_Desadv_ID set", row.getAsIdentifier(org.compiere.model.I_M_InOut.COLUMNNAME_M_InOut_ID)).isGreaterThan(0);
+
+			if (firstDesadvId < 0)
+			{
+				firstDesadvId = desadvId;
+			}
+			else
+			{
+				assertThat(desadvId)
+						.as("All M_InOut records should share the same EDI_Desadv_ID")
+						.isEqualTo(firstDesadvId);
+			}
+		}
 	}
 
 	private void validateEdiDesadv(@NonNull final Map<String, String> tableRow)

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
@@ -434,3 +434,144 @@ Feature: EDI DESADV export via postgREST
     And after not more than 1s, M_InOut records have the following export status
       | M_InOut_ID | EDI_ExportStatus |
       | s_cg       | S                |
+
+  @Id:S0468_030
+  @from:cucumber
+  Scenario: DESADV export with multiple shipments only includes packs from the requested shipment
+
+    # One simple product — no compensation groups needed (that's tested in S0468_020)
+    Given metasfresh contains M_Products:
+      | Identifier     |
+      | prod_multiShip |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_Product_ID | C_BPartner_ID | M_Product_ID   |
+      | bp_ms                 | customer1     | prod_multiShip |
+    And metasfresh contains M_HU_PackingMaterial:
+      | M_HU_PackingMaterial_ID | M_Product_ID   | Name       |
+      | pm_ms                   | prod_multiShip | pmMultiShip |
+    And load M_HU_PackagingCode:
+      | M_HU_PackagingCode_ID | PackagingCode | HU_UnitType |
+      | huPkgCodeLU_ms        | ISO1          | LU          |
+      | huPkgCodeTU_ms        | CART          | TU          |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID     |
+      | huPILU_ms      |
+      | huPITU_ms      |
+      | huPIVirtual_ms |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID     | HU_UnitType | IsCurrent | M_HU_PackagingCode_ID |
+      | huPIVerLU_ms       | huPILU_ms      | LU          | Y         |                       |
+      | huPIVerTU_ms       | huPITU_ms      | TU          | Y         | huPkgCodeTU_ms        |
+      | huPIVerCU_ms       | huPIVirtual_ms | V           | Y         |                       |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID | M_HU_PackingMaterial_ID |
+      | huPiItemLU_ms              | huPIVerLU_ms       | 10  | HU       | huPITU_ms         |                         |
+      | huPiItemTU_ms              | huPIVerTU_ms       | 0   | PM       |                    | pm_ms                   |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID   | Qty | ValidFrom  | M_HU_PackagingCode_LU_Fallback_ID | GTIN_LU_PackingMaterial_Fallback |
+      | huPiProd_ms             | huPiItemTU_ms    | prod_multiShip | 10  | 2025-01-01 | huPkgCodeLU_ms                    | msLuGTIN                         |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID   | PriceStd | C_UOM_ID |
+      | salesPLV               | prod_multiShip | 5.00     | PCE      |
+
+    # Order 1 — POReference "multiShipRef"
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | POReference  |
+      | o_ms_1     | true    | customer1     | 2025-04-17  | 2025-04-18Z  | multiShipRef |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID   | QtyEntered | M_HU_PI_Item_Product_ID |
+      | ol_ms_1    | o_ms_1     | prod_multiShip | 10         | huPiProd_ms             |
+    And the order identified by o_ms_1 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ss_ms_1    | ol_ms_1        | N             |
+
+    And setup the SSCC18 code generator with GS1ManufacturerCode 1234567, GS1ExtensionDigit 0 and next sequence number always=1000000.
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_ms_1                          | D            | true                | false       |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | REST.Context.M_InOut_ID | REST.Context.DocumentNo |
+      | ss_ms_1                          | s_ms_1                | shipment_ms1_ID         | shipment_ms1_DocNo      |
+
+    And reset the SSCC18 code generator's next sequence number back to its actual sequence.
+
+    # Order 2 — same BPartner, same POReference → reuses the same DESADV
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | POReference  |
+      | o_ms_2     | true    | customer1     | 2025-04-17  | 2025-04-18Z  | multiShipRef |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID   | QtyEntered | M_HU_PI_Item_Product_ID |
+      | ol_ms_2    | o_ms_2     | prod_multiShip | 10         | huPiProd_ms             |
+    And the order identified by o_ms_2 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ss_ms_2    | ol_ms_2        | N             |
+
+    And setup the SSCC18 code generator with GS1ManufacturerCode 1234567, GS1ExtensionDigit 0 and next sequence number always=2000000.
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_ms_2                          | D            | true                | false       |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | REST.Context.M_InOut_ID | REST.Context.DocumentNo |
+      | ss_ms_2                          | s_ms_2                | shipment_ms2_ID         | shipment_ms2_DocNo      |
+
+    And reset the SSCC18 code generator's next sequence number back to its actual sequence.
+
+    # Verify both shipments share the same DESADV (test precondition)
+    Then M_InOut records share the same EDI_Desadv:
+      | M_InOut_ID |
+      | s_ms_1     |
+      | s_ms_2     |
+
+    # Export shipment 1 and verify it has exactly 1 pack (not 2)
+    And the following API_Audit_Config records are created:
+      | Identifier | SeqNo | OPT.Method | OPT.PathPrefix   | IsForceProcessedAsync | IsSynchronousAuditLoggingEnabled | IsWrapApiResponse |
+      | c_ms_1     | 10    | GET        | api/v2/processes | N                     | Y                                | N                 |
+    And add HTTP headers
+      | Key          | Value                          |
+      | Content-Type | application/json;charset=UTF-8 |
+      | accept       | application/json;charset=UTF-8 |
+
+    When a 'POST' request with the below payload and headers from context is sent to the metasfresh REST-API 'api/v2/processes/M_InOut_EDI_Export_JSON/invoke' and fulfills with '200' status code
+    """
+{
+    "processParameters": [
+    {
+      "name": "M_InOut_ID",
+      "value": "@shipment_ms1_ID@"
+    }
+  ]
+}
+    """
+    Then verify DESADV JSON export has compensation group packing:
+      | PackingCount | MainArticleCount | SubArticleCount |
+      | 1            | 1                | 0               |
+
+    # Export shipment 2 and verify it also has exactly 1 pack (not 2)
+    And add HTTP headers
+      | Key          | Value                          |
+      | Content-Type | application/json;charset=UTF-8 |
+      | accept       | application/json;charset=UTF-8 |
+
+    When a 'POST' request with the below payload and headers from context is sent to the metasfresh REST-API 'api/v2/processes/M_InOut_EDI_Export_JSON/invoke' and fulfills with '200' status code
+    """
+{
+    "processParameters": [
+    {
+      "name": "M_InOut_ID",
+      "value": "@shipment_ms2_ID@"
+    }
+  ]
+}
+    """
+    Then verify DESADV JSON export has compensation group packing:
+      | PackingCount | MainArticleCount | SubArticleCount |
+      | 1            | 1                | 0               |

--- a/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/desadv_json/get_desadv_lines_no_pack_json_fn.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/desadv_json/get_desadv_lines_no_pack_json_fn.sql
@@ -22,7 +22,7 @@
 
 -- Function for desadv lines with no pack
 -- Ensure edi_desadv_line_object_v is defined and efficient
-CREATE OR REPLACE FUNCTION "de.metas.edi".get_desadv_lines_no_pack_json_fn(p_edi_desadv_id NUMERIC)
+CREATE OR REPLACE FUNCTION "de.metas.edi".get_desadv_lines_no_pack_json_fn(p_edi_desadv_id NUMERIC, p_m_inout_id NUMERIC)
     RETURNS JSONB AS $$
 DECLARE
     v_lines_no_pack_json JSONB;
@@ -39,12 +39,19 @@ BEGIN
              LEFT JOIN "de.metas.edi".edi_desadv_line_object_v line_obj_no_pack ON line_obj_no_pack.edi_desadvline_id = edl_lat.edi_desadvline_id
     WHERE edl_lat.edi_desadv_id = p_edi_desadv_id -- Filter by parameter!
       AND edl_lat.isactive = 'Y'
+      AND EXISTS (
+        SELECT 1 FROM m_inoutline iol_exist
+        WHERE iol_exist.m_inout_id = p_m_inout_id
+          AND iol_exist.edi_desadvline_id = edl_lat.edi_desadvline_id
+    )
       AND NOT EXISTS (
         SELECT 1
         FROM edi_desadv_pack_item edpi_check
                  JOIN edi_desadv_pack edp_check ON edp_check.edi_desadv_pack_id = edpi_check.edi_desadv_pack_id
-            AND edp_check.edi_desadv_id = edl_lat.edi_desadv_id -- Correct: ensures pack is for same desadv
+            AND edp_check.edi_desadv_id = edl_lat.edi_desadv_id
             AND edp_check.isactive = 'Y'
+                 JOIN m_inoutline iol_check ON iol_check.m_inoutline_id = edpi_check.m_inoutline_id
+            AND iol_check.m_inout_id = p_m_inout_id
         WHERE edpi_check.edi_desadvline_id = edl_lat.edi_desadvline_id
           AND edpi_check.isactive = 'Y'
     );

--- a/backend/de.metas.edi/src/main/sql/postgresql/ddl/views/desadv_json/M_InOut_Export_EDI_DESADV_JSON_V.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/ddl/views/desadv_json/M_InOut_Export_EDI_DESADV_JSON_V.sql
@@ -23,7 +23,7 @@ SELECT io.m_inout_id,
                'EDI_Desadv_ID', d.edi_desadv_id,
                'MovementDate', io.movementdate,
                'POReference', COALESCE(d.poreference, io.poreference),
-               'Packings', "de.metas.edi".get_desadv_packs_json_fn(d.edi_desadv_id),
+               'Packings', "de.metas.edi".get_desadv_packs_json_fn(d.edi_desadv_id, io.m_inout_id),
                'Currency', COALESCE(curr.currency_json, '{}'::jsonb),
                'InvoicableQtyBasedOn', (SELECT edl_ib.invoicableqtybasedon
                                 FROM edi_desadvline edl_ib
@@ -32,7 +32,7 @@ SELECT io.m_inout_id,
                                 ORDER BY edl_ib.line
                                 LIMIT 1),
                'DeliveryViaRule', COALESCE(d.deliveryviarule, io.deliveryviarule),
-               'DesadvLineWithNoPacking', "de.metas.edi".get_desadv_lines_no_pack_json_fn(d.edi_desadv_id),
+               'DesadvLineWithNoPacking', "de.metas.edi".get_desadv_lines_no_pack_json_fn(d.edi_desadv_id, io.m_inout_id),
                'M_InOut_ID', io.m_inout_id,
                'DatePromised', o.datepromised)
        ) as embedded_json

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5792220_sys_gh26915_desadv_json_filter_packs_by_shipment.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5792220_sys_gh26915_desadv_json_filter_packs_by_shipment.sql
@@ -1,7 +1,12 @@
--- Function for desadv packs
--- Handles compensation group sub-articles: sub-article pack items are merged
--- into the main article's pack, adding IsSubArticle and MainArticleLine to each LineItem.
--- Packs NOT in a compensation group are output as before (backward-compatible).
+-- gh#26915: DESADV JSON export — filter packs and no-pack lines by shipment (m_inout_id)
+-- When a DESADV is shared across multiple shipments, the JSON export must only include
+-- packs and lines belonging to the specific shipment being exported.
+
+-- 1) Drop old single-parameter functions
+DROP FUNCTION IF EXISTS "de.metas.edi".get_desadv_packs_json_fn(NUMERIC);
+DROP FUNCTION IF EXISTS "de.metas.edi".get_desadv_lines_no_pack_json_fn(NUMERIC);
+
+-- 2) Recreate get_desadv_packs_json_fn with p_m_inout_id parameter
 CREATE OR REPLACE FUNCTION "de.metas.edi".get_desadv_packs_json_fn(p_edi_desadv_id NUMERIC, p_m_inout_id NUMERIC)
     RETURNS JSONB
 AS
@@ -10,8 +15,6 @@ DECLARE
     v_packs_json JSONB;
 BEGIN
     WITH pack_item_comp AS (
-        -- For each pack_item, resolve its compensation group via:
-        -- pack_item.m_inoutline_id -> m_inoutline.c_orderline_id -> c_orderline.c_order_compensationgroup_id
         SELECT epi.edi_desadv_pack_item_id,
                epi.edi_desadv_pack_id,
                epi.edi_desadvline_id,
@@ -31,7 +34,6 @@ BEGIN
           AND epi.isactive = 'Y'
     ),
          main_per_group AS (
-             -- The main line in each comp group = the one with the lowest order_line
              SELECT DISTINCT ON (comp_group_id)
                  comp_group_id,
                  edi_desadvline_id AS main_desadvline_id,
@@ -41,7 +43,6 @@ BEGIN
              ORDER BY comp_group_id, order_line
          ),
          pack_with_role AS (
-             -- Enrich each pack_item with its role (main vs sub-article)
              SELECT ep.edi_desadv_pack_id,
                     ep.seqno,
                     ep.ipa_sscc18,
@@ -78,9 +79,6 @@ BEGIN
                AND ep.isactive = 'Y'
          ),
          main_packs AS (
-             -- Identify the main pack per compensation group
-             -- (the pack containing the main article item, i.e. lowest order_line).
-             -- Uses DISTINCT ON to pick one main pack per group regardless of seqno ordering.
              SELECT DISTINCT ON (comp_group_id)
                  comp_group_id, edi_desadv_pack_id AS main_pack_id
              FROM pack_with_role
@@ -88,7 +86,6 @@ BEGIN
              ORDER BY comp_group_id, seqno
          ),
          items_assigned AS (
-             -- Sub-article items are reassigned to the main pack in their compensation group
              SELECT pwr.*,
                     CASE
                         WHEN pwr.is_sub_article THEN mp.main_pack_id
@@ -98,7 +95,6 @@ BEGIN
                       LEFT JOIN main_packs mp ON mp.comp_group_id = pwr.comp_group_id
          ),
          pack_header AS (
-             -- Use the main pack's header info (SSCC, packaging code) for each effective_pack_id
              SELECT DISTINCT ON (ia.effective_pack_id)
                  ia.effective_pack_id,
                  ep.seqno,
@@ -123,9 +119,6 @@ BEGIN
              LEFT JOIN m_hu_packagingcode pc_lu
                        ON pc_lu.m_hu_packagingcode_id = ph.m_hu_packagingcode_id
              LEFT JOIN LATERAL (
-        -- Build LineItems JSON per effective pack.
-        -- Inlines the edi_desadv_line_object_v logic using ia.m_inoutline_id
-        -- to get the correct orderline/order context (avoiding 1:N multiplication).
         SELECT JSONB_AGG(
                        JSONB_BUILD_OBJECT(
                                'BestBeforeDate', ia.bestbeforedate,
@@ -173,11 +166,9 @@ BEGIN
                  JOIN "de.metas.edi".edi_uom_object_v dl_uom ON dl_uom.c_uom_id = dl.c_uom_id
                  LEFT JOIN "de.metas.edi".edi_uom_object_v inv_uom ON inv_uom.c_uom_id = dl.c_uom_invoice_id
                  LEFT JOIN "de.metas.edi".edi_uom_object_v gw_uom ON gw_uom.c_uom_id = p.grossweight_uom_id
-            -- Use pack_item's m_inoutline_id for 1:1 join (not desadvline-level N:M)
                  LEFT JOIN m_inoutline iol ON iol.m_inoutline_id = ia.m_inoutline_id
                  LEFT JOIN c_orderline ol ON ol.c_orderline_id = iol.c_orderline_id
                  LEFT JOIN c_order o ON o.c_order_id = ol.c_order_id
-            -- BPartner product lookup
                  LEFT JOIN LATERAL (
             SELECT gtin, productno
             FROM c_bpartner_product
@@ -186,7 +177,6 @@ BEGIN
               AND c_bpartner_id = d.c_bpartner_id
             LIMIT 1
             ) bpp ON TRUE
-            -- Packing instruction product lookup
                  LEFT JOIN LATERAL (
             SELECT gtin
             FROM m_hu_pi_item_product
@@ -205,4 +195,100 @@ BEGIN
 END;
 $$
     LANGUAGE plpgsql STABLE
+;
+
+-- 3) Recreate get_desadv_lines_no_pack_json_fn with p_m_inout_id parameter
+CREATE OR REPLACE FUNCTION "de.metas.edi".get_desadv_lines_no_pack_json_fn(p_edi_desadv_id NUMERIC, p_m_inout_id NUMERIC)
+    RETURNS JSONB AS $$
+DECLARE
+    v_lines_no_pack_json JSONB;
+BEGIN
+    SELECT
+        jsonb_agg(
+                jsonb_build_object(
+                        'DesadvLine', COALESCE(line_obj_no_pack.desadv_line_object_json, '{}'::jsonb)
+                ) ORDER BY edl_lat.line
+        )
+    INTO v_lines_no_pack_json
+    FROM edi_desadvline edl_lat
+             LEFT JOIN "de.metas.edi".edi_desadv_line_object_v line_obj_no_pack ON line_obj_no_pack.edi_desadvline_id = edl_lat.edi_desadvline_id
+    WHERE edl_lat.edi_desadv_id = p_edi_desadv_id
+      AND edl_lat.isactive = 'Y'
+      AND EXISTS (
+        SELECT 1 FROM m_inoutline iol_exist
+        WHERE iol_exist.m_inout_id = p_m_inout_id
+          AND iol_exist.edi_desadvline_id = edl_lat.edi_desadvline_id
+    )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM edi_desadv_pack_item edpi_check
+                 JOIN edi_desadv_pack edp_check ON edp_check.edi_desadv_pack_id = edpi_check.edi_desadv_pack_id
+            AND edp_check.edi_desadv_id = edl_lat.edi_desadv_id
+            AND edp_check.isactive = 'Y'
+                 JOIN m_inoutline iol_check ON iol_check.m_inoutline_id = edpi_check.m_inoutline_id
+            AND iol_check.m_inout_id = p_m_inout_id
+        WHERE edpi_check.edi_desadvline_id = edl_lat.edi_desadvline_id
+          AND edpi_check.isactive = 'Y'
+    );
+
+    RETURN COALESCE(v_lines_no_pack_json, '[]'::jsonb);
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+-- 4) Recreate the view to pass io.m_inout_id to both functions
+DROP VIEW IF EXISTS M_InOut_Export_EDI_DESADV_JSON_V;
+CREATE OR REPLACE VIEW M_InOut_Export_EDI_DESADV_JSON_V AS
+SELECT io.m_inout_id,
+       JSON_BUILD_OBJECT('metasfresh_DESADV', JSONB_BUILD_OBJECT(
+               'Version', '0.2',
+               'TechnicalRecipientGLN', buyer.edidesadvrecipientgln,
+               'Parties', JSONB_BUILD_OBJECT(
+                       'Supplier', COALESCE(bp_supplier.bpartner_json, '{}'::jsonb),
+                       'Supplier_Location', COALESCE(bpl_supplier.bpartner_location_json, '{}'::jsonb),
+                       'Buyer', COALESCE(bp_buyer.bpartner_json, '{}'::jsonb),
+                       'Buyer_Location', COALESCE(bpl_buyer.bpartner_location_json, '{}'::jsonb),
+                       'Invoicee', COALESCE(bp_bill.bpartner_json, '{}'::jsonb),
+                       'Invoicee_Location', COALESCE(bpl_bill.bpartner_location_json, '{}'::jsonb),
+                       'DeliveryParty', COALESCE(bp_handover.bpartner_json, '{}'::jsonb),
+                       'DeliveryParty_Location', COALESCE(bpl_handover.bpartner_location_json, '{}'::jsonb),
+                       'UltimateConsignee', COALESCE(bp_dropship.bpartner_json, '{}'::jsonb),
+                       'UltimateConsignee_Location', COALESCE(bpl_dropship.bpartner_location_json, '{}'::jsonb)
+               ),
+               'DateOrdered', d.dateordered,
+               'ShipmentDocumentNo', io.documentno,
+               'EDI_Desadv_ID', d.edi_desadv_id,
+               'MovementDate', io.movementdate,
+               'POReference', COALESCE(d.poreference, io.poreference),
+               'Packings', "de.metas.edi".get_desadv_packs_json_fn(d.edi_desadv_id, io.m_inout_id),
+               'Currency', COALESCE(curr.currency_json, '{}'::jsonb),
+               'InvoicableQtyBasedOn', (SELECT edl_ib.invoicableqtybasedon
+                                FROM edi_desadvline edl_ib
+                                WHERE edl_ib.edi_desadv_id = d.edi_desadv_id
+                                  AND edl_ib.isactive = 'Y'
+                                ORDER BY edl_ib.line
+                                LIMIT 1),
+               'DeliveryViaRule', COALESCE(d.deliveryviarule, io.deliveryviarule),
+               'DesadvLineWithNoPacking', "de.metas.edi".get_desadv_lines_no_pack_json_fn(d.edi_desadv_id, io.m_inout_id),
+               'M_InOut_ID', io.m_inout_id,
+               'DatePromised', o.datepromised)
+       ) as embedded_json
+                         FROM m_inout io
+                         LEFT JOIN c_order o ON io.c_order_id = o.c_order_id
+                         JOIN edi_desadv d ON io.edi_desadv_id = d.edi_desadv_id
+                         JOIN c_bpartner buyer ON d.c_bpartner_id = buyer.c_bpartner_id
+                         LEFT JOIN "de.metas.edi".edi_currency_object_v curr ON curr.c_currency_id = d.c_currency_id
+                         LEFT JOIN "de.metas.edi".edi_bpartner_object_v bp_buyer ON bp_buyer.c_bpartner_id = d.c_bpartner_id
+                         LEFT JOIN "de.metas.edi".edi_bpartner_location_object_v bpl_buyer ON bpl_buyer.c_bpartner_location_id = d.c_bpartner_location_id
+                         LEFT JOIN c_bpartner_location bpl_bill_table ON bpl_bill_table.c_bpartner_location_id = d.bill_location_id
+                         LEFT JOIN "de.metas.edi".edi_bpartner_object_v bp_bill ON bp_bill.c_bpartner_id = bpl_bill_table.c_bpartner_id
+                         LEFT JOIN "de.metas.edi".edi_bpartner_location_object_v bpl_bill ON bpl_bill.c_bpartner_location_id = d.bill_location_id
+                         LEFT JOIN "de.metas.edi".edi_bpartner_object_v bp_handover ON bp_handover.c_bpartner_id = d.handover_partner_id
+                         LEFT JOIN "de.metas.edi".edi_bpartner_location_object_v bpl_handover ON bpl_handover.c_bpartner_location_id = d.handover_location_id
+                         LEFT JOIN "de.metas.edi".edi_bpartner_object_v bp_dropship ON bp_dropship.c_bpartner_id = d.dropship_bpartner_id
+                         LEFT JOIN "de.metas.edi".edi_bpartner_location_object_v bpl_dropship ON bpl_dropship.c_bpartner_location_id = d.dropship_location_id
+                         LEFT JOIN ad_orginfo org ON org.ad_org_id = io.ad_org_id
+                         JOIN "de.metas.edi".edi_bpartner_object_v bp_supplier ON bp_supplier.c_bpartner_id = org.org_bpartner_id
+                         JOIN "de.metas.edi".edi_bpartner_location_object_v bpl_supplier ON bpl_supplier.c_bpartner_location_id = org.orgbp_location_id
+                         WHERE io.isactive = 'Y'
+  AND io.docstatus IN ('CO', 'CL')
 ;

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5792220_sys_gh26915_desadv_json_filter_packs_by_shipment.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5792220_sys_gh26915_desadv_json_filter_packs_by_shipment.sql
@@ -2,11 +2,14 @@
 -- When a DESADV is shared across multiple shipments, the JSON export must only include
 -- packs and lines belonging to the specific shipment being exported.
 
--- 1) Drop old single-parameter functions
+-- 1) Drop the view first (it depends on the old single-parameter functions)
+DROP VIEW IF EXISTS M_InOut_Export_EDI_DESADV_JSON_V;
+
+-- 2) Drop old single-parameter functions
 DROP FUNCTION IF EXISTS "de.metas.edi".get_desadv_packs_json_fn(NUMERIC);
 DROP FUNCTION IF EXISTS "de.metas.edi".get_desadv_lines_no_pack_json_fn(NUMERIC);
 
--- 2) Recreate get_desadv_packs_json_fn with p_m_inout_id parameter
+-- 3) Recreate get_desadv_packs_json_fn with p_m_inout_id parameter
 CREATE OR REPLACE FUNCTION "de.metas.edi".get_desadv_packs_json_fn(p_edi_desadv_id NUMERIC, p_m_inout_id NUMERIC)
     RETURNS JSONB
 AS
@@ -197,7 +200,7 @@ $$
     LANGUAGE plpgsql STABLE
 ;
 
--- 3) Recreate get_desadv_lines_no_pack_json_fn with p_m_inout_id parameter
+-- 4) Recreate get_desadv_lines_no_pack_json_fn with p_m_inout_id parameter
 CREATE OR REPLACE FUNCTION "de.metas.edi".get_desadv_lines_no_pack_json_fn(p_edi_desadv_id NUMERIC, p_m_inout_id NUMERIC)
     RETURNS JSONB AS $$
 DECLARE
@@ -235,7 +238,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql STABLE;
 
--- 4) Recreate the view to pass io.m_inout_id to both functions
+-- 5) Recreate the view to pass io.m_inout_id to both functions
 DROP VIEW IF EXISTS M_InOut_Export_EDI_DESADV_JSON_V;
 CREATE OR REPLACE VIEW M_InOut_Export_EDI_DESADV_JSON_V AS
 SELECT io.m_inout_id,


### PR DESCRIPTION
## Summary

- **Fix**: When a DESADV is shared across multiple shipments, the JSON export (`M_InOut_Export_EDI_DESADV_JSON_V`) incorrectly included packs from ALL shipments instead of just the one being exported
- **Root cause**: `get_desadv_packs_json_fn` and `get_desadv_lines_no_pack_json_fn` filtered only by `edi_desadv_id`, not by `m_inout_id`
- **Solution**: Added `p_m_inout_id` parameter to both functions and joined through `m_inoutline` to filter pack items to the target shipment
- **Cucumber test**: New scenario `S0468_030` creates two orders with the same POReference (sharing one DESADV), generates separate shipments, and verifies each export contains only its own packs (PackingCount=1, not 2)

## Changes

| File | Change |
|------|--------|
| `get_desadv_packs_json_fn.sql` | Added `p_m_inout_id` param, filter in `pack_item_comp` and `pack_with_role` CTEs |
| `get_desadv_lines_no_pack_json_fn.sql` | Added `p_m_inout_id` param, filter in EXISTS/NOT EXISTS subqueries |
| `M_InOut_Export_EDI_DESADV_JSON_V.sql` | Pass `io.m_inout_id` to both function calls |
| `5792220_sys_gh26915_*.sql` | Migration script: drops old functions, recreates with new signatures, recreates view |
| `ediDesadvExport.feature` | New scenario `@Id:S0468_030` — multi-shipment DESADV isolation |
| `EDI_Desadv_StepDef.java` | New step: `M_InOut records share the same EDI_Desadv:` |

## Test plan

- [ ] Existing scenarios S0468_010 (single shipment export) and S0468_020 (compensation group merging) still pass
- [ ] New scenario S0468_030 verifies multi-shipment DESADV isolation
- [ ] Migration script applies cleanly on CI preloaded-db