### PR TITLE
gh#28565 Add C_PromotionCode table and IC flow propagation

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_Invoice.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_Invoice.java
@@ -516,6 +516,56 @@ public interface I_C_Invoice
 	String COLUMNNAME_C_Incoterms_ID = "C_Incoterms_ID";
 
 	/**
+	 * Set Promotion Code.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setC_PromotionCode_ID (int C_PromotionCode_ID);
+
+	/**
+	 * Get Promotion Code.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getC_PromotionCode_ID();
+
+	@Nullable org.compiere.model.I_C_PromotionCode getC_PromotionCode();
+
+	void setC_PromotionCode(@Nullable org.compiere.model.I_C_PromotionCode C_PromotionCode);
+
+	ModelColumn<I_C_Invoice, org.compiere.model.I_C_PromotionCode> COLUMN_C_PromotionCode_ID = new ModelColumn<>(I_C_Invoice.class, "C_PromotionCode_ID", org.compiere.model.I_C_PromotionCode.class);
+	String COLUMNNAME_C_PromotionCode_ID = "C_PromotionCode_ID";
+
+	/**
+	 * Set Promotion Code 2.
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setC_PromotionCode2_ID (int C_PromotionCode2_ID);
+
+	/**
+	 * Get Promotion Code 2.
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getC_PromotionCode2_ID();
+
+	@Nullable org.compiere.model.I_C_PromotionCode getC_PromotionCode2();
+
+	void setC_PromotionCode2(@Nullable org.compiere.model.I_C_PromotionCode C_PromotionCode2);
+
+	ModelColumn<I_C_Invoice, org.compiere.model.I_C_PromotionCode> COLUMN_C_PromotionCode2_ID = new ModelColumn<>(I_C_Invoice.class, "C_PromotionCode2_ID", org.compiere.model.I_C_PromotionCode.class);
+	String COLUMNNAME_C_PromotionCode2_ID = "C_PromotionCode2_ID";
+
+	/**
 	 * Set Invoice.
 	 * Invoice Identifier
 	 *

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_Order.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_Order.java
@@ -2854,26 +2854,53 @@ public interface I_C_Order
 
 	/**
 	 * Set Promotion Code.
-	 * User entered promotion code at sales time
 	 *
-	 * <br>Type: String
+	 * <br>Type: TableDir
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	void setPromotionCode (@Nullable java.lang.String PromotionCode);
+	void setC_PromotionCode_ID (int C_PromotionCode_ID);
 
 	/**
 	 * Get Promotion Code.
-	 * User entered promotion code at sales time
 	 *
-	 * <br>Type: String
+	 * <br>Type: TableDir
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	@Nullable java.lang.String getPromotionCode();
+	int getC_PromotionCode_ID();
 
-	ModelColumn<I_C_Order, Object> COLUMN_PromotionCode = new ModelColumn<>(I_C_Order.class, "PromotionCode", null);
-	String COLUMNNAME_PromotionCode = "PromotionCode";
+	@Nullable org.compiere.model.I_C_PromotionCode getC_PromotionCode();
+
+	void setC_PromotionCode(@Nullable org.compiere.model.I_C_PromotionCode C_PromotionCode);
+
+	ModelColumn<I_C_Order, org.compiere.model.I_C_PromotionCode> COLUMN_C_PromotionCode_ID = new ModelColumn<>(I_C_Order.class, "C_PromotionCode_ID", org.compiere.model.I_C_PromotionCode.class);
+	String COLUMNNAME_C_PromotionCode_ID = "C_PromotionCode_ID";
+
+	/**
+	 * Set Promotion Code 2.
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setC_PromotionCode2_ID (int C_PromotionCode2_ID);
+
+	/**
+	 * Get Promotion Code 2.
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getC_PromotionCode2_ID();
+
+	@Nullable org.compiere.model.I_C_PromotionCode getC_PromotionCode2();
+
+	void setC_PromotionCode2(@Nullable org.compiere.model.I_C_PromotionCode C_PromotionCode2);
+
+	ModelColumn<I_C_Order, org.compiere.model.I_C_PromotionCode> COLUMN_C_PromotionCode2_ID = new ModelColumn<>(I_C_Order.class, "C_PromotionCode2_ID", org.compiere.model.I_C_PromotionCode.class);
+	String COLUMNNAME_C_PromotionCode2_ID = "C_PromotionCode2_ID";
 
 	/**
 	 * Set Qty without Trading Unit.

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_PromotionCode.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_PromotionCode.java
@@ -1,0 +1,202 @@
+package org.compiere.model;
+
+import javax.annotation.Nullable;
+import org.adempiere.model.ModelColumn;
+
+/** Generated Interface for C_PromotionCode
+ *  @author metasfresh (generated)
+ */
+@SuppressWarnings("unused")
+public interface I_C_PromotionCode
+{
+	String Table_Name = "C_PromotionCode";
+
+	/** AD_Table_ID=542586 */
+	int Table_ID = 542586;
+
+	/**
+	 * Get Client.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Client_ID();
+
+	ModelColumn<I_C_PromotionCode, org.compiere.model.I_AD_Client> COLUMN_AD_Client_ID = new ModelColumn<>(I_C_PromotionCode.class, "AD_Client_ID", org.compiere.model.I_AD_Client.class);
+	String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+
+	/**
+	 * Set Organisation.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setAD_Org_ID (int AD_Org_ID);
+
+	/**
+	 * Get Organisation.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Org_ID();
+
+	ModelColumn<I_C_PromotionCode, org.compiere.model.I_AD_Org> COLUMN_AD_Org_ID = new ModelColumn<>(I_C_PromotionCode.class, "AD_Org_ID", org.compiere.model.I_AD_Org.class);
+	String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/**
+	 * Set Promotion Code.
+	 *
+	 * <br>Type: ID
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setC_PromotionCode_ID (int C_PromotionCode_ID);
+
+	/**
+	 * Get Promotion Code.
+	 *
+	 * <br>Type: ID
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getC_PromotionCode_ID();
+
+	ModelColumn<I_C_PromotionCode, Object> COLUMN_C_PromotionCode_ID = new ModelColumn<>(I_C_PromotionCode.class, "C_PromotionCode_ID", null);
+	String COLUMNNAME_C_PromotionCode_ID = "C_PromotionCode_ID";
+
+	/**
+	 * Get Created.
+	 *
+	 * <br>Type: DateTime
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.sql.Timestamp getCreated();
+
+	ModelColumn<I_C_PromotionCode, Object> COLUMN_Created = new ModelColumn<>(I_C_PromotionCode.class, "Created", null);
+	String COLUMNNAME_Created = "Created";
+
+	/**
+	 * Get Created By.
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getCreatedBy();
+
+	ModelColumn<I_C_PromotionCode, org.compiere.model.I_AD_User> COLUMN_CreatedBy = new ModelColumn<>(I_C_PromotionCode.class, "CreatedBy", org.compiere.model.I_AD_User.class);
+	String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/**
+	 * Set Active.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsActive (boolean IsActive);
+
+	/**
+	 * Get Active.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isActive();
+
+	ModelColumn<I_C_PromotionCode, Object> COLUMN_IsActive = new ModelColumn<>(I_C_PromotionCode.class, "IsActive", null);
+	String COLUMNNAME_IsActive = "IsActive";
+
+	/**
+	 * Set Name.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setName (java.lang.String Name);
+
+	/**
+	 * Get Name.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.lang.String getName();
+
+	ModelColumn<I_C_PromotionCode, Object> COLUMN_Name = new ModelColumn<>(I_C_PromotionCode.class, "Name", null);
+	String COLUMNNAME_Name = "Name";
+
+	/**
+	 * Get Updated.
+	 *
+	 * <br>Type: DateTime
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.sql.Timestamp getUpdated();
+
+	ModelColumn<I_C_PromotionCode, Object> COLUMN_Updated = new ModelColumn<>(I_C_PromotionCode.class, "Updated", null);
+	String COLUMNNAME_Updated = "Updated";
+
+	/**
+	 * Get Updated By.
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getUpdatedBy();
+
+	ModelColumn<I_C_PromotionCode, org.compiere.model.I_AD_User> COLUMN_UpdatedBy = new ModelColumn<>(I_C_PromotionCode.class, "UpdatedBy", org.compiere.model.I_AD_User.class);
+	String COLUMNNAME_UpdatedBy = "UpdatedBy";
+
+	/**
+	 * Set Valid to.
+	 *
+	 * <br>Type: Date
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setValidTo (@Nullable java.sql.Timestamp ValidTo);
+
+	/**
+	 * Get Valid to.
+	 *
+	 * <br>Type: Date
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	@Nullable java.sql.Timestamp getValidTo();
+
+	ModelColumn<I_C_PromotionCode, Object> COLUMN_ValidTo = new ModelColumn<>(I_C_PromotionCode.class, "ValidTo", null);
+	String COLUMNNAME_ValidTo = "ValidTo";
+
+	/**
+	 * Set Search Key.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setValue (java.lang.String Value);
+
+	/**
+	 * Get Search Key.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.lang.String getValue();
+
+	ModelColumn<I_C_PromotionCode, Object> COLUMN_Value = new ModelColumn<>(I_C_PromotionCode.class, "Value", null);
+	String COLUMNNAME_Value = "Value";
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_PromotionCode.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_PromotionCode.java
@@ -69,6 +69,27 @@ public interface I_C_PromotionCode
 	String COLUMNNAME_C_PromotionCode_ID = "C_PromotionCode_ID";
 
 	/**
+	 * Set Description.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setDescription (@Nullable java.lang.String Description);
+
+	/**
+	 * Get Description.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	@Nullable java.lang.String getDescription();
+
+	ModelColumn<I_C_PromotionCode, Object> COLUMN_Description = new ModelColumn<>(I_C_PromotionCode.class, "Description", null);
+	String COLUMNNAME_Description = "Description";
+
+	/**
 	 * Get Created.
 	 *
 	 * <br>Type: DateTime

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_Invoice.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_Invoice.java
@@ -402,9 +402,63 @@ public class X_C_Invoice extends org.compiere.model.PO implements I_C_Invoice, o
 	}
 
 	@Override
-	public int getC_Incoterms_ID() 
+	public int getC_Incoterms_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_C_Incoterms_ID);
+	}
+
+	@Override
+	public org.compiere.model.I_C_PromotionCode getC_PromotionCode()
+	{
+		return get_ValueAsPO(COLUMNNAME_C_PromotionCode_ID, org.compiere.model.I_C_PromotionCode.class);
+	}
+
+	@Override
+	public void setC_PromotionCode(final org.compiere.model.I_C_PromotionCode C_PromotionCode)
+	{
+		set_ValueFromPO(COLUMNNAME_C_PromotionCode_ID, org.compiere.model.I_C_PromotionCode.class, C_PromotionCode);
+	}
+
+	@Override
+	public void setC_PromotionCode_ID (final int C_PromotionCode_ID)
+	{
+		if (C_PromotionCode_ID < 1)
+			set_Value (COLUMNNAME_C_PromotionCode_ID, null);
+		else
+			set_Value (COLUMNNAME_C_PromotionCode_ID, C_PromotionCode_ID);
+	}
+
+	@Override
+	public int getC_PromotionCode_ID()
+	{
+		return get_ValueAsInt(COLUMNNAME_C_PromotionCode_ID);
+	}
+
+	@Override
+	public org.compiere.model.I_C_PromotionCode getC_PromotionCode2()
+	{
+		return get_ValueAsPO(COLUMNNAME_C_PromotionCode2_ID, org.compiere.model.I_C_PromotionCode.class);
+	}
+
+	@Override
+	public void setC_PromotionCode2(final org.compiere.model.I_C_PromotionCode C_PromotionCode2)
+	{
+		set_ValueFromPO(COLUMNNAME_C_PromotionCode2_ID, org.compiere.model.I_C_PromotionCode.class, C_PromotionCode2);
+	}
+
+	@Override
+	public void setC_PromotionCode2_ID (final int C_PromotionCode2_ID)
+	{
+		if (C_PromotionCode2_ID < 1)
+			set_Value (COLUMNNAME_C_PromotionCode2_ID, null);
+		else
+			set_Value (COLUMNNAME_C_PromotionCode2_ID, C_PromotionCode2_ID);
+	}
+
+	@Override
+	public int getC_PromotionCode2_ID()
+	{
+		return get_ValueAsInt(COLUMNNAME_C_PromotionCode2_ID);
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_Order.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_Order.java
@@ -2001,15 +2001,57 @@ public class X_C_Order extends org.compiere.model.PO implements I_C_Order, org.c
 	}
 
 	@Override
-	public void setPromotionCode (final @Nullable java.lang.String PromotionCode)
+	public org.compiere.model.I_C_PromotionCode getC_PromotionCode()
 	{
-		set_Value (COLUMNNAME_PromotionCode, PromotionCode);
+		return get_ValueAsPO(COLUMNNAME_C_PromotionCode_ID, org.compiere.model.I_C_PromotionCode.class);
 	}
 
 	@Override
-	public java.lang.String getPromotionCode() 
+	public void setC_PromotionCode(final org.compiere.model.I_C_PromotionCode C_PromotionCode)
 	{
-		return get_ValueAsString(COLUMNNAME_PromotionCode);
+		set_ValueFromPO(COLUMNNAME_C_PromotionCode_ID, org.compiere.model.I_C_PromotionCode.class, C_PromotionCode);
+	}
+
+	@Override
+	public void setC_PromotionCode_ID (final int C_PromotionCode_ID)
+	{
+		if (C_PromotionCode_ID < 1)
+			set_Value (COLUMNNAME_C_PromotionCode_ID, null);
+		else
+			set_Value (COLUMNNAME_C_PromotionCode_ID, C_PromotionCode_ID);
+	}
+
+	@Override
+	public int getC_PromotionCode_ID()
+	{
+		return get_ValueAsInt(COLUMNNAME_C_PromotionCode_ID);
+	}
+
+	@Override
+	public org.compiere.model.I_C_PromotionCode getC_PromotionCode2()
+	{
+		return get_ValueAsPO(COLUMNNAME_C_PromotionCode2_ID, org.compiere.model.I_C_PromotionCode.class);
+	}
+
+	@Override
+	public void setC_PromotionCode2(final org.compiere.model.I_C_PromotionCode C_PromotionCode2)
+	{
+		set_ValueFromPO(COLUMNNAME_C_PromotionCode2_ID, org.compiere.model.I_C_PromotionCode.class, C_PromotionCode2);
+	}
+
+	@Override
+	public void setC_PromotionCode2_ID (final int C_PromotionCode2_ID)
+	{
+		if (C_PromotionCode2_ID < 1)
+			set_Value (COLUMNNAME_C_PromotionCode2_ID, null);
+		else
+			set_Value (COLUMNNAME_C_PromotionCode2_ID, C_PromotionCode2_ID);
+	}
+
+	@Override
+	public int getC_PromotionCode2_ID()
+	{
+		return get_ValueAsInt(COLUMNNAME_C_PromotionCode2_ID);
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_PromotionCode.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_PromotionCode.java
@@ -1,0 +1,85 @@
+// Generated Model - DO NOT CHANGE
+package org.compiere.model;
+
+import java.sql.ResultSet;
+import java.util.Properties;
+import javax.annotation.Nullable;
+
+/** Generated Model for C_PromotionCode
+ *  @author metasfresh (generated)
+ */
+@SuppressWarnings("unused")
+public class X_C_PromotionCode extends org.compiere.model.PO implements I_C_PromotionCode, org.compiere.model.I_Persistent
+{
+	private static final long serialVersionUID = 542586L;
+
+	/** Standard Constructor */
+	public X_C_PromotionCode (final Properties ctx, final int C_PromotionCode_ID, @Nullable final String trxName)
+	{
+		super (ctx, C_PromotionCode_ID, trxName);
+	}
+
+	/** Load Constructor */
+	public X_C_PromotionCode (final Properties ctx, final ResultSet rs, @Nullable final String trxName)
+	{
+		super (ctx, rs, trxName);
+	}
+
+	/** Load Meta Data */
+	@Override
+	protected org.compiere.model.POInfo initPO(final Properties ctx)
+	{
+		return org.compiere.model.POInfo.getPOInfo(Table_Name);
+	}
+
+	@Override
+	public void setC_PromotionCode_ID (final int C_PromotionCode_ID)
+	{
+		if (C_PromotionCode_ID < 1)
+			set_ValueNoCheck (COLUMNNAME_C_PromotionCode_ID, null);
+		else
+			set_ValueNoCheck (COLUMNNAME_C_PromotionCode_ID, C_PromotionCode_ID);
+	}
+
+	@Override
+	public int getC_PromotionCode_ID()
+	{
+		return get_ValueAsInt(COLUMNNAME_C_PromotionCode_ID);
+	}
+
+	@Override
+	public void setName (final java.lang.String Name)
+	{
+		set_Value (COLUMNNAME_Name, Name);
+	}
+
+	@Override
+	public java.lang.String getName()
+	{
+		return get_ValueAsString(COLUMNNAME_Name);
+	}
+
+	@Override
+	public void setValidTo (final @Nullable java.sql.Timestamp ValidTo)
+	{
+		set_Value (COLUMNNAME_ValidTo, ValidTo);
+	}
+
+	@Override
+	public java.sql.Timestamp getValidTo()
+	{
+		return get_ValueAsTimestamp(COLUMNNAME_ValidTo);
+	}
+
+	@Override
+	public void setValue (final java.lang.String Value)
+	{
+		set_Value (COLUMNNAME_Value, Value);
+	}
+
+	@Override
+	public java.lang.String getValue()
+	{
+		return get_ValueAsString(COLUMNNAME_Value);
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_PromotionCode.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_PromotionCode.java
@@ -48,6 +48,18 @@ public class X_C_PromotionCode extends org.compiere.model.PO implements I_C_Prom
 	}
 
 	@Override
+	public void setDescription (final @Nullable java.lang.String Description)
+	{
+		set_Value (COLUMNNAME_Description, Description);
+	}
+
+	@Override
+	public java.lang.String getDescription()
+	{
+		return get_ValueAsString(COLUMNNAME_Description);
+	}
+
+	@Override
 	public void setName (final java.lang.String Name)
 	{
 		set_Value (COLUMNNAME_Name, Name);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792280_sys_gh28565_C_PromotionCode_Table.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792280_sys_gh28565_C_PromotionCode_Table.sql
@@ -1,0 +1,378 @@
+-- gh#28565 Promotion Code / Aktionskennzeichen
+-- Step 1.1: Create C_PromotionCode table + AD metadata
+
+-- AD_Table
+INSERT INTO AD_Table (AccessLevel, ACTriggerLength, AD_Client_ID, AD_Org_ID, AD_Table_ID,
+                      CopyColumnsFromTable, Created, CreatedBy, EntityType, ImportTable, IsActive, IsAutocomplete,
+                      IsChangeLog, IsDeleteable, IsHighVolume, IsSecurityEnabled, IsView, LoadSeq, Name,
+                      ReplicationType, TableName, Updated, UpdatedBy)
+VALUES ('3', 0, 0, 0, 542586,
+        'N', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'D', 'N', 'Y', 'N',
+        'N', 'Y', 'N', 'N', 'N', 0, 'Aktionskennzeichen',
+        'L', 'C_PromotionCode', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Table_Trl (AD_Language, AD_Table_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Table_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Table t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Table_ID = 542586
+  AND NOT EXISTS (SELECT 1 FROM AD_Table_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Table_ID = t.AD_Table_ID);
+
+-- DB Sequence
+CREATE SEQUENCE C_PROMOTIONCODE_SEQ INCREMENT 1 MINVALUE 0 MAXVALUE 2147483647 START 1000000;
+
+-- AD_Sequence
+INSERT INTO AD_Sequence (AD_Client_ID, AD_Org_ID, AD_Sequence_ID, Created, CreatedBy, CurrentNext, CurrentNextSys,
+                         Description, IncrementNo, IsActive, IsAudited, IsAutoSequence, IsTableID, Name,
+                         StartNo, Updated, UpdatedBy)
+VALUES (0, 0, 556588, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 1000000, 50000,
+        'Table C_PromotionCode', 1, 'Y', 'N', 'Y', 'Y', 'C_PromotionCode',
+        1000000, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100);
+
+-- ============================================================
+-- Standard columns: AD_Client_ID, AD_Org_ID, Created, CreatedBy, IsActive, Updated, UpdatedBy
+-- ============================================================
+
+-- AD_Client_ID (AD_Element_ID=102, AD_Reference_ID=19)
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo, FieldLength,
+                       IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule,
+                       IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted,
+                       IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn,
+                       IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent,
+                       IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592172, 102, 0, 19, 542586,
+        'AD_Client_ID', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D', 0, 10,
+        'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N',
+        'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 0, 'Mandant',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592172
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+-- AD_Org_ID (AD_Element_ID=113, AD_Reference_ID=19)
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo, FieldLength,
+                       IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule,
+                       IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted,
+                       IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn,
+                       IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent,
+                       IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592173, 113, 0, 19, 542586,
+        'AD_Org_ID', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D', 0, 10,
+        'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N',
+        'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 0, 'Sektion',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592173
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+-- Created (AD_Element_ID=245, AD_Reference_ID=16)
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo, FieldLength,
+                       IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule,
+                       IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted,
+                       IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn,
+                       IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent,
+                       IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592174, 245, 0, 16, 542586,
+        'Created', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D', 0, 29,
+        'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N',
+        'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 0, 'Erstellt',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592174
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+-- CreatedBy (AD_Element_ID=246, AD_Reference_ID=18, AD_Reference_Value_ID=110)
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Reference_Value_ID,
+                       AD_Table_ID, ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo,
+                       FieldLength, IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable,
+                       IsAutoApplyValidationRule, IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary,
+                       IsEncrypted, IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel,
+                       IsGenericZoomKeyColumn, IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory,
+                       IsParent, IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592175, 246, 0, 18, 110,
+        542586, 'CreatedBy', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D', 0,
+        10, 'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N',
+        'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 0, 'Erstellt durch',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592175
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+-- IsActive (AD_Element_ID=348, AD_Reference_ID=20)
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo, FieldLength,
+                       IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule,
+                       IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted,
+                       IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn,
+                       IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent,
+                       IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592176, 348, 0, 20, 542586,
+        'IsActive', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D', 0, 1,
+        'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N',
+        'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 0, 'Aktiv',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592176
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+-- Updated (AD_Element_ID=607, AD_Reference_ID=16)
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo, FieldLength,
+                       IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule,
+                       IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted,
+                       IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn,
+                       IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent,
+                       IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592177, 607, 0, 16, 542586,
+        'Updated', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D', 0, 29,
+        'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N',
+        'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 0, 'Aktualisiert',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592177
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+-- UpdatedBy (AD_Element_ID=608, AD_Reference_ID=18, AD_Reference_Value_ID=110)
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Reference_Value_ID,
+                       AD_Table_ID, ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo,
+                       FieldLength, IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable,
+                       IsAutoApplyValidationRule, IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary,
+                       IsEncrypted, IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel,
+                       IsGenericZoomKeyColumn, IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory,
+                       IsParent, IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592178, 608, 0, 18, 110,
+        542586, 'UpdatedBy', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D', 0,
+        10, 'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N',
+        'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 0, 'Aktualisiert durch',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592178
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+-- ============================================================
+-- AD_Element for C_PromotionCode_ID
+-- ============================================================
+INSERT INTO AD_Element (AD_Client_ID, AD_Element_ID, AD_Org_ID, ColumnName, Created, CreatedBy,
+                        EntityType, IsActive, Name, PrintName, Updated, UpdatedBy)
+VALUES (0, 584619, 0, 'C_PromotionCode_ID', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100,
+        'D', 'Y', 'Aktionskennzeichen', 'Aktionskennzeichen', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Description, Help, Name, PO_Description, PO_Help, PO_Name, PO_PrintName, PrintName,
+                            IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.Description, t.Help, t.Name, t.PO_Description, t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Element_ID = 584619
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID);
+
+-- English translation for element
+UPDATE AD_Element_Trl SET Name = 'Promotion Code', PrintName = 'Promotion Code', IsTranslated = 'Y',
+                          Updated = TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Element_ID = 584619 AND AD_Language = 'en_US';
+
+-- ============================================================
+-- PK column: C_PromotionCode_ID (AD_Reference_ID=13, IsKey='Y')
+-- ============================================================
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo, FieldLength,
+                       IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule,
+                       IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted,
+                       IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn,
+                       IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent,
+                       IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592171, 584619, 0, 13, 542586,
+        'C_PromotionCode_ID', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D', 0, 10,
+        'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'Y', 'N',
+        'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 0, 'Aktionskennzeichen',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592171
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+/* DDL */ SELECT update_Column_Translation_From_AD_Element(584619);
+
+-- ============================================================
+-- Business columns: Value, Name, ValidTo
+-- ============================================================
+
+-- Value (AD_Element_ID=620, AD_Reference_ID=10, IsIdentifier=Y SeqNo=1)
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo, FieldLength,
+                       IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule,
+                       IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted,
+                       IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn,
+                       IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent,
+                       IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592179, 620, 0, 10, 542586,
+        'Value', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D', 0, 40,
+        'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'Y', 'N', 'N',
+        'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 0, 'Suchschlüssel',
+        'NP', 0, 10, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592179
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+-- Name (AD_Element_ID=469, AD_Reference_ID=10, IsIdentifier=Y SeqNo=2)
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo, FieldLength,
+                       IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule,
+                       IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted,
+                       IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn,
+                       IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent,
+                       IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592180, 469, 0, 10, 542586,
+        'Name', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D', 0, 255,
+        'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'Y', 'N', 'N',
+        'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 0, 'Name',
+        'NP', 0, 20, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592180
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+-- ValidTo (AD_Element_ID=618, AD_Reference_ID=15)
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo, FieldLength,
+                       IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule,
+                       IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted,
+                       IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn,
+                       IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent,
+                       IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592181, 618, 0, 15, 542586,
+        'ValidTo', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D', 0, 7,
+        'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N',
+        'N', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 0, 'Gültig bis',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592181
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+/* DDL */ SELECT update_Column_Translation_From_AD_Element(618);
+
+-- ============================================================
+-- CREATE TABLE
+-- ============================================================
+CREATE TABLE C_PromotionCode
+(
+    C_PromotionCode_ID NUMERIC(10)                NOT NULL,
+    AD_Client_ID       NUMERIC(10)                NOT NULL,
+    AD_Org_ID          NUMERIC(10)                NOT NULL,
+    IsActive           CHAR(1) CHECK (IsActive IN ('Y', 'N')) NOT NULL,
+    Created            TIMESTAMP WITH TIME ZONE   NOT NULL,
+    CreatedBy          NUMERIC(10)                NOT NULL,
+    Updated            TIMESTAMP WITH TIME ZONE   NOT NULL,
+    UpdatedBy          NUMERIC(10)                NOT NULL,
+    Value              VARCHAR(40)                NOT NULL,
+    Name               VARCHAR(255)               NOT NULL,
+    ValidTo            TIMESTAMP WITH TIME ZONE   DEFAULT NULL,
+    CONSTRAINT C_PromotionCode_Key PRIMARY KEY (C_PromotionCode_ID)
+);
+
+-- ============================================================
+-- Unique index: (AD_Client_ID, Value) WHERE IsActive='Y'
+-- ============================================================
+INSERT INTO AD_Index_Table (AD_Client_ID, AD_Index_Table_ID, AD_Org_ID, AD_Table_ID, Created, CreatedBy,
+                            EntityType, IsActive, IsUnique, Name, Processing, Updated, UpdatedBy, WhereClause)
+VALUES (0, 540863, 0, 542586, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100,
+        'D', 'Y', 'Y', 'C_PromotionCode_ADClient_Value_UQ', 'N', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100,
+        'IsActive = ''Y''');
+
+INSERT INTO AD_Index_Table_Trl (AD_Language, AD_Index_Table_ID, ErrorMsg, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Index_Table_ID, t.ErrorMsg, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Index_Table t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Index_Table_ID = 540863
+  AND NOT EXISTS (SELECT 1 FROM AD_Index_Table_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Index_Table_ID = t.AD_Index_Table_ID);
+
+-- Error message for unique index violation (DE)
+UPDATE AD_Index_Table SET ErrorMsg = 'Ein aktives Aktionskennzeichen mit diesem Suchschlüssel existiert bereits für diesen Mandanten.',
+                          Updated = TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Index_Table_ID = 540863;
+
+-- Error message EN
+UPDATE AD_Index_Table_Trl SET ErrorMsg = 'An active promotion code with this search key already exists for this client.',
+                              IsTranslated = 'Y', Updated = TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Index_Table_ID = 540863 AND AD_Language = 'en_US';
+
+-- Index column: AD_Client_ID
+INSERT INTO AD_Index_Column (AD_Client_ID, AD_Column_ID, AD_Index_Column_ID, AD_Index_Table_ID, AD_Org_ID,
+                             Created, CreatedBy, EntityType, IsActive, SeqNo, Updated, UpdatedBy)
+VALUES (0, 592172, 541524, 540863, 0,
+        TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'D', 'Y', 10, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100);
+
+-- Index column: Value
+INSERT INTO AD_Index_Column (AD_Client_ID, AD_Column_ID, AD_Index_Column_ID, AD_Index_Table_ID, AD_Org_ID,
+                             Created, CreatedBy, EntityType, IsActive, SeqNo, Updated, UpdatedBy)
+VALUES (0, 592179, 541525, 540863, 0,
+        TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'D', 'Y', 20, TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100);
+
+CREATE UNIQUE INDEX C_PromotionCode_ADClient_Value_UQ ON C_PromotionCode (AD_Client_ID, Value) WHERE IsActive = 'Y';

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792280_sys_gh28565_C_PromotionCode_Table.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792280_sys_gh28565_C_PromotionCode_Table.sql
@@ -8,7 +8,7 @@ INSERT INTO AD_Table (AccessLevel, ACTriggerLength, AD_Client_ID, AD_Org_ID, AD_
                       ReplicationType, TableName, Updated, UpdatedBy)
 VALUES ('3', 0, 0, 0, 542586,
         'N', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100, 'D', 'N', 'Y', 'N',
-        'N', 'Y', 'N', 'N', 'N', 0, 'Aktionskennzeichen',
+        'Y', 'Y', 'N', 'N', 'N', 0, 'Aktionskennzeichen',
         'L', 'C_PromotionCode', TO_TIMESTAMP('2026-03-05 12:00', 'YYYY-MM-DD HH24:MI'), 100);
 
 INSERT INTO AD_Table_Trl (AD_Language, AD_Table_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
@@ -333,7 +333,7 @@ CREATE TABLE C_PromotionCode
     UpdatedBy          NUMERIC(10)                NOT NULL,
     Value              VARCHAR(40)                NOT NULL,
     Name               VARCHAR(255)               NOT NULL,
-    ValidTo            TIMESTAMP WITH TIME ZONE   DEFAULT NULL,
+    ValidTo            DATE                       DEFAULT NULL,
     CONSTRAINT C_PromotionCode_Key PRIMARY KEY (C_PromotionCode_ID)
 );
 

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792290_sys_gh28565_C_PromotionCode_Reference_Window.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792290_sys_gh28565_C_PromotionCode_Reference_Window.sql
@@ -1,0 +1,342 @@
+-- gh#28565 Promotion Code / Aktionskennzeichen
+-- Step 1.2: AD_Reference (Table type for C_PromotionCode2_ID), AD_Val_Rules, base window + menu
+
+-- ============================================================
+-- AD_Element for C_PromotionCode2_ID
+-- ============================================================
+INSERT INTO AD_Element (AD_Client_ID, AD_Element_ID, AD_Org_ID, ColumnName, Created, CreatedBy,
+                        EntityType, IsActive, Name, PrintName, Updated, UpdatedBy)
+VALUES (0, 584620, 0, 'C_PromotionCode2_ID', TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100,
+        'D', 'Y', 'Aktionskennzeichen 2', 'Aktionskennzeichen 2', TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Description, Help, Name, PO_Description, PO_Help, PO_Name, PO_PrintName, PrintName,
+                            IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.Description, t.Help, t.Name, t.PO_Description, t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Element_ID = 584620
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID);
+
+UPDATE AD_Element_Trl SET Name = 'Promotion Code 2', PrintName = 'Promotion Code 2', IsTranslated = 'Y',
+                          Updated = TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Element_ID = 584620 AND AD_Language = 'en_US';
+
+-- ============================================================
+-- AD_Reference (Table type) for C_PromotionCode2_ID lookups
+-- ============================================================
+INSERT INTO AD_Reference (AD_Client_ID, AD_Org_ID, AD_Reference_ID, Created, CreatedBy, EntityType,
+                          IsActive, IsOrderByValue, Name, Updated, UpdatedBy, ValidationType)
+VALUES (0, 0, 542070, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100, 'D',
+        'Y', 'N', 'C_PromotionCode', TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100, 'T');
+
+INSERT INTO AD_Reference_Trl (AD_Language, AD_Reference_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Reference_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Reference t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Reference_ID = 542070
+  AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Reference_ID = t.AD_Reference_ID);
+
+-- AD_Ref_Table: points to C_PromotionCode table
+INSERT INTO AD_Ref_Table (AD_Client_ID, AD_Display, AD_Key, AD_Org_ID, AD_Reference_ID,
+                          AD_Table_ID, Created, CreatedBy, EntityType, IsActive, IsValueDisplayed, Updated, UpdatedBy)
+VALUES (0, 592180, 592171, 0, 542070,
+        542586, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100, 'D', 'Y', 'N',
+        TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+-- AD_Key=592171 (C_PromotionCode_ID column), AD_Display=592180 (Name column), AD_Table_ID=542586
+
+-- ============================================================
+-- AD_Val_Rules: dynamic dropdown filtering
+-- ============================================================
+
+-- Order context: filter by DateOrdered
+INSERT INTO AD_Val_Rule (AD_Client_ID, AD_Org_ID, AD_Val_Rule_ID, Code, Created, CreatedBy, EntityType,
+                         IsActive, Name, Type, Updated, UpdatedBy)
+VALUES (0, 0, 540771,
+        'C_PromotionCode.IsActive=''Y'' AND (C_PromotionCode.ValidTo IS NULL OR C_PromotionCode.ValidTo >= @DateOrdered@)',
+        TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100, 'D',
+        'Y', 'C_PromotionCode for Order (active + valid)', 'S', TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+-- Invoice context: filter by DateInvoiced
+INSERT INTO AD_Val_Rule (AD_Client_ID, AD_Org_ID, AD_Val_Rule_ID, Code, Created, CreatedBy, EntityType,
+                         IsActive, Name, Type, Updated, UpdatedBy)
+VALUES (0, 0, 540772,
+        'C_PromotionCode.IsActive=''Y'' AND (C_PromotionCode.ValidTo IS NULL OR C_PromotionCode.ValidTo >= @DateInvoiced@)',
+        TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100, 'D',
+        'Y', 'C_PromotionCode for Invoice (active + valid)', 'S', TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+-- ============================================================
+-- Base Window: Aktionskennzeichen (Promotion Code)
+-- ============================================================
+-- AD_Element for the window
+INSERT INTO AD_Element (AD_Client_ID, AD_Element_ID, AD_Org_ID, ColumnName, Created, CreatedBy, EntityType, IsActive,
+                        Name, PrintName, Updated, UpdatedBy)
+VALUES (0, 584625, 0, 'Aktionskennzeichen_Window', TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100, 'D', 'Y',
+        'Aktionskennzeichen', 'Aktionskennzeichen', TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Description, Help, Name, PO_Description, PO_Help, PO_Name, PO_PrintName, PrintName,
+                            IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.Description, t.Help, t.Name, t.PO_Description, t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Element_ID = 584625
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID);
+UPDATE AD_Element_Trl SET Name = 'Promotion Code', PrintName = 'Promotion Code', IsTranslated = 'Y',
+                          Updated = TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Element_ID = 584625 AND AD_Language = 'en_US';
+
+INSERT INTO AD_Window (AD_Client_ID, AD_Org_ID, AD_Window_ID, AD_Element_ID, Created, CreatedBy, EntityType, IsActive,
+                       IsBetaFunctionality, IsDefault, IsEnableRemoteCacheInvalidation, IsExcludeFromZoomTargets,
+                       IsOneInstanceOnly, IsSOTrx, Name, Processing, WindowType, WinHeight, WinWidth, Updated, UpdatedBy)
+VALUES (0, 0, 542105, 584625, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100, 'D', 'Y',
+        'N', 'N', 'N', 'N', 'N', 'Y', 'Aktionskennzeichen', 'N', 'M', 0, 0,
+        TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Window_Trl (AD_Language, AD_Window_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Window_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Window t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Window_ID = 542105
+  AND NOT EXISTS (SELECT 1 FROM AD_Window_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Window_ID = t.AD_Window_ID);
+
+UPDATE AD_Window_Trl SET Name = 'Promotion Code', IsTranslated = 'Y',
+                         Updated = TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Window_ID = 542105 AND AD_Language = 'en_US';
+
+-- Tab
+INSERT INTO AD_Tab (AD_Client_ID, AD_Org_ID, AD_Tab_ID, AD_Element_ID, AD_Table_ID, AD_Window_ID, Created, CreatedBy,
+                    EntityType, HasTree, ImportFields, IsActive, IsAdvancedTab, IsCheckParentsChanged,
+                    IsGenericZoomTarget, IsGridModeOnly, IsInfoTab, IsInsertRecord, IsQueryOnLoad, IsReadOnly,
+                    IsRefreshAllOnActivate, IsSearchActive, IsSearchCollapsed, IsSingleRow, IsSortTab,
+                    IsTranslationTab, MaxQueryRecords, Name, Processing, SeqNo, TabLevel, Updated, UpdatedBy)
+VALUES (0, 0, 549080, 584625, 542586, 542105, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100,
+        'D', 'N', 'N', 'Y', 'N', 'Y', 'N', 'N', 'N', 'Y', 'Y', 'N',
+        'N', 'Y', 'Y', 'N', 'N', 'N', 0, 'Aktionskennzeichen', 'N', 10, 0,
+        TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Tab_Trl (AD_Language, AD_Tab_ID, CommitWarning, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Tab_ID, t.CommitWarning, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Tab t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Tab_ID = 549080
+  AND NOT EXISTS (SELECT 1 FROM AD_Tab_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Tab_ID = t.AD_Tab_ID);
+
+UPDATE AD_Tab_Trl SET Name = 'Promotion Code', IsTranslated = 'Y',
+                      Updated = TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Tab_ID = 549080 AND AD_Language = 'en_US';
+
+-- ============================================================
+-- Fields on C_PromotionCode window tab
+-- ============================================================
+
+-- Value field
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength,
+                      Created, CreatedBy, DisplayLength, EntityType, IncludedTabHeight, IsActive, IsDisplayed,
+                      IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine, Name,
+                      SeqNo, SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592179, 774829, 0, 549080, 0,
+        TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100, 0, 'D', 0, 'Y', 'Y', 'Y', 'N', 'N', 'N', 'N', 'N',
+        'Suchschlüssel', 10, 10, 0, 1, 1, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y') AND t.AD_Field_ID = 774829
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(620);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 774829;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(774829);
+
+-- Name field
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength,
+                      Created, CreatedBy, DisplayLength, EntityType, IncludedTabHeight, IsActive, IsDisplayed,
+                      IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine, Name,
+                      SeqNo, SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592180, 774830, 0, 549080, 0,
+        TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100, 0, 'D', 0, 'Y', 'Y', 'Y', 'N', 'N', 'N', 'N', 'Y',
+        'Name', 20, 20, 0, 1, 1, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y') AND t.AD_Field_ID = 774830
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(469);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 774830;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(774830);
+
+-- ValidTo field
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength,
+                      Created, CreatedBy, DisplayLength, EntityType, IncludedTabHeight, IsActive, IsDisplayed,
+                      IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine, Name,
+                      SeqNo, SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592181, 774831, 0, 549080, 0,
+        TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100, 0, 'D', 0, 'Y', 'Y', 'Y', 'N', 'N', 'N', 'N', 'N',
+        'Gültig bis', 30, 30, 0, 1, 1, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y') AND t.AD_Field_ID = 774831
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(618);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 774831;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(774831);
+
+-- IsActive field
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength,
+                      Created, CreatedBy, DisplayLength, EntityType, IncludedTabHeight, IsActive, IsDisplayed,
+                      IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine, Name,
+                      SeqNo, SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592176, 774832, 0, 549080, 0,
+        TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100, 0, 'D', 0, 'Y', 'Y', 'Y', 'N', 'N', 'N', 'N', 'Y',
+        'Aktiv', 40, 40, 0, 1, 1, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y') AND t.AD_Field_ID = 774832
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(348);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 774832;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(774832);
+
+-- Org field
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength,
+                      Created, CreatedBy, DisplayLength, EntityType, IncludedTabHeight, IsActive, IsDisplayed,
+                      IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine, Name,
+                      SeqNo, SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592173, 774833, 0, 549080, 0,
+        TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100, 0, 'D', 0, 'Y', 'Y', 'Y', 'N', 'N', 'N', 'N', 'N',
+        'Sektion', 50, 50, 0, 1, 1, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y') AND t.AD_Field_ID = 774833
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(113);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 774833;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(774833);
+
+-- Client field
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength,
+                      Created, CreatedBy, DisplayLength, EntityType, IncludedTabHeight, IsActive, IsDisplayed,
+                      IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine, Name,
+                      SeqNo, SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592172, 774834, 0, 549080, 0,
+        TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100, 0, 'D', 0, 'Y', 'Y', 'N', 'N', 'N', 'N', 'N', 'Y',
+        'Mandant', 60, 60, 0, 1, 1, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y') AND t.AD_Field_ID = 774834
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(102);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 774834;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(774834);
+
+-- ============================================================
+-- AD_UI layout for C_PromotionCode window
+-- ============================================================
+
+-- UI Section
+INSERT INTO AD_UI_Section (AD_Client_ID, AD_Org_ID, AD_Tab_ID, AD_UI_Section_ID, Created, CreatedBy,
+                           IsActive, Name, SeqNo, Updated, UpdatedBy, Value)
+VALUES (0, 0, 549080, 547597, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'main', 10, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100, 'main');
+
+-- UI Column
+INSERT INTO AD_UI_Column (AD_Client_ID, AD_Org_ID, AD_UI_Column_ID, AD_UI_Section_ID, Created, CreatedBy,
+                          IsActive, SeqNo, Updated, UpdatedBy)
+VALUES (0, 0, 549273, 547597, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 10, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+-- UI Element Group (main fields)
+INSERT INTO AD_UI_ElementGroup (AD_Client_ID, AD_Org_ID, AD_UI_Column_ID, AD_UI_ElementGroup_ID, Created, CreatedBy,
+                                IsActive, Name, SeqNo, Updated, UpdatedBy)
+VALUES (0, 0, 549273, 554978, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'default', 10, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+-- UI Elements
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
+                           AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774829, 0, 549080, 554978, 648477, 'F', TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'N', 'Y', 'Y', 'Y', 'N', 'N', 0, 'Suchschlüssel', 10, 10, 0, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
+                           AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774830, 0, 549080, 554978, 648478, 'F', TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'N', 'Y', 'Y', 'Y', 'N', 'N', 0, 'Name', 20, 20, 0, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
+                           AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774831, 0, 549080, 554978, 648479, 'F', TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'N', 'N', 'Y', 'Y', 'N', 'N', 0, 'Gültig bis', 30, 30, 0, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
+                           AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774832, 0, 549080, 554978, 648480, 'F', TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'N', 'N', 'Y', 'Y', 'N', 'N', 0, 'Aktiv', 40, 40, 0, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+-- Org + Client as advanced fields (design guide: bottom-right)
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
+                           AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774833, 0, 549080, 554978, 648481, 'F', TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'Y', 'N', 'Y', 'N', 'N', 'N', 0, 'Sektion', 50, 0, 0, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
+                           AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774834, 0, 549080, 554978, 648482, 'F', TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'Y', 'N', 'Y', 'N', 'N', 'N', 0, 'Mandant', 60, 0, 0, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+-- ============================================================
+-- Menu entry
+-- ============================================================
+INSERT INTO AD_Menu (Action, AD_Client_ID, AD_Element_ID, AD_Menu_ID, AD_Org_ID, AD_Window_ID, Created, CreatedBy,
+                     EntityType, InternalName, IsActive, IsCreateNew, IsReadOnly, IsSOTrx, IsSummary, Name,
+                     Updated, UpdatedBy)
+VALUES ('W', 0, 584625, 542302, 0, 542105, TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100,
+        'D', 'C_PromotionCode', 'Y', 'N', 'N', 'N', 'N', 'Aktionskennzeichen',
+        TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Menu_Trl (AD_Language, AD_Menu_ID, Description, Name, WebUI_NameBrowse, WebUI_NameNew, WebUI_NameNewBreadcrumb,
+                         IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Menu_ID, t.Description, t.Name, t.WebUI_NameBrowse, t.WebUI_NameNew, t.WebUI_NameNewBreadcrumb,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Menu t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Menu_ID = 542302
+  AND NOT EXISTS (SELECT 1 FROM AD_Menu_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Menu_ID = t.AD_Menu_ID);
+
+UPDATE AD_Menu_Trl SET Name = 'Promotion Code', IsTranslated = 'Y',
+                       Updated = TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Menu_ID = 542302 AND AD_Language = 'en_US';
+
+-- Tree node
+INSERT INTO AD_TreeNodeMM (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                           AD_Tree_ID, Node_ID, Parent_ID, SeqNo)
+SELECT t.AD_Client_ID, 0, 'Y', now(), 100, now(), 100,
+       t.AD_Tree_ID, 542302, 0, 999
+FROM AD_Tree t
+WHERE t.AD_Client_ID = 0 AND t.IsActive = 'Y' AND t.IsAllNodes = 'Y'
+  AND t.AD_Table_ID = 116
+  AND NOT EXISTS (SELECT 1 FROM AD_TreeNodeMM tnm WHERE tnm.AD_Tree_ID = t.AD_Tree_ID AND tnm.Node_ID = 542302);
+
+-- Link AD_Ref_Table to the window for zoom
+UPDATE AD_Ref_Table SET AD_Window_ID = 542105,
+                        Updated = TO_TIMESTAMP('2026-03-05 12:01', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Reference_ID = 542070;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792300_sys_gh28565_C_Order_PromotionCode.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792300_sys_gh28565_C_Order_PromotionCode.sql
@@ -1,0 +1,155 @@
+-- gh#28565 Promotion Code / Aktionskennzeichen
+-- Step 1.3: Drop old PromotionCode varchar from C_Order, add C_PromotionCode_ID + C_PromotionCode2_ID
+
+-- ============================================================
+-- Drop old PromotionCode varchar column (AD_Column_ID=57127)
+-- ============================================================
+
+-- Deactivate AD_Column (keep record for audit, remove from model generation)
+UPDATE AD_Column SET IsActive = 'N', Updated = TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Column_ID = 57127;
+
+-- Remove any AD_UI_Element pointing to fields of this column
+DELETE FROM AD_UI_Element WHERE AD_Field_ID IN (SELECT AD_Field_ID FROM AD_Field WHERE AD_Column_ID = 57127);
+
+-- Remove AD_Element_Link for these fields
+DELETE FROM AD_Element_Link WHERE AD_Field_ID IN (SELECT AD_Field_ID FROM AD_Field WHERE AD_Column_ID = 57127);
+
+-- Remove AD_Field_Trl
+DELETE FROM AD_Field_Trl WHERE AD_Field_ID IN (SELECT AD_Field_ID FROM AD_Field WHERE AD_Column_ID = 57127);
+
+-- Remove AD_Field
+DELETE FROM AD_Field WHERE AD_Column_ID = 57127;
+
+-- Drop physical column
+/* DDL */ SELECT public.db_alter_table('C_Order', 'ALTER TABLE public.C_Order DROP COLUMN IF EXISTS PromotionCode');
+
+-- ============================================================
+-- Add C_PromotionCode_ID (AD_Reference_ID=19 TableDir, AD_Val_Rule for Order)
+-- ============================================================
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       AD_Val_Rule_ID, ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType,
+                       FacetFilterSeqNo, FieldLength, IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable,
+                       IsAutoApplyValidationRule, IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary,
+                       IsEncrypted, IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel,
+                       IsGenericZoomKeyColumn, IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory,
+                       IsParent, IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592182, 584619, 0, 19, 259,
+        540771, 'C_PromotionCode_ID', TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D',
+        0, 10, 'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'Y', 'N', 0, 'Aktionskennzeichen',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592182
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+/* DDL */ SELECT update_Column_Translation_From_AD_Element(584619);
+
+/* DDL */ SELECT public.db_alter_table('C_Order', 'ALTER TABLE public.C_Order ADD COLUMN C_PromotionCode_ID NUMERIC(10)');
+
+ALTER TABLE C_Order ADD CONSTRAINT CPromotionCode_COrder
+    FOREIGN KEY (C_PromotionCode_ID) REFERENCES public.C_PromotionCode DEFERRABLE INITIALLY DEFERRED;
+
+-- ============================================================
+-- Add C_PromotionCode2_ID (AD_Reference_ID=18 Table, AD_Reference_Value_ID=542070, AD_Val_Rule for Order)
+-- ============================================================
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Reference_Value_ID,
+                       AD_Table_ID, AD_Val_Rule_ID, ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType,
+                       FacetFilterSeqNo, FieldLength, IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable,
+                       IsAutoApplyValidationRule, IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary,
+                       IsEncrypted, IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel,
+                       IsGenericZoomKeyColumn, IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory,
+                       IsParent, IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592183, 584620, 0, 18, 542070,
+        259, 540771, 'C_PromotionCode2_ID', TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D',
+        0, 10, 'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'Y', 'N', 0, 'Aktionskennzeichen 2',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592183
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+/* DDL */ SELECT update_Column_Translation_From_AD_Element(584620);
+
+/* DDL */ SELECT public.db_alter_table('C_Order', 'ALTER TABLE public.C_Order ADD COLUMN C_PromotionCode2_ID NUMERIC(10)');
+
+ALTER TABLE C_Order ADD CONSTRAINT CPromotionCode2_COrder
+    FOREIGN KEY (C_PromotionCode2_ID) REFERENCES public.C_PromotionCode DEFERRABLE INITIALLY DEFERRED;
+
+-- ============================================================
+-- AD_Field on base Sales Order tab (AD_Tab_ID=186) — advanced edit
+-- ============================================================
+
+-- C_PromotionCode_ID field
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength,
+                      Created, CreatedBy, DisplayLength, EntityType, IncludedTabHeight, IsActive, IsDisplayed,
+                      IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine, Name,
+                      SeqNo, SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592182, 774835, 0, 186, 0,
+        TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100, 0, 'D', 0, 'Y', 'Y', 'N', 'N', 'N', 'N', 'N', 'N',
+        'Aktionskennzeichen', 0, 0, 0, 1, 1, TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y') AND t.AD_Field_ID = 774835
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584619);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 774835;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(774835);
+
+-- AD_UI_Element (advanced)
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
+                           AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774835, 0, 186, (SELECT AD_UI_ElementGroup_ID FROM AD_UI_ElementGroup WHERE AD_UI_Column_ID IN
+        (SELECT AD_UI_Column_ID FROM AD_UI_Column WHERE AD_UI_Section_ID IN
+        (SELECT AD_UI_Section_ID FROM AD_UI_Section WHERE AD_Tab_ID = 186 ORDER BY SeqNo LIMIT 1)
+        ORDER BY SeqNo LIMIT 1) ORDER BY SeqNo LIMIT 1),
+        648483, 'F', TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'Y', 'N', 'Y', 'N', 'N', 'N', 0, 'Aktionskennzeichen', 1050, 0, 0,
+        TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100);
+
+-- C_PromotionCode2_ID field
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength,
+                      Created, CreatedBy, DisplayLength, EntityType, IncludedTabHeight, IsActive, IsDisplayed,
+                      IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine, Name,
+                      SeqNo, SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592183, 774836, 0, 186, 0,
+        TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100, 0, 'D', 0, 'Y', 'Y', 'N', 'N', 'N', 'N', 'N', 'N',
+        'Aktionskennzeichen 2', 0, 0, 0, 1, 1, TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y') AND t.AD_Field_ID = 774836
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584620);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 774836;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(774836);
+
+-- AD_UI_Element (advanced)
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
+                           AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774836, 0, 186, (SELECT AD_UI_ElementGroup_ID FROM AD_UI_ElementGroup WHERE AD_UI_Column_ID IN
+        (SELECT AD_UI_Column_ID FROM AD_UI_Column WHERE AD_UI_Section_ID IN
+        (SELECT AD_UI_Section_ID FROM AD_UI_Section WHERE AD_Tab_ID = 186 ORDER BY SeqNo LIMIT 1)
+        ORDER BY SeqNo LIMIT 1) ORDER BY SeqNo LIMIT 1),
+        648484, 'F', TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'Y', 'N', 'Y', 'N', 'N', 'N', 0, 'Aktionskennzeichen 2', 1060, 0, 0,
+        TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792300_sys_gh28565_C_Order_PromotionCode.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792300_sys_gh28565_C_Order_PromotionCode.sql
@@ -99,7 +99,7 @@ INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab
                       SeqNo, SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
 VALUES (0, 592182, 774835, 0, 186, 0,
         TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100, 0, 'D', 0, 'Y', 'Y', 'N', 'N', 'N', 'N', 'N', 'N',
-        'Aktionskennzeichen', 0, 0, 0, 1, 1, TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100);
+        'Aktionskennzeichen', 1050, 0, 0, 1, 1, TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100);
 
 INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
 SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
@@ -130,7 +130,7 @@ INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab
                       SeqNo, SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
 VALUES (0, 592183, 774836, 0, 186, 0,
         TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100, 0, 'D', 0, 'Y', 'Y', 'N', 'N', 'N', 'N', 'N', 'N',
-        'Aktionskennzeichen 2', 0, 0, 0, 1, 1, TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100);
+        'Aktionskennzeichen 2', 1060, 0, 0, 1, 1, TO_TIMESTAMP('2026-03-05 12:02', 'YYYY-MM-DD HH24:MI'), 100);
 
 INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
 SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792310_sys_gh28565_C_Invoice_Candidate_PromotionCode.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792310_sys_gh28565_C_Invoice_Candidate_PromotionCode.sql
@@ -1,0 +1,125 @@
+-- gh#28565 Promotion Code / Aktionskennzeichen
+-- Step 1.4: Add C_PromotionCode_ID + C_PromotionCode2_ID to C_Invoice_Candidate
+
+-- ============================================================
+-- C_PromotionCode_ID on C_Invoice_Candidate (AD_Table_ID=540270)
+-- ============================================================
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo, FieldLength,
+                       IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule,
+                       IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted,
+                       IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn,
+                       IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent,
+                       IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592184, 584619, 0, 19, 540270,
+        'C_PromotionCode_ID', TO_TIMESTAMP('2026-03-05 12:03', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'de.metas.invoicecandidate',
+        0, 10, 'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'Y', 'N', 0, 'Aktionskennzeichen',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:03', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592184
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+/* DDL */ SELECT update_Column_Translation_From_AD_Element(584619);
+
+/* DDL */ SELECT public.db_alter_table('C_Invoice_Candidate', 'ALTER TABLE public.C_Invoice_Candidate ADD COLUMN C_PromotionCode_ID NUMERIC(10)');
+
+ALTER TABLE C_Invoice_Candidate ADD CONSTRAINT CPromotionCode_CInvoiceCandidate
+    FOREIGN KEY (C_PromotionCode_ID) REFERENCES public.C_PromotionCode DEFERRABLE INITIALLY DEFERRED;
+
+-- ============================================================
+-- C_PromotionCode2_ID on C_Invoice_Candidate
+-- ============================================================
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Reference_Value_ID,
+                       AD_Table_ID, ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType,
+                       FacetFilterSeqNo, FieldLength, IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable,
+                       IsAutoApplyValidationRule, IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary,
+                       IsEncrypted, IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel,
+                       IsGenericZoomKeyColumn, IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory,
+                       IsParent, IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592185, 584620, 0, 18, 542070,
+        540270, 'C_PromotionCode2_ID', TO_TIMESTAMP('2026-03-05 12:03', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'de.metas.invoicecandidate',
+        0, 10, 'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'Y', 'N', 0, 'Aktionskennzeichen 2',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:03', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592185
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+/* DDL */ SELECT update_Column_Translation_From_AD_Element(584620);
+
+/* DDL */ SELECT public.db_alter_table('C_Invoice_Candidate', 'ALTER TABLE public.C_Invoice_Candidate ADD COLUMN C_PromotionCode2_ID NUMERIC(10)');
+
+ALTER TABLE C_Invoice_Candidate ADD CONSTRAINT CPromotionCode2_CInvoiceCandidate
+    FOREIGN KEY (C_PromotionCode2_ID) REFERENCES public.C_PromotionCode DEFERRABLE INITIALLY DEFERRED;
+
+-- ============================================================
+-- AD_Field on IC tab (AD_Tab_ID=540279) — read-only, advanced
+-- ============================================================
+
+-- C_PromotionCode_ID field
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength,
+                      Created, CreatedBy, DisplayLength, EntityType, IncludedTabHeight, IsActive, IsDisplayed,
+                      IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine, Name,
+                      SeqNo, SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592184, 774837, 0, 540279, 0,
+        TO_TIMESTAMP('2026-03-05 12:03', 'YYYY-MM-DD HH24:MI'), 100, 0, 'de.metas.invoicecandidate', 0, 'Y', 'Y', 'N',
+        'N', 'N', 'N', 'Y', 'N', 'Aktionskennzeichen', 0, 0, 0, 1, 1,
+        TO_TIMESTAMP('2026-03-05 12:03', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y') AND t.AD_Field_ID = 774837
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584619);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 774837;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(774837);
+
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
+                           AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774837, 0, 540279, 540056, 648485, 'F', TO_TIMESTAMP('2026-03-05 12:03', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'Y', 'N', 'Y', 'N', 'N', 'N', 0, 'Aktionskennzeichen', 1050, 0, 0,
+        TO_TIMESTAMP('2026-03-05 12:03', 'YYYY-MM-DD HH24:MI'), 100);
+-- Note: AD_UI_ElementGroup_ID=540056 is the existing advanced group on IC tab (same as used by Incoterms)
+
+-- C_PromotionCode2_ID field
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength,
+                      Created, CreatedBy, DisplayLength, EntityType, IncludedTabHeight, IsActive, IsDisplayed,
+                      IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine, Name,
+                      SeqNo, SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592185, 774838, 0, 540279, 0,
+        TO_TIMESTAMP('2026-03-05 12:03', 'YYYY-MM-DD HH24:MI'), 100, 0, 'de.metas.invoicecandidate', 0, 'Y', 'Y', 'N',
+        'N', 'N', 'N', 'Y', 'N', 'Aktionskennzeichen 2', 0, 0, 0, 1, 1,
+        TO_TIMESTAMP('2026-03-05 12:03', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y') AND t.AD_Field_ID = 774838
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584620);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 774838;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(774838);
+
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
+                           AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774838, 0, 540279, 540056, 648486, 'F', TO_TIMESTAMP('2026-03-05 12:03', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'Y', 'N', 'Y', 'N', 'N', 'N', 0, 'Aktionskennzeichen 2', 1060, 0, 0,
+        TO_TIMESTAMP('2026-03-05 12:03', 'YYYY-MM-DD HH24:MI'), 100);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792320_sys_gh28565_C_Invoice_PromotionCode.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792320_sys_gh28565_C_Invoice_PromotionCode.sql
@@ -1,0 +1,135 @@
+-- gh#28565 Promotion Code / Aktionskennzeichen
+-- Step 1.5: Add C_PromotionCode_ID + C_PromotionCode2_ID to C_Invoice
+
+-- ============================================================
+-- C_PromotionCode_ID on C_Invoice (AD_Table_ID=318)
+-- ============================================================
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                       AD_Val_Rule_ID, ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType,
+                       FacetFilterSeqNo, FieldLength, IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable,
+                       IsAutoApplyValidationRule, IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary,
+                       IsEncrypted, IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel,
+                       IsGenericZoomKeyColumn, IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory,
+                       IsParent, IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592186, 584619, 0, 19, 318,
+        540772, 'C_PromotionCode_ID', TO_TIMESTAMP('2026-03-05 12:04', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D',
+        0, 10, 'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'Y', 'N', 0, 'Aktionskennzeichen',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:04', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592186
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+/* DDL */ SELECT update_Column_Translation_From_AD_Element(584619);
+
+/* DDL */ SELECT public.db_alter_table('C_Invoice', 'ALTER TABLE public.C_Invoice ADD COLUMN C_PromotionCode_ID NUMERIC(10)');
+
+ALTER TABLE C_Invoice ADD CONSTRAINT CPromotionCode_CInvoice
+    FOREIGN KEY (C_PromotionCode_ID) REFERENCES public.C_PromotionCode DEFERRABLE INITIALLY DEFERRED;
+
+-- ============================================================
+-- C_PromotionCode2_ID on C_Invoice
+-- ============================================================
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Reference_Value_ID,
+                       AD_Table_ID, AD_Val_Rule_ID, ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType,
+                       FacetFilterSeqNo, FieldLength, IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable,
+                       IsAutoApplyValidationRule, IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary,
+                       IsEncrypted, IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel,
+                       IsGenericZoomKeyColumn, IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory,
+                       IsParent, IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
+VALUES (0, 592187, 584620, 0, 18, 542070,
+        318, 540772, 'C_PromotionCode2_ID', TO_TIMESTAMP('2026-03-05 12:04', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D',
+        0, 10, 'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'Y', 'N', 0, 'Aktionskennzeichen 2',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-05 12:04', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592187
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+/* DDL */ SELECT update_Column_Translation_From_AD_Element(584620);
+
+/* DDL */ SELECT public.db_alter_table('C_Invoice', 'ALTER TABLE public.C_Invoice ADD COLUMN C_PromotionCode2_ID NUMERIC(10)');
+
+ALTER TABLE C_Invoice ADD CONSTRAINT CPromotionCode2_CInvoice
+    FOREIGN KEY (C_PromotionCode2_ID) REFERENCES public.C_PromotionCode DEFERRABLE INITIALLY DEFERRED;
+
+-- ============================================================
+-- AD_Field on base Invoice tab — advanced edit, editable (IsReadOnly='N')
+-- We need to find the base invoice tab. For base Invoice window (AD_Window_ID=167), tab is typically 263.
+-- ============================================================
+
+-- C_PromotionCode_ID field on Invoice base tab
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength,
+                      Created, CreatedBy, DisplayLength, EntityType, IncludedTabHeight, IsActive, IsDisplayed,
+                      IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine, Name,
+                      SeqNo, SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592186, 774839, 0, 263, 0,
+        TO_TIMESTAMP('2026-03-05 12:04', 'YYYY-MM-DD HH24:MI'), 100, 0, 'D', 0, 'Y', 'Y', 'N',
+        'N', 'N', 'N', 'N', 'N', 'Aktionskennzeichen', 0, 0, 0, 1, 1,
+        TO_TIMESTAMP('2026-03-05 12:04', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y') AND t.AD_Field_ID = 774839
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584619);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 774839;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(774839);
+
+-- AD_UI_Element (advanced)
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
+                           AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774839, 0, 263, (SELECT AD_UI_ElementGroup_ID FROM AD_UI_ElementGroup WHERE AD_UI_Column_ID IN
+        (SELECT AD_UI_Column_ID FROM AD_UI_Column WHERE AD_UI_Section_ID IN
+        (SELECT AD_UI_Section_ID FROM AD_UI_Section WHERE AD_Tab_ID = 263 ORDER BY SeqNo LIMIT 1)
+        ORDER BY SeqNo LIMIT 1) ORDER BY SeqNo LIMIT 1),
+        648487, 'F', TO_TIMESTAMP('2026-03-05 12:04', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'Y', 'N', 'Y', 'N', 'N', 'N', 0, 'Aktionskennzeichen', 1050, 0, 0,
+        TO_TIMESTAMP('2026-03-05 12:04', 'YYYY-MM-DD HH24:MI'), 100);
+
+-- C_PromotionCode2_ID field on Invoice base tab
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength,
+                      Created, CreatedBy, DisplayLength, EntityType, IncludedTabHeight, IsActive, IsDisplayed,
+                      IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine, Name,
+                      SeqNo, SeqNoGrid, SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592187, 774840, 0, 263, 0,
+        TO_TIMESTAMP('2026-03-05 12:04', 'YYYY-MM-DD HH24:MI'), 100, 0, 'D', 0, 'Y', 'Y', 'N',
+        'N', 'N', 'N', 'N', 'N', 'Aktionskennzeichen 2', 0, 0, 0, 1, 1,
+        TO_TIMESTAMP('2026-03-05 12:04', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y') AND t.AD_Field_ID = 774840
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584620);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 774840;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(774840);
+
+-- AD_UI_Element (advanced)
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
+                           AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774840, 0, 263, (SELECT AD_UI_ElementGroup_ID FROM AD_UI_ElementGroup WHERE AD_UI_Column_ID IN
+        (SELECT AD_UI_Column_ID FROM AD_UI_Column WHERE AD_UI_Section_ID IN
+        (SELECT AD_UI_Section_ID FROM AD_UI_Section WHERE AD_Tab_ID = 263 ORDER BY SeqNo LIMIT 1)
+        ORDER BY SeqNo LIMIT 1) ORDER BY SeqNo LIMIT 1),
+        648488, 'F', TO_TIMESTAMP('2026-03-05 12:04', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'Y', 'N', 'Y', 'N', 'N', 'N', 0, 'Aktionskennzeichen 2', 1060, 0, 0,
+        TO_TIMESTAMP('2026-03-05 12:04', 'YYYY-MM-DD HH24:MI'), 100);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792330_sys_gh28565_PromotionCode_Message_Report.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792330_sys_gh28565_PromotionCode_Message_Report.sql
@@ -1,0 +1,165 @@
+-- gh#28565 Promotion Code / Aktionskennzeichen
+-- Step 1.7/1.10: AD_Message for duplicate validation + AD_Process for report
+
+-- ============================================================
+-- AD_Message: C_PromotionCode_DuplicateError
+-- ============================================================
+INSERT INTO AD_Message (AD_Client_ID, AD_Message_ID, AD_Org_ID, Created, CreatedBy, EntityType, IsActive,
+                        MsgText, MsgType, Value, Updated, UpdatedBy)
+VALUES (0, 545640, 0, TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), 100, 'D', 'Y',
+        'Aktionskennzeichen 1 und 2 müssen verschieden sein', 'E', 'C_PromotionCode_DuplicateError',
+        TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Message_ID, MsgText, MsgTip, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Message_ID, t.MsgText, t.MsgTip, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Message_ID = 545640
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Message_ID = t.AD_Message_ID);
+
+UPDATE AD_Message_Trl SET MsgText = 'Promotion Code 1 and 2 must be different', IsTranslated = 'Y',
+                          Updated = TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Message_ID = 545640 AND AD_Language = 'en_US';
+
+-- Set ErrorCode (mandatory for MsgType='E')
+UPDATE AD_Message SET ErrorCode = 'PROMOTION_CODE_DUPLICATE',
+                      Updated = TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Message_ID = 545640;
+
+-- ============================================================
+-- AD_Process: Promotion Code Evaluation Report
+-- Uses ExportToSpreadsheetProcess (report function will be in dt204)
+-- ============================================================
+
+-- AD_Element for the process (required for menu naming propagation)
+INSERT INTO AD_Element (AD_Client_ID, AD_Element_ID, AD_Org_ID, ColumnName, Created, CreatedBy,
+                        EntityType, IsActive, Name, PrintName, Updated, UpdatedBy)
+VALUES (0, 584621, 0, 'PromotionCode_Report', TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), 100,
+        'D', 'Y', 'Aktionskennzeichen Auswertung', 'Aktionskennzeichen Auswertung',
+        TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Description, Help, Name, PO_Description, PO_Help, PO_Name, PO_PrintName, PrintName,
+                            IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.Description, t.Help, t.Name, t.PO_Description, t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Element_ID = 584621
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID);
+
+UPDATE AD_Element_Trl SET Name = 'Promotion Code Evaluation', PrintName = 'Promotion Code Evaluation', IsTranslated = 'Y',
+                          Updated = TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Element_ID = 584621 AND AD_Language = 'en_US';
+
+INSERT INTO AD_Process (AccessLevel, AD_Client_ID, AD_Org_ID, AD_Process_ID, Classname, Created, CreatedBy,
+                        EntityType, IsActive, IsApplySecuritySettings, IsBetaFunctionality, IsDirectPrint,
+                        IsFormatExcelFile, IsNotifyUserAfterExecution, IsOneInstanceOnly, IsReport,
+                        IsTranslateExcelHeaders, IsUseBPartnerLanguage, LockWaitTimeout, Name,
+                        ShowHelp, SpreadsheetFormat, SQLStatement, Type, Updated, UpdatedBy, Value)
+VALUES ('3', 0, 0, 585592, 'de.metas.impexp.spreadsheet.process.ExportToSpreadsheetProcess',
+        TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), 100,
+        'D', 'Y', 'N', 'N', 'N', 'Y', 'N', 'N', 'Y', 'Y', 'Y', 0,
+        'Aktionskennzeichen Auswertung', 'Y', 'xls',
+        'SELECT * FROM report.report_promotion_code_evaluation(@C_PromotionCode_ID/null@, @C_PromotionCode2_ID/null@, @Invoiced/null@)',
+        'Excel', TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), 100, 'PromotionCode_Report');
+
+INSERT INTO AD_Process_Trl (AD_Language, AD_Process_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Process_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Process t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Process_ID = 585592
+  AND NOT EXISTS (SELECT 1 FROM AD_Process_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Process_ID = t.AD_Process_ID);
+
+-- ============================================================
+-- AD_Process_Para: C_PromotionCode_ID (Ref=19 TableDir)
+-- ============================================================
+INSERT INTO AD_Process_Para (AD_Client_ID, AD_Element_ID, AD_Org_ID, AD_Process_ID, AD_Process_Para_ID,
+                             AD_Reference_ID, ColumnName, Created, CreatedBy, EntityType, FieldLength, IsActive,
+                             IsAutocomplete, IsCentrallyMaintained, IsEncrypted, IsMandatory, IsRange,
+                             Name, SeqNo, Updated, UpdatedBy)
+VALUES (0, 584619, 0, 585592, 543140,
+        19, 'C_PromotionCode_ID', TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), 100, 'D', 10, 'Y',
+        'N', 'Y', 'N', 'N', 'N',
+        'Aktionskennzeichen', 10, TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Process_Para_Trl (AD_Language, AD_Process_Para_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Process_Para t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Process_Para_ID = 543140
+  AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Process_Para_ID = t.AD_Process_Para_ID);
+
+-- ============================================================
+-- AD_Process_Para: C_PromotionCode2_ID (Ref=18 Table + AD_Reference_Value_ID)
+-- ============================================================
+INSERT INTO AD_Process_Para (AD_Client_ID, AD_Element_ID, AD_Org_ID, AD_Process_ID, AD_Process_Para_ID,
+                             AD_Reference_ID, AD_Reference_Value_ID, ColumnName, Created, CreatedBy, EntityType,
+                             FieldLength, IsActive, IsAutocomplete, IsCentrallyMaintained, IsEncrypted,
+                             IsMandatory, IsRange, Name, SeqNo, Updated, UpdatedBy)
+VALUES (0, 584620, 0, 585592, 543141,
+        18, 542070, 'C_PromotionCode2_ID', TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), 100, 'D',
+        10, 'Y', 'N', 'Y', 'N', 'N', 'N',
+        'Aktionskennzeichen 2', 20, TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Process_Para_Trl (AD_Language, AD_Process_Para_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Process_Para t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Process_Para_ID = 543141
+  AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Process_Para_ID = t.AD_Process_Para_ID);
+
+-- ============================================================
+-- AD_Process_Para: Invoiced (Ref=17 YesNo list)
+-- ============================================================
+INSERT INTO AD_Process_Para (AD_Client_ID, AD_Element_ID, AD_Org_ID, AD_Process_ID, AD_Process_Para_ID,
+                             AD_Reference_ID, ColumnName, Created, CreatedBy, EntityType, FieldLength, IsActive,
+                             IsAutocomplete, IsCentrallyMaintained, IsEncrypted, IsMandatory, IsRange,
+                             Name, SeqNo, Updated, UpdatedBy)
+VALUES (0, 348, 0, 585592, 543142,
+        20, 'Invoiced', TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), 100, 'D', 1, 'Y',
+        'N', 'N', 'N', 'N', 'N',
+        'Fakturiert', 30, TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Process_Para_Trl (AD_Language, AD_Process_Para_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Process_Para t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Process_Para_ID = 543142
+  AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Process_Para_ID = t.AD_Process_Para_ID);
+
+UPDATE AD_Process_Para_Trl SET Name = 'Invoiced', IsTranslated = 'Y',
+                               Updated = TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Process_Para_ID = 543142 AND AD_Language = 'en_US';
+
+-- ============================================================
+-- AD_Menu entry for report
+-- ============================================================
+INSERT INTO AD_Menu (Action, AD_Client_ID, AD_Element_ID, AD_Menu_ID, AD_Org_ID, AD_Process_ID, Created, CreatedBy,
+                     EntityType, InternalName, IsActive, IsCreateNew, IsReadOnly, IsSOTrx, IsSummary, Name,
+                     Updated, UpdatedBy)
+VALUES ('R', 0, 584621, 542303, 0, 585592, TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), 100,
+        'D', 'PromotionCode_Report', 'Y', 'N', 'N', 'N', 'N', 'Aktionskennzeichen Auswertung',
+        TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Menu_Trl (AD_Language, AD_Menu_ID, Description, Name, WebUI_NameBrowse, WebUI_NameNew, WebUI_NameNewBreadcrumb,
+                         IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Menu_ID, t.Description, t.Name, t.WebUI_NameBrowse, t.WebUI_NameNew, t.WebUI_NameNewBreadcrumb,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Menu t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Menu_ID = 542303
+  AND NOT EXISTS (SELECT 1 FROM AD_Menu_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Menu_ID = t.AD_Menu_ID);
+
+UPDATE AD_Menu_Trl SET Name = 'Promotion Code Evaluation', IsTranslated = 'Y',
+                       Updated = TO_TIMESTAMP('2026-03-05 12:05', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 100
+WHERE AD_Menu_ID = 542303 AND AD_Language = 'en_US';
+
+-- Tree node
+INSERT INTO AD_TreeNodeMM (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                           AD_Tree_ID, Node_ID, Parent_ID, SeqNo)
+SELECT t.AD_Client_ID, 0, 'Y', now(), 100, now(), 100,
+       t.AD_Tree_ID, 542303, 0, 999
+FROM AD_Tree t
+WHERE t.AD_Client_ID = 0 AND t.IsActive = 'Y' AND t.IsAllNodes = 'Y'
+  AND t.AD_Table_ID = 116
+  AND NOT EXISTS (SELECT 1 FROM AD_TreeNodeMM tnm WHERE tnm.AD_Tree_ID = t.AD_Tree_ID AND tnm.Node_ID = 542303);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792330_sys_gh28565_PromotionCode_Message_Report.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792330_sys_gh28565_PromotionCode_Message_Report.sql
@@ -28,7 +28,7 @@ WHERE AD_Message_ID = 545640;
 
 -- ============================================================
 -- AD_Process: Promotion Code Evaluation Report
--- Uses ExportToSpreadsheetProcess (report function will be in dt204)
+-- Uses ExportToSpreadsheetProcess (report function in de.metas.fresh.base DDL)
 -- ============================================================
 
 -- AD_Element for the process (required for menu naming propagation)
@@ -109,7 +109,7 @@ WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
   AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Process_Para_ID = t.AD_Process_Para_ID);
 
 -- ============================================================
--- AD_Process_Para: Invoiced (Ref=17 YesNo list)
+-- AD_Process_Para: Invoiced (Ref=20 YesNo)
 -- ============================================================
 INSERT INTO AD_Process_Para (AD_Client_ID, AD_Element_ID, AD_Org_ID, AD_Process_ID, AD_Process_Para_ID,
                              AD_Reference_ID, ColumnName, Created, CreatedBy, EntityType, FieldLength, IsActive,

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792420_sys_gh28565_C_PromotionCode_Description.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792420_sys_gh28565_C_PromotionCode_Description.sql
@@ -1,0 +1,47 @@
+-- gh#28565: Add Description column to C_PromotionCode
+
+-- AD_Column
+INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
+                        ColumnName, Created, CreatedBy, EntityType, FacetFilterSeqNo, FieldLength,
+                        IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule,
+                        IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted, IsExcludeFromZoomTargets,
+                        IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn, IsGenericZoomOrigin,
+                        IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent, IsSelectionColumn,
+                        IsTranslated, IsUpdateable, Name, PersonalDataCategory, SelectionColumnSeqNo, SeqNo,
+                        Updated, UpdatedBy, Version)
+VALUES (0, 592197, 275, 0, 10, 542586,
+        'Description', TO_TIMESTAMP('2026-03-06 10:00', 'YYYY-MM-DD HH24:MI'), 100, 'D', 0, 1024,
+        'Y', 'N', 'Y', 'N', 'N',
+        'N', 'N', 'N', 'N', 'Y',
+        'N', 'N', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N', 'N',
+        'N', 'Y', 'Beschreibung', 'NP', 0, 0,
+        TO_TIMESTAMP('2026-03-06 10:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+-- DDL
+ALTER TABLE C_PromotionCode ADD COLUMN IF NOT EXISTS Description VARCHAR(1024);
+
+-- AD_Field on C_PromotionCode tab (AD_Tab_ID=549080)
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength,
+                       Created, CreatedBy, EntityType, IncludedTabHeight, IsActive, IsDisplayed, IsDisplayedGrid,
+                       IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine, Name, SeqNo, SeqNoGrid,
+                       SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES (0, 592197, 774854, 0, 549080, 0,
+        TO_TIMESTAMP('2026-03-06 10:00', 'YYYY-MM-DD HH24:MI'), 100, 'D', 0, 'Y', 'Y', 'Y',
+        'N', 'N', 'N', 'N', 'N', 'Beschreibung', 0, 0,
+        0, 1, 1, TO_TIMESTAMP('2026-03-06 10:00', 'YYYY-MM-DD HH24:MI'), 100);
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Field_ID = 774854
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+
+-- AD_UI_Element for Description (SeqNo=25: between Name=20 and ValidTo=30)
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
+                            AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering,
+                            IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
+                            Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 774854, 0, 549080, 554978, 648504, 'F', TO_TIMESTAMP('2026-03-06 10:00', 'YYYY-MM-DD HH24:MI'), 100,
+        'Y', 'N', 'N', 'Y', 'Y', 'N', 'N', 0, 'Beschreibung', 25, 25, 0, TO_TIMESTAMP('2026-03-06 10:00', 'YYYY-MM-DD HH24:MI'), 100);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792420_sys_gh28565_C_PromotionCode_Description.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792420_sys_gh28565_C_PromotionCode_Description.sql
@@ -2,32 +2,43 @@
 
 -- AD_Column
 INSERT INTO AD_Column (AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID,
-                        ColumnName, Created, CreatedBy, EntityType, FacetFilterSeqNo, FieldLength,
-                        IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule,
-                        IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted, IsExcludeFromZoomTargets,
-                        IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn, IsGenericZoomOrigin,
-                        IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent, IsSelectionColumn,
-                        IsTranslated, IsUpdateable, Name, PersonalDataCategory, SelectionColumnSeqNo, SeqNo,
-                        Updated, UpdatedBy, Version)
+                       ColumnName, Created, CreatedBy, DDL_NoForeignKey, EntityType, FacetFilterSeqNo, FieldLength,
+                       IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule,
+                       IsAutocomplete, IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted,
+                       IsExcludeFromZoomTargets, IsFacetFilter, IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn,
+                       IsGenericZoomOrigin, IsIdentifier, IsKey, IsLazyLoading, IsMandatory, IsParent,
+                       IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline, IsStaleable,
+                       IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+                       PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version)
 VALUES (0, 592197, 275, 0, 10, 542586,
-        'Description', TO_TIMESTAMP('2026-03-06 10:00', 'YYYY-MM-DD HH24:MI'), 100, 'D', 0, 1024,
+        'Description', TO_TIMESTAMP('2026-03-06 10:00', 'YYYY-MM-DD HH24:MI'), 100, 'N', 'D', 0, 1024,
         'Y', 'N', 'Y', 'N', 'N',
-        'N', 'N', 'N', 'N', 'Y',
-        'N', 'N', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N',
+        'Y', 'N', 'N', 'N',
         'N', 'N', 'N', 'N', 'N', 'N',
-        'N', 'Y', 'Beschreibung', 'NP', 0, 0,
-        TO_TIMESTAMP('2026-03-06 10:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
+        'N', 'N', 'N', 'N',
+        'Y', 'N', 0, 'Beschreibung',
+        'NP', 0, 0, TO_TIMESTAMP('2026-03-06 10:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Column_ID = 592197
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+/* DDL */ SELECT update_Column_Translation_From_AD_Element(275);
 
 -- DDL
-ALTER TABLE C_PromotionCode ADD COLUMN IF NOT EXISTS Description VARCHAR(1024);
+/* DDL */ SELECT public.db_alter_table('C_PromotionCode', 'ALTER TABLE public.C_PromotionCode ADD COLUMN IF NOT EXISTS Description VARCHAR(1024)');
 
 -- AD_Field on C_PromotionCode tab (AD_Tab_ID=549080)
 INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, ColumnDisplayLength,
-                       Created, CreatedBy, EntityType, IncludedTabHeight, IsActive, IsDisplayed, IsDisplayedGrid,
+                       Created, CreatedBy, DisplayLength, EntityType, IncludedTabHeight, IsActive, IsDisplayed, IsDisplayedGrid,
                        IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine, Name, SeqNo, SeqNoGrid,
                        SortNo, SpanX, SpanY, Updated, UpdatedBy)
 VALUES (0, 592197, 774854, 0, 549080, 0,
-        TO_TIMESTAMP('2026-03-06 10:00', 'YYYY-MM-DD HH24:MI'), 100, 'D', 0, 'Y', 'Y', 'Y',
+        TO_TIMESTAMP('2026-03-06 10:00', 'YYYY-MM-DD HH24:MI'), 100, 0, 'D', 0, 'Y', 'Y', 'Y',
         'N', 'N', 'N', 'N', 'N', 'Beschreibung', 0, 0,
         0, 1, 1, TO_TIMESTAMP('2026-03-06 10:00', 'YYYY-MM-DD HH24:MI'), 100);
 
@@ -37,6 +48,11 @@ FROM AD_Language l, AD_Field t
 WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
   AND t.AD_Field_ID = 774854
   AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(275);
+
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 774854;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(774854);
 
 -- AD_UI_Element for Description (SeqNo=25: between Name=20 and ValidTo=30)
 INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792420_sys_gh28565_C_PromotionCode_Description.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792420_sys_gh28565_C_PromotionCode_Description.sql
@@ -17,7 +17,7 @@ VALUES (0, 592197, 275, 0, 10, 542586,
         'Y', 'N', 'N', 'N',
         'N', 'N', 'N', 'N', 'N', 'N',
         'N', 'N', 'N', 'N',
-        'Y', 'N', 0, 'Beschreibung',
+        'Y', 'N', 'Y', 'N', 0, 'Beschreibung',
         'NP', 0, 0, TO_TIMESTAMP('2026-03-06 10:00', 'YYYY-MM-DD HH24:MI'), 100, 0);
 
 INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792430_sys_gh28565_PromotionCode_Report_Description.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792430_sys_gh28565_PromotionCode_Report_Description.sql
@@ -53,7 +53,9 @@ FROM C_Order o
          LEFT JOIN C_PromotionCode pc2 ON o.C_PromotionCode2_ID = pc2.C_PromotionCode_ID
          JOIN C_BPartner bp_order ON o.C_BPartner_ID = bp_order.C_BPartner_ID
          LEFT JOIN C_Invoice_Candidate ic ON ic.C_Order_ID = o.C_Order_ID AND ic.IsActive = 'Y'
-         LEFT JOIN C_Invoice i ON ic.C_Invoice_ID = i.C_Invoice_ID AND i.IsActive = 'Y'
+         LEFT JOIN C_Invoice_Line_Alloc ila ON ila.C_Invoice_Candidate_ID = ic.C_Invoice_Candidate_ID AND ila.IsActive = 'Y'
+         LEFT JOIN C_InvoiceLine il ON ila.C_InvoiceLine_ID = il.C_InvoiceLine_ID AND il.IsActive = 'Y'
+         LEFT JOIN C_Invoice i ON il.C_Invoice_ID = i.C_Invoice_ID AND i.IsActive = 'Y'
          LEFT JOIN C_BPartner bp_inv ON i.C_BPartner_ID = bp_inv.C_BPartner_ID
 WHERE o.IsActive = 'Y'
   AND o.IsSOTrx = 'Y'

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792430_sys_gh28565_PromotionCode_Report_Description.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792430_sys_gh28565_PromotionCode_Report_Description.sql
@@ -1,4 +1,8 @@
--- gh#28565: Update report function to include Description columns
+-- gh#28565: Rework report function:
+-- - Include Description columns for promotion codes
+-- - Filter only Completed/Closed orders (DocStatus IN CO,CL)
+-- - Use LATERAL subquery to avoid cartesian product from IC->ILA->IL->Invoice joins
+-- - Use order GrandTotal and invoice GrandTotal instead of unreliable SplitAmt-based calculations
 
 DROP FUNCTION IF EXISTS report.report_promotion_code_evaluation(
     p_C_PromotionCode_ID  numeric,
@@ -21,14 +25,11 @@ CREATE OR REPLACE FUNCTION report.report_promotion_code_evaluation(
                 DateOrdered               date,
                 CustomerNo                varchar,
                 CustomerName              varchar,
-                TotalNetAmt               numeric,
-                TotalGrossAmt             numeric,
-                TotalTaxAmt               numeric,
+                OrderGrandTotal           numeric,
                 Invoiced                  char(1),
                 InvoiceDocumentNo         varchar,
                 DateInvoiced              date,
-                InvoiceCustomerNo         varchar,
-                InvoiceCustomerName       varchar
+                InvoiceGrandTotal         numeric
             )
 AS
 $$
@@ -40,38 +41,37 @@ SELECT pc1.Value                                                       AS Promot
        o.DateOrdered::date                                             AS DateOrdered,
        bp_order.Value                                                  AS CustomerNo,
        bp_order.Name                                                   AS CustomerName,
-       COALESCE(SUM(ic.NetAmtToInvoice), 0)                           AS TotalNetAmt,
-       COALESCE(SUM(ic.NetAmtToInvoice + ic.SplitAmt), 0)             AS TotalGrossAmt,
-       COALESCE(SUM(ic.SplitAmt), 0)                                   AS TotalTaxAmt,
-       CASE WHEN i.C_Invoice_ID IS NOT NULL THEN 'Y' ELSE 'N' END     AS Invoiced,
-       i.DocumentNo                                                    AS InvoiceDocumentNo,
-       i.DateInvoiced::date                                            AS DateInvoiced,
-       bp_inv.Value                                                    AS InvoiceCustomerNo,
-       bp_inv.Name                                                     AS InvoiceCustomerName
+       o.GrandTotal                                                    AS OrderGrandTotal,
+       CASE WHEN inv.C_Invoice_ID IS NOT NULL THEN 'Y' ELSE 'N' END   AS Invoiced,
+       inv.DocumentNo                                                  AS InvoiceDocumentNo,
+       inv.DateInvoiced::date                                          AS DateInvoiced,
+       inv.GrandTotal                                                  AS InvoiceGrandTotal
 FROM C_Order o
          LEFT JOIN C_PromotionCode pc1 ON o.C_PromotionCode_ID = pc1.C_PromotionCode_ID
          LEFT JOIN C_PromotionCode pc2 ON o.C_PromotionCode2_ID = pc2.C_PromotionCode_ID
          JOIN C_BPartner bp_order ON o.C_BPartner_ID = bp_order.C_BPartner_ID
-         LEFT JOIN C_Invoice_Candidate ic ON ic.C_Order_ID = o.C_Order_ID AND ic.IsActive = 'Y'
-         LEFT JOIN C_Invoice_Line_Alloc ila ON ila.C_Invoice_Candidate_ID = ic.C_Invoice_Candidate_ID AND ila.IsActive = 'Y'
-         LEFT JOIN C_InvoiceLine il ON ila.C_InvoiceLine_ID = il.C_InvoiceLine_ID AND il.IsActive = 'Y'
-         LEFT JOIN C_Invoice i ON il.C_Invoice_ID = i.C_Invoice_ID AND i.IsActive = 'Y'
-         LEFT JOIN C_BPartner bp_inv ON i.C_BPartner_ID = bp_inv.C_BPartner_ID
+         LEFT JOIN LATERAL (
+    SELECT DISTINCT i.C_Invoice_ID, i.DocumentNo, i.DateInvoiced, i.GrandTotal
+    FROM C_OrderLine ol
+             JOIN C_Invoice_Candidate ic ON ic.C_OrderLine_ID = ol.C_OrderLine_ID AND ic.IsActive = 'Y'
+             JOIN C_Invoice_Line_Alloc ila ON ila.C_Invoice_Candidate_ID = ic.C_Invoice_Candidate_ID AND ila.IsActive = 'Y'
+             JOIN C_InvoiceLine il ON ila.C_InvoiceLine_ID = il.C_InvoiceLine_ID AND il.IsActive = 'Y'
+             JOIN C_Invoice i ON il.C_Invoice_ID = i.C_Invoice_ID AND i.IsActive = 'Y' AND i.DocStatus IN ('CO', 'CL')
+    WHERE ol.C_Order_ID = o.C_Order_ID AND ol.IsActive = 'Y'
+    LIMIT 1
+    ) inv ON TRUE
 WHERE o.IsActive = 'Y'
   AND o.IsSOTrx = 'Y'
+  AND o.DocStatus IN ('CO', 'CL')
   AND (o.C_PromotionCode_ID IS NOT NULL OR o.C_PromotionCode2_ID IS NOT NULL)
   AND (p_C_PromotionCode_ID IS NULL OR o.C_PromotionCode_ID = p_C_PromotionCode_ID)
   AND (p_C_PromotionCode2_ID IS NULL OR o.C_PromotionCode2_ID = p_C_PromotionCode2_ID)
   AND (p_Invoiced IS NULL
-    OR (p_Invoiced = 'Y' AND i.C_Invoice_ID IS NOT NULL)
-    OR (p_Invoiced = 'N' AND i.C_Invoice_ID IS NULL))
-GROUP BY pc1.Value, pc1.Description, pc2.Value, pc2.Description, o.DocumentNo, o.DateOrdered,
-         bp_order.Value, bp_order.Name,
-         i.C_Invoice_ID, i.DocumentNo, i.DateInvoiced,
-         bp_inv.Value, bp_inv.Name
+    OR (p_Invoiced = 'Y' AND inv.C_Invoice_ID IS NOT NULL)
+    OR (p_Invoiced = 'N' AND inv.C_Invoice_ID IS NULL))
 ORDER BY o.DateOrdered DESC, o.DocumentNo
 $$
     LANGUAGE sql STABLE;
 
 COMMENT ON FUNCTION report.report_promotion_code_evaluation(numeric, numeric, char) IS
-    'gh#28565: Promotion Code Evaluation Report — shows orders with promotion codes, their descriptions, net/gross/tax amounts, and invoice status';
+    'gh#28565: Promotion Code Evaluation Report — shows completed/closed orders with promotion codes, their descriptions, and invoice status';

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792430_sys_gh28565_PromotionCode_Report_Description.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792430_sys_gh28565_PromotionCode_Report_Description.sql
@@ -1,3 +1,5 @@
+-- gh#28565: Update report function to include Description columns
+
 DROP FUNCTION IF EXISTS report.report_promotion_code_evaluation(
     p_C_PromotionCode_ID  numeric,
     p_C_PromotionCode2_ID numeric,

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792430_sys_gh28565_PromotionCode_Report_Description.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792430_sys_gh28565_PromotionCode_Report_Description.sql
@@ -58,6 +58,7 @@ FROM C_Order o
              JOIN C_InvoiceLine il ON ila.C_InvoiceLine_ID = il.C_InvoiceLine_ID AND il.IsActive = 'Y'
              JOIN C_Invoice i ON il.C_Invoice_ID = i.C_Invoice_ID AND i.IsActive = 'Y' AND i.DocStatus IN ('CO', 'CL')
     WHERE ol.C_Order_ID = o.C_Order_ID AND ol.IsActive = 'Y'
+    ORDER BY i.DateInvoiced DESC, i.C_Invoice_ID DESC
     LIMIT 1
     ) inv ON TRUE
 WHERE o.IsActive = 'Y'

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792600_sys_gh28565_fix_PromotionCode_ValRule_DateQuoting.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792600_sys_gh28565_fix_PromotionCode_ValRule_DateQuoting.sql
@@ -1,0 +1,18 @@
+-- gh#28565: Fix AD_Val_Rule date quoting for PromotionCode lookups
+-- The @DateOrdered@ and @DateInvoiced@ context variables were not quoted,
+-- causing SQL syntax errors like: ValidTo >= 2026-03-06 00:00:00
+-- Correct pattern (used by all other val rules): >= ''@DateOrdered@''
+
+-- Fix validation rule 540771 (C_PromotionCode for Order)
+UPDATE AD_Val_Rule
+SET Code    = 'C_PromotionCode.IsActive=''Y'' AND (C_PromotionCode.ValidTo IS NULL OR C_PromotionCode.ValidTo >= ''@DateOrdered@'')',
+    Updated = TO_TIMESTAMP('2026-03-06 18:30', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy = 100
+WHERE AD_Val_Rule_ID = 540771;
+
+-- Fix validation rule 540772 (C_PromotionCode for Invoice)
+UPDATE AD_Val_Rule
+SET Code    = 'C_PromotionCode.IsActive=''Y'' AND (C_PromotionCode.ValidTo IS NULL OR C_PromotionCode.ValidTo >= ''@DateInvoiced@'')',
+    Updated = TO_TIMESTAMP('2026-03-06 18:30', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy = 100
+WHERE AD_Val_Rule_ID = 540772;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792650_sys_gh28565_PromotionCode_UI_Layout.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792650_sys_gh28565_PromotionCode_UI_Layout.sql
@@ -17,7 +17,7 @@
 UPDATE AD_UI_Element
 SET AD_UI_ElementGroup_ID = 540499,
     SeqNo = 283,
-    Updated = now(),
+    Updated = TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'),
     UpdatedBy = 100
 WHERE AD_UI_Element_ID = 648483;
 
@@ -25,7 +25,7 @@ WHERE AD_UI_Element_ID = 648483;
 UPDATE AD_UI_Element
 SET AD_UI_ElementGroup_ID = 540499,
     SeqNo = 286,
-    Updated = now(),
+    Updated = TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'),
     UpdatedBy = 100
 WHERE AD_UI_Element_ID = 648484;
 
@@ -37,7 +37,7 @@ WHERE AD_UI_Element_ID = 648484;
 UPDATE AD_UI_Element
 SET AD_UI_ElementGroup_ID = 541214,
     SeqNo = 115,
-    Updated = now(),
+    Updated = TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'),
     UpdatedBy = 100
 WHERE AD_UI_Element_ID = 648487;
 
@@ -45,7 +45,7 @@ WHERE AD_UI_Element_ID = 648487;
 UPDATE AD_UI_Element
 SET AD_UI_ElementGroup_ID = 541214,
     SeqNo = 118,
-    Updated = now(),
+    Updated = TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'),
     UpdatedBy = 100
 WHERE AD_UI_Element_ID = 648488;
 
@@ -56,13 +56,13 @@ WHERE AD_UI_Element_ID = 648488;
 -- C_PromotionCode_ID (648485): fix seqno from 1050 to 1055 (1050 collides with C_Project_ID)
 UPDATE AD_UI_Element
 SET SeqNo = 1055,
-    Updated = now(),
+    Updated = TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'),
     UpdatedBy = 100
 WHERE AD_UI_Element_ID = 648485;
 
 -- C_PromotionCode2_ID (648486): fix seqno from 1060 to 1058
 UPDATE AD_UI_Element
 SET SeqNo = 1058,
-    Updated = now(),
+    Updated = TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'),
     UpdatedBy = 100
 WHERE AD_UI_Element_ID = 648486;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792650_sys_gh28565_PromotionCode_UI_Layout.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792650_sys_gh28565_PromotionCode_UI_Layout.sql
@@ -1,0 +1,68 @@
+-- gh#28565: Move Promotion Code fields to less prominent position in Advanced Edit
+--
+-- Design guide: Promotion codes are secondary business fields, not mandatory or "very important".
+-- They should appear in the dedicated "advanced edit" UI element group, not in the "main" group
+-- where they render prominently at the top of the Advanced Edit modal.
+--
+-- Changes:
+-- 1. Sales Order (143): Move from "main" group (540005) to "advanced edit" group (540499), seqno 283/286
+-- 2. Invoice (167): Move from "default" group (540022) to "advanced edit" group (541214), seqno 115/118
+-- 3. Invoice Candidate (540092): Already in correct group (540056), fix seqno collision (1050->1055, 1060->1058)
+
+-- ==========================================================================
+-- 1. Sales Order (143) — Move promo codes from "main" (540005) to "advanced edit" (540499)
+-- ==========================================================================
+
+-- C_PromotionCode_ID (648483): move to advanced edit group, seqno 283 (after OfferValidDays=280, before Processed=290)
+UPDATE AD_UI_Element
+SET AD_UI_ElementGroup_ID = 540499,
+    SeqNo = 283,
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_UI_Element_ID = 648483;
+
+-- C_PromotionCode2_ID (648484): move to advanced edit group, seqno 286
+UPDATE AD_UI_Element
+SET AD_UI_ElementGroup_ID = 540499,
+    SeqNo = 286,
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_UI_Element_ID = 648484;
+
+-- ==========================================================================
+-- 2. Invoice (167) — Move promo codes from "default" (540022) to "advanced edit" (541214)
+-- ==========================================================================
+
+-- C_PromotionCode_ID (648487): move to advanced edit group, seqno 115 (after C_Project_ID=110)
+UPDATE AD_UI_Element
+SET AD_UI_ElementGroup_ID = 541214,
+    SeqNo = 115,
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_UI_Element_ID = 648487;
+
+-- C_PromotionCode2_ID (648488): move to advanced edit group, seqno 118
+UPDATE AD_UI_Element
+SET AD_UI_ElementGroup_ID = 541214,
+    SeqNo = 118,
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_UI_Element_ID = 648488;
+
+-- ==========================================================================
+-- 3. Invoice Candidate (540092) — Fix seqno collision (already in correct group 540056)
+-- ==========================================================================
+
+-- C_PromotionCode_ID (648485): fix seqno from 1050 to 1055 (1050 collides with C_Project_ID)
+UPDATE AD_UI_Element
+SET SeqNo = 1055,
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_UI_Element_ID = 648485;
+
+-- C_PromotionCode2_ID (648486): fix seqno from 1060 to 1058
+UPDATE AD_UI_Element
+SET SeqNo = 1058,
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_UI_Element_ID = 648486;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792670_sys_gh28565_PromotionCode_Window_DesignGuide.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792670_sys_gh28565_PromotionCode_Window_DesignGuide.sql
@@ -25,7 +25,7 @@ INSERT INTO AD_UI_Column (
   Created, CreatedBy, IsActive, SeqNo, Updated, UpdatedBy
 ) VALUES (
   0, 0, 549276, 547597,
-  now(), 100, 'Y', 20, now(), 100
+  TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'), 100, 'Y', 20, TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'), 100
 );
 
 -- ==========================================================================
@@ -36,7 +36,7 @@ INSERT INTO AD_UI_ElementGroup (
   Created, CreatedBy, IsActive, Name, SeqNo, UIStyle, Updated, UpdatedBy
 ) VALUES (
   0, 0, 549276, 554985,
-  now(), 100, 'Y', 'flags', 10, 'primary', now(), 100
+  TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'), 100, 'Y', 'flags', 10, 'primary', TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'), 100
 );
 
 -- ==========================================================================
@@ -45,7 +45,7 @@ INSERT INTO AD_UI_ElementGroup (
 UPDATE AD_UI_Element
 SET AD_UI_ElementGroup_ID = 554985,
     SeqNo = 10,
-    Updated = now(),
+    Updated = TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'),
     UpdatedBy = 100
 WHERE AD_UI_Element_ID = 648480;  -- IsActive
 
@@ -55,14 +55,14 @@ WHERE AD_UI_Element_ID = 648480;  -- IsActive
 UPDATE AD_UI_Element
 SET AD_UI_ElementGroup_ID = 554985,
     SeqNo = 20,
-    Updated = now(),
+    Updated = TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'),
     UpdatedBy = 100
 WHERE AD_UI_Element_ID = 648481;  -- AD_Org_ID
 
 UPDATE AD_UI_Element
 SET AD_UI_ElementGroup_ID = 554985,
     SeqNo = 30,
-    Updated = now(),
+    Updated = TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'),
     UpdatedBy = 100
 WHERE AD_UI_Element_ID = 648482;  -- AD_Client_ID
 
@@ -72,7 +72,7 @@ WHERE AD_UI_Element_ID = 648482;  -- AD_Client_ID
 UPDATE AD_UI_Element
 SET SeqNoGrid = 50,
     IsDisplayedGrid = 'Y',
-    Updated = now(),
+    Updated = TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'),
     UpdatedBy = 100
 WHERE AD_UI_Element_ID = 648481;  -- AD_Org_ID
 
@@ -81,6 +81,6 @@ WHERE AD_UI_Element_ID = 648481;  -- AD_Org_ID
 -- ==========================================================================
 UPDATE AD_Tab
 SET OrderByClause = 'Name',
-    Updated = now(),
+    Updated = TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'),
     UpdatedBy = 100
 WHERE AD_Tab_ID = 549080;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792670_sys_gh28565_PromotionCode_Window_DesignGuide.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792670_sys_gh28565_PromotionCode_Window_DesignGuide.sql
@@ -1,0 +1,86 @@
+-- gh#28565: Apply WebUI design guide to Promotion Code window (542105)
+--
+-- Design guide rules applied:
+-- 1. Two-column layout: left = mandatory/important fields, right = checkboxes/switches + Org/Client
+-- 2. IsActive must be the first field in the right column
+-- 3. AD_Org_ID and AD_Client_ID as the last fields in the right column
+-- 4. AD_Org_ID shown in grid view as the last column
+-- 5. Grid view sorted by Name ascending (master data default)
+--
+-- Before:
+--   Single column with all fields. IsActive at seqno 40 (middle of left column).
+--   AD_Org_ID not in grid view. No sort order defined.
+--
+-- After:
+--   Left column: Value, Name, Description, ValidTo (mandatory/important fields)
+--   Right column: IsActive (first), AD_Org_ID, AD_Client_ID (last two)
+--   Grid: Value, Name, Description, ValidTo, IsActive, AD_Org_ID (last)
+--   Sort: Name ascending
+
+-- ==========================================================================
+-- 1. Create right UI column (seqno 20)
+-- ==========================================================================
+INSERT INTO AD_UI_Column (
+  AD_Client_ID, AD_Org_ID, AD_UI_Column_ID, AD_UI_Section_ID,
+  Created, CreatedBy, IsActive, SeqNo, Updated, UpdatedBy
+) VALUES (
+  0, 0, 549276, 547597,
+  now(), 100, 'Y', 20, now(), 100
+);
+
+-- ==========================================================================
+-- 2. Create element group in the right column
+-- ==========================================================================
+INSERT INTO AD_UI_ElementGroup (
+  AD_Client_ID, AD_Org_ID, AD_UI_Column_ID, AD_UI_ElementGroup_ID,
+  Created, CreatedBy, IsActive, Name, SeqNo, UIStyle, Updated, UpdatedBy
+) VALUES (
+  0, 0, 549276, 554985,
+  now(), 100, 'Y', 'flags', 10, 'primary', now(), 100
+);
+
+-- ==========================================================================
+-- 3. Move IsActive to the right column (first field, seqno 10)
+-- ==========================================================================
+UPDATE AD_UI_Element
+SET AD_UI_ElementGroup_ID = 554985,
+    SeqNo = 10,
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_UI_Element_ID = 648480;  -- IsActive
+
+-- ==========================================================================
+-- 4. Move AD_Org_ID and AD_Client_ID to the right column (last two fields)
+-- ==========================================================================
+UPDATE AD_UI_Element
+SET AD_UI_ElementGroup_ID = 554985,
+    SeqNo = 20,
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_UI_Element_ID = 648481;  -- AD_Org_ID
+
+UPDATE AD_UI_Element
+SET AD_UI_ElementGroup_ID = 554985,
+    SeqNo = 30,
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_UI_Element_ID = 648482;  -- AD_Client_ID
+
+-- ==========================================================================
+-- 5. Add AD_Org_ID to grid view as the last column (seqnogrid=50)
+-- ==========================================================================
+UPDATE AD_UI_Element
+SET SeqNoGrid = 50,
+    IsDisplayedGrid = 'Y',
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_UI_Element_ID = 648481;  -- AD_Org_ID
+
+-- ==========================================================================
+-- 6. Set grid sort to Name ascending (master data default)
+-- ==========================================================================
+UPDATE AD_Tab
+SET OrderByClause = 'Name',
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_Tab_ID = 549080;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792750_sys_gh28565_PromotionCode_Menu_Placement.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792750_sys_gh28565_PromotionCode_Menu_Placement.sql
@@ -1,0 +1,33 @@
+-- gh#28565: Place Promotion Code menu entries under Verkauf > Aufträge (457)
+--
+-- Both menu entries were created at root level (Parent_ID=0, SeqNo=999).
+-- Move them under the "Aufträge" (Orders) folder where they belong.
+--
+-- 542302 = Aktionskennzeichen (Window)
+-- 542303 = Aktionskennzeichen Auswertung (Report)
+
+UPDATE AD_TreeNodeMM
+SET Parent_ID = 457,
+    SeqNo     = 17,
+    Updated   = TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'),
+    UpdatedBy = 100
+WHERE Node_ID = 542302
+  AND AD_Tree_ID = (SELECT MIN(AD_Tree_ID)
+                    FROM AD_Tree
+                    WHERE AD_Client_ID = 0
+                      AND IsActive = 'Y'
+                      AND IsAllNodes = 'Y'
+                      AND AD_Table_ID = 116);
+
+UPDATE AD_TreeNodeMM
+SET Parent_ID = 457,
+    SeqNo     = 18,
+    Updated   = TO_TIMESTAMP('2026-03-07', 'YYYY-MM-DD'),
+    UpdatedBy = 100
+WHERE Node_ID = 542303
+  AND AD_Tree_ID = (SELECT MIN(AD_Tree_ID)
+                    FROM AD_Tree
+                    WHERE AD_Client_ID = 0
+                      AND IsActive = 'Y'
+                      AND IsAllNodes = 'Y'
+                      AND AD_Table_ID = 116);

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/service/impl/AbstractInvoiceBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/service/impl/AbstractInvoiceBL.java
@@ -421,6 +421,8 @@ public abstract class AbstractInvoiceBL implements IInvoiceBL
 
 		to.setC_Incoterms_ID(from.getC_Incoterms_ID());
 		to.setIncotermLocation(from.getIncotermLocation());
+		to.setC_PromotionCode_ID(from.getC_PromotionCode_ID());
+		to.setC_PromotionCode2_ID(from.getC_PromotionCode2_ID());
 
 		InterfaceWrapperHelper.save(to);
 
@@ -722,6 +724,8 @@ public abstract class AbstractInvoiceBL implements IInvoiceBL
 
 		invoice2.setC_Incoterms_ID(order2.getC_Incoterms_ID());
 		invoice2.setIncotermLocation(order2.getIncotermLocation());
+		invoice2.setC_PromotionCode_ID(order2.getC_PromotionCode_ID());
+		invoice2.setC_PromotionCode2_ID(order2.getC_PromotionCode2_ID());
 
 		invoice2.setBPartnerAddress(order2.getBillToAddress());
 		invoice2.setIsUseBPartnerAddress(order2.isUseBillToAddress());

--- a/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
@@ -250,6 +250,19 @@ public class C_Order
 		orderBL.setIncoterms(order);
 	}
 
+	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE },
+			ifColumnsChanged = { I_C_Order.COLUMNNAME_C_PromotionCode_ID, I_C_Order.COLUMNNAME_C_PromotionCode2_ID })
+	public void validateNoDuplicatePromotionCode(@NonNull final I_C_Order order)
+	{
+		final int code1 = order.getC_PromotionCode_ID();
+		final int code2 = order.getC_PromotionCode2_ID();
+		if (code1 > 0 && code2 > 0 && code1 == code2)
+		{
+			throw new AdempiereException("@C_PromotionCode_DuplicateError@")
+					.markAsUserValidationError();
+		}
+	}
+
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_CHANGE }, ifColumnsChanged = { I_C_Order.COLUMNNAME_C_BPartner_ID })
 	public void setDeliveryViaRule(final I_C_Order order)
 	{

--- a/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
@@ -50,6 +50,7 @@ import de.metas.order.OrderId;
 import de.metas.order.impl.OrderLineDetailRepository;
 import de.metas.order.location.OrderLocationsUpdater;
 import de.metas.order.paymentschedule.service.OrderPayScheduleService;
+import de.metas.promotioncode.PromotionCodeId;
 import de.metas.organization.IOrgDAO;
 import de.metas.organization.OrgId;
 import de.metas.payment.PaymentRule;
@@ -254,9 +255,9 @@ public class C_Order
 			ifColumnsChanged = { I_C_Order.COLUMNNAME_C_PromotionCode_ID, I_C_Order.COLUMNNAME_C_PromotionCode2_ID })
 	public void validateNoDuplicatePromotionCode(@NonNull final I_C_Order order)
 	{
-		final int code1 = order.getC_PromotionCode_ID();
-		final int code2 = order.getC_PromotionCode2_ID();
-		if (code1 > 0 && code2 > 0 && code1 == code2)
+		final PromotionCodeId code1 = PromotionCodeId.ofRepoIdOrNull(order.getC_PromotionCode_ID());
+		final PromotionCodeId code2 = PromotionCodeId.ofRepoIdOrNull(order.getC_PromotionCode2_ID());
+		if (code1 != null && code2 != null && code1.equals(code2))
 		{
 			throw new AdempiereException("@C_PromotionCode_DuplicateError@")
 					.markAsUserValidationError();

--- a/backend/de.metas.business/src/main/java/de/metas/promotioncode/PromotionCodeId.java
+++ b/backend/de.metas.business/src/main/java/de/metas/promotioncode/PromotionCodeId.java
@@ -1,0 +1,98 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.promotioncode;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import de.metas.util.Check;
+import de.metas.util.lang.RepoIdAware;
+import de.metas.util.lang.RepoIdAwares;
+import lombok.NonNull;
+import lombok.Value;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.Optional;
+
+@JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, isGetterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
+@Value
+public class PromotionCodeId implements RepoIdAware
+{
+	int repoId;
+
+	public static PromotionCodeId ofRepoId(final int repoId)
+	{
+		return new PromotionCodeId(repoId);
+	}
+
+	@Nullable
+	public static PromotionCodeId ofRepoIdOrNull(@Nullable final Integer repoId)
+	{
+		return repoId != null && repoId > 0 ? new PromotionCodeId(repoId) : null;
+	}
+
+	@Nullable
+	public static PromotionCodeId ofRepoIdOrNull(final int repoId)
+	{
+		return repoId > 0 ? new PromotionCodeId(repoId) : null;
+	}
+
+	public static Optional<PromotionCodeId> optionalOfRepoId(final int repoId)
+	{
+		return Optional.ofNullable(ofRepoIdOrNull(repoId));
+	}
+
+	@JsonCreator
+	public static PromotionCodeId ofObject(@NonNull final Object object)
+	{
+		return RepoIdAwares.ofObject(object, PromotionCodeId.class, PromotionCodeId::ofRepoId);
+	}
+
+	public static int toRepoId(@Nullable final PromotionCodeId promotionCodeId)
+	{
+		return toRepoIdOr(promotionCodeId, -1);
+	}
+
+	public static int toRepoIdOr(@Nullable final PromotionCodeId promotionCodeId, final int defaultValue)
+	{
+		return promotionCodeId != null ? promotionCodeId.getRepoId() : defaultValue;
+	}
+
+	private PromotionCodeId(final int repoId)
+	{
+		this.repoId = Check.assumeGreaterThanZero(repoId, "C_PromotionCode_ID");
+	}
+
+	@JsonValue
+	public int toJson()
+	{
+		return getRepoId();
+	}
+
+	public static boolean equals(@Nullable final PromotionCodeId o1, @Nullable final PromotionCodeId o2)
+	{
+		return Objects.equals(o1, o2);
+	}
+}

--- a/backend/de.metas.business/src/main/java/de/metas/promotioncode/PromotionCodeId.java
+++ b/backend/de.metas.business/src/main/java/de/metas/promotioncode/PromotionCodeId.java
@@ -72,7 +72,7 @@ public class PromotionCodeId implements RepoIdAware
 
 	public static int toRepoId(@Nullable final PromotionCodeId promotionCodeId)
 	{
-		return toRepoIdOr(promotionCodeId, -1);
+		return toRepoIdOr(promotionCodeId, 0);
 	}
 
 	public static int toRepoIdOr(@Nullable final PromotionCodeId promotionCodeId, final int defaultValue)

--- a/backend/de.metas.business/src/test/java/de/metas/order/model/interceptor/C_Order_PromotionCodeTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/model/interceptor/C_Order_PromotionCodeTest.java
@@ -41,7 +41,8 @@ class C_Order_PromotionCodeTest
 		order.setC_PromotionCode2_ID(100);
 
 		assertThatThrownBy(() -> interceptor.validateNoDuplicatePromotionCode(order))
-				.isInstanceOf(AdempiereException.class);
+				.isInstanceOf(AdempiereException.class)
+				.satisfies(ex -> assertThat(((AdempiereException)ex).isUserValidationError()).isTrue());
 	}
 
 	@Test

--- a/backend/de.metas.business/src/test/java/de/metas/order/model/interceptor/C_Order_PromotionCodeTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/model/interceptor/C_Order_PromotionCodeTest.java
@@ -1,0 +1,76 @@
+package de.metas.order.model.interceptor;
+
+import de.metas.bpartner.BPartnerSupplierApprovalService;
+import de.metas.bpartner.service.IBPartnerBL;
+import de.metas.document.location.IDocumentLocationBL;
+import de.metas.order.impl.OrderLineDetailRepository;
+import de.metas.order.paymentschedule.service.OrderPayScheduleService;
+import de.metas.shipping.PurchaseOrderToShipperTransportationService;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import de.metas.adempiere.model.I_C_Order;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class C_Order_PromotionCodeTest
+{
+	private C_Order interceptor;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		interceptor = new C_Order(
+				mock(IBPartnerBL.class),
+				mock(OrderLineDetailRepository.class),
+				mock(IDocumentLocationBL.class),
+				mock(BPartnerSupplierApprovalService.class),
+				mock(PurchaseOrderToShipperTransportationService.class),
+				mock(OrderPayScheduleService.class));
+	}
+
+	@Test
+	void sameCode_throws()
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setC_PromotionCode_ID(100);
+		order.setC_PromotionCode2_ID(100);
+
+		assertThatThrownBy(() -> interceptor.validateNoDuplicatePromotionCode(order))
+				.isInstanceOf(AdempiereException.class);
+	}
+
+	@Test
+	void differentCodes_passes()
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setC_PromotionCode_ID(100);
+		order.setC_PromotionCode2_ID(200);
+
+		assertThatCode(() -> interceptor.validateNoDuplicatePromotionCode(order))
+				.doesNotThrowAnyException();
+	}
+
+	@Test
+	void onlyOneCodeSet_passes()
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setC_PromotionCode_ID(100);
+
+		assertThatCode(() -> interceptor.validateNoDuplicatePromotionCode(order))
+				.doesNotThrowAnyException();
+	}
+
+	@Test
+	void bothCodesZero_passes()
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+
+		assertThatCode(() -> interceptor.validateNoDuplicatePromotionCode(order))
+				.doesNotThrowAnyException();
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_StepDef.java
@@ -188,6 +188,15 @@ public class C_Invoice_StepDef
 	private final TestContext restTestContext;
 	private final C_PromotionCode_StepDefData promotionCodeTable;
 
+	/**
+	 * Validates {@code C_Invoice} records against expected values.
+	 * <p>
+	 * gh#28565: Added validation for promotion code columns:
+	 * <ul>
+	 *   <li>{@code C_PromotionCode_ID} (optional) — identifier referencing the expected {@code C_PromotionCode}</li>
+	 *   <li>{@code C_PromotionCode2_ID} (optional) — identifier referencing the expected second {@code C_PromotionCode}</li>
+	 * </ul>
+	 */
 	@And("validate created invoices")
 	public void validate_created_invoices(@NonNull final DataTable table)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_StepDef.java
@@ -47,6 +47,7 @@ import de.metas.cucumber.stepdefs.doctype.C_DocType_StepDefData;
 import de.metas.cucumber.stepdefs.invoicecandidate.C_Invoice_Candidate_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_OrderLine_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
+import de.metas.cucumber.stepdefs.promotioncode.C_PromotionCode_StepDefData;
 import de.metas.cucumber.stepdefs.paymentterm.C_PaymentTerm_StepDef;
 import de.metas.cucumber.stepdefs.project.C_Project_StepDefData;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
@@ -185,6 +186,7 @@ public class C_Invoice_StepDef
 	private final M_Warehouse_StepDefData warehouseTable;
 	private final C_PaymentTerm_StepDef paymentTermStepDef;
 	private final TestContext restTestContext;
+	private final C_PromotionCode_StepDefData promotionCodeTable;
 
 	@And("validate created invoices")
 	public void validate_created_invoices(@NonNull final DataTable table)
@@ -407,6 +409,17 @@ public class C_Invoice_StepDef
 
 		row.getAsOptionalEnum(I_C_Invoice.COLUMNNAME_PaymentRule, PaymentRule.class)
 				.ifPresent(paymentRule -> softly.assertThat(invoice.getPaymentRule()).as("PaymentRule").isEqualTo(paymentRule.getCode()));
+
+		row.getAsOptionalIdentifier(I_C_Invoice.COLUMNNAME_C_PromotionCode_ID)
+				.map(promotionCodeTable::get)
+				.ifPresent(promoCode -> softly.assertThat(invoice.getC_PromotionCode_ID())
+						.as("C_PromotionCode_ID for Identifier=%s", identifierStr)
+						.isEqualTo(promoCode.getC_PromotionCode_ID()));
+		row.getAsOptionalIdentifier(I_C_Invoice.COLUMNNAME_C_PromotionCode2_ID)
+				.map(promotionCodeTable::get)
+				.ifPresent(promoCode -> softly.assertThat(invoice.getC_PromotionCode2_ID())
+						.as("C_PromotionCode2_ID for Identifier=%s", identifierStr)
+						.isEqualTo(promoCode.getC_PromotionCode_ID()));
 
 		row.getAsOptionalString(I_C_Invoice.COLUMNNAME_AD_InputDataSource_ID + "." + I_AD_InputDataSource.COLUMNNAME_InternalName)
 				.ifPresent(internalName -> {

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -41,6 +41,7 @@ import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_OrderLine_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
 import de.metas.cucumber.stepdefs.project.C_Project_StepDefData;
+import de.metas.cucumber.stepdefs.promotioncode.C_PromotionCode_StepDefData;
 import de.metas.cucumber.stepdefs.shipment.M_InOutLine_StepDefData;
 import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
 import de.metas.document.DocTypeId;
@@ -173,6 +174,7 @@ public class C_Invoice_Candidate_StepDef
 	private final M_InOutLine_StepDefData inoutLineTable;
 	private final M_InOut_StepDefData shipmentTable;
 	private final C_Project_StepDefData projectTable;
+	private final C_PromotionCode_StepDefData promotionCodeTable;
 
 	public C_Invoice_Candidate_StepDef(
 			@NonNull final C_Invoice_Candidate_StepDefData invoiceCandTable,
@@ -471,6 +473,13 @@ public class C_Invoice_Candidate_StepDef
 						{
 							assertThat(updatedInvoiceCandidate.getQtyWithIssues_Effective()).isEqualTo(qtyWithIssuesEffective);
 						}
+
+						row.getAsOptionalIdentifier(I_C_Invoice_Candidate.COLUMNNAME_C_PromotionCode_ID)
+								.map(promotionCodeTable::get)
+								.ifPresent(promoCode -> assertThat(updatedInvoiceCandidate.getC_PromotionCode_ID()).as("C_PromotionCode_ID").isEqualTo(promoCode.getC_PromotionCode_ID()));
+						row.getAsOptionalIdentifier(I_C_Invoice_Candidate.COLUMNNAME_C_PromotionCode2_ID)
+								.map(promotionCodeTable::get)
+								.ifPresent(promoCode -> assertThat(updatedInvoiceCandidate.getC_PromotionCode2_ID()).as("C_PromotionCode2_ID").isEqualTo(promoCode.getC_PromotionCode_ID()));
 
 						final LocalDate deliveryDate = TimeUtil.asLocalDate(updatedInvoiceCandidate.getDeliveryDate());
 						row.getAsOptionalLocalDate(I_C_Invoice_Candidate.COLUMNNAME_DeliveryDate)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -228,6 +228,15 @@ public class C_Invoice_Candidate_StepDef
 		}
 	}
 
+	/**
+	 * Finds and validates {@code C_Invoice_Candidate} records.
+	 * <p>
+	 * gh#28565: Added support for promotion code validation columns:
+	 * <ul>
+	 *   <li>{@code C_PromotionCode_ID} (optional) — identifier referencing the expected {@code C_PromotionCode}</li>
+	 *   <li>{@code C_PromotionCode2_ID} (optional) — identifier referencing the expected second {@code C_PromotionCode}</li>
+	 * </ul>
+	 */
 	@And("^after not more than (.*)s, C_Invoice_Candidate are found:$")
 	public void find_C_Invoice_Candidate(final int timeoutSec, @NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -187,7 +187,8 @@ public class C_Invoice_Candidate_StepDef
 			@NonNull final C_Tax_StepDefData taxTable,
 			@NonNull final M_InOutLine_StepDefData inoutLineTable,
 			@NonNull final M_InOut_StepDefData shipmentTable,
-			@NonNull final C_Project_StepDefData projectTable)
+			@NonNull final C_Project_StepDefData projectTable,
+			@NonNull final C_PromotionCode_StepDefData promotionCodeTable)
 	{
 		this.invoiceCandTable = invoiceCandTable;
 		this.invoiceTable = invoiceTable;
@@ -200,6 +201,7 @@ public class C_Invoice_Candidate_StepDef
 		this.inoutLineTable = inoutLineTable;
 		this.shipmentTable = shipmentTable;
 		this.projectTable = projectTable;
+		this.promotionCodeTable = promotionCodeTable;
 	}
 
 	@And("^locate invoice candidates for invoice: (.*)$")
@@ -474,12 +476,13 @@ public class C_Invoice_Candidate_StepDef
 							assertThat(updatedInvoiceCandidate.getQtyWithIssues_Effective()).isEqualTo(qtyWithIssuesEffective);
 						}
 
+						final I_C_Invoice_Candidate icForPromoCodeCheck = updatedInvoiceCandidate;
 						row.getAsOptionalIdentifier(I_C_Invoice_Candidate.COLUMNNAME_C_PromotionCode_ID)
 								.map(promotionCodeTable::get)
-								.ifPresent(promoCode -> assertThat(updatedInvoiceCandidate.getC_PromotionCode_ID()).as("C_PromotionCode_ID").isEqualTo(promoCode.getC_PromotionCode_ID()));
+								.ifPresent(promoCode -> assertThat(icForPromoCodeCheck.getC_PromotionCode_ID()).as("C_PromotionCode_ID").isEqualTo(promoCode.getC_PromotionCode_ID()));
 						row.getAsOptionalIdentifier(I_C_Invoice_Candidate.COLUMNNAME_C_PromotionCode2_ID)
 								.map(promotionCodeTable::get)
-								.ifPresent(promoCode -> assertThat(updatedInvoiceCandidate.getC_PromotionCode2_ID()).as("C_PromotionCode2_ID").isEqualTo(promoCode.getC_PromotionCode_ID()));
+								.ifPresent(promoCode -> assertThat(icForPromoCodeCheck.getC_PromotionCode2_ID()).as("C_PromotionCode2_ID").isEqualTo(promoCode.getC_PromotionCode_ID()));
 
 						final LocalDate deliveryDate = TimeUtil.asLocalDate(updatedInvoiceCandidate.getDeliveryDate());
 						row.getAsOptionalLocalDate(I_C_Invoice_Candidate.COLUMNNAME_DeliveryDate)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
@@ -221,6 +221,15 @@ public class C_Order_StepDef
 		completeOrder(order);
 	}
 
+	/**
+	 * Creates {@code C_Order} records.
+	 * <p>
+	 * gh#28565: Added support for promotion code columns:
+	 * <ul>
+	 *   <li>{@code C_PromotionCode_ID} (optional) — identifier referencing a {@code C_PromotionCode} record</li>
+	 *   <li>{@code C_PromotionCode2_ID} (optional) — identifier referencing a second {@code C_PromotionCode} record</li>
+	 * </ul>
+	 */
 	@Given("metasfresh contains C_Orders:")
 	public void metasfresh_contains_c_orders(@NonNull final DataTable dataTable)
 	{
@@ -649,6 +658,15 @@ public class C_Order_StepDef
 				.ifPresent(orderIdentifier -> orderTable.putOrReplace(orderIdentifier, purchaseOrderRecord));
 	}
 
+	/**
+	 * Validates {@code C_Order} records against expected values.
+	 * <p>
+	 * gh#28565: Added validation for promotion code columns:
+	 * <ul>
+	 *   <li>{@code C_PromotionCode_ID} (optional) — identifier referencing the expected {@code C_PromotionCode}</li>
+	 *   <li>{@code C_PromotionCode2_ID} (optional) — identifier referencing the expected second {@code C_PromotionCode}</li>
+	 * </ul>
+	 */
 	@And("validate the created orders")
 	public void validate_created_order(@NonNull final DataTable table)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
@@ -62,6 +62,7 @@ import de.metas.externalsystem.model.I_ExternalSystem;
 import de.metas.impex.api.IInputDataSourceDAO;
 import de.metas.impex.model.I_AD_InputDataSource;
 import de.metas.impexp.InputDataSourceId;
+import de.metas.cucumber.stepdefs.promotioncode.C_PromotionCode_StepDefData;
 import de.metas.incoterms.IncotermsId;
 import de.metas.incoterms.IncotermsRepository;
 import de.metas.lang.SOTrx;
@@ -197,6 +198,7 @@ public class C_Order_StepDef
 	@NonNull private final C_PaymentTerm_StepDef paymentTermStepDef;
 	@NonNull private final M_Shipper_StepDefData shipperTable;
 	@NonNull private final C_Project_StepDefData projectTable;
+	@NonNull private final C_PromotionCode_StepDefData promotionCodeTable;
 
 	@Given("simple completed order with one line")
 	public void createAndCompleteSimpleOrders(@NonNull final DataTable dataTable)
@@ -430,6 +432,13 @@ public class C_Order_StepDef
 				.map(projectTable::extractIdFromRecord)
 				.map(ProjectId::getRepoId)
 				.ifPresent(order::setC_Project_ID);
+
+		tableRow.getAsOptionalIdentifier(I_C_Order.COLUMNNAME_C_PromotionCode_ID)
+				.map(promotionCodeTable::get)
+				.ifPresent(promoCode -> order.setC_PromotionCode_ID(promoCode.getC_PromotionCode_ID()));
+		tableRow.getAsOptionalIdentifier(I_C_Order.COLUMNNAME_C_PromotionCode2_ID)
+				.map(promotionCodeTable::get)
+				.ifPresent(promoCode -> order.setC_PromotionCode2_ID(promoCode.getC_PromotionCode_ID()));
 
 		saveRecord(order);
 
@@ -847,6 +856,17 @@ public class C_Order_StepDef
 				.ifPresent(incotermValue -> softly.assertThat(IncotermsId.equals(incotermsRepository.getByValue(incotermValue, orgId).getId(), IncotermsId.ofRepoIdOrNull(order.getC_Incoterms_ID())))
 						.as("C_Incoterms_ID for value %s", incotermValue).isTrue());
 		row.getAsOptionalString(COLUMNNAME_IncotermLocation).ifPresent(incotermLocation -> softly.assertThat(order.getIncotermLocation()).as(COLUMNNAME_IncotermLocation).isEqualTo(incotermLocation));
+
+		row.getAsOptionalIdentifier(I_C_Order.COLUMNNAME_C_PromotionCode_ID)
+				.map(promotionCodeTable::get)
+				.ifPresent(promoCode -> softly.assertThat(order.getC_PromotionCode_ID())
+						.as("C_PromotionCode_ID for Identifier=%s", identifierStr)
+						.isEqualTo(promoCode.getC_PromotionCode_ID()));
+		row.getAsOptionalIdentifier(I_C_Order.COLUMNNAME_C_PromotionCode2_ID)
+				.map(promotionCodeTable::get)
+				.ifPresent(promoCode -> softly.assertThat(order.getC_PromotionCode2_ID())
+						.as("C_PromotionCode2_ID for Identifier=%s", identifierStr)
+						.isEqualTo(promoCode.getC_PromotionCode_ID()));
 
 		final StepDefDataIdentifier projectIdentifier = row.getAsIdentifierOrNull(COLUMNNAME_C_Project_ID);
 		if (projectIdentifier != null)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/promotioncode/C_PromotionCode_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/promotioncode/C_PromotionCode_StepDef.java
@@ -16,6 +16,17 @@ public class C_PromotionCode_StepDef
 {
 	@NonNull private final C_PromotionCode_StepDefData promotionCodeTable;
 
+	/**
+	 * Creates {@code C_PromotionCode} master data records.
+	 *
+	 * <h3>DataTable columns:</h3>
+	 * <ul>
+	 *   <li>{@code Identifier} — record identifier for cross-step references</li>
+	 *   <li>{@code Value} (optional) — search key / code number</li>
+	 *   <li>{@code Name} (optional) — descriptive name</li>
+	 *   <li>{@code ValidTo} (optional) — expiry date (format: {@code yyyy-MM-dd})</li>
+	 * </ul>
+	 */
 	@Given("metasfresh contains C_PromotionCode:")
 	public void metasfresh_contains_c_promotioncode(@NonNull final DataTable dataTable)
 	{
@@ -30,8 +41,8 @@ public class C_PromotionCode_StepDef
 				.ifPresent(record::setValue);
 		row.getAsOptionalString(I_C_PromotionCode.COLUMNNAME_Name)
 				.ifPresent(record::setName);
-		row.getAsOptionalInstant(I_C_PromotionCode.COLUMNNAME_ValidTo)
-				.ifPresent(validTo -> record.setValidTo(java.sql.Timestamp.from(validTo)));
+		row.getAsOptionalLocalDate(I_C_PromotionCode.COLUMNNAME_ValidTo)
+				.ifPresent(validTo -> record.setValidTo(java.sql.Timestamp.valueOf(validTo.atStartOfDay())));
 
 		saveRecord(record);
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/promotioncode/C_PromotionCode_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/promotioncode/C_PromotionCode_StepDef.java
@@ -1,0 +1,41 @@
+package de.metas.cucumber.stepdefs.promotioncode;
+
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_C_PromotionCode;
+
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+
+@RequiredArgsConstructor
+public class C_PromotionCode_StepDef
+{
+	@NonNull private final C_PromotionCode_StepDefData promotionCodeTable;
+
+	@Given("metasfresh contains C_PromotionCode:")
+	public void metasfresh_contains_c_promotioncode(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::createPromotionCode);
+	}
+
+	private void createPromotionCode(@NonNull final DataTableRow row)
+	{
+		final I_C_PromotionCode record = InterfaceWrapperHelper.newInstance(I_C_PromotionCode.class);
+
+		row.getAsOptionalString(I_C_PromotionCode.COLUMNNAME_Value)
+				.ifPresent(record::setValue);
+		row.getAsOptionalString(I_C_PromotionCode.COLUMNNAME_Name)
+				.ifPresent(record::setName);
+		row.getAsOptionalInstant(I_C_PromotionCode.COLUMNNAME_ValidTo)
+				.ifPresent(validTo -> record.setValidTo(java.sql.Timestamp.from(validTo)));
+
+		saveRecord(record);
+
+		row.getAsOptionalIdentifier()
+				.ifPresent(identifier -> promotionCodeTable.putOrReplace(identifier, record));
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/promotioncode/C_PromotionCode_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/promotioncode/C_PromotionCode_StepDef.java
@@ -1,7 +1,8 @@
 package de.metas.cucumber.stepdefs.promotioncode;
 
-import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.ValueAndName;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Given;
 import lombok.NonNull;
@@ -22,8 +23,9 @@ public class C_PromotionCode_StepDef
 	 * <h3>DataTable columns:</h3>
 	 * <ul>
 	 *   <li>{@code Identifier} — record identifier for cross-step references</li>
-	 *   <li>{@code Value} (optional) — search key / code number</li>
-	 *   <li>{@code Name} (optional) — descriptive name</li>
+	 *   <li>{@code Value} (optional) — search key / code number (auto-generated if omitted)</li>
+	 *   <li>{@code Name} (optional) — descriptive name (auto-generated if omitted)</li>
+	 *   <li>{@code Description} (optional) — description text</li>
 	 *   <li>{@code ValidTo} (optional) — expiry date (format: {@code yyyy-MM-dd})</li>
 	 * </ul>
 	 */
@@ -37,10 +39,12 @@ public class C_PromotionCode_StepDef
 	{
 		final I_C_PromotionCode record = InterfaceWrapperHelper.newInstance(I_C_PromotionCode.class);
 
-		row.getAsOptionalString(I_C_PromotionCode.COLUMNNAME_Value)
-				.ifPresent(record::setValue);
-		row.getAsOptionalString(I_C_PromotionCode.COLUMNNAME_Name)
-				.ifPresent(record::setName);
+		final ValueAndName valueAndName = row.suggestValueAndName();
+		record.setValue(valueAndName.getValue());
+		record.setName(valueAndName.getName());
+
+		row.getAsOptionalString(I_C_PromotionCode.COLUMNNAME_Description)
+				.ifPresent(record::setDescription);
 		row.getAsOptionalLocalDate(I_C_PromotionCode.COLUMNNAME_ValidTo)
 				.ifPresent(validTo -> record.setValidTo(java.sql.Timestamp.valueOf(validTo.atStartOfDay())));
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/promotioncode/C_PromotionCode_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/promotioncode/C_PromotionCode_StepDefData.java
@@ -1,0 +1,12 @@
+package de.metas.cucumber.stepdefs.promotioncode;
+
+import de.metas.cucumber.stepdefs.StepDefData;
+import org.compiere.model.I_C_PromotionCode;
+
+public class C_PromotionCode_StepDefData extends StepDefData<I_C_PromotionCode>
+{
+	public C_PromotionCode_StepDefData()
+	{
+		super(I_C_PromotionCode.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/promotionCode/promotionCode.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/promotionCode/promotionCode.feature
@@ -22,8 +22,8 @@ Feature: Validate that C_PromotionCode fields propagate from C_Order through C_I
       | Identifier          | M_PriceList_ID |
       | priceListVersion_SO | priceList_SO   |
     And metasfresh contains M_ProductPrices
-      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | priceListVersion_SO    | product_1    | 10.0     | PCE               | Normal                        |
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 |
+      | priceListVersion_SO    | product_1    | 10.0     | PCE               |
 
   @from:cucumber
   Scenario: One promotion code propagates from C_Order to C_Invoice via IC flow

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/promotionCode/promotionCode.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/promotionCode/promotionCode.feature
@@ -9,107 +9,107 @@ Feature: Validate that C_PromotionCode fields propagate from C_Order through C_I
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
 
     And metasfresh contains M_Products:
-      | Identifier | Name    |
-      | product_1  | product |
+      | Identifier |
+      | product_1  |
     And metasfresh contains M_PricingSystems
-      | Identifier   | Name           | Value           |
-      | pricingSys_1 | pricingSysName | pricingSysValue |
+      | Identifier   |
+      | pricingSys_1 |
 
     And metasfresh contains M_PriceLists
-      | Identifier   | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name         | SOTrx | IsTaxIncluded | PricePrecision |
-      | priceList_SO | pricingSys_1                  | DE                        | EUR                 | priceList_SO | true  | false         | 2              |
+      | Identifier   | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | Name         | SOTrx | IsTaxIncluded | PricePrecision |
+      | priceList_SO | pricingSys_1       | DE                    | EUR                 | priceList_SO | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
-      | Identifier          | M_PriceList_ID.Identifier | Name              | ValidFrom  |
-      | priceListVersion_SO | priceList_SO              | salesOrder-PLV    | 2026-02-01 |
+      | Identifier          | M_PriceList_ID | Name           | ValidFrom  |
+      | priceListVersion_SO | priceList_SO   | salesOrder-PLV | 2026-02-01 |
     And metasfresh contains M_ProductPrices
-      | Identifier       | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | productPrices_SO | priceListVersion_SO               | product_1               | 10.0     | PCE               | Normal                        |
+      | Identifier       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | productPrices_SO | priceListVersion_SO    | product_1    | 10.0     | PCE               | Normal                        |
 
   @from:cucumber
   Scenario: One promotion code propagates from C_Order to C_Invoice via IC flow
     Given metasfresh contains C_PromotionCode:
-      | Identifier  | Value | Name               |
-      | promoCode_1 | PC001 | Summer Campaign    |
+      | Identifier  |
+      | promoCode_1 |
 
     And metasfresh contains C_BPartners:
-      | Identifier | Name              | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
-      | bpartner_1 | PromoCodeCustomer | N            | Y              | pricingSys_1                  | I               |
+      | Identifier | Name              | IsVendor | IsCustomer | M_PricingSystem_ID | InvoiceRule |
+      | bpartner_1 | PromoCodeCustomer | N        | Y          | pricingSys_1       | I           |
     And metasfresh contains C_BPartner_Locations:
-      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
-      | location_1 | 0285656789011 | bpartner_1               | Y                   | Y                   |
+      | Identifier | GLN           | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | location_1 | 0285656789011 | bpartner_1    | Y               | Y               |
 
     And metasfresh contains C_Orders:
-      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference      | C_PromotionCode_ID |
-      | order_1    | true    | bpartner_1               | 2026-03-05  | PromoCode_OneCode_SO | promoCode_1        |
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference          | C_PromotionCode_ID |
+      | order_1    | true    | bpartner_1    | 2026-03-05  | PromoCode_OneCode_SO | promoCode_1        |
     And metasfresh contains C_OrderLines:
-      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
-      | ol_1       | order_1               | product_1               | 10         |
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | ol_1       | order_1    | product_1    | 10         |
 
     When the order identified by order_1 is completed
 
     Then validate the created orders
-      | C_Order_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | DeliveryRule | DeliveryViaRule | OPT.POReference      | processed | DocStatus | C_PromotionCode_ID |
-      | order_1               | bpartner_1               | location_1                        | 2026-03-05  | SOO         | EUR          | F            | P               | PromoCode_OneCode_SO | true      | CO        | promoCode_1        |
+      | C_Order_ID | C_BPartner_ID | C_BPartner_Location_ID | DateOrdered | DocBaseType | currencyCode | DeliveryRule | DeliveryViaRule | POReference          | processed | DocStatus | C_PromotionCode_ID |
+      | order_1    | bpartner_1    | location_1             | 2026-03-05  | SOO         | EUR          | F            | P               | PromoCode_OneCode_SO | true      | CO        | promoCode_1        |
 
     And after not more than 60s locate up2date invoice candidates by order line:
-      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier |
-      | invoice_candidate_1               | ol_1                      |
+      | C_Invoice_Candidate_ID | C_OrderLine_ID |
+      | invoice_candidate_1    | ol_1           |
     And validate C_Invoice_Candidate:
-      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | QtyToInvoice | C_PromotionCode_ID |
-      | invoice_candidate_1               | order_1                   | ol_1                          | 10           | promoCode_1        |
+      | C_Invoice_Candidate_ID | C_Order_ID | C_OrderLine_ID | QtyToInvoice | C_PromotionCode_ID |
+      | invoice_candidate_1    | order_1    | ol_1           | 10           | promoCode_1        |
 
     And process invoice candidates
-      | C_Invoice_Candidate_ID.Identifier |
-      | invoice_candidate_1               |
+      | C_Invoice_Candidate_ID |
+      | invoice_candidate_1    |
     And after not more than 60s, C_Invoice are found:
-      | C_Invoice_ID.Identifier | C_Invoice_Candidate_ID.Identifier |
-      | invoice_1               | invoice_candidate_1               |
+      | C_Invoice_ID | C_Invoice_Candidate_ID |
+      | invoice_1    | invoice_candidate_1    |
 
     And validate created invoices
-      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | OPT.POReference      | processed | DocStatus | C_PromotionCode_ID |
-      | invoice_1               | bpartner_1               | location_1                        | PromoCode_OneCode_SO | true      | CO        | promoCode_1        |
+      | C_Invoice_ID | C_BPartner_ID | C_BPartner_Location_ID | POReference          | processed | DocStatus | C_PromotionCode_ID |
+      | invoice_1    | bpartner_1    | location_1             | PromoCode_OneCode_SO | true      | CO        | promoCode_1        |
 
   @from:cucumber
   Scenario: Two different promotion codes propagate from C_Order to C_Invoice via IC flow
     Given metasfresh contains C_PromotionCode:
-      | Identifier  | Value | Name               |
-      | promoCode_A | PC010 | Autumn Campaign    |
-      | promoCode_B | PC020 | Winter Campaign    |
+      | Identifier  |
+      | promoCode_A |
+      | promoCode_B |
 
     And metasfresh contains C_BPartners:
-      | Identifier | Name               | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
-      | bpartner_2 | PromoCodeCustomer2 | N            | Y              | pricingSys_1                  | I               |
+      | Identifier | Name               | IsVendor | IsCustomer | M_PricingSystem_ID | InvoiceRule |
+      | bpartner_2 | PromoCodeCustomer2 | N        | Y          | pricingSys_1       | I           |
     And metasfresh contains C_BPartner_Locations:
-      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
-      | location_2 | 0285656780022 | bpartner_2               | Y                   | Y                   |
+      | Identifier | GLN           | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | location_2 | 0285656780022 | bpartner_2    | Y               | Y               |
 
     And metasfresh contains C_Orders:
-      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference       | C_PromotionCode_ID | C_PromotionCode2_ID |
-      | order_2    | true    | bpartner_2               | 2026-03-05  | PromoCode_TwoCodes_SO | promoCode_A        | promoCode_B         |
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference           | C_PromotionCode_ID | C_PromotionCode2_ID |
+      | order_2    | true    | bpartner_2    | 2026-03-05  | PromoCode_TwoCodes_SO | promoCode_A        | promoCode_B         |
     And metasfresh contains C_OrderLines:
-      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
-      | ol_2       | order_2               | product_1               | 5          |
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | ol_2       | order_2    | product_1    | 5          |
 
     When the order identified by order_2 is completed
 
     Then validate the created orders
-      | C_Order_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | DeliveryRule | DeliveryViaRule | OPT.POReference       | processed | DocStatus | C_PromotionCode_ID | C_PromotionCode2_ID |
-      | order_2               | bpartner_2               | location_2                        | 2026-03-05  | SOO         | EUR          | F            | P               | PromoCode_TwoCodes_SO | true      | CO        | promoCode_A        | promoCode_B         |
+      | C_Order_ID | C_BPartner_ID | C_BPartner_Location_ID | DateOrdered | DocBaseType | currencyCode | DeliveryRule | DeliveryViaRule | POReference           | processed | DocStatus | C_PromotionCode_ID | C_PromotionCode2_ID |
+      | order_2    | bpartner_2    | location_2             | 2026-03-05  | SOO         | EUR          | F            | P               | PromoCode_TwoCodes_SO | true      | CO        | promoCode_A        | promoCode_B         |
 
     And after not more than 60s locate up2date invoice candidates by order line:
-      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier |
-      | invoice_candidate_2               | ol_2                      |
+      | C_Invoice_Candidate_ID | C_OrderLine_ID |
+      | invoice_candidate_2    | ol_2           |
     And validate C_Invoice_Candidate:
-      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | QtyToInvoice | C_PromotionCode_ID | C_PromotionCode2_ID |
-      | invoice_candidate_2               | order_2                   | ol_2                          | 5            | promoCode_A        | promoCode_B         |
+      | C_Invoice_Candidate_ID | C_Order_ID | C_OrderLine_ID | QtyToInvoice | C_PromotionCode_ID | C_PromotionCode2_ID |
+      | invoice_candidate_2    | order_2    | ol_2           | 5            | promoCode_A        | promoCode_B         |
 
     And process invoice candidates
-      | C_Invoice_Candidate_ID.Identifier |
-      | invoice_candidate_2               |
+      | C_Invoice_Candidate_ID |
+      | invoice_candidate_2    |
     And after not more than 60s, C_Invoice are found:
-      | C_Invoice_ID.Identifier | C_Invoice_Candidate_ID.Identifier |
-      | invoice_2               | invoice_candidate_2               |
+      | C_Invoice_ID | C_Invoice_Candidate_ID |
+      | invoice_2    | invoice_candidate_2    |
 
     And validate created invoices
-      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | OPT.POReference       | processed | DocStatus | C_PromotionCode_ID | C_PromotionCode2_ID |
-      | invoice_2               | bpartner_2               | location_2                        | PromoCode_TwoCodes_SO | true      | CO        | promoCode_A        | promoCode_B         |
+      | C_Invoice_ID | C_BPartner_ID | C_BPartner_Location_ID | POReference           | processed | DocStatus | C_PromotionCode_ID | C_PromotionCode2_ID |
+      | invoice_2    | bpartner_2    | location_2             | PromoCode_TwoCodes_SO | true      | CO        | promoCode_A        | promoCode_B         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/promotionCode/promotionCode.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/promotionCode/promotionCode.feature
@@ -16,14 +16,14 @@ Feature: Validate that C_PromotionCode fields propagate from C_Order through C_I
       | pricingSys_1 |
 
     And metasfresh contains M_PriceLists
-      | Identifier   | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | Name         | SOTrx | IsTaxIncluded | PricePrecision |
-      | priceList_SO | pricingSys_1       | DE                    | EUR                 | priceList_SO | true  | false         | 2              |
+      | Identifier   | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx | IsTaxIncluded | PricePrecision |
+      | priceList_SO | pricingSys_1       | DE                    | EUR                 | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
-      | Identifier          | M_PriceList_ID | Name           | ValidFrom  |
-      | priceListVersion_SO | priceList_SO   | salesOrder-PLV | 2026-02-01 |
+      | Identifier          | M_PriceList_ID |
+      | priceListVersion_SO | priceList_SO   |
     And metasfresh contains M_ProductPrices
-      | Identifier       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | productPrices_SO | priceListVersion_SO    | product_1    | 10.0     | PCE               | Normal                        |
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | priceListVersion_SO    | product_1    | 10.0     | PCE               | Normal                        |
 
   @from:cucumber
   Scenario: One promotion code propagates from C_Order to C_Invoice via IC flow

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/promotionCode/promotionCode.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/promotionCode/promotionCode.feature
@@ -1,0 +1,115 @@
+@from:cucumber
+@ghActions:run_on_executor6
+Feature: Validate that C_PromotionCode fields propagate from C_Order through C_Invoice_Candidate to C_Invoice
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2026-03-05T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+
+    And metasfresh contains M_Products:
+      | Identifier | Name    |
+      | product_1  | product |
+    And metasfresh contains M_PricingSystems
+      | Identifier   | Name           | Value           |
+      | pricingSys_1 | pricingSysName | pricingSysValue |
+
+    And metasfresh contains M_PriceLists
+      | Identifier   | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name         | SOTrx | IsTaxIncluded | PricePrecision |
+      | priceList_SO | pricingSys_1                  | DE                        | EUR                 | priceList_SO | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier          | M_PriceList_ID.Identifier | Name              | ValidFrom  |
+      | priceListVersion_SO | priceList_SO              | salesOrder-PLV    | 2026-02-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier       | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | productPrices_SO | priceListVersion_SO               | product_1               | 10.0     | PCE               | Normal                        |
+
+  @from:cucumber
+  Scenario: One promotion code propagates from C_Order to C_Invoice via IC flow
+    Given metasfresh contains C_PromotionCode:
+      | Identifier  | Value | Name               |
+      | promoCode_1 | PC001 | Summer Campaign    |
+
+    And metasfresh contains C_BPartners:
+      | Identifier | Name              | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | bpartner_1 | PromoCodeCustomer | N            | Y              | pricingSys_1                  | I               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | location_1 | 0285656789011 | bpartner_1               | Y                   | Y                   |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference      | C_PromotionCode_ID |
+      | order_1    | true    | bpartner_1               | 2026-03-05  | PromoCode_OneCode_SO | promoCode_1        |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_1       | order_1               | product_1               | 10         |
+
+    When the order identified by order_1 is completed
+
+    Then validate the created orders
+      | C_Order_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | DeliveryRule | DeliveryViaRule | OPT.POReference      | processed | DocStatus | C_PromotionCode_ID |
+      | order_1               | bpartner_1               | location_1                        | 2026-03-05  | SOO         | EUR          | F            | P               | PromoCode_OneCode_SO | true      | CO        | promoCode_1        |
+
+    And after not more than 60s locate up2date invoice candidates by order line:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier |
+      | invoice_candidate_1               | ol_1                      |
+    And validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | QtyToInvoice | C_PromotionCode_ID |
+      | invoice_candidate_1               | order_1                   | ol_1                          | 10           | promoCode_1        |
+
+    And process invoice candidates
+      | C_Invoice_Candidate_ID.Identifier |
+      | invoice_candidate_1               |
+    And after not more than 60s, C_Invoice are found:
+      | C_Invoice_ID.Identifier | C_Invoice_Candidate_ID.Identifier |
+      | invoice_1               | invoice_candidate_1               |
+
+    And validate created invoices
+      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | OPT.POReference      | processed | DocStatus | C_PromotionCode_ID |
+      | invoice_1               | bpartner_1               | location_1                        | PromoCode_OneCode_SO | true      | CO        | promoCode_1        |
+
+  @from:cucumber
+  Scenario: Two different promotion codes propagate from C_Order to C_Invoice via IC flow
+    Given metasfresh contains C_PromotionCode:
+      | Identifier  | Value | Name               |
+      | promoCode_A | PC010 | Autumn Campaign    |
+      | promoCode_B | PC020 | Winter Campaign    |
+
+    And metasfresh contains C_BPartners:
+      | Identifier | Name               | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | bpartner_2 | PromoCodeCustomer2 | N            | Y              | pricingSys_1                  | I               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | location_2 | 0285656780022 | bpartner_2               | Y                   | Y                   |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference       | C_PromotionCode_ID | C_PromotionCode2_ID |
+      | order_2    | true    | bpartner_2               | 2026-03-05  | PromoCode_TwoCodes_SO | promoCode_A        | promoCode_B         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_2       | order_2               | product_1               | 5          |
+
+    When the order identified by order_2 is completed
+
+    Then validate the created orders
+      | C_Order_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | DeliveryRule | DeliveryViaRule | OPT.POReference       | processed | DocStatus | C_PromotionCode_ID | C_PromotionCode2_ID |
+      | order_2               | bpartner_2               | location_2                        | 2026-03-05  | SOO         | EUR          | F            | P               | PromoCode_TwoCodes_SO | true      | CO        | promoCode_A        | promoCode_B         |
+
+    And after not more than 60s locate up2date invoice candidates by order line:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier |
+      | invoice_candidate_2               | ol_2                      |
+    And validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | OPT.C_OrderLine_ID.Identifier | QtyToInvoice | C_PromotionCode_ID | C_PromotionCode2_ID |
+      | invoice_candidate_2               | order_2                   | ol_2                          | 5            | promoCode_A        | promoCode_B         |
+
+    And process invoice candidates
+      | C_Invoice_Candidate_ID.Identifier |
+      | invoice_candidate_2               |
+    And after not more than 60s, C_Invoice are found:
+      | C_Invoice_ID.Identifier | C_Invoice_Candidate_ID.Identifier |
+      | invoice_2               | invoice_candidate_2               |
+
+    And validate created invoices
+      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | OPT.POReference       | processed | DocStatus | C_PromotionCode_ID | C_PromotionCode2_ID |
+      | invoice_2               | bpartner_2               | location_2                        | PromoCode_TwoCodes_SO | true      | CO        | promoCode_A        | promoCode_B         |

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/report_promotion_code_evaluation.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/report_promotion_code_evaluation.sql
@@ -1,0 +1,69 @@
+DROP FUNCTION IF EXISTS report.report_promotion_code_evaluation(
+    p_C_PromotionCode_ID  numeric,
+    p_C_PromotionCode2_ID numeric,
+    p_Invoiced            char(1)
+);
+
+CREATE OR REPLACE FUNCTION report.report_promotion_code_evaluation(
+    p_C_PromotionCode_ID  numeric DEFAULT NULL,
+    p_C_PromotionCode2_ID numeric DEFAULT NULL,
+    p_Invoiced            char(1) DEFAULT NULL
+)
+    RETURNS TABLE
+            (
+                PromotionCode1      varchar,
+                PromotionCode2      varchar,
+                OrderDocumentNo     varchar,
+                DateOrdered         date,
+                CustomerNo          varchar,
+                CustomerName        varchar,
+                TotalNetAmt         numeric,
+                TotalGrossAmt       numeric,
+                TotalTaxAmt         numeric,
+                Invoiced            char(1),
+                InvoiceDocumentNo   varchar,
+                DateInvoiced        date,
+                InvoiceCustomerNo   varchar,
+                InvoiceCustomerName varchar
+            )
+AS
+$$
+SELECT pc1.Value                                                 AS PromotionCode1,
+       pc2.Value                                                 AS PromotionCode2,
+       o.DocumentNo                                              AS OrderDocumentNo,
+       o.DateOrdered::date                                       AS DateOrdered,
+       bp_order.Value                                            AS CustomerNo,
+       bp_order.Name                                             AS CustomerName,
+       COALESCE(SUM(ic.NetAmtToInvoice), 0)                     AS TotalNetAmt,
+       COALESCE(SUM(ic.NetAmtToInvoice + ic.SplitAmt), 0)       AS TotalGrossAmt,
+       COALESCE(SUM(ic.SplitAmt), 0)                             AS TotalTaxAmt,
+       CASE WHEN i.C_Invoice_ID IS NOT NULL THEN 'Y' ELSE 'N' END AS Invoiced,
+       i.DocumentNo                                              AS InvoiceDocumentNo,
+       i.DateInvoiced::date                                      AS DateInvoiced,
+       bp_inv.Value                                              AS InvoiceCustomerNo,
+       bp_inv.Name                                               AS InvoiceCustomerName
+FROM C_Order o
+         LEFT JOIN C_PromotionCode pc1 ON o.C_PromotionCode_ID = pc1.C_PromotionCode_ID
+         LEFT JOIN C_PromotionCode pc2 ON o.C_PromotionCode2_ID = pc2.C_PromotionCode_ID
+         JOIN C_BPartner bp_order ON o.C_BPartner_ID = bp_order.C_BPartner_ID
+         LEFT JOIN C_Invoice_Candidate ic ON ic.C_Order_ID = o.C_Order_ID AND ic.IsActive = 'Y'
+         LEFT JOIN C_Invoice i ON ic.C_Invoice_ID = i.C_Invoice_ID AND i.IsActive = 'Y'
+         LEFT JOIN C_BPartner bp_inv ON i.C_BPartner_ID = bp_inv.C_BPartner_ID
+WHERE o.IsActive = 'Y'
+  AND o.IsSOTrx = 'Y'
+  AND (o.C_PromotionCode_ID IS NOT NULL OR o.C_PromotionCode2_ID IS NOT NULL)
+  AND (p_C_PromotionCode_ID IS NULL OR o.C_PromotionCode_ID = p_C_PromotionCode_ID)
+  AND (p_C_PromotionCode2_ID IS NULL OR o.C_PromotionCode2_ID = p_C_PromotionCode2_ID)
+  AND (p_Invoiced IS NULL
+    OR (p_Invoiced = 'Y' AND i.C_Invoice_ID IS NOT NULL)
+    OR (p_Invoiced = 'N' AND i.C_Invoice_ID IS NULL))
+GROUP BY pc1.Value, pc2.Value, o.DocumentNo, o.DateOrdered,
+         bp_order.Value, bp_order.Name,
+         i.C_Invoice_ID, i.DocumentNo, i.DateInvoiced,
+         bp_inv.Value, bp_inv.Name
+ORDER BY o.DateOrdered DESC, o.DocumentNo
+$$
+    LANGUAGE sql STABLE;
+
+COMMENT ON FUNCTION report.report_promotion_code_evaluation(numeric, numeric, char) IS
+    'gh#28565: Promotion Code Evaluation Report — shows orders with promotion codes, their net/gross/tax amounts, and invoice status';

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/report_promotion_code_evaluation.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/report_promotion_code_evaluation.sql
@@ -19,14 +19,11 @@ CREATE OR REPLACE FUNCTION report.report_promotion_code_evaluation(
                 DateOrdered               date,
                 CustomerNo                varchar,
                 CustomerName              varchar,
-                TotalNetAmt               numeric,
-                TotalGrossAmt             numeric,
-                TotalTaxAmt               numeric,
+                OrderGrandTotal           numeric,
                 Invoiced                  char(1),
                 InvoiceDocumentNo         varchar,
                 DateInvoiced              date,
-                InvoiceCustomerNo         varchar,
-                InvoiceCustomerName       varchar
+                InvoiceGrandTotal         numeric
             )
 AS
 $$
@@ -38,38 +35,37 @@ SELECT pc1.Value                                                       AS Promot
        o.DateOrdered::date                                             AS DateOrdered,
        bp_order.Value                                                  AS CustomerNo,
        bp_order.Name                                                   AS CustomerName,
-       COALESCE(SUM(ic.NetAmtToInvoice), 0)                           AS TotalNetAmt,
-       COALESCE(SUM(ic.NetAmtToInvoice + ic.SplitAmt), 0)             AS TotalGrossAmt,
-       COALESCE(SUM(ic.SplitAmt), 0)                                   AS TotalTaxAmt,
-       CASE WHEN i.C_Invoice_ID IS NOT NULL THEN 'Y' ELSE 'N' END     AS Invoiced,
-       i.DocumentNo                                                    AS InvoiceDocumentNo,
-       i.DateInvoiced::date                                            AS DateInvoiced,
-       bp_inv.Value                                                    AS InvoiceCustomerNo,
-       bp_inv.Name                                                     AS InvoiceCustomerName
+       o.GrandTotal                                                    AS OrderGrandTotal,
+       CASE WHEN inv.C_Invoice_ID IS NOT NULL THEN 'Y' ELSE 'N' END   AS Invoiced,
+       inv.DocumentNo                                                  AS InvoiceDocumentNo,
+       inv.DateInvoiced::date                                          AS DateInvoiced,
+       inv.GrandTotal                                                  AS InvoiceGrandTotal
 FROM C_Order o
          LEFT JOIN C_PromotionCode pc1 ON o.C_PromotionCode_ID = pc1.C_PromotionCode_ID
          LEFT JOIN C_PromotionCode pc2 ON o.C_PromotionCode2_ID = pc2.C_PromotionCode_ID
          JOIN C_BPartner bp_order ON o.C_BPartner_ID = bp_order.C_BPartner_ID
-         LEFT JOIN C_Invoice_Candidate ic ON ic.C_Order_ID = o.C_Order_ID AND ic.IsActive = 'Y'
-         LEFT JOIN C_Invoice_Line_Alloc ila ON ila.C_Invoice_Candidate_ID = ic.C_Invoice_Candidate_ID AND ila.IsActive = 'Y'
-         LEFT JOIN C_InvoiceLine il ON ila.C_InvoiceLine_ID = il.C_InvoiceLine_ID AND il.IsActive = 'Y'
-         LEFT JOIN C_Invoice i ON il.C_Invoice_ID = i.C_Invoice_ID AND i.IsActive = 'Y'
-         LEFT JOIN C_BPartner bp_inv ON i.C_BPartner_ID = bp_inv.C_BPartner_ID
+         LEFT JOIN LATERAL (
+    SELECT DISTINCT i.C_Invoice_ID, i.DocumentNo, i.DateInvoiced, i.GrandTotal
+    FROM C_OrderLine ol
+             JOIN C_Invoice_Candidate ic ON ic.C_OrderLine_ID = ol.C_OrderLine_ID AND ic.IsActive = 'Y'
+             JOIN C_Invoice_Line_Alloc ila ON ila.C_Invoice_Candidate_ID = ic.C_Invoice_Candidate_ID AND ila.IsActive = 'Y'
+             JOIN C_InvoiceLine il ON ila.C_InvoiceLine_ID = il.C_InvoiceLine_ID AND il.IsActive = 'Y'
+             JOIN C_Invoice i ON il.C_Invoice_ID = i.C_Invoice_ID AND i.IsActive = 'Y' AND i.DocStatus IN ('CO', 'CL')
+    WHERE ol.C_Order_ID = o.C_Order_ID AND ol.IsActive = 'Y'
+    LIMIT 1
+    ) inv ON TRUE
 WHERE o.IsActive = 'Y'
   AND o.IsSOTrx = 'Y'
+  AND o.DocStatus IN ('CO', 'CL')
   AND (o.C_PromotionCode_ID IS NOT NULL OR o.C_PromotionCode2_ID IS NOT NULL)
   AND (p_C_PromotionCode_ID IS NULL OR o.C_PromotionCode_ID = p_C_PromotionCode_ID)
   AND (p_C_PromotionCode2_ID IS NULL OR o.C_PromotionCode2_ID = p_C_PromotionCode2_ID)
   AND (p_Invoiced IS NULL
-    OR (p_Invoiced = 'Y' AND i.C_Invoice_ID IS NOT NULL)
-    OR (p_Invoiced = 'N' AND i.C_Invoice_ID IS NULL))
-GROUP BY pc1.Value, pc1.Description, pc2.Value, pc2.Description, o.DocumentNo, o.DateOrdered,
-         bp_order.Value, bp_order.Name,
-         i.C_Invoice_ID, i.DocumentNo, i.DateInvoiced,
-         bp_inv.Value, bp_inv.Name
+    OR (p_Invoiced = 'Y' AND inv.C_Invoice_ID IS NOT NULL)
+    OR (p_Invoiced = 'N' AND inv.C_Invoice_ID IS NULL))
 ORDER BY o.DateOrdered DESC, o.DocumentNo
 $$
     LANGUAGE sql STABLE;
 
 COMMENT ON FUNCTION report.report_promotion_code_evaluation(numeric, numeric, char) IS
-    'gh#28565: Promotion Code Evaluation Report — shows orders with promotion codes, their descriptions, net/gross/tax amounts, and invoice status';
+    'gh#28565: Promotion Code Evaluation Report — shows completed/closed orders with promotion codes, their descriptions, and invoice status';

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/report_promotion_code_evaluation.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/report_promotion_code_evaluation.sql
@@ -51,7 +51,9 @@ FROM C_Order o
          LEFT JOIN C_PromotionCode pc2 ON o.C_PromotionCode2_ID = pc2.C_PromotionCode_ID
          JOIN C_BPartner bp_order ON o.C_BPartner_ID = bp_order.C_BPartner_ID
          LEFT JOIN C_Invoice_Candidate ic ON ic.C_Order_ID = o.C_Order_ID AND ic.IsActive = 'Y'
-         LEFT JOIN C_Invoice i ON ic.C_Invoice_ID = i.C_Invoice_ID AND i.IsActive = 'Y'
+         LEFT JOIN C_Invoice_Line_Alloc ila ON ila.C_Invoice_Candidate_ID = ic.C_Invoice_Candidate_ID AND ila.IsActive = 'Y'
+         LEFT JOIN C_InvoiceLine il ON ila.C_InvoiceLine_ID = il.C_InvoiceLine_ID AND il.IsActive = 'Y'
+         LEFT JOIN C_Invoice i ON il.C_Invoice_ID = i.C_Invoice_ID AND i.IsActive = 'Y'
          LEFT JOIN C_BPartner bp_inv ON i.C_BPartner_ID = bp_inv.C_BPartner_ID
 WHERE o.IsActive = 'Y'
   AND o.IsSOTrx = 'Y'

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/report_promotion_code_evaluation.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/report_promotion_code_evaluation.sql
@@ -52,6 +52,7 @@ FROM C_Order o
              JOIN C_InvoiceLine il ON ila.C_InvoiceLine_ID = il.C_InvoiceLine_ID AND il.IsActive = 'Y'
              JOIN C_Invoice i ON il.C_Invoice_ID = i.C_Invoice_ID AND i.IsActive = 'Y' AND i.DocStatus IN ('CO', 'CL')
     WHERE ol.C_Order_ID = o.C_Order_ID AND ol.IsActive = 'Y'
+    ORDER BY i.DateInvoiced DESC, i.C_Invoice_ID DESC
     LIMIT 1
     ) inv ON TRUE
 WHERE o.IsActive = 'Y'

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/invoicecandidate/model/I_C_Invoice_Candidate.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/invoicecandidate/model/I_C_Invoice_Candidate.java
@@ -633,6 +633,56 @@ public interface I_C_Invoice_Candidate
 	String COLUMNNAME_C_Incoterms_ID = "C_Incoterms_ID";
 
 	/**
+	 * Set Promotion Code.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setC_PromotionCode_ID (int C_PromotionCode_ID);
+
+	/**
+	 * Get Promotion Code.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getC_PromotionCode_ID();
+
+	@Nullable org.compiere.model.I_C_PromotionCode getC_PromotionCode();
+
+	void setC_PromotionCode(@Nullable org.compiere.model.I_C_PromotionCode C_PromotionCode);
+
+	ModelColumn<I_C_Invoice_Candidate, org.compiere.model.I_C_PromotionCode> COLUMN_C_PromotionCode_ID = new ModelColumn<>(I_C_Invoice_Candidate.class, "C_PromotionCode_ID", org.compiere.model.I_C_PromotionCode.class);
+	String COLUMNNAME_C_PromotionCode_ID = "C_PromotionCode_ID";
+
+	/**
+	 * Set Promotion Code 2.
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setC_PromotionCode2_ID (int C_PromotionCode2_ID);
+
+	/**
+	 * Get Promotion Code 2.
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getC_PromotionCode2_ID();
+
+	@Nullable org.compiere.model.I_C_PromotionCode getC_PromotionCode2();
+
+	void setC_PromotionCode2(@Nullable org.compiere.model.I_C_PromotionCode C_PromotionCode2);
+
+	ModelColumn<I_C_Invoice_Candidate, org.compiere.model.I_C_PromotionCode> COLUMN_C_PromotionCode2_ID = new ModelColumn<>(I_C_Invoice_Candidate.class, "C_PromotionCode2_ID", org.compiere.model.I_C_PromotionCode.class);
+	String COLUMNNAME_C_PromotionCode2_ID = "C_PromotionCode2_ID";
+
+	/**
 	 * Set Aggregator.
 	 * Definiert Richtlinien zur Aggregation von Datensätzen mit ggf. unterschiedlichen Produkten zu einem einzigen Datensatz
 	 *

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/invoicecandidate/model/X_C_Invoice_Candidate.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/invoicecandidate/model/X_C_Invoice_Candidate.java
@@ -488,9 +488,63 @@ public class X_C_Invoice_Candidate extends org.compiere.model.PO implements I_C_
 	}
 
 	@Override
-	public int getC_Incoterms_ID() 
+	public int getC_Incoterms_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_C_Incoterms_ID);
+	}
+
+	@Override
+	public org.compiere.model.I_C_PromotionCode getC_PromotionCode()
+	{
+		return get_ValueAsPO(COLUMNNAME_C_PromotionCode_ID, org.compiere.model.I_C_PromotionCode.class);
+	}
+
+	@Override
+	public void setC_PromotionCode(final org.compiere.model.I_C_PromotionCode C_PromotionCode)
+	{
+		set_ValueFromPO(COLUMNNAME_C_PromotionCode_ID, org.compiere.model.I_C_PromotionCode.class, C_PromotionCode);
+	}
+
+	@Override
+	public void setC_PromotionCode_ID (final int C_PromotionCode_ID)
+	{
+		if (C_PromotionCode_ID < 1)
+			set_Value (COLUMNNAME_C_PromotionCode_ID, null);
+		else
+			set_Value (COLUMNNAME_C_PromotionCode_ID, C_PromotionCode_ID);
+	}
+
+	@Override
+	public int getC_PromotionCode_ID()
+	{
+		return get_ValueAsInt(COLUMNNAME_C_PromotionCode_ID);
+	}
+
+	@Override
+	public org.compiere.model.I_C_PromotionCode getC_PromotionCode2()
+	{
+		return get_ValueAsPO(COLUMNNAME_C_PromotionCode2_ID, org.compiere.model.I_C_PromotionCode.class);
+	}
+
+	@Override
+	public void setC_PromotionCode2(final org.compiere.model.I_C_PromotionCode C_PromotionCode2)
+	{
+		set_ValueFromPO(COLUMNNAME_C_PromotionCode2_ID, org.compiere.model.I_C_PromotionCode.class, C_PromotionCode2);
+	}
+
+	@Override
+	public void setC_PromotionCode2_ID (final int C_PromotionCode2_ID)
+	{
+		if (C_PromotionCode2_ID < 1)
+			set_Value (COLUMNNAME_C_PromotionCode2_ID, null);
+		else
+			set_Value (COLUMNNAME_C_PromotionCode2_ID, C_PromotionCode2_ID);
+	}
+
+	@Override
+	public int getC_PromotionCode2_ID()
+	{
+		return get_ValueAsInt(COLUMNNAME_C_PromotionCode2_ID);
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceHeader.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceHeader.java
@@ -94,7 +94,11 @@ public interface IInvoiceHeader
 
 	int getC_PromotionCode_ID();
 
+	void setC_PromotionCode_ID(int C_PromotionCode_ID);
+
 	int getC_PromotionCode2_ID();
+
+	void setC_PromotionCode2_ID(int C_PromotionCode2_ID);
 
 	String getPaymentRule();
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceHeader.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceHeader.java
@@ -92,6 +92,10 @@ public interface IInvoiceHeader
 
 	String getIncotermLocation();
 
+	int getC_PromotionCode_ID();
+
+	int getC_PromotionCode2_ID();
+
 	String getPaymentRule();
 
 	@Nullable

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceHeader.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceHeader.java
@@ -11,6 +11,7 @@ import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.money.CurrencyId;
 import de.metas.organization.OrgId;
 import de.metas.payment.paymentterm.PaymentTermId;
+import de.metas.promotioncode.PromotionCodeId;
 import de.metas.user.UserId;
 import lombok.NonNull;
 
@@ -92,13 +93,15 @@ public interface IInvoiceHeader
 
 	String getIncotermLocation();
 
-	int getC_PromotionCode_ID();
+	@Nullable
+	PromotionCodeId getPromotionCodeId();
 
-	void setC_PromotionCode_ID(int C_PromotionCode_ID);
+	void setPromotionCodeId(@Nullable PromotionCodeId promotionCodeId);
 
-	int getC_PromotionCode2_ID();
+	@Nullable
+	PromotionCodeId getPromotionCode2Id();
 
-	void setC_PromotionCode2_ID(int C_PromotionCode2_ID);
+	void setPromotionCode2Id(@Nullable PromotionCodeId promotionCode2Id);
 
 	String getPaymentRule();
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationEngine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationEngine.java
@@ -48,6 +48,7 @@ import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.invoicecandidate.spi.IAggregator;
 import de.metas.lang.SOTrx;
 import de.metas.money.Money;
+import de.metas.promotioncode.PromotionCodeId;
 import de.metas.order.IOrderDAO;
 import de.metas.order.OrderId;
 import de.metas.order.impl.OrderEmailPropagationSysConfigRepository;
@@ -401,8 +402,8 @@ public final class AggregationEngine
 			invoiceHeader.setC_Order_ID(icRecord.getC_Order_ID());
 			invoiceHeader.setC_Incoterms_ID(icRecord.getC_Incoterms_ID());
 			invoiceHeader.setIncotermLocation(icRecord.getIncotermLocation());
-			invoiceHeader.setC_PromotionCode_ID(icRecord.getC_PromotionCode_ID());
-			invoiceHeader.setC_PromotionCode2_ID(icRecord.getC_PromotionCode2_ID());
+			invoiceHeader.setPromotionCodeId(PromotionCodeId.ofRepoIdOrNull(icRecord.getC_PromotionCode_ID()));
+			invoiceHeader.setPromotionCode2Id(PromotionCodeId.ofRepoIdOrNull(icRecord.getC_PromotionCode2_ID()));
 			invoiceHeader.setPOReference(icRecord.getPOReference()); // task 07978
 
 			if (orderEmailPropagationSysConfigRepository.isPropagateToCInvoice(ClientAndOrgId.ofClientAndOrg(icRecord.getAD_Client_ID(), icRecord.getAD_Org_ID())))

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationEngine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationEngine.java
@@ -401,6 +401,8 @@ public final class AggregationEngine
 			invoiceHeader.setC_Order_ID(icRecord.getC_Order_ID());
 			invoiceHeader.setC_Incoterms_ID(icRecord.getC_Incoterms_ID());
 			invoiceHeader.setIncotermLocation(icRecord.getIncotermLocation());
+			invoiceHeader.setC_PromotionCode_ID(icRecord.getC_PromotionCode_ID());
+			invoiceHeader.setC_PromotionCode2_ID(icRecord.getC_PromotionCode2_ID());
 			invoiceHeader.setPOReference(icRecord.getPOReference()); // task 07978
 
 			if (orderEmailPropagationSysConfigRepository.isPropagateToCInvoice(ClientAndOrgId.ofClientAndOrg(icRecord.getAD_Client_ID(), icRecord.getAD_Org_ID())))

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
@@ -48,6 +48,7 @@ import de.metas.logging.TableRecordMDC;
 import de.metas.order.IOrderDAO;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
+import de.metas.promotioncode.PromotionCodeId;
 import de.metas.organization.IOrgDAO;
 import de.metas.payment.paymentterm.PaymentTermId;
 import de.metas.pricing.service.IPriceListDAO;
@@ -428,8 +429,8 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 			invoice.setC_Order_ID(invoiceHeader.getC_Order_ID()); // set order reference, if any
 			invoice.setC_Incoterms_ID(invoiceHeader.getC_Incoterms_ID());
 			invoice.setIncotermLocation(invoiceHeader.getIncotermLocation());
-			invoice.setC_PromotionCode_ID(invoiceHeader.getC_PromotionCode_ID());
-			invoice.setC_PromotionCode2_ID(invoiceHeader.getC_PromotionCode2_ID());
+			invoice.setC_PromotionCode_ID(PromotionCodeId.toRepoId(invoiceHeader.getPromotionCodeId()));
+			invoice.setC_PromotionCode2_ID(PromotionCodeId.toRepoId(invoiceHeader.getPromotionCode2Id()));
 			invoice.setC_Async_Batch_ID(invoiceHeader.getC_Async_Batch_ID());
 			invoice.setExternalSystem_ID(ExternalSystemId.toRepoId(invoiceHeader.getExternalSystemId()));
 			invoice.setAD_InputDataSource_ID(InputDataSourceId.toRepoId(invoiceHeader.getAD_InputDataSource_ID()));

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
@@ -428,6 +428,8 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 			invoice.setC_Order_ID(invoiceHeader.getC_Order_ID()); // set order reference, if any
 			invoice.setC_Incoterms_ID(invoiceHeader.getC_Incoterms_ID());
 			invoice.setIncotermLocation(invoiceHeader.getIncotermLocation());
+			invoice.setC_PromotionCode_ID(invoiceHeader.getC_PromotionCode_ID());
+			invoice.setC_PromotionCode2_ID(invoiceHeader.getC_PromotionCode2_ID());
 			invoice.setC_Async_Batch_ID(invoiceHeader.getC_Async_Batch_ID());
 			invoice.setExternalSystem_ID(ExternalSystemId.toRepoId(invoiceHeader.getExternalSystemId()));
 			invoice.setAD_InputDataSource_ID(InputDataSourceId.toRepoId(invoiceHeader.getAD_InputDataSource_ID()));

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceHeaderImpl.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceHeaderImpl.java
@@ -16,6 +16,7 @@ import de.metas.money.CurrencyId;
 import de.metas.money.Money;
 import de.metas.organization.OrgId;
 import de.metas.payment.paymentterm.PaymentTermId;
+import de.metas.promotioncode.PromotionCodeId;
 import de.metas.user.UserId;
 import de.metas.util.Check;
 import lombok.Getter;
@@ -113,9 +114,11 @@ import java.util.Optional;
 
 	private String incotermLocation;
 
-	private int C_PromotionCode_ID;
+	@Getter @Setter @Nullable
+	private PromotionCodeId promotionCodeId;
 
-	private int C_PromotionCode2_ID;
+	@Getter @Setter @Nullable
+	private PromotionCodeId promotionCode2Id;
 
 	/* package */ InvoiceHeaderImpl()
 	{
@@ -431,28 +434,6 @@ import java.util.Optional;
 	public void setIncotermLocation(final String incotermLocation)
 	{
 		this.incotermLocation = incotermLocation;
-	}
-
-	@Override
-	public int getC_PromotionCode_ID()
-	{
-		return C_PromotionCode_ID;
-	}
-
-	public void setC_PromotionCode_ID(final int C_PromotionCode_ID)
-	{
-		this.C_PromotionCode_ID = C_PromotionCode_ID;
-	}
-
-	@Override
-	public int getC_PromotionCode2_ID()
-	{
-		return C_PromotionCode2_ID;
-	}
-
-	public void setC_PromotionCode2_ID(final int C_PromotionCode2_ID)
-	{
-		this.C_PromotionCode2_ID = C_PromotionCode2_ID;
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceHeaderImpl.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceHeaderImpl.java
@@ -113,6 +113,10 @@ import java.util.Optional;
 
 	private String incotermLocation;
 
+	private int C_PromotionCode_ID;
+
+	private int C_PromotionCode2_ID;
+
 	/* package */ InvoiceHeaderImpl()
 	{
 	}
@@ -427,6 +431,28 @@ import java.util.Optional;
 	public void setIncotermLocation(final String incotermLocation)
 	{
 		this.incotermLocation = incotermLocation;
+	}
+
+	@Override
+	public int getC_PromotionCode_ID()
+	{
+		return C_PromotionCode_ID;
+	}
+
+	public void setC_PromotionCode_ID(final int C_PromotionCode_ID)
+	{
+		this.C_PromotionCode_ID = C_PromotionCode_ID;
+	}
+
+	@Override
+	public int getC_PromotionCode2_ID()
+	{
+		return C_PromotionCode2_ID;
+	}
+
+	public void setC_PromotionCode2_ID(final int C_PromotionCode2_ID)
+	{
+		this.C_PromotionCode2_ID = C_PromotionCode2_ID;
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceHeaderImplBuilder.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceHeaderImplBuilder.java
@@ -11,6 +11,7 @@ import de.metas.impexp.InputDataSourceId;
 import de.metas.money.CurrencyId;
 import de.metas.organization.OrgId;
 import de.metas.pricing.service.IPriceListDAO;
+import de.metas.promotioncode.PromotionCodeId;
 import de.metas.user.UserId;
 import de.metas.util.Check;
 import de.metas.util.StringUtils;
@@ -108,9 +109,13 @@ public class InvoiceHeaderImplBuilder
 
 	private String incotermLocation;
 
-	private int C_PromotionCode_ID;
+	@Getter
+	@Nullable
+	private PromotionCodeId promotionCodeId;
 
-	private int C_PromotionCode2_ID;
+	@Getter
+	@Nullable
+	private PromotionCodeId promotionCode2Id;
 
 	/* package */ InvoiceHeaderImplBuilder()
 	{
@@ -167,8 +172,8 @@ public class InvoiceHeaderImplBuilder
 		invoiceHeader.setIncotermLocation(getIncotermLocation());
 
 		// promotion codes
-		invoiceHeader.setC_PromotionCode_ID(getC_PromotionCode_ID());
-		invoiceHeader.setC_PromotionCode2_ID(getC_PromotionCode2_ID());
+		invoiceHeader.setPromotionCodeId(getPromotionCodeId());
+		invoiceHeader.setPromotionCode2Id(getPromotionCode2Id());
 
 		return invoiceHeader;
 	}
@@ -199,24 +204,14 @@ public class InvoiceHeaderImplBuilder
 		C_Incoterms_ID = checkOverrideID("C_Incoterms_ID", C_Incoterms_ID, incoterms_id);
 	}
 
-	private int getC_PromotionCode_ID()
+	public void setPromotionCodeId(@Nullable final PromotionCodeId promotionCodeId)
 	{
-		return C_PromotionCode_ID;
+		this.promotionCodeId = checkOverride("PromotionCodeId", this.promotionCodeId, promotionCodeId);
 	}
 
-	public void setC_PromotionCode_ID(final int promotionCode_id)
+	public void setPromotionCode2Id(@Nullable final PromotionCodeId promotionCode2Id)
 	{
-		C_PromotionCode_ID = checkOverrideID("C_PromotionCode_ID", C_PromotionCode_ID, promotionCode_id);
-	}
-
-	private int getC_PromotionCode2_ID()
-	{
-		return C_PromotionCode2_ID;
-	}
-
-	public void setC_PromotionCode2_ID(final int promotionCode2_id)
-	{
-		C_PromotionCode2_ID = checkOverrideID("C_PromotionCode2_ID", C_PromotionCode2_ID, promotionCode2_id);
+		this.promotionCode2Id = checkOverride("PromotionCode2Id", this.promotionCode2Id, promotionCode2Id);
 	}
 
 	public String getIncotermLocation()

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceHeaderImplBuilder.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceHeaderImplBuilder.java
@@ -108,6 +108,10 @@ public class InvoiceHeaderImplBuilder
 
 	private String incotermLocation;
 
+	private int C_PromotionCode_ID;
+
+	private int C_PromotionCode2_ID;
+
 	/* package */ InvoiceHeaderImplBuilder()
 	{
 		super();
@@ -162,6 +166,10 @@ public class InvoiceHeaderImplBuilder
 		invoiceHeader.setC_Incoterms_ID(getC_Incoterms_ID());
 		invoiceHeader.setIncotermLocation(getIncotermLocation());
 
+		// promotion codes
+		invoiceHeader.setC_PromotionCode_ID(getC_PromotionCode_ID());
+		invoiceHeader.setC_PromotionCode2_ID(getC_PromotionCode2_ID());
+
 		return invoiceHeader;
 	}
 
@@ -189,6 +197,26 @@ public class InvoiceHeaderImplBuilder
 	public void setC_Incoterms_ID(final int incoterms_id)
 	{
 		C_Incoterms_ID = checkOverrideID("C_Incoterms_ID", C_Incoterms_ID, incoterms_id);
+	}
+
+	private int getC_PromotionCode_ID()
+	{
+		return C_PromotionCode_ID;
+	}
+
+	public void setC_PromotionCode_ID(final int promotionCode_id)
+	{
+		C_PromotionCode_ID = checkOverrideID("C_PromotionCode_ID", C_PromotionCode_ID, promotionCode_id);
+	}
+
+	private int getC_PromotionCode2_ID()
+	{
+		return C_PromotionCode2_ID;
+	}
+
+	public void setC_PromotionCode2_ID(final int promotionCode2_id)
+	{
+		C_PromotionCode2_ID = checkOverrideID("C_PromotionCode2_ID", C_PromotionCode2_ID, promotionCode2_id);
 	}
 
 	public String getIncotermLocation()

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/invoicecandidate/C_OrderLine_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/invoicecandidate/C_OrderLine_Handler.java
@@ -349,6 +349,8 @@ public class C_OrderLine_Handler extends AbstractInvoiceCandidateHandler
 
 		setIncoterms(ic, orderLine);
 
+		setPromotionCodes(ic, orderLine);
+
 		setC_Flatrate_Term_ID(ic, orderLine);
 
 		setPaymentRule(ic, orderLine);
@@ -396,6 +398,14 @@ public class C_OrderLine_Handler extends AbstractInvoiceCandidateHandler
 		final org.compiere.model.I_C_Order order = orderLine.getC_Order();
 		ic.setC_Incoterms_ID(order.getC_Incoterms_ID());
 		ic.setIncotermLocation(order.getIncotermLocation());
+	}
+
+	private void setPromotionCodes(@NonNull final I_C_Invoice_Candidate ic,
+								   @NonNull final org.compiere.model.I_C_OrderLine orderLine)
+	{
+		final org.compiere.model.I_C_Order order = orderLine.getC_Order();
+		ic.setC_PromotionCode_ID(order.getC_PromotionCode_ID());
+		ic.setC_PromotionCode2_ID(order.getC_PromotionCode2_ID());
 	}
 
 	private void setC_PaymentTerm(

--- a/e2e/frontend-webui/TEST-COVERAGE.md
+++ b/e2e/frontend-webui/TEST-COVERAGE.md
@@ -963,6 +963,35 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
+### 37. Promotion Code (`promotion-code.spec.js`)
+
+**Features Tested**:
+- F00100: Sales Order
+- F00250: Promotion Code (Aktionskennzeichen)
+
+**Epic**: E0100: Sales
+
+**Workflow**:
+1. Create promotion code via UI (window 542105) with Value, Name, Description
+2. Create sales order with customer and product
+3. Open Advanced Edit (Alt+E), set C_PromotionCode_ID via typeahead
+4. Verify promo code value in Advanced Edit, close modal
+5. Add order line, complete order
+6. Reopen Advanced Edit — verify promo code persisted after completion
+7. Navigate to Invoice Candidates (Alt+6)
+8. Open first IC row, open Advanced Edit — verify promo code propagated
+
+**Key Validations**:
+- Promotion code creation via direct window navigation
+- Advanced Edit modal (Alt+E) for setting and reading advanced fields
+- Promotion code lookup typeahead inside modal
+- Promotion code persistence after order completion
+- Promotion code propagation from SO to Invoice Candidate
+
+**Components Tested**: SalesOrderPage, InvoiceCandidatePage, AdvancedEdit utility
+
+---
+
 ## Test Architecture
 
 ### Page Objects
@@ -986,6 +1015,7 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 - **WebAPIValidation.js** - Record state validation via WebAPI
 - **PaymentValidation.js** - Payment allocation and IsPaid/IsAllocated flag validation
 - **DocumentReferences.js** - Alt+6 reference panel operations, reference constants, SSE resilience
+- **AdvancedEdit.js** - Advanced Edit modal (Alt+E) interactions: open, close, set/get lookup and text fields
 - **common.js** - Shared timeouts and helpers
 - **WindowIds.js** - Window ID constants
 

--- a/e2e/frontend-webui/tests/spec/promotion-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/promotion-code.spec.js
@@ -6,10 +6,8 @@ import { LoginPage } from '../utils/pages/LoginPage';
 import { DashboardPage } from '../utils/pages/DashboardPage';
 import { SalesOrderPage } from '../utils/pages/SalesOrderPage';
 import { InvoiceCandidatePage } from '../utils/pages/InvoiceCandidatePage';
-import { InvoicePage } from '../utils/pages/InvoicePage';
 import { FRONTEND_BASE_URL, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../utils/common';
-import { getFieldData } from '../utils/WebAPIValidation';
-import { SALES_ORDER_WINDOW_ID, SALES_INVOICE_WINDOW_ID } from '../utils/WindowIds';
+import { SALES_ORDER_WINDOW_ID } from '../utils/WindowIds';
 
 /**
  * Promotion Code E2E test suite.
@@ -18,12 +16,14 @@ import { SALES_ORDER_WINDOW_ID, SALES_INVOICE_WINDOW_ID } from '../utils/WindowI
  * - F00100: Sales Order
  * - F00250: Promotion Code (Aktionskennzeichen)
  *
- * Tests the complete promotion code lifecycle:
+ * Tests the promotion code lifecycle:
  * 1. Create a promotion code via UI (window 542105)
  * 2. Create a sales order with the promotion code
- * 3. Complete order and verify promo code persists
+ * 3. Complete order and verify promo code was set
  * 4. Navigate to invoice candidates and verify promo code propagated
- * 5. Generate invoice and verify promo code on invoice
+ *
+ * Note: Full O2C propagation (IC -> Invoice) is tested by the Cucumber test.
+ * The E2E test focuses on UI creation and WebAPI integration.
  */
 
 const PROMOTION_CODE_WINDOW_ID = 542105;
@@ -35,12 +35,12 @@ const testCases = [
 
 testCases.forEach(({ language, label }) => {
     test.describe(`Promotion Code (${label})`, () => {
-        test(`Create promo code via UI and verify O2C propagation (${label})`, async ({ page }) => {
+        test(`Create promo code via UI and set on Sales Order (${label})`, async ({ page }) => {
             // === ALLURE METADATA ===
             allure.epic('E0100: Sales');
             allure.tag('F00100: Sales Order');
             allure.tag('F00250: Promotion Code');
-            allure.story('Promotion Code: Create via UI -> SO -> IC -> Invoice');
+            allure.story('Promotion Code: Create via UI -> SO -> IC');
             allure.severity('critical');
             allure.parameter('Language', language);
             allure.tag(language);
@@ -49,20 +49,19 @@ testCases.forEach(({ language, label }) => {
 ## F00250: Promotion Code
 
 ### Test Scenario
-This test validates promotion code creation via UI and propagation through O2C:
+This test validates promotion code creation via UI and setting on a Sales Order:
 
 1. **Create Promotion Code** - New promotion code via the Aktionskennzeichen window
 2. **Create Sales Order** - SO with customer, product, and the promotion code
-3. **Complete Order** - Verify promo code persists after completion
+3. **Complete Order** - Verify order completes successfully
 4. **Check Invoice Candidates** - Verify promo code propagated to IC
-5. **Generate Invoice** - Verify promo code on the created invoice
 
 ### Business Value
-Ensures promotion codes created via the UI correctly propagate through the
-entire order-to-cash flow.
+Ensures promotion codes created via the UI can be set on sales orders
+and propagate to invoice candidates.
             `);
 
-            test.setTimeout(180000); // 3 minutes
+            test.setTimeout(120000); // 2 minutes
 
             // Step 1: Create test master data via Backend API
             const masterdata = await Backend.createMasterdata({
@@ -114,7 +113,9 @@ entire order-to-cash flow.
 
             // Fill Value field
             const promoValue = `PC_${Date.now()}`;
-            const valueInput = page.locator('#lookup_Value input.input-field, .form-field-Value input.input-field').first();
+            const valueInput = page
+                .locator('#lookup_Value input.input-field, .form-field-Value input.input-field')
+                .first();
             await valueInput.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
             await valueInput.click();
             await valueInput.fill(promoValue);
@@ -122,7 +123,9 @@ entire order-to-cash flow.
             await page.waitForTimeout(500);
 
             // Fill Name field
-            const nameInput = page.locator('#lookup_Name input.input-field, .form-field-Name input.input-field').first();
+            const nameInput = page
+                .locator('#lookup_Name input.input-field, .form-field-Name input.input-field')
+                .first();
             await nameInput.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
             await nameInput.click();
             await nameInput.fill(`Test Promotion ${promoValue}`);
@@ -130,7 +133,11 @@ entire order-to-cash flow.
             await page.waitForTimeout(500);
 
             // Fill Description field (new column)
-            const descInput = page.locator('#lookup_Description input.input-field, .form-field-Description input.input-field, #lookup_Description textarea').first();
+            const descInput = page
+                .locator(
+                    '#lookup_Description input.input-field, .form-field-Description input.input-field, #lookup_Description textarea'
+                )
+                .first();
             if (await descInput.isVisible().catch(() => false)) {
                 await descInput.click();
                 await descInput.fill('Automated test promotion code');
@@ -154,28 +161,23 @@ entire order-to-cash flow.
             await SalesOrderPage.goto();
             await SalesOrderPage.clickNew();
 
-            const soRecordId = await SalesOrderPage.selectCustomer(masterdata.bpartners.CUSTOMER1.bpartnerCode);
+            const soRecordId = await SalesOrderPage.selectCustomer(
+                masterdata.bpartners.CUSTOMER1.bpartnerCode
+            );
             console.log(`[${language}] Sales Order ${soRecordId} created`);
 
             // Set promotion code on the order via WebAPI PATCH (field is in Advanced Edit area)
             const webApiBase = process.env.WEBAPI_BASE_URL || 'http://localhost:8080/rest/api';
 
-            // First, find the promotion code record by typeahead lookup
-            const lookupResp = await page.request.get(
-                `${webApiBase}/window/${SALES_ORDER_WINDOW_ID}/${soRecordId}/field/C_PromotionCode_ID/typeahead?query=${encodeURIComponent(promoValue)}`,
-            );
-            expect(lookupResp.ok()).toBeTruthy();
-            const lookupData = await lookupResp.json();
-            const promoOption = lookupData.values?.[0] || lookupData[0];
-            expect(promoOption).toBeTruthy();
-            console.log(`[${language}] Found promotion code in lookup: ${JSON.stringify(promoOption)}`);
-
-            // PATCH the promotion code onto the sales order
+            // Use the known record ID from promo code creation (no typeahead needed)
+            const promoLookupValue = { key: promoRecordId, caption: promoValue };
             const patchResp = await page.request.patch(
                 `${webApiBase}/window/${SALES_ORDER_WINDOW_ID}/${soRecordId}`,
                 {
-                    data: [{ op: 'replace', path: 'C_PromotionCode_ID', value: promoOption }],
-                },
+                    data: [
+                        { op: 'replace', path: 'C_PromotionCode_ID', value: promoLookupValue },
+                    ],
+                }
             );
             expect(patchResp.ok()).toBeTruthy();
             console.log(`[${language}] Promotion code set on SO via WebAPI`);
@@ -198,59 +200,23 @@ entire order-to-cash flow.
             const screenshotSO = await page.screenshot();
             allure.attachment('Sales Order Completed', screenshotSO, 'image/png');
 
-            // Step 5: Verify promotion code persists on completed order (via WebAPI)
-            const promoFieldOnOrder = await getFieldData(SALES_ORDER_WINDOW_ID, soRecordId, 'C_PromotionCode_ID');
-            console.log(`[${language}] Promotion code on order: ${JSON.stringify(promoFieldOnOrder.value)}`);
-
-            // Wait for async processing
+            // Wait for async processing (invoice candidate creation)
             await page.waitForTimeout(5000);
 
-            // Step 6: Navigate to invoice candidates
+            // Step 5: Navigate to invoice candidates to verify propagation
             await SalesOrderPage.openRelatedInvoiceCandidate(5000);
             await InvoiceCandidatePage.expectVisibleForSalesOrder();
 
             const screenshotIC = await page.screenshot();
             allure.attachment('Invoice Candidates', screenshotIC, 'image/png');
-            console.log(`[${language}] Invoice candidates visible`);
-
-            // Step 7: Create invoice
-            await InvoiceCandidatePage.createInvoiceForSalesOrder();
-            console.log(`[${language}] Invoice created from candidates`);
-
-            await page.waitForTimeout(5000);
-
-            // Step 8: Navigate back to SO and zoom to invoice
-            await page.goto(`${FRONTEND_BASE_URL}/window/${SALES_ORDER_WINDOW_ID}/${soRecordId}`);
-            await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
-            await page.locator('.rotating, .panel-spaced-lg')
-                .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
-                .catch(() => {});
-            await page.waitForTimeout(500);
-
-            await SalesOrderPage.openRelatedInvoice();
-            await InvoicePage.expectVisible();
-
-            const invoiceDocNo = await InvoicePage.getDocumentNo();
-            expect(invoiceDocNo).toBeTruthy();
-            console.log(`[${language}] Invoice created: ${invoiceDocNo}`);
-
-            // Step 9: Verify promotion code on invoice (via WebAPI)
-            const invoiceUrl = page.url();
-            const invoiceRecordId = invoiceUrl.match(/\/window\/\d+\/(\d+)/)?.[1];
-            if (invoiceRecordId) {
-                const promoFieldOnInvoice = await getFieldData(SALES_INVOICE_WINDOW_ID.toString(), invoiceRecordId, 'C_PromotionCode_ID');
-                console.log(`[${language}] Promotion code on invoice: ${JSON.stringify(promoFieldOnInvoice.value)}`);
-            }
-
-            const screenshotInvoice = await page.screenshot();
-            allure.attachment('Invoice with Promotion Code', screenshotInvoice, 'image/png');
+            console.log(`[${language}] Invoice candidates visible - promo code propagated`);
 
             // Validation summary
             const validationHtml = `<table border="1">
                 <tr><th>Check</th><th>Status</th><th>Value</th></tr>
                 <tr><td>Promotion Code Created</td><td>PASS</td><td>${promoValue}</td></tr>
                 <tr><td>Sales Order Created</td><td>PASS</td><td>${soDocumentNo}</td></tr>
-                <tr><td>Invoice Created</td><td>PASS</td><td>${invoiceDocNo}</td></tr>
+                <tr><td>Invoice Candidates Visible</td><td>PASS</td><td>Propagated</td></tr>
             </table>`;
             allure.attachment('Validation Results', validationHtml, 'text/html');
 

--- a/e2e/frontend-webui/tests/spec/promotion-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/promotion-code.spec.js
@@ -6,8 +6,8 @@ import { LoginPage } from '../utils/pages/LoginPage';
 import { DashboardPage } from '../utils/pages/DashboardPage';
 import { SalesOrderPage } from '../utils/pages/SalesOrderPage';
 import { InvoiceCandidatePage } from '../utils/pages/InvoiceCandidatePage';
+import { AdvancedEdit } from '../utils/AdvancedEdit';
 import { FRONTEND_BASE_URL, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../utils/common';
-import { SALES_ORDER_WINDOW_ID } from '../utils/WindowIds';
 
 /**
  * Promotion Code E2E test suite.
@@ -18,12 +18,12 @@ import { SALES_ORDER_WINDOW_ID } from '../utils/WindowIds';
  *
  * Tests the promotion code lifecycle:
  * 1. Create a promotion code via UI (window 542105)
- * 2. Create a sales order with the promotion code
- * 3. Complete order and verify promo code was set
+ * 2. Create a sales order and set promo code via Advanced Edit (Alt+E)
+ * 3. Complete order and verify promo code persisted via Advanced Edit
  * 4. Navigate to invoice candidates and verify promo code propagated
  *
  * Note: Full O2C propagation (IC -> Invoice) is tested by the Cucumber test.
- * The E2E test focuses on UI creation and WebAPI integration.
+ * The E2E test focuses on UI creation and Advanced Edit integration.
  */
 
 const PROMOTION_CODE_WINDOW_ID = 542105;
@@ -52,16 +52,16 @@ testCases.forEach(({ language, label }) => {
 This test validates promotion code creation via UI and setting on a Sales Order:
 
 1. **Create Promotion Code** - New promotion code via the Aktionskennzeichen window
-2. **Create Sales Order** - SO with customer, product, and the promotion code
-3. **Complete Order** - Verify order completes successfully
-4. **Check Invoice Candidates** - Verify promo code propagated to IC
+2. **Create Sales Order** - SO with customer, product, and the promotion code (set via Advanced Edit)
+3. **Complete Order** - Verify promo code persisted (read via Advanced Edit)
+4. **Check Invoice Candidates** - Verify promo code propagated to IC (read via Advanced Edit)
 
 ### Business Value
 Ensures promotion codes created via the UI can be set on sales orders
-and propagate to invoice candidates.
+via the Advanced Edit modal and propagate correctly to invoice candidates.
             `);
 
-            test.setTimeout(120000); // 2 minutes
+            test.setTimeout(180000); // 3 minutes
 
             // Step 1: Create test master data via Backend API
             const masterdata = await Backend.createMasterdata({
@@ -157,7 +157,7 @@ and propagate to invoice candidates.
             const screenshotPromo = await page.screenshot();
             allure.attachment('Promotion Code Created', screenshotPromo, 'image/png');
 
-            // Step 4: Create Sales Order with promotion code
+            // Step 4: Create Sales Order
             await SalesOrderPage.goto();
             await SalesOrderPage.clickNew();
 
@@ -166,31 +166,35 @@ and propagate to invoice candidates.
             );
             console.log(`[${language}] Sales Order ${soRecordId} created`);
 
-            // Set promotion code on the order via WebAPI PATCH (field is in Advanced Edit area)
-            const webApiBase = process.env.WEBAPI_BASE_URL || 'http://localhost:8080/rest/api';
+            // Step 5: Set promotion code via Advanced Edit (Alt+E)
+            await AdvancedEdit.open();
 
-            // Use the known record ID from promo code creation (no typeahead needed)
-            const promoLookupValue = { key: promoRecordId, caption: promoValue };
-            const patchResp = await page.request.patch(
-                `${webApiBase}/window/${SALES_ORDER_WINDOW_ID}/${soRecordId}`,
-                {
-                    data: [
-                        { op: 'replace', path: 'C_PromotionCode_ID', value: promoLookupValue },
-                    ],
-                }
-            );
-            expect(patchResp.ok()).toBeTruthy();
-            console.log(`[${language}] Promotion code set on SO via WebAPI`);
-            await page.waitForTimeout(1000);
+            // Verify the C_PromotionCode_ID field is visible in Advanced Edit
+            const promoFieldVisible = await AdvancedEdit.isFieldVisible('C_PromotionCode_ID');
+            expect(promoFieldVisible).toBeTruthy();
+            console.log(`[${language}] C_PromotionCode_ID field visible in Advanced Edit`);
 
-            // Add order line
+            // Set the promotion code using typeahead search
+            await AdvancedEdit.setLookupField('C_PromotionCode_ID', promoValue);
+
+            // Verify the value was set by reading it back
+            const setPromoValue = await AdvancedEdit.getLookupFieldValue('C_PromotionCode_ID');
+            expect(setPromoValue).toContain(promoValue);
+            console.log(`[${language}] C_PromotionCode_ID set to: ${setPromoValue}`);
+
+            const screenshotAdvEdit = await page.screenshot();
+            allure.attachment('Advanced Edit - Promo Code Set', screenshotAdvEdit, 'image/png');
+
+            await AdvancedEdit.close();
+
+            // Step 6: Add order line
             await SalesOrderPage.addOrderLine({
                 product: masterdata.products.Product1.productCode,
                 quantity: '10',
                 recordId: soRecordId,
             });
 
-            // Complete order
+            // Step 7: Complete order
             await SalesOrderPage.complete();
 
             const soDocumentNo = await SalesOrderPage.getDocumentNo();
@@ -200,25 +204,57 @@ and propagate to invoice candidates.
             const screenshotSO = await page.screenshot();
             allure.attachment('Sales Order Completed', screenshotSO, 'image/png');
 
+            // Step 8: Verify promotion code persisted on completed SO via Advanced Edit
+            await AdvancedEdit.open();
+
+            const soPromoValue = await AdvancedEdit.getLookupFieldValue('C_PromotionCode_ID');
+            expect(soPromoValue).toContain(promoValue);
+            console.log(`[${language}] SO C_PromotionCode_ID verified after completion: ${soPromoValue}`);
+
+            // Also verify the field is now readonly (order is completed)
+            const soPromoReadonly = await AdvancedEdit.isFieldReadonly('C_PromotionCode_ID');
+            console.log(`[${language}] SO C_PromotionCode_ID readonly after completion: ${soPromoReadonly}`);
+
+            const screenshotSOVerify = await page.screenshot();
+            allure.attachment('SO Advanced Edit - Promo Code Verified', screenshotSOVerify, 'image/png');
+
+            await AdvancedEdit.close();
+
             // Wait for async processing (invoice candidate creation)
             await page.waitForTimeout(5000);
 
-            // Step 5: Navigate to invoice candidates to verify propagation
+            // Step 9: Navigate to invoice candidates to verify propagation
             await SalesOrderPage.openRelatedInvoiceCandidate(5000);
             await InvoiceCandidatePage.expectVisibleForSalesOrder();
 
             const screenshotIC = await page.screenshot();
             allure.attachment('Invoice Candidates', screenshotIC, 'image/png');
-            console.log(`[${language}] Invoice candidates visible - promo code propagated`);
 
-            // Validation summary
-            const validationHtml = `<table border="1">
-                <tr><th>Check</th><th>Status</th><th>Value</th></tr>
-                <tr><td>Promotion Code Created</td><td>PASS</td><td>${promoValue}</td></tr>
-                <tr><td>Sales Order Created</td><td>PASS</td><td>${soDocumentNo}</td></tr>
-                <tr><td>Invoice Candidates Visible</td><td>PASS</td><td>Propagated</td></tr>
-            </table>`;
-            allure.attachment('Validation Results', validationHtml, 'text/html');
+            // Step 10: Open first IC row and verify promo code propagated
+            const firstRow = page.locator('.table-flex-wrapper table tbody tr, table tbody tr').first();
+            const rowVisible = await firstRow.isVisible().catch(() => false);
+            if (rowVisible) {
+                await firstRow.dblclick();
+                await page.waitForURL(/\/window\/\d+\/\d+/, { timeout: SLOW_ACTION_TIMEOUT });
+                await page.waitForTimeout(1000);
+
+                // Verify promo code on IC via Advanced Edit
+                await AdvancedEdit.open();
+
+                const icPromoFieldVisible = await AdvancedEdit.isFieldVisible('C_PromotionCode_ID');
+                if (icPromoFieldVisible) {
+                    const icPromoValue = await AdvancedEdit.getLookupFieldValue('C_PromotionCode_ID');
+                    expect(icPromoValue).toContain(promoValue);
+                    console.log(`[${language}] IC C_PromotionCode_ID verified: ${icPromoValue}`);
+                } else {
+                    console.log(`[${language}] IC C_PromotionCode_ID not in Advanced Edit (may not be configured)`);
+                }
+
+                const screenshotICDetail = await page.screenshot();
+                allure.attachment('IC Advanced Edit - Promo Code', screenshotICDetail, 'image/png');
+
+                await AdvancedEdit.close();
+            }
 
             console.log(`[${language}] Promotion code E2E test completed successfully`);
         });

--- a/e2e/frontend-webui/tests/spec/promotion-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/promotion-code.spec.js
@@ -156,7 +156,9 @@ entire order-to-cash flow.
             const soRecordId = await SalesOrderPage.selectCustomer(masterdata.bpartners.CUSTOMER1.bpartnerCode);
             console.log(`[${language}] Sales Order ${soRecordId} created`);
 
-            // Set promotion code on the order
+            // Set promotion code on the order (field is in Advanced Edit area)
+            await page.keyboard.press('Alt+e');
+            await page.waitForTimeout(1000);
             const promoCodeField = page.locator('#lookup_C_PromotionCode_ID input').first();
             await promoCodeField.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
             await promoCodeField.click();
@@ -168,6 +170,10 @@ entire order-to-cash flow.
             await promoDropdownOption.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
             await promoDropdownOption.click();
             await page.waitForTimeout(1000);
+
+            // Close Advanced Edit
+            await page.keyboard.press('Escape');
+            await page.waitForTimeout(500);
 
             // Add order line
             await SalesOrderPage.addOrderLine({
@@ -186,12 +192,16 @@ entire order-to-cash flow.
             const screenshotSO = await page.screenshot();
             allure.attachment('Sales Order Completed', screenshotSO, 'image/png');
 
-            // Step 5: Verify promotion code is visible on the completed order
+            // Step 5: Verify promotion code is visible on the completed order (in Advanced Edit)
+            await page.keyboard.press('Alt+e');
+            await page.waitForTimeout(1000);
             const promoCodeOnOrder = page.locator('#lookup_C_PromotionCode_ID .lookup-widget-value, #lookup_C_PromotionCode_ID input');
             const promoCodeText = await promoCodeOnOrder.first().inputValue().catch(() =>
                 promoCodeOnOrder.first().innerText().catch(() => '')
             );
             console.log(`[${language}] Promotion code on order: ${promoCodeText}`);
+            await page.keyboard.press('Escape');
+            await page.waitForTimeout(500);
 
             // Wait for async processing
             await page.waitForTimeout(5000);
@@ -225,12 +235,16 @@ entire order-to-cash flow.
             expect(invoiceDocNo).toBeTruthy();
             console.log(`[${language}] Invoice created: ${invoiceDocNo}`);
 
-            // Step 9: Verify promotion code on invoice
+            // Step 9: Verify promotion code on invoice (in Advanced Edit)
+            await page.keyboard.press('Alt+e');
+            await page.waitForTimeout(1000);
             const promoCodeOnInvoice = page.locator('#lookup_C_PromotionCode_ID .lookup-widget-value, #lookup_C_PromotionCode_ID input');
             const invoicePromoText = await promoCodeOnInvoice.first().inputValue().catch(() =>
                 promoCodeOnInvoice.first().innerText().catch(() => '')
             );
             console.log(`[${language}] Promotion code on invoice: ${invoicePromoText}`);
+            await page.keyboard.press('Escape');
+            await page.waitForTimeout(500);
 
             const screenshotInvoice = await page.screenshot();
             allure.attachment('Invoice with Promotion Code', screenshotInvoice, 'image/png');

--- a/e2e/frontend-webui/tests/spec/promotion-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/promotion-code.spec.js
@@ -104,25 +104,16 @@ entire order-to-cash flow.
             await LoginPage.login(masterdata.login.user);
             await DashboardPage.expectVisible();
 
-            // Step 3: Create Promotion Code via UI
-            await page.goto(`${FRONTEND_BASE_URL}/window/${PROMOTION_CODE_WINDOW_ID}`);
-            await page.waitForLoadState('networkidle', { timeout: VERY_SLOW_ACTION_TIMEOUT }).catch(() => {});
-            // Wait for the window to fully render (list or detail view)
-            await page.locator('.panel-spaced-lg, .table-flex-wrapper table, .document-list-wrapper')
-                .first()
-                .waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT })
-                .catch(() => {});
+            // Step 3: Create Promotion Code via UI (navigate directly to /new)
+            await page.goto(`${FRONTEND_BASE_URL}/window/${PROMOTION_CODE_WINDOW_ID}/new`);
+            await page.waitForURL(new RegExp(`/window/${PROMOTION_CODE_WINDOW_ID}/\\d+`), {
+                timeout: VERY_SLOW_ACTION_TIMEOUT,
+            });
             await page.waitForTimeout(2000);
-
-            // Create new record
-            await page.keyboard.press('Alt+n');
-            // Wait for URL to change to the new record detail view
-            await page.waitForURL(/\/window\/\d+\/\d+/, { timeout: VERY_SLOW_ACTION_TIMEOUT }).catch(() => {});
-            await page.waitForTimeout(3000);
 
             // Fill Value field
             const promoValue = `PC_${Date.now()}`;
-            const valueInput = page.locator('#lookup_Value input, input[name="Value"]').first();
+            const valueInput = page.locator('#lookup_Value input.input-field, .form-field-Value input.input-field').first();
             await valueInput.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
             await valueInput.click();
             await valueInput.fill(promoValue);
@@ -130,7 +121,7 @@ entire order-to-cash flow.
             await page.waitForTimeout(500);
 
             // Fill Name field
-            const nameInput = page.locator('#lookup_Name input, input[name="Name"]').first();
+            const nameInput = page.locator('#lookup_Name input.input-field, .form-field-Name input.input-field').first();
             await nameInput.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
             await nameInput.click();
             await nameInput.fill(`Test Promotion ${promoValue}`);
@@ -138,7 +129,7 @@ entire order-to-cash flow.
             await page.waitForTimeout(500);
 
             // Fill Description field (new column)
-            const descInput = page.locator('#lookup_Description input, input[name="Description"], textarea[name="Description"]').first();
+            const descInput = page.locator('#lookup_Description input.input-field, .form-field-Description input.input-field, #lookup_Description textarea').first();
             if (await descInput.isVisible().catch(() => false)) {
                 await descInput.click();
                 await descInput.fill('Automated test promotion code');

--- a/e2e/frontend-webui/tests/spec/promotion-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/promotion-code.spec.js
@@ -49,7 +49,7 @@ testCases.forEach(({ language, label }) => {
 ## F00250: Promotion Code
 
 ### Test Scenario
-This test validates promotion code creation via UI and setting on a Sales Order:
+This test validates promotion code creation via UI and propagation to Invoice Candidates:
 
 1. **Create Promotion Code** - New promotion code via the Aktionskennzeichen window
 2. **Create Sales Order** - SO with customer, product, and the promotion code (set via Advanced Edit)
@@ -59,6 +59,7 @@ This test validates promotion code creation via UI and setting on a Sales Order:
 ### Business Value
 Ensures promotion codes created via the UI can be set on sales orders
 via the Advanced Edit modal and propagate correctly to invoice candidates.
+Full O2C chain (IC -> Invoice) is covered by the Cucumber test.
             `);
 
             test.setTimeout(180000); // 3 minutes
@@ -228,33 +229,33 @@ via the Advanced Edit modal and propagate correctly to invoice candidates.
             await InvoiceCandidatePage.expectVisibleForSalesOrder();
 
             const screenshotIC = await page.screenshot();
-            allure.attachment('Invoice Candidates', screenshotIC, 'image/png');
+            allure.attachment('Invoice Candidates List', screenshotIC, 'image/png');
 
             // Step 10: Open first IC row and verify promo code propagated
             const firstRow = page.locator('.table-flex-wrapper table tbody tr, table tbody tr').first();
             const rowVisible = await firstRow.isVisible().catch(() => false);
-            if (rowVisible) {
-                await firstRow.dblclick();
-                await page.waitForURL(/\/window\/\d+\/\d+/, { timeout: SLOW_ACTION_TIMEOUT });
-                await page.waitForTimeout(1000);
+            expect(rowVisible).toBeTruthy();
+            await firstRow.dblclick();
+            await page.waitForURL(/\/window\/\d+\/\d+/, { timeout: SLOW_ACTION_TIMEOUT });
+            await page.waitForTimeout(1000);
 
-                // Verify promo code on IC via Advanced Edit
-                await AdvancedEdit.open();
+            // Verify promo code on IC via Advanced Edit
+            await AdvancedEdit.open();
 
-                const icPromoFieldVisible = await AdvancedEdit.isFieldVisible('C_PromotionCode_ID');
-                if (icPromoFieldVisible) {
-                    const icPromoValue = await AdvancedEdit.getListFieldValue('C_PromotionCode_ID');
-                    expect(icPromoValue).toContain(promoValue);
-                    console.log(`[${language}] IC C_PromotionCode_ID verified: ${icPromoValue}`);
-                } else {
-                    console.log(`[${language}] IC C_PromotionCode_ID not in Advanced Edit (may not be configured)`);
-                }
+            const icPromoFieldVisible = await AdvancedEdit.isFieldVisible('C_PromotionCode_ID');
+            expect(icPromoFieldVisible).toBeTruthy();
+            const icPromoValue = await AdvancedEdit.getListFieldValue('C_PromotionCode_ID');
+            expect(icPromoValue).toContain(promoValue);
+            console.log(`[${language}] IC C_PromotionCode_ID verified: ${icPromoValue}`);
 
-                const screenshotICDetail = await page.screenshot();
-                allure.attachment('IC Advanced Edit - Promo Code', screenshotICDetail, 'image/png');
+            // Pause so the video clearly shows the promo code on the IC
+            await page.waitForTimeout(3000);
 
-                await AdvancedEdit.close();
-            }
+            const screenshotICDetail = await page.screenshot();
+            allure.attachment('IC Advanced Edit - Promo Code', screenshotICDetail, 'image/png');
+
+            await AdvancedEdit.close();
+            await page.waitForTimeout(1000);
 
             console.log(`[${language}] Promotion code E2E test completed successfully`);
         });

--- a/e2e/frontend-webui/tests/spec/promotion-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/promotion-code.spec.js
@@ -8,6 +8,7 @@ import { SalesOrderPage } from '../utils/pages/SalesOrderPage';
 import { InvoiceCandidatePage } from '../utils/pages/InvoiceCandidatePage';
 import { InvoicePage } from '../utils/pages/InvoicePage';
 import { FRONTEND_BASE_URL, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../utils/common';
+import { getFieldData } from '../utils/WebAPIValidation';
 import { SALES_ORDER_WINDOW_ID, SALES_INVOICE_WINDOW_ID } from '../utils/WindowIds';
 
 /**
@@ -156,26 +157,29 @@ entire order-to-cash flow.
             const soRecordId = await SalesOrderPage.selectCustomer(masterdata.bpartners.CUSTOMER1.bpartnerCode);
             console.log(`[${language}] Sales Order ${soRecordId} created`);
 
-            // Set promotion code on the order (field is in Advanced Edit modal)
-            await page.keyboard.press('Alt+e');
-            await page.locator('.panel-modal').waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-            console.log(`[${language}] Advanced edit modal opened on SO`);
+            // Set promotion code on the order via WebAPI PATCH (field is in Advanced Edit area)
+            const webApiBase = process.env.WEBAPI_BASE_URL || 'http://localhost:8080/rest/api';
 
-            const promoCodeField = page.locator('.panel-modal-content #lookup_C_PromotionCode_ID input').first();
-            await promoCodeField.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-            await promoCodeField.click();
-            await promoCodeField.fill(promoValue);
+            // First, find the promotion code record by typeahead lookup
+            const lookupResp = await page.request.get(
+                `${webApiBase}/window/${SALES_ORDER_WINDOW_ID}/${soRecordId}/field/C_PromotionCode_ID/typeahead?query=${encodeURIComponent(promoValue)}`,
+            );
+            expect(lookupResp.ok()).toBeTruthy();
+            const lookupData = await lookupResp.json();
+            const promoOption = lookupData.values?.[0] || lookupData[0];
+            expect(promoOption).toBeTruthy();
+            console.log(`[${language}] Found promotion code in lookup: ${JSON.stringify(promoOption)}`);
+
+            // PATCH the promotion code onto the sales order
+            const patchResp = await page.request.patch(
+                `${webApiBase}/window/${SALES_ORDER_WINDOW_ID}/${soRecordId}`,
+                {
+                    data: [{ op: 'replace', path: 'C_PromotionCode_ID', value: promoOption }],
+                },
+            );
+            expect(patchResp.ok()).toBeTruthy();
+            console.log(`[${language}] Promotion code set on SO via WebAPI`);
             await page.waitForTimeout(1000);
-
-            // Select from dropdown
-            const promoDropdownOption = page.locator('.input-dropdown-list-option').first();
-            await promoDropdownOption.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-            await promoDropdownOption.click();
-            await page.waitForTimeout(1000);
-
-            // Close Advanced Edit modal
-            await page.keyboard.press('Escape');
-            await page.locator('.panel-modal').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
 
             // Add order line
             await SalesOrderPage.addOrderLine({
@@ -194,16 +198,9 @@ entire order-to-cash flow.
             const screenshotSO = await page.screenshot();
             allure.attachment('Sales Order Completed', screenshotSO, 'image/png');
 
-            // Step 5: Verify promotion code is visible on the completed order (in Advanced Edit modal)
-            await page.keyboard.press('Alt+e');
-            await page.locator('.panel-modal').waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-            const promoCodeOnOrder = page.locator('.panel-modal-content #lookup_C_PromotionCode_ID .lookup-widget-value, .panel-modal-content #lookup_C_PromotionCode_ID input');
-            const promoCodeText = await promoCodeOnOrder.first().inputValue().catch(() =>
-                promoCodeOnOrder.first().innerText().catch(() => '')
-            );
-            console.log(`[${language}] Promotion code on order: ${promoCodeText}`);
-            await page.keyboard.press('Escape');
-            await page.locator('.panel-modal').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+            // Step 5: Verify promotion code persists on completed order (via WebAPI)
+            const promoFieldOnOrder = await getFieldData(SALES_ORDER_WINDOW_ID, soRecordId, 'C_PromotionCode_ID');
+            console.log(`[${language}] Promotion code on order: ${JSON.stringify(promoFieldOnOrder.value)}`);
 
             // Wait for async processing
             await page.waitForTimeout(5000);
@@ -237,16 +234,13 @@ entire order-to-cash flow.
             expect(invoiceDocNo).toBeTruthy();
             console.log(`[${language}] Invoice created: ${invoiceDocNo}`);
 
-            // Step 9: Verify promotion code on invoice (in Advanced Edit modal)
-            await page.keyboard.press('Alt+e');
-            await page.locator('.panel-modal').waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-            const promoCodeOnInvoice = page.locator('.panel-modal-content #lookup_C_PromotionCode_ID .lookup-widget-value, .panel-modal-content #lookup_C_PromotionCode_ID input');
-            const invoicePromoText = await promoCodeOnInvoice.first().inputValue().catch(() =>
-                promoCodeOnInvoice.first().innerText().catch(() => '')
-            );
-            console.log(`[${language}] Promotion code on invoice: ${invoicePromoText}`);
-            await page.keyboard.press('Escape');
-            await page.locator('.panel-modal').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+            // Step 9: Verify promotion code on invoice (via WebAPI)
+            const invoiceUrl = page.url();
+            const invoiceRecordId = invoiceUrl.match(/\/window\/\d+\/(\d+)/)?.[1];
+            if (invoiceRecordId) {
+                const promoFieldOnInvoice = await getFieldData(SALES_INVOICE_WINDOW_ID.toString(), invoiceRecordId, 'C_PromotionCode_ID');
+                console.log(`[${language}] Promotion code on invoice: ${JSON.stringify(promoFieldOnInvoice.value)}`);
+            }
 
             const screenshotInvoice = await page.screenshot();
             allure.attachment('Invoice with Promotion Code', screenshotInvoice, 'image/png');

--- a/e2e/frontend-webui/tests/spec/promotion-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/promotion-code.spec.js
@@ -174,11 +174,11 @@ via the Advanced Edit modal and propagate correctly to invoice candidates.
             expect(promoFieldVisible).toBeTruthy();
             console.log(`[${language}] C_PromotionCode_ID field visible in Advanced Edit`);
 
-            // Set the promotion code using typeahead search
-            await AdvancedEdit.setLookupField('C_PromotionCode_ID', promoValue);
+            // Set the promotion code using dropdown selection
+            await AdvancedEdit.setListField('C_PromotionCode_ID', promoValue);
 
             // Verify the value was set by reading it back
-            const setPromoValue = await AdvancedEdit.getLookupFieldValue('C_PromotionCode_ID');
+            const setPromoValue = await AdvancedEdit.getListFieldValue('C_PromotionCode_ID');
             expect(setPromoValue).toContain(promoValue);
             console.log(`[${language}] C_PromotionCode_ID set to: ${setPromoValue}`);
 
@@ -207,7 +207,7 @@ via the Advanced Edit modal and propagate correctly to invoice candidates.
             // Step 8: Verify promotion code persisted on completed SO via Advanced Edit
             await AdvancedEdit.open();
 
-            const soPromoValue = await AdvancedEdit.getLookupFieldValue('C_PromotionCode_ID');
+            const soPromoValue = await AdvancedEdit.getListFieldValue('C_PromotionCode_ID');
             expect(soPromoValue).toContain(promoValue);
             console.log(`[${language}] SO C_PromotionCode_ID verified after completion: ${soPromoValue}`);
 
@@ -243,7 +243,7 @@ via the Advanced Edit modal and propagate correctly to invoice candidates.
 
                 const icPromoFieldVisible = await AdvancedEdit.isFieldVisible('C_PromotionCode_ID');
                 if (icPromoFieldVisible) {
-                    const icPromoValue = await AdvancedEdit.getLookupFieldValue('C_PromotionCode_ID');
+                    const icPromoValue = await AdvancedEdit.getListFieldValue('C_PromotionCode_ID');
                     expect(icPromoValue).toContain(promoValue);
                     console.log(`[${language}] IC C_PromotionCode_ID verified: ${icPromoValue}`);
                 } else {

--- a/e2e/frontend-webui/tests/spec/promotion-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/promotion-code.spec.js
@@ -1,0 +1,252 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { LoginPage } from '../utils/pages/LoginPage';
+import { DashboardPage } from '../utils/pages/DashboardPage';
+import { SalesOrderPage } from '../utils/pages/SalesOrderPage';
+import { InvoiceCandidatePage } from '../utils/pages/InvoiceCandidatePage';
+import { InvoicePage } from '../utils/pages/InvoicePage';
+import { FRONTEND_BASE_URL, SLOW_ACTION_TIMEOUT } from '../utils/common';
+import { SALES_ORDER_WINDOW_ID, SALES_INVOICE_WINDOW_ID } from '../utils/WindowIds';
+
+/**
+ * Promotion Code E2E test suite.
+ *
+ * Features tested:
+ * - F00100: Sales Order
+ * - F00250: Promotion Code (Aktionskennzeichen)
+ *
+ * Tests the complete promotion code lifecycle:
+ * 1. Create a promotion code via UI (window 542105)
+ * 2. Create a sales order with the promotion code
+ * 3. Complete order and verify promo code persists
+ * 4. Navigate to invoice candidates and verify promo code propagated
+ * 5. Generate invoice and verify promo code on invoice
+ */
+
+const PROMOTION_CODE_WINDOW_ID = 542105;
+
+const testCases = [
+    { language: 'en_US', label: 'English' },
+    { language: 'de_DE', label: 'German' },
+];
+
+testCases.forEach(({ language, label }) => {
+    test.describe(`Promotion Code (${label})`, () => {
+        test(`Create promo code via UI and verify O2C propagation (${label})`, async ({ page }) => {
+            // === ALLURE METADATA ===
+            allure.epic('E0100: Sales');
+            allure.tag('F00100: Sales Order');
+            allure.tag('F00250: Promotion Code');
+            allure.story('Promotion Code: Create via UI -> SO -> IC -> Invoice');
+            allure.severity('critical');
+            allure.parameter('Language', language);
+            allure.tag(language);
+
+            allure.description(`
+## F00250: Promotion Code
+
+### Test Scenario
+This test validates promotion code creation via UI and propagation through O2C:
+
+1. **Create Promotion Code** - New promotion code via the Aktionskennzeichen window
+2. **Create Sales Order** - SO with customer, product, and the promotion code
+3. **Complete Order** - Verify promo code persists after completion
+4. **Check Invoice Candidates** - Verify promo code propagated to IC
+5. **Generate Invoice** - Verify promo code on the created invoice
+
+### Business Value
+Ensures promotion codes created via the UI correctly propagate through the
+entire order-to-cash flow.
+            `);
+
+            test.setTimeout(180000); // 3 minutes
+
+            // Step 1: Create test master data via Backend API
+            const masterdata = await Backend.createMasterdata({
+                request: {
+                    login: {
+                        user: {
+                            language,
+                            firstname: 'first',
+                            lastname: 'last',
+                        },
+                    },
+                    bpartners: {
+                        CUSTOMER1: {
+                            isVendor: false,
+                            isCustomer: true,
+                            isSoPriceList: true,
+                            name: 'PromoCodeCustomer',
+                        },
+                    },
+                    products: {
+                        Product1: {
+                            name: 'PromoProduct',
+                            type: 'Item',
+                            prices: [
+                                {
+                                    price: 10.0,
+                                    currencyCode: 'EUR',
+                                },
+                            ],
+                        },
+                    },
+                },
+            });
+
+            allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+            console.log(`[${language}] Master data created`);
+
+            // Step 2: Login
+            await LoginPage.goto();
+            await LoginPage.login(masterdata.login.user);
+            await DashboardPage.expectVisible();
+
+            // Step 3: Create Promotion Code via UI
+            await page.goto(`${FRONTEND_BASE_URL}/window/${PROMOTION_CODE_WINDOW_ID}`);
+            await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+            await page.waitForTimeout(1000);
+
+            // Create new record
+            await page.keyboard.press('Alt+n');
+            await page.waitForTimeout(2000);
+
+            // Fill Value field
+            const promoValue = `PC_${Date.now()}`;
+            const valueInput = page.locator('#lookup_Value input, input[name="Value"]').first();
+            await valueInput.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+            await valueInput.click();
+            await valueInput.fill(promoValue);
+            await page.keyboard.press('Tab');
+            await page.waitForTimeout(500);
+
+            // Fill Name field
+            const nameInput = page.locator('#lookup_Name input, input[name="Name"]').first();
+            await nameInput.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+            await nameInput.click();
+            await nameInput.fill(`Test Promotion ${promoValue}`);
+            await page.keyboard.press('Tab');
+            await page.waitForTimeout(500);
+
+            // Fill Description field (new column)
+            const descInput = page.locator('#lookup_Description input, input[name="Description"], textarea[name="Description"]').first();
+            if (await descInput.isVisible().catch(() => false)) {
+                await descInput.click();
+                await descInput.fill('Automated test promotion code');
+                await page.keyboard.press('Tab');
+                await page.waitForTimeout(500);
+            }
+
+            // Wait for auto-save
+            await page.waitForTimeout(2000);
+
+            // Get the record ID from URL
+            const promoUrl = page.url();
+            const promoRecordId = promoUrl.match(/\/window\/\d+\/(\d+)/)?.[1];
+            expect(promoRecordId).toBeTruthy();
+            console.log(`[${language}] Promotion Code created: ${promoValue} (ID: ${promoRecordId})`);
+
+            const screenshotPromo = await page.screenshot();
+            allure.attachment('Promotion Code Created', screenshotPromo, 'image/png');
+
+            // Step 4: Create Sales Order with promotion code
+            await SalesOrderPage.goto();
+            await SalesOrderPage.clickNew();
+
+            const soRecordId = await SalesOrderPage.selectCustomer(masterdata.bpartners.CUSTOMER1.bpartnerCode);
+            console.log(`[${language}] Sales Order ${soRecordId} created`);
+
+            // Set promotion code on the order
+            const promoCodeField = page.locator('#lookup_C_PromotionCode_ID input').first();
+            await promoCodeField.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+            await promoCodeField.click();
+            await promoCodeField.fill(promoValue);
+            await page.waitForTimeout(1000);
+
+            // Select from dropdown
+            const promoDropdownOption = page.locator('.input-dropdown-list-option').first();
+            await promoDropdownOption.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+            await promoDropdownOption.click();
+            await page.waitForTimeout(1000);
+
+            // Add order line
+            await SalesOrderPage.addOrderLine({
+                product: masterdata.products.Product1.productCode,
+                quantity: '10',
+                recordId: soRecordId,
+            });
+
+            // Complete order
+            await SalesOrderPage.complete();
+
+            const soDocumentNo = await SalesOrderPage.getDocumentNo();
+            expect(soDocumentNo).toBeTruthy();
+            console.log(`[${language}] Sales Order completed: ${soDocumentNo}`);
+
+            const screenshotSO = await page.screenshot();
+            allure.attachment('Sales Order Completed', screenshotSO, 'image/png');
+
+            // Step 5: Verify promotion code is visible on the completed order
+            const promoCodeOnOrder = page.locator('#lookup_C_PromotionCode_ID .lookup-widget-value, #lookup_C_PromotionCode_ID input');
+            const promoCodeText = await promoCodeOnOrder.first().inputValue().catch(() =>
+                promoCodeOnOrder.first().innerText().catch(() => '')
+            );
+            console.log(`[${language}] Promotion code on order: ${promoCodeText}`);
+
+            // Wait for async processing
+            await page.waitForTimeout(5000);
+
+            // Step 6: Navigate to invoice candidates
+            await SalesOrderPage.openRelatedInvoiceCandidate(5000);
+            await InvoiceCandidatePage.expectVisibleForSalesOrder();
+
+            const screenshotIC = await page.screenshot();
+            allure.attachment('Invoice Candidates', screenshotIC, 'image/png');
+            console.log(`[${language}] Invoice candidates visible`);
+
+            // Step 7: Create invoice
+            await InvoiceCandidatePage.createInvoiceForSalesOrder();
+            console.log(`[${language}] Invoice created from candidates`);
+
+            await page.waitForTimeout(5000);
+
+            // Step 8: Navigate back to SO and zoom to invoice
+            await page.goto(`${FRONTEND_BASE_URL}/window/${SALES_ORDER_WINDOW_ID}/${soRecordId}`);
+            await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+            await page.locator('.rotating, .panel-spaced-lg')
+                .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+                .catch(() => {});
+            await page.waitForTimeout(500);
+
+            await SalesOrderPage.openRelatedInvoice();
+            await InvoicePage.expectVisible();
+
+            const invoiceDocNo = await InvoicePage.getDocumentNo();
+            expect(invoiceDocNo).toBeTruthy();
+            console.log(`[${language}] Invoice created: ${invoiceDocNo}`);
+
+            // Step 9: Verify promotion code on invoice
+            const promoCodeOnInvoice = page.locator('#lookup_C_PromotionCode_ID .lookup-widget-value, #lookup_C_PromotionCode_ID input');
+            const invoicePromoText = await promoCodeOnInvoice.first().inputValue().catch(() =>
+                promoCodeOnInvoice.first().innerText().catch(() => '')
+            );
+            console.log(`[${language}] Promotion code on invoice: ${invoicePromoText}`);
+
+            const screenshotInvoice = await page.screenshot();
+            allure.attachment('Invoice with Promotion Code', screenshotInvoice, 'image/png');
+
+            // Validation summary
+            const validationHtml = `<table border="1">
+                <tr><th>Check</th><th>Status</th><th>Value</th></tr>
+                <tr><td>Promotion Code Created</td><td>PASS</td><td>${promoValue}</td></tr>
+                <tr><td>Sales Order Created</td><td>PASS</td><td>${soDocumentNo}</td></tr>
+                <tr><td>Invoice Created</td><td>PASS</td><td>${invoiceDocNo}</td></tr>
+            </table>`;
+            allure.attachment('Validation Results', validationHtml, 'text/html');
+
+            console.log(`[${language}] Promotion code E2E test completed successfully`);
+        });
+    });
+});

--- a/e2e/frontend-webui/tests/spec/promotion-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/promotion-code.spec.js
@@ -7,7 +7,7 @@ import { DashboardPage } from '../utils/pages/DashboardPage';
 import { SalesOrderPage } from '../utils/pages/SalesOrderPage';
 import { InvoiceCandidatePage } from '../utils/pages/InvoiceCandidatePage';
 import { InvoicePage } from '../utils/pages/InvoicePage';
-import { FRONTEND_BASE_URL, SLOW_ACTION_TIMEOUT } from '../utils/common';
+import { FRONTEND_BASE_URL, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../utils/common';
 import { SALES_ORDER_WINDOW_ID, SALES_INVOICE_WINDOW_ID } from '../utils/WindowIds';
 
 /**
@@ -106,17 +106,24 @@ entire order-to-cash flow.
 
             // Step 3: Create Promotion Code via UI
             await page.goto(`${FRONTEND_BASE_URL}/window/${PROMOTION_CODE_WINDOW_ID}`);
-            await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
-            await page.waitForTimeout(1000);
+            await page.waitForLoadState('networkidle', { timeout: VERY_SLOW_ACTION_TIMEOUT }).catch(() => {});
+            // Wait for the window to fully render (list or detail view)
+            await page.locator('.panel-spaced-lg, .table-flex-wrapper table, .document-list-wrapper')
+                .first()
+                .waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT })
+                .catch(() => {});
+            await page.waitForTimeout(2000);
 
             // Create new record
             await page.keyboard.press('Alt+n');
-            await page.waitForTimeout(2000);
+            // Wait for URL to change to the new record detail view
+            await page.waitForURL(/\/window\/\d+\/\d+/, { timeout: VERY_SLOW_ACTION_TIMEOUT }).catch(() => {});
+            await page.waitForTimeout(3000);
 
             // Fill Value field
             const promoValue = `PC_${Date.now()}`;
             const valueInput = page.locator('#lookup_Value input, input[name="Value"]').first();
-            await valueInput.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+            await valueInput.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
             await valueInput.click();
             await valueInput.fill(promoValue);
             await page.keyboard.press('Tab');
@@ -124,7 +131,7 @@ entire order-to-cash flow.
 
             // Fill Name field
             const nameInput = page.locator('#lookup_Name input, input[name="Name"]').first();
-            await nameInput.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+            await nameInput.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
             await nameInput.click();
             await nameInput.fill(`Test Promotion ${promoValue}`);
             await page.keyboard.press('Tab');
@@ -160,14 +167,14 @@ entire order-to-cash flow.
 
             // Set promotion code on the order
             const promoCodeField = page.locator('#lookup_C_PromotionCode_ID input').first();
-            await promoCodeField.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+            await promoCodeField.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
             await promoCodeField.click();
             await promoCodeField.fill(promoValue);
             await page.waitForTimeout(1000);
 
             // Select from dropdown
             const promoDropdownOption = page.locator('.input-dropdown-list-option').first();
-            await promoDropdownOption.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+            await promoDropdownOption.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
             await promoDropdownOption.click();
             await page.waitForTimeout(1000);
 

--- a/e2e/frontend-webui/tests/spec/promotion-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/promotion-code.spec.js
@@ -156,24 +156,26 @@ entire order-to-cash flow.
             const soRecordId = await SalesOrderPage.selectCustomer(masterdata.bpartners.CUSTOMER1.bpartnerCode);
             console.log(`[${language}] Sales Order ${soRecordId} created`);
 
-            // Set promotion code on the order (field is in Advanced Edit area)
+            // Set promotion code on the order (field is in Advanced Edit modal)
             await page.keyboard.press('Alt+e');
-            await page.waitForTimeout(1000);
-            const promoCodeField = page.locator('#lookup_C_PromotionCode_ID input').first();
-            await promoCodeField.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
+            await page.locator('.panel-modal').waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+            console.log(`[${language}] Advanced edit modal opened on SO`);
+
+            const promoCodeField = page.locator('.panel-modal-content #lookup_C_PromotionCode_ID input').first();
+            await promoCodeField.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
             await promoCodeField.click();
             await promoCodeField.fill(promoValue);
             await page.waitForTimeout(1000);
 
             // Select from dropdown
             const promoDropdownOption = page.locator('.input-dropdown-list-option').first();
-            await promoDropdownOption.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
+            await promoDropdownOption.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
             await promoDropdownOption.click();
             await page.waitForTimeout(1000);
 
-            // Close Advanced Edit
+            // Close Advanced Edit modal
             await page.keyboard.press('Escape');
-            await page.waitForTimeout(500);
+            await page.locator('.panel-modal').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
 
             // Add order line
             await SalesOrderPage.addOrderLine({
@@ -192,16 +194,16 @@ entire order-to-cash flow.
             const screenshotSO = await page.screenshot();
             allure.attachment('Sales Order Completed', screenshotSO, 'image/png');
 
-            // Step 5: Verify promotion code is visible on the completed order (in Advanced Edit)
+            // Step 5: Verify promotion code is visible on the completed order (in Advanced Edit modal)
             await page.keyboard.press('Alt+e');
-            await page.waitForTimeout(1000);
-            const promoCodeOnOrder = page.locator('#lookup_C_PromotionCode_ID .lookup-widget-value, #lookup_C_PromotionCode_ID input');
+            await page.locator('.panel-modal').waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+            const promoCodeOnOrder = page.locator('.panel-modal-content #lookup_C_PromotionCode_ID .lookup-widget-value, .panel-modal-content #lookup_C_PromotionCode_ID input');
             const promoCodeText = await promoCodeOnOrder.first().inputValue().catch(() =>
                 promoCodeOnOrder.first().innerText().catch(() => '')
             );
             console.log(`[${language}] Promotion code on order: ${promoCodeText}`);
             await page.keyboard.press('Escape');
-            await page.waitForTimeout(500);
+            await page.locator('.panel-modal').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
 
             // Wait for async processing
             await page.waitForTimeout(5000);
@@ -235,16 +237,16 @@ entire order-to-cash flow.
             expect(invoiceDocNo).toBeTruthy();
             console.log(`[${language}] Invoice created: ${invoiceDocNo}`);
 
-            // Step 9: Verify promotion code on invoice (in Advanced Edit)
+            // Step 9: Verify promotion code on invoice (in Advanced Edit modal)
             await page.keyboard.press('Alt+e');
-            await page.waitForTimeout(1000);
-            const promoCodeOnInvoice = page.locator('#lookup_C_PromotionCode_ID .lookup-widget-value, #lookup_C_PromotionCode_ID input');
+            await page.locator('.panel-modal').waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+            const promoCodeOnInvoice = page.locator('.panel-modal-content #lookup_C_PromotionCode_ID .lookup-widget-value, .panel-modal-content #lookup_C_PromotionCode_ID input');
             const invoicePromoText = await promoCodeOnInvoice.first().inputValue().catch(() =>
                 promoCodeOnInvoice.first().innerText().catch(() => '')
             );
             console.log(`[${language}] Promotion code on invoice: ${invoicePromoText}`);
             await page.keyboard.press('Escape');
-            await page.waitForTimeout(500);
+            await page.locator('.panel-modal').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
 
             const screenshotInvoice = await page.screenshot();
             allure.attachment('Invoice with Promotion Code', screenshotInvoice, 'image/png');

--- a/e2e/frontend-webui/tests/utils/AdvancedEdit.js
+++ b/e2e/frontend-webui/tests/utils/AdvancedEdit.js
@@ -1,0 +1,220 @@
+/**
+ * Advanced Edit (Alt+E) Utility
+ *
+ * Opens the Advanced Edit modal and provides methods to interact with fields
+ * inside it. Fields marked as IsAdvancedField='Y' in the Application Dictionary
+ * are only accessible through this modal.
+ *
+ * The modal is opened via Alt+E keyboard shortcut and scoped via .panel-modal-content.
+ *
+ * Usage:
+ *   import { AdvancedEdit } from '../utils/AdvancedEdit';
+ *
+ *   await AdvancedEdit.open();
+ *   await AdvancedEdit.setLookupField('C_PromotionCode_ID', 'PC_12345');
+ *   const value = await AdvancedEdit.getLookupFieldValue('C_PromotionCode_ID');
+ *   await AdvancedEdit.close();
+ */
+import { test } from '../../playwright.config';
+import { getPage, SLOW_ACTION_TIMEOUT } from './common';
+import { WidgetCommon } from './widgets/WidgetCommon';
+
+export class AdvancedEdit {
+  /**
+   * Open the Advanced Edit modal via Alt+E.
+   * Waits for the modal to be fully visible before returning.
+   */
+  static async open() {
+    return await test.step('AdvancedEdit - Open modal (Alt+E)', async () => {
+      const page = getPage();
+
+      await page.keyboard.press('Alt+e');
+      await page.locator('.panel-modal').waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      // Wait for content to render inside the modal
+      await page.locator('.panel-modal-content').waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await page.waitForTimeout(500);
+    });
+  }
+
+  /**
+   * Close the Advanced Edit modal.
+   * Clicks the Done/Apply button or presses Escape.
+   */
+  static async close() {
+    return await test.step('AdvancedEdit - Close modal', async () => {
+      const page = getPage();
+      const modal = page.locator('.panel-modal');
+
+      // Try the Done/Apply button first (language-independent: uses data-testid or class)
+      const doneButton = modal.locator(
+        'button[data-testid="done"], .btn-meta-primary, .btn-meta-success'
+      ).first();
+      const doneVisible = await doneButton.isVisible().catch(() => false);
+
+      if (doneVisible) {
+        await doneButton.click();
+      } else {
+        // Fallback: press Escape
+        await page.keyboard.press('Escape');
+      }
+
+      await modal.waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT }).catch(() => {
+        // Modal may just become hidden rather than detached
+      });
+      await page.waitForTimeout(500);
+    });
+  }
+
+  /**
+   * Get the modal content container locator.
+   * All field selectors inside Advanced Edit should be scoped to this.
+   *
+   * @returns {import('@playwright/test').Locator}
+   */
+  static _getModalContent() {
+    const page = getPage();
+    return page.locator('.panel-modal-content');
+  }
+
+  /**
+   * Get a field container inside the Advanced Edit modal.
+   *
+   * @param {string} fieldName - Database column name (e.g., 'C_PromotionCode_ID')
+   * @returns {import('@playwright/test').Locator}
+   */
+  static _getFieldContainer(fieldName) {
+    const modal = this._getModalContent();
+    return modal.locator(`#lookup_${fieldName}, .form-field-${fieldName}`).first();
+  }
+
+  /**
+   * Set a lookup field value inside the Advanced Edit modal.
+   * Types the search text, waits for the dropdown, and selects the matching option.
+   *
+   * @param {string} fieldName - Database column name (e.g., 'C_PromotionCode_ID')
+   * @param {string} searchText - Text to type for typeahead search
+   * @param {Object} options - Optional settings
+   * @param {boolean} options.exactMatch - Require exact text match (default: false)
+   */
+  static async setLookupField(fieldName, searchText, { exactMatch = false } = {}) {
+    return await test.step(`AdvancedEdit - Set lookup ${fieldName} to "${searchText}"`, async () => {
+      const page = getPage();
+      const container = this._getFieldContainer(fieldName);
+
+      const input = container.locator('input.input-field, input[type="text"]').first();
+      await input.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+      // Check if readonly
+      const isDisabled = await input.isDisabled().catch(() => false);
+      if (isDisabled) {
+        throw new Error(`AdvancedEdit - Field ${fieldName} is readonly/disabled`);
+      }
+
+      await input.click();
+      await page.waitForTimeout(300);
+
+      await input.fill(searchText);
+      await page.waitForTimeout(WidgetCommon.DEBOUNCE_DELAY);
+
+      // Wait for dropdown
+      const dropdown = page.locator('.input-dropdown-list');
+      await dropdown.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+      // Select option
+      if (exactMatch) {
+        await dropdown.locator('.input-dropdown-list-option').getByText(searchText, { exact: true }).first().click();
+      } else {
+        await dropdown.locator('.input-dropdown-list-option').getByText(searchText).first().click();
+      }
+
+      // Wait for dropdown to close and value to be set
+      await WidgetCommon.waitForDropdownClosed();
+      await page.waitForTimeout(500);
+    });
+  }
+
+  /**
+   * Get the displayed value of a lookup field inside the Advanced Edit modal.
+   *
+   * @param {string} fieldName - Database column name
+   * @returns {Promise<string>} The displayed text value
+   */
+  static async getLookupFieldValue(fieldName) {
+    return await test.step(`AdvancedEdit - Get lookup ${fieldName} value`, async () => {
+      const container = this._getFieldContainer(fieldName);
+      const input = container.locator('input.input-field, input[type="text"]').first();
+      await input.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      return await input.inputValue();
+    });
+  }
+
+  /**
+   * Set a text field value inside the Advanced Edit modal.
+   *
+   * @param {string} fieldName - Database column name
+   * @param {string} value - Text to set
+   */
+  static async setTextField(fieldName, value) {
+    return await test.step(`AdvancedEdit - Set text ${fieldName} to "${value}"`, async () => {
+      const page = getPage();
+      const container = this._getFieldContainer(fieldName);
+
+      let input = container.locator('input.input-field, input[type="text"]').first();
+      let inputCount = await input.count();
+      if (inputCount === 0) {
+        input = container.locator('textarea').first();
+      }
+
+      await input.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await input.click();
+      await page.keyboard.press('Control+a');
+      await input.fill(value);
+      await page.waitForTimeout(300);
+    });
+  }
+
+  /**
+   * Get a text field value inside the Advanced Edit modal.
+   *
+   * @param {string} fieldName - Database column name
+   * @returns {Promise<string>}
+   */
+  static async getTextFieldValue(fieldName) {
+    return await test.step(`AdvancedEdit - Get text ${fieldName} value`, async () => {
+      const container = this._getFieldContainer(fieldName);
+      let input = container.locator('input.input-field, input[type="text"]').first();
+      let inputCount = await input.count();
+      if (inputCount === 0) {
+        input = container.locator('textarea').first();
+      }
+      return await input.inputValue();
+    });
+  }
+
+  /**
+   * Check if a field is visible inside the Advanced Edit modal.
+   *
+   * @param {string} fieldName - Database column name
+   * @returns {Promise<boolean>}
+   */
+  static async isFieldVisible(fieldName) {
+    return await test.step(`AdvancedEdit - Check if ${fieldName} is visible`, async () => {
+      const container = this._getFieldContainer(fieldName);
+      return await container.isVisible().catch(() => false);
+    });
+  }
+
+  /**
+   * Check if a lookup field is readonly inside the Advanced Edit modal.
+   *
+   * @param {string} fieldName - Database column name
+   * @returns {Promise<boolean>}
+   */
+  static async isFieldReadonly(fieldName) {
+    return await test.step(`AdvancedEdit - Check if ${fieldName} is readonly`, async () => {
+      const container = this._getFieldContainer(fieldName);
+      const input = container.locator('input.input-field, input[type="text"]').first();
+      return await input.isDisabled().catch(() => true);
+    });
+  }
+}

--- a/e2e/frontend-webui/tests/utils/AdvancedEdit.js
+++ b/e2e/frontend-webui/tests/utils/AdvancedEdit.js
@@ -205,6 +205,57 @@ export class AdvancedEdit {
   }
 
   /**
+   * Set a list/dropdown field value inside the Advanced Edit modal.
+   * Clicks the dropdown trigger, waits for options, and selects the matching one.
+   *
+   * @param {string} fieldName - Database column name (e.g., 'C_PromotionCode_ID')
+   * @param {string} optionText - Text of the option to select
+   * @param {Object} options - Optional settings
+   * @param {boolean} options.exactMatch - Require exact text match (default: false)
+   */
+  static async setListField(fieldName, optionText, { exactMatch = false } = {}) {
+    return await test.step(`AdvancedEdit - Set list ${fieldName} to "${optionText}"`, async () => {
+      const page = getPage();
+      const container = this._getFieldContainer(fieldName);
+
+      // Click the dropdown trigger (the container or chevron icon)
+      const dropdownTrigger = container.locator('.input-dropdown, input, [class*="dropdown"]').first();
+      await dropdownTrigger.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await dropdownTrigger.click();
+
+      // Wait for dropdown to appear
+      const dropdown = page.locator('.input-dropdown-list');
+      await dropdown.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+      // Select the matching option
+      if (exactMatch) {
+        await dropdown.locator('.input-dropdown-list-option').getByText(optionText, { exact: true }).first().click();
+      } else {
+        await dropdown.locator('.input-dropdown-list-option').getByText(optionText).first().click();
+      }
+
+      // Wait for dropdown to close
+      await WidgetCommon.waitForDropdownClosed();
+      await page.waitForTimeout(500);
+    });
+  }
+
+  /**
+   * Get the displayed value of a list/dropdown field inside the Advanced Edit modal.
+   *
+   * @param {string} fieldName - Database column name
+   * @returns {Promise<string>} The displayed text value
+   */
+  static async getListFieldValue(fieldName) {
+    return await test.step(`AdvancedEdit - Get list ${fieldName} value`, async () => {
+      const container = this._getFieldContainer(fieldName);
+      const input = container.locator('input').first();
+      await input.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      return await input.inputValue();
+    });
+  }
+
+  /**
    * Check if a lookup field is readonly inside the Advanced Edit modal.
    *
    * @param {string} fieldName - Database column name

--- a/e2e/frontend-webui/tests/utils/AdvancedEdit.js
+++ b/e2e/frontend-webui/tests/utils/AdvancedEdit.js
@@ -11,8 +11,8 @@
  *   import { AdvancedEdit } from '../utils/AdvancedEdit';
  *
  *   await AdvancedEdit.open();
- *   await AdvancedEdit.setLookupField('C_PromotionCode_ID', 'PC_12345');
- *   const value = await AdvancedEdit.getLookupFieldValue('C_PromotionCode_ID');
+ *   await AdvancedEdit.setListField('C_PromotionCode_ID', 'PC_12345');
+ *   const value = await AdvancedEdit.getListFieldValue('C_PromotionCode_ID');
  *   await AdvancedEdit.close();
  */
 import { test } from '../../playwright.config';


### PR DESCRIPTION
## Summary
- Add `C_PromotionCode` master data table with Value, Name, ValidTo columns and base window
- Add `C_PromotionCode_ID` / `C_PromotionCode2_ID` FK columns to C_Order, C_Invoice_Candidate, and C_Invoice (replacing old unused `PromotionCode` varchar)
- Propagate promotion codes through the IC flow (Order → IC → Invoice) via C_OrderLine_Handler, AggregationEngine, InvoiceHeaderImpl, InvoiceCandBLCreateInvoices, and AbstractInvoiceBL
- Add duplicate validation interceptor (rejects same code in both fields)
- Add AD_Process for Promotion Code Evaluation report (ExportToSpreadsheetProcess)
- AD_Val_Rules for date-based dropdown filtering by DateOrdered/DateInvoiced

## Test plan
- [x] Unit tests: C_Order_PromotionCodeTest (4 tests, all pass locally)
- [x] Migration scripts: All 6 scripts applied successfully against local DB
- [x] Compilation: base, business, swat.base modules compile clean
- [ ] CI: Await green pipeline
- [ ] Cucumber: promotionCode.feature (2 scenarios — single code propagation, dual code propagation)