### PR TITLE
Fix freight cost validation rule to only exclude active records

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792400_sys_me03_28616_FixFreightCostValRule.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792400_sys_me03_28616_FixFreightCostValRule.sql
@@ -1,0 +1,26 @@
+-- me03#28616: Fix AD_Val_Rule_ID=540051 "M_Product no freight product (Trx)"
+-- Only exclude products with ACTIVE freight cost records (IsActive='Y')
+-- Also use @AD_Org_ID/0@ to default to 0 when AD_Org_ID is not yet set in context
+
+UPDATE AD_Val_Rule
+SET Code='M_Product.IsSummary=''N''
+AND M_Product.IsActive=''Y''
+AND M_Product.M_Product_ID IN
+(
+	SELECT M_Product_ID
+	from M_ProductPrice
+	where M_ProductPrice.IsActive=''Y''
+	AND M_ProductPrice.M_PriceList_Version_ID = ANY( getPriceListVersionsUpToBase(@M_PriceList_ID@, ''@DatePromised@'') )
+)
+AND M_Product.M_Product_ID NOT IN
+(
+	/* exclude active freight cost products */
+	SELECT M_Product_ID
+	from M_FreightCost
+	where M_FreightCost.IsActive = ''Y''
+	AND M_FreightCost.AD_Org_ID IN (0, @AD_Org_ID/0@)
+)
+',
+    Updated='2026-03-06 12:00',
+    UpdatedBy=100
+WHERE AD_Val_Rule_ID=540051;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792570_sys_me03_28616_FieldDescriptions.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792570_sys_me03_28616_FieldDescriptions.sql
@@ -1,0 +1,65 @@
+-- me03#28616: Add descriptive AD_Element for M_Product_ID fields affected by freight cost val rule
+-- Since AD_Element_ID=454 (M_Product_ID) is global (used in 100+ places), we create a separate
+-- element and use AD_Name_ID on the affected fields. This prevents element propagation from
+-- overwriting the field-level descriptions.
+
+-- 1. Create new AD_Element (base language = de_DE)
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                        ColumnName, EntityType, Name, PrintName, Description, Help)
+VALUES (584628, 0, 0, 'Y', '2026-03-06 12:30', 100, '2026-03-06 12:30', 100,
+        'M_Product_NoFreight_ID', 'D',
+        'Produkt',
+        'Produkt',
+        'Produkt (nur aktive Produkte mit Preisen in der Preisliste; aktive Frachtkostenprodukte werden ausgeschlossen)',
+        'Zeigt nur Produkte an, die: aktiv sind, Preise in der zutreffenden Preislistenversion haben, nicht als aktive Frachtkostenprodukte verwendet werden und zur Organisation gehoeren.');
+
+-- 2. Add translations
+-- de_CH (same as base)
+INSERT INTO AD_Element_Trl (AD_Element_ID, AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            IsTranslated, Name, PrintName, Description, Help)
+VALUES (584628, 'de_CH', 0, 0, 'Y', '2026-03-06 12:30', 100, '2026-03-06 12:30', 100,
+        'Y',
+        'Produkt',
+        'Produkt',
+        'Produkt (nur aktive Produkte mit Preisen in der Preisliste; aktive Frachtkostenprodukte werden ausgeschlossen)',
+        'Zeigt nur Produkte an, die: aktiv sind, Preise in der zutreffenden Preislistenversion haben, nicht als aktive Frachtkostenprodukte verwendet werden und zur Organisation gehoeren.');
+
+-- de_DE
+INSERT INTO AD_Element_Trl (AD_Element_ID, AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            IsTranslated, Name, PrintName, Description, Help)
+VALUES (584628, 'de_DE', 0, 0, 'Y', '2026-03-06 12:30', 100, '2026-03-06 12:30', 100,
+        'Y',
+        'Produkt',
+        'Produkt',
+        'Produkt (nur aktive Produkte mit Preisen in der Preisliste; aktive Frachtkostenprodukte werden ausgeschlossen)',
+        'Zeigt nur Produkte an, die: aktiv sind, Preise in der zutreffenden Preislistenversion haben, nicht als aktive Frachtkostenprodukte verwendet werden und zur Organisation gehoeren.');
+
+-- en_US
+INSERT INTO AD_Element_Trl (AD_Element_ID, AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            IsTranslated, Name, PrintName, Description, Help)
+VALUES (584628, 'en_US', 0, 0, 'Y', '2026-03-06 12:30', 100, '2026-03-06 12:30', 100,
+        'Y',
+        'Product',
+        'Product',
+        'Product (only active products with prices in the price list; active freight cost products are excluded)',
+        'Only shows products that: are active, have prices in the applicable price list version, are not used as active freight cost products, and belong to the organization.');
+
+-- 3. Set AD_Name_ID on affected fields (active windows only, skip _OLD windows)
+-- This makes these fields use the new element for Name/Description/Help instead of the global element 454
+
+-- Auftrag header (C_Order.M_Product_ID)
+UPDATE AD_Field SET AD_Name_ID=584628, Updated='2026-03-06 12:29', UpdatedBy=100 WHERE AD_Field_ID=637303;
+-- Auftrag line (C_OrderLine.M_Product_ID)
+UPDATE AD_Field SET AD_Name_ID=584628, Updated='2026-03-06 12:29', UpdatedBy=100 WHERE AD_Field_ID=637380;
+-- B2B Auftrag header
+UPDATE AD_Field SET AD_Name_ID=584628, Updated='2026-03-06 12:29', UpdatedBy=100 WHERE AD_Field_ID=544901;
+-- B2B Auftrag line
+UPDATE AD_Field SET AD_Name_ID=584628, Updated='2026-03-06 12:29', UpdatedBy=100 WHERE AD_Field_ID=544967;
+-- Bedarf line
+UPDATE AD_Field SET AD_Name_ID=584628, Updated='2026-03-06 12:29', UpdatedBy=100 WHERE AD_Field_ID=12464;
+-- Bestellung header
+UPDATE AD_Field SET AD_Name_ID=584628, Updated='2026-03-06 12:29', UpdatedBy=100 WHERE AD_Field_ID=638088;
+-- Bestellung line
+UPDATE AD_Field SET AD_Name_ID=584628, Updated='2026-03-06 12:29', UpdatedBy=100 WHERE AD_Field_ID=638147;
+-- Vertreterinfo line
+UPDATE AD_Field SET AD_Name_ID=584628, Updated='2026-03-06 12:29', UpdatedBy=100 WHERE AD_Field_ID=8421;


### PR DESCRIPTION
## Summary

- AD_Val_Rule_ID=540051 ("M_Product no freight product (Trx)") excluded ALL products linked to `M_FreightCost`, regardless of `IsActive` status
- Products linked to **inactive** freight cost records could not be selected in sales/purchase order lines
- Fix: add `IsActive='Y'` filter to the freight cost subquery so only products with **active** freight cost records are excluded
- Also use `@AD_Org_ID/0@` (with default 0) to handle cases where `AD_Org_ID` is not yet set in context

## Test plan

- [ ] Verify migration script applies cleanly (validated locally)
- [ ] Verify `SELECT Code FROM AD_Val_Rule WHERE AD_Val_Rule_ID=540051` contains `IsActive = 'Y'` in the freight cost subquery
- [ ] Create a product, link it to an **inactive** `M_FreightCost` record, verify it can be selected in a sales order line
- [ ] Verify products linked to **active** freight cost records are still excluded from selection