### PR TITLE
gh#26915: Improve MainArticleLine cross-reference in DESADV JSON

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
@@ -56,8 +56,8 @@ public class EDI_Desadv_JSON_Export_StepDef
 	 * Inspects the {@code Packings[].LineItems[]} in the last API response and counts:
 	 * <ul>
 	 *     <li>Total packings (should be reduced after merging)</li>
-	 *     <li>Main articles ({@code IsSubArticle=false}): must have {@code MainArticleLine=null}</li>
-	 *     <li>Sub-articles ({@code IsSubArticle=true}): must have {@code MainArticleLine > 0}</li>
+	 *     <li>Main articles ({@code IsSubArticle=false}): must have {@code MainArticleItemLine=null}</li>
+	 *     <li>Sub-articles ({@code IsSubArticle=true}): must have {@code MainArticleItemLine > 0}</li>
 	 * </ul>
 	 * <p>
 	 * DataTable columns:
@@ -107,16 +107,16 @@ public class EDI_Desadv_JSON_Export_StepDef
 					if (isSubArticle)
 					{
 						actualSubArticles++;
-						final JsonNode mainArticleLine = item.path("MainArticleLine");
-						assertThat(mainArticleLine.isNull()).as("SubArticle should have MainArticleLine set").isFalse();
+						final JsonNode mainArticleLine = item.path("MainArticleItemLine");
+						assertThat(mainArticleLine.isNull()).as("SubArticle should have MainArticleItemLine set").isFalse();
 						subArticleMainLines.add(mainArticleLine.asInt());
 					}
 					else
 					{
 						actualMainArticles++;
-						final JsonNode mainArticleLine = item.path("MainArticleLine");
+						final JsonNode mainArticleLine = item.path("MainArticleItemLine");
 						assertThat(mainArticleLine.isNull())
-								.as("Non-sub-article should have MainArticleLine=null")
+								.as("Non-sub-article should have MainArticleItemLine=null")
 								.isTrue();
 					}
 				}
@@ -132,7 +132,7 @@ public class EDI_Desadv_JSON_Export_StepDef
 			// Verify all sub-articles reference a valid main line
 			for (final Integer mainLine : subArticleMainLines)
 			{
-				assertThat(mainLine).as("MainArticleLine should be > 0").isGreaterThan(0);
+				assertThat(mainLine).as("MainArticleItemLine should be > 0").isGreaterThan(0);
 			}
 		});
 	}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
@@ -246,7 +246,7 @@ Feature: EDI DESADV export via postgREST
             "QtyCUsPerTU_InInvoiceUOM": 10,
             "M_HU_PackagingCode_TU_Text": "CART",
             "IsSubArticle": false,
-            "MainArticleLine": null
+            "MainArticleItemLine": null
           }
         ],
         "IPA_SSCC18": "012345670010000005",
@@ -426,7 +426,7 @@ Feature: EDI DESADV export via postgREST
     """
     # The compensation group merging should produce 1 pack (from originally 3):
     # the main article's pack absorbs the sub-article packs.
-    # Result: 1 main article LineItem (IsSubArticle=false) + 2 sub-article LineItems (IsSubArticle=true with MainArticleLine)
+    # Result: 1 main article LineItem (IsSubArticle=false) + 2 sub-article LineItems (IsSubArticle=true with MainArticleItemLine)
     Then verify DESADV JSON export has compensation group packing:
       | PackingCount | MainArticleCount | SubArticleCount |
       | 1            | 1                | 2               |

--- a/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/desadv_json/get_desadv_packs_json_fn.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/desadv_json/get_desadv_packs_json_fn.sql
@@ -174,7 +174,7 @@ BEGIN
                                'DesadvLineNo', dl.line,
                                'GTIN_TU_PackingMaterial', ia.gtin_tu_packingmaterial,
                                'IsSubArticle', ia.is_sub_article,
-                               'MainArticleLine',
+                               'MainArticleItemLine',
                                CASE WHEN ia.is_sub_article THEN ia.main_pi_line ELSE NULL END
                        ) ORDER BY ia.is_sub_article, ia.pi_line
                ) AS items_data

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5792550_sys_gh26915_desadv_json_main_article_line_reference.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5792550_sys_gh26915_desadv_json_main_article_line_reference.sql
@@ -1,7 +1,17 @@
--- Function for desadv packs
--- Handles compensation group sub-articles: sub-article pack items are merged
--- into the main article's pack, adding IsSubArticle and MainArticleLine to each LineItem.
--- Packs NOT in a compensation group are output as before (backward-compatible).
+-- gh#26915: Improve MainArticleLine cross-reference in DESADV JSON export
+--
+-- Changes:
+-- 1. Add top-level DesadvLineNo to each LineItem (was only available buried inside DesadvLine.DesadvLine)
+-- 2. MainArticleLine now references the main article's pack_item Line (not the desadv line number),
+--    so receivers can unambiguously match sub-articles to their main article LineItem
+--    even when one desadv line is spread across multiple LineItems (different lots/BBDs).
+
+-- Drop dependent view first
+DROP VIEW IF EXISTS M_InOut_Export_EDI_DESADV_JSON_V;
+
+-- Drop and recreate the function with updated output
+DROP FUNCTION IF EXISTS "de.metas.edi".get_desadv_packs_json_fn(NUMERIC, NUMERIC);
+
 CREATE OR REPLACE FUNCTION "de.metas.edi".get_desadv_packs_json_fn(p_edi_desadv_id NUMERIC, p_m_inout_id NUMERIC)
     RETURNS JSONB
 AS
@@ -218,3 +228,67 @@ END;
 $$
     LANGUAGE plpgsql STABLE
 ;
+
+-- Recreate the view (same definition as before, just needs to exist after function recreation)
+DROP VIEW IF EXISTS M_InOut_Export_EDI_DESADV_JSON_V;
+
+CREATE OR REPLACE VIEW M_InOut_Export_EDI_DESADV_JSON_V AS
+SELECT io.m_inout_id,
+       JSONB_BUILD_OBJECT(
+               'metasfresh_DESADV', JSONB_BUILD_OBJECT(
+                       'Version', '0.2',
+                       'M_InOut_ID', io.m_inout_id,
+                       'EDI_Desadv_ID', d.edi_desadv_id,
+                       'ShipmentDocumentNo', io.documentno,
+                       'POReference', d.poreference,
+                       'DateOrdered', d.dateordered,
+                       'MovementDate', io.movementdate,
+                       'DatePromised', d.datepromised,
+                       'DeliveryViaRule', io.deliveryviarule,
+                       'InvoicableQtyBasedOn', d.invoicableqtybasedon,
+                       'TechnicalRecipientGLN', d.recipientgln,
+                       'Parties', JSONB_BUILD_OBJECT(
+                               'Buyer', COALESCE(buyer.partner_json, '{}'::jsonb),
+                               'Buyer_Location', COALESCE(buyer_loc.location_json, '{}'::jsonb),
+                               'DeliveryParty', COALESCE(delivery.partner_json, '{}'::jsonb),
+                               'DeliveryParty_Location', COALESCE(delivery_loc.location_json, '{}'::jsonb),
+                               'Supplier', COALESCE(supplier.partner_json, '{}'::jsonb),
+                               'Supplier_Location', COALESCE(supplier_loc.location_json, '{}'::jsonb),
+                               'Invoicee', COALESCE(invoicee.partner_json, '{}'::jsonb),
+                               'Invoicee_Location', COALESCE(invoicee_loc.location_json, '{}'::jsonb),
+                               'UltimateConsignee', COALESCE(consignee.partner_json, '{}'::jsonb),
+                               'UltimateConsignee_Location', COALESCE(consignee_loc.location_json, '{}'::jsonb)
+                                  ),
+                       'Currency', COALESCE(curr.currency_json, '{}'::jsonb),
+                       'Packings', "de.metas.edi".get_desadv_packs_json_fn(d.edi_desadv_id, io.m_inout_id),
+                       'DesadvLineWithNoPacking',
+                       "de.metas.edi".get_desadv_lines_no_pack_json_fn(d.edi_desadv_id, io.m_inout_id)
+                                  )
+       ) AS embedded_json
+FROM m_inout io
+         JOIN edi_desadv d ON d.edi_desadv_id = io.edi_desadv_id
+    -- Buyer
+         LEFT JOIN "de.metas.edi".edi_bpartner_object_v buyer ON buyer.c_bpartner_id = d.c_bpartner_id
+         LEFT JOIN "de.metas.edi".edi_bpartner_location_object_v buyer_loc
+                   ON buyer_loc.c_bpartner_location_id = d.c_bpartner_location_id
+    -- DeliveryParty
+         LEFT JOIN "de.metas.edi".edi_bpartner_object_v delivery ON delivery.c_bpartner_id = d.handover_partner_id
+         LEFT JOIN "de.metas.edi".edi_bpartner_location_object_v delivery_loc
+                   ON delivery_loc.c_bpartner_location_id = d.handover_location_id
+    -- Supplier
+         LEFT JOIN "de.metas.edi".edi_bpartner_object_v supplier
+                   ON supplier.c_bpartner_id = d.bill_bpartner_id
+         LEFT JOIN "de.metas.edi".edi_bpartner_location_object_v supplier_loc
+                   ON supplier_loc.c_bpartner_location_id = d.bill_location_id
+    -- Invoicee
+         LEFT JOIN "de.metas.edi".edi_bpartner_object_v invoicee
+                   ON invoicee.c_bpartner_id = d.c_invoice_bpartner_id
+         LEFT JOIN "de.metas.edi".edi_bpartner_location_object_v invoicee_loc
+                   ON invoicee_loc.c_bpartner_location_id = d.c_invoice_location_id
+    -- UltimateConsignee
+         LEFT JOIN "de.metas.edi".edi_bpartner_object_v consignee
+                   ON consignee.c_bpartner_id = d.dropship_bpartner_id
+         LEFT JOIN "de.metas.edi".edi_bpartner_location_object_v consignee_loc
+                   ON consignee_loc.c_bpartner_location_id = d.dropship_location_id
+    -- Currency
+         LEFT JOIN "de.metas.edi".edi_currency_object_v curr ON curr.c_currency_id = d.c_currency_id;

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5792550_sys_gh26915_desadv_json_main_article_line_reference.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5792550_sys_gh26915_desadv_json_main_article_line_reference.sql
@@ -184,7 +184,7 @@ BEGIN
                                'DesadvLineNo', dl.line,
                                'GTIN_TU_PackingMaterial', ia.gtin_tu_packingmaterial,
                                'IsSubArticle', ia.is_sub_article,
-                               'MainArticleLine',
+                               'MainArticleItemLine',
                                CASE WHEN ia.is_sub_article THEN ia.main_pi_line ELSE NULL END
                        ) ORDER BY ia.is_sub_article, ia.pi_line
                ) AS items_data


### PR DESCRIPTION
## Summary

- Add top-level `DesadvLineNo` to each LineItem (the DESADV line number, previously only available buried inside `DesadvLine.DesadvLine`)
- `MainArticleLine` now references the main article's pack_item `Line` instead of the DESADV line number, so receivers can unambiguously match sub-articles to their main article LineItem — even when one DESADV line is spread across multiple LineItems (different lots/BBDs)

## Before

```json
{"Line": 80, "IsSubArticle": true, "MainArticleLine": 10, ...}
```
`MainArticleLine: 10` references `DesadvLine.DesadvLine: 10` on the main article — buried inside a nested object, hard to find.

## After

```json
{"Line": 80, "DesadvLineNo": 20, "IsSubArticle": true, "MainArticleLine": 70, ...}
```
`MainArticleLine: 70` directly references `Line: 70` on the main article — same level, unambiguous.

## Test plan

- [ ] Run DESADV JSON export for shipment with compensation groups
- [ ] Verify `MainArticleLine` on sub-articles matches main article's `Line`
- [ ] Verify `DesadvLineNo` appears at top level of each LineItem