### PR TITLE
Add Confirm Issue button to manufacturing BOM line screen

### DIFF
--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobService.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobService.java
@@ -36,6 +36,7 @@ import de.metas.manufacturing.job.model.RawMaterialsIssueLine;
 import de.metas.manufacturing.job.model.RawMaterialsIssueStep;
 import de.metas.manufacturing.job.model.ScaleDevice;
 import de.metas.manufacturing.job.service.commands.create_job.ManufacturingJobCreateCommand;
+import de.metas.manufacturing.job.service.commands.issue.IssueBOMLineCommand;
 import de.metas.manufacturing.job.service.commands.issue.IssueRawMaterialsCommand;
 import de.metas.manufacturing.job.service.commands.issue.IssueRawMaterialsCommand.IssueRawMaterialsCommandBuilder;
 import de.metas.manufacturing.job.service.commands.issue_what_was_received.IssueWhatWasReceivedCommand;
@@ -477,6 +478,21 @@ public class ManufacturingJobService
 				.job(job)
 				.request(request)
 				//
+				.build().execute();
+	}
+
+	public ManufacturingJob issueAllStepsOfLine(
+			@NonNull final ManufacturingJob job,
+			@NonNull final PPOrderRoutingActivityId activityId,
+			final int lineIndex)
+	{
+		return IssueBOMLineCommand.builder()
+				.trxManager(trxManager)
+				.ppOrderIssueScheduleService(ppOrderIssueScheduleService)
+				.loadingAndSavingSupportServices(loadingAndSavingSupportServices)
+				.job(job)
+				.activityId(activityId)
+				.lineIndex(lineIndex)
 				.build().execute();
 	}
 

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/commands/issue/IssueBOMLineCommand.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/commands/issue/IssueBOMLineCommand.java
@@ -1,0 +1,101 @@
+package de.metas.manufacturing.job.service.commands.issue;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueSchedule;
+import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleProcessRequest;
+import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleService;
+import de.metas.manufacturing.job.model.ManufacturingJob;
+import de.metas.manufacturing.job.model.ManufacturingJobActivityId;
+import de.metas.manufacturing.job.model.RawMaterialsIssue;
+import de.metas.manufacturing.job.model.RawMaterialsIssueLine;
+import de.metas.manufacturing.job.model.RawMaterialsIssueStep;
+import de.metas.manufacturing.job.service.ManufacturingJobLoaderAndSaver;
+import de.metas.manufacturing.job.service.ManufacturingJobLoaderAndSaverSupportingServices;
+import lombok.Builder;
+import lombok.NonNull;
+import org.adempiere.ad.trx.api.ITrxManager;
+import org.adempiere.exceptions.AdempiereException;
+import org.eevolution.api.PPOrderRoutingActivityId;
+
+public class IssueBOMLineCommand
+{
+	// Services
+	@NonNull private final ITrxManager trxManager;
+	@NonNull private final PPOrderIssueScheduleService ppOrderIssueScheduleService;
+	@NonNull private final ManufacturingJobLoaderAndSaverSupportingServices loadingAndSavingSupportServices;
+
+	// Params
+	@NonNull private final PPOrderRoutingActivityId activityId;
+	private final int lineIndex;
+
+	// State
+	@NonNull private ManufacturingJob job;
+
+	@Builder
+	private IssueBOMLineCommand(
+			@NonNull final ITrxManager trxManager,
+			@NonNull final PPOrderIssueScheduleService ppOrderIssueScheduleService,
+			@NonNull final ManufacturingJobLoaderAndSaverSupportingServices loadingAndSavingSupportServices,
+			//
+			@NonNull final ManufacturingJob job,
+			@NonNull final PPOrderRoutingActivityId activityId,
+			final int lineIndex)
+	{
+		this.trxManager = trxManager;
+		this.ppOrderIssueScheduleService = ppOrderIssueScheduleService;
+		this.loadingAndSavingSupportServices = loadingAndSavingSupportServices;
+
+		this.job = job;
+		this.activityId = activityId;
+		this.lineIndex = lineIndex;
+	}
+
+	public ManufacturingJob execute()
+	{
+		trxManager.runInThreadInheritedTrx(this::execute0);
+		return job;
+	}
+
+	private void execute0()
+	{
+		final RawMaterialsIssue rawMaterialsIssue = job.getActivityById(ManufacturingJobActivityId.of(activityId)).getRawMaterialsIssueAssumingNotNull();
+		final ImmutableList<RawMaterialsIssueLine> lines = rawMaterialsIssue.getLines();
+
+		if (lineIndex < 0 || lineIndex >= lines.size())
+		{
+			throw new AdempiereException("Invalid lineIndex: " + lineIndex + " (lines count: " + lines.size() + ")");
+		}
+
+		final RawMaterialsIssueLine line = lines.get(lineIndex);
+		if (!line.isAllowManualIssue())
+		{
+			throw new AdempiereException("Line does not allow manual issue (IssueOnlyForReceived)")
+					.setParameter("lineIndex", lineIndex)
+					.setParameter("productId", line.getProductId());
+		}
+
+		for (final RawMaterialsIssueStep step : line.getSteps())
+		{
+			if (step.isIssued())
+			{
+				continue;
+			}
+
+			final PPOrderIssueScheduleProcessRequest request = PPOrderIssueScheduleProcessRequest.builder()
+					.activityId(activityId)
+					.issueScheduleId(step.getId())
+					.qtyIssued(step.getQtyToIssue().toBigDecimal())
+					.failIfIssueOnlyForReceived(true)
+					.build();
+
+			final PPOrderIssueSchedule issueSchedule = ppOrderIssueScheduleService.issue(request);
+
+			job = job.withChangedRawMaterialsIssueStep(
+					activityId,
+					step.getId(),
+					s -> s.withIssued(issueSchedule.getIssued()));
+		}
+
+		new ManufacturingJobLoaderAndSaver(loadingAndSavingSupportServices).saveActivityStatuses(job);
+	}
+}

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/ManufacturingRestService.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/ManufacturingRestService.java
@@ -153,6 +153,14 @@ public class ManufacturingRestService
 					.failIfIssueOnlyForReceived(true)
 					.build());
 		}
+		else if (event.getIssueToLine() != null)
+		{
+			final JsonManufacturingOrderEvent.IssueToLine issueToLine = event.getIssueToLine();
+			return manufacturingJobService.issueAllStepsOfLine(
+					job,
+					PPOrderRoutingActivityId.ofRepoId(job.getPpOrderId(), event.getWfActivityId()),
+					issueToLine.getLineIndex());
+		}
 		else if (event.getReceiveFrom() != null)
 		{
 			final JsonManufacturingOrderEvent.ReceiveFrom receiveFrom = event.getReceiveFrom();

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/rest_api/json/JsonManufacturingOrderEvent.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/rest_api/json/JsonManufacturingOrderEvent.java
@@ -41,6 +41,16 @@ public class JsonManufacturingOrderEvent
 	@Value
 	@Builder
 	@Jacksonized
+	public static class IssueToLine
+	{
+		int lineIndex;
+	}
+
+	@Nullable IssueToLine issueToLine;
+
+	@Value
+	@Builder
+	@Jacksonized
 	public static class ReceiveFrom
 	{
 		@NonNull String lineId;
@@ -79,18 +89,20 @@ public class JsonManufacturingOrderEvent
 			@NonNull final String wfActivityId,
 			//
 			@Nullable final IssueTo issueTo,
+			@Nullable final IssueToLine issueToLine,
 			@Nullable final ReceiveFrom receiveFrom,
 			@Nullable final PickTo pickTo)
 	{
-		if (CoalesceUtil.countNotNulls(issueTo, receiveFrom) != 1)
+		if (CoalesceUtil.countNotNulls(issueTo, issueToLine, receiveFrom) != 1)
 		{
-			throw new AdempiereException("One and only one action like issueTo, receiveFrom etc shall be specified in an event.");
+			throw new AdempiereException("One and only one action like issueTo, issueToLine, receiveFrom etc shall be specified in an event.");
 		}
 
 		this.wfProcessId = wfProcessId;
 		this.wfActivityId = wfActivityId;
 
 		this.issueTo = issueTo;
+		this.issueToLine = issueToLine;
 		this.receiveFrom = receiveFrom;
 		this.pickTo = pickTo;
 	}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/actions/ManufacturingActions.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/actions/ManufacturingActions.js
@@ -4,7 +4,11 @@ import {
 } from '../constants/ManufacturingActionTypes';
 
 import { getLineById, getStepByIdFromLine } from '../reducers/wfProcesses';
-import { postManufacturingIssueEvent, postManufacturingReceiveEvent } from '../api/manufacturing';
+import {
+  postManufacturingIssueEvent,
+  postManufacturingIssueToLineEvent,
+  postManufacturingReceiveEvent,
+} from '../api/manufacturing';
 import { toQRCodeString } from '../utils/qrCode/hu';
 import { updateWFProcess } from './WorkflowActions';
 
@@ -42,6 +46,20 @@ export const postManufacturingIssueEventThunk = ({
     } else {
       return Promise.reject('No line found');
     }
+  };
+};
+
+export const postManufacturingIssueToLineEventThunk = ({ wfProcessId, activityId, lineId }) => {
+  return (dispatch) => {
+    return postManufacturingIssueToLineEvent({
+      wfProcessId,
+      activityId,
+      issueToLine: {
+        lineIndex: Number(lineId),
+      },
+    }).then((wfProcess) => {
+      return dispatch(updateWFProcess({ wfProcess }));
+    });
   };
 };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/manufacturing.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/manufacturing.js
@@ -22,3 +22,13 @@ export function postManufacturingIssueEvent({ wfProcessId, activityId, issueTo }
     })
     .then((response) => unboxAxiosResponse(response));
 }
+
+export function postManufacturingIssueToLineEvent({ wfProcessId, activityId, issueToLine }) {
+  return axios
+    .post(`${apiBasePath}/manufacturing/event`, {
+      wfProcessId,
+      wfActivityId: activityId,
+      issueToLine,
+    })
+    .then((response) => unboxAxiosResponse(response));
+}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/RawMaterialIssueLineScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/RawMaterialIssueLineScreen.jsx
@@ -1,9 +1,11 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import { trl } from '../../../../utils/translations';
 import { updateHeaderEntry } from '../../../../actions/HeaderActions';
+import { postManufacturingIssueToLineEventThunk } from '../../../../actions/ManufacturingActions';
 import { getActivityById, getLineByIdFromActivity, getStepsArrayFromLine } from '../../../../reducers/wfProcesses';
+import * as CompleteStatus from '../../../../constants/CompleteStatus';
 
 import {
   manufacturingLineScanScreenLocation,
@@ -12,6 +14,8 @@ import {
 } from '../../../../routes/manufacturing_issue';
 import ButtonWithIndicator from '../../../../components/buttons/ButtonWithIndicator';
 import ButtonQuantityProp from '../../../../components/buttons/ButtonQuantityProp';
+import ConfirmButton from '../../../../components/buttons/ConfirmButton';
+import { toastError } from '../../../../utils/toast';
 import { toQRCodeDisplayable } from '../../../../utils/qrCode/hu';
 import { formatQtyToHumanReadableStr } from '../../../../utils/qtys';
 import { useScreenDefinition } from '../../../../hooks/useScreenDefinition';
@@ -34,10 +38,13 @@ const RawMaterialIssueLineScreen = () => {
     qtyToIssueRemaining,
     qtyIssued,
     readOnly,
+    weightable,
+    completeStatus,
     steps,
   } = useSelector((state) => getPropsFromState({ state, wfProcessId, activityId, lineId }), shallowEqual);
 
   const dispatch = useDispatch();
+  const [isConfirming, setConfirming] = useState(false);
   useEffect(() => {
     dispatch(
       updateHeaderEntry(
@@ -64,8 +71,28 @@ const RawMaterialIssueLineScreen = () => {
     history.push(manufacturingStepScreenLocation({ applicationId, wfProcessId, activityId, lineId, stepId }));
   };
 
+  const hasUnissuedSteps = steps.some((step) => !step.qtyIssued && !step.qtyRejectedReasonCode);
+  const showConfirmButton = !readOnly && !weightable && hasUnissuedSteps && completeStatus !== CompleteStatus.COMPLETED;
+
+  const onConfirmLine = () => {
+    setConfirming(true);
+    dispatch(postManufacturingIssueToLineEventThunk({ wfProcessId, activityId, lineId }))
+      .catch((axiosError) => toastError({ axiosError }))
+      .finally(() => setConfirming(false));
+  };
+
   return (
     <div className="section pt-2">
+      {showConfirmButton && (
+        <ConfirmButton
+          id="confirmIssueLine-button"
+          caption={trl('activities.mfg.issues.confirmLine.caption')}
+          promptQuestion={trl('activities.mfg.issues.confirmLine.promptQuestion')}
+          isUserEditable={!isConfirming}
+          isProcessing={isConfirming}
+          onUserConfirmed={onConfirmLine}
+        />
+      )}
       {!readOnly && (
         <ButtonWithIndicator caption={trl('general.scanQRCode')} onClick={onScanHUClicked} testId="scanQRCode-button" />
       )}
@@ -110,6 +137,8 @@ const getPropsFromState = ({ state, wfProcessId, activityId, lineId }) => {
     qtyToIssueRemaining: line?.qtyToIssueRemaining,
     qtyIssued: line?.qtyIssued,
     readOnly: line?.readOnly,
+    weightable: line?.weightable,
+    completeStatus: line?.completeStatus,
     steps: getStepsArrayFromLine(line),
   };
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -177,6 +177,10 @@ const translations = {
         step: {
           name: 'HU einfüllen',
         },
+        confirmLine: {
+          caption: 'Zuführung bestätigen',
+          promptQuestion: 'Alle geplanten Materialien für diese Position zuführen?',
+        },
       },
       receipts: {
         qtyToReceiveTarget: 'Sollmenge',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -174,6 +174,10 @@ const translations = {
         step: {
           name: 'Issue HU',
         },
+        confirmLine: {
+          caption: 'Confirm Issue',
+          promptQuestion: 'Issue all planned materials for this line?',
+        },
       },
       receipts: {
         qtyToReceiveTarget: 'Qty to Receive Target',


### PR DESCRIPTION
## Summary

- Adds a "Confirm Issue" / "Zuführung bestätigen" button on the manufacturing raw materials issue line detail screen
- When pressed, issues all planned (unissued) HUs for that BOM line in a single transaction
- New backend event type `IssueToLine` with `IssueBOMLineCommand` that iterates all unissued steps of a line
- Button is hidden for weightable lines (need individual scale measurements), read-only lines, completed lines, and IssueOnlyForReceived lines

## Changes

**Backend (4 files, 1 new):**
- `JsonManufacturingOrderEvent.java` — new `IssueToLine` nested class and field
- `IssueBOMLineCommand.java` — new command that issues all steps of a BOM line
- `ManufacturingJobService.java` — new `issueAllStepsOfLine()` method
- `ManufacturingRestService.java` — handle `issueToLine` event in `processEvent()`

**Frontend (5 files):**
- `manufacturing.js` — new `postManufacturingIssueToLineEvent` API function
- `ManufacturingActions.js` — new `postManufacturingIssueToLineEventThunk`
- `RawMaterialIssueLineScreen.jsx` — `ConfirmButton` component with visibility logic
- `translations_en.js` / `translations_de.js` — EN/DE translations for the button

## Test plan

- [ ] Open a manufacturing order with raw materials issue activity
- [ ] Navigate to a BOM line detail screen
- [ ] Verify "Confirm Issue" button appears for non-weightable lines with unissued steps
- [ ] Click button → confirm prompt → all HUs for the line get issued
- [ ] Verify button disappears after all steps are issued
- [ ] Verify button does NOT appear for weightable lines
- [ ] Verify button does NOT appear for completed/read-only lines