### PR TITLE
gh#28679 enrich forecast event creator with PP_Product_Planning ASI fallback

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/forecast/M_ForecastLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/forecast/M_ForecastLine_StepDef.java
@@ -25,6 +25,7 @@ package de.metas.cucumber.stepdefs.forecast;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.cucumber.stepdefs.attribute.M_AttributeSetInstance_StepDefData;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
 import de.metas.mforecast.impl.ForecastId;
 import de.metas.product.ProductId;
@@ -34,6 +35,7 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Given;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_ForecastLine;
 import org.compiere.model.I_M_Warehouse;
@@ -51,15 +53,18 @@ public class M_ForecastLine_StepDef
 	private final M_Product_StepDefData productTable;
 	private final M_Warehouse_StepDefData warehouseTable;
 	private final M_Forecast_StepDefData forecastTable;
+	private final M_AttributeSetInstance_StepDefData attributeSetInstanceTable;
 
 	public M_ForecastLine_StepDef(
 			@NonNull final M_Product_StepDefData productTable,
 			@NonNull final M_Warehouse_StepDefData warehouseTable,
-			@NonNull final M_Forecast_StepDefData forecastTable)
+			@NonNull final M_Forecast_StepDefData forecastTable,
+			@NonNull final M_AttributeSetInstance_StepDefData attributeSetInstanceTable)
 	{
 		this.productTable = productTable;
 		this.warehouseTable = warehouseTable;
 		this.forecastTable = forecastTable;
+		this.attributeSetInstanceTable = attributeSetInstanceTable;
 	}
 
 	@Given("metasfresh contains M_ForecastLines:")
@@ -94,7 +99,12 @@ public class M_ForecastLine_StepDef
 					forecastLine.setQty(tableRow.getAsBigDecimal(I_M_ForecastLine.COLUMNNAME_Qty));
 					forecastLine.setM_Warehouse_ID(warehouseId);
 					forecastLine.setC_UOM_ID(UomId.toRepoId(uomId));
-					
+
+					tableRow.getAsOptionalIdentifier(I_M_ForecastLine.COLUMNNAME_M_AttributeSetInstance_ID)
+							.map(attributeSetInstanceTable::getId)
+							.map(AttributeSetInstanceId::getRepoId)
+							.ifPresent(forecastLine::setM_AttributeSetInstance_ID);
+
 					saveRecord(forecastLine);
 				});
 	}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/forecast_with_attributes.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/forecast_with_attributes.feature
@@ -1,0 +1,126 @@
+@from:cucumber
+@allure.label.epic:E0155_Material_Disposition
+@allure.label.feature:F5100
+@ghActions:run_on_executor6
+Feature: Forecast ASI enrichment from PP_Product_Planning
+  When a forecast line has no ASI but PP_Product_Planning has one,
+  the event creator enriches the MD_Candidate with the planning ASI.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2021-04-11T08:00:00+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+
+    And load M_AttributeSet:
+      | M_AttributeSet_ID.Identifier | Name               |
+      | attributeSet_convenienceSalate | Convenience Salate |
+    And load M_Product_Category:
+      | M_Product_Category_ID.Identifier | Name     | Value    |
+      | standard_category                | Standard | Standard |
+    And update M_Product_Category:
+      | M_Product_Category_ID.Identifier | OPT.M_AttributeSet_ID.Identifier |
+      | standard_category                | attributeSet_convenienceSalate   |
+
+  @Id:S0463_100
+  @from:cucumber
+  Scenario: Forecast line with explicit ASI — MD_Candidate gets the forecast line's ASI
+    Given metasfresh contains M_Products:
+      | Identifier | OPT.M_Product_Category_ID.Identifier |
+      | p_1        | standard_category                    |
+    And metasfresh contains M_AttributeSetInstance with identifier "planningASI":
+  """
+  {
+    "attributeInstances":[
+      {
+        "attributeCode":"1000002",
+          "valueStr":"Bio"
+      }
+    ]
+  }
+  """
+    And metasfresh contains M_AttributeSetInstance with identifier "forecastASI":
+  """
+  {
+    "attributeInstances":[
+      {
+        "attributeCode":"1000002",
+          "valueStr":"Bio"
+      }
+    ]
+  }
+  """
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID |
+      | warehouse      |
+    And metasfresh contains PP_Product_Plannings
+      | Identifier | M_Product_ID | IsCreatePlan | M_AttributeSetInstance_ID |
+      | ppln_1     | p_1          | false        | planningASI               |
+    And metasfresh contains M_Forecasts:
+      | Identifier | Name | DatePromised | M_Warehouse_ID |
+      | f_1        | test | 2021-04-17   | warehouse      |
+    And metasfresh contains M_ForecastLines:
+      | M_Forecast_ID | M_Product_ID | Qty | M_Warehouse_ID | C_UOM_ID.X12DE355 | M_AttributeSetInstance_ID |
+      | f_1           | p_1          | 10  | warehouse      | PCE                | forecastASI               |
+    When the forecast identified by f_1 is completed
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | M_AttributeSetInstance_ID |
+      | c_1        | STOCK_UP          | FORECAST                  | p_1          | 2021-04-16T22:00:00Z | 10  | forecastASI               |
+
+  @Id:S0463_110
+  @from:cucumber
+  Scenario: Forecast line WITHOUT ASI, PP_Product_Planning HAS ASI — enrichment from planning
+    Given metasfresh contains M_Products:
+      | Identifier | OPT.M_Product_Category_ID.Identifier |
+      | p_1        | standard_category                    |
+    And metasfresh contains M_AttributeSetInstance with identifier "planningASI":
+  """
+  {
+    "attributeInstances":[
+      {
+        "attributeCode":"1000002",
+          "valueStr":"Bio"
+      }
+    ]
+  }
+  """
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID |
+      | warehouse      |
+    And metasfresh contains PP_Product_Plannings
+      | Identifier | M_Product_ID | IsCreatePlan | M_AttributeSetInstance_ID |
+      | ppln_1     | p_1          | false        | planningASI               |
+    And metasfresh contains M_Forecasts:
+      | Identifier | Name | DatePromised | M_Warehouse_ID |
+      | f_1        | test | 2021-04-17   | warehouse      |
+    And metasfresh contains M_ForecastLines:
+      | M_Forecast_ID | M_Product_ID | Qty | M_Warehouse_ID | C_UOM_ID.X12DE355 |
+      | f_1           | p_1          | 10  | warehouse      | PCE                |
+    When the forecast identified by f_1 is completed
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | M_AttributeSetInstance_ID |
+      | c_1        | STOCK_UP          | FORECAST                  | p_1          | 2021-04-16T22:00:00Z | 10  | planningASI               |
+
+  @Id:S0463_120
+  @from:cucumber
+  Scenario: Forecast line WITHOUT ASI, PP_Product_Planning also no ASI — storageAttributesKey is NONE
+    Given metasfresh contains M_Products:
+      | Identifier | OPT.M_Product_Category_ID.Identifier |
+      | p_1        | standard_category                    |
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID |
+      | warehouse      |
+    And metasfresh contains PP_Product_Plannings
+      | Identifier | M_Product_ID | IsCreatePlan |
+      | ppln_1     | p_1          | false        |
+    And metasfresh contains M_Forecasts:
+      | Identifier | Name | DatePromised | M_Warehouse_ID |
+      | f_1        | test | 2021-04-17   | warehouse      |
+    And metasfresh contains M_ForecastLines:
+      | M_Forecast_ID | M_Product_ID | Qty | M_Warehouse_ID | C_UOM_ID.X12DE355 |
+      | f_1           | p_1          | 10  | warehouse      | PCE                |
+    When the forecast identified by f_1 is completed
+    Then after not more than 60s, the MD_Candidate table has only the following records
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | Qty_AvailableToPromise |
+      | c_1        | STOCK_UP          | FORECAST                  | p_1          | 2021-04-16T22:00:00Z | 10  | 0                      |

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/material/interceptor/M_ForecastEventCreator.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/material/interceptor/M_ForecastEventCreator.java
@@ -11,11 +11,17 @@ import de.metas.material.event.forecast.Forecast;
 import de.metas.material.event.forecast.ForecastCreatedEvent;
 import de.metas.material.event.forecast.ForecastDeletedEvent;
 import de.metas.material.event.forecast.ForecastLine;
+import de.metas.material.planning.IProductPlanningDAO;
+import de.metas.material.planning.IProductPlanningDAO.ProductPlanningQuery;
+import de.metas.material.planning.ProductPlanning;
 import de.metas.mforecast.IForecastDAO;
 import de.metas.mforecast.impl.ForecastId;
+import de.metas.organization.OrgId;
+import de.metas.product.ProductId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.modelvalidator.DocTimingType;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.I_M_Forecast;
 import org.compiere.model.I_M_ForecastLine;
@@ -49,6 +55,7 @@ import java.util.Optional;
 public class M_ForecastEventCreator
 {
 	private final IForecastDAO forecastsRepo = Services.get(IForecastDAO.class);
+	private final IProductPlanningDAO productPlanningDAO = Services.get(IProductPlanningDAO.class);
 
 	private final ModelProductDescriptorExtractor productDescriptorFactory;
 
@@ -107,7 +114,7 @@ public class M_ForecastEventCreator
 			@NonNull final I_M_ForecastLine forecastLine,
 			@NonNull final I_M_Forecast forecast)
 	{
-		final ProductDescriptor productDescriptor = productDescriptorFactory.createProductDescriptor(forecastLine);
+		final ProductDescriptor productDescriptor = createProductDescriptorWithPlanningFallback(forecastLine);
 
 		final BPartnerId customerId = BPartnerId.ofRepoIdOrNull(CoalesceUtil.firstGreaterThanZero(forecastLine.getC_BPartner_ID(), forecast.getC_BPartner_ID()));
 
@@ -123,5 +130,43 @@ public class M_ForecastEventCreator
 				.forecastLineId(forecastLine.getM_ForecastLine_ID())
 				.materialDescriptor(materialDescriptor)
 				.build();
+	}
+
+	private ProductDescriptor createProductDescriptorWithPlanningFallback(@NonNull final I_M_ForecastLine forecastLine)
+	{
+		final AttributeSetInstanceId forecastAsiId = AttributeSetInstanceId
+				.ofRepoIdOrNone(forecastLine.getM_AttributeSetInstance_ID());
+
+		if (!forecastAsiId.isNone())
+		{
+			// forecast line has explicit ASI — use it directly, no enrichment needed
+			return productDescriptorFactory.createProductDescriptor(forecastLine);
+		}
+
+		// forecast line has no ASI — look up PP_Product_Planning for a fallback ASI
+		final AttributeSetInstanceId planningAsiId = resolvePlanningAsiId(forecastLine);
+		if (!planningAsiId.isNone())
+		{
+			return productDescriptorFactory.createProductDescriptor(
+					forecastLine.getM_Product_ID(), planningAsiId);
+		}
+
+		// no ASI anywhere — default NONE behavior
+		return productDescriptorFactory.createProductDescriptor(forecastLine);
+	}
+
+	private AttributeSetInstanceId resolvePlanningAsiId(@NonNull final I_M_ForecastLine forecastLine)
+	{
+		final ProductPlanningQuery query = ProductPlanningQuery.builder()
+				.productId(ProductId.ofRepoId(forecastLine.getM_Product_ID()))
+				.warehouseId(WarehouseId.ofRepoIdOrNull(forecastLine.getM_Warehouse_ID()))
+				.orgId(OrgId.ofRepoId(forecastLine.getAD_Org_ID()))
+				.attributeSetInstanceId(AttributeSetInstanceId.NONE)
+				.build();
+
+		return productPlanningDAO.find(query)
+				.map(ProductPlanning::getAttributeSetInstanceId)
+				.filter(asiId -> !asiId.isNone())
+				.orElse(AttributeSetInstanceId.NONE);
 	}
 }


### PR DESCRIPTION
## Summary

- When a forecast line has no ASI but `PP_Product_Planning` has one, `M_ForecastEventCreator` now uses the planning ASI to create the `ProductDescriptor` — ensuring `MD_Candidate` gets the correct `storageAttributesKey` and `attributeSetInstanceId`
- This is a safety net covering ALL forecast creation paths (UI, import, replenish, generator) — the "last mile" before events enter material dispo
- Adds 3 Cucumber scenarios validating the enrichment behavior (explicit ASI, planning fallback, no ASI anywhere)

## Behavior

| Forecast Line ASI | PP_Product_Planning ASI | Result |
|---|---|---|
| Explicit (non-zero) | Any | From forecast line ASI (no enrichment) |
| 0 / NONE | Has ASI | From PP_Product_Planning ASI |
| 0 / NONE | 0 / NONE / no record | NONE |

## Test plan

- [x] 3 Cucumber scenarios pass locally (`forecast_with_attributes.feature`)
- [x] Existing `forecast.feature` and `forecast_corner_cases.feature` pass (no regression)
- [ ] CI green