### PR TITLE
Fix cicd-dispatch: restore working workflow_dispatch approach

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2261,34 +2261,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ init, compatibility-images ]
     steps:
-      - name: dispatch-to-mf15-private-extensions
+      - name: dispatch-workflow
         env:
           CICD_RUN_ID: ${{ github.run_id }}
           TAG_FIXED: ${{ needs.init.outputs.tag-fixed }}
           SOURCE_BRANCH: ${{ github.ref_name }}
           GH_TOKEN: ${{ secrets.CICD_TRIGGER_DISPATCH }}
-        run: |
-          # Dispatch to mf15-private-extensions which will build private libs
-          # and then call me03-gh-automation for context-aware dispatch to customers
-          echo "Dispatching to mf15-private-extensions..."
-          echo "  Version (TAG_FIXED): ${TAG_FIXED}"
-          echo "  CICD Run ID: ${CICD_RUN_ID}"
-          echo "  Branch: ${BRANCH}"
-
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/metasfresh/mf15-private-extensions/dispatches \
-            -f "event_type=update_base_version" \
-            -F "client_payload[version]=${TAG_FIXED}" \
-            -F "client_payload[cicd_run_id]=${CICD_RUN_ID}" \
-            -F "client_payload[ref]=${BRANCH}"
-
-      - name: produce-dispatch-summary
-        env:
-          TAG_FIXED: ${{ needs.init.outputs.tag-fixed }}
-          CICD_RUN_ID: ${{ github.run_id }}
-          BRANCH: ${{ github.ref_name }}
+          CICD_DISPATCH_REPO: ${{ fromJson(vars.CICD_DISPATCH_CONFIG).repo }}
+          CICD_DISPATCH_WORKFLOW_FILE: ${{ fromJson(vars.CICD_DISPATCH_CONFIG).workflow_file }}
         run: |
           gh workflow run "${CICD_DISPATCH_WORKFLOW_FILE}" --repo "${CICD_DISPATCH_REPO}" -f "cicd_run_id=${CICD_RUN_ID}" -f "tag_fixed=${TAG_FIXED}" -f "source_branch=${SOURCE_BRANCH}"


### PR DESCRIPTION
## Summary

- Restores the working `cicd-dispatch` job that uses `gh workflow run` with `vars.CICD_DISPATCH_CONFIG`
- A stale local commit (`450a194d8a3`, Jan 6) had replaced this with `gh api /repos/.../dispatches` (repository_dispatch API), which the `CICD_TRIGGER_DISPATCH` PAT lacks permission for — causing 403 errors on every CI run

Same fix as https://github.com/metasfresh/metasfresh/pull/22655 (for `new_dawn_uat`).

## Root cause

The broken version had three bugs:
1. Used `gh api` repository_dispatch → 403 (PAT lacks `repo` scope for `mf15-private-extensions`)
2. Referenced `${BRANCH}` but env defined `SOURCE_BRANCH` → empty branch in dispatch payload
3. Second step referenced `${CICD_DISPATCH_WORKFLOW_FILE}` and `${CICD_DISPATCH_REPO}` not in its env block

## Test plan

- [ ] CI passes on this PR (cicd-dispatch skipped on feature branches — expected)
- [ ] After merge, verify next `science_vessel_release` CI run has cicd-dispatch SUCCESS