### PR TITLE
Add IsInheritPackingInstruction to CompensationGroup Schema

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/de/metas/order/model/I_C_CompensationGroup_Schema.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/de/metas/order/model/I_C_CompensationGroup_Schema.java
@@ -175,6 +175,29 @@ public interface I_C_CompensationGroup_Schema
 	String COLUMNNAME_Updated = "Updated";
 
 	/**
+	 * Set Inherit Packing Instruction.
+	 * If set, the packing instruction from the main article is applied to all sub-articles created from the compensation group schema template.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsInheritPackingInstruction (boolean IsInheritPackingInstruction);
+
+	/**
+	 * Get Inherit Packing Instruction.
+	 * If set, the packing instruction from the main article is applied to all sub-articles created from the compensation group schema template.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isInheritPackingInstruction();
+
+	ModelColumn<I_C_CompensationGroup_Schema, Object> COLUMN_IsInheritPackingInstruction = new ModelColumn<>(I_C_CompensationGroup_Schema.class, "IsInheritPackingInstruction", null);
+	String COLUMNNAME_IsInheritPackingInstruction = "IsInheritPackingInstruction";
+
+	/**
 	 * Get Updated By.
 	 * User who updated this records
 	 *

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/de/metas/order/model/X_C_CompensationGroup_Schema.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/de/metas/order/model/X_C_CompensationGroup_Schema.java
@@ -65,13 +65,25 @@ public class X_C_CompensationGroup_Schema extends org.compiere.model.PO implemen
 	}
 
 	@Override
+	public void setIsInheritPackingInstruction (final boolean IsInheritPackingInstruction)
+	{
+		set_Value (COLUMNNAME_IsInheritPackingInstruction, IsInheritPackingInstruction);
+	}
+
+	@Override
+	public boolean isInheritPackingInstruction()
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsInheritPackingInstruction);
+	}
+
+	@Override
 	public void setName (final java.lang.String Name)
 	{
 		set_Value (COLUMNNAME_Name, Name);
 	}
 
 	@Override
-	public java.lang.String getName() 
+	public java.lang.String getName()
 	{
 		return get_ValueAsString(COLUMNNAME_Name);
 	}

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792610_sys_gh26915_IsInheritPackingInstruction.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792610_sys_gh26915_IsInheritPackingInstruction.sql
@@ -99,7 +99,7 @@ WHERE NOT EXISTS (SELECT 1 FROM AD_UI_ElementGroup eg
 
 -- AD_UI_Element for IsInheritPackingInstruction
 INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
-                           AD_UI_ElementGroup_ID, AD_Field_ID, SeqNo, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name)
+                           AD_UI_ElementGroup_ID, AD_Field_ID, AD_Tab_ID, SeqNo, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name)
 VALUES (648505, 0, 0, 'Y', TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100,
         (SELECT eg.AD_UI_ElementGroup_ID
          FROM AD_UI_ElementGroup eg
@@ -107,4 +107,4 @@ VALUES (648505, 0, 0, 'Y', TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'
                   JOIN AD_UI_Section us ON uc.AD_UI_Section_ID = us.AD_UI_Section_ID
          WHERE us.AD_Tab_ID = 541041 AND lower(eg.Name) = 'flags'
          ORDER BY eg.SeqNo LIMIT 1),
-        774855, 10, 'Y', 'N', 'N', 'Inherit Packing Instruction');
+        774855, 541041, 10, 'Y', 'N', 'N', 'Inherit Packing Instruction');

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792610_sys_gh26915_IsInheritPackingInstruction.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792610_sys_gh26915_IsInheritPackingInstruction.sql
@@ -45,8 +45,10 @@ VALUES (592198, 0, 0, 'Y', TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'
         'N', 'N', 'N', 'N', 'N', 'N',
         'Y', 'NP');
 
--- Physical column
-INSERT INTO t_alter_column VALUES ('C_CompensationGroup_Schema', 'IsInheritPackingInstruction', 'CHAR(1)', 'NOT NULL', 'N');
+-- Physical column (add new column, then enforce constraints)
+ALTER TABLE C_CompensationGroup_Schema ADD COLUMN IF NOT EXISTS IsInheritPackingInstruction CHAR(1) DEFAULT 'N';
+UPDATE C_CompensationGroup_Schema SET IsInheritPackingInstruction = 'N' WHERE IsInheritPackingInstruction IS NULL;
+ALTER TABLE C_CompensationGroup_Schema ALTER COLUMN IsInheritPackingInstruction SET NOT NULL;
 
 -- AD_Field on tab 541041 (Schema tab)
 INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792610_sys_gh26915_IsInheritPackingInstruction.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792610_sys_gh26915_IsInheritPackingInstruction.sql
@@ -27,9 +27,22 @@ SET Name         = 'Packvorschrift vererben',
 WHERE AD_Element_ID = 584629
   AND AD_Language = 'de_DE';
 
+-- English translation
+UPDATE AD_Element_Trl
+SET Name         = 'Inherit Packing Instruction',
+    PrintName    = 'Inherit Packing Instruction',
+    Description  = 'If set, the packing instruction from the main article is applied to all sub-articles created from the compensation group schema template.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 584629
+  AND AD_Language = 'en_US';
+
 -- propagate element translations
 SELECT update_ad_element_on_ad_element_trl_update(584629, 'de_DE');
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584629, 'de_DE');
+SELECT update_ad_element_on_ad_element_trl_update(584629, 'en_US');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584629, 'en_US');
 
 -- AD_Column on C_CompensationGroup_Schema (AD_Table_ID=540940)
 INSERT INTO AD_Column (AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
@@ -107,4 +120,4 @@ VALUES (648505, 0, 0, 'Y', TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'
                   JOIN AD_UI_Section us ON uc.AD_UI_Section_ID = us.AD_UI_Section_ID
          WHERE us.AD_Tab_ID = 541041 AND lower(eg.Name) = 'flags'
          ORDER BY eg.SeqNo LIMIT 1),
-        774855, 541041, 10, 'Y', 'N', 'N', 'Inherit Packing Instruction');
+        774855, 541041, 20, 'Y', 'N', 'N', 'Inherit Packing Instruction');

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792610_sys_gh26915_IsInheritPackingInstruction.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5792610_sys_gh26915_IsInheritPackingInstruction.sql
@@ -1,0 +1,108 @@
+-- 2026-03-07
+-- me03#26915: Add IsInheritPackingInstruction flag to C_CompensationGroup_Schema
+-- When Y, Quick Input copies the main article's packing instruction to all template-created sub-article order lines
+
+-- AD_Element
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                        ColumnName, EntityType, Name, PrintName, Description)
+VALUES (584629, 0, 0, 'Y', TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100,
+        'IsInheritPackingInstruction', 'D', 'Inherit Packing Instruction', 'Inherit Packing Instruction',
+        'If set, the packing instruction from the main article is applied to all sub-articles created from the compensation group schema template.');
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Name, PrintName, Description, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, 584629, t.Name, t.PrintName, t.Description, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Element_ID = 584629
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID);
+
+-- German translation
+UPDATE AD_Element_Trl
+SET Name         = 'Packvorschrift vererben',
+    PrintName    = 'Packvorschrift vererben',
+    Description  = 'Wenn gesetzt, wird die Packvorschrift des Hauptartikels auf alle aus dem Kompensationsgruppen-Schema erstellten Unterartikel uebertragen.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 584629
+  AND AD_Language = 'de_DE';
+
+-- propagate element translations
+SELECT update_ad_element_on_ad_element_trl_update(584629, 'de_DE');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584629, 'de_DE');
+
+-- AD_Column on C_CompensationGroup_Schema (AD_Table_ID=540940)
+INSERT INTO AD_Column (AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                       Version, EntityType, ColumnName, AD_Table_ID, AD_Element_ID, AD_Reference_ID,
+                       FieldLength, Name, Description,
+                       IsMandatory, IsUpdateable, IsAlwaysUpdateable, DefaultValue,
+                       IsKey, IsParent, IsTranslated, IsIdentifier, IsEncrypted, IsSelectionColumn,
+                       IsAllowLogging, PersonalDataCategory)
+VALUES (592198, 0, 0, 'Y', TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100,
+        0, 'D', 'IsInheritPackingInstruction', 540940, 584629, 20,
+        1, 'Inherit Packing Instruction', 'If set, the packing instruction from the main article is applied to all sub-articles created from the compensation group schema template.',
+        'Y', 'Y', 'N', 'N',
+        'N', 'N', 'N', 'N', 'N', 'N',
+        'Y', 'NP');
+
+-- Physical column
+INSERT INTO t_alter_column VALUES ('C_CompensationGroup_Schema', 'IsInheritPackingInstruction', 'CHAR(1)', 'NOT NULL', 'N');
+
+-- AD_Field on tab 541041 (Schema tab)
+INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                      AD_Tab_ID, AD_Column_ID, Name, Description, EntityType,
+                      IsDisplayed, IsDisplayedGrid, IsSameLine, IsHeading, IsFieldOnly, IsEncrypted, IsReadOnly)
+VALUES (774855, 0, 0, 'Y', TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100,
+        541041, 592198, 'Inherit Packing Instruction',
+        'If set, the packing instruction from the main article is applied to all sub-articles created from the compensation group schema template.',
+        'de.metas.order',
+        'Y', 'Y', 'N', 'N', 'N', 'N', 'N');
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Name, Description, Help, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, 774855, t.Name, t.Description, t.Help, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Field_ID = 774855
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+
+-- AD_UI_Section for tab 541041 (create if not exists)
+INSERT INTO AD_UI_Section (AD_UI_Section_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                           AD_Tab_ID, SeqNo, Name)
+SELECT 547599, 0, 0, 'Y', TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100,
+       541041, 10, 'main'
+WHERE NOT EXISTS (SELECT 1 FROM AD_UI_Section WHERE AD_Tab_ID = 541041 AND IsActive = 'Y');
+
+-- AD_UI_Column
+INSERT INTO AD_UI_Column (AD_UI_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                          AD_UI_Section_ID, SeqNo)
+SELECT 549275, 0, 0, 'Y', TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100,
+       (SELECT AD_UI_Section_ID FROM AD_UI_Section WHERE AD_Tab_ID = 541041 AND IsActive = 'Y' ORDER BY SeqNo LIMIT 1),
+       10
+WHERE NOT EXISTS (SELECT 1 FROM AD_UI_Column uc JOIN AD_UI_Section us ON uc.AD_UI_Section_ID = us.AD_UI_Section_ID WHERE us.AD_Tab_ID = 541041 AND uc.IsActive = 'Y');
+
+-- AD_UI_ElementGroup (flags group)
+INSERT INTO AD_UI_ElementGroup (AD_UI_ElementGroup_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                                AD_UI_Column_ID, SeqNo, Name)
+SELECT 554984, 0, 0, 'Y', TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100,
+       (SELECT uc.AD_UI_Column_ID
+        FROM AD_UI_Column uc
+                 JOIN AD_UI_Section us ON uc.AD_UI_Section_ID = us.AD_UI_Section_ID
+        WHERE us.AD_Tab_ID = 541041 AND uc.IsActive = 'Y'
+        ORDER BY us.SeqNo, uc.SeqNo LIMIT 1),
+       20, 'flags'
+WHERE NOT EXISTS (SELECT 1 FROM AD_UI_ElementGroup eg
+                               JOIN AD_UI_Column uc ON eg.AD_UI_Column_ID = uc.AD_UI_Column_ID
+                               JOIN AD_UI_Section us ON uc.AD_UI_Section_ID = us.AD_UI_Section_ID
+                  WHERE us.AD_Tab_ID = 541041 AND lower(eg.Name) = 'flags');
+
+-- AD_UI_Element for IsInheritPackingInstruction
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                           AD_UI_ElementGroup_ID, AD_Field_ID, SeqNo, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name)
+VALUES (648505, 0, 0, 'Y', TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100, TO_TIMESTAMP('2026-03-07 10:00', 'YYYY-MM-DD HH24:MI'), 100,
+        (SELECT eg.AD_UI_ElementGroup_ID
+         FROM AD_UI_ElementGroup eg
+                  JOIN AD_UI_Column uc ON eg.AD_UI_Column_ID = uc.AD_UI_Column_ID
+                  JOIN AD_UI_Section us ON uc.AD_UI_Section_ID = us.AD_UI_Section_ID
+         WHERE us.AD_Tab_ID = 541041 AND lower(eg.Name) = 'flags'
+         ORDER BY eg.SeqNo LIMIT 1),
+        774855, 10, 'Y', 'N', 'N', 'Inherit Packing Instruction');

--- a/backend/de.metas.business/src/main/java/de/metas/order/compensationGroup/GroupTemplate.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/compensationGroup/GroupTemplate.java
@@ -47,6 +47,7 @@ public class GroupTemplate
 	@Nullable GroupTemplateId id;
 	@NonNull String name;
 	boolean isNamePrinted;
+	boolean isInheritPackingInstruction;
 	@Nullable ActivityId activityId;
 	@Nullable ProductCategoryId productCategoryId;
 
@@ -58,6 +59,7 @@ public class GroupTemplate
 			@Nullable final GroupTemplateId id,
 			@NonNull final String name,
 			@Nullable final Boolean isNamePrinted,
+			final boolean isInheritPackingInstruction,
 			@Nullable final ActivityId activityId,
 			@Nullable final ProductCategoryId productCategoryId,
 			@NonNull final List<GroupTemplateRegularLine> regularLinesToAdd,
@@ -66,6 +68,7 @@ public class GroupTemplate
 		this.id = id;
 		this.name = name;
 		this.isNamePrinted = OptionalBoolean.ofNullableBoolean(isNamePrinted).orElseTrue();
+		this.isInheritPackingInstruction = isInheritPackingInstruction;
 		this.activityId = activityId;
 		this.productCategoryId = productCategoryId;
 		this.regularLinesToAdd = ImmutableList.copyOf(regularLinesToAdd);

--- a/backend/de.metas.business/src/main/java/de/metas/order/compensationGroup/GroupTemplateRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/compensationGroup/GroupTemplateRepository.java
@@ -88,6 +88,7 @@ public class GroupTemplateRepository
 		return GroupTemplate.builder()
 				.id(GroupTemplateId.ofRepoId(schemaRecord.getC_CompensationGroup_Schema_ID()))
 				.name(schemaRecord.getName())
+				.isInheritPackingInstruction(schemaRecord.isInheritPackingInstruction())
 				.activityId(ActivityId.ofRepoIdOrNull(schemaRecord.getC_Activity_ID()))
 				.regularLinesToAdd(mainLines)
 				.compensationLines(compensationLines)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/orderline/OrderLineQuickInputProcessor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/orderline/OrderLineQuickInputProcessor.java
@@ -137,6 +137,11 @@ public class OrderLineQuickInputProcessor implements IQuickInputProcessor
 				.qty(extractQty(quickInput))
 				.createGroup(orderId, contractConditionsId);
 
+		if (groupTemplate.isInheritPackingInstruction())
+		{
+			applyPackingInstructionFromQuickInput(quickInput, group);
+		}
+
 		final HashSet<OrderLineId> newOrderLineIds = new HashSet<>();
 		group.getRegularLines()
 				.stream()
@@ -189,6 +194,23 @@ public class OrderLineQuickInputProcessor implements IQuickInputProcessor
 	{
 		final IOrderLineQuickInput orderLineQuickInput = quickInput.getQuickInputDocumentAs(IOrderLineQuickInput.class);
 		return orderLineQuickInput.getQty();
+	}
+
+	private static void applyPackingInstructionFromQuickInput(final QuickInput quickInput, final Group group)
+	{
+		final IOrderLineQuickInput quickInputModel = quickInput.getQuickInputDocumentAs(IOrderLineQuickInput.class);
+		final HUPIItemProductId piItemProductId = HUPIItemProductId.ofRepoIdOrNull(quickInputModel.getM_HU_PI_Item_Product_ID());
+		if (!HUPIItemProductId.isRegular(piItemProductId))
+		{
+			return;
+		}
+
+		for (final GroupRegularLine regularLine : group.getRegularLines())
+		{
+			final de.metas.handlingunits.model.I_C_OrderLine orderLine = InterfaceWrapperHelper.load(regularLine.getRepoId(), de.metas.handlingunits.model.I_C_OrderLine.class);
+			orderLine.setM_HU_PI_Item_Product_ID(piItemProductId.getRepoId());
+			InterfaceWrapperHelper.save(orderLine);
+		}
 	}
 
 	private void validateInput(final OrderLineCandidate candidate)

--- a/misc/dev-support/docker/infrastructure/env-files/science_vessel_uat.env
+++ b/misc/dev-support/docker/infrastructure/env-files/science_vessel_uat.env
@@ -1,0 +1,62 @@
+#
+# environment file for docker-compose.yml
+#
+# In docker-compose, this env-file is used via the "--env-file" cmdline parameter
+#
+# If you want to use these variables as environment-variables in the git-bash shell, you can do
+# set -a
+# source <this file>
+# set +a
+#
+# Then you can run the de.metas.cucumber/pom.xml with "mvn test" and use the infrastructure as if you were using this env file in intellij.
+# Note that this is why we have no dots (.) in the variable names
+#
+
+BRANCH_NAME=science_vessel_uat
+
+DB_PORT=40432
+DB_DOCKER_IMG=docker.io/metasfresh/metas-db:5.175-new-dawn-uat-preloaded
+
+RABBITMQ_PORT=40672
+RABBITMQ_MGMT_PORT=40673
+RABBITMQ_USER=guest
+RABBITMQ_PASS=guest
+
+SEARCH_PORT=40300
+
+POSTGREST_PORT=40001
+
+PAPERCUT_SMTP_PORT=40025
+PAPERCUT_MGMT_PORT=40408
+
+#
+# Migration-Tool (de.metas.migration.cli.workspace_migrate.Main)
+#
+# When running the migration-Tool from intellij, we use this env-file via this plugin: https://plugins.jetbrains.com/plugin/7861-envfile/
+
+db_url=jdbc:postgresql://localhost:${DB_PORT}/metasfresh
+
+#
+# For Cucucumber (de.metas.cucumber.InfrastructureSupport)
+#
+# When running cucumber from intellij, we use this env-file via this plugin: https://plugins.jetbrains.com/plugin/7861-envfile/
+CUCUMBER_IS_USING_PROVIDED_INFRASTRUCTURE=true
+
+CUCUMBER_EXTERNALLY_RUNNING_RABBITMQ_HOST=localhost
+CUCUMBER_EXTERNALLY_RUNNING_RABBITMQ_PORT=${RABBITMQ_PORT}
+CUCUMBER_EXTERNALLY_RUNNING_RABBITMQ_USER=${RABBITMQ_USER}
+CUCUMBER_EXTERNALLY_RUNNING_RABBITMQ_PASS=${RABBITMQ_PASS}
+
+CUCUMBER_EXTERNALLY_RUNNING_POSTGRESQL_HOST=localhost
+CUCUMBER_EXTERNALLY_RUNNING_POSTGRESQL_PORT=${DB_PORT}
+
+CUCUMBER_EXTERNALLY_RUNNING_POSTGREST_HOST=localhost
+CUCUMBER_EXTERNALLY_RUNNING_POSTGREST_PORT=${POSTGREST_PORT}
+
+#
+# For IntelliJ run-configs
+#
+# for app and webapi:
+SPRING_RABBITMQ_PORT=${RABBITMQ_PORT}
+# for camel-edi and camel-externalsystems
+CAMEL_COMPONENT_RABBITMQ_PORT_NUMBER=${RABBITMQ_PORT}


### PR DESCRIPTION
## Summary
- Add `IsInheritPackingInstruction` flag to `C_CompensationGroup_Schema` table with full AD metadata (Element, Column, Field, UI Element)
- When enabled, Quick Input processor copies the main article's packing instruction (`M_HU_PI_Item_Product_ID`) to all template-created sub-article order lines after compensation group creation
- Only applies regular packing instructions (excludes Virtual HU and Template HU)

## Test plan
- [ ] Apply migration script `5792610_sys_gh26915_IsInheritPackingInstruction.sql`
- [ ] Verify new checkbox appears in Compensation Group Schema window
- [ ] Create a sales order, set packing instruction in Quick Input, select a compensation group template with `IsInheritPackingInstruction = Y`
- [ ] Verify all sub-article order lines receive the same packing instruction as the main article
- [ ] Verify that with `IsInheritPackingInstruction = N`, sub-articles do NOT get the packing instruction copied