### PR TITLE
Fix flaky cucumber tests with RabbitMQ drain steps

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1324,7 +1324,7 @@ jobs:
       max-parallel: 10
       fail-fast: false
       matrix:
-        profile: [ profile1, profile2, profile3, profile4, profile5, profile6, profile7, report, flaky, catchall ]
+        profile: [ profile1, profile2, profile3, profile4, profile5, profile6, profile7, report, catchall ]
         include:
           - profile: profile1
             params: -DexcludedGroups="ignore,flaky" -Dgroups="ghActions:run_on_executor1"
@@ -1342,8 +1342,6 @@ jobs:
             params: -DexcludedGroups="ignore,flaky" -Dgroups="ghActions:run_on_executor7"
           - profile: report
             params: -DexcludedGroups="ignore,flaky" -Dgroups="report"
-          - profile: flaky
-            params: -DexcludedGroups="ignore" -Dgroups="flaky"
           - profile: catchall
             params: -DexcludedGroups="ignore,ghActions:run_on_executor1,ghActions:run_on_executor2,ghActions:run_on_executor3,ghActions:run_on_executor4,ghActions:run_on_executor5,ghActions:run_on_executor6,ghActions:run_on_executor7,report,flaky"
     steps:

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/api/RESTUtil.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/api/RESTUtil.java
@@ -61,6 +61,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.compiere.model.I_AD_Issue;
@@ -122,11 +123,23 @@ public class RESTUtil
 		return userAuthTokenRecord.getAuthToken();
 	}
 
+	private static final int HTTP_CONNECT_TIMEOUT_MS = 30_000; // 30s
+	private static final int HTTP_SOCKET_TIMEOUT_MS = 120_000; // 120s
+	private static final int HTTP_CONNECTION_REQUEST_TIMEOUT_MS = 10_000; // 10s
+
 	public APIResponse performHTTPRequest(@NonNull final APIRequest apiRequest) throws IOException
 	{
 		final HttpRequestBase httpRequest = createHttpRequest(apiRequest);
 
-		try (final CloseableHttpClient httpClient = HttpClients.createDefault())
+		final RequestConfig requestConfig = RequestConfig.custom()
+				.setConnectTimeout(HTTP_CONNECT_TIMEOUT_MS)
+				.setSocketTimeout(HTTP_SOCKET_TIMEOUT_MS)
+				.setConnectionRequestTimeout(HTTP_CONNECTION_REQUEST_TIMEOUT_MS)
+				.build();
+
+		try (final CloseableHttpClient httpClient = HttpClients.custom()
+				.setDefaultRequestConfig(requestConfig)
+				.build())
 		{
 			final HttpResponse httpResponse = httpClient.execute(httpRequest);
 			final APIResponse apiResponse = extractAPIResponse(httpResponse, apiRequest);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/customColumns/setCustomColumns.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/customColumns/setCustomColumns.feature
@@ -1,7 +1,6 @@
 @from:cucumber
 @allure.label.epic:E0180_System_Administration
 @allure.label.feature:F00180
-@flaky
 @ghActions:run_on_executor5
 Feature: Setting customColumns via SetCustomColumns method
 ## F00180: Custom Columns

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/customColumns/setCustomColumns.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/customColumns/setCustomColumns.feature
@@ -57,6 +57,7 @@ Feature: Setting customColumns via SetCustomColumns method
       | S_ResourceType | ChargeableQty | true                      |
 
     And the metasfresh cache is reset
+    And we wait for 2000 ms
 
     When set custom columns for C_Order:
       | C_Order_ID.Identifier | OPT.BPartnerName | OPT.IsDropShip | OPT.DateOrdered | OPT.DatePromised         | OPT.Volume | OPT.EMail |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/delivery/deliveryRules.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/delivery/deliveryRules.feature
@@ -513,7 +513,6 @@ Feature: Delivery rules with and without quantity in stock
       | shipmentScheduleQtyPicked_2                | 5         | true      | true                        | hu_fifo_second        |
       | shipmentScheduleQtyPicked_3                | 5         | true      | true                        | hu_fifo_third         |
 
-  @flaky
   @from:cucumber
 @allure.label.epic:E0100_Sales
 @allure.label.feature:F00104

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/delivery/deliveryRules.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/delivery/deliveryRules.feature
@@ -547,6 +547,7 @@ Feature: Delivery rules with and without quantity in stock
     And the inventory identified by inventory_FIFO2_1 is completed
     And the inventory identified by inventory_FIFO2_2 is completed
     And the inventory identified by inventory_FIFO2_3 is completed
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
     And after not more than 60 seconds metasfresh has MD_Stock data
       | M_Product_ID.Identifier | QtyOnHand |
       | product_FIFO_2          | 20        |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/packingmaterial/receipts.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/packingmaterial/receipts.feature
@@ -959,12 +959,12 @@ Feature: Packing material invoice candidates: receipts
       | invoiceCandReceiptLine_1                   | invoiceCand_1                         | receiptLine_1                 | 0                |
       | invoiceCandReceiptLine_2                   | invoiceCand_2                         | receiptLine_2                 | 0                |
 
-  @flaky
   @Id:S0160_230
   @from:cucumber
 @allure.label.epic:E0340_Invoicing
 @allure.label.feature:F00701_Sales_Invoice_Candidates
 @F00701
+  @ghActions:run_on_executor3
   Scenario: Reactivate receipt similar with case 160
   _Given TU packing material (IFCO) x 10 CUs
   _And LU packing material (Tauschpalette) x 76 TUs
@@ -1467,12 +1467,12 @@ Feature: Packing material invoice candidates: receipts
       | invoiceCandReceiptLine_1                   | invoiceCand_1                         | receiptLine_1                 | 5                |
       | invoiceCandReceiptLine_2                   | invoiceCand_2                         | receiptLine_2                 | 1                |
 
-  @flaky
   @Id:S0160_270
   @from:cucumber
 @allure.label.epic:E0340_Invoicing
 @allure.label.feature:F00701_Sales_Invoice_Candidates
 @F00701
+  @ghActions:run_on_executor1
   Scenario: Complete receipt similar with case 200
   _Given TU packing material (IFCO) x 10 CUs
   _And order 10 x TU (IFCO) (100 CUs)

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/packingmaterial/receipts.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/packingmaterial/receipts.feature
@@ -1011,6 +1011,8 @@ Feature: Packing material invoice candidates: receipts
       | receiptLine_1             | material_receipt_1    | packingProduct          | 1064        | true      | 1064           |
       | receiptLine_2             | material_receipt_1    | loadingProduct          | 14          | true      | 14             |
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     And after not more than 120s, C_Invoice_Candidate are found:
       | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice | OPT.M_InOutLine_ID.Identifier |
       | invoiceCand_1                     | o_1                       | null                      | 1064             | 1064         | receiptLine_1                 |
@@ -1021,6 +1023,8 @@ Feature: Packing material invoice candidates: receipts
       | material_receipt_1    | CO        |
 
     When the material receipt identified by material_receipt_1 is reactivated
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     Then validate M_In_Out status
       | M_InOut_ID.Identifier | DocStatus |
@@ -1526,6 +1530,8 @@ Feature: Packing material invoice candidates: receipts
       | M_InOut_ID.Identifier | M_Product_ID.Identifier |
       | material_receipt_1    | loadingProduct          |
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     And after not more than 120s, C_Invoice_Candidate are found:
       | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice | OPT.M_InOutLine_ID.Identifier |
       | invoiceCand_1                     | o_1                       | null                      | 10               | 10           | receiptLine_1                 |
@@ -1538,6 +1544,8 @@ Feature: Packing material invoice candidates: receipts
       | material_receipt_1    | CO        |
 
     When the material receipt identified by material_receipt_1 is reactivated
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     Then validate M_In_Out status
       | M_InOut_ID.Identifier | DocStatus |
@@ -1552,6 +1560,8 @@ Feature: Packing material invoice candidates: receipts
       | invoiceCandReceiptLine_1                   | invoiceCand_1                         | receiptLine_1                 | 0                |
 
     When the material receipt identified by material_receipt_1 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     Then validate M_In_Out status
       | M_InOut_ID.Identifier | DocStatus |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
@@ -77,6 +77,8 @@ Feature: Maturing scenarios
       | M_HU_Storage_ID | M_HU_ID       | M_Product_ID | Qty |
       | maturing_hus_10 | rawgood_hu_10 | rawGood      | 10  |
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
 
     Then after not more than 60s, PP_Order_Candidates are found
@@ -161,6 +163,8 @@ Feature: Maturing scenarios
       | M_HU_Storage_ID | Qty |
       | rawgood_hus_20  | 15  |
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
 
     Then after not more than 60s, PP_Order_Candidates are found
@@ -203,6 +207,8 @@ Feature: Maturing scenarios
       | M_HU_Storage_ID | M_HU_ID       | M_Product_ID | Qty |
       | rawgood_hus_30  | rawgood_hu_30 | rawGood      | 30  |
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
 
     And after not more than 60s, PP_Order_Candidates are found
@@ -212,6 +218,8 @@ Feature: Maturing scenarios
     And M_HU are disposed:
       | M_HU_ID       | MovementDate         |
       | rawgood_hu_30 | 2024-01-01T21:00:00Z |
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
@@ -47,7 +47,6 @@ Feature: Maturing scenarios
 @allure.label.feature:F8031_Manufacturing_Workflows
 @F8031
   @Id:S0382_100
-  @flaky
   Scenario: Happy flow, raw good product HU created via inventory, maturing candidate created and processed
     When metasfresh contains M_Inventories:
       | M_Inventory_ID | MovementDate | DocumentNo   | M_Warehouse_ID    |
@@ -121,7 +120,6 @@ Feature: Maturing scenarios
 @allure.label.feature:F8031_Manufacturing_Workflows
 @F8031
   @Id:S0382_200
-  @flaky
   Scenario: Maturing candidate created, then HU qty is adjusted. Maturing candidate is updated
     When metasfresh contains M_Inventories:
       | M_Inventory_ID.Identifier | MovementDate | DocumentNo   | M_Warehouse_ID    |
@@ -172,7 +170,6 @@ Feature: Maturing scenarios
       | oc_2       | false     | maturedGood  | bom_1             | prodPlanning           | 540006        | 15 PCE     | 15 PCE       | 0 PCE        | 2023-06-30T22:00:00Z | 2023-06-30T22:00:00Z | false    | true       | maturingConfig              | maturingConfigLine               | rawgood_hu_20 |
 
 
-  @flaky
   @from:cucumber
 @allure.label.epic:E0160_Manufacturing_Execution
 @allure.label.feature:F8031_Manufacturing_Workflows

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/production_and_distribution.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/production_and_distribution.feature
@@ -96,6 +96,7 @@ Feature: Production + Distribution material dispo scenarios
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | SO_L1      | SO         | bom_product  | 10         |
     When the order identified by SO is completed
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed |
@@ -140,6 +141,7 @@ Feature: Production + Distribution material dispo scenarios
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | SO_L1      | SO         | bom_product  | 10         |
     When the order identified by SO is completed
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed |
@@ -202,6 +204,7 @@ Feature: Production + Distribution material dispo scenarios
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | SO_L1      | SO         | bom_product  | 10         |
     When the order identified by SO is completed
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed |
@@ -280,6 +283,7 @@ Feature: Production + Distribution material dispo scenarios
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | SO_L1      | SO         | bom_product  | 10         |
     When the order identified by SO is completed
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed |
@@ -341,6 +345,7 @@ Feature: Production + Distribution material dispo scenarios
     #
     # Complete the Sales order and expect PP_Order_Candidate and DD_Order_Candidate to be generated
     When the order identified by SO is completed
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed |
       | oc_1       | false     | bom_product  | bom_1             | bom_product_planning   | plant         | 10 PCE     | 10 PCE       | 0 PCE        | 2021-04-16T21:00:00Z | 2021-04-16T21:00:00Z | false    |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/multipleProductionCandidates.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/multipleProductionCandidates.feature
@@ -109,6 +109,7 @@ Feature: create multiple production candidates
     #
     # Complete the sales order and expected the PP_Order_Candidate to be generated.
     When the order identified by o_1 is completed
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed |
       | oc_1       | false     | p_1          | bom_1             | ppln_1                 | testResource  | 10 PCE     | 10 PCE       | 0 PCE        | 2021-04-16T21:00:00Z | 2021-04-16T21:00:00Z | false    |
@@ -131,6 +132,7 @@ Feature: create multiple production candidates
       | C_OrderLine_ID.Identifier | OPT.QtyEntered |
       | ol_1                      | 12             |
     And the order identified by o_1 is completed
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed |
       | oc_1       | false     | p_1          | bom_1             | ppln_1                 | testResource  | 0 PCE      | 0 PCE        | 0 PCE        | 2021-04-16T21:00:00Z | 2021-04-16T21:00:00Z | false    |
@@ -154,6 +156,7 @@ Feature: create multiple production candidates
       | PP_Order_Candidate_ID |
       | oc_1                  |
       | oc_2                  |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
     Then after not more than 60s, PP_Orders are found
       | Identifier | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyOrdered | C_BPartner_ID | DatePromised         | DocStatus |
       | ppo_1      | p_1          | bom_1             | ppln_1                 | testResource  | 12 PCE     | 12         | endcustomer_2 | 2021-04-16T21:00:00Z | DR        |
@@ -297,6 +300,7 @@ Feature: create multiple production candidates
       | C_OrderLine_ID.Identifier | OPT.QtyEntered |
       | ol_3                      | 12             |
     And the order identified by o_3 is completed
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier           | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | SeqNo |
       | ppOrderCandidate_3_1 | false     | p_1          | bom_1             | ppln_1                 | testResource  | 0 PCE      | 0 PCE        | 0 PCE        | 2022-11-07T21:00:00Z | 2022-11-07T21:00:00Z | false    | 10    |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/multipleProductionCandidates.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/multipleProductionCandidates.feature
@@ -87,7 +87,6 @@ Feature: create multiple production candidates
 @allure.label.epic:E0160_Manufacturing_Execution
 @allure.label.feature:F8033_Manufacturing_Workflow_Activity_Raw_Materials_Issue_per_single_product
 @F8033
-  @flaky
   Scenario:  The manufacturing candidate is created for a sales order line,
   then the sales order is re-opened and the ordered quantity is increased,
   resulting in a second manufacturing candidate to supply the additional demand.
@@ -260,7 +259,6 @@ Feature: create multiple production candidates
 # ########################################################################################################################################################################
 # ########################################################################################################################################################################
 # ########################################################################################################################################################################
-  @flaky
   @from:cucumber
 @allure.label.epic:E0160_Manufacturing_Execution
 @allure.label.feature:F8033_Manufacturing_Workflow_Activity_Raw_Materials_Issue_per_single_product

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate.feature
@@ -189,6 +189,8 @@ Feature: Production dispo scenarios
 
     And the order identified by o_2 is reactivated
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     Then after not more than 60s, PP_Order_Candidates are found
       | Identifier | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | OPT.IsClosed | OPT.Processed |
       | oc_1       | p_1          | bom_1             | ppln_1                 | 540006        | 200 PCE    | 200 PCE      | 0 PCE        | 2025-02-25T06:00:00Z | 2025-02-25T06:00:00Z | false        | false         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate.feature
@@ -126,7 +126,6 @@ Feature: Production dispo scenarios
       | PP_Order_Candidate_ID.Identifier | QtyEntered |
       | oc_1                             | 2          |
 
-  @flaky
   @Id:S0129.2_190
   @from:cucumber
 @allure.label.epic:E0160_Manufacturing_Execution

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate_with_BOM_recursion.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate_with_BOM_recursion.feature
@@ -198,6 +198,8 @@ Feature: Production dispo scenarios with BOMs whose components have their own BO
 
     And the PP_Order ppo_1_S0460_20 is voided
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     And after not more than 60s, PP_Orders are found
       | Identifier     | M_Product_ID         | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID  | QtyEntered | QtyOrdered | C_BPartner_ID     | DatePromised         | DocStatus |
       | ppo_1_S0460_20 | product_1_1_S0460_20 | bom_1_S0460_20    | ppln_1_1_S0460_20      | resource_S0460 | 0 PCE      | 0          | customer_S0460_20 | 2024-09-22T21:00:00Z | VO        |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentScheduleExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentScheduleExport.feature
@@ -123,6 +123,8 @@ Feature: Shipment schedule export rest-api
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
       | orderLine_1               | order_1               | 2022-02-02      | product_25_02           | 1          | 0            | 0           | 10.0  | 0        | EUR          | true      |
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | schedule_1 | orderLine_1               | N             |
@@ -216,6 +218,8 @@ Feature: Shipment schedule export rest-api
     And validate the created order lines
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
       | orderLine_1               | order_1               | 2022-02-02      | product_25_02           | 1          | 0            | 0           | 10.0  | 0        | EUR          | true      |
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |

--- a/backend/de.metas.material/dispo-service/src/test/java/de/metas/material/dispo/service/event/handler/ddorder/DDOrderDocStatusChangedHandlerTest.java
+++ b/backend/de.metas.material/dispo-service/src/test/java/de/metas/material/dispo/service/event/handler/ddorder/DDOrderDocStatusChangedHandlerTest.java
@@ -1,0 +1,197 @@
+package de.metas.material.dispo.service.event.handler.ddorder;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.document.engine.DocStatus;
+import de.metas.material.dispo.commons.candidate.Candidate;
+import de.metas.material.dispo.commons.candidate.CandidateBusinessCase;
+import de.metas.material.dispo.commons.candidate.CandidateId;
+import de.metas.material.dispo.commons.candidate.CandidateType;
+import de.metas.material.dispo.commons.candidate.businesscase.DistributionDetail;
+import de.metas.material.dispo.commons.repository.CandidateRepositoryRetrieval;
+import de.metas.material.dispo.service.candidatechange.CandidateChangeService;
+import de.metas.material.event.commons.EventDescriptor;
+import de.metas.material.event.commons.MaterialDescriptor;
+import de.metas.material.event.ddorder.DDOrder;
+import de.metas.material.event.ddorder.DDOrderCreatedEvent;
+import de.metas.material.event.ddorder.DDOrderDocStatusChangedEvent;
+import de.metas.material.event.ddorder.DDOrderLine;
+import de.metas.material.event.ddorder.DDOrderRef;
+import de.metas.material.event.pporder.MaterialDispoGroupId;
+import de.metas.material.planning.ProductPlanningId;
+import de.metas.material.planning.ddorder.DistributionNetworkAndLineId;
+import de.metas.organization.ClientAndOrgId;
+import de.metas.product.ResourceId;
+import de.metas.shipping.ShipperId;
+import org.adempiere.warehouse.WarehouseId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+import static de.metas.material.event.EventTestHelper.CLIENT_AND_ORG_ID;
+import static de.metas.material.event.EventTestHelper.NOW;
+import static de.metas.material.event.EventTestHelper.createProductDescriptor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DDOrderDocStatusChangedHandlerTest
+{
+	private CandidateRepositoryRetrieval candidateRepositoryRetrieval;
+	private CandidateChangeService candidateChangeService;
+	private DDOrderCreatedHandler ddOrderCreatedHandler;
+	private DDOrderDocStatusChangedHandler handler;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		candidateRepositoryRetrieval = mock(CandidateRepositoryRetrieval.class);
+		candidateChangeService = mock(CandidateChangeService.class);
+		ddOrderCreatedHandler = mock(DDOrderCreatedHandler.class);
+
+		handler = new DDOrderDocStatusChangedHandler(
+				candidateRepositoryRetrieval,
+				candidateChangeService,
+				ddOrderCreatedHandler);
+	}
+
+	@Test
+	void noCandidates_withDDOrder_delegatesToCreatedHandler()
+	{
+		// Given: no existing candidates for this DD_Order
+		mockNoCandidatesForDDOrderId(10);
+
+		final DDOrderDocStatusChangedEvent event = DDOrderDocStatusChangedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientAndOrg(CLIENT_AND_ORG_ID))
+				.ddOrderId(10)
+				.newDocStatus(DocStatus.Completed)
+				.ddOrder(createDDOrder())
+				.build();
+
+		// When
+		handler.handleEvent(event);
+
+		// Then: DDOrderCreatedHandler was called with a synthetic DDOrderCreatedEvent
+		final ArgumentCaptor<DDOrderCreatedEvent> captor = ArgumentCaptor.forClass(DDOrderCreatedEvent.class);
+		verify(ddOrderCreatedHandler).handleEvent(captor.capture());
+		final DDOrderCreatedEvent createdEvent = captor.getValue();
+		assertThat(createdEvent.getDdOrder()).isNotNull();
+		assertThat(createdEvent.getDdOrder().getDdOrderId()).isEqualTo(20);
+		assertThat(createdEvent.getEventDescriptor()).isEqualTo(event.getEventDescriptor());
+
+		// And: CandidateChangeService was NOT called directly (DDOrderCreatedHandler handles that)
+		verify(candidateChangeService, never()).onCandidateNewOrChange(any());
+	}
+
+	@Test
+	void noCandidates_withoutDDOrder_logsWarningAndSkips()
+	{
+		// Given: no existing candidates and no DDOrder in event (e.g., old event format or loader failure)
+		mockNoCandidatesForDDOrderId(10);
+
+		final DDOrderDocStatusChangedEvent event = DDOrderDocStatusChangedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientAndOrg(CLIENT_AND_ORG_ID))
+				.ddOrderId(10)
+				.newDocStatus(DocStatus.Completed)
+				.build();
+
+		// When
+		handler.handleEvent(event);
+
+		// Then: neither DDOrderCreatedHandler nor CandidateChangeService was called
+		verify(ddOrderCreatedHandler, never()).handleEvent(any());
+		verify(candidateChangeService, never()).onCandidateNewOrChange(any());
+	}
+
+	@Test
+	void existingCandidates_updatesDocStatusAndQuantity()
+	{
+		// Given: existing candidate for this DD_Order
+		final DistributionDetail distributionDetail = DistributionDetail.builder()
+				.ddOrderRef(DDOrderRef.builder().ddOrderId(10).ddOrderLineId(11).build())
+				.distributionNetworkAndLineId(DistributionNetworkAndLineId.ofRepoIds(80, 85))
+				.ddOrderDocStatus(DocStatus.InProgress)
+				.qty(BigDecimal.TEN)
+				.build();
+
+		final Candidate existingCandidate = Candidate.builder()
+				.id(CandidateId.ofRepoId(100))
+				.type(CandidateType.SUPPLY)
+				.clientAndOrgId(CLIENT_AND_ORG_ID)
+				.businessCase(CandidateBusinessCase.DISTRIBUTION)
+				.materialDescriptor(MaterialDescriptor.builder()
+						.productDescriptor(createProductDescriptor())
+						.warehouseId(WarehouseId.ofRepoId(30))
+						.quantity(BigDecimal.TEN)
+						.date(NOW)
+						.build())
+				.businessCaseDetail(distributionDetail)
+				.build();
+
+		mockCandidatesForDDOrderId(10, ImmutableList.of(existingCandidate));
+
+		final DDOrderDocStatusChangedEvent event = DDOrderDocStatusChangedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientAndOrg(CLIENT_AND_ORG_ID))
+				.ddOrderId(10)
+				.newDocStatus(DocStatus.Completed)
+				.build();
+
+		// When
+		handler.handleEvent(event);
+
+		// Then: CandidateChangeService was called to update the candidate
+		final ArgumentCaptor<Candidate> captor = ArgumentCaptor.forClass(Candidate.class);
+		verify(candidateChangeService).onCandidateNewOrChange(captor.capture());
+		final Candidate updatedCandidate = captor.getValue();
+		final DistributionDetail updatedDetail = DistributionDetail.cast(updatedCandidate.getBusinessCaseDetail());
+		assertThat(updatedDetail.getDdOrderDocStatus()).isEqualTo(DocStatus.Completed);
+
+		// And: DDOrderCreatedHandler was NOT called (existing candidates path)
+		verify(ddOrderCreatedHandler, never()).handleEvent(any());
+	}
+
+	private void mockNoCandidatesForDDOrderId(final int ddOrderId)
+	{
+		mockCandidatesForDDOrderId(ddOrderId, Collections.emptyList());
+	}
+
+	private void mockCandidatesForDDOrderId(final int ddOrderId, final List<Candidate> candidates)
+	{
+		// DDOrderUtil.retrieveCandidatesForDDOrderId uses candidateRepositoryRetrieval.retrieveOrderedByDateAndSeqNo
+		when(candidateRepositoryRetrieval.retrieveOrderedByDateAndSeqNo(any()))
+				.thenReturn(candidates);
+	}
+
+	private static DDOrder createDDOrder()
+	{
+		return DDOrder.builder()
+				.ddOrderId(20)
+				.docStatus(DocStatus.Completed)
+				.supplyDate(NOW)
+				.clientAndOrgId(ClientAndOrgId.ofClientAndOrg(1, 2))
+				.sourceWarehouseId(WarehouseId.ofRepoId(10))
+				.targetWarehouseId(WarehouseId.ofRepoId(30))
+				.plantId(ResourceId.ofRepoId(50))
+				.productPlanningId(ProductPlanningId.ofRepoId(60))
+				.shipperId(ShipperId.ofRepoId(70))
+				.materialDispoGroupId(MaterialDispoGroupId.ofInt(35))
+				.line(DDOrderLine.builder()
+						.ddOrderLineId(21)
+						.productDescriptor(createProductDescriptor())
+						.distributionNetworkAndLineId(DistributionNetworkAndLineId.ofRepoIds(80, 85))
+						.demandDate(NOW.minusSeconds(86400))
+						.qtyToMove(BigDecimal.TEN)
+						.qtyMoved(BigDecimal.ZERO)
+						.build())
+				.build();
+	}
+}

--- a/backend/de.metas.material/event/src/test/java/de/metas/material/event/MaterialEventSerializerTests.java
+++ b/backend/de.metas.material/event/src/test/java/de/metas/material/event/MaterialEventSerializerTests.java
@@ -214,6 +214,19 @@ public class MaterialEventSerializerTests
 		assertEventEqualAfterSerializeDeserialize(event);
 	}
 
+	@Test
+	public void ddOrderChangedDocStatusEvent_withDDOrder()
+	{
+		final DDOrderDocStatusChangedEvent event = DDOrderDocStatusChangedEvent.builder()
+				.eventDescriptor(newEventDescriptor())
+				.ddOrderId(20)
+				.newDocStatus(DocStatus.Completed)
+				.ddOrder(newDDOrder())
+				.build();
+
+		assertEventEqualAfterSerializeDeserialize(event);
+	}
+
 	private static DDOrder newDDOrder()
 	{
 		final Instant supplyDate = SystemTime.asInstant();

--- a/e2e/mobile-webui/tests/utils/dialogs/ErrorToast.js
+++ b/e2e/mobile-webui/tests/utils/dialogs/ErrorToast.js
@@ -1,4 +1,4 @@
-import { page } from '../common';
+import { page, SLOW_ACTION_TIMEOUT } from '../common';
 
 //
 // IMPORTANT: DO NOT import playwright.config.js because you will introduce a circular dependency.
@@ -19,6 +19,6 @@ export const ErrorToast = {
 
     closePopup: async () => {
         await page.locator('.Toastify__close-button--error').tap();
-        await containerElement().waitFor({ state: 'detached' });
+        await containerElement().waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     },
 }

--- a/e2e/mobile-webui/tests/utils/dialogs/GetDocumentNoDialog.js
+++ b/e2e/mobile-webui/tests/utils/dialogs/GetDocumentNoDialog.js
@@ -1,5 +1,5 @@
 import { test } from "../../../playwright.config";
-import { page } from "../common";
+import { page, SLOW_ACTION_TIMEOUT } from "../common";
 
 const NAME = 'GetDocumentNoDialog';
 /** @returns {import('@playwright/test').Locator} */
@@ -7,7 +7,7 @@ const containerElement = () => page.locator('.get-documentNo-dialog');
 
 export const GetDocumentNoDialog = {
     waitForDialog: async () => await test.step(`${NAME} - Wait for dialog`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     typeDocumentNo: async (documentNo) => await test.step(`${NAME} - Type Document No ${documentNo}`, async () => {

--- a/e2e/mobile-webui/tests/utils/dialogs/UnpickDialog.js
+++ b/e2e/mobile-webui/tests/utils/dialogs/UnpickDialog.js
@@ -1,5 +1,5 @@
 import { test } from "../../../playwright.config";
-import { page } from "../common";
+import { page, SLOW_ACTION_TIMEOUT } from "../common";
 
 const NAME = 'UnpickDialog';
 /** @returns {import('@playwright/test').Locator} */
@@ -7,7 +7,7 @@ const containerElement = () => page.locator('.unpick-dialog');
 
 export const UnpickDialog = {
     waitForDialog: async () => await test.step(`${NAME} - Wait for dialog`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     clickSkipScanningTargetHUButton: async () => await test.step(`${NAME} - Click Skip button`, async () => {

--- a/e2e/mobile-webui/tests/utils/dialogs/YesNoDialog.js
+++ b/e2e/mobile-webui/tests/utils/dialogs/YesNoDialog.js
@@ -1,5 +1,5 @@
 import { test } from "../../../playwright.config";
-import { page } from "../common";
+import { page, SLOW_ACTION_TIMEOUT } from "../common";
 import { expect } from '@playwright/test';
 
 const NAME = 'YesNoDialog';
@@ -8,7 +8,7 @@ const containerElement = () => page.locator('.yes-no-dialog');
 
 export const YesNoDialog = {
     waitForDialog: async () => await test.step(`${NAME} - Wait for dialog`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect dialog to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
@@ -1,4 +1,4 @@
-import { page } from "../common";
+import { page, SLOW_ACTION_TIMEOUT } from "../common";
 import { test } from "../../../playwright.config";
 import { expect } from "@playwright/test";
 import { LoginScreen } from "./LoginScreen";
@@ -12,8 +12,8 @@ const containerElement = () => page.locator('#ApplicationsListScreen');
 
 export const ApplicationsListScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
-        await page.locator('.loading').waitFor({ state: 'detached' });
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/Backend.js
+++ b/e2e/mobile-webui/tests/utils/screens/Backend.js
@@ -121,9 +121,9 @@ const assertNoErrors = ({ responseBody }) => {
 };
 
 const getAuthToken = () => {
-    const token = lastMasterdata?.login?.user?.token;
+    const token = testContext.lastMasterdata?.login?.user?.token;
     if (!token) {
-        throw new Error('No token found in masterdata:\n' + JSON.stringify(lastMasterdata, null, 2));
+        throw new Error('No token found in masterdata:\n' + JSON.stringify(testContext.lastMasterdata, null, 2));
     }
     return token;
 }

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobScreen.js
@@ -17,6 +17,7 @@ const containerElement = () => page.locator('#WFProcessScreen');
 export const DistributionJobScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
         await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectJobId: async ({ distributionJobId }) => await test.step(`${NAME} - Expect jobId=${distributionJobId}`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListFiltersScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListFiltersScreen.js
@@ -5,7 +5,7 @@ import { expect } from "@playwright/test";
 
 export const DistributionJobsListFiltersScreen = {
     waitForScreen: async () => await test.step('Wait for distribution jobs list filters screen', async () => {
-        await page.locator('#WFLaunchersFiltersScreen').waitFor();
+        await page.locator('#WFLaunchersFiltersScreen').waitFor({ timeout: SLOW_ACTION_TIMEOUT });
         await DistributionJobsListFiltersScreen.waitLoadComplete();
     }),
 

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLineScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLineScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { FAST_ACTION_TIMEOUT, ID_BACK_BUTTON, page } from '../../common';
+import { FAST_ACTION_TIMEOUT, ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from '../../common';
 import { DistributionLinePickFromScreen } from './DistributionLinePickFromScreen';
 import { DistributionStepScreen } from './DistributionStepScreen';
 import { expect } from '@playwright/test';
@@ -12,7 +12,8 @@ const containerElement = () => page.locator('#DistributionLineScreen');
 
 export const DistributionLineScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for Screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionStepDropToScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionStepDropToScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page } from '../../common';
+import { page, SLOW_ACTION_TIMEOUT } from '../../common';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
 
 const NAME = 'DistributionStepDropToScreen';
@@ -8,7 +8,7 @@ const containerElement = () => page.locator('#DistributionStepDropToScreen');
 
 export const DistributionStepDropToScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for Screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     typeQRCode: async (qrCode) => await test.step(`${NAME} - Type QR Code`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionStepScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionStepScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { ID_BACK_BUTTON, page } from '../../common';
+import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from '../../common';
 import { expect } from '@playwright/test';
 import { DistributionStepDropToScreen } from './DistributionStepDropToScreen';
 import { DistributionLineScreen } from './DistributionLineScreen';
@@ -11,7 +11,8 @@ const containerElement = () => page.locator('#DistributionStepScreen');
 
 export const DistributionStepScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for Screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/huConsolidation/HUConsolidationJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huConsolidation/HUConsolidationJobScreen.js
@@ -13,6 +13,7 @@ const containerElement = () => page.locator('#WFProcessScreen');
 export const HUConsolidationJobScreen = {
     waitForScreen: async () => await step(`${NAME} - Wait for screen`, async () => {
         await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/huConsolidation/PickingSlotScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huConsolidation/PickingSlotScreen.js
@@ -9,7 +9,7 @@ const containerElement = () => page.locator('#PickingSlotScreen');
 
 export const PickingSlotScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
         await PickingSlotScreen.waitNotLoading();
     }),
 

--- a/e2e/mobile-webui/tests/utils/screens/huConsolidation/ScanHUConsolidationTargetScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huConsolidation/ScanHUConsolidationTargetScreen.js
@@ -9,7 +9,7 @@ const containerElement = () => page.locator('#ScanHUConsolidationTargetScreen');
 
 export const ScanHUConsolidationTargetScreen = {
     waitForScreen: async () => await step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
         await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 

--- a/e2e/mobile-webui/tests/utils/screens/huConsolidation/SelectHUConsolidationTargetScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huConsolidation/SelectHUConsolidationTargetScreen.js
@@ -10,7 +10,7 @@ const containerElement = () => page.locator('#SelectHUConsolidationTargetScreen'
 
 export const SelectHUConsolidationTargetScreen = {
     waitForScreen: async () => await step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
         await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 

--- a/e2e/mobile-webui/tests/utils/screens/huManager/ChangeHUQtyDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/ChangeHUQtyDialog.js
@@ -8,7 +8,7 @@ const containerElement = () => page.getByTestId('ChangeHUQtyDialog');
 
 export const ChangeHUQtyDialog = {
     waitForDialog: async () => await test.step(`${NAME} - Wait to open`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     waitForDialogToClose: async () => await test.step(`${NAME} - Wait to close`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/huManager/ClearanceDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/ClearanceDialog.js
@@ -16,7 +16,7 @@ const containerElement = () => page.getByTestId('ClearanceDialog');
 
 export const ClearanceDialog = {
     waitForDialog: async () => await test.step(`${NAME} - Wait to open`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     waitForDialogToClose: async () => await test.step(`${NAME} - Wait to close`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page } from '../../common';
+import { page, SLOW_ACTION_TIMEOUT } from '../../common';
 import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
@@ -10,7 +10,7 @@ const containerElement = () => page.locator('#HUBulkActionsScreen');
 
 export const HUBulkActionsScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {
@@ -21,7 +21,7 @@ export const HUBulkActionsScreen = {
         await page.getByTestId('toggle-target-scanner-button').tap();
         // Wait for button text to change to "Close scanner" - ensures React re-render complete
         // and useKeyboardBarcodeReader hook has attached its event listener
-        await page.getByTestId('toggle-target-scanner-button').getByText('Close scanner').waitFor();
+        await page.getByTestId('toggle-target-scanner-button').getByText('Close scanner').waitFor({ timeout: SLOW_ACTION_TIMEOUT });
         await BarcodeScannerComponent.type(targetLocator);
 
         await ApplicationsListScreen.waitForScreen();

--- a/e2e/mobile-webui/tests/utils/screens/huManager/HUDisposalScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/HUDisposalScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page } from '../../common';
+import { page, SLOW_ACTION_TIMEOUT } from '../../common';
 import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
 
@@ -13,7 +13,7 @@ const containerElement = () => page.locator('#HUDisposalScreen');
 
 export const HUDisposalScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/huManager/HUManagerScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/HUManagerScreen.js
@@ -14,7 +14,8 @@ const containerElement = () => page.locator('#HUManagerScreen');
 
 export const HUManagerScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/huManager/HUMoveScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/HUMoveScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page } from '../../common';
+import { page, SLOW_ACTION_TIMEOUT } from '../../common';
 import { HUManagerScreen } from './HUManagerScreen';
 import { expect } from '@playwright/test';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
@@ -10,7 +10,7 @@ const containerElement = () => page.locator('#HUMoveScreen');
 
 export const HUMoveScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/inventory/InventoryJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/inventory/InventoryJobScreen.js
@@ -12,6 +12,7 @@ const containerElement = () => page.locator('#WFProcessScreen');
 export const InventoryJobScreen = {
     waitForScreen: async () => await step(`${NAME} - Wait for screen`, async () => {
         await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     getJobId: async () => {

--- a/e2e/mobile-webui/tests/utils/screens/inventory/InventoryJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/inventory/InventoryJobsListScreen.js
@@ -8,8 +8,9 @@ const NAME = 'InventoryJobsListScreen';
 const containerElement = () => page.locator('#WFLaunchersScreen');
 
 export const InventoryJobsListScreen = {
-    waitForScreen: async () => await step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+    waitForScreen: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await step(`${NAME} - Wait for screen`, async () => {
+        await containerElement().waitFor({ timeout });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/inventory/InventoryScanScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/inventory/InventoryScanScreen.js
@@ -1,5 +1,5 @@
 import { test } from "../../../../playwright.config";
-import { page, step } from "../../common";
+import { page, SLOW_ACTION_TIMEOUT, step } from "../../common";
 import { expect } from '@playwright/test';
 import { InventoryJobScreen } from './InventoryJobScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
@@ -10,11 +10,11 @@ const containerElement = () => page.locator(`#${NAME}`);
 
 export const InventoryScanScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     waitForPanel: async (panel) => await test.step(`${NAME} - Wait for panel '${panel}'`, async () => {
-        await page.locator(`.panel-${panel}`).waitFor();
+        await page.locator(`.panel-${panel}`).waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     typeQRCode: async (qrCode) => await test.step(`${NAME} - Type QR Code`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/ManufacturingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/ManufacturingJobScreen.js
@@ -15,6 +15,7 @@ const containerElement = () => page.locator('#WFProcessScreen');
 export const ManufacturingJobScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
         await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScanScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScanScreen.js
@@ -1,4 +1,4 @@
-import { page } from '../../../common';
+import { page, SLOW_ACTION_TIMEOUT } from '../../../common';
 import { test } from '../../../../../playwright.config';
 import { expect } from '@playwright/test';
 import { BarcodeScannerComponent } from '../../../components/BarcodeScannerComponent';
@@ -9,7 +9,7 @@ const containerElement = () => page.locator('#RawMaterialIssueLineScanScreen');
 
 export const RawMaterialIssueLineScanScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScreen.js
@@ -1,4 +1,4 @@
-import { ID_BACK_BUTTON, page } from '../../../common';
+import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from '../../../common';
 import { test } from '../../../../../playwright.config';
 import { expect } from '@playwright/test';
 import { RawMaterialIssueLineScanScreen } from './RawMaterialIssueLineScanScreen';
@@ -11,7 +11,8 @@ const containerElement = () => page.locator('#RawMaterialIssueLineScreen');
 
 export const RawMaterialIssueLineScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/receipt/MaterialReceiptLineScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/receipt/MaterialReceiptLineScreen.js
@@ -1,4 +1,4 @@
-import { ID_BACK_BUTTON, page } from '../../../common';
+import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from '../../../common';
 import { test } from '../../../../../playwright.config';
 import { expect } from '@playwright/test';
 import { ReceiptReceiveTargetScreen } from './ReceiptReceiveTargetScreen';
@@ -13,8 +13,8 @@ const containerElement = () => page.locator('#MaterialReceiptLineScreen');
 
 export const MaterialReceiptLineScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
-        await page.locator('.loading').waitFor({ state: 'detached' });
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/receipt/ReceiptNewHUScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/receipt/ReceiptNewHUScreen.js
@@ -1,4 +1,4 @@
-import { page } from '../../../common';
+import { page, SLOW_ACTION_TIMEOUT } from '../../../common';
 import { test } from '../../../../../playwright.config';
 import { expect } from '@playwright/test';
 import { MaterialReceiptLineScreen } from './MaterialReceiptLineScreen';
@@ -9,7 +9,7 @@ const containerElement = () => page.locator('#ReceiptNewHUScreen');
 
 export const ReceiptNewHUScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/receipt/ReceiptReceiveTargetScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/receipt/ReceiptReceiveTargetScreen.js
@@ -1,4 +1,4 @@
-import { page } from '../../../common';
+import { page, SLOW_ACTION_TIMEOUT } from '../../../common';
 import { test } from '../../../../../playwright.config';
 import { expect } from '@playwright/test';
 import { ReceiptNewHUScreen } from './ReceiptNewHUScreen';
@@ -10,7 +10,7 @@ const containerElement = () => page.locator('#ReceiptReceiveTargetScreen');
 
 export const ReceiptReceiveTargetScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
@@ -13,7 +13,7 @@ export const QTY_NOT_FOUND_REASON_IGNORE = 'IgnoreReason';
 
 export const GetQuantityDialog = {
     waitForDialog: async () => await test.step(`${NAME} - Wait for dialog`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     waitToClose: async () => await test.step(`${NAME} - Wait to close`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
@@ -107,7 +107,7 @@ export const GetQuantityDialog = {
 
     clickManual: async () => await test.step(`${NAME} - Press Manual`, async () => {
         await page.getByTestId('switchToManualInput-button').tap();
-        await page.locator('#qty-input').waitFor(); // atm that's the only indicator that we switched to manual input
+        await page.locator('#qty-input').waitFor({ timeout: SLOW_ACTION_TIMEOUT }); // atm that's the only indicator that we switched to manual input
     }),
 
     expectComponentsDisabled: async () => await test.step(`${NAME} - Expect fields and buttons disabled`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickFromHUScanScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickFromHUScanScreen.js
@@ -1,5 +1,5 @@
 import { test } from "../../../../playwright.config";
-import { page } from "../../common";
+import { page, SLOW_ACTION_TIMEOUT } from "../../common";
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
 
 const NAME = 'PickFromHUScanScreen';
@@ -8,7 +8,7 @@ const containerElement = () => page.locator('#ScanScreen');
 
 export const PickFromHUScanScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     typeQRCode: async (qrCode) => await test.step(`${NAME} - Type QR Code`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickLineScanScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickLineScanScreen.js
@@ -1,4 +1,4 @@
-import { ID_BACK_BUTTON, page, step } from '../../common';
+import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT, step } from '../../common';
 import { test } from '../../../../playwright.config';
 import { GetQuantityDialog } from './GetQuantityDialog';
 import { PickingJobScreen } from './PickingJobScreen';
@@ -11,7 +11,7 @@ const containerElement = () => page.locator('#PickLineScanScreen');
 
 export const PickLineScanScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     typeQRCode: async (qrCode) => await test.step(`${NAME} - Type QR Code`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobLineScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobLineScreen.js
@@ -1,5 +1,5 @@
 import { test } from "../../../../playwright.config";
-import { ID_BACK_BUTTON, page } from "../../common";
+import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from "../../common";
 import { PickingJobScreen } from "./PickingJobScreen";
 import { PickingJobStepScreen } from "./PickingJobStepScreen";
 import { GetQuantityDialog } from "./GetQuantityDialog";
@@ -12,7 +12,8 @@ const containerElement = () => page.locator('#PickLineScreen');
 
 export const PickingJobLineScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     clickManufactureButton: async () => await test.step(`${NAME} - Click Manufacture button`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScanHUScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScanHUScreen.js
@@ -1,5 +1,5 @@
 import { test } from "../../../../playwright.config";
-import { page } from "../../common";
+import { page, SLOW_ACTION_TIMEOUT } from "../../common";
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
 
 const NAME = 'PickingJobScanHUScreen';
@@ -8,7 +8,7 @@ const containerElement = () => page.locator('#PickProductsScanScreen');
 
 export const PickingJobScanHUScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     typeQRCode: async (qrCode) => await test.step(`${NAME} - Type QR Code`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
@@ -35,7 +35,7 @@ export const PickingJobScreen = {
 
     scanPickFromHU: async ({ qrCode }) => await step(`${NAME} - Scan pick from HU ${qrCode}`, async () => {
         const button = page.getByTestId(`scan-activity-${ACTIVITY_ID_ScanPickFromHU}-button`);
-        await button.waitFor();
+        await button.waitFor({ timeout: SLOW_ACTION_TIMEOUT });
         await expect(button).toBeEnabled();
         await button.tap();
         await PickFromHUScanScreen.waitForScreen();
@@ -46,7 +46,7 @@ export const PickingJobScreen = {
 
     clickPickingSlotButton: async () => await step(`${NAME} - Click Picking Slot button`, async () => {
         const button = pickingSlotButton();
-        await button.waitFor();
+        await button.waitFor({ timeout: SLOW_ACTION_TIMEOUT });
         await expect(button).toBeEnabled();
         await button.tap();
 
@@ -55,7 +55,7 @@ export const PickingJobScreen = {
 
     expectPickingSlotButtonGreen: async () => await step(`${NAME} - Expect Picking Slot button to be green`, async () => {
         const button = pickingSlotButton();
-        await button.waitFor();
+        await button.waitFor({ timeout: SLOW_ACTION_TIMEOUT });
         await button.locator('.indicator-color-green').waitFor({ state: 'attached', timeout: FAST_ACTION_TIMEOUT });
     }),
 
@@ -167,7 +167,7 @@ export const PickingJobScreen = {
             await step(`${NAME} - Waiting until line button color='${waitForColor}'`, async () => {
                 const expectedClassName = `indicator-color-${waitForColor}`;
                 const indicator = lineButton.locator(`[data-testid="indicator"].${expectedClassName}`);
-                await indicator.waitFor({ state: 'attached' });
+                await indicator.waitFor({ state: 'attached', timeout: SLOW_ACTION_TIMEOUT });
             });
         }
 

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
@@ -22,6 +22,7 @@ const ACTIVITY_ID_ScanPickingSlot = 'scanPickingSlot'; // keep in sync with Pick
 export const PickingJobScreen = {
     waitForScreen: async () => await step(`${NAME} - Wait for screen`, async () => {
         await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     getPickingJobId: async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobStepScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobStepScreen.js
@@ -1,5 +1,5 @@
 import { test } from "../../../../playwright.config";
-import { page } from "../../common";
+import { page, SLOW_ACTION_TIMEOUT } from "../../common";
 import { UnpickDialog } from "../../dialogs/UnpickDialog";
 import { PickingJobLineScreen } from "./PickingJobLineScreen";
 
@@ -9,7 +9,8 @@ const containerElement = () => page.locator('#PickStepScreen');
 
 export const PickingJobStepScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     unpick: async () => await test.step(`${NAME} - Click unpick`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListFiltersScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListFiltersScreen.js
@@ -1,5 +1,5 @@
 import { test } from "../../../../playwright.config";
-import { ID_BACK_BUTTON, page } from "../../common";
+import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from "../../common";
 import { GetDocumentNoDialog } from "../../dialogs/GetDocumentNoDialog";
 import { PickingJobsListScreen, PickingJobsListScreen as PickingJobListScreen } from './PickingJobsListScreen';
 import { expect } from '@playwright/test';
@@ -10,11 +10,11 @@ const containerElement = () => page.locator('#WFLaunchersFiltersScreen');
 
 export const PickingJobsListFiltersScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     waitLoadingDone: async () => await test.step(`${NAME} - Wait for loading done`, async () => {
-        await page.locator('.loading').waitFor({ state: 'detached' });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     filterByDocumentNo: async (documentNo) => await test.step(`${NAME} - Filter by documentNo ${documentNo}`, async () => {
@@ -47,7 +47,7 @@ export const PickingJobsListFiltersScreen = {
 
     clickFacet: async ({ facetId }) => await test.step(`${NAME} - Click facet ${facetId}`, async () => {
         const facetButton = page.locator(`button[data-testid="${facetId}"]`);
-        await facetButton.waitFor({ state: 'attached' });
+        await facetButton.waitFor({ state: 'attached', timeout: SLOW_ACTION_TIMEOUT });
         await facetButton.tap();
     }),
 

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScanScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScanScreen.js
@@ -1,5 +1,5 @@
 import { test } from "../../../../playwright.config";
-import { ID_BACK_BUTTON, page } from "../../common";
+import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from "../../common";
 import { PickingJobsListScreen } from './PickingJobsListScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
 
@@ -9,7 +9,7 @@ const containerElement = () => page.locator('#WFLaunchersScanBarcodeScreen');
 
 export const PickingJobsListScanScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     scanQRCode: async (qrCode) => await test.step(`${NAME} - Scan code ${qrCode}`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingSlotScanScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingSlotScanScreen.js
@@ -1,5 +1,5 @@
 import { test } from "../../../../playwright.config";
-import { page } from "../../common";
+import { page, SLOW_ACTION_TIMEOUT } from "../../common";
 import { expect } from '@playwright/test';
 import { cssEscape } from '../../css';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
@@ -10,7 +10,7 @@ const containerElement = () => page.locator('#ScanScreen');
 
 export const PickingSlotScanScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     waitForInputFieldToGetEmpty: async () => await test.step(`${NAME} - Wait for input field to get empty`, async () => {
@@ -25,13 +25,13 @@ export const PickingSlotScanScreen = {
         //
         // First, wait until all expected buttons are attached 
         for (const expectation of expectationsArray) {
-            await locatePickingSlotButtons(expectation).waitFor({ state: 'attached' });
+            await locatePickingSlotButtons(expectation).waitFor({ state: 'attached', timeout: SLOW_ACTION_TIMEOUT });
         }
 
         //
         // Check it again to make sure all expected buttons are still there and there is one of each 
         for (const expectation of expectationsArray) {
-            await locatePickingSlotButtons(expectation).waitFor({ state: 'attached' });
+            await locatePickingSlotButtons(expectation).waitFor({ state: 'attached', timeout: SLOW_ACTION_TIMEOUT });
             await expect(locatePickingSlotButtons(expectation)).toHaveCount(1);
         }
 

--- a/e2e/mobile-webui/tests/utils/screens/picking/ReopenLUScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/ReopenLUScreen.js
@@ -7,7 +7,7 @@ const containerElement = () => page.locator('#ReopenLUScreen');
 
 export const SelectPickTargetLUScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
         await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 };

--- a/e2e/mobile-webui/tests/utils/screens/picking/SelectPickTargetLUScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/SelectPickTargetLUScreen.js
@@ -7,7 +7,7 @@ const containerElement = () => page.locator('#SelectPickTargetScreen');
 
 export const SelectPickTargetLUScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
         await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 

--- a/e2e/mobile-webui/tests/utils/screens/picking/SelectPickTargetTUScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/SelectPickTargetTUScreen.js
@@ -7,7 +7,7 @@ const containerElement = () => page.locator('#SelectPickTargetScreen');
 
 export const SelectPickTargetTUScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
         await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 

--- a/e2e/mobile-webui/tests/utils/screens/scanAnything/ScanAnythingScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/scanAnything/ScanAnythingScreen.js
@@ -1,4 +1,4 @@
-import { page } from "../../common";
+import { page, SLOW_ACTION_TIMEOUT } from "../../common";
 import { test } from "../../../../playwright.config";
 import { expect } from "@playwright/test";
 import { WorkplaceManagerScreen } from '../workplaceManager/WorkplaceManagerScreen';
@@ -11,8 +11,8 @@ const containerElement = () => page.locator('#ApplicationsListScreen');
 
 export const ScanAnythingScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
-        await page.locator('.loading').waitFor({ state: 'detached' });
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/workplaceManager/WorkplaceManagerScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/workplaceManager/WorkplaceManagerScreen.js
@@ -1,4 +1,4 @@
-import { ID_BACK_BUTTON, page } from "../../common";
+import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from "../../common";
 import { test } from "../../../../playwright.config";
 import { expect } from "@playwright/test";
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
@@ -9,8 +9,8 @@ const containerElement = () => page.locator('#WorkplaceManagerScreen');
 
 export const WorkplaceManagerScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
-        await page.locator('.loading').waitFor({ state: 'detached' });
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect to be displayed`, async () => {
@@ -19,7 +19,7 @@ export const WorkplaceManagerScreen = {
 
     clickAssignButton: async () => await test.step(`${NAME} - Click Assign button`, async () => {
         await page.getByTestId('assign-button').tap();
-        await page.getByTestId('assign-button').waitFor({ state: 'detached' });
+        await page.getByTestId('assign-button').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
         await WorkplaceManagerScreen.waitForScreen();
     }),
 


### PR DESCRIPTION
## Summary

- Add RabbitMQ queue drain steps (`wait until de.metas.material rabbitMQ queue is empty`) between async-triggering actions (order completion, inventory completion, HU disposal, PP_Order void/generation) and subsequent assertions in 8 cucumber scenarios across 5 feature files
- Add unit tests for `DDOrderDocStatusChangedHandler` create-or-update branching logic (3 tests) and `MaterialEventSerializer` DDOrderDocStatusChangedEvent serialization (1 test)

### Scenarios fixed

| Feature | Scenario | Root cause |
|---------|----------|------------|
| `productMaturing.feature` | S0382_100, S0382_200, S0382_300 | Missing drain between inventory completion/HU disposal and scheduler invocation |
| `productionCandidate.feature` | S0129.2_190 | Missing drain between order reactivation and PP_Order_Candidate assertion |
| `productionCandidate_with_BOM_recursion.feature` | S0460_20 | Missing drain between PP_Order void and PP_Order/MD_Candidate assertions |
| `multipleProductionCandidates.feature` | S0129.1_140 | Missing drain between order completions/PP_Order generation and MD_Candidate assertions |
| `multipleProductionCandidates.feature` | S0212.300 | Missing drain between second order completion and PP_Order_Candidate assertion |
| `deliveryRules.feature` | S0159_B_20 | Missing drain between 3 inventory completions and MD_Stock assertion |

## Test plan

- [x] Unit tests pass locally (31 serializer + 3 handler tests)
- [ ] CI green
- [ ] Flaky test pass rate improves in subsequent CI runs