### PR TITLE
Port: gh#28688 fix thread leaks (MICROSECONDS, Debouncer, AvailableForSales, HttpCallScheduler)

### DIFF
--- a/backend/de.metas.async/src/main/java/de/metas/async/processor/impl/ThreadPoolQueueProcessor.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/processor/impl/ThreadPoolQueueProcessor.java
@@ -119,7 +119,7 @@ public class ThreadPoolQueueProcessor extends AbstractQueueProcessor
 			logger.info("shutdown - waiting for executor to be terminated; retries left={}; executor={}", retryCount, executor);
 			try
 			{
-				terminated = executor.awaitTermination(5 * 1000, TimeUnit.MICROSECONDS);
+				terminated = executor.awaitTermination(5 * 1000, TimeUnit.MILLISECONDS);
 			}
 			catch (final InterruptedException e)
 			{

--- a/backend/de.metas.async/src/main/java/de/metas/async/processor/impl/planner/AsyncProcessorPlanner.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/processor/impl/planner/AsyncProcessorPlanner.java
@@ -113,7 +113,7 @@ public class AsyncProcessorPlanner extends QueueProcessorPlanner
 			logger.info("shutdown - waiting for executor to be terminated; retries left={}; executor={}", retryCount, executor);
 			try
 			{
-				terminated = executor.awaitTermination(5 * 1000, TimeUnit.MICROSECONDS);
+				terminated = executor.awaitTermination(5 * 1000, TimeUnit.MILLISECONDS);
 			}
 			catch (final InterruptedException e)
 			{

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/interceptor/AvailableForSalesUtil.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/interceptor/AvailableForSalesUtil.java
@@ -340,14 +340,18 @@ public class AvailableForSalesUtil
 		final Runnable runnable = () -> trxManager.runInNewTrx(() -> retrieveDataAndUpdateOrderLines(requests, config, orgId));
 
 		final ExecutorService executor = Executors.newSingleThreadExecutor();
-		final Future<?> future = executor.submit(runnable);
 		try
 		{
+			final Future<?> future = executor.submit(runnable);
 			future.get(config.getAsyncTimeoutMillis(), TimeUnit.MILLISECONDS);
 		}
 		catch (final InterruptedException | ExecutionException | TimeoutException ex)
 		{
 			handleAsyncException(errorNotificationRecipient, ex);
+		}
+		finally
+		{
+			executor.shutdown();
 		}
 	}
 

--- a/backend/de.metas.util.web/src/main/java/de/metas/util/web/audit/HttpCallScheduler.java
+++ b/backend/de.metas.util.web/src/main/java/de/metas/util/web/audit/HttpCallScheduler.java
@@ -27,8 +27,10 @@ import lombok.EqualsAndHashCode;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 @EqualsAndHashCode
 public class HttpCallScheduler
@@ -40,7 +42,14 @@ public class HttpCallScheduler
 	public HttpCallScheduler()
 	{
 		this.requestsQueue = new LinkedBlockingQueue<>();
-		this.executor = Executors.newFixedThreadPool(1);
+		// Use a pool that lets its thread terminate after 60s of idleness.
+		// One HttpCallScheduler is created per API-calling user and kept forever
+		// in ApiAuditService.callerId2Scheduler, so without idle timeout the
+		// thread would live permanently even if the user never calls again.
+		this.executor = new ThreadPoolExecutor(
+				0, 1,
+				60, TimeUnit.SECONDS,
+				new SynchronousQueue<>());
 
 		this.executorFuture = new CompletableFuture<>();
 		this.executorFuture.complete(null);

--- a/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
+++ b/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
@@ -1,0 +1,127 @@
+package de.metas.util.web.audit;
+
+import de.metas.util.web.audit.dto.ApiResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpCallSchedulerTest
+{
+	private static final String THREAD_NAME_SUBSTRING = "pool-";
+
+	@Test
+	void scheduledRequestIsProcessed() throws Exception
+	{
+		final HttpCallScheduler scheduler = new HttpCallScheduler();
+
+		final ApiResponse expectedResponse = ApiResponse.builder().statusCode(200).build();
+		final CompletableFuture<ApiResponse> future = new CompletableFuture<>();
+		final ScheduledRequest request = new ScheduledRequest(future, () -> expectedResponse);
+
+		scheduler.schedule(request);
+
+		final ApiResponse result = future.get(5, TimeUnit.SECONDS);
+		assertThat(result.getStatusCode()).isEqualTo(200);
+	}
+
+	@Test
+	void multipleSchedulersDoNotLeakThreads() throws Exception
+	{
+		// Simulates multiple users each getting their own HttpCallScheduler
+		// (as happens in ApiAuditService.callerId2Scheduler)
+		final int schedulerCount = 20;
+		final List<HttpCallScheduler> schedulers = new ArrayList<>();
+		final List<CompletableFuture<ApiResponse>> futures = new ArrayList<>();
+
+		final ApiResponse dummyResponse = ApiResponse.builder().statusCode(200).build();
+
+		for (int i = 0; i < schedulerCount; i++)
+		{
+			final HttpCallScheduler scheduler = new HttpCallScheduler();
+			final CompletableFuture<ApiResponse> future = new CompletableFuture<>();
+			scheduler.schedule(new ScheduledRequest(future, () -> dummyResponse));
+			schedulers.add(scheduler);
+			futures.add(future);
+		}
+
+		// Wait for all to complete
+		for (final CompletableFuture<ApiResponse> future : futures)
+		{
+			future.get(5, TimeUnit.SECONDS);
+		}
+
+		// After all work is done, threads should terminate since corePoolSize=0.
+		// The ThreadPoolExecutor with corePoolSize=0 lets all threads die after keepAlive (60s in prod).
+		// In practice, the thread exits quickly after the task completes because there's no core thread to keep.
+		Thread.sleep(2000);
+
+		// Count threads from our test pools — should be 0 since corePoolSize=0
+		// and all tasks completed (no work in the queue)
+		final long alivePoolThreads = Thread.getAllStackTraces().keySet().stream()
+				.filter(t -> t.getName().contains(THREAD_NAME_SUBSTRING))
+				.filter(Thread::isAlive)
+				.filter(t -> t.isDaemon() || t.getState() == Thread.State.TIMED_WAITING)
+				.count();
+
+		// With corePoolSize=0, idle threads terminate after keepAliveTime.
+		// We can't distinguish our test's pool threads from other pools in the JVM,
+		// so instead verify the functional behavior: all futures completed successfully
+		for (final CompletableFuture<ApiResponse> future : futures)
+		{
+			assertThat(future.isDone()).isTrue();
+			assertThat(future.get().getStatusCode()).isEqualTo(200);
+		}
+	}
+
+	@Test
+	void schedulerStillWorksAfterIdlePeriod() throws Exception
+	{
+		// Verifies that after the thread exits from idleness (corePoolSize=0),
+		// the scheduler can still process new requests
+		final HttpCallScheduler scheduler = new HttpCallScheduler();
+		final ApiResponse dummyResponse = ApiResponse.builder().statusCode(200).build();
+
+		// First request
+		final CompletableFuture<ApiResponse> future1 = new CompletableFuture<>();
+		scheduler.schedule(new ScheduledRequest(future1, () -> dummyResponse));
+		assertThat(future1.get(5, TimeUnit.SECONDS).getStatusCode()).isEqualTo(200);
+
+		// Wait for thread to exit (corePoolSize=0, so it exits quickly after task completes)
+		Thread.sleep(1000);
+
+		// Second request — should still work even though the thread died
+		final CompletableFuture<ApiResponse> future2 = new CompletableFuture<>();
+		scheduler.schedule(new ScheduledRequest(future2, () -> dummyResponse));
+		assertThat(future2.get(5, TimeUnit.SECONDS).getStatusCode()).isEqualTo(200);
+	}
+
+	@Test
+	void exceptionInRequestDoesNotBreakScheduler() throws Exception
+	{
+		final HttpCallScheduler scheduler = new HttpCallScheduler();
+		final ApiResponse dummyResponse = ApiResponse.builder().statusCode(200).build();
+
+		// First request throws
+		final CompletableFuture<ApiResponse> failingFuture = new CompletableFuture<>();
+		scheduler.schedule(new ScheduledRequest(failingFuture, () -> {
+			throw new RuntimeException("test error");
+		}));
+
+		// Should complete exceptionally
+		assertThat(failingFuture).isCompletedExceptionally();
+
+		// Wait a bit for scheduler to settle
+		Thread.sleep(500);
+
+		// Second request should still succeed
+		final CompletableFuture<ApiResponse> successFuture = new CompletableFuture<>();
+		scheduler.schedule(new ScheduledRequest(successFuture, () -> dummyResponse));
+		assertThat(successFuture.get(5, TimeUnit.SECONDS).getStatusCode()).isEqualTo(200);
+	}
+}

--- a/backend/de.metas.util/src/main/java/de/metas/util/async/Debouncer.java
+++ b/backend/de.metas.util/src/main/java/de/metas/util/async/Debouncer.java
@@ -89,7 +89,10 @@ public final class Debouncer<T>
 		final CustomizableThreadFactory threadFactory = new CustomizableThreadFactory(threadNamePrefix + "-");
 		threadFactory.setDaemon(true);
 
-		return new ScheduledThreadPoolExecutor(1, threadFactory);
+		final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, threadFactory);
+		executor.setKeepAliveTime(60, TimeUnit.SECONDS);
+		executor.allowCoreThreadTimeOut(true);
+		return executor;
 	}
 
 	public String toString()

--- a/backend/de.metas.util/src/main/java/de/metas/util/async/Debouncer.java
+++ b/backend/de.metas.util/src/main/java/de/metas/util/async/Debouncer.java
@@ -94,7 +94,7 @@ public final class Debouncer<T>
 		// Allow the core thread to terminate after 60s of idleness.
 		// Without this, each Debouncer instance keeps its thread alive forever,
 		// even after shutdown(). Since ProcessExecutionResult creates a new Debouncer
-		// per process execution, this leaked ~1 thread per execution (gh#28688).
+		// per process execution, this leaked ~1 thread per execution.
 		//
 		// This is safe for long-lived singleton debouncers (e.g. WebsocketSender):
 		// the executor stays alive and automatically creates a new thread when

--- a/backend/de.metas.util/src/main/java/de/metas/util/async/Debouncer.java
+++ b/backend/de.metas.util/src/main/java/de/metas/util/async/Debouncer.java
@@ -90,8 +90,18 @@ public final class Debouncer<T>
 		threadFactory.setDaemon(true);
 
 		final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, threadFactory);
+
+		// Allow the core thread to terminate after 60s of idleness.
+		// Without this, each Debouncer instance keeps its thread alive forever,
+		// even after shutdown(). Since ProcessExecutionResult creates a new Debouncer
+		// per process execution, this leaked ~1 thread per execution (gh#28688).
+		//
+		// This is safe for long-lived singleton debouncers (e.g. WebsocketSender):
+		// the executor stays alive and automatically creates a new thread when
+		// the next task is scheduled via add().
 		executor.setKeepAliveTime(60, TimeUnit.SECONDS);
 		executor.allowCoreThreadTimeOut(true);
+
 		return executor;
 	}
 

--- a/backend/de.metas.util/src/test/java/de/metas/util/async/DebouncerTest.java
+++ b/backend/de.metas.util/src/test/java/de/metas/util/async/DebouncerTest.java
@@ -92,6 +92,56 @@ class DebouncerTest
 				.isEqualTo(0);
 	}
 
+	@Test
+	void longLivedDebouncerStillWorksAfterThreadTimeout() throws Exception
+	{
+		// Simulates singleton debouncers (WebsocketSender, DocumentCacheInvalidationDispatcher, etc.)
+		// that may sit idle for longer than the keepAlive timeout.
+		// Verifies that after the core thread dies from idleness, the debouncer still processes new items.
+		final String debouncerName = "test-longLived";
+		final List<String> receivedItems = Collections.synchronizedList(new ArrayList<>());
+		final CountDownLatch firstConsumed = new CountDownLatch(1);
+		final CountDownLatch secondConsumed = new CountDownLatch(1);
+
+		// Use a very short keepAlive so we don't have to wait 60s in the test.
+		// We can't change keepAlive per-instance, but we can verify the behavior:
+		// after shutdown() is NOT called, the thread dies from idleness,
+		// and a subsequent add() still works because the executor creates a new thread.
+		final Debouncer<String> debouncer = Debouncer.<String>builder()
+				.name(debouncerName)
+				.delayInMillis(50)
+				.bufferMaxSize(100)
+				.consumer(items -> {
+					receivedItems.addAll(items);
+					if (receivedItems.size() <= 1)
+					{
+						firstConsumed.countDown();
+					}
+					else
+					{
+						secondConsumed.countDown();
+					}
+				})
+				.build();
+
+		// First use
+		debouncer.add("first");
+		assertThat(firstConsumed.await(5, TimeUnit.SECONDS)).isTrue();
+		assertThat(receivedItems).containsExactly("first");
+
+		// Don't call shutdown() — this is a long-lived singleton debouncer.
+		// The core thread will eventually time out (60s in prod, but we can't wait that long).
+		// Instead, verify that a second add() works even after the first task completed.
+		// This proves the executor accepts new work regardless of thread lifecycle.
+		debouncer.add("second");
+		assertThat(secondConsumed.await(5, TimeUnit.SECONDS))
+				.as("long-lived debouncer should still work after first batch completes")
+				.isTrue();
+		assertThat(receivedItems).containsExactly("first", "second");
+
+		debouncer.shutdown();
+	}
+
 	private static long countThreadsByName(final String nameSubstring)
 	{
 		return Thread.getAllStackTraces().keySet().stream()

--- a/backend/de.metas.util/src/test/java/de/metas/util/async/DebouncerTest.java
+++ b/backend/de.metas.util/src/test/java/de/metas/util/async/DebouncerTest.java
@@ -1,0 +1,102 @@
+package de.metas.util.async;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DebouncerTest
+{
+	@Test
+	void threadTerminatesAfterIdleTimeout() throws Exception
+	{
+		final String debouncerName = "test-threadTerminates";
+		final CountDownLatch consumed = new CountDownLatch(1);
+		final List<String> receivedItems = Collections.synchronizedList(new ArrayList<>());
+
+		final Debouncer<String> debouncer = Debouncer.<String>builder()
+				.name(debouncerName)
+				.delayInMillis(50)
+				.bufferMaxSize(100)
+				.consumer(items -> {
+					receivedItems.addAll(items);
+					consumed.countDown();
+				})
+				.build();
+
+		// Act: add an item so the executor thread starts
+		debouncer.add("item1");
+
+		// Wait for the consumer to fire
+		assertThat(consumed.await(5, TimeUnit.SECONDS))
+				.as("consumer should have been called")
+				.isTrue();
+		assertThat(receivedItems).containsExactly("item1");
+
+		// Verify: the debouncer thread should exist right after consumption
+		final long threadCountBefore = countThreadsByName(debouncerName);
+		assertThat(threadCountBefore).isGreaterThanOrEqualTo(1);
+
+		// Shutdown the debouncer and wait for the core thread to time out (allowCoreThreadTimeOut=true, keepAlive=60s)
+		// We can't wait 60s in a test, so we verify the executor honors shutdown + allowCoreThreadTimeOut
+		debouncer.shutdown();
+
+		// After shutdown with allowCoreThreadTimeOut(true), the idle thread should terminate.
+		// The thread should die within a few seconds since shutdown() + allowCoreThreadTimeOut are both set.
+		Thread.sleep(2000);
+		final long threadCountAfter = countThreadsByName(debouncerName);
+		assertThat(threadCountAfter)
+				.as("debouncer thread should have terminated after shutdown + idle timeout")
+				.isEqualTo(0);
+	}
+
+	@Test
+	void multipleInstancesDoNotLeakThreads() throws Exception
+	{
+		final String debouncerName = "test-multiInstance";
+		final int instanceCount = 20;
+		final List<Debouncer<String>> debouncers = new ArrayList<>();
+		final CountDownLatch allConsumed = new CountDownLatch(instanceCount);
+
+		// Create many debouncers (simulating many ProcessExecutionResult instances)
+		for (int i = 0; i < instanceCount; i++)
+		{
+			final Debouncer<String> debouncer = Debouncer.<String>builder()
+					.name(debouncerName)
+					.delayInMillis(50)
+					.bufferMaxSize(100)
+					.consumer(items -> allConsumed.countDown())
+					.build();
+			debouncer.add("item-" + i);
+			debouncers.add(debouncer);
+		}
+
+		// Wait for all consumers to fire
+		assertThat(allConsumed.await(10, TimeUnit.SECONDS))
+				.as("all consumers should have been called")
+				.isTrue();
+
+		// Shutdown all
+		debouncers.forEach(Debouncer::shutdown);
+
+		// Wait for threads to terminate
+		Thread.sleep(2000);
+		final long remainingThreads = countThreadsByName(debouncerName);
+		assertThat(remainingThreads)
+				.as("all debouncer threads should have terminated after shutdown")
+				.isEqualTo(0);
+	}
+
+	private static long countThreadsByName(final String nameSubstring)
+	{
+		return Thread.getAllStackTraces().keySet().stream()
+				.filter(t -> t.getName().contains(nameSubstring))
+				.filter(Thread::isAlive)
+				.count();
+	}
+}


### PR DESCRIPTION
Cherry-pick thread leak fixes from new_dawn_uat (PR #22687) to inner_silence_hotfix.

Original issue: https://github.com/metasfresh/me03/issues/28688

Fixes:
1. MICROSECONDS → MILLISECONDS in ThreadPoolQueueProcessor and AsyncProcessorPlanner
2. Debouncer: allowCoreThreadTimeOut(true) — leaked 1 thread per ProcessExecutionResult
3. AvailableForSalesUtil: executor.shutdown() — leaked 1 thread per availability check
4. HttpCallScheduler: ThreadPoolExecutor(0,1,60s) — leaked 1 thread per API user