### PR TITLE
gh#28336: add IsIncludeCSVHeaderRow flag to suppress CSV header

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Process.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Process.java
@@ -519,6 +519,29 @@ public interface I_AD_Process
 	String COLUMNNAME_IsFormatExcelFile = "IsFormatExcelFile";
 
 	/**
+	 * Set Include CSV Header Row.
+	 * If enabled, the first row of the CSV file will contain column headers.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsIncludeCSVHeaderRow (boolean IsIncludeCSVHeaderRow);
+
+	/**
+	 * Get Include CSV Header Row.
+	 * If enabled, the first row of the CSV file will contain column headers.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isIncludeCSVHeaderRow();
+
+	ModelColumn<I_AD_Process, Object> COLUMN_IsIncludeCSVHeaderRow = new ModelColumn<>(I_AD_Process.class, "IsIncludeCSVHeaderRow", null);
+	String COLUMNNAME_IsIncludeCSVHeaderRow = "IsIncludeCSVHeaderRow";
+
+	/**
 	 * Set Log Warning.
 	 *
 	 * <br>Type: YesNo

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Process.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Process.java
@@ -324,6 +324,18 @@ public class X_AD_Process extends org.compiere.model.PO implements I_AD_Process,
 	}
 
 	@Override
+	public void setIsIncludeCSVHeaderRow (final boolean IsIncludeCSVHeaderRow)
+	{
+		set_Value (COLUMNNAME_IsIncludeCSVHeaderRow, IsIncludeCSVHeaderRow);
+	}
+
+	@Override
+	public boolean isIncludeCSVHeaderRow()
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsIncludeCSVHeaderRow);
+	}
+
+	@Override
 	public void setIsLogWarning (final boolean IsLogWarning)
 	{
 		set_Value (COLUMNNAME_IsLogWarning, IsLogWarning);

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/impexp/spreadsheet/csv/CSVWriter.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/impexp/spreadsheet/csv/CSVWriter.java
@@ -57,6 +57,8 @@ public class CSVWriter
 
 	private static final String lineEnding = "\n";
 
+	private final boolean includeHeader;
+
 	private final ImmutableList<String> header;
 
 	private final DateFormat dateFormat;
@@ -75,7 +77,8 @@ public class CSVWriter
 			@NonNull final List<String> header,
 			@NonNull final String adLanguage,
 			@Nullable final String fieldDelimiter,
-			@Nullable final String fieldQualifier)
+			@Nullable final String fieldQualifier,
+			@Nullable final Boolean includeHeader)
 	{
 		Check.assume(!header.isEmpty(), "header not empty");
 
@@ -85,6 +88,7 @@ public class CSVWriter
 		this.header = ImmutableList.copyOf(header);
 		this.fieldDelimiter = CoalesceUtil.coalesceNotNull(fieldDelimiter, DEFAULT_FIELD_DELIMITER);
 		this.fieldQualifier = CoalesceUtil.coalesceNotNull(fieldQualifier, DEFAULT_FIELD_QUALIFIER);
+		this.includeHeader = includeHeader == null || includeHeader;
 
 		// we need to clone it because of concurrency issues
 		// see http://www.danielschneller.com/2007/04/calendar-dateformat-and-multi-threading.html
@@ -125,6 +129,12 @@ public class CSVWriter
 	{
 		if (headerAppended)
 		{
+			return;
+		}
+
+		if (!includeHeader)
+		{
+			headerAppended = true;
 			return;
 		}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/impexp/spreadsheet/csv/JdbcCSVExporter.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/impexp/spreadsheet/csv/JdbcCSVExporter.java
@@ -50,6 +50,7 @@ public class JdbcCSVExporter implements DataConsumer<ResultSet>
 	private final boolean translateHeaders;
 	private final String fieldDelimiter;
 	private final String fieldQualifier;
+	private final boolean includeHeader;
 
 	private ImmutableList<String> _columnHeaders;
 
@@ -61,12 +62,14 @@ public class JdbcCSVExporter implements DataConsumer<ResultSet>
 			@NonNull final String adLanguage,
 			@Nullable final Boolean translateHeaders,
 			@Nullable final String fieldDelimiter,
-			@Nullable final String fieldQualifier)
+			@Nullable final String fieldQualifier,
+			@Nullable final Boolean includeHeader)
 	{
 		this.adLanguage = adLanguage;
 		this.translateHeaders = translateHeaders != null ? translateHeaders : true;
 		this.fieldDelimiter = fieldDelimiter != null ? fieldDelimiter : CSVWriter.DEFAULT_FIELD_DELIMITER;
 		this.fieldQualifier = fieldQualifier != null  ? fieldQualifier : CSVWriter.DEFAULT_FIELD_QUALIFIER;
+		this.includeHeader = includeHeader == null || includeHeader;
 	}
 
 	@Override
@@ -176,6 +179,7 @@ public class JdbcCSVExporter implements DataConsumer<ResultSet>
 				.adLanguage(adLanguage)
 				.fieldDelimiter(fieldDelimiter)
 				.fieldQualifier(fieldQualifier)
+				.includeHeader(includeHeader)
 				.build();
 	}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/impexp/spreadsheet/process/ExportToSpreadsheetProcess.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/impexp/spreadsheet/process/ExportToSpreadsheetProcess.java
@@ -88,6 +88,7 @@ public class ExportToSpreadsheetProcess extends JavaProcess
 					.translateHeaders(spreadsheetExportOptions.isTranslateHeaders())
 					.fieldDelimiter(spreadsheetExportOptions.getCsvFieldDelimiter())
 					.fieldQualifier(spreadsheetExportOptions.getCsvFieldQualifier())
+					.includeHeader(spreadsheetExportOptions.isIncludeCSVHeaderRow())
 					.build();
 
 			spreadsheetExporterService.processDataFromSQL(sql, evalCtx, jdbcCSVExporter);

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessInfo.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessInfo.java
@@ -1237,6 +1237,7 @@ public final class ProcessInfo implements Serializable
 						.excelApplyFormatting(spreadsheetFormat.isFormatExcelFile())
 						.csvFieldDelimiter(StringUtils.trimSpacesToNull(process.getCSVFieldDelimiter()))
 						.csvFieldQualifier(process.getCSVFieldQuote())
+						.includeCSVHeaderRow(process.isIncludeCSVHeaderRow())
 						.build();
 			}
 		}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/SpreadsheetExportOptions.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/SpreadsheetExportOptions.java
@@ -46,4 +46,7 @@ public class SpreadsheetExportOptions
 	@Nullable
 	@Builder.Default
 	String csvFieldQualifier = null;
+
+	@Builder.Default
+	boolean includeCSVHeaderRow = true;
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/impexp/spreadsheet/csv/CSVWriterTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/impexp/spreadsheet/csv/CSVWriterTest.java
@@ -48,6 +48,17 @@ class CSVWriterTest
 				.build();
 	}
 
+	private CSVWriter createWriter(final List<String> header, final String fieldQualifier, final Boolean includeHeader)
+	{
+		return CSVWriter.builder()
+				.outputFile(outputFile)
+				.header(header)
+				.adLanguage("en_US")
+				.fieldQualifier(fieldQualifier)
+				.includeHeader(includeHeader)
+				.build();
+	}
+
 	private String readOutput() throws IOException
 	{
 		final String raw = new String(Files.readAllBytes(outputFile.toPath()), StandardCharsets.UTF_8);
@@ -229,5 +240,81 @@ class CSVWriterTest
 
 		assertThat(lines[0]).isEqualTo("Col1\tCol2");
 		assertThat(lines[1]).isEqualTo("no tab\talso clean");
+	}
+
+	// -------------------------------------------------------------------
+	// MUST: includeHeader=false suppresses the header row
+	// -------------------------------------------------------------------
+
+	@Test
+	void includeHeaderFalse_dataRowsOnly() throws IOException
+	{
+		final CSVWriter writer = createWriter(Arrays.asList("Col1", "Col2"), "\"", false);
+		writer.appendRow(Arrays.asList("a", "b"));
+		writer.appendRow(Arrays.asList("c", "d"));
+		writer.close();
+
+		final String content = readOutput();
+		final String[] lines = content.split("\n");
+
+		// No header line — only data rows
+		assertThat(lines).hasSize(2);
+		assertThat(lines[0]).isEqualTo("\"a\";\"b\"");
+		assertThat(lines[1]).isEqualTo("\"c\";\"d\"");
+	}
+
+	@Test
+	void includeHeaderFalse_noDataRows_emptyOutput() throws IOException
+	{
+		final CSVWriter writer = createWriter(Arrays.asList("Col1"), "\"", false);
+		// No rows appended, just close
+		writer.close();
+
+		// File should contain only the UTF-8 BOM (stripped by readOutput), so empty
+		final String content = readOutput();
+		assertThat(content).isEmpty();
+	}
+
+	@Test
+	void includeHeaderFalse_emptyQualifier_dataOnly() throws IOException
+	{
+		// RTIC scenario: no header, no quotes
+		final CSVWriter writer = createWriter(Arrays.asList("Col1", "Col2"), "", false);
+		writer.appendRow(Arrays.asList("val1", "val2"));
+		writer.close();
+
+		final String content = readOutput();
+		final String[] lines = content.split("\n");
+
+		assertThat(lines).hasSize(1);
+		assertThat(lines[0]).isEqualTo("val1;val2");
+	}
+
+	@Test
+	void includeHeaderNull_defaultIncludesHeader() throws IOException
+	{
+		// null defaults to true (backward compat)
+		final CSVWriter writer = createWriter(Arrays.asList("Col1"), "\"", null);
+		writer.appendRow(Arrays.asList("val"));
+		writer.close();
+
+		final String content = readOutput();
+		final String[] lines = content.split("\n");
+
+		assertThat(lines).hasSize(2);
+		assertThat(lines[0]).isEqualTo("\"Col1\"");
+		assertThat(lines[1]).isEqualTo("\"val\"");
+	}
+
+	@Test
+	void includeHeaderFalse_linesWroteCountsOnlyDataRows() throws IOException
+	{
+		final CSVWriter writer = createWriter(Arrays.asList("Col1", "Col2"), "\"", false);
+		writer.appendRow(Arrays.asList("a", "b"));
+		writer.appendRow(Arrays.asList("c", "d"));
+		writer.close();
+
+		// linesWrote should count only data rows (no header line)
+		assertThat(writer.getLinesWrote()).isEqualTo(2);
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5793220_sys_gh28336_AD_Process_IsIncludeCSVHeaderRow.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5793220_sys_gh28336_AD_Process_IsIncludeCSVHeaderRow.sql
@@ -1,0 +1,117 @@
+-- gh28336: Add IsIncludeCSVHeaderRow flag to AD_Process
+-- Controls whether CSV exports include a header row with column names.
+-- Default 'Y' for backward compatibility. Set to 'N' for Intrastat export.
+
+-- AD_Element for IsIncludeCSVHeaderRow
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Description,Help,Updated,UpdatedBy)
+VALUES (0,584646,0,'IsIncludeCSVHeaderRow',TO_TIMESTAMP('2026-03-09 16:00','YYYY-MM-DD HH24:MI'),100,'D','Y',
+        'CSV-Kopfzeile einschließen','CSV-Kopfzeile einschließen',
+        'Wenn aktiviert, enthält die erste Zeile der CSV-Datei die Spaltenüberschriften.',
+        'Wenn aktiviert, enthält die erste Zeile der CSV-Datei die Spaltenüberschriften.',
+        TO_TIMESTAMP('2026-03-09 16:00','YYYY-MM-DD HH24:MI'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID,Name,PrintName,Description,Help,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,584646,t.Name,t.PrintName,t.Description,t.Help,'N',0,0,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=584646
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- de_DE (base language): German
+UPDATE AD_Element_Trl SET
+    Name='CSV-Kopfzeile einschließen',
+    PrintName='CSV-Kopfzeile einschließen',
+    Description='Wenn aktiviert, enthält die erste Zeile der CSV-Datei die Spaltenüberschriften.',
+    Help='Wenn aktiviert, enthält die erste Zeile der CSV-Datei die Spaltenüberschriften.',
+    IsTranslated='N',
+    Updated=TO_TIMESTAMP('2026-03-09 16:00','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Element_ID=584646 AND AD_Language='de_DE'
+;
+
+/* DDL */ select update_ad_element_on_ad_element_trl_update(584646,'de_DE')
+;
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(584646,'de_DE')
+;
+
+-- de_CH: same as de_DE
+UPDATE AD_Element_Trl SET
+    Name='CSV-Kopfzeile einschließen',
+    PrintName='CSV-Kopfzeile einschließen',
+    Description='Wenn aktiviert, enthält die erste Zeile der CSV-Datei die Spaltenüberschriften.',
+    Help='Wenn aktiviert, enthält die erste Zeile der CSV-Datei die Spaltenüberschriften.',
+    IsTranslated='N',
+    Updated=TO_TIMESTAMP('2026-03-09 16:00','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Element_ID=584646 AND AD_Language='de_CH'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(584646,'de_CH')
+;
+
+-- en_US: English
+UPDATE AD_Element_Trl SET
+    Name='Include CSV Header Row',
+    PrintName='Include CSV Header Row',
+    Description='If enabled, the first row of the CSV file will contain column headers.',
+    Help='If enabled, the first row of the CSV file will contain column headers.',
+    IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-03-09 16:00','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Element_ID=584646 AND AD_Language='en_US'
+;
+
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(584646,'en_US')
+;
+
+
+-- Column: AD_Process.IsIncludeCSVHeaderRow
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,CloningStrategy,ColumnName,Created,CreatedBy,DDL_NoForeignKey,DefaultValue,Description,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,PersonalDataCategory,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592207,584646,0,20,284,'XX','IsIncludeCSVHeaderRow',TO_TIMESTAMP('2026-03-09 16:00','YYYY-MM-DD HH24:MI'),100,'N','Y','Wenn aktiviert, enthält die erste Zeile der CSV-Datei die Spaltenüberschriften.','D',0,1,'Y','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','N','Y','N',0,'CSV-Kopfzeile einschließen','NP',0,0,TO_TIMESTAMP('2026-03-09 16:00','YYYY-MM-DD HH24:MI'),100,0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=592207
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+/* DDL */ select update_Column_Translation_From_AD_Element(584646)
+;
+
+
+-- Field: Bericht & Prozess(165,D) -> Bericht & Prozess(245,D) -> CSV-Kopfzeile einschließen
+-- Column: AD_Process.IsIncludeCSVHeaderRow
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,DisplayLogic,EntityType,FacetFilterSeqNo,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy)
+VALUES (0,592207,774879,0,245,0,TO_TIMESTAMP('2026-03-09 16:00','YYYY-MM-DD HH24:MI'),100,'Wenn aktiviert, enthält die erste Zeile der CSV-Datei die Spaltenüberschriften.',0,'@SpreadsheetFormat@=csv','D',0,0,'Y','Y','Y','N','N','N','N','N','N','N',0,'CSV-Kopfzeile einschließen',0,316,352,0,1,1,TO_TIMESTAMP('2026-03-09 16:00','YYYY-MM-DD HH24:MI'),100)
+;
+
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=774879
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+/* DDL */ select update_FieldTranslation_From_AD_Name_Element(584646)
+;
+
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=774879
+;
+
+/* DDL */ select AD_Element_Link_Create_Missing_Field(774879)
+;
+
+
+-- UI Element: Bericht & Prozess(165,D) -> Bericht & Prozess(245,D) -> main -> 10 -> description.IsIncludeCSVHeaderRow
+-- Column: AD_Process.IsIncludeCSVHeaderRow
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,774879,0,245,541397,648527,'F',TO_TIMESTAMP('2026-03-09 16:00','YYYY-MM-DD HH24:MI'),100,'Wenn aktiviert, enthält die erste Zeile der CSV-Datei die Spaltenüberschriften.','Y','N','N','Y','N','N','N',0,'IsIncludeCSVHeaderRow',36,0,0,TO_TIMESTAMP('2026-03-09 16:00','YYYY-MM-DD HH24:MI'),100)
+;
+
+
+-- DDL: Add the physical column
+ALTER TABLE ad_process ADD COLUMN IsIncludeCSVHeaderRow char(1) DEFAULT 'Y' CHECK (IsIncludeCSVHeaderRow IN ('Y','N')) NOT NULL;
+
+
+-- Set Intrastat_Export process to suppress CSV header
+UPDATE AD_Process SET IsIncludeCSVHeaderRow='N', Updated=TO_TIMESTAMP('2026-03-09 16:00','YYYY-MM-DD HH24:MI'), UpdatedBy=100 WHERE AD_Process_ID=585508;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/intrastat/IntrastatView_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/intrastat/IntrastatView_StepDef.java
@@ -1,0 +1,245 @@
+package de.metas.cucumber.stepdefs.intrastat;
+
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.M_Product_StepDefData;
+import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.trx.api.ITrx;
+import org.assertj.core.api.SoftAssertions;
+import org.compiere.model.I_M_InOut;
+import org.compiere.model.I_M_Product;
+import org.compiere.util.DB;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Step definitions for testing {@code de_metas_endcustomer_fresh_reports.M_InOut_V}
+ * (the Intrastat aggregation view).
+ * <p>
+ * Uses raw SQL to query the view because no Java model class exists for it.
+ * <p>
+ * The critical invariant being tested: weight must be per-line (per commodity group),
+ * NOT the total shipment weight. Before gh#28336, the view used
+ * {@code Docs_Sales_InOut_Sum_Weight(m_inout_id)} which returned the entire shipment's
+ * total weight, causing every commodity group to show the full shipment weight.
+ *
+ * @see <a href="https://github.com/metasfresh/me03/issues/28336">me03#28336</a>
+ */
+@RequiredArgsConstructor
+public class IntrastatView_StepDef
+{
+	@NonNull private final M_Product_StepDefData productTable;
+	@NonNull private final M_InOut_StepDefData inOutTable;
+
+	private final List<Map<String, String>> viewResults = new ArrayList<>();
+
+	/**
+	 * Sets M_Product.Weight for the given products.
+	 * This is the fallback weight used by M_InOut_V when no catch weight or UOM conversion is available.
+	 *
+	 * <pre>
+	 * | M_Product_ID.Identifier | Weight |
+	 * | p_1                     | 2.5    |
+	 * </pre>
+	 */
+	@And("M_Product weight is set:")
+	public void setProductWeight(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_M_Product product = productTable.get(row.getAsIdentifier("M_Product_ID"));
+			final BigDecimal weight = row.getAsBigDecimal("Weight");
+
+			DB.executeUpdateAndThrowExceptionOnFail(
+					"UPDATE M_Product SET Weight=" + weight + " WHERE M_Product_ID=" + product.getM_Product_ID(),
+					ITrx.TRXNAME_None);
+		});
+	}
+
+	/**
+	 * Creates M_CommodityNumber records and links them to products.
+	 *
+	 * <pre>
+	 * | M_Product_ID.Identifier | CommodityNumberValue |
+	 * | p_1                     | 12345678             |
+	 * </pre>
+	 */
+	@And("M_CommodityNumber is set for products:")
+	public void setCommodityNumbers(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_M_Product product = productTable.get(row.getAsIdentifier("M_Product_ID"));
+			final String value = row.getAsString("CommodityNumberValue");
+
+			final int cnId = DB.getSQLValueEx(ITrx.TRXNAME_None, "SELECT nextval('M_CommodityNumber_Seq')");
+			DB.executeUpdateAndThrowExceptionOnFail(
+					"INSERT INTO M_CommodityNumber (M_CommodityNumber_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Value, Name)"
+							+ " VALUES (" + cnId + ", 1000000, 0, 'Y', now(), 100, now(), 100, "
+							+ sqlQuote(value) + ", " + sqlQuote(value) + ")",
+					ITrx.TRXNAME_None);
+
+			DB.executeUpdateAndThrowExceptionOnFail(
+					"UPDATE M_Product SET M_CommodityNumber_ID=" + cnId + " WHERE M_Product_ID=" + product.getM_Product_ID(),
+					ITrx.TRXNAME_None);
+		});
+	}
+
+	/**
+	 * Creates M_CustomsTariff records and links them to products.
+	 *
+	 * <pre>
+	 * | M_Product_ID.Identifier | CustomsTariffValue |
+	 * | p_1                     | 1234567890         |
+	 * </pre>
+	 */
+	@And("M_CustomsTariff is set for products:")
+	public void setCustomsTariffs(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_M_Product product = productTable.get(row.getAsIdentifier("M_Product_ID"));
+			final String value = row.getAsString("CustomsTariffValue");
+
+			final int ctId = DB.getSQLValueEx(ITrx.TRXNAME_None, "SELECT nextval('M_CustomsTariff_Seq')");
+			DB.executeUpdateAndThrowExceptionOnFail(
+					"INSERT INTO M_CustomsTariff (M_CustomsTariff_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Value, Name)"
+							+ " VALUES (" + ctId + ", 1000000, 0, 'Y', now(), 100, now(), 100, "
+							+ sqlQuote(value) + ", " + sqlQuote(value) + ")",
+					ITrx.TRXNAME_None);
+
+			DB.executeUpdateAndThrowExceptionOnFail(
+					"UPDATE M_Product SET M_CustomsTariff_ID=" + ctId + " WHERE M_Product_ID=" + product.getM_Product_ID(),
+					ITrx.TRXNAME_None);
+		});
+	}
+
+	/**
+	 * Queries the M_InOut_V view filtering by a specific M_InOut (via its invoice).
+	 * The view is filtered by the products that appear in the given shipment's lines.
+	 *
+	 * <pre>
+	 * | M_InOut_ID.Identifier |
+	 * | shipment_1            |
+	 * </pre>
+	 */
+	@When("M_InOut_V is queried for shipment {string}")
+	public void queryInOutView(@NonNull final String shipmentIdentifier) throws SQLException
+	{
+		viewResults.clear();
+
+		final I_M_InOut inOut = inOutTable.get(shipmentIdentifier);
+		final int inOutId = inOut.getM_InOut_ID();
+
+		final String sql = "SELECT v.commoditynumber, v.productname, v.weight, v.movementqty, v.grandtotal, v.customstariff, v.deliveredFromCountry, v.deliveryCountry"
+				+ " FROM de_metas_endcustomer_fresh_reports.M_InOut_V v"
+				+ " WHERE EXISTS ("
+				+ "   SELECT 1 FROM M_InOutLine iol"
+				+ "   JOIN M_Product p ON p.M_Product_ID = iol.M_Product_ID"
+				+ "   WHERE iol.M_InOut_ID = ? AND p.Name = v.productname"
+				+ " )"
+				+ " ORDER BY v.commoditynumber";
+
+		try (final PreparedStatement pstmt = DB.prepareStatement(sql, ITrx.TRXNAME_None))
+		{
+			pstmt.setInt(1, inOutId);
+			try (final ResultSet rs = pstmt.executeQuery())
+			{
+				while (rs.next())
+				{
+					final Map<String, String> row = new LinkedHashMap<>();
+					row.put("commoditynumber", rs.getString("commoditynumber"));
+					row.put("productname", rs.getString("productname"));
+					row.put("weight", bigDecimalToString(rs.getBigDecimal("weight")));
+					row.put("movementqty", bigDecimalToString(rs.getBigDecimal("movementqty")));
+					row.put("grandtotal", bigDecimalToString(rs.getBigDecimal("grandtotal")));
+					row.put("customstariff", rs.getString("customstariff"));
+					row.put("deliveredFromCountry", rs.getString("deliveredFromCountry"));
+					row.put("deliveryCountry", rs.getString("deliveryCountry"));
+					viewResults.add(row);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Validates the M_InOut_V results contain the expected rows, matched by productname.
+	 * The critical assertion is that weight is per-product, not the total shipment weight.
+	 *
+	 * <pre>
+	 * | productname | weight | movementqty |
+	 * | Product A   | 25     | 10          |
+	 * | Product B   | 15     | 5           |
+	 * </pre>
+	 */
+	@Then("M_InOut_V result contains:")
+	public void verifyResults(@NonNull final DataTable dataTable)
+	{
+		final List<Map<String, String>> expectedRows = dataTable.asMaps();
+		final SoftAssertions softly = new SoftAssertions();
+
+		softly.assertThat(viewResults)
+				.as("M_InOut_V should return rows")
+				.isNotEmpty();
+
+		for (final Map<String, String> expectedRow : expectedRows)
+		{
+			final String expectedProductName = expectedRow.get("productname");
+
+			final Map<String, String> actualRow = viewResults.stream()
+					.filter(r -> expectedProductName.equals(r.get("productname")))
+					.findFirst()
+					.orElse(null);
+
+			softly.assertThat(actualRow)
+					.as("M_InOut_V row for productname=" + expectedProductName)
+					.isNotNull();
+
+			if (actualRow == null)
+			{
+				continue;
+			}
+
+			final String expectedWeight = expectedRow.get("weight");
+			if (expectedWeight != null && !expectedWeight.isEmpty())
+			{
+				softly.assertThat(new BigDecimal(actualRow.get("weight")))
+						.as("weight for " + expectedProductName)
+						.isEqualByComparingTo(new BigDecimal(expectedWeight));
+			}
+
+			final String expectedMovementqty = expectedRow.get("movementqty");
+			if (expectedMovementqty != null && !expectedMovementqty.isEmpty())
+			{
+				softly.assertThat(new BigDecimal(actualRow.get("movementqty")))
+						.as("movementqty for " + expectedProductName)
+						.isEqualByComparingTo(new BigDecimal(expectedMovementqty));
+			}
+		}
+
+		softly.assertThat(viewResults)
+				.as("M_InOut_V should have exactly one row per expected product (no row multiplication)")
+				.hasSize(expectedRows.size());
+
+		softly.assertAll();
+	}
+
+	private static String sqlQuote(@NonNull final String value)
+	{
+		return "'" + value.replace("'", "''") + "'";
+	}
+
+	private static String bigDecimalToString(final BigDecimal value)
+	{
+		return value != null ? value.stripTrailingZeros().toPlainString() : null;
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/intrastat/IntrastatView_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/intrastat/IntrastatView_StepDef.java
@@ -182,28 +182,36 @@ public class IntrastatView_StepDef
 	}
 
 	/**
-	 * Validates the M_InOut_V results contain the expected rows, matched by productname.
+	 * Validates the M_InOut_V results contain the expected rows, matched by product identifier.
 	 * The critical assertion is that weight is per-product, not the total shipment weight.
 	 *
+	 * <p>Uses M_Product_ID.Identifier to look up the product's actual Name,
+	 * then matches it against the view's productname column. This avoids
+	 * dependence on hardcoded product names and isolates test runs from
+	 * stale data in the view (which aggregates globally by productname).
+	 *
 	 * <pre>
-	 * | productname | weight | movementqty |
-	 * | Product A   | 25     | 10          |
-	 * | Product B   | 15     | 5           |
+	 * | M_Product_ID.Identifier | weight | movementqty |
+	 * | p_intra_1               | 25     | 10          |
+	 * | p_intra_2               | 15     | 5           |
 	 * </pre>
 	 */
 	@Then("M_InOut_V result contains:")
 	public void verifyResults(@NonNull final DataTable dataTable)
 	{
-		final List<Map<String, String>> expectedRows = dataTable.asMaps();
+		final DataTableRows rows = DataTableRows.of(dataTable);
 		final SoftAssertions softly = new SoftAssertions();
 
 		softly.assertThat(viewResults)
 				.as("M_InOut_V should return rows")
 				.isNotEmpty();
 
-		for (final Map<String, String> expectedRow : expectedRows)
-		{
-			final String expectedProductName = expectedRow.get("productname");
+		final int[] expectedCount = {0};
+		rows.forEach(row -> {
+			expectedCount[0]++;
+			final String expectedProductName = row.getAsOptionalIdentifier("M_Product_ID")
+					.map(id -> productTable.get(id).getName())
+					.orElseGet(() -> row.getAsString("productname"));
 
 			final Map<String, String> actualRow = viewResults.stream()
 					.filter(r -> expectedProductName.equals(r.get("productname")))
@@ -216,29 +224,23 @@ public class IntrastatView_StepDef
 
 			if (actualRow == null)
 			{
-				continue;
+				return;
 			}
 
-			final String expectedWeight = expectedRow.get("weight");
-			if (expectedWeight != null && !expectedWeight.isEmpty())
-			{
-				softly.assertThat(new BigDecimal(actualRow.get("weight")))
-						.as("weight for " + expectedProductName)
-						.isEqualByComparingTo(new BigDecimal(expectedWeight));
-			}
+			row.getAsOptionalBigDecimal("weight")
+					.ifPresent(expectedWeight -> softly.assertThat(new BigDecimal(actualRow.get("weight")))
+							.as("weight for " + expectedProductName)
+							.isEqualByComparingTo(expectedWeight));
 
-			final String expectedMovementqty = expectedRow.get("movementqty");
-			if (expectedMovementqty != null && !expectedMovementqty.isEmpty())
-			{
-				softly.assertThat(new BigDecimal(actualRow.get("movementqty")))
-						.as("movementqty for " + expectedProductName)
-						.isEqualByComparingTo(new BigDecimal(expectedMovementqty));
-			}
-		}
+			row.getAsOptionalBigDecimal("movementqty")
+					.ifPresent(expectedQty -> softly.assertThat(new BigDecimal(actualRow.get("movementqty")))
+							.as("movementqty for " + expectedProductName)
+							.isEqualByComparingTo(expectedQty));
+		});
 
 		softly.assertThat(viewResults)
 				.as("M_InOut_V should have exactly one row per expected product (no row multiplication)")
-				.hasSize(expectedRows.size());
+				.hasSize(expectedCount[0]);
 
 		softly.assertAll();
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/intrastat/IntrastatView_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/intrastat/IntrastatView_StepDef.java
@@ -82,12 +82,17 @@ public class IntrastatView_StepDef
 			final I_M_Product product = productTable.get(row.getAsIdentifier("M_Product_ID"));
 			final String value = row.getAsString("CommodityNumberValue");
 
-			final int cnId = DB.getSQLValueEx(ITrx.TRXNAME_None, "SELECT nextval('M_CommodityNumber_Seq')");
-			DB.executeUpdateAndThrowExceptionOnFail(
-					"INSERT INTO M_CommodityNumber (M_CommodityNumber_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Value, Name)"
-							+ " VALUES (" + cnId + ", 1000000, 0, 'Y', now(), 100, now(), 100, "
-							+ sqlQuote(value) + ", " + sqlQuote(value) + ")",
-					ITrx.TRXNAME_None);
+			int cnId = DB.getSQLValueEx(ITrx.TRXNAME_None,
+					"SELECT M_CommodityNumber_ID FROM M_CommodityNumber WHERE Value=" + sqlQuote(value));
+			if (cnId <= 0)
+			{
+				cnId = DB.getSQLValueEx(ITrx.TRXNAME_None, "SELECT nextval('M_CommodityNumber_Seq')");
+				DB.executeUpdateAndThrowExceptionOnFail(
+						"INSERT INTO M_CommodityNumber (M_CommodityNumber_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Value, Name)"
+								+ " VALUES (" + cnId + ", 1000000, 0, 'Y', now(), 100, now(), 100, "
+								+ sqlQuote(value) + ", " + sqlQuote(value) + ")",
+						ITrx.TRXNAME_None);
+			}
 
 			DB.executeUpdateAndThrowExceptionOnFail(
 					"UPDATE M_Product SET M_CommodityNumber_ID=" + cnId + " WHERE M_Product_ID=" + product.getM_Product_ID(),
@@ -110,12 +115,17 @@ public class IntrastatView_StepDef
 			final I_M_Product product = productTable.get(row.getAsIdentifier("M_Product_ID"));
 			final String value = row.getAsString("CustomsTariffValue");
 
-			final int ctId = DB.getSQLValueEx(ITrx.TRXNAME_None, "SELECT nextval('M_CustomsTariff_Seq')");
-			DB.executeUpdateAndThrowExceptionOnFail(
-					"INSERT INTO M_CustomsTariff (M_CustomsTariff_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Value, Name)"
-							+ " VALUES (" + ctId + ", 1000000, 0, 'Y', now(), 100, now(), 100, "
-							+ sqlQuote(value) + ", " + sqlQuote(value) + ")",
-					ITrx.TRXNAME_None);
+			int ctId = DB.getSQLValueEx(ITrx.TRXNAME_None,
+					"SELECT M_CustomsTariff_ID FROM M_CustomsTariff WHERE Value=" + sqlQuote(value));
+			if (ctId <= 0)
+			{
+				ctId = DB.getSQLValueEx(ITrx.TRXNAME_None, "SELECT nextval('M_CustomsTariff_Seq')");
+				DB.executeUpdateAndThrowExceptionOnFail(
+						"INSERT INTO M_CustomsTariff (M_CustomsTariff_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Value, Name)"
+								+ " VALUES (" + ctId + ", 1000000, 0, 'Y', now(), 100, now(), 100, "
+								+ sqlQuote(value) + ", " + sqlQuote(value) + ")",
+						ITrx.TRXNAME_None);
+			}
 
 			DB.executeUpdateAndThrowExceptionOnFail(
 					"UPDATE M_Product SET M_CustomsTariff_ID=" + ctId + " WHERE M_Product_ID=" + product.getM_Product_ID(),

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/intrastat/intrastatViewWeight.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/intrastat/intrastatViewWeight.feature
@@ -49,7 +49,7 @@ Feature: Intrastat view M_InOut_V computes weight per commodity group
       | ps_intra    | intra_pricing_system     | intra_pricing_system_val  |
     And metasfresh contains M_PriceLists
       | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name              | SOTrx | IsTaxIncluded | PricePrecision |
-      | pl_intra   | ps_intra                      | DE                        | EUR                 | intra_price_list  | true  | false         | 2              |
+      | pl_intra   | ps_intra                      | FR                        | EUR                 | intra_price_list  | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID.Identifier | Name         | ValidFrom  |
       | plv_intra  | pl_intra                  | intra_PLV    | 2025-01-01 |
@@ -58,13 +58,13 @@ Feature: Intrastat view M_InOut_V computes weight per commodity group
       | pp_1       | plv_intra                         | p_intra_1               | 100.0    | PCE               | Normal                        |
       | pp_2       | plv_intra                         | p_intra_2               | 200.0    | PCE               | Normal                        |
 
-    # --- Customer in a foreign country (DE) shipping from AT org ---
+    # --- Customer in a foreign country (FR) — must differ from org country (AT or DE) for cross-border filter ---
     And metasfresh contains C_BPartners:
       | Identifier     | Name                   | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule | OPT.VATaxID      |
-      | bp_intra       | Intrastat Test Partner | N            | Y              | ps_intra                      | D               | DE123456789       |
+      | bp_intra       | Intrastat Test Partner | N            | Y              | ps_intra                      | D               | FR123456789       |
     And metasfresh contains C_BPartner_Locations:
       | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault | C_Country_ID |
-      | bpl_intra  | 9012345678901 | bp_intra                 | Y                   | Y                   | DE           |
+      | bpl_intra  | 9012345678901 | bp_intra                 | Y                   | Y                   | FR           |
 
     # --- Sales order with 2 lines ---
     And metasfresh contains C_Orders:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/intrastat/intrastatViewWeight.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/intrastat/intrastatViewWeight.feature
@@ -48,8 +48,8 @@ Feature: Intrastat view M_InOut_V computes weight per commodity group
       | Identifier  | Name                     | Value                     |
       | ps_intra    | intra_pricing_system     | intra_pricing_system_val  |
     And metasfresh contains M_PriceLists
-      | Identifier | M_PricingSystem_ID.Identifier | C_Currency.ISO_Code | Name              | SOTrx | IsTaxIncluded | PricePrecision |
-      | pl_intra   | ps_intra                      | EUR                 | intra_price_list  | true  | false         | 2              |
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name              | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_intra   | ps_intra                      | DE                        | EUR                 | intra_price_list  | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID.Identifier | Name         | ValidFrom  |
       | plv_intra  | pl_intra                  | intra_PLV    | 2025-01-01 |
@@ -58,13 +58,13 @@ Feature: Intrastat view M_InOut_V computes weight per commodity group
       | pp_1       | plv_intra                         | p_intra_1               | 100.0    | PCE               | Normal                        |
       | pp_2       | plv_intra                         | p_intra_2               | 200.0    | PCE               | Normal                        |
 
-    # --- Customer in a foreign country (AT, not DE) ---
+    # --- Customer in a foreign country (DE) shipping from AT org ---
     And metasfresh contains C_BPartners:
       | Identifier     | Name                   | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule | OPT.VATaxID      |
-      | bp_intra       | Intrastat Test Partner | N            | Y              | ps_intra                      | D               | ATU12345678       |
+      | bp_intra       | Intrastat Test Partner | N            | Y              | ps_intra                      | D               | DE123456789       |
     And metasfresh contains C_BPartner_Locations:
       | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault | C_Country_ID |
-      | bpl_intra  | 9012345678901 | bp_intra                 | Y                   | Y                   | AT           |
+      | bpl_intra  | 9012345678901 | bp_intra                 | Y                   | Y                   | DE           |
 
     # --- Sales order with 2 lines ---
     And metasfresh contains C_Orders:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/intrastat/intrastatViewWeight.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/intrastat/intrastatViewWeight.feature
@@ -1,0 +1,111 @@
+@from:cucumber
+@ghActions:run_on_executor7
+Feature: Intrastat view M_InOut_V computes weight per commodity group
+
+  gh#28336: The M_InOut_V view must report weight per line/commodity group,
+  NOT the total shipment weight. Before the fix, the view used
+  Docs_Sales_InOut_Sum_Weight (which sums all lines of the entire shipment),
+  causing every commodity group to show the full shipment weight.
+
+  This test ships two products with different commodity numbers in a single
+  shipment and verifies that each row in the view shows the correct per-product
+  weight — not the total.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
+
+  @from:cucumber
+  @Id:S0_gh28336
+  Scenario: Weight in M_InOut_V is per commodity group, not total shipment weight
+    Given metasfresh has date and time 2026-01-15T13:30:13+01:00[Europe/Berlin]
+
+    # --- Products ---
+    And metasfresh contains M_Products:
+      | Identifier | Name                     |
+      | p_intra_1  | Intrastat Test Product A |
+      | p_intra_2  | Intrastat Test Product B |
+
+    And M_Product weight is set:
+      | M_Product_ID.Identifier | Weight |
+      | p_intra_1               | 2.5    |
+      | p_intra_2               | 3.0    |
+
+    And M_CommodityNumber is set for products:
+      | M_Product_ID.Identifier | CommodityNumberValue |
+      | p_intra_1               | 85171200             |
+      | p_intra_2               | 73181500             |
+
+    And M_CustomsTariff is set for products:
+      | M_Product_ID.Identifier | CustomsTariffValue |
+      | p_intra_1               | 8517120000         |
+      | p_intra_2               | 7318150000         |
+
+    # --- Pricing ---
+    And metasfresh contains M_PricingSystems
+      | Identifier  | Name                     | Value                     |
+      | ps_intra    | intra_pricing_system     | intra_pricing_system_val  |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name              | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_intra   | ps_intra                      | DE                        | EUR                 | intra_price_list  | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name         | ValidFrom  |
+      | plv_intra  | pl_intra                  | intra_PLV    | 2025-01-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_intra                         | p_intra_1               | 100.0    | PCE               | Normal                        |
+      | pp_2       | plv_intra                         | p_intra_2               | 200.0    | PCE               | Normal                        |
+
+    # --- Customer in a foreign country (AT, not DE) ---
+    And metasfresh contains C_BPartners:
+      | Identifier     | Name                   | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule | OPT.VATaxID      |
+      | bp_intra       | Intrastat Test Partner | N            | Y              | ps_intra                      | D               | ATU12345678       |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault | C_Country_ID |
+      | bpl_intra  | 9012345678901 | bp_intra                 | Y                   | Y                   | AT           |
+
+    # --- Sales order with 2 lines ---
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | o_intra    | true    | bp_intra                 | 2026-01-15  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_1       | o_intra               | p_intra_1               | 10         |
+      | ol_2       | o_intra               | p_intra_2               | 5          |
+    When the order identified by o_intra is completed
+
+    # --- Generate shipment ---
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | ss_1       | ol_1                      | N             |
+      | ss_2       | ol_2                      | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_1                             | D            | true                | false       |
+      | ss_2                             | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | ss_1                             | ship_intra            |
+
+    # --- Generate invoice ---
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_1                              | ol_1                      | 10           |
+      | ic_2                              | ol_2                      | 5            |
+    When process invoice candidates and wait 60s for C_Invoice_Candidate to be processed
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_1                              |
+      | ic_2                              |
+
+    # --- Query and validate the Intrastat view ---
+    # Weight must be PER PRODUCT, not the total shipment weight:
+    #   Product A: 10 PCE * 2.5 kg/PCE = 25 kg
+    #   Product B:  5 PCE * 3.0 kg/PCE = 15 kg
+    # Before the fix, both would show 40 kg (total shipment weight).
+    When M_InOut_V is queried for shipment "ship_intra"
+    Then M_InOut_V result contains:
+      | productname              | weight | movementqty |
+      | Intrastat Test Product A | 25     | 10          |
+      | Intrastat Test Product B | 15     | 5           |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/intrastat/intrastatViewWeight.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/intrastat/intrastatViewWeight.feature
@@ -48,8 +48,8 @@ Feature: Intrastat view M_InOut_V computes weight per commodity group
       | Identifier  | Name                     | Value                     |
       | ps_intra    | intra_pricing_system     | intra_pricing_system_val  |
     And metasfresh contains M_PriceLists
-      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name              | SOTrx | IsTaxIncluded | PricePrecision |
-      | pl_intra   | ps_intra                      | DE                        | EUR                 | intra_price_list  | true  | false         | 2              |
+      | Identifier | M_PricingSystem_ID.Identifier | C_Currency.ISO_Code | Name              | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_intra   | ps_intra                      | EUR                 | intra_price_list  | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID.Identifier | Name         | ValidFrom  |
       | plv_intra  | pl_intra                  | intra_PLV    | 2025-01-01 |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/intrastat/intrastatViewWeight.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/intrastat/intrastatViewWeight.feature
@@ -76,15 +76,15 @@ Feature: Intrastat view M_InOut_V computes weight per commodity group
       | ol_2       | o_intra               | p_intra_2               | 5          |
     When the order identified by o_intra is completed
 
-    # --- Generate shipment ---
+    # --- Generate shipment (batch mode: both products merge into one M_InOut) ---
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | ss_1       | ol_1                      | N             |
       | ss_2       | ol_2                      | N             |
-    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
-      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
-      | ss_1                             | D            | true                | false       |
-      | ss_2                             | D            | true                | false       |
+    And 'generate shipments' process is invoked with QuantityType=D, IsCompleteShipments=true and IsShipToday=false
+      | M_ShipmentSchedule_ID.Identifier |
+      | ss_1                             |
+      | ss_2                             |
     And after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
       | ss_1                             | ship_intra            |
@@ -106,6 +106,6 @@ Feature: Intrastat view M_InOut_V computes weight per commodity group
     # Before the fix, both would show 40 kg (total shipment weight).
     When M_InOut_V is queried for shipment "ship_intra"
     Then M_InOut_V result contains:
-      | productname              | weight | movementqty |
-      | Intrastat Test Product A | 25     | 10          |
-      | Intrastat Test Product B | 15     | 5           |
+      | M_Product_ID.Identifier | weight | movementqty |
+      | p_intra_1               | 25     | 10          |
+      | p_intra_2               | 15     | 5           |

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5792720_sys_gh28336_M_InOut_V_fix_weight.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5792720_sys_gh28336_M_InOut_V_fix_weight.sql
@@ -1,6 +1,16 @@
-DROP VIEW IF EXISTS de_metas_endcustomer_fresh_reports.M_InOut_V;
+-- gh#28336: Fix M_InOut_V weight calculation for Intrastat
+--
+-- Bug: weight came from Docs_Sales_InOut_Sum_Weight() which returns the TOTAL
+-- shipment weight (sum of all lines). Since the inner subquery iterates per
+-- M_InOutLine but the function aggregates at M_InOut level, every commodity
+-- group received the full shipment weight instead of its per-line share.
+--
+-- Fix: compute weight per line (same logic as the function, minus the SUM),
+-- then SUM(weight) in the outer query instead of GROUP BY weight.
 
-CREATE OR REPLACE VIEW de_metas_endcustomer_fresh_reports.M_InOut_V AS
+DROP VIEW IF EXISTS de_metas_endcustomer_fresh_reports.m_inout_v$new;
+
+CREATE OR REPLACE VIEW de_metas_endcustomer_fresh_reports.m_inout_v$new AS
 select commoditynumber,
        productName,
        productDescription,
@@ -75,7 +85,7 @@ from (
                 per.c_year_id
          from M_InOut io
                   join AD_Org o on io.ad_org_id = o.ad_org_id
-                  -- Org's country via AD_OrgInfo → OrgBP_Location → C_Location → C_Country
+                  -- Org's country via AD_OrgInfo -> OrgBP_Location -> C_Location -> C_Country
                   join AD_OrgInfo org_info on io.ad_org_id = org_info.ad_org_id
                   left join C_BPartner_Location org_bpl on org_info.OrgBP_Location_ID = org_bpl.C_BPartner_Location_ID
                   left join C_Location org_loc on org_bpl.C_Location_ID = org_loc.C_Location_ID
@@ -137,3 +147,13 @@ group by commoditynumber,
          vataxid,
          c_year_id
 order by deliveryCountry, commoditynumber;
+
+SELECT db_alter_view(
+    'de_metas_endcustomer_fresh_reports.m_inout_v',
+    (SELECT view_definition
+     FROM information_schema.views
+     WHERE lower(views.table_name) = lower('m_inout_v$new')
+       AND lower(views.table_schema) = lower('de_metas_endcustomer_fresh_reports'))
+);
+
+DROP VIEW IF EXISTS de_metas_endcustomer_fresh_reports.m_inout_v$new;


### PR DESCRIPTION
## Summary
- Add `IsIncludeCSVHeaderRow` (YesNo, default Y) column to `AD_Process` to control whether CSV exports include a header row
- Set to `N` for `Intrastat_Export` (AD_Process_ID=585508) so Austrian RTIC no longer rejects submissions due to unexpected column header rows
- Wire through `SpreadsheetExportOptions` → `JdbcCSVExporter` → `CSVWriter`

## Test plan
- [x] 15 unit tests pass locally (5 new tests for header suppression)
- [x] CI green
- [x] Verify Intrastat CSV export produces no header row
- [x] Verify other CSV exports still include header row (backward compatible)