### PR TITLE
Fix IsInheritPackingInstruction: German base language translations

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5793240_sys_gh26915_fix_IsInheritPackingInstruction_translations.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5793240_sys_gh26915_fix_IsInheritPackingInstruction_translations.sql
@@ -1,0 +1,43 @@
+-- 2026-03-09
+-- me03#26915: Fix IsInheritPackingInstruction translations
+-- Base language is de_DE, so AD_Element must have German text.
+-- The original script (5792610) incorrectly set English text on the base AD_Element record.
+
+-- Fix base AD_Element: set German text (de_DE is the base language)
+UPDATE AD_Element
+SET Name        = 'Packvorschrift vererben',
+    PrintName   = 'Packvorschrift vererben',
+    Description = 'Wenn gesetzt, wird die Packvorschrift des Hauptartikels auf alle aus dem Kompensationsgruppen-Schema erstellten Unterartikel uebertragen.',
+    Updated     = TO_TIMESTAMP('2026-03-09 17:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy   = 100
+WHERE AD_Element_ID = 584629;
+
+-- Fix de_DE translation row (base language row mirrors the element)
+UPDATE AD_Element_Trl
+SET Name         = 'Packvorschrift vererben',
+    PrintName    = 'Packvorschrift vererben',
+    Description  = 'Wenn gesetzt, wird die Packvorschrift des Hauptartikels auf alle aus dem Kompensationsgruppen-Schema erstellten Unterartikel uebertragen.',
+    IsTranslated = 'N',
+    Updated      = TO_TIMESTAMP('2026-03-09 17:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 584629
+  AND AD_Language = 'de_DE';
+
+-- Ensure en_US translation is correct
+UPDATE AD_Element_Trl
+SET Name         = 'Inherit Packing Instruction',
+    PrintName    = 'Inherit Packing Instruction',
+    Description  = 'If set, the packing instruction from the main article is applied to all sub-articles created from the compensation group schema template.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-03-09 17:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 584629
+  AND AD_Language = 'en_US';
+
+-- Propagate: de_DE element text → AD_Column, AD_Field, AD_Process_Para, AD_UI_Element names
+SELECT update_ad_element_on_ad_element_trl_update(584629, 'de_DE');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584629, 'de_DE');
+
+-- Propagate: en_US
+SELECT update_ad_element_on_ad_element_trl_update(584629, 'en_US');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584629, 'en_US');

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5793250_sys_ensure_standard_UOM_conversions.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5793250_sys_ensure_standard_UOM_conversions.sql
@@ -1,0 +1,183 @@
+-- 2026-03-09
+-- Ensure standard UOM conversions exist between system-level measurement units (AD_Client_ID=0).
+-- Some instances may be missing conversions (e.g., GRM↔KGM) which causes NoUOMConversionException
+-- in OrderLineBL.setGrossWeightInKg and similar code paths.
+--
+-- Each INSERT checks both directions: if either A→B or B→A already exists, we skip the insert.
+-- UOM IDs are looked up by X12DE355 code to be instance-independent.
+
+-- ============================================================
+-- Weight: GRM (Gramm) ↔ KGM (Kilogramm)
+-- 1 GRM = 0.001 KGM
+-- ============================================================
+INSERT INTO C_UOM_Conversion (C_UOM_Conversion_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                              Created, CreatedBy, Updated, UpdatedBy,
+                              C_UOM_ID, C_UOM_To_ID, MultiplyRate, DivideRate, M_Product_ID)
+SELECT 540050, 0, 0, 'Y',
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       grm.C_UOM_ID, kgm.C_UOM_ID,
+       0.001, 1000, NULL
+FROM C_UOM grm, C_UOM kgm
+WHERE grm.X12DE355 = 'GRM' AND grm.AD_Client_ID = 0
+  AND kgm.X12DE355 = 'KGM' AND kgm.AD_Client_ID = 0
+  AND NOT EXISTS (
+    SELECT 1 FROM C_UOM_Conversion uc
+    WHERE uc.AD_Client_ID = 0 AND uc.M_Product_ID IS NULL AND uc.IsActive = 'Y'
+      AND (  (uc.C_UOM_ID = grm.C_UOM_ID AND uc.C_UOM_To_ID = kgm.C_UOM_ID)
+          OR (uc.C_UOM_ID = kgm.C_UOM_ID AND uc.C_UOM_To_ID = grm.C_UOM_ID))
+);
+
+-- ============================================================
+-- Weight: KGM (Kilogramm) ↔ TNE (Tonne)
+-- 1 KGM = 0.001 TNE
+-- ============================================================
+INSERT INTO C_UOM_Conversion (C_UOM_Conversion_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                              Created, CreatedBy, Updated, UpdatedBy,
+                              C_UOM_ID, C_UOM_To_ID, MultiplyRate, DivideRate, M_Product_ID)
+SELECT 540051, 0, 0, 'Y',
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       kgm.C_UOM_ID, tne.C_UOM_ID,
+       0.001, 1000, NULL
+FROM C_UOM kgm, C_UOM tne
+WHERE kgm.X12DE355 = 'KGM' AND kgm.AD_Client_ID = 0
+  AND tne.X12DE355 = 'TNE' AND tne.AD_Client_ID = 0
+  AND NOT EXISTS (
+    SELECT 1 FROM C_UOM_Conversion uc
+    WHERE uc.AD_Client_ID = 0 AND uc.M_Product_ID IS NULL AND uc.IsActive = 'Y'
+      AND (  (uc.C_UOM_ID = kgm.C_UOM_ID AND uc.C_UOM_To_ID = tne.C_UOM_ID)
+          OR (uc.C_UOM_ID = tne.C_UOM_ID AND uc.C_UOM_To_ID = kgm.C_UOM_ID))
+);
+
+-- ============================================================
+-- Weight: GRM (Gramm) ↔ TNE (Tonne)
+-- 1 GRM = 0.000001 TNE
+-- ============================================================
+INSERT INTO C_UOM_Conversion (C_UOM_Conversion_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                              Created, CreatedBy, Updated, UpdatedBy,
+                              C_UOM_ID, C_UOM_To_ID, MultiplyRate, DivideRate, M_Product_ID)
+SELECT 540052, 0, 0, 'Y',
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       grm.C_UOM_ID, tne.C_UOM_ID,
+       0.000001, 1000000, NULL
+FROM C_UOM grm, C_UOM tne
+WHERE grm.X12DE355 = 'GRM' AND grm.AD_Client_ID = 0
+  AND tne.X12DE355 = 'TNE' AND tne.AD_Client_ID = 0
+  AND NOT EXISTS (
+    SELECT 1 FROM C_UOM_Conversion uc
+    WHERE uc.AD_Client_ID = 0 AND uc.M_Product_ID IS NULL AND uc.IsActive = 'Y'
+      AND (  (uc.C_UOM_ID = grm.C_UOM_ID AND uc.C_UOM_To_ID = tne.C_UOM_ID)
+          OR (uc.C_UOM_ID = tne.C_UOM_ID AND uc.C_UOM_To_ID = grm.C_UOM_ID))
+);
+
+-- ============================================================
+-- Length: CM (Centimeter) ↔ mm (Millimeter)
+-- 1 CM = 10 mm
+-- ============================================================
+INSERT INTO C_UOM_Conversion (C_UOM_Conversion_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                              Created, CreatedBy, Updated, UpdatedBy,
+                              C_UOM_ID, C_UOM_To_ID, MultiplyRate, DivideRate, M_Product_ID)
+SELECT 540053, 0, 0, 'Y',
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       cm.C_UOM_ID, mm.C_UOM_ID,
+       10, 0.1, NULL
+FROM C_UOM cm, C_UOM mm
+WHERE cm.X12DE355 = 'CM' AND cm.AD_Client_ID = 0
+  AND mm.X12DE355 = 'mm' AND mm.AD_Client_ID = 0
+  AND NOT EXISTS (
+    SELECT 1 FROM C_UOM_Conversion uc
+    WHERE uc.AD_Client_ID = 0 AND uc.M_Product_ID IS NULL AND uc.IsActive = 'Y'
+      AND (  (uc.C_UOM_ID = cm.C_UOM_ID AND uc.C_UOM_To_ID = mm.C_UOM_ID)
+          OR (uc.C_UOM_ID = mm.C_UOM_ID AND uc.C_UOM_To_ID = cm.C_UOM_ID))
+);
+
+-- ============================================================
+-- Time: MJ (Minute) ↔ HR (Stunde/Hour)
+-- 1 MJ = 1/60 HR
+-- ============================================================
+INSERT INTO C_UOM_Conversion (C_UOM_Conversion_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                              Created, CreatedBy, Updated, UpdatedBy,
+                              C_UOM_ID, C_UOM_To_ID, MultiplyRate, DivideRate, M_Product_ID)
+SELECT 540054, 0, 0, 'Y',
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       mj.C_UOM_ID, hr.C_UOM_ID,
+       0.016666666667, 60, NULL
+FROM C_UOM mj, C_UOM hr
+WHERE mj.X12DE355 = 'MJ' AND mj.AD_Client_ID = 0
+  AND hr.X12DE355 = 'HR' AND hr.AD_Client_ID = 0
+  AND NOT EXISTS (
+    SELECT 1 FROM C_UOM_Conversion uc
+    WHERE uc.AD_Client_ID = 0 AND uc.M_Product_ID IS NULL AND uc.IsActive = 'Y'
+      AND (  (uc.C_UOM_ID = mj.C_UOM_ID AND uc.C_UOM_To_ID = hr.C_UOM_ID)
+          OR (uc.C_UOM_ID = hr.C_UOM_ID AND uc.C_UOM_To_ID = mj.C_UOM_ID))
+);
+
+-- ============================================================
+-- Time: HR (Stunde/Hour) ↔ DA (Tag/Day)
+-- 1 HR = 1/24 DA
+-- ============================================================
+INSERT INTO C_UOM_Conversion (C_UOM_Conversion_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                              Created, CreatedBy, Updated, UpdatedBy,
+                              C_UOM_ID, C_UOM_To_ID, MultiplyRate, DivideRate, M_Product_ID)
+SELECT 540055, 0, 0, 'Y',
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       hr.C_UOM_ID, da.C_UOM_ID,
+       0.041666666667, 24, NULL
+FROM C_UOM hr, C_UOM da
+WHERE hr.X12DE355 = 'HR' AND hr.AD_Client_ID = 0
+  AND da.X12DE355 = 'DA' AND da.AD_Client_ID = 0
+  AND NOT EXISTS (
+    SELECT 1 FROM C_UOM_Conversion uc
+    WHERE uc.AD_Client_ID = 0 AND uc.M_Product_ID IS NULL AND uc.IsActive = 'Y'
+      AND (  (uc.C_UOM_ID = hr.C_UOM_ID AND uc.C_UOM_To_ID = da.C_UOM_ID)
+          OR (uc.C_UOM_ID = da.C_UOM_ID AND uc.C_UOM_To_ID = hr.C_UOM_ID))
+);
+
+-- ============================================================
+-- Count: PCE (Stück) ↔ TSTK (1000 Stk)
+-- 1 PCE = 0.001 TSTK
+-- ============================================================
+INSERT INTO C_UOM_Conversion (C_UOM_Conversion_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                              Created, CreatedBy, Updated, UpdatedBy,
+                              C_UOM_ID, C_UOM_To_ID, MultiplyRate, DivideRate, M_Product_ID)
+SELECT 540056, 0, 0, 'Y',
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       pce.C_UOM_ID, tstk.C_UOM_ID,
+       0.001, 1000, NULL
+FROM C_UOM pce, C_UOM tstk
+WHERE pce.X12DE355 = 'PCE' AND pce.AD_Client_ID = 0
+  AND tstk.X12DE355 = 'TSTK' AND tstk.AD_Client_ID = 0
+  AND NOT EXISTS (
+    SELECT 1 FROM C_UOM_Conversion uc
+    WHERE uc.AD_Client_ID = 0 AND uc.M_Product_ID IS NULL AND uc.IsActive = 'Y'
+      AND (  (uc.C_UOM_ID = pce.C_UOM_ID AND uc.C_UOM_To_ID = tstk.C_UOM_ID)
+          OR (uc.C_UOM_ID = tstk.C_UOM_ID AND uc.C_UOM_To_ID = pce.C_UOM_ID))
+);
+
+-- ============================================================
+-- Count: COLI (Kollo) ↔ PCE (Stück)
+-- 1 COLI = 1 PCE (default; product-specific overrides may differ)
+-- ============================================================
+INSERT INTO C_UOM_Conversion (C_UOM_Conversion_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                              Created, CreatedBy, Updated, UpdatedBy,
+                              C_UOM_ID, C_UOM_To_ID, MultiplyRate, DivideRate, M_Product_ID)
+SELECT 540057, 0, 0, 'Y',
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       TO_TIMESTAMP('2026-03-09 17:30', 'YYYY-MM-DD HH24:MI'), 100,
+       coli.C_UOM_ID, pce.C_UOM_ID,
+       1, 1, NULL
+FROM C_UOM coli, C_UOM pce
+WHERE coli.X12DE355 = 'COLI' AND coli.AD_Client_ID = 0
+  AND pce.X12DE355 = 'PCE' AND pce.AD_Client_ID = 0
+  AND NOT EXISTS (
+    SELECT 1 FROM C_UOM_Conversion uc
+    WHERE uc.AD_Client_ID = 0 AND uc.M_Product_ID IS NULL AND uc.IsActive = 'Y'
+      AND (  (uc.C_UOM_ID = coli.C_UOM_ID AND uc.C_UOM_To_ID = pce.C_UOM_ID)
+          OR (uc.C_UOM_ID = pce.C_UOM_ID AND uc.C_UOM_To_ID = coli.C_UOM_ID))
+);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5793350_sys_gh26915_update_IsInheritPackingInstruction_description.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5793350_sys_gh26915_update_IsInheritPackingInstruction_description.sql
@@ -1,0 +1,49 @@
+-- 2026-03-09
+-- Update IsInheritPackingInstruction description to document that a compatible
+-- M_HU_PI_Item_Product must exist for each sub-article, otherwise inheritance is skipped.
+
+-- Fix base element: must be German (de_DE is base language)
+UPDATE AD_Element
+SET Name = 'Packvorschrift vererben',
+    PrintName = 'Packvorschrift vererben',
+    Description = 'Wenn gesetzt, wird die Packvorschrift des Hauptartikels auf alle Unterartikel übertragen, die aus dem Kompensationsgruppen-Schema erstellt werden. Voraussetzung: Für jeden Unterartikel muss eine kompatible Packvorschrift-Zuordnung (M_HU_PI_Item_Product) für denselben TU-Typ existieren, sonst wird die Vererbung für diesen Artikel übersprungen.',
+    Updated = TO_TIMESTAMP('2026-03-09 19:55', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy = 100
+WHERE AD_Element_ID = 584629;
+
+-- de_DE: mirror of base (IsTranslated=N)
+UPDATE AD_Element_Trl
+SET Name = 'Packvorschrift vererben',
+    PrintName = 'Packvorschrift vererben',
+    Description = 'Wenn gesetzt, wird die Packvorschrift des Hauptartikels auf alle Unterartikel übertragen, die aus dem Kompensationsgruppen-Schema erstellt werden. Voraussetzung: Für jeden Unterartikel muss eine kompatible Packvorschrift-Zuordnung (M_HU_PI_Item_Product) für denselben TU-Typ existieren, sonst wird die Vererbung für diesen Artikel übersprungen.',
+    IsTranslated = 'N',
+    Updated = TO_TIMESTAMP('2026-03-09 19:55', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy = 100
+WHERE AD_Element_ID = 584629 AND AD_Language = 'de_DE';
+
+-- de_CH: same German text (IsTranslated=N)
+UPDATE AD_Element_Trl
+SET Name = 'Packvorschrift vererben',
+    PrintName = 'Packvorschrift vererben',
+    Description = 'Wenn gesetzt, wird die Packvorschrift des Hauptartikels auf alle Unterartikel übertragen, die aus dem Kompensationsgruppen-Schema erstellt werden. Voraussetzung: Für jeden Unterartikel muss eine kompatible Packvorschrift-Zuordnung (M_HU_PI_Item_Product) für denselben TU-Typ existieren, sonst wird die Vererbung für diesen Artikel übersprungen.',
+    IsTranslated = 'N',
+    Updated = TO_TIMESTAMP('2026-03-09 19:55', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy = 100
+WHERE AD_Element_ID = 584629 AND AD_Language = 'de_CH';
+
+-- en_US: English translation
+UPDATE AD_Element_Trl
+SET Name = 'Inherit Packing Instruction',
+    PrintName = 'Inherit Packing Instruction',
+    Description = 'If set, the packing instruction from the main article is applied to all sub-articles created from the compensation group schema template. Prerequisite: Each sub-article must have a compatible packing instruction assignment (M_HU_PI_Item_Product) for the same TU type, otherwise inheritance is skipped for that article.',
+    IsTranslated = 'Y',
+    Updated = TO_TIMESTAMP('2026-03-09 19:55', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy = 100
+WHERE AD_Element_ID = 584629 AND AD_Language = 'en_US';
+
+-- Propagate element changes to all dependent AD records
+SELECT update_ad_element_on_ad_element_trl_update(584629, 'de_DE');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584629, 'de_DE');
+
+SELECT update_ad_element_on_ad_element_trl_update(584629, 'en_US');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584629, 'en_US');

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_CreateFromSchema_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_CreateFromSchema_StepDef.java
@@ -1,0 +1,166 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.order;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.hu.M_HU_PI_Item_Product_StepDefData;
+import de.metas.handlingunits.HUPIItemProduct;
+import de.metas.handlingunits.HUPIItemProductId;
+import de.metas.handlingunits.HuPackingInstructionsItemId;
+import de.metas.handlingunits.IHUPIItemProductDAO;
+import de.metas.handlingunits.model.I_M_HU_PI_Item;
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.order.OrderId;
+import de.metas.order.compensationGroup.Group;
+import de.metas.order.compensationGroup.GroupRegularLine;
+import de.metas.order.compensationGroup.GroupTemplate;
+import de.metas.order.compensationGroup.GroupTemplateId;
+import de.metas.order.compensationGroup.GroupTemplateRepository;
+import de.metas.order.compensationGroup.OrderGroupRepository;
+import de.metas.order.model.I_C_CompensationGroup_Schema;
+import de.metas.product.ProductId;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_OrderLine;
+import org.compiere.SpringContextHolder;
+
+import java.math.BigDecimal;
+
+/**
+ * Step definitions for creating compensation groups from schema templates and applying PI inheritance.
+ * <p>
+ * This tests the same logic path as the Quick Input flow in {@code OrderLineQuickInputProcessor},
+ * but without requiring the WebUI Quick Input abstraction.
+ * <p>
+ * DataTable columns for "create compensation group from schema template":
+ * <ul>
+ *     <li>{@code C_Order_ID} (required) — identifier of the target order</li>
+ *     <li>{@code C_CompensationGroup_Schema_ID} (required) — identifier of the schema</li>
+ *     <li>{@code Qty} (optional, default 1) — number of template sets to create</li>
+ *     <li>{@code M_HU_PI_Item_Product_ID} (optional) — identifier of the main article's PI Item Product.
+ *         If the schema has IsInheritPackingInstruction=Y and this is provided, PI inheritance is applied
+ *         to all template-created order lines.</li>
+ * </ul>
+ */
+@RequiredArgsConstructor
+public class C_CompensationGroup_CreateFromSchema_StepDef
+{
+	private final @NonNull C_Order_StepDefData orderTable;
+	private final @NonNull C_OrderLine_StepDefData orderLineTable;
+	private final @NonNull C_CompensationGroup_Schema_StepDefData schemaTable;
+	private final @NonNull M_HU_PI_Item_Product_StepDefData huPiItemProductTable;
+
+	private final OrderGroupRepository orderGroupsRepo = SpringContextHolder.instance.getBean(OrderGroupRepository.class);
+	private final GroupTemplateRepository groupTemplateRepo = SpringContextHolder.instance.getBean(GroupTemplateRepository.class);
+
+	/**
+	 * Creates a compensation group from a schema template on the given order, then optionally
+	 * applies PI inheritance if the schema has IsInheritPackingInstruction=Y.
+	 * <p>
+	 * Created order lines are stored in {@link C_OrderLine_StepDefData} using generated identifiers
+	 * of the form {@code schema_ol_1}, {@code schema_ol_2}, etc.
+	 */
+	@When("create compensation group from schema template:")
+	public void createGroupFromSchemaTemplate(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_C_Order order = row.getAsIdentifier("C_Order_ID")
+					.lookupNotNullIn(orderTable);
+			final OrderId orderId = OrderId.ofRepoId(order.getC_Order_ID());
+
+			final I_C_CompensationGroup_Schema schemaRecord = row.getAsIdentifier("C_CompensationGroup_Schema_ID")
+					.lookupNotNullIn(schemaTable);
+
+			final GroupTemplateId groupTemplateId = GroupTemplateId.ofRepoId(schemaRecord.getC_CompensationGroup_Schema_ID());
+			final GroupTemplate groupTemplate = groupTemplateRepo.getById(groupTemplateId);
+
+			final BigDecimal qty = row.getAsOptionalBigDecimal("Qty").orElse(BigDecimal.ONE);
+
+			final Group group = orderGroupsRepo.prepareNewGroup()
+					.groupTemplate(groupTemplate)
+					.qty(qty)
+					.createGroup(orderId, null);
+
+			// Apply PI inheritance if the schema flag is set and a PI was provided
+			if (groupTemplate.isInheritPackingInstruction())
+			{
+				row.getAsOptionalIdentifier("M_HU_PI_Item_Product_ID")
+						.ifPresent(piIdentifier -> {
+							final I_M_HU_PI_Item_Product mainPiItemProductRecord = piIdentifier.lookupNotNullIn(huPiItemProductTable);
+							final HUPIItemProductId mainPiItemProductId = HUPIItemProductId.ofRepoId(mainPiItemProductRecord.getM_HU_PI_Item_Product_ID());
+
+							applyPackingInstructionInheritance(order, group, mainPiItemProductId);
+						});
+			}
+
+			// Store created order lines for later verification
+			int lineIndex = 1;
+			for (final GroupRegularLine regularLine : group.getRegularLines())
+			{
+				final I_C_OrderLine orderLine = InterfaceWrapperHelper.load(regularLine.getRepoId(), I_C_OrderLine.class);
+				orderLineTable.putOrReplace("schema_ol_" + lineIndex, orderLine);
+				lineIndex++;
+			}
+		});
+	}
+
+	/**
+	 * Applies PI inheritance: resolves a compatible M_HU_PI_Item_Product for each sub-article
+	 * using the same M_HU_PI_Item (TU type) as the main article's PI.
+	 * <p>
+	 * This mirrors the logic in {@code OrderLineQuickInputProcessor.applyPackingInstructionFromQuickInput()}.
+	 */
+	private static void applyPackingInstructionInheritance(
+			@NonNull final I_C_Order order,
+			@NonNull final Group group,
+			@NonNull final HUPIItemProductId mainPiItemProductId)
+	{
+		final IHUPIItemProductDAO piItemProductDAO = Services.get(IHUPIItemProductDAO.class);
+		final HUPIItemProduct mainPiItemProduct = piItemProductDAO.getById(mainPiItemProductId);
+		final HuPackingInstructionsItemId piItemId = mainPiItemProduct.getPiItemId();
+		final I_M_HU_PI_Item piItem = InterfaceWrapperHelper.load(piItemId.getRepoId(), I_M_HU_PI_Item.class);
+
+		final BPartnerId bpartnerId = BPartnerId.ofRepoIdOrNull(order.getC_BPartner_ID());
+
+		for (final GroupRegularLine regularLine : group.getRegularLines())
+		{
+			final de.metas.handlingunits.model.I_C_OrderLine orderLine = InterfaceWrapperHelper.load(
+					regularLine.getRepoId(), de.metas.handlingunits.model.I_C_OrderLine.class);
+			final ProductId productId = ProductId.ofRepoId(orderLine.getM_Product_ID());
+
+			final I_M_HU_PI_Item_Product matchingPiItemProduct = piItemProductDAO.retrievePIMaterialItemProduct(
+					piItem, bpartnerId, productId, null);
+			if (matchingPiItemProduct != null)
+			{
+				orderLine.setM_HU_PI_Item_Product_ID(matchingPiItemProduct.getM_HU_PI_Item_Product_ID());
+				InterfaceWrapperHelper.save(orderLine);
+			}
+		}
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_CreateFromSchema_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_CreateFromSchema_StepDef.java
@@ -22,15 +22,11 @@
 
 package de.metas.cucumber.stepdefs.order;
 
-import de.metas.bpartner.BPartnerId;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.hu.M_HU_PI_Item_Product_StepDefData;
-import de.metas.handlingunits.HUPIItemProduct;
 import de.metas.handlingunits.HUPIItemProductId;
-import de.metas.handlingunits.HuPackingInstructionsItemId;
-import de.metas.handlingunits.IHUPIItemProductDAO;
-import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.handlingunits.order.OrderGroupPIInheritanceService;
 import de.metas.order.OrderId;
 import de.metas.order.compensationGroup.Group;
 import de.metas.order.compensationGroup.GroupRegularLine;
@@ -39,8 +35,6 @@ import de.metas.order.compensationGroup.GroupTemplateId;
 import de.metas.order.compensationGroup.GroupTemplateRepository;
 import de.metas.order.compensationGroup.OrderGroupRepository;
 import de.metas.order.model.I_C_CompensationGroup_Schema;
-import de.metas.product.ProductId;
-import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.When;
 import lombok.NonNull;
@@ -55,18 +49,33 @@ import java.math.BigDecimal;
 /**
  * Step definitions for creating compensation groups from schema templates and applying PI inheritance.
  * <p>
- * This tests the same logic path as the Quick Input flow in {@code OrderLineQuickInputProcessor},
- * but without requiring the WebUI Quick Input abstraction.
+ * Uses {@link OrderGroupRepository} to create group order lines from a {@link GroupTemplate},
+ * then optionally applies packing instruction (PI) inheritance by calling the production code in
+ * {@link OrderGroupPIInheritanceService#applyPackingInstructionInheritance}.
  * <p>
- * DataTable columns for "create compensation group from schema template":
+ * <b>Prerequisites</b>:
+ * <ul>
+ *     <li>The schema must already have {@link de.metas.order.model.I_C_CompensationGroup_Schema_TemplateLine} records
+ *         (created via "metasfresh contains C_CompensationGroup_Schema_TemplateLine:" step)</li>
+ *     <li>The target order must exist (created via "metasfresh contains C_Orders:" step)</li>
+ *     <li>All template-line products must have prices in the order's price list</li>
+ * </ul>
+ * <p>
+ * <b>DataTable columns</b> for {@code "create compensation group from schema template:"}:
  * <ul>
  *     <li>{@code C_Order_ID} (required) — identifier of the target order</li>
  *     <li>{@code C_CompensationGroup_Schema_ID} (required) — identifier of the schema</li>
  *     <li>{@code Qty} (optional, default 1) — number of template sets to create</li>
  *     <li>{@code M_HU_PI_Item_Product_ID} (optional) — identifier of the main article's PI Item Product.
- *         If the schema has IsInheritPackingInstruction=Y and this is provided, PI inheritance is applied
- *         to all template-created order lines.</li>
+ *         When the schema has {@code IsInheritPackingInstruction=Y} and this is provided,
+ *         each created order line gets a <b>per-product compatible</b> {@code M_HU_PI_Item_Product}
+ *         resolved via {@link IHUPIItemProductDAO#retrievePIMaterialItemProduct} for the same TU type.
+ *         If no compatible PI exists for a sub-article, that line is skipped (keeps default PI=101).</li>
  * </ul>
+ * <p>
+ * <b>Output identifiers</b>: Created order lines are stored in {@link C_OrderLine_StepDefData}
+ * as {@code schema_ol_1}, {@code schema_ol_2}, etc., following the template line sequence order.
+ * Use these identifiers in subsequent "validate C_OrderLine:" steps.
  */
 @RequiredArgsConstructor
 public class C_CompensationGroup_CreateFromSchema_StepDef
@@ -78,13 +87,20 @@ public class C_CompensationGroup_CreateFromSchema_StepDef
 
 	private final OrderGroupRepository orderGroupsRepo = SpringContextHolder.instance.getBean(OrderGroupRepository.class);
 	private final GroupTemplateRepository groupTemplateRepo = SpringContextHolder.instance.getBean(GroupTemplateRepository.class);
+	private final OrderGroupPIInheritanceService piInheritanceService = new OrderGroupPIInheritanceService();
 
 	/**
 	 * Creates a compensation group from a schema template on the given order, then optionally
-	 * applies PI inheritance if the schema has IsInheritPackingInstruction=Y.
+	 * applies PI inheritance if the schema has {@code IsInheritPackingInstruction=Y}.
 	 * <p>
-	 * Created order lines are stored in {@link C_OrderLine_StepDefData} using generated identifiers
-	 * of the form {@code schema_ol_1}, {@code schema_ol_2}, etc.
+	 * Created order lines are registered in {@link C_OrderLine_StepDefData} as
+	 * {@code schema_ol_1}, {@code schema_ol_2}, etc. (1-based, following template line {@code SeqNo} order).
+	 * These identifiers can be used in subsequent verification steps, e.g.:
+	 * <pre>{@code
+	 * Then validate C_OrderLine:
+	 *   | C_OrderLine_ID | M_Product_ID | OPT.M_HU_PI_Item_Product_ID.Identifier |
+	 *   | schema_ol_1    | subProduct1  | piProd_sub1                             |
+	 * }</pre>
 	 */
 	@When("create compensation group from schema template:")
 	public void createGroupFromSchemaTemplate(@NonNull final DataTable dataTable)
@@ -107,7 +123,7 @@ public class C_CompensationGroup_CreateFromSchema_StepDef
 					.qty(qty)
 					.createGroup(orderId, null);
 
-			// Apply PI inheritance if the schema flag is set and a PI was provided
+			// Apply PI inheritance using the production code path (OrderLineQuickInputProcessor)
 			if (groupTemplate.isInheritPackingInstruction())
 			{
 				row.getAsOptionalIdentifier("M_HU_PI_Item_Product_ID")
@@ -115,7 +131,7 @@ public class C_CompensationGroup_CreateFromSchema_StepDef
 							final I_M_HU_PI_Item_Product mainPiItemProductRecord = piIdentifier.lookupNotNullIn(huPiItemProductTable);
 							final HUPIItemProductId mainPiItemProductId = HUPIItemProductId.ofRepoId(mainPiItemProductRecord.getM_HU_PI_Item_Product_ID());
 
-							applyPackingInstructionInheritance(order, group, mainPiItemProductId);
+							piInheritanceService.applyPackingInstructionInheritance(order, group, mainPiItemProductId);
 						});
 			}
 
@@ -128,39 +144,5 @@ public class C_CompensationGroup_CreateFromSchema_StepDef
 				lineIndex++;
 			}
 		});
-	}
-
-	/**
-	 * Applies PI inheritance: resolves a compatible M_HU_PI_Item_Product for each sub-article
-	 * using the same M_HU_PI_Item (TU type) as the main article's PI.
-	 * <p>
-	 * This mirrors the logic in {@code OrderLineQuickInputProcessor.applyPackingInstructionFromQuickInput()}.
-	 */
-	private static void applyPackingInstructionInheritance(
-			@NonNull final I_C_Order order,
-			@NonNull final Group group,
-			@NonNull final HUPIItemProductId mainPiItemProductId)
-	{
-		final IHUPIItemProductDAO piItemProductDAO = Services.get(IHUPIItemProductDAO.class);
-		final HUPIItemProduct mainPiItemProduct = piItemProductDAO.getById(mainPiItemProductId);
-		final HuPackingInstructionsItemId piItemId = mainPiItemProduct.getPiItemId();
-		final I_M_HU_PI_Item piItem = InterfaceWrapperHelper.load(piItemId.getRepoId(), I_M_HU_PI_Item.class);
-
-		final BPartnerId bpartnerId = BPartnerId.ofRepoIdOrNull(order.getC_BPartner_ID());
-
-		for (final GroupRegularLine regularLine : group.getRegularLines())
-		{
-			final de.metas.handlingunits.model.I_C_OrderLine orderLine = InterfaceWrapperHelper.load(
-					regularLine.getRepoId(), de.metas.handlingunits.model.I_C_OrderLine.class);
-			final ProductId productId = ProductId.ofRepoId(orderLine.getM_Product_ID());
-
-			final I_M_HU_PI_Item_Product matchingPiItemProduct = piItemProductDAO.retrievePIMaterialItemProduct(
-					piItem, bpartnerId, productId, null);
-			if (matchingPiItemProduct != null)
-			{
-				orderLine.setM_HU_PI_Item_Product_ID(matchingPiItemProduct.getM_HU_PI_Item_Product_ID());
-				InterfaceWrapperHelper.save(orderLine);
-			}
-		}
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_Schema_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_Schema_StepDef.java
@@ -52,6 +52,7 @@ public class C_CompensationGroup_Schema_StepDef
 {
 	private final @NonNull C_CompensationGroup_Schema_StepDefData schemaTable;
 
+	/** Creates compensation group schema records. Add template lines via the separate TemplateLine step. */
 	@Given("metasfresh contains C_CompensationGroup_Schema:")
 	public void createSchemas(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_Schema_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_Schema_StepDef.java
@@ -1,0 +1,70 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.order;
+
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.order.model.I_C_CompensationGroup_Schema;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+
+/**
+ * Step definitions for creating {@link I_C_CompensationGroup_Schema} records.
+ * <p>
+ * These schemas define compensation group templates that are used when creating
+ * order lines via Quick Input for "Mischkarton" (mixed carton) products.
+ * <p>
+ * DataTable columns:
+ * <ul>
+ *     <li>{@code Identifier} (required) — identifier for later reference</li>
+ *     <li>{@code Name} (required) — name of the schema</li>
+ *     <li>{@code IsInheritPackingInstruction} (optional, default N) — if Y, sub-article order lines
+ *         inherit the packing instruction from the main article. Each sub-article must have a compatible
+ *         M_HU_PI_Item_Product for the same TU type, otherwise inheritance is skipped for that article.</li>
+ * </ul>
+ */
+@RequiredArgsConstructor
+public class C_CompensationGroup_Schema_StepDef
+{
+	private final @NonNull C_CompensationGroup_Schema_StepDefData schemaTable;
+
+	@Given("metasfresh contains C_CompensationGroup_Schema:")
+	public void createSchemas(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_C_CompensationGroup_Schema record = newInstance(I_C_CompensationGroup_Schema.class);
+			record.setName(row.getAsString(I_C_CompensationGroup_Schema.COLUMNNAME_Name));
+
+			row.getAsOptionalBoolean(I_C_CompensationGroup_Schema.COLUMNNAME_IsInheritPackingInstruction)
+					.ifPresent(record::setIsInheritPackingInstruction);
+
+			saveRecord(record);
+
+			schemaTable.putOrReplace(row.getAsIdentifier(), record);
+		});
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_Schema_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_Schema_StepDefData.java
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.order;
+
+import de.metas.cucumber.stepdefs.StepDefData;
+import de.metas.order.model.I_C_CompensationGroup_Schema;
+
+/** StepDefData holder for {@link I_C_CompensationGroup_Schema} records, auto-discovered by PicoContainer. */
+public class C_CompensationGroup_Schema_StepDefData extends StepDefData<I_C_CompensationGroup_Schema>
+{
+	public C_CompensationGroup_Schema_StepDefData()
+	{
+		super(I_C_CompensationGroup_Schema.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_Schema_TemplateLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_Schema_TemplateLine_StepDef.java
@@ -64,6 +64,12 @@ public class C_CompensationGroup_Schema_TemplateLine_StepDef
 	private final @NonNull C_CompensationGroup_Schema_TemplateLine_StepDefData templateLineTable;
 	private final @NonNull M_Product_StepDefData productTable;
 
+	/**
+	 * Creates template line records that define which sub-article products (and quantities) are added
+	 * when a compensation group is generated from the parent schema.
+	 * <p>
+	 * Note: {@code C_UOM_ID} expects an X12DE355 code (e.g., "PCE", "KGM"), not an identifier reference.
+	 */
 	@Given("metasfresh contains C_CompensationGroup_Schema_TemplateLine:")
 	public void createTemplateLines(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_Schema_TemplateLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_Schema_TemplateLine_StepDef.java
@@ -1,0 +1,93 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.order;
+
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.M_Product_StepDefData;
+import de.metas.order.model.I_C_CompensationGroup_Schema;
+import de.metas.order.model.I_C_CompensationGroup_Schema_TemplateLine;
+import de.metas.uom.IUOMDAO;
+import de.metas.uom.UomId;
+import de.metas.uom.X12DE355;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.compiere.model.I_M_Product;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+
+/**
+ * Step definitions for creating {@link I_C_CompensationGroup_Schema_TemplateLine} records.
+ * <p>
+ * Template lines define which sub-article products (and their quantities) are created
+ * when a compensation group is generated from a schema template.
+ * <p>
+ * DataTable columns:
+ * <ul>
+ *     <li>{@code Identifier} (required) — identifier for later reference</li>
+ *     <li>{@code C_CompensationGroup_Schema_ID} (required) — identifier of the parent schema</li>
+ *     <li>{@code M_Product_ID} (required) — identifier of the sub-article product</li>
+ *     <li>{@code Qty} (required) — quantity per template line</li>
+ *     <li>{@code C_UOM_ID} (required) — X12DE355 code of the UOM (e.g., "PCE", "KGM")</li>
+ *     <li>{@code SeqNo} (required) — sequence number for ordering</li>
+ * </ul>
+ */
+@RequiredArgsConstructor
+public class C_CompensationGroup_Schema_TemplateLine_StepDef
+{
+	private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
+
+	private final @NonNull C_CompensationGroup_Schema_StepDefData schemaTable;
+	private final @NonNull C_CompensationGroup_Schema_TemplateLine_StepDefData templateLineTable;
+	private final @NonNull M_Product_StepDefData productTable;
+
+	@Given("metasfresh contains C_CompensationGroup_Schema_TemplateLine:")
+	public void createTemplateLines(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_C_CompensationGroup_Schema schema = row.getAsIdentifier(I_C_CompensationGroup_Schema_TemplateLine.COLUMNNAME_C_CompensationGroup_Schema_ID)
+					.lookupNotNullIn(schemaTable);
+
+			final I_M_Product product = row.getAsIdentifier(I_C_CompensationGroup_Schema_TemplateLine.COLUMNNAME_M_Product_ID)
+					.lookupNotNullIn(productTable);
+
+			final String x12de355 = row.getAsString(I_C_CompensationGroup_Schema_TemplateLine.COLUMNNAME_C_UOM_ID);
+			final UomId uomId = uomDAO.getUomIdByX12DE355(X12DE355.ofCode(x12de355));
+
+			final I_C_CompensationGroup_Schema_TemplateLine record = newInstance(I_C_CompensationGroup_Schema_TemplateLine.class);
+			record.setAD_Org_ID(schema.getAD_Org_ID());
+			record.setC_CompensationGroup_Schema_ID(schema.getC_CompensationGroup_Schema_ID());
+			record.setM_Product_ID(product.getM_Product_ID());
+			record.setC_UOM_ID(uomId.getRepoId());
+			record.setQty(row.getAsBigDecimal(I_C_CompensationGroup_Schema_TemplateLine.COLUMNNAME_Qty));
+			record.setSeqNo(row.getAsInt(I_C_CompensationGroup_Schema_TemplateLine.COLUMNNAME_SeqNo));
+
+			saveRecord(record);
+
+			templateLineTable.putOrReplace(row.getAsIdentifier(), record);
+		});
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_Schema_TemplateLine_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_Schema_TemplateLine_StepDefData.java
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.order;
+
+import de.metas.cucumber.stepdefs.StepDefData;
+import de.metas.order.model.I_C_CompensationGroup_Schema_TemplateLine;
+
+/** StepDefData holder for {@link I_C_CompensationGroup_Schema_TemplateLine} records, auto-discovered by PicoContainer. */
+public class C_CompensationGroup_Schema_TemplateLine_StepDefData extends StepDefData<I_C_CompensationGroup_Schema_TemplateLine>
+{
+	public C_CompensationGroup_Schema_TemplateLine_StepDefData()
+	{
+		super(I_C_CompensationGroup_Schema_TemplateLine.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/compensationGroupPIInheritance.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/compensationGroupPIInheritance.feature
@@ -1,0 +1,170 @@
+@from:cucumber
+@ghActions:run_on_executor5
+Feature: Compensation Group PI Inheritance
+
+  When a compensation group schema has IsInheritPackingInstruction=Y, creating a group
+  from the template should apply a compatible packing instruction to each sub-article
+  order line, based on the main article's M_HU_PI_Item (TU type).
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-05-17T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+
+  @from:cucumber
+  @Id:S0468_040
+  Scenario: Compensation group with IsInheritPackingInstruction=Y copies PI to sub-articles
+    # -- Products: main article + 2 sub-articles --
+    Given metasfresh contains M_Products:
+      | Identifier   |
+      | mainProduct  |
+      | subProduct1  |
+      | subProduct2  |
+
+    # -- Pricing setup --
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name             | Value            |
+      | ps_pi      | ps_pi_inherit    | ps_pi_inherit    |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Currency.ISO_Code | Name       | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_pi      | ps_pi              | EUR                 | pl_pi_inh  | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID | Name       | ValidFrom  |
+      | plv_pi     | pl_pi          | plv_pi_inh | 2022-01-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_TaxCategory_ID.InternalName | C_UOM_ID.X12DE355 |
+      | pp_main    | plv_pi                 | mainProduct  | 10.0     | Normal                        | PCE               |
+      | pp_sub1    | plv_pi                 | subProduct1  | 5.0      | Normal                        | PCE               |
+      | pp_sub2    | plv_pi                 | subProduct2  | 3.0      | Normal                        | PCE               |
+
+    # -- HU Packing Instructions: a TU (e.g., "Mischkarton") with PI Item Products for all 3 products --
+    And metasfresh contains M_HU_PI:
+      | Identifier | Name           |
+      | huPI_TU    | Mischkarton_TU |
+    And metasfresh contains M_HU_PI_Version:
+      | Identifier   | M_HU_PI_ID | HU_UnitType |
+      | huPIV_TU     | huPI_TU     | TU          |
+    And metasfresh contains M_HU_PI_Item:
+      | Identifier   | M_HU_PI_Version_ID | ItemType |
+      | huPIItem_mat | huPIV_TU            | MI       |
+
+    # PI Item Product for main article (this is the one Quick Input would resolve)
+    And metasfresh contains M_HU_PI_Item_Product:
+      | Identifier       | M_HU_PI_Item_ID | M_Product_ID | Qty | C_UOM_ID.X12DE355 |
+      | piProd_main      | huPIItem_mat     | mainProduct  | 1   | PCE                |
+    # PI Item Product for sub-article 1 (compatible — same M_HU_PI_Item)
+    And metasfresh contains M_HU_PI_Item_Product:
+      | Identifier       | M_HU_PI_Item_ID | M_Product_ID | Qty | C_UOM_ID.X12DE355 |
+      | piProd_sub1      | huPIItem_mat     | subProduct1  | 8   | PCE                |
+    # PI Item Product for sub-article 2 (compatible — same M_HU_PI_Item)
+    And metasfresh contains M_HU_PI_Item_Product:
+      | Identifier       | M_HU_PI_Item_ID | M_Product_ID | Qty | C_UOM_ID.X12DE355 |
+      | piProd_sub2      | huPIItem_mat     | subProduct2  | 8   | PCE                |
+
+    # -- Compensation Group Schema with IsInheritPackingInstruction=Y --
+    And metasfresh contains C_CompensationGroup_Schema:
+      | Identifier | Name        | IsInheritPackingInstruction |
+      | schema_1   | Mischkarton | Y                           |
+    And metasfresh contains C_CompensationGroup_Schema_TemplateLine:
+      | Identifier | C_CompensationGroup_Schema_ID | M_Product_ID | Qty | C_UOM_ID | SeqNo |
+      | tl_sub1    | schema_1                      | subProduct1  | 8   | PCE      | 10    |
+      | tl_sub2    | schema_1                      | subProduct2  | 8   | PCE      | 20    |
+
+    # -- BPartner + Order --
+    And metasfresh contains C_BPartners:
+      | Identifier  | Name           | IsCustomer | M_PricingSystem_ID |
+      | bp_pi_test  | PI_Test_BP     | Y          | ps_pi              |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered |
+      | order_pi   | true    | bp_pi_test    | 2022-05-17  |
+
+    # -- Create group from schema template, applying PI from main article --
+    When create compensation group from schema template:
+      | C_Order_ID | C_CompensationGroup_Schema_ID | Qty | M_HU_PI_Item_Product_ID |
+      | order_pi   | schema_1                      | 1   | piProd_main             |
+
+    # -- Verify: both sub-article order lines got their own compatible PI --
+    Then metasfresh has C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | OPT.M_HU_PI_Item_Product_ID.Identifier |
+      | schema_ol_1 | order_pi   | subProduct1  | piProd_sub1                             |
+      | schema_ol_2 | order_pi   | subProduct2  | piProd_sub2                             |
+
+  @from:cucumber
+  @Id:S0468_050
+  Scenario: Compensation group with IsInheritPackingInstruction=Y skips articles without compatible PI
+    # -- Products: main article + 1 sub-article WITH PI + 1 sub-article WITHOUT PI --
+    Given metasfresh contains M_Products:
+      | Identifier      |
+      | mainProduct2    |
+      | subWithPI       |
+      | subWithoutPI    |
+
+    # -- Pricing setup --
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name              | Value             |
+      | ps_pi2     | ps_pi_skip        | ps_pi_skip        |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Currency.ISO_Code | Name        | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_pi2     | ps_pi2             | EUR                 | pl_pi_skip  | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID | Name        | ValidFrom  |
+      | plv_pi2    | pl_pi2         | plv_pi_skip | 2022-01-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_TaxCategory_ID.InternalName | C_UOM_ID.X12DE355 |
+      | pp_main2   | plv_pi2                | mainProduct2 | 10.0     | Normal                        | PCE               |
+      | pp_sub3    | plv_pi2                | subWithPI    | 5.0      | Normal                        | PCE               |
+      | pp_sub4    | plv_pi2                | subWithoutPI | 3.0      | Normal                        | PCE               |
+
+    # -- HU PI: only main + subWithPI have PI Item Products --
+    And metasfresh contains M_HU_PI:
+      | Identifier  | Name            |
+      | huPI_TU2    | Mischkarton_TU2 |
+    And metasfresh contains M_HU_PI_Version:
+      | Identifier  | M_HU_PI_ID | HU_UnitType |
+      | huPIV_TU2   | huPI_TU2    | TU          |
+    And metasfresh contains M_HU_PI_Item:
+      | Identifier    | M_HU_PI_Version_ID | ItemType |
+      | huPIItem_mat2 | huPIV_TU2           | MI       |
+
+    And metasfresh contains M_HU_PI_Item_Product:
+      | Identifier        | M_HU_PI_Item_ID | M_Product_ID | Qty | C_UOM_ID.X12DE355 |
+      | piProd_main2      | huPIItem_mat2    | mainProduct2 | 1   | PCE                |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | Identifier        | M_HU_PI_Item_ID | M_Product_ID | Qty | C_UOM_ID.X12DE355 |
+      | piProd_subWithPI   | huPIItem_mat2    | subWithPI    | 8   | PCE                |
+    # NOTE: No M_HU_PI_Item_Product for subWithoutPI — inheritance should be skipped for it
+
+    # -- Schema + template lines --
+    And metasfresh contains C_CompensationGroup_Schema:
+      | Identifier | Name         | IsInheritPackingInstruction |
+      | schema_2   | Mischkarton2 | Y                           |
+    And metasfresh contains C_CompensationGroup_Schema_TemplateLine:
+      | Identifier | C_CompensationGroup_Schema_ID | M_Product_ID | Qty | C_UOM_ID | SeqNo |
+      | tl2_sub1   | schema_2                      | subWithPI    | 8   | PCE      | 10    |
+      | tl2_sub2   | schema_2                      | subWithoutPI | 4   | PCE      | 20    |
+
+    # -- BPartner + Order --
+    And metasfresh contains C_BPartners:
+      | Identifier   | Name            | IsCustomer | M_PricingSystem_ID |
+      | bp_pi_test2  | PI_Test_BP2     | Y          | ps_pi2             |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered |
+      | order_pi2  | true    | bp_pi_test2   | 2022-05-17  |
+
+    # -- Create group, providing main article's PI --
+    When create compensation group from schema template:
+      | C_Order_ID | C_CompensationGroup_Schema_ID | Qty | M_HU_PI_Item_Product_ID |
+      | order_pi2  | schema_2                      | 1   | piProd_main2            |
+
+    # -- Verify: subWithPI got PI, subWithoutPI kept default (101 = Virtual/No Packing Item) --
+    Then metasfresh has C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | OPT.M_HU_PI_Item_Product_ID.Identifier |
+      | schema_ol_1 | order_pi2  | subWithPI    | piProd_subWithPI                        |
+    # subWithoutPI should NOT have piProd_subWithPI — it should have the default (101)
+    # We verify it exists but don't check PI (no compatible PI was found, so it stays at default)
+    And metasfresh has C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID |
+      | schema_ol_2 | order_pi2  | subWithoutPI |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/compensationGroupPIInheritance.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/compensationGroupPIInheritance.feature
@@ -86,10 +86,10 @@ Feature: Compensation Group PI Inheritance
       | order_pi   | schema_1                      | 1   | piProd_main             |
 
     # -- Verify: both sub-article order lines got their own compatible PI --
-    Then metasfresh has C_OrderLines:
-      | Identifier  | C_Order_ID | M_Product_ID | OPT.M_HU_PI_Item_Product_ID.Identifier |
-      | schema_ol_1 | order_pi   | subProduct1  | piProd_sub1                             |
-      | schema_ol_2 | order_pi   | subProduct2  | piProd_sub2                             |
+    Then validate C_OrderLine:
+      | C_OrderLine_ID | M_Product_ID | OPT.M_HU_PI_Item_Product_ID.Identifier |
+      | schema_ol_1    | subProduct1  | piProd_sub1                             |
+      | schema_ol_2    | subProduct2  | piProd_sub2                             |
 
   @from:cucumber
   @Id:S0468_050
@@ -160,11 +160,11 @@ Feature: Compensation Group PI Inheritance
       | order_pi2  | schema_2                      | 1   | piProd_main2            |
 
     # -- Verify: subWithPI got PI, subWithoutPI kept default (101 = Virtual/No Packing Item) --
-    Then metasfresh has C_OrderLines:
-      | Identifier  | C_Order_ID | M_Product_ID | OPT.M_HU_PI_Item_Product_ID.Identifier |
-      | schema_ol_1 | order_pi2  | subWithPI    | piProd_subWithPI                        |
+    Then validate C_OrderLine:
+      | C_OrderLine_ID | M_Product_ID | OPT.M_HU_PI_Item_Product_ID.Identifier |
+      | schema_ol_1    | subWithPI    | piProd_subWithPI                        |
     # subWithoutPI should NOT have piProd_subWithPI — it should have the default (101)
     # We verify it exists but don't check PI (no compatible PI was found, so it stays at default)
-    And metasfresh has C_OrderLines:
-      | Identifier  | C_Order_ID | M_Product_ID |
-      | schema_ol_2 | order_pi2  | subWithoutPI |
+    And validate C_OrderLine:
+      | C_OrderLine_ID | M_Product_ID |
+      | schema_ol_2    | subWithoutPI |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/order/OrderGroupPIInheritanceService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/order/OrderGroupPIInheritanceService.java
@@ -1,0 +1,93 @@
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.handlingunits.order;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.handlingunits.HUPIItemProduct;
+import de.metas.handlingunits.HUPIItemProductId;
+import de.metas.handlingunits.HuPackingInstructionsItemId;
+import de.metas.handlingunits.IHUPIItemProductDAO;
+import de.metas.handlingunits.model.I_M_HU_PI_Item;
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.order.compensationGroup.Group;
+import de.metas.order.compensationGroup.GroupRegularLine;
+import de.metas.product.ProductId;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_C_Order;
+
+/**
+ * Applies packing instruction (PI) inheritance to compensation group order lines.
+ * <p>
+ * Given a main article's {@link HUPIItemProductId}, resolves a product-specific compatible
+ * {@link I_M_HU_PI_Item_Product} for each regular line in the group, using the same
+ * {@code M_HU_PI_Item} (TU type) as the main article.
+ * <p>
+ * If no compatible PI exists for a sub-article's product, that order line is left unchanged
+ * (retains default PI=101 "No Packing Item").
+ * <p>
+ * Used by:
+ * <ul>
+ *     <li>{@code OrderLineQuickInputProcessor} — production path via Quick Input</li>
+ *     <li>Cucumber step defs — integration testing</li>
+ * </ul>
+ */
+public class OrderGroupPIInheritanceService
+{
+	private final IHUPIItemProductDAO piItemProductDAO = Services.get(IHUPIItemProductDAO.class);
+
+	/**
+	 * Applies PI inheritance to all regular lines in the given compensation group.
+	 *
+	 * @param order                the target order (used to resolve BPartner for PI lookup)
+	 * @param group                the compensation group whose regular lines will be updated
+	 * @param mainPiItemProductId  the main article's PI Item Product (determines the TU type to match)
+	 */
+	public void applyPackingInstructionInheritance(
+			@NonNull final I_C_Order order,
+			@NonNull final Group group,
+			@NonNull final HUPIItemProductId mainPiItemProductId)
+	{
+		final HUPIItemProduct mainPiItemProduct = piItemProductDAO.getById(mainPiItemProductId);
+		final HuPackingInstructionsItemId piItemId = mainPiItemProduct.getPiItemId();
+		final I_M_HU_PI_Item piItem = InterfaceWrapperHelper.load(piItemId.getRepoId(), I_M_HU_PI_Item.class);
+
+		final BPartnerId bpartnerId = BPartnerId.ofRepoIdOrNull(order.getC_BPartner_ID());
+
+		for (final GroupRegularLine regularLine : group.getRegularLines())
+		{
+			final de.metas.handlingunits.model.I_C_OrderLine orderLine = InterfaceWrapperHelper.load(
+					regularLine.getRepoId(), de.metas.handlingunits.model.I_C_OrderLine.class);
+			final ProductId productId = ProductId.ofRepoId(orderLine.getM_Product_ID());
+
+			final I_M_HU_PI_Item_Product matchingPiItemProduct = piItemProductDAO.retrievePIMaterialItemProduct(
+					piItem, bpartnerId, productId, null);
+			if (matchingPiItemProduct != null)
+			{
+				orderLine.setM_HU_PI_Item_Product_ID(matchingPiItemProduct.getM_HU_PI_Item_Product_ID());
+				InterfaceWrapperHelper.save(orderLine);
+			}
+		}
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/orderline/OrderLineQuickInputProcessor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/orderline/OrderLineQuickInputProcessor.java
@@ -31,10 +31,14 @@ import de.metas.adempiere.model.I_C_Order;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.ShipmentAllocationBestBeforePolicy;
 import de.metas.contracts.ConditionsId;
+import de.metas.handlingunits.HUPIItemProduct;
 import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.handlingunits.HuPackingInstructionsId;
+import de.metas.handlingunits.HuPackingInstructionsItemId;
+import de.metas.handlingunits.IHUPIItemProductDAO;
 import de.metas.handlingunits.IHandlingUnitsDAO;
 import de.metas.handlingunits.model.I_M_HU_PI_Item;
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.i18n.ITranslatableString;
 import de.metas.i18n.TranslatableStrings;
 import de.metas.lang.SOTrx;
@@ -196,7 +200,7 @@ public class OrderLineQuickInputProcessor implements IQuickInputProcessor
 		return orderLineQuickInput.getQty();
 	}
 
-	private static void applyPackingInstructionFromQuickInput(final QuickInput quickInput, final Group group)
+	private void applyPackingInstructionFromQuickInput(final QuickInput quickInput, final Group group)
 	{
 		final IOrderLineQuickInput quickInputModel = quickInput.getQuickInputDocumentAs(IOrderLineQuickInput.class);
 		final HUPIItemProductId piItemProductId = HUPIItemProductId.ofRepoIdOrNull(quickInputModel.getM_HU_PI_Item_Product_ID());
@@ -205,11 +209,25 @@ public class OrderLineQuickInputProcessor implements IQuickInputProcessor
 			return;
 		}
 
+		final IHUPIItemProductDAO piItemProductDAO = Services.get(IHUPIItemProductDAO.class);
+		final HUPIItemProduct mainPiItemProduct = piItemProductDAO.getById(piItemProductId);
+		final HuPackingInstructionsItemId piItemId = mainPiItemProduct.getPiItemId();
+		final I_M_HU_PI_Item piItem = InterfaceWrapperHelper.load(piItemId.getRepoId(), I_M_HU_PI_Item.class);
+
+		final I_C_Order order = quickInput.getRootDocumentAs(I_C_Order.class);
+		final BPartnerId bpartnerId = BPartnerId.ofRepoIdOrNull(order.getC_BPartner_ID());
+
 		for (final GroupRegularLine regularLine : group.getRegularLines())
 		{
 			final de.metas.handlingunits.model.I_C_OrderLine orderLine = InterfaceWrapperHelper.load(regularLine.getRepoId(), de.metas.handlingunits.model.I_C_OrderLine.class);
-			orderLine.setM_HU_PI_Item_Product_ID(piItemProductId.getRepoId());
-			InterfaceWrapperHelper.save(orderLine);
+			final ProductId productId = ProductId.ofRepoId(orderLine.getM_Product_ID());
+
+			final I_M_HU_PI_Item_Product matchingPiItemProduct = piItemProductDAO.retrievePIMaterialItemProduct(piItem, bpartnerId, productId, null);
+			if (matchingPiItemProduct != null)
+			{
+				orderLine.setM_HU_PI_Item_Product_ID(matchingPiItemProduct.getM_HU_PI_Item_Product_ID());
+				InterfaceWrapperHelper.save(orderLine);
+			}
 		}
 	}
 

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/orderline/OrderLineQuickInputProcessor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/orderline/OrderLineQuickInputProcessor.java
@@ -34,6 +34,7 @@ import de.metas.contracts.ConditionsId;
 import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.handlingunits.HuPackingInstructionsId;
 import de.metas.handlingunits.IHandlingUnitsDAO;
+import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.order.OrderGroupPIInheritanceService;
 import de.metas.i18n.ITranslatableString;
 import de.metas.i18n.TranslatableStrings;

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/orderline/OrderLineQuickInputProcessor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/orderline/OrderLineQuickInputProcessor.java
@@ -31,14 +31,10 @@ import de.metas.adempiere.model.I_C_Order;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.ShipmentAllocationBestBeforePolicy;
 import de.metas.contracts.ConditionsId;
-import de.metas.handlingunits.HUPIItemProduct;
 import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.handlingunits.HuPackingInstructionsId;
-import de.metas.handlingunits.HuPackingInstructionsItemId;
-import de.metas.handlingunits.IHUPIItemProductDAO;
 import de.metas.handlingunits.IHandlingUnitsDAO;
-import de.metas.handlingunits.model.I_M_HU_PI_Item;
-import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.handlingunits.order.OrderGroupPIInheritanceService;
 import de.metas.i18n.ITranslatableString;
 import de.metas.i18n.TranslatableStrings;
 import de.metas.lang.SOTrx;
@@ -101,6 +97,7 @@ public class OrderLineQuickInputProcessor implements IQuickInputProcessor
 	private final IProductBL productBL = Services.get(IProductBL.class);
 	private final IAttributeSetInstanceBL asiBL = Services.get(IAttributeSetInstanceBL.class);
 	private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
+	private final OrderGroupPIInheritanceService piInheritanceService = new OrderGroupPIInheritanceService();
 
 	private final OrderGroupRepository orderGroupsRepo = SpringContextHolder.instance.getBean(OrderGroupRepository.class);
 	private final GroupTemplateRepository groupTemplateRepo = SpringContextHolder.instance.getBean(GroupTemplateRepository.class);
@@ -209,26 +206,8 @@ public class OrderLineQuickInputProcessor implements IQuickInputProcessor
 			return;
 		}
 
-		final IHUPIItemProductDAO piItemProductDAO = Services.get(IHUPIItemProductDAO.class);
-		final HUPIItemProduct mainPiItemProduct = piItemProductDAO.getById(piItemProductId);
-		final HuPackingInstructionsItemId piItemId = mainPiItemProduct.getPiItemId();
-		final I_M_HU_PI_Item piItem = InterfaceWrapperHelper.load(piItemId.getRepoId(), I_M_HU_PI_Item.class);
-
 		final I_C_Order order = quickInput.getRootDocumentAs(I_C_Order.class);
-		final BPartnerId bpartnerId = BPartnerId.ofRepoIdOrNull(order.getC_BPartner_ID());
-
-		for (final GroupRegularLine regularLine : group.getRegularLines())
-		{
-			final de.metas.handlingunits.model.I_C_OrderLine orderLine = InterfaceWrapperHelper.load(regularLine.getRepoId(), de.metas.handlingunits.model.I_C_OrderLine.class);
-			final ProductId productId = ProductId.ofRepoId(orderLine.getM_Product_ID());
-
-			final I_M_HU_PI_Item_Product matchingPiItemProduct = piItemProductDAO.retrievePIMaterialItemProduct(piItem, bpartnerId, productId, null);
-			if (matchingPiItemProduct != null)
-			{
-				orderLine.setM_HU_PI_Item_Product_ID(matchingPiItemProduct.getM_HU_PI_Item_Product_ID());
-				InterfaceWrapperHelper.save(orderLine);
-			}
-		}
+		piInheritanceService.applyPackingInstructionInheritance(order, group, piItemProductId);
 	}
 
 	private void validateInput(final OrderLineCandidate candidate)


### PR DESCRIPTION
## Summary
- The original migration (5792610) set English text on the base `AD_Element` record, but metasfresh base language is `de_DE`
- This caused the field to display "Inherit Packing Instruction" (English) instead of "Packvorschrift vererben" (German) when logged in with `de_DE`
- Fix: update base `AD_Element` with German text, re-propagate to all downstream AD records

## Test plan
- [ ] Apply migration on test DB
- [ ] Log in with `de_DE` → field shows "Packvorschrift vererben"
- [ ] Log in with `en_US` → field shows "Inherit Packing Instruction"