### PR TITLE
gh#28675 Expose field description and help text as tooltips in WebUI

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/GridFieldVO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/GridFieldVO.java
@@ -848,7 +848,7 @@ public class GridFieldVO implements Serializable
 	 * Help
 	 */
 	@Getter private String help = "";
-	private Map<String, String> helpTrls = null; // lazy
+	@Getter private Map<String, String> helpTrls = null; // lazy
 	/**
 	 * Mandatory Logic
 	 */

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/datatypes/json/JSONDocumentLayoutElement.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/datatypes/json/JSONDocumentLayoutElement.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import de.metas.process.BarcodeScannerType;
 import de.metas.ui.web.process.ProcessId;
@@ -91,6 +92,10 @@ public final class JSONDocumentLayoutElement
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private final String description;
 
+	@JsonProperty("help")
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private final String help;
+
 	@JsonProperty("widgetType")
 	private final JSONLayoutWidgetType widgetType;
 
@@ -173,7 +178,8 @@ public final class JSONDocumentLayoutElement
 			this.caption = caption;
 		}
 
-		description = element.getDescription(adLanguage);
+		description = Strings.emptyToNull(element.getDescription(adLanguage));
+		help = Strings.emptyToNull(element.getHelp(adLanguage));
 
 		widgetType = JSONLayoutWidgetType.fromNullable(element.getWidgetType());
 		maxLength = element.getMaxLength() > 0 ? element.getMaxLength() : null;
@@ -224,6 +230,7 @@ public final class JSONDocumentLayoutElement
 	{
 		caption = fieldName;
 		description = null;
+		help = null;
 
 		this.widgetType = JSONLayoutWidgetType.fromNullable(widgetType);
 		allowShowPassword = null;

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/DocumentFieldDescriptor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/DocumentFieldDescriptor.java
@@ -79,6 +79,7 @@ public final class DocumentFieldDescriptor
 	@Getter private final String fieldName;
 	@Getter private final ITranslatableString caption;
 	@Getter private final ITranslatableString description;
+	@Getter private final ITranslatableString help;
 	/**
 	 * Detail ID or null if this is a field in main sections
 	 */
@@ -161,6 +162,7 @@ public final class DocumentFieldDescriptor
 		fieldName = Preconditions.checkNotNull(builder.fieldName, "name is null");
 		caption = builder.getCaption();
 		description = builder.getDescription();
+		help = builder.getHelp();
 		detailId = builder.getDetailId();
 
 		key = builder.isKey();
@@ -313,6 +315,7 @@ public final class DocumentFieldDescriptor
 		@Getter private final String fieldName;
 		private ITranslatableString caption;
 		private ITranslatableString description;
+		private ITranslatableString help;
 		public DetailId _detailId;
 
 		private boolean key = false;
@@ -454,6 +457,27 @@ public final class DocumentFieldDescriptor
 				return TranslatableStrings.empty();
 			}
 			return description;
+		}
+
+		public Builder setHelp(final Map<String, String> helpTrls, final String defaultHelp)
+		{
+			help = TranslatableStrings.ofMap(helpTrls, defaultHelp);
+			return this;
+		}
+
+		public Builder setHelp(final ITranslatableString help)
+		{
+			this.help = help;
+			return this;
+		}
+
+		public ITranslatableString getHelp()
+		{
+			if (help == null)
+			{
+				return TranslatableStrings.empty();
+			}
+			return help;
 		}
 
 		/* package */Builder setDetailId(final DetailId detailId)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/DocumentLayoutElementDescriptor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/DocumentLayoutElementDescriptor.java
@@ -64,7 +64,8 @@ public final class DocumentLayoutElementDescriptor
 
 		final Builder elementBuilder = new Builder()
 				.setCaption(firstField.getCaption())
-				// .setDescription(firstField.getDescription())
+				.setDescription(firstField.getDescription())
+				.setHelp(firstField.getHelp())
 				.setWidgetType(firstField.getWidgetType())
 				.setMaxLength(firstField.getFieldMaxLength())
 				.setWidgetSize(firstField.getWidgetSize());
@@ -106,6 +107,7 @@ public final class DocumentLayoutElementDescriptor
 
 	private final ITranslatableString caption;
 	private final ITranslatableString description;
+	private final ITranslatableString help;
 
 	@Getter
 	private final DocumentFieldWidgetType widgetType;
@@ -154,6 +156,7 @@ public final class DocumentLayoutElementDescriptor
 
 		caption = builder.getCaption();
 		description = builder.getDescription();
+		help = builder.getHelp();
 
 		widgetType = builder.getWidgetType();
 
@@ -216,6 +219,11 @@ public final class DocumentLayoutElementDescriptor
 		return description.translate(adLanguage);
 	}
 
+	public String getHelp(final String adLanguage)
+	{
+		return help.translate(adLanguage);
+	}
+
 	public boolean isEmpty()
 	{
 		return getFields().isEmpty() && inlineTabId == null;
@@ -239,6 +247,7 @@ public final class DocumentLayoutElementDescriptor
 		private String _internalName;
 		private ITranslatableString _caption = null;
 		private ITranslatableString _description = null;
+		private ITranslatableString _help = null;
 
 		private DocumentFieldWidgetType _widgetType;
 		private boolean _allowShowPassword = false; // in case widgetType is Password
@@ -411,6 +420,17 @@ public final class DocumentLayoutElementDescriptor
 		private ITranslatableString getDescription()
 		{
 			return TranslatableStrings.nullToEmpty(_description);
+		}
+
+		public Builder setHelp(@Nullable final ITranslatableString help)
+		{
+			_help = TranslatableStrings.nullToEmpty(help);
+			return this;
+		}
+
+		private ITranslatableString getHelp()
+		{
+			return TranslatableStrings.nullToEmpty(_help);
 		}
 
 		public Builder setWidgetType(final DocumentFieldWidgetType widgetType)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/GridTabVOBasedDocumentEntityDescriptorFactory.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/GridTabVOBasedDocumentEntityDescriptorFactory.java
@@ -538,6 +538,7 @@ import static de.metas.ui.web.window.WindowConstants.SYS_CONFIG_AD_ORG_ID_IS_DIS
 		final DocumentFieldDescriptor.Builder fieldBuilder = DocumentFieldDescriptor.builder(sqlColumnName)
 				.setCaption(gridFieldVO.getHeaderTrls(), gridFieldVO.getHeader())
 				.setDescription(gridFieldVO.getDescriptionTrls(), gridFieldVO.getDescription())
+				.setHelp(gridFieldVO.getHelpTrls(), gridFieldVO.getHelp())
 				//
 				.setKey(keyColumn)
 				.setParentLink(isParentLinkColumn, parentLinkFieldName)

--- a/frontend/src/assets/css/inputs.scss
+++ b/frontend/src/assets/css/inputs.scss
@@ -73,6 +73,44 @@ input {
     text-decoration: underline;
     cursor: pointer;
   }
+
+  &.field-tooltip-trigger {
+    position: relative;
+    overflow: visible;
+
+    .field-tooltip-popup {
+      display: none;
+      position: absolute;
+      left: 0;
+      top: 100%;
+      z-index: 1000;
+      min-width: 200px;
+      max-width: 360px;
+      padding: 8px 10px;
+      background: #333;
+      color: #fff;
+      border-radius: 4px;
+      font-size: 12px;
+      font-weight: normal;
+      line-height: 1.4;
+      white-space: normal;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+      pointer-events: none;
+    }
+
+    &:hover .field-tooltip-popup {
+      display: block;
+    }
+
+    .field-tooltip-description {
+      font-weight: 600;
+    }
+
+    .field-tooltip-help {
+      margin-top: 4px;
+      opacity: 0.85;
+    }
+  }
 }
 
 .form-group {

--- a/frontend/src/components/widget/RawWidget.js
+++ b/frontend/src/components/widget/RawWidget.js
@@ -535,6 +535,7 @@ export class RawWidget extends PureComponent {
     const {
       caption,
       description,
+      help,
       captionElement,
       fields,
       type,
@@ -634,11 +635,20 @@ export class RawWidget extends PureComponent {
           <label
             className={classnames('form-control-label', labelClass, {
               'zoom-into': fields[0].supportZoomInto,
+              'field-tooltip-trigger': !!(description || help),
             })}
-            title={description || caption}
+            title={!description && !help ? caption : undefined}
             {...labelProps}
           >
             {caption}
+            {(description || help) && (
+              <div className="field-tooltip-popup">
+                {description && (
+                  <div className="field-tooltip-description">{description}</div>
+                )}
+                {help && <div className="field-tooltip-help">{help}</div>}
+              </div>
+            )}
           </label>
         )}
         <div
@@ -756,6 +766,7 @@ RawWidget.propTypes = {
   barcodeScannerType: PropTypes.string,
   layoutType: PropTypes.string,
   description: PropTypes.string,
+  help: PropTypes.string,
   captionElement: PropTypes.string,
   //
   // Callbacks and other functions:


### PR DESCRIPTION
## Summary
- Exposes AD_Element **Description** and **Help** text as styled hover tooltips on field labels in the WebUI
- The pipeline was half-built: backend had the plumbing but `setDescription` was commented out and `help` was never carried through
- Now both `description` and `help` are sent in the layout JSON and rendered as a dark popup tooltip on label hover

## Changes

### Backend (5 files)
- **GridFieldVO**: Add `@Getter` to `helpTrls` for translation map access
- **DocumentFieldDescriptor**: Add `help` field with `ITranslatableString` and builder methods
- **DocumentLayoutElementDescriptor**: Uncomment `setDescription`, add `help` field and builder
- **JSONDocumentLayoutElement**: Add `help` JSON property, convert empty strings to null
- **GridTabVOBasedDocumentEntityDescriptorFactory**: Populate `help` from `gridFieldVO`

### Frontend (2 files)
- **RawWidget.js**: Render CSS tooltip popup (description bold, help lighter) on label hover; fallback to native `title` when neither exists
- **inputs.scss**: Tooltip styling (dark background, positioned below label, z-index 1000)

## Test plan
- [ ] Open any window with fields that have Description/Help text in AD_Element (e.g., Forecast window with the new descriptions from PR #22694)
- [ ] Hover over the field label — should see a dark tooltip popup with description (bold) and help text
- [ ] Fields without Description or Help should show the caption as native browser tooltip (unchanged behavior)
- [ ] Verify tooltip disappears on mouse leave
- [ ] Check in both German and English — translations should work