### PR TITLE
Propagate C_Project_ID to ICs and ShipmentSchedule on order line change

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/order/PurchaseOrderProjectListener.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/PurchaseOrderProjectListener.java
@@ -23,6 +23,7 @@
 package de.metas.order;
 
 import de.metas.project.ProjectId;
+import de.metas.user.UserId;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
@@ -51,5 +52,6 @@ public interface PurchaseOrderProjectListener
 	{
 		@NonNull ProjectId projectId;
 		@NonNull Set<OrderAndLineId> purchaseOrderLineIds;
+		@NonNull UserId byUserId;
 	}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order_Project.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order_Project.java
@@ -50,6 +50,7 @@ import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.ModelValidator;
+import org.compiere.util.Env;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
@@ -187,6 +188,7 @@ public class C_Order_Project
 		eventDispatcher.fireProjectCreatedEvent(ProjectCreatedEvent.builder()
 				.projectId(newProjectId)
 				.purchaseOrderLineIds(ImmutableSet.copyOf(poLinesUpdated.keySet()))
+				.byUserId(Env.getLoggedUserId())
 				.build());
 	}
 }

--- a/backend/de.metas.business/src/test/java/de/metas/order/ProjectCreatedEventTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/ProjectCreatedEventTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import de.metas.order.PurchaseOrderProjectListener.ProjectCreatedEvent;
 import de.metas.project.ProjectId;
+import de.metas.user.UserId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +27,7 @@ class ProjectCreatedEventTest
 	{
 		testSerializeDeserialize(ProjectCreatedEvent.builder()
 				.projectId(ProjectId.ofRepoId(123))
+				.byUserId(UserId.METASFRESH)
 				.purchaseOrderLineIds(ImmutableSet.of(
 						OrderAndLineId.ofRepoIds(1, 2),
 						OrderAndLineId.ofRepoIds(1, 3),

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
@@ -439,6 +439,13 @@ public class C_OrderLine_StepDef
 				orderLine.setM_AttributeSetInstance_ID(asiId);
 			}
 
+			final String projectIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_C_Project_ID + "." + TABLECOLUMN_IDENTIFIER);
+			if (Check.isNotBlank(projectIdentifier))
+			{
+				final I_C_Project project = projectTable.get(projectIdentifier);
+				orderLine.setC_Project_ID(project.getC_Project_ID());
+			}
+
 			saveRecord(orderLine);
 
 			orderLineTable.putOrReplace(olIdentifier, orderLine);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/salesOrderProjectPropagationOnChange.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/salesOrderProjectPropagationOnChange.feature
@@ -1,0 +1,75 @@
+@from:cucumber
+@ghActions:run_on_executor4
+Feature: C_Project_ID propagates when changed on existing order line
+
+  When C_Project_ID changes on a completed sales order line (e.g. inherited back from a dropship PO),
+  the interceptor pushes the new project to the corresponding invoice candidates and shipment schedule.
+
+  @from:cucumber
+  @me03_28709
+  Scenario: C_Project_ID update on order line propagates to invoice candidate and shipment schedule
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2021-04-16T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config de.metas.report.jasper.IsMockReportService
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_1       |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx |
+      | pl_1       | ps_1               | DE                    | EUR                 | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_1      | pl_1           |
+    And metasfresh contains C_BPartners:
+      | Identifier | IsCustomer | M_PricingSystem_ID |
+      | customer_1 | Y          | ps_1               |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | p_1        |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | plv_1                  | p_1          | 10.0     | PCE      |
+    And metasfresh contains C_Projects:
+      | Identifier |
+      | project_1  |
+
+    # Create and complete SO without project on order line
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered |
+      | so_1       | true    | customer_1    | 2021-04-17  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_1      | so_1       | p_1          | 10         |
+    And the order identified by so_1 is completed
+
+    # Wait for IC and shipment schedule to be created
+    Then after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ss_1       | sol_1          | N             |
+    And after not more than 60s, C_Invoice_Candidates are found:
+      | C_Invoice_Candidate_ID | C_OrderLine_ID |
+      | ic_1                   | sol_1          |
+
+    # Verify they have no project yet
+    And validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID | C_OrderLine_ID |
+      | ic_1                   | sol_1          |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID | C_OrderLine_ID |
+      | ss_1                  | sol_1          |
+
+    # Now simulate project being set on order line (as would happen in dropship scenario)
+    When update C_OrderLine:
+      | C_OrderLine_ID.Identifier | OPT.C_Project_ID.Identifier |
+      | sol_1                     | project_1                   |
+
+    # Verify project propagated to invoice candidate
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID | C_Project_ID |
+      | ic_1                   | project_1    |
+
+    # Verify project propagated to shipment schedule
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID | C_Project_ID |
+      | ss_1                  | project_1    |

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/UpdateSalesOrderFromPurchaseOrderProjectListener.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/UpdateSalesOrderFromPurchaseOrderProjectListener.java
@@ -87,6 +87,10 @@ public class UpdateSalesOrderFromPurchaseOrderProjectListener implements Purchas
 
 	private void saveAllForUserId(@NonNull final ProjectCreatedEvent event, @NonNull final Set<I_C_OrderLine> updatedOrderLines)
 	{
+		if (updatedOrderLines.isEmpty())
+		{
+			return;
+		}
 		final I_C_OrderLine firstOrderLine = CollectionUtils.first(updatedOrderLines);
 		final Properties properties = Env.copyCtx(InterfaceWrapperHelper.getCtx(firstOrderLine, true));
 		Env.setLoggedUserId(properties, event.getByUserId());

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/UpdateSalesOrderFromPurchaseOrderProjectListener.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/UpdateSalesOrderFromPurchaseOrderProjectListener.java
@@ -30,14 +30,18 @@ import de.metas.order.OrderLineId;
 import de.metas.order.PurchaseOrderProjectListener;
 import de.metas.project.ProjectId;
 import de.metas.util.Services;
+import de.metas.util.collections.CollectionUtils;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.util.lang.IAutoCloseable;
+import org.compiere.util.Env;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -46,6 +50,7 @@ import java.util.stream.Collectors;
  * <p>
  * This propagation ensures that when a project is associated with purchase order lines, the related sales order lines
  * (determined through {@link PurchaseCandidate}) are updated to reflect the same project ID.
+ * Since this is triggered via the EventBus, the environment needs to be switched to the user who triggered the event.
  */
 @Component
 @RequiredArgsConstructor
@@ -77,7 +82,17 @@ public class UpdateSalesOrderFromPurchaseOrderProjectListener implements Purchas
 				.filter(orderLine -> ProjectId.ofRepoIdOrNull(orderLine.getC_Project_ID()) == null)
 				.peek(orderLine -> orderLine.setC_Project_ID(projectId.getRepoId()))
 				.collect(Collectors.toSet());
-		InterfaceWrapperHelper.saveAll(updatedOrderLines);
+		saveAllForUserId(event, updatedOrderLines);
+	}
 
+	private void saveAllForUserId(@NonNull final ProjectCreatedEvent event, @NonNull final Set<I_C_OrderLine> updatedOrderLines)
+	{
+		final I_C_OrderLine firstOrderLine = CollectionUtils.first(updatedOrderLines);
+		final Properties properties = Env.copyCtx(InterfaceWrapperHelper.getCtx(firstOrderLine, true));
+		Env.setLoggedUserId(properties, event.getByUserId());
+		try (final IAutoCloseable ignored = Env.switchContext(properties))
+		{
+			InterfaceWrapperHelper.saveAll(updatedOrderLines);
+		}
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleBL.java
@@ -35,6 +35,7 @@ import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
 import de.metas.process.PInstanceId;
+import de.metas.project.ProjectId;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
 import de.metas.storage.IStorageQuery;
@@ -42,6 +43,8 @@ import de.metas.uom.UomId;
 import de.metas.util.ISingletonService;
 import lombok.NonNull;
 import org.adempiere.mm.attributes.asi_aware.IAttributeSetInstanceAware;
+
+import javax.annotation.Nullable;
 import org.adempiere.util.lang.IAutoCloseable;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.adempiere.warehouse.WarehouseId;
@@ -206,4 +209,9 @@ public interface IShipmentScheduleBL extends ISingletonService
 	ShipmentScheduleLoadingCache<I_M_ShipmentSchedule> newLoadingCache();
 
 	<T extends I_M_ShipmentSchedule> ShipmentScheduleLoadingCache<T> newLoadingCache(@NonNull Class<T> modelClass);
+
+	/**
+	 * Updates C_Project_ID on the shipment schedule for the given order line, if not yet processed.
+	 */
+	void updateProjectId(@NonNull OrderLineId orderLineId, @Nullable ProjectId projectId);
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
@@ -1026,14 +1026,10 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 	@Override
 	public void updateProjectId(@NonNull final OrderLineId orderLineId, @Nullable final ProjectId projectId)
 	{
-		final I_M_ShipmentSchedule shipmentSchedule;
-		try
+		final I_M_ShipmentSchedule shipmentSchedule = getByOrderLineId(orderLineId);
+		if (shipmentSchedule == null)
 		{
-			shipmentSchedule = getByOrderLineId(orderLineId);
-		}
-		catch (final AdempiereException e)
-		{
-			logger.debug("No shipment schedule found for C_OrderLine_ID={}; skip project propagation", orderLineId, e);
+			logger.debug("No shipment schedule found for C_OrderLine_ID={}; skip project propagation", orderLineId);
 			return;
 		}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
@@ -42,6 +42,7 @@ import de.metas.order.OrderLineId;
 import de.metas.organization.OrgId;
 import de.metas.process.PInstanceId;
 import de.metas.product.IProductBL;
+import de.metas.project.ProjectId;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
 import de.metas.quantity.Quantitys;
@@ -53,6 +54,8 @@ import de.metas.util.Check;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
+
+import javax.annotation.Nullable;
 import org.adempiere.ad.dao.ICompositeQueryUpdater;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.persistence.ModelDynAttributeAccessor;
@@ -1018,5 +1021,35 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 				.shipmentSchedulePA(shipmentSchedulePA)
 				.modelClass(modelClass)
 				.build();
+	}
+
+	@Override
+	public void updateProjectId(@NonNull final OrderLineId orderLineId, @Nullable final ProjectId projectId)
+	{
+		final I_M_ShipmentSchedule shipmentSchedule;
+		try
+		{
+			shipmentSchedule = getByOrderLineId(orderLineId);
+		}
+		catch (final AdempiereException e)
+		{
+			logger.debug("No shipment schedule found for C_OrderLine_ID={}; skip project propagation", orderLineId, e);
+			return;
+		}
+
+		if (shipmentSchedule.isProcessed())
+		{
+			return;
+		}
+
+		final ProjectId schedProjectId = ProjectId.ofRepoIdOrNull(shipmentSchedule.getC_Project_ID());
+		if (ProjectId.equals(schedProjectId, projectId))
+		{
+			return;
+		}
+
+		shipmentSchedule.setC_Project_ID(ProjectId.toRepoId(projectId));
+		InterfaceWrapperHelper.save(shipmentSchedule);
+		logger.debug("Updated C_Project_ID={} on M_ShipmentSchedule_ID={} from C_OrderLine_ID={}", projectId, shipmentSchedule.getM_ShipmentSchedule_ID(), orderLineId);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
@@ -1049,7 +1049,7 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 		}
 
 		shipmentSchedule.setC_Project_ID(ProjectId.toRepoId(projectId));
-		InterfaceWrapperHelper.save(shipmentSchedule);
+		shipmentSchedulePA.save(shipmentSchedule);
 		logger.debug("Updated C_Project_ID={} on M_ShipmentSchedule_ID={} from C_OrderLine_ID={}", projectId, shipmentSchedule.getM_ShipmentSchedule_ID(), orderLineId);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
@@ -450,4 +450,9 @@ public interface IInvoiceCandBL extends ISingletonService
 	 * (null, null) => null
 	 */
 	Optional<ProjectId> extractCommonProjectId(Collection<I_C_Invoice_Candidate> invoiceCandidates);
+
+	/**
+	 * Updates C_Project_ID on all unprocessed invoice candidates for the given order line.
+	 */
+	void updateProjectId(@NonNull OrderLineId orderLineId, @Nullable ProjectId projectId);
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -2816,7 +2816,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 			}
 
 			ic.setC_Project_ID(ProjectId.toRepoId(projectId));
-			InterfaceWrapperHelper.save(ic);
+			invoiceCandDAO.save(ic);
 			logger.debug("Updated C_Project_ID={} on C_Invoice_Candidate_ID={} from C_OrderLine_ID={}", projectId, ic.getC_Invoice_Candidate_ID(), orderLineId);
 		}
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -2802,22 +2802,12 @@ public class InvoiceCandBL implements IInvoiceCandBL
 	public void updateProjectId(@NonNull final OrderLineId orderLineId, @Nullable final ProjectId projectId)
 	{
 		final List<I_C_Invoice_Candidate> invoiceCandidates = invoiceCandDAO.retrieveInvoiceCandidatesForOrderLineId(orderLineId);
-		for (final I_C_Invoice_Candidate ic : invoiceCandidates)
-		{
-			if (ic.isProcessed())
-			{
-				continue;
-			}
-
-			final ProjectId icProjectId = ProjectId.ofRepoIdOrNull(ic.getC_Project_ID());
-			if (ProjectId.equals(icProjectId, projectId))
-			{
-				continue;
-			}
-
-			ic.setC_Project_ID(ProjectId.toRepoId(projectId));
-			invoiceCandDAO.save(ic);
-			logger.debug("Updated C_Project_ID={} on C_Invoice_Candidate_ID={} from C_OrderLine_ID={}", projectId, ic.getC_Invoice_Candidate_ID(), orderLineId);
-		}
+		final List<I_C_Invoice_Candidate> updatedInvoiceCandidates = invoiceCandidates.stream()
+				.filter(ic -> !ic.isProcessed())
+				.filter(ic -> ProjectId.equals(ProjectId.ofRepoIdOrNull(ic.getC_Project_ID()), projectId))
+				.peek(ic -> ic.setC_Project_ID(ProjectId.toRepoId(projectId)))
+				.collect(Collectors.toList());
+		invoiceCandDAO.saveAll(updatedInvoiceCandidates);
+		logger.debug("Updated C_Project_ID={} on {} C_Invoice_Candidates for C_OrderLine_ID={}", projectId, updatedInvoiceCandidates.size(), orderLineId);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -2797,4 +2797,27 @@ public class InvoiceCandBL implements IInvoiceCandBL
 
 		return ZERO;
 	}
+
+	@Override
+	public void updateProjectId(@NonNull final OrderLineId orderLineId, @Nullable final ProjectId projectId)
+	{
+		final List<I_C_Invoice_Candidate> invoiceCandidates = invoiceCandDAO.retrieveInvoiceCandidatesForOrderLineId(orderLineId);
+		for (final I_C_Invoice_Candidate ic : invoiceCandidates)
+		{
+			if (ic.isProcessed())
+			{
+				continue;
+			}
+
+			final ProjectId icProjectId = ProjectId.ofRepoIdOrNull(ic.getC_Project_ID());
+			if (ProjectId.equals(icProjectId, projectId))
+			{
+				continue;
+			}
+
+			ic.setC_Project_ID(ProjectId.toRepoId(projectId));
+			InterfaceWrapperHelper.save(ic);
+			logger.debug("Updated C_Project_ID={} on C_Invoice_Candidate_ID={} from C_OrderLine_ID={}", projectId, ic.getC_Invoice_Candidate_ID(), orderLineId);
+		}
+	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
@@ -18,6 +18,11 @@ import javax.annotation.Nullable;
 @Interceptor(I_C_OrderLine.class)
 public class C_OrderLine
 {
+	private final IInvoiceCandidateHandlerBL invoiceCandidateHandlerBL = Services.get(IInvoiceCandidateHandlerBL.class);
+	private final IInvoiceCandDAO invoiceCandDAO = Services.get(IInvoiceCandDAO.class);
+	private final IInvoiceCandBL invoiceCandBL = Services.get(IInvoiceCandBL.class);
+	private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
+
 	@ModelChange(timings = ModelValidator.TYPE_AFTER_CHANGE
 			, ifColumnsChanged = {
 					I_C_OrderLine.COLUMNNAME_QtyOrdered // task 08452: make sure the IC gets invalidated when we sort of "close" a single line
@@ -27,13 +32,13 @@ public class C_OrderLine
 			})
 	public void invalidateInvoiceCandidates(final I_C_OrderLine ol)
 	{
-		Services.get(IInvoiceCandidateHandlerBL.class).invalidateCandidatesFor(ol);
+		invoiceCandidateHandlerBL.invalidateCandidatesFor(ol);
 	}
 
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_DELETE)
 	public void deleteInvoiceCandidates(final I_C_OrderLine ol)
 	{
-		Services.get(IInvoiceCandDAO.class).deleteAllReferencingInvoiceCandidates(ol);
+		invoiceCandDAO.deleteAllReferencingInvoiceCandidates(ol);
 	}
 
 	/**
@@ -49,7 +54,7 @@ public class C_OrderLine
 		final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
 		@Nullable final ProjectId projectId = ProjectId.ofRepoIdOrNull(orderLine.getC_Project_ID());
 
-		Services.get(IInvoiceCandBL.class).updateProjectId(orderLineId, projectId);
-		Services.get(IShipmentScheduleBL.class).updateProjectId(orderLineId, projectId);
+		invoiceCandBL.updateProjectId(orderLineId, projectId);
+		shipmentScheduleBL.updateProjectId(orderLineId, projectId);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
@@ -1,31 +1,23 @@
 package de.metas.invoicecandidate.modelvalidator;
 
-import de.metas.inoutcandidate.api.IShipmentSchedulePA;
-import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.interfaces.I_C_OrderLine;
+import de.metas.invoicecandidate.api.IInvoiceCandBL;
 import de.metas.invoicecandidate.api.IInvoiceCandDAO;
 import de.metas.invoicecandidate.api.IInvoiceCandidateHandlerBL;
-import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
-import de.metas.logging.LogManager;
 import de.metas.order.OrderLineId;
 import de.metas.project.ProjectId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
-import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.ModelValidator;
-import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
-import java.util.List;
 
 @Interceptor(I_C_OrderLine.class)
 public class C_OrderLine
 {
-	private static final Logger logger = LogManager.getLogger(C_OrderLine.class);
-
 	@ModelChange(timings = ModelValidator.TYPE_AFTER_CHANGE
 			, ifColumnsChanged = {
 					I_C_OrderLine.COLUMNNAME_QtyOrdered // task 08452: make sure the IC gets invalidated when we sort of "close" a single line
@@ -57,59 +49,7 @@ public class C_OrderLine
 		final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
 		@Nullable final ProjectId projectId = ProjectId.ofRepoIdOrNull(orderLine.getC_Project_ID());
 
-		propagateProjectIdToInvoiceCandidates(orderLineId, projectId);
-		propagateProjectIdToShipmentSchedule(orderLineId, projectId);
-	}
-
-	private void propagateProjectIdToInvoiceCandidates(@NonNull final OrderLineId orderLineId, @Nullable final ProjectId projectId)
-	{
-		final List<I_C_Invoice_Candidate> invoiceCandidates = Services.get(IInvoiceCandDAO.class)
-				.retrieveInvoiceCandidatesForOrderLineId(orderLineId);
-		for (final I_C_Invoice_Candidate ic : invoiceCandidates)
-		{
-			if (ic.isProcessed())
-			{
-				continue;
-			}
-
-			@Nullable final ProjectId icProjectId = ProjectId.ofRepoIdOrNull(ic.getC_Project_ID());
-			if (ProjectId.equals(icProjectId, projectId))
-			{
-				continue;
-			}
-
-			ic.setC_Project_ID(ProjectId.toRepoId(projectId));
-			InterfaceWrapperHelper.save(ic);
-			logger.debug("Updated C_Project_ID={} on C_Invoice_Candidate_ID={} from C_OrderLine_ID={}", projectId, ic.getC_Invoice_Candidate_ID(), orderLineId);
-		}
-	}
-
-	private void propagateProjectIdToShipmentSchedule(@NonNull final OrderLineId orderLineId, @Nullable final ProjectId projectId)
-	{
-		final I_M_ShipmentSchedule shipmentSchedule;
-		try
-		{
-			shipmentSchedule = Services.get(IShipmentSchedulePA.class).getByOrderLineId(orderLineId);
-		}
-		catch (final AdempiereException e)
-		{
-			logger.debug("No shipment schedule found for C_OrderLine_ID={}; skip project propagation", orderLineId, e);
-			return;
-		}
-
-		if (shipmentSchedule.isProcessed())
-		{
-			return;
-		}
-
-		@Nullable final ProjectId schedProjectId = ProjectId.ofRepoIdOrNull(shipmentSchedule.getC_Project_ID());
-		if (ProjectId.equals(schedProjectId, projectId))
-		{
-			return;
-		}
-
-		shipmentSchedule.setC_Project_ID(ProjectId.toRepoId(projectId));
-		InterfaceWrapperHelper.save(shipmentSchedule);
-		logger.debug("Updated C_Project_ID={} on M_ShipmentSchedule_ID={} from C_OrderLine_ID={}", projectId, shipmentSchedule.getM_ShipmentSchedule_ID(), orderLineId);
+		Services.get(IInvoiceCandBL.class).updateProjectId(orderLineId, projectId);
+		Services.get(IShipmentScheduleBL.class).updateProjectId(orderLineId, projectId);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
@@ -6,7 +6,9 @@ import de.metas.interfaces.I_C_OrderLine;
 import de.metas.invoicecandidate.api.IInvoiceCandDAO;
 import de.metas.invoicecandidate.api.IInvoiceCandidateHandlerBL;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
+import de.metas.logging.LogManager;
 import de.metas.order.OrderLineId;
+import de.metas.project.ProjectId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
@@ -15,8 +17,8 @@ import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.ModelValidator;
 import org.slf4j.Logger;
-import de.metas.logging.LogManager;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 @Interceptor(I_C_OrderLine.class)
@@ -53,13 +55,13 @@ public class C_OrderLine
 	public void propagateProjectIdToICAndShipmentSchedule(@NonNull final I_C_OrderLine orderLine)
 	{
 		final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
-		final int projectId = orderLine.getC_Project_ID();
+		@Nullable final ProjectId projectId = ProjectId.ofRepoIdOrNull(orderLine.getC_Project_ID());
 
 		propagateProjectIdToInvoiceCandidates(orderLineId, projectId);
 		propagateProjectIdToShipmentSchedule(orderLineId, projectId);
 	}
 
-	private void propagateProjectIdToInvoiceCandidates(@NonNull final OrderLineId orderLineId, final int projectId)
+	private void propagateProjectIdToInvoiceCandidates(@NonNull final OrderLineId orderLineId, @Nullable final ProjectId projectId)
 	{
 		final List<I_C_Invoice_Candidate> invoiceCandidates = Services.get(IInvoiceCandDAO.class)
 				.retrieveInvoiceCandidatesForOrderLineId(orderLineId);
@@ -69,18 +71,20 @@ public class C_OrderLine
 			{
 				continue;
 			}
-			if (ic.getC_Project_ID() == projectId)
+
+			@Nullable final ProjectId icProjectId = ProjectId.ofRepoIdOrNull(ic.getC_Project_ID());
+			if (ProjectId.equals(icProjectId, projectId))
 			{
 				continue;
 			}
 
-			ic.setC_Project_ID(projectId);
+			ic.setC_Project_ID(ProjectId.toRepoId(projectId));
 			InterfaceWrapperHelper.save(ic);
 			logger.debug("Updated C_Project_ID={} on C_Invoice_Candidate_ID={} from C_OrderLine_ID={}", projectId, ic.getC_Invoice_Candidate_ID(), orderLineId);
 		}
 	}
 
-	private void propagateProjectIdToShipmentSchedule(@NonNull final OrderLineId orderLineId, final int projectId)
+	private void propagateProjectIdToShipmentSchedule(@NonNull final OrderLineId orderLineId, @Nullable final ProjectId projectId)
 	{
 		final I_M_ShipmentSchedule shipmentSchedule;
 		try
@@ -97,12 +101,14 @@ public class C_OrderLine
 		{
 			return;
 		}
-		if (shipmentSchedule.getC_Project_ID() == projectId)
+
+		@Nullable final ProjectId schedProjectId = ProjectId.ofRepoIdOrNull(shipmentSchedule.getC_Project_ID());
+		if (ProjectId.equals(schedProjectId, projectId))
 		{
 			return;
 		}
 
-		shipmentSchedule.setC_Project_ID(projectId);
+		shipmentSchedule.setC_Project_ID(ProjectId.toRepoId(projectId));
 		InterfaceWrapperHelper.save(shipmentSchedule);
 		logger.debug("Updated C_Project_ID={} on M_ShipmentSchedule_ID={} from C_OrderLine_ID={}", projectId, shipmentSchedule.getM_ShipmentSchedule_ID(), orderLineId);
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
@@ -1,17 +1,29 @@
 package de.metas.invoicecandidate.modelvalidator;
 
-import org.adempiere.ad.modelvalidator.annotations.Interceptor;
-import org.adempiere.ad.modelvalidator.annotations.ModelChange;
-import org.compiere.model.ModelValidator;
-
+import de.metas.inoutcandidate.api.IShipmentSchedulePA;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.invoicecandidate.api.IInvoiceCandDAO;
 import de.metas.invoicecandidate.api.IInvoiceCandidateHandlerBL;
+import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
+import de.metas.order.OrderLineId;
 import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.ad.modelvalidator.annotations.ModelChange;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.ModelValidator;
+import org.slf4j.Logger;
+import de.metas.logging.LogManager;
+
+import java.util.List;
 
 @Interceptor(I_C_OrderLine.class)
 public class C_OrderLine
 {
+	private static final Logger logger = LogManager.getLogger(C_OrderLine.class);
+
 	@ModelChange(timings = ModelValidator.TYPE_AFTER_CHANGE
 			, ifColumnsChanged = {
 					I_C_OrderLine.COLUMNNAME_QtyOrdered // task 08452: make sure the IC gets invalidated when we sort of "close" a single line
@@ -28,5 +40,70 @@ public class C_OrderLine
 	public void deleteInvoiceCandidates(final I_C_OrderLine ol)
 	{
 		Services.get(IInvoiceCandDAO.class).deleteAllReferencingInvoiceCandidates(ol);
+	}
+
+	/**
+	 * When C_Project_ID changes on an order line (e.g. inherited back from a dropship purchase order),
+	 * propagate it to the corresponding invoice candidates and shipment schedule.
+	 *
+	 * @see <a href="https://github.com/metasfresh/me03/issues/28709">me03#28709</a>
+	 */
+	@ModelChange(timings = ModelValidator.TYPE_AFTER_CHANGE,
+			ifColumnsChanged = I_C_OrderLine.COLUMNNAME_C_Project_ID)
+	public void propagateProjectIdToICAndShipmentSchedule(@NonNull final I_C_OrderLine orderLine)
+	{
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
+		final int projectId = orderLine.getC_Project_ID();
+
+		propagateProjectIdToInvoiceCandidates(orderLineId, projectId);
+		propagateProjectIdToShipmentSchedule(orderLineId, projectId);
+	}
+
+	private void propagateProjectIdToInvoiceCandidates(@NonNull final OrderLineId orderLineId, final int projectId)
+	{
+		final List<I_C_Invoice_Candidate> invoiceCandidates = Services.get(IInvoiceCandDAO.class)
+				.retrieveInvoiceCandidatesForOrderLineId(orderLineId);
+		for (final I_C_Invoice_Candidate ic : invoiceCandidates)
+		{
+			if (ic.isProcessed())
+			{
+				continue;
+			}
+			if (ic.getC_Project_ID() == projectId)
+			{
+				continue;
+			}
+
+			ic.setC_Project_ID(projectId);
+			InterfaceWrapperHelper.save(ic);
+			logger.debug("Updated C_Project_ID={} on C_Invoice_Candidate_ID={} from C_OrderLine_ID={}", projectId, ic.getC_Invoice_Candidate_ID(), orderLineId);
+		}
+	}
+
+	private void propagateProjectIdToShipmentSchedule(@NonNull final OrderLineId orderLineId, final int projectId)
+	{
+		final I_M_ShipmentSchedule shipmentSchedule;
+		try
+		{
+			shipmentSchedule = Services.get(IShipmentSchedulePA.class).getByOrderLineId(orderLineId);
+		}
+		catch (final AdempiereException e)
+		{
+			logger.debug("No shipment schedule found for C_OrderLine_ID={}; skip project propagation", orderLineId, e);
+			return;
+		}
+
+		if (shipmentSchedule.isProcessed())
+		{
+			return;
+		}
+		if (shipmentSchedule.getC_Project_ID() == projectId)
+		{
+			return;
+		}
+
+		shipmentSchedule.setC_Project_ID(projectId);
+		InterfaceWrapperHelper.save(shipmentSchedule);
+		logger.debug("Updated C_Project_ID={} on M_ShipmentSchedule_ID={} from C_OrderLine_ID={}", projectId, shipmentSchedule.getM_ShipmentSchedule_ID(), orderLineId);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
@@ -23,6 +23,9 @@ public class C_OrderLine
 	private final IInvoiceCandBL invoiceCandBL = Services.get(IInvoiceCandBL.class);
 	private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
 
+	/** Guard against recursive interceptor invocation when saving IC/ShipmentSchedule triggers C_OrderLine model change */
+	private static final ThreadLocal<Boolean> PROPAGATING_PROJECT_ID = ThreadLocal.withInitial(() -> false);
+
 	@ModelChange(timings = ModelValidator.TYPE_AFTER_CHANGE
 			, ifColumnsChanged = {
 					I_C_OrderLine.COLUMNNAME_QtyOrdered // task 08452: make sure the IC gets invalidated when we sort of "close" a single line
@@ -51,10 +54,23 @@ public class C_OrderLine
 			ifColumnsChanged = I_C_OrderLine.COLUMNNAME_C_Project_ID)
 	public void propagateProjectIdToICAndShipmentSchedule(@NonNull final I_C_OrderLine orderLine)
 	{
-		final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
-		@Nullable final ProjectId projectId = ProjectId.ofRepoIdOrNull(orderLine.getC_Project_ID());
+		if (PROPAGATING_PROJECT_ID.get())
+		{
+			return;
+		}
 
-		invoiceCandBL.updateProjectId(orderLineId, projectId);
-		shipmentScheduleBL.updateProjectId(orderLineId, projectId);
+		PROPAGATING_PROJECT_ID.set(true);
+		try
+		{
+			final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
+			@Nullable final ProjectId projectId = ProjectId.ofRepoIdOrNull(orderLine.getC_Project_ID());
+
+			invoiceCandBL.updateProjectId(orderLineId, projectId);
+			shipmentScheduleBL.updateProjectId(orderLineId, projectId);
+		}
+		finally
+		{
+			PROPAGATING_PROJECT_ID.set(false);
+		}
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
@@ -23,9 +23,6 @@ public class C_OrderLine
 	private final IInvoiceCandBL invoiceCandBL = Services.get(IInvoiceCandBL.class);
 	private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
 
-	/** Guard against recursive interceptor invocation when saving IC/ShipmentSchedule triggers C_OrderLine model change */
-	private static final ThreadLocal<Boolean> PROPAGATING_PROJECT_ID = ThreadLocal.withInitial(() -> false);
-
 	@ModelChange(timings = ModelValidator.TYPE_AFTER_CHANGE
 			, ifColumnsChanged = {
 					I_C_OrderLine.COLUMNNAME_QtyOrdered // task 08452: make sure the IC gets invalidated when we sort of "close" a single line
@@ -47,30 +44,15 @@ public class C_OrderLine
 	/**
 	 * When C_Project_ID changes on an order line (e.g. inherited back from a dropship purchase order),
 	 * propagate it to the corresponding invoice candidates and shipment schedule.
-	 *
-	 * @see <a href="https://github.com/metasfresh/me03/issues/28709">me03#28709</a>
 	 */
 	@ModelChange(timings = ModelValidator.TYPE_AFTER_CHANGE,
 			ifColumnsChanged = I_C_OrderLine.COLUMNNAME_C_Project_ID)
 	public void propagateProjectIdToICAndShipmentSchedule(@NonNull final I_C_OrderLine orderLine)
 	{
-		if (PROPAGATING_PROJECT_ID.get())
-		{
-			return;
-		}
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
+		@Nullable final ProjectId projectId = ProjectId.ofRepoIdOrNull(orderLine.getC_Project_ID());
 
-		PROPAGATING_PROJECT_ID.set(true);
-		try
-		{
-			final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
-			@Nullable final ProjectId projectId = ProjectId.ofRepoIdOrNull(orderLine.getC_Project_ID());
-
-			invoiceCandBL.updateProjectId(orderLineId, projectId);
-			shipmentScheduleBL.updateProjectId(orderLineId, projectId);
-		}
-		finally
-		{
-			PROPAGATING_PROJECT_ID.set(false);
-		}
+		invoiceCandBL.updateProjectId(orderLineId, projectId);
+		shipmentScheduleBL.updateProjectId(orderLineId, projectId);
 	}
 }


### PR DESCRIPTION
## Summary
- When `C_Project_ID` changes on a `C_OrderLine` (e.g. inherited back from a dropship purchase order), propagate it to existing unprocessed `C_Invoice_Candidate` and `M_ShipmentSchedule` records
- Fixes the case where ICs and shipment schedules are created before the project ID is set on the SO line, resulting in missing project on invoices

## Test plan
- [ ] Create a sales order without a project, complete it
- [ ] Verify IC and shipment schedule are created (no project)
- [ ] Update the order line with a project ID (simulating the dropship PO propagation)
- [ ] Verify the IC and shipment schedule now have the project ID
- [ ] Verify processed ICs are not modified
- [ ] Verify processed shipment schedules are not modified
- [ ] Existing Cucumber test `salesOrderProjectPropagation.feature` still passes