### PR TITLE
gh#28126: Project linkage in qty reservation — propagate C_Project_ID to sales order line

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderBL.java
@@ -1507,6 +1507,11 @@ public class OrderBL implements IOrderBL
 	@Override
 	public void updateASIFromProjectId(@NonNull final I_C_OrderLine orderLine)
 	{
+		if (!attributeSetInstanceBL.isStorageRelevant(AttributeConstants.ATTR_Project))
+		{
+			return;
+		}
+
 		AttributeSetInstanceId asiId = AttributeSetInstanceId.ofRepoIdOrNone(orderLine.getM_AttributeSetInstance_ID());
 		final ProjectId projectId = ProjectId.ofRepoIdOrNull(orderLine.getC_Project_ID());
 

--- a/backend/de.metas.business/src/main/java/de/metas/project/ProjectValue.java
+++ b/backend/de.metas.business/src/main/java/de/metas/project/ProjectValue.java
@@ -1,0 +1,53 @@
+package de.metas.project;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import de.metas.util.StringUtils;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+
+import javax.annotation.Nullable;
+
+@EqualsAndHashCode
+public class ProjectValue
+{
+	@NonNull private final String value;
+
+	private ProjectValue(@NonNull final String value)
+	{
+		final String valueNorm = StringUtils.trimBlankToNull(value);
+		if (valueNorm == null)
+		{
+			throw new AdempiereException("ProjectValue is not valid: " + value);
+		}
+
+		this.value = valueNorm;
+	}
+
+	public static ProjectValue ofString(@NonNull final String value)
+	{
+		return new ProjectValue(value);
+	}
+
+	@JsonCreator
+	public static ProjectValue ofNullableString(@Nullable final String value)
+	{
+		final String valueNorm = StringUtils.trimBlankToNull(value);
+		return valueNorm != null ? new ProjectValue(valueNorm) : null;
+	}
+
+	@Override
+	@Deprecated
+	public String toString()
+	{
+		return value;
+	}
+
+	@NonNull
+	@JsonValue
+	public String getAsString()
+	{
+		return value;
+	}
+}

--- a/backend/de.metas.business/src/main/java/de/metas/project/service/ProjectRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/project/service/ProjectRepository.java
@@ -23,6 +23,7 @@
 package de.metas.project.service;
 
 import de.metas.project.ProjectId;
+import de.metas.project.ProjectValue;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
@@ -53,6 +54,17 @@ public class ProjectRepository
 		return queryBL.createQueryBuilder(I_C_Project.class)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_C_Project.COLUMNNAME_Value, value)
+				.create()
+				.firstId(ProjectId::ofRepoIdOrNull);
+	}
+
+	@Nullable
+	public ProjectId getIdByValueOrNull(@NonNull final ProjectValue value)
+	{
+		return queryBL.createQueryBuilder(I_C_Project.class)
+				.addEqualsFilter(I_C_Project.COLUMNNAME_Value, value)
+				.orderByDescending(I_C_Project.COLUMNNAME_IsActive)
+				.orderByDescending(I_C_Project.COLUMNNAME_C_Project_ID)
 				.create()
 				.firstId(ProjectId::ofRepoIdOrNull);
 	}

--- a/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/IAttributeDAO.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/IAttributeDAO.java
@@ -172,4 +172,6 @@ public interface IAttributeDAO extends ISingletonService
 	}
 
 	Optional<ITranslatableString> getAttributeDisplayNameByValue(String value);
+
+	boolean isStorageRelevant(@NonNull AttributeCode attributeCode);
 }

--- a/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/IAttributeSetInstanceBL.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/IAttributeSetInstanceBL.java
@@ -153,6 +153,8 @@ public interface IAttributeSetInstanceBL extends ISingletonService
 
 	boolean isStorageRelevant(I_M_AttributeInstance ai);
 
+	boolean isStorageRelevant(@NonNull AttributeCode attributeCode);
+
 	ImmutableAttributeSet getImmutableAttributeSetById(AttributeSetInstanceId asiId);
 
 	Map<AttributeSetInstanceId, ImmutableAttributeSet> getAttributesForASIs(@NonNull Set<AttributeSetInstanceId> asiIds);

--- a/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/AttributeDAO.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/AttributeDAO.java
@@ -813,6 +813,19 @@ public class AttributeDAO implements IAttributeDAO
 		return getAttributeRecordById(attributeId);
 	}
 
+	@Override
+	public boolean isStorageRelevant(@NonNull final AttributeCode attributeCode)
+	{
+		final Attribute attribute = getAttributesMap().getByCodeOrNull(attributeCode);
+		return attribute != null && attribute.isActive() && attribute.isStorageRelevant();
+	}
+
+	//
+	//
+	// -------------------------------------------------------------------------
+	//
+	//
+
 	private static final class AttributeListValueMap
 	{
 		public static AttributeListValueMap ofList(final List<AttributeListValue> list)

--- a/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/AttributeSetInstanceBL.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/AttributeSetInstanceBL.java
@@ -524,6 +524,12 @@ public class AttributeSetInstanceBL implements IAttributeSetInstanceBL
 	}
 
 	@Override
+	public boolean isStorageRelevant(@NonNull final AttributeCode attributeCode)
+	{
+		return attributeDAO.isStorageRelevant(attributeCode);
+	}
+
+	@Override
 	public ImmutableAttributeSet getImmutableAttributeSetById(@NonNull final AttributeSetInstanceId asiId)
 	{
 		if (asiId.isNone())

--- a/backend/de.metas.business/src/test/java/de/metas/order/IOrderBL_UpdateASIFromProjectIdTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/IOrderBL_UpdateASIFromProjectIdTest.java
@@ -113,7 +113,9 @@ class IOrderBL_UpdateASIFromProjectIdTest
 	@Nullable
 	private String getProjectValueFromASI(final AttributeSetInstanceId asiId)
 	{
-		return attributeSetInstanceBL.getImmutableAttributeSetById(asiId).getValueAsString(AttributeConstants.ATTR_Project);
+		return attributeSetInstanceBL.getImmutableAttributeSetById(asiId)
+				.getValueAsStringIfExists(AttributeConstants.ATTR_Project)
+				.orElse(null);
 	}
 
 	@Test

--- a/backend/de.metas.business/src/test/java/de/metas/order/IOrderBL_UpdateASIFromProjectIdTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/IOrderBL_UpdateASIFromProjectIdTest.java
@@ -73,6 +73,7 @@ class IOrderBL_UpdateASIFromProjectIdTest
 		final I_M_Attribute attribute = newInstance(I_M_Attribute.class);
 		attribute.setValue(AttributeConstants.ATTR_Project.getCode());
 		attribute.setAttributeValueType(ATTRIBUTEVALUETYPE_StringMax40);
+		attribute.setIsStorageRelevant(true);
 		saveRecord(attribute);
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/attribute/M_Attribute_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/attribute/M_Attribute_StepDef.java
@@ -91,6 +91,9 @@
 					 row.getAsOptionalEnum(I_M_Attribute.COLUMNNAME_AttributeValueType, AttributeValueType.class)
 							 .ifPresent(type -> attributeRecord.setAttributeValueType(type.getCode()));
 
+					 row.getAsOptionalBoolean(I_M_Attribute.COLUMNNAME_IsStorageRelevant)
+							 .ifPresent(attributeRecord::setIsStorageRelevant);
+
 					 row.getAsOptionalString(I_M_Attribute.COLUMNNAME_DefaultValueSQL)
 							 .ifPresent(attributeRecord::setDefaultValueSQL);
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/project/C_Project_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/project/C_Project_StepDef.java
@@ -25,10 +25,13 @@ package de.metas.cucumber.stepdefs.project;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.ValueAndName;
+import de.metas.util.CoalesceUtil;
+import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Given;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
 import org.compiere.model.I_C_Project;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
@@ -39,6 +42,7 @@ public class C_Project_StepDef
 {
 	public static final int DEFAULT_CURRENCY_ID = 102;
 	@NonNull private final C_Project_StepDefData projectTable;
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 	/**
 	 * Create C_Project records with minimal required fields.
@@ -66,7 +70,13 @@ public class C_Project_StepDef
 	private void createProject(@NonNull final DataTableRow row)
 	{
 		final ValueAndName valueAndName = row.suggestValueAndName();
-		final I_C_Project project = newInstance(I_C_Project.class);
+		final I_C_Project project = CoalesceUtil.coalesceSuppliersNotNull(
+				() -> queryBL.createQueryBuilder(I_C_Project.class)
+						.addOnlyActiveRecordsFilter()
+						.addEqualsFilter(I_C_Project.COLUMNNAME_Value, valueAndName.getValue())
+						.create()
+						.firstOnly(I_C_Project.class),
+				() -> newInstance(I_C_Project.class));
 
 		project.setName(valueAndName.getName());
 		project.setValue(valueAndName.getValue());

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/project/C_Project_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/project/C_Project_StepDef.java
@@ -22,10 +22,10 @@
 
 package de.metas.cucumber.stepdefs.project;
 
+import de.metas.common.util.CoalesceUtil;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.ValueAndName;
-import de.metas.util.CoalesceUtil;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Given;
@@ -48,12 +48,10 @@ public class C_Project_StepDef
 	 * Create C_Project records with minimal required fields.
 	 *
 	 * @cucumber.stepdef
-	 * @cucumber.columns
-	 *   <b>Identifier</b> — (required) alias to store the project under<br>
-	 *   <b>Name</b> — (required) project name<br>
-	 *   <b>Value</b> — (optional) project value/search key, defaults to Name if not specified<br>
-	 * @cucumber.example
-	 * <pre>
+	 * @cucumber.columns <b>Identifier</b> — (required) alias to store the project under<br>
+	 * <b>Name</b> — (required) project name<br>
+	 * <b>Value</b> — (optional) project value/search key, defaults to Name if not specified<br>
+	 * @cucumber.example <pre>
 	 * Given metasfresh contains C_Projects:
 	 *   | Identifier | Name         | Value        |
 	 *   | project_1  | TestProject1 | PROJ_001     |
@@ -81,7 +79,7 @@ public class C_Project_StepDef
 		project.setName(valueAndName.getName());
 		project.setValue(valueAndName.getValue());
 
-		project.setC_Currency_ID( row.getAsOptionalInt(I_C_Project.COLUMNNAME_C_Currency_ID)
+		project.setC_Currency_ID(row.getAsOptionalInt(I_C_Project.COLUMNNAME_C_Currency_ID)
 				.orElse(DEFAULT_CURRENCY_ID));
 
 		saveRecord(project);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/qtyreservation/M_QtyReservation_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/qtyreservation/M_QtyReservation_StepDef.java
@@ -27,12 +27,14 @@ import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.StepDefUtil;
 import de.metas.cucumber.stepdefs.order.C_OrderLine_StepDefData;
+import de.metas.cucumber.stepdefs.project.C_Project_StepDefData;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
 import de.metas.handlingunits.QtyTU;
 import de.metas.inoutcandidate.qty_reservation.CreateQtyReservationRequest;
 import de.metas.inoutcandidate.qty_reservation.QtyReservationId;
 import de.metas.inoutcandidate.qty_reservation.QtyReservationService;
 import de.metas.inoutcandidate.qty_reservation.SupplyType;
+import de.metas.project.ProjectId;
 import de.metas.uom.IUOMDAO;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
@@ -68,6 +70,7 @@ import org.compiere.model.I_M_QtyReservation;
  *   <li><b>C_UOM_ID.X12DE355</b> — (required) UOM of the quantity, e.g. {@code PCE}</li>
  *   <li><b>QtyTU</b> — (required) transport-unit quantity (e.g. number of pallets / boxes)</li>
  *   <li><b>SupplyType</b> — (optional, default {@code OH}) supply type code: {@code OH} = on-hand, {@code PS} = planned supply</li>
+ *   <li><b>C_Project_ID</b> — (optional, identifier-ref) project to link; when set, also propagates {@code C_Project_ID} to the sales order line</li>
  * </ul>
  *
  * <h3>{@code validate M_QtyReservations:}</h3>
@@ -94,6 +97,7 @@ public class M_QtyReservation_StepDef
 	@NonNull private final C_OrderLine_StepDefData orderLineTable;
 	@NonNull private final M_Product_StepDefData productTable;
 	@NonNull private final M_Warehouse_StepDefData warehouseTable;
+	@NonNull private final C_Project_StepDefData projectTable;
 
 	/**
 	 * Creates {@code M_QtyReservation} records directly in the DB, bypassing the cockpit V2 UI process.
@@ -107,6 +111,11 @@ public class M_QtyReservation_StepDef
 
 	private void createReservation(@NonNull final DataTableRow row)
 	{
+		final ProjectId projectId = row.getAsOptionalIdentifier("C_Project_ID")
+				.map(projectTable::get)
+				.map(project -> ProjectId.ofRepoId(project.getC_Project_ID()))
+				.orElse(null);
+
 		final QtyReservationId qtyReservationId = qtyReservationService.makeReservation(CreateQtyReservationRequest.builder()
 				.orderAndLineId(orderLineTable.getOrderAndLineId(row.getAsIdentifier("C_OrderLine_ID")))
 				.productId(row.getAsIdentifier("M_Product_ID").lookupNotNullIdIn(productTable))
@@ -114,6 +123,7 @@ public class M_QtyReservation_StepDef
 				.supplyType(row.getAsOptionalEnum("SupplyType", SupplyType.class).orElse(SupplyType.ON_HAND))
 				.qtyTU(QtyTU.ofInt(row.getAsInt("QtyTU")))
 				.qty(row.getAsQuantity("Qty", "C_UOM_ID", uomDAO::getByX12DE355))
+				.projectId(projectId)
 				.build());
 
 		// final I_M_QtyReservation record = InterfaceWrapperHelper.newInstance(I_M_QtyReservation.class);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation.feature
@@ -280,8 +280,8 @@ Feature: Qty Reservation delivery tracking
       | bp_vendor_60_loc | bp_vendor_60  | true     | true     |
 
     And metasfresh contains C_Projects:
-      | Identifier |
-      | project_60 |
+      | Identifier | Value      |
+      | project_60 | PROJECT-60 |
 
     ## 3. Purchase order with C_Project_ID on the line — triggers updateASIFromProjectId before save
     And metasfresh contains C_Orders:
@@ -306,10 +306,10 @@ Feature: Qty Reservation delivery tracking
       | M_ReceiptSchedule_ID.Identifier | M_HU_ID.Identifier | M_InOut_ID.Identifier |
       | receiptSched_60                 | hu_60              | inout_60              |
 
-    ## 6. The received TU must carry the project as a storage-relevant attribute (any non-empty value)
+    ## 6. The received TU must carry the project value as a storage-relevant attribute
     Then M_HU_Attribute is validated
-      | M_HU_ID | M_Attribute_ID.Value |
-      | hu_60   | ProjectValue         |
+      | M_HU_ID | M_Attribute_ID.Value | Value      |
+      | hu_60   | ProjectValue         | PROJECT-60 |
 
     ## 7. Sales order — no project set initially
     And metasfresh contains C_Orders:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation.feature
@@ -276,8 +276,8 @@ Feature: Qty Reservation delivery tracking
       | Identifier   | IsVendor | M_PricingSystem_ID |
       | bp_vendor_60 | true     | psP_60             |
     And metasfresh contains C_BPartner_Locations:
-      | Identifier       | C_BPartner_ID |
-      | bp_vendor_60_loc | bp_vendor_60  |
+      | Identifier       | C_BPartner_ID | IsShipTo | IsBillTo |
+      | bp_vendor_60_loc | bp_vendor_60  | true     | true     |
 
     And metasfresh contains C_Projects:
       | Identifier | Value      |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation.feature
@@ -244,3 +244,41 @@ Feature: Qty Reservation delivery tracking
       | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver |
       | shipmentSchedule_5A              | 0                |
       | shipmentSchedule_5B              | 10               |
+
+
+  @from:cucumber
+  @Id:S_QtyRes_60
+  Scenario: Reservation with project propagates C_Project_ID to the sales order line
+  ## _Given a C_Project and a sales order line with no project set
+  ## _When an M_QtyReservation is created with C_Project_ID referencing that project
+  ## _Then QtyReservationService.makeReservation() propagates the C_Project_ID to the order line
+
+    Given metasfresh contains C_Projects:
+      | Identifier |
+      | project_60 |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | order_6    | true    | bp_1          | 2026-03-01  | warehouse_1    | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered |
+      | orderLine_6 | order_6    | product_1    | 10         |
+    And the order identified by order_6 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier         | C_OrderLine_ID | IsToRecompute |
+      | shipmentSchedule_6 | orderLine_6    | N             |
+
+    ## Order line has no project yet
+    Then validate C_OrderLine:
+      | Identifier  | C_Project_ID |
+      | orderLine_6 | null         |
+
+    ## Create reservation referencing the project
+    When metasfresh contains M_QtyReservations:
+      | Identifier       | C_OrderLine_ID | M_Product_ID | M_Warehouse_ID | Qty    | QtyTU | C_Project_ID |
+      | qtyReservation_6 | orderLine_6    | product_1    | warehouse_1    | 10 PCE | 1     | project_60   |
+
+    ## The service must have propagated C_Project_ID to the order line
+    Then validate C_OrderLine:
+      | Identifier  | C_Project_ID |
+      | orderLine_6 | project_60   |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation.feature
@@ -222,7 +222,7 @@ Feature: Qty Reservation delivery tracking
       | Identifier          | C_OrderLine_ID | IsToRecompute |
       | shipmentSchedule_5A | orderLine_5A   | N             |
       | shipmentSchedule_5B | orderLine_5B   | N             |
-    
+
     ## Before reservation: order_5A gets QtyToDeliver=10 (in the normal order of priorities, by Date in this case)
     Then after not more than 60s, validate shipment schedules:
       | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver |
@@ -248,15 +248,70 @@ Feature: Qty Reservation delivery tracking
 
   @from:cucumber
   @Id:S_QtyRes_60
-  Scenario: Reservation with project propagates C_Project_ID to the sales order line
-  ## _Given a C_Project and a sales order line with no project set
-  ## _When an M_QtyReservation is created with C_Project_ID referencing that project
-  ## _Then QtyReservationService.makeReservation() propagates the C_Project_ID to the order line
+  Scenario: Project propagates from PO receipt to HU attribute; OH reservation from stock references same project
+  ## _Given the ProjectValue attribute is storage-relevant and a vendor PO line has C_Project_ID set
+  ## _When goods are received into a TU HU via the receipt schedule
+  ## _Then the TU carries the ProjectValue attribute matching the project value
+  ## _And an OH reservation with C_Project_ID propagates it to the sales order line
 
-    Given metasfresh contains C_Projects:
+    ## 1. Make ProjectValue storage-relevant so updateASIFromProjectId propagates it to received HUs
+    Given metasfresh contains M_Attributes:
+      | Identifier          | Value        | AttributeValueType | IsStorageRelevant |
+      | projectValueAttr_60 | ProjectValue | S                  | Y                 |
+
+    ## 2. PO pricing chain (SOTrx=false) and vendor bpartner without auto-location
+    And metasfresh contains M_PricingSystems
       | Identifier |
-      | project_60 |
+      | psP_60     |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Currency.ISO_Code | SOTrx |
+      | plP_60     | psP_60             | EUR                 | false |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plvP_60    | plP_60         |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 |
+      | plvP_60                | product_1    | 5.00     | PCE               |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier   | IsVendor | M_PricingSystem_ID |
+      | bp_vendor_60 | true     | psP_60             |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier       | C_BPartner_ID |
+      | bp_vendor_60_loc | bp_vendor_60  |
 
+    And metasfresh contains C_Projects:
+      | Identifier | Value      |
+      | project_60 | PROJECT-60 |
+
+    ## 3. Purchase order with C_Project_ID on the line — triggers updateASIFromProjectId before save
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID |
+      | order_60po | false   | bp_vendor_60  | 2026-03-01  | warehouse_1    |
+    And metasfresh contains C_OrderLines:
+      | Identifier     | C_Order_ID | M_Product_ID | QtyEntered | C_Project_ID |
+      | orderLine_60po | order_60po | product_1    | 10         | project_60   |
+    And the order identified by order_60po is completed
+
+    ## 4. Receipt schedule is created automatically from the completed PO
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier |
+      | receiptSched_60                 | order_60po            | orderLine_60po            | bp_vendor_60             | bp_vendor_60_loc                  | product_1               | 10         | warehouse_1               |
+
+    ## 5. Generate 1 TU (10 PCE) and receive it — QtyLU=0 means TU-only, no pallet wrapper
+    And create M_HU_LUTU_Configuration for M_ReceiptSchedule and generate M_HUs
+      | M_HU_LUTU_Configuration_ID.Identifier | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier |
+      | huLuTuConfig_60                       | hu_60              | receiptSched_60                 | N               | 0     | N               | 1     | N               | 10          | huPIP_TU_10PCE                     |
+
+    And create material receipt
+      | M_ReceiptSchedule_ID.Identifier | M_HU_ID.Identifier | M_InOut_ID.Identifier |
+      | receiptSched_60                 | hu_60              | inout_60              |
+
+    ## 6. The received TU must carry the project as a storage-relevant attribute
+    Then M_HU_Attribute is validated
+      | M_HU_ID | M_Attribute_ID.Value | Value      |
+      | hu_60   | ProjectValue         | PROJECT-60 |
+
+    ## 7. Sales order — no project set initially
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
       | order_6    | true    | bp_1          | 2026-03-01  | warehouse_1    | F            |
@@ -273,10 +328,10 @@ Feature: Qty Reservation delivery tracking
       | Identifier  | C_Project_ID |
       | orderLine_6 | null         |
 
-    ## Create reservation referencing the project
+    ## 8. Create OH reservation from on-hand stock with project → propagates C_Project_ID to order line
     When metasfresh contains M_QtyReservations:
-      | Identifier       | C_OrderLine_ID | M_Product_ID | M_Warehouse_ID | Qty    | QtyTU | C_Project_ID |
-      | qtyReservation_6 | orderLine_6    | product_1    | warehouse_1    | 10 PCE | 1     | project_60   |
+      | Identifier       | C_OrderLine_ID | M_Product_ID | M_Warehouse_ID | Qty    | QtyTU | SupplyType | C_Project_ID |
+      | qtyReservation_6 | orderLine_6    | product_1    | warehouse_1    | 10 PCE | 1     | OH         | project_60   |
 
     ## The service must have propagated C_Project_ID to the order line
     Then validate C_OrderLine:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation.feature
@@ -280,8 +280,8 @@ Feature: Qty Reservation delivery tracking
       | bp_vendor_60_loc | bp_vendor_60  | true     | true     |
 
     And metasfresh contains C_Projects:
-      | Identifier | Value      |
-      | project_60 | PROJECT-60 |
+      | Identifier |
+      | project_60 |
 
     ## 3. Purchase order with C_Project_ID on the line — triggers updateASIFromProjectId before save
     And metasfresh contains C_Orders:
@@ -306,10 +306,10 @@ Feature: Qty Reservation delivery tracking
       | M_ReceiptSchedule_ID.Identifier | M_HU_ID.Identifier | M_InOut_ID.Identifier |
       | receiptSched_60                 | hu_60              | inout_60              |
 
-    ## 6. The received TU must carry the project as a storage-relevant attribute
+    ## 6. The received TU must carry the project as a storage-relevant attribute (any non-empty value)
     Then M_HU_Attribute is validated
-      | M_HU_ID | M_Attribute_ID.Value | Value      |
-      | hu_60   | ProjectValue         | PROJECT-60 |
+      | M_HU_ID | M_Attribute_ID.Value |
+      | hu_60   | ProjectValue         |
 
     ## 7. Sales order — no project set initially
     And metasfresh contains C_Orders:

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/CreateQtyReservationRequest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/CreateQtyReservationRequest.java
@@ -5,6 +5,7 @@ import de.metas.handlingunits.QtyTU;
 import de.metas.material.event.commons.AttributesKey;
 import de.metas.order.OrderAndLineId;
 import de.metas.product.ProductId;
+import de.metas.project.ProjectId;
 import de.metas.quantity.Quantity;
 import lombok.Builder;
 import lombok.NonNull;
@@ -27,4 +28,5 @@ public class CreateQtyReservationRequest
 	@NonNull QtyTU qtyTU;
 	@NonNull Quantity qty;
 	@Nullable AttributesKey attributesKey;
+	@Nullable ProjectId projectId;
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
@@ -42,6 +42,13 @@ public class QtyReservationService
 
 		final QtyReservationId qtyReservationId = repository.createReservation(request);
 
+		if (request.getProjectId() != null)
+		{
+			orderLine.setC_Project_ID(request.getProjectId().getRepoId());
+			// assume the ProjectValue attribute will be automatically set/updated in ASI 
+			orderLineBL.save(orderLine);
+		}
+
 		invalidateShipmentSchedulesForSalesOrderLine(orderLine);
 
 		return qtyReservationId;

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/reservation/MD_CockpitV2_MakeQtyReservation.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/reservation/MD_CockpitV2_MakeQtyReservation.java
@@ -2,11 +2,14 @@ package de.metas.ui.web.material.cockpit.v2.reservation;
 
 import de.metas.handlingunits.QtyTU;
 import de.metas.inoutcandidate.qty_reservation.CreateQtyReservationRequest;
+import de.metas.inoutcandidate.qty_reservation.QtyReservationService;
 import de.metas.process.IProcessDefaultParameter;
 import de.metas.process.IProcessDefaultParametersProvider;
 import de.metas.process.IProcessPrecondition;
 import de.metas.process.Param;
 import de.metas.process.ProcessPreconditionsResolution;
+import de.metas.project.ProjectId;
+import de.metas.project.service.ProjectRepository;
 import de.metas.ui.web.order.sales.hu.reservation.process.MaterialCockpitSalesOrderLine;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
@@ -20,7 +23,8 @@ public class MD_CockpitV2_MakeQtyReservation
 		extends MaterialCockpitV2BasedProcess
 		implements IProcessPrecondition, IProcessDefaultParametersProvider
 {
-	@Autowired private de.metas.inoutcandidate.qty_reservation.QtyReservationService qtyReservationService;
+	@Autowired private QtyReservationService qtyReservationService;
+	@Autowired private ProjectRepository projectRepository;
 
 	private static final String PARAM_QtyOrderedNotReserved_TU = "QtyOrderedNotReserved_TU";
 	@Param(parameterName = PARAM_QtyOrderedNotReserved_TU)
@@ -86,6 +90,7 @@ public class MD_CockpitV2_MakeQtyReservation
 	{
 		final QtyTU qtyToReserveTU = getAndValidateQtyToReserveTUParam();
 		final MaterialCockpitV2RowVO rowVO = getSingleSelectedMaterialCockpitRow();
+
 		qtyReservationService.makeReservation(
 				CreateQtyReservationRequest.builder()
 						.orderAndLineId(getSalesOrderAndLineId())
@@ -95,13 +100,20 @@ public class MD_CockpitV2_MakeQtyReservation
 						.datePromised(rowVO.getDatePromised())
 						.vendorBPartnerId(rowVO.getVendorBPartnerId())
 						.attributesKey(rowVO.getAttributesKey())
-						.projectId(getMaterialCockpitViewContext().getProjectId())
+						.projectId(extractProjectId(rowVO))
 						.qtyTU(qtyToReserveTU)
 						.qty(rowVO.computeQtyCUToReserve(qtyToReserveTU))
 						.build()
 		);
 
 		return MSG_OK;
+	}
+
+	private ProjectId extractProjectId(final MaterialCockpitV2RowVO rowVO)
+	{
+		return rowVO.getProjectValue() != null
+				? projectRepository.getIdByValueOrNull(rowVO.getProjectValue())
+				: null;
 	}
 
 	@Override

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/reservation/MD_CockpitV2_MakeQtyReservation.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/reservation/MD_CockpitV2_MakeQtyReservation.java
@@ -95,6 +95,7 @@ public class MD_CockpitV2_MakeQtyReservation
 						.datePromised(rowVO.getDatePromised())
 						.vendorBPartnerId(rowVO.getVendorBPartnerId())
 						.attributesKey(rowVO.getAttributesKey())
+						.projectId(getMaterialCockpitViewContext().getProjectId())
 						.qtyTU(qtyToReserveTU)
 						.qty(rowVO.computeQtyCUToReserve(qtyToReserveTU))
 						.build()

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/reservation/MaterialCockpitV2RowVO.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/reservation/MaterialCockpitV2RowVO.java
@@ -4,6 +4,7 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.handlingunits.QtyTU;
 import de.metas.material.event.commons.AttributesKey;
 import de.metas.product.ProductId;
+import de.metas.project.ProjectValue;
 import de.metas.quantity.Quantity;
 import lombok.Builder;
 import lombok.NonNull;
@@ -28,6 +29,7 @@ public class MaterialCockpitV2RowVO
 	@Nullable Instant datePromised;
 	@Nullable BPartnerId vendorBPartnerId;
 	@Nullable AttributesKey attributesKey;
+	@Nullable ProjectValue projectValue;
 	@NonNull QtyTU qtyTU;
 	@NonNull Quantity qtyStock;
 

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/reservation/MaterialCockpitV2RowVOs.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/cockpit/v2/reservation/MaterialCockpitV2RowVOs.java
@@ -5,6 +5,7 @@ import de.metas.handlingunits.QtyTU;
 import de.metas.material.cockpit.model.I_QtyDemand_QtySupply_V;
 import de.metas.material.event.commons.AttributesKey;
 import de.metas.product.ProductId;
+import de.metas.project.ProjectValue;
 import de.metas.quantity.Quantity;
 import de.metas.quantity.Quantitys;
 import de.metas.ui.web.view.IViewRow;
@@ -25,6 +26,7 @@ public class MaterialCockpitV2RowVOs
 	private static final String COLUMNNAME_AvailabilityStatus = "AvailabilityStatus";
 	private static final String COLUMNNAME_DatePromised = "DatePromised";
 	private static final String COLUMNNAME_C_BPartner_Vendor_ID = "C_BPartner_Vendor_ID";
+	private static final String COLUMNNAME_ProjectValue = "ProjectValue";
 
 	@NonNull
 	public static MaterialCockpitV2RowVO ofViewRow(@NonNull final IViewRow row)
@@ -37,6 +39,7 @@ public class MaterialCockpitV2RowVOs
 				.datePromised(extractDatePromised(row))
 				.vendorBPartnerId(extractVendorBPartnerId(row))
 				.attributesKey(extractAttributesKey(row))
+				.projectValue(extractProjectValue(row))
 				.qtyTU(QtyTU.ofBigDecimal(row.getFieldValueAsBigDecimal(COLUMNNAME_QtyTU, BigDecimal.ZERO)))
 				.qtyStock(extractQtyStock(row))
 				.build();
@@ -92,4 +95,11 @@ public class MaterialCockpitV2RowVOs
 			return null;
 		}
 	}
+
+	@Nullable
+	private static ProjectValue extractProjectValue(@NonNull final IViewRow row)
+	{
+		return ProjectValue.ofNullableString(row.getFieldNameAndJsonValues().getAsString(COLUMNNAME_ProjectValue));
+	}
+
 }

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/sales/hu/reservation/process/MaterialCockpitViewContext.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/sales/hu/reservation/process/MaterialCockpitViewContext.java
@@ -4,15 +4,12 @@ import com.google.common.collect.ImmutableMap;
 import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderLineId;
 import de.metas.process.PInstanceId;
-import de.metas.project.ProjectId;
 import de.metas.ui.web.view.IView;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 import org.adempiere.exceptions.AdempiereException;
-
-import javax.annotation.Nullable;
 
 @Value
 @Builder
@@ -23,7 +20,6 @@ public class MaterialCockpitViewContext
 
 	@NonNull PInstanceId sourceSelectionId;
 	@NonNull OrderAndLineId salesOrderAndLineId;
-	@Nullable ProjectId projectId;
 
 	@NonNull
 	public static MaterialCockpitViewContext of(@NonNull final IView view)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/sales/hu/reservation/process/MaterialCockpitViewContext.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/sales/hu/reservation/process/MaterialCockpitViewContext.java
@@ -4,12 +4,15 @@ import com.google.common.collect.ImmutableMap;
 import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderLineId;
 import de.metas.process.PInstanceId;
+import de.metas.project.ProjectId;
 import de.metas.ui.web.view.IView;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 import org.adempiere.exceptions.AdempiereException;
+
+import javax.annotation.Nullable;
 
 @Value
 @Builder
@@ -20,6 +23,7 @@ public class MaterialCockpitViewContext
 
 	@NonNull PInstanceId sourceSelectionId;
 	@NonNull OrderAndLineId salesOrderAndLineId;
+	@Nullable ProjectId projectId;
 
 	@NonNull
 	public static MaterialCockpitViewContext of(@NonNull final IView view)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/sales/hu/reservation/process/WEBUI_C_OrderLineSO_Launch_HUEditor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/sales/hu/reservation/process/WEBUI_C_OrderLineSO_Launch_HUEditor.java
@@ -2,6 +2,7 @@ package de.metas.ui.web.order.sales.hu.reservation.process;
 
 import de.metas.document.engine.DocStatus;
 import de.metas.handlingunits.reservation.HUReservationService;
+import de.metas.interfaces.I_C_OrderLine;
 import de.metas.order.IOrderBL;
 import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderId;
@@ -12,6 +13,7 @@ import de.metas.process.JavaProcess;
 import de.metas.process.ProcessExecutionResult.ViewOpenTarget;
 import de.metas.process.ProcessExecutionResult.WebuiViewToOpen;
 import de.metas.process.ProcessPreconditionsResolution;
+import de.metas.project.ProjectId;
 import de.metas.ui.web.document.filter.DocumentFilter;
 import de.metas.ui.web.material.cockpit.v2.MaterialCockpitV2Service;
 import de.metas.ui.web.order.sales.hu.reservation.HUReservationDocumentFilterService;
@@ -26,7 +28,7 @@ import lombok.NonNull;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_Order;
-import org.compiere.model.I_C_OrderLine;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
 
@@ -61,6 +63,10 @@ public class WEBUI_C_OrderLineSO_Launch_HUEditor
 	@NonNull private final HUReservationDocumentFilterService huReservationDocumentFilterService = SpringContextHolder.instance.getBean(HUReservationDocumentFilterService.class);
 	@NonNull private final IViewsRepository viewsRepo = SpringContextHolder.instance.getBean(IViewsRepository.class);
 	@NonNull private final MaterialCockpitV2Service materialCockpitV2Service = SpringContextHolder.instance.getBean(MaterialCockpitV2Service.class);
+
+	// state
+	private I_C_Order _salesOrder;
+	private I_C_OrderLine _salesOrderLine;
 
 	@Override
 	public ProcessPreconditionsResolution checkPreconditionsApplicable(@NonNull final IProcessPreconditionsContext context)
@@ -157,7 +163,46 @@ public class WEBUI_C_OrderLineSO_Launch_HUEditor
 	{
 		return MaterialCockpitViewContext.builder()
 				.sourceSelectionId(getPinstanceId())
-				.salesOrderAndLineId(OrderAndLineId.of(getOrderId(), getSingleOrderLineId()))
+				.salesOrderAndLineId(getSalesOrderAndLineId())
+				.projectId(getProjectId())
 				.build();
+	}
+
+	private ProjectId getProjectId()
+	{
+		final I_C_OrderLine salesOrderLine = getSalesOrderLine();
+		final ProjectId lineProjectId = ProjectId.ofRepoIdOrNull(salesOrderLine.getC_Project_ID());
+		if (lineProjectId != null)
+		{
+			return lineProjectId;
+		}
+
+		final I_C_Order salesOrder = getSalesOrder();
+		return ProjectId.ofRepoIdOrNull(salesOrder.getC_Project_ID());
+	}
+
+	private I_C_Order getSalesOrder()
+	{
+		if (_salesOrder == null)
+		{
+			final OrderAndLineId salesOrderAndLineId = getSalesOrderAndLineId();
+			_salesOrder = orderBL.getById(salesOrderAndLineId.getOrderId());
+		}
+		return _salesOrder;
+	}
+
+	private I_C_OrderLine getSalesOrderLine()
+	{
+		if (_salesOrderLine == null)
+		{
+			final OrderAndLineId salesOrderAndLineId = getSalesOrderAndLineId();
+			_salesOrderLine = orderBL.getLineById(salesOrderAndLineId);
+		}
+		return _salesOrderLine;
+	}
+
+	private @NotNull OrderAndLineId getSalesOrderAndLineId()
+	{
+		return OrderAndLineId.of(getOrderId(), getSingleOrderLineId());
 	}
 }

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/sales/hu/reservation/process/WEBUI_C_OrderLineSO_Launch_HUEditor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/sales/hu/reservation/process/WEBUI_C_OrderLineSO_Launch_HUEditor.java
@@ -13,7 +13,6 @@ import de.metas.process.JavaProcess;
 import de.metas.process.ProcessExecutionResult.ViewOpenTarget;
 import de.metas.process.ProcessExecutionResult.WebuiViewToOpen;
 import de.metas.process.ProcessPreconditionsResolution;
-import de.metas.project.ProjectId;
 import de.metas.ui.web.document.filter.DocumentFilter;
 import de.metas.ui.web.material.cockpit.v2.MaterialCockpitV2Service;
 import de.metas.ui.web.order.sales.hu.reservation.HUReservationDocumentFilterService;
@@ -63,10 +62,6 @@ public class WEBUI_C_OrderLineSO_Launch_HUEditor
 	@NonNull private final HUReservationDocumentFilterService huReservationDocumentFilterService = SpringContextHolder.instance.getBean(HUReservationDocumentFilterService.class);
 	@NonNull private final IViewsRepository viewsRepo = SpringContextHolder.instance.getBean(IViewsRepository.class);
 	@NonNull private final MaterialCockpitV2Service materialCockpitV2Service = SpringContextHolder.instance.getBean(MaterialCockpitV2Service.class);
-
-	// state
-	private I_C_Order _salesOrder;
-	private I_C_OrderLine _salesOrderLine;
 
 	@Override
 	public ProcessPreconditionsResolution checkPreconditionsApplicable(@NonNull final IProcessPreconditionsContext context)
@@ -164,41 +159,7 @@ public class WEBUI_C_OrderLineSO_Launch_HUEditor
 		return MaterialCockpitViewContext.builder()
 				.sourceSelectionId(getPinstanceId())
 				.salesOrderAndLineId(getSalesOrderAndLineId())
-				.projectId(getProjectId())
 				.build();
-	}
-
-	private ProjectId getProjectId()
-	{
-		final I_C_OrderLine salesOrderLine = getSalesOrderLine();
-		final ProjectId lineProjectId = ProjectId.ofRepoIdOrNull(salesOrderLine.getC_Project_ID());
-		if (lineProjectId != null)
-		{
-			return lineProjectId;
-		}
-
-		final I_C_Order salesOrder = getSalesOrder();
-		return ProjectId.ofRepoIdOrNull(salesOrder.getC_Project_ID());
-	}
-
-	private I_C_Order getSalesOrder()
-	{
-		if (_salesOrder == null)
-		{
-			final OrderAndLineId salesOrderAndLineId = getSalesOrderAndLineId();
-			_salesOrder = orderBL.getById(salesOrderAndLineId.getOrderId());
-		}
-		return _salesOrder;
-	}
-
-	private I_C_OrderLine getSalesOrderLine()
-	{
-		if (_salesOrderLine == null)
-		{
-			final OrderAndLineId salesOrderAndLineId = getSalesOrderAndLineId();
-			_salesOrderLine = orderBL.getLineById(salesOrderAndLineId);
-		}
-		return _salesOrderLine;
 	}
 
 	private @NotNull OrderAndLineId getSalesOrderAndLineId()

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/ViewRowFieldNameAndJsonValues.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/ViewRowFieldNameAndJsonValues.java
@@ -200,6 +200,29 @@ public final class ViewRowFieldNameAndJsonValues
 		return TimeUtil.asInstant(valueObj);
 	}
 
+	@Nullable
+	public String getAsString(@NonNull final String fieldName)
+	{
+		final Object valueObj = map.get(fieldName);
+
+		if (valueObj == null || JSONNullValue.isNull(valueObj))
+		{
+			return null;
+		}
+		else if (valueObj instanceof LookupValue)
+		{
+			return ((LookupValue)valueObj).getIdAsString();
+		}
+		else if (valueObj instanceof ReferenceListAwareEnum)
+		{
+			return ((ReferenceListAwareEnum)valueObj).getCode();
+		}
+		else
+		{
+			return valueObj.toString();
+		}
+	}
+
 	public boolean isEmpty(@NonNull final String fieldName)
 	{
 		final Object valueObj = map.get(fieldName);


### PR DESCRIPTION
## Summary

- `QtyReservationService.makeReservation()`: when `projectId` is set in the request, propagate it to the linked sales order line (`C_OrderLine.C_Project_ID`)
- `MD_CockpitV2_MakeQtyReservation`: pass `projectId` from cockpit context when creating a reservation
- `MaterialCockpitV2RowVO/VOs`: expose `projectId` from the reservation row for use in the process
- `ProjectValue` / `ProjectRepository`: new `ProjectValue` type + `findIdByValue()` lookup method
- `WEBUI_C_OrderLineSO_Launch_HUEditor`: refactored to use shared cockpit context
- Cucumber: `M_QtyReservation_StepDef` extended with optional `C_Project_ID` column; new scenario `S_QtyRes_60` validates end-to-end project propagation

## Test plan

- [ ] Run `qtyReservation` Cucumber feature — all scenarios S_QtyRes_10/20/30/40/50/60 pass
- [ ] Create a reservation with a project in the cockpit — verify `C_OrderLine.C_Project_ID` is updated
- [ ] Create a reservation without a project — verify order line is unchanged