### PR TITLE
gh#28679 Align forecast ASI matching + field description

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5793260_sys_gh28679_ForecastLine_ASI_AD_Name_Override.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5793260_sys_gh28679_ForecastLine_ASI_AD_Name_Override.sql
@@ -1,0 +1,80 @@
+-- gh#28679: Override AD_Element for Forecast Line ASI field (AD_Field_ID=747570)
+-- Adds field-specific description explaining PP_Product_Planning fallback behavior
+
+-- New override AD_Element (no ColumnName — override elements don't have one)
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                        Created, CreatedBy, Updated, UpdatedBy,
+                        ColumnName, EntityType,
+                        Name, PrintName,
+                        Description, Help)
+VALUES (584647, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-03-09 12:00', 'YYYY-MM-DD HH24:MI'), 0,
+        TO_TIMESTAMP('2026-03-09 12:00', 'YYYY-MM-DD HH24:MI'), 0,
+        NULL, 'D',
+        'Merkmale', 'Merkmale',
+        'Merkmals Ausprägungen zum Produkt. Wenn leer, wird automatisch die Merkmalsausprägung aus der Produktionsplanung (PP_Product_Planning) übernommen.',
+        'Ordnet dem Prognoseeintrag eine bestimmte Merkmalsausprägung zu. Wenn dieses Feld leer bleibt, verwendet das System automatisch die Merkmalsausprägung aus dem passenden Produktionsplanungseintrag (PP_Product_Planning), sofern vorhanden. Damit wird sichergestellt, dass die Materialbedarfsplanung (Material Dispo) mit den richtigen Attributen arbeitet.');
+
+-- AD_Element_Trl skeleton rows
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID,
+                            Name, PrintName, Description, Help,
+                            IsTranslated, AD_Client_ID, AD_Org_ID,
+                            Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Element_ID,
+       t.Name, t.PrintName, t.Description, t.Help,
+       'N', t.AD_Client_ID, t.AD_Org_ID,
+       t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Element_ID = 584647
+  AND NOT EXISTS (SELECT 1
+                  FROM AD_Element_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language
+                    AND tt.AD_Element_ID = t.AD_Element_ID);
+
+-- de_DE: German (base language) — same as AD_Element base, istranslated='N'
+UPDATE AD_Element_Trl
+SET Name        = 'Merkmale',
+    PrintName   = 'Merkmale',
+    Description = 'Merkmals Ausprägungen zum Produkt. Wenn leer, wird automatisch die Merkmalsausprägung aus der Produktionsplanung (PP_Product_Planning) übernommen.',
+    Help        = 'Ordnet dem Prognoseeintrag eine bestimmte Merkmalsausprägung zu. Wenn dieses Feld leer bleibt, verwendet das System automatisch die Merkmalsausprägung aus dem passenden Produktionsplanungseintrag (PP_Product_Planning), sofern vorhanden. Damit wird sichergestellt, dass die Materialbedarfsplanung (Material Dispo) mit den richtigen Attributen arbeitet.',
+    IsTranslated = 'N',
+    Updated     = TO_TIMESTAMP('2026-03-09 12:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy   = 0
+WHERE AD_Element_ID = 584647
+  AND AD_Language = 'de_DE';
+
+-- de_CH: same as de_DE
+UPDATE AD_Element_Trl
+SET Name        = 'Merkmale',
+    PrintName   = 'Merkmale',
+    Description = 'Merkmals Ausprägungen zum Produkt. Wenn leer, wird automatisch die Merkmalsausprägung aus der Produktionsplanung (PP_Product_Planning) übernommen.',
+    Help        = 'Ordnet dem Prognoseeintrag eine bestimmte Merkmalsausprägung zu. Wenn dieses Feld leer bleibt, verwendet das System automatisch die Merkmalsausprägung aus dem passenden Produktionsplanungseintrag (PP_Product_Planning), sofern vorhanden. Damit wird sichergestellt, dass die Materialbedarfsplanung (Material Dispo) mit den richtigen Attributen arbeitet.',
+    IsTranslated = 'N',
+    Updated     = TO_TIMESTAMP('2026-03-09 12:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy   = 0
+WHERE AD_Element_ID = 584647
+  AND AD_Language = 'de_CH';
+
+-- en_US: English translation
+UPDATE AD_Element_Trl
+SET Name        = 'Attributes',
+    PrintName   = 'Attributes',
+    Description = 'Attribute set instance for this forecast line. When left empty, the system automatically uses the ASI from the matching Product Planning (PP_Product_Planning) record.',
+    Help        = 'Assigns a specific attribute set instance to this forecast entry. When left empty, the system automatically falls back to the ASI from the best-fitting Product Planning record (PP_Product_Planning), if one exists. This ensures that Material Disposition (MD_Candidate) operates with the correct storage attributes key.',
+    IsTranslated = 'Y',
+    Updated     = TO_TIMESTAMP('2026-03-09 12:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy   = 0
+WHERE AD_Element_ID = 584647
+  AND AD_Language = 'en_US';
+
+-- Link AD_Field 747570 (Forecast Line ASI field) to the new override element
+UPDATE AD_Field
+SET AD_Name_ID  = 584647,
+    Updated     = TO_TIMESTAMP('2026-03-09 12:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy   = 0
+WHERE AD_Field_ID = 747570;
+
+-- Propagate translations from the override element to the field
+SELECT update_FieldTranslation_From_AD_Name_Element(584647);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/forecast_with_attributes.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/forecast_with_attributes.feature
@@ -124,3 +124,37 @@ Feature: Forecast ASI enrichment from PP_Product_Planning
     Then after not more than 60s, the MD_Candidate table has only the following records
       | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | Qty_AvailableToPromise |
       | c_1        | STOCK_UP          | FORECAST                  | p_1          | 2021-04-16T22:00:00Z | 10  | 0                      |
+
+  @Id:S0463_130
+  @from:cucumber
+  Scenario: Forecast line WITHOUT ASI, attribute-DEPENDENT planning — enrichment from planning
+    Given metasfresh contains M_Products:
+      | Identifier | OPT.M_Product_Category_ID.Identifier |
+      | p_1        | standard_category                    |
+    And metasfresh contains M_AttributeSetInstance with identifier "planningASI":
+  """
+  {
+    "attributeInstances":[
+      {
+        "attributeCode":"1000002",
+          "valueStr":"Bio"
+      }
+    ]
+  }
+  """
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID |
+      | warehouse      |
+    And metasfresh contains PP_Product_Plannings
+      | Identifier | M_Product_ID | IsCreatePlan | M_AttributeSetInstance_ID | IsAttributeDependant |
+      | ppln_1     | p_1          | false        | planningASI               | true                 |
+    And metasfresh contains M_Forecasts:
+      | Identifier | Name | DatePromised | M_Warehouse_ID |
+      | f_1        | test | 2021-04-17   | warehouse      |
+    And metasfresh contains M_ForecastLines:
+      | M_Forecast_ID | M_Product_ID | Qty | M_Warehouse_ID | C_UOM_ID.X12DE355 |
+      | f_1           | p_1          | 10  | warehouse      | PCE                |
+    When the forecast identified by f_1 is completed
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | M_AttributeSetInstance_ID |
+      | c_1        | STOCK_UP          | FORECAST                  | p_1          | 2021-04-16T22:00:00Z | 10  | planningASI               |

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/material/interceptor/M_ForecastEventCreator.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/material/interceptor/M_ForecastEventCreator.java
@@ -144,7 +144,7 @@ public class M_ForecastEventCreator
 		}
 
 		// forecast line has no ASI — look up PP_Product_Planning for a fallback ASI
-		final AttributeSetInstanceId planningAsiId = resolvePlanningAsiId(forecastLine);
+		final AttributeSetInstanceId planningAsiId = resolvePlanningAsiId(forecastLine, forecastAsiId);
 		if (!planningAsiId.isNone())
 		{
 			return productDescriptorFactory.createProductDescriptor(
@@ -155,13 +155,15 @@ public class M_ForecastEventCreator
 		return productDescriptorFactory.createProductDescriptor(forecastLine);
 	}
 
-	private AttributeSetInstanceId resolvePlanningAsiId(@NonNull final I_M_ForecastLine forecastLine)
+	private AttributeSetInstanceId resolvePlanningAsiId(
+			@NonNull final I_M_ForecastLine forecastLine,
+			@NonNull final AttributeSetInstanceId forecastAsiId)
 	{
 		final ProductPlanningQuery query = ProductPlanningQuery.builder()
 				.productId(ProductId.ofRepoId(forecastLine.getM_Product_ID()))
 				.warehouseId(WarehouseId.ofRepoIdOrNull(forecastLine.getM_Warehouse_ID()))
 				.orgId(OrgId.ofRepoId(forecastLine.getAD_Org_ID()))
-				.attributeSetInstanceId(AttributeSetInstanceId.NONE)
+				.attributeSetInstanceId(forecastAsiId)
 				.build();
 
 		return productPlanningDAO.find(query)


### PR DESCRIPTION
## Summary
- Pass forecast line's actual ASI to `ProductPlanningQuery` in `M_ForecastEventCreator.resolvePlanningAsiId()` instead of hardcoding `NONE` — aligns with `SupplyRequiredHandlerHelper` and `PPOrderUtil` patterns
- Add AD_Name_ID override (AD_Element 584647) on forecast line ASI field to document PP_Product_Planning fallback behavior
- Add Cucumber scenario S0463_130: forecast line WITHOUT ASI + attribute-dependent planning record

## Test plan
- [ ] Existing Cucumber scenarios S0463_100, S0463_110, S0463_120 still pass (no regression)
- [ ] New scenario S0463_130 passes (attribute-dependent planning enrichment)
- [ ] Migration script applies cleanly
- [ ] AD_Field 747570 shows updated description/help in WebUI