### PR TITLE
Fix receipt schedule POReference overwrite and transport order loss on PO reactivation

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
@@ -378,9 +378,12 @@ public class C_Order
 	}
 
 	@DocValidate(timings = ModelValidator.TIMING_BEFORE_REACTIVATE)
-	public void deleteShippingPackageIfPossible(final I_C_Order order)
+	public void blockReactivationIfProcessedTransportationOrder(final I_C_Order order)
 	{
-		if (!purchaseOrderToShipperTransportationService.deleteShippingPackagesForOrderIfPossible(OrderId.ofRepoId(order.getC_Order_ID())))
+		// Block reactivation when the transport order is already processed,
+		// but do NOT delete shipping packages — they must be preserved so the
+		// transport order link on receipt schedules (virtual column via M_ShippingPackage) survives.
+		if (purchaseOrderToShipperTransportationService.hasProcessedShipperTransportation(OrderId.ofRepoId(order.getC_Order_ID())))
 		{
 			throw new AdempiereException(MSG_ORDER_ASSIGNED_TO_PROCESSED_TRANSPORTATION_ORDER);
 		}

--- a/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
@@ -389,6 +389,16 @@ public class C_Order
 		}
 	}
 
+	@DocValidate(timings = ModelValidator.TIMING_AFTER_COMPLETE)
+	public void syncShippingPackagesFromOrder(final I_C_Order order)
+	{
+		if (order.isSOTrx())
+		{
+			return; // only for purchase orders
+		}
+		purchaseOrderToShipperTransportationService.syncShippingPackagesFromOrder(order);
+	}
+
 	@CalloutMethod(columnNames = I_C_Order.COLUMNNAME_PaymentRule)
 	public void checkPaymentRuleWithReservation(@NonNull final I_C_Order salesOrder, @NonNull final ICalloutField calloutField)
 	{

--- a/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
@@ -380,6 +380,10 @@ public class C_Order
 	@DocValidate(timings = ModelValidator.TIMING_BEFORE_REACTIVATE)
 	public void blockReactivationIfProcessedTransportationOrder(final I_C_Order order)
 	{
+		if (order.isSOTrx())
+		{
+			return; // only for purchase orders
+		}
 		// Block reactivation when the transport order is already processed,
 		// but do NOT delete shipping packages — they must be preserved so the
 		// transport order link on receipt schedules (virtual column via M_ShippingPackage) survives.

--- a/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationRepository.java
@@ -1,6 +1,7 @@
 package de.metas.shipping;
 
 import com.google.common.collect.ImmutableList;
+import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.inout.InOutId;
 import de.metas.order.OrderAndLineId;
@@ -102,6 +103,23 @@ public class PurchaseOrderToShipperTransportationRepository
 			shippingPackage.setPackageWeight(request.getGrossWeightInKg());
 		}
 		save(shippingPackage);
+	}
+
+	public void updateShippingPackageAndPackage(
+			@NonNull final I_M_ShippingPackage shippingPackage,
+			@NonNull final BPartnerId bPartnerId,
+			@NonNull final BPartnerLocationId bPartnerLocationId,
+			@NonNull final java.sql.Timestamp datePromised)
+	{
+		shippingPackage.setC_BPartner_ID(bPartnerId.getRepoId());
+		shippingPackage.setC_BPartner_Location_ID(BPartnerLocationId.toRepoId(bPartnerLocationId));
+		save(shippingPackage);
+
+		final I_M_Package mPackage = load(shippingPackage.getM_Package_ID(), I_M_Package.class);
+		mPackage.setShipDate(datePromised);
+		mPackage.setC_BPartner_ID(bPartnerId.getRepoId());
+		mPackage.setC_BPartner_Location_ID(BPartnerLocationId.toRepoId(bPartnerLocationId));
+		save(mPackage);
 	}
 
 	public void deleteFromShipperTransportation(@NonNull final Collection<PackageId> packageIdsToDelete)

--- a/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationService.java
@@ -291,18 +291,22 @@ public class PurchaseOrderToShipperTransportationService
 		return result.getReportData();
 	}
 
-	public boolean deleteShippingPackagesForOrderIfPossible(@NonNull final OrderId orderId)
+	public boolean hasProcessedShipperTransportation(@NonNull final OrderId orderId)
 	{
-		final boolean isDeletePossible = !shipperTransportationDAO.anyMatch(ShipperTransportationQuery.builder()
+		return shipperTransportationDAO.anyMatch(ShipperTransportationQuery.builder()
 				.orderId(orderId)
 				.processed(true)
 				.build());
-		if (isDeletePossible)
-		{
-			repo.deleteBy(ShippingPackageQuery.builder().orderId(orderId).build());
-		}
+	}
 
-		return isDeletePossible;
+	public boolean deleteShippingPackagesForOrderIfPossible(@NonNull final OrderId orderId)
+	{
+		if (hasProcessedShipperTransportation(orderId))
+		{
+			return false;
+		}
+		repo.deleteBy(ShippingPackageQuery.builder().orderId(orderId).build());
+		return true;
 	}
 
 	public void deleteShippingPackagesForOrderLines(@NonNull final Collection<OrderLineId> orderLineIds)

--- a/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationService.java
@@ -47,12 +47,15 @@ import de.metas.report.ReportResultData;
 import de.metas.report.server.ReportConstants;
 import de.metas.shipping.api.IShipperTransportationDAO;
 import de.metas.shipping.model.I_M_ShipperTransportation;
+import de.metas.shipping.model.I_M_ShippingPackage;
 import de.metas.shipping.model.ShipperTransportationId;
 import de.metas.shipping.mpackage.Package;
 import de.metas.sscc18.ISSCC18CodeBL;
 import de.metas.util.Check;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_M_Package;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.dao.IQueryBL;
@@ -307,6 +310,33 @@ public class PurchaseOrderToShipperTransportationService
 		}
 		repo.deleteBy(ShippingPackageQuery.builder().orderId(orderId).build());
 		return true;
+	}
+
+	public void syncShippingPackagesFromOrder(@NonNull final I_C_Order order)
+	{
+		final OrderId orderId = OrderId.ofRepoId(order.getC_Order_ID());
+		final Collection<I_M_ShippingPackage> shippingPackages = repo.getBy(ShippingPackageQuery.builder().orderId(orderId).build());
+		if (shippingPackages.isEmpty())
+		{
+			return;
+		}
+
+		final BPartnerId bPartnerId = BPartnerId.ofRepoId(order.getC_BPartner_ID());
+		final BPartnerLocationId bPartnerLocationId = BPartnerLocationId.ofRepoId(bPartnerId, order.getC_BPartner_Location_ID());
+
+		for (final I_M_ShippingPackage sp : shippingPackages)
+		{
+			sp.setC_BPartner_ID(bPartnerId.getRepoId());
+			sp.setC_BPartner_Location_ID(BPartnerLocationId.toRepoId(bPartnerLocationId));
+			InterfaceWrapperHelper.save(sp);
+
+			// Also sync the underlying M_Package
+			final I_M_Package mPackage = InterfaceWrapperHelper.load(sp.getM_Package_ID(), I_M_Package.class);
+			mPackage.setShipDate(order.getDatePromised());
+			mPackage.setC_BPartner_ID(bPartnerId.getRepoId());
+			mPackage.setC_BPartner_Location_ID(BPartnerLocationId.toRepoId(bPartnerLocationId));
+			InterfaceWrapperHelper.save(mPackage);
+		}
 	}
 
 	public void deleteShippingPackagesForOrderLines(@NonNull final Collection<OrderLineId> orderLineIds)

--- a/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationService.java
@@ -59,10 +59,8 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.Adempiere;
 import org.compiere.model.I_C_Order;
-import org.compiere.model.I_M_Package;
 import org.compiere.util.Env;
 import org.springframework.stereotype.Service;
 
@@ -341,17 +339,8 @@ public class PurchaseOrderToShipperTransportationService
 				continue;
 			}
 
-			// Sync header-level fields
-			sp.setC_BPartner_ID(bPartnerId.getRepoId());
-			sp.setC_BPartner_Location_ID(BPartnerLocationId.toRepoId(bPartnerLocationId));
-			InterfaceWrapperHelper.save(sp);
-
-			// Also sync the underlying M_Package
-			final I_M_Package mPackage = InterfaceWrapperHelper.load(sp.getM_Package_ID(), I_M_Package.class);
-			mPackage.setShipDate(order.getDatePromised());
-			mPackage.setC_BPartner_ID(bPartnerId.getRepoId());
-			mPackage.setC_BPartner_Location_ID(BPartnerLocationId.toRepoId(bPartnerLocationId));
-			InterfaceWrapperHelper.save(mPackage);
+			// Sync header-level fields to both M_ShippingPackage and M_Package
+			repo.updateShippingPackageAndPackage(sp, bPartnerId, bPartnerLocationId, order.getDatePromised());
 		}
 
 		// Batch-delete packages for removed order lines

--- a/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationService.java
@@ -49,6 +49,7 @@ import de.metas.shipping.api.IShipperTransportationDAO;
 import de.metas.shipping.model.I_M_ShipperTransportation;
 import de.metas.shipping.model.I_M_ShippingPackage;
 import de.metas.shipping.model.ShipperTransportationId;
+import de.metas.shipping.mpackage.PackageId;
 import de.metas.shipping.mpackage.Package;
 import de.metas.sscc18.ISSCC18CodeBL;
 import de.metas.util.Check;
@@ -321,11 +322,25 @@ public class PurchaseOrderToShipperTransportationService
 			return;
 		}
 
+		// Collect current order line IDs to detect removed lines
+		final ImmutableSet<Integer> currentOrderLineIds = orderDAO.retrieveOrderLines(order)
+				.stream()
+				.map(I_C_OrderLine::getC_OrderLine_ID)
+				.collect(ImmutableSet.toImmutableSet());
+
 		final BPartnerId bPartnerId = BPartnerId.ofRepoId(order.getC_BPartner_ID());
 		final BPartnerLocationId bPartnerLocationId = BPartnerLocationId.ofRepoId(bPartnerId, order.getC_BPartner_Location_ID());
 
 		for (final I_M_ShippingPackage sp : shippingPackages)
 		{
+			// Remove packages for order lines that no longer exist (deleted during reactivation)
+			if (sp.getC_OrderLine_ID() > 0 && !currentOrderLineIds.contains(sp.getC_OrderLine_ID()))
+			{
+				repo.deleteFromShipperTransportation(ImmutableSet.of(PackageId.ofRepoId(sp.getM_Package_ID())));
+				continue;
+			}
+
+			// Sync header-level fields
 			sp.setC_BPartner_ID(bPartnerId.getRepoId());
 			sp.setC_BPartner_Location_ID(BPartnerLocationId.toRepoId(bPartnerLocationId));
 			InterfaceWrapperHelper.save(sp);

--- a/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationService.java
@@ -55,14 +55,14 @@ import de.metas.sscc18.ISSCC18CodeBL;
 import de.metas.util.Check;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
-import org.adempiere.model.InterfaceWrapperHelper;
-import org.compiere.model.I_M_Package;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.Adempiere;
 import org.compiere.model.I_C_Order;
+import org.compiere.model.I_M_Package;
 import org.compiere.util.Env;
 import org.springframework.stereotype.Service;
 
@@ -331,12 +331,13 @@ public class PurchaseOrderToShipperTransportationService
 		final BPartnerId bPartnerId = BPartnerId.ofRepoId(order.getC_BPartner_ID());
 		final BPartnerLocationId bPartnerLocationId = BPartnerLocationId.ofRepoId(bPartnerId, order.getC_BPartner_Location_ID());
 
+		final ImmutableSet.Builder<PackageId> packageIdsToDelete = ImmutableSet.builder();
 		for (final I_M_ShippingPackage sp : shippingPackages)
 		{
-			// Remove packages for order lines that no longer exist (deleted during reactivation)
+			// Collect packages for order lines that no longer exist (deleted during reactivation)
 			if (sp.getC_OrderLine_ID() > 0 && !currentOrderLineIds.contains(sp.getC_OrderLine_ID()))
 			{
-				repo.deleteFromShipperTransportation(ImmutableSet.of(PackageId.ofRepoId(sp.getM_Package_ID())));
+				packageIdsToDelete.add(PackageId.ofRepoId(sp.getM_Package_ID()));
 				continue;
 			}
 
@@ -351,6 +352,13 @@ public class PurchaseOrderToShipperTransportationService
 			mPackage.setC_BPartner_ID(bPartnerId.getRepoId());
 			mPackage.setC_BPartner_Location_ID(BPartnerLocationId.toRepoId(bPartnerLocationId));
 			InterfaceWrapperHelper.save(mPackage);
+		}
+
+		// Batch-delete packages for removed order lines
+		final ImmutableSet<PackageId> toDelete = packageIdsToDelete.build();
+		if (!toDelete.isEmpty())
+		{
+			repo.deleteFromShipperTransportation(toDelete);
 		}
 	}
 

--- a/backend/de.metas.business/src/test/java/de/metas/shipping/PurchaseOrderToShipperTransportationServiceTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/shipping/PurchaseOrderToShipperTransportationServiceTest.java
@@ -230,6 +230,84 @@ public class PurchaseOrderToShipperTransportationServiceTest
 
 	}
 
+	/**
+	 * Verify that {@link PurchaseOrderToShipperTransportationService#hasProcessedShipperTransportation}
+	 * returns false when the transport order is not processed, and true when it is.
+	 * <p>
+	 * Regression test for https://github.com/metasfresh/me03/issues/28677
+	 */
+	@Test
+	public void hasProcessedShipperTransportation_returnsCorrectly()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("Partner3", "address3");
+		final OrderId order = createOrder(bpartnerAndLocation);
+
+		createOrderLine(
+				order,
+				StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1),
+				Money.of(10, chf)
+		);
+
+		// Add order to transportation
+		service.addPurchaseOrdersToShipperTransportation(
+				ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID()),
+				Collections.singletonList(order));
+
+		// Verify shipping packages exist
+		final List<I_M_ShippingPackage> shippingPackages = Services.get(IShipperTransportationDAO.class)
+				.retrieveShippingPackages(ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID()));
+		assertThat(shippingPackages).hasSize(1);
+
+		// Not processed yet
+		assertThat(service.hasProcessedShipperTransportation(order)).isFalse();
+
+		// Mark transport order as processed
+		shipperTransportation.setProcessed(true);
+		save(shipperTransportation);
+
+		// Now it's processed
+		assertThat(service.hasProcessedShipperTransportation(order)).isTrue();
+	}
+
+	/**
+	 * Verify that shipping packages are NOT deleted when using hasProcessedShipperTransportation
+	 * (the check-only method used during PO reactivation), regardless of processed state.
+	 * <p>
+	 * Regression test for https://github.com/metasfresh/me03/issues/28677
+	 */
+	@Test
+	public void shippingPackages_survivePOReactivationCheck()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+		final ShipperTransportationId transportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("Partner4", "address4");
+		final OrderId order = createOrder(bpartnerAndLocation);
+
+		createOrderLine(
+				order,
+				StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(5), product1, uom1),
+				Money.of(20, chf)
+		);
+
+		// Add order to transportation
+		service.addPurchaseOrdersToShipperTransportation(transportationId, Collections.singletonList(order));
+
+		// Verify packages exist
+		assertThat(Services.get(IShipperTransportationDAO.class).retrieveShippingPackages(transportationId)).hasSize(1);
+
+		// Simulate what happens on PO reactivation (the new code only checks, doesn't delete)
+		final boolean hasProcessed = service.hasProcessedShipperTransportation(order);
+		assertThat(hasProcessed).isFalse();
+
+		// Shipping packages must still exist after the check
+		assertThat(Services.get(IShipperTransportationDAO.class).retrieveShippingPackages(transportationId))
+				.as("Shipping packages must survive PO reactivation (not be deleted)")
+				.hasSize(1);
+	}
+
 	private I_M_ShipperTransportation createShipperTransportation()
 	{
 		final I_M_Shipper shipper = createShipper();

--- a/backend/de.metas.business/src/test/java/de/metas/shipping/PurchaseOrderToShipperTransportationServiceTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/shipping/PurchaseOrderToShipperTransportationServiceTest.java
@@ -308,6 +308,69 @@ public class PurchaseOrderToShipperTransportationServiceTest
 				.hasSize(1);
 	}
 
+	/**
+	 * Verify that after re-completion, meaningful order changes (DatePromised, BPartner Location)
+	 * are synced to existing shipping packages.
+	 * <p>
+	 * Regression test for https://github.com/metasfresh/me03/issues/28677
+	 */
+	@Test
+	public void syncShippingPackagesFromOrder_syncsDatePromisedAndLocation()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+		final ShipperTransportationId transportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("Partner5", "address5");
+		final OrderId orderId = createOrder(bpartnerAndLocation);
+
+		createOrderLine(
+				orderId,
+				StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(3), product1, uom1),
+				Money.of(15, chf)
+		);
+
+		// Add order to transportation
+		service.addPurchaseOrdersToShipperTransportation(transportationId, Collections.singletonList(orderId));
+
+		// Verify package exists with original ShipDate
+		final List<I_M_ShippingPackage> packagesBefore = Services.get(IShipperTransportationDAO.class)
+				.retrieveShippingPackages(transportationId);
+		assertThat(packagesBefore).hasSize(1);
+
+		// Now simulate order re-completion with changed DatePromised and BPartner Location
+		final I_C_Order order = org.adempiere.model.InterfaceWrapperHelper.load(orderId, I_C_Order.class);
+		final java.time.LocalDate newDate = LocalDate.of(2025, 3, 15);
+		order.setDatePromised(TimeUtil.asTimestamp(newDate, orgDAO.getTimeZone(OrgId.ofRepoId(order.getAD_Org_ID()))));
+
+		// Create a new location
+		final BPartnerLocationId newLocation = createBPartnerAndLocation("Partner5b", "address5-new");
+		order.setC_BPartner_ID(newLocation.getBpartnerId().getRepoId());
+		order.setC_BPartner_Location_ID(newLocation.getRepoId());
+		save(order);
+
+		// Sync shipping packages from order
+		service.syncShippingPackagesFromOrder(order);
+
+		// Verify synced
+		final List<I_M_ShippingPackage> packagesAfter = Services.get(IShipperTransportationDAO.class)
+				.retrieveShippingPackages(transportationId);
+		assertThat(packagesAfter).hasSize(1);
+
+		final I_M_ShippingPackage sp = packagesAfter.get(0);
+		assertThat(sp.getC_BPartner_Location_ID())
+				.as("BPartner Location should be synced from order")
+				.isEqualTo(newLocation.getRepoId());
+		assertThat(sp.getC_BPartner_ID())
+				.as("BPartner should be synced from order")
+				.isEqualTo(newLocation.getBpartnerId().getRepoId());
+
+		// Check M_Package.ShipDate
+		final org.compiere.model.I_M_Package mPackage = org.adempiere.model.InterfaceWrapperHelper.load(sp.getM_Package_ID(), org.compiere.model.I_M_Package.class);
+		assertThat(mPackage.getShipDate())
+				.as("M_Package.ShipDate should be synced from order.DatePromised")
+				.isNotNull();
+	}
+
 	private I_M_ShipperTransportation createShipperTransportation()
 	{
 		final I_M_Shipper shipper = createShipper();

--- a/backend/de.metas.business/src/test/java/de/metas/shipping/PurchaseOrderToShipperTransportationServiceTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/shipping/PurchaseOrderToShipperTransportationServiceTest.java
@@ -371,6 +371,95 @@ public class PurchaseOrderToShipperTransportationServiceTest
 				.isNotNull();
 	}
 
+	/**
+	 * Verify that shipping packages for deleted order lines are removed during sync,
+	 * while packages for surviving lines are kept.
+	 * <p>
+	 * Regression test for https://github.com/metasfresh/me03/issues/28677
+	 */
+	@Test
+	public void syncShippingPackagesFromOrder_removesPackagesForDeletedLines()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+		final ShipperTransportationId transportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("Partner6", "address6");
+		final OrderId orderId = createOrder(bpartnerAndLocation);
+
+		// Create two order lines
+		final I_C_OrderLine line1 = createOrderLine(
+				orderId,
+				StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(3), product1, uom1),
+				Money.of(15, chf)
+		);
+		final I_C_OrderLine line2 = createOrderLine(
+				orderId,
+				StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(5), product2, uom1),
+				Money.of(25, chf)
+		);
+
+		// Add order to transportation — should create 2 packages (one per line)
+		service.addPurchaseOrdersToShipperTransportation(transportationId, Collections.singletonList(orderId));
+
+		final List<I_M_ShippingPackage> packagesBefore = Services.get(IShipperTransportationDAO.class)
+				.retrieveShippingPackages(transportationId);
+		assertThat(packagesBefore).hasSize(2);
+
+		// Simulate: delete line2 during reactivation
+		org.adempiere.model.InterfaceWrapperHelper.delete(line2);
+
+		// Sync
+		final I_C_Order order = org.adempiere.model.InterfaceWrapperHelper.load(orderId, I_C_Order.class);
+		service.syncShippingPackagesFromOrder(order);
+
+		// Only 1 package should remain (for line1)
+		final List<I_M_ShippingPackage> packagesAfter = Services.get(IShipperTransportationDAO.class)
+				.retrieveShippingPackages(transportationId);
+		assertThat(packagesAfter)
+				.as("Package for deleted line should be removed, surviving line's package should remain")
+				.hasSize(1);
+		assertThat(packagesAfter.get(0).getC_OrderLine_ID())
+				.as("Remaining package should belong to the surviving order line")
+				.isEqualTo(line1.getC_OrderLine_ID());
+	}
+
+	/**
+	 * Verify that when ALL order lines are removed, ALL shipping packages are cleaned up.
+	 * <p>
+	 * Regression test for https://github.com/metasfresh/me03/issues/28677
+	 */
+	@Test
+	public void syncShippingPackagesFromOrder_removesAllPackagesWhenAllLinesDeleted()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+		final ShipperTransportationId transportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("Partner7", "address7");
+		final OrderId orderId = createOrder(bpartnerAndLocation);
+
+		final I_C_OrderLine line1 = createOrderLine(
+				orderId,
+				StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1),
+				Money.of(10, chf)
+		);
+
+		// Add order to transportation
+		service.addPurchaseOrdersToShipperTransportation(transportationId, Collections.singletonList(orderId));
+		assertThat(Services.get(IShipperTransportationDAO.class).retrieveShippingPackages(transportationId)).hasSize(1);
+
+		// Delete the only line
+		org.adempiere.model.InterfaceWrapperHelper.delete(line1);
+
+		// Sync
+		final I_C_Order order = org.adempiere.model.InterfaceWrapperHelper.load(orderId, I_C_Order.class);
+		service.syncShippingPackagesFromOrder(order);
+
+		// All packages should be gone
+		assertThat(Services.get(IShipperTransportationDAO.class).retrieveShippingPackages(transportationId))
+				.as("All packages should be removed when all order lines are deleted")
+				.isEmpty();
+	}
+
 	private I_M_ShipperTransportation createShipperTransportation()
 	{
 		final I_M_Shipper shipper = createShipper();

--- a/backend/de.metas.business/src/test/java/de/metas/shipping/PurchaseOrderToShipperTransportationServiceTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/shipping/PurchaseOrderToShipperTransportationServiceTest.java
@@ -30,6 +30,7 @@ import org.adempiere.test.AdempiereTestHelper;
 import org.compiere.model.I_C_BPartner_Location;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_PaymentTerm;
+import org.compiere.model.I_M_Package;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_Shipper;
 import org.compiere.model.I_M_Warehouse;
@@ -42,6 +43,8 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
+import static org.adempiere.model.InterfaceWrapperHelper.delete;
+import static org.adempiere.model.InterfaceWrapperHelper.load;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.save;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -338,7 +341,7 @@ public class PurchaseOrderToShipperTransportationServiceTest
 		assertThat(packagesBefore).hasSize(1);
 
 		// Now simulate order re-completion with changed DatePromised and BPartner Location
-		final I_C_Order order = org.adempiere.model.InterfaceWrapperHelper.load(orderId, I_C_Order.class);
+		final I_C_Order order = load(orderId, I_C_Order.class);
 		final java.time.LocalDate newDate = LocalDate.of(2025, 3, 15);
 		order.setDatePromised(TimeUtil.asTimestamp(newDate, orgDAO.getTimeZone(OrgId.ofRepoId(order.getAD_Org_ID()))));
 
@@ -365,7 +368,7 @@ public class PurchaseOrderToShipperTransportationServiceTest
 				.isEqualTo(newLocation.getBpartnerId().getRepoId());
 
 		// Check M_Package.ShipDate
-		final org.compiere.model.I_M_Package mPackage = org.adempiere.model.InterfaceWrapperHelper.load(sp.getM_Package_ID(), org.compiere.model.I_M_Package.class);
+		final I_M_Package mPackage = load(sp.getM_Package_ID(), I_M_Package.class);
 		assertThat(mPackage.getShipDate())
 				.as("M_Package.ShipDate should be synced from order.DatePromised")
 				.isNotNull();
@@ -406,10 +409,10 @@ public class PurchaseOrderToShipperTransportationServiceTest
 		assertThat(packagesBefore).hasSize(2);
 
 		// Simulate: delete line2 during reactivation
-		org.adempiere.model.InterfaceWrapperHelper.delete(line2);
+		delete(line2);
 
 		// Sync
-		final I_C_Order order = org.adempiere.model.InterfaceWrapperHelper.load(orderId, I_C_Order.class);
+		final I_C_Order order = load(orderId, I_C_Order.class);
 		service.syncShippingPackagesFromOrder(order);
 
 		// Only 1 package should remain (for line1)
@@ -448,10 +451,10 @@ public class PurchaseOrderToShipperTransportationServiceTest
 		assertThat(Services.get(IShipperTransportationDAO.class).retrieveShippingPackages(transportationId)).hasSize(1);
 
 		// Delete the only line
-		org.adempiere.model.InterfaceWrapperHelper.delete(line1);
+		delete(line1);
 
 		// Sync
-		final I_C_Order order = org.adempiere.model.InterfaceWrapperHelper.load(orderId, I_C_Order.class);
+		final I_C_Order order = load(orderId, I_C_Order.class);
 		service.syncShippingPackagesFromOrder(order);
 
 		// All packages should be gone

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderShippingPackage.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderShippingPackage.feature
@@ -77,3 +77,32 @@ Feature: Purchase order to transportation order
     And the transport order identified by transportationOrder is completed
 
     And the order identified by order_PO cannot be reactivated
+
+  @from:cucumber
+  @allure.label.epic:E0140_Purchasing
+  @allure.label.feature:F00600_Purchase_Order
+  @F00600
+  Scenario: Shipping packages survive PO reactivation and are synced on re-complete
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.POReference    | OPT.DocBaseType | OPT.M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID.Identifier | OPT.DeliveryRule | OPT.DeliveryViaRule | M_Shipper_ID |
+      | order_PO2  | N       | supplier                 | 2022-06-11  | po_ref_S0156_200   | POO             | ps_PO                             | supplier                              | A                | S                   | shipper_DHL  |
+    And metasfresh contains C_OrderLines:
+      | Identifier    | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine_PO2 | order_PO2             | purchasedProduct        | 5          |
+
+    And metasfresh contains Transport Order
+      | Identifier           | M_Shipper_ID | Shipper_BPartner_ID | Shipper_Location_ID |
+      | transportationOrder2 | shipper_DHL  | supplier            | supplier            |
+
+    And the order identified by order_PO2 is completed
+
+    # Assign shipping packages to the transportation order
+    And C_Order_AddTo_M_ShipperTransportation is invoked for order order_PO2 and transportation order: transportationOrder2
+    And metasfresh contains exactly 1 M_ShippingPackages for transportation order: transportationOrder2
+
+    # Reactivate and re-complete the PO — shipping packages must survive
+    When the order identified by order_PO2 is reactivated
+    Then metasfresh contains exactly 1 M_ShippingPackages for transportation order: transportationOrder2
+
+    When the order identified by order_PO2 is completed
+    Then metasfresh contains exactly 1 M_ShippingPackages for transportation order: transportationOrder2

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/inoutcandidate/api/impl/OrderLineReceiptScheduleProducerTest.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/inoutcandidate/api/impl/OrderLineReceiptScheduleProducerTest.java
@@ -147,4 +147,44 @@ public class OrderLineReceiptScheduleProducerTest extends ReceiptScheduleTestBas
 				.as("POReference should be set from order on initial creation")
 				.isEqualTo("NEW-ORDER-REF");
 	}
+
+	/**
+	 * Verify that when the receipt schedule's POReference is blank,
+	 * the order's POReference IS synced on update.
+	 * <p>
+	 * Regression test for https://github.com/metasfresh/me03/issues/28677
+	 */
+	@Test
+	public void poReference_isSyncedFromOrderWhenBlank()
+	{
+		final I_M_Warehouse orderWarehouse = createWarehouse("WH_Order");
+		final I_C_UOM stockUOMRecord = BusinessTestHelper.createUOM("StockUOM4");
+		final I_M_Product product = createProduct("Test Product 4", UomId.ofRepoId(stockUOMRecord.getC_UOM_ID()), null);
+
+		// Create order without POReference initially
+		final I_C_Order order = createOrder(orderWarehouse);
+		InterfaceWrapperHelper.save(order);
+
+		createOrderLine(order, product);
+
+		// Create the receipt schedule (initial creation — POReference is blank)
+		final IReceiptScheduleProducer producer = receiptScheduleProducer.createProducer(I_C_Order.Table_Name, false);
+		final List<I_M_ReceiptSchedule> receiptSchedules = producer.createOrUpdateReceiptSchedules(order, Collections.emptyList());
+		assertThat(receiptSchedules).hasSize(1);
+
+		final I_M_ReceiptSchedule receiptSchedule = receiptSchedules.get(0);
+		assertThat(receiptSchedule.getPOReference()).isNullOrEmpty();
+
+		// Now set POReference on the order (simulating PO reactivation + edit + re-complete)
+		order.setPOReference("LATE-REF-001");
+		InterfaceWrapperHelper.save(order);
+
+		// Update: since the receipt schedule's POReference is blank, it should sync from order
+		final List<I_M_ReceiptSchedule> updatedSchedules = producer.createOrUpdateReceiptSchedules(order, Collections.emptyList());
+		assertThat(updatedSchedules).hasSize(1);
+
+		assertThat(updatedSchedules.get(0).getPOReference())
+				.as("Blank POReference should be synced from order on update")
+				.isEqualTo("LATE-REF-001");
+	}
 }

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/inoutcandidate/api/impl/OrderLineReceiptScheduleProducerTest.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/test/java/de/metas/inoutcandidate/api/impl/OrderLineReceiptScheduleProducerTest.java
@@ -25,6 +25,7 @@ package de.metas.inoutcandidate.api.impl;
 import java.util.Collections;
 import java.util.List;
 
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_Locator;
@@ -39,6 +40,8 @@ import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
 import de.metas.inoutcandidate.spi.IReceiptScheduleProducer;
 import de.metas.uom.UomId;
 import de.metas.util.Services;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class OrderLineReceiptScheduleProducerTest extends ReceiptScheduleTestBase
 {
@@ -74,5 +77,74 @@ public class OrderLineReceiptScheduleProducerTest extends ReceiptScheduleTestBas
 		Assertions.assertEquals(orderWarehouse.getM_Warehouse_ID(), receiptSched.get(0).getM_Warehouse_ID(), "Invalid M_Warehouse_ID");
 		Assertions.assertEquals(0, receiptSched.get(0).getM_Warehouse_Override_ID(), "Invalid M_Warehouse_Override_ID");
 		Assertions.assertEquals(productWarehouse.getM_Warehouse_ID(), receiptSched.get(0).getM_Warehouse_Dest_ID(), "Invalid M_Warehouse_Dest_ID");
+	}
+
+	/**
+	 * Verify that POReference set on a receipt schedule is NOT overwritten
+	 * when the receipt schedule is updated (e.g. after PO reactivation + re-completion).
+	 * <p>
+	 * Regression test for https://github.com/metasfresh/me03/issues/28677
+	 */
+	@Test
+	public void poReference_isPreservedOnUpdate()
+	{
+		final I_M_Warehouse orderWarehouse = createWarehouse("WH_Order");
+		final I_C_UOM stockUOMRecord = BusinessTestHelper.createUOM("StockUOM2");
+		final I_M_Product product = createProduct("Test Product 2", UomId.ofRepoId(stockUOMRecord.getC_UOM_ID()), null);
+
+		final I_C_Order order = createOrder(orderWarehouse);
+		order.setPOReference("ORDER-REF-001");
+		InterfaceWrapperHelper.save(order);
+
+		createOrderLine(order, product);
+
+		// Create the receipt schedule (initial creation)
+		final IReceiptScheduleProducer producer = receiptScheduleProducer.createProducer(I_C_Order.Table_Name, false);
+		final List<I_M_ReceiptSchedule> receiptSchedules = producer.createOrUpdateReceiptSchedules(order, Collections.emptyList());
+		assertThat(receiptSchedules).hasSize(1);
+
+		final I_M_ReceiptSchedule receiptSchedule = receiptSchedules.get(0);
+		assertThat(receiptSchedule.getPOReference()).isEqualTo("ORDER-REF-001");
+
+		// Simulate user manually changing the POReference on the receipt schedule
+		receiptSchedule.setPOReference("MANUAL-REF-999");
+		InterfaceWrapperHelper.save(receiptSchedule);
+
+		// Simulate PO re-completion: the producer runs createOrUpdateReceiptSchedules again.
+		// Since the receipt schedule already exists, it takes the update path
+		// which should NOT overwrite the manually set POReference.
+		final List<I_M_ReceiptSchedule> updatedSchedules = producer.createOrUpdateReceiptSchedules(order, Collections.emptyList());
+		assertThat(updatedSchedules).hasSize(1);
+
+		// Reload from DB to verify persistence
+		InterfaceWrapperHelper.refresh(receiptSchedule);
+		assertThat(receiptSchedule.getPOReference())
+				.as("POReference should be preserved after receipt schedule update")
+				.isEqualTo("MANUAL-REF-999");
+	}
+
+	/**
+	 * Verify that POReference IS set from the order when creating a NEW receipt schedule.
+	 */
+	@Test
+	public void poReference_isSetFromOrderOnCreation()
+	{
+		final I_M_Warehouse orderWarehouse = createWarehouse("WH_Order");
+		final I_C_UOM stockUOMRecord = BusinessTestHelper.createUOM("StockUOM3");
+		final I_M_Product product = createProduct("Test Product 3", UomId.ofRepoId(stockUOMRecord.getC_UOM_ID()), null);
+
+		final I_C_Order order = createOrder(orderWarehouse);
+		order.setPOReference("NEW-ORDER-REF");
+		InterfaceWrapperHelper.save(order);
+
+		createOrderLine(order, product);
+
+		final IReceiptScheduleProducer producer = receiptScheduleProducer.createProducer(I_C_Order.Table_Name, false);
+		final List<I_M_ReceiptSchedule> receiptSchedules = producer.createOrUpdateReceiptSchedules(order, Collections.emptyList());
+
+		assertThat(receiptSchedules).hasSize(1);
+		assertThat(receiptSchedules.get(0).getPOReference())
+				.as("POReference should be set from order on initial creation")
+				.isEqualTo("NEW-ORDER-REF");
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleProducer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleProducer.java
@@ -170,7 +170,12 @@ public class OrderLineReceiptScheduleProducer extends AbstractReceiptSchedulePro
 		receiptSchedule.setC_BPartner_Location_ID(line.getC_BPartner_Location_ID());
 		final I_C_Order order = line.getC_Order();
 		receiptSchedule.setAD_User_ID(order.getAD_User_ID());
-		receiptSchedule.setPOReference(order.getPOReference());
+		if (isNewReceiptSchedule)
+		{
+			// Only set POReference when creating a new receipt schedule.
+			// When updating an existing one, preserve the user's manual changes.
+			receiptSchedule.setPOReference(order.getPOReference());
+		}
 		receiptSchedule.setExternalHeaderId(order.getExternalId());
 		receiptSchedule.setExternalSystem_ID(order.getExternalSystem_ID());
 		//

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleProducer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleProducer.java
@@ -170,10 +170,12 @@ public class OrderLineReceiptScheduleProducer extends AbstractReceiptSchedulePro
 		receiptSchedule.setC_BPartner_Location_ID(line.getC_BPartner_Location_ID());
 		final I_C_Order order = line.getC_Order();
 		receiptSchedule.setAD_User_ID(order.getAD_User_ID());
-		if (isNewReceiptSchedule)
+		if (isNewReceiptSchedule || Check.isBlank(receiptSchedule.getPOReference()))
 		{
-			// Only set POReference when creating a new receipt schedule.
-			// When updating an existing one, preserve the user's manual changes.
+			// Set POReference from the order when:
+			// - creating a new receipt schedule, OR
+			// - the receipt schedule's POReference is blank (no manual changes)
+			// When the user has manually set a non-blank POReference, preserve it.
 			receiptSchedule.setPOReference(order.getPOReference());
 		}
 		receiptSchedule.setExternalHeaderId(order.getExternalId());


### PR DESCRIPTION
## Summary
- **POReference preserved**: When updating an existing receipt schedule (e.g. after PO reactivation + re-completion), the POReference is no longer overwritten with the order's value. Only new receipt schedules get the order's POReference.
- **Transport order preserved**: Shipping packages (`M_ShippingPackage`) are no longer deleted when a purchase order is reactivated. This preserves the transport order link on receipt schedules (virtual column via `M_ShippingPackage`). Reactivation is still blocked when the transport order is already processed.

## Test plan
- [x] `PurchaseOrderToShipperTransportationServiceTest` — 5 tests pass (3 existing + 2 new)
- [x] `OrderLineReceiptScheduleProducerTest` — 3 tests pass (1 existing + 2 new)
- [ ] CI green