### PR TITLE
Fix flaky cucumber tests with RabbitMQ drain steps

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/historicalShipmentsExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/historicalShipmentsExport.feature
@@ -61,6 +61,8 @@ Feature: Shipments export via postgREST
 
     And the order identified by o_1 is completed
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
@@ -205,6 +207,8 @@ Feature: Shipments export via postgREST
 
     And the order identified by o_1 is completed
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
@@ -344,6 +348,8 @@ Feature: Shipments export via postgREST
       | ol_1       | o_1                   | product_S0475_030 | 100        | externalLineId_S0475_030 |
 
     And the order identified by o_1 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
@@ -485,6 +491,8 @@ Feature: Shipments export via postgREST
 
     And the order identified by o_1 is completed
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
@@ -625,6 +633,8 @@ Feature: Shipments export via postgREST
       | ol_2       | o_1                   | product_S0475_050 | 100        | externalLineId_S0475_050_2 |
 
     And the order identified by o_1 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
@@ -882,6 +892,8 @@ Feature: Shipments export via postgREST
 
     And the order identified by o_1 is completed
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
@@ -1028,6 +1040,8 @@ Feature: Shipments export via postgREST
 
     And the order identified by o_1 is completed
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
@@ -1173,6 +1187,8 @@ Feature: Shipments export via postgREST
       | ol_2       | o_2                   | product_S0475_080_2 | 100        | externalLineId_S0475_080_2 |
 
     And the order identified by o_2 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/packingmaterial/receipts.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/packingmaterial/receipts.feature
@@ -1811,6 +1811,8 @@ Feature: Packing material invoice candidates: receipts
 
     When the order identified by o_1 is completed
 
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     Then validate the created order lines
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | qtydelivered | QtyOrdered | qtyinvoiced | price | discount | currencyCode | processed |
       | ol_2                      | o_1                   | 2022-07-26      | packingProduct          | 0            | 1000       | 0           | 1     | 0        | EUR          | true      |


### PR DESCRIPTION
## Summary

- Add RabbitMQ queue drain steps (`wait until de.metas.material rabbitMQ queue is empty`) after order completions in 9 cucumber scenarios across 2 feature files
- Prevents race conditions where async material-dispo events are still processing when subsequent steps check results

### Scenarios fixed

| Feature | Scenario(s) | CI Profile | Failure |
|---------|-------------|------------|---------|
| `receipts.feature` | S0160_300 "Complete receipt similar with case 230" | profile3 | `Parent PO reference expired` during material receipt creation |
| `historicalShipmentsExport.feature` | All 8 scenarios (S0475_010 through S0475_080) | profile5 | 60s timeout waiting for `M_ShipmentSchedules` / `M_InOut` |

### Root cause

Order completion triggers async material events via RabbitMQ. Without a drain step, subsequent steps (receipt creation, shipment schedule lookup) may execute before the material-dispo service finishes processing, causing either:
- `Parent PO reference expired` (stale reference due to concurrent processing)
- Timeout waiting for records that depend on completed async processing

### Note on profile7 failures

The `shipmentScheduleExport.feature` scenarios (profile7) already have drain steps but still intermittently fail with `Queue has not been entirely processed in 5 minutes` when 1-3 messages remain. This is CI contention — the material-dispo consumer is marginally too slow under load. A re-run resolves these. A separate improvement could increase the timeout or optimize the consumer.

## Test plan

- [ ] CI green on profile3 (receipts.feature S0160_300)
- [ ] CI green on profile5 (historicalShipmentsExport.feature)
- [ ] Profile7 flakiness reduced (drain steps in other features reduce overall queue pressure)