### PR TITLE
Add concurrency group to cicd workflow

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -7,6 +7,10 @@ on:
       - '**/README.md'
   workflow_dispatch:
 
+concurrency:
+  group: cicd-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   packages: read


### PR DESCRIPTION
## Summary

- Add `concurrency` group keyed by `github.ref` to `cicd.yaml`
- Ensures only one cicd run executes per branch at a time; subsequent runs queue instead of running in parallel
- `cancel-in-progress: false` so queued runs are not cancelled — they wait and run in order

## Why

When two pushes to `new_dawn_uat` happen minutes apart (e.g. runs 22899926711 and 22900041188 started 4 min apart on Mar 10), both spawn ~10 cucumber profiles simultaneously. That's ~20 Docker containers competing for CPU on GitHub's shared runners, causing:

- RabbitMQ queue drain timeouts in profile7 (material-dispo consumer starved)
- Workpackage processing timeouts in profile5
- Runner disconnects (health check runner lost comms after 51 min on Mar 9)

## Test plan

- [ ] CI passes on this branch (proves the concurrency key is syntactically valid)
- [ ] Next time two pushes land on `new_dawn_uat` close together, verify the second run queues instead of running in parallel