### PR TITLE
gh#28612: Add M_Product.SyncEANAndGTIN sysconfig (#22824)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5793550_sys_gh28612_SyncEANAndGTIN_sysconfig.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5793550_sys_gh28612_SyncEANAndGTIN_sysconfig.sql
@@ -1,0 +1,7 @@
+-- gh#28612: Add sysconfig M_Product.SyncEANAndGTIN
+-- When Y (default), GTIN/UPC/EAN_CU fields are synced automatically on M_Product and C_BPartner_Product.
+-- When N, fields can be maintained independently.
+
+INSERT INTO AD_SysConfig (AD_SysConfig_ID, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive, Name, Value, Description, EntityType, ConfigurationLevel)
+VALUES (541799, 0, 0, TO_TIMESTAMP('2026-03-10 11:11:11.000000', 'YYYY-MM-DD HH24:MI:SS.US'), 100, TO_TIMESTAMP('2026-03-10 11:11:11.000000', 'YYYY-MM-DD HH24:MI:SS.US'), 100, 'Y', 'M_Product.SyncEANAndGTIN', 'Y', 'When Y, GTIN/UPC/EAN_CU fields are automatically synchronized on M_Product and C_BPartner_Product. When N, fields can be maintained independently.', 'de.metas.product', 'O')
+;

--- a/backend/de.metas.business/src/main/java/de/metas/bpartner_product/interceptor/C_BPartner_Product.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner_product/interceptor/C_BPartner_Product.java
@@ -19,6 +19,7 @@ import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.mm.attributes.api.IAttributeSetInstanceBL;
 import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ISysConfigBL;
 import org.compiere.model.I_C_BPartner_Product;
 import org.compiere.model.ModelValidator;
 import org.compiere.util.Env;
@@ -55,6 +56,9 @@ public class C_BPartner_Product
 	private final static AdMessageKey MSG_C_BPartner_Product_Duplicate_ASI = AdMessageKey.of("C_BPartner_Product_Duplicate_ASI");
 
 	private final IBPartnerProductBL bpartnerProductBL = Services.get(IBPartnerProductBL.class);
+	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+
+	private static final String SYSCONFIG_SyncEANAndGTIN = "M_Product.SyncEANAndGTIN";
 
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE }, ifColumnsChanged = I_C_BPartner_Product.COLUMNNAME_M_AttributeSetInstance_ID)
 	public void onASISet(final I_C_BPartner_Product bpProduct)
@@ -116,6 +120,12 @@ public class C_BPartner_Product
 			ifColumnsChanged = { I_C_BPartner_Product.COLUMNNAME_GTIN, I_C_BPartner_Product.COLUMNNAME_EAN_CU, I_C_BPartner_Product.COLUMNNAME_EAN13_ProductCode })
 	private void normalizeProductCodeFields(@NonNull I_C_BPartner_Product record)
 	{
+		final boolean syncEANAndGTIN = sysConfigBL.getBooleanValue(SYSCONFIG_SyncEANAndGTIN, true, record.getAD_Client_ID(), record.getAD_Org_ID());
+		if (!syncEANAndGTIN)
+		{
+			return;
+		}
+
 		if (InterfaceWrapperHelper.isValueChanged(record, I_C_BPartner_Product.COLUMNNAME_GTIN))
 		{
 			final GTIN gtin = GTIN.ofNullableString(record.getGTIN());

--- a/backend/de.metas.business/src/main/java/de/metas/product/model/interceptor/M_Product.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/model/interceptor/M_Product.java
@@ -27,6 +27,7 @@ import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ISysConfigBL;
 import org.compiere.model.I_M_Product;
 import org.compiere.model.ModelValidator;
 import org.compiere.util.Env;
@@ -73,6 +74,9 @@ public class M_Product
 
 	private final IProductDAO productDAO = Services.get(IProductDAO.class);
 	private final IProductBL productBL = Services.get(IProductBL.class);
+	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+
+	private static final String SYSCONFIG_SyncEANAndGTIN = "M_Product.SyncEANAndGTIN";
 
 	@Init
 	public void registerCallouts()
@@ -182,8 +186,15 @@ public class M_Product
 				});
 	}
 
-	private void normalizeProductCodeFields(@NonNull I_M_Product record)
+	private void normalizeProductCodeFields(@NonNull final I_M_Product record)
 	{
+		final boolean syncEANAndGTIN = sysConfigBL.getBooleanValue(SYSCONFIG_SyncEANAndGTIN, true, record.getAD_Client_ID(), record.getAD_Org_ID());
+
+		if (!syncEANAndGTIN)
+		{
+			return;
+		}
+
 		if (InterfaceWrapperHelper.isValueChanged(record, I_M_Product.COLUMNNAME_GTIN))
 		{
 			final GTIN gtin = GTIN.ofNullableString(record.getGTIN());

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/FastCucumberDevRunner.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/FastCucumberDevRunner.java
@@ -16,6 +16,7 @@ public class FastCucumberDevRunner
 	public static void main(final String[] args)
 	{
 		System.setProperty("user.timezone", "Europe/Berlin");
+		CucumberLifeCycleSupport.beforeAll();
 		loopReadAndExecute();
 	}
 
@@ -26,7 +27,9 @@ public class FastCucumberDevRunner
 		String lastFeatureFilePath = null;
 		while (true)
 		{
-			System.out.println("\n=======================================================");
+			System.out.flush();
+			System.err.flush();
+			System.out.println("\n\n\n=======================================================");
 			System.out.println("WAITING: Paste absolute path to .feature file (or 'exit'):");
 			// Line 2: Contextual Instruction (Conditional)
 			if (lastFeatureFilePath != null)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_Product_Raw_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_Product_Raw_StepDefData.java
@@ -1,0 +1,11 @@
+package de.metas.cucumber.stepdefs;
+
+import org.compiere.model.I_C_BPartner_Product;
+
+public class C_BPartner_Product_Raw_StepDefData extends StepDefData<I_C_BPartner_Product>
+{
+	public C_BPartner_Product_Raw_StepDefData()
+	{
+		super(I_C_BPartner_Product.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_Product_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_Product_StepDef.java
@@ -39,6 +39,7 @@ import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_BPartner_Product;
 import org.compiere.model.I_M_Product;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
@@ -48,6 +49,7 @@ import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_C_BPartner_ID;
 import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_C_BPartner_Product_ID;
 import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_CustomerLabelName;
 import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_Description;
+import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_EAN13_ProductCode;
 import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_EAN_CU;
 import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_ExclusionFromPurchaseReason;
 import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_ExclusionFromSaleReason;
@@ -67,6 +69,7 @@ public class C_BPartner_Product_StepDef
 {
 	private final M_Product_StepDefData productTable;
 	private final BPartnerProductStepDefData bpartnerProductTable;
+	private final C_BPartner_Product_Raw_StepDefData bpartnerProductRawTable;
 	private final C_BPartner_StepDefData bPartnerTable;
 
 	private final ProductRepository productRepository = SpringContextHolder.instance.getBean(ProductRepository.class);
@@ -74,10 +77,12 @@ public class C_BPartner_Product_StepDef
 	public C_BPartner_Product_StepDef(
 			@NonNull final M_Product_StepDefData productTable,
 			@NonNull final BPartnerProductStepDefData bpartnerProductTable,
+			@NonNull final C_BPartner_Product_Raw_StepDefData bpartnerProductRawTable,
 			@NonNull final C_BPartner_StepDefData bPartnerTable)
 	{
 		this.productTable = productTable;
 		this.bpartnerProductTable = bpartnerProductTable;
+		this.bpartnerProductRawTable = bpartnerProductRawTable;
 		this.bPartnerTable = bPartnerTable;
 	}
 
@@ -185,6 +190,72 @@ public class C_BPartner_Product_StepDef
 		saveRecord(bPartnerProductRecord);
 
 		tableRow.getAsOptionalIdentifier(COLUMNNAME_C_BPartner_Product_ID)
-				.ifPresent(i -> bpartnerProductTable.putOrReplace(i, ProductRepository.fromRecord(bPartnerProductRecord)));
+				.ifPresent(i -> {
+					bpartnerProductTable.putOrReplace(i, ProductRepository.fromRecord(bPartnerProductRecord));
+					bpartnerProductRawTable.putOrReplace(i, bPartnerProductRecord);
+				});
 	}
+
+	/**
+	 * Updates C_BPartner_Product fields and saves (triggers interceptor).
+	 * Supported columns: C_BPartner_Product_ID.Identifier (required), GTIN, EAN_CU, UPC, EAN13_ProductCode.
+	 */
+	@Given("update C_BPartner_Product:")
+	public void update_C_BPartner_Product(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable)
+				.setAdditionalRowIdentifierColumnName(COLUMNNAME_C_BPartner_Product_ID)
+				.forEach(this::updateBPartnerProduct);
+	}
+
+	private void updateBPartnerProduct(@NonNull final DataTableRow row)
+	{
+		final I_C_BPartner_Product record = row.getAsIdentifier().lookupIn(bpartnerProductRawTable);
+		assertThat(record).isNotNull();
+		InterfaceWrapperHelper.refresh(record);
+
+		row.getAsOptionalString(COLUMNNAME_GTIN).ifPresent(value -> record.setGTIN(nullToken2Null(value)));
+		row.getAsOptionalString(COLUMNNAME_UPC).ifPresent(value -> record.setUPC(nullToken2Null(value)));
+		row.getAsOptionalString(COLUMNNAME_EAN_CU).ifPresent(value -> record.setEAN_CU(nullToken2Null(value)));
+		row.getAsOptionalString(COLUMNNAME_EAN13_ProductCode).ifPresent(value -> record.setEAN13_ProductCode(nullToken2Null(value)));
+
+		saveRecord(record);
+		bpartnerProductRawTable.putOrReplace(row.getAsIdentifier(), record);
+	}
+
+	/**
+	 * Verifies C_BPartner_Product fields. Only checks the columns provided.
+	 * Supported columns: C_BPartner_Product_ID.Identifier (required), GTIN, EAN_CU, UPC, EAN13_ProductCode.
+	 * The record is refreshed from DB before assertion.
+	 */
+	@Then("C_BPartner_Product is verified:")
+	public void c_bpartner_product_is_verified(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable)
+				.setAdditionalRowIdentifierColumnName(COLUMNNAME_C_BPartner_Product_ID)
+				.forEach(this::verifyBPartnerProductFields);
+	}
+
+	private void verifyBPartnerProductFields(@NonNull final DataTableRow row)
+	{
+		final I_C_BPartner_Product record = row.getAsIdentifier().lookupIn(bpartnerProductRawTable);
+		assertThat(record).isNotNull();
+		InterfaceWrapperHelper.refresh(record);
+
+		row.getAsOptionalString(COLUMNNAME_GTIN)
+				.ifPresent(expected -> assertThat(record.getGTIN()).as("GTIN").isEqualTo(nullToken2Null(expected)));
+		row.getAsOptionalString(COLUMNNAME_EAN_CU)
+				.ifPresent(expected -> assertThat(record.getEAN_CU()).as("EAN_CU").isEqualTo(nullToken2Null(expected)));
+		row.getAsOptionalString(COLUMNNAME_UPC)
+				.ifPresent(expected -> assertThat(record.getUPC()).as("UPC").isEqualTo(nullToken2Null(expected)));
+		row.getAsOptionalString(I_C_BPartner_Product.COLUMNNAME_EAN13_ProductCode)
+				.ifPresent(expected -> assertThat(record.getEAN13_ProductCode()).as("EAN13_ProductCode").isEqualTo(nullToken2Null(expected)));
+	}
+
+	@Nullable
+	private static String nullToken2Null(@NonNull final String value)
+	{
+		return "null".equals(value) ? null : value;
+	}
+
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/product/M_Product_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/product/M_Product_StepDef.java
@@ -54,6 +54,7 @@ import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.dao.IQueryBL;
@@ -69,6 +70,7 @@ import org.compiere.model.I_M_Product;
 import org.compiere.model.X_M_Product;
 import org.compiere.util.DB;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -413,11 +415,46 @@ public class M_Product_StepDef
 		assertThat(productRecord).isNotNull();
 
 		row.getAsOptionalString(I_M_Product.COLUMNNAME_Value).ifPresent(productRecord::setValue);
-		row.getAsOptionalString(I_M_Product.COLUMNNAME_GTIN).ifPresent(productRecord::setGTIN);
+		row.getAsOptionalString(I_M_Product.COLUMNNAME_GTIN).ifPresent(value -> productRecord.setGTIN(nullToken2Null(value)));
+		row.getAsOptionalString(I_M_Product.COLUMNNAME_UPC).ifPresent(value -> productRecord.setUPC(nullToken2Null(value)));
+		row.getAsOptionalString(I_M_Product.COLUMNNAME_EAN13_ProductCode).ifPresent(value -> productRecord.setEAN13_ProductCode(nullToken2Null(value)));
 		row.getAsOptionalBoolean(I_M_Product.COLUMNNAME_IsStocked).ifPresent(productRecord::setIsStocked);
 		row.getAsOptionalBoolean(I_M_Product.COLUMNNAME_IsActive).ifPresent(productRecord::setIsActive);
 
 		saveRecord(productRecord);
 		productTable.putOrReplace(row.getAsIdentifier(), productRecord);
+	}
+
+	/**
+	 * Verifies M_Product fields. Only checks the columns provided in the data table.
+	 * Supported columns: M_Product_ID.Identifier (required), GTIN, UPC, EAN13_ProductCode.
+	 * The record is refreshed from DB before assertion.
+	 */
+	@Then("M_Product is verified:")
+	public void m_product_is_verified(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable)
+				.setAdditionalRowIdentifierColumnName(I_M_Product.COLUMNNAME_M_Product_ID)
+				.forEach(this::verifyMProductFields);
+	}
+
+	private void verifyMProductFields(@NonNull final DataTableRow row)
+	{
+		final I_M_Product productRecord = row.getAsIdentifier().lookupIn(productTable);
+		assertThat(productRecord).isNotNull();
+		InterfaceWrapperHelper.refresh(productRecord);
+
+		row.getAsOptionalString(I_M_Product.COLUMNNAME_GTIN)
+				.ifPresent(expected -> assertThat(productRecord.getGTIN()).as("GTIN").isEqualTo(nullToken2Null(expected)));
+		row.getAsOptionalString(I_M_Product.COLUMNNAME_UPC)
+				.ifPresent(expected -> assertThat(productRecord.getUPC()).as("UPC").isEqualTo(nullToken2Null(expected)));
+		row.getAsOptionalString(I_M_Product.COLUMNNAME_EAN13_ProductCode)
+				.ifPresent(expected -> assertThat(productRecord.getEAN13_ProductCode()).as("EAN13_ProductCode").isEqualTo(nullToken2Null(expected)));
+	}
+
+	@Nullable
+	private static String nullToken2Null(@NonNull final String value)
+	{
+		return "null".equals(value) ? null : value;
 	}
 }

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/syncEANAndGTIN.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/syncEANAndGTIN.feature
@@ -1,0 +1,232 @@
+@from:cucumber
+@ghActions:run_on_executor3
+Feature: M_Product.SyncEANAndGTIN sysconfig controls GTIN/UPC/EAN_CU sync
+  The sysconfig M_Product.SyncEANAndGTIN controls whether GTIN, UPC, and EAN_CU fields
+  are automatically synchronized on M_Product and C_BPartner_Product.
+  When Y (default), fields are synced. When N, fields can be maintained independently.
+  EAN13_ProductCode behavior is always active regardless of the sysconfig value.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2026-03-10T13:30:00+01:00[Europe/Berlin]
+
+  @from:cucumber
+  @Id:S0612_010
+  Scenario: TC-01 M_Product - Sync ON - GTIN auto-fills UPC
+    Given set sys config boolean value true for sys config M_Product.SyncEANAndGTIN
+    And metasfresh contains M_Products:
+      | Identifier |
+      | p_tc01     |
+    When update M_Product:
+      | Identifier | GTIN          |
+      | p_tc01     | 4012345678901 |
+    Then M_Product is verified:
+      | Identifier | GTIN          | UPC           |
+      | p_tc01     | 4012345678901 | 4012345678901 |
+
+  @from:cucumber
+  @Id:S0612_020
+  Scenario: TC-02 M_Product - Sync ON - UPC auto-fills GTIN
+    Given set sys config boolean value true for sys config M_Product.SyncEANAndGTIN
+    And metasfresh contains M_Products:
+      | Identifier |
+      | p_tc02     |
+    When update M_Product:
+      | Identifier | UPC           |
+      | p_tc02     | 9876543210987 |
+    Then M_Product is verified:
+      | Identifier | GTIN          | UPC           |
+      | p_tc02     | 9876543210987 | 9876543210987 |
+
+  @from:cucumber
+  @Id:S0612_030
+  Scenario: TC-03 M_Product - Sync OFF - GTIN does NOT auto-fill UPC
+    Given set sys config boolean value false for sys config M_Product.SyncEANAndGTIN
+    And metasfresh contains M_Products:
+      | Identifier |
+      | p_tc03     |
+    When update M_Product:
+      | Identifier | GTIN          |
+      | p_tc03     | 4012345678901 |
+    Then M_Product is verified:
+      | Identifier | GTIN          | UPC  |
+      | p_tc03     | 4012345678901 | null |
+
+  @from:cucumber
+  @Id:S0612_040
+  Scenario: TC-04 M_Product - Sync OFF - UPC does NOT auto-fill GTIN
+    Given set sys config boolean value false for sys config M_Product.SyncEANAndGTIN
+    And metasfresh contains M_Products:
+      | Identifier |
+      | p_tc04     |
+    When update M_Product:
+      | Identifier | UPC           |
+      | p_tc04     | 9876543210987 |
+    Then M_Product is verified:
+      | Identifier | GTIN | UPC           |
+      | p_tc04     | null | 9876543210987 |
+
+  @from:cucumber
+  @Id:S0612_050
+  Scenario: TC-05 M_Product - Sync OFF - Clearing UPC does NOT clear GTIN
+    Given set sys config boolean value false for sys config M_Product.SyncEANAndGTIN
+    And metasfresh contains M_Products:
+      | Identifier |
+      | p_tc05     |
+    # Set both fields independently (sync OFF, so no auto-fill)
+    And update M_Product:
+      | Identifier | GTIN          |
+      | p_tc05     | 4012345678901 |
+    And update M_Product:
+      | Identifier | UPC           |
+      | p_tc05     | 9876543210987 |
+    # Clear UPC
+    When update M_Product:
+      | Identifier | UPC  |
+      | p_tc05     | null |
+    Then M_Product is verified:
+      | Identifier | GTIN          | UPC  |
+      | p_tc05     | 4012345678901 | null |
+
+  @from:cucumber
+  @Id:S0612_060
+  Scenario: TC-06 M_Product - Sync OFF - Clearing GTIN does NOT clear UPC
+    Given set sys config boolean value false for sys config M_Product.SyncEANAndGTIN
+    And metasfresh contains M_Products:
+      | Identifier |
+      | p_tc06     |
+    And update M_Product:
+      | Identifier | GTIN          |
+      | p_tc06     | 4012345678901 |
+    And update M_Product:
+      | Identifier | UPC           |
+      | p_tc06     | 9876543210987 |
+    # Clear GTIN
+    When update M_Product:
+      | Identifier | GTIN |
+      | p_tc06     | null |
+    Then M_Product is verified:
+      | Identifier | GTIN | UPC           |
+      | p_tc06     | null | 9876543210987 |
+
+  @from:cucumber
+  @Id:S0612_070
+  Scenario: TC-07 M_Product - Sync OFF - EAN13_ProductCode does not clear GTIN and UPC
+    Given set sys config boolean value false for sys config M_Product.SyncEANAndGTIN
+    And metasfresh contains M_Products:
+      | Identifier |
+      | p_tc07     |
+    And update M_Product:
+      | Identifier | GTIN          |
+      | p_tc07     | 4012345678901 |
+    And update M_Product:
+      | Identifier | UPC           |
+      | p_tc07     | 9876543210987 |
+    When update M_Product:
+      | Identifier | EAN13_ProductCode |
+      | p_tc07     | 123456789         |
+    Then M_Product is verified:
+      | Identifier | GTIN          | UPC           | EAN13_ProductCode |
+      | p_tc07     | 4012345678901 | 9876543210987 | 123456789         |
+
+  @from:cucumber
+  @Id:S0612_080
+  Scenario: TC-08 M_Product - Sync ON - EAN13_ProductCode clears GTIN and UPC
+    Given set sys config boolean value true for sys config M_Product.SyncEANAndGTIN
+    And metasfresh contains M_Products:
+      | Identifier |
+      | p_tc08     |
+    And update M_Product:
+      | Identifier | GTIN          |
+      | p_tc08     | 4012345678901 |
+    When update M_Product:
+      | Identifier | EAN13_ProductCode |
+      | p_tc08     | 123456789         |
+    Then M_Product is verified:
+      | Identifier | GTIN | UPC  | EAN13_ProductCode |
+      | p_tc08     | null | null | 123456789         |
+
+  @from:cucumber
+  @Id:S0612_090
+  Scenario: TC-09 C_BPartner_Product - Sync OFF - GTIN does NOT auto-fill CU-EAN or CU-UPC
+    Given set sys config boolean value false for sys config M_Product.SyncEANAndGTIN
+    And metasfresh contains M_Products:
+      | Identifier |
+      | p_tc09     |
+    And metasfresh contains C_BPartners:
+      | Identifier | IsVendor | IsCustomer |
+      | bp_tc09    | Y        | Y          |
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_Product_ID | C_BPartner_ID | M_Product_ID |
+      | bpp_tc09              | bp_tc09       | p_tc09       |
+    When update C_BPartner_Product:
+      | Identifier | GTIN          |
+      | bpp_tc09   | 4012345678901 |
+    Then C_BPartner_Product is verified:
+      | C_BPartner_Product_ID.Identifier | GTIN          | EAN_CU | UPC  |
+      | bpp_tc09                         | 4012345678901 | null   | null |
+
+  @from:cucumber
+  @Id:S0612_100
+  Scenario: TC-10 C_BPartner_Product - Sync OFF - CU-EAN does NOT auto-fill GTIN or CU-UPC
+    Given set sys config boolean value false for sys config M_Product.SyncEANAndGTIN
+    And metasfresh contains M_Products:
+      | Identifier |
+      | p_tc10     |
+    And metasfresh contains C_BPartners:
+      | Identifier | IsVendor | IsCustomer |
+      | bp_tc10    | Y        | Y          |
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_Product_ID | C_BPartner_ID | M_Product_ID |
+      | bpp_tc10              | bp_tc10       | p_tc10       |
+    When update C_BPartner_Product:
+      | Identifier | EAN_CU        |
+      | bpp_tc10   | 4012345678901 |
+    Then C_BPartner_Product is verified:
+      | C_BPartner_Product_ID.Identifier | GTIN | EAN_CU        | UPC  |
+      | bpp_tc10                         | null | 4012345678901 | null |
+
+  @from:cucumber
+  @Id:S0612_110
+  Scenario: TC-11 C_BPartner_Product - Sync OFF - EAN13_ProductCode does not clear all fields
+    Given set sys config boolean value false for sys config M_Product.SyncEANAndGTIN
+    And metasfresh contains M_Products:
+      | Identifier |
+      | p_tc11     |
+    And metasfresh contains C_BPartners:
+      | Identifier | IsVendor | IsCustomer |
+      | bp_tc11    | Y        | Y          |
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_Product_ID | C_BPartner_ID | M_Product_ID |
+      | bpp_tc11              | bp_tc11       | p_tc11       |
+    And update C_BPartner_Product:
+      | Identifier | GTIN          |
+      | bpp_tc11   | 4012345678901 |
+    And update C_BPartner_Product:
+      | Identifier | EAN_CU        |
+      | bpp_tc11   | 4012345678902 |
+    And update C_BPartner_Product:
+      | Identifier | UPC           |
+      | bpp_tc11   | 4012345678903 |
+    When update C_BPartner_Product:
+      | Identifier | EAN13_ProductCode |
+      | bpp_tc11   | 6789              |
+    Then C_BPartner_Product is verified:
+      | C_BPartner_Product_ID.Identifier | GTIN          | EAN_CU        | UPC           | EAN13_ProductCode |
+      | bpp_tc11                         | 4012345678901 | 4012345678902 | 4012345678903 | 6789              |
+
+  @from:cucumber
+  @Id:S0612_120
+  Scenario: TC-12 Sysconfig missing - behaves as sync ON
+    # Delete the sysconfig to simulate "missing"
+    Given set sys config String value null for sys config M_Product.SyncEANAndGTIN
+    And metasfresh contains M_Products:
+      | Identifier |
+      | p_tc12     |
+    When update M_Product:
+      | Identifier | GTIN          |
+      | p_tc12     | 4012345678901 |
+    Then M_Product is verified:
+      | Identifier | GTIN          | UPC           |
+      | p_tc12     | 4012345678901 | 4012345678901 |


### PR DESCRIPTION
* gh#28612: Add M_Product.SyncEANAndGTIN sysconfig to control GTIN/UPC/EAN sync

When Y (default), GTIN/UPC/EAN_CU fields are synchronized on save (existing behavior). When N, fields can be maintained independently. EAN13_ProductCode behavior is always active regardless of sysconfig.

Changes:
- M_Product interceptor: add sysconfig guard to GTIN/UPC sync branches
- C_BPartner_Product interceptor: add sysconfig guard to GTIN/EAN_CU/UPC sync
- Migration: insert AD_SysConfig default Y at client=0, org=0
- Cucumber: 12 test scenarios covering sync ON/OFF for both tables
- Step defs: add UPC/EAN13_ProductCode to M_Product update, add update/verify steps for C_BPartner_Product



* Change INSERT statement for M_Product.SyncEANAndGTIN

Updated the insertion method for M_Product.SyncEANAndGTIN configuration.

* Simplify product code normalization logic by adding early return when `syncEANAndGTIN` is disabled.

* Normalize product code handling by replacing `M_Product::emptyToNull` with `StringUtils::trimBlankToNull`.

* Refactor product code handling by replacing redundant `emptyToNull` method with streamlined `nullToken2Null`, ensuring consistent GTIN, UPC, and EAN13 field updates and validation.

* Flush system streams and invoke `CucumberLifeCycleSupport.beforeAll` in `FastCucumberDevRunner` to improve test lifecycle handling and debugging clarity.

---------