### PR TITLE
gh#28598: Add MD_Candidate_Rebuild process

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/material/dispo/MD_Candidate_Rebuild_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/material/dispo/MD_Candidate_Rebuild_StepDef.java
@@ -1,0 +1,72 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.material.dispo;
+
+import de.metas.logging.LogManager;
+import de.metas.process.AdProcessId;
+import de.metas.process.IADProcessDAO;
+import de.metas.process.ProcessInfo;
+import de.metas.util.Services;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+
+/**
+ * Step definitions for running the {@code MD_Candidate_Rebuild} process.
+ * <p>
+ * Steps:
+ * <ul>
+ *   <li>{@code When the MD_Candidate_Rebuild process is run with IsBackupBeforeDelete=Y/N}</li>
+ * </ul>
+ */
+@RequiredArgsConstructor
+public class MD_Candidate_Rebuild_StepDef
+{
+	@NonNull private static final Logger logger = LogManager.getLogger(MD_Candidate_Rebuild_StepDef.class);
+
+	@NonNull private final IADProcessDAO processDAO = Services.get(IADProcessDAO.class);
+
+	/**
+	 * Runs the MD_Candidate_Rebuild AD_Process with the given backup parameter.
+	 *
+	 * @param isBackupBeforeDelete "Y" or "N"
+	 */
+	@When("the MD_Candidate_Rebuild process is run with IsBackupBeforeDelete={string}")
+	public void run_md_candidate_rebuild(@NonNull final String isBackupBeforeDelete)
+	{
+		final AdProcessId processId = processDAO.retrieveProcessIdByValue("MD_Candidate_Rebuild");
+		logger.info("Running MD_Candidate_Rebuild (AD_Process_ID={}, IsBackupBeforeDelete={})", processId, isBackupBeforeDelete);
+
+		final boolean backup = "Y".equals(isBackupBeforeDelete);
+
+		ProcessInfo.builder()
+				.setAD_Process_ID(processId.getRepoId())
+				.addParameter("IsBackupBeforeDelete", backup)
+				.buildAndPrepareExecution()
+				.executeSync()
+				.getResult();
+
+		logger.info("MD_Candidate_Rebuild completed successfully");
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/material/dispo/MD_Candidate_Rebuild_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/material/dispo/MD_Candidate_Rebuild_StepDef.java
@@ -22,7 +22,16 @@
 
 package de.metas.cucumber.stepdefs.material.dispo;
 
+import de.metas.cucumber.stepdefs.M_Product_StepDefData;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.logging.LogManager;
+import de.metas.material.dispo.model.I_MD_Candidate;
+import de.metas.material.dispo.model.I_MD_Candidate_Demand_Detail;
+import de.metas.material.dispo.model.I_MD_Candidate_Dist_Detail;
+import de.metas.material.dispo.model.I_MD_Candidate_Prod_Detail;
+import de.metas.material.dispo.model.I_MD_Candidate_Purchase_Detail;
+import de.metas.material.dispo.model.I_MD_Candidate_StockChange_Detail;
+import de.metas.material.dispo.model.I_MD_Candidate_Transaction_Detail;
 import de.metas.process.AdProcessId;
 import de.metas.process.IADProcessDAO;
 import de.metas.process.ProcessInfo;
@@ -30,6 +39,8 @@ import de.metas.util.Services;
 import io.cucumber.java.en.When;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
+import org.compiere.model.I_M_Product;
 import org.slf4j.Logger;
 
 /**
@@ -38,6 +49,7 @@ import org.slf4j.Logger;
  * Steps:
  * <ul>
  *   <li>{@code When the MD_Candidate_Rebuild process is run with IsBackupBeforeDelete=Y/N}</li>
+ *   <li>{@code When all MD_Candidates for product {identifier} are deleted}</li>
  * </ul>
  */
 @RequiredArgsConstructor
@@ -46,6 +58,8 @@ public class MD_Candidate_Rebuild_StepDef
 	@NonNull private static final Logger logger = LogManager.getLogger(MD_Candidate_Rebuild_StepDef.class);
 
 	@NonNull private final IADProcessDAO processDAO = Services.get(IADProcessDAO.class);
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	@NonNull private final M_Product_StepDefData productTable;
 
 	/**
 	 * Runs the MD_Candidate_Rebuild AD_Process with the given backup parameter.
@@ -68,5 +82,68 @@ public class MD_Candidate_Rebuild_StepDef
 				.getResult();
 
 		logger.info("MD_Candidate_Rebuild completed successfully");
+	}
+
+	/**
+	 * Deletes all MD_Candidate records (and their detail records) for the given product identifier.
+	 * This simulates the condition where source documents exist but no MD_Candidates are present,
+	 * allowing tests to verify that the rebuild process creates missing candidates (INSERT path / Pass B).
+	 *
+	 * @param productIdentifier identifier referencing a previously created M_Product
+	 */
+	@When("all MD_Candidates for product {string} are deleted")
+	public void delete_all_md_candidates_for_product(@NonNull final String productIdentifier)
+	{
+		final I_M_Product product = productTable.get(StepDefDataIdentifier.ofString(productIdentifier));
+		final int productId = product.getM_Product_ID();
+
+		// Collect candidate IDs for this product
+		final java.util.List<Integer> candidateIds = queryBL.createQueryBuilder(I_MD_Candidate.class)
+				.addEqualsFilter(I_MD_Candidate.COLUMNNAME_M_Product_ID, productId)
+				.create()
+				.listIds();
+
+		if (candidateIds.isEmpty())
+		{
+			logger.info("No MD_Candidates found for product {} (M_Product_ID={})", productIdentifier, productId);
+			return;
+		}
+
+		// Delete child detail records first (FK constraints)
+		deleteDetailRecords(I_MD_Candidate_Demand_Detail.class, I_MD_Candidate_Demand_Detail.COLUMNNAME_MD_Candidate_ID, candidateIds);
+		deleteDetailRecords(I_MD_Candidate_Purchase_Detail.class, I_MD_Candidate_Purchase_Detail.COLUMNNAME_MD_Candidate_ID, candidateIds);
+		deleteDetailRecords(I_MD_Candidate_Prod_Detail.class, I_MD_Candidate_Prod_Detail.COLUMNNAME_MD_Candidate_ID, candidateIds);
+		deleteDetailRecords(I_MD_Candidate_Dist_Detail.class, I_MD_Candidate_Dist_Detail.COLUMNNAME_MD_Candidate_ID, candidateIds);
+		deleteDetailRecords(I_MD_Candidate_Transaction_Detail.class, I_MD_Candidate_Transaction_Detail.COLUMNNAME_MD_Candidate_ID, candidateIds);
+		deleteDetailRecords(I_MD_Candidate_StockChange_Detail.class, I_MD_Candidate_StockChange_Detail.COLUMNNAME_MD_Candidate_ID, candidateIds);
+
+		// Delete the candidates themselves
+		final int deletedCount = queryBL.createQueryBuilder(I_MD_Candidate.class)
+				.addEqualsFilter(I_MD_Candidate.COLUMNNAME_M_Product_ID, productId)
+				.create()
+				.delete();
+
+		logger.info("Deleted {} MD_Candidates (and their details) for product {} (M_Product_ID={})", deletedCount, productIdentifier, productId);
+	}
+
+	private <T> void deleteDetailRecords(
+			@NonNull final Class<T> modelClass,
+			@NonNull final String candidateIdColumnName,
+			@NonNull final java.util.List<Integer> candidateIds)
+	{
+		if (candidateIds.isEmpty())
+		{
+			return;
+		}
+
+		final int deleted = queryBL.createQueryBuilder(modelClass)
+				.addInArrayFilter(candidateIdColumnName, candidateIds)
+				.create()
+				.delete();
+
+		if (deleted > 0)
+		{
+			logger.info("Deleted {} {} records", deleted, modelClass.getSimpleName());
+		}
 	}
 }

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/md_candidate_rebuild.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/md_candidate_rebuild.feature
@@ -127,3 +127,39 @@ Feature: MD_Candidate_Rebuild process
       | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | Qty |
       | c_dem_post | DEMAND            | SHIPMENT                      | p_1                     | -25 |
     And after not more than 60s, metasfresh has no MD_Candidate for identifier c_inv
+
+  @from:cucumber
+  @topic:materialdispo
+  Scenario: Rebuild creates missing SHIPMENT demand candidates from open shipment schedules (INSERT path)
+    And metasfresh contains M_Products:
+      | Identifier | Name                     |
+      | p_1        | rebuild_insert_test_1    |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_so                            | p_1                     | 10.0     | PCE               | Normal                        |
+
+    # Create a sales order → shipment schedule + demand candidate via events
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.PreparationDate     |
+      | o_1        | true    | customer_1               | 2026-03-10  | 2026-03-15T10:00:00.00Z |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_1       | o_1                   | p_1                     | 40         |
+    When the order identified by o_1 is completed
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # Confirm candidate exists
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | Qty |
+      | c_demand   | DEMAND            | SHIPMENT                      | p_1                     | -40 |
+
+    # Now delete all MD_Candidates for this product — simulates missing candidates
+    When all MD_Candidates for product "p_1" are deleted
+
+    # Run rebuild — should recreate the demand candidate from the open shipment schedule
+    When the MD_Candidate_Rebuild process is run with IsBackupBeforeDelete="N"
+
+    # Verify: demand candidate recreated with correct qty
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | Qty |
+      | c_rebuilt  | DEMAND            | SHIPMENT                      | p_1                     | -40 |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/md_candidate_rebuild.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/md_candidate_rebuild.feature
@@ -1,0 +1,129 @@
+@from:cucumber
+@topic:materialdispo
+@ghActions:run_on_executor6
+Feature: MD_Candidate_Rebuild process
+  As a user going live with metasfresh
+  I want to rebuild all MD_Candidate data from source documents
+  So that the ATP is clean and consistent
+  See: https://github.com/metasfresh/me03/issues/28598
+
+  Background: Initial Data
+    Given infrastructure and metasfresh are running
+    And metasfresh has date and time 2026-03-10T08:00:00+01:00[Europe/Berlin]
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                   | Value                   |
+      | ps_1       | rebuild_pricing_system | rebuild_pricing_system  |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name               | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_so      | ps_1                          | DE                        | EUR                 | rebuild_so_pl      | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name             | ValidFrom  |
+      | plv_so     | pl_so                     | rebuild_so_plv   | 2020-01-01 |
+    And metasfresh contains C_BPartners:
+      | Identifier  | Name             | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | customer_1  | rebuild_customer | N            | Y              | ps_1                          |
+
+  @from:cucumber
+  @topic:materialdispo
+  Scenario: Rebuild preserves SHIPMENT demand candidates from open sales orders
+    And metasfresh contains M_Products:
+      | Identifier | Name                    |
+      | p_1        | rebuild_shipment_test_1 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_so                            | p_1                     | 10.0     | PCE               | Normal                        |
+
+    # Create a sales order that generates shipment schedule + demand candidate
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.PreparationDate     |
+      | o_1        | true    | customer_1               | 2026-03-10  | 2026-03-15T10:00:00.00Z |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_1       | o_1                   | p_1                     | 50         |
+    When the order identified by o_1 is completed
+
+    # Wait for event-driven candidates to be created
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | Qty |
+      | c_demand   | DEMAND            | SHIPMENT                      | p_1                     | -50 |
+
+    # Now run the rebuild process
+    When the MD_Candidate_Rebuild process is run with IsBackupBeforeDelete="N"
+
+    # Verify: demand candidate still exists with correct qty after rebuild
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | Qty |
+      | c_demand_r | DEMAND            | SHIPMENT                      | p_1                     | -50 |
+
+  @from:cucumber
+  @topic:materialdispo
+  Scenario: Rebuild is idempotent — running twice gives same result
+    And metasfresh contains M_Products:
+      | Identifier | Name                       |
+      | p_1        | rebuild_idempotency_test_1 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_so                            | p_1                     | 10.0     | PCE               | Normal                        |
+
+    # Create sales order → demand candidate
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.PreparationDate     |
+      | o_1        | true    | customer_1               | 2026-03-10  | 2026-03-15T10:00:00.00Z |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_1       | o_1                   | p_1                     | 30         |
+    When the order identified by o_1 is completed
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # Run rebuild FIRST time
+    When the MD_Candidate_Rebuild process is run with IsBackupBeforeDelete="N"
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | Qty |
+      | c_demand_1 | DEMAND            | SHIPMENT                      | p_1                     | -30 |
+
+    # Run rebuild SECOND time — idempotent, same result
+    When the MD_Candidate_Rebuild process is run with IsBackupBeforeDelete="N"
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | Qty |
+      | c_demand_2 | DEMAND            | SHIPMENT                      | p_1                     | -30 |
+
+  @from:cucumber
+  @topic:materialdispo
+  Scenario: Rebuild cleans orphan INVENTORY_UP candidates while preserving demand from open orders
+    And metasfresh contains M_Products:
+      | Identifier | Name                  |
+      | p_1        | rebuild_orphan_test_1 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_so                            | p_1                     | 10.0     | PCE               | Normal                        |
+
+    # Pre-populate: an INVENTORY_UP candidate that represents a historical adjustment (no source doc)
+    Given metasfresh initially has this MD_Candidate data
+      | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected           | Qty | Qty_AvailableToPromise |
+      | c_inv      | INVENTORY_UP      |                               | p_1                     | 2026-03-01T10:00:00.00Z | 200 | 200                    |
+
+    # Also create a real sales order → demand candidate
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.PreparationDate     |
+      | o_1        | true    | customer_1               | 2026-03-10  | 2026-03-15T10:00:00.00Z |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_1       | o_1                   | p_1                     | 25         |
+    When the order identified by o_1 is completed
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # Confirm both candidates exist before rebuild
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | Qty |
+      | c_inv_pre  | INVENTORY_UP      |                               | p_1                     | 200 |
+      | c_dem_pre  | DEMAND            | SHIPMENT                      | p_1                     | -25 |
+
+    # Run rebuild — should delete INVENTORY_UP (no source doc) but keep SHIPMENT DEMAND
+    When the MD_Candidate_Rebuild process is run with IsBackupBeforeDelete="N"
+
+    # Verify: demand candidate preserved, INVENTORY_UP gone
+    Then after not more than 60s, MD_Candidates are found
+      | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | Qty |
+      | c_dem_post | DEMAND            | SHIPMENT                      | p_1                     | -25 |
+    And after not more than 60s, metasfresh has no MD_Candidate for identifier c_inv

--- a/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/process/MD_Candidate_Rebuild.java
+++ b/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/process/MD_Candidate_Rebuild.java
@@ -1,0 +1,74 @@
+/*
+ * #%L
+ * metasfresh-material-dispo-commons
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.material.dispo.commons.process;
+
+import de.metas.process.JavaProcess;
+import de.metas.process.Param;
+import de.metas.process.PInstanceId;
+import de.metas.util.Loggables;
+import org.compiere.util.DB;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+public class MD_Candidate_Rebuild extends JavaProcess
+{
+	@Param(parameterName = "IsBackupBeforeDelete", mandatory = true)
+	private boolean isBackupBeforeDelete;
+
+	@Override
+	protected String doIt() throws Exception
+	{
+		final int adPInstanceId = PInstanceId.toRepoId(getPinstanceId());
+		final String backupFlag = isBackupBeforeDelete ? "Y" : "N";
+
+		Loggables.get().addLog("Starting MD_Candidate_Rebuild (AD_PInstance_ID={}, Backup={})", adPInstanceId, backupFlag);
+
+		final String sql = "SELECT action, business_case, record_count FROM de_metas_material.MD_Candidate_Rebuild(?, ?)";
+
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		try
+		{
+			pstmt = DB.prepareStatement(sql, get_TrxName());
+			pstmt.setInt(1, adPInstanceId);
+			pstmt.setString(2, backupFlag);
+			rs = pstmt.executeQuery();
+
+			while (rs.next())
+			{
+				final String action = rs.getString("action");
+				final String businessCase = rs.getString("business_case");
+				final long recordCount = rs.getLong("record_count");
+				Loggables.get().addLog("{}: {} = {}", action, businessCase, recordCount);
+			}
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+		}
+
+		Loggables.get().addLog("MD_Candidate_Rebuild completed successfully.");
+		return MSG_OK;
+	}
+}

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/ddl/de_metas_material/MD_Candidate_Rebuild.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/ddl/de_metas_material/MD_Candidate_Rebuild.sql
@@ -1,0 +1,934 @@
+-- Function: de_metas_material.MD_Candidate_Rebuild
+-- Purpose: Rebuild all MD_Candidate records from source documents (open orders, schedules, etc.)
+-- Approach: Three-pass per business case (UPDATE existing / INSERT missing / DELETE orphans) + rebuild STOCK timeline
+-- See: https://github.com/metasfresh/me03/issues/28598
+
+DROP FUNCTION IF EXISTS de_metas_material.MD_Candidate_Rebuild(numeric, character);
+CREATE OR REPLACE FUNCTION de_metas_material.MD_Candidate_Rebuild(
+    p_AD_PInstance_ID numeric,
+    p_IsBackupBeforeDelete character DEFAULT 'Y'
+)
+RETURNS TABLE (
+    action text,
+    business_case text,
+    record_count bigint
+) AS
+$BODY$
+DECLARE
+    v_now timestamp with time zone := now();
+    v_suffix text := '_pinstance_' || p_AD_PInstance_ID::text;
+    v_count bigint;
+BEGIN
+    -- ============================================================
+    -- STEP 1: Backup (if enabled)
+    -- ============================================================
+    IF p_IsBackupBeforeDelete = 'Y' THEN
+        PERFORM backup_table('md_candidate', v_suffix);
+        PERFORM backup_table('md_candidate_demand_detail', v_suffix);
+        PERFORM backup_table('md_candidate_purchase_detail', v_suffix);
+        PERFORM backup_table('md_candidate_prod_detail', v_suffix);
+        PERFORM backup_table('md_candidate_dist_detail', v_suffix);
+        PERFORM backup_table('md_candidate_stockchange_detail', v_suffix);
+        PERFORM backup_table('md_candidate_transaction_detail', v_suffix);
+    END IF;
+
+    -- ============================================================
+    -- STEP 2: SHIPMENT business case (DEMAND candidates)
+    -- Match key: MD_Candidate_Demand_Detail.M_ShipmentSchedule_ID
+    -- Source: M_ShipmentSchedule (open, active)
+    -- ============================================================
+
+    -- Pass A: UPDATE existing SHIPMENT candidates from open shipment schedules
+    UPDATE md_candidate c
+    SET qty             = ss.qtyordered - ss.qtydelivered,
+        dateprojected   = COALESCE(ss.deliverydate, ss.preparationdate, o.dateordered, v_now),
+        m_warehouse_id  = ss.m_warehouse_id,
+        storageattributeskey = COALESCE(GenerateASIStorageAttributesKey(ss.m_attributesetinstance_id), ''),
+        m_attributesetinstance_id = COALESCE(ss.m_attributesetinstance_id, 0),
+        m_shipmentschedule_id = ss.m_shipmentschedule_id,
+        c_orderso_id    = o.c_order_id,
+        updated         = v_now,
+        updatedby       = 0
+    FROM md_candidate_demand_detail dd
+    JOIN m_shipmentschedule ss ON ss.m_shipmentschedule_id = dd.m_shipmentschedule_id
+    JOIN c_orderline ol ON ol.c_orderline_id = ss.c_orderline_id
+    JOIN c_order o ON o.c_order_id = ol.c_order_id
+    WHERE dd.md_candidate_id = c.md_candidate_id
+      AND dd.isactive = 'Y'
+      AND c.md_candidate_businesscase = 'SHIPMENT'
+      AND c.md_candidate_type = 'DEMAND'
+      AND ss.processed = 'N'
+      AND ss.isactive = 'Y';
+
+    -- Also update the demand detail PlannedQty
+    UPDATE md_candidate_demand_detail dd
+    SET plannedqty      = ss.qtyordered,
+        actualqty       = ss.qtydelivered,
+        c_orderline_id  = ss.c_orderline_id,
+        updated         = v_now,
+        updatedby       = 0
+    FROM m_shipmentschedule ss
+    WHERE dd.m_shipmentschedule_id = ss.m_shipmentschedule_id
+      AND dd.isactive = 'Y'
+      AND ss.processed = 'N'
+      AND ss.isactive = 'Y'
+      AND EXISTS (SELECT 1 FROM md_candidate c
+                  WHERE c.md_candidate_id = dd.md_candidate_id
+                    AND c.md_candidate_businesscase = 'SHIPMENT'
+                    AND c.md_candidate_type = 'DEMAND');
+
+    -- Pass B: INSERT missing SHIPMENT candidates (open schedules with no MD_Candidate)
+    WITH new_candidates AS (
+        INSERT INTO md_candidate (
+            md_candidate_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_type, md_candidate_businesscase, md_candidate_status,
+            m_product_id, m_warehouse_id, dateprojected, qty,
+            storageattributeskey, m_attributesetinstance_id, seqno,
+            m_shipmentschedule_id, c_orderso_id,
+            replenish_minqty, replenish_maxqty, isreservedforcustomer
+        )
+        SELECT
+            nextval('md_candidate_seq'),
+            ss.ad_client_id, ss.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            'DEMAND', 'SHIPMENT', 'doc_created',
+            ss.m_product_id, ss.m_warehouse_id,
+            COALESCE(ss.deliverydate, ss.preparationdate, o.dateordered, v_now),
+            ss.qtyordered - ss.qtydelivered,
+            COALESCE(GenerateASIStorageAttributesKey(ss.m_attributesetinstance_id), ''),
+            COALESCE(ss.m_attributesetinstance_id, 0),
+            0, -- seqno
+            ss.m_shipmentschedule_id, o.c_order_id,
+            0, 0, 'N'
+        FROM m_shipmentschedule ss
+        JOIN c_orderline ol ON ol.c_orderline_id = ss.c_orderline_id
+        JOIN c_order o ON o.c_order_id = ol.c_order_id
+        WHERE ss.processed = 'N'
+          AND ss.isactive = 'Y'
+          AND NOT EXISTS (
+              SELECT 1 FROM md_candidate_demand_detail dd
+              JOIN md_candidate c2 ON c2.md_candidate_id = dd.md_candidate_id
+              WHERE dd.m_shipmentschedule_id = ss.m_shipmentschedule_id
+                AND dd.isactive = 'Y'
+                AND c2.md_candidate_businesscase = 'SHIPMENT'
+          )
+        RETURNING md_candidate_id, ad_client_id, ad_org_id, m_shipmentschedule_id
+    )
+    INSERT INTO md_candidate_demand_detail (
+        md_candidate_demand_detail_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+        md_candidate_id, m_shipmentschedule_id, c_orderline_id, plannedqty, actualqty
+    )
+    SELECT
+        nextval('md_candidate_demand_detail_seq'),
+        nc.ad_client_id, nc.ad_org_id, v_now, 0, v_now, 0, 'Y',
+        nc.md_candidate_id, nc.m_shipmentschedule_id,
+        ss.c_orderline_id, ss.qtyordered, ss.qtydelivered
+    FROM new_candidates nc
+    JOIN m_shipmentschedule ss ON ss.m_shipmentschedule_id = nc.m_shipmentschedule_id;
+
+    -- Pass C: DELETE orphan SHIPMENT candidates (shipment schedule closed/processed/deleted)
+    -- First delete detail records, then parent
+    DELETE FROM md_candidate_demand_detail dd
+    WHERE dd.isactive = 'Y'
+      AND dd.m_shipmentschedule_id IS NOT NULL
+      AND EXISTS (
+          SELECT 1 FROM md_candidate c
+          WHERE c.md_candidate_id = dd.md_candidate_id
+            AND c.md_candidate_businesscase = 'SHIPMENT'
+            AND c.md_candidate_type = 'DEMAND'
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM m_shipmentschedule ss
+          WHERE ss.m_shipmentschedule_id = dd.m_shipmentschedule_id
+            AND ss.processed = 'N'
+            AND ss.isactive = 'Y'
+      );
+
+    -- Delete orphan SHIPMENT candidates that have no demand detail (detail was deleted above)
+    DELETE FROM md_candidate c
+    WHERE c.md_candidate_businesscase = 'SHIPMENT'
+      AND c.md_candidate_type = 'DEMAND'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_demand_detail dd
+          WHERE dd.md_candidate_id = c.md_candidate_id AND dd.isactive = 'Y'
+      );
+
+    -- ============================================================
+    -- STEP 3: PURCHASE business case (SUPPLY candidates)
+    -- Match key: MD_Candidate_Purchase_Detail.M_ReceiptSchedule_ID
+    -- Source: M_ReceiptSchedule (open, active)
+    -- ============================================================
+
+    -- Pass A: UPDATE existing PURCHASE candidates from open receipt schedules
+    UPDATE md_candidate c
+    SET qty             = rs.qtyordered - COALESCE(rs.qtymoved, 0),
+        dateprojected   = COALESCE(o.datepromised, o.dateordered, v_now),
+        m_warehouse_id  = rs.m_warehouse_id,
+        storageattributeskey = COALESCE(GenerateASIStorageAttributesKey(rs.m_attributesetinstance_id), ''),
+        m_attributesetinstance_id = COALESCE(rs.m_attributesetinstance_id, 0),
+        updated         = v_now,
+        updatedby       = 0
+    FROM md_candidate_purchase_detail pd
+    JOIN m_receiptschedule rs ON rs.m_receiptschedule_id = pd.m_receiptschedule_id
+    JOIN c_orderline ol ON ol.c_orderline_id = rs.c_orderline_id
+    JOIN c_order o ON o.c_order_id = ol.c_order_id
+    WHERE pd.md_candidate_id = c.md_candidate_id
+      AND c.md_candidate_businesscase = 'PURCHASE'
+      AND c.md_candidate_type = 'SUPPLY'
+      AND rs.processed = 'N'
+      AND rs.isactive = 'Y';
+
+    -- Also update the purchase detail
+    UPDATE md_candidate_purchase_detail pd
+    SET plannedqty          = rs.qtyordered,
+        qtyordered          = rs.qtyordered,
+        c_orderlinepo_id    = rs.c_orderline_id,
+        c_bpartner_vendor_id = ol.c_bpartner_id,
+        updated             = v_now,
+        updatedby           = 0
+    FROM m_receiptschedule rs
+    JOIN c_orderline ol ON ol.c_orderline_id = rs.c_orderline_id
+    WHERE pd.m_receiptschedule_id = rs.m_receiptschedule_id
+      AND rs.processed = 'N'
+      AND rs.isactive = 'Y'
+      AND EXISTS (SELECT 1 FROM md_candidate c
+                  WHERE c.md_candidate_id = pd.md_candidate_id
+                    AND c.md_candidate_businesscase = 'PURCHASE'
+                    AND c.md_candidate_type = 'SUPPLY');
+
+    -- Pass B: INSERT missing PURCHASE candidates
+    WITH new_candidates AS (
+        INSERT INTO md_candidate (
+            md_candidate_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_type, md_candidate_businesscase, md_candidate_status,
+            m_product_id, m_warehouse_id, dateprojected, qty,
+            storageattributeskey, m_attributesetinstance_id, seqno,
+            replenish_minqty, replenish_maxqty, isreservedforcustomer
+        )
+        SELECT
+            nextval('md_candidate_seq'),
+            rs.ad_client_id, rs.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            'SUPPLY', 'PURCHASE', 'doc_created',
+            rs.m_product_id, rs.m_warehouse_id,
+            COALESCE(o.datepromised, o.dateordered, v_now),
+            rs.qtyordered - COALESCE(rs.qtymoved, 0),
+            COALESCE(GenerateASIStorageAttributesKey(rs.m_attributesetinstance_id), ''),
+            COALESCE(rs.m_attributesetinstance_id, 0),
+            0, -- seqno
+            0, 0, 'N'
+        FROM m_receiptschedule rs
+        JOIN c_orderline ol ON ol.c_orderline_id = rs.c_orderline_id
+        JOIN c_order o ON o.c_order_id = ol.c_order_id
+        WHERE rs.processed = 'N'
+          AND rs.isactive = 'Y'
+          AND NOT EXISTS (
+              SELECT 1 FROM md_candidate_purchase_detail pd
+              JOIN md_candidate c2 ON c2.md_candidate_id = pd.md_candidate_id
+              WHERE pd.m_receiptschedule_id = rs.m_receiptschedule_id
+                AND c2.md_candidate_businesscase = 'PURCHASE'
+          )
+        RETURNING md_candidate_id, ad_client_id, ad_org_id,
+                  (SELECT rs2.m_receiptschedule_id FROM m_receiptschedule rs2
+                   JOIN c_orderline ol2 ON ol2.c_orderline_id = rs2.c_orderline_id
+                   WHERE rs2.m_product_id = md_candidate.m_product_id
+                     AND rs2.m_warehouse_id = md_candidate.m_warehouse_id
+                     AND rs2.processed = 'N' AND rs2.isactive = 'Y'
+                   LIMIT 1) AS m_receiptschedule_id
+    )
+    INSERT INTO md_candidate_purchase_detail (
+        md_candidate_purchase_detail_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+        md_candidate_id, m_receiptschedule_id, c_orderlinepo_id, plannedqty, c_bpartner_vendor_id, isadvised
+    )
+    SELECT
+        nextval('md_candidate_purchase_detail_seq'),
+        nc.ad_client_id, nc.ad_org_id, v_now, 0, v_now, 0, 'Y',
+        nc.md_candidate_id, nc.m_receiptschedule_id,
+        rs.c_orderline_id, rs.qtyordered, ol.c_bpartner_id, 'N'
+    FROM new_candidates nc
+    JOIN m_receiptschedule rs ON rs.m_receiptschedule_id = nc.m_receiptschedule_id
+    JOIN c_orderline ol ON ol.c_orderline_id = rs.c_orderline_id;
+
+    -- Pass C: DELETE orphan PURCHASE candidates
+    DELETE FROM md_candidate_purchase_detail pd
+    WHERE pd.m_receiptschedule_id IS NOT NULL
+      AND EXISTS (
+          SELECT 1 FROM md_candidate c
+          WHERE c.md_candidate_id = pd.md_candidate_id
+            AND c.md_candidate_businesscase = 'PURCHASE'
+            AND c.md_candidate_type = 'SUPPLY'
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM m_receiptschedule rs
+          WHERE rs.m_receiptschedule_id = pd.m_receiptschedule_id
+            AND rs.processed = 'N'
+            AND rs.isactive = 'Y'
+      );
+
+    DELETE FROM md_candidate c
+    WHERE c.md_candidate_businesscase = 'PURCHASE'
+      AND c.md_candidate_type = 'SUPPLY'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_purchase_detail pd
+          WHERE pd.md_candidate_id = c.md_candidate_id
+      );
+
+    -- ============================================================
+    -- STEP 4: PRODUCTION business case
+    -- Header: PP_Order → SUPPLY candidate (finished product)
+    -- BOM Lines: PP_Order_BOMLine → DEMAND candidates (components)
+    -- Match key: MD_Candidate_Prod_Detail.PP_Order_ID + PP_Order_BOMLine_ID
+    -- ============================================================
+
+    -- Pass A: UPDATE existing PRODUCTION header candidates (SUPPLY, finished product)
+    UPDATE md_candidate c
+    SET qty             = ppo.qtyordered - ppo.qtydelivered,
+        dateprojected   = COALESCE(ppo.datepromised, ppo.dateordered, v_now),
+        m_warehouse_id  = ppo.m_warehouse_id,
+        storageattributeskey = COALESCE(GenerateASIStorageAttributesKey(ppo.m_attributesetinstance_id), ''),
+        m_attributesetinstance_id = COALESCE(ppo.m_attributesetinstance_id, 0),
+        updated         = v_now,
+        updatedby       = 0
+    FROM md_candidate_prod_detail ppd
+    JOIN pp_order ppo ON ppo.pp_order_id = ppd.pp_order_id
+    WHERE ppd.md_candidate_id = c.md_candidate_id
+      AND ppd.pp_order_bomline_id IS NULL  -- header (no BOM line)
+      AND c.md_candidate_businesscase = 'PRODUCTION'
+      AND c.md_candidate_type = 'SUPPLY'
+      AND ppo.docstatus IN ('DR', 'IP', 'CO')
+      AND ppo.isactive = 'Y';
+
+    -- Update prod detail for headers
+    UPDATE md_candidate_prod_detail ppd
+    SET pp_order_docstatus = ppo.docstatus,
+        plannedqty         = ppo.qtyordered,
+        actualqty          = ppo.qtydelivered,
+        pp_plant_id        = ppo.s_resource_id,
+        updated            = v_now,
+        updatedby          = 0
+    FROM pp_order ppo
+    WHERE ppd.pp_order_id = ppo.pp_order_id
+      AND ppd.pp_order_bomline_id IS NULL
+      AND ppo.docstatus IN ('DR', 'IP', 'CO')
+      AND ppo.isactive = 'Y'
+      AND EXISTS (SELECT 1 FROM md_candidate c
+                  WHERE c.md_candidate_id = ppd.md_candidate_id
+                    AND c.md_candidate_businesscase = 'PRODUCTION'
+                    AND c.md_candidate_type = 'SUPPLY');
+
+    -- Pass A: UPDATE existing PRODUCTION BOM line candidates (DEMAND, components)
+    UPDATE md_candidate c
+    SET qty             = CASE
+                              WHEN bl.componenttype IN ('CO', 'PK') THEN bl.qtyrequiered - COALESCE(bl.qtydelivered, 0)
+                              ELSE bl.qtyrequiered - COALESCE(bl.qtydelivered, 0)
+                          END,
+        dateprojected   = CASE
+                              WHEN bl.componenttype IN ('BY', 'CP') THEN COALESCE(ppo.datepromised, ppo.dateordered, v_now)
+                              ELSE COALESCE(ppo.datestartschedule, ppo.dateordered, v_now)
+                          END,
+        m_warehouse_id  = COALESCE(bl.m_warehouse_id, ppo.m_warehouse_id),
+        storageattributeskey = COALESCE(GenerateASIStorageAttributesKey(bl.m_attributesetinstance_id), ''),
+        m_attributesetinstance_id = COALESCE(bl.m_attributesetinstance_id, 0),
+        updated         = v_now,
+        updatedby       = 0
+    FROM md_candidate_prod_detail ppd
+    JOIN pp_order_bomline bl ON bl.pp_order_bomline_id = ppd.pp_order_bomline_id
+    JOIN pp_order ppo ON ppo.pp_order_id = bl.pp_order_id
+    WHERE ppd.md_candidate_id = c.md_candidate_id
+      AND ppd.pp_order_bomline_id IS NOT NULL  -- BOM line
+      AND c.md_candidate_businesscase = 'PRODUCTION'
+      AND ppo.docstatus IN ('DR', 'IP', 'CO')
+      AND ppo.isactive = 'Y';
+
+    -- Update prod detail for BOM lines
+    UPDATE md_candidate_prod_detail ppd
+    SET pp_order_docstatus = ppo.docstatus,
+        plannedqty         = bl.qtyrequiered,
+        actualqty          = COALESCE(bl.qtydelivered, 0),
+        pp_plant_id        = ppo.s_resource_id,
+        updated            = v_now,
+        updatedby          = 0
+    FROM pp_order_bomline bl
+    JOIN pp_order ppo ON ppo.pp_order_id = bl.pp_order_id
+    WHERE ppd.pp_order_bomline_id = bl.pp_order_bomline_id
+      AND ppd.pp_order_bomline_id IS NOT NULL
+      AND ppo.docstatus IN ('DR', 'IP', 'CO')
+      AND ppo.isactive = 'Y'
+      AND EXISTS (SELECT 1 FROM md_candidate c
+                  WHERE c.md_candidate_id = ppd.md_candidate_id
+                    AND c.md_candidate_businesscase = 'PRODUCTION');
+
+    -- Pass B: INSERT missing PRODUCTION header candidates (SUPPLY for finished product)
+    -- Use CTE with RETURNING to capture the new MD_Candidate_ID for GroupId assignment
+    WITH new_headers AS (
+        INSERT INTO md_candidate (
+            md_candidate_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_type, md_candidate_businesscase, md_candidate_status,
+            m_product_id, m_warehouse_id, dateprojected, qty,
+            storageattributeskey, m_attributesetinstance_id, seqno,
+            replenish_minqty, replenish_maxqty, isreservedforcustomer
+        )
+        SELECT
+            nextval('md_candidate_seq'),
+            ppo.ad_client_id, ppo.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            'SUPPLY', 'PRODUCTION', 'doc_created',
+            ppo.m_product_id, ppo.m_warehouse_id,
+            COALESCE(ppo.datepromised, ppo.dateordered, v_now),
+            ppo.qtyordered - ppo.qtydelivered,
+            COALESCE(GenerateASIStorageAttributesKey(ppo.m_attributesetinstance_id), ''),
+            COALESCE(ppo.m_attributesetinstance_id, 0),
+            0, 0, 0, 'N'
+        FROM pp_order ppo
+        WHERE ppo.docstatus IN ('DR', 'IP', 'CO')
+          AND ppo.isactive = 'Y'
+          AND NOT EXISTS (
+              SELECT 1 FROM md_candidate_prod_detail ppd
+              JOIN md_candidate c2 ON c2.md_candidate_id = ppd.md_candidate_id
+              WHERE ppd.pp_order_id = ppo.pp_order_id
+                AND ppd.pp_order_bomline_id IS NULL
+                AND c2.md_candidate_businesscase = 'PRODUCTION'
+          )
+        RETURNING md_candidate_id, ad_client_id, ad_org_id, m_product_id
+    ),
+    -- Set GroupId to the header candidate's own ID
+    group_update AS (
+        UPDATE md_candidate c
+        SET md_candidate_groupid = c.md_candidate_id
+        FROM new_headers nh
+        WHERE c.md_candidate_id = nh.md_candidate_id
+        RETURNING c.md_candidate_id, c.md_candidate_groupid
+    )
+    -- Insert prod detail for new headers
+    INSERT INTO md_candidate_prod_detail (
+        md_candidate_prod_detail_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+        md_candidate_id, pp_order_id, pp_order_bomline_id, pp_product_bomline_id,
+        pp_plant_id, pp_order_docstatus, plannedqty, actualqty, isadvised, ispickdirectlyiffeasible
+    )
+    SELECT
+        nextval('md_candidate_prod_detail_seq'),
+        nh.ad_client_id, nh.ad_org_id, v_now, 0, v_now, 0, 'Y',
+        nh.md_candidate_id, ppo.pp_order_id, NULL, 0, -- NULL bomline = header, 0 = header indicator
+        ppo.s_resource_id, ppo.docstatus, ppo.qtyordered, ppo.qtydelivered, 'N', 'N'
+    FROM new_headers nh
+    JOIN pp_order ppo ON ppo.m_product_id = nh.m_product_id
+      AND ppo.docstatus IN ('DR', 'IP', 'CO')
+      AND ppo.isactive = 'Y'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_prod_detail ppd2
+          WHERE ppd2.pp_order_id = ppo.pp_order_id AND ppd2.pp_order_bomline_id IS NULL
+      );
+
+    -- Pass B: INSERT missing PRODUCTION BOM line candidates (DEMAND for components)
+    WITH new_bomlines AS (
+        INSERT INTO md_candidate (
+            md_candidate_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_type, md_candidate_businesscase, md_candidate_status,
+            m_product_id, m_warehouse_id, dateprojected, qty,
+            storageattributeskey, m_attributesetinstance_id, seqno,
+            md_candidate_groupid,
+            replenish_minqty, replenish_maxqty, isreservedforcustomer
+        )
+        SELECT
+            nextval('md_candidate_seq'),
+            bl.ad_client_id, bl.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            -- ComponentType BY/CP = co-product/by-product → SUPPLY; otherwise CO/PK = component → DEMAND
+            CASE WHEN bl.componenttype IN ('BY', 'CP') THEN 'SUPPLY' ELSE 'DEMAND' END,
+            'PRODUCTION', 'doc_created',
+            bl.m_product_id, COALESCE(bl.m_warehouse_id, ppo.m_warehouse_id),
+            CASE
+                WHEN bl.componenttype IN ('BY', 'CP') THEN COALESCE(ppo.datepromised, ppo.dateordered, v_now)
+                ELSE COALESCE(ppo.datestartschedule, ppo.dateordered, v_now)
+            END,
+            bl.qtyrequiered - COALESCE(bl.qtydelivered, 0),
+            COALESCE(GenerateASIStorageAttributesKey(bl.m_attributesetinstance_id), ''),
+            COALESCE(bl.m_attributesetinstance_id, 0),
+            0,
+            -- GroupId: find the header candidate's ID for this PP_Order
+            (SELECT c_hdr.md_candidate_id FROM md_candidate c_hdr
+             JOIN md_candidate_prod_detail ppd_hdr ON ppd_hdr.md_candidate_id = c_hdr.md_candidate_id
+             WHERE ppd_hdr.pp_order_id = ppo.pp_order_id
+               AND ppd_hdr.pp_order_bomline_id IS NULL
+               AND c_hdr.md_candidate_businesscase = 'PRODUCTION'
+             LIMIT 1),
+            0, 0, 'N'
+        FROM pp_order_bomline bl
+        JOIN pp_order ppo ON ppo.pp_order_id = bl.pp_order_id
+        WHERE ppo.docstatus IN ('DR', 'IP', 'CO')
+          AND ppo.isactive = 'Y'
+          AND bl.isactive = 'Y'
+          AND NOT EXISTS (
+              SELECT 1 FROM md_candidate_prod_detail ppd
+              JOIN md_candidate c2 ON c2.md_candidate_id = ppd.md_candidate_id
+              WHERE ppd.pp_order_bomline_id = bl.pp_order_bomline_id
+                AND c2.md_candidate_businesscase = 'PRODUCTION'
+          )
+        RETURNING md_candidate_id, ad_client_id, ad_org_id, m_product_id, m_warehouse_id
+    )
+    INSERT INTO md_candidate_prod_detail (
+        md_candidate_prod_detail_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+        md_candidate_id, pp_order_id, pp_order_bomline_id, pp_product_bomline_id,
+        pp_plant_id, pp_order_docstatus, plannedqty, actualqty, isadvised, ispickdirectlyiffeasible
+    )
+    SELECT
+        nextval('md_candidate_prod_detail_seq'),
+        nb.ad_client_id, nb.ad_org_id, v_now, 0, v_now, 0, 'Y',
+        nb.md_candidate_id, bl.pp_order_id, bl.pp_order_bomline_id, bl.pp_product_bomline_id,
+        ppo.s_resource_id, ppo.docstatus, bl.qtyrequiered, COALESCE(bl.qtydelivered, 0), 'N', 'N'
+    FROM new_bomlines nb
+    JOIN pp_order_bomline bl ON bl.m_product_id = nb.m_product_id
+    JOIN pp_order ppo ON ppo.pp_order_id = bl.pp_order_id
+      AND ppo.docstatus IN ('DR', 'IP', 'CO')
+      AND ppo.isactive = 'Y'
+      AND bl.isactive = 'Y'
+      AND COALESCE(bl.m_warehouse_id, ppo.m_warehouse_id) = nb.m_warehouse_id
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_prod_detail ppd2
+          WHERE ppd2.pp_order_bomline_id = bl.pp_order_bomline_id
+      );
+
+    -- Pass C: DELETE orphan PRODUCTION candidates (PP_Order closed/voided)
+    DELETE FROM md_candidate_prod_detail ppd
+    WHERE ppd.pp_order_id IS NOT NULL
+      AND EXISTS (
+          SELECT 1 FROM md_candidate c
+          WHERE c.md_candidate_id = ppd.md_candidate_id
+            AND c.md_candidate_businesscase = 'PRODUCTION'
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM pp_order ppo
+          WHERE ppo.pp_order_id = ppd.pp_order_id
+            AND ppo.docstatus IN ('DR', 'IP', 'CO')
+            AND ppo.isactive = 'Y'
+      );
+
+    -- Delete orphan BOM line prod details where the BOM line no longer exists
+    DELETE FROM md_candidate_prod_detail ppd
+    WHERE ppd.pp_order_bomline_id IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1 FROM pp_order_bomline bl
+          WHERE bl.pp_order_bomline_id = ppd.pp_order_bomline_id
+            AND bl.isactive = 'Y'
+      );
+
+    -- Delete PRODUCTION candidates that have no prod detail
+    DELETE FROM md_candidate c
+    WHERE c.md_candidate_businesscase = 'PRODUCTION'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_prod_detail ppd
+          WHERE ppd.md_candidate_id = c.md_candidate_id
+      );
+
+    -- ============================================================
+    -- STEP 5: DISTRIBUTION business case
+    -- Each DD_OrderLine creates 2 candidates:
+    --   DEMAND at source warehouse (M_Warehouse_From_ID)
+    --   SUPPLY at destination warehouse (M_Warehouse_To_ID)
+    -- Match key: MD_Candidate_Dist_Detail.DD_OrderLine_ID + warehouse
+    -- ============================================================
+
+    -- Pass A: UPDATE existing DISTRIBUTION DEMAND candidates (source warehouse)
+    UPDATE md_candidate c
+    SET qty             = ddl.qtyordered - COALESCE(ddl.qtydelivered, 0),
+        dateprojected   = COALESCE(ddl.datepromised, ddo.datepromised, v_now)
+                          - COALESCE(
+                              (SELECT make_interval(days => ndl.transferttime::int)
+                               FROM dd_networkdistributionline ndl
+                               WHERE ndl.dd_networkdistributionline_id = dist.dd_networkdistributionline_id),
+                              interval '0 days'),
+        m_warehouse_id  = ddo.m_warehouse_from_id,
+        storageattributeskey = COALESCE(GenerateASIStorageAttributesKey(ddl.m_attributesetinstance_id), ''),
+        m_attributesetinstance_id = COALESCE(ddl.m_attributesetinstance_id, 0),
+        updated         = v_now,
+        updatedby       = 0
+    FROM md_candidate_dist_detail dist
+    JOIN dd_orderline ddl ON ddl.dd_orderline_id = dist.dd_orderline_id
+    JOIN dd_order ddo ON ddo.dd_order_id = ddl.dd_order_id
+    WHERE dist.md_candidate_id = c.md_candidate_id
+      AND c.md_candidate_businesscase = 'DISTRIBUTION'
+      AND c.md_candidate_type = 'DEMAND'
+      AND c.m_warehouse_id = ddo.m_warehouse_from_id  -- identify DEMAND by warehouse
+      AND ddo.docstatus IN ('DR', 'IP', 'CO')
+      AND ddo.isactive = 'Y';
+
+    -- Pass A: UPDATE existing DISTRIBUTION SUPPLY candidates (destination warehouse)
+    UPDATE md_candidate c
+    SET qty             = ddl.qtyordered - COALESCE(ddl.qtydelivered, 0),
+        dateprojected   = COALESCE(ddl.datepromised, ddo.datepromised, v_now),
+        m_warehouse_id  = ddo.m_warehouse_to_id,
+        storageattributeskey = COALESCE(GenerateASIStorageAttributesKey(ddl.m_attributesetinstance_id), ''),
+        m_attributesetinstance_id = COALESCE(ddl.m_attributesetinstance_id, 0),
+        updated         = v_now,
+        updatedby       = 0
+    FROM md_candidate_dist_detail dist
+    JOIN dd_orderline ddl ON ddl.dd_orderline_id = dist.dd_orderline_id
+    JOIN dd_order ddo ON ddo.dd_order_id = ddl.dd_order_id
+    WHERE dist.md_candidate_id = c.md_candidate_id
+      AND c.md_candidate_businesscase = 'DISTRIBUTION'
+      AND c.md_candidate_type = 'SUPPLY'
+      AND c.m_warehouse_id = ddo.m_warehouse_to_id  -- identify SUPPLY by warehouse
+      AND ddo.docstatus IN ('DR', 'IP', 'CO')
+      AND ddo.isactive = 'Y';
+
+    -- Update dist detail records
+    UPDATE md_candidate_dist_detail dist
+    SET dd_order_docstatus = ddo.docstatus,
+        plannedqty         = ddl.qtyordered,
+        actualqty          = COALESCE(ddl.qtydelivered, 0),
+        updated            = v_now,
+        updatedby          = 0
+    FROM dd_orderline ddl
+    JOIN dd_order ddo ON ddo.dd_order_id = ddl.dd_order_id
+    WHERE dist.dd_orderline_id = ddl.dd_orderline_id
+      AND ddo.docstatus IN ('DR', 'IP', 'CO')
+      AND ddo.isactive = 'Y'
+      AND EXISTS (SELECT 1 FROM md_candidate c
+                  WHERE c.md_candidate_id = dist.md_candidate_id
+                    AND c.md_candidate_businesscase = 'DISTRIBUTION');
+
+    -- Pass B: INSERT missing DISTRIBUTION candidates
+    -- For each open DD_OrderLine missing a DEMAND candidate, create DEMAND + SUPPLY pair
+    WITH new_demand AS (
+        INSERT INTO md_candidate (
+            md_candidate_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_type, md_candidate_businesscase, md_candidate_status,
+            m_product_id, m_warehouse_id, dateprojected, qty,
+            storageattributeskey, m_attributesetinstance_id, seqno,
+            replenish_minqty, replenish_maxqty, isreservedforcustomer
+        )
+        SELECT
+            nextval('md_candidate_seq'),
+            ddl.ad_client_id, ddl.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            'DEMAND', 'DISTRIBUTION', 'doc_created',
+            ddl.m_product_id, ddo.m_warehouse_from_id,
+            COALESCE(ddl.datepromised, ddo.datepromised, v_now)
+                - COALESCE(
+                    (SELECT make_interval(days => ndl.transferttime::int)
+                     FROM dd_networkdistributionline ndl
+                     WHERE ndl.dd_networkdistributionline_id = (
+                         SELECT dd2.dd_networkdistributionline_id FROM md_candidate_dist_detail dd2
+                         WHERE dd2.dd_orderline_id = ddl.dd_orderline_id LIMIT 1)),
+                    interval '0 days'),
+            ddl.qtyordered - COALESCE(ddl.qtydelivered, 0),
+            COALESCE(GenerateASIStorageAttributesKey(ddl.m_attributesetinstance_id), ''),
+            COALESCE(ddl.m_attributesetinstance_id, 0),
+            0, 0, 0, 'N'
+        FROM dd_orderline ddl
+        JOIN dd_order ddo ON ddo.dd_order_id = ddl.dd_order_id
+        WHERE ddo.docstatus IN ('DR', 'IP', 'CO')
+          AND ddo.isactive = 'Y'
+          AND ddl.isactive = 'Y'
+          AND NOT EXISTS (
+              SELECT 1 FROM md_candidate_dist_detail dist
+              JOIN md_candidate c2 ON c2.md_candidate_id = dist.md_candidate_id
+              WHERE dist.dd_orderline_id = ddl.dd_orderline_id
+                AND c2.md_candidate_businesscase = 'DISTRIBUTION'
+                AND c2.md_candidate_type = 'DEMAND'
+          )
+        RETURNING md_candidate_id, ad_client_id, ad_org_id, m_product_id
+    ),
+    new_demand_detail AS (
+        INSERT INTO md_candidate_dist_detail (
+            md_candidate_dist_detail_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_id, dd_order_id, dd_orderline_id, dd_order_docstatus,
+            plannedqty, actualqty, isadvised, ispickdirectlyiffeasible
+        )
+        SELECT
+            nextval('md_candidate_dist_detail_seq'),
+            nd.ad_client_id, nd.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            nd.md_candidate_id, ddo.dd_order_id, ddl.dd_orderline_id, ddo.docstatus,
+            ddl.qtyordered, COALESCE(ddl.qtydelivered, 0), 'N', 'N'
+        FROM new_demand nd
+        JOIN dd_orderline ddl ON ddl.m_product_id = nd.m_product_id
+        JOIN dd_order ddo ON ddo.dd_order_id = ddl.dd_order_id
+          AND ddo.docstatus IN ('DR', 'IP', 'CO')
+          AND ddo.isactive = 'Y'
+          AND ddl.isactive = 'Y'
+        -- Only for lines that were just inserted (no existing detail)
+        WHERE NOT EXISTS (
+            SELECT 1 FROM md_candidate_dist_detail dist2
+            WHERE dist2.dd_orderline_id = ddl.dd_orderline_id
+              AND dist2.md_candidate_id != nd.md_candidate_id
+              AND EXISTS (SELECT 1 FROM md_candidate c3
+                          WHERE c3.md_candidate_id = dist2.md_candidate_id
+                            AND c3.md_candidate_type = 'DEMAND')
+        )
+        RETURNING md_candidate_id
+    ),
+    -- Now insert SUPPLY candidates for the same DD_OrderLines (destination warehouse)
+    new_supply AS (
+        INSERT INTO md_candidate (
+            md_candidate_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_type, md_candidate_businesscase, md_candidate_status,
+            m_product_id, m_warehouse_id, dateprojected, qty,
+            storageattributeskey, m_attributesetinstance_id, seqno,
+            replenish_minqty, replenish_maxqty, isreservedforcustomer
+        )
+        SELECT
+            nextval('md_candidate_seq'),
+            ddl.ad_client_id, ddl.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            'SUPPLY', 'DISTRIBUTION', 'doc_created',
+            ddl.m_product_id, ddo.m_warehouse_to_id,
+            COALESCE(ddl.datepromised, ddo.datepromised, v_now),
+            ddl.qtyordered - COALESCE(ddl.qtydelivered, 0),
+            COALESCE(GenerateASIStorageAttributesKey(ddl.m_attributesetinstance_id), ''),
+            COALESCE(ddl.m_attributesetinstance_id, 0),
+            0, 0, 0, 'N'
+        FROM dd_orderline ddl
+        JOIN dd_order ddo ON ddo.dd_order_id = ddl.dd_order_id
+        WHERE ddo.docstatus IN ('DR', 'IP', 'CO')
+          AND ddo.isactive = 'Y'
+          AND ddl.isactive = 'Y'
+          AND NOT EXISTS (
+              SELECT 1 FROM md_candidate_dist_detail dist
+              JOIN md_candidate c2 ON c2.md_candidate_id = dist.md_candidate_id
+              WHERE dist.dd_orderline_id = ddl.dd_orderline_id
+                AND c2.md_candidate_businesscase = 'DISTRIBUTION'
+                AND c2.md_candidate_type = 'SUPPLY'
+          )
+        RETURNING md_candidate_id, ad_client_id, ad_org_id, m_product_id
+    )
+    INSERT INTO md_candidate_dist_detail (
+        md_candidate_dist_detail_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+        md_candidate_id, dd_order_id, dd_orderline_id, dd_order_docstatus,
+        plannedqty, actualqty, isadvised, ispickdirectlyiffeasible
+    )
+    SELECT
+        nextval('md_candidate_dist_detail_seq'),
+        ns.ad_client_id, ns.ad_org_id, v_now, 0, v_now, 0, 'Y',
+        ns.md_candidate_id, ddo.dd_order_id, ddl.dd_orderline_id, ddo.docstatus,
+        ddl.qtyordered, COALESCE(ddl.qtydelivered, 0), 'N', 'N'
+    FROM new_supply ns
+    JOIN dd_orderline ddl ON ddl.m_product_id = ns.m_product_id
+    JOIN dd_order ddo ON ddo.dd_order_id = ddl.dd_order_id
+      AND ddo.docstatus IN ('DR', 'IP', 'CO')
+      AND ddo.isactive = 'Y'
+      AND ddl.isactive = 'Y'
+    WHERE NOT EXISTS (
+        SELECT 1 FROM md_candidate_dist_detail dist2
+        WHERE dist2.dd_orderline_id = ddl.dd_orderline_id
+          AND dist2.md_candidate_id != ns.md_candidate_id
+          AND EXISTS (SELECT 1 FROM md_candidate c3
+                      WHERE c3.md_candidate_id = dist2.md_candidate_id
+                        AND c3.md_candidate_type = 'SUPPLY')
+    );
+
+    -- Pass C: DELETE orphan DISTRIBUTION candidates
+    DELETE FROM md_candidate_dist_detail dist
+    WHERE dist.dd_order_id IS NOT NULL
+      AND EXISTS (
+          SELECT 1 FROM md_candidate c
+          WHERE c.md_candidate_id = dist.md_candidate_id
+            AND c.md_candidate_businesscase = 'DISTRIBUTION'
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM dd_order ddo
+          WHERE ddo.dd_order_id = dist.dd_order_id
+            AND ddo.docstatus IN ('DR', 'IP', 'CO')
+            AND ddo.isactive = 'Y'
+      );
+
+    DELETE FROM md_candidate c
+    WHERE c.md_candidate_businesscase = 'DISTRIBUTION'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_dist_detail dist
+          WHERE dist.md_candidate_id = c.md_candidate_id
+      );
+
+    -- ============================================================
+    -- STEP 6: Delete non-business-case candidates
+    -- These represent historical adjustments already captured in MD_Stock
+    -- ============================================================
+
+    -- Delete StockChange details first
+    DELETE FROM md_candidate_stockchange_detail scd
+    WHERE EXISTS (
+        SELECT 1 FROM md_candidate c
+        WHERE c.md_candidate_id = scd.md_candidate_id
+          AND c.md_candidate_type IN (
+              'STOCK_UP', 'UNEXPECTED_INCREASE', 'UNEXPECTED_DECREASE',
+              'INVENTORY_UP', 'INVENTORY_DOWN',
+              'ATTRIBUTES_CHANGED_FROM', 'ATTRIBUTES_CHANGED_TO'
+          )
+    );
+
+    -- Delete forecast demand details
+    DELETE FROM md_candidate_demand_detail dd
+    WHERE dd.m_forecastline_id IS NOT NULL;
+
+    -- Delete the non-business-case candidates themselves
+    DELETE FROM md_candidate c
+    WHERE c.md_candidate_type IN (
+        'STOCK_UP', 'UNEXPECTED_INCREASE', 'UNEXPECTED_DECREASE',
+        'INVENTORY_UP', 'INVENTORY_DOWN',
+        'ATTRIBUTES_CHANGED_FROM', 'ATTRIBUTES_CHANGED_TO'
+    );
+
+    -- Delete FORECAST candidates (md_candidate_businesscase is null but linked via m_forecast_id or demand_detail.m_forecastline_id)
+    DELETE FROM md_candidate_demand_detail dd
+    WHERE EXISTS (
+        SELECT 1 FROM md_candidate c
+        WHERE c.md_candidate_id = dd.md_candidate_id
+          AND c.m_forecast_id IS NOT NULL
+          AND c.md_candidate_businesscase IS NULL
+    );
+
+    DELETE FROM md_candidate c
+    WHERE c.m_forecast_id IS NOT NULL
+      AND c.md_candidate_businesscase IS NULL
+      AND c.md_candidate_type != 'STOCK';
+
+    -- ============================================================
+    -- STEP 7: Delete orphan transaction details for candidates that were deleted
+    -- (FK is deferred, so we can clean up now)
+    -- ============================================================
+    DELETE FROM md_candidate_transaction_detail td
+    WHERE NOT EXISTS (
+        SELECT 1 FROM md_candidate c WHERE c.md_candidate_id = td.md_candidate_id
+    );
+
+    -- ============================================================
+    -- STEP 8: Rebuild STOCK timeline
+    -- Delete ALL existing STOCK candidates, then create new ones based on
+    -- MD_Stock.QtyOnHand (baseline) + running sum of DEMAND/SUPPLY deltas
+    -- ============================================================
+
+    -- First, clear parent_id references FROM stock candidates
+    UPDATE md_candidate SET md_candidate_parent_id = NULL
+    WHERE md_candidate_type = 'STOCK';
+
+    -- Clear parent_id references TO stock candidates (SUPPLY candidates point to STOCK as parent)
+    UPDATE md_candidate c SET md_candidate_parent_id = NULL
+    WHERE md_candidate_parent_id IS NOT NULL
+      AND EXISTS (
+          SELECT 1 FROM md_candidate s
+          WHERE s.md_candidate_id = c.md_candidate_parent_id
+            AND s.md_candidate_type = 'STOCK'
+      );
+
+    -- Delete all STOCK candidates
+    DELETE FROM md_candidate WHERE md_candidate_type = 'STOCK';
+
+    -- Rebuild STOCK candidates: one per DEMAND/SUPPLY candidate, showing cumulative ATP
+    -- Plus one baseline per (product, warehouse, attributesKey) from MD_Stock
+    WITH
+    -- Collect all demand/supply events with their stock delta
+    events AS (
+        SELECT
+            c.md_candidate_id,
+            c.ad_client_id,
+            c.ad_org_id,
+            c.m_product_id,
+            c.m_warehouse_id,
+            c.storageattributeskey,
+            c.dateprojected,
+            c.seqno,
+            c.md_candidate_type,
+            CASE
+                WHEN c.md_candidate_type = 'DEMAND' THEN -c.qty
+                WHEN c.md_candidate_type = 'SUPPLY' THEN c.qty
+                ELSE 0
+            END AS stock_delta
+        FROM md_candidate c
+        WHERE c.isactive = 'Y'
+          AND c.md_candidate_type IN ('DEMAND', 'SUPPLY')
+    ),
+    -- Get baseline stock per product/warehouse/attributes
+    baselines AS (
+        SELECT
+            ms.m_product_id,
+            ms.m_warehouse_id,
+            ms.attributeskey AS storageattributeskey,
+            COALESCE(ms.qtyonhand, 0) AS qtyonhand
+        FROM md_stock ms
+        WHERE ms.isactive = 'Y'
+    ),
+    -- Compute running sum for each event
+    stock_timeline AS (
+        SELECT
+            e.md_candidate_id,
+            e.ad_client_id,
+            e.ad_org_id,
+            e.m_product_id,
+            e.m_warehouse_id,
+            e.storageattributeskey,
+            e.dateprojected,
+            e.seqno,
+            e.md_candidate_type,
+            COALESCE(b.qtyonhand, 0) + SUM(e.stock_delta) OVER (
+                PARTITION BY e.m_product_id, e.m_warehouse_id, e.storageattributeskey
+                ORDER BY e.dateprojected, e.seqno
+                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            ) AS cumulative_qty
+        FROM events e
+        LEFT JOIN baselines b ON b.m_product_id = e.m_product_id
+            AND b.m_warehouse_id = e.m_warehouse_id
+            AND b.storageattributeskey = e.storageattributeskey
+    ),
+    -- Insert STOCK candidates
+    new_stock AS (
+        INSERT INTO md_candidate (
+            md_candidate_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_type, md_candidate_businesscase, md_candidate_status,
+            m_product_id, m_warehouse_id, dateprojected, qty,
+            storageattributeskey, m_attributesetinstance_id, seqno,
+            replenish_minqty, replenish_maxqty, isreservedforcustomer
+        )
+        SELECT
+            nextval('md_candidate_seq'),
+            st.ad_client_id, st.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            'STOCK', NULL, NULL,
+            st.m_product_id, st.m_warehouse_id, st.dateprojected, st.cumulative_qty,
+            st.storageattributeskey, 0, st.seqno,
+            0, 0, 'N'
+        FROM stock_timeline st
+        RETURNING md_candidate_id, m_product_id, m_warehouse_id, storageattributeskey, dateprojected, seqno
+    )
+    -- Consume the CTE result (PL/pgSQL requires a destination for SELECT)
+    SELECT count(*) INTO v_count FROM new_stock;
+
+    -- Link STOCK → DEMAND: set STOCK.MD_Candidate_Parent_ID = DEMAND candidate
+    UPDATE md_candidate stock
+    SET md_candidate_parent_id = demand.md_candidate_id
+    FROM md_candidate demand
+    WHERE demand.md_candidate_type IN ('DEMAND')
+      AND demand.isactive = 'Y'
+      AND stock.md_candidate_type = 'STOCK'
+      AND stock.m_product_id = demand.m_product_id
+      AND stock.m_warehouse_id = demand.m_warehouse_id
+      AND stock.storageattributeskey = demand.storageattributeskey
+      AND stock.dateprojected = demand.dateprojected
+      AND stock.seqno = demand.seqno;
+
+    -- Link SUPPLY → STOCK: set SUPPLY.MD_Candidate_Parent_ID = STOCK candidate
+    UPDATE md_candidate supply
+    SET md_candidate_parent_id = stock.md_candidate_id
+    FROM md_candidate stock
+    WHERE stock.md_candidate_type = 'STOCK'
+      AND stock.isactive = 'Y'
+      AND supply.md_candidate_type = 'SUPPLY'
+      AND supply.isactive = 'Y'
+      AND stock.m_product_id = supply.m_product_id
+      AND stock.m_warehouse_id = supply.m_warehouse_id
+      AND stock.storageattributeskey = supply.storageattributeskey
+      AND stock.dateprojected = supply.dateprojected
+      AND stock.seqno = supply.seqno;
+
+    -- ============================================================
+    -- STEP 9: Return summary statistics
+    -- ============================================================
+    RETURN QUERY
+    SELECT 'RESULT'::text AS action,
+           c.md_candidate_type || '/' || COALESCE(c.md_candidate_businesscase, '-') AS business_case,
+           count(*)::bigint AS record_count
+    FROM md_candidate c
+    WHERE c.isactive = 'Y'
+    GROUP BY c.md_candidate_type, c.md_candidate_businesscase
+    ORDER BY c.md_candidate_type, c.md_candidate_businesscase;
+END;
+$BODY$
+LANGUAGE plpgsql VOLATILE;
+
+COMMENT ON FUNCTION de_metas_material.MD_Candidate_Rebuild(numeric, character) IS
+'Rebuilds all MD_Candidate records from source documents.
+Three-pass approach per business case: UPDATE existing, INSERT missing, DELETE orphans.
+Then rebuilds STOCK timeline from MD_Stock.QtyOnHand + running sum of demand/supply deltas.
+Preserves MD_Candidate_Transaction_Detail on updated candidates.
+See: https://github.com/metasfresh/me03/issues/28598';

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/ddl/de_metas_material/MD_Candidate_Rebuild_Validate.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/ddl/de_metas_material/MD_Candidate_Rebuild_Validate.sql
@@ -1,0 +1,270 @@
+-- Function: de_metas_material.MD_Candidate_Rebuild_Validate
+-- Purpose: Compare MD_Candidate state after rebuild against source documents
+-- Returns discrepancies: qty mismatches, missing candidates, orphan candidates, ATP drift
+-- See: https://github.com/metasfresh/me03/issues/28598
+
+DROP FUNCTION IF EXISTS de_metas_material.MD_Candidate_Rebuild_Validate();
+CREATE OR REPLACE FUNCTION de_metas_material.MD_Candidate_Rebuild_Validate()
+RETURNS TABLE (
+    check_name text,
+    severity text,  -- 'ERROR', 'WARNING', 'INFO'
+    business_case text,
+    detail text,
+    expected_value text,
+    actual_value text
+) AS
+$BODY$
+BEGIN
+    -- ============================================================
+    -- CHECK 1: SHIPMENT qty mismatch
+    -- Expected: MD_Candidate.Qty = ShipmentSchedule.QtyOrdered - QtyDelivered
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'SHIPMENT_QTY_MISMATCH'::text,
+        'ERROR'::text,
+        'SHIPMENT'::text,
+        format('MD_Candidate_ID=%s, M_ShipmentSchedule_ID=%s', c.md_candidate_id, dd.m_shipmentschedule_id),
+        (ss.qtyordered - ss.qtydelivered)::text,
+        c.qty::text
+    FROM md_candidate c
+    JOIN md_candidate_demand_detail dd ON dd.md_candidate_id = c.md_candidate_id AND dd.isactive = 'Y'
+    JOIN m_shipmentschedule ss ON ss.m_shipmentschedule_id = dd.m_shipmentschedule_id
+    WHERE c.md_candidate_businesscase = 'SHIPMENT'
+      AND c.md_candidate_type = 'DEMAND'
+      AND c.isactive = 'Y'
+      AND c.qty != (ss.qtyordered - ss.qtydelivered);
+
+    -- ============================================================
+    -- CHECK 2: PURCHASE qty mismatch
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'PURCHASE_QTY_MISMATCH'::text,
+        'ERROR'::text,
+        'PURCHASE'::text,
+        format('MD_Candidate_ID=%s, M_ReceiptSchedule_ID=%s', c.md_candidate_id, pd.m_receiptschedule_id),
+        (rs.qtyordered - COALESCE(rs.qtymoved, 0))::text,
+        c.qty::text
+    FROM md_candidate c
+    JOIN md_candidate_purchase_detail pd ON pd.md_candidate_id = c.md_candidate_id
+    JOIN m_receiptschedule rs ON rs.m_receiptschedule_id = pd.m_receiptschedule_id
+    WHERE c.md_candidate_businesscase = 'PURCHASE'
+      AND c.md_candidate_type = 'SUPPLY'
+      AND c.isactive = 'Y'
+      AND c.qty != (rs.qtyordered - COALESCE(rs.qtymoved, 0));
+
+    -- ============================================================
+    -- CHECK 3: PRODUCTION header qty mismatch
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'PRODUCTION_HEADER_QTY_MISMATCH'::text,
+        'ERROR'::text,
+        'PRODUCTION'::text,
+        format('MD_Candidate_ID=%s, PP_Order_ID=%s', c.md_candidate_id, ppd.pp_order_id),
+        (ppo.qtyordered - ppo.qtydelivered)::text,
+        c.qty::text
+    FROM md_candidate c
+    JOIN md_candidate_prod_detail ppd ON ppd.md_candidate_id = c.md_candidate_id
+    JOIN pp_order ppo ON ppo.pp_order_id = ppd.pp_order_id
+    WHERE c.md_candidate_businesscase = 'PRODUCTION'
+      AND c.md_candidate_type = 'SUPPLY'
+      AND ppd.pp_order_bomline_id IS NULL
+      AND c.isactive = 'Y'
+      AND c.qty != (ppo.qtyordered - ppo.qtydelivered);
+
+    -- ============================================================
+    -- CHECK 4: Missing SHIPMENT candidates (open schedule, no candidate)
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'MISSING_SHIPMENT_CANDIDATE'::text,
+        'ERROR'::text,
+        'SHIPMENT'::text,
+        format('M_ShipmentSchedule_ID=%s, Product=%s', ss.m_shipmentschedule_id, ss.m_product_id),
+        'candidate should exist'::text,
+        'no candidate found'::text
+    FROM m_shipmentschedule ss
+    WHERE ss.processed = 'N' AND ss.isactive = 'Y'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_demand_detail dd
+          JOIN md_candidate c ON c.md_candidate_id = dd.md_candidate_id
+          WHERE dd.m_shipmentschedule_id = ss.m_shipmentschedule_id
+            AND dd.isactive = 'Y'
+            AND c.md_candidate_businesscase = 'SHIPMENT'
+      );
+
+    -- ============================================================
+    -- CHECK 5: Missing PURCHASE candidates
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'MISSING_PURCHASE_CANDIDATE'::text,
+        'ERROR'::text,
+        'PURCHASE'::text,
+        format('M_ReceiptSchedule_ID=%s, Product=%s', rs.m_receiptschedule_id, rs.m_product_id),
+        'candidate should exist'::text,
+        'no candidate found'::text
+    FROM m_receiptschedule rs
+    WHERE rs.processed = 'N' AND rs.isactive = 'Y'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_purchase_detail pd
+          JOIN md_candidate c ON c.md_candidate_id = pd.md_candidate_id
+          WHERE pd.m_receiptschedule_id = rs.m_receiptschedule_id
+            AND c.md_candidate_businesscase = 'PURCHASE'
+      );
+
+    -- ============================================================
+    -- CHECK 6: Missing PRODUCTION candidates (open PP_Order, no header candidate)
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'MISSING_PRODUCTION_CANDIDATE'::text,
+        'ERROR'::text,
+        'PRODUCTION'::text,
+        format('PP_Order_ID=%s, Product=%s', ppo.pp_order_id, ppo.m_product_id),
+        'candidate should exist'::text,
+        'no candidate found'::text
+    FROM pp_order ppo
+    WHERE ppo.docstatus IN ('DR', 'IP', 'CO') AND ppo.isactive = 'Y'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_prod_detail ppd
+          JOIN md_candidate c ON c.md_candidate_id = ppd.md_candidate_id
+          WHERE ppd.pp_order_id = ppo.pp_order_id
+            AND ppd.pp_order_bomline_id IS NULL
+            AND c.md_candidate_businesscase = 'PRODUCTION'
+      );
+
+    -- ============================================================
+    -- CHECK 7: Orphan candidates (detail FK points to closed/deleted source doc)
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'ORPHAN_SHIPMENT_CANDIDATE'::text,
+        'WARNING'::text,
+        'SHIPMENT'::text,
+        format('MD_Candidate_ID=%s, M_ShipmentSchedule_ID=%s', c.md_candidate_id, dd.m_shipmentschedule_id),
+        'should be deleted'::text,
+        'still exists'::text
+    FROM md_candidate c
+    JOIN md_candidate_demand_detail dd ON dd.md_candidate_id = c.md_candidate_id AND dd.isactive = 'Y'
+    WHERE c.md_candidate_businesscase = 'SHIPMENT' AND c.md_candidate_type = 'DEMAND'
+      AND dd.m_shipmentschedule_id IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1 FROM m_shipmentschedule ss
+          WHERE ss.m_shipmentschedule_id = dd.m_shipmentschedule_id
+            AND ss.processed = 'N' AND ss.isactive = 'Y'
+      );
+
+    -- ============================================================
+    -- CHECK 8: STOCK timeline consistency
+    -- For each DEMAND/SUPPLY candidate, there should be a matching STOCK candidate
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'MISSING_STOCK_CANDIDATE'::text,
+        'ERROR'::text,
+        COALESCE(c.md_candidate_businesscase, c.md_candidate_type)::text,
+        format('MD_Candidate_ID=%s, Type=%s, Product=%s', c.md_candidate_id, c.md_candidate_type, c.m_product_id),
+        'should have paired STOCK'::text,
+        'no STOCK candidate found'::text
+    FROM md_candidate c
+    WHERE c.isactive = 'Y'
+      AND c.md_candidate_type IN ('DEMAND', 'SUPPLY')
+      -- Check: there should be a STOCK candidate with matching product/warehouse/attributes/date/seqno
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate s
+          WHERE s.md_candidate_type = 'STOCK'
+            AND s.isactive = 'Y'
+            AND s.m_product_id = c.m_product_id
+            AND s.m_warehouse_id = c.m_warehouse_id
+            AND s.storageattributeskey = c.storageattributeskey
+            AND s.dateprojected = c.dateprojected
+            AND s.seqno = c.seqno
+      );
+
+    -- ============================================================
+    -- CHECK 9: ATP sanity check per product/warehouse
+    -- Compare ATP from STOCK timeline vs computed (MD_Stock.QtyOnHand + sum of open supply - demand)
+    -- ============================================================
+    RETURN QUERY
+    WITH
+    -- Latest STOCK candidate per product/warehouse/attributes
+    latest_stock AS (
+        SELECT DISTINCT ON (m_product_id, m_warehouse_id, storageattributeskey)
+            m_product_id, m_warehouse_id, storageattributeskey, qty
+        FROM md_candidate
+        WHERE isactive = 'Y' AND md_candidate_type = 'STOCK'
+        ORDER BY m_product_id, m_warehouse_id, storageattributeskey, dateprojected DESC, seqno DESC
+    ),
+    -- Computed ATP from source docs
+    computed_atp AS (
+        SELECT
+            c.m_product_id, c.m_warehouse_id, c.storageattributeskey,
+            COALESCE(ms.qtyonhand, 0)
+                + COALESCE(SUM(CASE WHEN c.md_candidate_type = 'SUPPLY' THEN c.qty ELSE 0 END), 0)
+                - COALESCE(SUM(CASE WHEN c.md_candidate_type = 'DEMAND' THEN c.qty ELSE 0 END), 0)
+            AS expected_atp
+        FROM md_candidate c
+        LEFT JOIN md_stock ms ON ms.m_product_id = c.m_product_id
+            AND ms.m_warehouse_id = c.m_warehouse_id
+            AND ms.attributeskey = c.storageattributeskey
+        WHERE c.isactive = 'Y' AND c.md_candidate_type IN ('DEMAND', 'SUPPLY')
+        GROUP BY c.m_product_id, c.m_warehouse_id, c.storageattributeskey, ms.qtyonhand
+    )
+    SELECT
+        'ATP_MISMATCH'::text,
+        'ERROR'::text,
+        'STOCK'::text,
+        format('Product=%s, Warehouse=%s', ca.m_product_id, ca.m_warehouse_id),
+        ca.expected_atp::text,
+        COALESCE(ls.qty, 0)::text
+    FROM computed_atp ca
+    LEFT JOIN latest_stock ls ON ls.m_product_id = ca.m_product_id
+        AND ls.m_warehouse_id = ca.m_warehouse_id
+        AND ls.storageattributeskey = ca.storageattributeskey
+    WHERE COALESCE(ls.qty, 0) != ca.expected_atp;
+
+    -- ============================================================
+    -- CHECK 10: TransactionDetail integrity
+    -- Transaction details should only reference existing candidates
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'ORPHAN_TRANSACTION_DETAIL'::text,
+        'ERROR'::text,
+        '-'::text,
+        format('MD_Candidate_Transaction_Detail_ID=%s, references MD_Candidate_ID=%s', td.md_candidate_transaction_detail_id, td.md_candidate_id),
+        'should reference existing candidate'::text,
+        'candidate not found'::text
+    FROM md_candidate_transaction_detail td
+    WHERE td.isactive = 'Y'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate c WHERE c.md_candidate_id = td.md_candidate_id
+      );
+
+    -- ============================================================
+    -- Summary: overall counts
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'SUMMARY'::text,
+        'INFO'::text,
+        c.md_candidate_type || '/' || COALESCE(c.md_candidate_businesscase, '-'),
+        'Total count'::text,
+        ''::text,
+        count(*)::text
+    FROM md_candidate c
+    WHERE c.isactive = 'Y'
+    GROUP BY c.md_candidate_type, c.md_candidate_businesscase
+    ORDER BY c.md_candidate_type, c.md_candidate_businesscase;
+END;
+$BODY$
+LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION de_metas_material.MD_Candidate_Rebuild_Validate() IS
+'Validates MD_Candidate data after a rebuild.
+Checks: qty mismatches, missing candidates, orphans, STOCK timeline consistency, ATP sanity.
+Returns all discrepancies as rows. Empty result = all clean.
+See: https://github.com/metasfresh/me03/issues/28598';

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5793830_sys_gh28598_MD_Candidate_Rebuild.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5793830_sys_gh28598_MD_Candidate_Rebuild.sql
@@ -1,0 +1,934 @@
+-- Function: de_metas_material.MD_Candidate_Rebuild
+-- Purpose: Rebuild all MD_Candidate records from source documents (open orders, schedules, etc.)
+-- Approach: Three-pass per business case (UPDATE existing / INSERT missing / DELETE orphans) + rebuild STOCK timeline
+-- See: https://github.com/metasfresh/me03/issues/28598
+
+DROP FUNCTION IF EXISTS de_metas_material.MD_Candidate_Rebuild(numeric, character);
+CREATE OR REPLACE FUNCTION de_metas_material.MD_Candidate_Rebuild(
+    p_AD_PInstance_ID numeric,
+    p_IsBackupBeforeDelete character DEFAULT 'Y'
+)
+RETURNS TABLE (
+    action text,
+    business_case text,
+    record_count bigint
+) AS
+$BODY$
+DECLARE
+    v_now timestamp with time zone := now();
+    v_suffix text := '_pinstance_' || p_AD_PInstance_ID::text;
+    v_count bigint;
+BEGIN
+    -- ============================================================
+    -- STEP 1: Backup (if enabled)
+    -- ============================================================
+    IF p_IsBackupBeforeDelete = 'Y' THEN
+        PERFORM backup_table('md_candidate', v_suffix);
+        PERFORM backup_table('md_candidate_demand_detail', v_suffix);
+        PERFORM backup_table('md_candidate_purchase_detail', v_suffix);
+        PERFORM backup_table('md_candidate_prod_detail', v_suffix);
+        PERFORM backup_table('md_candidate_dist_detail', v_suffix);
+        PERFORM backup_table('md_candidate_stockchange_detail', v_suffix);
+        PERFORM backup_table('md_candidate_transaction_detail', v_suffix);
+    END IF;
+
+    -- ============================================================
+    -- STEP 2: SHIPMENT business case (DEMAND candidates)
+    -- Match key: MD_Candidate_Demand_Detail.M_ShipmentSchedule_ID
+    -- Source: M_ShipmentSchedule (open, active)
+    -- ============================================================
+
+    -- Pass A: UPDATE existing SHIPMENT candidates from open shipment schedules
+    UPDATE md_candidate c
+    SET qty             = ss.qtyordered - ss.qtydelivered,
+        dateprojected   = COALESCE(ss.deliverydate, ss.preparationdate, o.dateordered, v_now),
+        m_warehouse_id  = ss.m_warehouse_id,
+        storageattributeskey = COALESCE(GenerateASIStorageAttributesKey(ss.m_attributesetinstance_id), ''),
+        m_attributesetinstance_id = COALESCE(ss.m_attributesetinstance_id, 0),
+        m_shipmentschedule_id = ss.m_shipmentschedule_id,
+        c_orderso_id    = o.c_order_id,
+        updated         = v_now,
+        updatedby       = 0
+    FROM md_candidate_demand_detail dd
+    JOIN m_shipmentschedule ss ON ss.m_shipmentschedule_id = dd.m_shipmentschedule_id
+    JOIN c_orderline ol ON ol.c_orderline_id = ss.c_orderline_id
+    JOIN c_order o ON o.c_order_id = ol.c_order_id
+    WHERE dd.md_candidate_id = c.md_candidate_id
+      AND dd.isactive = 'Y'
+      AND c.md_candidate_businesscase = 'SHIPMENT'
+      AND c.md_candidate_type = 'DEMAND'
+      AND ss.processed = 'N'
+      AND ss.isactive = 'Y';
+
+    -- Also update the demand detail PlannedQty
+    UPDATE md_candidate_demand_detail dd
+    SET plannedqty      = ss.qtyordered,
+        actualqty       = ss.qtydelivered,
+        c_orderline_id  = ss.c_orderline_id,
+        updated         = v_now,
+        updatedby       = 0
+    FROM m_shipmentschedule ss
+    WHERE dd.m_shipmentschedule_id = ss.m_shipmentschedule_id
+      AND dd.isactive = 'Y'
+      AND ss.processed = 'N'
+      AND ss.isactive = 'Y'
+      AND EXISTS (SELECT 1 FROM md_candidate c
+                  WHERE c.md_candidate_id = dd.md_candidate_id
+                    AND c.md_candidate_businesscase = 'SHIPMENT'
+                    AND c.md_candidate_type = 'DEMAND');
+
+    -- Pass B: INSERT missing SHIPMENT candidates (open schedules with no MD_Candidate)
+    WITH new_candidates AS (
+        INSERT INTO md_candidate (
+            md_candidate_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_type, md_candidate_businesscase, md_candidate_status,
+            m_product_id, m_warehouse_id, dateprojected, qty,
+            storageattributeskey, m_attributesetinstance_id, seqno,
+            m_shipmentschedule_id, c_orderso_id,
+            replenish_minqty, replenish_maxqty, isreservedforcustomer
+        )
+        SELECT
+            nextval('md_candidate_seq'),
+            ss.ad_client_id, ss.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            'DEMAND', 'SHIPMENT', 'doc_created',
+            ss.m_product_id, ss.m_warehouse_id,
+            COALESCE(ss.deliverydate, ss.preparationdate, o.dateordered, v_now),
+            ss.qtyordered - ss.qtydelivered,
+            COALESCE(GenerateASIStorageAttributesKey(ss.m_attributesetinstance_id), ''),
+            COALESCE(ss.m_attributesetinstance_id, 0),
+            0, -- seqno
+            ss.m_shipmentschedule_id, o.c_order_id,
+            0, 0, 'N'
+        FROM m_shipmentschedule ss
+        JOIN c_orderline ol ON ol.c_orderline_id = ss.c_orderline_id
+        JOIN c_order o ON o.c_order_id = ol.c_order_id
+        WHERE ss.processed = 'N'
+          AND ss.isactive = 'Y'
+          AND NOT EXISTS (
+              SELECT 1 FROM md_candidate_demand_detail dd
+              JOIN md_candidate c2 ON c2.md_candidate_id = dd.md_candidate_id
+              WHERE dd.m_shipmentschedule_id = ss.m_shipmentschedule_id
+                AND dd.isactive = 'Y'
+                AND c2.md_candidate_businesscase = 'SHIPMENT'
+          )
+        RETURNING md_candidate_id, ad_client_id, ad_org_id, m_shipmentschedule_id
+    )
+    INSERT INTO md_candidate_demand_detail (
+        md_candidate_demand_detail_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+        md_candidate_id, m_shipmentschedule_id, c_orderline_id, plannedqty, actualqty
+    )
+    SELECT
+        nextval('md_candidate_demand_detail_seq'),
+        nc.ad_client_id, nc.ad_org_id, v_now, 0, v_now, 0, 'Y',
+        nc.md_candidate_id, nc.m_shipmentschedule_id,
+        ss.c_orderline_id, ss.qtyordered, ss.qtydelivered
+    FROM new_candidates nc
+    JOIN m_shipmentschedule ss ON ss.m_shipmentschedule_id = nc.m_shipmentschedule_id;
+
+    -- Pass C: DELETE orphan SHIPMENT candidates (shipment schedule closed/processed/deleted)
+    -- First delete detail records, then parent
+    DELETE FROM md_candidate_demand_detail dd
+    WHERE dd.isactive = 'Y'
+      AND dd.m_shipmentschedule_id IS NOT NULL
+      AND EXISTS (
+          SELECT 1 FROM md_candidate c
+          WHERE c.md_candidate_id = dd.md_candidate_id
+            AND c.md_candidate_businesscase = 'SHIPMENT'
+            AND c.md_candidate_type = 'DEMAND'
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM m_shipmentschedule ss
+          WHERE ss.m_shipmentschedule_id = dd.m_shipmentschedule_id
+            AND ss.processed = 'N'
+            AND ss.isactive = 'Y'
+      );
+
+    -- Delete orphan SHIPMENT candidates that have no demand detail (detail was deleted above)
+    DELETE FROM md_candidate c
+    WHERE c.md_candidate_businesscase = 'SHIPMENT'
+      AND c.md_candidate_type = 'DEMAND'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_demand_detail dd
+          WHERE dd.md_candidate_id = c.md_candidate_id AND dd.isactive = 'Y'
+      );
+
+    -- ============================================================
+    -- STEP 3: PURCHASE business case (SUPPLY candidates)
+    -- Match key: MD_Candidate_Purchase_Detail.M_ReceiptSchedule_ID
+    -- Source: M_ReceiptSchedule (open, active)
+    -- ============================================================
+
+    -- Pass A: UPDATE existing PURCHASE candidates from open receipt schedules
+    UPDATE md_candidate c
+    SET qty             = rs.qtyordered - COALESCE(rs.qtymoved, 0),
+        dateprojected   = COALESCE(o.datepromised, o.dateordered, v_now),
+        m_warehouse_id  = rs.m_warehouse_id,
+        storageattributeskey = COALESCE(GenerateASIStorageAttributesKey(rs.m_attributesetinstance_id), ''),
+        m_attributesetinstance_id = COALESCE(rs.m_attributesetinstance_id, 0),
+        updated         = v_now,
+        updatedby       = 0
+    FROM md_candidate_purchase_detail pd
+    JOIN m_receiptschedule rs ON rs.m_receiptschedule_id = pd.m_receiptschedule_id
+    JOIN c_orderline ol ON ol.c_orderline_id = rs.c_orderline_id
+    JOIN c_order o ON o.c_order_id = ol.c_order_id
+    WHERE pd.md_candidate_id = c.md_candidate_id
+      AND c.md_candidate_businesscase = 'PURCHASE'
+      AND c.md_candidate_type = 'SUPPLY'
+      AND rs.processed = 'N'
+      AND rs.isactive = 'Y';
+
+    -- Also update the purchase detail
+    UPDATE md_candidate_purchase_detail pd
+    SET plannedqty          = rs.qtyordered,
+        qtyordered          = rs.qtyordered,
+        c_orderlinepo_id    = rs.c_orderline_id,
+        c_bpartner_vendor_id = ol.c_bpartner_id,
+        updated             = v_now,
+        updatedby           = 0
+    FROM m_receiptschedule rs
+    JOIN c_orderline ol ON ol.c_orderline_id = rs.c_orderline_id
+    WHERE pd.m_receiptschedule_id = rs.m_receiptschedule_id
+      AND rs.processed = 'N'
+      AND rs.isactive = 'Y'
+      AND EXISTS (SELECT 1 FROM md_candidate c
+                  WHERE c.md_candidate_id = pd.md_candidate_id
+                    AND c.md_candidate_businesscase = 'PURCHASE'
+                    AND c.md_candidate_type = 'SUPPLY');
+
+    -- Pass B: INSERT missing PURCHASE candidates
+    WITH new_candidates AS (
+        INSERT INTO md_candidate (
+            md_candidate_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_type, md_candidate_businesscase, md_candidate_status,
+            m_product_id, m_warehouse_id, dateprojected, qty,
+            storageattributeskey, m_attributesetinstance_id, seqno,
+            replenish_minqty, replenish_maxqty, isreservedforcustomer
+        )
+        SELECT
+            nextval('md_candidate_seq'),
+            rs.ad_client_id, rs.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            'SUPPLY', 'PURCHASE', 'doc_created',
+            rs.m_product_id, rs.m_warehouse_id,
+            COALESCE(o.datepromised, o.dateordered, v_now),
+            rs.qtyordered - COALESCE(rs.qtymoved, 0),
+            COALESCE(GenerateASIStorageAttributesKey(rs.m_attributesetinstance_id), ''),
+            COALESCE(rs.m_attributesetinstance_id, 0),
+            0, -- seqno
+            0, 0, 'N'
+        FROM m_receiptschedule rs
+        JOIN c_orderline ol ON ol.c_orderline_id = rs.c_orderline_id
+        JOIN c_order o ON o.c_order_id = ol.c_order_id
+        WHERE rs.processed = 'N'
+          AND rs.isactive = 'Y'
+          AND NOT EXISTS (
+              SELECT 1 FROM md_candidate_purchase_detail pd
+              JOIN md_candidate c2 ON c2.md_candidate_id = pd.md_candidate_id
+              WHERE pd.m_receiptschedule_id = rs.m_receiptschedule_id
+                AND c2.md_candidate_businesscase = 'PURCHASE'
+          )
+        RETURNING md_candidate_id, ad_client_id, ad_org_id,
+                  (SELECT rs2.m_receiptschedule_id FROM m_receiptschedule rs2
+                   JOIN c_orderline ol2 ON ol2.c_orderline_id = rs2.c_orderline_id
+                   WHERE rs2.m_product_id = md_candidate.m_product_id
+                     AND rs2.m_warehouse_id = md_candidate.m_warehouse_id
+                     AND rs2.processed = 'N' AND rs2.isactive = 'Y'
+                   LIMIT 1) AS m_receiptschedule_id
+    )
+    INSERT INTO md_candidate_purchase_detail (
+        md_candidate_purchase_detail_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+        md_candidate_id, m_receiptschedule_id, c_orderlinepo_id, plannedqty, c_bpartner_vendor_id, isadvised
+    )
+    SELECT
+        nextval('md_candidate_purchase_detail_seq'),
+        nc.ad_client_id, nc.ad_org_id, v_now, 0, v_now, 0, 'Y',
+        nc.md_candidate_id, nc.m_receiptschedule_id,
+        rs.c_orderline_id, rs.qtyordered, ol.c_bpartner_id, 'N'
+    FROM new_candidates nc
+    JOIN m_receiptschedule rs ON rs.m_receiptschedule_id = nc.m_receiptschedule_id
+    JOIN c_orderline ol ON ol.c_orderline_id = rs.c_orderline_id;
+
+    -- Pass C: DELETE orphan PURCHASE candidates
+    DELETE FROM md_candidate_purchase_detail pd
+    WHERE pd.m_receiptschedule_id IS NOT NULL
+      AND EXISTS (
+          SELECT 1 FROM md_candidate c
+          WHERE c.md_candidate_id = pd.md_candidate_id
+            AND c.md_candidate_businesscase = 'PURCHASE'
+            AND c.md_candidate_type = 'SUPPLY'
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM m_receiptschedule rs
+          WHERE rs.m_receiptschedule_id = pd.m_receiptschedule_id
+            AND rs.processed = 'N'
+            AND rs.isactive = 'Y'
+      );
+
+    DELETE FROM md_candidate c
+    WHERE c.md_candidate_businesscase = 'PURCHASE'
+      AND c.md_candidate_type = 'SUPPLY'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_purchase_detail pd
+          WHERE pd.md_candidate_id = c.md_candidate_id
+      );
+
+    -- ============================================================
+    -- STEP 4: PRODUCTION business case
+    -- Header: PP_Order → SUPPLY candidate (finished product)
+    -- BOM Lines: PP_Order_BOMLine → DEMAND candidates (components)
+    -- Match key: MD_Candidate_Prod_Detail.PP_Order_ID + PP_Order_BOMLine_ID
+    -- ============================================================
+
+    -- Pass A: UPDATE existing PRODUCTION header candidates (SUPPLY, finished product)
+    UPDATE md_candidate c
+    SET qty             = ppo.qtyordered - ppo.qtydelivered,
+        dateprojected   = COALESCE(ppo.datepromised, ppo.dateordered, v_now),
+        m_warehouse_id  = ppo.m_warehouse_id,
+        storageattributeskey = COALESCE(GenerateASIStorageAttributesKey(ppo.m_attributesetinstance_id), ''),
+        m_attributesetinstance_id = COALESCE(ppo.m_attributesetinstance_id, 0),
+        updated         = v_now,
+        updatedby       = 0
+    FROM md_candidate_prod_detail ppd
+    JOIN pp_order ppo ON ppo.pp_order_id = ppd.pp_order_id
+    WHERE ppd.md_candidate_id = c.md_candidate_id
+      AND ppd.pp_order_bomline_id IS NULL  -- header (no BOM line)
+      AND c.md_candidate_businesscase = 'PRODUCTION'
+      AND c.md_candidate_type = 'SUPPLY'
+      AND ppo.docstatus IN ('DR', 'IP', 'CO')
+      AND ppo.isactive = 'Y';
+
+    -- Update prod detail for headers
+    UPDATE md_candidate_prod_detail ppd
+    SET pp_order_docstatus = ppo.docstatus,
+        plannedqty         = ppo.qtyordered,
+        actualqty          = ppo.qtydelivered,
+        pp_plant_id        = ppo.s_resource_id,
+        updated            = v_now,
+        updatedby          = 0
+    FROM pp_order ppo
+    WHERE ppd.pp_order_id = ppo.pp_order_id
+      AND ppd.pp_order_bomline_id IS NULL
+      AND ppo.docstatus IN ('DR', 'IP', 'CO')
+      AND ppo.isactive = 'Y'
+      AND EXISTS (SELECT 1 FROM md_candidate c
+                  WHERE c.md_candidate_id = ppd.md_candidate_id
+                    AND c.md_candidate_businesscase = 'PRODUCTION'
+                    AND c.md_candidate_type = 'SUPPLY');
+
+    -- Pass A: UPDATE existing PRODUCTION BOM line candidates (DEMAND, components)
+    UPDATE md_candidate c
+    SET qty             = CASE
+                              WHEN bl.componenttype IN ('CO', 'PK') THEN bl.qtyrequiered - COALESCE(bl.qtydelivered, 0)
+                              ELSE bl.qtyrequiered - COALESCE(bl.qtydelivered, 0)
+                          END,
+        dateprojected   = CASE
+                              WHEN bl.componenttype IN ('BY', 'CP') THEN COALESCE(ppo.datepromised, ppo.dateordered, v_now)
+                              ELSE COALESCE(ppo.datestartschedule, ppo.dateordered, v_now)
+                          END,
+        m_warehouse_id  = COALESCE(bl.m_warehouse_id, ppo.m_warehouse_id),
+        storageattributeskey = COALESCE(GenerateASIStorageAttributesKey(bl.m_attributesetinstance_id), ''),
+        m_attributesetinstance_id = COALESCE(bl.m_attributesetinstance_id, 0),
+        updated         = v_now,
+        updatedby       = 0
+    FROM md_candidate_prod_detail ppd
+    JOIN pp_order_bomline bl ON bl.pp_order_bomline_id = ppd.pp_order_bomline_id
+    JOIN pp_order ppo ON ppo.pp_order_id = bl.pp_order_id
+    WHERE ppd.md_candidate_id = c.md_candidate_id
+      AND ppd.pp_order_bomline_id IS NOT NULL  -- BOM line
+      AND c.md_candidate_businesscase = 'PRODUCTION'
+      AND ppo.docstatus IN ('DR', 'IP', 'CO')
+      AND ppo.isactive = 'Y';
+
+    -- Update prod detail for BOM lines
+    UPDATE md_candidate_prod_detail ppd
+    SET pp_order_docstatus = ppo.docstatus,
+        plannedqty         = bl.qtyrequiered,
+        actualqty          = COALESCE(bl.qtydelivered, 0),
+        pp_plant_id        = ppo.s_resource_id,
+        updated            = v_now,
+        updatedby          = 0
+    FROM pp_order_bomline bl
+    JOIN pp_order ppo ON ppo.pp_order_id = bl.pp_order_id
+    WHERE ppd.pp_order_bomline_id = bl.pp_order_bomline_id
+      AND ppd.pp_order_bomline_id IS NOT NULL
+      AND ppo.docstatus IN ('DR', 'IP', 'CO')
+      AND ppo.isactive = 'Y'
+      AND EXISTS (SELECT 1 FROM md_candidate c
+                  WHERE c.md_candidate_id = ppd.md_candidate_id
+                    AND c.md_candidate_businesscase = 'PRODUCTION');
+
+    -- Pass B: INSERT missing PRODUCTION header candidates (SUPPLY for finished product)
+    -- Use CTE with RETURNING to capture the new MD_Candidate_ID for GroupId assignment
+    WITH new_headers AS (
+        INSERT INTO md_candidate (
+            md_candidate_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_type, md_candidate_businesscase, md_candidate_status,
+            m_product_id, m_warehouse_id, dateprojected, qty,
+            storageattributeskey, m_attributesetinstance_id, seqno,
+            replenish_minqty, replenish_maxqty, isreservedforcustomer
+        )
+        SELECT
+            nextval('md_candidate_seq'),
+            ppo.ad_client_id, ppo.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            'SUPPLY', 'PRODUCTION', 'doc_created',
+            ppo.m_product_id, ppo.m_warehouse_id,
+            COALESCE(ppo.datepromised, ppo.dateordered, v_now),
+            ppo.qtyordered - ppo.qtydelivered,
+            COALESCE(GenerateASIStorageAttributesKey(ppo.m_attributesetinstance_id), ''),
+            COALESCE(ppo.m_attributesetinstance_id, 0),
+            0, 0, 0, 'N'
+        FROM pp_order ppo
+        WHERE ppo.docstatus IN ('DR', 'IP', 'CO')
+          AND ppo.isactive = 'Y'
+          AND NOT EXISTS (
+              SELECT 1 FROM md_candidate_prod_detail ppd
+              JOIN md_candidate c2 ON c2.md_candidate_id = ppd.md_candidate_id
+              WHERE ppd.pp_order_id = ppo.pp_order_id
+                AND ppd.pp_order_bomline_id IS NULL
+                AND c2.md_candidate_businesscase = 'PRODUCTION'
+          )
+        RETURNING md_candidate_id, ad_client_id, ad_org_id, m_product_id
+    ),
+    -- Set GroupId to the header candidate's own ID
+    group_update AS (
+        UPDATE md_candidate c
+        SET md_candidate_groupid = c.md_candidate_id
+        FROM new_headers nh
+        WHERE c.md_candidate_id = nh.md_candidate_id
+        RETURNING c.md_candidate_id, c.md_candidate_groupid
+    )
+    -- Insert prod detail for new headers
+    INSERT INTO md_candidate_prod_detail (
+        md_candidate_prod_detail_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+        md_candidate_id, pp_order_id, pp_order_bomline_id, pp_product_bomline_id,
+        pp_plant_id, pp_order_docstatus, plannedqty, actualqty, isadvised, ispickdirectlyiffeasible
+    )
+    SELECT
+        nextval('md_candidate_prod_detail_seq'),
+        nh.ad_client_id, nh.ad_org_id, v_now, 0, v_now, 0, 'Y',
+        nh.md_candidate_id, ppo.pp_order_id, NULL, 0, -- NULL bomline = header, 0 = header indicator
+        ppo.s_resource_id, ppo.docstatus, ppo.qtyordered, ppo.qtydelivered, 'N', 'N'
+    FROM new_headers nh
+    JOIN pp_order ppo ON ppo.m_product_id = nh.m_product_id
+      AND ppo.docstatus IN ('DR', 'IP', 'CO')
+      AND ppo.isactive = 'Y'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_prod_detail ppd2
+          WHERE ppd2.pp_order_id = ppo.pp_order_id AND ppd2.pp_order_bomline_id IS NULL
+      );
+
+    -- Pass B: INSERT missing PRODUCTION BOM line candidates (DEMAND for components)
+    WITH new_bomlines AS (
+        INSERT INTO md_candidate (
+            md_candidate_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_type, md_candidate_businesscase, md_candidate_status,
+            m_product_id, m_warehouse_id, dateprojected, qty,
+            storageattributeskey, m_attributesetinstance_id, seqno,
+            md_candidate_groupid,
+            replenish_minqty, replenish_maxqty, isreservedforcustomer
+        )
+        SELECT
+            nextval('md_candidate_seq'),
+            bl.ad_client_id, bl.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            -- ComponentType BY/CP = co-product/by-product → SUPPLY; otherwise CO/PK = component → DEMAND
+            CASE WHEN bl.componenttype IN ('BY', 'CP') THEN 'SUPPLY' ELSE 'DEMAND' END,
+            'PRODUCTION', 'doc_created',
+            bl.m_product_id, COALESCE(bl.m_warehouse_id, ppo.m_warehouse_id),
+            CASE
+                WHEN bl.componenttype IN ('BY', 'CP') THEN COALESCE(ppo.datepromised, ppo.dateordered, v_now)
+                ELSE COALESCE(ppo.datestartschedule, ppo.dateordered, v_now)
+            END,
+            bl.qtyrequiered - COALESCE(bl.qtydelivered, 0),
+            COALESCE(GenerateASIStorageAttributesKey(bl.m_attributesetinstance_id), ''),
+            COALESCE(bl.m_attributesetinstance_id, 0),
+            0,
+            -- GroupId: find the header candidate's ID for this PP_Order
+            (SELECT c_hdr.md_candidate_id FROM md_candidate c_hdr
+             JOIN md_candidate_prod_detail ppd_hdr ON ppd_hdr.md_candidate_id = c_hdr.md_candidate_id
+             WHERE ppd_hdr.pp_order_id = ppo.pp_order_id
+               AND ppd_hdr.pp_order_bomline_id IS NULL
+               AND c_hdr.md_candidate_businesscase = 'PRODUCTION'
+             LIMIT 1),
+            0, 0, 'N'
+        FROM pp_order_bomline bl
+        JOIN pp_order ppo ON ppo.pp_order_id = bl.pp_order_id
+        WHERE ppo.docstatus IN ('DR', 'IP', 'CO')
+          AND ppo.isactive = 'Y'
+          AND bl.isactive = 'Y'
+          AND NOT EXISTS (
+              SELECT 1 FROM md_candidate_prod_detail ppd
+              JOIN md_candidate c2 ON c2.md_candidate_id = ppd.md_candidate_id
+              WHERE ppd.pp_order_bomline_id = bl.pp_order_bomline_id
+                AND c2.md_candidate_businesscase = 'PRODUCTION'
+          )
+        RETURNING md_candidate_id, ad_client_id, ad_org_id, m_product_id, m_warehouse_id
+    )
+    INSERT INTO md_candidate_prod_detail (
+        md_candidate_prod_detail_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+        md_candidate_id, pp_order_id, pp_order_bomline_id, pp_product_bomline_id,
+        pp_plant_id, pp_order_docstatus, plannedqty, actualqty, isadvised, ispickdirectlyiffeasible
+    )
+    SELECT
+        nextval('md_candidate_prod_detail_seq'),
+        nb.ad_client_id, nb.ad_org_id, v_now, 0, v_now, 0, 'Y',
+        nb.md_candidate_id, bl.pp_order_id, bl.pp_order_bomline_id, bl.pp_product_bomline_id,
+        ppo.s_resource_id, ppo.docstatus, bl.qtyrequiered, COALESCE(bl.qtydelivered, 0), 'N', 'N'
+    FROM new_bomlines nb
+    JOIN pp_order_bomline bl ON bl.m_product_id = nb.m_product_id
+    JOIN pp_order ppo ON ppo.pp_order_id = bl.pp_order_id
+      AND ppo.docstatus IN ('DR', 'IP', 'CO')
+      AND ppo.isactive = 'Y'
+      AND bl.isactive = 'Y'
+      AND COALESCE(bl.m_warehouse_id, ppo.m_warehouse_id) = nb.m_warehouse_id
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_prod_detail ppd2
+          WHERE ppd2.pp_order_bomline_id = bl.pp_order_bomline_id
+      );
+
+    -- Pass C: DELETE orphan PRODUCTION candidates (PP_Order closed/voided)
+    DELETE FROM md_candidate_prod_detail ppd
+    WHERE ppd.pp_order_id IS NOT NULL
+      AND EXISTS (
+          SELECT 1 FROM md_candidate c
+          WHERE c.md_candidate_id = ppd.md_candidate_id
+            AND c.md_candidate_businesscase = 'PRODUCTION'
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM pp_order ppo
+          WHERE ppo.pp_order_id = ppd.pp_order_id
+            AND ppo.docstatus IN ('DR', 'IP', 'CO')
+            AND ppo.isactive = 'Y'
+      );
+
+    -- Delete orphan BOM line prod details where the BOM line no longer exists
+    DELETE FROM md_candidate_prod_detail ppd
+    WHERE ppd.pp_order_bomline_id IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1 FROM pp_order_bomline bl
+          WHERE bl.pp_order_bomline_id = ppd.pp_order_bomline_id
+            AND bl.isactive = 'Y'
+      );
+
+    -- Delete PRODUCTION candidates that have no prod detail
+    DELETE FROM md_candidate c
+    WHERE c.md_candidate_businesscase = 'PRODUCTION'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_prod_detail ppd
+          WHERE ppd.md_candidate_id = c.md_candidate_id
+      );
+
+    -- ============================================================
+    -- STEP 5: DISTRIBUTION business case
+    -- Each DD_OrderLine creates 2 candidates:
+    --   DEMAND at source warehouse (M_Warehouse_From_ID)
+    --   SUPPLY at destination warehouse (M_Warehouse_To_ID)
+    -- Match key: MD_Candidate_Dist_Detail.DD_OrderLine_ID + warehouse
+    -- ============================================================
+
+    -- Pass A: UPDATE existing DISTRIBUTION DEMAND candidates (source warehouse)
+    UPDATE md_candidate c
+    SET qty             = ddl.qtyordered - COALESCE(ddl.qtydelivered, 0),
+        dateprojected   = COALESCE(ddl.datepromised, ddo.datepromised, v_now)
+                          - COALESCE(
+                              (SELECT make_interval(days => ndl.transferttime::int)
+                               FROM dd_networkdistributionline ndl
+                               WHERE ndl.dd_networkdistributionline_id = dist.dd_networkdistributionline_id),
+                              interval '0 days'),
+        m_warehouse_id  = ddo.m_warehouse_from_id,
+        storageattributeskey = COALESCE(GenerateASIStorageAttributesKey(ddl.m_attributesetinstance_id), ''),
+        m_attributesetinstance_id = COALESCE(ddl.m_attributesetinstance_id, 0),
+        updated         = v_now,
+        updatedby       = 0
+    FROM md_candidate_dist_detail dist
+    JOIN dd_orderline ddl ON ddl.dd_orderline_id = dist.dd_orderline_id
+    JOIN dd_order ddo ON ddo.dd_order_id = ddl.dd_order_id
+    WHERE dist.md_candidate_id = c.md_candidate_id
+      AND c.md_candidate_businesscase = 'DISTRIBUTION'
+      AND c.md_candidate_type = 'DEMAND'
+      AND c.m_warehouse_id = ddo.m_warehouse_from_id  -- identify DEMAND by warehouse
+      AND ddo.docstatus IN ('DR', 'IP', 'CO')
+      AND ddo.isactive = 'Y';
+
+    -- Pass A: UPDATE existing DISTRIBUTION SUPPLY candidates (destination warehouse)
+    UPDATE md_candidate c
+    SET qty             = ddl.qtyordered - COALESCE(ddl.qtydelivered, 0),
+        dateprojected   = COALESCE(ddl.datepromised, ddo.datepromised, v_now),
+        m_warehouse_id  = ddo.m_warehouse_to_id,
+        storageattributeskey = COALESCE(GenerateASIStorageAttributesKey(ddl.m_attributesetinstance_id), ''),
+        m_attributesetinstance_id = COALESCE(ddl.m_attributesetinstance_id, 0),
+        updated         = v_now,
+        updatedby       = 0
+    FROM md_candidate_dist_detail dist
+    JOIN dd_orderline ddl ON ddl.dd_orderline_id = dist.dd_orderline_id
+    JOIN dd_order ddo ON ddo.dd_order_id = ddl.dd_order_id
+    WHERE dist.md_candidate_id = c.md_candidate_id
+      AND c.md_candidate_businesscase = 'DISTRIBUTION'
+      AND c.md_candidate_type = 'SUPPLY'
+      AND c.m_warehouse_id = ddo.m_warehouse_to_id  -- identify SUPPLY by warehouse
+      AND ddo.docstatus IN ('DR', 'IP', 'CO')
+      AND ddo.isactive = 'Y';
+
+    -- Update dist detail records
+    UPDATE md_candidate_dist_detail dist
+    SET dd_order_docstatus = ddo.docstatus,
+        plannedqty         = ddl.qtyordered,
+        actualqty          = COALESCE(ddl.qtydelivered, 0),
+        updated            = v_now,
+        updatedby          = 0
+    FROM dd_orderline ddl
+    JOIN dd_order ddo ON ddo.dd_order_id = ddl.dd_order_id
+    WHERE dist.dd_orderline_id = ddl.dd_orderline_id
+      AND ddo.docstatus IN ('DR', 'IP', 'CO')
+      AND ddo.isactive = 'Y'
+      AND EXISTS (SELECT 1 FROM md_candidate c
+                  WHERE c.md_candidate_id = dist.md_candidate_id
+                    AND c.md_candidate_businesscase = 'DISTRIBUTION');
+
+    -- Pass B: INSERT missing DISTRIBUTION candidates
+    -- For each open DD_OrderLine missing a DEMAND candidate, create DEMAND + SUPPLY pair
+    WITH new_demand AS (
+        INSERT INTO md_candidate (
+            md_candidate_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_type, md_candidate_businesscase, md_candidate_status,
+            m_product_id, m_warehouse_id, dateprojected, qty,
+            storageattributeskey, m_attributesetinstance_id, seqno,
+            replenish_minqty, replenish_maxqty, isreservedforcustomer
+        )
+        SELECT
+            nextval('md_candidate_seq'),
+            ddl.ad_client_id, ddl.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            'DEMAND', 'DISTRIBUTION', 'doc_created',
+            ddl.m_product_id, ddo.m_warehouse_from_id,
+            COALESCE(ddl.datepromised, ddo.datepromised, v_now)
+                - COALESCE(
+                    (SELECT make_interval(days => ndl.transferttime::int)
+                     FROM dd_networkdistributionline ndl
+                     WHERE ndl.dd_networkdistributionline_id = (
+                         SELECT dd2.dd_networkdistributionline_id FROM md_candidate_dist_detail dd2
+                         WHERE dd2.dd_orderline_id = ddl.dd_orderline_id LIMIT 1)),
+                    interval '0 days'),
+            ddl.qtyordered - COALESCE(ddl.qtydelivered, 0),
+            COALESCE(GenerateASIStorageAttributesKey(ddl.m_attributesetinstance_id), ''),
+            COALESCE(ddl.m_attributesetinstance_id, 0),
+            0, 0, 0, 'N'
+        FROM dd_orderline ddl
+        JOIN dd_order ddo ON ddo.dd_order_id = ddl.dd_order_id
+        WHERE ddo.docstatus IN ('DR', 'IP', 'CO')
+          AND ddo.isactive = 'Y'
+          AND ddl.isactive = 'Y'
+          AND NOT EXISTS (
+              SELECT 1 FROM md_candidate_dist_detail dist
+              JOIN md_candidate c2 ON c2.md_candidate_id = dist.md_candidate_id
+              WHERE dist.dd_orderline_id = ddl.dd_orderline_id
+                AND c2.md_candidate_businesscase = 'DISTRIBUTION'
+                AND c2.md_candidate_type = 'DEMAND'
+          )
+        RETURNING md_candidate_id, ad_client_id, ad_org_id, m_product_id
+    ),
+    new_demand_detail AS (
+        INSERT INTO md_candidate_dist_detail (
+            md_candidate_dist_detail_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_id, dd_order_id, dd_orderline_id, dd_order_docstatus,
+            plannedqty, actualqty, isadvised, ispickdirectlyiffeasible
+        )
+        SELECT
+            nextval('md_candidate_dist_detail_seq'),
+            nd.ad_client_id, nd.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            nd.md_candidate_id, ddo.dd_order_id, ddl.dd_orderline_id, ddo.docstatus,
+            ddl.qtyordered, COALESCE(ddl.qtydelivered, 0), 'N', 'N'
+        FROM new_demand nd
+        JOIN dd_orderline ddl ON ddl.m_product_id = nd.m_product_id
+        JOIN dd_order ddo ON ddo.dd_order_id = ddl.dd_order_id
+          AND ddo.docstatus IN ('DR', 'IP', 'CO')
+          AND ddo.isactive = 'Y'
+          AND ddl.isactive = 'Y'
+        -- Only for lines that were just inserted (no existing detail)
+        WHERE NOT EXISTS (
+            SELECT 1 FROM md_candidate_dist_detail dist2
+            WHERE dist2.dd_orderline_id = ddl.dd_orderline_id
+              AND dist2.md_candidate_id != nd.md_candidate_id
+              AND EXISTS (SELECT 1 FROM md_candidate c3
+                          WHERE c3.md_candidate_id = dist2.md_candidate_id
+                            AND c3.md_candidate_type = 'DEMAND')
+        )
+        RETURNING md_candidate_id
+    ),
+    -- Now insert SUPPLY candidates for the same DD_OrderLines (destination warehouse)
+    new_supply AS (
+        INSERT INTO md_candidate (
+            md_candidate_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_type, md_candidate_businesscase, md_candidate_status,
+            m_product_id, m_warehouse_id, dateprojected, qty,
+            storageattributeskey, m_attributesetinstance_id, seqno,
+            replenish_minqty, replenish_maxqty, isreservedforcustomer
+        )
+        SELECT
+            nextval('md_candidate_seq'),
+            ddl.ad_client_id, ddl.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            'SUPPLY', 'DISTRIBUTION', 'doc_created',
+            ddl.m_product_id, ddo.m_warehouse_to_id,
+            COALESCE(ddl.datepromised, ddo.datepromised, v_now),
+            ddl.qtyordered - COALESCE(ddl.qtydelivered, 0),
+            COALESCE(GenerateASIStorageAttributesKey(ddl.m_attributesetinstance_id), ''),
+            COALESCE(ddl.m_attributesetinstance_id, 0),
+            0, 0, 0, 'N'
+        FROM dd_orderline ddl
+        JOIN dd_order ddo ON ddo.dd_order_id = ddl.dd_order_id
+        WHERE ddo.docstatus IN ('DR', 'IP', 'CO')
+          AND ddo.isactive = 'Y'
+          AND ddl.isactive = 'Y'
+          AND NOT EXISTS (
+              SELECT 1 FROM md_candidate_dist_detail dist
+              JOIN md_candidate c2 ON c2.md_candidate_id = dist.md_candidate_id
+              WHERE dist.dd_orderline_id = ddl.dd_orderline_id
+                AND c2.md_candidate_businesscase = 'DISTRIBUTION'
+                AND c2.md_candidate_type = 'SUPPLY'
+          )
+        RETURNING md_candidate_id, ad_client_id, ad_org_id, m_product_id
+    )
+    INSERT INTO md_candidate_dist_detail (
+        md_candidate_dist_detail_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+        md_candidate_id, dd_order_id, dd_orderline_id, dd_order_docstatus,
+        plannedqty, actualqty, isadvised, ispickdirectlyiffeasible
+    )
+    SELECT
+        nextval('md_candidate_dist_detail_seq'),
+        ns.ad_client_id, ns.ad_org_id, v_now, 0, v_now, 0, 'Y',
+        ns.md_candidate_id, ddo.dd_order_id, ddl.dd_orderline_id, ddo.docstatus,
+        ddl.qtyordered, COALESCE(ddl.qtydelivered, 0), 'N', 'N'
+    FROM new_supply ns
+    JOIN dd_orderline ddl ON ddl.m_product_id = ns.m_product_id
+    JOIN dd_order ddo ON ddo.dd_order_id = ddl.dd_order_id
+      AND ddo.docstatus IN ('DR', 'IP', 'CO')
+      AND ddo.isactive = 'Y'
+      AND ddl.isactive = 'Y'
+    WHERE NOT EXISTS (
+        SELECT 1 FROM md_candidate_dist_detail dist2
+        WHERE dist2.dd_orderline_id = ddl.dd_orderline_id
+          AND dist2.md_candidate_id != ns.md_candidate_id
+          AND EXISTS (SELECT 1 FROM md_candidate c3
+                      WHERE c3.md_candidate_id = dist2.md_candidate_id
+                        AND c3.md_candidate_type = 'SUPPLY')
+    );
+
+    -- Pass C: DELETE orphan DISTRIBUTION candidates
+    DELETE FROM md_candidate_dist_detail dist
+    WHERE dist.dd_order_id IS NOT NULL
+      AND EXISTS (
+          SELECT 1 FROM md_candidate c
+          WHERE c.md_candidate_id = dist.md_candidate_id
+            AND c.md_candidate_businesscase = 'DISTRIBUTION'
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM dd_order ddo
+          WHERE ddo.dd_order_id = dist.dd_order_id
+            AND ddo.docstatus IN ('DR', 'IP', 'CO')
+            AND ddo.isactive = 'Y'
+      );
+
+    DELETE FROM md_candidate c
+    WHERE c.md_candidate_businesscase = 'DISTRIBUTION'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_dist_detail dist
+          WHERE dist.md_candidate_id = c.md_candidate_id
+      );
+
+    -- ============================================================
+    -- STEP 6: Delete non-business-case candidates
+    -- These represent historical adjustments already captured in MD_Stock
+    -- ============================================================
+
+    -- Delete StockChange details first
+    DELETE FROM md_candidate_stockchange_detail scd
+    WHERE EXISTS (
+        SELECT 1 FROM md_candidate c
+        WHERE c.md_candidate_id = scd.md_candidate_id
+          AND c.md_candidate_type IN (
+              'STOCK_UP', 'UNEXPECTED_INCREASE', 'UNEXPECTED_DECREASE',
+              'INVENTORY_UP', 'INVENTORY_DOWN',
+              'ATTRIBUTES_CHANGED_FROM', 'ATTRIBUTES_CHANGED_TO'
+          )
+    );
+
+    -- Delete forecast demand details
+    DELETE FROM md_candidate_demand_detail dd
+    WHERE dd.m_forecastline_id IS NOT NULL;
+
+    -- Delete the non-business-case candidates themselves
+    DELETE FROM md_candidate c
+    WHERE c.md_candidate_type IN (
+        'STOCK_UP', 'UNEXPECTED_INCREASE', 'UNEXPECTED_DECREASE',
+        'INVENTORY_UP', 'INVENTORY_DOWN',
+        'ATTRIBUTES_CHANGED_FROM', 'ATTRIBUTES_CHANGED_TO'
+    );
+
+    -- Delete FORECAST candidates (md_candidate_businesscase is null but linked via m_forecast_id or demand_detail.m_forecastline_id)
+    DELETE FROM md_candidate_demand_detail dd
+    WHERE EXISTS (
+        SELECT 1 FROM md_candidate c
+        WHERE c.md_candidate_id = dd.md_candidate_id
+          AND c.m_forecast_id IS NOT NULL
+          AND c.md_candidate_businesscase IS NULL
+    );
+
+    DELETE FROM md_candidate c
+    WHERE c.m_forecast_id IS NOT NULL
+      AND c.md_candidate_businesscase IS NULL
+      AND c.md_candidate_type != 'STOCK';
+
+    -- ============================================================
+    -- STEP 7: Delete orphan transaction details for candidates that were deleted
+    -- (FK is deferred, so we can clean up now)
+    -- ============================================================
+    DELETE FROM md_candidate_transaction_detail td
+    WHERE NOT EXISTS (
+        SELECT 1 FROM md_candidate c WHERE c.md_candidate_id = td.md_candidate_id
+    );
+
+    -- ============================================================
+    -- STEP 8: Rebuild STOCK timeline
+    -- Delete ALL existing STOCK candidates, then create new ones based on
+    -- MD_Stock.QtyOnHand (baseline) + running sum of DEMAND/SUPPLY deltas
+    -- ============================================================
+
+    -- First, clear parent_id references FROM stock candidates
+    UPDATE md_candidate SET md_candidate_parent_id = NULL
+    WHERE md_candidate_type = 'STOCK';
+
+    -- Clear parent_id references TO stock candidates (SUPPLY candidates point to STOCK as parent)
+    UPDATE md_candidate c SET md_candidate_parent_id = NULL
+    WHERE md_candidate_parent_id IS NOT NULL
+      AND EXISTS (
+          SELECT 1 FROM md_candidate s
+          WHERE s.md_candidate_id = c.md_candidate_parent_id
+            AND s.md_candidate_type = 'STOCK'
+      );
+
+    -- Delete all STOCK candidates
+    DELETE FROM md_candidate WHERE md_candidate_type = 'STOCK';
+
+    -- Rebuild STOCK candidates: one per DEMAND/SUPPLY candidate, showing cumulative ATP
+    -- Plus one baseline per (product, warehouse, attributesKey) from MD_Stock
+    WITH
+    -- Collect all demand/supply events with their stock delta
+    events AS (
+        SELECT
+            c.md_candidate_id,
+            c.ad_client_id,
+            c.ad_org_id,
+            c.m_product_id,
+            c.m_warehouse_id,
+            c.storageattributeskey,
+            c.dateprojected,
+            c.seqno,
+            c.md_candidate_type,
+            CASE
+                WHEN c.md_candidate_type = 'DEMAND' THEN -c.qty
+                WHEN c.md_candidate_type = 'SUPPLY' THEN c.qty
+                ELSE 0
+            END AS stock_delta
+        FROM md_candidate c
+        WHERE c.isactive = 'Y'
+          AND c.md_candidate_type IN ('DEMAND', 'SUPPLY')
+    ),
+    -- Get baseline stock per product/warehouse/attributes
+    baselines AS (
+        SELECT
+            ms.m_product_id,
+            ms.m_warehouse_id,
+            ms.attributeskey AS storageattributeskey,
+            COALESCE(ms.qtyonhand, 0) AS qtyonhand
+        FROM md_stock ms
+        WHERE ms.isactive = 'Y'
+    ),
+    -- Compute running sum for each event
+    stock_timeline AS (
+        SELECT
+            e.md_candidate_id,
+            e.ad_client_id,
+            e.ad_org_id,
+            e.m_product_id,
+            e.m_warehouse_id,
+            e.storageattributeskey,
+            e.dateprojected,
+            e.seqno,
+            e.md_candidate_type,
+            COALESCE(b.qtyonhand, 0) + SUM(e.stock_delta) OVER (
+                PARTITION BY e.m_product_id, e.m_warehouse_id, e.storageattributeskey
+                ORDER BY e.dateprojected, e.seqno
+                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            ) AS cumulative_qty
+        FROM events e
+        LEFT JOIN baselines b ON b.m_product_id = e.m_product_id
+            AND b.m_warehouse_id = e.m_warehouse_id
+            AND b.storageattributeskey = e.storageattributeskey
+    ),
+    -- Insert STOCK candidates
+    new_stock AS (
+        INSERT INTO md_candidate (
+            md_candidate_id, ad_client_id, ad_org_id, created, createdby, updated, updatedby, isactive,
+            md_candidate_type, md_candidate_businesscase, md_candidate_status,
+            m_product_id, m_warehouse_id, dateprojected, qty,
+            storageattributeskey, m_attributesetinstance_id, seqno,
+            replenish_minqty, replenish_maxqty, isreservedforcustomer
+        )
+        SELECT
+            nextval('md_candidate_seq'),
+            st.ad_client_id, st.ad_org_id, v_now, 0, v_now, 0, 'Y',
+            'STOCK', NULL, NULL,
+            st.m_product_id, st.m_warehouse_id, st.dateprojected, st.cumulative_qty,
+            st.storageattributeskey, 0, st.seqno,
+            0, 0, 'N'
+        FROM stock_timeline st
+        RETURNING md_candidate_id, m_product_id, m_warehouse_id, storageattributeskey, dateprojected, seqno
+    )
+    -- Consume the CTE result (PL/pgSQL requires a destination for SELECT)
+    SELECT count(*) INTO v_count FROM new_stock;
+
+    -- Link STOCK → DEMAND: set STOCK.MD_Candidate_Parent_ID = DEMAND candidate
+    UPDATE md_candidate stock
+    SET md_candidate_parent_id = demand.md_candidate_id
+    FROM md_candidate demand
+    WHERE demand.md_candidate_type IN ('DEMAND')
+      AND demand.isactive = 'Y'
+      AND stock.md_candidate_type = 'STOCK'
+      AND stock.m_product_id = demand.m_product_id
+      AND stock.m_warehouse_id = demand.m_warehouse_id
+      AND stock.storageattributeskey = demand.storageattributeskey
+      AND stock.dateprojected = demand.dateprojected
+      AND stock.seqno = demand.seqno;
+
+    -- Link SUPPLY → STOCK: set SUPPLY.MD_Candidate_Parent_ID = STOCK candidate
+    UPDATE md_candidate supply
+    SET md_candidate_parent_id = stock.md_candidate_id
+    FROM md_candidate stock
+    WHERE stock.md_candidate_type = 'STOCK'
+      AND stock.isactive = 'Y'
+      AND supply.md_candidate_type = 'SUPPLY'
+      AND supply.isactive = 'Y'
+      AND stock.m_product_id = supply.m_product_id
+      AND stock.m_warehouse_id = supply.m_warehouse_id
+      AND stock.storageattributeskey = supply.storageattributeskey
+      AND stock.dateprojected = supply.dateprojected
+      AND stock.seqno = supply.seqno;
+
+    -- ============================================================
+    -- STEP 9: Return summary statistics
+    -- ============================================================
+    RETURN QUERY
+    SELECT 'RESULT'::text AS action,
+           c.md_candidate_type || '/' || COALESCE(c.md_candidate_businesscase, '-') AS business_case,
+           count(*)::bigint AS record_count
+    FROM md_candidate c
+    WHERE c.isactive = 'Y'
+    GROUP BY c.md_candidate_type, c.md_candidate_businesscase
+    ORDER BY c.md_candidate_type, c.md_candidate_businesscase;
+END;
+$BODY$
+LANGUAGE plpgsql VOLATILE;
+
+COMMENT ON FUNCTION de_metas_material.MD_Candidate_Rebuild(numeric, character) IS
+'Rebuilds all MD_Candidate records from source documents.
+Three-pass approach per business case: UPDATE existing, INSERT missing, DELETE orphans.
+Then rebuilds STOCK timeline from MD_Stock.QtyOnHand + running sum of demand/supply deltas.
+Preserves MD_Candidate_Transaction_Detail on updated candidates.
+See: https://github.com/metasfresh/me03/issues/28598';

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5793840_sys_gh28598_MD_Candidate_Rebuild_Process.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5793840_sys_gh28598_MD_Candidate_Rebuild_Process.sql
@@ -1,0 +1,102 @@
+-- gh#28598: Register AD_Process for MD_Candidate_Rebuild
+-- https://github.com/metasfresh/me03/issues/28598
+
+-- AD_Process
+INSERT INTO AD_Process (
+    AD_Process_ID, AD_Client_ID, AD_Org_ID, IsActive,
+    Created, CreatedBy, Updated, UpdatedBy,
+    Value, Name, Description,
+    Classname, EntityType, AccessLevel, Type,
+    IsReport, IsDirectPrint, IsBetaFunctionality, IsServerProcess,
+    ShowHelp, AllowProcessReRun, CopyFromProcess,
+    IsApplySecuritySettings, IsOneInstanceOnly,
+    RefreshAllAfterExecution, IsUseBPartnerLanguage,
+    IsTranslateExcelHeaders, IsFormatExcelFile, SpreadsheetFormat,
+    IsNotifyUserAfterExecution, PostgrestResponseFormat,
+    LockWaitTimeout
+)
+VALUES (
+    585595, 0, 0, 'Y',
+    TO_TIMESTAMP('2026-03-11 16:00', 'YYYY-MM-DD HH24:MI'), 0,
+    TO_TIMESTAMP('2026-03-11 16:00', 'YYYY-MM-DD HH24:MI'), 0,
+    'MD_Candidate_Rebuild', 'MaterialDispo neu aufbauen', 'Baut alle MD_Candidate-Datensaetze aus Quelldokumenten (offene Auftraege, Bestellungen, Produktionsauftraege) neu auf.',
+    'de.metas.material.dispo.commons.process.MD_Candidate_Rebuild',
+    'de.metas.material.dispo', '7', 'Java',
+    'N', 'N', 'N', 'N',
+    'N', 'Y', 'N',
+    'N', 'Y',
+    'Y', 'Y',
+    'Y', 'Y', 'xls',
+    'Y', 'json',
+    0
+);
+
+-- AD_Process_Trl
+INSERT INTO AD_Process_Trl (AD_Language, AD_Process_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, 585595, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Process t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Process_ID = 585595
+  AND NOT EXISTS (SELECT 1 FROM AD_Process_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Process_ID = t.AD_Process_ID);
+
+-- English translation
+UPDATE AD_Process_Trl
+SET Name = 'Rebuild MaterialDispo Candidates',
+    Description = 'Rebuilds all MD_Candidate records from source documents (open orders, production orders, distribution orders).',
+    IsTranslated = 'Y',
+    Updated = TO_TIMESTAMP('2026-03-11 16:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy = 0
+WHERE AD_Process_ID = 585595 AND AD_Language = 'en_US';
+
+-- AD_Process_Para: IsBackupBeforeDelete (Yes/No)
+INSERT INTO AD_Process_Para (
+    AD_Process_Para_ID, AD_Client_ID, AD_Org_ID, IsActive,
+    Created, CreatedBy, Updated, UpdatedBy,
+    AD_Process_ID, Name, Description,
+    ColumnName, AD_Reference_ID,
+    SeqNo, IsMandatory, IsRange, IsCentrallyMaintained,
+    EntityType, FieldLength, DefaultValue
+)
+VALUES (
+    543155, 0, 0, 'Y',
+    TO_TIMESTAMP('2026-03-11 16:00', 'YYYY-MM-DD HH24:MI'), 0,
+    TO_TIMESTAMP('2026-03-11 16:00', 'YYYY-MM-DD HH24:MI'), 0,
+    585595, 'Backup vor Loeschung', 'Sichert die bestehenden MD_Candidate-Daten vor dem Neuaufbau.',
+    'IsBackupBeforeDelete', 20,  -- 20 = Yes-No
+    10, 'Y', 'N', 'Y',
+    'de.metas.material.dispo', 0, 'Y'
+);
+
+-- AD_Process_Para_Trl
+INSERT INTO AD_Process_Para_Trl (AD_Language, AD_Process_Para_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, 543155, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Process_Para t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Process_Para_ID = 543155
+  AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Process_Para_ID = t.AD_Process_Para_ID);
+
+-- English translation for parameter
+UPDATE AD_Process_Para_Trl
+SET Name = 'Backup Before Delete',
+    Description = 'Creates backup of existing MD_Candidate data before rebuilding.',
+    IsTranslated = 'Y',
+    Updated = TO_TIMESTAMP('2026-03-11 16:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy = 0
+WHERE AD_Process_Para_ID = 543155 AND AD_Language = 'en_US';
+
+-- Link process to MD_Candidate table (AD_Table_ID=540808) for WebUI action
+INSERT INTO AD_Table_Process (
+    AD_Table_Process_ID, AD_Client_ID, AD_Org_ID, IsActive,
+    Created, CreatedBy, Updated, UpdatedBy,
+    AD_Process_ID, AD_Table_ID, EntityType,
+    WEBUI_DocumentAction, WEBUI_IncludedTabTopAction,
+    WEBUI_ViewAction, WEBUI_ViewQuickAction, WEBUI_ViewQuickAction_Default
+)
+VALUES (
+    541631, 0, 0, 'Y',
+    TO_TIMESTAMP('2026-03-11 16:00', 'YYYY-MM-DD HH24:MI'), 0,
+    TO_TIMESTAMP('2026-03-11 16:00', 'YYYY-MM-DD HH24:MI'), 0,
+    585595, 540808, 'de.metas.material.dispo',
+    'Y', 'N',
+    'Y', 'N', 'N'
+);

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5793850_sys_gh28598_MD_Candidate_Rebuild_Validate.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5793850_sys_gh28598_MD_Candidate_Rebuild_Validate.sql
@@ -1,0 +1,270 @@
+-- Function: de_metas_material.MD_Candidate_Rebuild_Validate
+-- Purpose: Compare MD_Candidate state after rebuild against source documents
+-- Returns discrepancies: qty mismatches, missing candidates, orphan candidates, ATP drift
+-- See: https://github.com/metasfresh/me03/issues/28598
+
+DROP FUNCTION IF EXISTS de_metas_material.MD_Candidate_Rebuild_Validate();
+CREATE OR REPLACE FUNCTION de_metas_material.MD_Candidate_Rebuild_Validate()
+RETURNS TABLE (
+    check_name text,
+    severity text,  -- 'ERROR', 'WARNING', 'INFO'
+    business_case text,
+    detail text,
+    expected_value text,
+    actual_value text
+) AS
+$BODY$
+BEGIN
+    -- ============================================================
+    -- CHECK 1: SHIPMENT qty mismatch
+    -- Expected: MD_Candidate.Qty = ShipmentSchedule.QtyOrdered - QtyDelivered
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'SHIPMENT_QTY_MISMATCH'::text,
+        'ERROR'::text,
+        'SHIPMENT'::text,
+        format('MD_Candidate_ID=%s, M_ShipmentSchedule_ID=%s', c.md_candidate_id, dd.m_shipmentschedule_id),
+        (ss.qtyordered - ss.qtydelivered)::text,
+        c.qty::text
+    FROM md_candidate c
+    JOIN md_candidate_demand_detail dd ON dd.md_candidate_id = c.md_candidate_id AND dd.isactive = 'Y'
+    JOIN m_shipmentschedule ss ON ss.m_shipmentschedule_id = dd.m_shipmentschedule_id
+    WHERE c.md_candidate_businesscase = 'SHIPMENT'
+      AND c.md_candidate_type = 'DEMAND'
+      AND c.isactive = 'Y'
+      AND c.qty != (ss.qtyordered - ss.qtydelivered);
+
+    -- ============================================================
+    -- CHECK 2: PURCHASE qty mismatch
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'PURCHASE_QTY_MISMATCH'::text,
+        'ERROR'::text,
+        'PURCHASE'::text,
+        format('MD_Candidate_ID=%s, M_ReceiptSchedule_ID=%s', c.md_candidate_id, pd.m_receiptschedule_id),
+        (rs.qtyordered - COALESCE(rs.qtymoved, 0))::text,
+        c.qty::text
+    FROM md_candidate c
+    JOIN md_candidate_purchase_detail pd ON pd.md_candidate_id = c.md_candidate_id
+    JOIN m_receiptschedule rs ON rs.m_receiptschedule_id = pd.m_receiptschedule_id
+    WHERE c.md_candidate_businesscase = 'PURCHASE'
+      AND c.md_candidate_type = 'SUPPLY'
+      AND c.isactive = 'Y'
+      AND c.qty != (rs.qtyordered - COALESCE(rs.qtymoved, 0));
+
+    -- ============================================================
+    -- CHECK 3: PRODUCTION header qty mismatch
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'PRODUCTION_HEADER_QTY_MISMATCH'::text,
+        'ERROR'::text,
+        'PRODUCTION'::text,
+        format('MD_Candidate_ID=%s, PP_Order_ID=%s', c.md_candidate_id, ppd.pp_order_id),
+        (ppo.qtyordered - ppo.qtydelivered)::text,
+        c.qty::text
+    FROM md_candidate c
+    JOIN md_candidate_prod_detail ppd ON ppd.md_candidate_id = c.md_candidate_id
+    JOIN pp_order ppo ON ppo.pp_order_id = ppd.pp_order_id
+    WHERE c.md_candidate_businesscase = 'PRODUCTION'
+      AND c.md_candidate_type = 'SUPPLY'
+      AND ppd.pp_order_bomline_id IS NULL
+      AND c.isactive = 'Y'
+      AND c.qty != (ppo.qtyordered - ppo.qtydelivered);
+
+    -- ============================================================
+    -- CHECK 4: Missing SHIPMENT candidates (open schedule, no candidate)
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'MISSING_SHIPMENT_CANDIDATE'::text,
+        'ERROR'::text,
+        'SHIPMENT'::text,
+        format('M_ShipmentSchedule_ID=%s, Product=%s', ss.m_shipmentschedule_id, ss.m_product_id),
+        'candidate should exist'::text,
+        'no candidate found'::text
+    FROM m_shipmentschedule ss
+    WHERE ss.processed = 'N' AND ss.isactive = 'Y'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_demand_detail dd
+          JOIN md_candidate c ON c.md_candidate_id = dd.md_candidate_id
+          WHERE dd.m_shipmentschedule_id = ss.m_shipmentschedule_id
+            AND dd.isactive = 'Y'
+            AND c.md_candidate_businesscase = 'SHIPMENT'
+      );
+
+    -- ============================================================
+    -- CHECK 5: Missing PURCHASE candidates
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'MISSING_PURCHASE_CANDIDATE'::text,
+        'ERROR'::text,
+        'PURCHASE'::text,
+        format('M_ReceiptSchedule_ID=%s, Product=%s', rs.m_receiptschedule_id, rs.m_product_id),
+        'candidate should exist'::text,
+        'no candidate found'::text
+    FROM m_receiptschedule rs
+    WHERE rs.processed = 'N' AND rs.isactive = 'Y'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_purchase_detail pd
+          JOIN md_candidate c ON c.md_candidate_id = pd.md_candidate_id
+          WHERE pd.m_receiptschedule_id = rs.m_receiptschedule_id
+            AND c.md_candidate_businesscase = 'PURCHASE'
+      );
+
+    -- ============================================================
+    -- CHECK 6: Missing PRODUCTION candidates (open PP_Order, no header candidate)
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'MISSING_PRODUCTION_CANDIDATE'::text,
+        'ERROR'::text,
+        'PRODUCTION'::text,
+        format('PP_Order_ID=%s, Product=%s', ppo.pp_order_id, ppo.m_product_id),
+        'candidate should exist'::text,
+        'no candidate found'::text
+    FROM pp_order ppo
+    WHERE ppo.docstatus IN ('DR', 'IP', 'CO') AND ppo.isactive = 'Y'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate_prod_detail ppd
+          JOIN md_candidate c ON c.md_candidate_id = ppd.md_candidate_id
+          WHERE ppd.pp_order_id = ppo.pp_order_id
+            AND ppd.pp_order_bomline_id IS NULL
+            AND c.md_candidate_businesscase = 'PRODUCTION'
+      );
+
+    -- ============================================================
+    -- CHECK 7: Orphan candidates (detail FK points to closed/deleted source doc)
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'ORPHAN_SHIPMENT_CANDIDATE'::text,
+        'WARNING'::text,
+        'SHIPMENT'::text,
+        format('MD_Candidate_ID=%s, M_ShipmentSchedule_ID=%s', c.md_candidate_id, dd.m_shipmentschedule_id),
+        'should be deleted'::text,
+        'still exists'::text
+    FROM md_candidate c
+    JOIN md_candidate_demand_detail dd ON dd.md_candidate_id = c.md_candidate_id AND dd.isactive = 'Y'
+    WHERE c.md_candidate_businesscase = 'SHIPMENT' AND c.md_candidate_type = 'DEMAND'
+      AND dd.m_shipmentschedule_id IS NOT NULL
+      AND NOT EXISTS (
+          SELECT 1 FROM m_shipmentschedule ss
+          WHERE ss.m_shipmentschedule_id = dd.m_shipmentschedule_id
+            AND ss.processed = 'N' AND ss.isactive = 'Y'
+      );
+
+    -- ============================================================
+    -- CHECK 8: STOCK timeline consistency
+    -- For each DEMAND/SUPPLY candidate, there should be a matching STOCK candidate
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'MISSING_STOCK_CANDIDATE'::text,
+        'ERROR'::text,
+        COALESCE(c.md_candidate_businesscase, c.md_candidate_type)::text,
+        format('MD_Candidate_ID=%s, Type=%s, Product=%s', c.md_candidate_id, c.md_candidate_type, c.m_product_id),
+        'should have paired STOCK'::text,
+        'no STOCK candidate found'::text
+    FROM md_candidate c
+    WHERE c.isactive = 'Y'
+      AND c.md_candidate_type IN ('DEMAND', 'SUPPLY')
+      -- Check: there should be a STOCK candidate with matching product/warehouse/attributes/date/seqno
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate s
+          WHERE s.md_candidate_type = 'STOCK'
+            AND s.isactive = 'Y'
+            AND s.m_product_id = c.m_product_id
+            AND s.m_warehouse_id = c.m_warehouse_id
+            AND s.storageattributeskey = c.storageattributeskey
+            AND s.dateprojected = c.dateprojected
+            AND s.seqno = c.seqno
+      );
+
+    -- ============================================================
+    -- CHECK 9: ATP sanity check per product/warehouse
+    -- Compare ATP from STOCK timeline vs computed (MD_Stock.QtyOnHand + sum of open supply - demand)
+    -- ============================================================
+    RETURN QUERY
+    WITH
+    -- Latest STOCK candidate per product/warehouse/attributes
+    latest_stock AS (
+        SELECT DISTINCT ON (m_product_id, m_warehouse_id, storageattributeskey)
+            m_product_id, m_warehouse_id, storageattributeskey, qty
+        FROM md_candidate
+        WHERE isactive = 'Y' AND md_candidate_type = 'STOCK'
+        ORDER BY m_product_id, m_warehouse_id, storageattributeskey, dateprojected DESC, seqno DESC
+    ),
+    -- Computed ATP from source docs
+    computed_atp AS (
+        SELECT
+            c.m_product_id, c.m_warehouse_id, c.storageattributeskey,
+            COALESCE(ms.qtyonhand, 0)
+                + COALESCE(SUM(CASE WHEN c.md_candidate_type = 'SUPPLY' THEN c.qty ELSE 0 END), 0)
+                - COALESCE(SUM(CASE WHEN c.md_candidate_type = 'DEMAND' THEN c.qty ELSE 0 END), 0)
+            AS expected_atp
+        FROM md_candidate c
+        LEFT JOIN md_stock ms ON ms.m_product_id = c.m_product_id
+            AND ms.m_warehouse_id = c.m_warehouse_id
+            AND ms.attributeskey = c.storageattributeskey
+        WHERE c.isactive = 'Y' AND c.md_candidate_type IN ('DEMAND', 'SUPPLY')
+        GROUP BY c.m_product_id, c.m_warehouse_id, c.storageattributeskey, ms.qtyonhand
+    )
+    SELECT
+        'ATP_MISMATCH'::text,
+        'ERROR'::text,
+        'STOCK'::text,
+        format('Product=%s, Warehouse=%s', ca.m_product_id, ca.m_warehouse_id),
+        ca.expected_atp::text,
+        COALESCE(ls.qty, 0)::text
+    FROM computed_atp ca
+    LEFT JOIN latest_stock ls ON ls.m_product_id = ca.m_product_id
+        AND ls.m_warehouse_id = ca.m_warehouse_id
+        AND ls.storageattributeskey = ca.storageattributeskey
+    WHERE COALESCE(ls.qty, 0) != ca.expected_atp;
+
+    -- ============================================================
+    -- CHECK 10: TransactionDetail integrity
+    -- Transaction details should only reference existing candidates
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'ORPHAN_TRANSACTION_DETAIL'::text,
+        'ERROR'::text,
+        '-'::text,
+        format('MD_Candidate_Transaction_Detail_ID=%s, references MD_Candidate_ID=%s', td.md_candidate_transaction_detail_id, td.md_candidate_id),
+        'should reference existing candidate'::text,
+        'candidate not found'::text
+    FROM md_candidate_transaction_detail td
+    WHERE td.isactive = 'Y'
+      AND NOT EXISTS (
+          SELECT 1 FROM md_candidate c WHERE c.md_candidate_id = td.md_candidate_id
+      );
+
+    -- ============================================================
+    -- Summary: overall counts
+    -- ============================================================
+    RETURN QUERY
+    SELECT
+        'SUMMARY'::text,
+        'INFO'::text,
+        c.md_candidate_type || '/' || COALESCE(c.md_candidate_businesscase, '-'),
+        'Total count'::text,
+        ''::text,
+        count(*)::text
+    FROM md_candidate c
+    WHERE c.isactive = 'Y'
+    GROUP BY c.md_candidate_type, c.md_candidate_businesscase
+    ORDER BY c.md_candidate_type, c.md_candidate_businesscase;
+END;
+$BODY$
+LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION de_metas_material.MD_Candidate_Rebuild_Validate() IS
+'Validates MD_Candidate data after a rebuild.
+Checks: qty mismatches, missing candidates, orphans, STOCK timeline consistency, ATP sanity.
+Returns all discrepancies as rows. Empty result = all clean.
+See: https://github.com/metasfresh/me03/issues/28598';


### PR DESCRIPTION
## Summary
- SQL function `de_metas_material.MD_Candidate_Rebuild()` — three-pass (UPDATE/INSERT/DELETE) rebuild for all 4 business cases (SHIPMENT, PURCHASE, PRODUCTION, DISTRIBUTION) + STOCK timeline rebuild + parent-child linking
- SQL function `de_metas_material.MD_Candidate_Rebuild_Validate()` — 10 post-rebuild validation checks (qty mismatches, missing/orphan candidates, STOCK consistency, ATP sanity)
- Java process `MD_Candidate_Rebuild` — thin wrapper exposing the SQL function as an AD_Process with backup parameter
- AD_Process registration with `IsBackupBeforeDelete` Yes/No parameter (default: Yes), linked to MD_Candidate table

## Test plan
- [ ] CI green (compilation, migration scripts)
- [ ] Cucumber integration tests (to be added)
- [ ] Manual validation: run rebuild on DB with existing MD_Candidate data, verify validate function returns no errors