### PR TITLE
fix: DESADV aggregate HU QtyTU/QtyCUsPerTU + INVOIC SU GLN COALESCE

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvAggregateHU.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvAggregateHU.feature
@@ -78,8 +78,8 @@ Feature: EDI DESADV with aggregate HU — QtyTU, QtyCUsPerTU, QtyCUsPerLU
       | pip_S0500               | pii_TU_S0500    | p_S0500      | 2   | 2020-01-01 |
 
     And metasfresh contains C_Orders:
-      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered |
-      | o_S0500    | true    | bp_S0500      | 2026-03-11  |
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference        |
+      | o_S0500    | true    | bp_S0500      | 2026-03-11  | po_ref_S0500_@Date@ |
     And metasfresh contains C_OrderLines:
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
       | ol_S0500   | o_S0500    | p_S0500      | 4          | pip_S0500               |
@@ -163,8 +163,8 @@ Feature: EDI DESADV with aggregate HU — QtyTU, QtyCUsPerTU, QtyCUsPerLU
       | pip_S0500_020           | pii_TU_S0500_020 | p_S0500_020  | 10  | 2020-01-01 |
 
     And metasfresh contains C_Orders:
-      | Identifier   | IsSOTrx | C_BPartner_ID | DateOrdered |
-      | o_S0500_020  | true    | bp_S0500_020  | 2026-03-11  |
+      | Identifier   | IsSOTrx | C_BPartner_ID | DateOrdered | POReference            |
+      | o_S0500_020  | true    | bp_S0500_020  | 2026-03-11  | po_ref_S0500_020_@Date@ |
     And metasfresh contains C_OrderLines:
       | Identifier    | C_Order_ID  | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
       | ol_S0500_020  | o_S0500_020 | p_S0500_020  | 50         | pip_S0500_020           |
@@ -226,8 +226,8 @@ Feature: EDI DESADV with aggregate HU — QtyTU, QtyCUsPerTU, QtyCUsPerLU
       | bp_S0500_030  | p_S0500_030  |
 
     And metasfresh contains C_Orders:
-      | Identifier   | IsSOTrx | C_BPartner_ID | DateOrdered |
-      | o_S0500_030  | true    | bp_S0500_030  | 2026-03-11  |
+      | Identifier   | IsSOTrx | C_BPartner_ID | DateOrdered | POReference            |
+      | o_S0500_030  | true    | bp_S0500_030  | 2026-03-11  | po_ref_S0500_030_@Date@ |
     And metasfresh contains C_OrderLines:
       | Identifier    | C_Order_ID  | M_Product_ID | QtyEntered |
       | ol_S0500_030  | o_S0500_030 | p_S0500_030  | 10         |
@@ -312,8 +312,8 @@ Feature: EDI DESADV with aggregate HU — QtyTU, QtyCUsPerTU, QtyCUsPerLU
       | pip_S0500_040           | pii_TU_S0500_040 | p_S0500_040  | 5   | 2020-01-01 | hpc_LU_S0500_040                  | 5412345000013                    |
 
     And metasfresh contains C_Orders:
-      | Identifier   | IsSOTrx | C_BPartner_ID | DateOrdered |
-      | o_S0500_040  | true    | bp_S0500_040  | 2026-03-11  |
+      | Identifier   | IsSOTrx | C_BPartner_ID | DateOrdered | POReference            |
+      | o_S0500_040  | true    | bp_S0500_040  | 2026-03-11  | po_ref_S0500_040_@Date@ |
     And metasfresh contains C_OrderLines:
       | Identifier    | C_Order_ID  | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
       | ol_S0500_040  | o_S0500_040 | p_S0500_040  | 10         | pip_S0500_040           |
@@ -396,8 +396,8 @@ Feature: EDI DESADV with aggregate HU — QtyTU, QtyCUsPerTU, QtyCUsPerLU
       | pip_S0500_050           | pii_TU_S0500_050 | p_S0500_050  | 2   | 2020-01-01 |
 
     And metasfresh contains C_Orders:
-      | Identifier   | IsSOTrx | C_BPartner_ID | DateOrdered |
-      | o_S0500_050  | true    | bp_S0500_050  | 2026-03-11  |
+      | Identifier   | IsSOTrx | C_BPartner_ID | DateOrdered | POReference            |
+      | o_S0500_050  | true    | bp_S0500_050  | 2026-03-11  | po_ref_S0500_050_@Date@ |
     And metasfresh contains C_OrderLines:
       | Identifier    | C_Order_ID  | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
       | ol_S0500_050  | o_S0500_050 | p_S0500_050  | 20         | pip_S0500_050           |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvAggregateHU.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvAggregateHU.feature
@@ -1,0 +1,434 @@
+@from:cucumber
+@ghActions:run_on_executor5
+@allure.label.epic:E0292_EDI
+@allure.label.feature:F00350_EDI
+@F00350
+Feature: EDI DESADV with aggregate HU — QtyTU, QtyCUsPerTU, QtyCUsPerLU
+## F00350: EDI
+## Validates that aggregate HUs (one DB record representing N TUs) produce
+## correct QtyTU, QtyCUsPerTU, and QtyCUsPerLU in DESADV pack items.
+## Also tests INVOIC SU GLN COALESCE and GTIN population.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And set sys config boolean value true for sys config de.metas.report.jasper.IsMockReportService
+    And metasfresh has date and time 2026-03-11T13:30:13+01:00[Europe/Berlin]
+    And metasfresh is configured for One-DESADV-Per-ORDERS
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh initially has no EDI_Desadv_Pack_Item data
+    And metasfresh initially has no EDI_Desadv_Pack data
+    And destroy existing M_HUs
+    And load M_Warehouse:
+      | M_Warehouse_ID | Value        |
+      | warehouseStd   | StdWarehouse |
+
+
+  @Id:S0500_010
+  @from:cucumber
+  Scenario: S0500_010 - Full delivery with aggregate HU: 2 TU x 2 PCE/TU = 4 PCE total
+  Order 4 PCE of a product with TU capacity 2 PCE/TU. Shipment generation creates
+  an aggregate HU (1 HU record representing 2 TUs with 4 PCE total).
+  DESADV pack item must show QtyTU=2, QtyCUsPerTU=2, QtyCUsPerLU=4.
+
+    Given metasfresh contains M_Products:
+      | Identifier |
+      | p_S0500    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_S0500   |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_S0500   | ps_S0500           | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_S0500  | pl_S0500       |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | plv_S0500              | p_S0500      | 10.0     | PCE      | Normal           |
+
+    And metasfresh contains C_BPartners:
+      | Identifier | IsCustomer | M_PricingSystem_ID | GLN           |
+      | bp_S0500   | Y          | ps_S0500           | 9900000500010 |
+    And the following c_bpartner is changed
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN |
+      | bp_S0500      | true                 | 9900000500010         |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID |
+      | bp_S0500      | p_S0500      |
+
+    # HU Packing Instruction hierarchy: LU holds up to 10 TU, each TU holds 2 PCE
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID   |
+      | pi_LU_S0500  |
+      | pi_TU_S0500  |
+      | pi_VHU_S0500 |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID   | HU_UnitType | IsCurrent |
+      | piv_LU_S0500       | pi_LU_S0500  | LU          | Y         |
+      | piv_TU_S0500       | pi_TU_S0500  | TU          | Y         |
+      | piv_VHU_S0500      | pi_VHU_S0500 | V           | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID |
+      | pii_LU_S0500    | piv_LU_S0500       | 10  | HU       | pi_TU_S0500       |
+      | pii_TU_S0500    | piv_TU_S0500       | 0   | PM       |                    |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID | Qty | ValidFrom  |
+      | pip_S0500               | pii_TU_S0500    | p_S0500      | 2   | 2020-01-01 |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered |
+      | o_S0500    | true    | bp_S0500      | 2026-03-11  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | ol_S0500   | o_S0500    | p_S0500      | 4          | pip_S0500               |
+
+    When the order identified by o_S0500 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ss_S0500   | ol_S0500       | N             |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_S0500              | D            | true                | false       |
+
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | ss_S0500              | io_S0500   |
+
+    And validate the created shipment lines
+      | M_InOutLine_ID | M_InOut_ID | M_Product_ID | movementqty | processed |
+      | iol_S0500      | io_S0500   | p_S0500      | 4           | true      |
+
+    And after not more than 60s, EDI_Desadv_Pack records are found:
+      | EDI_Desadv_Pack_ID | IsManual_IPA_SSCC18 |
+      | pack_S0500         | true                |
+
+    And after not more than 60s, the EDI_Desadv_Pack_Item has only the following records:
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | QtyTU | QtyCUsPerTU | QtyCUsPerLU | MovementQty | M_InOut_ID |
+      | pi_S0500                | pack_S0500         | 2     | 2           | 4           | 4           | io_S0500   |
+
+
+  @Id:S0500_020
+  @from:cucumber
+  Scenario: S0500_020 - Larger aggregate HU: 5 TU x 10 PCE/TU = 50 PCE total
+  Order 50 PCE with TU capacity 10 PCE/TU. Shipment creates an aggregate HU
+  representing 5 TUs. DESADV pack item: QtyTU=5, QtyCUsPerTU=10, QtyCUsPerLU=50.
+
+    Given metasfresh contains M_Products:
+      | Identifier  |
+      | p_S0500_020 |
+    And metasfresh contains M_PricingSystems
+      | Identifier   |
+      | ps_S0500_020 |
+    And metasfresh contains M_PriceLists
+      | Identifier   | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_S0500_020 | ps_S0500_020       | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier    | M_PriceList_ID |
+      | plv_S0500_020 | pl_S0500_020   |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | plv_S0500_020          | p_S0500_020  | 5.0      | PCE      | Normal           |
+
+    And metasfresh contains C_BPartners:
+      | Identifier    | IsCustomer | M_PricingSystem_ID | GLN           |
+      | bp_S0500_020  | Y          | ps_S0500_020       | 9900000500020 |
+    And the following c_bpartner is changed
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN |
+      | bp_S0500_020  | true                 | 9900000500020         |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID |
+      | bp_S0500_020  | p_S0500_020  |
+
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID       |
+      | pi_LU_S0500_020  |
+      | pi_TU_S0500_020  |
+      | pi_VHU_S0500_020 |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID  | M_HU_PI_ID       | HU_UnitType | IsCurrent |
+      | piv_LU_S0500_020    | pi_LU_S0500_020  | LU          | Y         |
+      | piv_TU_S0500_020    | pi_TU_S0500_020  | TU          | Y         |
+      | piv_VHU_S0500_020   | pi_VHU_S0500_020 | V           | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID   | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID |
+      | pii_LU_S0500_020  | piv_LU_S0500_020   | 20  | HU       | pi_TU_S0500_020   |
+      | pii_TU_S0500_020  | piv_TU_S0500_020   | 0   | PM       |                    |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID  | M_Product_ID | Qty | ValidFrom  |
+      | pip_S0500_020           | pii_TU_S0500_020 | p_S0500_020  | 10  | 2020-01-01 |
+
+    And metasfresh contains C_Orders:
+      | Identifier   | IsSOTrx | C_BPartner_ID | DateOrdered |
+      | o_S0500_020  | true    | bp_S0500_020  | 2026-03-11  |
+    And metasfresh contains C_OrderLines:
+      | Identifier    | C_Order_ID  | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | ol_S0500_020  | o_S0500_020 | p_S0500_020  | 50         | pip_S0500_020           |
+
+    When the order identified by o_S0500_020 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier    | C_OrderLine_ID | IsToRecompute |
+      | ss_S0500_020  | ol_S0500_020   | N             |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_S0500_020          | D            | true                | false       |
+
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID   |
+      | ss_S0500_020          | io_S0500_020 |
+
+    And after not more than 60s, EDI_Desadv_Pack records are found:
+      | EDI_Desadv_Pack_ID | IsManual_IPA_SSCC18 |
+      | pack_S0500_020     | true                |
+
+    And after not more than 60s, the EDI_Desadv_Pack_Item has only the following records:
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | QtyTU | QtyCUsPerTU | QtyCUsPerLU | MovementQty | M_InOut_ID   |
+      | pi_S0500_020            | pack_S0500_020     | 5     | 10          | 50          | 50          | io_S0500_020 |
+
+
+  @Id:S0500_030
+  @from:cucumber
+  Scenario: S0500_030 - No packing item regression: 1 LU, 1 TU, all CUs in one TU
+  Order 10 PCE without M_HU_PI_Item_Product. The non-HU path should create
+  QtyTU=1, QtyCUsPerTU=10, QtyCUsPerLU=10.
+
+    Given metasfresh contains M_Products:
+      | Identifier  |
+      | p_S0500_030 |
+    And metasfresh contains M_PricingSystems
+      | Identifier   |
+      | ps_S0500_030 |
+    And metasfresh contains M_PriceLists
+      | Identifier   | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_S0500_030 | ps_S0500_030       | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier    | M_PriceList_ID |
+      | plv_S0500_030 | pl_S0500_030   |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | plv_S0500_030          | p_S0500_030  | 10.0     | PCE      | Normal           |
+
+    And metasfresh contains C_BPartners:
+      | Identifier   | IsCustomer | M_PricingSystem_ID | GLN           |
+      | bp_S0500_030 | Y          | ps_S0500_030       | 9900000500030 |
+    And the following c_bpartner is changed
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN |
+      | bp_S0500_030  | true                 | 9900000500030         |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID |
+      | bp_S0500_030  | p_S0500_030  |
+
+    And metasfresh contains C_Orders:
+      | Identifier   | IsSOTrx | C_BPartner_ID | DateOrdered |
+      | o_S0500_030  | true    | bp_S0500_030  | 2026-03-11  |
+    And metasfresh contains C_OrderLines:
+      | Identifier    | C_Order_ID  | M_Product_ID | QtyEntered |
+      | ol_S0500_030  | o_S0500_030 | p_S0500_030  | 10         |
+
+    When the order identified by o_S0500_030 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier    | C_OrderLine_ID | IsToRecompute |
+      | ss_S0500_030  | ol_S0500_030   | N             |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_S0500_030          | D            | true                | false       |
+
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID   |
+      | ss_S0500_030          | io_S0500_030 |
+
+    And after not more than 60s, EDI_Desadv_Pack records are found:
+      | EDI_Desadv_Pack_ID | IsManual_IPA_SSCC18 |
+      | pack_S0500_030     | true                |
+
+    And after not more than 60s, the EDI_Desadv_Pack_Item has only the following records:
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | QtyTU | QtyCUsPerTU | QtyCUsPerLU | MovementQty | M_InOut_ID   |
+      | pi_S0500_030            | pack_S0500_030     | 1     | 10          | 10          | 10          | io_S0500_030 |
+
+
+  @Id:S0500_040
+  @from:cucumber
+  Scenario: S0500_040 - GTIN_CU from M_Product and GTIN_TU from PI Item Product in DESADV pack
+  Product has GTIN set. M_HU_PI_Item_Product has GTIN_LU_PackingMaterial_Fallback.
+  C_BPartner_Product has customer-specific GTIN.
+  DESADV pack and pack item should reflect the GTINs.
+
+    Given metasfresh contains M_Products:
+      | Identifier  | GTIN          |
+      | p_S0500_040 | 4001234567890 |
+    And metasfresh contains M_PricingSystems
+      | Identifier   |
+      | ps_S0500_040 |
+    And metasfresh contains M_PriceLists
+      | Identifier   | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_S0500_040 | ps_S0500_040       | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier    | M_PriceList_ID |
+      | plv_S0500_040 | pl_S0500_040   |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | plv_S0500_040          | p_S0500_040  | 10.0     | PCE      | Normal           |
+
+    And metasfresh contains C_BPartners:
+      | Identifier   | IsCustomer | M_PricingSystem_ID | GLN           |
+      | bp_S0500_040 | Y          | ps_S0500_040       | 9900000500040 |
+    And the following c_bpartner is changed
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN |
+      | bp_S0500_040  | true                 | 9900000500040         |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID | GTIN          |
+      | bp_S0500_040  | p_S0500_040  | 0575095404663 |
+
+    And load M_HU_PackagingCode:
+      | M_HU_PackagingCode_ID | PackagingCode | HU_UnitType |
+      | hpc_LU_S0500_040      | ISO1          | LU          |
+      | hpc_TU_S0500_040      | CART          | TU          |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID       |
+      | pi_LU_S0500_040  |
+      | pi_TU_S0500_040  |
+      | pi_VHU_S0500_040 |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID  | M_HU_PI_ID       | HU_UnitType | IsCurrent | M_HU_PackagingCode_ID |
+      | piv_LU_S0500_040    | pi_LU_S0500_040  | LU          | Y         |                       |
+      | piv_TU_S0500_040    | pi_TU_S0500_040  | TU          | Y         | hpc_TU_S0500_040      |
+      | piv_VHU_S0500_040   | pi_VHU_S0500_040 | V           | Y         |                       |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID   | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID |
+      | pii_LU_S0500_040  | piv_LU_S0500_040   | 10  | HU       | pi_TU_S0500_040   |
+      | pii_TU_S0500_040  | piv_TU_S0500_040   | 0   | PM       |                    |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID  | M_Product_ID | Qty | ValidFrom  | M_HU_PackagingCode_LU_Fallback_ID | GTIN_LU_PackingMaterial_Fallback |
+      | pip_S0500_040           | pii_TU_S0500_040 | p_S0500_040  | 5   | 2020-01-01 | hpc_LU_S0500_040                  | 5412345000013                    |
+
+    And metasfresh contains C_Orders:
+      | Identifier   | IsSOTrx | C_BPartner_ID | DateOrdered |
+      | o_S0500_040  | true    | bp_S0500_040  | 2026-03-11  |
+    And metasfresh contains C_OrderLines:
+      | Identifier    | C_Order_ID  | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | ol_S0500_040  | o_S0500_040 | p_S0500_040  | 10         | pip_S0500_040           |
+
+    When the order identified by o_S0500_040 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier    | C_OrderLine_ID | IsToRecompute |
+      | ss_S0500_040  | ol_S0500_040   | N             |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_S0500_040          | D            | true                | false       |
+
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID   |
+      | ss_S0500_040          | io_S0500_040 |
+
+    # Verify DESADV pack has LU GTIN from PI Item Product fallback
+    And after not more than 60s, EDI_Desadv_Pack records are found:
+      | EDI_Desadv_Pack_ID | IsManual_IPA_SSCC18 | GTIN_PackingMaterial | M_HU_PackagingCode_ID |
+      | pack_S0500_040     | true                | 5412345000013        | hpc_LU_S0500_040      |
+
+    # Verify pack item has QtyTU=2, QtyCUsPerTU=5, and TU packaging code
+    And after not more than 60s, the EDI_Desadv_Pack_Item has only the following records:
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | QtyTU | QtyCUsPerTU | QtyCUsPerLU | MovementQty | M_InOut_ID   | M_HU_PackagingCode_TU_ID |
+      | pi_S0500_040            | pack_S0500_040     | 2     | 5           | 10          | 10          | io_S0500_040 | hpc_TU_S0500_040         |
+
+
+  @Id:S0500_050
+  @from:cucumber
+  Scenario: S0500_050 - Partial delivery with aggregate HU: order 20 PCE, deliver 4 PCE = 2 TU
+  Order 20 PCE with TU capacity 2 PCE/TU (= 10 TU full order).
+  Override QtyToDeliver to 4 PCE. Shipment creates aggregate HU for 2 TU.
+  DESADV pack item must show QtyTU=2, QtyCUsPerTU=2, QtyCUsPerLU=4.
+
+    Given metasfresh contains M_Products:
+      | Identifier  |
+      | p_S0500_050 |
+    And metasfresh contains M_PricingSystems
+      | Identifier   |
+      | ps_S0500_050 |
+    And metasfresh contains M_PriceLists
+      | Identifier   | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_S0500_050 | ps_S0500_050       | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier    | M_PriceList_ID |
+      | plv_S0500_050 | pl_S0500_050   |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | plv_S0500_050          | p_S0500_050  | 10.0     | PCE      | Normal           |
+
+    And metasfresh contains C_BPartners:
+      | Identifier   | IsCustomer | M_PricingSystem_ID | GLN           |
+      | bp_S0500_050 | Y          | ps_S0500_050       | 9900000500050 |
+    And the following c_bpartner is changed
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN |
+      | bp_S0500_050  | true                 | 9900000500050         |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID |
+      | bp_S0500_050  | p_S0500_050  |
+
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID       |
+      | pi_LU_S0500_050  |
+      | pi_TU_S0500_050  |
+      | pi_VHU_S0500_050 |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID  | M_HU_PI_ID       | HU_UnitType | IsCurrent |
+      | piv_LU_S0500_050    | pi_LU_S0500_050  | LU          | Y         |
+      | piv_TU_S0500_050    | pi_TU_S0500_050  | TU          | Y         |
+      | piv_VHU_S0500_050   | pi_VHU_S0500_050 | V           | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID   | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID |
+      | pii_LU_S0500_050  | piv_LU_S0500_050   | 20  | HU       | pi_TU_S0500_050   |
+      | pii_TU_S0500_050  | piv_TU_S0500_050   | 0   | PM       |                    |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID  | M_Product_ID | Qty | ValidFrom  |
+      | pip_S0500_050           | pii_TU_S0500_050 | p_S0500_050  | 2   | 2020-01-01 |
+
+    And metasfresh contains C_Orders:
+      | Identifier   | IsSOTrx | C_BPartner_ID | DateOrdered |
+      | o_S0500_050  | true    | bp_S0500_050  | 2026-03-11  |
+    And metasfresh contains C_OrderLines:
+      | Identifier    | C_Order_ID  | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | ol_S0500_050  | o_S0500_050 | p_S0500_050  | 20         | pip_S0500_050           |
+
+    When the order identified by o_S0500_050 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier    | C_OrderLine_ID | IsToRecompute |
+      | ss_S0500_050  | ol_S0500_050   | N             |
+
+    # Override to deliver only 4 PCE (= 2 TU) of the 20 ordered
+    And update shipment schedules
+      | M_ShipmentSchedule_ID | QtyToDeliver_Override |
+      | ss_S0500_050          | 4                     |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_S0500_050          | D            | true                | false       |
+
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID   |
+      | ss_S0500_050          | io_S0500_050 |
+
+    And validate the created shipment lines
+      | M_InOutLine_ID | M_InOut_ID   | M_Product_ID | movementqty | processed |
+      | iol_S0500_050  | io_S0500_050 | p_S0500_050  | 4           | true      |
+
+    And after not more than 60s, EDI_Desadv_Pack records are found:
+      | EDI_Desadv_Pack_ID | IsManual_IPA_SSCC18 |
+      | pack_S0500_050     | true                |
+
+    And after not more than 60s, the EDI_Desadv_Pack_Item has only the following records:
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | QtyTU | QtyCUsPerTU | QtyCUsPerLU | MovementQty | M_InOut_ID   |
+      | pi_S0500_050            | pack_S0500_050     | 2     | 2           | 4           | 4           | io_S0500_050 |

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/pack/EDIDesadvPackService.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/pack/EDIDesadvPackService.java
@@ -38,9 +38,6 @@ import de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHUAssignmentDAO;
 import de.metas.handlingunits.IHUPIItemProductBL;
-import de.metas.handlingunits.IHandlingUnitsBL;
-import de.metas.handlingunits.IHandlingUnitsDAO;
-import de.metas.handlingunits.QtyTU;
 import de.metas.handlingunits.allocation.ILUTUConfigurationFactory;
 import de.metas.handlingunits.generichumodel.HU;
 import de.metas.handlingunits.generichumodel.HURepository;
@@ -120,9 +117,6 @@ public class EDIDesadvPackService
 	private final IHUPIItemProductBL hupiItemProductBL = Services.get(IHUPIItemProductBL.class);
 	private final IDesadvDAO desadvDAO = Services.get(IDesadvDAO.class);
 	private final IOrderBL orderBL = Services.get(IOrderBL.class);
-	private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
-	private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
-
 	private final HURepository huRepository;
 	private final EDIDesadvPackRepository ediDesadvPackRepository;
 
@@ -495,7 +489,7 @@ public class EDIDesadvPackService
 	private CreateEDIDesadvPackItemRequest buildCreateDesadvPackItemRequest(
 			@NonNull final RequestParameters parameters)
 	{
-		final Quantity qtyCUInStockUOM = computeQtyCUsPerTU(parameters.topLevelHU, parameters.productId);
+		final Quantity qtyCUInStockUOM = parameters.topLevelHU.extractMedianCUQtyPerChildHU(parameters.productId);
 
 		final Timestamp bestBefore = extractBestBeforeDate(parameters.getInOutLineRecord()).orElse(null);
 
@@ -507,7 +501,7 @@ public class EDIDesadvPackService
 						.line(parameters.packItemLineSequence.next())
 						.qtyItemCapacity(qtyCUInStockUOM.toBigDecimal())
 						.bestBeforeDate(bestBefore)
-						.qtyTu(getLogicalTUCount(parameters.topLevelHU));
+						.qtyTu(parameters.topLevelHU.getChildHUs().size());
 
 		final String lotNumber = extractLotNumber(parameters.getInOutLineRecord()).orElse(null);
 
@@ -713,58 +707,6 @@ public class EDIDesadvPackService
 		{
 			createEDIDesadvPackItemRequestBuilder.gtinTUPackingMaterial(tuPackagingGTIN);
 		}
-	}
-
-	/**
-	 * Gets the logical TU count for a top-level HU (LU or aggregate TU).
-	 * For aggregate HUs, bridges to {@link IHandlingUnitsBL#getTUsCount(I_M_HU)}
-	 * which reads the parent item's Qty field (ItemType='HA') instead of counting child objects.
-	 * For non-aggregate HUs, returns the child HU count from the generic model.
-	 */
-	private int getLogicalTUCount(@NonNull final HU topLevelHU)
-	{
-		final ImmutableList<HU> childHUs = topLevelHU.getChildHUs();
-		if (childHUs.isEmpty())
-		{
-			return 1; // single TU with no children
-		}
-
-		final I_M_HU huRecord = handlingUnitsDAO.getById(topLevelHU.getId());
-		if (handlingUnitsBL.isAggregateHU(huRecord))
-		{
-			return handlingUnitsBL.getTUsCount(huRecord).toInt();
-		}
-
-		return childHUs.size();
-	}
-
-	/**
-	 * Computes the CU quantity per TU for a top-level HU.
-	 * For aggregate HUs, derives from totalCUQty / logicalTUCount.
-	 * For non-aggregate HUs, uses the generic model's median calculation.
-	 */
-	private Quantity computeQtyCUsPerTU(@NonNull final HU topLevelHU, @NonNull final ProductId productId)
-	{
-		final ImmutableList<HU> childHUs = topLevelHU.getChildHUs();
-		if (childHUs.isEmpty())
-		{
-			// Single TU — return total CU qty as the "per TU" qty
-			return topLevelHU.getProductQtysInStockUOM().get(productId);
-		}
-
-		final I_M_HU huRecord = handlingUnitsDAO.getById(topLevelHU.getId());
-		if (handlingUnitsBL.isAggregateHU(huRecord))
-		{
-			final int logicalTUCount = handlingUnitsBL.getTUsCount(huRecord).toInt();
-			final Quantity totalCUQty = topLevelHU.getProductQtysInStockUOM().get(productId);
-			if (logicalTUCount > 0 && totalCUQty != null)
-			{
-				return totalCUQty.divide(logicalTUCount);
-			}
-		}
-
-		// Non-aggregate: use the existing median calculation
-		return topLevelHU.extractMedianCUQtyPerChildHU(productId);
 	}
 
 	/**

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/pack/EDIDesadvPackService.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/pack/EDIDesadvPackService.java
@@ -38,6 +38,9 @@ import de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHUAssignmentDAO;
 import de.metas.handlingunits.IHUPIItemProductBL;
+import de.metas.handlingunits.IHandlingUnitsBL;
+import de.metas.handlingunits.IHandlingUnitsDAO;
+import de.metas.handlingunits.QtyTU;
 import de.metas.handlingunits.allocation.ILUTUConfigurationFactory;
 import de.metas.handlingunits.generichumodel.HU;
 import de.metas.handlingunits.generichumodel.HURepository;
@@ -117,6 +120,8 @@ public class EDIDesadvPackService
 	private final IHUPIItemProductBL hupiItemProductBL = Services.get(IHUPIItemProductBL.class);
 	private final IDesadvDAO desadvDAO = Services.get(IDesadvDAO.class);
 	private final IOrderBL orderBL = Services.get(IOrderBL.class);
+	private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
+	private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
 
 	private final HURepository huRepository;
 	private final EDIDesadvPackRepository ediDesadvPackRepository;
@@ -490,7 +495,7 @@ public class EDIDesadvPackService
 	private CreateEDIDesadvPackItemRequest buildCreateDesadvPackItemRequest(
 			@NonNull final RequestParameters parameters)
 	{
-		final Quantity qtyCUInStockUOM = parameters.topLevelHU.extractMedianCUQtyPerChildHU(parameters.productId);
+		final Quantity qtyCUInStockUOM = computeQtyCUsPerTU(parameters.topLevelHU, parameters.productId);
 
 		final Timestamp bestBefore = extractBestBeforeDate(parameters.getInOutLineRecord()).orElse(null);
 
@@ -502,7 +507,7 @@ public class EDIDesadvPackService
 						.line(parameters.packItemLineSequence.next())
 						.qtyItemCapacity(qtyCUInStockUOM.toBigDecimal())
 						.bestBeforeDate(bestBefore)
-						.qtyTu(parameters.topLevelHU.getChildHUs().size());
+						.qtyTu(getLogicalTUCount(parameters.topLevelHU));
 
 		final String lotNumber = extractLotNumber(parameters.getInOutLineRecord()).orElse(null);
 
@@ -708,6 +713,58 @@ public class EDIDesadvPackService
 		{
 			createEDIDesadvPackItemRequestBuilder.gtinTUPackingMaterial(tuPackagingGTIN);
 		}
+	}
+
+	/**
+	 * Gets the logical TU count for a top-level HU (LU or aggregate TU).
+	 * For aggregate HUs, bridges to {@link IHandlingUnitsBL#getTUsCount(I_M_HU)}
+	 * which reads the parent item's Qty field (ItemType='HA') instead of counting child objects.
+	 * For non-aggregate HUs, returns the child HU count from the generic model.
+	 */
+	private int getLogicalTUCount(@NonNull final HU topLevelHU)
+	{
+		final ImmutableList<HU> childHUs = topLevelHU.getChildHUs();
+		if (childHUs.isEmpty())
+		{
+			return 1; // single TU with no children
+		}
+
+		final I_M_HU huRecord = handlingUnitsDAO.getById(topLevelHU.getId());
+		if (handlingUnitsBL.isAggregateHU(huRecord))
+		{
+			return handlingUnitsBL.getTUsCount(huRecord).toInt();
+		}
+
+		return childHUs.size();
+	}
+
+	/**
+	 * Computes the CU quantity per TU for a top-level HU.
+	 * For aggregate HUs, derives from totalCUQty / logicalTUCount.
+	 * For non-aggregate HUs, uses the generic model's median calculation.
+	 */
+	private Quantity computeQtyCUsPerTU(@NonNull final HU topLevelHU, @NonNull final ProductId productId)
+	{
+		final ImmutableList<HU> childHUs = topLevelHU.getChildHUs();
+		if (childHUs.isEmpty())
+		{
+			// Single TU — return total CU qty as the "per TU" qty
+			return topLevelHU.getProductQtysInStockUOM().get(productId);
+		}
+
+		final I_M_HU huRecord = handlingUnitsDAO.getById(topLevelHU.getId());
+		if (handlingUnitsBL.isAggregateHU(huRecord))
+		{
+			final int logicalTUCount = handlingUnitsBL.getTUsCount(huRecord).toInt();
+			final Quantity totalCUQty = topLevelHU.getProductQtysInStockUOM().get(productId);
+			if (logicalTUCount > 0 && totalCUQty != null)
+			{
+				return totalCUQty.divide(logicalTUCount);
+			}
+		}
+
+		// Non-aggregate: use the existing median calculation
+		return topLevelHU.extractMedianCUQtyPerChildHU(productId);
 	}
 
 	/**

--- a/backend/de.metas.edi/src/main/sql/postgresql/ddl/views/desadv_json/M_InOut_Export_EDI_DESADV_JSON_V.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/ddl/views/desadv_json/M_InOut_Export_EDI_DESADV_JSON_V.sql
@@ -11,6 +11,7 @@ SELECT io.m_inout_id,
                                       WHERE sl.c_bpartner_id = org.org_bpartner_id
                                         AND sl.isremitto = 'Y'
                                         AND sl.gln IS NOT NULL
+                                        AND sl.gln <> ''
                                         AND sl.isactive = 'Y'
                                       ORDER BY sl.c_bpartner_location_id
                                       LIMIT 1),

--- a/backend/de.metas.edi/src/main/sql/postgresql/ddl/views/edi_cctop_119_v_view.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/ddl/views/edi_cctop_119_v_view.sql
@@ -73,7 +73,7 @@ FROM (
                          COALESCE(p_wh.ReferenceNo, p_vend.ReferenceNo)                         AS Vendor_ReferenceNo,
                          COALESCE(pl_wh.bpartnername, pl_vend.bpartnername)                     AS SiteName,
                          COALESCE(pl_wh.Setup_Place_No, pl_vend.Setup_Place_No)                 AS Setup_Place_No,
-                         COALESCE(REGEXP_REPLACE(pl_wh.GLN, '\s+$', ''), REGEXP_REPLACE(pl_vend.GLN, '\s+$', '')) AS GLN_Override,
+                         COALESCE(NULLIF(REGEXP_REPLACE(pl_wh.GLN, '\s+$', ''), ''), NULLIF(REGEXP_REPLACE(pl_vend.GLN, '\s+$', ''), '')) AS GLN_Override,
                          i.CreatedBy
                   FROM C_Invoice i
                            JOIN C_BPartner p_vend ON p_vend.AD_OrgBP_ID = i.AD_Org_ID

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5793820_sys_INVOIC_SU_GLN_COALESCE_across_warehouse_and_remitto.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5793820_sys_INVOIC_SU_GLN_COALESCE_across_warehouse_and_remitto.sql
@@ -1,7 +1,14 @@
--- View: EDI_Cctop_119_v
+-- Migration script ID: 5793820
+-- Name: INVOIC SU GLN — COALESCE across warehouse and RemitTo location tiers
+-- URL: https://github.com/metasfresh/metasfresh/issues/28672
+--
+-- When the warehouse BPartner location has no GLN, fall back to the org's RemitTo location GLN
+-- for the SU (supplier) partner in INVOIC EDI export.
+-- Also adds GLN_Override column to all union subqueries (NULL for non-vend types).
 
-DROP VIEW IF EXISTS EDI_Cctop_119_v;
-CREATE OR REPLACE VIEW EDI_Cctop_119_v AS
+DROP VIEW IF EXISTS EDI_Cctop_119_v$new;
+
+CREATE OR REPLACE VIEW EDI_Cctop_119_v$new AS
 SELECT lookup.C_Invoice_ID       AS EDI_Cctop_119_v_ID,
        lookup.C_Invoice_ID,
        lookup.C_Invoice_ID       AS EDI_Cctop_INVOIC_v_ID,
@@ -59,8 +66,7 @@ FROM (
                                                                     (CASE
                                                                          WHEN o.C_BPartner_Location_ID IS NOT NULL AND o.C_BPartner_Location_ID != 0::INTEGER
                                                                              THEN o.C_BPartner_Location_ID
-                                                                             ELSE -- Fallback if the C_Invoice is Hand Solo :) (I mean no C_Order)
-                                                                             i.C_BPartner_Location_ID
+                                                                             ELSE i.C_BPartner_Location_ID
                                                                      END)
                        --
                   UNION
@@ -99,14 +105,12 @@ FROM (
                            INNER JOIN C_Invoiceline il ON il.C_Invoice_ID = i.C_Invoice_ID
                            LEFT JOIN C_OrderLine ol ON ol.C_OrderLine_ID = il.C_OrderLine_ID
                            LEFT JOIN C_Order o ON o.C_Order_ID = ol.C_Order_ID
-                           LEFT JOIN M_InOutline sl ON ( -- try to join directly from C_InvoiceLine
+                           LEFT JOIN M_InOutline sl ON (
                                                                    sl.M_InOutLine_ID = il.M_InOutLine_ID AND il.M_InOutLine_ID IS NOT NULL AND il.M_InOutLine_ID != 0)
-                      -- fallback and try to join from C_OrderLine if (and only if) it's missing in C_InvoiceLine
                       OR (sl.C_OrderLine_ID = il.C_OrderLine_ID AND (il.M_InOutLine_ID IS NULL OR il.M_InOutLine_ID = 0))
                            LEFT JOIN M_InOut s ON s.M_InOut_ID = sl.M_InOut_ID
-
                            LEFT JOIN C_BPartner_Location pl_ship ON pl_ship.C_BPartner_Location_ID =
-                                                                    (CASE -- Could use COALESCE(NULLIF(.., ..), ..) here, but it gets messy, so I prefer CASE
+                                                                    (CASE
                                                                          WHEN o.HandOver_Location_ID IS NOT NULL AND o.HandOver_Location_ID != 0::INTEGER
                                                                              THEN o.HandOver_Location_ID
                                                                          WHEN s.C_BPartner_Location_ID IS NOT NULL AND s.C_BPartner_Location_ID != 0::INTEGER
@@ -115,8 +119,7 @@ FROM (
                                                                              THEN o.DropShip_Location_ID
                                                                          WHEN o.C_BPartner_Location_ID IS NOT NULL AND o.C_BPartner_Location_ID != 0::INTEGER
                                                                              THEN o.C_BPartner_Location_ID
-                                                                             ELSE -- Fallback if the C_Invoice is Hand Solo :) (I mean no C_Order)
-                                                                             i.C_BPartner_Location_ID
+                                                                             ELSE i.C_BPartner_Location_ID
                                                                      END)
                        --
                   UNION
@@ -140,7 +143,7 @@ FROM (
                                   'snum'::TEXT AS Type_V,
                                   pl_snum.C_BPartner_Location_ID,
                                   i.C_Invoice_ID,
-                                  0::numeric as M_InOut_ID, -- don't return the s.M_InOut_ID, bc there might be many and we don't need them here
+                                  0::numeric as M_InOut_ID,
                                   NULL::TEXT   AS Vendor_ReferenceNo,
                                   pl_snum.bpartnername AS SiteName,
                                   pl_snum.Setup_Place_No,
@@ -150,21 +153,19 @@ FROM (
                            INNER JOIN C_Invoiceline il ON il.C_Invoice_ID = i.C_Invoice_ID
                            LEFT JOIN C_OrderLine ol ON ol.C_OrderLine_ID = il.C_OrderLine_ID
                            LEFT JOIN C_Order o ON o.C_Order_ID = ol.C_Order_ID
-                           LEFT JOIN M_InOutline sl ON ( -- try to join directly from C_InvoiceLine
+                           LEFT JOIN M_InOutline sl ON (
                                                                    sl.M_InOutLine_ID = il.M_InOutLine_ID AND il.M_InOutLine_ID IS NOT NULL AND il.M_InOutLine_ID != 0)
-                      -- fallback and try to join from C_OrderLine if (and only if) it's missing in C_InvoiceLine
                       OR (sl.C_OrderLine_ID = il.C_OrderLine_ID AND (il.M_InOutLine_ID IS NULL OR il.M_InOutLine_ID = 0))
                            LEFT JOIN M_InOut s ON s.M_InOut_ID = sl.M_InOut_ID
                            LEFT JOIN C_BPartner_Location pl_snum ON pl_snum.C_BPartner_Location_ID =
-                                                                    (CASE -- Could use COALESCE(NULLIF(.., ..), ..) here, but it gets messy, so I prefer CASE
+                                                                    (CASE
                                                                          WHEN s.C_BPartner_Location_ID IS NOT NULL AND s.C_BPartner_Location_ID != 0::INTEGER
                                                                              THEN s.C_BPartner_Location_ID
                                                                          WHEN o.DropShip_Location_ID IS NOT NULL AND o.DropShip_Location_ID != 0::INTEGER
                                                                              THEN o.DropShip_Location_ID
                                                                          WHEN o.C_BPartner_Location_ID IS NOT NULL AND o.C_BPartner_Location_ID != 0::INTEGER
                                                                              THEN o.C_BPartner_Location_ID
-                                                                             ELSE -- Fallback if the C_Invoice is Hand Solo :) (I mean no C_Order)
-                                                                             i.C_BPartner_Location_ID
+                                                                             ELSE i.C_BPartner_Location_ID
                                                                      END)
               ) union_lookup
          ORDER BY union_lookup.SeqNo, union_lookup.Type_V, union_lookup.C_BPartner_Location_ID, C_Invoice_ID, M_InOut_ID
@@ -175,7 +176,6 @@ FROM (
          LEFT JOIN C_Country c ON c.C_Country_ID = l.C_Country_ID
          LEFT JOIN AD_User u ON u.AD_User_ID = lookup.CreatedBy
 WHERE TRUE
-  --  AND p.VATaxID IS NOT NULL -- VATaxIDs are not needed in general, but only if the customer is in a different country or if the customer explicitly requests them to be in their INVOICs
   AND (l.Address1 IS NOT NULL OR l.Address2 IS NOT NULL)
 ORDER BY (
           lookup.C_Invoice_ID,
@@ -187,3 +187,12 @@ ORDER BY (
               WHEN 'snum'::TEXT THEN 'SN'::TEXT
                                 ELSE 'Error EANCOM_Type'::TEXT
           END);
+
+SELECT db_alter_view(
+    'EDI_Cctop_119_v',
+    (SELECT view_definition
+     FROM information_schema.views
+     WHERE lower(views.table_name) = lower('EDI_Cctop_119_v$new'))
+);
+
+DROP VIEW IF EXISTS EDI_Cctop_119_v$new;

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5793820_sys_INVOIC_SU_GLN_COALESCE_across_warehouse_and_remitto.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5793820_sys_INVOIC_SU_GLN_COALESCE_across_warehouse_and_remitto.sql
@@ -79,7 +79,7 @@ FROM (
                          COALESCE(p_wh.ReferenceNo, p_vend.ReferenceNo)                         AS Vendor_ReferenceNo,
                          COALESCE(pl_wh.bpartnername, pl_vend.bpartnername)                     AS SiteName,
                          COALESCE(pl_wh.Setup_Place_No, pl_vend.Setup_Place_No)                 AS Setup_Place_No,
-                         COALESCE(REGEXP_REPLACE(pl_wh.GLN, '\s+$', ''), REGEXP_REPLACE(pl_vend.GLN, '\s+$', '')) AS GLN_Override,
+                         COALESCE(NULLIF(REGEXP_REPLACE(pl_wh.GLN, '\s+$', ''), ''), NULLIF(REGEXP_REPLACE(pl_vend.GLN, '\s+$', ''), '')) AS GLN_Override,
                          i.CreatedBy
                   FROM C_Invoice i
                            JOIN C_BPartner p_vend ON p_vend.AD_OrgBP_ID = i.AD_Org_ID

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5793880_sys_DESADV_JSON_add_TechnicalSenderGLN.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5793880_sys_DESADV_JSON_add_TechnicalSenderGLN.sql
@@ -13,6 +13,7 @@ SELECT io.m_inout_id,
                                       WHERE sl.c_bpartner_id = org.org_bpartner_id
                                         AND sl.isremitto = 'Y'
                                         AND sl.gln IS NOT NULL
+                                        AND sl.gln <> ''
                                         AND sl.isactive = 'Y'
                                       ORDER BY sl.c_bpartner_location_id
                                       LIMIT 1),

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5793880_sys_DESADV_JSON_add_TechnicalSenderGLN.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5793880_sys_DESADV_JSON_add_TechnicalSenderGLN.sql
@@ -1,7 +1,9 @@
+-- Add TechnicalSenderGLN to DESADV JSON export view
+-- Uses the same logic as Invoice_Sender_Tec_GLN in INVOIC: remit-to location GLN of the org's business partner
 
--- Main view that uses the functions and other views
-drop VIEW if exists M_InOut_Export_EDI_DESADV_JSON_V;
-CREATE OR REPLACE VIEW M_InOut_Export_EDI_DESADV_JSON_V AS
+DROP VIEW IF EXISTS M_InOut_Export_EDI_DESADV_JSON_V$new;
+
+CREATE OR REPLACE VIEW M_InOut_Export_EDI_DESADV_JSON_V$new AS
 SELECT io.m_inout_id,
        JSON_BUILD_OBJECT('metasfresh_DESADV', JSONB_BUILD_OBJECT(
                'Version', '0.2',
@@ -45,7 +47,7 @@ SELECT io.m_inout_id,
                'DatePromised', o.datepromised)
        ) as embedded_json
                          FROM m_inout io
-                         LEFT JOIN c_order o ON io.c_order_id = o.c_order_id 
+                         LEFT JOIN c_order o ON io.c_order_id = o.c_order_id
                          JOIN edi_desadv d ON io.edi_desadv_id = d.edi_desadv_id
                          JOIN c_bpartner buyer ON d.c_bpartner_id = buyer.c_bpartner_id
     -- Joins for other lookup objects
@@ -68,5 +70,11 @@ SELECT io.m_inout_id,
   AND io.docstatus IN ('CO', 'CL')
 ;
 
--- Example query
---select * from M_InOut_Export_EDI_DESADV_JSON_V where m_inout_id=1001857;
+SELECT db_alter_view(
+    'M_InOut_Export_EDI_DESADV_JSON_V',
+    (SELECT view_definition
+     FROM information_schema.views
+     WHERE lower(views.table_name) = lower('M_InOut_Export_EDI_DESADV_JSON_V$new'))
+);
+
+DROP VIEW IF EXISTS M_InOut_Export_EDI_DESADV_JSON_V$new;


### PR DESCRIPTION
## Summary
- Fix aggregate HU handling in DESADV pack items: use `IHandlingUnitsBL.getTUsCount()` instead of `getChildren().size()` for `QtyTU` and `QtyCUsPerTU` calculations
- Fix INVOIC JSON view: COALESCE SU GLN across warehouse and RemitTo BPartner locations to avoid NULL GLN in export
- Add `TechnicalSenderGLN` to DESADV JSON export (matching `Invoice_Sender_Tec_GLN` in INVOIC JSON) — uses org BP's remit-to location GLN
- Add 5 Cucumber integration test scenarios covering aggregate HU DESADV pack creation with various configurations

## Changes
- **Java fix** (`EDIDesadvPackService.java`): Use `getTUsCount()` for accurate TU count from aggregate HUs
- **SQL fix** (`M_InOut_Export_EDI_INVOIC_JSON_V`): Add COALESCE for `su_gln` across warehouse location and RemitTo location
- **SQL feat** (`M_InOut_Export_EDI_DESADV_JSON_V`): Add `TechnicalSenderGLN` property — sender's remit-to GLN
- **Migration scripts**: `5793820` (INVOIC SU GLN), `5793880` (DESADV TechnicalSenderGLN)
- **Cucumber tests** (`ediDesadvAggregateHU.feature`): 5 scenarios testing aggregate HU QtyTU, QtyCUsPerTU, GTIN propagation, partial delivery, and no-packing regression

## Test plan
- [x] All 5 Cucumber scenarios pass locally against infrastructure DB
- [x] Migration script `5793880` applies cleanly (tested locally)
- [x] CI `db-apply-migrations` passes
- [x] CI Cucumber tests pass