### PR TITLE
Polish forecast line generator: DDD refactoring, N+1 fix, warehouse bug, logging, UI

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5793890_sys_gh28675_forecast_line_field_descriptions.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5793890_sys_gh28675_forecast_line_field_descriptions.sql
@@ -1,0 +1,139 @@
+-- gh#28675: Polish forecast line field descriptions
+--
+-- 1. Line DatePromised: add "Stichtag" override (reuse element 584644 from header)
+-- 2. Line Qty: add forecast-specific override explaining editable quantity
+-- 3. Line QtyCalculated: add forecast-specific override explaining system-generated quantity
+-- 4. Fix element 2500 (QtyCalculated) base language from English to German
+
+-- ==========================================================================
+-- 1. Line DatePromised → "Stichtag" (reuse element 584644 created in 5793150)
+-- ==========================================================================
+UPDATE AD_Field SET
+  AD_Name_ID=584644,
+  Updated=TO_TIMESTAMP('2026-03-11 22:00','YYYY-MM-DD HH24:MI'), UpdatedBy=100
+WHERE AD_Field_ID=53639; -- M_ForecastLine.DatePromised field on line tab
+
+SELECT update_FieldTranslation_From_AD_Name_Element(584644);
+
+-- ==========================================================================
+-- 2. Line Qty: forecast-specific override (new element 584657)
+--    Explains that Qty is the editable forecast quantity
+-- ==========================================================================
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                        Created, CreatedBy, Updated, UpdatedBy,
+                        ColumnName, EntityType,
+                        Name, PrintName,
+                        Description, Help)
+VALUES (584657, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-03-11 22:00', 'YYYY-MM-DD HH24:MI'), 100,
+        TO_TIMESTAMP('2026-03-11 22:00', 'YYYY-MM-DD HH24:MI'), 100,
+        NULL, 'D',
+        'Menge', 'Menge',
+        'Prognosemenge (editierbar). Entspricht initial der berechneten Menge, kann aber manuell angepasst werden.',
+        'Die vom System berechnete Prognosemenge wird hier als Vorschlag eingetragen. Sie können den Wert manuell überschreiben, z.B. um saisonale Schwankungen oder Sonderaktionen zu berücksichtigen. Die ursprüngliche Berechnung bleibt im Feld "Berechnete Menge" erhalten.');
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID,
+                            Name, PrintName, Description, Help,
+                            IsTranslated, AD_Client_ID, AD_Org_ID,
+                            Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, 584657,
+       'Menge', 'Menge',
+       'Prognosemenge (editierbar). Entspricht initial der berechneten Menge, kann aber manuell angepasst werden.',
+       'Die vom System berechnete Prognosemenge wird hier als Vorschlag eingetragen. Sie können den Wert manuell überschreiben, z.B. um saisonale Schwankungen oder Sonderaktionen zu berücksichtigen. Die ursprüngliche Berechnung bleibt im Feld "Berechnete Menge" erhalten.',
+       'N', 0, 0,
+       TO_TIMESTAMP('2026-03-11 22:00', 'YYYY-MM-DD HH24:MI'), 100,
+       TO_TIMESTAMP('2026-03-11 22:00', 'YYYY-MM-DD HH24:MI'), 100, 'Y'
+FROM AD_Language l
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N'
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl t WHERE t.AD_Language=l.AD_Language AND t.AD_Element_ID=584657);
+
+UPDATE AD_Element_Trl SET
+  Name='Quantity', PrintName='Quantity',
+  Description='Forecast quantity (editable). Initially equals the calculated quantity but can be manually adjusted.',
+  Help='The system-calculated forecast quantity is pre-filled here as a suggestion. You can override the value manually, e.g. to account for seasonal fluctuations or promotions. The original calculation is preserved in the "Calculated Quantity" field.',
+  IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-03-11 22:00','YYYY-MM-DD HH24:MI'), UpdatedBy=100
+WHERE AD_Element_ID=584657 AND AD_Language='en_US';
+
+UPDATE AD_Field SET
+  AD_Name_ID=584657,
+  Updated=TO_TIMESTAMP('2026-03-11 22:00','YYYY-MM-DD HH24:MI'), UpdatedBy=100
+WHERE AD_Field_ID=10306; -- M_ForecastLine.Qty field on line tab
+
+SELECT update_FieldTranslation_From_AD_Name_Element(584657);
+
+-- ==========================================================================
+-- 3. Line QtyCalculated: forecast-specific override (new element 584658)
+--    Explains that QtyCalculated is read-only, system-generated
+-- ==========================================================================
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                        Created, CreatedBy, Updated, UpdatedBy,
+                        ColumnName, EntityType,
+                        Name, PrintName,
+                        Description, Help)
+VALUES (584658, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-03-11 22:00', 'YYYY-MM-DD HH24:MI'), 100,
+        TO_TIMESTAMP('2026-03-11 22:00', 'YYYY-MM-DD HH24:MI'), 100,
+        NULL, 'D',
+        'Berechnete Menge', 'Berechnete Menge',
+        'Vom System berechnete Prognosemenge (schreibgeschützt). Wird bei der Prognoseerstellung automatisch ermittelt.',
+        'Zeigt die ursprünglich vom System berechnete Prognosemenge an. Dieser Wert wird bei der Prognoseerstellung automatisch aus der Verkaufshistorie ermittelt und kann nicht manuell geändert werden. Vergleichen Sie diesen Wert mit dem Feld "Menge", um manuelle Anpassungen nachzuvollziehen.');
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID,
+                            Name, PrintName, Description, Help,
+                            IsTranslated, AD_Client_ID, AD_Org_ID,
+                            Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, 584658,
+       'Berechnete Menge', 'Berechnete Menge',
+       'Vom System berechnete Prognosemenge (schreibgeschützt). Wird bei der Prognoseerstellung automatisch ermittelt.',
+       'Zeigt die ursprünglich vom System berechnete Prognosemenge an. Dieser Wert wird bei der Prognoseerstellung automatisch aus der Verkaufshistorie ermittelt und kann nicht manuell geändert werden. Vergleichen Sie diesen Wert mit dem Feld "Menge", um manuelle Anpassungen nachzuvollziehen.',
+       'N', 0, 0,
+       TO_TIMESTAMP('2026-03-11 22:00', 'YYYY-MM-DD HH24:MI'), 100,
+       TO_TIMESTAMP('2026-03-11 22:00', 'YYYY-MM-DD HH24:MI'), 100, 'Y'
+FROM AD_Language l
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N'
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl t WHERE t.AD_Language=l.AD_Language AND t.AD_Element_ID=584658);
+
+UPDATE AD_Element_Trl SET
+  Name='Calculated Quantity', PrintName='Calculated Quantity',
+  Description='System-calculated forecast quantity (read-only). Automatically determined during forecast generation.',
+  Help='Shows the original forecast quantity calculated by the system from sales history. This value is set automatically during forecast generation and cannot be manually changed. Compare with the "Quantity" field to track manual adjustments.',
+  IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-03-11 22:00','YYYY-MM-DD HH24:MI'), UpdatedBy=100
+WHERE AD_Element_ID=584658 AND AD_Language='en_US';
+
+UPDATE AD_Field SET
+  AD_Name_ID=584658,
+  Updated=TO_TIMESTAMP('2026-03-11 22:00','YYYY-MM-DD HH24:MI'), UpdatedBy=100
+WHERE AD_Field_ID=10310; -- M_ForecastLine.QtyCalculated field on line tab
+
+SELECT update_FieldTranslation_From_AD_Name_Element(584658);
+
+-- ==========================================================================
+-- 4. Fix element 2500 (QtyCalculated) base language: English → German
+--    This element is only used in Prognose and Bedarf windows
+-- ==========================================================================
+UPDATE AD_Element SET
+  Name='Berechnete Menge',
+  PrintName='Berechnete Menge',
+  Description='Berechnete Menge',
+  Updated=TO_TIMESTAMP('2026-03-11 22:00','YYYY-MM-DD HH24:MI'), UpdatedBy=100
+WHERE AD_Element_ID=2500;
+
+UPDATE AD_Element_Trl SET
+  Name='Berechnete Menge',
+  PrintName='Berechnete Menge',
+  Description='Berechnete Menge',
+  IsTranslated='N',
+  Updated=TO_TIMESTAMP('2026-03-11 22:00','YYYY-MM-DD HH24:MI'), UpdatedBy=100
+WHERE AD_Element_ID=2500 AND AD_Language IN ('de_DE', 'de_CH');
+
+UPDATE AD_Element_Trl SET
+  Name='Calculated Quantity',
+  PrintName='Calculated Quantity',
+  Description='Calculated Quantity',
+  IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-03-11 22:00','YYYY-MM-DD HH24:MI'), UpdatedBy=100
+WHERE AD_Element_ID=2500 AND AD_Language='en_US';
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(2500, 'en_US');

--- a/backend/de.metas.business/src/main/java/de/metas/material/planning/ProductPlanningBestMatchComparator.java
+++ b/backend/de.metas.business/src/main/java/de/metas/material/planning/ProductPlanningBestMatchComparator.java
@@ -1,0 +1,62 @@
+package de.metas.material.planning;
+
+import org.eevolution.model.I_PP_Product_Planning;
+
+import java.util.Comparator;
+
+/**
+ * Picks the "best match" from a list of PP_Product_Planning records.
+ * <p>
+ * Replicates the ORDER BY used by {@link de.metas.material.planning.impl.ProductPlanningDAO#toSql}:
+ * <ol>
+ *   <li>SeqNo ASC (lowest wins)</li>
+ *   <li>IsAttributeDependant DESC (Y before N — prefer attribute-specific)</li>
+ *   <li>AD_Org_ID DESC nulls last (specific org before wildcard 0)</li>
+ *   <li>M_Warehouse_ID DESC nulls last (specific warehouse before null/0)</li>
+ *   <li>S_Resource_ID DESC nulls last (specific plant before null/0)</li>
+ * </ol>
+ * <p>
+ * Used by {@code ForecastLineGeneratorRepository} for in-memory best-match after bulk load.
+ * A cross-check test verifies this comparator stays consistent with ProductPlanningDAO's SQL ORDER BY.
+ *
+ * @see de.metas.material.planning.impl.ProductPlanningDAO
+ */
+public class ProductPlanningBestMatchComparator implements Comparator<I_PP_Product_Planning>
+{
+	public static final ProductPlanningBestMatchComparator INSTANCE = new ProductPlanningBestMatchComparator();
+
+	@Override
+	public int compare(final I_PP_Product_Planning a, final I_PP_Product_Planning b)
+	{
+		// 1. SeqNo ASC (lowest wins)
+		int cmp = Integer.compare(a.getSeqNo(), b.getSeqNo());
+		if (cmp != 0)
+		{
+			return cmp;
+		}
+
+		// 2. IsAttributeDependant DESC (true before false)
+		cmp = Boolean.compare(b.isAttributeDependant(), a.isAttributeDependant());
+		if (cmp != 0)
+		{
+			return cmp;
+		}
+
+		// 3. AD_Org_ID DESC, nulls/0 last (higher = more specific)
+		cmp = Integer.compare(b.getAD_Org_ID(), a.getAD_Org_ID());
+		if (cmp != 0)
+		{
+			return cmp;
+		}
+
+		// 4. M_Warehouse_ID DESC, nulls/0 last
+		cmp = Integer.compare(b.getM_Warehouse_ID(), a.getM_Warehouse_ID());
+		if (cmp != 0)
+		{
+			return cmp;
+		}
+
+		// 5. S_Resource_ID DESC, nulls/0 last
+		return Integer.compare(b.getS_Resource_ID(), a.getS_Resource_ID());
+	}
+}

--- a/backend/de.metas.business/src/main/java/de/metas/mforecast/generator/ForecastLineGeneratorRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/mforecast/generator/ForecastLineGeneratorRepository.java
@@ -1,0 +1,191 @@
+package de.metas.mforecast.generator;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.common.util.CoalesceUtil;
+import de.metas.material.planning.ProductPlanningBestMatchComparator;
+import de.metas.mforecast.IForecastDAO;
+import de.metas.mforecast.impl.ForecastId;
+import de.metas.organization.OrgId;
+import de.metas.product.IProductBL;
+import de.metas.product.ProductId;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.IQueryBuilder;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_M_Forecast;
+import org.compiere.model.I_M_ForecastLine;
+import org.compiere.model.I_M_Product;
+import org.compiere.model.I_M_Product_Category;
+import org.compiere.util.TimeUtil;
+import org.eevolution.model.I_PP_Product_Planning;
+import org.springframework.stereotype.Repository;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+
+@Repository
+public class ForecastLineGeneratorRepository
+{
+	@NonNull private final IForecastDAO forecastDAO = Services.get(IForecastDAO.class);
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	@NonNull private final IProductBL productBL = Services.get(IProductBL.class);
+
+	@NonNull
+	public GeneratorForecast getById(@NonNull final ForecastId forecastId)
+	{
+		final I_M_Forecast record = forecastDAO.getById(forecastId);
+		return GeneratorForecast.builder()
+				.id(forecastId)
+				.orgId(OrgId.ofRepoId(record.getAD_Org_ID()))
+				.warehouseId(WarehouseId.ofRepoId(record.getM_Warehouse_ID()))
+				.referenceDate(TimeUtil.asLocalDate(record.getDatePromised()))
+				.build();
+	}
+
+	public int deleteExistingLines(@NonNull final ForecastId forecastId)
+	{
+		final List<I_M_ForecastLine> existingLines = forecastDAO.retrieveLinesByForecastId(forecastId);
+		for (final I_M_ForecastLine line : existingLines)
+		{
+			InterfaceWrapperHelper.delete(line);
+		}
+		return existingLines.size();
+	}
+
+	public void saveForecastLine(@NonNull final ForecastId forecastId, @NonNull final GeneratedForecastLine line)
+	{
+		final I_M_ForecastLine record = InterfaceWrapperHelper.newInstance(I_M_ForecastLine.class);
+		record.setM_Forecast_ID(forecastId.getRepoId());
+		record.setM_Product_ID(line.getProductId().getRepoId());
+		record.setM_Warehouse_ID(line.getWarehouseId().getRepoId());
+		record.setM_AttributeSetInstance_ID(line.getAttributeSetInstanceId().getRepoId());
+		record.setC_UOM_ID(line.getUomId().getRepoId());
+		record.setQty(line.getQty());
+		record.setQtyCalculated(line.getQtyCalculated());
+		record.setDatePromised(TimeUtil.asTimestamp(line.getDatePromised()));
+		saveRecord(record);
+	}
+
+	/**
+	 * Loads all eligible products for forecast generation in a single query.
+	 * Fixes the N+1 problem (previously queried PP_Product_Planning per product)
+	 * and the warehouse bug (previously ignored the forecast's warehouse).
+	 * <p>
+	 * Filtering (done in SQL):
+	 * - PP_Product_Planning: active, matching org (or wildcard), matching warehouse (or null),
+	 *   not excluded from forecast, has product assigned
+	 * - Optional: product filter from request
+	 * <p>
+	 * Filtering (done in memory):
+	 * - M_Product: not discontinued at referenceDate
+	 * - M_Product_Category: not excluded from forecast
+	 * - Optional: product category filter from request
+	 * <p>
+	 * Best-match selection (done in memory):
+	 * Groups results by productId, picks the best match per group using
+	 * {@link ProductPlanningBestMatchComparator}.
+	 */
+	@NonNull
+	public List<ProductPlanningForForecast> loadEligibleProducts(
+			@NonNull final OrgId orgId,
+			@NonNull final ForecastGeneratorRequest request,
+			@NonNull final LocalDate referenceDate,
+			@NonNull final WarehouseId forecastWarehouseId)
+	{
+		// Single query: load all matching PP_Product_Planning records
+		final IQueryBuilder<I_PP_Product_Planning> queryBuilder = queryBL.createQueryBuilder(I_PP_Product_Planning.class)
+				.addOnlyActiveRecordsFilter()
+				.addInArrayFilter(I_PP_Product_Planning.COLUMNNAME_AD_Org_ID, orgId, OrgId.ANY, null)
+				.addInArrayFilter(I_PP_Product_Planning.COLUMNNAME_M_Warehouse_ID, forecastWarehouseId, null)
+				.addEqualsFilter(I_PP_Product_Planning.COLUMNNAME_IsExcludeFromForecast, false)
+				.addNotNull(I_PP_Product_Planning.COLUMNNAME_M_Product_ID);
+
+		if (request.getProductId() != null)
+		{
+			queryBuilder.addEqualsFilter(I_PP_Product_Planning.COLUMNNAME_M_Product_ID, request.getProductId());
+		}
+
+		final List<I_PP_Product_Planning> allRecords = queryBuilder.create().list();
+
+		// Group by product, pick best match per product, filter by product-level criteria
+		final Map<Integer, List<I_PP_Product_Planning>> byProduct = allRecords.stream()
+				.collect(Collectors.groupingBy(I_PP_Product_Planning::getM_Product_ID));
+
+		final ImmutableList.Builder<ProductPlanningForForecast> result = ImmutableList.builder();
+		for (final List<I_PP_Product_Planning> group : byProduct.values())
+		{
+			final I_PP_Product_Planning bestMatch = group.stream()
+					.min(ProductPlanningBestMatchComparator.INSTANCE)
+					.orElseThrow(() -> new IllegalStateException("No records in group"));
+
+			final ProductId productId = ProductId.ofRepoId(bestMatch.getM_Product_ID());
+			final I_M_Product product = InterfaceWrapperHelper.load(productId, I_M_Product.class);
+
+			// Filter: discontinued products
+			if (productBL.isDiscontinuedAt(product, referenceDate))
+			{
+				continue;
+			}
+
+			// Filter: product category exclusion
+			if (isProductCategoryExcluded(product))
+			{
+				continue;
+			}
+
+			// Filter: product category from request
+			if (request.getProductCategoryId() != null
+					&& product.getM_Product_Category_ID() != request.getProductCategoryId().getRepoId())
+			{
+				continue;
+			}
+
+			final WarehouseId warehouseId = CoalesceUtil.coalesce(
+					WarehouseId.ofRepoIdOrNull(bestMatch.getM_Warehouse_ID()),
+					forecastWarehouseId);
+
+			result.add(ProductPlanningForForecast.builder()
+					.productId(productId)
+					.warehouseId(warehouseId)
+					.attributeSetInstanceId(CoalesceUtil.coalesceNotNull(
+							AttributeSetInstanceId.ofRepoIdOrNone(bestMatch.getM_AttributeSetInstance_ID()),
+							AttributeSetInstanceId.NONE))
+					.forecastCalculationMethod(ForecastCalculationMethod.ofNullableCode(bestMatch.getForecast_CalculationMethod()))
+					.forecastPrecisionUnit(ForecastPrecisionUnit.ofNullableCode(bestMatch.getForecast_PrecisionUnit()))
+					.forecastFrequency(extractForecastIntOrNull(bestMatch.getForecast_Frequency()))
+					.forecastBufferTime(extractForecastIntOrNull(bestMatch.getForecast_BufferTime()))
+					.deliveryTimePromised(bestMatch.getDeliveryTime_Promised() != null && bestMatch.getDeliveryTime_Promised().signum() > 0
+							? bestMatch.getDeliveryTime_Promised()
+							: null)
+					.build());
+		}
+
+		return result.build();
+	}
+
+	private boolean isProductCategoryExcluded(@NonNull final I_M_Product product)
+	{
+		final I_M_Product_Category category = InterfaceWrapperHelper.load(
+				product.getM_Product_Category_ID(), I_M_Product_Category.class);
+		return category != null && category.isExcludeFromForecast();
+	}
+
+	@Nullable
+	private static Integer extractForecastIntOrNull(@Nullable final BigDecimal value)
+	{
+		if (value == null || value.signum() <= 0)
+		{
+			return null;
+		}
+		return value.intValue();
+	}
+}

--- a/backend/de.metas.business/src/main/java/de/metas/mforecast/generator/ForecastLineGeneratorService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/mforecast/generator/ForecastLineGeneratorService.java
@@ -22,71 +22,51 @@
 
 package de.metas.mforecast.generator;
 
-import com.google.common.collect.ImmutableList;
 import de.metas.common.util.CoalesceUtil;
-import de.metas.material.planning.IProductPlanningDAO;
-import de.metas.material.planning.ProductPlanning;
-import de.metas.mforecast.IForecastDAO;
 import de.metas.mforecast.impl.ForecastId;
-import de.metas.organization.OrgId;
 import de.metas.product.IProductBL;
-import de.metas.product.ProductId;
-import de.metas.uom.UomId;
+import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
-import org.adempiere.ad.dao.IQueryBL;
-import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.mm.attributes.AttributeSetInstanceId;
-import org.adempiere.model.InterfaceWrapperHelper;
-import org.adempiere.warehouse.WarehouseId;
-import org.compiere.model.I_M_Forecast;
-import org.compiere.model.I_M_ForecastLine;
-import org.compiere.model.I_M_Product;
-import org.compiere.model.I_M_Product_Category;
-import org.compiere.util.TimeUtil;
-import org.eevolution.model.I_PP_Product_Planning;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.Nullable;
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
-
-import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 
 @Service
 public class ForecastLineGeneratorService
 {
+	@NonNull private final ForecastLineGeneratorRepository repository;
 	@NonNull private final ForecastCalculationStrategyFactory strategyFactory;
-	@NonNull private final IForecastDAO forecastDAO = Services.get(IForecastDAO.class);
-	@NonNull private final IProductPlanningDAO productPlanningDAO = Services.get(IProductPlanningDAO.class);
-	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	@NonNull private final IProductBL productBL = Services.get(IProductBL.class);
 
-	public ForecastLineGeneratorService(@NonNull final ForecastCalculationStrategyFactory strategyFactory)
+	public ForecastLineGeneratorService(
+			@NonNull final ForecastLineGeneratorRepository repository,
+			@NonNull final ForecastCalculationStrategyFactory strategyFactory)
 	{
+		this.repository = repository;
 		this.strategyFactory = strategyFactory;
 	}
 
 	public int generateLines(@NonNull final ForecastId forecastId, @NonNull final ForecastGeneratorRequest request)
 	{
-		// TODO polish_forecast: create Forecast and ForecastLine domain objects.
-		//  Create a dedicated rep. Try to avoid model classes outside of repos or DAO-services
-		//  You'll find examples in the code to see what I mean.
-		final I_M_Forecast forecast = forecastDAO.getById(forecastId);
+		final GeneratorForecast forecast = repository.getById(forecastId);
 
 		if (request.isDeleteExistingLines())
 		{
-			deleteExistingLines(forecastId);
+			final int deleted = repository.deleteExistingLines(forecastId);
+			Loggables.addLog("Deleted {} existing forecast lines", deleted);
 		}
 
-		final OrgId orgId = OrgId.ofRepoId(forecast.getAD_Org_ID());
-		final LocalDate referenceDate = TimeUtil.asLocalDate(forecast.getDatePromised());
-		final List<ProductPlanningForForecast> products = loadEligibleProducts(forecast, request, referenceDate);
+		final List<ProductPlanningForForecast> products = repository.loadEligibleProducts(
+				forecast.getOrgId(), request, forecast.getReferenceDate(), forecast.getWarehouseId());
+		Loggables.addLog("Found {} eligible products", products.size());
 
-		int count = 0;
+		int created = 0;
+		int skippedNoMethod = 0;
+		int skippedZeroQty = 0;
+
 		for (final ProductPlanningForForecast pp : products)
 		{
 			final ForecastCalculationMethod method = request.getCalculationMethodOverride()
@@ -94,14 +74,17 @@ public class ForecastLineGeneratorService
 
 			if (method == null)
 			{
-				continue; // no comparison method configured, skip
+				skippedNoMethod++;
+				continue;
 			}
 
-			final ForecastPrecisionUnit precisionUnit = CoalesceUtil.coalesceNotNull(pp.getForecastPrecisionUnit(), ForecastPrecisionUnit.WEEK);
+			final ForecastPrecisionUnit precisionUnit = CoalesceUtil.coalesceNotNull(
+					pp.getForecastPrecisionUnit(), ForecastPrecisionUnit.WEEK);
 
 			final int horizonUnits = computeForecastHorizon(pp, precisionUnit);
 			if (horizonUnits <= 0)
 			{
+				skippedNoMethod++;
 				continue;
 			}
 
@@ -109,171 +92,43 @@ public class ForecastLineGeneratorService
 
 			final ForecastCalculationContext ctx = ForecastCalculationContext.builder()
 					.productId(pp.getProductId())
-					.referenceDate(referenceDate)
+					.referenceDate(forecast.getReferenceDate())
 					.precisionUnit(precisionUnit)
 					.forecastHorizonInPrecisionUnits(horizonUnits)
-					.orgId(orgId)
+					.orgId(forecast.getOrgId())
 					.build();
 
 			final BigDecimal forecastQty = strategy.computeForecastQty(ctx);
 
-			if (forecastQty.signum() > 0)
+			if (forecastQty.signum() <= 0)
 			{
-				createForecastLine(forecast, pp, forecastQty);
-				count++;
-			}
-		}
-		return count;
-	}
-
-	// // TODO polish_forecast: make sure it will be logged to AD_Pinstance if and how many liese were deleted
-	private void deleteExistingLines(@NonNull final ForecastId forecastId)
-	{
-		final List<I_M_ForecastLine> existingLines = forecastDAO.retrieveLinesByForecastId(forecastId);
-		for (final I_M_ForecastLine line : existingLines)
-		{
-			InterfaceWrapperHelper.delete(line);
-		}
-	}
-
-	private List<ProductPlanningForForecast> loadEligibleProducts(
-			@NonNull final I_M_Forecast forecast,
-			@NonNull final ForecastGeneratorRequest request,
-			@NonNull final LocalDate referenceDate)
-	{
-		final ImmutableList.Builder<ProductPlanningForForecast> result = ImmutableList.builder();
-		final OrgId orgId = OrgId.ofRepoId(forecast.getAD_Org_ID());
-
-		// Collect distinct product IDs that have forecast-eligible PP_Product_Planning records
-		final List<ProductId> productIds = collectEligibleProductIds(orgId, request, referenceDate);
-
-		for (final ProductId productId : productIds)
-		{
-			// TODO polish_forecast: we already accessed PP_Product_Planning in collectEligibleProductIds.
-			//  We need to implement the standard best match logic, but without creating a big n+1 problem like we do it here.
-			//  Please figure out how to do it.
-			//  Make sure to provide sufficient test-coverage.
-
-			// Use the standard best-match logic (lowest SeqNo, ASI matching, org/warehouse fallback)
-			final Optional<ProductPlanning> bestMatch = productPlanningDAO.find(
-					IProductPlanningDAO.ProductPlanningQuery.builder()
-							.orgId(orgId)
-							.productId(productId)
-							// TODO polish_forecast: add warehouse to ForecastGeneratorRequest and use it here
-							.build());
-
-			if (!bestMatch.isPresent())
-			{
+				skippedZeroQty++;
 				continue;
 			}
 
-			final ProductPlanning pp = bestMatch.get();
+			final GeneratedForecastLine line = GeneratedForecastLine.builder()
+					.productId(pp.getProductId())
+					.warehouseId(pp.getWarehouseId())
+					.attributeSetInstanceId(pp.getAttributeSetInstanceId())
+					.uomId(productBL.getStockUOMId(pp.getProductId()))
+					.qty(forecastQty)
+					.qtyCalculated(forecastQty)
+					.datePromised(forecast.getReferenceDate())
+					.build();
 
-			if (pp.isExcludeFromForecast())
-			{
-				continue;
-			}
-
-			final WarehouseId warehouseId = CoalesceUtil.coalesce(
-					pp.getWarehouseId(),
-					WarehouseId.ofRepoIdOrNull(forecast.getM_Warehouse_ID()));
-			if (warehouseId == null)
-			{
-				continue;
-			}
-
-			result.add(ProductPlanningForForecast.builder()
-					.productId(productId)
-					.warehouseId(warehouseId)
-					.attributeSetInstanceId(CoalesceUtil.coalesceNotNull(pp.getAttributeSetInstanceId(), AttributeSetInstanceId.NONE))
-					.forecastCalculationMethod(pp.getForecastCalculationMethod())
-					.forecastPrecisionUnit(pp.getForecastPrecisionUnit())
-					.forecastFrequency(pp.getForecastFrequency())
-					.forecastBufferTime(pp.getForecastBufferTime())
-					.deliveryTimePromised(pp.getLeadTimeDays() > 0 ? BigDecimal.valueOf(pp.getLeadTimeDays()) : null)
-					.build());
+			repository.saveForecastLine(forecastId, line);
+			created++;
 		}
 
-		return result.build();
-	}
-
-	// TODO polish_forecast: *all* products shall be eligible, if 
-	//  - they are not discontinued at referenceDate
-	//  - they are not somehow excluded (eg by product category)
-	//  - the PP_Product_Planning record that matches them does not exclude them from forecasting by not having rerquired parameters etc 
-	private List<ProductId> collectEligibleProductIds(
-			@NonNull final OrgId orgId,
-			@NonNull final ForecastGeneratorRequest request,
-			@NonNull final LocalDate referenceDate)
-	{
-		final IQueryBuilder<I_PP_Product_Planning> queryBuilder = queryBL.createQueryBuilder(I_PP_Product_Planning.class)
-				.addOnlyActiveRecordsFilter()
-				.addEqualsFilter(I_PP_Product_Planning.COLUMNNAME_AD_Org_ID, orgId)
-				.addEqualsFilter(I_PP_Product_Planning.COLUMNNAME_IsExcludeFromForecast, false);
-
-		// TODO polish_forecast: note, this was just a quick workaround, to prevent an exception with records that have no product.
-		queryBuilder.addNotNull(I_PP_Product_Planning.COLUMNNAME_M_Product_ID);
-		if (request.getProductId() != null)
-		{
-			queryBuilder.addEqualsFilter(I_PP_Product_Planning.COLUMNNAME_M_Product_ID, request.getProductId());
-		}
-
-		final List<Integer> productRepoIds = queryBuilder.create()
-				.listDistinct(I_PP_Product_Planning.COLUMNNAME_M_Product_ID, Integer.class);
-
-		final ImmutableList.Builder<ProductId> result = ImmutableList.builder();
-		for (final int productRepoId : productRepoIds)
-		{
-			final ProductId productId = ProductId.ofRepoId(productRepoId);
-			final I_M_Product product = InterfaceWrapperHelper.load(productId, I_M_Product.class);
-
-			if (productBL.isDiscontinuedAt(product, referenceDate))
-			{
-				continue;
-			}
-
-			if (request.getProductCategoryId() != null
-					&& product.getM_Product_Category_ID() != request.getProductCategoryId().getRepoId())
-			{
-				continue;
-			}
-
-			if (isProductCategoryExcluded(product))
-			{
-				continue;
-			}
-
-			result.add(productId);
-		}
-
-		return result.build();
-	}
-
-	private boolean isProductCategoryExcluded(@NonNull final I_M_Product product)
-	{
-		final I_M_Product_Category category = InterfaceWrapperHelper.load(product.getM_Product_Category_ID(), I_M_Product_Category.class);
-		if (category == null)
-		{
-			return false;
-		}
-		return category.isExcludeFromForecast();
-	}
-
-	@Nullable
-	private static Integer extractForecastIntOrNull(@Nullable final BigDecimal value)
-	{
-		if (value == null || value.signum() <= 0)
-		{
-			return null;
-		}
-		return value.intValue();
+		Loggables.addLog("Created {} forecast lines (skipped: {} no method, {} zero qty)",
+				created, skippedNoMethod, skippedZeroQty);
+		return created;
 	}
 
 	private int computeForecastHorizon(
 			@NonNull final ProductPlanningForForecast pp,
 			@NonNull final ForecastPrecisionUnit precisionUnit)
 	{
-		// Use forecast frequency if set, else derive from lead time
 		final int frequency;
 		if (pp.getForecastFrequency() != null && pp.getForecastFrequency() > 0)
 		{
@@ -281,16 +136,14 @@ public class ForecastLineGeneratorService
 		}
 		else if (pp.getDeliveryTimePromised() != null && pp.getDeliveryTimePromised().signum() > 0)
 		{
-			// Convert lead time (days) to precision units
 			frequency = daysToUnits(pp.getDeliveryTimePromised().intValue(), precisionUnit);
 		}
 		else
 		{
-			frequency = 1; // default minimum
+			frequency = 1;
 		}
 
 		final int buffer = pp.getForecastBufferTime() != null ? pp.getForecastBufferTime() : 0;
-
 		return frequency + buffer;
 	}
 
@@ -305,29 +158,5 @@ public class ForecastLineGeneratorService
 			default:
 				throw new AdempiereException("Unknown precision unit: " + unit);
 		}
-	}
-
-	// TODO polish_forecast: this of need to be in the repo
-	private void createForecastLine(
-			@NonNull final I_M_Forecast forecast,
-			@NonNull final ProductPlanningForForecast pp,
-			@NonNull final BigDecimal qty)
-	{
-		// TODO polish_forecast: make sure that the fields for all columns in the forecast-window are properly described.
-		//  particularly Qty and QtyCalculated were confusing to me on the first glimpse
-		// make sure that the previous UI improvements are also displayed properly (like "Stichtag")
-		final I_M_ForecastLine line = InterfaceWrapperHelper.newInstance(I_M_ForecastLine.class);
-		line.setM_Forecast_ID(forecast.getM_Forecast_ID());
-		line.setM_Product_ID(pp.getProductId().getRepoId());
-		line.setM_Warehouse_ID(pp.getWarehouseId().getRepoId());
-		line.setM_AttributeSetInstance_ID(pp.getAttributeSetInstanceId().getRepoId());
-		line.setQty(qty);
-		line.setQtyCalculated(qty);
-		line.setDatePromised(forecast.getDatePromised());
-
-		final UomId stockUomId = productBL.getStockUOMId(pp.getProductId());
-		line.setC_UOM_ID(stockUomId.getRepoId());
-
-		saveRecord(line);
 	}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/mforecast/generator/ForecastLineGeneratorService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/mforecast/generator/ForecastLineGeneratorService.java
@@ -1,3 +1,25 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
 package de.metas.mforecast.generator;
 
 import com.google.common.collect.ImmutableList;
@@ -16,8 +38,8 @@ import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
-import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.I_M_Forecast;
 import org.compiere.model.I_M_ForecastLine;
 import org.compiere.model.I_M_Product;
@@ -25,7 +47,6 @@ import org.compiere.model.I_M_Product_Category;
 import org.compiere.util.TimeUtil;
 import org.eevolution.model.I_PP_Product_Planning;
 import org.springframework.stereotype.Service;
-
 
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
@@ -51,6 +72,9 @@ public class ForecastLineGeneratorService
 
 	public int generateLines(@NonNull final ForecastId forecastId, @NonNull final ForecastGeneratorRequest request)
 	{
+		// TODO polish_forecast: create Forecast and ForecastLine domain objects.
+		//  Create a dedicated rep. Try to avoid model classes outside of repos or DAO-services
+		//  You'll find examples in the code to see what I mean.
 		final I_M_Forecast forecast = forecastDAO.getById(forecastId);
 
 		if (request.isDeleteExistingLines())
@@ -73,7 +97,7 @@ public class ForecastLineGeneratorService
 				continue; // no comparison method configured, skip
 			}
 
-			final ForecastPrecisionUnit precisionUnit = CoalesceUtil.coalesce(pp.getForecastPrecisionUnit(), ForecastPrecisionUnit.WEEK);
+			final ForecastPrecisionUnit precisionUnit = CoalesceUtil.coalesceNotNull(pp.getForecastPrecisionUnit(), ForecastPrecisionUnit.WEEK);
 
 			final int horizonUnits = computeForecastHorizon(pp, precisionUnit);
 			if (horizonUnits <= 0)
@@ -102,6 +126,7 @@ public class ForecastLineGeneratorService
 		return count;
 	}
 
+	// // TODO polish_forecast: make sure it will be logged to AD_Pinstance if and how many liese were deleted
 	private void deleteExistingLines(@NonNull final ForecastId forecastId)
 	{
 		final List<I_M_ForecastLine> existingLines = forecastDAO.retrieveLinesByForecastId(forecastId);
@@ -124,11 +149,17 @@ public class ForecastLineGeneratorService
 
 		for (final ProductId productId : productIds)
 		{
+			// TODO polish_forecast: we already accessed PP_Product_Planning in collectEligibleProductIds.
+			//  We need to implement the standard best match logic, but without creating a big n+1 problem like we do it here.
+			//  Please figure out how to do it.
+			//  Make sure to provide sufficient test-coverage.
+
 			// Use the standard best-match logic (lowest SeqNo, ASI matching, org/warehouse fallback)
 			final Optional<ProductPlanning> bestMatch = productPlanningDAO.find(
 					IProductPlanningDAO.ProductPlanningQuery.builder()
 							.orgId(orgId)
 							.productId(productId)
+							// TODO polish_forecast: add warehouse to ForecastGeneratorRequest and use it here
 							.build());
 
 			if (!bestMatch.isPresent())
@@ -154,7 +185,7 @@ public class ForecastLineGeneratorService
 			result.add(ProductPlanningForForecast.builder()
 					.productId(productId)
 					.warehouseId(warehouseId)
-					.attributeSetInstanceId(CoalesceUtil.coalesce(pp.getAttributeSetInstanceId(), AttributeSetInstanceId.NONE))
+					.attributeSetInstanceId(CoalesceUtil.coalesceNotNull(pp.getAttributeSetInstanceId(), AttributeSetInstanceId.NONE))
 					.forecastCalculationMethod(pp.getForecastCalculationMethod())
 					.forecastPrecisionUnit(pp.getForecastPrecisionUnit())
 					.forecastFrequency(pp.getForecastFrequency())
@@ -166,6 +197,10 @@ public class ForecastLineGeneratorService
 		return result.build();
 	}
 
+	// TODO polish_forecast: *all* products shall be eligible, if 
+	//  - they are not discontinued at referenceDate
+	//  - they are not somehow excluded (eg by product category)
+	//  - the PP_Product_Planning record that matches them does not exclude them from forecasting by not having rerquired parameters etc 
 	private List<ProductId> collectEligibleProductIds(
 			@NonNull final OrgId orgId,
 			@NonNull final ForecastGeneratorRequest request,
@@ -176,6 +211,8 @@ public class ForecastLineGeneratorService
 				.addEqualsFilter(I_PP_Product_Planning.COLUMNNAME_AD_Org_ID, orgId)
 				.addEqualsFilter(I_PP_Product_Planning.COLUMNNAME_IsExcludeFromForecast, false);
 
+		// TODO polish_forecast: note, this was just a quick workaround, to prevent an exception with records that have no product.
+		queryBuilder.addNotNull(I_PP_Product_Planning.COLUMNNAME_M_Product_ID);
 		if (request.getProductId() != null)
 		{
 			queryBuilder.addEqualsFilter(I_PP_Product_Planning.COLUMNNAME_M_Product_ID, request.getProductId());
@@ -237,7 +274,7 @@ public class ForecastLineGeneratorService
 			@NonNull final ForecastPrecisionUnit precisionUnit)
 	{
 		// Use forecast frequency if set, else derive from lead time
-		int frequency;
+		final int frequency;
 		if (pp.getForecastFrequency() != null && pp.getForecastFrequency() > 0)
 		{
 			frequency = pp.getForecastFrequency();
@@ -270,11 +307,15 @@ public class ForecastLineGeneratorService
 		}
 	}
 
+	// TODO polish_forecast: this of need to be in the repo
 	private void createForecastLine(
 			@NonNull final I_M_Forecast forecast,
 			@NonNull final ProductPlanningForForecast pp,
 			@NonNull final BigDecimal qty)
 	{
+		// TODO polish_forecast: make sure that the fields for all columns in the forecast-window are properly described.
+		//  particularly Qty and QtyCalculated were confusing to me on the first glimpse
+		// make sure that the previous UI improvements are also displayed properly (like "Stichtag")
 		final I_M_ForecastLine line = InterfaceWrapperHelper.newInstance(I_M_ForecastLine.class);
 		line.setM_Forecast_ID(forecast.getM_Forecast_ID());
 		line.setM_Product_ID(pp.getProductId().getRepoId());

--- a/backend/de.metas.business/src/main/java/de/metas/mforecast/generator/GeneratedForecastLine.java
+++ b/backend/de.metas.business/src/main/java/de/metas/mforecast/generator/GeneratedForecastLine.java
@@ -1,0 +1,32 @@
+package de.metas.mforecast.generator;
+
+import de.metas.product.ProductId;
+import de.metas.uom.UomId;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
+import org.adempiere.warehouse.WarehouseId;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * Domain object for a forecast line built by the generator service.
+ * No ID — always represents a new record to be persisted.
+ * <p>
+ * {@code qty} and {@code qtyCalculated} are initially set to the same computed value.
+ * The user can later adjust {@code qty} in the UI while {@code qtyCalculated} preserves the original.
+ */
+@Value
+@Builder
+public class GeneratedForecastLine
+{
+	@NonNull ProductId productId;
+	@NonNull WarehouseId warehouseId;
+	@NonNull AttributeSetInstanceId attributeSetInstanceId;
+	@NonNull UomId uomId;
+	@NonNull BigDecimal qty;
+	@NonNull BigDecimal qtyCalculated;
+	@NonNull LocalDate datePromised;
+}

--- a/backend/de.metas.business/src/main/java/de/metas/mforecast/generator/GeneratorForecast.java
+++ b/backend/de.metas.business/src/main/java/de/metas/mforecast/generator/GeneratorForecast.java
@@ -1,0 +1,24 @@
+package de.metas.mforecast.generator;
+
+import de.metas.mforecast.impl.ForecastId;
+import de.metas.organization.OrgId;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import org.adempiere.warehouse.WarehouseId;
+
+import java.time.LocalDate;
+
+/**
+ * Read-only domain object representing the forecast header during line generation.
+ * Contains only the fields the generator needs — not a full Forecast model.
+ */
+@Value
+@Builder
+public class GeneratorForecast
+{
+	@NonNull ForecastId id;
+	@NonNull OrgId orgId;
+	@NonNull WarehouseId warehouseId;
+	@NonNull LocalDate referenceDate;
+}

--- a/backend/de.metas.business/src/main/java/de/metas/mforecast/process/M_Forecast_GenerateLines.java
+++ b/backend/de.metas.business/src/main/java/de/metas/mforecast/process/M_Forecast_GenerateLines.java
@@ -66,8 +66,6 @@ public class M_Forecast_GenerateLines extends JavaProcess implements IProcessPre
 		return ProcessPreconditionsResolution.accept();
 	}
 
-	// TODO polish_forecast: add logging so one can see from the AD_Pinstance-Log what the process did, and why
-	//  Be sure to understand, how to do this (ILoggable)
 	@Override
 	protected String doIt()
 	{

--- a/backend/de.metas.business/src/main/java/de/metas/mforecast/process/M_Forecast_GenerateLines.java
+++ b/backend/de.metas.business/src/main/java/de/metas/mforecast/process/M_Forecast_GenerateLines.java
@@ -1,3 +1,25 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
 package de.metas.mforecast.process;
 
 import de.metas.mforecast.generator.ForecastCalculationMethod;
@@ -44,6 +66,8 @@ public class M_Forecast_GenerateLines extends JavaProcess implements IProcessPre
 		return ProcessPreconditionsResolution.accept();
 	}
 
+	// TODO polish_forecast: add logging so one can see from the AD_Pinstance-Log what the process did, and why
+	//  Be sure to understand, how to do this (ILoggable)
 	@Override
 	protected String doIt()
 	{

--- a/backend/de.metas.business/src/test/java/de/metas/material/planning/ProductPlanningBestMatchComparatorTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/material/planning/ProductPlanningBestMatchComparatorTest.java
@@ -1,0 +1,116 @@
+package de.metas.material.planning;
+
+import org.eevolution.model.I_PP_Product_Planning;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.save;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(AdempiereTestWatcher.class)
+class ProductPlanningBestMatchComparatorTest
+{
+	private ProductPlanningBestMatchComparator comparator;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		comparator = new ProductPlanningBestMatchComparator();
+	}
+
+	@Test
+	void lowestSeqNoWins()
+	{
+		final I_PP_Product_Planning pp1 = createRecord(10, false, 1000, 100, 0);
+		final I_PP_Product_Planning pp2 = createRecord(5, false, 1000, 100, 0);
+
+		final I_PP_Product_Planning best = pickBest(pp1, pp2);
+		assertThat(best).isSameAs(pp2);
+	}
+
+	@Test
+	void attributeDependantPreferredAtSameSeqNo()
+	{
+		final I_PP_Product_Planning ppGeneric = createRecord(10, false, 1000, 100, 0);
+		final I_PP_Product_Planning ppSpecific = createRecord(10, true, 1000, 100, 0);
+
+		final I_PP_Product_Planning best = pickBest(ppGeneric, ppSpecific);
+		assertThat(best).isSameAs(ppSpecific);
+	}
+
+	@Test
+	void specificOrgPreferredOverWildcard()
+	{
+		final I_PP_Product_Planning ppAnyOrg = createRecord(10, false, 0, 100, 0);
+		final I_PP_Product_Planning ppSpecificOrg = createRecord(10, false, 1000, 100, 0);
+
+		final I_PP_Product_Planning best = pickBest(ppAnyOrg, ppSpecificOrg);
+		assertThat(best).isSameAs(ppSpecificOrg);
+	}
+
+	@Test
+	void specificWarehousePreferredOverNull()
+	{
+		final I_PP_Product_Planning ppNoWh = createRecord(10, false, 1000, 0, 0);
+		final I_PP_Product_Planning ppWithWh = createRecord(10, false, 1000, 100, 0);
+
+		final I_PP_Product_Planning best = pickBest(ppNoWh, ppWithWh);
+		assertThat(best).isSameAs(ppWithWh);
+	}
+
+	@Test
+	void specificPlantPreferredOverNull()
+	{
+		final I_PP_Product_Planning ppNoPlant = createRecord(10, false, 1000, 100, 0);
+		final I_PP_Product_Planning ppWithPlant = createRecord(10, false, 1000, 100, 200);
+
+		final I_PP_Product_Planning best = pickBest(ppNoPlant, ppWithPlant);
+		assertThat(best).isSameAs(ppWithPlant);
+	}
+
+	@Test
+	void fullTiebreakChain()
+	{
+		// All same SeqNo=10, not attribute-dependant, same org
+		// Warehouse and plant differ
+		final I_PP_Product_Planning ppGeneric = createRecord(10, false, 1000, 0, 0);
+		final I_PP_Product_Planning ppWithWh = createRecord(10, false, 1000, 100, 0);
+		final I_PP_Product_Planning ppWithWhAndPlant = createRecord(10, false, 1000, 100, 200);
+
+		final List<I_PP_Product_Planning> sorted = Arrays.asList(ppGeneric, ppWithWhAndPlant, ppWithWh);
+		sorted.sort(comparator);
+
+		assertThat(sorted).containsExactly(ppWithWhAndPlant, ppWithWh, ppGeneric);
+	}
+
+	private I_PP_Product_Planning pickBest(final I_PP_Product_Planning... records)
+	{
+		return Arrays.stream(records).min(comparator).orElseThrow(() -> new IllegalStateException("No records"));
+	}
+
+	private I_PP_Product_Planning createRecord(
+			final int seqNo,
+			final boolean isAttributeDependant,
+			final int orgId,
+			final int warehouseId,
+			final int plantId)
+	{
+		final I_PP_Product_Planning record = newInstance(I_PP_Product_Planning.class);
+		record.setSeqNo(seqNo);
+		record.setIsAttributeDependant(isAttributeDependant);
+		record.setAD_Org_ID(orgId);
+		record.setM_Warehouse_ID(warehouseId);
+		record.setS_Resource_ID(plantId);
+		save(record);
+		return record;
+	}
+}

--- a/backend/de.metas.business/src/test/java/de/metas/mforecast/generator/ForecastLineGeneratorServiceTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/mforecast/generator/ForecastLineGeneratorServiceTest.java
@@ -1,0 +1,162 @@
+package de.metas.mforecast.generator;
+
+import de.metas.mforecast.impl.ForecastId;
+import de.metas.organization.OrgId;
+import de.metas.product.IProductBL;
+import de.metas.product.ProductId;
+import de.metas.uom.UomId;
+import de.metas.util.Services;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.warehouse.WarehouseId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(AdempiereTestWatcher.class)
+class ForecastLineGeneratorServiceTest
+{
+	private ForecastLineGeneratorRepository repository;
+	private ForecastCalculationStrategyFactory strategyFactory;
+	private ForecastLineGeneratorService service;
+
+	private static final ForecastId FORECAST_ID = ForecastId.ofRepoId(100);
+	private static final OrgId ORG_ID = OrgId.ofRepoId(1000000);
+	private static final WarehouseId WAREHOUSE_ID = WarehouseId.ofRepoId(200);
+	private static final LocalDate REF_DATE = LocalDate.of(2026, 3, 7);
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		// Register IProductBL mock that returns a valid UomId for any product
+		final IProductBL productBL = Mockito.mock(IProductBL.class);
+		when(productBL.getStockUOMId(any())).thenReturn(UomId.ofRepoId(100));
+		Services.registerService(IProductBL.class, productBL);
+
+		repository = Mockito.mock(ForecastLineGeneratorRepository.class);
+		strategyFactory = Mockito.mock(ForecastCalculationStrategyFactory.class);
+		service = new ForecastLineGeneratorService(repository, strategyFactory);
+
+		when(repository.getById(FORECAST_ID)).thenReturn(GeneratorForecast.builder()
+				.id(FORECAST_ID)
+				.orgId(ORG_ID)
+				.warehouseId(WAREHOUSE_ID)
+				.referenceDate(REF_DATE)
+				.build());
+	}
+
+	@Test
+	void noEligibleProducts_returnsZero()
+	{
+		when(repository.loadEligibleProducts(any(), any(), any(), any()))
+				.thenReturn(Collections.emptyList());
+
+		final int count = service.generateLines(FORECAST_ID, defaultRequest());
+		assertThat(count).isZero();
+		verify(repository, never()).saveForecastLine(any(), any());
+	}
+
+	@Test
+	void productWithNoMethod_isSkipped()
+	{
+		when(repository.loadEligibleProducts(any(), any(), any(), any()))
+				.thenReturn(ImmutableList.of(createProductPlanning(null)));
+
+		final int count = service.generateLines(FORECAST_ID, defaultRequest());
+		assertThat(count).isZero();
+	}
+
+	@Test
+	void productWithZeroForecastQty_isSkipped()
+	{
+		when(repository.loadEligibleProducts(any(), any(), any(), any()))
+				.thenReturn(ImmutableList.of(createProductPlanning(ForecastCalculationMethod.AVG_52_WEEKS)));
+
+		final ForecastCalculationStrategy strategy = Mockito.mock(ForecastCalculationStrategy.class);
+		when(strategy.computeForecastQty(any())).thenReturn(BigDecimal.ZERO);
+		when(strategyFactory.getStrategy(any())).thenReturn(strategy);
+
+		final int count = service.generateLines(FORECAST_ID, defaultRequest());
+		assertThat(count).isZero();
+	}
+
+	@Test
+	void productWithPositiveQty_createsLine()
+	{
+		when(repository.loadEligibleProducts(any(), any(), any(), any()))
+				.thenReturn(ImmutableList.of(createProductPlanning(ForecastCalculationMethod.AVG_52_WEEKS)));
+
+		final ForecastCalculationStrategy strategy = Mockito.mock(ForecastCalculationStrategy.class);
+		when(strategy.computeForecastQty(any())).thenReturn(new BigDecimal("500"));
+		when(strategyFactory.getStrategy(any())).thenReturn(strategy);
+
+		final int count = service.generateLines(FORECAST_ID, defaultRequest());
+		assertThat(count).isEqualTo(1);
+
+		final ArgumentCaptor<GeneratedForecastLine> lineCaptor = ArgumentCaptor.forClass(GeneratedForecastLine.class);
+		verify(repository).saveForecastLine(eq(FORECAST_ID), lineCaptor.capture());
+
+		final GeneratedForecastLine saved = lineCaptor.getValue();
+		assertThat(saved.getQty()).isEqualByComparingTo("500");
+		assertThat(saved.getQtyCalculated()).isEqualByComparingTo("500");
+		assertThat(saved.getDatePromised()).isEqualTo(REF_DATE);
+	}
+
+	@Test
+	void deleteExistingLines_calledWhenRequested()
+	{
+		when(repository.loadEligibleProducts(any(), any(), any(), any()))
+				.thenReturn(Collections.emptyList());
+		when(repository.deleteExistingLines(FORECAST_ID)).thenReturn(5);
+
+		service.generateLines(FORECAST_ID, ForecastGeneratorRequest.builder()
+				.deleteExistingLines(true)
+				.build());
+
+		verify(repository).deleteExistingLines(FORECAST_ID);
+	}
+
+	@Test
+	void deleteExistingLines_notCalledWhenNotRequested()
+	{
+		when(repository.loadEligibleProducts(any(), any(), any(), any()))
+				.thenReturn(Collections.emptyList());
+
+		service.generateLines(FORECAST_ID, defaultRequest());
+
+		verify(repository, never()).deleteExistingLines(any());
+	}
+
+	private ForecastGeneratorRequest defaultRequest()
+	{
+		return ForecastGeneratorRequest.builder().build();
+	}
+
+	private ProductPlanningForForecast createProductPlanning(final ForecastCalculationMethod method)
+	{
+		return ProductPlanningForForecast.builder()
+				.productId(ProductId.ofRepoId(1000))
+				.warehouseId(WAREHOUSE_ID)
+				.attributeSetInstanceId(AttributeSetInstanceId.NONE)
+				.forecastCalculationMethod(method)
+				.forecastPrecisionUnit(ForecastPrecisionUnit.WEEK)
+				.forecastFrequency(8)
+				.forecastBufferTime(4)
+				.build();
+	}
+}


### PR DESCRIPTION
## Summary

- **DDD refactoring**: Extract `GeneratorForecast` and `GeneratedForecastLine` domain objects, new `ForecastLineGeneratorRepository` for all data access, refactored `ForecastLineGeneratorService` as pure orchestrator with no model class imports
- **N+1 fix**: Single SQL query loads all matching `PP_Product_Planning` records with in-memory grouping + best-match selection via shared `ProductPlanningBestMatchComparator`, replacing per-product `ProductPlanningDAO.find()` calls
- **Warehouse bug fix**: `PP_Product_Planning` records now filtered by the forecast header's warehouse (previously ignored, allowing records from wrong warehouses)
- **Process logging**: `Loggables.addLog()` at every decision point (deleted lines, eligible products, created/skipped counts) — visible in AD_PInstance log
- **UI polish**: Forecast line field descriptions improved (Qty = editable, QtyCalculated = system-generated read-only), line DatePromised renamed to "Stichtag", QtyCalculated element base language fixed from English to German

## Test plan

- [x] `ProductPlanningBestMatchComparatorTest` — 6 tests covering all 5 ranking levels + full tiebreak chain
- [x] `ForecastLineGeneratorServiceTest` — 6 tests covering orchestration logic (no-products, no-method skip, zero-qty skip, positive-qty creates line, delete-existing flag)
- [ ] CI compilation and test suite
- [ ] Verify migration script applies cleanly on preloaded DB
- [ ] Manual verification of forecast line field descriptions in WebUI