### PR TITLE
ci: add publish-test-reports to modus_operandi_hotfix

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1299,6 +1299,380 @@ jobs:
           path: docker-builds/mobiletest/playwright-report/
           retention-days: 30
 
+
+  publish-test-reports:
+    name: publish test reports
+    runs-on: ubuntu-latest
+    needs: [ init, cucumber-run, mobile_test ]
+    if: always() && needs.init.result == 'success'
+    permissions:
+      actions: write    # trigger reports-cleanup workflow when disk space is low
+      contents: read
+    steps:
+      - name: Check for report server secret
+        id: check-secret
+        run: |
+          if [ -z "${{ secrets.REPORTS_SERVER_SSH_KEY }}" ]; then
+            echo "available=false" >> $GITHUB_OUTPUT
+            echo "::warning::REPORTS_SERVER_SSH_KEY not configured — skipping report upload"
+          else
+            echo "available=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup SSH
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
+        env:
+          REPORTS_SERVER_HOSTNAME: ${{ secrets.TESTREPORTS_HOSTNAME }}
+          REPORTS_SERVER_USER: ${{ secrets.TESTREPORTS_USER }}
+          REPORTS_SERVER_SSH_PORT: ${{ secrets.TESTREPORTS_SSH_PORT }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.REPORTS_SERVER_SSH_KEY }}" > ~/.ssh/reports_key
+          chmod 600 ~/.ssh/reports_key
+          ssh-keyscan -H test-reports.metasfresh.com >> ~/.ssh/known_hosts 2>/dev/null
+          cat >> ~/.ssh/config <<EOF
+          Host reports-server
+            HostName $REPORTS_SERVER_HOSTNAME
+            User $REPORTS_SERVER_USER
+            Port $REPORTS_SERVER_SSH_PORT
+            IdentityFile ~/.ssh/reports_key
+            StrictHostKeyChecking accept-new
+          EOF
+
+      - name: Download allure-report-cucumber
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: allure-report-cucumber
+          path: reports/cucumber
+        continue-on-error: true
+
+      - name: Download allure-report-mobile-webui
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: allure-report-mobile-webui
+          path: reports/mobile-webui
+        continue-on-error: true
+
+      - name: Download allure-report-frontend-webui
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: allure-report-frontend-webui
+          path: reports/frontend-webui
+        continue-on-error: true
+
+      - name: Inventory available reports
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
+        id: inventory
+        run: |
+          REPORTS=""
+          COUNT=0
+          for report_type in cucumber mobile-webui frontend-webui; do
+            if [ -d "reports/${report_type}" ] && [ -f "reports/${report_type}/index.html" ]; then
+              REPORTS="${REPORTS}${report_type} "
+              COUNT=$((COUNT + 1))
+            else
+              echo "::notice::No report found for ${report_type}"
+            fi
+          done
+          echo "reports=${REPORTS}" >> $GITHUB_OUTPUT
+          echo "count=${COUNT}" >> $GITHUB_OUTPUT
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::warning::No Allure report artifacts available — nothing to upload"
+          else
+            echo "Found ${COUNT} report(s): ${REPORTS}"
+          fi
+
+      - name: Upload reports to server
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true' && steps.inventory.outputs.count != '0'
+        env:
+          BRANCH: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          VERSION: ${{ needs.init.outputs.tag-fixed }}
+          REPORTS_SERVER_BASE_PATH: ${{ secrets.TESTREPORTS_BASE_PATH }}
+        run: |
+          BASE_PATH="${REPORTS_SERVER_BASE_PATH}/branches/${BRANCH}/builds/${VERSION}/allure"
+
+          # Create target directories on server
+          ssh reports-server "mkdir -p ${BASE_PATH}"
+
+          for report_type in ${{ steps.inventory.outputs.reports }}; do
+            echo "Uploading ${report_type} report..."
+            rsync -az --delete \
+              "reports/${report_type}/" \
+              "reports-server:${BASE_PATH}/${report_type}/"
+            echo "✓ ${report_type} uploaded"
+          done
+
+          # Generate index.html in the allure parent directory so the URL doesn't 403
+          REPORT_LINKS=""
+          for report_type in ${{ steps.inventory.outputs.reports }}; do
+            REPORT_LINKS="${REPORT_LINKS}<li><a href=\"${report_type}/\">${report_type}</a></li>"
+          done
+          ssh reports-server "cat > ${BASE_PATH}/index.html" <<EOF
+          <!DOCTYPE html>
+          <html><head><title>Allure Reports — ${VERSION}</title>
+          <style>body{font-family:sans-serif;margin:40px}a{color:#0066cc}</style>
+          </head><body>
+          <h1>Allure Reports</h1>
+          <p><strong>Build:</strong> ${VERSION}</p>
+          <ul>${REPORT_LINKS}</ul>
+          <p><a href="https://test-reports.metasfresh.com/">← Back to all reports</a></p>
+          </body></html>
+          EOF
+
+      - name: Update branch metadata and prune old builds
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true' && steps.inventory.outputs.count != '0'
+        env:
+          BRANCH: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          VERSION: ${{ needs.init.outputs.tag-fixed }}
+        run: |
+          ssh reports-server "python3 - '${BRANCH}' '${VERSION}'" <<'PYEOF'
+          import json, sys, os, shutil
+          from datetime import datetime, timezone
+
+          MAX_BUILDS_PER_BRANCH = 3
+
+          branch = sys.argv[1]
+          version = sys.argv[2]
+          metadata_dir = "/var/www/test-reports/_metadata"
+          metadata_file = os.path.join(metadata_dir, f"{branch}.json")
+          builds_dir = f"/var/www/test-reports/branches/{branch}/builds"
+
+          os.makedirs(metadata_dir, exist_ok=True)
+
+          # Read existing metadata or create new
+          if os.path.exists(metadata_file):
+              with open(metadata_file, "r") as f:
+                  try:
+                      data = json.load(f)
+                  except json.JSONDecodeError:
+                      data = {"branch": branch, "builds": []}
+          else:
+              data = {"branch": branch, "builds": []}
+
+          # Deduplicate: remove existing entry for this version
+          data["builds"] = [b for b in data["builds"] if b.get("version") != version]
+
+          # Prepend new build
+          data["builds"].insert(0, {
+              "version": version,
+              "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+          })
+
+          # Cap metadata and collect evicted versions
+          evicted = [b["version"] for b in data["builds"][MAX_BUILDS_PER_BRANCH:]]
+          data["builds"] = data["builds"][:MAX_BUILDS_PER_BRANCH]
+
+          with open(metadata_file, "w") as f:
+              json.dump(data, f, indent=2)
+
+          # Delete build directories for evicted versions
+          for ver in evicted:
+              build_path = os.path.join(builds_dir, ver)
+              if os.path.isdir(build_path):
+                  shutil.rmtree(build_path)
+                  print(f"Pruned old build: {branch}/{ver}")
+
+          print(f"Kept {len(data['builds'])} build(s), pruned {len(evicted)} old build(s)")
+          PYEOF
+
+      - name: Update landing page
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true' && steps.inventory.outputs.count != '0'
+        run: |
+          ssh reports-server "cat > /var/www/test-reports/index.html" <<'HTMLEOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+              <meta charset="UTF-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1.0">
+              <title>Test Reports - metasfresh</title>
+              <style>
+                  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 40px; background: #f5f5f5; }
+                  .container { max-width: 1200px; margin: 0 auto; }
+                  h1 { color: #333; }
+                  .branch { background: white; border-radius: 8px; padding: 20px; margin: 20px 0; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+                  .branch h2 { margin-top: 0; color: #0066cc; }
+                  .builds { display: grid; gap: 10px; }
+                  .build { padding: 10px; background: #f9f9f9; border-radius: 4px; }
+                  .build-header { font-weight: bold; margin-bottom: 5px; }
+                  .timestamp { color: #666; font-size: 0.9em; margin-left: 10px; }
+                  .report-links { margin-top: 5px; }
+                  .report-links a { color: #0066cc; text-decoration: none; margin-right: 15px; }
+                  .report-links a:hover { text-decoration: underline; }
+                  .loading { color: #666; }
+                  .error { color: #cc0000; }
+              </style>
+          </head>
+          <body>
+              <div class="container">
+                  <h1>📊 Test Reports</h1>
+                  <div id="branches"><p class="loading">Loading reports...</p></div>
+              </div>
+              <script>
+                  function createTextElement(tag, text, className) {
+                      const el = document.createElement(tag);
+                      el.textContent = text;
+                      if (className) el.className = className;
+                      return el;
+                  }
+
+                  function createLink(href, text) {
+                      const a = document.createElement('a');
+                      a.href = href;
+                      a.textContent = text;
+                      return a;
+                  }
+
+                  function createBuildElement(branchName, build) {
+                      const buildDiv = document.createElement('div');
+                      buildDiv.className = 'build';
+
+                      const header = document.createElement('div');
+                      header.className = 'build-header';
+
+                      const versionSpan = document.createElement('span');
+                      versionSpan.textContent = build.version;
+                      header.appendChild(versionSpan);
+
+                      const timestampSpan = document.createElement('span');
+                      timestampSpan.className = 'timestamp';
+                      timestampSpan.textContent = new Date(build.timestamp).toLocaleString();
+                      header.appendChild(timestampSpan);
+
+                      buildDiv.appendChild(header);
+
+                      const linksDiv = document.createElement('div');
+                      linksDiv.className = 'report-links';
+
+                      const basePath = '/branches/' + encodeURIComponent(branchName) + '/builds/' + encodeURIComponent(build.version);
+
+                      const reports = [
+                          { name: 'Frontend', path: '/allure/frontend-webui/' },
+                          { name: 'Mobile', path: '/allure/mobile-webui/' },
+                          { name: 'Cucumber', path: '/allure/cucumber/' }
+                      ];
+
+                      reports.forEach(function(report) {
+                          const link = createLink(basePath + report.path, report.name);
+                          linksDiv.appendChild(link);
+                      });
+
+                      buildDiv.appendChild(linksDiv);
+                      return buildDiv;
+                  }
+
+                  function createBranchElement(branchData) {
+                      const branchDiv = document.createElement('div');
+                      branchDiv.className = 'branch';
+
+                      const heading = createTextElement('h2', branchData.branch);
+                      branchDiv.appendChild(heading);
+
+                      const buildsDiv = document.createElement('div');
+                      buildsDiv.className = 'builds';
+
+                      // Show all builds (metadata is capped to 3 per branch at publish time)
+                      const builds = branchData.builds;
+                      builds.forEach(function(build) {
+                          buildsDiv.appendChild(createBuildElement(branchData.branch, build));
+                      });
+
+                      branchDiv.appendChild(buildsDiv);
+                      return branchDiv;
+                  }
+
+                  async function loadReports() {
+                      const container = document.getElementById('branches');
+
+                      try {
+                          const response = await fetch('/_metadata/');
+                          if (!response.ok) throw new Error('Failed to load metadata');
+
+                          const files = await response.json();
+                          const jsonFiles = files.filter(function(f) {
+                              return f.name.endsWith('.json');
+                          });
+
+                          if (jsonFiles.length === 0) {
+                              container.textContent = 'No reports available yet.';
+                              return;
+                          }
+
+                          container.textContent = '';
+
+                          for (const file of jsonFiles) {
+                              try {
+                                  const branchResponse = await fetch('/_metadata/' + file.name);
+                                  if (branchResponse.ok) {
+                                      const branchData = await branchResponse.json();
+                                      container.appendChild(createBranchElement(branchData));
+                                  }
+                              } catch (e) {
+                                  console.error('Error loading branch:', file.name, e);
+                              }
+                          }
+                      } catch (error) {
+                          container.textContent = '';
+                          const errorP = createTextElement('p', 'Error loading reports: ' + error.message, 'error');
+                          container.appendChild(errorP);
+                      }
+                  }
+
+                  loadReports();
+              </script>
+          </body>
+          </html>
+          HTMLEOF
+
+      - name: Check disk space and trigger cleanup
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true' && steps.inventory.outputs.count != '0'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          AVAIL_KB=$(ssh reports-server "df --output=avail /var/www/test-reports | tail -1 | tr -d ' '")
+          AVAIL_MB=$((AVAIL_KB / 1024))
+          AVAIL_GB=$(echo "scale=1; $AVAIL_KB / 1048576" | bc)
+          echo "Available disk space: ${AVAIL_GB} GB (${AVAIL_MB} MB)"
+
+          THRESHOLD_KB=2097152  # 2 GB
+          if [ "$AVAIL_KB" -lt "$THRESHOLD_KB" ]; then
+            echo "::warning::Disk space below 2 GB (${AVAIL_GB} GB) — triggering reports-cleanup workflow"
+            gh workflow run reports-cleanup.yml --repo "$GITHUB_REPOSITORY"
+          fi
+
+      - name: Produce summary
+        if: always()
+        env:
+          BRANCH: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          VERSION: ${{ needs.init.outputs.tag-fixed }}
+        run: |
+          echo "### 📊 Test Reports" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ steps.check-secret.outputs.available }}" != "true" ]; then
+            echo "⚠️ Report upload skipped — \`REPORTS_SERVER_SSH_KEY\` not configured" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+          if [ "${{ steps.inventory.outputs.count }}" = "0" ] || [ -z "${{ steps.inventory.outputs.count }}" ]; then
+            echo "⚠️ No Allure report artifacts available" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          BASE_URL="https://test-reports.metasfresh.com/branches/${BRANCH}/builds/${VERSION}/allure"
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Report | Link |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|------|" >> $GITHUB_STEP_SUMMARY
+          for report_type in ${{ steps.inventory.outputs.reports }}; do
+            echo "| ${report_type} | [Open report](${BASE_URL}/${report_type}/) |" >> $GITHUB_STEP_SUMMARY
+          done
+
+      - name: Cleanup SSH
+        if: always() && steps.check-secret.outputs.available == 'true'
+        run: rm -rf ~/.ssh/reports_key
+
+
   cicd-dispatch:
     if: contains(fromJson(vars.CICD_BRANCH_MAP), github.ref_name) == true
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1330,11 +1330,18 @@ jobs:
           echo "${{ secrets.REPORTS_SERVER_SSH_KEY }}" > ~/.ssh/reports_key
           chmod 600 ~/.ssh/reports_key
           ssh-keyscan -H test-reports.metasfresh.com >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -p "$REPORTS_SERVER_SSH_PORT" -H "$REPORTS_SERVER_HOSTNAME" >> ~/.ssh/known_hosts 2>/dev/null
           cat >> ~/.ssh/config <<EOF
-          Host reports-server
+          Host reports-storage
             HostName $REPORTS_SERVER_HOSTNAME
             User $REPORTS_SERVER_USER
             Port $REPORTS_SERVER_SSH_PORT
+            IdentityFile ~/.ssh/reports_key
+            StrictHostKeyChecking accept-new
+
+          Host reports-server
+            HostName test-reports.metasfresh.com
+            User ci-reports
             IdentityFile ~/.ssh/reports_key
             StrictHostKeyChecking accept-new
           EOF
@@ -1390,18 +1397,22 @@ jobs:
         env:
           BRANCH: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
           VERSION: ${{ needs.init.outputs.tag-fixed }}
-          REPORTS_SERVER_BASE_PATH: ${{ secrets.TESTREPORTS_BASE_PATH }}
+          STORAGEBOX_BASE_PATH: ${{ secrets.TESTREPORTS_BASE_PATH }}
         run: |
-          BASE_PATH="${REPORTS_SERVER_BASE_PATH}/branches/${BRANCH}/builds/${VERSION}/allure"
+          # Two different base paths -- same content, different mount points:
+          #   STORAGEBOX_PATH: used by rsync to reports-storage (storagebox internal path)
+          #   SERVER_PATH:     used by ssh to reports-server (test server mount point)
+          STORAGEBOX_PATH="${STORAGEBOX_BASE_PATH}/branches/${BRANCH}/builds/${VERSION}/allure"
+          SERVER_PATH="/var/www/test-reports/branches/${BRANCH}/builds/${VERSION}/allure"
 
           # Create target directories on server
-          ssh reports-server "mkdir -p ${BASE_PATH}"
+          ssh reports-server "mkdir -p ${SERVER_PATH}"
 
           for report_type in ${{ steps.inventory.outputs.reports }}; do
             echo "Uploading ${report_type} report..."
             rsync -az --delete \
               "reports/${report_type}/" \
-              "reports-server:${BASE_PATH}/${report_type}/"
+              "reports-storage:${STORAGEBOX_PATH}/${report_type}/"
             echo "✓ ${report_type} uploaded"
           done
 
@@ -1410,7 +1421,7 @@ jobs:
           for report_type in ${{ steps.inventory.outputs.reports }}; do
             REPORT_LINKS="${REPORT_LINKS}<li><a href=\"${report_type}/\">${report_type}</a></li>"
           done
-          ssh reports-server "cat > ${BASE_PATH}/index.html" <<EOF
+          ssh reports-server "cat > ${SERVER_PATH}/index.html" <<EOF
           <!DOCTYPE html>
           <html><head><title>Allure Reports — ${VERSION}</title>
           <style>body{font-family:sans-serif;margin:40px}a{color:#0066cc}</style>

--- a/.github/workflows/reports-cleanup.yml
+++ b/.github/workflows/reports-cleanup.yml
@@ -1,0 +1,283 @@
+# ===========================================================================
+# Cleanup old test reports on test-reports.metasfresh.com
+# ===========================================================================
+# Removes stale branch directories and orphaned builds to reclaim disk space.
+#
+# Trigger:
+#   - Nightly cron (2:30 AM UTC)
+#   - Manual via workflow_dispatch
+#   - Programmatic via gh workflow run (from publish-test-reports when disk < 2GB)
+#
+# Logic:
+#   1. Stale branches: If the newest metadata entry is older than 30 days,
+#      remove the entire branch directory + metadata file. This handles
+#      branches deleted from GitHub (they stop receiving builds and age out).
+#   2. Orphaned builds: Build directories not tracked in metadata and older
+#      than 7 days are removed. This handles partial uploads, merge-queue
+#      branches, and builds that fell out of the 20-entry metadata cap.
+#   3. Empty branches: After pruning builds, remove any branch directory
+#      with no builds left.
+#   4. Orphaned metadata: Remove metadata JSON files with no matching
+#      branch directory.
+# ===========================================================================
+
+name: Cleanup test reports
+
+on:
+  schedule:
+    - cron: '30 2 * * *'   # Daily at 2:30 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for report server secret
+        id: check-secret
+        run: |
+          if [ -z "${{ secrets.REPORTS_SERVER_SSH_KEY }}" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::REPORTS_SERVER_SSH_KEY not configured — skipping cleanup"
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup SSH
+        if: steps.check-secret.outputs.available == 'true'
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.REPORTS_SERVER_SSH_KEY }}" > ~/.ssh/reports_key
+          chmod 600 ~/.ssh/reports_key
+          ssh-keyscan -H test-reports.metasfresh.com >> ~/.ssh/known_hosts 2>/dev/null
+          cat >> ~/.ssh/config <<EOF
+          Host reports-server
+            HostName test-reports.metasfresh.com
+            User ci-reports
+            IdentityFile ~/.ssh/reports_key
+            StrictHostKeyChecking accept-new
+          EOF
+
+      - name: Run cleanup
+        if: steps.check-secret.outputs.available == 'true'
+        id: cleanup
+        run: |
+          ssh reports-server "python3 -" <<'PYEOF' | tee /tmp/cleanup-output.txt
+          import json, os, shutil, time, sys
+          from pathlib import Path
+          from datetime import datetime, timezone
+
+          REPORTS_ROOT = Path("/var/www/test-reports")
+          BRANCHES_DIR = REPORTS_ROOT / "branches"
+          METADATA_DIR = REPORTS_ROOT / "_metadata"
+
+          MAX_BUILDS_PER_BRANCH = 3
+          MAX_BRANCH_AGE_DAYS = 30
+          MAX_ORPHAN_BUILD_AGE_DAYS = 7
+
+          def get_avail_bytes():
+              stat = os.statvfs(str(REPORTS_ROOT))
+              return stat.f_bavail * stat.f_frsize
+
+          def dir_size(path):
+              total = 0
+              for entry in path.rglob("*"):
+                  if entry.is_file():
+                      total += entry.stat().st_size
+              return total
+
+          def fmt(size_bytes):
+              for unit in ("B", "KB", "MB", "GB"):
+                  if abs(size_bytes) < 1024:
+                      return f"{size_bytes:.1f} {unit}"
+                  size_bytes /= 1024
+              return f"{size_bytes:.1f} TB"
+
+          now = time.time()
+          before = get_avail_bytes()
+          removed_branches = []
+          removed_builds = []
+          freed = 0
+
+          if not BRANCHES_DIR.exists():
+              print("No branches directory — nothing to clean")
+              sys.exit(0)
+
+          for branch_dir in sorted(BRANCHES_DIR.iterdir()):
+              if not branch_dir.is_dir():
+                  continue
+
+              branch = branch_dir.name
+              builds_dir = branch_dir / "builds"
+              metadata_file = METADATA_DIR / f"{branch}.json"
+
+              # --- Load metadata ---
+              known_versions = set()
+              newest_ts = 0
+              if metadata_file.exists():
+                  try:
+                      data = json.loads(metadata_file.read_text())
+                      for b in data.get("builds", []):
+                          known_versions.add(b["version"])
+                          try:
+                              ts = datetime.fromisoformat(
+                                  b["timestamp"].replace("Z", "+00:00")
+                              ).timestamp()
+                              newest_ts = max(newest_ts, ts)
+                          except Exception:
+                              pass
+                  except (json.JSONDecodeError, KeyError):
+                      pass
+
+              # --- Stale branch (newest metadata entry > MAX_BRANCH_AGE_DAYS) ---
+              if newest_ts > 0:
+                  age_days = (now - newest_ts) / 86400
+                  if age_days > MAX_BRANCH_AGE_DAYS:
+                      size = dir_size(branch_dir)
+                      shutil.rmtree(branch_dir)
+                      if metadata_file.exists():
+                          metadata_file.unlink()
+                      removed_branches.append(
+                          f"{branch} (stale: {int(age_days)}d, {fmt(size)})"
+                      )
+                      freed += size
+                      continue
+
+              # --- No metadata at all (merge-queue, orphaned) — check file age ---
+              if newest_ts == 0 and not known_versions:
+                  # Use directory mtime as proxy
+                  try:
+                      dir_age = (now - branch_dir.stat().st_mtime) / 86400
+                  except OSError:
+                      dir_age = 999
+                  if dir_age > MAX_ORPHAN_BUILD_AGE_DAYS:
+                      size = dir_size(branch_dir)
+                      shutil.rmtree(branch_dir)
+                      if metadata_file.exists():
+                          metadata_file.unlink()
+                      removed_branches.append(
+                          f"{branch} (no metadata, {int(dir_age)}d old, {fmt(size)})"
+                      )
+                      freed += size
+                      continue
+
+              # --- Enforce per-branch build cap ---
+              if metadata_file.exists() and len(data.get("builds", [])) > MAX_BUILDS_PER_BRANCH:
+                  builds_list = data["builds"]
+                  evicted = builds_list[MAX_BUILDS_PER_BRANCH:]
+                  data["builds"] = builds_list[:MAX_BUILDS_PER_BRANCH]
+                  metadata_file.write_text(json.dumps(data, indent=2))
+                  for ev in evicted:
+                      ev_ver = ev.get("version", "")
+                      ev_path = builds_dir / ev_ver
+                      if ev_path.is_dir():
+                          size = dir_size(ev_path)
+                          shutil.rmtree(ev_path)
+                          removed_builds.append(
+                              f"{branch}/{ev_ver} (over cap, {fmt(size)})"
+                          )
+                          freed += size
+                      known_versions.discard(ev_ver)
+
+              # --- Prune orphaned builds within active branches ---
+              if builds_dir.exists():
+                  for build_dir in sorted(builds_dir.iterdir()):
+                      if not build_dir.is_dir():
+                          continue
+                      version = build_dir.name
+                      if version not in known_versions:
+                          try:
+                              build_age = (now - build_dir.stat().st_mtime) / 86400
+                          except OSError:
+                              build_age = 999
+                          if build_age > MAX_ORPHAN_BUILD_AGE_DAYS:
+                              size = dir_size(build_dir)
+                              shutil.rmtree(build_dir)
+                              removed_builds.append(
+                                  f"{branch}/{version} ({int(build_age)}d, {fmt(size)})"
+                              )
+                              freed += size
+
+              # --- Remove empty branch directory ---
+              if builds_dir.exists() and not any(builds_dir.iterdir()):
+                  shutil.rmtree(branch_dir)
+                  if metadata_file.exists():
+                      metadata_file.unlink()
+                  removed_branches.append(f"{branch} (empty after pruning)")
+
+          # --- Orphaned metadata files (no matching branch directory) ---
+          orphaned_meta = []
+          if METADATA_DIR.exists():
+              for meta_file in sorted(METADATA_DIR.glob("*.json")):
+                  branch = meta_file.stem
+                  if not (BRANCHES_DIR / branch).exists():
+                      meta_file.unlink()
+                      orphaned_meta.append(branch)
+
+          after = get_avail_bytes()
+
+          # --- Output (parsed by step summary) ---
+          print(f"BEFORE_AVAIL={fmt(before)}")
+          print(f"AFTER_AVAIL={fmt(after)}")
+          print(f"FREED={fmt(after - before)}")
+          print(f"BRANCHES_REMOVED={len(removed_branches)}")
+          for b in removed_branches:
+              print(f"  BRANCH: {b}")
+          print(f"BUILDS_PRUNED={len(removed_builds)}")
+          for b in removed_builds:
+              print(f"  BUILD: {b}")
+          if orphaned_meta:
+              print(f"ORPHANED_METADATA={len(orphaned_meta)}")
+              for m in orphaned_meta:
+                  print(f"  META: {m}")
+          PYEOF
+
+      - name: Step summary
+        if: steps.check-secret.outputs.available == 'true'
+        run: |
+          OUTPUT="/tmp/cleanup-output.txt"
+          BEFORE=$(grep 'BEFORE_AVAIL=' "$OUTPUT" | cut -d= -f2)
+          AFTER=$(grep 'AFTER_AVAIL=' "$OUTPUT" | cut -d= -f2)
+          FREED=$(grep 'FREED=' "$OUTPUT" | cut -d= -f2)
+          BRANCHES=$(grep 'BRANCHES_REMOVED=' "$OUTPUT" | cut -d= -f2)
+          BUILDS=$(grep 'BUILDS_PRUNED=' "$OUTPUT" | cut -d= -f2)
+
+          {
+            echo "## Test Reports Cleanup"
+            echo ""
+            echo "| Metric | Value |"
+            echo "|--------|-------|"
+            echo "| Trigger | \`${{ github.event_name }}\` |"
+            echo "| Timestamp | $(date -u '+%Y-%m-%dT%H:%M:%SZ') |"
+            echo "| Disk before | ${BEFORE:-unknown} |"
+            echo "| Disk after | ${AFTER:-unknown} |"
+            echo "| Space freed | ${FREED:-unknown} |"
+            echo "| Branches removed | ${BRANCHES:-0} |"
+            echo "| Builds pruned | ${BUILDS:-0} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # List removed branches if any
+          if grep -q '  BRANCH:' "$OUTPUT"; then
+            {
+              echo ""
+              echo "### Removed Branches"
+              echo ""
+              grep '  BRANCH:' "$OUTPUT" | sed 's/  BRANCH: /- /'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # List pruned builds if any
+          if grep -q '  BUILD:' "$OUTPUT"; then
+            {
+              echo ""
+              echo "### Pruned Builds"
+              echo ""
+              grep '  BUILD:' "$OUTPUT" | sed 's/  BUILD: /- /'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Cleanup SSH
+        if: always() && steps.check-secret.outputs.available == 'true'
+        run: rm -f ~/.ssh/reports_key


### PR DESCRIPTION
## Summary
- Add `publish-test-reports` job to cicd.yaml for uploading Allure test reports to the dedicated storagebox
- Add `reports-cleanup.yml` workflow for nightly pruning of stale reports
- Uses new secrets: `TESTREPORTS_HOSTNAME`, `TESTREPORTS_USER`, `TESTREPORTS_SSH_PORT`, `TESTREPORTS_BASE_PATH`

Part of the CI improvement to move test report storage from the test server to a dedicated 1TB storagebox.

## Test plan
- [ ] CI passes on this branch
- [ ] Verify publish-test-reports job runs (may skip if secrets not yet configured)