### PR TITLE
gh#28529: Fix Close_PartiallyShipped to close unshipped schedules

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/FrontendTestingRestController.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/FrontendTestingRestController.java
@@ -8,6 +8,7 @@ import de.metas.frontend_testing.masterdata.CreateMasterdataCommand;
 import de.metas.frontend_testing.masterdata.CreateMasterdataCommandSupportingServices;
 import de.metas.frontend_testing.masterdata.JsonCreateMasterdataRequest;
 import de.metas.frontend_testing.masterdata.JsonCreateMasterdataResponse;
+import de.metas.frontend_testing.masterdata.sysconfig.SysconfigCommand;
 import de.metas.i18n.TranslatableStrings;
 import de.metas.logging.LogManager;
 import de.metas.organization.OrgId;
@@ -112,5 +113,17 @@ public class FrontendTestingRestController
 				.expectations(jsonExpectations)
 				.build()
 				.execute();
+	}
+
+	@PostMapping("setSysconfigs")
+	public void setSysconfigs(@RequestBody @NonNull final java.util.Map<String, String> sysconfigs)
+	{
+		callInContext(() -> {
+			SysconfigCommand.builder()
+					.sysconfigs(sysconfigs)
+					.build()
+					.execute();
+			return null;
+		});
 	}
 }

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/AssertPickingExpectationsCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/AssertPickingExpectationsCommand.java
@@ -148,6 +148,60 @@ class AssertPickingExpectationsCommand
 			final List<I_M_ShipmentSchedule_QtyPicked> actualQtyPickedRecords = services.getShipmentScheduleQtyPickedRecords(actualsById.keySet());
 			assertQtyPickedList(expectation.getQtyPicked(), actualQtyPickedRecords, actualsById);
 		}
+
+		if (expectation.getIsClosed() != null)
+		{
+			assertThat(actuals).isNotEmpty();
+			waitShipmentSchedulesClosed(actuals, expectation.getIsClosed());
+			actuals.forEach(actual -> softly(() -> {
+				softlyPutContext("shipmentSchedule", actual);
+				assertThat(actual.isClosed()).as("IsClosed").isEqualTo(expectation.getIsClosed());
+			}));
+		}
+	}
+
+	private void waitShipmentSchedulesClosed(
+			@NonNull final List<I_M_ShipmentSchedule> actuals,
+			final boolean expectedClosed) throws InterruptedException
+	{
+		if (!expectedClosed)
+		{
+			return; // no need to wait if we expect them NOT closed
+		}
+
+		final ArrayList<I_M_ShipmentSchedule> notYetClosed = new ArrayList<>();
+		for (final I_M_ShipmentSchedule actual : actuals)
+		{
+			if (!actual.isClosed())
+			{
+				notYetClosed.add(actual);
+			}
+		}
+
+		if (notYetClosed.isEmpty())
+		{
+			return;
+		}
+
+		final Stopwatch stopwatch = Stopwatch.createStarted();
+		while (!notYetClosed.isEmpty() && stopwatch.elapsed().compareTo(DEFAULT_TIMEOUT) < 0)
+		{
+			logger.info("Waiting for {}/{} shipment schedules to be closed", notYetClosed.size(), actuals.size());
+			//noinspection BusyWait
+			Thread.sleep(1000);
+
+			InterfaceWrapperHelper.refreshAll(notYetClosed);
+			notYetClosed.removeIf(I_M_ShipmentSchedule::isClosed);
+		}
+		stopwatch.stop();
+
+		if (!notYetClosed.isEmpty())
+		{
+			throw new AdempiereException("Not all shipment schedules were closed after " + stopwatch + ": " + notYetClosed);
+		}
+
+		// Refresh all actuals so subsequent assertions see updated state
+		InterfaceWrapperHelper.refreshAll(actuals);
 	}
 
 	private void assertQtyPickedList(

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/request/JsonShipmentScheduleExpectation.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/request/JsonShipmentScheduleExpectation.java
@@ -15,5 +15,6 @@ public class JsonShipmentScheduleExpectation
 {
 	@Nullable Boolean isScheduledForPicking;
 	@Nullable BigDecimal qtyScheduledForPicking;
+	@Nullable Boolean isClosed;
 	@Nullable List<JsonShipmentScheduleQtyPickedExpectation> qtyPicked;
 }

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommand.java
@@ -40,6 +40,7 @@ import de.metas.frontend_testing.masterdata.resource.JsonCreateResourceResponse;
 import de.metas.frontend_testing.masterdata.sales_order.JsonSalesOrderCreateRequest;
 import de.metas.frontend_testing.masterdata.sales_order.JsonSalesOrderCreateResponse;
 import de.metas.frontend_testing.masterdata.sales_order.SalesOrderCreateCommand;
+import de.metas.frontend_testing.masterdata.sysconfig.SysconfigCommand;
 import de.metas.frontend_testing.masterdata.user.JsonLoginUserRequest;
 import de.metas.frontend_testing.masterdata.user.JsonLoginUserResponse;
 import de.metas.frontend_testing.masterdata.user.LoginUserCommand;
@@ -68,6 +69,9 @@ public class CreateMasterdataCommand
 	{
 		this.context.putFromJson(request.getContext());
 
+		// Apply sysconfigs early (before any masterdata creation)
+		final ImmutableMap<String, String> previousSysconfigs = applySysconfigs();
+
 		// IMPORTANT: the order is very important
 		final ImmutableMap<String, JsonLoginUserResponse> login = createLoginUsers();
 		final ImmutableMap<String, JsonCreateBPartnerResponse> bpartners = createBPartners();
@@ -89,6 +93,7 @@ public class CreateMasterdataCommand
 
 		return JsonCreateMasterdataResponse.builder()
 				.context(context.toJson())
+				.previousSysconfigs(previousSysconfigs.isEmpty() ? null : previousSysconfigs)
 				.mobileConfig(mobileConfig)
 				.login(login)
 				.bpartners(bpartners)
@@ -386,6 +391,14 @@ public class CreateMasterdataCommand
 				.build()
 				.execute();
 
+	}
+
+	private ImmutableMap<String, String> applySysconfigs()
+	{
+		return SysconfigCommand.builder()
+				.sysconfigs(request.getSysconfigs())
+				.build()
+				.execute();
 	}
 
 }

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/JsonCreateMasterdataRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/JsonCreateMasterdataRequest.java
@@ -31,7 +31,9 @@ import java.util.Map;
 public class JsonCreateMasterdataRequest
 {
 	@Nullable Map<String, Object> context;
-	
+
+	@Nullable Map<String, String> sysconfigs;
+
 	@Nullable JsonMobileConfigRequest mobileConfig;
 	@Nullable Map<String, JsonLoginUserRequest> login;
 	@Nullable Map<String, JsonCreateBPartnerRequest> bpartners;

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/JsonCreateMasterdataResponse.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/JsonCreateMasterdataResponse.java
@@ -31,7 +31,9 @@ import java.util.Map;
 public class JsonCreateMasterdataResponse
 {
 	@Nullable Map<String, Object> context;
-	
+
+	@Nullable @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, String> previousSysconfigs;
+
 	@Nullable @JsonInclude(JsonInclude.Include.NON_EMPTY) JsonMobileConfigResponse mobileConfig;
 	@NonNull Map<String, JsonLoginUserResponse> login;
 	@NonNull Map<String, JsonCreateBPartnerResponse> bpartners;

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/sysconfig/SysconfigCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/sysconfig/SysconfigCommand.java
@@ -1,0 +1,52 @@
+package de.metas.frontend_testing.masterdata.sysconfig;
+
+import com.google.common.collect.ImmutableMap;
+import de.metas.organization.OrgId;
+import de.metas.util.Services;
+import lombok.Builder;
+import org.adempiere.service.ClientId;
+import org.adempiere.service.ISysConfigBL;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+@Builder
+public class SysconfigCommand
+{
+	@Nullable private final Map<String, String> sysconfigs;
+
+	/**
+	 * Sets the given sysconfigs and returns the previous values.
+	 *
+	 * @return map from sysconfig name to its previous value (null if it didn't exist before)
+	 */
+	public ImmutableMap<String, String> execute()
+	{
+		if (sysconfigs == null || sysconfigs.isEmpty())
+		{
+			return ImmutableMap.of();
+		}
+
+		final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+		final int adClientId = ClientId.METASFRESH.getRepoId();
+		final int adOrgId = OrgId.MAIN.getRepoId();
+
+		final ImmutableMap.Builder<String, String> previousValues = ImmutableMap.builder();
+
+		for (final Map.Entry<String, String> entry : sysconfigs.entrySet())
+		{
+			final String name = entry.getKey();
+			final String newValue = entry.getValue();
+
+			final String previousValue = sysConfigBL.getValue(name, null, adClientId, adOrgId);
+			if (previousValue != null)
+			{
+				previousValues.put(name, previousValue);
+			}
+
+			sysConfigBL.setValue(name, newValue, ClientId.METASFRESH, OrgId.MAIN);
+		}
+
+		return previousValues.build();
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
@@ -38,6 +38,8 @@ import de.metas.logging.LogManager;
 import de.metas.logging.TableRecordMDC;
 import de.metas.order.IOrderBL;
 import de.metas.order.OrderId;
+import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
 import de.metas.order.OrderLineId;
 import de.metas.organization.OrgId;
 import de.metas.process.PInstanceId;
@@ -704,26 +706,50 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 			return;
 		}
 
+		// Track which schedules were fully shipped in this shipment (MovementQty >= QtyOrdered)
+		final HashSet<ShipmentScheduleId> fullyShippedScheduleIds = new HashSet<>();
+		final HashSet<OrderId> orderIds = new HashSet<>();
+
 		for (final I_M_InOutLine iolrecord : inOutDAO.retrieveLines(inoutRecord))
 		{
 			try (final MDCCloseable ignored = TableRecordMDC.putTableRecordReference(iolrecord))
 			{
 				for (final I_M_ShipmentSchedule shipmentScheduleRecord : shipmentSchedulePA.retrieveForInOutLine(iolrecord))
 				{
-					try (final MDCCloseable ignored1 = TableRecordMDC.putTableRecordReference(shipmentScheduleRecord))
+					final ShipmentScheduleId scheduleId = ShipmentScheduleId.ofRepoId(shipmentScheduleRecord.getM_ShipmentSchedule_ID());
+					final OrderId orderId = OrderId.ofRepoIdOrNull(shipmentScheduleRecord.getC_Order_ID());
+					if (orderId != null)
 					{
-						if (iolrecord.getMovementQty().compareTo(shipmentScheduleRecord.getQtyOrdered()) < 0)
-						{
-							logger.debug("inoutLine.MovementQty={} is < shipmentSchedule.qtyOrdered={}; -> closing shipment schedule",
-									iolrecord.getMovementQty(), shipmentScheduleRecord.getQtyOrdered());
-							closeShipmentSchedule(shipmentScheduleRecord);
-						}
-						else
-						{
-							logger.debug("inoutLine.MovementQty={} is >= shipmentSchedule.qtyOrdered={}; -> not closing shipment schedule",
-									iolrecord.getMovementQty(), shipmentScheduleRecord.getQtyOrdered());
-						}
+						orderIds.add(orderId);
 					}
+
+					if (iolrecord.getMovementQty().compareTo(shipmentScheduleRecord.getQtyOrdered()) >= 0)
+					{
+						fullyShippedScheduleIds.add(scheduleId);
+					}
+				}
+			}
+		}
+
+		// Close all schedules from the involved orders that were NOT fully shipped.
+		// This includes partially shipped schedules (MovementQty < QtyOrdered) and
+		// completely unshipped schedules (no shipment line at all).
+		for (final OrderId orderId : orderIds)
+		{
+			final ImmutableSet<ShipmentScheduleId> allScheduleIds = shipmentSchedulePA.retrieveScheduleIdsByOrderId(orderId);
+			for (final ShipmentScheduleId scheduleId : allScheduleIds)
+			{
+				if (fullyShippedScheduleIds.contains(scheduleId))
+				{
+					logger.debug("Not closing shipment schedule {} - fully shipped in this delivery", scheduleId);
+					continue;
+				}
+
+				final I_M_ShipmentSchedule schedule = shipmentSchedulePA.getById(scheduleId);
+				if (!schedule.isClosed())
+				{
+					logger.debug("Closing shipment schedule {} for order {} (M_ShipmentSchedule_Close_PartiallyShipped=Y)", scheduleId, orderId);
+					closeShipmentSchedule(schedule);
 				}
 			}
 		}

--- a/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
@@ -67,12 +67,6 @@ const createMasterdata = async () => {
     return masterdata;
 }
 
-test.afterAll(async ({ page: _page }) => {
-    if (previousSysconfigs && Object.keys(previousSysconfigs).length > 0) {
-        await Backend.setSysconfigs(previousSysconfigs);
-    }
-});
-
 // noinspection JSUnusedLocalSymbols
 test('Sysconfig M_ShipmentSchedule_Close_PartiallyShipped: partial and unshipped schedules are closed', async ({ page }) => {
     // === ALLURE METADATA ===
@@ -157,5 +151,11 @@ test('Sysconfig M_ShipmentSchedule_Close_PartiallyShipped: partial and unshipped
                 }
             },
         });
+    });
+
+    await test.step("Restore sysconfigs", async () => {
+        if (previousSysconfigs && Object.keys(previousSysconfigs).length > 0) {
+            await Backend.setSysconfigs(previousSysconfigs);
+        }
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
@@ -1,0 +1,162 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { Backend } from '../../utils/screens/Backend';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { PickingJobsListScreen } from '../../utils/screens/picking/PickingJobsListScreen';
+import { PickingJobScreen } from '../../utils/screens/picking/PickingJobScreen';
+import { QTY_NOT_FOUND_REASON_NOT_FOUND } from '../../utils/screens/picking/GetQuantityDialog';
+import { generateEAN13 } from '../../utils/ean13';
+
+let previousSysconfigs = null;
+
+const createMasterdata = async () => {
+    const masterdata = await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            sysconfigs: {
+                "M_ShipmentSchedule_Close_PartiallyShipped": "Y",
+            },
+            login: {
+                user: { language: "en_US" },
+            },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CO',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                    allowCompletingPartialPickingJob: true,
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                "P1": { price: 1, gtin: generateEAN13().ean13 },
+                "P2": { price: 1, gtin: generateEAN13().ean13 },
+                "P3": { price: 1, gtin: generateEAN13().ean13 },
+            },
+            packingInstructions: {
+                "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "P1", qtyCUsPerTU: 4 },
+                "PI2": { lu: "LU2", qtyTUsPerLU: 20, tu: "TU2", product: "P2", qtyCUsPerTU: 4 },
+                "PI3": { lu: "LU3", qtyTUsPerLU: 20, tu: "TU3", product: "P3", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', qty: 1000, packingInstructions: 'PI' },
+                "HU2": { product: 'P2', warehouse: 'wh', qty: 1000, packingInstructions: 'PI2' },
+                "HU3": { product: 'P3', warehouse: 'wh', qty: 1000, packingInstructions: 'PI3' },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [
+                        { product: 'P1', qty: 12, piItemProduct: 'TU' },
+                        { product: 'P2', qty: 12, piItemProduct: 'TU2' },
+                        { product: 'P3', qty: 12, piItemProduct: 'TU3' },
+                    ]
+                }
+            },
+        }
+    });
+
+    previousSysconfigs = masterdata.previousSysconfigs;
+    return masterdata;
+}
+
+test.afterAll(async ({ page: _page }) => {
+    if (previousSysconfigs && Object.keys(previousSysconfigs).length > 0) {
+        await Backend.setSysconfigs(previousSysconfigs);
+    }
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Sysconfig M_ShipmentSchedule_Close_PartiallyShipped: partial and unshipped schedules are closed', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Close partially shipped shipment schedules');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication("picking");
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+
+    await test.step("Pick line 1 (P1) - completely", async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.qrCode,
+            isScanDirectly: true,
+            expectQtyEntered: '3',
+        });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '12 Stk', qtyPickedCatchWeight: '' });
+    });
+
+    await test.step("Pick line 2 (P2) - partially (2 TUs out of 3)", async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU2.qrCode,
+            qtyEntered: 2,
+            expectQtyEntered: "3",
+            qtyNotFoundReason: QTY_NOT_FOUND_REASON_NOT_FOUND,
+        });
+        await PickingJobScreen.expectLineButton({ index: 2, qtyToPick: '12 Stk', qtyPicked: '8 Stk', qtyPickedCatchWeight: '' });
+    });
+
+    await test.step("Skip line 3 (P3) - do not pick", async () => {
+        // Intentionally not picking P3
+    });
+
+    await test.step("Complete the picking job", async () => {
+        await PickingJobScreen.complete();
+    });
+
+    await test.step("Assert shipment schedules: P2 and P3 should be closed", async () => {
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: {
+                            isClosed: false,
+                            qtyPicked: [{
+                                qtyPicked: "12 PCE",
+                                qtyTUs: 3,
+                                qtyLUs: 1,
+                                vhu: 'vhu1',
+                                tu: 'tu1',
+                                lu: 'lu1',
+                                processed: true,
+                                shipmentLineId: 'shipmentLineId1',
+                            }]
+                        },
+                        P2: {
+                            isClosed: true,
+                            qtyPicked: [{
+                                qtyPicked: "8 PCE",
+                                qtyTUs: 2,
+                                qtyLUs: 1,
+                                vhu: 'vhu2',
+                                tu: 'tu2',
+                                lu: 'lu2',
+                                processed: true,
+                                shipmentLineId: 'shipmentLineId2',
+                            }]
+                        },
+                        P3: {
+                            isClosed: true,
+                        },
+                    }
+                }
+            },
+        });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
@@ -99,7 +99,7 @@ test('Sysconfig M_ShipmentSchedule_Close_PartiallyShipped: partial and unshipped
             isScanDirectly: true,
             expectQtyEntered: '3',
         });
-        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '12 Stk', qtyPickedCatchWeight: '' });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });
     });
 
     await test.step("Pick line 2 (P2) - partially (2 TUs out of 3)", async () => {
@@ -109,7 +109,7 @@ test('Sysconfig M_ShipmentSchedule_Close_PartiallyShipped: partial and unshipped
             expectQtyEntered: "3",
             qtyNotFoundReason: QTY_NOT_FOUND_REASON_NOT_FOUND,
         });
-        await PickingJobScreen.expectLineButton({ index: 2, qtyToPick: '12 Stk', qtyPicked: '8 Stk', qtyPickedCatchWeight: '' });
+        await PickingJobScreen.expectLineButton({ index: 2, qtyToPick: '3 TU', qtyPicked: '2 TU', qtyPickedCatchWeight: '' });
     });
 
     await test.step("Skip line 3 (P3) - do not pick", async () => {

--- a/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
@@ -44,9 +44,9 @@ const createMasterdata = async () => {
                 "PI3": { lu: "LU3", qtyTUsPerLU: 20, tu: "TU3", product: "P3", qtyCUsPerTU: 4 },
             },
             handlingUnits: {
-                "HU1": { product: 'P1', warehouse: 'wh', qty: 1000, packingInstructions: 'PI' },
-                "HU2": { product: 'P2', warehouse: 'wh', qty: 1000, packingInstructions: 'PI2' },
-                "HU3": { product: 'P3', warehouse: 'wh', qty: 1000, packingInstructions: 'PI3' },
+                "HU1": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
+                "HU2": { product: 'P2', warehouse: 'wh', packingInstructions: 'PI2' },
+                "HU3": { product: 'P3', warehouse: 'wh', packingInstructions: 'PI3' },
             },
             salesOrders: {
                 "SO1": {

--- a/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
@@ -40,13 +40,13 @@ const createMasterdata = async () => {
             },
             packingInstructions: {
                 "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "P1", qtyCUsPerTU: 4 },
-                "PI2": { lu: "LU2", qtyTUsPerLU: 20, tu: "TU2", product: "P2", qtyCUsPerTU: 4 },
-                "PI3": { lu: "LU3", qtyTUsPerLU: 20, tu: "TU3", product: "P3", qtyCUsPerTU: 4 },
+                "PI2": { lu: "LU", qtyTUsPerLU: 20, tu: "TU2", product: "P2", qtyCUsPerTU: 4 },
+                "PI3": { lu: "LU", qtyTUsPerLU: 20, tu: "TU3", product: "P3", qtyCUsPerTU: 4 },
             },
             handlingUnits: {
-                "HU1": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
-                "HU2": { product: 'P2', warehouse: 'wh', packingInstructions: 'PI2' },
-                "HU3": { product: 'P3', warehouse: 'wh', packingInstructions: 'PI3' },
+                "HU1": { product: 'P1', warehouse: 'wh', qty: 200 },
+                "HU2": { product: 'P2', warehouse: 'wh', qty: 200 },
+                "HU3": { product: 'P3', warehouse: 'wh', qty: 200 },
             },
             salesOrders: {
                 "SO1": {
@@ -96,7 +96,6 @@ test('Sysconfig M_ShipmentSchedule_Close_PartiallyShipped: partial and unshipped
     await test.step("Pick line 1 (P1) - completely", async () => {
         await PickingJobScreen.pickHU({
             qrCode: masterdata.handlingUnits.HU1.qrCode,
-            isScanDirectly: true,
             expectQtyEntered: '3',
         });
         await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });

--- a/e2e/mobile-webui/tests/utils/screens/Backend.js
+++ b/e2e/mobile-webui/tests/utils/screens/Backend.js
@@ -59,6 +59,21 @@ export const Backend = {
         };
     }),
 
+    setSysconfigs: async (sysconfigs) => await test.step(`Backend: set sysconfigs`, async () => {
+        const backendBaseUrl = await getBackendBaseUrl();
+        const response = await page.request.post(`${backendBaseUrl}/frontendTesting/setSysconfigs`, {
+            data: sysconfigs,
+            headers: {
+                'Content-Type': 'application/json',
+            }
+        });
+
+        if (!response.ok()) {
+            const responseBody = await response.json();
+            assertNoErrors({ responseBody });
+        }
+    }),
+
     getWFProcess: async ({ wfProcessId }) => {
         const backendBaseUrl = await getBackendBaseUrl();
         const response = await page.request.get(`${backendBaseUrl}/userWorkflows/wfProcess/${wfProcessId}`, {


### PR DESCRIPTION
## Summary
- Fix `M_ShipmentSchedule_Close_PartiallyShipped` sysconfig: previously only closed schedules with a shipment line (MovementQty < QtyOrdered), now also closes schedules with NO shipment line (completely unpicked lines)
- Add Playwright E2E test that picks P1 fully, P2 partially, skips P3, then asserts P2+P3 are closed
- Add sysconfig backup/restore support in frontendTesting API for test isolation

## Test plan
- [ ] CI passes (Java compilation, existing tests)
- [ ] Playwright test `close_partially_shipped.spec.js` runs successfully against local stack
- [ ] Manual verification: create SO with 3 lines, partially pick, complete — verify unshipped schedules are closed