### PR TITLE
M_HU_PI_Item_Product consolidation process

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794110_sys_M_HU_PI_Item_Product_Consolidate_Messages.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794110_sys_M_HU_PI_Item_Product_Consolidate_Messages.sql
@@ -1,0 +1,68 @@
+-- 2026-03-12
+-- AD_Messages for M_HU_PI_Item_Product consolidation report
+
+-- Message 1: M_HU_PI_Item_Product_Conflict_DifferentPI
+INSERT INTO AD_Message (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, MsgType, Value, MsgText, EntityType, AD_Message_ID)
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        'I', 'M_HU_PI_Item_Product_Conflict_DifferentPI',
+        'Konflikt: Gleiche GTIN, unterschiedliche Packvorschrift',
+        'de.metas.handlingunits', 545644 /*From ID Server*/);
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        545644 /*From ID Server*/,
+        'Konflikt: Gleiche GTIN, unterschiedliche Packvorschrift', NULL, 'N', 'Y');
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        545644 /*From ID Server*/,
+        'Konflikt: Gleiche GTIN, unterschiedliche Packvorschrift', NULL, 'N', 'N');
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        545644 /*From ID Server*/,
+        'Conflict: Same GTIN, different packing instruction', NULL, 'Y', 'N');
+
+-- Message 2: M_HU_PI_Item_Product_Conflict_DifferentProduct
+INSERT INTO AD_Message (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, MsgType, Value, MsgText, EntityType, AD_Message_ID)
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        'I', 'M_HU_PI_Item_Product_Conflict_DifferentProduct',
+        'Konflikt: Gleiche GTIN, unterschiedliches Produkt',
+        'de.metas.handlingunits', 545645 /*From ID Server*/);
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        545645 /*From ID Server*/,
+        'Konflikt: Gleiche GTIN, unterschiedliches Produkt', NULL, 'N', 'Y');
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        545645 /*From ID Server*/,
+        'Konflikt: Gleiche GTIN, unterschiedliches Produkt', NULL, 'N', 'N');
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        545645 /*From ID Server*/,
+        'Conflict: Same GTIN, different product', NULL, 'Y', 'N');
+
+-- Message 3: M_HU_PI_Item_Product_Conflict_DifferentFields
+INSERT INTO AD_Message (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, MsgType, Value, MsgText, EntityType, AD_Message_ID)
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        'I', 'M_HU_PI_Item_Product_Conflict_DifferentFields',
+        'Konflikt: Gleiche GTIN/Packvorschrift, unterschiedliche Felder',
+        'de.metas.handlingunits', 545646 /*From ID Server*/);
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        545646 /*From ID Server*/,
+        'Konflikt: Gleiche GTIN/Packvorschrift, unterschiedliche Felder', NULL, 'N', 'Y');
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        545646 /*From ID Server*/,
+        'Konflikt: Gleiche GTIN/Packvorschrift, unterschiedliche Felder', NULL, 'N', 'N');
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        545646 /*From ID Server*/,
+        'Conflict: Same GTIN/packing instruction, different fields', NULL, 'Y', 'N');

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794110_sys_M_HU_PI_Item_Product_Consolidate_Messages.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794110_sys_M_HU_PI_Item_Product_Consolidate_Messages.sql
@@ -8,20 +8,20 @@ VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO
         'Konflikt: Gleiche GTIN, unterschiedliche Packvorschrift',
         'de.metas.handlingunits', 545644 /*From ID Server*/);
 
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
 VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         545644 /*From ID Server*/,
-        'Konflikt: Gleiche GTIN, unterschiedliche Packvorschrift', NULL, 'N', 'Y');
+        'Konflikt: Gleiche GTIN, unterschiedliche Packvorschrift', NULL, 'N');
 
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
 VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         545644 /*From ID Server*/,
-        'Konflikt: Gleiche GTIN, unterschiedliche Packvorschrift', NULL, 'N', 'N');
+        'Konflikt: Gleiche GTIN, unterschiedliche Packvorschrift', NULL, 'N');
 
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
 VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         545644 /*From ID Server*/,
-        'Conflict: Same GTIN, different packing instruction', NULL, 'Y', 'N');
+        'Conflict: Same GTIN, different packing instruction', NULL, 'Y');
 
 -- Message 2: M_HU_PI_Item_Product_Conflict_DifferentProduct
 INSERT INTO AD_Message (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, MsgType, Value, MsgText, EntityType, AD_Message_ID)
@@ -30,20 +30,20 @@ VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO
         'Konflikt: Gleiche GTIN, unterschiedliches Produkt',
         'de.metas.handlingunits', 545645 /*From ID Server*/);
 
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
 VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         545645 /*From ID Server*/,
-        'Konflikt: Gleiche GTIN, unterschiedliches Produkt', NULL, 'N', 'Y');
+        'Konflikt: Gleiche GTIN, unterschiedliches Produkt', NULL, 'N');
 
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
 VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         545645 /*From ID Server*/,
-        'Konflikt: Gleiche GTIN, unterschiedliches Produkt', NULL, 'N', 'N');
+        'Konflikt: Gleiche GTIN, unterschiedliches Produkt', NULL, 'N');
 
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
 VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         545645 /*From ID Server*/,
-        'Conflict: Same GTIN, different product', NULL, 'Y', 'N');
+        'Conflict: Same GTIN, different product', NULL, 'Y');
 
 -- Message 3: M_HU_PI_Item_Product_Conflict_DifferentFields
 INSERT INTO AD_Message (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, MsgType, Value, MsgText, EntityType, AD_Message_ID)
@@ -52,17 +52,17 @@ VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO
         'Konflikt: Gleiche GTIN/Packvorschrift, unterschiedliche Felder',
         'de.metas.handlingunits', 545646 /*From ID Server*/);
 
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
 VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         545646 /*From ID Server*/,
-        'Konflikt: Gleiche GTIN/Packvorschrift, unterschiedliche Felder', NULL, 'N', 'Y');
+        'Konflikt: Gleiche GTIN/Packvorschrift, unterschiedliche Felder', NULL, 'N');
 
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
 VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         545646 /*From ID Server*/,
-        'Konflikt: Gleiche GTIN/Packvorschrift, unterschiedliche Felder', NULL, 'N', 'N');
+        'Konflikt: Gleiche GTIN/Packvorschrift, unterschiedliche Felder', NULL, 'N');
 
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated, IsTrlBase)
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
 VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         545646 /*From ID Server*/,
-        'Conflict: Same GTIN/packing instruction, different fields', NULL, 'Y', 'N');
+        'Conflict: Same GTIN/packing instruction, different fields', NULL, 'Y');

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794120_sys_M_HU_PI_Item_Product_Consolidate_Elements.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794120_sys_M_HU_PI_Item_Product_Consolidate_Elements.sql
@@ -7,7 +7,7 @@ INSERT INTO AD_Element (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, U
 VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         584660 /*From ID Server*/, 'IsNormalizeGTIN',
         'GTIN/EAN normalisieren', 'GTIN/EAN normalisieren',
-        'Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN',
+        'Kopiert EAN in GTIN wenn GTIN leer ist, löscht EAN wenn identisch mit GTIN',
         'de.metas.handlingunits');
 
 INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
@@ -15,7 +15,7 @@ INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Crea
 VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         584660 /*From ID Server*/,
         'GTIN/EAN normalisieren', 'GTIN/EAN normalisieren',
-        'Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN',
+        'Kopiert EAN in GTIN wenn GTIN leer ist, löscht EAN wenn identisch mit GTIN',
         'N');
 
 INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
@@ -23,7 +23,7 @@ INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Crea
 VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         584660 /*From ID Server*/,
         'GTIN/EAN normalisieren', 'GTIN/EAN normalisieren',
-        'Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN',
+        'Kopiert EAN in GTIN wenn GTIN leer ist, löscht EAN wenn identisch mit GTIN',
         'N');
 
 INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
@@ -39,7 +39,7 @@ INSERT INTO AD_Element (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, U
                         AD_Element_ID, ColumnName, Name, PrintName, Description, EntityType)
 VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         584661 /*From ID Server*/, 'IsConsolidate',
-        'Doppelte Eintraege konsolidieren', 'Doppelte Eintraege konsolidieren',
+        'Doppelte Einträge konsolidieren', 'Doppelte Einträge konsolidieren',
         'Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zusammen',
         'de.metas.handlingunits');
 
@@ -47,7 +47,7 @@ INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Crea
                             AD_Element_ID, Name, PrintName, Description, IsTranslated)
 VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         584661 /*From ID Server*/,
-        'Doppelte Eintraege konsolidieren', 'Doppelte Eintraege konsolidieren',
+        'Doppelte Einträge konsolidieren', 'Doppelte Einträge konsolidieren',
         'Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zusammen',
         'N');
 
@@ -55,7 +55,7 @@ INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Crea
                             AD_Element_ID, Name, PrintName, Description, IsTranslated)
 VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         584661 /*From ID Server*/,
-        'Doppelte Eintraege konsolidieren', 'Doppelte Eintraege konsolidieren',
+        'Doppelte Einträge konsolidieren', 'Doppelte Einträge konsolidieren',
         'Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zusammen',
         'N');
 

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794120_sys_M_HU_PI_Item_Product_Consolidate_Elements.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794120_sys_M_HU_PI_Item_Product_Consolidate_Elements.sql
@@ -1,0 +1,68 @@
+-- 2026-03-12
+-- AD_Elements for M_HU_PI_Item_Product consolidation process parameters
+
+-- Element 1: IsNormalizeGTIN
+INSERT INTO AD_Element (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                        AD_Element_ID, ColumnName, Name, PrintName, Description, EntityType)
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        584660 /*From ID Server*/, 'IsNormalizeGTIN',
+        'GTIN/EAN normalisieren', 'GTIN/EAN normalisieren',
+        'Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN',
+        'de.metas.handlingunits');
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            AD_Element_ID, Name, PrintName, Description, IsTranslated)
+VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        584660 /*From ID Server*/,
+        'GTIN/EAN normalisieren', 'GTIN/EAN normalisieren',
+        'Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN',
+        'N');
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            AD_Element_ID, Name, PrintName, Description, IsTranslated)
+VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        584660 /*From ID Server*/,
+        'GTIN/EAN normalisieren', 'GTIN/EAN normalisieren',
+        'Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN',
+        'N');
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            AD_Element_ID, Name, PrintName, Description, IsTranslated)
+VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        584660 /*From ID Server*/,
+        'Normalize GTIN/EAN', 'Normalize GTIN/EAN',
+        'Copies EAN to GTIN when GTIN is empty, clears EAN when identical to GTIN',
+        'Y');
+
+-- Element 2: IsConsolidate
+INSERT INTO AD_Element (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                        AD_Element_ID, ColumnName, Name, PrintName, Description, EntityType)
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        584661 /*From ID Server*/, 'IsConsolidate',
+        'Doppelte Eintraege konsolidieren', 'Doppelte Eintraege konsolidieren',
+        'Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zusammen',
+        'de.metas.handlingunits');
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            AD_Element_ID, Name, PrintName, Description, IsTranslated)
+VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        584661 /*From ID Server*/,
+        'Doppelte Eintraege konsolidieren', 'Doppelte Eintraege konsolidieren',
+        'Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zusammen',
+        'N');
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            AD_Element_ID, Name, PrintName, Description, IsTranslated)
+VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        584661 /*From ID Server*/,
+        'Doppelte Eintraege konsolidieren', 'Doppelte Eintraege konsolidieren',
+        'Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zusammen',
+        'N');
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            AD_Element_ID, Name, PrintName, Description, IsTranslated)
+VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        584661 /*From ID Server*/,
+        'Consolidate duplicates', 'Consolidate duplicates',
+        'Merges duplicate packing instruction allocations with the same GTIN',
+        'Y');

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794130_sys_M_HU_PI_Item_Product_Consolidate_Process.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794130_sys_M_HU_PI_Item_Product_Consolidate_Process.sql
@@ -1,0 +1,179 @@
+-- 2026-03-12
+-- AD_Process, parameters, table-process link, menu entry, and tree node
+-- for M_HU_PI_Item_Product consolidation
+
+-- =============================================
+-- 1. AD_Process
+-- =============================================
+INSERT INTO AD_Process (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                        AD_Process_ID, Value, Name, Description, Help,
+                        Classname, IsReport, AccessLevel, EntityType, ShowHelp, Type)
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        585596 /*From ID Server*/,
+        'M_HU_PI_Item_Product_Consolidate_Report',
+        'CU-TU Zuordnung konsolidieren',
+        'Normalisiert GTIN/EAN und konsolidiert doppelte Packvorschrift-Zuordnungen. Erstellt einen Excel-Bericht ueber Konflikte.',
+        'Dieser Prozess fuehrt zwei optionale Schritte aus: (1) GTIN/EAN Normalisierung: Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN. (2) Konsolidierung: Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zu einem Eintrag ohne Geschaeftspartner zusammen. Beide Schritte muessen explizit aktiviert werden. Betroffene Tabellen werden vor Aenderungen gesichert. Der Prozess erstellt immer einen Excel-Bericht mit verbleibenden Konflikten.',
+        'de.metas.handlingunits.process.M_HU_PI_Item_Product_Consolidate_Report',
+        'N', '3', 'de.metas.handlingunits', 'Y', 'Java');
+
+-- AD_Process_Trl: de_DE
+INSERT INTO AD_Process_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            AD_Process_ID, Name, Description, Help, IsTranslated)
+VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        585596 /*From ID Server*/,
+        'CU-TU Zuordnung konsolidieren',
+        'Normalisiert GTIN/EAN und konsolidiert doppelte Packvorschrift-Zuordnungen. Erstellt einen Excel-Bericht ueber Konflikte.',
+        'Dieser Prozess fuehrt zwei optionale Schritte aus: (1) GTIN/EAN Normalisierung: Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN. (2) Konsolidierung: Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zu einem Eintrag ohne Geschaeftspartner zusammen. Beide Schritte muessen explizit aktiviert werden. Betroffene Tabellen werden vor Aenderungen gesichert. Der Prozess erstellt immer einen Excel-Bericht mit verbleibenden Konflikten.',
+        'N');
+
+-- AD_Process_Trl: de_CH
+INSERT INTO AD_Process_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            AD_Process_ID, Name, Description, Help, IsTranslated)
+VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        585596 /*From ID Server*/,
+        'CU-TU Zuordnung konsolidieren',
+        'Normalisiert GTIN/EAN und konsolidiert doppelte Packvorschrift-Zuordnungen. Erstellt einen Excel-Bericht ueber Konflikte.',
+        'Dieser Prozess fuehrt zwei optionale Schritte aus: (1) GTIN/EAN Normalisierung: Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN. (2) Konsolidierung: Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zu einem Eintrag ohne Geschaeftspartner zusammen. Beide Schritte muessen explizit aktiviert werden. Betroffene Tabellen werden vor Aenderungen gesichert. Der Prozess erstellt immer einen Excel-Bericht mit verbleibenden Konflikten.',
+        'N');
+
+-- AD_Process_Trl: en_US
+INSERT INTO AD_Process_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            AD_Process_ID, Name, Description, Help, IsTranslated)
+VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        585596 /*From ID Server*/,
+        'Consolidate CU-TU Allocation',
+        'Normalizes GTIN/EAN and consolidates duplicate packing instruction allocations. Generates an Excel report of conflicts.',
+        'This process performs two optional steps: (1) GTIN/EAN normalization: Copies EAN to GTIN when GTIN is empty, clears EAN when identical to GTIN. (2) Consolidation: Merges duplicate packing instruction allocations with the same GTIN into one record without a business partner. Both steps must be explicitly activated. Affected tables are backed up before modifications. The process always generates an Excel report of remaining conflicts.',
+        'Y');
+
+-- =============================================
+-- 2. AD_Process_Para: IsNormalizeGTIN
+-- =============================================
+INSERT INTO AD_Process_Para (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                             AD_Process_Para_ID, AD_Process_ID, AD_Element_ID, ColumnName, Name, Description,
+                             AD_Reference_ID, DefaultValue, SeqNo, IsMandatory, FieldLength, IsRange, EntityType, IsCentrallyMaintained)
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        543156 /*From ID Server*/, 585596 /*From ID Server*/, 584660 /*From ID Server*/,
+        'IsNormalizeGTIN', 'GTIN/EAN normalisieren',
+        'Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN',
+        20, 'N', 10, 'Y', 1, 'N', 'de.metas.handlingunits', 'Y');
+
+-- AD_Process_Para_Trl: de_DE
+INSERT INTO AD_Process_Para_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                                 AD_Process_Para_ID, Name, Description, Help, IsTranslated)
+VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        543156 /*From ID Server*/,
+        'GTIN/EAN normalisieren',
+        'Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN',
+        NULL, 'N');
+
+-- AD_Process_Para_Trl: de_CH
+INSERT INTO AD_Process_Para_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                                 AD_Process_Para_ID, Name, Description, Help, IsTranslated)
+VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        543156 /*From ID Server*/,
+        'GTIN/EAN normalisieren',
+        'Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN',
+        NULL, 'N');
+
+-- AD_Process_Para_Trl: en_US
+INSERT INTO AD_Process_Para_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                                 AD_Process_Para_ID, Name, Description, Help, IsTranslated)
+VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        543156 /*From ID Server*/,
+        'Normalize GTIN/EAN',
+        'Copies EAN to GTIN when GTIN is empty, clears EAN when identical to GTIN',
+        NULL, 'Y');
+
+-- =============================================
+-- 3. AD_Process_Para: IsConsolidate
+-- =============================================
+INSERT INTO AD_Process_Para (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                             AD_Process_Para_ID, AD_Process_ID, AD_Element_ID, ColumnName, Name, Description,
+                             AD_Reference_ID, DefaultValue, SeqNo, IsMandatory, FieldLength, IsRange, EntityType, IsCentrallyMaintained)
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        543157 /*From ID Server*/, 585596 /*From ID Server*/, 584661 /*From ID Server*/,
+        'IsConsolidate', 'Doppelte Eintraege konsolidieren',
+        'Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zusammen',
+        20, 'N', 20, 'Y', 1, 'N', 'de.metas.handlingunits', 'Y');
+
+-- AD_Process_Para_Trl: de_DE
+INSERT INTO AD_Process_Para_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                                 AD_Process_Para_ID, Name, Description, Help, IsTranslated)
+VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        543157 /*From ID Server*/,
+        'Doppelte Eintraege konsolidieren',
+        'Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zusammen',
+        NULL, 'N');
+
+-- AD_Process_Para_Trl: de_CH
+INSERT INTO AD_Process_Para_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                                 AD_Process_Para_ID, Name, Description, Help, IsTranslated)
+VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        543157 /*From ID Server*/,
+        'Doppelte Eintraege konsolidieren',
+        'Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zusammen',
+        NULL, 'N');
+
+-- AD_Process_Para_Trl: en_US
+INSERT INTO AD_Process_Para_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                                 AD_Process_Para_ID, Name, Description, Help, IsTranslated)
+VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        543157 /*From ID Server*/,
+        'Consolidate duplicates',
+        'Merges duplicate packing instruction allocations with the same GTIN',
+        NULL, 'Y');
+
+-- =============================================
+-- 4. AD_Table_Process (link process to M_HU_PI_Item_Product table)
+-- =============================================
+INSERT INTO AD_Table_Process (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                              AD_Table_Process_ID, AD_Table_ID, AD_Process_ID, EntityType)
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        541632 /*From ID Server*/, 540508, 585596 /*From ID Server*/, 'de.metas.handlingunits');
+
+-- =============================================
+-- 5. AD_Menu
+-- =============================================
+INSERT INTO AD_Menu (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                     AD_Menu_ID, Name, Action, AD_Process_ID, EntityType, IsSOTrx, IsSummary, IsReadOnly)
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        542306 /*From ID Server*/,
+        'CU-TU Zuordnung konsolidieren',
+        'P', 585596 /*From ID Server*/, 'de.metas.handlingunits', 'N', 'N', 'N');
+
+-- AD_Menu_Trl: de_DE
+INSERT INTO AD_Menu_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                         AD_Menu_ID, Name, Description, IsTranslated)
+VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        542306 /*From ID Server*/,
+        'CU-TU Zuordnung konsolidieren', NULL, 'N');
+
+-- AD_Menu_Trl: de_CH
+INSERT INTO AD_Menu_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                         AD_Menu_ID, Name, Description, IsTranslated)
+VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        542306 /*From ID Server*/,
+        'CU-TU Zuordnung konsolidieren', NULL, 'N');
+
+-- AD_Menu_Trl: en_US
+INSERT INTO AD_Menu_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                         AD_Menu_ID, Name, Description, IsTranslated)
+VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        542306 /*From ID Server*/,
+        'Consolidate CU-TU Allocation', NULL, 'Y');
+
+-- =============================================
+-- 6. AD_TreeNodeMM (place menu entry under parent 1000016)
+-- =============================================
+INSERT INTO AD_TreeNodeMM (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                           AD_Tree_ID, Node_ID, Parent_ID, SeqNo)
+SELECT 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+       (SELECT MIN(AD_Tree_ID) FROM AD_Tree WHERE AD_Client_ID = 0 AND IsActive = 'Y' AND IsAllNodes = 'Y' AND AD_Table_ID = 116),
+       542306 /*From ID Server*/,
+       1000016,
+       COALESCE((SELECT MAX(SeqNo) FROM AD_TreeNodeMM
+                 WHERE Parent_ID = 1000016
+                   AND AD_Tree_ID = (SELECT MIN(AD_Tree_ID) FROM AD_Tree WHERE AD_Client_ID = 0 AND IsActive = 'Y' AND IsAllNodes = 'Y' AND AD_Table_ID = 116)),
+                0) + 10;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794130_sys_M_HU_PI_Item_Product_Consolidate_Process.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794130_sys_M_HU_PI_Item_Product_Consolidate_Process.sql
@@ -12,8 +12,8 @@ VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO
         585596 /*From ID Server*/,
         'M_HU_PI_Item_Product_Consolidate_Report',
         'CU-TU Zuordnung konsolidieren',
-        'Normalisiert GTIN/EAN und konsolidiert doppelte Packvorschrift-Zuordnungen. Erstellt einen Excel-Bericht ueber Konflikte.',
-        'Dieser Prozess fuehrt zwei optionale Schritte aus: (1) GTIN/EAN Normalisierung: Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN. (2) Konsolidierung: Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zu einem Eintrag ohne Geschaeftspartner zusammen. Beide Schritte muessen explizit aktiviert werden. Betroffene Tabellen werden vor Aenderungen gesichert. Der Prozess erstellt immer einen Excel-Bericht mit verbleibenden Konflikten.',
+        'Normalisiert GTIN/EAN und konsolidiert doppelte Packvorschrift-Zuordnungen. Erstellt einen Excel-Bericht über Konflikte.',
+        'Dieser Prozess führt zwei optionale Schritte aus: (1) GTIN/EAN Normalisierung: Kopiert EAN in GTIN wenn GTIN leer ist, löscht EAN wenn identisch mit GTIN. (2) Konsolidierung: Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zu einem Eintrag ohne Geschäftspartner zusammen. Beide Schritte müssen explizit aktiviert werden. Betroffene Tabellen werden vor Änderungen gesichert. Der Prozess erstellt immer einen Excel-Bericht mit verbleibenden Konflikten.',
         'de.metas.handlingunits.process.M_HU_PI_Item_Product_Consolidate_Report',
         'N', '3', 'de.metas.handlingunits', 'Y', 'Java');
 
@@ -23,8 +23,8 @@ INSERT INTO AD_Process_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Crea
 VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         585596 /*From ID Server*/,
         'CU-TU Zuordnung konsolidieren',
-        'Normalisiert GTIN/EAN und konsolidiert doppelte Packvorschrift-Zuordnungen. Erstellt einen Excel-Bericht ueber Konflikte.',
-        'Dieser Prozess fuehrt zwei optionale Schritte aus: (1) GTIN/EAN Normalisierung: Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN. (2) Konsolidierung: Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zu einem Eintrag ohne Geschaeftspartner zusammen. Beide Schritte muessen explizit aktiviert werden. Betroffene Tabellen werden vor Aenderungen gesichert. Der Prozess erstellt immer einen Excel-Bericht mit verbleibenden Konflikten.',
+        'Normalisiert GTIN/EAN und konsolidiert doppelte Packvorschrift-Zuordnungen. Erstellt einen Excel-Bericht über Konflikte.',
+        'Dieser Prozess führt zwei optionale Schritte aus: (1) GTIN/EAN Normalisierung: Kopiert EAN in GTIN wenn GTIN leer ist, löscht EAN wenn identisch mit GTIN. (2) Konsolidierung: Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zu einem Eintrag ohne Geschäftspartner zusammen. Beide Schritte müssen explizit aktiviert werden. Betroffene Tabellen werden vor Änderungen gesichert. Der Prozess erstellt immer einen Excel-Bericht mit verbleibenden Konflikten.',
         'N');
 
 -- AD_Process_Trl: de_CH
@@ -33,8 +33,8 @@ INSERT INTO AD_Process_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Crea
 VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         585596 /*From ID Server*/,
         'CU-TU Zuordnung konsolidieren',
-        'Normalisiert GTIN/EAN und konsolidiert doppelte Packvorschrift-Zuordnungen. Erstellt einen Excel-Bericht ueber Konflikte.',
-        'Dieser Prozess fuehrt zwei optionale Schritte aus: (1) GTIN/EAN Normalisierung: Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN. (2) Konsolidierung: Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zu einem Eintrag ohne Geschaeftspartner zusammen. Beide Schritte muessen explizit aktiviert werden. Betroffene Tabellen werden vor Aenderungen gesichert. Der Prozess erstellt immer einen Excel-Bericht mit verbleibenden Konflikten.',
+        'Normalisiert GTIN/EAN und konsolidiert doppelte Packvorschrift-Zuordnungen. Erstellt einen Excel-Bericht über Konflikte.',
+        'Dieser Prozess führt zwei optionale Schritte aus: (1) GTIN/EAN Normalisierung: Kopiert EAN in GTIN wenn GTIN leer ist, löscht EAN wenn identisch mit GTIN. (2) Konsolidierung: Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zu einem Eintrag ohne Geschäftspartner zusammen. Beide Schritte müssen explizit aktiviert werden. Betroffene Tabellen werden vor Änderungen gesichert. Der Prozess erstellt immer einen Excel-Bericht mit verbleibenden Konflikten.',
         'N');
 
 -- AD_Process_Trl: en_US
@@ -56,7 +56,7 @@ INSERT INTO AD_Process_Para (AD_Client_ID, AD_Org_ID, IsActive, Created, Created
 VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         543156 /*From ID Server*/, 585596 /*From ID Server*/, 584660 /*From ID Server*/,
         'IsNormalizeGTIN', 'GTIN/EAN normalisieren',
-        'Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN',
+        'Kopiert EAN in GTIN wenn GTIN leer ist, löscht EAN wenn identisch mit GTIN',
         20, 'N', 10, 'Y', 1, 'N', 'de.metas.handlingunits', 'Y');
 
 -- AD_Process_Para_Trl: de_DE
@@ -65,7 +65,7 @@ INSERT INTO AD_Process_Para_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive,
 VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         543156 /*From ID Server*/,
         'GTIN/EAN normalisieren',
-        'Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN',
+        'Kopiert EAN in GTIN wenn GTIN leer ist, löscht EAN wenn identisch mit GTIN',
         NULL, 'N');
 
 -- AD_Process_Para_Trl: de_CH
@@ -74,7 +74,7 @@ INSERT INTO AD_Process_Para_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive,
 VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         543156 /*From ID Server*/,
         'GTIN/EAN normalisieren',
-        'Kopiert EAN in GTIN wenn GTIN leer ist, loescht EAN wenn identisch mit GTIN',
+        'Kopiert EAN in GTIN wenn GTIN leer ist, löscht EAN wenn identisch mit GTIN',
         NULL, 'N');
 
 -- AD_Process_Para_Trl: en_US
@@ -94,7 +94,7 @@ INSERT INTO AD_Process_Para (AD_Client_ID, AD_Org_ID, IsActive, Created, Created
                              AD_Reference_ID, DefaultValue, SeqNo, IsMandatory, FieldLength, IsRange, EntityType, IsCentrallyMaintained)
 VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         543157 /*From ID Server*/, 585596 /*From ID Server*/, 584661 /*From ID Server*/,
-        'IsConsolidate', 'Doppelte Eintraege konsolidieren',
+        'IsConsolidate', 'Doppelte Einträge konsolidieren',
         'Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zusammen',
         20, 'N', 20, 'Y', 1, 'N', 'de.metas.handlingunits', 'Y');
 
@@ -103,7 +103,7 @@ INSERT INTO AD_Process_Para_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive,
                                  AD_Process_Para_ID, Name, Description, Help, IsTranslated)
 VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         543157 /*From ID Server*/,
-        'Doppelte Eintraege konsolidieren',
+        'Doppelte Einträge konsolidieren',
         'Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zusammen',
         NULL, 'N');
 
@@ -112,7 +112,7 @@ INSERT INTO AD_Process_Para_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive,
                                  AD_Process_Para_ID, Name, Description, Help, IsTranslated)
 VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         543157 /*From ID Server*/,
-        'Doppelte Eintraege konsolidieren',
+        'Doppelte Einträge konsolidieren',
         'Fasst doppelte Packvorschrift-Zuordnungen mit gleicher GTIN zusammen',
         NULL, 'N');
 

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794130_sys_M_HU_PI_Item_Product_Consolidate_Process.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794130_sys_M_HU_PI_Item_Product_Consolidate_Process.sql
@@ -134,14 +134,48 @@ VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO
         541632 /*From ID Server*/, 540508, 585596 /*From ID Server*/, 'de.metas.handlingunits');
 
 -- =============================================
--- 5. AD_Menu
+-- 5. AD_Element for the process menu entry
+-- =============================================
+INSERT INTO AD_Element (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                        AD_Element_ID, ColumnName, Name, PrintName, EntityType)
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        584662 /*From ID Server*/,
+        'M_HU_PI_Item_Product_Consolidate',
+        'CU-TU Zuordnung konsolidieren',
+        'CU-TU Zuordnung konsolidieren',
+        'de.metas.handlingunits');
+
+-- AD_Element_Trl: de_DE
+INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            AD_Element_ID, Name, PrintName, Description, Help, IsTranslated)
+VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        584662 /*From ID Server*/,
+        'CU-TU Zuordnung konsolidieren', 'CU-TU Zuordnung konsolidieren', NULL, NULL, 'N');
+
+-- AD_Element_Trl: de_CH
+INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            AD_Element_ID, Name, PrintName, Description, Help, IsTranslated)
+VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        584662 /*From ID Server*/,
+        'CU-TU Zuordnung konsolidieren', 'CU-TU Zuordnung konsolidieren', NULL, NULL, 'N');
+
+-- AD_Element_Trl: en_US
+INSERT INTO AD_Element_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                            AD_Element_ID, Name, PrintName, Description, Help, IsTranslated)
+VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        584662 /*From ID Server*/,
+        'Consolidate CU-TU Allocation', 'Consolidate CU-TU Allocation', NULL, NULL, 'Y');
+
+-- =============================================
+-- 6. AD_Menu
 -- =============================================
 INSERT INTO AD_Menu (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
-                     AD_Menu_ID, Name, Action, AD_Process_ID, EntityType, IsSOTrx, IsSummary, IsReadOnly)
+                     AD_Menu_ID, Name, InternalName, Action, AD_Process_ID, AD_Element_ID, EntityType, IsSOTrx, IsSummary, IsReadOnly)
 VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0, TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), 0,
         542306 /*From ID Server*/,
         'CU-TU Zuordnung konsolidieren',
-        'P', 585596 /*From ID Server*/, 'de.metas.handlingunits', 'N', 'N', 'N');
+        'M_HU_PI_Item_Product_Consolidate',
+        'P', 585596 /*From ID Server*/, 584662 /*From ID Server*/, 'de.metas.handlingunits', 'N', 'N', 'N');
 
 -- AD_Menu_Trl: de_DE
 INSERT INTO AD_Menu_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
@@ -165,7 +199,7 @@ VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI
         'Consolidate CU-TU Allocation', NULL, 'Y');
 
 -- =============================================
--- 6. AD_TreeNodeMM (place menu entry under parent 1000016)
+-- 7. AD_TreeNodeMM (place menu entry under parent 1000016)
 -- =============================================
 INSERT INTO AD_TreeNodeMM (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
                            AD_Tree_ID, Node_ID, Parent_ID, SeqNo)

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794140_sys_M_HU_PI_Item_Product_Consolidate_UI_Reorder.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794140_sys_M_HU_PI_Item_Product_Consolidate_UI_Reorder.sql
@@ -1,0 +1,10 @@
+-- 2026-03-12
+-- Reorder GTIN/EAN_TU UI elements in Packvorschrift Nachweis window (540717)
+
+-- Move GTIN to front (SeqNo=10)
+UPDATE AD_UI_Element SET SeqNo = 10, Updated = TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 99
+WHERE AD_UI_Element_ID = 563180;
+
+-- Move EAN_TU to advanced edit
+UPDATE AD_UI_Element SET IsAdvancedField = 'Y', Updated = TO_TIMESTAMP('2026-03-12 14:00', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 99
+WHERE AD_UI_Element_ID = 563186;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794150_sys_M_HU_PI_Item_Product_Consolidate_Functions.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5794150_sys_M_HU_PI_Item_Product_Consolidate_Functions.sql
@@ -1,0 +1,464 @@
+-- 2026-03-12
+-- Migration script for M_HU_PI_Item_Product consolidation SQL functions.
+-- Authoritative source files:
+--   backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/m_hu_pi_item_product_consolidate.sql
+--   backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/m_hu_pi_item_product_consolidate_report.sql
+
+-- =============================================
+-- Function 1: m_hu_pi_item_product_consolidate
+-- =============================================
+CREATE OR REPLACE FUNCTION m_hu_pi_item_product_consolidate(
+    p_normalize_gtin_ean boolean,
+    p_consolidate        boolean,
+    p_ad_pinstance_id    numeric DEFAULT 0
+)
+    RETURNS text
+    LANGUAGE plpgsql
+    VOLATILE
+AS
+$$
+DECLARE
+    v_count          bigint;
+    v_summary        text := '';
+    v_backup_name    text;
+    v_groups_count   bigint := 0;
+    v_deactivated    bigint := 0;
+    v_fk_record      record;
+BEGIN
+    -- Early return if nothing requested
+    IF NOT p_normalize_gtin_ean AND NOT p_consolidate THEN
+        RETURN 'No action requested';
+    END IF;
+
+    -- Backup main table
+    v_backup_name := backup_table('M_HU_PI_Item_Product', '_pi' || p_ad_pinstance_id);
+    RAISE NOTICE 'Backup: %', v_backup_name;
+
+    -- ==========================================
+    -- Step 1: Normalize GTIN/EAN
+    -- ==========================================
+    IF p_normalize_gtin_ean THEN
+        -- Copy EAN_TU to GTIN where GTIN is missing
+        UPDATE M_HU_PI_Item_Product
+        SET GTIN    = EAN_TU,
+            Updated = now(),
+            UpdatedBy = 99
+        WHERE GTIN IS NULL
+          AND EAN_TU IS NOT NULL
+          AND IsActive = 'Y';
+        GET DIAGNOSTICS v_count = ROW_COUNT;
+        RAISE NOTICE 'Normalized EAN->GTIN: % records', v_count;
+        v_summary := v_summary || 'Normalized EAN->GTIN: ' || v_count || ' records. ';
+
+        -- Clear EAN_TU where it duplicates GTIN
+        UPDATE M_HU_PI_Item_Product
+        SET EAN_TU  = NULL,
+            Updated = now(),
+            UpdatedBy = 99
+        WHERE GTIN = EAN_TU
+          AND EAN_TU IS NOT NULL
+          AND IsActive = 'Y';
+        GET DIAGNOSTICS v_count = ROW_COUNT;
+        RAISE NOTICE 'Cleared duplicate EAN: % records', v_count;
+        v_summary := v_summary || 'Cleared duplicate EAN: ' || v_count || ' records. ';
+    END IF;
+
+    -- ==========================================
+    -- Step 2: Consolidate duplicates
+    -- (Intentionally global -- no AD_Client/AD_Org filter.
+    --  This is a one-time migration tool meant to run across
+    --  all records in the database.)
+    -- ==========================================
+    IF p_consolidate THEN
+        -- Clean up temp tables in case of re-run after error
+        DROP TABLE IF EXISTS tmp_consolidation_groups;
+        DROP TABLE IF EXISTS tmp_survivors;
+
+        -- 2a: Find consolidation groups (same Product + GTIN + PI_Item, multiple active records)
+        CREATE TEMP TABLE tmp_consolidation_groups AS
+        SELECT M_Product_ID,
+               GTIN,
+               M_HU_PI_Item_ID,
+               COUNT(*) AS record_count
+        FROM M_HU_PI_Item_Product
+        WHERE IsActive = 'Y'
+          AND GTIN IS NOT NULL
+        GROUP BY M_Product_ID, GTIN, M_HU_PI_Item_ID
+        HAVING COUNT(*) > 1;
+
+        SELECT COUNT(*) INTO v_groups_count FROM tmp_consolidation_groups;
+        RAISE NOTICE 'Found % consolidation groups', v_groups_count;
+
+        IF v_groups_count = 0 THEN
+            DROP TABLE IF EXISTS tmp_consolidation_groups;
+            v_summary := v_summary || 'Consolidation: 0 groups found, nothing to do.';
+            RETURN v_summary;
+        END IF;
+
+        -- 2b: Remove groups with field conflicts
+        DELETE FROM tmp_consolidation_groups g
+        WHERE EXISTS (
+            SELECT 1
+            FROM M_HU_PI_Item_Product p1
+                     JOIN M_HU_PI_Item_Product p2
+                          ON p1.M_Product_ID = p2.M_Product_ID
+                              AND p1.GTIN = p2.GTIN
+                              AND p1.M_HU_PI_Item_ID = p2.M_HU_PI_Item_ID
+                              AND p1.M_HU_PI_Item_Product_ID < p2.M_HU_PI_Item_Product_ID
+            WHERE p1.IsActive = 'Y'
+              AND p2.IsActive = 'Y'
+              AND p1.M_Product_ID = g.M_Product_ID
+              AND p1.GTIN = g.GTIN
+              AND p1.M_HU_PI_Item_ID = g.M_HU_PI_Item_ID
+              AND (p1.Qty != p2.Qty
+                OR COALESCE(p1.C_UOM_ID, 0) != COALESCE(p2.C_UOM_ID, 0)
+                OR p1.IsInfiniteCapacity != p2.IsInfiniteCapacity
+                OR COALESCE(p1.EAN_TU, '') != COALESCE(p2.EAN_TU, '')
+                OR COALESCE(p1.UPC, '') != COALESCE(p2.UPC, '')
+                OR p1.IsAllowAnyProduct != p2.IsAllowAnyProduct
+                OR p1.IsDefaultForProduct != p2.IsDefaultForProduct)
+        );
+        GET DIAGNOSTICS v_count = ROW_COUNT;
+        RAISE NOTICE 'Skipped % groups with field conflicts', v_count;
+
+        SELECT COUNT(*) INTO v_groups_count FROM tmp_consolidation_groups;
+        RAISE NOTICE 'Proceeding with % conflict-free groups', v_groups_count;
+
+        IF v_groups_count = 0 THEN
+            DROP TABLE IF EXISTS tmp_consolidation_groups;
+            v_summary := v_summary || 'Consolidation: all groups had conflicts, nothing consolidated.';
+            RETURN v_summary;
+        END IF;
+
+        -- 2c: Pick survivors (prefer C_BPartner_ID IS NULL, then lowest ID)
+        CREATE TEMP TABLE tmp_survivors AS
+        SELECT DISTINCT ON (g.M_Product_ID, g.GTIN, g.M_HU_PI_Item_ID)
+            p.M_HU_PI_Item_Product_ID AS survivor_id,
+            g.M_Product_ID,
+            g.GTIN,
+            g.M_HU_PI_Item_ID
+        FROM tmp_consolidation_groups g
+                 JOIN M_HU_PI_Item_Product p
+                      ON p.M_Product_ID = g.M_Product_ID
+                          AND p.GTIN = g.GTIN
+                          AND p.M_HU_PI_Item_ID = g.M_HU_PI_Item_ID
+                          AND p.IsActive = 'Y'
+        ORDER BY g.M_Product_ID, g.GTIN, g.M_HU_PI_Item_ID,
+                 (CASE WHEN p.C_BPartner_ID IS NULL THEN 0 ELSE 1 END),
+                 p.M_HU_PI_Item_Product_ID;
+
+        -- 2d: Discover and update FK references dynamically
+        FOR v_fk_record IN
+            SELECT DISTINCT
+                tc.table_name  AS fk_table,
+                kcu.column_name AS fk_column
+            FROM information_schema.table_constraints tc
+                     JOIN information_schema.key_column_usage kcu
+                          ON tc.constraint_name = kcu.constraint_name
+                     JOIN information_schema.constraint_column_usage ccu
+                          ON tc.constraint_name = ccu.constraint_name
+            WHERE tc.constraint_type = 'FOREIGN KEY'
+              AND ccu.table_name = 'm_hu_pi_item_product'
+              AND ccu.column_name = 'm_hu_pi_item_product_id'
+            LOOP
+                -- Backup FK table
+                v_backup_name := backup_table(v_fk_record.fk_table, '_pi' || p_ad_pinstance_id);
+                RAISE NOTICE 'Backup FK table: %', v_backup_name;
+
+                -- Update FK references from non-survivors to survivors
+                BEGIN
+                    EXECUTE format(
+                            'UPDATE %I SET %I = s.survivor_id, Updated = now(), UpdatedBy = 99
+                             FROM tmp_survivors s
+                             JOIN M_HU_PI_Item_Product p ON p.M_Product_ID = s.M_Product_ID
+                                 AND p.GTIN = s.GTIN AND p.M_HU_PI_Item_ID = s.M_HU_PI_Item_ID
+                                 AND p.M_HU_PI_Item_Product_ID != s.survivor_id AND p.IsActive = ''Y''
+                             WHERE %I.%I = p.M_HU_PI_Item_Product_ID',
+                            v_fk_record.fk_table, v_fk_record.fk_column,
+                            v_fk_record.fk_table, v_fk_record.fk_column
+                            );
+                    GET DIAGNOSTICS v_count = ROW_COUNT;
+                    IF v_count > 0 THEN
+                        RAISE NOTICE 'Updated % FK references in %.%', v_count, v_fk_record.fk_table, v_fk_record.fk_column;
+                    END IF;
+                EXCEPTION
+                    WHEN unique_violation THEN
+                        RAISE NOTICE 'WARNING: Could not update FK references in %.% due to unique constraint violation -- skipping', v_fk_record.fk_table, v_fk_record.fk_column;
+                END;
+            END LOOP;
+
+        -- 2e: Update survivors with widest date range and clear C_BPartner_ID
+        UPDATE M_HU_PI_Item_Product survivor
+        SET C_BPartner_ID = NULL,
+            ValidFrom     = sub.min_validfrom,
+            ValidTo       = sub.max_validto,
+            Updated       = now(),
+            UpdatedBy     = 99
+        FROM (SELECT s.survivor_id,
+                     MIN(p.ValidFrom) AS min_validfrom,
+                     MAX(p.ValidTo)   AS max_validto
+              FROM tmp_survivors s
+                       JOIN M_HU_PI_Item_Product p
+                            ON p.M_Product_ID = s.M_Product_ID
+                                AND p.GTIN = s.GTIN
+                                AND p.M_HU_PI_Item_ID = s.M_HU_PI_Item_ID
+                                AND p.IsActive = 'Y'
+              GROUP BY s.survivor_id) sub
+        WHERE survivor.M_HU_PI_Item_Product_ID = sub.survivor_id;
+        GET DIAGNOSTICS v_count = ROW_COUNT;
+        RAISE NOTICE 'Updated % survivors (date range + cleared partner)', v_count;
+
+        -- 2f: Deactivate non-survivors
+        UPDATE M_HU_PI_Item_Product p
+        SET IsActive  = 'N',
+            Updated   = now(),
+            UpdatedBy = 99
+        FROM tmp_survivors s
+        WHERE p.M_Product_ID = s.M_Product_ID
+          AND p.GTIN = s.GTIN
+          AND p.M_HU_PI_Item_ID = s.M_HU_PI_Item_ID
+          AND p.M_HU_PI_Item_Product_ID != s.survivor_id
+          AND p.IsActive = 'Y';
+        GET DIAGNOSTICS v_deactivated = ROW_COUNT;
+        RAISE NOTICE 'Deactivated % non-survivor records across % groups', v_deactivated, v_groups_count;
+
+        -- 2g: Drop temp tables
+        DROP TABLE IF EXISTS tmp_consolidation_groups;
+        DROP TABLE IF EXISTS tmp_survivors;
+
+        v_summary := v_summary || 'Consolidated ' || v_groups_count || ' groups, deactivated ' || v_deactivated || ' records.';
+    END IF;
+
+    RETURN v_summary;
+END;
+$$;
+
+COMMENT ON FUNCTION m_hu_pi_item_product_consolidate(boolean, boolean, numeric) IS
+    'Normalizes GTIN/EAN fields and consolidates duplicate M_HU_PI_Item_Product records with the same GTIN into one partner-less record. Backs up affected tables before modifications.';
+
+-- =============================================
+-- Function 2: m_hu_pi_item_product_consolidate_report
+-- =============================================
+CREATE OR REPLACE FUNCTION m_hu_pi_item_product_consolidate_report(p_ad_language text DEFAULT 'de_DE')
+    RETURNS TABLE
+            (
+                issue_type              text,
+                gtin                    text,
+                product_value           text,
+                product_name            text,
+                pi_name                 text,
+                m_hu_pi_item_product_id numeric,
+                bpartner_value          text,
+                bpartner_name           text,
+                qty                     numeric,
+                uom_symbol              text,
+                validfrom               timestamp,
+                validto                 timestamp,
+                conflicting_field       text
+            )
+    LANGUAGE plpgsql
+    STABLE
+AS
+$BODY$
+BEGIN
+    RETURN QUERY
+
+        --
+        -- 1. CONFLICT_DIFFERENT_PI
+        --    Active records sharing a GTIN but with different M_HU_PI_Item_ID
+        --
+        SELECT COALESCE(trl1.MsgText, msg1.MsgText)::text AS issue_type,
+               pip.GTIN::text                              AS gtin,
+               prod.Value::text                            AS product_value,
+               prod.Name::text                             AS product_name,
+               pi.Name::text                               AS pi_name,
+               pip.M_HU_PI_Item_Product_ID                 AS m_hu_pi_item_product_id,
+               bp.Value::text                              AS bpartner_value,
+               bp.Name::text                               AS bpartner_name,
+               pip.Qty                                     AS qty,
+               uom.UOMSymbol::text                         AS uom_symbol,
+               pip.ValidFrom::timestamp                    AS validfrom,
+               pip.ValidTo::timestamp                      AS validto,
+               NULL::text                                  AS conflicting_field
+        FROM M_HU_PI_Item_Product pip
+                 JOIN M_Product prod ON prod.M_Product_ID = pip.M_Product_ID
+                 JOIN M_HU_PI_Item pi_item ON pi_item.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                 JOIN M_HU_PI_Version piv ON piv.M_HU_PI_Version_ID = pi_item.M_HU_PI_Version_ID
+                 JOIN M_HU_PI pi ON pi.M_HU_PI_ID = piv.M_HU_PI_ID
+                 LEFT JOIN C_BPartner bp ON bp.C_BPartner_ID = pip.C_BPartner_ID
+                 LEFT JOIN C_UOM uom ON uom.C_UOM_ID = pip.C_UOM_ID
+                 JOIN AD_Message msg1 ON msg1.Value = 'M_HU_PI_Item_Product_Conflict_DifferentPI'
+                 LEFT JOIN AD_Message_Trl trl1
+                           ON trl1.AD_Message_ID = msg1.AD_Message_ID
+                               AND trl1.AD_Language = p_ad_language
+                               AND trl1.IsActive = 'Y'
+        WHERE pip.IsActive = 'Y'
+          AND pip.GTIN IS NOT NULL
+          AND pip.GTIN <> ''
+          AND pip.GTIN IN (SELECT sub.GTIN
+                           FROM M_HU_PI_Item_Product sub
+                           WHERE sub.IsActive = 'Y'
+                             AND sub.GTIN IS NOT NULL
+                             AND sub.GTIN <> ''
+                           GROUP BY sub.GTIN
+                           HAVING COUNT(DISTINCT sub.M_HU_PI_Item_ID) > 1)
+
+        UNION ALL
+
+        --
+        -- 2. CONFLICT_DIFFERENT_PRODUCT
+        --    Active records sharing a GTIN and M_HU_PI_Item_ID but with different M_Product_ID
+        --
+        SELECT COALESCE(trl2.MsgText, msg2.MsgText)::text AS issue_type,
+               pip.GTIN::text                              AS gtin,
+               prod.Value::text                            AS product_value,
+               prod.Name::text                             AS product_name,
+               pi.Name::text                               AS pi_name,
+               pip.M_HU_PI_Item_Product_ID                 AS m_hu_pi_item_product_id,
+               bp.Value::text                              AS bpartner_value,
+               bp.Name::text                               AS bpartner_name,
+               pip.Qty                                     AS qty,
+               uom.UOMSymbol::text                         AS uom_symbol,
+               pip.ValidFrom::timestamp                    AS validfrom,
+               pip.ValidTo::timestamp                      AS validto,
+               NULL::text                                  AS conflicting_field
+        FROM M_HU_PI_Item_Product pip
+                 JOIN M_Product prod ON prod.M_Product_ID = pip.M_Product_ID
+                 JOIN M_HU_PI_Item pi_item ON pi_item.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                 JOIN M_HU_PI_Version piv ON piv.M_HU_PI_Version_ID = pi_item.M_HU_PI_Version_ID
+                 JOIN M_HU_PI pi ON pi.M_HU_PI_ID = piv.M_HU_PI_ID
+                 LEFT JOIN C_BPartner bp ON bp.C_BPartner_ID = pip.C_BPartner_ID
+                 LEFT JOIN C_UOM uom ON uom.C_UOM_ID = pip.C_UOM_ID
+                 JOIN AD_Message msg2 ON msg2.Value = 'M_HU_PI_Item_Product_Conflict_DifferentProduct'
+                 LEFT JOIN AD_Message_Trl trl2
+                           ON trl2.AD_Message_ID = msg2.AD_Message_ID
+                               AND trl2.AD_Language = p_ad_language
+                               AND trl2.IsActive = 'Y'
+        WHERE pip.IsActive = 'Y'
+          AND pip.GTIN IS NOT NULL
+          AND pip.GTIN <> ''
+          AND (pip.GTIN, pip.M_HU_PI_Item_ID) IN (SELECT sub.GTIN, sub.M_HU_PI_Item_ID
+                                                   FROM M_HU_PI_Item_Product sub
+                                                   WHERE sub.IsActive = 'Y'
+                                                     AND sub.GTIN IS NOT NULL
+                                                     AND sub.GTIN <> ''
+                                                   GROUP BY sub.GTIN, sub.M_HU_PI_Item_ID
+                                                   HAVING COUNT(DISTINCT sub.M_Product_ID) > 1)
+
+        UNION ALL
+
+        --
+        -- 3. CONFLICT_DIFFERENT_FIELDS
+        --    Active records sharing (M_Product_ID, GTIN, M_HU_PI_Item_ID) with >1 record
+        --    where non-date fields differ
+        --
+        SELECT COALESCE(trl3.MsgText, msg3.MsgText)::text AS issue_type,
+               pip.GTIN::text                              AS gtin,
+               prod.Value::text                            AS product_value,
+               prod.Name::text                             AS product_name,
+               pi.Name::text                               AS pi_name,
+               pip.M_HU_PI_Item_Product_ID                 AS m_hu_pi_item_product_id,
+               bp.Value::text                              AS bpartner_value,
+               bp.Name::text                               AS bpartner_name,
+               pip.Qty                                     AS qty,
+               uom.UOMSymbol::text                         AS uom_symbol,
+               pip.ValidFrom::timestamp                    AS validfrom,
+               pip.ValidTo::timestamp                      AS validto,
+               diffs.conflicting_fields::text              AS conflicting_field
+        FROM M_HU_PI_Item_Product pip
+                 JOIN M_Product prod ON prod.M_Product_ID = pip.M_Product_ID
+                 JOIN M_HU_PI_Item pi_item ON pi_item.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                 JOIN M_HU_PI_Version piv ON piv.M_HU_PI_Version_ID = pi_item.M_HU_PI_Version_ID
+                 JOIN M_HU_PI pi ON pi.M_HU_PI_ID = piv.M_HU_PI_ID
+                 LEFT JOIN C_BPartner bp ON bp.C_BPartner_ID = pip.C_BPartner_ID
+                 LEFT JOIN C_UOM uom ON uom.C_UOM_ID = pip.C_UOM_ID
+                 JOIN AD_Message msg3 ON msg3.Value = 'M_HU_PI_Item_Product_Conflict_DifferentFields'
+                 LEFT JOIN AD_Message_Trl trl3
+                           ON trl3.AD_Message_ID = msg3.AD_Message_ID
+                               AND trl3.AD_Language = p_ad_language
+                               AND trl3.IsActive = 'Y'
+                 JOIN LATERAL (
+                    SELECT string_agg(DISTINCT field_name, ', ' ORDER BY field_name) AS conflicting_fields
+                    FROM (
+                             SELECT 'Qty' AS field_name
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.Qty, 0) <> COALESCE(pip.Qty, 0)
+                             UNION
+                             SELECT 'C_UOM_ID'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.C_UOM_ID, 0) <> COALESCE(pip.C_UOM_ID, 0)
+                             UNION
+                             SELECT 'IsInfiniteCapacity'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.IsInfiniteCapacity, 'N') <> COALESCE(pip.IsInfiniteCapacity, 'N')
+                             UNION
+                             SELECT 'EAN_TU'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.EAN_TU, '') <> COALESCE(pip.EAN_TU, '')
+                             UNION
+                             SELECT 'UPC'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.UPC, '') <> COALESCE(pip.UPC, '')
+                             UNION
+                             SELECT 'IsAllowAnyProduct'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.IsAllowAnyProduct, 'N') <> COALESCE(pip.IsAllowAnyProduct, 'N')
+                             UNION
+                             SELECT 'IsDefaultForProduct'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.IsDefaultForProduct, 'N') <> COALESCE(pip.IsDefaultForProduct, 'N')
+                         ) fields
+                    ) diffs ON diffs.conflicting_fields IS NOT NULL
+        WHERE pip.IsActive = 'Y'
+          AND pip.GTIN IS NOT NULL
+          AND pip.GTIN <> ''
+          AND (pip.M_Product_ID, pip.GTIN, pip.M_HU_PI_Item_ID) IN
+              (SELECT sub.M_Product_ID, sub.GTIN, sub.M_HU_PI_Item_ID
+               FROM M_HU_PI_Item_Product sub
+               WHERE sub.IsActive = 'Y'
+                 AND sub.GTIN IS NOT NULL
+                 AND sub.GTIN <> ''
+               GROUP BY sub.M_Product_ID, sub.GTIN, sub.M_HU_PI_Item_ID
+               HAVING COUNT(*) > 1)
+
+        ORDER BY issue_type, gtin, product_value;
+END;
+$BODY$;
+
+COMMENT ON FUNCTION m_hu_pi_item_product_consolidate_report(text) IS
+    'Returns a data quality report of M_HU_PI_Item_Product records with GTIN conflicts: same GTIN across different packing instructions, different products, or records that could not be consolidated due to differing field values.';

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Item_Product_Consolidation_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Item_Product_Consolidation_StepDef.java
@@ -1,0 +1,242 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.hu;
+
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.util.DB;
+import org.compiere.util.SQLValueStringResult;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Step definitions for testing the {@code m_hu_pi_item_product_consolidate()} and
+ * {@code m_hu_pi_item_product_consolidate_report()} SQL functions.
+ *
+ * <p>These tests require a running database (tagged {@code @ignore} in the feature file)
+ * because the SQL functions operate directly on the DB tables.</p>
+ *
+ * <h3>Steps provided:</h3>
+ * <ul>
+ *   <li>{@code When M_HU_PI_Item_Product consolidation is called with p_normalize_gtin_ean=... and p_consolidate=...}
+ *       — Calls the consolidation SQL function</li>
+ *   <li>{@code When M_HU_PI_Item_Product consolidation report is called}
+ *       — Calls the report SQL function</li>
+ *   <li>{@code Then M_HU_PI_Item_Product identified by '...' has GTIN='...' and EAN_TU=...}
+ *       — Validates GTIN and EAN_TU fields after normalization</li>
+ *   <li>{@code Then M_HU_PI_Item_Product identified by '...' has IsActive='...'}
+ *       — Validates active/inactive state after consolidation</li>
+ *   <li>{@code Then the surviving M_HU_PI_Item_Product for GTIN '...' has ValidFrom='...' and ValidTo='...'}
+ *       — Validates date range on the surviving record</li>
+ *   <li>{@code Then the consolidation report contains a conflict row for GTIN '...'}
+ *       — Validates that the report function returns conflict rows for a given GTIN</li>
+ * </ul>
+ */
+@RequiredArgsConstructor
+public class M_HU_PI_Item_Product_Consolidation_StepDef
+{
+	@NonNull private final M_HU_PI_Item_Product_StepDefData huPiItemProductTable;
+
+	private List<ReportRow> lastReportResult;
+
+	// -------------------------------------------------------------------
+	// When steps
+	// -------------------------------------------------------------------
+
+	@When("M_HU_PI_Item_Product consolidation is called with p_normalize_gtin_ean={string} and p_consolidate={string}")
+	public void consolidation_called(@NonNull final String normalizeGtinEanStr, @NonNull final String consolidateStr)
+	{
+		final boolean normalizeGtinEan = Boolean.parseBoolean(normalizeGtinEanStr);
+		final boolean consolidate = Boolean.parseBoolean(consolidateStr);
+
+		final String sql = "SELECT m_hu_pi_item_product_consolidate(?, ?, 0)";
+		final SQLValueStringResult result = DB.getSQLValueStringWithWarningEx(
+				ITrx.TRXNAME_None,
+				sql,
+				normalizeGtinEan,
+				consolidate);
+		assertThat(result).isNotNull();
+	}
+
+	@When("M_HU_PI_Item_Product consolidation report is called")
+	public void consolidation_report_called()
+	{
+		lastReportResult = new ArrayList<>();
+		final String sql = "SELECT * FROM m_hu_pi_item_product_consolidate_report(?)";
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		try
+		{
+			pstmt = DB.prepareStatement(sql, ITrx.TRXNAME_None);
+			pstmt.setString(1, "de_DE");
+			rs = pstmt.executeQuery();
+			while (rs.next())
+			{
+				lastReportResult.add(ReportRow.builder()
+						.issueType(rs.getString("issue_type"))
+						.gtin(rs.getString("gtin"))
+						.productValue(rs.getString("product_value"))
+						.conflictingField(rs.getString("conflicting_field"))
+						.build());
+			}
+		}
+		catch (final Exception e)
+		{
+			throw new RuntimeException("Failed to call m_hu_pi_item_product_consolidate_report", e);
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+		}
+	}
+
+	// -------------------------------------------------------------------
+	// Then steps
+	// -------------------------------------------------------------------
+
+	@Then("M_HU_PI_Item_Product identified by {string} has GTIN={string} and EAN_TU=null")
+	public void verify_gtin_and_ean_null(
+			@NonNull final String identifier,
+			@NonNull final String expectedGtin)
+	{
+		final I_M_HU_PI_Item_Product record = refreshRecord(identifier);
+		assertThat(record.getGTIN()).as("GTIN of " + identifier).isEqualTo(expectedGtin);
+		assertThat(record.getEAN_TU()).as("EAN_TU of " + identifier).isNull();
+	}
+
+	@Then("M_HU_PI_Item_Product identified by {string} has GTIN={string} and EAN_TU={string}")
+	public void verify_gtin_and_ean(
+			@NonNull final String identifier,
+			@NonNull final String expectedGtin,
+			@NonNull final String expectedEan)
+	{
+		final I_M_HU_PI_Item_Product record = refreshRecord(identifier);
+		assertThat(record.getGTIN()).as("GTIN of " + identifier).isEqualTo(expectedGtin);
+		assertThat(record.getEAN_TU()).as("EAN_TU of " + identifier).isEqualTo(expectedEan);
+	}
+
+	@Then("M_HU_PI_Item_Product identified by {string} has IsActive={string}")
+	public void verify_is_active(
+			@NonNull final String identifier,
+			@NonNull final String expectedIsActive)
+	{
+		final I_M_HU_PI_Item_Product record = refreshRecord(identifier);
+		final boolean expectedActive = "Y".equalsIgnoreCase(expectedIsActive);
+		assertThat(record.isActive()).as("IsActive of " + identifier).isEqualTo(expectedActive);
+	}
+
+	@Then("the surviving M_HU_PI_Item_Product for GTIN {string} has ValidFrom={string} and ValidTo={string}")
+	public void verify_survivor_date_range(
+			@NonNull final String gtin,
+			@NonNull final String expectedValidFromStr,
+			@NonNull final String expectedValidToStr)
+	{
+		final LocalDate expectedValidFrom = LocalDate.parse(expectedValidFromStr);
+		final LocalDate expectedValidTo = LocalDate.parse(expectedValidToStr);
+
+		// Find the surviving (active) record for the given GTIN
+		final String sql = "SELECT M_HU_PI_Item_Product_ID, ValidFrom, ValidTo"
+				+ " FROM M_HU_PI_Item_Product"
+				+ " WHERE GTIN = ? AND IsActive = 'Y'"
+				+ " ORDER BY M_HU_PI_Item_Product_ID"
+				+ " LIMIT 1";
+
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		try
+		{
+			pstmt = DB.prepareStatement(sql, ITrx.TRXNAME_None);
+			pstmt.setString(1, gtin);
+			rs = pstmt.executeQuery();
+			assertThat(rs.next()).as("Expected at least one active record for GTIN " + gtin).isTrue();
+
+			final Timestamp validFrom = rs.getTimestamp("ValidFrom");
+			final Timestamp validTo = rs.getTimestamp("ValidTo");
+
+			assertThat(validFrom).as("ValidFrom for GTIN " + gtin).isNotNull();
+			assertThat(validFrom.toLocalDateTime().toLocalDate()).isEqualTo(expectedValidFrom);
+
+			assertThat(validTo).as("ValidTo for GTIN " + gtin).isNotNull();
+			assertThat(validTo.toLocalDateTime().toLocalDate()).isEqualTo(expectedValidTo);
+		}
+		catch (final Exception e)
+		{
+			throw new RuntimeException("Failed to query survivor for GTIN " + gtin, e);
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+		}
+	}
+
+	@Then("the consolidation report contains a conflict row for GTIN {string}")
+	public void verify_report_contains_conflict_for_gtin(@NonNull final String expectedGtin)
+	{
+		assertThat(lastReportResult)
+				.as("Report should contain rows")
+				.isNotEmpty();
+
+		final boolean found = lastReportResult.stream()
+				.anyMatch(row -> expectedGtin.equals(row.gtin));
+
+		assertThat(found)
+				.as("Report should contain a conflict row for GTIN " + expectedGtin)
+				.isTrue();
+	}
+
+	// -------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------
+
+	/**
+	 * Refresh the record from the database to pick up changes made by the SQL function.
+	 */
+	private I_M_HU_PI_Item_Product refreshRecord(@NonNull final String identifier)
+	{
+		final I_M_HU_PI_Item_Product record = huPiItemProductTable.get(identifier);
+		InterfaceWrapperHelper.refresh(record);
+		return record;
+	}
+
+	@lombok.Value
+	@lombok.Builder
+	private static class ReportRow
+	{
+		String issueType;
+		String gtin;
+		String productValue;
+		String conflictingField;
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Item_Product_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Item_Product_StepDef.java
@@ -79,6 +79,36 @@ public class M_HU_PI_Item_Product_StepDef
 	@NonNull private final C_BPartner_StepDefData bpartnerTable;
 	@NonNull private final TestContext restTestContext;
 
+	/**
+	 * Creates or updates {@link I_M_HU_PI_Item_Product} records.
+	 * Looks up an existing record by (M_Product_ID, M_HU_PI_Item_ID, IsActive, Qty/UOM) before creating a new one.
+	 *
+	 * <h3>Required columns:</h3>
+	 * <ul>
+	 *   <li>{@code Identifier} — step-def identifier for cross-step references</li>
+	 *   <li>{@code M_Product_ID} — product identifier (references M_Product_StepDefData)</li>
+	 *   <li>{@code M_HU_PI_Item_ID} — packing instruction item identifier (references M_HU_PI_Item_StepDefData, or raw ID)</li>
+	 *   <li>{@code Qty} + {@code C_UOM_ID.X12DE355} — quantity per TU and UOM (required unless IsInfiniteCapacity=true)</li>
+	 * </ul>
+	 *
+	 * <h3>Optional columns:</h3>
+	 * <ul>
+	 *   <li>{@code GTIN} — Global Trade Item Number</li>
+	 *   <li>{@code EAN_TU} — EAN code of the TU</li>
+	 *   <li>{@code UPC} — Universal Product Code</li>
+	 *   <li>{@code C_BPartner_ID} — business partner identifier (references C_BPartner_StepDefData)</li>
+	 *   <li>{@code ValidFrom} — valid-from date (default: {@link StepDefConstants#DEFAULT_ValidFrom})</li>
+	 *   <li>{@code ValidTo} — valid-to date</li>
+	 *   <li>{@code IsActive} — active flag (default: true)</li>
+	 *   <li>{@code IsAllowAnyProduct} — allow any product flag (default: false)</li>
+	 *   <li>{@code IsDefaultForProduct} — default for product flag (default: false)</li>
+	 *   <li>{@code IsInfiniteCapacity} — infinite capacity flag (default: false); when true, Qty is set to 0</li>
+	 *   <li>{@code IsOrderInTuUomWhenMatched} — order in TU UOM when matched</li>
+	 *   <li>{@code Name} — display name</li>
+	 *   <li>{@code M_HU_PackagingCode_LU_Fallback_ID} — fallback LU packaging code (references M_HU_PackagingCode_StepDefData)</li>
+	 *   <li>{@code GTIN_LU_PackingMaterial_Fallback} — fallback GTIN for LU packing material</li>
+	 * </ul>
+	 */
 	@Given("metasfresh contains M_HU_PI_Item_Product:")
 	public void metasfresh_contains_m_hu_pi_item_product(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Item_Product_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Item_Product_StepDef.java
@@ -132,7 +132,10 @@ public class M_HU_PI_Item_Product_StepDef
 		huPiItemProductRecord.setValidFrom(TimeUtil.asTimestamp(validFrom));
 		huPiItemProductRecord.setIsActive(active);
 		tableRow.getAsOptionalString(COLUMNNAME_GTIN).ifPresent(huPiItemProductRecord::setGTIN);
+		tableRow.getAsOptionalString(I_M_HU_PI_Item_Product.COLUMNNAME_EAN_TU).ifPresent(huPiItemProductRecord::setEAN_TU);
 		tableRow.getAsOptionalBoolean(COLUMNNAME_IsOrderInTuUomWhenMatched).ifPresent(huPiItemProductRecord::setIsOrderInTuUomWhenMatched);
+		tableRow.getAsOptionalLocalDate(I_M_HU_PI_Item_Product.COLUMNNAME_ValidTo)
+				.ifPresent(validTo -> huPiItemProductRecord.setValidTo(TimeUtil.asTimestamp(validTo)));
 
 		huPiItemProductRecord.setIsInfiniteCapacity(isInfiniteCapacity);
 		if (isInfiniteCapacity)

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/m_hu_pi_item_product_consolidation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/m_hu_pi_item_product_consolidation.feature
@@ -1,0 +1,115 @@
+@from:developer
+@ignore
+Feature: M_HU_PI_Item_Product consolidation SQL function tests
+  Verifies that the m_hu_pi_item_product_consolidate() and
+  m_hu_pi_item_product_consolidate_report() SQL functions correctly:
+  - Normalize GTIN/EAN_TU fields
+  - Consolidate duplicate records (same Product + GTIN + PI_Item)
+  - Detect and report conflicts
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-05-17T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+
+    # Common test data: product, UOM, BPartners, PI hierarchy
+    And metasfresh contains M_Products:
+      | Identifier     |
+      | consol_product |
+    And metasfresh contains C_BPartners:
+      | Identifier  | Name              | IsCustomer | IsVendor |
+      | consol_bp1  | Consolidation BP1 | Y          | N        |
+      | consol_bp2  | Consolidation BP2 | Y          | N        |
+    And metasfresh contains M_HU_PI:
+      | Identifier | Name            |
+      | consol_pi  | Consolidation PI |
+    And metasfresh contains M_HU_PI_Version:
+      | Identifier     | M_HU_PI_ID | HU_UnitType |
+      | consol_pi_ver  | consol_pi  | TU          |
+    And metasfresh contains M_HU_PI_Item:
+      | Identifier      | M_HU_PI_Version_ID | ItemType |
+      | consol_pi_item  | consol_pi_ver      | MI       |
+
+  @from:developer
+  Scenario: GTIN normalization — EAN_TU copied to GTIN, then EAN_TU cleared
+    Given metasfresh contains M_HU_PI_Item_Product:
+      | Identifier | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | EAN_TU        |
+      | pip_ean1   | consol_product | consol_pi_item  | 10  | PCE               | 4006381333931 |
+    When M_HU_PI_Item_Product consolidation is called with p_normalize_gtin_ean='true' and p_consolidate='false'
+    Then M_HU_PI_Item_Product identified by 'pip_ean1' has GTIN='4006381333931' and EAN_TU=null
+
+  @from:developer
+  Scenario: GTIN normalization — EAN_TU cleared when same as GTIN
+    Given metasfresh contains M_HU_PI_Item_Product:
+      | Identifier | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          | EAN_TU        |
+      | pip_dup1   | consol_product | consol_pi_item  | 10  | PCE               | 4006381333931 | 4006381333931 |
+    When M_HU_PI_Item_Product consolidation is called with p_normalize_gtin_ean='true' and p_consolidate='false'
+    Then M_HU_PI_Item_Product identified by 'pip_dup1' has GTIN='4006381333931' and EAN_TU=null
+
+  @from:developer
+  Scenario: Consolidation — identical records merged, partner-less record survives
+    Given metasfresh contains M_HU_PI_Item_Product:
+      | Identifier | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          |
+      | pip_nopart | consol_product | consol_pi_item  | 10  | PCE               | 4007817525074 |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | Identifier | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          | C_BPartner_ID |
+      | pip_bp1    | consol_product | consol_pi_item  | 10  | PCE               | 4007817525074 | consol_bp1    |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | Identifier | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          | C_BPartner_ID |
+      | pip_bp2    | consol_product | consol_pi_item  | 10  | PCE               | 4007817525074 | consol_bp2    |
+    When M_HU_PI_Item_Product consolidation is called with p_normalize_gtin_ean='false' and p_consolidate='true'
+    Then M_HU_PI_Item_Product identified by 'pip_nopart' has IsActive='Y'
+    And M_HU_PI_Item_Product identified by 'pip_bp1' has IsActive='N'
+    And M_HU_PI_Item_Product identified by 'pip_bp2' has IsActive='N'
+
+  @from:developer
+  Scenario: Consolidation — different date ranges produce widest range on survivor
+    Given metasfresh contains M_HU_PI_Item_Product:
+      | Identifier | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          | ValidFrom  | ValidTo    | C_BPartner_ID |
+      | pip_date1  | consol_product | consol_pi_item  | 10  | PCE               | 4015400346353 | 2020-01-01 | 2024-12-31 | consol_bp1    |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | Identifier | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          | ValidFrom  | ValidTo    | C_BPartner_ID |
+      | pip_date2  | consol_product | consol_pi_item  | 10  | PCE               | 4015400346353 | 2022-06-15 | 2026-06-30 | consol_bp2    |
+    When M_HU_PI_Item_Product consolidation is called with p_normalize_gtin_ean='false' and p_consolidate='true'
+    Then the surviving M_HU_PI_Item_Product for GTIN '4015400346353' has ValidFrom='2020-01-01' and ValidTo='2026-06-30'
+
+  @from:developer
+  Scenario: Consolidation skipped — different Qty creates a field conflict
+    Given metasfresh contains M_HU_PI_Item_Product:
+      | Identifier   | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          | C_BPartner_ID |
+      | pip_qty_10   | consol_product | consol_pi_item  | 10  | PCE               | 4005808262151 | consol_bp1    |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | Identifier   | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          | C_BPartner_ID |
+      | pip_qty_20   | consol_product | consol_pi_item  | 20  | PCE               | 4005808262151 | consol_bp2    |
+    When M_HU_PI_Item_Product consolidation is called with p_normalize_gtin_ean='false' and p_consolidate='true'
+    Then M_HU_PI_Item_Product identified by 'pip_qty_10' has IsActive='Y'
+    And M_HU_PI_Item_Product identified by 'pip_qty_20' has IsActive='Y'
+
+  @from:developer
+  Scenario: Report — different PI conflict detected for same GTIN
+    Given metasfresh contains M_HU_PI:
+      | Identifier  | Name              |
+      | consol_pi2  | Consolidation PI2 |
+    And metasfresh contains M_HU_PI_Version:
+      | Identifier      | M_HU_PI_ID | HU_UnitType |
+      | consol_pi_ver2  | consol_pi2 | TU          |
+    And metasfresh contains M_HU_PI_Item:
+      | Identifier       | M_HU_PI_Version_ID | ItemType |
+      | consol_pi_item2  | consol_pi_ver2     | MI       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | Identifier   | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          |
+      | pip_rpt_a    | consol_product | consol_pi_item  | 10  | PCE               | 4005900036131 |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | Identifier   | M_Product_ID   | M_HU_PI_Item_ID  | Qty | C_UOM_ID.X12DE355 | GTIN          |
+      | pip_rpt_b    | consol_product | consol_pi_item2  | 10  | PCE               | 4005900036131 |
+    When M_HU_PI_Item_Product consolidation report is called
+    Then the consolidation report contains a conflict row for GTIN '4005900036131'
+
+  @from:developer
+  Scenario: Both flags off — no changes made
+    Given metasfresh contains M_HU_PI_Item_Product:
+      | Identifier   | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          | EAN_TU        |
+      | pip_noop     | consol_product | consol_pi_item  | 10  | PCE               | 4006381333931 | 4006381333931 |
+    When M_HU_PI_Item_Product consolidation is called with p_normalize_gtin_ean='false' and p_consolidate='false'
+    Then M_HU_PI_Item_Product identified by 'pip_noop' has GTIN='4006381333931' and EAN_TU='4006381333931'

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/m_hu_pi_item_product_consolidation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/m_hu_pi_item_product_consolidation.feature
@@ -1,4 +1,4 @@
-@from:developer
+@from:cucumber
 @ignore
 Feature: M_HU_PI_Item_Product consolidation SQL function tests
   Verifies that the m_hu_pi_item_product_consolidate() and
@@ -31,7 +31,7 @@ Feature: M_HU_PI_Item_Product consolidation SQL function tests
       | Identifier      | M_HU_PI_Version_ID | ItemType |
       | consol_pi_item  | consol_pi_ver      | MI       |
 
-  @from:developer
+  @from:cucumber
   Scenario: GTIN normalization — EAN_TU copied to GTIN, then EAN_TU cleared
     Given metasfresh contains M_HU_PI_Item_Product:
       | Identifier | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | EAN_TU        |
@@ -39,7 +39,7 @@ Feature: M_HU_PI_Item_Product consolidation SQL function tests
     When M_HU_PI_Item_Product consolidation is called with p_normalize_gtin_ean='true' and p_consolidate='false'
     Then M_HU_PI_Item_Product identified by 'pip_ean1' has GTIN='4006381333931' and EAN_TU=null
 
-  @from:developer
+  @from:cucumber
   Scenario: GTIN normalization — EAN_TU cleared when same as GTIN
     Given metasfresh contains M_HU_PI_Item_Product:
       | Identifier | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          | EAN_TU        |
@@ -47,7 +47,7 @@ Feature: M_HU_PI_Item_Product consolidation SQL function tests
     When M_HU_PI_Item_Product consolidation is called with p_normalize_gtin_ean='true' and p_consolidate='false'
     Then M_HU_PI_Item_Product identified by 'pip_dup1' has GTIN='4006381333931' and EAN_TU=null
 
-  @from:developer
+  @from:cucumber
   Scenario: Consolidation — identical records merged, partner-less record survives
     Given metasfresh contains M_HU_PI_Item_Product:
       | Identifier | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          |
@@ -63,7 +63,7 @@ Feature: M_HU_PI_Item_Product consolidation SQL function tests
     And M_HU_PI_Item_Product identified by 'pip_bp1' has IsActive='N'
     And M_HU_PI_Item_Product identified by 'pip_bp2' has IsActive='N'
 
-  @from:developer
+  @from:cucumber
   Scenario: Consolidation — different date ranges produce widest range on survivor
     Given metasfresh contains M_HU_PI_Item_Product:
       | Identifier | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          | ValidFrom  | ValidTo    | C_BPartner_ID |
@@ -74,7 +74,7 @@ Feature: M_HU_PI_Item_Product consolidation SQL function tests
     When M_HU_PI_Item_Product consolidation is called with p_normalize_gtin_ean='false' and p_consolidate='true'
     Then the surviving M_HU_PI_Item_Product for GTIN '4015400346353' has ValidFrom='2020-01-01' and ValidTo='2026-06-30'
 
-  @from:developer
+  @from:cucumber
   Scenario: Consolidation skipped — different Qty creates a field conflict
     Given metasfresh contains M_HU_PI_Item_Product:
       | Identifier   | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          | C_BPartner_ID |
@@ -86,7 +86,7 @@ Feature: M_HU_PI_Item_Product consolidation SQL function tests
     Then M_HU_PI_Item_Product identified by 'pip_qty_10' has IsActive='Y'
     And M_HU_PI_Item_Product identified by 'pip_qty_20' has IsActive='Y'
 
-  @from:developer
+  @from:cucumber
   Scenario: Report — different PI conflict detected for same GTIN
     Given metasfresh contains M_HU_PI:
       | Identifier  | Name              |
@@ -106,7 +106,7 @@ Feature: M_HU_PI_Item_Product consolidation SQL function tests
     When M_HU_PI_Item_Product consolidation report is called
     Then the consolidation report contains a conflict row for GTIN '4005900036131'
 
-  @from:developer
+  @from:cucumber
   Scenario: Both flags off — no changes made
     Given metasfresh contains M_HU_PI_Item_Product:
       | Identifier   | M_Product_ID   | M_HU_PI_Item_ID | Qty | C_UOM_ID.X12DE355 | GTIN          | EAN_TU        |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/process/M_HU_PI_Item_Product_Consolidate_Report.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/process/M_HU_PI_Item_Product_Consolidate_Report.java
@@ -1,0 +1,102 @@
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.handlingunits.process;
+
+import de.metas.impexp.spreadsheet.excel.JdbcExcelExporter;
+import de.metas.impexp.spreadsheet.service.SpreadsheetExporterService;
+import de.metas.process.JavaProcess;
+import de.metas.process.Param;
+import de.metas.process.RunOutOfTrx;
+import lombok.NonNull;
+import org.apache.poi.ss.usermodel.Font;
+import org.compiere.SpringContextHolder;
+import org.compiere.util.DB;
+import org.compiere.util.Env;
+import org.compiere.util.SQLValueStringResult;
+
+import java.io.File;
+import java.util.List;
+
+public class M_HU_PI_Item_Product_Consolidate_Report extends JavaProcess
+{
+	@NonNull private final SpreadsheetExporterService spreadsheetExporterService =
+			SpringContextHolder.instance.getBean(SpreadsheetExporterService.class);
+
+	@Param(parameterName = "IsNormalizeGTIN")
+	private boolean p_IsNormalizeGTIN;
+
+	@Param(parameterName = "IsConsolidate")
+	private boolean p_IsConsolidate;
+
+	@Override
+	@RunOutOfTrx
+	protected String doIt()
+	{
+		// Step 1: Execute consolidation function, capture RAISE NOTICE via SQLWarning
+		final String consolidateSql = "SELECT m_hu_pi_item_product_consolidate(?, ?, ?)";
+		final SQLValueStringResult result = DB.getSQLValueStringWithWarningEx(
+				null, // trxName — RunOutOfTrx, no transaction
+				consolidateSql,
+				p_IsNormalizeGTIN,
+				p_IsConsolidate,
+				getPinstanceId().getRepoId());
+
+		// Log each RAISE NOTICE message (backup table names, counts)
+		final List<String> warningMessages = result.getWarningMessages();
+		if (warningMessages != null)
+		{
+			for (final String warning : warningMessages)
+			{
+				addLog(warning);
+			}
+		}
+
+		// Log summary
+		final String summary = result.getReturnedValue();
+		if (summary != null)
+		{
+			addLog(summary);
+		}
+
+		// Step 2: Generate Excel report of remaining conflicts
+		final String adLanguage = Env.getAD_Language(getCtx());
+		final String reportSql = "SELECT * FROM m_hu_pi_item_product_consolidate_report("
+				+ DB.TO_STRING(adLanguage)
+				+ ")";
+
+		final JdbcExcelExporter exporter = JdbcExcelExporter.builder()
+				.ctx(getCtx())
+				.build();
+		exporter.setFontCharset(Font.ANSI_CHARSET);
+
+		spreadsheetExporterService.processDataFromSQL(reportSql, exporter);
+
+		if (!exporter.isNoDataAddedYet())
+		{
+			final File tempFile = exporter.getResultFile();
+			getResult().setReportData(tempFile);
+		}
+
+		return MSG_OK;
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/m_hu_pi_item_product_consolidate.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/m_hu_pi_item_product_consolidate.sql
@@ -1,0 +1,216 @@
+CREATE OR REPLACE FUNCTION m_hu_pi_item_product_consolidate(
+    p_normalize_gtin_ean boolean,
+    p_consolidate        boolean,
+    p_ad_pinstance_id    numeric DEFAULT 0
+)
+    RETURNS text
+    LANGUAGE plpgsql
+    VOLATILE
+AS
+$$
+DECLARE
+    v_count          bigint;
+    v_summary        text := '';
+    v_backup_name    text;
+    v_groups_count   bigint := 0;
+    v_deactivated    bigint := 0;
+    v_fk_record      record;
+BEGIN
+    -- Early return if nothing requested
+    IF NOT p_normalize_gtin_ean AND NOT p_consolidate THEN
+        RETURN 'No action requested';
+    END IF;
+
+    -- Backup main table
+    v_backup_name := backup_table('M_HU_PI_Item_Product', '_pi' || p_ad_pinstance_id);
+    RAISE NOTICE 'Backup: %', v_backup_name;
+
+    -- ==========================================
+    -- Step 1: Normalize GTIN/EAN
+    -- ==========================================
+    IF p_normalize_gtin_ean THEN
+        -- Copy EAN_TU to GTIN where GTIN is missing
+        UPDATE M_HU_PI_Item_Product
+        SET GTIN    = EAN_TU,
+            Updated = now(),
+            UpdatedBy = 99
+        WHERE GTIN IS NULL
+          AND EAN_TU IS NOT NULL
+          AND IsActive = 'Y';
+        GET DIAGNOSTICS v_count = ROW_COUNT;
+        RAISE NOTICE 'Normalized EAN→GTIN: % records', v_count;
+        v_summary := v_summary || 'Normalized EAN→GTIN: ' || v_count || ' records. ';
+
+        -- Clear EAN_TU where it duplicates GTIN
+        UPDATE M_HU_PI_Item_Product
+        SET EAN_TU  = NULL,
+            Updated = now(),
+            UpdatedBy = 99
+        WHERE GTIN = EAN_TU
+          AND EAN_TU IS NOT NULL
+          AND IsActive = 'Y';
+        GET DIAGNOSTICS v_count = ROW_COUNT;
+        RAISE NOTICE 'Cleared duplicate EAN: % records', v_count;
+        v_summary := v_summary || 'Cleared duplicate EAN: ' || v_count || ' records. ';
+    END IF;
+
+    -- ==========================================
+    -- Step 2: Consolidate duplicates
+    -- ==========================================
+    IF p_consolidate THEN
+        -- 2a: Find consolidation groups (same Product + GTIN + PI_Item, multiple active records)
+        CREATE TEMP TABLE tmp_consolidation_groups AS
+        SELECT M_Product_ID,
+               GTIN,
+               M_HU_PI_Item_ID,
+               COUNT(*) AS record_count
+        FROM M_HU_PI_Item_Product
+        WHERE IsActive = 'Y'
+          AND GTIN IS NOT NULL
+        GROUP BY M_Product_ID, GTIN, M_HU_PI_Item_ID
+        HAVING COUNT(*) > 1;
+
+        SELECT COUNT(*) INTO v_groups_count FROM tmp_consolidation_groups;
+        RAISE NOTICE 'Found % consolidation groups', v_groups_count;
+
+        IF v_groups_count = 0 THEN
+            DROP TABLE IF EXISTS tmp_consolidation_groups;
+            v_summary := v_summary || 'Consolidation: 0 groups found, nothing to do.';
+            RETURN v_summary;
+        END IF;
+
+        -- 2b: Remove groups with field conflicts
+        DELETE FROM tmp_consolidation_groups g
+        WHERE EXISTS (
+            SELECT 1
+            FROM M_HU_PI_Item_Product p1
+                     JOIN M_HU_PI_Item_Product p2
+                          ON p1.M_Product_ID = p2.M_Product_ID
+                              AND p1.GTIN = p2.GTIN
+                              AND p1.M_HU_PI_Item_ID = p2.M_HU_PI_Item_ID
+                              AND p1.M_HU_PI_Item_Product_ID < p2.M_HU_PI_Item_Product_ID
+            WHERE p1.IsActive = 'Y'
+              AND p2.IsActive = 'Y'
+              AND p1.M_Product_ID = g.M_Product_ID
+              AND p1.GTIN = g.GTIN
+              AND p1.M_HU_PI_Item_ID = g.M_HU_PI_Item_ID
+              AND (p1.Qty != p2.Qty
+                OR COALESCE(p1.C_UOM_ID, 0) != COALESCE(p2.C_UOM_ID, 0)
+                OR p1.IsInfiniteCapacity != p2.IsInfiniteCapacity
+                OR COALESCE(p1.EAN_TU, '') != COALESCE(p2.EAN_TU, '')
+                OR COALESCE(p1.UPC, '') != COALESCE(p2.UPC, '')
+                OR p1.IsAllowAnyProduct != p2.IsAllowAnyProduct
+                OR p1.IsDefaultForProduct != p2.IsDefaultForProduct)
+        );
+        GET DIAGNOSTICS v_count = ROW_COUNT;
+        RAISE NOTICE 'Skipped % groups with field conflicts', v_count;
+
+        SELECT COUNT(*) INTO v_groups_count FROM tmp_consolidation_groups;
+        RAISE NOTICE 'Proceeding with % conflict-free groups', v_groups_count;
+
+        IF v_groups_count = 0 THEN
+            DROP TABLE IF EXISTS tmp_consolidation_groups;
+            v_summary := v_summary || 'Consolidation: all groups had conflicts, nothing consolidated.';
+            RETURN v_summary;
+        END IF;
+
+        -- 2c: Pick survivors (prefer C_BPartner_ID IS NULL, then lowest ID)
+        CREATE TEMP TABLE tmp_survivors AS
+        SELECT DISTINCT ON (g.M_Product_ID, g.GTIN, g.M_HU_PI_Item_ID)
+            p.M_HU_PI_Item_Product_ID AS survivor_id,
+            g.M_Product_ID,
+            g.GTIN,
+            g.M_HU_PI_Item_ID
+        FROM tmp_consolidation_groups g
+                 JOIN M_HU_PI_Item_Product p
+                      ON p.M_Product_ID = g.M_Product_ID
+                          AND p.GTIN = g.GTIN
+                          AND p.M_HU_PI_Item_ID = g.M_HU_PI_Item_ID
+                          AND p.IsActive = 'Y'
+        ORDER BY g.M_Product_ID, g.GTIN, g.M_HU_PI_Item_ID,
+                 (CASE WHEN p.C_BPartner_ID IS NULL THEN 0 ELSE 1 END),
+                 p.M_HU_PI_Item_Product_ID;
+
+        -- 2d: Discover and update FK references dynamically
+        FOR v_fk_record IN
+            SELECT DISTINCT
+                tc.table_name  AS fk_table,
+                kcu.column_name AS fk_column
+            FROM information_schema.table_constraints tc
+                     JOIN information_schema.key_column_usage kcu
+                          ON tc.constraint_name = kcu.constraint_name
+                     JOIN information_schema.constraint_column_usage ccu
+                          ON tc.constraint_name = ccu.constraint_name
+            WHERE tc.constraint_type = 'FOREIGN KEY'
+              AND ccu.table_name = 'm_hu_pi_item_product'
+              AND ccu.column_name = 'm_hu_pi_item_product_id'
+            LOOP
+                -- Backup FK table
+                v_backup_name := backup_table(v_fk_record.fk_table, '_pi' || p_ad_pinstance_id);
+                RAISE NOTICE 'Backup FK table: %', v_backup_name;
+
+                -- Update FK references from non-survivors to survivors
+                EXECUTE format(
+                        'UPDATE %I SET %I = s.survivor_id, Updated = now(), UpdatedBy = 99
+                         FROM tmp_survivors s
+                         JOIN M_HU_PI_Item_Product p ON p.M_Product_ID = s.M_Product_ID
+                             AND p.GTIN = s.GTIN AND p.M_HU_PI_Item_ID = s.M_HU_PI_Item_ID
+                             AND p.M_HU_PI_Item_Product_ID != s.survivor_id AND p.IsActive = ''Y''
+                         WHERE %I.%I = p.M_HU_PI_Item_Product_ID',
+                        v_fk_record.fk_table, v_fk_record.fk_column,
+                        v_fk_record.fk_table, v_fk_record.fk_column
+                        );
+                GET DIAGNOSTICS v_count = ROW_COUNT;
+                IF v_count > 0 THEN
+                    RAISE NOTICE 'Updated % FK references in %.%', v_count, v_fk_record.fk_table, v_fk_record.fk_column;
+                END IF;
+            END LOOP;
+
+        -- 2e: Update survivors with widest date range and clear C_BPartner_ID
+        UPDATE M_HU_PI_Item_Product survivor
+        SET C_BPartner_ID = NULL,
+            ValidFrom     = sub.min_validfrom,
+            ValidTo       = sub.max_validto,
+            Updated       = now(),
+            UpdatedBy     = 99
+        FROM (SELECT s.survivor_id,
+                     MIN(p.ValidFrom) AS min_validfrom,
+                     MAX(p.ValidTo)   AS max_validto
+              FROM tmp_survivors s
+                       JOIN M_HU_PI_Item_Product p
+                            ON p.M_Product_ID = s.M_Product_ID
+                                AND p.GTIN = s.GTIN
+                                AND p.M_HU_PI_Item_ID = s.M_HU_PI_Item_ID
+                                AND p.IsActive = 'Y'
+              GROUP BY s.survivor_id) sub
+        WHERE survivor.M_HU_PI_Item_Product_ID = sub.survivor_id;
+        GET DIAGNOSTICS v_count = ROW_COUNT;
+        RAISE NOTICE 'Updated % survivors (date range + cleared partner)', v_count;
+
+        -- 2f: Deactivate non-survivors
+        UPDATE M_HU_PI_Item_Product p
+        SET IsActive  = 'N',
+            Updated   = now(),
+            UpdatedBy = 99
+        FROM tmp_survivors s
+        WHERE p.M_Product_ID = s.M_Product_ID
+          AND p.GTIN = s.GTIN
+          AND p.M_HU_PI_Item_ID = s.M_HU_PI_Item_ID
+          AND p.M_HU_PI_Item_Product_ID != s.survivor_id
+          AND p.IsActive = 'Y';
+        GET DIAGNOSTICS v_deactivated = ROW_COUNT;
+        RAISE NOTICE 'Deactivated % non-survivor records across % groups', v_deactivated, v_groups_count;
+
+        -- 2g: Drop temp tables
+        DROP TABLE IF EXISTS tmp_consolidation_groups;
+        DROP TABLE IF EXISTS tmp_survivors;
+
+        v_summary := v_summary || 'Consolidated ' || v_groups_count || ' groups, deactivated ' || v_deactivated || ' records.';
+    END IF;
+
+    RETURN v_summary;
+END;
+$$;
+
+COMMENT ON FUNCTION m_hu_pi_item_product_consolidate(boolean, boolean, numeric) IS
+    'Normalizes GTIN/EAN fields and consolidates duplicate M_HU_PI_Item_Product records with the same GTIN into one partner-less record. Backs up affected tables before modifications.';

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/m_hu_pi_item_product_consolidate.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/m_hu_pi_item_product_consolidate.sql
@@ -56,8 +56,15 @@ BEGIN
 
     -- ==========================================
     -- Step 2: Consolidate duplicates
+    -- (Intentionally global — no AD_Client/AD_Org filter.
+    --  This is a one-time migration tool meant to run across
+    --  all records in the database.)
     -- ==========================================
     IF p_consolidate THEN
+        -- Clean up temp tables in case of re-run after error
+        DROP TABLE IF EXISTS tmp_consolidation_groups;
+        DROP TABLE IF EXISTS tmp_survivors;
+
         -- 2a: Find consolidation groups (same Product + GTIN + PI_Item, multiple active records)
         CREATE TEMP TABLE tmp_consolidation_groups AS
         SELECT M_Product_ID,
@@ -150,20 +157,25 @@ BEGIN
                 RAISE NOTICE 'Backup FK table: %', v_backup_name;
 
                 -- Update FK references from non-survivors to survivors
-                EXECUTE format(
-                        'UPDATE %I SET %I = s.survivor_id, Updated = now(), UpdatedBy = 99
-                         FROM tmp_survivors s
-                         JOIN M_HU_PI_Item_Product p ON p.M_Product_ID = s.M_Product_ID
-                             AND p.GTIN = s.GTIN AND p.M_HU_PI_Item_ID = s.M_HU_PI_Item_ID
-                             AND p.M_HU_PI_Item_Product_ID != s.survivor_id AND p.IsActive = ''Y''
-                         WHERE %I.%I = p.M_HU_PI_Item_Product_ID',
-                        v_fk_record.fk_table, v_fk_record.fk_column,
-                        v_fk_record.fk_table, v_fk_record.fk_column
-                        );
-                GET DIAGNOSTICS v_count = ROW_COUNT;
-                IF v_count > 0 THEN
-                    RAISE NOTICE 'Updated % FK references in %.%', v_count, v_fk_record.fk_table, v_fk_record.fk_column;
-                END IF;
+                BEGIN
+                    EXECUTE format(
+                            'UPDATE %I SET %I = s.survivor_id, Updated = now(), UpdatedBy = 99
+                             FROM tmp_survivors s
+                             JOIN M_HU_PI_Item_Product p ON p.M_Product_ID = s.M_Product_ID
+                                 AND p.GTIN = s.GTIN AND p.M_HU_PI_Item_ID = s.M_HU_PI_Item_ID
+                                 AND p.M_HU_PI_Item_Product_ID != s.survivor_id AND p.IsActive = ''Y''
+                             WHERE %I.%I = p.M_HU_PI_Item_Product_ID',
+                            v_fk_record.fk_table, v_fk_record.fk_column,
+                            v_fk_record.fk_table, v_fk_record.fk_column
+                            );
+                    GET DIAGNOSTICS v_count = ROW_COUNT;
+                    IF v_count > 0 THEN
+                        RAISE NOTICE 'Updated % FK references in %.%', v_count, v_fk_record.fk_table, v_fk_record.fk_column;
+                    END IF;
+                EXCEPTION
+                    WHEN unique_violation THEN
+                        RAISE NOTICE 'WARNING: Could not update FK references in %.% due to unique constraint violation — skipping', v_fk_record.fk_table, v_fk_record.fk_column;
+                END;
             END LOOP;
 
         -- 2e: Update survivors with widest date range and clear C_BPartner_ID

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/m_hu_pi_item_product_consolidate_report.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/m_hu_pi_item_product_consolidate_report.sql
@@ -1,0 +1,223 @@
+CREATE OR REPLACE FUNCTION m_hu_pi_item_product_consolidate_report(p_ad_language text DEFAULT 'de_DE')
+    RETURNS TABLE
+            (
+                issue_type              text,
+                gtin                    text,
+                product_value           text,
+                product_name            text,
+                pi_name                 text,
+                m_hu_pi_item_product_id numeric,
+                bpartner_value          text,
+                bpartner_name           text,
+                qty                     numeric,
+                uom_symbol              text,
+                validfrom               timestamp,
+                validto                 timestamp,
+                conflicting_field       text
+            )
+    LANGUAGE plpgsql
+    STABLE
+AS
+$BODY$
+BEGIN
+    RETURN QUERY
+
+        --
+        -- 1. CONFLICT_DIFFERENT_PI
+        --    Active records sharing a GTIN but with different M_HU_PI_Item_ID
+        --
+        SELECT COALESCE(trl1.MsgText, msg1.MsgText)::text AS issue_type,
+               pip.GTIN::text                              AS gtin,
+               prod.Value::text                            AS product_value,
+               prod.Name::text                             AS product_name,
+               pi.Name::text                               AS pi_name,
+               pip.M_HU_PI_Item_Product_ID                 AS m_hu_pi_item_product_id,
+               bp.Value::text                              AS bpartner_value,
+               bp.Name::text                               AS bpartner_name,
+               pip.Qty                                     AS qty,
+               uom.UOMSymbol::text                         AS uom_symbol,
+               pip.ValidFrom::timestamp                    AS validfrom,
+               pip.ValidTo::timestamp                      AS validto,
+               NULL::text                                  AS conflicting_field
+        FROM M_HU_PI_Item_Product pip
+                 JOIN M_Product prod ON prod.M_Product_ID = pip.M_Product_ID
+                 JOIN M_HU_PI_Item pi_item ON pi_item.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                 JOIN M_HU_PI_Version piv ON piv.M_HU_PI_Version_ID = pi_item.M_HU_PI_Version_ID
+                 JOIN M_HU_PI pi ON pi.M_HU_PI_ID = piv.M_HU_PI_ID
+                 LEFT JOIN C_BPartner bp ON bp.C_BPartner_ID = pip.C_BPartner_ID
+                 LEFT JOIN C_UOM uom ON uom.C_UOM_ID = pip.C_UOM_ID
+                 JOIN AD_Message msg1 ON msg1.Value = 'M_HU_PI_Item_Product_Conflict_DifferentPI'
+                 LEFT JOIN AD_Message_Trl trl1
+                           ON trl1.AD_Message_ID = msg1.AD_Message_ID
+                               AND trl1.AD_Language = p_ad_language
+                               AND trl1.IsActive = 'Y'
+        WHERE pip.IsActive = 'Y'
+          AND pip.GTIN IS NOT NULL
+          AND pip.GTIN <> ''
+          AND pip.GTIN IN (SELECT sub.GTIN
+                           FROM M_HU_PI_Item_Product sub
+                           WHERE sub.IsActive = 'Y'
+                             AND sub.GTIN IS NOT NULL
+                             AND sub.GTIN <> ''
+                           GROUP BY sub.GTIN
+                           HAVING COUNT(DISTINCT sub.M_HU_PI_Item_ID) > 1)
+
+        UNION ALL
+
+        --
+        -- 2. CONFLICT_DIFFERENT_PRODUCT
+        --    Active records sharing a GTIN and M_HU_PI_Item_ID but with different M_Product_ID
+        --
+        SELECT COALESCE(trl2.MsgText, msg2.MsgText)::text AS issue_type,
+               pip.GTIN::text                              AS gtin,
+               prod.Value::text                            AS product_value,
+               prod.Name::text                             AS product_name,
+               pi.Name::text                               AS pi_name,
+               pip.M_HU_PI_Item_Product_ID                 AS m_hu_pi_item_product_id,
+               bp.Value::text                              AS bpartner_value,
+               bp.Name::text                               AS bpartner_name,
+               pip.Qty                                     AS qty,
+               uom.UOMSymbol::text                         AS uom_symbol,
+               pip.ValidFrom::timestamp                    AS validfrom,
+               pip.ValidTo::timestamp                      AS validto,
+               NULL::text                                  AS conflicting_field
+        FROM M_HU_PI_Item_Product pip
+                 JOIN M_Product prod ON prod.M_Product_ID = pip.M_Product_ID
+                 JOIN M_HU_PI_Item pi_item ON pi_item.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                 JOIN M_HU_PI_Version piv ON piv.M_HU_PI_Version_ID = pi_item.M_HU_PI_Version_ID
+                 JOIN M_HU_PI pi ON pi.M_HU_PI_ID = piv.M_HU_PI_ID
+                 LEFT JOIN C_BPartner bp ON bp.C_BPartner_ID = pip.C_BPartner_ID
+                 LEFT JOIN C_UOM uom ON uom.C_UOM_ID = pip.C_UOM_ID
+                 JOIN AD_Message msg2 ON msg2.Value = 'M_HU_PI_Item_Product_Conflict_DifferentProduct'
+                 LEFT JOIN AD_Message_Trl trl2
+                           ON trl2.AD_Message_ID = msg2.AD_Message_ID
+                               AND trl2.AD_Language = p_ad_language
+                               AND trl2.IsActive = 'Y'
+        WHERE pip.IsActive = 'Y'
+          AND pip.GTIN IS NOT NULL
+          AND pip.GTIN <> ''
+          AND (pip.GTIN, pip.M_HU_PI_Item_ID) IN (SELECT sub.GTIN, sub.M_HU_PI_Item_ID
+                                                   FROM M_HU_PI_Item_Product sub
+                                                   WHERE sub.IsActive = 'Y'
+                                                     AND sub.GTIN IS NOT NULL
+                                                     AND sub.GTIN <> ''
+                                                   GROUP BY sub.GTIN, sub.M_HU_PI_Item_ID
+                                                   HAVING COUNT(DISTINCT sub.M_Product_ID) > 1)
+
+        UNION ALL
+
+        --
+        -- 3. CONFLICT_DIFFERENT_FIELDS
+        --    Active records sharing (M_Product_ID, GTIN, M_HU_PI_Item_ID) with >1 record
+        --    where non-date fields differ
+        --
+        SELECT COALESCE(trl3.MsgText, msg3.MsgText)::text AS issue_type,
+               pip.GTIN::text                              AS gtin,
+               prod.Value::text                            AS product_value,
+               prod.Name::text                             AS product_name,
+               pi.Name::text                               AS pi_name,
+               pip.M_HU_PI_Item_Product_ID                 AS m_hu_pi_item_product_id,
+               bp.Value::text                              AS bpartner_value,
+               bp.Name::text                               AS bpartner_name,
+               pip.Qty                                     AS qty,
+               uom.UOMSymbol::text                         AS uom_symbol,
+               pip.ValidFrom::timestamp                    AS validfrom,
+               pip.ValidTo::timestamp                      AS validto,
+               diffs.conflicting_fields::text              AS conflicting_field
+        FROM M_HU_PI_Item_Product pip
+                 JOIN M_Product prod ON prod.M_Product_ID = pip.M_Product_ID
+                 JOIN M_HU_PI_Item pi_item ON pi_item.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                 JOIN M_HU_PI_Version piv ON piv.M_HU_PI_Version_ID = pi_item.M_HU_PI_Version_ID
+                 JOIN M_HU_PI pi ON pi.M_HU_PI_ID = piv.M_HU_PI_ID
+                 LEFT JOIN C_BPartner bp ON bp.C_BPartner_ID = pip.C_BPartner_ID
+                 LEFT JOIN C_UOM uom ON uom.C_UOM_ID = pip.C_UOM_ID
+                 JOIN AD_Message msg3 ON msg3.Value = 'M_HU_PI_Item_Product_Conflict_DifferentFields'
+                 LEFT JOIN AD_Message_Trl trl3
+                           ON trl3.AD_Message_ID = msg3.AD_Message_ID
+                               AND trl3.AD_Language = p_ad_language
+                               AND trl3.IsActive = 'Y'
+                 JOIN LATERAL (
+                    SELECT string_agg(DISTINCT field_name, ', ' ORDER BY field_name) AS conflicting_fields
+                    FROM (
+                             SELECT 'Qty' AS field_name
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.Qty, 0) <> COALESCE(pip.Qty, 0)
+                             UNION
+                             SELECT 'C_UOM_ID'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.C_UOM_ID, 0) <> COALESCE(pip.C_UOM_ID, 0)
+                             UNION
+                             SELECT 'IsInfiniteCapacity'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.IsInfiniteCapacity, 'N') <> COALESCE(pip.IsInfiniteCapacity, 'N')
+                             UNION
+                             SELECT 'EAN_TU'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.EAN_TU, '') <> COALESCE(pip.EAN_TU, '')
+                             UNION
+                             SELECT 'UPC'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.UPC, '') <> COALESCE(pip.UPC, '')
+                             UNION
+                             SELECT 'IsAllowAnyProduct'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.IsAllowAnyProduct, 'N') <> COALESCE(pip.IsAllowAnyProduct, 'N')
+                             UNION
+                             SELECT 'IsDefaultForProduct'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.IsDefaultForProduct, 'N') <> COALESCE(pip.IsDefaultForProduct, 'N')
+                         ) fields
+                    ) diffs ON diffs.conflicting_fields IS NOT NULL
+        WHERE pip.IsActive = 'Y'
+          AND pip.GTIN IS NOT NULL
+          AND pip.GTIN <> ''
+          AND (pip.M_Product_ID, pip.GTIN, pip.M_HU_PI_Item_ID) IN
+              (SELECT sub.M_Product_ID, sub.GTIN, sub.M_HU_PI_Item_ID
+               FROM M_HU_PI_Item_Product sub
+               WHERE sub.IsActive = 'Y'
+                 AND sub.GTIN IS NOT NULL
+                 AND sub.GTIN <> ''
+               GROUP BY sub.M_Product_ID, sub.GTIN, sub.M_HU_PI_Item_ID
+               HAVING COUNT(*) > 1)
+
+        ORDER BY issue_type, gtin, product_value;
+END;
+$BODY$;
+
+COMMENT ON FUNCTION m_hu_pi_item_product_consolidate_report(text) IS
+    'Returns a data quality report of M_HU_PI_Item_Product records with GTIN conflicts: same GTIN across different packing instructions, different products, or records that could not be consolidated due to differing field values.';

--- a/e2e/frontend-webui/tests/spec/hu-pi-item-product-consolidation.spec.js
+++ b/e2e/frontend-webui/tests/spec/hu-pi-item-product-consolidation.spec.js
@@ -63,20 +63,20 @@ the correct parameters with descriptions.
         await page.locator('body').click();
         await page.waitForTimeout(200);
         await page.keyboard.press('Alt+2');
-        await expect(page.locator('.navigation-menu-overlay')).toBeVisible({
+        await expect(page.locator('.menu-overlay')).toBeVisible({
           timeout: SLOW_ACTION_TIMEOUT,
         });
       });
 
       // === SEARCH FOR THE PROCESS ===
       await test.step(`Search for "${menuName}"`, async () => {
-        const searchInput = page.locator('.navigation-menu-overlay input[type="text"]');
+        const searchInput = page.locator('.menu-overlay input.input-field');
         await expect(searchInput).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
         await searchInput.fill(menuName);
         await page.waitForTimeout(500);
 
         // Verify the menu entry appears in search results
-        const menuItem = page.locator('.navigation-menu-overlay').getByText(menuName, { exact: false });
+        const menuItem = page.locator('.menu-overlay').getByText(menuName, { exact: false });
         await expect(menuItem).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
 
         // Click the menu entry to open the process dialog

--- a/e2e/frontend-webui/tests/spec/hu-pi-item-product-consolidation.spec.js
+++ b/e2e/frontend-webui/tests/spec/hu-pi-item-product-consolidation.spec.js
@@ -27,7 +27,7 @@ test.describe('M_HU_PI_Item_Product Consolidation Process', () => {
 
     test(`Menu entry exists and process dialog opens (${language})`, async ({ page }) => {
       allure.epic('E0193: Handling Units');
-      allure.tag('F5001: CU-TU Consolidation');
+      allure.tag('F5001.1: Consolidate CU-TU Allocation');
       allure.story('Process menu entry and dialog');
       allure.severity('normal');
       allure.parameter('Language', language);

--- a/e2e/frontend-webui/tests/spec/hu-pi-item-product-consolidation.spec.js
+++ b/e2e/frontend-webui/tests/spec/hu-pi-item-product-consolidation.spec.js
@@ -22,7 +22,7 @@ test.describe('M_HU_PI_Item_Product Consolidation Process', () => {
       : 'Consolidate CU-TU Allocation';
 
     const paramLabels = language === 'de_DE'
-      ? ['GTIN/EAN normalisieren', 'Doppelte Eintraege konsolidieren']
+      ? ['GTIN/EAN normalisieren', 'Doppelte Einträge konsolidieren']
       : ['Normalize GTIN/EAN', 'Consolidate duplicates'];
 
     test(`Menu entry exists and process dialog opens (${language})`, async ({ page }) => {

--- a/e2e/frontend-webui/tests/spec/hu-pi-item-product-consolidation.spec.js
+++ b/e2e/frontend-webui/tests/spec/hu-pi-item-product-consolidation.spec.js
@@ -1,0 +1,105 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { LoginPage } from '../utils/pages/LoginPage';
+import { DashboardPage } from '../utils/pages/DashboardPage';
+import { SLOW_ACTION_TIMEOUT } from '../utils/common';
+
+/**
+ * M_HU_PI_Item_Product consolidation process E2E tests.
+ *
+ * Verifies:
+ * - Menu entry exists and is findable (DE + EN)
+ * - Process dialog opens with correct parameters
+ * - Process description/help text is shown
+ */
+
+test.describe('M_HU_PI_Item_Product Consolidation Process', () => {
+  ['de_DE', 'en_US'].forEach((language) => {
+    const menuName = language === 'de_DE'
+      ? 'CU-TU Zuordnung konsolidieren'
+      : 'Consolidate CU-TU Allocation';
+
+    const paramLabels = language === 'de_DE'
+      ? ['GTIN/EAN normalisieren', 'Doppelte Eintraege konsolidieren']
+      : ['Normalize GTIN/EAN', 'Consolidate duplicates'];
+
+    test(`Menu entry exists and process dialog opens (${language})`, async ({ page }) => {
+      allure.epic('E0193: Handling Units');
+      allure.tag('F5001: CU-TU Consolidation');
+      allure.story('Process menu entry and dialog');
+      allure.severity('normal');
+      allure.parameter('Language', language);
+
+      allure.description(`
+## CU-TU Consolidation Process
+
+Verifies that the "CU-TU Zuordnung konsolidieren" / "Consolidate CU-TU Allocation"
+process is accessible via the navigation menu and that the process dialog shows
+the correct parameters with descriptions.
+
+**Language:** ${language}
+      `);
+
+      test.setTimeout(120000); // 2 minutes
+
+      // === CREATE TEST DATA ===
+      const masterdata = await Backend.createMasterdata({
+        request: {
+          login: {
+            user: { language },
+          },
+        },
+      });
+
+      // === LOGIN ===
+      await LoginPage.goto();
+      await LoginPage.login(masterdata.login.user);
+      await DashboardPage.expectVisible();
+
+      // === OPEN NAVIGATION MENU ===
+      await test.step('Open navigation menu via Alt+2', async () => {
+        await page.locator('body').click();
+        await page.waitForTimeout(200);
+        await page.keyboard.press('Alt+2');
+        await expect(page.locator('.navigation-menu-overlay')).toBeVisible({
+          timeout: SLOW_ACTION_TIMEOUT,
+        });
+      });
+
+      // === SEARCH FOR THE PROCESS ===
+      await test.step(`Search for "${menuName}"`, async () => {
+        const searchInput = page.locator('.navigation-menu-overlay input[type="text"]');
+        await expect(searchInput).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+        await searchInput.fill(menuName);
+        await page.waitForTimeout(500);
+
+        // Verify the menu entry appears in search results
+        const menuItem = page.locator('.navigation-menu-overlay').getByText(menuName, { exact: false });
+        await expect(menuItem).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+
+        // Click the menu entry to open the process dialog
+        await menuItem.click();
+      });
+
+      // === VERIFY PROCESS DIALOG ===
+      await test.step('Verify process dialog opens with parameters', async () => {
+        // Wait for the process modal/dialog to appear
+        const processDialog = page.locator('.process-modal, .modal-content, [class*="process"]').first();
+        await expect(processDialog).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+
+        // Check that both parameter labels are visible
+        for (const label of paramLabels) {
+          const paramElement = page.getByText(label, { exact: false });
+          await expect(paramElement).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+        }
+      });
+
+      // === CLOSE DIALOG ===
+      await test.step('Close process dialog', async () => {
+        await page.keyboard.press('Escape');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add DB function `m_hu_pi_item_product_consolidate` to normalize GTIN/EAN and merge duplicate M_HU_PI_Item_Product records with the same GTIN into one (C_BPartner_ID=null)
- Add DB function `m_hu_pi_item_product_consolidate_report` for Excel conflict report (different PI, different product, different fields)
- Add Java process `M_HU_PI_Item_Product_Consolidate_Report` with two boolean parameters (IsNormalizeGTIN, IsConsolidate), both unchecked by default
- Register as AD_Process with menu entry under Packvorschrift Nachweis parent (1000016)
- Reorder GTIN to front and EAN_TU to advanced edit in the Packvorschrift Nachweis window
- Add 3 AD_Messages with DE/EN translations for conflict types
- Add Cucumber test coverage (7 scenarios) and Playwright E2E test (menu + dialog in DE/EN)

## Test plan

- [ ] Migration scripts apply cleanly (verified locally against soft_panda_uat DB)
- [ ] Java compilation passes
- [ ] Process appears in navigation menu (DE: "CU-TU Zuordnung konsolidieren", EN: "Consolidate CU-TU Allocation")
- [ ] Process dialog shows both parameters with correct labels
- [ ] GTIN field appears before EAN_TU in the Packvorschrift Nachweis window
- [ ] EAN_TU is in advanced edit mode
- [ ] Cucumber scenarios pass (GTIN normalization, consolidation, conflict detection, report)