### PR TITLE
Add initialization for `BPBankAcctUse` in BPartnerBankAccount

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/composite/BPartnerBankAccount.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/composite/BPartnerBankAccount.java
@@ -136,6 +136,7 @@ public class BPartnerBankAccount
 			@Nullable final Boolean active,
 			@Nullable final RecordChangeLog changeLog,
 			@Nullable final OrgMappingId orgMappingId,
+			@Nullable final BPBankAcctUse bpBankAcctUse,
 			@Nullable final BankId bankId,
 			@Nullable final String accountName,
 			@Nullable final String accountStreet,
@@ -158,6 +159,7 @@ public class BPartnerBankAccount
 		this.accountZip = accountZip;
 		this.accountCity = accountCity;
 		this.accountCountry = accountCountry;
+		this.bpBankAcctUse = bpBankAcctUse;
 	}
 
 	public final void setId(@Nullable final BPartnerBankAccountId id)

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/composite/BPartnerBankAccount.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/composite/BPartnerBankAccount.java
@@ -136,13 +136,13 @@ public class BPartnerBankAccount
 			@Nullable final Boolean active,
 			@Nullable final RecordChangeLog changeLog,
 			@Nullable final OrgMappingId orgMappingId,
-			@Nullable final BPBankAcctUse bpBankAcctUse,
 			@Nullable final BankId bankId,
 			@Nullable final String accountName,
 			@Nullable final String accountStreet,
 			@Nullable final String accountZip,
 			@Nullable final String accountCity,
-			@Nullable final String accountCountry)
+			@Nullable final String accountCountry,
+			@Nullable final BPBankAcctUse bpBankAcctUse)
 	{
 		setId(id);
 		this.iban = iban;

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/BPBankAcctUse.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/BPBankAcctUse.java
@@ -30,6 +30,8 @@ import lombok.Getter;
 import lombok.NonNull;
 import org.compiere.model.X_C_BP_BankAccount;
 
+import javax.annotation.Nullable;
+
 @Getter
 @JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, isGetterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public enum BPBankAcctUse implements ReferenceListAwareEnum
@@ -50,6 +52,12 @@ public enum BPBankAcctUse implements ReferenceListAwareEnum
 	public static BPBankAcctUse ofCode(@NonNull final String code)
 	{
 		return typesByCode.ofCode(code);
+	}
+
+	@Nullable
+	public static BPBankAcctUse ofCodeOrNull(@Nullable final String code)
+	{
+		return code == null ? null : ofCode(code);
 	}
 
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPBankAccountDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPBankAccountDAO.java
@@ -181,6 +181,7 @@ public class BPBankAccountDAO implements IBPBankAccountDAO
 				.accountZip(record.getA_Zip())
 				.accountCity(record.getA_City())
 				.accountCountry(record.getA_Country())
+				.bpBankAcctUse(BPBankAcctUse.ofCodeOrNull(record.getBPBankAcctUse()))
 				//.changeLog()
 				.build();
 	}

--- a/backend/de.metas.business/src/main/java/de/metas/bpartner/composite/repository/BPartnerCompositesLoader.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner/composite/repository/BPartnerCompositesLoader.java
@@ -26,6 +26,7 @@ import de.metas.bpartner.composite.BPartnerLocationAddressPart;
 import de.metas.bpartner.composite.BPartnerLocationType;
 import de.metas.bpartner.composite.SalesRep;
 import de.metas.bpartner.composite.SalesRepContact;
+import de.metas.bpartner.service.BPBankAcctUse;
 import de.metas.bpartner.service.BPartnerCreditLimitId;
 import de.metas.bpartner.service.BPartnerCreditLimitRepository;
 import de.metas.bpartner.service.CreditLimitType;
@@ -621,6 +622,7 @@ final class BPartnerCompositesLoader
 				.accountZip(bankAccountRecord.getA_Zip())
 				.accountCity(bankAccountRecord.getA_City())
 				.accountCountry(bankAccountRecord.getA_Country())
+				.bpBankAcctUse(BPBankAcctUse.ofCodeOrNull(bankAccountRecord.getBPBankAcctUse()))
 				.build();
 	}
 


### PR DESCRIPTION
- Add `BPBankAcctUse` to `BPartnerBankAccount` constructor/builder.
- Initialize from `C_BP_BankAccount`.