### PR TITLE
Round forecast Qty and QtyCalculated with CEILING

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/adempiere/gui/search/impl/ForecastLineHUPackingAware.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/adempiere/gui/search/impl/ForecastLineHUPackingAware.java
@@ -23,6 +23,7 @@ package de.metas.adempiere.gui.search.impl;
  */
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_UOM;
@@ -92,11 +93,16 @@ public class ForecastLineHUPackingAware implements IHUPackingAware
 	@Override
 	public void setQty(final BigDecimal qty)
 	{
-		forecastLine.setQty(qty);
-
-		final ProductId productId = ProductId.ofRepoIdOrNull(getM_Product_ID());
 		final I_C_UOM uom = Services.get(IUOMDAO.class).getById(getC_UOM_ID());
-		final BigDecimal qtyCalculated = Services.get(IUOMConversionBL.class).convertToProductUOM(productId, uom, qty);
+
+		// Round Qty up (CEILING) to UOM precision — forecasts should not predict fractional indivisible units
+		final BigDecimal qtyRounded = qty.setScale(uom.getStdPrecision(), RoundingMode.CEILING);
+		forecastLine.setQty(qtyRounded);
+
+		// Convert rounded Qty to product UOM for QtyCalculated
+		// (UOM conversion internally rounds UP, which equals CEILING for positive quantities)
+		final ProductId productId = ProductId.ofRepoIdOrNull(getM_Product_ID());
+		final BigDecimal qtyCalculated = Services.get(IUOMConversionBL.class).convertToProductUOM(productId, uom, qtyRounded);
 		forecastLine.setQtyCalculated(qtyCalculated);
 	}
 


### PR DESCRIPTION
## Summary
- Round both `M_ForecastLine.Qty` and `QtyCalculated` with `RoundingMode.CEILING` to the UOM precision in `ForecastLineHUPackingAware.setQty()`
- Previously, `Qty` was stored unrounded (e.g., 3.27) while `QtyCalculated` was rounded UP (to 4) via UOM conversion, causing the Purchase Cockpit to display inconsistent values (Prognose=3 vs QtyCalculated=4)
- Root cause: the cockpit view uses `fl.qty` (unrounded), and `uomconvert()` rounds with HALF_UP (3.27 → 3), while `QtyCalculated` was rounded with `RoundingMode.UP` (3.27 → 4)

## Test plan
- [ ] Generate a forecast for a product with integer UOM (e.g., Stück, stdprecision=0) where the calculated average is fractional (e.g., 3.27)
- [ ] Verify both `Qty` and `QtyCalculated` are rounded up to the next integer (4)
- [ ] Verify the Purchase Cockpit (Einkaufs-Cockpit) shows the same rounded value in the Prognose column
- [ ] Verify products with higher-precision UOMs (e.g., kg with precision=3) are unaffected