### PR TITLE
HU Editor: propagate reservation attributes (Herkunft/Kaliber) to shipment schedule ASI

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/slot/IHUPickingSlotBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/slot/IHUPickingSlotBL.java
@@ -10,6 +10,7 @@ import de.metas.handlingunits.model.X_M_HU;
 import de.metas.handlingunits.picking.requests.RetrieveAvailableHUIdsToPickRequest;
 import de.metas.i18n.BooleanWithReason;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.material.event.commons.AttributesKey;
 import de.metas.picking.api.IPickingSlotBL;
 import de.metas.picking.api.PickingSlotId;
 import de.metas.picking.model.I_M_PickingSlot;
@@ -20,6 +21,7 @@ import lombok.NonNull;
 import lombok.Singular;
 import lombok.Value;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -188,5 +190,12 @@ public interface IHUPickingSlotBL extends IPickingSlotBL, ISingletonService
 		 */
 		@Default
 		boolean excludeAllReserved = false;
+
+		/**
+		 * When non-null, overrides the shipment schedule's ASI-based attribute filter with the given key.
+		 * Used for per-reservation HU picking passes to honor each reservation's specific attributes.
+		 */
+		@Nullable
+		AttributesKey attributesKeyOverride;
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/slot/impl/HUPickingSlotBLs/RetrieveAvailableHUsToPick.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/slot/impl/HUPickingSlotBLs/RetrieveAvailableHUsToPick.java
@@ -12,6 +12,7 @@ import de.metas.handlingunits.picking.PickingCandidateRepository;
 import de.metas.handlingunits.picking.slot.impl.HUPickingSlotBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.material.event.commons.AttributesKey;
 import de.metas.product.ProductId;
 import de.metas.storage.IStorageEngine;
 import de.metas.storage.IStorageEngineService;
@@ -21,10 +22,14 @@ import de.metas.storage.spi.hu.impl.HUStorageRecord;
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
+import org.adempiere.mm.attributes.api.IAttributeSet;
+import org.adempiere.mm.attributes.keys.AttributesKeys;
 import org.adempiere.model.PlainContextAware;
 import org.adempiere.util.lang.IContextAware;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_M_Locator;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -78,7 +83,8 @@ public class RetrieveAvailableHUsToPick
 		final List<I_M_HU> vhus = retrieveVHUsFromStorage(
 				query.getShipmentSchedules(),
 				query.isOnlyIfAttributesMatchWithShipmentSchedules(),
-				query.isExcludeAllReserved());
+				query.isExcludeAllReserved(),
+				query.getAttributesKeyOverride());
 
 		final List<I_M_HU> result = vhuToEndResultFunction.apply(vhus);
 
@@ -95,7 +101,8 @@ public class RetrieveAvailableHUsToPick
 	private List<I_M_HU> retrieveVHUsFromStorage(
 			@NonNull final List<I_M_ShipmentSchedule> shipmentSchedules,
 			final boolean considerAttributes,
-			final boolean isExcludeAllReserved)
+			final boolean isExcludeAllReserved,
+			@Nullable final AttributesKey attributesKeyOverride)
 	{
 		//
 		// Create storage queries from shipment schedules
@@ -103,7 +110,21 @@ public class RetrieveAvailableHUsToPick
 		final ArrayList<IStorageQuery> storageQueries = new ArrayList<>();
 		for (final I_M_ShipmentSchedule shipmentSchedule : shipmentSchedules)
 		{
-			final IStorageQuery storageQuery = shipmentScheduleBL.createStorageQuery(shipmentSchedule, considerAttributes, isExcludeAllReserved);
+			final IStorageQuery storageQuery;
+			if (attributesKeyOverride != null)
+			{
+				// Build query without SS ASI filtering, then apply the reservation's attributesKey
+				storageQuery = shipmentScheduleBL.createStorageQuery(shipmentSchedule, false, isExcludeAllReserved);
+				if (!attributesKeyOverride.isNone())
+				{
+					final IAttributeSet attributeSet = AttributesKeys.toImmutableAttributeSet(attributesKeyOverride);
+					storageQuery.addAttributes(attributeSet);
+				}
+			}
+			else
+			{
+				storageQuery = shipmentScheduleBL.createStorageQuery(shipmentSchedule, considerAttributes, isExcludeAllReserved);
+			}
 			storageQueries.add(storageQuery);
 		}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleAndQtyReservation.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleAndQtyReservation.java
@@ -1,0 +1,24 @@
+package de.metas.handlingunits.shipmentschedule.api;
+
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.inoutcandidate.qty_reservation.QtyReservation;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+import javax.annotation.Nullable;
+
+/**
+ * Pairs a shipment schedule with an optional qty reservation.
+ * <p>
+ * When {@code qtyReservation} is non-null, HU picking should be filtered by the reservation's
+ * {@code attributesKey} and capped at the reservation's effective qty.
+ * When {@code qtyReservation} is null, picking falls back to the shipment schedule's own ASI.
+ */
+@Value
+@Builder
+public class ShipmentScheduleAndQtyReservation
+{
+	@NonNull I_M_ShipmentSchedule shipmentSchedule;
+	@Nullable QtyReservation qtyReservation;
+}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleAndQtyReservation.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleAndQtyReservation.java
@@ -21,4 +21,12 @@ public class ShipmentScheduleAndQtyReservation
 {
 	@NonNull I_M_ShipmentSchedule shipmentSchedule;
 	@Nullable QtyReservation qtyReservation;
+
+	/**
+	 * Convenience factory for the fallback case: no specific reservation, use SS ASI.
+	 */
+	public static ShipmentScheduleAndQtyReservation of(@NonNull final I_M_ShipmentSchedule shipmentSchedule)
+	{
+		return builder().shipmentSchedule(shipmentSchedule).build();
+	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
@@ -67,6 +67,9 @@ import de.metas.handlingunits.reservation.HUReservation;
 import de.metas.handlingunits.reservation.HUReservationDocRef;
 import de.metas.handlingunits.reservation.HUReservationRepository;
 import de.metas.handlingunits.reservation.HUReservationService;
+import de.metas.inoutcandidate.qty_reservation.QtyReservation;
+import de.metas.inoutcandidate.qty_reservation.QtyReservationRepository;
+import de.metas.material.event.commons.AttributesKey;
 import de.metas.handlingunits.shipmentschedule.api.impl.ShipmentScheduleQtyPickedProductStorage;
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.ExplainedOptional;
@@ -145,10 +148,14 @@ public class ShipmentScheduleWithHUService
 	private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
 
 	private final HUReservationService huReservationService;
+	private final QtyReservationRepository qtyReservationRepository;
 
-	public ShipmentScheduleWithHUService(@NonNull final HUReservationService huReservationService)
+	public ShipmentScheduleWithHUService(
+			@NonNull final HUReservationService huReservationService,
+			@NonNull final QtyReservationRepository qtyReservationRepository)
 	{
 		this.huReservationService = huReservationService;
+		this.qtyReservationRepository = qtyReservationRepository;
 	}
 
 	public static ShipmentScheduleWithHUService newInstanceForUnitTesting()
@@ -156,7 +163,9 @@ public class ShipmentScheduleWithHUService
 		Adempiere.enableUnitTestMode();
 		return SpringContextHolder.getBeanOrSupply(
 				ShipmentScheduleWithHUService.class,
-				() -> new ShipmentScheduleWithHUService(new HUReservationService(new HUReservationRepository()))
+				() -> new ShipmentScheduleWithHUService(
+						new HUReservationService(new HUReservationRepository()),
+						new QtyReservationRepository())
 		);
 	}
 
@@ -431,32 +440,63 @@ public class ShipmentScheduleWithHUService
 
 		result.addAll(alreadyPickedOnTheFlyButNotDelivered);
 
-		final Quantity remainingQtyToAllocate = getQtyToAllocate(alreadyPickedOnTheFlyButNotDelivered, qtyToDeliver);
+		Quantity remainingQtyToAllocate = getQtyToAllocate(alreadyPickedOnTheFlyButNotDelivered, qtyToDeliver);
 
 		if (remainingQtyToAllocate.signum() <= 0)
 		{
 			return result.build();
 		}
 
-		final boolean firstHU = true;
-
+		// Pass 1: M_HU_Reservation HUs (physically reserved VHUs)
+		boolean anyHUProcessed = false;
 		final List<I_M_HU> reservedHUs = retrieveReservedHUs(scheduleRecord);
-		final Quantity remainingQtyToAllocateAfterReserved;
-		if (reservedHUs.isEmpty())
+		if (!reservedHUs.isEmpty())
 		{
-			remainingQtyToAllocateAfterReserved = remainingQtyToAllocate;
-		}
-		else
-		{
-			remainingQtyToAllocateAfterReserved = processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, reservedHUs, remainingQtyToAllocate, loggableWithLogger, firstHU, result, true);
+			remainingQtyToAllocate = processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, reservedHUs, remainingQtyToAllocate, loggableWithLogger, /*firstHU=*/true, result, true);
+			anyHUProcessed = true;
 		}
 
-		if (remainingQtyToAllocateAfterReserved.isPositive())
+		// Pass 2: For each M_QtyReservation, pick HUs filtered by the reservation's attributesKey
+		final OrderLineId orderLineId = OrderLineId.ofRepoIdOrNull(scheduleRecord.getC_OrderLine_ID());
+		if (remainingQtyToAllocate.isPositive() && orderLineId != null)
 		{
-			// if we have HUs on stock, get them now
-			final List<I_M_HU> husToPick = retrievePickOnTheFlySourceHUs(scheduleRecord);
+			final ImmutableList<QtyReservation> qtyReservations = qtyReservationRepository.getActiveByOrderLineId(orderLineId);
+			for (final QtyReservation qtyReservation : qtyReservations)
+			{
+				if (remainingQtyToAllocate.signum() <= 0)
+				{
+					break;
+				}
+				final Quantity effectiveQty = qtyReservation.getEffectiveQty();
+				if (effectiveQty.signum() <= 0)
+				{
+					continue;
+				}
+				final Quantity qtyCapForThisReservation = effectiveQty.min(remainingQtyToAllocate);
+				final List<I_M_HU> husToPick = retrievePickOnTheFlySourceHUs(
+						ShipmentScheduleAndQtyReservation.builder()
+								.shipmentSchedule(scheduleRecord)
+								.qtyReservation(qtyReservation)
+								.build());
+				final Quantity remainingAfterPass = processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, husToPick, qtyCapForThisReservation, loggableWithLogger, !anyHUProcessed, result, false);
+				final Quantity actuallyPicked = qtyCapForThisReservation.subtract(remainingAfterPass);
+				remainingQtyToAllocate = remainingQtyToAllocate.subtract(actuallyPicked);
+				if (actuallyPicked.isPositive())
+				{
+					anyHUProcessed = true;
+				}
+			}
+		}
 
-			processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, husToPick, remainingQtyToAllocateAfterReserved, loggableWithLogger, reservedHUs.isEmpty(), result, false);
+		// Pass 3: Fallback — remaining qty using the shipment schedule's own ASI (no specific attributesKey)
+		if (remainingQtyToAllocate.isPositive())
+		{
+			final List<I_M_HU> husToPick = retrievePickOnTheFlySourceHUs(
+					ShipmentScheduleAndQtyReservation.builder()
+							.shipmentSchedule(scheduleRecord)
+							.qtyReservation(null)
+							.build());
+			processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, husToPick, remainingQtyToAllocate, loggableWithLogger, !anyHUProcessed, result, false);
 		}
 
 		return result.build();
@@ -560,20 +600,38 @@ public class ShipmentScheduleWithHUService
 	}
 
 	@NonNull
-	private List<I_M_HU> retrievePickOnTheFlySourceHUs(final @NonNull I_M_ShipmentSchedule scheduleRecord)
+	private List<I_M_HU> retrievePickOnTheFlySourceHUs(
+			@NonNull final ShipmentScheduleAndQtyReservation scheduleAndReservation)
 	{
-		final ImmutableList.Builder<I_M_HU> result = ImmutableList.builder();
-		final boolean matchAttributes = sysConfigBL.getBooleanValue(SYSCFG_PICK_AVAILABLE_HUS_ON_THE_FLY_MATCH_ATTRIBS,
-				true,
-				scheduleRecord.getAD_Client_ID(),
-				scheduleRecord.getAD_Org_ID());
+		final I_M_ShipmentSchedule scheduleRecord = scheduleAndReservation.getShipmentSchedule();
+		final QtyReservation qtyReservation = scheduleAndReservation.getQtyReservation();
 
-		// second, get all unreserved HUs that are available for picking
+		final ImmutableList.Builder<I_M_HU> result = ImmutableList.builder();
+
+		// When a qty reservation is present, use its attributesKey to filter HUs.
+		// When null (fallback pass), use the shipment schedule's own ASI-based attribute matching.
+		final AttributesKey attributesKeyOverride;
+		final boolean matchAttributes;
+		if (qtyReservation != null)
+		{
+			attributesKeyOverride = qtyReservation.getAttributesKey();
+			matchAttributes = false; // overridden by attributesKeyOverride
+		}
+		else
+		{
+			attributesKeyOverride = null;
+			matchAttributes = sysConfigBL.getBooleanValue(SYSCFG_PICK_AVAILABLE_HUS_ON_THE_FLY_MATCH_ATTRIBS,
+					true,
+					scheduleRecord.getAD_Client_ID(),
+					scheduleRecord.getAD_Org_ID());
+		}
+
 		final IHUPickingSlotBL.PickingHUsQuery pickingHUsQuery = IHUPickingSlotBL.PickingHUsQuery
 				.builder()
 				.shipmentSchedule(scheduleRecord)
 				.onlyTopLevelHUs(true)
-				.onlyIfAttributesMatchWithShipmentSchedules(matchAttributes) // TODO make contingent on HU attribute propagation (iol-handler!)
+				.onlyIfAttributesMatchWithShipmentSchedules(matchAttributes)
+				.attributesKeyOverride(attributesKeyOverride)
 				.excludeAllReserved(true) // we already have the reserved HUs; make sure to not load them again.
 				.build();
 		result.addAll(huPickingSlotBL.retrieveAvailableHUsToPick(pickingHUsQuery));

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
@@ -492,10 +492,7 @@ public class ShipmentScheduleWithHUService
 		if (remainingQtyToAllocate.isPositive())
 		{
 			final List<I_M_HU> husToPick = retrievePickOnTheFlySourceHUs(
-					ShipmentScheduleAndQtyReservation.builder()
-							.shipmentSchedule(scheduleRecord)
-							.qtyReservation(null)
-							.build());
+					ShipmentScheduleAndQtyReservation.of(scheduleRecord));
 			processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, husToPick, remainingQtyToAllocate, loggableWithLogger, !anyHUProcessed, result, false);
 		}
 
@@ -630,7 +627,7 @@ public class ShipmentScheduleWithHUService
 				.builder()
 				.shipmentSchedule(scheduleRecord)
 				.onlyTopLevelHUs(true)
-				.onlyIfAttributesMatchWithShipmentSchedules(matchAttributes)
+				.onlyIfAttributesMatchWithShipmentSchedules(matchAttributes) // TODO make contingent on HU attribute propagation (iol-handler!)
 				.attributesKeyOverride(attributesKeyOverride)
 				.excludeAllReserved(true) // we already have the reserved HUs; make sure to not load them again.
 				.build();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
@@ -420,14 +420,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 		final AttributeSetInstanceId newAsiId;
 		if (attributeValues.isEmpty())
 		{
-			// No HU attribute values available (e.g. no HUs were picked on-the-fly).
-			// Fall back to the shipment schedule's own ASI so that storage attributes
-			// (e.g. Herkunft, Kaliber) are still propagated to the shipment line.
-			newAsiId = candidates.stream()
-					.map(c -> AttributeSetInstanceId.ofRepoIdOrNone(c.getM_AttributeSetInstance_ID()))
-					.filter(id -> id.isRegular())
-					.findFirst()
-					.orElse(AttributeSetInstanceId.NONE);
+			newAsiId = getShipmentScheduleAsiFromCandidates();
 		}
 		else
 		{
@@ -697,6 +690,20 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 	public List<ShipmentScheduleWithHU> getCandidates()
 	{
 		return ImmutableList.copyOf(candidates);
+	}
+
+	/**
+	 * When no HU attribute values are available (e.g. no HUs were picked on-the-fly),
+	 * fall back to the shipment schedule's own ASI so that storage attributes
+	 * (e.g. Herkunft, Kaliber) are still propagated to the shipment line.
+	 */
+	private AttributeSetInstanceId getShipmentScheduleAsiFromCandidates()
+	{
+		return candidates.stream()
+				.map(c -> AttributeSetInstanceId.ofRepoIdOrNone(c.getM_AttributeSetInstance_ID()))
+				.filter(id -> id.isRegular())
+				.findFirst()
+				.orElse(AttributeSetInstanceId.NONE);
 	}
 
 	/**

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
@@ -420,7 +420,14 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 		final AttributeSetInstanceId newAsiId;
 		if (attributeValues.isEmpty())
 		{
-			newAsiId = AttributeSetInstanceId.NONE;
+			// No HU attribute values available (e.g. no HUs were picked on-the-fly).
+			// Fall back to the shipment schedule's own ASI so that storage attributes
+			// (e.g. Herkunft, Kaliber) are still propagated to the shipment line.
+			newAsiId = candidates.stream()
+					.map(c -> AttributeSetInstanceId.ofRepoIdOrNone(c.getM_AttributeSetInstance_ID()))
+					.filter(id -> id.isRegular())
+					.findFirst()
+					.orElse(AttributeSetInstanceId.NONE);
 		}
 		else
 		{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleBL.java
@@ -222,4 +222,10 @@ public interface IShipmentScheduleBL extends ISingletonService
 	 * Existing ASI attributes not covered by the attributes key are preserved.
 	 */
 	void updateASIFromReservationAttributesKey(@NonNull OrderLineId orderLineId, @Nullable AttributesKey attributesKey);
+
+	/**
+	 * Resets the shipment schedule's ASI back to the ASI of the linked order line.
+	 * Used when all reservations for an order line are deleted, to undo any reservation-driven ASI updates.
+	 */
+	void resetSSASIFromOrderLine(@NonNull OrderLineId orderLineId);
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleBL.java
@@ -32,6 +32,7 @@ import de.metas.inoutcandidate.api.impl.ShipmentScheduleHeaderAggregationKeyBuil
 import de.metas.inoutcandidate.async.CreateMissingShipmentSchedulesWorkpackageProcessor;
 import de.metas.inoutcandidate.exportaudit.APIExportStatus;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.material.event.commons.AttributesKey;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
 import de.metas.process.PInstanceId;
@@ -214,4 +215,11 @@ public interface IShipmentScheduleBL extends ISingletonService
 	 * Updates C_Project_ID on the shipment schedule for the given order line, if not yet processed.
 	 */
 	void updateProjectId(@NonNull OrderLineId orderLineId, @Nullable ProjectId projectId);
+
+	/**
+	 * Merges the attributes from the given reservation attributes key into the shipment schedule's ASI,
+	 * for the shipment schedule linked to the given order line.
+	 * Existing ASI attributes not covered by the attributes key are preserved.
+	 */
+	void updateASIFromReservationAttributesKey(@NonNull OrderLineId orderLineId, @Nullable AttributesKey attributesKey);
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleBL.java
@@ -32,7 +32,6 @@ import de.metas.inoutcandidate.api.impl.ShipmentScheduleHeaderAggregationKeyBuil
 import de.metas.inoutcandidate.async.CreateMissingShipmentSchedulesWorkpackageProcessor;
 import de.metas.inoutcandidate.exportaudit.APIExportStatus;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
-import de.metas.material.event.commons.AttributesKey;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
 import de.metas.process.PInstanceId;
@@ -215,17 +214,4 @@ public interface IShipmentScheduleBL extends ISingletonService
 	 * Updates C_Project_ID on the shipment schedule for the given order line, if not yet processed.
 	 */
 	void updateProjectId(@NonNull OrderLineId orderLineId, @Nullable ProjectId projectId);
-
-	/**
-	 * Merges the attributes from the given reservation attributes key into the shipment schedule's ASI,
-	 * for the shipment schedule linked to the given order line.
-	 * Existing ASI attributes not covered by the attributes key are preserved.
-	 */
-	void updateASIFromReservationAttributesKey(@NonNull OrderLineId orderLineId, @Nullable AttributesKey attributesKey);
-
-	/**
-	 * Resets the shipment schedule's ASI back to the ASI of the linked order line.
-	 * Used when all reservations for an order line are deleted, to undo any reservation-driven ASI updates.
-	 */
-	void resetSSASIFromOrderLine(@NonNull OrderLineId orderLineId);
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
@@ -1085,4 +1085,30 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 		logger.debug("Updated ASI on M_ShipmentSchedule_ID={} from C_OrderLine_ID={} with attributesKey={}",
 				shipmentSchedule.getM_ShipmentSchedule_ID(), orderLineId, attributesKey);
 	}
+
+	@Override
+	public void resetSSASIFromOrderLine(@NonNull final OrderLineId orderLineId)
+	{
+		final I_M_ShipmentSchedule shipmentSchedule = getByOrderLineId(orderLineId);
+		if (shipmentSchedule == null)
+		{
+			logger.debug("No shipment schedule found for C_OrderLine_ID={}; skip ASI reset", orderLineId);
+			return;
+		}
+
+		if (shipmentSchedule.isProcessed())
+		{
+			return;
+		}
+
+		final I_C_OrderLine orderLine = InterfaceWrapperHelper.load(orderLineId.getRepoId(), I_C_OrderLine.class);
+		if (orderLine == null)
+		{
+			return;
+		}
+
+		shipmentSchedule.setM_AttributeSetInstance_ID(orderLine.getM_AttributeSetInstance_ID());
+		shipmentSchedulePA.save(shipmentSchedule);
+		logger.debug("Reset ASI on M_ShipmentSchedule_ID={} to orderline ASI from C_OrderLine_ID={}", shipmentSchedule.getM_ShipmentSchedule_ID(), orderLineId);
+	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
@@ -34,7 +34,6 @@ import de.metas.inoutcandidate.location.adapter.ShipmentScheduleDocumentLocation
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.lang.SOTrx;
 import de.metas.lock.api.ILockManager;
-import de.metas.material.event.commons.AttributesKey;
 import de.metas.logging.LogManager;
 import de.metas.logging.TableRecordMDC;
 import de.metas.order.IOrderBL;
@@ -67,7 +66,6 @@ import org.adempiere.mm.attributes.api.AttributeConstants;
 import org.adempiere.mm.attributes.api.CreateAttributeInstanceReq;
 import org.adempiere.mm.attributes.api.IAttributeSet;
 import org.adempiere.mm.attributes.api.IAttributeSetInstanceBL;
-import org.adempiere.mm.attributes.keys.AttributesKeys;
 import org.adempiere.mm.attributes.api.impl.AddAttributesRequest;
 import org.adempiere.mm.attributes.asi_aware.IAttributeSetInstanceAware;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -1051,64 +1049,4 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 		logger.debug("Updated C_Project_ID={} on M_ShipmentSchedule_ID={} from C_OrderLine_ID={}", projectId, shipmentSchedule.getM_ShipmentSchedule_ID(), orderLineId);
 	}
 
-	@Override
-	public void updateASIFromReservationAttributesKey(
-			@NonNull final OrderLineId orderLineId,
-			@Nullable final AttributesKey attributesKey)
-	{
-		if (attributesKey == null || AttributesKey.NONE.equals(attributesKey) || AttributesKey.ALL.equals(attributesKey))
-		{
-			return;
-		}
-
-		final I_M_ShipmentSchedule shipmentSchedule = getByOrderLineId(orderLineId);
-		if (shipmentSchedule == null)
-		{
-			logger.debug("No shipment schedule found for C_OrderLine_ID={}; skip ASI update from reservation", orderLineId);
-			return;
-		}
-
-		if (shipmentSchedule.isProcessed())
-		{
-			return;
-		}
-
-		final IAttributeSet attributeSet = AttributesKeys.toImmutableAttributeSet(attributesKey);
-		if (attributeSet.getAttributes().isEmpty())
-		{
-			return;
-		}
-
-		final IAttributeSetInstanceAware asiAware = toAttributeSetInstanceAware(shipmentSchedule);
-		Services.get(IAttributeSetInstanceBL.class).syncAttributesToASIAware(attributeSet, asiAware);
-		shipmentSchedulePA.save(shipmentSchedule);
-		logger.debug("Updated ASI on M_ShipmentSchedule_ID={} from C_OrderLine_ID={} with attributesKey={}",
-				shipmentSchedule.getM_ShipmentSchedule_ID(), orderLineId, attributesKey);
-	}
-
-	@Override
-	public void resetSSASIFromOrderLine(@NonNull final OrderLineId orderLineId)
-	{
-		final I_M_ShipmentSchedule shipmentSchedule = getByOrderLineId(orderLineId);
-		if (shipmentSchedule == null)
-		{
-			logger.debug("No shipment schedule found for C_OrderLine_ID={}; skip ASI reset", orderLineId);
-			return;
-		}
-
-		if (shipmentSchedule.isProcessed())
-		{
-			return;
-		}
-
-		final I_C_OrderLine orderLine = InterfaceWrapperHelper.load(orderLineId.getRepoId(), I_C_OrderLine.class);
-		if (orderLine == null)
-		{
-			return;
-		}
-
-		shipmentSchedule.setM_AttributeSetInstance_ID(orderLine.getM_AttributeSetInstance_ID());
-		shipmentSchedulePA.save(shipmentSchedule);
-		logger.debug("Reset ASI on M_ShipmentSchedule_ID={} to orderline ASI from C_OrderLine_ID={}", shipmentSchedule.getM_ShipmentSchedule_ID(), orderLineId);
-	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
@@ -34,6 +34,7 @@ import de.metas.inoutcandidate.location.adapter.ShipmentScheduleDocumentLocation
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.lang.SOTrx;
 import de.metas.lock.api.ILockManager;
+import de.metas.material.event.commons.AttributesKey;
 import de.metas.logging.LogManager;
 import de.metas.logging.TableRecordMDC;
 import de.metas.order.IOrderBL;
@@ -66,6 +67,7 @@ import org.adempiere.mm.attributes.api.AttributeConstants;
 import org.adempiere.mm.attributes.api.CreateAttributeInstanceReq;
 import org.adempiere.mm.attributes.api.IAttributeSet;
 import org.adempiere.mm.attributes.api.IAttributeSetInstanceBL;
+import org.adempiere.mm.attributes.keys.AttributesKeys;
 import org.adempiere.mm.attributes.api.impl.AddAttributesRequest;
 import org.adempiere.mm.attributes.asi_aware.IAttributeSetInstanceAware;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -1047,5 +1049,40 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 		shipmentSchedule.setC_Project_ID(ProjectId.toRepoId(projectId));
 		shipmentSchedulePA.save(shipmentSchedule);
 		logger.debug("Updated C_Project_ID={} on M_ShipmentSchedule_ID={} from C_OrderLine_ID={}", projectId, shipmentSchedule.getM_ShipmentSchedule_ID(), orderLineId);
+	}
+
+	@Override
+	public void updateASIFromReservationAttributesKey(
+			@NonNull final OrderLineId orderLineId,
+			@Nullable final AttributesKey attributesKey)
+	{
+		if (attributesKey == null || AttributesKey.NONE.equals(attributesKey) || AttributesKey.ALL.equals(attributesKey))
+		{
+			return;
+		}
+
+		final I_M_ShipmentSchedule shipmentSchedule = getByOrderLineId(orderLineId);
+		if (shipmentSchedule == null)
+		{
+			logger.debug("No shipment schedule found for C_OrderLine_ID={}; skip ASI update from reservation", orderLineId);
+			return;
+		}
+
+		if (shipmentSchedule.isProcessed())
+		{
+			return;
+		}
+
+		final IAttributeSet attributeSet = AttributesKeys.toImmutableAttributeSet(attributesKey);
+		if (attributeSet.getAttributes().isEmpty())
+		{
+			return;
+		}
+
+		final IAttributeSetInstanceAware asiAware = toAttributeSetInstanceAware(shipmentSchedule);
+		Services.get(IAttributeSetInstanceBL.class).syncAttributesToASIAware(attributeSet, asiAware);
+		shipmentSchedulePA.save(shipmentSchedule);
+		logger.debug("Updated ASI on M_ShipmentSchedule_ID={} from C_OrderLine_ID={} with attributesKey={}",
+				shipmentSchedule.getM_ShipmentSchedule_ID(), orderLineId, attributesKey);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationRepository.java
@@ -2,6 +2,7 @@ package de.metas.inoutcandidate.qty_reservation;
 
 import com.google.common.collect.ImmutableList;
 import de.metas.handlingunits.QtyTU;
+import de.metas.material.event.commons.AttributesKey;
 import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderLineId;
 import de.metas.product.ProductId;
@@ -107,6 +108,22 @@ public class QtyReservationRepository
 	{
 		final int deleteCount = toSqlQuery(request).create().delete();
 		return deleteCount > 0;
+	}
+
+	/**
+	 * Returns the attributesKey from any remaining active reservation for the given order line,
+	 * or {@link AttributesKey#NONE} if no reservation remains.
+	 */
+	@NonNull
+	public AttributesKey getFirstRemainingAttributesKeyByOrderLineId(@NonNull final OrderAndLineId orderAndLineId)
+	{
+		return queryNotProcessedByOrderLine(orderAndLineId)
+				.create()
+				.stream()
+				.map(record -> AttributesKey.ofString(record.getAttributesKey()))
+				.filter(key -> !key.isNone())
+				.findFirst()
+				.orElse(AttributesKey.NONE);
 	}
 
 	public QtyTU getReservedQtyTU(final @NotNull DeleteQtyReservationRequest request)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationRepository.java
@@ -2,7 +2,6 @@ package de.metas.inoutcandidate.qty_reservation;
 
 import com.google.common.collect.ImmutableList;
 import de.metas.handlingunits.QtyTU;
-import de.metas.material.event.commons.AttributesKey;
 import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderLineId;
 import de.metas.product.ProductId;
@@ -111,19 +110,21 @@ public class QtyReservationRepository
 	}
 
 	/**
-	 * Returns the attributesKey from any remaining active reservation for the given order line,
-	 * or {@link AttributesKey#NONE} if no reservation remains.
+	 * Returns all active, unprocessed reservations for the given order line.
+	 * Used by the HU picker to honor each reservation's attributes when picking on-the-fly.
 	 */
 	@NonNull
-	public AttributesKey getFirstRemainingAttributesKeyByOrderLineId(@NonNull final OrderAndLineId orderAndLineId)
+	public ImmutableList<QtyReservation> getActiveByOrderLineId(@NonNull final OrderLineId orderLineId)
 	{
-		return queryNotProcessedByOrderLine(orderAndLineId)
+		return queryBL.createQueryBuilder(I_M_QtyReservation.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_QtyReservation.COLUMNNAME_Processed, false)
+				.addEqualsFilter(I_M_QtyReservation.COLUMNNAME_C_OrderLine_ID, orderLineId)
+				.orderBy(I_M_QtyReservation.COLUMNNAME_M_QtyReservation_ID)
 				.create()
 				.stream()
-				.map(record -> AttributesKey.ofString(record.getAttributesKey()))
-				.filter(key -> !key.isNone())
-				.findFirst()
-				.orElse(AttributesKey.NONE);
+				.map(QtyReservationLoaderAndSaver::fromRecord)
+				.collect(ImmutableList.toImmutableList());
 	}
 
 	public QtyTU getReservedQtyTU(final @NotNull DeleteQtyReservationRequest request)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
@@ -1,13 +1,10 @@
 package de.metas.inoutcandidate.qty_reservation;
 
 import de.metas.handlingunits.QtyTU;
-import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
 import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleSegments;
-import de.metas.material.event.commons.AttributesKey;
 import de.metas.order.IOrderLineBL;
 import de.metas.order.OrderAndLineId;
-import de.metas.order.OrderLineId;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -23,7 +20,6 @@ import org.springframework.stereotype.Service;
 public class QtyReservationService
 {
 	@NonNull private final IOrderLineBL orderLineBL = Services.get(IOrderLineBL.class);
-	@NonNull private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
 	@NonNull private final IShipmentScheduleInvalidateBL shipmentScheduleInvalidateBL;
 	@NonNull private final QtyReservationRepository repository;
 
@@ -53,9 +49,6 @@ public class QtyReservationService
 			orderLineBL.save(orderLine);
 		}
 
-		final OrderLineId orderLineId = request.getOrderAndLineId().getOrderLineId();
-		shipmentScheduleBL.updateASIFromReservationAttributesKey(orderLineId, request.getAttributesKey());
-
 		invalidateShipmentSchedulesForSalesOrderLine(orderLine);
 
 		return qtyReservationId;
@@ -67,18 +60,6 @@ public class QtyReservationService
 
 		if (deleted)
 		{
-			final OrderLineId orderLineId = request.getOrderAndLineId().getOrderLineId();
-			final AttributesKey remainingAttributesKey = repository.getFirstRemainingAttributesKeyByOrderLineId(request.getOrderAndLineId());
-			if (!remainingAttributesKey.isNone())
-			{
-				// Another reservation still exists — re-apply its attributes to the SS ASI
-				shipmentScheduleBL.updateASIFromReservationAttributesKey(orderLineId, remainingAttributesKey);
-			}
-			else
-			{
-				// No reservations left — reset SS ASI back to the orderline's original ASI
-				shipmentScheduleBL.resetSSASIFromOrderLine(orderLineId);
-			}
 			invalidateShipmentSchedulesForSalesOrderLineId(request.getOrderAndLineId());
 		}
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
@@ -4,6 +4,7 @@ import de.metas.handlingunits.QtyTU;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
 import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleSegments;
+import de.metas.material.event.commons.AttributesKey;
 import de.metas.order.IOrderLineBL;
 import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderLineId;
@@ -66,6 +67,18 @@ public class QtyReservationService
 
 		if (deleted)
 		{
+			final OrderLineId orderLineId = request.getOrderAndLineId().getOrderLineId();
+			final AttributesKey remainingAttributesKey = repository.getFirstRemainingAttributesKeyByOrderLineId(request.getOrderAndLineId());
+			if (!remainingAttributesKey.isNone())
+			{
+				// Another reservation still exists — re-apply its attributes to the SS ASI
+				shipmentScheduleBL.updateASIFromReservationAttributesKey(orderLineId, remainingAttributesKey);
+			}
+			else
+			{
+				// No reservations left — reset SS ASI back to the orderline's original ASI
+				shipmentScheduleBL.resetSSASIFromOrderLine(orderLineId);
+			}
 			invalidateShipmentSchedulesForSalesOrderLineId(request.getOrderAndLineId());
 		}
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
@@ -1,10 +1,12 @@
 package de.metas.inoutcandidate.qty_reservation;
 
 import de.metas.handlingunits.QtyTU;
+import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
 import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleSegments;
 import de.metas.order.IOrderLineBL;
 import de.metas.order.OrderAndLineId;
+import de.metas.order.OrderLineId;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -20,6 +22,7 @@ import org.springframework.stereotype.Service;
 public class QtyReservationService
 {
 	@NonNull private final IOrderLineBL orderLineBL = Services.get(IOrderLineBL.class);
+	@NonNull private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
 	@NonNull private final IShipmentScheduleInvalidateBL shipmentScheduleInvalidateBL;
 	@NonNull private final QtyReservationRepository repository;
 
@@ -45,9 +48,12 @@ public class QtyReservationService
 		if (request.getProjectId() != null)
 		{
 			orderLine.setC_Project_ID(request.getProjectId().getRepoId());
-			// assume the ProjectValue attribute will be automatically set/updated in ASI 
+			// assume the ProjectValue attribute will be automatically set/updated in ASI
 			orderLineBL.save(orderLine);
 		}
+
+		final OrderLineId orderLineId = request.getOrderAndLineId().getOrderLineId();
+		shipmentScheduleBL.updateASIFromReservationAttributesKey(orderLineId, request.getAttributesKey());
 
 		invalidateShipmentSchedulesForSalesOrderLine(orderLine);
 


### PR DESCRIPTION
## Summary

- **Root cause**: When a qty reservation was made from Material Cockpit V2, the selected storage attributes (Herkunft, Kaliber) were stored in `M_QtyReservation.attributesKey` but never applied to the shipment schedule's ASI. The on-the-fly HU picker (`PickAvailableHUsOnTheFly.MatchAttributes=true`) only matches HUs whose attributes equal the shipment schedule's ASI — so HUs with `Herkunft=DE` were not picked for schedules with `Herkunft=NULL`.
- **Fix 1** (`QtyReservationService` + `ShipmentScheduleBL`): After creating the reservation, merge the reservation's `attributesKey` into the linked shipment schedule's ASI. This uses a merge (not replace) — existing ASI attributes not covered by the key are preserved. The SS ASI is intentionally not re-synced during recompute, so this update persists.
- **Fix 2** (`ShipmentLineBuilder`): When no HU attribute values are available (no HUs picked on-the-fly), fall back to the shipment schedule's own ASI instead of leaving the shipment line with an empty ASI.

## Files Changed

- `IShipmentScheduleBL.java` — new interface method `updateASIFromReservationAttributesKey`
- `ShipmentScheduleBL.java` — implementation following existing `updateProjectId` pattern
- `QtyReservationService.java` — calls the new method after reservation creation
- `ShipmentLineBuilder.java` — fallback to SS ASI when `attributeValues` is empty

## Test plan

- [ ] Make a qty reservation from Material Cockpit V2 selecting a row with Herkunft=DE
- [ ] Verify the linked shipment schedule's ASI now has Herkunft=DE
- [ ] Generate a shipment from the shipment schedule — verify the shipment line inherits the correct ASI and that HUs are assigned