### PR TITLE
ci: add Mergify rule to block direct merges between protected branches

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,10 @@
 #                               Must be combined with ops:auto_squash_merge or ops:auto_merge_commit.
 # ops:auto_ported            — Informational: PR was auto-created by auto-port.yml workflow.
 # ops:no_auto_port           — (reserved for future use)
+#
+# Protection: PRs that merge directly from one protected branch (*_hotfix,
+# *_release, *_uat) into another are automatically closed. Use auto-port
+# merge/ branches instead — they test the merged result via CI first.
 # =============================================================================
 
 # "Merge Gate" is the CI gate — a workflow_run-based commit status set by
@@ -134,6 +138,34 @@ pull_request_rules:
         add:
           - "branch:{{base}}"
       delete_head_branch: {}
+
+  - name: Block direct merges between protected branches (use auto-port instead)
+    conditions:
+      - -merged
+      - -closed
+      - or:
+          - or: *ALL_BASE_BRANCHES
+      - or:
+          - head~=_uat$
+          - head~=_hotfix$
+          - head~=_release$
+          - head=release
+      - -head~=^merge/
+    actions:
+      comment:
+        message: |
+          ⛔ **Direct merge between protected branches is not allowed.**
+
+          This PR merges `{{head}}` directly into `{{base}}`. Direct merges between
+          protected branches can cause silent content duplication — Git 3-way merge
+          adds non-overlapping changes from both sides (e.g. duplicate CI workflow
+          jobs added independently on each branch).
+
+          **What to do:** Close this PR and let
+          [auto-port](https://github.com/metasfresh/metasfresh/blob/new_dawn_uat/.github/workflows/auto-port.yml)
+          handle the merge. Auto-port creates `merge/<source>-to-<target>` branches
+          that test the merged result via CI before merging into the target branch.
+      close: {}
 
   - name: Automatic squash-merge successful PRs into the respective base-branch
     conditions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,10 +9,14 @@
 #                               Must be combined with ops:auto_squash_merge or ops:auto_merge_commit.
 # ops:auto_ported            — Informational: PR was auto-created by auto-port.yml workflow.
 # ops:no_auto_port           — (reserved for future use)
+# ops:allow_protected_merge  — Override the protection rule that blocks direct merges
+#                               between protected branches. Use sparingly and only when
+#                               auto-port merge/ branches are not feasible.
 #
 # Protection: PRs that merge directly from one protected branch (*_hotfix,
 # *_release, *_uat) into another are automatically closed. Use auto-port
 # merge/ branches instead — they test the merged result via CI first.
+# Set ops:allow_protected_merge label to override this for a specific PR.
 # =============================================================================
 
 # "Merge Gate" is the CI gate — a workflow_run-based commit status set by
@@ -143,6 +147,7 @@ pull_request_rules:
     conditions:
       - -merged
       - -closed
+      - -label=ops:allow_protected_merge
       - or:
           - or: *ALL_BASE_BRANCHES
       - or:


### PR DESCRIPTION
## Summary

- Adds a Mergify `pull_request_rules` entry that automatically **closes** PRs attempting to merge directly from one protected branch (`*_hotfix`, `*_release`, `*_uat`) into another
- Posts an explanatory comment directing users to use auto-port `merge/` branches instead
- Auto-port's `merge/<source>-to-<target>` branches are explicitly excluded from this rule

**Background:** A manual merge from `intensive_care_hotfix` directly into `new_dawn_uat` (PR #22916) caused Git 3-way merge to silently duplicate the `publish-test-reports` job — both branches had independently added it. GitHub Actions rejected the duplicate YAML job ID, breaking all CI on `new_dawn_uat` until PR #22924 removed the duplicate.

## How it works

| PR head branch | PR base branch | Result |
|---|---|---|
| `intensive_care_hotfix` | `new_dawn_uat` | **Closed** with comment |
| `soft_panda_release` | `soft_panda_uat` | **Closed** with comment |
| `merge/intensive_care_hotfix-to-new_dawn_uat` | `new_dawn_uat` | **Allowed** (auto-port merge branch) |
| `new_dawn_uat_SomeFeature` | `new_dawn_uat` | **Allowed** (feature branch) |

## Test plan

- [ ] Verify Mergify config is valid (Mergify dashboard validates on push)
- [ ] Confirm existing auto-port merge PRs (with `merge/` prefix) are not affected
- [ ] Confirm regular feature branch PRs are not affected