### PR TITLE
Guard M_HU_PI_Attribute insert against missing M_HU_PI_Version

### DIFF
--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5792270_add_gray_attribute.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5792270_add_gray_attribute.sql
@@ -5,9 +5,13 @@ INSERT INTO M_Attribute (AD_Client_ID,AD_Org_ID,AttributeValuesOrderBy,Attribute
 ;
 
 -- 2026-03-05T18:03:34.354Z
-INSERT INTO M_HU_PI_Attribute (AD_Client_ID,AD_Org_ID,Created,CreatedBy,HU_TansferStrategy_JavaClass_ID,IsActive,IsDisplayed,IsInstanceAttribute,IsMandatory,IsOnlyIfInProductAttributeSet,IsReadOnly,M_Attribute_ID,M_HU_PI_Attribute_ID,M_HU_PI_Version_ID,PropagationType,SeqNo,Updated,UpdatedBy,UseInASI) VALUES (1000000,1000000,TO_TIMESTAMP('2026-03-05 18:03:34.352000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,540027,'Y','Y','N','N','N','N',540192,540139,2001855,'NONE',200,TO_TIMESTAMP('2026-03-05 18:03:34.352000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y')
-;
+-- Guard: M_HU_PI_Version_ID=2001855 may not exist in environments where packing instructions were deleted
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM M_HU_PI_Version WHERE M_HU_PI_Version_ID = 2001855) THEN
+        INSERT INTO M_HU_PI_Attribute (AD_Client_ID,AD_Org_ID,Created,CreatedBy,HU_TansferStrategy_JavaClass_ID,IsActive,IsDisplayed,IsInstanceAttribute,IsMandatory,IsOnlyIfInProductAttributeSet,IsReadOnly,M_Attribute_ID,M_HU_PI_Attribute_ID,M_HU_PI_Version_ID,PropagationType,SeqNo,Updated,UpdatedBy,UseInASI) VALUES (1000000,1000000,TO_TIMESTAMP('2026-03-05 18:03:34.352000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,540027,'Y','Y','N','N','N','N',540192,540139,2001855,'NONE',200,TO_TIMESTAMP('2026-03-05 18:03:34.352000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y');
 
--- 2026-03-05T18:03:45.748Z
-UPDATE M_HU_PI_Attribute SET UseInASI='N',Updated=TO_TIMESTAMP('2026-03-05 18:03:45.748000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE M_HU_PI_Attribute_ID=540139
-;
+        -- 2026-03-05T18:03:45.748Z
+        UPDATE M_HU_PI_Attribute SET UseInASI='N',Updated=TO_TIMESTAMP('2026-03-05 18:03:45.748000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE M_HU_PI_Attribute_ID=540139;
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Migration script `5792270_add_gray_attribute.sql` (from https://github.com/metasfresh/metasfresh/pull/22532) hardcodes `M_HU_PI_Version_ID=2001855` in an INSERT into `M_HU_PI_Attribute`
- This fails in customer repos where packing instructions have been deleted or custom base dumps don't contain that record
- Wrap the INSERT + UPDATE in a `DO` block that checks `M_HU_PI_Version` existence first

## Affected repos
- bh197: customer script `5736410_sys_gh24_Delete_PackingInstructions.sql` explicitly deletes version 2001855
- mo96: uses a custom base dump (`metasfresh-db-custom-base:1`) that doesn't contain version 2001855

## Test plan
- [ ] CI passes on metasfresh base
- [ ] Once merged and base version bumped, re-run bh197 and mo96 CI to confirm green `build customer db`