### PR TITLE
ci: exclude patch/ branches from protected-branch merge block

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -156,6 +156,7 @@ pull_request_rules:
           - head~=_release$
           - head=release
       - -head~=^merge/
+      - -head~=^patch/
     actions:
       comment:
         message: |


### PR DESCRIPTION
## Summary

- Add `-head~=^patch/` exclusion to the Mergify rule that blocks direct merges between protected branches
- `patch/` branches are feature branches, not protected branches — they shouldn't trigger the block
- Example: `patch/publish-test-reports-to-task_force_hotfix` was incorrectly blocked because the branch name ends with `_hotfix`