### PR TITLE
Fix C_PaymentTerm N+1 query: register in IModelCacheService

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/modelvalidator/SwatValidator.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/modelvalidator/SwatValidator.java
@@ -61,6 +61,8 @@ import org.compiere.model.I_C_BP_Group;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_Campaign;
 import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_PaySchedule;
+import org.compiere.model.I_C_PaymentTerm;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_Attribute;
 import org.compiere.model.I_M_Locator;
@@ -267,6 +269,8 @@ public class SwatValidator implements ModelValidator
 				.register();
 
 		cachingService.addTableCacheConfigIfAbsent(I_C_BP_Group.class);
+		cachingService.addTableCacheConfigIfAbsent(I_C_PaymentTerm.class);
+		cachingService.addTableCacheConfigIfAbsent(I_C_PaySchedule.class);
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

- **Register `C_PaymentTerm` and `C_PaySchedule` in `IModelCacheService`** via `SwatValidator.setupTableCacheConfig()`, enabling framework-level caching with automatic invalidation through `CacheMgt`.
- `pg_stat_statements` on production showed **1.2 billion calls** to `SELECT * FROM C_PaymentTerm WHERE C_PaymentTerm_ID=?` during invoice processing runs — despite there being fewer than 100 unique payment terms. Every `PaymentTermRepository.getById()` was hitting the DB because the table was not registered in the model cache service.
- `C_PaySchedule` is also registered because `MPaymentTerm.getSchedule()` loads it as a child record, and it similarly benefits from caching.

## Test plan

- [ ] Verify `C_PaymentTerm` and `C_PaySchedule` records are cached after first load (check via debugger or cache stats)
- [ ] Verify cache is invalidated when a `C_PaymentTerm` record is modified via the UI
- [ ] Run an invoice generation process and confirm no regression in behavior