### PR TITLE
Add swingUI zip as CI build artifact

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -314,6 +314,14 @@ jobs:
             docker push metasfresh/metas-db:${{ needs.init.outputs.tag-floating }}
             docker push metasfresh/metas-edi:${{ needs.init.outputs.tag-fixed }}
             docker push metasfresh/metas-edi:${{ needs.init.outputs.tag-floating }}
+      - name: extract-swingui
+        run: |
+          docker cp "$(docker create --name swingui-extract metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-fixed }}):/backend/metasfresh-dist/swingui/target/metasfresh-dist-swingui-10.0.0-client.zip" ./metasfresh-swingui-${{ needs.init.outputs.tag-fixed }}.zip && docker rm swingui-extract
+          ls -la metasfresh-swingui-*.zip
+      - uses: actions/upload-artifact@v4
+        with:
+          name: metasfresh-swingui-${{ needs.init.outputs.tag-fixed }}
+          path: metasfresh-swingui-${{ needs.init.outputs.tag-fixed }}.zip
       - name: disk-cleanup
         run: |
           docker system prune -af --filter "until=1h"


### PR DESCRIPTION
## Summary

- Extract `metasfresh-dist-swingui` client.zip from the `metas-mvn-backend` Docker image during the backend job
- Upload it as a downloadable GitHub Actions artifact

## Test plan

- [ ] Backend job completes with the new extract-swingui step
- [ ] Artifact appears in the GH Actions run artifacts list
- [ ] Zip is downloadable and contains the swingUI client files