### PR TITLE
fix: Password field hidden on ExternalSystem_Endpoint (HTTP+Basic)

### DIFF
--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5794920_sys_gh28749_fix_password_displaylogic_parentheses.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5794920_sys_gh28749_fix_password_displaylogic_parentheses.sql
@@ -1,0 +1,20 @@
+-- Fix Password DisplayLogic: add parentheses for correct evaluation with UseOperatorPrecedence=N
+-- Without parentheses, left-to-right evaluation causes Password to be hidden when HTTP+Basic is selected
+-- because the trailing `& @SftpAuthType/X@='PASSWORD'` evaluates to false.
+
+-- AD_Field.DisplayLogic
+UPDATE AD_Field
+SET DisplayLogic   = '(@TransportType/X@=''HTTP'' & @AuthType/X@=''Basic'') | (@TransportType/X@=''SFTP'' & @SftpAuthType/X@=''PASSWORD'')',
+    Updated        = TO_TIMESTAMP('2026-03-20 10:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy      = 100
+WHERE AD_Field_ID = 755950;
+
+-- AD_Column.MandatoryLogic
+UPDATE AD_Column
+SET MandatoryLogic = '(@TransportType/X@=''HTTP'' & @AuthType/X@=''Basic'') | (@TransportType/X@=''SFTP'' & @SftpAuthType/X@=''PASSWORD'')',
+    Updated        = TO_TIMESTAMP('2026-03-20 10:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy      = 100
+WHERE AD_Column_ID = (SELECT AD_Column_ID
+                      FROM AD_Column
+                      WHERE AD_Table_ID = (SELECT AD_Table_ID FROM AD_Table WHERE TableName = 'ExternalSystem_Endpoint')
+                        AND ColumnName = 'Password');


### PR DESCRIPTION
## Summary

- Adds explicit parentheses to `DisplayLogic` and `MandatoryLogic` for the Password field on `ExternalSystem_Endpoint`
- Without parentheses, left-to-right evaluation (`UseOperatorPrecedence=N`) causes Password to be hidden when `TransportType=HTTP` and `AuthType=Basic`, because the trailing SFTP condition evaluates to false

## Test plan

- [ ] Apply migration `5794920` on target DB
- [ ] Open ExternalSystem_Endpoint window, set TransportType=HTTP, AuthType=Basic
- [ ] Verify Password field is visible and mandatory
- [ ] Set TransportType=SFTP, SftpAuthType=PASSWORD — verify Password field is visible
- [ ] Set TransportType=SFTP, SftpAuthType=SSH_KEY — verify Password field is hidden