### PR TITLE
Fix C_Order_M_InOut_C_Invoice_Overview_V orderline join bug

### DIFF
--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5794692_gh27927_overhaul_C_Order_M_InOut_C_Invoice_Overview_V_ddl.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5794692_gh27927_overhaul_C_Order_M_InOut_C_Invoice_Overview_V_ddl.sql
@@ -78,7 +78,7 @@ FROM (SELECT get_table_id('C_Order')                                   AS ad_Tab
              ol.priceactual,
              ol.linenetamt
       FROM c_order o
-               JOIN c_orderline ol ON ol.c_orderline_id = o.c_order_id
+               JOIN c_orderline ol ON ol.c_order_id = o.c_order_id
       UNION
 
       SELECT get_table_id('M_InOut')           AS ad_Table_id,

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5795070_sys_gh28680_fix_C_Order_M_InOut_C_Invoice_Overview_V_orderline_join.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5795070_sys_gh28680_fix_C_Order_M_InOut_C_Invoice_Overview_V_orderline_join.sql
@@ -1,29 +1,11 @@
-/*
- * #%L
- * de.metas.business
- * %%
- * Copyright (C) 2026 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
+-- gh#28680: Fix C_Order_M_InOut_C_Invoice_Overview_V orderline join
+-- Bug: JOIN c_orderline ol ON ol.c_orderline_id = o.c_order_id
+-- Fix: JOIN c_orderline ol ON ol.c_order_id = o.c_order_id
+-- The wrong join caused order lines to appear only when c_orderline_id happened to equal c_order_id
 
-DROP VIEW IF EXISTS C_Order_M_InOut_C_Invoice_Overview_V
-;
+DROP VIEW IF EXISTS C_Order_M_InOut_C_Invoice_Overview_V$new;
 
-CREATE OR REPLACE VIEW C_Order_M_InOut_C_Invoice_Overview_V AS
+CREATE OR REPLACE VIEW C_Order_M_InOut_C_Invoice_Overview_V$new AS
 SELECT ROW_NUMBER() OVER (ORDER BY ad_Table_id, head_id, line_id) AS C_Order_M_InOut_C_Invoice_Overview_V_ID,
        doc.ad_Table_id,
        doc.Record_ID,
@@ -117,7 +99,7 @@ FROM (SELECT get_table_id('C_Order')                                   AS ad_Tab
 
       SELECT get_table_id('C_Invoice')                                 AS ad_Table_id,
              i.c_invoice_id                                            AS Record_ID,
-             i.c_invoice_id                                              AS head_id,
+             i.c_invoice_id                                            AS head_id,
              il.c_invoiceline_id                                       AS line_id,
              il.ad_client_id,
              il.ad_org_id,
@@ -155,3 +137,12 @@ FROM (SELECT get_table_id('C_Order')                                   AS ad_Tab
                     WHERE s.isactive = 'Y'
                     GROUP BY s.m_product_id, s.m_warehouse_id) stock ON doc.m_product_id = stock.m_product_id AND doc.m_warehouse_id = stock.m_warehouse_id
 ;
+
+SELECT db_alter_view(
+    'C_Order_M_InOut_C_Invoice_Overview_V',
+    (SELECT view_definition
+     FROM information_schema.views
+     WHERE lower(views.table_name) = lower('C_Order_M_InOut_C_Invoice_Overview_V$new'))
+);
+
+DROP VIEW IF EXISTS C_Order_M_InOut_C_Invoice_Overview_V$new;


### PR DESCRIPTION
## Summary
- Fix incorrect JOIN in the C_Order subquery of `C_Order_M_InOut_C_Invoice_Overview_V`
- `ol.c_orderline_id = o.c_order_id` was wrong — should be `ol.c_order_id = o.c_order_id`
- This caused order lines to appear only when `c_orderline_id` happened to equal `c_order_id` (essentially random for most data)
- Fixed in DDL file, existing migration script, and a new fix migration using `db_alter_view` for environments that already applied the broken migration

## Test plan
- [ ] Apply migration `5795070` on a database that already has the view
- [ ] Verify `SELECT count(*) FROM C_Order_M_InOut_C_Invoice_Overview_V WHERE ad_table_id = get_table_id('C_Order')` returns expected row count (should now match `SELECT count(*) FROM c_orderline`)
- [ ] Verify the "Purchase & Sales Overview" window shows order lines in the grid