### PR TITLE
Auto-port: only post traceability on merged PRs

### DIFF
--- a/.github/workflows/auto-port.yml
+++ b/.github/workflows/auto-port.yml
@@ -418,7 +418,7 @@ jobs:
 
           # Find source PRs associated with the triggering cicd commit
           SOURCE_PRS=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
-            --jq '.[].number' 2>/dev/null || true)
+            --jq '[.[] | select(.merged_at != null)] | .[].number' 2>/dev/null || true)
 
           if [[ -z "$SOURCE_PRS" ]]; then
             echo "No source PRs found for commit $HEAD_SHA, skipping traceability"


### PR DESCRIPTION
## Summary
- Filter the `/commits/{sha}/pulls` API response in the auto-port traceability step to only include **merged** PRs (`select(.merged_at != null)`)
- Prevents premature traceability comments on open/unmerged PRs that share commit ancestry with the base branch

## Test plan
- [ ] Merge a test PR to any `_hotfix` branch
- [ ] Verify auto-port traceability comment appears only on the merged PR
- [ ] Verify no comment appears on open PRs targeting the same base branch