### PR TITLE
Fix profile3 Cucumber: move frontendTesting to executor6

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/frontend_testing/frontendTestingOrderLifecycle.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/frontend_testing/frontendTestingOrderLifecycle.feature
@@ -1,5 +1,5 @@
 @from:cucumber
-@ghActions:run_on_executor3
+@ghActions:run_on_executor6
 Feature: Frontend Testing API - Order Lifecycle
   Validates the business logic underlying the frontendTesting API:
   sales order completion, shipment generation from schedules, and


### PR DESCRIPTION
## Summary
Move `frontendTestingOrderLifecycle.feature` from executor3 to executor6 to fix DB state pollution.

## Root cause
Our feature (merged in #23079) creates orders, pricing systems, and BPartners on executor3 — same as `productionCandidate.feature`. The test data pollutes the shared DB, causing `PP_Order_Candidate` async processing to fail:
- `QtyToProcess expected: 0 but was: 10`
- `QtyProcessed expected: 10 but was: 0`

## Fix
`@ghActions:run_on_executor3` → `@ghActions:run_on_executor6` (1 line)

## Evidence
- profile3 fails consistently on `keen_hawk_hotfix` since #23079 was merged (19:10 UTC)
- All runs before that merge passed
- The failure is deterministic, not flaky