### PR TITLE
#28967 Fix SQLStatement date quoting for Package Licensing reports

### DIFF
--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5795170_sys_gh28967_Fix_Package_Licensing_SQLStatement_Quoting.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5795170_sys_gh28967_Fix_Package_Licensing_SQLStatement_Quoting.sql
@@ -1,0 +1,24 @@
+-- gh#28967: Fix SQLStatement quoting for Package Licensing reports
+-- Date parameters must be quoted and cast to timestamp, otherwise the raw
+-- substitution produces invalid SQL like: 2026-03-01 00:00:00.0 (unquoted)
+
+-- Fix detail report (585503)
+UPDATE AD_Process
+SET SQLStatement = 'SELECT * FROM report.Package_Licensing_InOut_Report(''@DateFrom@''::timestamp with time zone, ''@DateTo@''::timestamp with time zone, @C_Country_ID/null@, ''@IsIncludeAllProducts@'')',
+    Updated      = '2026-03-21 18:00',
+    UpdatedBy    = 100
+WHERE AD_Process_ID = 585503;
+
+-- Fix summary report (585504)
+UPDATE AD_Process
+SET SQLStatement = 'SELECT * FROM report.Package_Licensing_InOut_Summary_Report(''@DateFrom@''::timestamp with time zone, ''@DateTo@''::timestamp with time zone, @C_Country_ID/null@, ''@IsIncludeAllProducts@'')',
+    Updated      = '2026-03-21 18:00',
+    UpdatedBy    = 100
+WHERE AD_Process_ID = 585504;
+
+-- Fix product report (585578)
+UPDATE AD_Process
+SET SQLStatement = 'SELECT * FROM report.Package_Licensing_Product_Report(''@DateFrom@''::timestamp with time zone, ''@DateTo@''::timestamp with time zone, @C_Country_ID/null@, ''@IsIncludeAllProducts@'')',
+    Updated      = '2026-03-21 18:00',
+    UpdatedBy    = 100
+WHERE AD_Process_ID = 585578;


### PR DESCRIPTION
## Summary
- Date parameters in SQLStatement were unquoted, causing `syntax error at or near "00"` at runtime
- Fix: wrap dates as `''@DateFrom@''::timestamp with time zone`
- Applies to all three reports: detail (585503), summary (585504), product (585578)

## Test plan
- [x] Verified broken SQL from error trace
- [ ] CI green