### PR TITLE
Fix mobile UI logout button not visible on small screens

### DIFF
--- a/e2e/mobile-webui/tests/spec/login.spec.js
+++ b/e2e/mobile-webui/tests/spec/login.spec.js
@@ -23,7 +23,7 @@ test.describe('Login/Logout', () => {
                 const response = await Backend.createMasterdata({
                     request: {
                         mobileConfig: {
-                            defaultAuthMethod: authMethod,  
+                            defaultAuthMethod: authMethod,
                         },
                         login: {
                             user: { language },
@@ -41,4 +41,29 @@ test.describe('Login/Logout', () => {
             });
         });
     })
+
+    test('Logout button visible on small screen height', async ({ page }) => {
+        // === ALLURE METADATA ===
+        allure.epic('E0295: Frontend MobileUI');
+        allure.tag('F12000: Frontend MobileUI');
+        allure.tag('F12000');
+        allure.story('Logout button visible on small screen');
+        allure.severity('normal');
+
+        // Simulate Zebra MC3300x screen height (~450px)
+        await page.setViewportSize({ width: 412, height: 450 });
+
+        const response = await Backend.createMasterdata({
+            request: {
+                login: {
+                    user: { language: 'en_US' },
+                },
+            }
+        });
+
+        await LoginScreen.login(response.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.expectLogoutButtonReachable();
+        await ApplicationsListScreen.logout();
+    });
 });

--- a/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
@@ -20,6 +20,13 @@ export const ApplicationsListScreen = {
         await expect(containerElement()).toBeVisible();
     }),
 
+    expectLogoutButtonReachable: async () => await test.step(`${NAME} - Expect logout button reachable by scrolling`, async () => {
+        const logoutButton = page.locator('#logout-button');
+        await expect(logoutButton).toBeVisible();
+        await logoutButton.scrollIntoViewIfNeeded();
+        await expect(logoutButton).toBeInViewport();
+    }),
+
     startApplication: async (applicationId) => await test.step(`${NAME} - Start application ${applicationId}`, async () => {
         await page.locator('#' + applicationId + '-button').tap();
     }),

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/assets/applications-list.scss
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/assets/applications-list.scss
@@ -1,10 +1,17 @@
 .applications-list {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+
   .section {
     padding-top: 3rem;
     padding-bottom: 3rem;
+    flex: 1;
+    overflow-y: auto;
   }
 
-  @media only screen and (max-width: $small-screen-height) {
+  @media only screen and (max-height: $small-screen-height) {
     .section {
       padding-top: 1rem;
       padding-bottom: 1rem;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/assets/applications-list.scss
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/assets/applications-list.scss
@@ -9,13 +9,17 @@
     padding-bottom: 3rem;
     flex: 1;
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   @media only screen and (max-height: $small-screen-height) {
+    > .p-3 {
+      padding: 0.5rem !important;
+    }
+
     .section {
       padding-top: 1rem;
       padding-bottom: 1rem;
     }
   }
-
 }


### PR DESCRIPTION
## Summary
- The applications list screen (launcher) on the mobile UI was not scrollable, causing the logout button to be clipped on devices with small screen heights (e.g. ~450px)
- Made the `.applications-list` container a flex column filling the viewport, with the `.section` area scrollable via `overflow-y: auto`
- Fixed a bug in the responsive media query which used `max-width` instead of `max-height` for the small screen height breakpoint

## Test plan
- [ ] Open mobile UI launcher screen on a device or browser with ~450px viewport height
- [ ] Verify all buttons including "Abmelden" (logout) are visible (scroll if needed)
- [ ] Verify the logout button works when tapped
- [ ] Verify normal-height screens still look correct (no unnecessary scrollbar)