### PR TITLE
Fix Docker build failures on epic_party_uat

### DIFF
--- a/docker-builds/Dockerfile.backend.api
+++ b/docker-builds/Dockerfile.backend.api
@@ -1,9 +1,10 @@
 ARG REFNAME=local
-FROM metasfresh/metas-mvn-backend:$REFNAME as backend
+ARG REGISTRY=
+FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
-FROM openjdk:8-jre-bullseye
+FROM eclipse-temurin:8-jre-jammy
 
-RUN apt-get -y update && apt-get -y install locales zip && rm -rf /var/lib/apt/lists/*
+RUN apt-get -y update && apt-get -y install locales zip curl && rm -rf /var/lib/apt/lists/*
 RUN localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
 ENV LANG=de_DE.UTF-8 LANGUAGE=de_DE.UTF-8 LC_MESSAGES=de_DE.UTF-8
 ENV TZ=Europe/Berlin

--- a/docker-builds/Dockerfile.backend.app
+++ b/docker-builds/Dockerfile.backend.app
@@ -1,7 +1,7 @@
 ARG REFNAME=local
-FROM metasfresh/metas-mvn-backend:$REFNAME as backend
+FROM metasfresh/metas-mvn-backend:$REFNAME AS backend
 
-FROM openjdk:8-jre-bullseye
+FROM eclipse-temurin:8-jre-jammy
 
 RUN apt-get -y update && apt-get -y install locales zip && rm -rf /var/lib/apt/lists/*
 RUN localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8

--- a/docker-builds/Dockerfile.mobile
+++ b/docker-builds/Dockerfile.mobile
@@ -1,14 +1,20 @@
-FROM node:14 as build
+FROM node:14 AS build
 
 RUN npm install -g webpack webpack-cli
 
-RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
+# Temporarily override apt sources to use archive for EOL distribution
+RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian buster-updates main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y locales && rm -rf /var/lib/apt/lists/* && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
 ENV LANG=de_DE.UTF-8 LANGUAGE=de_DE.UTF-8 LC_MESSAGES=de_DE.UTF-8
 ENV TZ=Europe/Berlin
 
 WORKDIR /app 
 
 COPY misc/services/mobile-webui/mobile-webui-frontend/package.json .
+COPY misc/services/mobile-webui/mobile-webui-frontend/yarn.lock* .
 RUN yarn install
 
 COPY misc/services/mobile-webui/mobile-webui-frontend/ .
@@ -19,7 +25,7 @@ ENV PUBLIC_URL=/
 RUN yarn build
 
 
-FROM nginx:1.21.6 as runtime
+FROM nginx:1.21.6 AS runtime
 
 COPY docker-builds/nginx/default.conf /etc/nginx/conf.d
 

--- a/docker-builds/Dockerfile.procurement.frontend
+++ b/docker-builds/Dockerfile.procurement.frontend
@@ -1,9 +1,9 @@
-FROM node:16-alpine as build-step
+FROM node:16 AS build-step
 
 LABEL maintainer="info@metasfresh.com"
 LABEL runinfo="Run this image with -e PUBLIC_URL=https://yourdomain.org"
 
-COPY misc/services/procurement-webui/procurement-webui-frontend/package.json .
+COPY misc/services/procurement-webui/procurement-webui-frontend/package.json misc/services/procurement-webui/procurement-webui-frontend/yarn.lock* .
 
 RUN yarn install
 


### PR DESCRIPTION
## Summary
- Replace deprecated `openjdk:8-jre-bullseye` with `eclipse-temurin:8-jre-jammy` in backend Dockerfiles (image removed from Docker Hub)
- Add `archive.debian.org` sources override for EOL Debian buster in mobile Dockerfile (`node:14`)
- Copy `yarn.lock` alongside `package.json` in mobile and procurement frontend Dockerfiles to pin transitive dependency versions (fixes `expect@30.2.0` requiring Node >= 18)
- Minor consistency improvements: `as` → `AS`, add `curl` to api image, add `REGISTRY` ARG

## Test plan
- [ ] CI backend job passes (eclipse-temurin:8-jre-jammy resolves)
- [ ] CI frontend job passes (mobile build with archive.debian.org)
- [ ] CI procurement job passes (yarn.lock pins expect@26.6.2)