### PR TITLE
Filter invoices by completed/closed DocStatus

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/invoice/process/C_Invoice_MassDiscountOrWriteOff.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/process/C_Invoice_MassDiscountOrWriteOff.java
@@ -27,6 +27,7 @@ import de.metas.adempiere.model.I_C_Invoice;
 import de.metas.allocation.api.IAllocationBL;
 import de.metas.allocation.api.IAllocationBL.InvoiceDiscountAndWriteOffRequest;
 import de.metas.allocation.api.IAllocationDAO;
+import de.metas.document.engine.DocStatus;
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.IMsgBL;
 import de.metas.lang.SOTrx;
@@ -189,7 +190,8 @@ public class C_Invoice_MassDiscountOrWriteOff extends JavaProcess
 				.createQueryBuilder(I_C_Invoice.class)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_C_Invoice.COLUMNNAME_AD_Client_ID, getClientId())
-				.addEqualsFilter(I_C_Invoice.COLUMNNAME_IsPaid, false); // not already fully allocated
+				.addEqualsFilter(I_C_Invoice.COLUMNNAME_IsPaid, false) // not already fully allocated
+				.addInArrayFilter(I_C_Invoice.COLUMNNAME_DocStatus, DocStatus.completedOrClosedStatuses());
 
 		if (!getProcessInfo().isInvokedByScheduler())
 		{


### PR DESCRIPTION
Add a DocStatus import and restrict the invoice query to completed or closed document statuses by adding addInArrayFilter(I_C_Invoice.COLUMNNAME_DocStatus, DocStatus.completedOrClosedStatuses()). This ensures the mass discount/write-off process only considers invoices that are finalized (completed/closed) and skips drafts or other non-final statuses.