### PR TITLE
Robust BPartner lookup in bank statement and DATEV payment imports

### DIFF
--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/impexp/BankStatementImportTableSqlUpdater.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/impexp/BankStatementImportTableSqlUpdater.java
@@ -259,22 +259,20 @@ public class BankStatementImportTableSqlUpdater
 				+ " HAVING COUNT(*) = 1"
 				+ ") "
 				+ "WHERE i." + I_I_BankStatement.COLUMNNAME_C_BPartner_ID + " IS NULL "
-				+ "AND i.I_IsImported<>'Y' "
-				+ "OR i.I_IsImported IS NULL")
+				+ "AND (i.I_IsImported<>'Y' OR i.I_IsImported IS NULL)")
 				.append(selection.toSqlWhereClause("i"));
 
 		DB.executeUpdateAndThrowExceptionOnFail(sql.toString(), ITrx.TRXNAME_ThreadInherited);
 
-		// Flag records where multiple active BPartners match the same DebtorId/CreditorId
+		// Flag records where multiple active BPartners match (by Name, Value, DebtorId, or CreditorId)
 		final StringBuilder errorSql = new StringBuilder("UPDATE I_BankStatement i "
 				+ "SET I_IsImported='E', I_ErrorMsg=COALESCE(I_ErrorMsg,'')"
-				+ "||'ERR=Multiple BPartners found for the same DebtorId/CreditorId."
-				+ " Please make sure each DebtorId/CreditorId is unique among active BPartners, ' "
+				+ "||'ERR=Multiple BPartners found matching the import record (by Name, Value, DebtorId, or CreditorId)."
+				+ " Please make sure each identifier is unique among active BPartners.' "
 				+ "WHERE i." + I_I_BankStatement.COLUMNNAME_C_BPartner_ID + " IS NULL "
 				+ "AND (SELECT COUNT(*) FROM " + I_C_BPartner.Table_Name + " bp "
 				+ " WHERE " + bpartnerMatchCondition + ") > 1 "
-				+ "AND i.I_IsImported<>'Y' "
-				+ "OR i.I_IsImported IS NULL")
+				+ "AND (i.I_IsImported<>'Y' OR i.I_IsImported IS NULL)")
 				.append(selection.toSqlWhereClause("i"));
 
 		final int noAmbiguous = DB.executeUpdateAndThrowExceptionOnFail(errorSql.toString(), ITrx.TRXNAME_ThreadInherited);

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/impexp/BankStatementImportTableSqlUpdater.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/impexp/BankStatementImportTableSqlUpdater.java
@@ -172,8 +172,7 @@ public class BankStatementImportTableSqlUpdater
 																+ " AND a." + I_C_BP_BankAccount.COLUMNNAME_IsActive
 																+ " = 'Y' )"
 																+ "WHERE i.C_BP_BankAccount_ID IS NULL "
-																+ "AND i.I_IsImported<>'Y' "
-																+ "OR i.I_IsImported IS NULL")
+																+ "AND (i.I_IsImported<>'Y' OR i.I_IsImported IS NULL)")
 					.append(selection.toSqlWhereClause("i"));
 			DB.executeUpdateAndThrowExceptionOnFail(sql.toString(), ITrx.TRXNAME_ThreadInherited);
 		}
@@ -192,8 +191,7 @@ public class BankStatementImportTableSqlUpdater
 																+ " OR b.SwiftCode=i.RoutingNo) "
 																+ ") "
 																+ "WHERE i.C_BP_BankAccount_ID IS NULL "
-																+ "AND i.I_IsImported<>'Y' "
-																+ "OR i.I_IsImported IS NULL")
+																+ "AND (i.I_IsImported<>'Y' OR i.I_IsImported IS NULL)")
 					.append(selection.toSqlWhereClause("i"));
 			DB.executeUpdateAndThrowExceptionOnFail(sql.toString(), ITrx.TRXNAME_ThreadInherited);
 		}
@@ -205,8 +203,7 @@ public class BankStatementImportTableSqlUpdater
 			sql.append(" and a.AD_Client_ID=i.AD_Client_ID) "
 							   + "WHERE i.C_BP_BankAccount_ID IS NULL "
 							   + "AND i.BankAccountNo IS NULL "
-							   + "AND i.I_isImported<>'Y' "
-							   + "OR i.I_isImported IS NULL")
+							   + "AND (i.I_isImported<>'Y' OR i.I_isImported IS NULL)")
 					.append(selection.toSqlWhereClause("i"));
 			DB.executeUpdateAndThrowExceptionOnFail(sql.toString(), ITrx.TRXNAME_ThreadInherited);
 		}
@@ -215,8 +212,7 @@ public class BankStatementImportTableSqlUpdater
 			final StringBuilder sql = new StringBuilder("UPDATE I_BankStatement "
 																+ "SET I_isImported='E', I_ErrorMsg=I_ErrorMsg||'ERR=Invalid Bank Account, ' "
 																+ "WHERE C_BP_BankAccount_ID IS NULL "
-																+ "AND I_isImported<>'Y' "
-																+ "OR I_isImported IS NULL")
+																+ "AND (I_isImported<>'Y' OR I_isImported IS NULL)")
 					.append(selection.toSqlWhereClause());
 			DB.executeUpdateAndThrowExceptionOnFail(sql.toString(), ITrx.TRXNAME_ThreadInherited);
 		}
@@ -295,8 +291,7 @@ public class BankStatementImportTableSqlUpdater
 															+ " AND ba." + I_C_BP_BankAccount.COLUMNNAME_IsActive
 															+ " = 'Y' )"
 															+ "WHERE i." + I_I_BankStatement.COLUMNNAME_C_BP_BankAccountTo_ID + " IS NULL "
-															+ "AND i.I_IsImported<>'Y' "
-															+ "OR i.I_IsImported IS NULL")
+															+ "AND (i.I_IsImported<>'Y' OR i.I_IsImported IS NULL)")
 				.append(selection.toSqlWhereClause("i"));
 
 		DB.executeUpdateAndThrowExceptionOnFail(sql.toString(), ITrx.TRXNAME_ThreadInherited);

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/impexp/BankStatementImportTableSqlUpdater.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/impexp/BankStatementImportTableSqlUpdater.java
@@ -224,37 +224,64 @@ public class BankStatementImportTableSqlUpdater
 
 	private void updateC_BPartner(final ImportRecordsSelection selection)
 	{
+		final String bpartnerMatchCondition = "("
+				+ "i." + I_I_BankStatement.COLUMNNAME_Bill_BPartner_Name
+				+ " = bp." + I_C_BPartner.COLUMNNAME_Name
+				+ " OR i." + I_I_BankStatement.COLUMNNAME_BPartnerValue
+				+ " = bp." + I_C_BPartner.COLUMNNAME_Value
+				+ " OR "
+				+ "("
+				+ "i." + I_I_BankStatement.COLUMNNAME_DebitorOrCreditorId
+				+ " = bp." + I_C_BPartner.COLUMNNAME_DebtorId
+				+ " AND bp." + I_C_BPartner.COLUMNNAME_DebtorId + " > 0"
+				+ " AND bp." + I_C_BPartner.COLUMNNAME_IsCustomer + " = 'Y'"
+				+ ") "
+				+ " OR "
+				+ "("
+				+ "i." + I_I_BankStatement.COLUMNNAME_DebitorOrCreditorId
+				+ " = bp." + I_C_BPartner.COLUMNNAME_CreditorId
+				+ " AND bp." + I_C_BPartner.COLUMNNAME_CreditorId + " > 0"
+				+ " AND bp." + I_C_BPartner.COLUMNNAME_IsVendor + " = 'Y'"
+				+ ") "
+				+ ")"
+				+ " AND i." + I_I_BankStatement.COLUMNNAME_AD_Org_ID
+				+ " = bp." + I_C_BPartner.COLUMNNAME_AD_Org_ID
+				+ " AND bp.IsActive = 'Y'";
+
+		// Set C_BPartner_ID only when exactly one active BPartner matches.
+		// Uses HAVING COUNT(*)=1 so that duplicate DebtorId/CreditorId values
+		// (after relaxing the unique constraint) don't silently pick an arbitrary partner.
 		final StringBuilder sql = new StringBuilder("UPDATE I_BankStatement i "
-															+ "SET " + I_I_BankStatement.COLUMNNAME_C_BPartner_ID
-															+ " = (SELECT " + I_C_BPartner.COLUMNNAME_C_BPartner_ID
-															+ " FROM " + I_C_BPartner.Table_Name + " bp "
-															+ " WHERE " + "(i." + I_I_BankStatement.COLUMNNAME_Bill_BPartner_Name
-															+ " = bp." + I_C_BPartner.COLUMNNAME_Name
-															+ " OR i." + I_I_BankStatement.COLUMNNAME_BPartnerValue
-															+ " = bp." + I_C_BPartner.COLUMNNAME_Value
-															+ " OR "
-															+ "("
-															+ "i." + I_I_BankStatement.COLUMNNAME_DebitorOrCreditorId
-															+ " = bp." + I_C_BPartner.COLUMNNAME_DebtorId
-															+ " AND bp." + I_C_BPartner.COLUMNNAME_DebtorId + " > 0"
-															+ " AND bp." + I_C_BPartner.COLUMNNAME_IsCustomer + " = 'Y'"
-															+ " ) "
-															+ " OR "
-															+ "("
-															+ "i." + I_I_BankStatement.COLUMNNAME_DebitorOrCreditorId
-															+ " = bp." + I_C_BPartner.COLUMNNAME_CreditorId
-															+ " AND bp." + I_C_BPartner.COLUMNNAME_CreditorId + " > 0"
-															+ " AND  bp." + I_C_BPartner.COLUMNNAME_IsVendor + " = 'Y'"
-															+ " ) "
-															+ " AND i." + I_I_BankStatement.COLUMNNAME_AD_Org_ID
-															+ " = bp. " + I_C_BPartner.COLUMNNAME_AD_Org_ID
-															+ ")) "
-															+ "WHERE i." + I_I_BankStatement.COLUMNNAME_C_BPartner_ID + " IS NULL "
-															+ "AND i.I_IsImported<>'Y' "
-															+ "OR i.I_IsImported IS NULL")
+				+ "SET " + I_I_BankStatement.COLUMNNAME_C_BPartner_ID
+				+ " = (SELECT MIN(bp." + I_C_BPartner.COLUMNNAME_C_BPartner_ID + ")"
+				+ " FROM " + I_C_BPartner.Table_Name + " bp "
+				+ " WHERE " + bpartnerMatchCondition
+				+ " HAVING COUNT(*) = 1"
+				+ ") "
+				+ "WHERE i." + I_I_BankStatement.COLUMNNAME_C_BPartner_ID + " IS NULL "
+				+ "AND i.I_IsImported<>'Y' "
+				+ "OR i.I_IsImported IS NULL")
 				.append(selection.toSqlWhereClause("i"));
 
 		DB.executeUpdateAndThrowExceptionOnFail(sql.toString(), ITrx.TRXNAME_ThreadInherited);
+
+		// Flag records where multiple active BPartners match the same DebtorId/CreditorId
+		final StringBuilder errorSql = new StringBuilder("UPDATE I_BankStatement i "
+				+ "SET I_IsImported='E', I_ErrorMsg=COALESCE(I_ErrorMsg,'')"
+				+ "||'ERR=Multiple BPartners found for the same DebtorId/CreditorId."
+				+ " Please make sure each DebtorId/CreditorId is unique among active BPartners, ' "
+				+ "WHERE i." + I_I_BankStatement.COLUMNNAME_C_BPartner_ID + " IS NULL "
+				+ "AND (SELECT COUNT(*) FROM " + I_C_BPartner.Table_Name + " bp "
+				+ " WHERE " + bpartnerMatchCondition + ") > 1 "
+				+ "AND i.I_IsImported<>'Y' "
+				+ "OR i.I_IsImported IS NULL")
+				.append(selection.toSqlWhereClause("i"));
+
+		final int noAmbiguous = DB.executeUpdateAndThrowExceptionOnFail(errorSql.toString(), ITrx.TRXNAME_ThreadInherited);
+		if (noAmbiguous > 0)
+		{
+			logger.warn("Ambiguous BPartner matches (multiple active BPartners with same DebtorId/CreditorId): {}", noAmbiguous);
+		}
 	}
 
 	private void updateBankAccountTo(final ImportRecordsSelection selection)

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/impexp/CPaymentImportTableSqlUpdater.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/impexp/CPaymentImportTableSqlUpdater.java
@@ -75,7 +75,7 @@ public class CPaymentImportTableSqlUpdater
 		sql = new StringBuilder("UPDATE I_Datev_Payment i ")
 				.append("SET I_IsImported='E', I_ErrorMsg=COALESCE(I_ErrorMsg,'')")
 				.append("||'ERR=Multiple BPartners found for the same DebtorId/CreditorId.")
-				.append(" Please make sure each DebtorId/CreditorId is unique among active BPartners, ' ")
+				.append(" Please make sure each DebtorId/CreditorId is unique among active BPartners.' ")
 				.append("WHERE C_BPartner_ID IS NULL AND BPartnerValue IS NOT NULL ")
 				.append("AND (SELECT COUNT(*) FROM C_BPartner bp WHERE ").append(matchCondition).append(") > 1 ")
 				.append("AND I_IsImported<>'Y'  ")

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/impexp/CPaymentImportTableSqlUpdater.java
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/impexp/CPaymentImportTableSqlUpdater.java
@@ -55,13 +55,36 @@ public class CPaymentImportTableSqlUpdater
 
 	private void dbUpdateBPartners(@NonNull final ImportRecordsSelection selection)
 	{
+		final String matchCondition = "(i.BPartnerValue=bp.Debtorid OR i.BPartnerValue=bp.CreditorId)"
+				+ " AND i.AD_Client_ID=bp.AD_Client_ID AND i.AD_Org_ID=bp.AD_Org_ID"
+				+ " AND bp.IsActive='Y'";
+
+		// Set C_BPartner_ID only when exactly one active BPartner matches.
+		// Uses HAVING COUNT(*)=1 so that duplicate DebtorId/CreditorId values
+		// (after relaxing the unique constraint) don't silently pick an arbitrary partner.
 		StringBuilder sql = new StringBuilder("UPDATE I_Datev_Payment i ")
-				.append("SET C_BPartner_ID=(SELECT MAX(C_BPartner_ID) FROM C_BPartner bp ")
-				.append(" WHERE (i.BPartnerValue=bp.Debtorid OR i.BPartnerValue=bp.CreditorId) AND i.AD_Client_ID=bp.AD_Client_ID AND i.AD_Org_ID=bp.AD_Org_ID ) ")
+				.append("SET C_BPartner_ID=(SELECT MIN(C_BPartner_ID) FROM C_BPartner bp ")
+				.append(" WHERE ").append(matchCondition)
+				.append(" HAVING COUNT(*)=1) ")
 				.append("WHERE C_BPartner_ID IS NULL AND BPartnerValue IS NOT NULL ")
 				.append("AND I_IsImported<>'Y'  ")
 				.append(selection.toSqlWhereClause("i"));
 		DB.executeUpdateAndSaveErrorOnFail(sql.toString(), ITrx.TRXNAME_ThreadInherited);
+
+		// Flag records where multiple active BPartners match the same DebtorId/CreditorId
+		sql = new StringBuilder("UPDATE I_Datev_Payment i ")
+				.append("SET I_IsImported='E', I_ErrorMsg=COALESCE(I_ErrorMsg,'')")
+				.append("||'ERR=Multiple BPartners found for the same DebtorId/CreditorId.")
+				.append(" Please make sure each DebtorId/CreditorId is unique among active BPartners, ' ")
+				.append("WHERE C_BPartner_ID IS NULL AND BPartnerValue IS NOT NULL ")
+				.append("AND (SELECT COUNT(*) FROM C_BPartner bp WHERE ").append(matchCondition).append(") > 1 ")
+				.append("AND I_IsImported<>'Y'  ")
+				.append(selection.toSqlWhereClause("i"));
+		final int noAmbiguous = DB.executeUpdateAndSaveErrorOnFail(sql.toString(), ITrx.TRXNAME_ThreadInherited);
+		if (noAmbiguous > 0)
+		{
+			logger.warn("Ambiguous BPartner matches (multiple active BPartners with same DebtorId/CreditorId): {}", noAmbiguous);
+		}
 	}
 
 	private void dbUpdateInvoices(@NonNull final ImportRecordsSelection selection)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/data_import/I_BankStatement_Import_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/data_import/I_BankStatement_Import_StepDef.java
@@ -1,0 +1,208 @@
+package de.metas.cucumber.stepdefs.data_import;
+
+import de.metas.banking.BankAccountId;
+import de.metas.banking.impexp.BankStatementImportTableSqlUpdater;
+import de.metas.cucumber.stepdefs.C_BPartner_StepDef;
+import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.StepDefConstants;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.impexp.processing.ImportRecordsSelection;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_I_BankStatement;
+import org.compiere.util.DB;
+
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class I_BankStatement_Import_StepDef
+{
+	private final I_BankStatement_Import_StepDefData iBankStatementTable;
+	private final C_BPartner_StepDefData bPartnerTable;
+
+	public I_BankStatement_Import_StepDef(
+			@NonNull final I_BankStatement_Import_StepDefData iBankStatementTable,
+			@NonNull final C_BPartner_StepDefData bPartnerTable)
+	{
+		this.iBankStatementTable = iBankStatementTable;
+		this.bPartnerTable = bPartnerTable;
+	}
+
+	@Given("the C_BPartner Value unique constraint is relaxed")
+	public void the_c_bpartner_value_unique_constraint_is_relaxed()
+	{
+		DB.executeUpdateAndSaveErrorOnFail(
+				"DROP INDEX IF EXISTS C_BPartner_Value_Unique",
+				ITrx.TRXNAME_None);
+	}
+
+	@Given("metasfresh contains C_BPartners with duplicate Values allowed:")
+	public void metasfresh_contains_c_bpartners_with_duplicate_values(@NonNull final DataTable dataTable)
+	{
+		final java.util.Set<String> deactivatedValues = new java.util.HashSet<>();
+		DataTableRows.of(dataTable).forEach(row -> {
+			final String value = row.getAsString(I_C_BPartner.COLUMNNAME_Value);
+			if (deactivatedValues.add(value))
+			{
+				DB.executeUpdateAndSaveErrorOnFail(
+						"UPDATE C_BPartner SET IsActive='N' WHERE Value=" + DB.TO_STRING(value)
+								+ " AND AD_Client_ID=" + StepDefConstants.CLIENT_ID.getRepoId(),
+						ITrx.TRXNAME_None);
+			}
+		});
+
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_C_BPartner bp = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+			bp.setAD_Org_ID(StepDefConstants.ORG_ID.getRepoId());
+			bp.setValue(row.getAsString(I_C_BPartner.COLUMNNAME_Value));
+			bp.setName(row.getAsString(I_C_BPartner.COLUMNNAME_Name));
+			bp.setIsCustomer(row.getAsOptionalBoolean(I_C_BPartner.COLUMNNAME_IsCustomer).orElseFalse());
+			bp.setIsVendor(row.getAsOptionalBoolean(I_C_BPartner.COLUMNNAME_IsVendor).orElseFalse());
+			bp.setC_BP_Group_ID(C_BPartner_StepDef.BP_GROUP_ID);
+
+			row.getAsOptionalInt(I_C_BPartner.COLUMNNAME_DebtorId).ifPresent(bp::setDebtorId);
+			row.getAsOptionalInt(I_C_BPartner.COLUMNNAME_CreditorId).ifPresent(bp::setCreditorId);
+
+			InterfaceWrapperHelper.saveRecord(bp);
+
+			row.getAsOptionalIdentifier()
+					.ifPresent(identifier -> bPartnerTable.putOrReplace(identifier, bp));
+		});
+	}
+
+	@Given("metasfresh contains I_BankStatement:")
+	public void metasfresh_contains_I_BankStatement(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_I_BankStatement record = InterfaceWrapperHelper.newInstance(I_I_BankStatement.class);
+			record.setAD_Org_ID(StepDefConstants.ORG_ID.getRepoId());
+
+			row.getAsOptionalString(I_I_BankStatement.COLUMNNAME_Bill_BPartner_Name)
+					.ifPresent(record::setBill_BPartner_Name);
+			row.getAsOptionalString(I_I_BankStatement.COLUMNNAME_BPartnerValue)
+					.ifPresent(record::setBPartnerValue);
+			row.getAsOptionalInt(I_I_BankStatement.COLUMNNAME_DebitorOrCreditorId)
+					.ifPresent(record::setDebitorOrCreditorId);
+			row.getAsOptionalString(I_I_BankStatement.COLUMNNAME_IBAN)
+					.ifPresent(record::setIBAN);
+
+			final boolean isImported = row.getAsOptionalBoolean(I_I_BankStatement.COLUMNNAME_I_IsImported).orElseFalse();
+			record.setI_IsImported(isImported);
+
+			// If a C_BPartner_ID identifier is provided, set it (for pre-set scenarios)
+			row.getAsOptionalIdentifier(I_I_BankStatement.COLUMNNAME_C_BPartner_ID).ifPresent(bpIdentifier -> {
+				final I_C_BPartner bp = bpIdentifier.lookupNotNullIn(bPartnerTable);
+				record.setC_BPartner_ID(bp.getC_BPartner_ID());
+			});
+
+			InterfaceWrapperHelper.saveRecord(record);
+
+			// Null out C_BPartner_ID in DB if it was not explicitly set,
+			// because the ORM sets it to 0 (not NULL) by default
+			if (!row.getAsOptionalIdentifier(I_I_BankStatement.COLUMNNAME_C_BPartner_ID).isPresent())
+			{
+				DB.executeUpdateAndSaveErrorOnFail(
+						"UPDATE I_BankStatement SET C_BPartner_ID = NULL WHERE I_BankStatement_ID = " + record.getI_BankStatement_ID(),
+						ITrx.TRXNAME_None);
+			}
+
+			row.getAsOptionalIdentifier().ifPresent(identifier -> iBankStatementTable.putOrReplace(identifier, record));
+		});
+	}
+
+	@When("the BankStatementImportTableSqlUpdater is invoked")
+	public void the_BankStatementImportTableSqlUpdater_is_invoked()
+	{
+		// Mark stale I_BankStatement rows from previous test runs as imported
+		final String currentIdList = iBankStatementTable.streamRecords()
+				.map(r -> String.valueOf(r.getI_BankStatement_ID()))
+				.collect(Collectors.joining(","));
+
+		if (!currentIdList.isEmpty())
+		{
+			DB.executeUpdateAndSaveErrorOnFail(
+					"UPDATE I_BankStatement SET I_IsImported='Y' WHERE I_IsImported<>'Y' AND I_BankStatement_ID NOT IN (" + currentIdList + ")",
+					ITrx.TRXNAME_None);
+		}
+
+		final ImportRecordsSelection selection = ImportRecordsSelection.builder()
+				.importTableName(I_I_BankStatement.Table_Name)
+				.importKeyColumnName(I_I_BankStatement.COLUMNNAME_I_BankStatement_ID)
+				.clientId(ClientId.ofRepoId(StepDefConstants.CLIENT_ID.getRepoId()))
+				.build();
+
+		BankStatementImportTableSqlUpdater.updateBankStatementImportTable(
+				selection,
+				/*orgBankAccountId*/ (BankAccountId)null,
+				/*bankStatementName*/ null,
+				/*bankStatementDate*/ null,
+				/*bankStatementId*/ null);
+	}
+
+	@Then("validate I_BankStatement import:")
+	public void validate_I_BankStatement(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final StepDefDataIdentifier rowIdentifier = row.getAsIdentifier();
+			final I_I_BankStatement storedRecord = rowIdentifier.lookupNotNullIn(iBankStatementTable);
+			final int iBankStatementId = storedRecord.getI_BankStatement_ID();
+
+			row.getAsOptionalIdentifier(I_I_BankStatement.COLUMNNAME_C_BPartner_ID).ifPresent(bpIdentifier -> {
+				final I_C_BPartner expectedBP = bpIdentifier.lookupNotNullIn(bPartnerTable);
+				final int actualBPartnerId = DB.getSQLValueEx(
+						ITrx.TRXNAME_None,
+						"SELECT COALESCE(C_BPartner_ID, 0) FROM I_BankStatement WHERE I_BankStatement_ID = ?",
+						iBankStatementId);
+				assertThat(actualBPartnerId)
+						.as("I_BankStatement[%s].C_BPartner_ID should match %s", rowIdentifier, bpIdentifier)
+						.isEqualTo(expectedBP.getC_BPartner_ID());
+			});
+
+			row.getAsOptionalString("C_BPartner_ID.isNull").ifPresent(isNull -> {
+				if ("Y".equals(isNull))
+				{
+					final int actualBPartnerId = DB.getSQLValueEx(
+							ITrx.TRXNAME_None,
+							"SELECT COALESCE(C_BPartner_ID, 0) FROM I_BankStatement WHERE I_BankStatement_ID = ?",
+							iBankStatementId);
+					assertThat(actualBPartnerId)
+							.as("I_BankStatement[%s].C_BPartner_ID should be NULL", rowIdentifier)
+							.isEqualTo(0);
+				}
+			});
+
+			row.getAsOptionalString(I_I_BankStatement.COLUMNNAME_I_ErrorMsg).ifPresent(expectedSubstring -> {
+				final String actualErrorMsg = DB.getSQLValueStringEx(
+						ITrx.TRXNAME_None,
+						"SELECT I_ErrorMsg FROM I_BankStatement WHERE I_BankStatement_ID = ?",
+						iBankStatementId);
+				assertThat(actualErrorMsg)
+						.as("I_BankStatement[%s].I_ErrorMsg should contain '%s'", rowIdentifier, expectedSubstring)
+						.contains(expectedSubstring);
+			});
+
+			row.getAsOptionalString("I_ErrorMsg.isNull").ifPresent(isNull -> {
+				if ("Y".equals(isNull))
+				{
+					final String actualErrorMsg = DB.getSQLValueStringEx(
+							ITrx.TRXNAME_None,
+							"SELECT I_ErrorMsg FROM I_BankStatement WHERE I_BankStatement_ID = ?",
+							iBankStatementId);
+					assertThat(actualErrorMsg)
+							.as("I_BankStatement[%s].I_ErrorMsg should be NULL", rowIdentifier)
+							.isNullOrEmpty();
+				}
+			});
+		});
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/data_import/I_BankStatement_Import_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/data_import/I_BankStatement_Import_StepDef.java
@@ -44,21 +44,47 @@ public class I_BankStatement_Import_StepDef
 		DB.executeUpdateAndSaveErrorOnFail(
 				"DROP INDEX IF EXISTS C_BPartner_Value_Unique",
 				ITrx.TRXNAME_None);
+		// Also drop DebtorId/CreditorId unique constraints to allow duplicate IDs
+		DB.executeUpdateAndSaveErrorOnFail(
+				"DROP INDEX IF EXISTS c_bpartner_debtorid_unique",
+				ITrx.TRXNAME_None);
+		DB.executeUpdateAndSaveErrorOnFail(
+				"DROP INDEX IF EXISTS c_bpartner_creditorid_unique",
+				ITrx.TRXNAME_None);
 	}
 
 	@Given("metasfresh contains C_BPartners with duplicate Values allowed:")
 	public void metasfresh_contains_c_bpartners_with_duplicate_values(@NonNull final DataTable dataTable)
 	{
-		final java.util.Set<String> deactivatedValues = new java.util.HashSet<>();
+		// Deactivate stale BPartners from previous test runs — by Value and by DebtorId/CreditorId
+		final java.util.Set<String> deactivatedKeys = new java.util.HashSet<>();
 		DataTableRows.of(dataTable).forEach(row -> {
 			final String value = row.getAsString(I_C_BPartner.COLUMNNAME_Value);
-			if (deactivatedValues.add(value))
+			if (deactivatedKeys.add("val:" + value))
 			{
 				DB.executeUpdateAndSaveErrorOnFail(
 						"UPDATE C_BPartner SET IsActive='N' WHERE Value=" + DB.TO_STRING(value)
 								+ " AND AD_Client_ID=" + StepDefConstants.CLIENT_ID.getRepoId(),
 						ITrx.TRXNAME_None);
 			}
+			row.getAsOptionalInt(I_C_BPartner.COLUMNNAME_DebtorId).ifPresent(debtorId -> {
+				if (debtorId > 0 && deactivatedKeys.add("deb:" + debtorId))
+				{
+					DB.executeUpdateAndSaveErrorOnFail(
+							"UPDATE C_BPartner SET IsActive='N' WHERE DebtorId=" + debtorId
+									+ " AND AD_Org_ID=" + StepDefConstants.ORG_ID.getRepoId(),
+							ITrx.TRXNAME_None);
+				}
+			});
+			row.getAsOptionalInt(I_C_BPartner.COLUMNNAME_CreditorId).ifPresent(creditorId -> {
+				if (creditorId > 0 && deactivatedKeys.add("cred:" + creditorId))
+				{
+					DB.executeUpdateAndSaveErrorOnFail(
+							"UPDATE C_BPartner SET IsActive='N' WHERE CreditorId=" + creditorId
+									+ " AND AD_Org_ID=" + StepDefConstants.ORG_ID.getRepoId(),
+							ITrx.TRXNAME_None);
+				}
+			});
 		});
 
 		DataTableRows.of(dataTable).forEach(row -> {

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/data_import/I_BankStatement_Import_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/data_import/I_BankStatement_Import_StepDef.java
@@ -45,11 +45,12 @@ public class I_BankStatement_Import_StepDef
 				"DROP INDEX IF EXISTS C_BPartner_Value_Unique",
 				ITrx.TRXNAME_None);
 		// Also drop DebtorId/CreditorId unique constraints to allow duplicate IDs
+		// NOTE: index names have a typo ("Uniqe") from the original migration 5582410
 		DB.executeUpdateAndSaveErrorOnFail(
-				"DROP INDEX IF EXISTS c_bpartner_debtorid_unique",
+				"DROP INDEX IF EXISTS C_BPartner_DebtorID_Uniqe",
 				ITrx.TRXNAME_None);
 		DB.executeUpdateAndSaveErrorOnFail(
-				"DROP INDEX IF EXISTS c_bpartner_creditorid_unique",
+				"DROP INDEX IF EXISTS C_BPartner_CreditorID_Uniqe",
 				ITrx.TRXNAME_None);
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/data_import/I_BankStatement_Import_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/data_import/I_BankStatement_Import_StepDefData.java
@@ -1,0 +1,12 @@
+package de.metas.cucumber.stepdefs.data_import;
+
+import de.metas.cucumber.stepdefs.StepDefData;
+import org.compiere.model.I_I_BankStatement;
+
+public class I_BankStatement_Import_StepDefData extends StepDefData<I_I_BankStatement>
+{
+	public I_BankStatement_Import_StepDefData()
+	{
+		super(I_I_BankStatement.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner_value_uniqueness/importBankStatement_bpartner_disambiguation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner_value_uniqueness/importBankStatement_bpartner_disambiguation.feature
@@ -1,0 +1,69 @@
+@from:cucumber
+@ghActions:run_on_executor5
+Feature: BankStatement import BPartner disambiguation and AND/OR precedence
+  Tests the BankStatementImportTableSqlUpdater's BPartner matching logic:
+  - Unique BPartner match sets C_BPartner_ID
+  - Ambiguous matches (multiple BPartners) flag an error
+  - AND/OR precedence fix: rows with I_IsImported=NULL but C_BPartner_ID already set are NOT touched
+  - AND/OR precedence fix: rows with I_IsImported='Y' are NOT touched
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-05-17T13:30:13+01:00[Europe/Berlin]
+    And the C_BPartner Value unique constraint is relaxed
+
+  @from:cucumber
+  Scenario: Unique BPartner by DebtorId sets C_BPartner_ID
+    Given metasfresh contains C_BPartners with duplicate Values allowed:
+      | Identifier   | Name           | Value          | IsCustomer | IsVendor | DebtorId | CreditorId |
+      | bp_debtor_1  | Debtor One     | BP_DEBTOR_ONE  | Y          | N        | 99901    | 0          |
+    And metasfresh contains I_BankStatement:
+      | Identifier  | DebitorOrCreditorId |
+      | iBS_unique  | 99901               |
+    When the BankStatementImportTableSqlUpdater is invoked
+    Then validate I_BankStatement import:
+      | Identifier  | C_BPartner_ID |
+      | iBS_unique  | bp_debtor_1   |
+
+  @from:cucumber
+  Scenario: Ambiguous BPartner match flags error
+    Given metasfresh contains C_BPartners with duplicate Values allowed:
+      | Identifier     | Name              | Value             | IsCustomer | IsVendor | DebtorId | CreditorId |
+      | bp_ambig_1     | Ambiguous Cust 1  | BP_AMBIG_CUST_1   | Y          | N        | 99902    | 0          |
+      | bp_ambig_2     | Ambiguous Cust 2  | BP_AMBIG_CUST_2   | Y          | N        | 99902    | 0          |
+    And metasfresh contains I_BankStatement:
+      | Identifier  | DebitorOrCreditorId |
+      | iBS_ambig   | 99902               |
+    When the BankStatementImportTableSqlUpdater is invoked
+    Then validate I_BankStatement import:
+      | Identifier  | C_BPartner_ID.isNull | I_ErrorMsg               |
+      | iBS_ambig   | Y                    | Multiple BPartners found |
+
+  @from:cucumber
+  Scenario: AND/OR precedence - row with C_BPartner_ID already set and I_IsImported NULL is not overwritten
+    Given metasfresh contains C_BPartners with duplicate Values allowed:
+      | Identifier        | Name               | Value              | IsCustomer | IsVendor | DebtorId | CreditorId |
+      | bp_preset_target  | Preset Target BP   | BP_PRESET_TARGET   | Y          | N        | 99903    | 0          |
+      | bp_preset_other   | Preset Other BP    | BP_PRESET_OTHER    | Y          | N        | 99904    | 0          |
+    And metasfresh contains I_BankStatement:
+      | Identifier    | DebitorOrCreditorId | C_BPartner_ID    |
+      | iBS_preset    | 99904               | bp_preset_target |
+    When the BankStatementImportTableSqlUpdater is invoked
+    Then validate I_BankStatement import:
+      | Identifier    | C_BPartner_ID    | I_ErrorMsg.isNull |
+      | iBS_preset    | bp_preset_target | Y                 |
+
+  @from:cucumber
+  Scenario: AND/OR precedence - already imported row is not touched
+    Given metasfresh contains C_BPartners with duplicate Values allowed:
+      | Identifier       | Name                | Value               | IsCustomer | IsVendor | DebtorId | CreditorId |
+      | bp_imported_1    | Already Imported BP | BP_ALREADY_IMPORTED | Y          | N        | 99905    | 0          |
+      | bp_imported_2    | Already Imported 2  | BP_ALREADY_IMP_2    | Y          | N        | 99905    | 0          |
+    And metasfresh contains I_BankStatement:
+      | Identifier      | DebitorOrCreditorId | I_IsImported |
+      | iBS_imported    | 99905               | Y            |
+    When the BankStatementImportTableSqlUpdater is invoked
+    Then validate I_BankStatement import:
+      | Identifier      | C_BPartner_ID.isNull | I_ErrorMsg.isNull |
+      | iBS_imported    | Y                    | Y                 |


### PR DESCRIPTION
## Summary

- **Bank statement import** (`BankStatementImportTableSqlUpdater`): When multiple active BPartners share the same DebtorId or CreditorId (after relaxing the unique constraint), the subquery now uses `HAVING COUNT(*)=1` to only match when exactly one BPartner fits. Ambiguous matches are flagged with `I_IsImported='E'` and a clear error message. Also adds `IsActive='Y'` filter and fixes an AND/OR precedence bug where the `AD_Org_ID` check only applied to the CreditorId match branch.
- **DATEV payment import** (`CPaymentImportTableSqlUpdater`): Replaces `MAX(C_BPartner_ID)` (which silently picked an arbitrary partner on duplicates) with the same `HAVING COUNT(*)=1` pattern. Adds `IsActive='Y'` filter and ambiguous-match error flagging.
- Both fixes cover DebtorId **and** CreditorId, so if either unique constraint is relaxed, the imports remain safe.

## Test plan

- [ ] Import a bank statement where one import line's `DebitorOrCreditorId` matches exactly one active BPartner → BPartner is correctly assigned
- [ ] Import a bank statement where one import line's `DebitorOrCreditorId` matches two active BPartners with the same DebtorId → line is flagged with `I_IsImported='E'` and error message "Multiple BPartners found..."
- [ ] Import a DATEV payment file where `BPartnerValue` matches exactly one active BPartner's DebtorId/CreditorId → BPartner is correctly assigned
- [ ] Import a DATEV payment file where `BPartnerValue` matches multiple active BPartners → line is flagged with error message
- [ ] Verify inactive BPartners (`IsActive='N'`) are excluded from matching in both importers