### PR TITLE
Swing client: disable RabbitMQ to fix slow startup

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -112,6 +112,17 @@ jobs:
           --tag metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-floating }} \
           --tag metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-fixed }} \
           .
+      - name: extract-swingui-zip
+        run: |
+          CONTAINER_ID=$(docker create metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-floating }})
+          docker cp "$CONTAINER_ID:/backend/metasfresh-dist/swingui/target/metasfresh-dist-swingui-10.0.0-client.zip" "metasfresh-swingui-${{ needs.init.outputs.tag-fixed }}.zip"
+          docker rm "$CONTAINER_ID"
+          ls -lh metasfresh-swingui-*.zip
+      - uses: actions/upload-artifact@v4
+        with:
+          name: metasfresh-swingui-${{ needs.init.outputs.tag-fixed }}
+          path: metasfresh-swingui-${{ needs.init.outputs.tag-fixed }}.zip
+          retention-days: 90
       - name: build-camel
         run: |
           docker buildx build \

--- a/backend/metasfresh-dist/swingui/src/main/resources/application.properties
+++ b/backend/metasfresh-dist/swingui/src/main/resources/application.properties
@@ -1,0 +1,15 @@
+#
+# Swing UI application properties
+#
+
+# RabbitMQ: The Swing client doesn't need messaging infrastructure.
+# Without these settings, Spring AMQP tries to connect to RabbitMQ at startup
+# to declare exchanges/queues/bindings, causing multi-minute timeouts when
+# RabbitMQ is not reachable (e.g. remote DB without local RabbitMQ).
+spring.rabbitmq.connection-timeout=1000
+spring.rabbitmq.requested-heartbeat=0
+spring.rabbitmq.template.retry.enabled=false
+spring.rabbitmq.listener.direct.auto-startup=false
+spring.rabbitmq.listener.simple.auto-startup=false
+spring.rabbitmq.listener.direct.missing-queues-fatal=false
+spring.rabbitmq.listener.simple.missing-queues-fatal=false


### PR DESCRIPTION
## Summary
- Add `application.properties` for the Swing UI module to prevent RabbitMQ connection attempts at startup
- The Swing client doesn't need messaging, but Spring AMQP auto-configuration tries to connect and declare exchanges/queues/bindings, causing multi-minute timeouts when RabbitMQ is not reachable (e.g. running locally against a remote DB)
- Sets connection-timeout to 1s, disables listener auto-startup, marks missing queues as non-fatal

Cherry-picked from https://github.com/metasfresh/metasfresh/pull/23117

## Test plan
- [x] Run Swing client from IDE against a remote DB without local RabbitMQ — startup completes in seconds instead of ~10 minutes
- [ ] Run Swing client against local infrastructure (DB + RabbitMQ both available) — verify no regressions