### PR TITLE
Add Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,79 @@
+name: Claude Code Review
+
+# Triggered by @claude mentions in PR comments and review comments.
+# Checks out private mf15-ai-dev-support repo to overlay CLAUDE.md,
+# REVIEW.md, skills, agents, and commands that are not committed to
+# the public metasfresh repo.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout metasfresh (PR branch)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Checkout mf15-ai-dev-support (private config)
+        uses: actions/checkout@v6
+        with:
+          repository: metasfresh/mf15-ai-dev-support
+          token: ${{ secrets.CICD_TRIGGER_DISPATCH }}
+          path: _ai-config
+          fetch-depth: 1
+
+      - name: Overlay private config into metasfresh checkout
+        run: |
+          # --- CLAUDE.md files (150+ across the module hierarchy) ---
+          # The -n flag avoids overwriting any files that already exist in the repo.
+          cp -rn _ai-config/claude/metasfresh/. ./
+
+          # --- REVIEW.md (review-specific guidelines) ---
+          if [ -f _ai-config/claude/metasfresh/REVIEW.md ]; then
+            cp _ai-config/claude/metasfresh/REVIEW.md ./REVIEW.md
+          elif [ -f _ai-config/claude/REVIEW.md ]; then
+            cp _ai-config/claude/REVIEW.md ./REVIEW.md
+          fi
+
+          # --- Skills, agents, commands, templates ---
+          # Copy the .claude directory contents (skills, agents, commands) but
+          # skip settings files that contain local/desktop-specific config.
+          mkdir -p .claude
+          for dir in skills agents commands templates; do
+            if [ -d "_ai-config/claude/.claude/$dir" ]; then
+              cp -r "_ai-config/claude/.claude/$dir" .claude/
+            fi
+          done
+
+          # --- Coding rules (referenced by skills and CLAUDE.md) ---
+          if [ -d "_ai-config/claude/metasfresh/docs" ]; then
+            cp -rn _ai-config/claude/metasfresh/docs/. docs/ 2>/dev/null || true
+          fi
+
+          # Clean up the private repo checkout so Claude doesn't index it
+          rm -rf _ai-config
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-review.yml` — a standalone workflow (separate from cicd.yaml) that responds to `@claude` mentions in PR comments
- Checks out the private `mf15-ai-dev-support` repo to overlay CLAUDE.md files (150+), REVIEW.md, skills, agents, and commands before running `claude-code-action`
- Uses existing `CICD_TRIGGER_DISPATCH` PAT for private repo access and `ANTHROPIC_API_KEY` for Claude API

## How it works
1. Triggers on `@claude` in PR comments, review comments, or reviews
2. Checks out the PR branch
3. Checks out `mf15-ai-dev-support` into a temp directory
4. Copies all private config into the checkout (CLAUDE.md hierarchy, REVIEW.md, .claude/skills, .claude/agents, .claude/commands, docs/coding-rules)
5. Removes the temp checkout
6. Runs `anthropics/claude-code-action@v1`

## Test plan
- [ ] Merge this PR to `new_dawn_uat` (workflow must be on default branch for `issue_comment` triggers)
- [ ] Comment `@claude review` on any open PR
- [ ] Verify Claude responds with a review that references metasfresh-specific rules
- [ ] Verify the `CICD_TRIGGER_DISPATCH` PAT can read `mf15-ai-dev-support`

🤖 Generated with [Claude Code](https://claude.com/claude-code)