### PR TITLE
Fix claude-review: remove git symlinks before overlay

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -42,16 +42,12 @@ jobs:
 
       - name: Overlay private config into metasfresh checkout
         run: |
-          # The metasfresh repo has symlinks (e.g. docs/coding-rules) that git
-          # checks out as plain text files on Linux. These block cp from copying
-          # directories over them. Find and remove such broken symlink-files
-          # before overlaying.
-          find _ai-config/claude/metasfresh -type d | while read -r src_dir; do
-            rel="${src_dir#_ai-config/claude/metasfresh/}"
-            [ "$rel" = "$src_dir" ] && continue  # skip the root itself
-            if [ -f "./$rel" ] && [ ! -d "./$rel" ]; then
-              rm -f "./$rel"
-            fi
+          # The metasfresh repo has symlinks (e.g. docs/coding-rules) managed
+          # via mf15-ai-dev-support. Git stores them as mode 120000 entries.
+          # On Linux CI, they become plain text files containing the target path.
+          # cp cannot overwrite these files with directories, so remove them first.
+          git ls-files -s | awk '/^120000/{print $4}' | while read -r symfile; do
+            rm -f "$symfile"
           done
 
           # --- CLAUDE.md files (150+ across the module hierarchy) ---


### PR DESCRIPTION
## Summary
Fixes `cp: cannot overwrite non-directory` error in the claude-review workflow.

## Root cause
`docs/coding-rules` is a git symlink (mode 120000) pointing to `mf15-ai-dev-support`. On the Linux CI runner, git checks it out as a plain text file containing the Windows path. When the overlay step tries to copy the `docs/coding-rules/` directory from the private repo over this file, `cp` fails.

The previous fix tried to detect these by scanning source directories, but that approach didn't work.

## Fix
Use `git ls-files -s` to reliably find all mode-120000 (symlink) entries and `rm` them before copying. Currently only `docs/coding-rules` is affected.

## Test plan
- [ ] Merge, then `@claude review` on any PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)