### PR TITLE
Fix claude-review: stage overlay before git checkout

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -72,6 +72,12 @@ jobs:
           # Clean up the private repo checkout so Claude doesn't index it
           rm -rf _ai-config
 
+          # The claude-code-action internally does `git checkout <pr-branch>`.
+          # Our overlay replaced symlink-files with real directories (e.g.
+          # docs/coding-rules), which git sees as dirty working tree and
+          # refuses to switch. Stage everything so the checkout succeeds.
+          git add -A
+
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary
Adds `git add -A` after the overlay step to stage all changes before `claude-code-action` runs.

## Root cause
The action internally does `git checkout <pr-branch>`. Our overlay replaced the `docs/coding-rules` symlink-file with a real directory, leaving the tree dirty. Git refused to switch branches.

## Test plan
- [ ] Merge, then `@claude review` on any PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)