### PR TITLE
Switch runners to WarpBuild (inner_silence)

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
 
   init:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     outputs:
       tag-floating: ${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}
       tag-fixed: ${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }}
@@ -104,7 +104,7 @@ jobs:
           testspace github_run.txt
 
   java:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: init
     permissions:
       packages: write
@@ -260,7 +260,7 @@ jobs:
 #          docker run --rm --env GITHUB_ACTOR=${{ github.actor }} --env GITHUB_TOKEN=${{ github.token }} metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-fixed }}
 
   frontend:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: init
     steps:
       - uses: actions/checkout@v4
@@ -346,7 +346,7 @@ jobs:
 
   test-frontend:
     name: test (frontend)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [init, frontend]
     steps:
       - uses: actions/checkout@v4
@@ -379,7 +379,7 @@ jobs:
           path: jest/**/jest.log
 
   backend:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [init, java]
     steps:
       - uses: actions/checkout@v4
@@ -560,7 +560,7 @@ jobs:
           echo '* metasfresh/metas-edi:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
 
   preloaded-db:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init, backend ]
     env:
       mfversion: ${{ needs.init.outputs.tag-fixed }}
@@ -612,7 +612,7 @@ jobs:
           echo '* metasfresh/metas-db:${{ needs.init.outputs.tag-floating }}-preloaded' >> $GITHUB_STEP_SUMMARY
 
   procurement:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init, java ]
     steps:
       - uses: actions/checkout@v4
@@ -729,7 +729,7 @@ jobs:
         
 
   compatibility-images:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [init, frontend, backend, preloaded-db]
     steps:
       - uses: actions/checkout@v4
@@ -935,7 +935,7 @@ jobs:
 
   junit:
     name: test (java)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [init, java]
     steps:
       - uses: actions/checkout@v4
@@ -1018,7 +1018,7 @@ jobs:
 
   cucumber-build:
     name: build (cucumber)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [init, java]
     steps:
       - uses: actions/checkout@v4
@@ -1062,7 +1062,7 @@ jobs:
 
   cucumber-run:
     name: test (cucumber)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [init, backend, frontend, cucumber-build, preloaded-db]
     strategy:
       max-parallel: 10
@@ -1145,7 +1145,7 @@ jobs:
 
   health_check:
     name: health check
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [ init, backend, frontend, preloaded-db ]
     steps:
       - uses: actions/checkout@v4
@@ -1239,7 +1239,7 @@ jobs:
 #  mobile_test:
 #    name: mobile test
 #    timeout-minutes: 60
-#    runs-on: ubuntu-latest
+#    runs-on: ${{ vars.RUNNER_TEST }}
 #    needs: [ init, backend, frontend, preloaded-db ]
 #    steps:
 #      - uses: actions/checkout@v4
@@ -1288,7 +1288,7 @@ jobs:
 
   publish-test-reports:
     name: publish test reports
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     needs: [ init, cucumber-run ]
     if: always() && needs.init.result == 'success' && needs.init.outputs.skip-publish-reports != 'true'
     permissions:
@@ -1672,7 +1672,7 @@ jobs:
 
   cicd-dispatch:
     if: contains(fromJson(vars.CICD_BRANCH_MAP), github.ref_name) == true
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     needs: [init, compatibility-images]
     steps:
       - name: dispatch-workflow

--- a/.github/workflows/reports-cleanup.yml
+++ b/.github/workflows/reports-cleanup.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     steps:
       - name: Check for report server secret
         id: check-secret


### PR DESCRIPTION
## Summary
- Replace all `runs-on: ubuntu-latest` with org-level variables (`RUNNER_LIGHT`, `RUNNER_HEAVY`, `RUNNER_TEST`)
- Enable multi-threaded Maven builds (`-T1C`) in Dockerfiles

## Variables (set at org level)
| Variable | Value | Jobs |
|----------|-------|------|
| `RUNNER_LIGHT` | `warp-ubuntu-latest-x64-2x` | init, reports, dispatch |
| `RUNNER_HEAVY` | `warp-ubuntu-latest-x64-4x` | Maven/Docker builds |
| `RUNNER_TEST` | `ubuntu-latest` | All test/e2e jobs |

Closes metasfresh/me03#29015

🤖 Generated with [Claude Code](https://claude.com/claude-code)