### PR TITLE
Switch runners to WarpBuild (taloned_owl)

### DIFF
--- a/.github/workflows/auto-port.yml
+++ b/.github/workflows/auto-port.yml
@@ -41,7 +41,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       (endsWith(github.event.workflow_run.head_branch, '_hotfix') ||
        endsWith(github.event.workflow_run.head_branch, '_release'))
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/check-jaxb-sync.yaml
+++ b/.github/workflows/check-jaxb-sync.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   check-jaxb-sync:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
 
   init:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     outputs:
       tag-floating: ${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}
       tag-fixed: ${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }}
@@ -132,7 +132,7 @@ jobs:
   # Fast migration CLI build - runs in parallel with java job
   # This enables db-images to start ~10 minutes earlier
   migration-cli:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init ]
     steps:
       - uses: actions/checkout@v4
@@ -172,7 +172,7 @@ jobs:
           retention-days: 1
 
   java:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: init
     permissions:
       packages: write
@@ -355,7 +355,7 @@ jobs:
   #          docker run --rm --env GITHUB_ACTOR=${{ github.actor }} --env GITHUB_TOKEN=${{ github.token }} metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-fixed }}
 
   frontend:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: init
     steps:
       - uses: actions/checkout@v4
@@ -477,7 +477,7 @@ jobs:
 
   test-frontend:
     name: test (frontend)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [ init, frontend ]
     steps:
       - uses: actions/checkout@v4
@@ -522,7 +522,7 @@ jobs:
           path: jest/**/jest.log
 
   backend:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init, java ]
     steps:
       - uses: actions/checkout@v4
@@ -659,7 +659,7 @@ jobs:
   # db-images: Build database images independently from backend
   # Now runs in parallel with java job (depends on fast migration-cli job instead)
   db-images:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init, migration-cli ]
     steps:
       - uses: actions/checkout@v4
@@ -759,7 +759,7 @@ jobs:
           echo '* metasfresh/metas-db-migration-tool:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
 
   db-apply-migrations:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init, db-images ]
     env:
       mfversion: ${{ needs.init.outputs.tag-fixed }}
@@ -814,7 +814,7 @@ jobs:
           echo '* metasfresh/metas-db:${{ needs.init.outputs.tag-floating }}-preloaded' >> $GITHUB_STEP_SUMMARY
 
   procurement:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init, java ]
     steps:
       - uses: actions/checkout@v4
@@ -947,7 +947,7 @@ jobs:
   
 
   compatibility-images:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init, frontend, backend, db-apply-migrations ]
     steps:
       - uses: actions/checkout@v4
@@ -1175,7 +1175,7 @@ jobs:
 
   junit:
     name: test (java)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [ init, java ]
     steps:
       - uses: actions/checkout@v4
@@ -1286,7 +1286,7 @@ jobs:
 
   cucumber-build:
     name: build (cucumber)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init, java ]
     steps:
       - uses: actions/checkout@v4
@@ -1337,7 +1337,7 @@ jobs:
 
   cucumber-run:
     name: test (cucumber)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [ init, backend, frontend, cucumber-build, db-apply-migrations ]
     strategy:
       max-parallel: 10
@@ -1531,7 +1531,7 @@ jobs:
 
   cucumber-allure-report:
     name: Generate Cucumber Allure Report
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     needs: [ init, cucumber-run ]
     if: always()
     permissions:
@@ -1592,7 +1592,7 @@ jobs:
 
   health_check:
     name: health check
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [ init, backend, frontend, db-apply-migrations ]
     steps:
       - uses: actions/checkout@v4
@@ -1688,7 +1688,7 @@ jobs:
   mobile_test:
     name: mobile test
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [ init, backend, frontend, db-apply-migrations ]
     steps:
       - uses: actions/checkout@v4
@@ -1774,7 +1774,7 @@ jobs:
   frontend_webui_test:
     name: frontend webui test (${{ matrix.shard }})
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [ init, backend, frontend, db-apply-migrations ]
     strategy:
       max-parallel: 3
@@ -1872,7 +1872,7 @@ jobs:
   # =============================================================================
   frontend_allure_report:
     name: frontend allure report
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     needs: [ init, frontend_webui_test ]
     if: always() && needs.init.result == 'success'
     steps:
@@ -1911,7 +1911,7 @@ jobs:
   # =============================================================================
   publish-test-reports:
     name: publish test reports
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     needs: [ init, cucumber-allure-report, mobile_test, frontend_allure_report ]
     if: always() && needs.init.result == 'success' && needs.init.outputs.skip-publish-reports != 'true'
     permissions:
@@ -2295,7 +2295,7 @@ jobs:
 
   cicd-dispatch:
     if: contains(fromJson(vars.CICD_BRANCH_MAP), github.ref_name) == true
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     needs: [ init, compatibility-images ]
     steps:
       - name: dispatch-workflow

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   gate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     steps:
       - name: Set Merge Gate commit status
         env:

--- a/.github/workflows/reports-cleanup.yml
+++ b/.github/workflows/reports-cleanup.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     steps:
       - name: Check for report server secret
         id: check-secret

--- a/docker-builds/Dockerfile.backend
+++ b/docker-builds/Dockerfile.backend
@@ -34,4 +34,4 @@ COPY backend .
 # to enable repackaging version information in app and api images
 RUN sed -i 's/<executable>true<\/executable>/<executable>false<\/executable>/' metasfresh-dist/serverRoot/pom.xml && sed -i 's/<executable>true<\/executable>/<executable>false<\/executable>/' metasfresh-webui-api/pom.xml
 
-RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress clean install --offline -Dmaven.gitcommitid.skip=true -DskipTests
+RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress -T1C clean install --offline -Dmaven.gitcommitid.skip=true -DskipTests

--- a/docker-builds/Dockerfile.camel
+++ b/docker-builds/Dockerfile.camel
@@ -10,4 +10,4 @@ WORKDIR /camel
 COPY misc/services/camel .
 
 RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -DfailOnErrors=true
-RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress clean install --offline -Dmaven.gitcommitid.skip=true -DskipTests
+RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress -T1C clean install --offline -Dmaven.gitcommitid.skip=true -DskipTests

--- a/docker-builds/Dockerfile.common
+++ b/docker-builds/Dockerfile.common
@@ -8,9 +8,9 @@ COPY misc/parent-pom .
 RUN sed -i 's/json-snapshot-PR/json-snapshot-pr/' pom.xml
 
 RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -DfailOnErrors=true
-RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress clean install --offline -Dmaven.gitcommitid.skip=true
+RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress -T1C clean install --offline -Dmaven.gitcommitid.skip=true
 
 WORKDIR /commons
 COPY misc/de-metas-common .
 RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -DfailOnErrors=true
-RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress clean install --offline -Dmaven.gitcommitid.skip=true -DskipTests
+RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress -T1C clean install --offline -Dmaven.gitcommitid.skip=true -DskipTests

--- a/docker-builds/Dockerfile.cucumber
+++ b/docker-builds/Dockerfile.cucumber
@@ -15,7 +15,7 @@ WORKDIR /cucumber
 COPY backend/de.metas.cucumber/ .
 
 RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -DfailOnErrors=true
-RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress clean test-compile --offline
+RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress -T1C clean test-compile --offline
 
 COPY docker-builds/mvn/settings.xml /root/.m2/
 COPY docker-builds/cucumber/compose.yml /compose.yml

--- a/docker-builds/Dockerfile.procurement.backend
+++ b/docker-builds/Dockerfile.procurement.backend
@@ -10,7 +10,7 @@ WORKDIR /procurement-webui-backend
 COPY misc/services/procurement-webui/procurement-webui-backend .
 
 RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -DfailOnErrors=true
-RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress clean install --offline -Dmaven.gitcommitid.skip=true -DskipTests
+RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode --no-transfer-progress -T1C clean install --offline -Dmaven.gitcommitid.skip=true -DskipTests
 
 FROM adoptopenjdk:14.0.2_8-jdk-hotspot
 


### PR DESCRIPTION
## Summary
- Replace all `runs-on: ubuntu-latest` with org-level variables (`RUNNER_LIGHT`, `RUNNER_HEAVY`, `RUNNER_TEST`)
- Enable multi-threaded Maven builds (`-T1C`) in Dockerfiles

## Variables (set at org level)
| Variable | Value | Jobs |
|----------|-------|------|
| `RUNNER_LIGHT` | `warp-ubuntu-latest-x64-2x` | init, reports, dispatch |
| `RUNNER_HEAVY` | `warp-ubuntu-latest-x64-4x` | Maven/Docker builds |
| `RUNNER_TEST` | `ubuntu-latest` | All test/e2e jobs |

Closes metasfresh/me03#29015

🤖 Generated with [Claude Code](https://claude.com/claude-code)