### PR TITLE
Switch runners to WarpBuild (vampire_textbook)

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
 
   init:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     outputs:
       tag-floating: ${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}
       tag-fixed: ${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }}
@@ -104,7 +104,7 @@ jobs:
           testspace github_run.txt
 
   java:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: init
     permissions:
       packages: write
@@ -265,7 +265,7 @@ jobs:
   #          docker run --rm --env GITHUB_ACTOR=${{ github.actor }} --env GITHUB_TOKEN=${{ github.token }} metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-fixed }}
 
   frontend:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: init
     steps:
       - uses: actions/checkout@v4
@@ -354,7 +354,7 @@ jobs:
 
   test-frontend:
     name: test (frontend)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [ init, frontend ]
     steps:
       - uses: actions/checkout@v4
@@ -388,7 +388,7 @@ jobs:
           path: jest/**/jest.log
 
   backend:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init, java ]
     steps:
       - uses: actions/checkout@v4
@@ -566,7 +566,7 @@ jobs:
           echo '* metasfresh/metas-edi:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
 
   preloaded-db:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init, backend ]
     env:
       mfversion: ${{ needs.init.outputs.tag-fixed }}
@@ -619,7 +619,7 @@ jobs:
           echo '* metasfresh/metas-db:${{ needs.init.outputs.tag-floating }}-preloaded' >> $GITHUB_STEP_SUMMARY
 
   procurement:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init, java ]
     steps:
       - uses: actions/checkout@v4
@@ -740,7 +740,7 @@ jobs:
   
 
   compatibility-images:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init, frontend, backend, preloaded-db ]
     steps:
       - uses: actions/checkout@v4
@@ -936,7 +936,7 @@ jobs:
 
   junit:
     name: test (java)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [ init, java ]
     steps:
       - uses: actions/checkout@v4
@@ -1011,7 +1011,7 @@ jobs:
 
   cucumber-build:
     name: build (cucumber)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init, java ]
     steps:
       - uses: actions/checkout@v4
@@ -1056,7 +1056,7 @@ jobs:
 
   cucumber-run:
     name: test (cucumber)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [ init, backend, frontend, cucumber-build, preloaded-db ]
     strategy:
       max-parallel: 10
@@ -1189,7 +1189,7 @@ jobs:
 
   health_check:
     name: health check
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [ init, backend, frontend, preloaded-db ]
     steps:
       - uses: actions/checkout@v4
@@ -1283,7 +1283,7 @@ jobs:
   mobile_test:
     name: mobile test
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TEST }}
     needs: [ init, backend, frontend, preloaded-db ]
     steps:
       - uses: actions/checkout@v4
@@ -1335,7 +1335,7 @@ jobs:
 
   publish-test-reports:
     name: publish test reports
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     needs: [ init, cucumber-run, mobile_test ]
     if: always() && needs.init.result == 'success' && needs.init.outputs.skip-publish-reports != 'true'
     permissions:
@@ -1719,7 +1719,7 @@ jobs:
 
   cicd-dispatch:
     if: contains(fromJson(vars.CICD_BRANCH_MAP), github.ref_name) == true
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     needs: [ init, compatibility-images ]
     steps:
       - name: dispatch-workflow

--- a/.github/workflows/reports-cleanup.yml
+++ b/.github/workflows/reports-cleanup.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LIGHT }}
     steps:
       - name: Check for report server secret
         id: check-secret

--- a/docker-builds/Dockerfile.backend
+++ b/docker-builds/Dockerfile.backend
@@ -34,4 +34,4 @@ COPY backend .
 # to enable repackaging version information in app and api images
 RUN sed -i 's/<executable>true<\/executable>/<executable>false<\/executable>/' metasfresh-dist/serverRoot/pom.xml && sed -i 's/<executable>true<\/executable>/<executable>false<\/executable>/' metasfresh-webui-api/pom.xml
 
-RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode clean install --offline -Dmaven.gitcommitid.skip=true -DskipTests
+RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode -T1C clean install --offline -Dmaven.gitcommitid.skip=true -DskipTests

--- a/docker-builds/Dockerfile.camel
+++ b/docker-builds/Dockerfile.camel
@@ -10,4 +10,4 @@ WORKDIR /camel
 COPY misc/services/camel .
 
 RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -DfailOnErrors=true
-RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode clean install --offline -Dmaven.gitcommitid.skip=true -Djib.skip=true -DskipTests
+RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode -T1C clean install --offline -Dmaven.gitcommitid.skip=true -Djib.skip=true -DskipTests

--- a/docker-builds/Dockerfile.common
+++ b/docker-builds/Dockerfile.common
@@ -8,9 +8,9 @@ COPY misc/parent-pom .
 RUN sed -i 's/json-snapshot-PR/json-snapshot-pr/' pom.xml
 
 RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -DfailOnErrors=true
-RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode clean install --offline -Dmaven.gitcommitid.skip=true
+RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode -T1C clean install --offline -Dmaven.gitcommitid.skip=true
 
 WORKDIR /commons
 COPY misc/de-metas-common .
 RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -DfailOnErrors=true
-RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode clean install --offline -Dmaven.gitcommitid.skip=true -DskipTests
+RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode -T1C clean install --offline -Dmaven.gitcommitid.skip=true -DskipTests

--- a/docker-builds/Dockerfile.cucumber
+++ b/docker-builds/Dockerfile.cucumber
@@ -15,7 +15,7 @@ WORKDIR /cucumber
 COPY backend/de.metas.cucumber/ .
 
 RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -DfailOnErrors=true
-RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode clean test-compile --offline
+RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode -T1C clean test-compile --offline
 
 COPY docker-builds/mvn/settings.xml /root/.m2/
 COPY docker-builds/cucumber/compose.yml /compose.yml

--- a/docker-builds/Dockerfile.procurement.backend
+++ b/docker-builds/Dockerfile.procurement.backend
@@ -10,7 +10,7 @@ WORKDIR /procurement-webui-backend
 COPY misc/services/procurement-webui/procurement-webui-backend .
 
 RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -DfailOnErrors=true
-RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode clean install --offline -Dmaven.gitcommitid.skip=true -Djib.skip=true -DskipTests
+RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn --batch-mode -T1C clean install --offline -Dmaven.gitcommitid.skip=true -Djib.skip=true -DskipTests
 
 FROM adoptopenjdk:14.0.2_8-jdk-hotspot
 


### PR DESCRIPTION
## Summary
- Replace all `runs-on: ubuntu-latest` with org-level variables (`RUNNER_LIGHT`, `RUNNER_HEAVY`, `RUNNER_TEST`)
- Enable multi-threaded Maven builds (`-T1C`) in Dockerfiles

## Variables (set at org level)
| Variable | Value | Jobs |
|----------|-------|------|
| `RUNNER_LIGHT` | `warp-ubuntu-latest-x64-2x` | init, reports, dispatch |
| `RUNNER_HEAVY` | `warp-ubuntu-latest-x64-4x` | Maven/Docker builds |
| `RUNNER_TEST` | `ubuntu-latest` | All test/e2e jobs |

Closes metasfresh/me03#29015

🤖 Generated with [Claude Code](https://claude.com/claude-code)