### PR TITLE
Add `StorageAttributesKey` to `PP_Order_Candidate`

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/I_PP_Order_Candidate.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/I_PP_Order_Candidate.java
@@ -132,7 +132,7 @@ public interface I_PP_Order_Candidate
 	 * Set UOM.
 	 * Unit of Measure
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
@@ -142,7 +142,7 @@ public interface I_PP_Order_Candidate
 	 * Get UOM.
 	 * Unit of Measure
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
@@ -719,6 +719,27 @@ public interface I_PP_Order_Candidate
 
 	ModelColumn<I_PP_Order_Candidate, org.compiere.model.I_S_Resource> COLUMN_S_Resource_ID = new ModelColumn<>(I_PP_Order_Candidate.class, "S_Resource_ID", org.compiere.model.I_S_Resource.class);
 	String COLUMNNAME_S_Resource_ID = "S_Resource_ID";
+
+	/**
+	 * Set StorageAttributesKey (technical).
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setStorageAttributesKey (@Nullable java.lang.String StorageAttributesKey);
+
+	/**
+	 * Get StorageAttributesKey (technical).
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	@Nullable java.lang.String getStorageAttributesKey();
+
+	ModelColumn<I_PP_Order_Candidate, Object> COLUMN_StorageAttributesKey = new ModelColumn<>(I_PP_Order_Candidate.class, "StorageAttributesKey", null);
+	String COLUMNNAME_StorageAttributesKey = "StorageAttributesKey";
 
 	/**
 	 * Get Updated.

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/X_PP_Order_Candidate.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/X_PP_Order_Candidate.java
@@ -13,7 +13,7 @@ import java.util.Properties;
 public class X_PP_Order_Candidate extends org.compiere.model.PO implements I_PP_Order_Candidate, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 63995316L;
+	private static final long serialVersionUID = -1645678566L;
 
     /** Standard Constructor */
     public X_PP_Order_Candidate (final Properties ctx, final int PP_Order_Candidate_ID, @Nullable final String trxName)
@@ -193,14 +193,14 @@ public class X_PP_Order_Candidate extends org.compiere.model.PO implements I_PP_
 	@Override
 	public void setM_HU_PI_Item_Product_ID (final int M_HU_PI_Item_Product_ID)
 	{
-		if (M_HU_PI_Item_Product_ID < 1)
+		if (M_HU_PI_Item_Product_ID < 1) 
 			set_Value (COLUMNNAME_M_HU_PI_Item_Product_ID, null);
-		else
+		else 
 			set_Value (COLUMNNAME_M_HU_PI_Item_Product_ID, M_HU_PI_Item_Product_ID);
 	}
 
 	@Override
-	public int getM_HU_PI_Item_Product_ID()
+	public int getM_HU_PI_Item_Product_ID() 
 	{
 		return get_ValueAsInt(COLUMNNAME_M_HU_PI_Item_Product_ID);
 	}
@@ -417,7 +417,7 @@ public class X_PP_Order_Candidate extends org.compiere.model.PO implements I_PP_
 	}
 
 	@Override
-	public BigDecimal getQtyProcessed_OnDate()
+	public BigDecimal getQtyProcessed_OnDate() 
 	{
 		final BigDecimal bd = get_ValueAsBigDecimal(COLUMNNAME_QtyProcessed_OnDate);
 		return bd != null ? bd : BigDecimal.ZERO;
@@ -485,6 +485,18 @@ public class X_PP_Order_Candidate extends org.compiere.model.PO implements I_PP_
 	public void setWorkStation(final org.compiere.model.I_S_Resource WorkStation)
 	{
 		set_ValueFromPO(COLUMNNAME_WorkStation_ID, org.compiere.model.I_S_Resource.class, WorkStation);
+	}
+
+	@Override
+	public void setStorageAttributesKey (final @Nullable java.lang.String StorageAttributesKey)
+	{
+		set_Value (COLUMNNAME_StorageAttributesKey, StorageAttributesKey);
+	}
+
+	@Override
+	public java.lang.String getStorageAttributesKey() 
+	{
+		return get_ValueAsString(COLUMNNAME_StorageAttributesKey);
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/X_PP_Order_Candidate.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/X_PP_Order_Candidate.java
@@ -7,25 +7,25 @@ import java.sql.ResultSet;
 import java.util.Properties;
 
 /** Generated Model for PP_Order_Candidate
- *  @author metasfresh (generated) 
+ * @author metasfresh (generated)
  */
 @SuppressWarnings("unused")
-public class X_PP_Order_Candidate extends org.compiere.model.PO implements I_PP_Order_Candidate, org.compiere.model.I_Persistent 
+public class X_PP_Order_Candidate extends org.compiere.model.PO implements I_PP_Order_Candidate, org.compiere.model.I_Persistent
 {
 
 	private static final long serialVersionUID = -1645678566L;
 
     /** Standard Constructor */
-    public X_PP_Order_Candidate (final Properties ctx, final int PP_Order_Candidate_ID, @Nullable final String trxName)
-    {
-      super (ctx, PP_Order_Candidate_ID, trxName);
-    }
+	public X_PP_Order_Candidate(final Properties ctx, final int PP_Order_Candidate_ID, @Nullable final String trxName)
+	{
+		super(ctx, PP_Order_Candidate_ID, trxName);
+	}
 
     /** Load Constructor */
-    public X_PP_Order_Candidate (final Properties ctx, final ResultSet rs, @Nullable final String trxName)
-    {
-      super (ctx, rs, trxName);
-    }
+	public X_PP_Order_Candidate(final Properties ctx, final ResultSet rs, @Nullable final String trxName)
+	{
+		super(ctx, rs, trxName);
+	}
 
 
 	/** Load Meta Data */
@@ -36,14 +36,15 @@ public class X_PP_Order_Candidate extends org.compiere.model.PO implements I_PP_
 	}
 
 	@Override
-	public void setAD_Workflow_ID (final int AD_Workflow_ID)
-	{
-		throw new IllegalArgumentException ("AD_Workflow_ID is virtual column");	}
-
-	@Override
-	public int getAD_Workflow_ID() 
+	public int getAD_Workflow_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_AD_Workflow_ID);
+	}
+
+	@Override
+	public void setAD_Workflow_ID(final int AD_Workflow_ID)
+	{
+		throw new IllegalArgumentException("AD_Workflow_ID is virtual column");
 	}
 
 	@Override
@@ -59,108 +60,108 @@ public class X_PP_Order_Candidate extends org.compiere.model.PO implements I_PP_
 	}
 
 	@Override
-	public void setC_OrderLine_ID (final int C_OrderLine_ID)
-	{
-		if (C_OrderLine_ID < 1) 
-			set_Value (COLUMNNAME_C_OrderLine_ID, null);
-		else 
-			set_Value (COLUMNNAME_C_OrderLine_ID, C_OrderLine_ID);
-	}
-
-	@Override
-	public int getC_OrderLine_ID() 
+	public int getC_OrderLine_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_C_OrderLine_ID);
 	}
 
 	@Override
-	public void setC_UOM_ID (final int C_UOM_ID)
+	public void setC_OrderLine_ID(final int C_OrderLine_ID)
 	{
-		if (C_UOM_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_C_UOM_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_C_UOM_ID, C_UOM_ID);
+		if (C_OrderLine_ID < 1)
+			set_Value(COLUMNNAME_C_OrderLine_ID, null);
+		else
+			set_Value(COLUMNNAME_C_OrderLine_ID, C_OrderLine_ID);
 	}
 
 	@Override
-	public int getC_UOM_ID() 
+	public int getC_UOM_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_C_UOM_ID);
 	}
 
 	@Override
-	public void setDatePromised (final java.sql.Timestamp DatePromised)
+	public void setC_UOM_ID(final int C_UOM_ID)
 	{
-		set_Value (COLUMNNAME_DatePromised, DatePromised);
+		if (C_UOM_ID < 1)
+			set_ValueNoCheck(COLUMNNAME_C_UOM_ID, null);
+		else
+			set_ValueNoCheck(COLUMNNAME_C_UOM_ID, C_UOM_ID);
 	}
 
 	@Override
-	public java.sql.Timestamp getDatePromised() 
+	public java.sql.Timestamp getDatePromised()
 	{
 		return get_ValueAsTimestamp(COLUMNNAME_DatePromised);
 	}
 
 	@Override
-	public void setDateStartSchedule (final java.sql.Timestamp DateStartSchedule)
+	public void setDatePromised(final java.sql.Timestamp DatePromised)
 	{
-		set_Value (COLUMNNAME_DateStartSchedule, DateStartSchedule);
+		set_Value(COLUMNNAME_DatePromised, DatePromised);
 	}
 
 	@Override
-	public java.sql.Timestamp getDateStartSchedule() 
+	public java.sql.Timestamp getDateStartSchedule()
 	{
 		return get_ValueAsTimestamp(COLUMNNAME_DateStartSchedule);
 	}
 
 	@Override
-	public void setIsClosed (final boolean IsClosed)
+	public void setDateStartSchedule(final java.sql.Timestamp DateStartSchedule)
 	{
-		set_Value (COLUMNNAME_IsClosed, IsClosed);
+		set_Value(COLUMNNAME_DateStartSchedule, DateStartSchedule);
 	}
 
 	@Override
-	public boolean isClosed() 
+	public void setIsClosed(final boolean IsClosed)
+	{
+		set_Value(COLUMNNAME_IsClosed, IsClosed);
+	}
+
+	@Override
+	public boolean isClosed()
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsClosed);
 	}
 
 	@Override
-	public void setIsMaturing (final boolean IsMaturing)
+	public void setIsMaturing(final boolean IsMaturing)
 	{
-		set_Value (COLUMNNAME_IsMaturing, IsMaturing);
+		set_Value(COLUMNNAME_IsMaturing, IsMaturing);
 	}
 
 	@Override
-	public boolean isMaturing() 
+	public boolean isMaturing()
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsMaturing);
 	}
 
 	@Override
-	public void setIsSimulated (final boolean IsSimulated)
+	public void setIsSimulated(final boolean IsSimulated)
 	{
-		set_Value (COLUMNNAME_IsSimulated, IsSimulated);
+		set_Value(COLUMNNAME_IsSimulated, IsSimulated);
 	}
 
 	@Override
-	public boolean isSimulated() 
+	public boolean isSimulated()
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsSimulated);
 	}
 
 	@Override
-	public void setIssue_HU_ID (final int Issue_HU_ID)
+	public int getIssue_HU_ID()
 	{
-		if (Issue_HU_ID < 1) 
-			set_Value (COLUMNNAME_Issue_HU_ID, null);
-		else 
-			set_Value (COLUMNNAME_Issue_HU_ID, Issue_HU_ID);
+		return get_ValueAsInt(COLUMNNAME_Issue_HU_ID);
 	}
 
 	@Override
-	public int getIssue_HU_ID() 
+	public void setIssue_HU_ID(final int Issue_HU_ID)
 	{
-		return get_ValueAsInt(COLUMNNAME_Issue_HU_ID);
+		if (Issue_HU_ID < 1)
+			set_Value(COLUMNNAME_Issue_HU_ID, null);
+		else
+			set_Value(COLUMNNAME_Issue_HU_ID, Issue_HU_ID);
 	}
 
 	@Override
@@ -176,33 +177,33 @@ public class X_PP_Order_Candidate extends org.compiere.model.PO implements I_PP_
 	}
 
 	@Override
-	public void setM_AttributeSetInstance_ID (final int M_AttributeSetInstance_ID)
-	{
-		if (M_AttributeSetInstance_ID < 0) 
-			set_Value (COLUMNNAME_M_AttributeSetInstance_ID, null);
-		else 
-			set_Value (COLUMNNAME_M_AttributeSetInstance_ID, M_AttributeSetInstance_ID);
-	}
-
-	@Override
-	public int getM_AttributeSetInstance_ID() 
+	public int getM_AttributeSetInstance_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_M_AttributeSetInstance_ID);
 	}
 
 	@Override
-	public void setM_HU_PI_Item_Product_ID (final int M_HU_PI_Item_Product_ID)
+	public void setM_AttributeSetInstance_ID(final int M_AttributeSetInstance_ID)
 	{
-		if (M_HU_PI_Item_Product_ID < 1) 
-			set_Value (COLUMNNAME_M_HU_PI_Item_Product_ID, null);
-		else 
-			set_Value (COLUMNNAME_M_HU_PI_Item_Product_ID, M_HU_PI_Item_Product_ID);
+		if (M_AttributeSetInstance_ID < 0)
+			set_Value(COLUMNNAME_M_AttributeSetInstance_ID, null);
+		else
+			set_Value(COLUMNNAME_M_AttributeSetInstance_ID, M_AttributeSetInstance_ID);
 	}
 
 	@Override
-	public int getM_HU_PI_Item_Product_ID() 
+	public int getM_HU_PI_Item_Product_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_M_HU_PI_Item_Product_ID);
+	}
+
+	@Override
+	public void setM_HU_PI_Item_Product_ID(final int M_HU_PI_Item_Product_ID)
+	{
+		if (M_HU_PI_Item_Product_ID < 1)
+			set_Value(COLUMNNAME_M_HU_PI_Item_Product_ID, null);
+		else
+			set_Value(COLUMNNAME_M_HU_PI_Item_Product_ID, M_HU_PI_Item_Product_ID);
 	}
 
 	@Override
@@ -218,18 +219,18 @@ public class X_PP_Order_Candidate extends org.compiere.model.PO implements I_PP_
 	}
 
 	@Override
-	public void setM_Maturing_Configuration_ID (final int M_Maturing_Configuration_ID)
+	public int getM_Maturing_Configuration_ID()
 	{
-		if (M_Maturing_Configuration_ID < 1) 
-			set_Value (COLUMNNAME_M_Maturing_Configuration_ID, null);
-		else 
-			set_Value (COLUMNNAME_M_Maturing_Configuration_ID, M_Maturing_Configuration_ID);
+		return get_ValueAsInt(COLUMNNAME_M_Maturing_Configuration_ID);
 	}
 
 	@Override
-	public int getM_Maturing_Configuration_ID() 
+	public void setM_Maturing_Configuration_ID(final int M_Maturing_Configuration_ID)
 	{
-		return get_ValueAsInt(COLUMNNAME_M_Maturing_Configuration_ID);
+		if (M_Maturing_Configuration_ID < 1)
+			set_Value(COLUMNNAME_M_Maturing_Configuration_ID, null);
+		else
+			set_Value(COLUMNNAME_M_Maturing_Configuration_ID, M_Maturing_Configuration_ID);
 	}
 
 	@Override
@@ -245,89 +246,90 @@ public class X_PP_Order_Candidate extends org.compiere.model.PO implements I_PP_
 	}
 
 	@Override
-	public void setM_Maturing_Configuration_Line_ID (final int M_Maturing_Configuration_Line_ID)
-	{
-		if (M_Maturing_Configuration_Line_ID < 1) 
-			set_Value (COLUMNNAME_M_Maturing_Configuration_Line_ID, null);
-		else 
-			set_Value (COLUMNNAME_M_Maturing_Configuration_Line_ID, M_Maturing_Configuration_Line_ID);
-	}
-
-	@Override
-	public int getM_Maturing_Configuration_Line_ID() 
+	public int getM_Maturing_Configuration_Line_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_M_Maturing_Configuration_Line_ID);
 	}
 
 	@Override
-	public void setM_Product_ID (final int M_Product_ID)
+	public void setM_Maturing_Configuration_Line_ID(final int M_Maturing_Configuration_Line_ID)
 	{
-		if (M_Product_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_M_Product_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_M_Product_ID, M_Product_ID);
+		if (M_Maturing_Configuration_Line_ID < 1)
+			set_Value(COLUMNNAME_M_Maturing_Configuration_Line_ID, null);
+		else
+			set_Value(COLUMNNAME_M_Maturing_Configuration_Line_ID, M_Maturing_Configuration_Line_ID);
 	}
 
 	@Override
-	public int getM_Product_ID() 
+	public int getM_Product_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_M_Product_ID);
 	}
 
 	@Override
-	public void setM_ShipmentSchedule_ID (final int M_ShipmentSchedule_ID)
+	public void setM_Product_ID(final int M_Product_ID)
 	{
-		if (M_ShipmentSchedule_ID < 1) 
-			set_Value (COLUMNNAME_M_ShipmentSchedule_ID, null);
-		else 
-			set_Value (COLUMNNAME_M_ShipmentSchedule_ID, M_ShipmentSchedule_ID);
+		if (M_Product_ID < 1)
+			set_ValueNoCheck(COLUMNNAME_M_Product_ID, null);
+		else
+			set_ValueNoCheck(COLUMNNAME_M_Product_ID, M_Product_ID);
 	}
 
 	@Override
-	public int getM_ShipmentSchedule_ID() 
+	public int getM_ShipmentSchedule_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_M_ShipmentSchedule_ID);
 	}
 
 	@Override
-	public void setM_Warehouse_ID (final int M_Warehouse_ID)
+	public void setM_ShipmentSchedule_ID(final int M_ShipmentSchedule_ID)
 	{
-		if (M_Warehouse_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_M_Warehouse_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_M_Warehouse_ID, M_Warehouse_ID);
+		if (M_ShipmentSchedule_ID < 1)
+			set_Value(COLUMNNAME_M_ShipmentSchedule_ID, null);
+		else
+			set_Value(COLUMNNAME_M_ShipmentSchedule_ID, M_ShipmentSchedule_ID);
 	}
 
 	@Override
-	public int getM_Warehouse_ID() 
+	public int getM_Warehouse_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_M_Warehouse_ID);
 	}
 
 	@Override
-	public void setNumberOfResources_ToProcess (final int NumberOfResources_ToProcess)
+	public void setM_Warehouse_ID(final int M_Warehouse_ID)
 	{
-		throw new IllegalArgumentException ("NumberOfResources_ToProcess is virtual column");	}
+		if (M_Warehouse_ID < 1)
+			set_ValueNoCheck(COLUMNNAME_M_Warehouse_ID, null);
+		else
+			set_ValueNoCheck(COLUMNNAME_M_Warehouse_ID, M_Warehouse_ID);
+	}
 
 	@Override
-	public int getNumberOfResources_ToProcess() 
+	public int getNumberOfResources_ToProcess()
 	{
 		return get_ValueAsInt(COLUMNNAME_NumberOfResources_ToProcess);
 	}
 
 	@Override
-	public void setPP_Order_Candidate_ID (final int PP_Order_Candidate_ID)
+	public void setNumberOfResources_ToProcess(final int NumberOfResources_ToProcess)
 	{
-		if (PP_Order_Candidate_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_PP_Order_Candidate_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_PP_Order_Candidate_ID, PP_Order_Candidate_ID);
+		throw new IllegalArgumentException("NumberOfResources_ToProcess is virtual column");
 	}
 
 	@Override
-	public int getPP_Order_Candidate_ID() 
+	public int getPP_Order_Candidate_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_PP_Order_Candidate_ID);
+	}
+
+	@Override
+	public void setPP_Order_Candidate_ID(final int PP_Order_Candidate_ID)
+	{
+		if (PP_Order_Candidate_ID < 1)
+			set_ValueNoCheck(COLUMNNAME_PP_Order_Candidate_ID, null);
+		else
+			set_ValueNoCheck(COLUMNNAME_PP_Order_Candidate_ID, PP_Order_Candidate_ID);
 	}
 
 	@Override
@@ -343,109 +345,109 @@ public class X_PP_Order_Candidate extends org.compiere.model.PO implements I_PP_
 	}
 
 	@Override
-	public void setPP_Product_BOM_ID (final int PP_Product_BOM_ID)
-	{
-		if (PP_Product_BOM_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_PP_Product_BOM_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_PP_Product_BOM_ID, PP_Product_BOM_ID);
-	}
-
-	@Override
-	public int getPP_Product_BOM_ID() 
+	public int getPP_Product_BOM_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_PP_Product_BOM_ID);
 	}
 
 	@Override
-	public void setPP_Product_Planning_ID (final int PP_Product_Planning_ID)
+	public void setPP_Product_BOM_ID(final int PP_Product_BOM_ID)
 	{
-		if (PP_Product_Planning_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_PP_Product_Planning_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_PP_Product_Planning_ID, PP_Product_Planning_ID);
+		if (PP_Product_BOM_ID < 1)
+			set_ValueNoCheck(COLUMNNAME_PP_Product_BOM_ID, null);
+		else
+			set_ValueNoCheck(COLUMNNAME_PP_Product_BOM_ID, PP_Product_BOM_ID);
 	}
 
 	@Override
-	public int getPP_Product_Planning_ID() 
+	public int getPP_Product_Planning_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_PP_Product_Planning_ID);
 	}
 
 	@Override
-	public void setProcessed (final boolean Processed)
+	public void setPP_Product_Planning_ID(final int PP_Product_Planning_ID)
 	{
-		set_Value (COLUMNNAME_Processed, Processed);
+		if (PP_Product_Planning_ID < 1)
+			set_ValueNoCheck(COLUMNNAME_PP_Product_Planning_ID, null);
+		else
+			set_ValueNoCheck(COLUMNNAME_PP_Product_Planning_ID, PP_Product_Planning_ID);
 	}
 
 	@Override
-	public boolean isProcessed() 
+	public boolean isProcessed()
 	{
 		return get_ValueAsBoolean(COLUMNNAME_Processed);
 	}
 
 	@Override
-	public void setQtyEntered (final @Nullable BigDecimal QtyEntered)
+	public void setProcessed(final boolean Processed)
 	{
-		set_Value (COLUMNNAME_QtyEntered, QtyEntered);
+		set_Value(COLUMNNAME_Processed, Processed);
 	}
 
 	@Override
-	public BigDecimal getQtyEntered() 
+	public BigDecimal getQtyEntered()
 	{
 		final BigDecimal bd = get_ValueAsBigDecimal(COLUMNNAME_QtyEntered);
 		return bd != null ? bd : BigDecimal.ZERO;
 	}
 
 	@Override
-	public void setQtyProcessed (final @Nullable BigDecimal QtyProcessed)
+	public void setQtyEntered(final @Nullable BigDecimal QtyEntered)
 	{
-		set_Value (COLUMNNAME_QtyProcessed, QtyProcessed);
+		set_Value(COLUMNNAME_QtyEntered, QtyEntered);
 	}
 
 	@Override
-	public BigDecimal getQtyProcessed() 
+	public BigDecimal getQtyProcessed()
 	{
 		final BigDecimal bd = get_ValueAsBigDecimal(COLUMNNAME_QtyProcessed);
 		return bd != null ? bd : BigDecimal.ZERO;
 	}
 
 	@Override
-	public void setQtyProcessed_OnDate (final @Nullable BigDecimal QtyProcessed_OnDate)
+	public void setQtyProcessed(final @Nullable BigDecimal QtyProcessed)
 	{
-		set_Value (COLUMNNAME_QtyProcessed_OnDate, QtyProcessed_OnDate);
+		set_Value(COLUMNNAME_QtyProcessed, QtyProcessed);
 	}
 
 	@Override
-	public BigDecimal getQtyProcessed_OnDate() 
+	public BigDecimal getQtyProcessed_OnDate()
 	{
 		final BigDecimal bd = get_ValueAsBigDecimal(COLUMNNAME_QtyProcessed_OnDate);
 		return bd != null ? bd : BigDecimal.ZERO;
 	}
 
 	@Override
-	public void setQtyToProcess (final @Nullable BigDecimal QtyToProcess)
+	public void setQtyProcessed_OnDate(final @Nullable BigDecimal QtyProcessed_OnDate)
 	{
-		set_Value (COLUMNNAME_QtyToProcess, QtyToProcess);
+		set_Value(COLUMNNAME_QtyProcessed_OnDate, QtyProcessed_OnDate);
 	}
 
 	@Override
-	public BigDecimal getQtyToProcess() 
+	public BigDecimal getQtyToProcess()
 	{
 		final BigDecimal bd = get_ValueAsBigDecimal(COLUMNNAME_QtyToProcess);
 		return bd != null ? bd : BigDecimal.ZERO;
 	}
 
 	@Override
-	public void setSeqNo (final int SeqNo)
+	public void setQtyToProcess(final @Nullable BigDecimal QtyToProcess)
 	{
-		set_Value (COLUMNNAME_SeqNo, SeqNo);
+		set_Value(COLUMNNAME_QtyToProcess, QtyToProcess);
 	}
 
 	@Override
-	public int getSeqNo() 
+	public int getSeqNo()
 	{
 		return get_ValueAsInt(COLUMNNAME_SeqNo);
+	}
+
+	@Override
+	public void setSeqNo(final int SeqNo)
+	{
+		set_Value(COLUMNNAME_SeqNo, SeqNo);
 	}
 
 	@Override
@@ -461,18 +463,18 @@ public class X_PP_Order_Candidate extends org.compiere.model.PO implements I_PP_
 	}
 
 	@Override
-	public void setS_Resource_ID (final int S_Resource_ID)
+	public int getS_Resource_ID()
 	{
-		if (S_Resource_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_S_Resource_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_S_Resource_ID, S_Resource_ID);
+		return get_ValueAsInt(COLUMNNAME_S_Resource_ID);
 	}
 
 	@Override
-	public int getS_Resource_ID() 
+	public void setS_Resource_ID(final int S_Resource_ID)
 	{
-		return get_ValueAsInt(COLUMNNAME_S_Resource_ID);
+		if (S_Resource_ID < 1)
+			set_ValueNoCheck(COLUMNNAME_S_Resource_ID, null);
+		else
+			set_ValueNoCheck(COLUMNNAME_S_Resource_ID, S_Resource_ID);
 	}
 
 	@Override
@@ -488,29 +490,29 @@ public class X_PP_Order_Candidate extends org.compiere.model.PO implements I_PP_
 	}
 
 	@Override
-	public void setStorageAttributesKey (final @Nullable java.lang.String StorageAttributesKey)
-	{
-		set_Value (COLUMNNAME_StorageAttributesKey, StorageAttributesKey);
-	}
-
-	@Override
-	public java.lang.String getStorageAttributesKey() 
+	public java.lang.String getStorageAttributesKey()
 	{
 		return get_ValueAsString(COLUMNNAME_StorageAttributesKey);
 	}
 
 	@Override
-	public void setWorkStation_ID (final int WorkStation_ID)
+	public void setStorageAttributesKey(final @Nullable java.lang.String StorageAttributesKey)
 	{
-		if (WorkStation_ID < 1) 
-			set_Value (COLUMNNAME_WorkStation_ID, null);
-		else 
-			set_Value (COLUMNNAME_WorkStation_ID, WorkStation_ID);
+		set_Value(COLUMNNAME_StorageAttributesKey, StorageAttributesKey);
 	}
 
 	@Override
-	public int getWorkStation_ID() 
+	public int getWorkStation_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_WorkStation_ID);
+	}
+
+	@Override
+	public void setWorkStation_ID(final int WorkStation_ID)
+	{
+		if (WorkStation_ID < 1)
+			set_Value(COLUMNNAME_WorkStation_ID, null);
+		else
+			set_Value(COLUMNNAME_WorkStation_ID, WorkStation_ID);
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5795650_pp_order_candidate_storageAttributesKey.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5795650_pp_order_candidate_storageAttributesKey.sql
@@ -1,0 +1,27 @@
+-- Run mode: SWING_CLIENT
+
+-- Column: PP_Order_Candidate.StorageAttributesKey
+-- 2026-03-25T16:11:31.400Z
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,CloningStrategy,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FacetFilterSeqNo,FieldLength,Help,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterInactiveValues,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,ReadOnlyLogic,SelectionColumnSeqNo,SeqNo,TechnicalNote,Updated,UpdatedBy,Version) VALUES (0,592312,543463,0,10,541913,'XX','StorageAttributesKey',TO_TIMESTAMP('2026-03-25 16:11:31.131000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N','EE01',0,1024,'Note: in java we have the following constants
+* none: "-1002" (makes sense where this is used for stock-keeping)
+* other: "-1001" (makes sense where this is used information)
+* all: "-1000" (makes sense where this is used for matching)','Y','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','Y','N',0,'StorageAttributesKey (technical)','1=2',0,0,'Always computed based on M_AttributeSetInstance_ID',TO_TIMESTAMP('2026-03-25 16:11:31.131000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,0)
+;
+
+-- 2026-03-25T16:11:31.408Z
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=592312 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 2026-03-25T16:11:31.434Z
+/* DDL */  select update_Column_Translation_From_AD_Element(543463)
+;
+
+-- 2026-03-25T16:11:35.561Z
+/* DDL */ SELECT public.db_alter_table('PP_Order_Candidate','ALTER TABLE public.PP_Order_Candidate ADD COLUMN StorageAttributesKey VARCHAR(1024)')
+;
+
+-- Column: PP_Order_Candidate.StorageAttributesKey
+-- 2026-03-25T17:08:25.613Z
+UPDATE AD_Column SET IsUpdateable='N', ReadOnlyLogic='',Updated=TO_TIMESTAMP('2026-03-25 17:08:25.613000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=592312
+;
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5795651_populate_pp_order_candidate_storageAttributesKey.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5795651_populate_pp_order_candidate_storageAttributesKey.sql
@@ -1,0 +1,10 @@
+SELECT backup_table('pp_order_candidate')
+;
+
+UPDATE pp_order_candidate
+SET storageattributeskey = GenerateASIStorageAttributesKey(m_attributesetinstance_id),
+    updated              = TO_TIMESTAMP('2026-03-25 11:11:11.000000', 'YYYY-MM-DD HH24:MI:SS.US'),
+    updatedby            = 99
+WHERE storageattributeskey IS NULL
+;
+

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/productioncandidate/model/interceptor/PP_Order_Candidate.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/productioncandidate/model/interceptor/PP_Order_Candidate.java
@@ -28,6 +28,7 @@ import de.metas.handlingunits.HuId;
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.IMsgBL;
 import de.metas.material.event.PostMaterialEventService;
+import de.metas.material.event.commons.AttributesKey;
 import de.metas.material.event.commons.EventDescriptor;
 import de.metas.material.event.pporder.PPOrderCandidate;
 import de.metas.material.event.pporder.PPOrderCandidateCreatedEvent;
@@ -41,6 +42,8 @@ import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.exceptions.FillMandatoryException;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
+import org.adempiere.mm.attributes.keys.AttributesKeys;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.ModelValidator;
 import org.compiere.util.Env;
@@ -203,7 +206,7 @@ public class PP_Order_Candidate
 	{
 		final PPOrderCandidate ppOrderCandidatePojo = ppOrderCandidateConverter.toPPOrderCandidate(ppOrderCandidateRecord);
 		final UserId userId = UserId.ofRepoId(ppOrderCandidateRecord.getUpdatedBy());
-		
+
 		final EventDescriptor eventDescriptor = EventDescriptor.ofClientOrgUserIdAndTraceId(
 				ppOrderCandidatePojo.getPpOrderData().getClientAndOrgId(),
 				userId,
@@ -260,5 +263,15 @@ public class PP_Order_Candidate
 					.setParameter("PP_Order_Candidate.QtyProcessed", ppOrderCandidateRecord.getQtyProcessed())
 					.markAsUserValidationError();
 		}
+	}
+
+	@ModelChange(
+			timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE },
+			ifColumnsChanged = { I_PP_Order_Candidate.COLUMNNAME_M_AttributeSetInstance_ID })
+	public void updateStorageAttributesKey(@NonNull final I_PP_Order_Candidate ppOrderCandidateRecord)
+	{
+		final AttributesKey attributesKey = AttributesKeys.createAttributesKeyFromASIStorageAttributes(AttributeSetInstanceId.ofRepoIdOrNone(ppOrderCandidateRecord.getM_AttributeSetInstance_ID()))
+				.orElse(null);
+		ppOrderCandidateRecord.setStorageAttributesKey(AttributesKey.toString(attributesKey));
 	}
 }

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/productioncandidate/model/interceptor/PP_Order_Candidate.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/productioncandidate/model/interceptor/PP_Order_Candidate.java
@@ -272,6 +272,6 @@ public class PP_Order_Candidate
 	{
 		final AttributesKey attributesKey = AttributesKeys.createAttributesKeyFromASIStorageAttributes(AttributeSetInstanceId.ofRepoIdOrNone(ppOrderCandidateRecord.getM_AttributeSetInstance_ID()))
 				.orElse(null);
-		ppOrderCandidateRecord.setStorageAttributesKey(AttributesKey.toString(attributesKey));
+		ppOrderCandidateRecord.setStorageAttributesKey(AttributesKey.toStringOrNull(attributesKey));
 	}
 }

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5795670_pp_order_aggr_byStorageAttributesKey.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5795670_pp_order_aggr_byStorageAttributesKey.sql
@@ -1,0 +1,11 @@
+-- Run mode: WEBUI
+
+-- Change the aggregation item to use StorageAttributesKey instead of M_AttributeSetInstance_ID
+-- Why? because storage attributes may be identical for different ASIs
+
+-- 2026-03-25T17:29:26.830Z
+UPDATE C_AggregationItem
+SET AD_Column_ID=592312, Updated=TO_TIMESTAMP('2026-03-25 17:29:26.827000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE C_AggregationItem_ID = 540124
+;
+

--- a/backend/de.metas.material/event/src/main/java/de/metas/material/event/commons/AttributesKey.java
+++ b/backend/de.metas.material/event/src/main/java/de/metas/material/event/commons/AttributesKey.java
@@ -184,7 +184,7 @@ public final class AttributesKey implements Comparable<AttributesKey>
 	}
 
 	@Nullable
-	public static String toString(@Nullable final AttributesKey key)
+	public static String toStringOrNull(@Nullable final AttributesKey key)
 	{
 		if (key == null || key.isNone())
 		{

--- a/backend/de.metas.material/event/src/main/java/de/metas/material/event/commons/AttributesKey.java
+++ b/backend/de.metas.material/event/src/main/java/de/metas/material/event/commons/AttributesKey.java
@@ -54,7 +54,9 @@ public final class AttributesKey implements Comparable<AttributesKey>
 {
 	// first, declare the "static" constants that might be used within the "factory-method" constants
 
-	/** The delimiter should not contain any character that has a "regexp" meaning and would interfere with {@link String#replaceAll(String, String)}. */
+	/**
+	 * The delimiter should not contain any character that has a "regexp" meaning and would interfere with {@link String#replaceAll(String, String)}.
+	 */
 	@VisibleForTesting
 	public static final String ATTRIBUTES_KEY_DELIMITER = "§&§";
 	private static final Joiner ATTRIBUTEVALUEIDS_JOINER = Joiner.on(ATTRIBUTES_KEY_DELIMITER).skipNulls();
@@ -63,7 +65,9 @@ public final class AttributesKey implements Comparable<AttributesKey>
 	public static final AttributesKey ALL = AttributesKey.ofAttributeValueIds(-1000);
 	public static final AdMessageKey MSG_ATTRIBUTES_KEY_ALL = AdMessageKey.of("de.metas.material.dispo.<ALL_ATTRIBUTES_KEYS>");
 
-	/** This key's meaning depends on the other keys it comes with. */
+	/**
+	 * This key's meaning depends on the other keys it comes with.
+	 */
 	public static final AttributesKey OTHER = AttributesKey.ofAttributeValueIds(-1001);
 	public static final AdMessageKey MSG_ATTRIBUTES_KEY_OTHER = AdMessageKey.of("de.metas.material.dispo.<OTHER_ATTRIBUTES_KEYS>");
 
@@ -177,6 +181,16 @@ public final class AttributesKey implements Comparable<AttributesKey>
 	public String getAsString()
 	{
 		return attributesKeyString;
+	}
+
+	@Nullable
+	public static String toString(@Nullable final AttributesKey key)
+	{
+		if (key == null || key.isNone())
+		{
+			return null;
+		}
+		return key.getAsString();
 	}
 
 	public boolean isNone()


### PR DESCRIPTION
### Summary

This pull request introduces the `StorageAttributesKey` field to the `PP_Order_Candidate` entity. It includes attribute key generation logic and a corresponding database migration.

### Changes

- Added `StorageAttributesKey` field to `PP_Order_Candidate`.
- Implemented logic for generating the attribute key.
- Performed database migration to incorporate the new field.
- Changed `pp_order_candidates_ignore_sales_order` aggregation to use StorageAggregationKey instead of M_AttributeSetInstance_ID