### PR TITLE
gitignore: add REVIEW.md (Claude symlink, managed by mf15-ai-dev-support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ misc/services/camel/de-metas-camel-shipping/tmp/
 **/CLAUDE.md.backup
 .mcp.json
 **/claude-docs
+**/REVIEW.md
 /docs/
 
 


### PR DESCRIPTION
`REVIEW.md` is a symlink created by `mf15-ai-dev-support/install-claude-config.sh` pointing to the Claude code-review checklist. It was missing from `.gitignore`, causing it to appear as an unversioned file in IDEs.

Added alongside the existing Claude-related ignore patterns.