### PR TITLE
GRAI: move scanner above count to fix scroll jump

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5796110_sys_GRAI_create_missing_M_HU_Attribute_records.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5796110_sys_GRAI_create_missing_M_HU_Attribute_records.sql
@@ -1,0 +1,46 @@
+-- gh#28474 GRAI: Create missing M_HU_Attribute records for existing HUs
+--
+-- Problem: HUs created before the GRAI attribute was added to the PI template
+-- don't have an M_HU_Attribute record for GRAI (M_Attribute_ID=540192).
+-- The Java code (HUAttributesBL.updateHUAttribute) silently skips the update
+-- if the record doesn't exist (hasAttribute check returns false).
+--
+-- Prerequisite: 5795460_add_GRAI_attr_to_PI_template.sql already added
+-- the GRAI attribute to the Template PI (M_HU_PI_Version_ID=100).
+--
+-- Fix: Insert M_HU_Attribute records for existing TUs and VHUs (not LUs) that are missing the GRAI attribute.
+-- LUs are excluded because GRAIs are stored on TUs (one per TU) and VHUs (comma-separated for aggregate blocks).
+INSERT INTO M_HU_Attribute (AD_Client_ID, AD_Org_ID,
+                            Created, CreatedBy,
+                            IsActive,
+                            M_Attribute_ID,
+                            M_HU_Attribute_ID,
+                            M_HU_ID,
+                            M_HU_PI_Attribute_ID,
+                            Updated, UpdatedBy,
+                            Value)
+SELECT hu.AD_Client_ID,
+       hu.AD_Org_ID,
+       '2026-03-27',
+       99,
+       'Y',
+       540192,                                        -- GRAI attribute
+       nextval('m_hu_attribute_seq'),                 -- new PK
+       hu.M_HU_ID,
+       (SELECT pia.M_HU_PI_Attribute_ID
+        FROM M_HU_PI_Attribute pia
+        WHERE pia.M_HU_PI_Version_ID = 100
+          AND pia.M_Attribute_ID = 540192
+        LIMIT 1),                                     -- Template PI attribute
+       '2026-03-27',
+       99,
+       NULL                                           -- no GRAI assigned yet
+FROM M_HU hu
+         JOIN M_HU_PI_Version piv ON piv.M_HU_PI_Version_ID = hu.M_HU_PI_Version_ID
+WHERE hu.IsActive = 'Y'
+  AND piv.HU_UnitType IN ('TU', 'V')                 -- TUs and VHUs only, exclude LUs
+  AND NOT EXISTS (SELECT 1
+                  FROM M_HU_Attribute hua
+                  WHERE hua.M_HU_ID = hu.M_HU_ID
+                    AND hua.M_Attribute_ID = 540192)
+;

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -42,6 +42,11 @@ export const BarcodeScannerComponent = {
                 document.dispatchEvent(new KeyboardEvent('keydown', { key: char, bubbles: true }));
                 document.dispatchEvent(new KeyboardEvent('keyup', { key: char, bubbles: true }));
             }
+            // Terminate with Enter, matching real hardware scanner behavior (DataWedge default).
+            // Without this, rapid consecutive scans can merge buffers in useKeyboardBarcodeReader
+            // because the rate-drop flush (300ms) hasn't fired yet.
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            document.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', bubbles: true }));
         }, scannedCode);
     }),
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/huManager/containers/GRAIScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/huManager/containers/GRAIScreen.jsx
@@ -78,6 +78,8 @@ const GRAIScreen = () => {
     <div className="grai-screen">
       <HUInfoComponent handlingUnitInfo={handlingUnitInfo} />
 
+      {!loading && <BarcodeScannerComponent onResolvedResult={onResolvedResult} continuousRunning={true} />}
+
       <div className="grai-count" data-testid="grai-count">
         {trl('huManager.action.scanGRAI.count', { scanned: assignedGrais.length, total: tuCount })}
         {extraGrais.length > 0 && (
@@ -131,8 +133,6 @@ const GRAIScreen = () => {
           onNo={() => setShowClearAllDialog(false)}
         />
       )}
-
-      {!loading && <BarcodeScannerComponent onResolvedResult={onResolvedResult} continuousRunning={true} />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Move `BarcodeScannerComponent` above the grai-count div in `GRAIScreen.jsx`
- When scanning 40+ GRAIs via RFID, the chip list grows and pushes the scanner off-screen; its `focus()` call scrolls the browser down, making count/buttons jump out of view
- With the scanner above the count, `focus()` anchors the viewport at the top and the chip list grows downward without layout jumps
- Also includes SQL migration `5796110` to create missing `M_HU_Attribute` GRAI records for existing HUs

## Test plan
- [x] 14/15 GRAI E2E tests pass (`npx playwright test tests/spec/humanager/grai.spec.js`)
- [x] 1 pre-existing failure (`Non-GRAI barcode is silently ignored`) — same failure on `soft_panda_release` without this change

Closes metasfresh/me03#28474 (partial — scanner position fix from meeting minutes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)