### PR TITLE
#28967 Package Licensing: TotalSalesQty and weight calc fix

### DIFF
--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5796360_sys_gh28967_Package_Licensing_InOut_Report_TotalSalesQty.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5796360_sys_gh28967_Package_Licensing_InOut_Report_TotalSalesQty.sql
@@ -1,24 +1,5 @@
-/*
- * #%L
- * de.metas.fresh.base
- * %%
- * Copyright (C) 2025 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
+-- Replace MovementQty column with TotalSalesQty in Package_Licensing_InOut_Report.
+-- Prod already has this version; aligns hotfix with prod.
 
 DROP FUNCTION IF EXISTS report.Package_Licensing_InOut_Report(p_DateFrom              timestamp with time zone,
                                                               p_DateTo                timestamp with time zone,

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5796370_sys_gh28967_Package_Licensing_Product_Report_TotalSalesQty.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5796370_sys_gh28967_Package_Licensing_Product_Report_TotalSalesQty.sql
@@ -1,3 +1,6 @@
+-- Replace MovementQty with TotalSalesQty in Package_Licensing_Product_Report.
+-- Aligns hotfix with prod.
+
 DROP FUNCTION IF EXISTS report.Package_Licensing_Product_Report(numeric);
 DROP FUNCTION IF EXISTS report.Package_Licensing_Product_Report(numeric, varchar);
 DROP FUNCTION IF EXISTS report.Package_Licensing_Product_Report(timestamp with time zone, timestamp with time zone, numeric, varchar);

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5796380_sys_gh28967_Package_Licensing_InOut_Summary_Report_WeightCalc.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5796380_sys_gh28967_Package_Licensing_InOut_Summary_Report_WeightCalc.sql
@@ -1,3 +1,8 @@
+-- Fix weight calculation in Package_Licensing_InOut_Summary_Report:
+-- 1. Use (PurchaseQty - ForeignSalesQty) instead of MovementQty for weight calculation
+-- 2. Add ROUND(..., 3) to aggregated weight values
+-- Aligns hotfix with prod.
+
 DROP FUNCTION IF EXISTS report.Package_Licensing_InOut_Summary_Report(
     p_DateFrom             timestamp with time zone,
     p_DateTo               timestamp with time zone,
@@ -52,7 +57,7 @@ DECLARE
     v_report_func_call        text;
     v_column_aliases_list     text;
     v_prefixed_aliases_list   text;
-    v_q_prefixed_aliases_list text; -- **NEW: q.Glas, q.Kunststoff, etc.**
+    v_q_prefixed_aliases_list text;
 
 BEGIN
 
@@ -81,7 +86,6 @@ BEGIN
     INTO v_prefixed_aliases_list
     FROM UNNEST(v_column_aliases) AS material;
 
-    -- **NEW: Create the q. prefix list for the outer SELECT**
     SELECT TRIM(STRING_AGG(FORMAT('q.%I', material), ', '))
     INTO v_q_prefixed_aliases_list
     FROM UNNEST(v_column_aliases) AS material;
@@ -126,12 +130,12 @@ BEGIN
     SELECT
         q.ProductGroup,
         q.PackagingType,
-        %6$s -- **FIX: q.Glas, q.Kunststoff, etc.**
+        %6$s
     FROM (
         -- Inner Query: UNION ALL with sort column
         -- HEADER ROW
         SELECT
-               0 AS sort_order, -- Sort column (Integer)
+               0 AS sort_order,
                '---HEADER---'::varchar AS ProductGroup,
                'Material Name'::varchar AS PackagingType,
                %1$s -- v_header_cols_list
@@ -140,7 +144,7 @@ BEGIN
 
         -- DATA ROWS: Wrapped Aggregation
         SELECT
-            1 AS sort_order, -- Sort column (Integer)
+            1 AS sort_order,
             agg.ProductGroup,
             agg.PackagingType,
             %2$s -- v_prefixed_aliases_list
@@ -185,7 +189,7 @@ $f$,
                     v_data_cols_list, -- %3$s
                     v_report_func_call, -- %4$s
                     v_materials_sql_array, -- %5$s
-                    v_q_prefixed_aliases_list -- **%6$s (New q. prefixed list)**
+                    v_q_prefixed_aliases_list -- %6$s
              );
 
     -- 6) Execute and return the result.


### PR DESCRIPTION
## Summary
- Replace `MovementQty` column with `TotalSalesQty` (only sales shipments, not sign-flipped) in `Package_Licensing_InOut_Report` and `Package_Licensing_Product_Report`
- Fix weight calculation in `Package_Licensing_InOut_Summary_Report`: use `(PurchaseQty - ForeignSalesQty) * weight` instead of `MovementQty * weight`, and add `ROUND(..., 3)`
- Aligns the hotfix branch with what is already deployed on prod (these changes were applied directly on prod but never committed to the branch)

## Test plan
- [ ] Run Package Licensing Bewegungsdetails report and verify `TotalSalesQty` column appears instead of `MovementQty`
- [ ] Run Package Licensing Produktübersicht report and verify aggregated `TotalSalesQty`
- [ ] Run Package Licensing Mengenmeldung report and verify weight values are rounded to 3 decimals
- [ ] Compare report output with prod to confirm identical results