### PR TITLE
Implement allocation accounting for credit memo matching

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -336,7 +336,7 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 	 * not yet compensated for the given accounting schema.
 	 * Only the non-CM line drives the compensation to avoid double-posting.
 	 */
-	public boolean isCreditMemoInvoiceToCompensate(final AcctSchemaId acctSchemaId)
+	public boolean isInvoiceWithCreditMemoCounterLine(final AcctSchemaId acctSchemaId)
 	{
 		if (creditMemoAlreadyCompensated_AcctSchemaIds.contains(acctSchemaId))
 		{

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -137,6 +137,7 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 	private final int m_Counter_AllocationLine_ID;
 	private DocLine_Allocation counterDocLine;
 	private final Set<AcctSchemaId> salesPurchaseInvoiceAlreadyCompensated_AcctSchemaIds = new HashSet<>();
+	private final Set<AcctSchemaId> creditMemoAlreadyCompensated_AcctSchemaIds = new HashSet<>();
 
 	private final PaymentId _paymentId;
 	private final I_C_Payment _payment;
@@ -327,6 +328,46 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 	public void markAsSalesPurchaseInvoiceCompensated(final AcctSchema as)
 	{
 		final boolean added = salesPurchaseInvoiceAlreadyCompensated_AcctSchemaIds.add(as.getId());
+		Check.assume(added, "Line should not be already compensated: {}", this);
+	}
+
+	/**
+	 * @return true if this line is a non-credit-memo invoice with a same-SOTrx credit memo counter-line,
+	 * not yet compensated for the given accounting schema.
+	 * Only the non-CM line drives the compensation to avoid double-posting.
+	 */
+	public boolean isCreditMemoInvoiceToCompensate(final AcctSchemaId acctSchemaId)
+	{
+		if (creditMemoAlreadyCompensated_AcctSchemaIds.contains(acctSchemaId))
+		{
+			return false;
+		}
+
+		if (!hasInvoiceDocument())
+		{
+			return false;
+		}
+
+		// Only the non-credit-memo line drives the compensation
+		if (isCreditMemoInvoice())
+		{
+			return false;
+		}
+
+		final DocLine_Allocation counterLine = getCounterDocLine();
+		if (counterLine == null || !counterLine.hasInvoiceDocument())
+		{
+			return false;
+		}
+
+		// Same SOTrx, counter is credit memo
+		return isSOTrxInvoice() == counterLine.isSOTrxInvoice()
+				&& counterLine.isCreditMemoInvoice();
+	}
+
+	public void markAsCreditMemoInvoiceCompensated(final AcctSchema as)
+	{
+		final boolean added = creditMemoAlreadyCompensated_AcctSchemaIds.add(as.getId());
 		Check.assume(added, "Line should not be already compensated: {}", this);
 	}
 

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -32,7 +32,9 @@ import de.metas.acct.doc.AcctDocRequiredServicesFacade;
 import de.metas.acct.doc.PostingException;
 import de.metas.allocation.api.IAllocationDAO;
 import de.metas.currency.CurrencyConversionContext;
+import de.metas.currency.CurrencyConversionResult;
 import de.metas.currency.CurrencyPrecision;
+import de.metas.currency.ICurrencyBL;
 import de.metas.document.DocBaseType;
 import de.metas.invoice.InvoiceId;
 import de.metas.invoice.InvoiceTax;
@@ -218,15 +220,8 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		}
 		else if (countPayments == 0 && countInvoices > 0)
 		{
-			if (isReversedInvoiceAllocation())
-			{
-				return facts; // nothing to do, analog to isReversedPaymentAllocation()
-			}
-			else
-			{
-				// because we have just one fact line per allocation line
-				fact.setFactTrxLinesStrategy(PerDocumentFactTrxStrategy.instance);
-			}
+			// because we have just one fact line per allocation line
+			fact.setFactTrxLinesStrategy(PerDocumentFactTrxStrategy.instance);
 		}
 
 		for (final DocLine_Allocation line : getDocLines())
@@ -297,6 +292,20 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 				{
 					final AmountSourceAndAcct compensationAmt = createInvoiceToInvoiceCompensationFacts(fact, line);
 					invoiceTotalAllocatedAmtSourceAndAcctCollector.add(compensationAmt);
+				}
+
+				//
+				// Credit memo compensation (same SOTrx, invoice vs credit memo)
+				{
+					final AmountSourceAndAcct creditMemoCompensationAmt = createCreditMemoCompensationFacts(fact, line);
+					invoiceTotalAllocatedAmtSourceAndAcctCollector.add(creditMemoCompensationAmt);
+				}
+
+				//
+				// Direct allocation for reversed invoice allocations (no payment, no counter-line)
+				{
+					final AmountSourceAndAcct directAllocationAmt = createDirectInvoiceAllocationSource(fact, line);
+					invoiceTotalAllocatedAmtSourceAndAcctCollector.add(directAllocationAmt);
 				}
 
 				//
@@ -406,23 +415,6 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		boolean firstPaymentIsReversalOfSecond = firstPayment.getReversal_ID() == secondPayment.getC_Payment_ID();
 		boolean secondPaymentIsReversalOfFirst = secondPayment.getReversal_ID() == firstPayment.getC_Payment_ID();
 		return firstPaymentIsReversalOfSecond || secondPaymentIsReversalOfFirst;
-	}
-
-	private boolean isReversedInvoiceAllocation()
-	{
-		if (!mightBeReversedAllocation())
-		{
-			return false;
-		}
-
-		// note: the p_lines are not each others' counter doc lines, i.e. DocLine_Allocation.getCounterDocLine() == null and getCounter_AllocationLine_ID == 0
-		final List<DocLine_Allocation> lines = getDocLines();
-		final I_C_Invoice firstInvoice = lines.get(0).getC_Invoice();
-		final I_C_Invoice secondInvoice = lines.get(1).getC_Invoice();
-
-		boolean firstInvoiceIsReversalOfSecond = firstInvoice.getReversal_ID() == secondInvoice.getC_Invoice_ID();
-		boolean secondInvoiceIsReversalOfFirst = secondInvoice.getReversal_ID() == firstInvoice.getC_Invoice_ID();
-		return firstInvoiceIsReversalOfSecond || secondInvoiceIsReversalOfFirst;
 	}
 
 	private boolean mightBeReversedAllocation()
@@ -991,6 +983,139 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		//
 		// Return how much was booked here.
 		return factLine.getAmtSourceAndAcctDrOrCr();
+	}
+
+	/**
+	 * Creates the {@link FactLine} to book the credit memo compensation (same SOTrx, invoice vs credit memo).
+	 * <p>
+	 * When a regular invoice (ARI/API) is allocated against a credit memo (ARC/APC) of the same transaction type
+	 * without any payment, this method creates the clearing entry for the credit memo side.
+	 * The regular invoice's clearing entry is then created by {@link #createInvoiceFacts}.
+	 */
+	private AmountSourceAndAcct createCreditMemoCompensationFacts(final Fact fact, final DocLine_Allocation line)
+	{
+		final AcctSchema as = fact.getAcctSchema();
+
+		if (!line.isCreditMemoInvoiceToCompensate(as.getId()))
+		{
+			return AmountSourceAndAcct.ZERO;
+		}
+
+		Check.assume(!line.hasPaymentDocument(),
+				"Credit memo compensation line shall not have a payment: {}", line);
+
+		final BigDecimal compensationAmtSource = line.getAllocatedAmt();
+		if (compensationAmtSource.signum() == 0)
+		{
+			return AmountSourceAndAcct.ZERO;
+		}
+
+		final DocLine_Allocation counterLine = line.getCounterDocLine();
+		Check.assumeNotNull(counterLine, "counterLine not null");
+
+		// Verify amounts match
+		final BigDecimal counterCompensationAmtSource = counterLine.getAllocatedAmt();
+		if (compensationAmtSource.compareTo(counterCompensationAmtSource.negate()) != 0)
+		{
+			throw newPostingException()
+					.setFact(fact)
+					.setDocLine(line)
+					.setDetailMessage("Counter credit memo shall have matching allocated amount: " + counterLine);
+		}
+
+		if (!as.isAccrual())
+		{
+			throw newPostingException()
+					.setFact(fact)
+					.setDocLine(line)
+					.setDetailMessage("Cash based accounting not supported for credit memo compensation");
+		}
+
+		// Use the counter-invoice's currency conversion context for proper multi-currency handling
+		final CurrencyConversionContext currencyConversionCtx;
+		if (fact.isAccountingCurrency(counterLine.getInvoiceCurrencyId()))
+		{
+			currencyConversionCtx = null;
+		}
+		else
+		{
+			currencyConversionCtx = counterLine.getInvoiceCurrencyConversionCtx();
+		}
+
+		// Create fact line for the counter credit memo
+		final FactLineBuilder factLineBuilder = fact.createLine()
+				.setDocLine(counterLine)
+				.setCurrencyId(getCurrencyId())
+				.setCurrencyConversionCtx(currencyConversionCtx)
+				.orgId(counterLine.getInvoiceOrgId())
+				.bPartnerAndLocationId(counterLine.getInvoiceBPartnerId(), counterLine.getInvoiceBPartnerLocationId())
+				.alsoAddZeroLine();
+
+		if (counterLine.isSOTrxInvoice())
+		{
+			factLineBuilder.setAccount(getCustomerAccount(BPartnerCustomerAccountType.C_Receivable, as));
+			// ARC: DR to clear the credit memo's receivable
+			factLineBuilder.setAmtSource(compensationAmtSource, null);
+		}
+		else
+		{
+			factLineBuilder.setAccount(getVendorAccount(BPartnerVendorAccountType.V_Liability, as));
+			// APC: CR to clear the credit memo's liability
+			factLineBuilder.setAmtSource(null, compensationAmtSource.negate());
+		}
+
+		final FactLine factLine = factLineBuilder.buildAndAddNotNull();
+
+		// Mark both lines as compensated
+		line.markAsCreditMemoInvoiceCompensated(as);
+		counterLine.markAsCreditMemoInvoiceCompensated(as);
+
+		return factLine.getAmtSourceAndAcctDrOrCr();
+	}
+
+	/**
+	 * Creates the source amount for direct invoice allocations (no payment, no counter-line).
+	 * <p>
+	 * This handles reversed invoice allocations where two invoices (e.g., credit memo + its reversal)
+	 * are allocated together without any payment or counter-line linkage.
+	 * The allocated amount flows directly to {@link #createInvoiceFacts} for clearing.
+	 *
+	 * @return the allocated amount as both source and accounting amount (using invoice's FX rate to ensure zero gain/loss)
+	 */
+	private AmountSourceAndAcct createDirectInvoiceAllocationSource(final Fact fact, final DocLine_Allocation line)
+	{
+		if (line.hasPaymentDocument() || line.getCounterDocLine() != null)
+		{
+			return AmountSourceAndAcct.ZERO;
+		}
+
+		final BigDecimal allocatedAmt = line.getAllocatedAmt();
+		if (allocatedAmt.signum() == 0)
+		{
+			return AmountSourceAndAcct.ZERO;
+		}
+
+		// Compute amtAcct using the invoice's conversion context.
+		// This ensures allocationAcctOnPaymentDate equals allocationAcctOnInvoiceDate,
+		// producing zero gain/loss (correct: a reversal is not a realization event).
+		final BigDecimal amtAcct;
+		if (fact.isAccountingCurrency(line.getInvoiceCurrencyId()))
+		{
+			amtAcct = allocatedAmt;
+		}
+		else
+		{
+			final AcctSchema as = fact.getAcctSchema();
+			final ICurrencyBL currencyBL = Services.get(ICurrencyBL.class);
+			final CurrencyConversionResult convResult = currencyBL.convert(
+					line.getInvoiceCurrencyConversionCtx(),
+					allocatedAmt,
+					getCurrencyId(),
+					as.getCurrencyId());
+			amtAcct = convResult.getAmount();
+		}
+
+		return AmountSourceAndAcct.of(allocatedAmt, amtAcct);
 	}
 
 	/**

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -220,8 +220,17 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		}
 		else if (countPayments == 0 && countInvoices > 0)
 		{
-			// because we have just one fact line per allocation line
-			fact.setFactTrxLinesStrategy(PerDocumentFactTrxStrategy.instance);
+			if (mightBeReversedAllocation())
+			{
+				// Reversed invoice allocations produce two DR lines (positive + negative) that net to zero.
+				// PerDocumentFactTrxStrategy doesn't support this pattern, so disable it.
+				fact.setFactTrxLinesStrategy(null);
+			}
+			else
+			{
+				// because we have just one fact line per allocation line
+				fact.setFactTrxLinesStrategy(PerDocumentFactTrxStrategy.instance);
+			}
 		}
 
 		for (final DocLine_Allocation line : getDocLines())
@@ -1076,7 +1085,8 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 	/**
 	 * Creates the source amount for direct invoice allocations (no payment, no counter-line).
 	 * <p>
-	 * This handles reversed invoice allocations where two invoices (e.g., credit memo + its reversal)
+	 * This is a catch-all for any invoice-only allocation line that has no payment and no counter-line.
+	 * The primary use case is reversed invoice allocations where two invoices (e.g., credit memo + its reversal)
 	 * are allocated together without any payment or counter-line linkage.
 	 * The allocated amount flows directly to {@link #createInvoiceFacts} for clearing.
 	 *
@@ -1095,6 +1105,15 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			return AmountSourceAndAcct.ZERO;
 		}
 
+		final AcctSchema as = fact.getAcctSchema();
+		if (!as.isAccrual())
+		{
+			throw newPostingException()
+					.setFact(fact)
+					.setDocLine(line)
+					.setDetailMessage("Cash based accounting not supported for direct invoice allocation");
+		}
+
 		// Compute amtAcct using the invoice's conversion context.
 		// This ensures allocationAcctOnPaymentDate equals allocationAcctOnInvoiceDate,
 		// producing zero gain/loss (correct: a reversal is not a realization event).
@@ -1105,7 +1124,6 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		}
 		else
 		{
-			final AcctSchema as = fact.getAcctSchema();
 			final ICurrencyBL currencyBL = Services.get(ICurrencyBL.class);
 			final CurrencyConversionResult convResult = currencyBL.convert(
 					line.getInvoiceCurrencyConversionCtx(),

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -32,9 +32,7 @@ import de.metas.acct.doc.AcctDocRequiredServicesFacade;
 import de.metas.acct.doc.PostingException;
 import de.metas.allocation.api.IAllocationDAO;
 import de.metas.currency.CurrencyConversionContext;
-import de.metas.currency.CurrencyConversionResult;
 import de.metas.currency.CurrencyPrecision;
-import de.metas.currency.ICurrencyBL;
 import de.metas.document.DocBaseType;
 import de.metas.invoice.InvoiceId;
 import de.metas.invoice.InvoiceTax;
@@ -220,17 +218,8 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		}
 		else if (countPayments == 0 && countInvoices > 0)
 		{
-			if (mightBeReversedAllocation())
-			{
-				// Reversed invoice allocations produce two DR lines (positive + negative) that net to zero.
-				// PerDocumentFactTrxStrategy doesn't support this pattern, so disable it.
-				fact.setFactTrxLinesStrategy(null);
-			}
-			else
-			{
-				// because we have just one fact line per allocation line
-				fact.setFactTrxLinesStrategy(PerDocumentFactTrxStrategy.instance);
-			}
+			// because we have just one fact line per allocation line
+			fact.setFactTrxLinesStrategy(PerDocumentFactTrxStrategy.instance);
 		}
 
 		for (final DocLine_Allocation line : getDocLines())
@@ -313,8 +302,7 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 				//
 				// Direct allocation for reversed invoice allocations (no payment, no counter-line)
 				{
-					final AmountSourceAndAcct directAllocationAmt = createDirectInvoiceAllocationSource(fact, line);
-					invoiceTotalAllocatedAmtSourceAndAcctCollector.add(directAllocationAmt);
+					createDirectInvoiceAllocationFacts(fact, line);
 				}
 
 				//
@@ -1005,7 +993,7 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 	{
 		final AcctSchema as = fact.getAcctSchema();
 
-		if (!line.isCreditMemoInvoiceToCompensate(as.getId()))
+		if (!line.isInvoiceWithCreditMemoCounterLine(as.getId()))
 		{
 			return AmountSourceAndAcct.ZERO;
 		}
@@ -1083,16 +1071,19 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 	}
 
 	/**
-	 * Creates the source amount for direct invoice allocations (no payment, no counter-line).
+	 * Creates the {@link FactLine} for direct invoice allocations (no payment, no counter-line).
 	 * <p>
-	 * This is a catch-all for any invoice-only allocation line that has no payment and no counter-line.
-	 * The primary use case is reversed invoice allocations where two invoices (e.g., credit memo + its reversal)
+	 * This handles reversed invoice allocations where two invoices (e.g., credit memo + its reversal)
 	 * are allocated together without any payment or counter-line linkage.
-	 * The allocated amount flows directly to {@link #createInvoiceFacts} for clearing.
-	 *
-	 * @return the allocated amount as both source and accounting amount (using invoice's FX rate to ensure zero gain/loss)
+	 * Each line creates its own receivable/liability clearing entry directly.
+	 * <p>
+	 * Tested by S0465_CMA_100 (the reversal part after the credit memo is reversed).
+	 * <p>
+	 * Note: This method creates the final FactLine and returns ZERO so that {@link #createInvoiceFacts}
+	 * does not create a duplicate entry. The FactTrxLinesStrategy is disabled because reversed allocations
+	 * produce two DR lines (positive + negative) that net to zero but violate the 1-DR-N-CR pattern.
 	 */
-	private AmountSourceAndAcct createDirectInvoiceAllocationSource(final Fact fact, final DocLine_Allocation line)
+	private AmountSourceAndAcct createDirectInvoiceAllocationFacts(final Fact fact, final DocLine_Allocation line)
 	{
 		if (line.hasPaymentDocument() || line.getCounterDocLine() != null)
 		{
@@ -1114,26 +1105,63 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 					.setDetailMessage("Cash based accounting not supported for direct invoice allocation");
 		}
 
-		// Compute amtAcct using the invoice's conversion context.
-		// This ensures allocationAcctOnPaymentDate equals allocationAcctOnInvoiceDate,
-		// producing zero gain/loss (correct: a reversal is not a realization event).
-		final BigDecimal amtAcct;
+		// Reversed allocations produce two DR lines (positive + negative) that net to zero.
+		// PerDocumentFactTrxStrategy doesn't support this pattern, so disable it.
+		fact.setFactTrxLinesStrategy(null);
+
+		// Use the invoice's currency conversion context for proper multi-currency handling
+		final CurrencyConversionContext currencyConversionCtx;
 		if (fact.isAccountingCurrency(line.getInvoiceCurrencyId()))
 		{
-			amtAcct = allocatedAmt;
+			currencyConversionCtx = null;
 		}
 		else
 		{
-			final ICurrencyBL currencyBL = Services.get(ICurrencyBL.class);
-			final CurrencyConversionResult convResult = currencyBL.convert(
-					line.getInvoiceCurrencyConversionCtx(),
-					allocatedAmt,
-					getCurrencyId(),
-					as.getCurrencyId());
-			amtAcct = convResult.getAmount();
+			currencyConversionCtx = line.getInvoiceCurrencyConversionCtx();
 		}
 
-		return AmountSourceAndAcct.of(allocatedAmt, amtAcct);
+		// Create the clearing FactLine directly (same pattern as createCreditMemoCompensationFacts)
+		final FactLineBuilder factLineBuilder = fact.createLine()
+				.setDocLine(line)
+				.setCurrencyId(getCurrencyId())
+				.setCurrencyConversionCtx(currencyConversionCtx)
+				.orgId(line.getInvoiceOrgId())
+				.bPartnerAndLocationId(line.getInvoiceBPartnerId(), line.getInvoiceBPartnerLocationId())
+				.alsoAddZeroLine();
+
+		if (line.isSOTrxInvoice())
+		{
+			factLineBuilder.setAccount(getCustomerAccount(BPartnerCustomerAccountType.C_Receivable, as));
+			if (line.isCreditMemoInvoice())
+			{
+				// ARC (or ARC reversal): DR to clear receivable
+				factLineBuilder.setAmtSource(allocatedAmt, null);
+			}
+			else
+			{
+				// ARI: CR to clear receivable
+				factLineBuilder.setAmtSource(null, allocatedAmt);
+			}
+		}
+		else
+		{
+			factLineBuilder.setAccount(getVendorAccount(BPartnerVendorAccountType.V_Liability, as));
+			if (line.isCreditMemoInvoice())
+			{
+				// APC (or APC reversal): CR to clear liability
+				factLineBuilder.setAmtSource(null, allocatedAmt.negate());
+			}
+			else
+			{
+				// API: DR to clear liability
+				factLineBuilder.setAmtSource(allocatedAmt, null);
+			}
+		}
+
+		factLineBuilder.buildAndAdd();
+
+		// Return ZERO so createInvoiceFacts does not create a duplicate entry
+		return AmountSourceAndAcct.ZERO;
 	}
 
 	/**

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -2797,12 +2797,13 @@ Feature: invoice payment allocation
   @allure.label.feature:F00700_Invoicing
   @F00700
   Scenario: reverse correction - credit memo reversed, allocation produces Fact_Acct
+    # Amounts match issue summary: credit memo GrandTotal = 105.60 EUR (net 88.74 + 19% VAT 16.86)
     Given metasfresh contains M_Products:
       | Identifier      |
       | product_cma_100 |
     And metasfresh contains M_ProductPrices
       | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
-      | salesPLV               | product_cma_100 | 10.00    | PCE      |
+      | salesPLV               | product_cma_100 | 88.74    | PCE      |
     And metasfresh contains C_Invoice:
       | Identifier        | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | salesInv_cma_100  | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
@@ -2814,27 +2815,27 @@ Feature: invoice payment allocation
     # Create credit memo against the invoice (auto-allocates CM against invoice)
     And create credit memo for C_Invoice
       | CreditMemo         | C_Invoice_ID     | CreditMemo.PriceEntered |
-      | salesCM_cma_100    | salesInv_cma_100 | 10.00                   |
+      | salesCM_cma_100    | salesInv_cma_100 | 88.74                   |
     And the invoice identified by salesCM_cma_100 is completed
 
     # At this point alloc_cm is the auto-created allocation of CM against invoice
     And validate C_AllocationLines
-      | C_Invoice_ID     | Amount | C_AllocationHdr_ID |
-      | salesCM_cma_100  | -11.90 | alloc_cm           |
-      | salesInv_cma_100 | 11.90  | alloc_cm           |
+      | C_Invoice_ID     | Amount  | C_AllocationHdr_ID |
+      | salesCM_cma_100  | -105.60 | alloc_cm           |
+      | salesInv_cma_100 | 105.60  | alloc_cm           |
 
     # Verify: the credit memo compensation allocation has Fact_Acct entries
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID        |
-      # salesInv_cma_100 posting (GrandTotal=11.90)
-      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | customer1     | salesInv_cma_100 |
+      # salesInv_cma_100 posting (GrandTotal=105.60)
+      | C_Receivable_Acct     | 105.60 EUR  | 0 EUR       | customer1     | salesInv_cma_100 |
       | *                     |             |             |               | salesInv_cma_100 |
-      # salesCM_cma_100 posting (GrandTotal=11.90)
-      | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | customer1     | salesCM_cma_100  |
+      # salesCM_cma_100 posting (GrandTotal=105.60)
+      | C_Receivable_Acct     | 0 EUR       | 105.60 EUR  | customer1     | salesCM_cma_100  |
       | *                     |             |             |               | salesCM_cma_100  |
       # alloc_cm: credit memo compensation
-      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | customer1     | alloc_cm         |
-      | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | customer1     | alloc_cm         |
+      | C_Receivable_Acct     | 105.60 EUR  | 0 EUR       | customer1     | alloc_cm         |
+      | C_Receivable_Acct     | 0 EUR       | 105.60 EUR  | customer1     | alloc_cm         |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -2850,14 +2851,13 @@ Feature: invoice payment allocation
       | salesCM_cma_100  | true   |
 
     # After reversal, the CM has allocations: alloc_cm (original, now reversed) + alloc_cm_reversed (reversal) + alloc_cm_rev_pair (CM vs its reversal)
-    # Verify: the reversal-of-original allocation also has Fact_Acct
     And validate C_AllocationLines for invoice salesCM_cma_100
       | OPT.Amount | OPT.C_AllocationHdr_ID |
-      | -11.90     | alloc_cm               |
-      | 11.90      | alloc_cm_reversed      |
-      | -11.90     | alloc_cm_rev_pair      |
+      | -105.60    | alloc_cm               |
+      | 105.60     | alloc_cm_reversed      |
+      | -105.60    | alloc_cm_rev_pair      |
 
-    # The reversed allocation (CM vs its reversal) must have Fact_Acct entries (tests createDirectInvoiceAllocationSource)
+    # The reversed allocation (CM vs its reversal) must have Fact_Acct entries (tests createDirectInvoiceAllocationFacts)
     And Fact_Acct records balances for documents alloc_cm_rev_pair are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -2877,12 +2877,13 @@ Feature: invoice payment allocation
   @allure.label.feature:F00700_Invoicing
   @F00700
   Scenario: sales credit memo allocated against sales invoice - Fact_Acct entries (no payment)
+    # Amounts match issue summary: credit memo GrandTotal = 75.10 EUR (net 63.11 + 19% VAT 11.99)
     Given metasfresh contains M_Products:
       | Identifier |
       | product    |
     And metasfresh contains M_ProductPrices
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
-      | salesPLV               | product      | 10.00    | PCE      |
+      | salesPLV               | product      | 500.00   | PCE      |
     And metasfresh contains C_Invoice:
       | Identifier   | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | salesInvoice | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
@@ -2891,29 +2892,29 @@ Feature: invoice payment allocation
       | salesInvoice | product      | 1 PCE       |
     And the invoice identified by salesInvoice is completed
 
-    # Create credit memo linked to the invoice (auto-creates allocation with counter-lines)
+    # Create credit memo: GrandTotal = 75.10 EUR (partial credit of the 595.00 invoice)
     And create credit memo for C_Invoice
       | CreditMemo      | C_Invoice_ID | CreditMemo.PriceEntered |
-      | salesCreditMemo | salesInvoice | 5.00                    |
+      | salesCreditMemo | salesInvoice | 63.11                   |
     And the invoice identified by salesCreditMemo is completed
 
     And validate C_AllocationLines
       | C_Invoice_ID    | Amount | C_AllocationHdr_ID |
-      | salesCreditMemo | -5.95  | alloc_cm           |
-      | salesInvoice    | 5.95   | alloc_cm           |
+      | salesCreditMemo | -75.10 | alloc_cm           |
+      | salesInvoice    | 75.10  | alloc_cm           |
 
     # Verify: allocation has Fact_Acct entries — DR for credit memo, CR for invoice
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID       |
-      # salesInvoice posting (GrandTotal=11.90)
-      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | customer1     | salesInvoice    |
+      # salesInvoice posting (GrandTotal=595.00)
+      | C_Receivable_Acct     | 595.00 EUR  | 0 EUR       | customer1     | salesInvoice    |
       | *                     |             |             |               | salesInvoice    |
-      # salesCreditMemo posting (GrandTotal=5.95)
-      | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | customer1     | salesCreditMemo |
+      # salesCreditMemo posting (GrandTotal=75.10)
+      | C_Receivable_Acct     | 0 EUR       | 75.10 EUR   | customer1     | salesCreditMemo |
       | *                     |             |             |               | salesCreditMemo |
-      # alloc_cm: credit memo compensation
-      | C_Receivable_Acct     | 5.95 EUR    | 0 EUR       | customer1     | alloc_cm        |
-      | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | customer1     | alloc_cm        |
+      # alloc_cm: credit memo compensation (amount matches issue: 75.10)
+      | C_Receivable_Acct     | 75.10 EUR   | 0 EUR       | customer1     | alloc_cm        |
+      | C_Receivable_Acct     | 0 EUR       | 75.10 EUR   | customer1     | alloc_cm        |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -2928,12 +2929,13 @@ Feature: invoice payment allocation
   @allure.label.feature:F00700_Invoicing
   @F00700
   Scenario: purchase credit memo allocated against purchase invoice - Fact_Acct entries (no payment)
+    # Amounts match issue summary: credit memo GrandTotal = 75.10 EUR (net 63.11 + 19% VAT 11.99)
     Given metasfresh contains M_Products:
       | Identifier |
       | product    |
     And metasfresh contains M_ProductPrices
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
-      | purchasePLV            | product      | 10.00    | PCE      |
+      | purchasePLV            | product      | 500.00   | PCE      |
     And metasfresh contains C_Invoice:
       | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | purchaseInvoice | vendor1       | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
@@ -2942,29 +2944,29 @@ Feature: invoice payment allocation
       | purchaseInvoice | product      | 1 PCE       |
     And the invoice identified by purchaseInvoice is completed
 
-    # Create credit memo linked to the invoice (auto-creates allocation with counter-lines)
+    # Create credit memo: GrandTotal = 75.10 EUR (partial credit of the 595.00 invoice)
     And create credit memo for C_Invoice
       | CreditMemo         | C_Invoice_ID    | CreditMemo.PriceEntered |
-      | purchaseCreditMemo | purchaseInvoice | 5.00                    |
+      | purchaseCreditMemo | purchaseInvoice | 63.11                   |
     And the invoice identified by purchaseCreditMemo is completed
 
     And validate C_AllocationLines
       | C_Invoice_ID       | Amount | C_AllocationHdr_ID |
-      | purchaseCreditMemo | 5.95   | alloc_cm           |
-      | purchaseInvoice    | -5.95  | alloc_cm           |
+      | purchaseCreditMemo | 75.10  | alloc_cm           |
+      | purchaseInvoice    | -75.10 | alloc_cm           |
 
     # Verify: allocation has Fact_Acct entries — CR for credit memo, DR for invoice
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID          |
-      # purchaseInvoice posting (GrandTotal=11.90)
-      | V_Liability_Acct      | 0 EUR       | 11.90 EUR   | vendor1       | purchaseInvoice    |
+      # purchaseInvoice posting (GrandTotal=595.00)
+      | V_Liability_Acct      | 0 EUR       | 595.00 EUR  | vendor1       | purchaseInvoice    |
       | *                     |             |             |               | purchaseInvoice    |
-      # purchaseCreditMemo posting (GrandTotal=5.95)
-      | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | vendor1       | purchaseCreditMemo |
+      # purchaseCreditMemo posting (GrandTotal=75.10)
+      | V_Liability_Acct      | 75.10 EUR   | 0 EUR       | vendor1       | purchaseCreditMemo |
       | *                     |             |             |               | purchaseCreditMemo |
-      # alloc_cm: credit memo compensation
-      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | vendor1       | alloc_cm           |
-      | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | vendor1       | alloc_cm           |
+      # alloc_cm: credit memo compensation (amount matches issue: 75.10)
+      | V_Liability_Acct      | 0 EUR       | 75.10 EUR   | vendor1       | alloc_cm           |
+      | V_Liability_Acct      | 75.10 EUR   | 0 EUR       | vendor1       | alloc_cm           |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -2839,48 +2839,36 @@ Feature: invoice payment allocation
   @F00700
   Scenario: sales credit memo allocated against sales invoice - Fact_Acct entries (no payment)
     Given metasfresh contains M_Products:
-      | Identifier      |
-      | product_cma_110 |
+      | Identifier |
+      | product    |
     And metasfresh contains M_ProductPrices
-      | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
-      | salesPLV               | product_cma_110 | 100.00   | PCE      |
-    # Create the sales invoice (ARI) — GrandTotal = 119.00 EUR (100 + 19% VAT)
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | salesPLV               | product      | 10.00    | PCE      |
     And metasfresh contains C_Invoice:
-      | Identifier       | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | salesInv_cma_110 | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+      | Identifier   | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | salesInvoice | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
     And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID     | M_Product_ID    | QtyInvoiced |
-      | salesInv_cma_110 | product_cma_110 | 1 PCE       |
-    And the invoice identified by salesInv_cma_110 is completed
+      | C_Invoice_ID | M_Product_ID | QtyInvoiced |
+      | salesInvoice | product      | 1 PCE       |
+    And the invoice identified by salesInvoice is completed
 
-    # Create the sales credit memo (ARC) — GrandTotal = 59.50 EUR (50 + 19% VAT)
-    And metasfresh contains C_Invoice:
-      | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | salesCM_cma_110 | customer1     | Gutschrift              | 2022-05-11   | Spot                     | true    | EUR                 |
-    And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID    | M_Product_ID    | QtyInvoiced |
-      | salesCM_cma_110 | product_cma_110 | 0.5 PCE     |
-    And the invoice identified by salesCM_cma_110 is completed
-
-    # Allocate credit memo against invoice (no payment)
-    And allocate invoices (credit memo/purchase) to invoices
-      | C_Invoice_ID.Identifier | OPT.CreditMemo.C_Invoice_ID.Identifier |
-      | salesInv_cma_110        | salesCM_cma_110                        |
-
-    Then validate created invoices
-      | C_Invoice_ID.Identifier | IsPaid |
-      | salesCM_cma_110         | true   |
+    # Create credit memo linked to the invoice (auto-creates allocation with counter-lines)
+    And create credit memo for C_Invoice
+      | CreditMemo      | C_Invoice_ID | CreditMemo.PriceEntered |
+      | salesCreditMemo | salesInvoice | 5.00                    |
+    And the invoice identified by salesCreditMemo is completed
 
     And validate C_AllocationLines
-      | OPT.C_Invoice_ID.Identifier | OPT.C_AllocationHdr_ID.Identifier |
-      | salesCM_cma_110             | alloc_cma_110                     |
+      | C_Invoice_ID    | Amount | C_AllocationHdr_ID |
+      | salesCreditMemo | -5.95  | alloc_cm           |
+      | salesInvoice    | 5.95   | alloc_cm           |
 
     # Verify: allocation has Fact_Acct entries — DR for credit memo, CR for invoice
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID     |
-      | C_Receivable_Acct     | 59.50 EUR   | 0 EUR       | alloc_cma_110 |
-      | C_Receivable_Acct     | 0 EUR       | 59.50 EUR   | alloc_cma_110 |
-    And Fact_Acct records balances for documents alloc_cma_110 are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | C_Receivable_Acct     | 5.95 EUR    | 0 EUR       | alloc_cm  |
+      | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | alloc_cm  |
+    And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
 
@@ -2895,48 +2883,36 @@ Feature: invoice payment allocation
   @F00700
   Scenario: purchase credit memo allocated against purchase invoice - Fact_Acct entries (no payment)
     Given metasfresh contains M_Products:
-      | Identifier      |
-      | product_cma_120 |
+      | Identifier |
+      | product    |
     And metasfresh contains M_ProductPrices
-      | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
-      | purchasePLV            | product_cma_120 | 100.00   | PCE      |
-    # Create the purchase invoice (API) — GrandTotal = 119.00 EUR (100 + 19% VAT)
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | purchasePLV            | product      | 10.00    | PCE      |
     And metasfresh contains C_Invoice:
-      | Identifier          | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | purchaseInv_cma_120 | vendor1       | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
+      | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | purchaseInvoice | vendor1       | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
     And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID        | M_Product_ID    | QtyInvoiced |
-      | purchaseInv_cma_120 | product_cma_120 | 1 PCE       |
-    And the invoice identified by purchaseInv_cma_120 is completed
+      | C_Invoice_ID    | M_Product_ID | QtyInvoiced |
+      | purchaseInvoice | product      | 1 PCE       |
+    And the invoice identified by purchaseInvoice is completed
 
-    # Create the purchase credit memo (APC) — GrandTotal = 59.50 EUR (50 + 19% VAT)
-    And metasfresh contains C_Invoice:
-      | Identifier         | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | purchaseCM_cma_120 | vendor1       | Gutschrift (Lieferant)  | 2022-05-11   | Spot                     | false   | EUR                 |
-    And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID       | M_Product_ID    | QtyInvoiced |
-      | purchaseCM_cma_120 | product_cma_120 | 0.5 PCE     |
-    And the invoice identified by purchaseCM_cma_120 is completed
-
-    # Allocate credit memo against invoice (no payment)
-    And allocate invoices (credit memo/purchase) to invoices
-      | C_Invoice_ID.Identifier | OPT.CreditMemo.C_Invoice_ID.Identifier |
-      | purchaseInv_cma_120     | purchaseCM_cma_120                     |
-
-    Then validate created invoices
-      | C_Invoice_ID.Identifier | IsPaid |
-      | purchaseCM_cma_120      | true   |
+    # Create credit memo linked to the invoice (auto-creates allocation with counter-lines)
+    And create credit memo for C_Invoice
+      | CreditMemo         | C_Invoice_ID    | CreditMemo.PriceEntered |
+      | purchaseCreditMemo | purchaseInvoice | 5.00                    |
+    And the invoice identified by purchaseCreditMemo is completed
 
     And validate C_AllocationLines
-      | OPT.C_Invoice_ID.Identifier | OPT.C_AllocationHdr_ID.Identifier |
-      | purchaseCM_cma_120          | alloc_cma_120                     |
+      | C_Invoice_ID       | Amount | C_AllocationHdr_ID |
+      | purchaseCreditMemo | 5.95   | alloc_cm           |
+      | purchaseInvoice    | -5.95  | alloc_cm           |
 
     # Verify: allocation has Fact_Acct entries — CR for credit memo, DR for invoice
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID     |
-      | V_Liability_Acct      | 0 EUR       | 59.50 EUR   | alloc_cma_120 |
-      | V_Liability_Acct      | 59.50 EUR   | 0 EUR       | alloc_cma_120 |
-    And Fact_Acct records balances for documents alloc_cma_120 are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | alloc_cm  |
+      | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | alloc_cm  |
+    And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -711,7 +711,13 @@ Feature: invoice payment allocation
       | C_Invoice_ID  | C_Payment_ID | Amount | OverUnderAmt | C_AllocationHdr_ID |
       | salesInvoice1 | payment_160  | 3.57   | 0            | alloc2             |
 
-    And no Fact_Acct records are found for documents alloc1
+    And Fact_Acct records are matching
+      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | Record_ID |
+      | C_Receivable_Acct      | 2.38 EUR    | 0 EUR       | alloc1    |
+      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | alloc1    |
+    And Fact_Acct records balances for documents alloc1 are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | 0 EUR         |
     And Fact_Acct records are matching
       | AccountConceptualName  | AmtSourceDr | AmtSourceCr | Record_ID |
       | B_UnallocatedCash_Acct | 3.57 EUR    | 0 EUR       | alloc2    |
@@ -1314,7 +1320,13 @@ Feature: invoice payment allocation
       | C_Invoice_ID | C_Payment_ID | Amount | OverUnderAmt | C_AllocationHdr_ID |
       | inv_220      | payment_220  | -3.57  | 0            | alloc2             |
 
-    And no Fact_Acct records are found for documents alloc1
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | V_Liability_Acct      | 0 EUR       | 2.38 EUR    | alloc1    |
+      | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | alloc1    |
+    And Fact_Acct records balances for documents alloc1 are matching
+      | AccountConceptualName | SourceBalance |
+      | V_Liability_Acct      | 0 EUR         |
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
       | V_Liability_Acct      | 3.57 EUR    | 0 EUR       | alloc2    |
@@ -2762,6 +2774,165 @@ Feature: invoice payment allocation
     And validate C_AllocationLines
       | OPT.C_Invoice_ID.Identifier | OPT.C_Payment_ID.Identifier | OPT.Amount | OPT.DiscountAmt |
       | inv_10012025_1              | payment_10012025_1          | -20.25     | 0.02            |
+
+
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_CMA_100
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: reverse correction - credit memo reversed, allocation produces Fact_Acct
+    Given metasfresh contains M_Products:
+      | Identifier      |
+      | product_cma_100 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
+      | salesPLV               | product_cma_100 | 10.00    | PCE      |
+    And metasfresh contains C_Invoice:
+      | Identifier        | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | salesInv_cma_100  | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID      | M_Product_ID    | QtyInvoiced |
+      | salesInv_cma_100  | product_cma_100 | 1 PCE       |
+    And the invoice identified by salesInv_cma_100 is completed
+
+    # Create credit memo against the invoice (auto-allocates CM against invoice)
+    And create credit memo for C_Invoice
+      | CreditMemo         | C_Invoice_ID     | CreditMemo.PriceEntered |
+      | salesCM_cma_100    | salesInv_cma_100 | 10.00                   |
+    And the invoice identified by salesCM_cma_100 is completed
+
+    # At this point alloc_cm is the auto-created allocation of CM against invoice
+    And validate C_AllocationLines
+      | C_Invoice_ID    | Amount | C_AllocationHdr_ID |
+      | salesCM_cma_100 | -11.90 | alloc_cm           |
+      | salesInv_cma_100| 11.90  | alloc_cm           |
+
+    # Verify: the credit memo compensation allocation has Fact_Acct entries
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | alloc_cm  |
+      | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | alloc_cm  |
+    And Fact_Acct records balances for documents:
+      | AD_Table_ID.TableName | Record_ID |
+      | C_AllocationHdr       | alloc_cm  |
+
+    # Now reverse the credit memo — this creates a reversal allocation
+    And the invoice identified by salesCM_cma_100 is reversed
+
+    # The reversal creates allocations: one to undo the CM-vs-invoice, and one for the CM-vs-its-reversal
+    # The CM-vs-reversal allocation is a reversed invoice allocation and must produce Fact_Acct
+    Then validate created invoices
+      | C_Invoice_ID    | IsPaid |
+      | salesInv_cma_100| false  |
+      | salesCM_cma_100 | true   |
+
+
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_CMA_110
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: sales credit memo allocated against sales invoice - Fact_Acct entries (no payment)
+    Given metasfresh contains M_Products:
+      | Identifier      |
+      | product_cma_110 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
+      | salesPLV               | product_cma_110 | 100.00   | PCE      |
+    # Create the sales invoice (ARI) — GrandTotal = 119.00 EUR (100 + 19% VAT)
+    And metasfresh contains C_Invoice:
+      | Identifier       | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | salesInv_cma_110 | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID     | M_Product_ID    | QtyInvoiced |
+      | salesInv_cma_110 | product_cma_110 | 1 PCE       |
+    And the invoice identified by salesInv_cma_110 is completed
+
+    # Create the sales credit memo (ARC) — GrandTotal = 59.50 EUR (50 + 19% VAT)
+    And metasfresh contains C_Invoice:
+      | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | salesCM_cma_110 | customer1     | Gutschrift              | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID    | M_Product_ID    | QtyInvoiced |
+      | salesCM_cma_110 | product_cma_110 | 0.5 PCE     |
+    And the invoice identified by salesCM_cma_110 is completed
+
+    # Allocate credit memo against invoice (no payment)
+    And allocate invoices (credit memo/purchase) to invoices
+      | C_Invoice_ID.Identifier | OPT.CreditMemo.C_Invoice_ID.Identifier |
+      | salesInv_cma_110        | salesCM_cma_110                        |
+
+    Then validate created invoices
+      | C_Invoice_ID.Identifier | IsPaid |
+      | salesCM_cma_110         | true   |
+
+    # Verify: allocation has Fact_Acct entries — DR for credit memo, CR for invoice
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | C_Receivable_Acct     | 59.50 EUR   | 0 EUR       | alloc1    |
+      | C_Receivable_Acct     | 0 EUR       | 59.50 EUR   | alloc1    |
+    And Fact_Acct records balances for documents alloc1 are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | 0 EUR         |
+
+
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_CMA_120
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: purchase credit memo allocated against purchase invoice - Fact_Acct entries (no payment)
+    Given metasfresh contains M_Products:
+      | Identifier      |
+      | product_cma_120 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
+      | purchasePLV            | product_cma_120 | 100.00   | PCE      |
+    # Create the purchase invoice (API) — GrandTotal = 119.00 EUR (100 + 19% VAT)
+    And metasfresh contains C_Invoice:
+      | Identifier          | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | purchaseInv_cma_120 | vendor1       | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID        | M_Product_ID    | QtyInvoiced |
+      | purchaseInv_cma_120 | product_cma_120 | 1 PCE       |
+    And the invoice identified by purchaseInv_cma_120 is completed
+
+    # Create the purchase credit memo (APC) — GrandTotal = 59.50 EUR (50 + 19% VAT)
+    And metasfresh contains C_Invoice:
+      | Identifier         | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | purchaseCM_cma_120 | vendor1       | Gutschrift (Lieferant)  | 2022-05-11   | Spot                     | false   | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID       | M_Product_ID    | QtyInvoiced |
+      | purchaseCM_cma_120 | product_cma_120 | 0.5 PCE     |
+    And the invoice identified by purchaseCM_cma_120 is completed
+
+    # Allocate credit memo against invoice (no payment)
+    And allocate invoices (credit memo/purchase) to invoices
+      | C_Invoice_ID.Identifier | OPT.CreditMemo.C_Invoice_ID.Identifier |
+      | purchaseInv_cma_120     | purchaseCM_cma_120                     |
+
+    Then validate created invoices
+      | C_Invoice_ID.Identifier | IsPaid |
+      | purchaseCM_cma_120      | true   |
+
+    # Verify: allocation has Fact_Acct entries — CR for credit memo, DR for invoice
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | V_Liability_Acct      | 0 EUR       | 59.50 EUR   | alloc1    |
+      | V_Liability_Acct      | 59.50 EUR   | 0 EUR       | alloc1    |
+    And Fact_Acct records balances for documents alloc1 are matching
+      | AccountConceptualName | SourceBalance |
+      | V_Liability_Acct      | 0 EUR         |
 
 
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -712,18 +712,19 @@ Feature: invoice payment allocation
       | salesInvoice1 | payment_160  | 3.57   | 0            | alloc2             |
 
     And Fact_Acct records are matching
-      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID      |
-      # alloc1: credit memo compensation (CM vs invoice)
-      | C_Receivable_Acct      | 2.38 EUR    | 0 EUR       | customer1     | alloc1         |
-      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | customer1     | alloc1         |
-      # alloc2: payment vs invoice
-      | B_UnallocatedCash_Acct | 3.57 EUR    | 0 EUR       | customer1     | alloc2         |
-      | C_Receivable_Acct      | 0 EUR       | 3.57 EUR    | customer1     | alloc2         |
-      # invoice postings
-      | C_Receivable_Acct      |             |             | customer1     | salesInvoice1  |
-      | *                      |             |             |               | salesInvoice1  |
-      | C_Receivable_Acct      |             |             | customer1     | salesCreditMemo1 |
+      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID        |
+      # salesInvoice1 posting (GrandTotal=5.95)
+      | C_Receivable_Acct      | 5.95 EUR    | 0 EUR       | customer1     | salesInvoice1    |
+      | *                      |             |             |               | salesInvoice1    |
+      # salesCreditMemo1 posting (GrandTotal=2.38)
+      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | customer1     | salesCreditMemo1 |
       | *                      |             |             |               | salesCreditMemo1 |
+      # alloc1: credit memo compensation (CM vs invoice)
+      | C_Receivable_Acct      | 2.38 EUR    | 0 EUR       | customer1     | alloc1           |
+      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | customer1     | alloc1           |
+      # alloc2: payment vs invoice
+      | B_UnallocatedCash_Acct | 3.57 EUR    | 0 EUR       | customer1     | alloc2           |
+      | C_Receivable_Acct      | 0 EUR       | 3.57 EUR    | customer1     | alloc2           |
     And Fact_Acct records balances for documents alloc1 are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -1327,17 +1328,18 @@ Feature: invoice payment allocation
 
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID       |
+      # inv_220 posting (GrandTotal=5.95)
+      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | customer1     | inv_220         |
+      | *                     |             |             |               | inv_220         |
+      # credit_memo_220 posting (GrandTotal=2.38)
+      | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | customer1     | credit_memo_220 |
+      | *                     |             |             |               | credit_memo_220 |
       # alloc1: credit memo compensation (CM vs invoice)
       | V_Liability_Acct      | 0 EUR       | 2.38 EUR    | customer1     | alloc1          |
       | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | customer1     | alloc1          |
       # alloc2: payment vs invoice
       | V_Liability_Acct      | 3.57 EUR    | 0 EUR       | customer1     | alloc2          |
       | B_PaymentSelect_Acct  | 0 EUR       | 3.57 EUR    | customer1     | alloc2          |
-      # invoice postings
-      | V_Liability_Acct      |             |             | customer1     | inv_220         |
-      | *                     |             |             |               | inv_220         |
-      | V_Liability_Acct      |             |             | customer1     | credit_memo_220 |
-      | *                     |             |             |               | credit_memo_220 |
     And Fact_Acct records balances for documents alloc1 are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |
@@ -2824,13 +2826,15 @@ Feature: invoice payment allocation
     # Verify: the credit memo compensation allocation has Fact_Acct entries
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID        |
+      # salesInv_cma_100 posting (GrandTotal=11.90)
+      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | customer1     | salesInv_cma_100 |
+      | *                     |             |             |               | salesInv_cma_100 |
+      # salesCM_cma_100 posting (GrandTotal=11.90)
+      | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | customer1     | salesCM_cma_100  |
+      | *                     |             |             |               | salesCM_cma_100  |
+      # alloc_cm: credit memo compensation
       | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | customer1     | alloc_cm         |
       | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | customer1     | alloc_cm         |
-      # invoice postings
-      | C_Receivable_Acct     |             |             | customer1     | salesInv_cma_100 |
-      | *                     |             |             |               | salesInv_cma_100 |
-      | C_Receivable_Acct     |             |             | customer1     | salesCM_cma_100  |
-      | *                     |             |             |               | salesCM_cma_100  |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -2901,13 +2905,15 @@ Feature: invoice payment allocation
     # Verify: allocation has Fact_Acct entries — DR for credit memo, CR for invoice
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID       |
+      # salesInvoice posting (GrandTotal=11.90)
+      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | customer1     | salesInvoice    |
+      | *                     |             |             |               | salesInvoice    |
+      # salesCreditMemo posting (GrandTotal=5.95)
+      | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | customer1     | salesCreditMemo |
+      | *                     |             |             |               | salesCreditMemo |
+      # alloc_cm: credit memo compensation
       | C_Receivable_Acct     | 5.95 EUR    | 0 EUR       | customer1     | alloc_cm        |
       | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | customer1     | alloc_cm        |
-      # invoice postings
-      | C_Receivable_Acct     |             |             | customer1     | salesInvoice    |
-      | *                     |             |             |               | salesInvoice    |
-      | C_Receivable_Acct     |             |             | customer1     | salesCreditMemo |
-      | *                     |             |             |               | salesCreditMemo |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -2950,13 +2956,15 @@ Feature: invoice payment allocation
     # Verify: allocation has Fact_Acct entries — CR for credit memo, DR for invoice
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID          |
+      # purchaseInvoice posting (GrandTotal=11.90)
+      | V_Liability_Acct      | 0 EUR       | 11.90 EUR   | vendor1       | purchaseInvoice    |
+      | *                     |             |             |               | purchaseInvoice    |
+      # purchaseCreditMemo posting (GrandTotal=5.95)
+      | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | vendor1       | purchaseCreditMemo |
+      | *                     |             |             |               | purchaseCreditMemo |
+      # alloc_cm: credit memo compensation
       | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | vendor1       | alloc_cm           |
       | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | vendor1       | alloc_cm           |
-      # invoice postings
-      | V_Liability_Acct      |             |             | vendor1       | purchaseInvoice    |
-      | *                     |             |             |               | purchaseInvoice    |
-      | V_Liability_Acct      |             |             | vendor1       | purchaseCreditMemo |
-      | *                     |             |             |               | purchaseCreditMemo |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |
@@ -3034,13 +3042,15 @@ Feature: invoice payment allocation
     # Purchase invoice side: V_Liability DR (clearing the liability)
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID      |
+      # salesInv200 posting (GrandTotal=11.90)
+      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | bp200         | salesInv200    |
+      | *                     |             |             |               | salesInv200    |
+      # purchaseInv200 posting (GrandTotal=5.95)
+      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | bp200         | purchaseInv200 |
+      | *                     |             |             |               | purchaseInv200 |
+      # alloc200: sales-purchase compensation
       | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | bp200         | alloc200       |
       | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | bp200         | alloc200       |
-      # invoice postings
-      | C_Receivable_Acct     |             |             | bp200         | salesInv200    |
-      | *                     |             |             |               | salesInv200    |
-      | V_Liability_Acct      |             |             | bp200         | purchaseInv200 |
-      | *                     |             |             |               | purchaseInv200 |
     And Fact_Acct records balances for documents alloc200 are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | -5.95 EUR     |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -2962,6 +2962,91 @@ Feature: invoice payment allocation
       | V_Liability_Acct      | 0 EUR         |
 
 
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_CMA_200
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: sales-purchase invoice compensation (CH Verrechnung) - Fact_Acct entries
+    # Same BPartner is both customer and vendor. A sales invoice is compensated against a purchase invoice.
+    # This is legal in Switzerland (Verrechnung) and produces cross-account clearing entries.
+    Given metasfresh contains M_PricingSystems
+      | Identifier    |
+      | pricingSys200 |
+    And metasfresh contains M_PriceLists
+      | Identifier     | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | salesPL200     | pricingSys200      | DE           | EUR           | true  |
+      | purchasePL200  | pricingSys200      | DE           | EUR           | false |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier     | M_PriceList_ID |
+      | salesPLV200    | salesPL200     |
+      | purchasePLV200 | purchasePL200  |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsCustomer | IsVendor | M_PricingSystem_ID |
+      | bp200      | Y          | Y        | pricingSys200      |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier  | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | bp200_loc   | bp200         | Y               | Y               |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product200 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | salesPLV200            | product200   | 10.00    | PCE      |
+      | purchasePLV200         | product200   | 5.00     | PCE      |
+
+    # Sales invoice: GrandTotal = 11.90 EUR
+    And metasfresh contains C_Invoice:
+      | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | salesInv200     | bp200         | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID | M_Product_ID | QtyInvoiced |
+      | salesInv200  | product200   | 1 PCE       |
+    And the invoice identified by salesInv200 is completed
+
+    # Purchase invoice: GrandTotal = 5.95 EUR
+    And metasfresh contains C_Invoice:
+      | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | purchaseInv200  | bp200         | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID   | M_Product_ID | QtyInvoiced |
+      | purchaseInv200 | product200   | 1 PCE       |
+    And the invoice identified by purchaseInv200 is completed
+
+    # Compensate: sales invoice vs purchase invoice (no payment)
+    And allocate invoices (credit memo/purchase) to invoices
+      | C_Invoice_ID.Identifier | OPT.Purchase.C_Invoice_ID.Identifier |
+      | salesInv200             | purchaseInv200                       |
+
+    Then validate created invoices
+      | C_Invoice_ID.Identifier | IsPaid |
+      | purchaseInv200          | true   |
+
+    And validate C_AllocationLines
+      | OPT.C_Invoice_ID.Identifier | OPT.C_AllocationHdr_ID.Identifier |
+      | salesInv200                 | alloc200                          |
+
+    # Verify: allocation has Fact_Acct entries — cross-account compensation
+    # Sales invoice side: C_Receivable CR (clearing the receivable)
+    # Purchase invoice side: V_Liability DR (clearing the liability)
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID      |
+      | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | bp200         | alloc200       |
+      | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | bp200         | alloc200       |
+      # invoice postings
+      | C_Receivable_Acct     |             |             | bp200         | salesInv200    |
+      | *                     |             |             |               | salesInv200    |
+      | V_Liability_Acct      |             |             | bp200         | purchaseInv200 |
+      | *                     |             |             |               | purchaseInv200 |
+    And Fact_Acct records balances for documents alloc200 are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | -5.95 EUR     |
+      | V_Liability_Acct      | 5.95 EUR      |
+
+
 
 
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -2820,13 +2820,33 @@ Feature: invoice payment allocation
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
 
-    # Now reverse the credit memo — this creates reversal allocations
+    # Now reverse the credit memo — this creates reversal allocations:
+    # 1. A reversal of alloc_cm (undoing the CM-vs-invoice allocation)
+    # 2. A new allocation matching the CM against its reversal (reversed invoice allocation)
     And the invoice identified by salesCM_cma_100 is reversed
 
     Then validate created invoices
       | C_Invoice_ID     | IsPaid |
       | salesInv_cma_100 | false  |
       | salesCM_cma_100  | true   |
+
+    # After reversal, the CM has allocations: alloc_cm (original, now reversed) + alloc_cm_reversed (reversal) + alloc_cm_rev_pair (CM vs its reversal)
+    # Verify: the reversal-of-original allocation also has Fact_Acct
+    And validate C_AllocationLines for invoice salesCM_cma_100
+      | OPT.Amount | OPT.C_AllocationHdr_ID |
+      | -11.90     | alloc_cm               |
+      | 11.90      | alloc_cm_reversed      |
+      | -11.90     | alloc_cm_rev_pair      |
+
+    # The reversed allocation (CM vs its reversal) must have Fact_Acct entries (tests createDirectInvoiceAllocationSource)
+    And Fact_Acct records balances for documents alloc_cm_rev_pair are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | 0 EUR         |
+
+    # Overall: all allocation Fact_Acct entries for this CM should net to zero
+    And Fact_Acct records balances for documents alloc_cm,alloc_cm_reversed,alloc_cm_rev_pair are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | 0 EUR         |
 
 
 # ############################################################################################################################################

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -712,16 +712,21 @@ Feature: invoice payment allocation
       | salesInvoice1 | payment_160  | 3.57   | 0            | alloc2             |
 
     And Fact_Acct records are matching
-      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | Record_ID |
-      | C_Receivable_Acct      | 2.38 EUR    | 0 EUR       | alloc1    |
-      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | alloc1    |
+      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID      |
+      # alloc1: credit memo compensation (CM vs invoice)
+      | C_Receivable_Acct      | 2.38 EUR    | 0 EUR       | customer1     | alloc1         |
+      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | customer1     | alloc1         |
+      # alloc2: payment vs invoice
+      | B_UnallocatedCash_Acct | 3.57 EUR    | 0 EUR       | customer1     | alloc2         |
+      | C_Receivable_Acct      | 0 EUR       | 3.57 EUR    | customer1     | alloc2         |
+      # invoice postings
+      | C_Receivable_Acct      |             |             | customer1     | salesInvoice1  |
+      | *                      |             |             |               | salesInvoice1  |
+      | C_Receivable_Acct      |             |             | customer1     | salesCreditMemo1 |
+      | *                      |             |             |               | salesCreditMemo1 |
     And Fact_Acct records balances for documents alloc1 are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
-    And Fact_Acct records are matching
-      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | Record_ID |
-      | B_UnallocatedCash_Acct | 3.57 EUR    | 0 EUR       | alloc2    |
-      | C_Receivable_Acct      | 0 EUR       | 3.57 EUR    | alloc2    |
 
 
 
@@ -1321,16 +1326,21 @@ Feature: invoice payment allocation
       | inv_220      | payment_220  | -3.57  | 0            | alloc2             |
 
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
-      | V_Liability_Acct      | 0 EUR       | 2.38 EUR    | alloc1    |
-      | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | alloc1    |
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID       |
+      # alloc1: credit memo compensation (CM vs invoice)
+      | V_Liability_Acct      | 0 EUR       | 2.38 EUR    | customer1     | alloc1          |
+      | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | customer1     | alloc1          |
+      # alloc2: payment vs invoice
+      | V_Liability_Acct      | 3.57 EUR    | 0 EUR       | customer1     | alloc2          |
+      | B_PaymentSelect_Acct  | 0 EUR       | 3.57 EUR    | customer1     | alloc2          |
+      # invoice postings
+      | V_Liability_Acct      |             |             | customer1     | inv_220         |
+      | *                     |             |             |               | inv_220         |
+      | V_Liability_Acct      |             |             | customer1     | credit_memo_220 |
+      | *                     |             |             |               | credit_memo_220 |
     And Fact_Acct records balances for documents alloc1 are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |
-    And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
-      | V_Liability_Acct      | 3.57 EUR    | 0 EUR       | alloc2    |
-      | B_PaymentSelect_Acct  | 0 EUR       | 3.57 EUR    | alloc2    |
 
 
 
@@ -2813,9 +2823,14 @@ Feature: invoice payment allocation
 
     # Verify: the credit memo compensation allocation has Fact_Acct entries
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
-      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | alloc_cm  |
-      | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | alloc_cm  |
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID        |
+      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | customer1     | alloc_cm         |
+      | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | customer1     | alloc_cm         |
+      # invoice postings
+      | C_Receivable_Acct     |             |             | customer1     | salesInv_cma_100 |
+      | *                     |             |             |               | salesInv_cma_100 |
+      | C_Receivable_Acct     |             |             | customer1     | salesCM_cma_100  |
+      | *                     |             |             |               | salesCM_cma_100  |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -2885,9 +2900,14 @@ Feature: invoice payment allocation
 
     # Verify: allocation has Fact_Acct entries — DR for credit memo, CR for invoice
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
-      | C_Receivable_Acct     | 5.95 EUR    | 0 EUR       | alloc_cm  |
-      | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | alloc_cm  |
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID       |
+      | C_Receivable_Acct     | 5.95 EUR    | 0 EUR       | customer1     | alloc_cm        |
+      | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | customer1     | alloc_cm        |
+      # invoice postings
+      | C_Receivable_Acct     |             |             | customer1     | salesInvoice    |
+      | *                     |             |             |               | salesInvoice    |
+      | C_Receivable_Acct     |             |             | customer1     | salesCreditMemo |
+      | *                     |             |             |               | salesCreditMemo |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -2929,9 +2949,14 @@ Feature: invoice payment allocation
 
     # Verify: allocation has Fact_Acct entries — CR for credit memo, DR for invoice
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
-      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | alloc_cm  |
-      | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | alloc_cm  |
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID          |
+      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | vendor1       | alloc_cm           |
+      | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | vendor1       | alloc_cm           |
+      # invoice postings
+      | V_Liability_Acct      |             |             | vendor1       | purchaseInvoice    |
+      | *                     |             |             |               | purchaseInvoice    |
+      | V_Liability_Acct      |             |             | vendor1       | purchaseCreditMemo |
+      | *                     |             |             |               | purchaseCreditMemo |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -2807,28 +2807,26 @@ Feature: invoice payment allocation
 
     # At this point alloc_cm is the auto-created allocation of CM against invoice
     And validate C_AllocationLines
-      | C_Invoice_ID    | Amount | C_AllocationHdr_ID |
-      | salesCM_cma_100 | -11.90 | alloc_cm           |
-      | salesInv_cma_100| 11.90  | alloc_cm           |
+      | C_Invoice_ID     | Amount | C_AllocationHdr_ID |
+      | salesCM_cma_100  | -11.90 | alloc_cm           |
+      | salesInv_cma_100 | 11.90  | alloc_cm           |
 
     # Verify: the credit memo compensation allocation has Fact_Acct entries
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
       | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | alloc_cm  |
       | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | alloc_cm  |
-    And Fact_Acct records balances for documents:
-      | AD_Table_ID.TableName | Record_ID |
-      | C_AllocationHdr       | alloc_cm  |
+    And Fact_Acct records balances for documents alloc_cm are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | 0 EUR         |
 
-    # Now reverse the credit memo — this creates a reversal allocation
+    # Now reverse the credit memo — this creates reversal allocations
     And the invoice identified by salesCM_cma_100 is reversed
 
-    # The reversal creates allocations: one to undo the CM-vs-invoice, and one for the CM-vs-its-reversal
-    # The CM-vs-reversal allocation is a reversed invoice allocation and must produce Fact_Acct
     Then validate created invoices
-      | C_Invoice_ID    | IsPaid |
-      | salesInv_cma_100| false  |
-      | salesCM_cma_100 | true   |
+      | C_Invoice_ID     | IsPaid |
+      | salesInv_cma_100 | false  |
+      | salesCM_cma_100  | true   |
 
 
 # ############################################################################################################################################
@@ -2873,12 +2871,16 @@ Feature: invoice payment allocation
       | C_Invoice_ID.Identifier | IsPaid |
       | salesCM_cma_110         | true   |
 
+    And validate C_AllocationLines
+      | OPT.C_Invoice_ID.Identifier | OPT.C_AllocationHdr_ID.Identifier |
+      | salesCM_cma_110             | alloc_cma_110                     |
+
     # Verify: allocation has Fact_Acct entries — DR for credit memo, CR for invoice
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
-      | C_Receivable_Acct     | 59.50 EUR   | 0 EUR       | alloc1    |
-      | C_Receivable_Acct     | 0 EUR       | 59.50 EUR   | alloc1    |
-    And Fact_Acct records balances for documents alloc1 are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID     |
+      | C_Receivable_Acct     | 59.50 EUR   | 0 EUR       | alloc_cma_110 |
+      | C_Receivable_Acct     | 0 EUR       | 59.50 EUR   | alloc_cma_110 |
+    And Fact_Acct records balances for documents alloc_cma_110 are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
 
@@ -2925,12 +2927,16 @@ Feature: invoice payment allocation
       | C_Invoice_ID.Identifier | IsPaid |
       | purchaseCM_cma_120      | true   |
 
+    And validate C_AllocationLines
+      | OPT.C_Invoice_ID.Identifier | OPT.C_AllocationHdr_ID.Identifier |
+      | purchaseCM_cma_120          | alloc_cma_120                     |
+
     # Verify: allocation has Fact_Acct entries — CR for credit memo, DR for invoice
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
-      | V_Liability_Acct      | 0 EUR       | 59.50 EUR   | alloc1    |
-      | V_Liability_Acct      | 59.50 EUR   | 0 EUR       | alloc1    |
-    And Fact_Acct records balances for documents alloc1 are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID     |
+      | V_Liability_Acct      | 0 EUR       | 59.50 EUR   | alloc_cma_120 |
+      | V_Liability_Acct      | 59.50 EUR   | 0 EUR       | alloc_cma_120 |
+    And Fact_Acct records balances for documents alloc_cma_120 are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |
 


### PR DESCRIPTION
## Summary
- Create Fact_Acct entries when an allocation matches an invoice against a credit memo of the same transaction type (ARI+ARC or API+APC), without any payment involved
- Previously these allocations produced no Fact_Acct entries, breaking open item reports that rely solely on fact_acct for year-end audit
- Also handles reversed invoice allocations (credit memo + its reversal) which were previously skipped entirely

## Changes
- **`Doc_AllocationHdr.java`**: Added `createCreditMemoCompensationFacts()` for same-SOTrx invoice-vs-credit-memo allocations, `createDirectInvoiceAllocationSource()` for reversed invoice allocations with proper currency conversion, removed `isReversedInvoiceAllocation()` skip
- **`DocLine_Allocation.java`**: Added credit memo compensation tracking (`isCreditMemoInvoiceToCompensate()`, `markAsCreditMemoInvoiceCompensated()`)
- **`invoicePaymentAllocation.feature`**: Updated 2 existing test assertions, added 3 new scenarios

## Industry Validation
The approach matches Oracle Financials which creates the same DR Receivable(CM) / CR Receivable(Invoice) pattern. SAP and Business Central don't need GL entries because they have dedicated subledger infrastructure; metasfresh derives open items from Fact_Acct like Oracle.

## Test plan
- [ ] S0465_160: Sales invoice with allocated credit memo + inbound payment — verify new Fact_Acct entries for CM allocation + balance check
- [ ] S0465_220: Purchase invoice with allocated credit memo + outbound payment — verify new Fact_Acct entries for CM allocation + balance check
- [ ] S0465_CMA_100: Reverse correction — credit memo reversed, allocation produces Fact_Acct
- [ ] S0465_CMA_110: Sales credit memo allocated against sales invoice (no payment) — verify DR/CR entries + balance
- [ ] S0465_CMA_120: Purchase credit memo allocated against purchase invoice (no payment) — verify DR/CR entries + balance
- [ ] All other existing allocation scenarios must continue passing (regression)