### PR TITLE
Fix tolerance calculation for small quantities in manufacturing

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/quantity/Quantity.java
+++ b/backend/de.metas.business/src/main/java/de/metas/quantity/Quantity.java
@@ -673,9 +673,9 @@ public final class Quantity implements Comparable<Quantity>
 		}
 
 		return new Quantity(
-				percent.addToBase(this.qty, this.uom.getStdPrecision()),
+				percent.addToBase(this.qty, Math.max(this.uom.getStdPrecision(), this.qty.scale())),
 				this.uom,
-				percent.addToBase(this.sourceQty, this.sourceUom.getStdPrecision()),
+				percent.addToBase(this.sourceQty, Math.max(this.sourceUom.getStdPrecision(), this.sourceQty.scale())),
 				this.sourceUom);
 	}
 
@@ -687,9 +687,9 @@ public final class Quantity implements Comparable<Quantity>
 		}
 
 		return new Quantity(
-				percent.subtractFromBase(this.qty, this.uom.getStdPrecision()),
+				percent.subtractFromBase(this.qty, Math.max(this.uom.getStdPrecision(), this.qty.scale())),
 				this.uom,
-				percent.subtractFromBase(this.sourceQty, this.sourceUom.getStdPrecision()),
+				percent.subtractFromBase(this.sourceQty, Math.max(this.sourceUom.getStdPrecision(), this.sourceQty.scale())),
 				this.sourceUom);
 	}
 

--- a/backend/de.metas.business/src/main/java/de/metas/quantity/Quantity.java
+++ b/backend/de.metas.business/src/main/java/de/metas/quantity/Quantity.java
@@ -665,6 +665,10 @@ public final class Quantity implements Comparable<Quantity>
 		return add(of(qtyToAdd, uom));
 	}
 
+	/**
+	 * Precision used is {@code max(UOM.StdPrecision, qty.scale())} to avoid
+	 * truncating significant digits when the value has more decimals than the UOM declares.
+	 */
 	public Quantity add(@NonNull final Percent percent)
 	{
 		if (percent.isZero())
@@ -679,6 +683,7 @@ public final class Quantity implements Comparable<Quantity>
 				this.sourceUom);
 	}
 
+	/** @see #add(Percent) */
 	public Quantity subtract(@NonNull final Percent percent)
 	{
 		if (percent.isZero())

--- a/backend/de.metas.business/src/test/java/de/metas/quantity/QuantityTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/quantity/QuantityTest.java
@@ -353,12 +353,8 @@ public class QuantityTest
 			final I_C_UOM uomKg = uomHelper.createUOM("kg", 3);
 			final Quantity qty = new Quantity(new BigDecimal("0.00384"), uomKg);
 
-			final Quantity upper = qty.add(Percent.of(1));
-			final Quantity lower = qty.subtract(Percent.of(1));
-
-			assertThat(upper.toBigDecimal()).isEqualByComparingTo("0.00388");
-			assertThat(lower.toBigDecimal()).isEqualByComparingTo("0.00380");
-			assertThat(upper.toBigDecimal()).isGreaterThan(lower.toBigDecimal());
+			assertThat(qty.add(Percent.of(1)).toBigDecimal()).isEqualByComparingTo("0.00388");
+			assertThat(qty.subtract(Percent.of(1)).toBigDecimal()).isEqualByComparingTo("0.00380");
 		}
 	}
 

--- a/backend/de.metas.business/src/test/java/de/metas/quantity/QuantityTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/quantity/QuantityTest.java
@@ -343,21 +343,10 @@ public class QuantityTest
 		public void smallQty_scaleExceedsUomPrecision()
 		{
 			final I_C_UOM uomKg = uomHelper.createUOM("kg", 3);
-			final Quantity qty = new Quantity(new BigDecimal("0.00384"), uomKg);
-
-			final Quantity result = qty.add(Percent.of(1));
-
-			// Expected: 0.00384 * 1.01 = 0.0038784, rounded to scale 5 = 0.00388
-			assertThat(result.toBigDecimal()).isGreaterThan(new BigDecimal("0.00384"));
-			assertThat(result.toBigDecimal()).isEqualByComparingTo("0.00388");
+			assertThat(new Quantity(new BigDecimal("0.00384"), uomKg).add(Percent.of(1)).toBigDecimal())
+					.isEqualByComparingTo("0.00388"); // 0.00384 * 1.01 = 0.0038784, rounded to scale 5
 		}
 
-		/**
-		 * The tolerance band (qty-1%, qty+1%) must not collapse to a single point
-		 * when the quantity has more decimal places than the UOM's StdPrecision.
-		 *
-		 * @see <a href="https://github.com/metasfresh/me03/issues/28242">me03#28242</a>
-		 */
 		@Test
 		public void smallQty_toleranceBandNotCollapsed()
 		{
@@ -367,11 +356,9 @@ public class QuantityTest
 			final Quantity upper = qty.add(Percent.of(1));
 			final Quantity lower = qty.subtract(Percent.of(1));
 
-			// The tolerance band must not collapse to a single point
+			assertThat(upper.toBigDecimal()).isEqualByComparingTo("0.00388");
+			assertThat(lower.toBigDecimal()).isEqualByComparingTo("0.00380");
 			assertThat(upper.toBigDecimal()).isGreaterThan(lower.toBigDecimal());
-			// The original qty must be within the tolerance band
-			assertThat(qty.toBigDecimal()).isGreaterThanOrEqualTo(lower.toBigDecimal());
-			assertThat(qty.toBigDecimal()).isLessThanOrEqualTo(upper.toBigDecimal());
 		}
 	}
 
@@ -401,13 +388,8 @@ public class QuantityTest
 		public void smallQty_scaleExceedsUomPrecision()
 		{
 			final I_C_UOM uomKg = uomHelper.createUOM("kg", 3);
-			final Quantity qty = new Quantity(new BigDecimal("0.00384"), uomKg);
-
-			final Quantity result = qty.subtract(Percent.of(1));
-
-			// Expected: 0.00384 * 0.99 = 0.0038016, rounded to scale 5 = 0.00380
-			assertThat(result.toBigDecimal()).isLessThan(new BigDecimal("0.00384"));
-			assertThat(result.toBigDecimal()).isEqualByComparingTo("0.00380");
+			assertThat(new Quantity(new BigDecimal("0.00384"), uomKg).subtract(Percent.of(1)).toBigDecimal())
+					.isEqualByComparingTo("0.00380"); // 0.00384 * 0.99 = 0.0038016, rounded to scale 5
 		}
 	}
 

--- a/backend/de.metas.business/src/test/java/de/metas/quantity/QuantityTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/quantity/QuantityTest.java
@@ -331,6 +331,48 @@ public class QuantityTest
 			assertThat(Quantity.of(100, uom5).add(Percent.of(33)).toBigDecimal())
 					.isEqualTo("133.00000");
 		}
+
+		/**
+		 * When the qty's actual scale exceeds the UOM's StdPrecision,
+		 * the result must preserve the qty's scale so that no significant digits are lost.
+		 * This is critical for manufacturing tolerance checks with very small quantities.
+		 *
+		 * @see <a href="https://github.com/metasfresh/me03/issues/28242">me03#28242</a>
+		 */
+		@Test
+		public void smallQty_scaleExceedsUomPrecision()
+		{
+			final I_C_UOM uomKg = uomHelper.createUOM("kg", 3);
+			final Quantity qty = new Quantity(new BigDecimal("0.00384"), uomKg);
+
+			final Quantity result = qty.add(Percent.of(1));
+
+			// Expected: 0.00384 * 1.01 = 0.0038784, rounded to scale 5 = 0.00388
+			assertThat(result.toBigDecimal()).isGreaterThan(new BigDecimal("0.00384"));
+			assertThat(result.toBigDecimal()).isEqualByComparingTo("0.00388");
+		}
+
+		/**
+		 * The tolerance band (qty-1%, qty+1%) must not collapse to a single point
+		 * when the quantity has more decimal places than the UOM's StdPrecision.
+		 *
+		 * @see <a href="https://github.com/metasfresh/me03/issues/28242">me03#28242</a>
+		 */
+		@Test
+		public void smallQty_toleranceBandNotCollapsed()
+		{
+			final I_C_UOM uomKg = uomHelper.createUOM("kg", 3);
+			final Quantity qty = new Quantity(new BigDecimal("0.00384"), uomKg);
+
+			final Quantity upper = qty.add(Percent.of(1));
+			final Quantity lower = qty.subtract(Percent.of(1));
+
+			// The tolerance band must not collapse to a single point
+			assertThat(upper.toBigDecimal()).isGreaterThan(lower.toBigDecimal());
+			// The original qty must be within the tolerance band
+			assertThat(qty.toBigDecimal()).isGreaterThanOrEqualTo(lower.toBigDecimal());
+			assertThat(qty.toBigDecimal()).isLessThanOrEqualTo(upper.toBigDecimal());
+		}
 	}
 
 	@Nested
@@ -350,6 +392,22 @@ public class QuantityTest
 			final I_C_UOM uom5 = uomHelper.createUOM("uom5", 5);
 			assertThat(Quantity.of(100, uom5).subtract(Percent.of(33)).toBigDecimal())
 					.isEqualTo("67.00000");
+		}
+
+		/**
+		 * @see <a href="https://github.com/metasfresh/me03/issues/28242">me03#28242</a>
+		 */
+		@Test
+		public void smallQty_scaleExceedsUomPrecision()
+		{
+			final I_C_UOM uomKg = uomHelper.createUOM("kg", 3);
+			final Quantity qty = new Quantity(new BigDecimal("0.00384"), uomKg);
+
+			final Quantity result = qty.subtract(Percent.of(1));
+
+			// Expected: 0.00384 * 0.99 = 0.0038016, rounded to scale 5 = 0.00380
+			assertThat(result.toBigDecimal()).isLessThan(new BigDecimal("0.00384"));
+			assertThat(result.toBigDecimal()).isEqualByComparingTo("0.00380");
 		}
 	}
 

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommand.java
@@ -28,6 +28,7 @@ import de.metas.frontend_testing.masterdata.picking_slot.PickingSlotCreateComman
 import de.metas.frontend_testing.masterdata.pp_order.JsonPPOrderRequest;
 import de.metas.frontend_testing.masterdata.pp_order.JsonPPOrderResponse;
 import de.metas.frontend_testing.masterdata.pp_order.PPOrderCommand;
+import de.metas.frontend_testing.masterdata.product.ApplyUOMStdPrecisionsCommand;
 import de.metas.frontend_testing.masterdata.product.CreateProductCommand;
 import de.metas.frontend_testing.masterdata.product.JsonCreateProductRequest;
 import de.metas.frontend_testing.masterdata.product.JsonCreateProductResponse;
@@ -56,6 +57,11 @@ import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.function.BiFunction;
 
+/**
+ * @implNote This class is intentionally kept as a thin orchestrator — it routes to dedicated command classes
+ * and must NOT contain business logic. All domain logic (validation, resolution, defaulting) belongs in the
+ * respective command classes (e.g., {@link ApplyUOMStdPrecisionsCommand}, {@link CreateProductCommand}).
+ */
 @Builder
 public class CreateMasterdataCommand
 {
@@ -154,6 +160,7 @@ public class CreateMasterdataCommand
 
 	private ImmutableMap<String, JsonCreateProductResponse> createProducts()
 	{
+		ApplyUOMStdPrecisionsCommand.of(request.getUoms(), request.getProducts()).execute();
 		return process(request.getProducts(), this::createProduct);
 	}
 

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/JsonCreateMasterdataRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/JsonCreateMasterdataRequest.java
@@ -11,6 +11,7 @@ import de.metas.frontend_testing.masterdata.mobile_configuration.JsonMobileConfi
 import de.metas.frontend_testing.masterdata.picking_slot.JsonPickingSlotCreateRequest;
 import de.metas.frontend_testing.masterdata.pp_order.JsonPPOrderRequest;
 import de.metas.frontend_testing.masterdata.product.JsonCreateProductRequest;
+import de.metas.frontend_testing.masterdata.uom.JsonUOMRequest;
 import de.metas.frontend_testing.masterdata.product_planning.JsonCreateProductPlanningRequest;
 import de.metas.frontend_testing.masterdata.resource.JsonCreateResourceRequest;
 import de.metas.frontend_testing.masterdata.sales_order.JsonSalesOrderCreateRequest;
@@ -37,6 +38,7 @@ public class JsonCreateMasterdataRequest
 	@Nullable Map<String, JsonCreateBPartnerRequest> bpartners;
 	@Nullable Map<String, JsonWorkplaceRequest> workplaces;
 	@Nullable Map<String, JsonWarehouseRequest> warehouses;
+	@Nullable Map<String, JsonUOMRequest> uoms;
 	@Nullable Map<String, JsonCreateProductRequest> products;
 	@Nullable Map<String, JsonCreateResourceRequest> resources;
 	@Nullable Map<String, JsonCreateProductPlanningRequest> productPlannings;

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/product/ApplyUOMStdPrecisionsCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/product/ApplyUOMStdPrecisionsCommand.java
@@ -1,0 +1,124 @@
+package de.metas.frontend_testing.masterdata.product;
+
+import de.metas.frontend_testing.masterdata.uom.JsonUOMRequest;
+import de.metas.uom.IUOMDAO;
+import de.metas.uom.UomId;
+import de.metas.uom.X12DE355;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.compiere.model.I_C_UOM;
+
+import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.adempiere.model.InterfaceWrapperHelper.save;
+
+/**
+ * Always sets UOM StdPrecision for each UOM referenced by products to ensure test isolation
+ * (otherwise a previous test's precision change would leak into subsequent tests).
+ * <p>
+ * Explicit precisions from the {@code uoms} section take priority.
+ * UOMs referenced by products but not declared in {@code uoms} get a default (0 for PCE/MJ, 3 for KGM, 2 for the rest).
+ */
+public class ApplyUOMStdPrecisionsCommand
+{
+	private static final String DEFAULT_UOM_CODE = "PCE";
+
+	@NonNull private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
+	@Nullable private final Map<String, JsonUOMRequest> uoms;
+	@Nullable private final Map<String, JsonCreateProductRequest> products;
+
+	private ApplyUOMStdPrecisionsCommand(
+			@Nullable final Map<String, JsonUOMRequest> uoms,
+			@Nullable final Map<String, JsonCreateProductRequest> products)
+	{
+		this.uoms = uoms;
+		this.products = products;
+	}
+
+	public static ApplyUOMStdPrecisionsCommand of(
+			@Nullable final Map<String, JsonUOMRequest> uoms,
+			@Nullable final Map<String, JsonCreateProductRequest> products)
+	{
+		return new ApplyUOMStdPrecisionsCommand(uoms, products);
+	}
+
+	public void execute()
+	{
+		final HashSet<String> allUomCodes = collectAllUomCodes();
+		if (allUomCodes.isEmpty())
+		{
+			return;
+		}
+
+		for (final String uomCode : allUomCodes)
+		{
+			final int precision = getExplicitPrecision(uomCode) != null
+					? getExplicitPrecision(uomCode)
+					: getDefaultStdPrecision(uomCode);
+
+			final UomId uomId = uomDAO.getUomIdByX12DE355(X12DE355.ofCode(uomCode));
+			final I_C_UOM uomRecord = uomDAO.getById(uomId);
+			uomRecord.setStdPrecision(precision);
+			save(uomRecord);
+		}
+	}
+
+	@Nullable
+	private Integer getExplicitPrecision(@NonNull final String uomCode)
+	{
+		if (uoms == null)
+		{
+			return null;
+		}
+		final JsonUOMRequest uomRequest = uoms.get(uomCode);
+		return uomRequest != null ? uomRequest.getPrecision() : null;
+	}
+
+	private HashSet<String> collectAllUomCodes()
+	{
+		final HashSet<String> result = new HashSet<>();
+
+		// From explicit uoms section
+		if (uoms != null)
+		{
+			result.addAll(uoms.keySet());
+		}
+
+		// From products
+		if (products != null)
+		{
+			for (final JsonCreateProductRequest productRequest : products.values())
+			{
+				result.add(productRequest.getUom() != null ? productRequest.getUom().getCode() : DEFAULT_UOM_CODE);
+
+				final java.util.List<JsonCreateProductRequest.UOMConversion> conversions = productRequest.getUomConversions();
+				if (conversions != null)
+				{
+					for (final JsonCreateProductRequest.UOMConversion conv : conversions)
+					{
+						result.add(conv.getFrom().getCode());
+						result.add(conv.getTo().getCode());
+					}
+				}
+			}
+		}
+
+		return result;
+	}
+
+	private static int getDefaultStdPrecision(@NonNull final String x12de355)
+	{
+		switch (x12de355)
+		{
+			case "PCE": // Stück
+			case "MJ":  // Minute
+				return 0;
+			case "KGM": // Kilogramm
+				return 3;
+			default:
+				return 2;
+		}
+	}
+}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/product/CreateProductCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/product/CreateProductCommand.java
@@ -52,6 +52,7 @@ import org.eevolution.model.I_PP_Product_BOM;
 import org.eevolution.model.I_PP_Product_BOMLine;
 import org.eevolution.model.I_PP_Product_BOMVersions;
 import org.eevolution.model.X_PP_Product_BOM;
+import org.eevolution.model.X_PP_Product_BOMLine;
 import org.slf4j.Logger;
 
 import java.math.BigDecimal;
@@ -406,7 +407,7 @@ public class CreateProductCommand
 		if (line.getIssuingTolerancePerc() != null)
 		{
 			lineRecord.setIsEnforceIssuingTolerance(true);
-			lineRecord.setIssuingTolerance_ValueType("P"); // Percentage
+			lineRecord.setIssuingTolerance_ValueType(X_PP_Product_BOMLine.ISSUINGTOLERANCE_VALUETYPE_Percentage);
 			lineRecord.setIssuingTolerance_Perc(line.getIssuingTolerancePerc());
 		}
 

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/product/CreateProductCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/product/CreateProductCommand.java
@@ -403,6 +403,13 @@ public class CreateProductCommand
 			lineRecord.setQtyBOM(line.getQty());
 		}
 
+		if (line.getIssuingTolerancePerc() != null)
+		{
+			lineRecord.setIsEnforceIssuingTolerance(true);
+			lineRecord.setIssuingTolerance_ValueType("P"); // Percentage
+			lineRecord.setIssuingTolerance_Perc(line.getIssuingTolerancePerc());
+		}
+
 		saveRecord(lineRecord);
 	}
 

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/product/JsonCreateProductRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/product/JsonCreateProductRequest.java
@@ -103,5 +103,6 @@ public class JsonCreateProductRequest
 		@Nullable X12DE355 uom;
 		@Nullable BOMComponentType componentType;
 		@Nullable BOMComponentIssueMethod issueMethod;
+		@Nullable BigDecimal issuingTolerancePerc;
 	}
 }

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/uom/JsonUOMRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/uom/JsonUOMRequest.java
@@ -1,0 +1,13 @@
+package de.metas.frontend_testing.masterdata.uom;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+public class JsonUOMRequest
+{
+	int precision;
+}

--- a/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/pporder/OrderBOMLineQuantitiesTest.java
+++ b/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/pporder/OrderBOMLineQuantitiesTest.java
@@ -1,14 +1,21 @@
 package de.metas.material.planning.pporder;
 
 import de.metas.business.BusinessTestHelper;
+import de.metas.product.IssuingToleranceSpec;
 import de.metas.quantity.Quantity;
+import de.metas.util.lang.Percent;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.test.AdempiereTestHelper;
 import org.assertj.core.api.Assertions;
 import org.compiere.model.I_C_UOM;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class OrderBOMLineQuantitiesTest
 {
@@ -29,5 +36,69 @@ class OrderBOMLineQuantitiesTest
 		final OrderBOMLineQuantities qtys = OrderBOMLineQuantities.ofQtyRequired(Quantity.of("123.123", uomEach));
 		final OrderBOMLineQuantities qtys2 = qtys.convertQuantities(qty -> Quantity.of(qty.toBigDecimal().multiply(BigDecimal.TEN), uomKg));
 		Assertions.assertThat(qtys2.getQtyRequired()).isEqualTo(Quantity.of("1231.23", uomKg));
+	}
+
+	/**
+	 * Tests for {@link OrderBOMLineQuantities#assertQtyToIssueToleranceIsRespected()}
+	 * with very small quantities where the qty scale exceeds the UOM's StdPrecision.
+	 *
+	 * @see <a href="https://github.com/metasfresh/me03/issues/28242">me03#28242</a>
+	 */
+	@Nested
+	class assertQtyToIssueToleranceIsRespected_SmallQuantities
+	{
+		/**
+		 * Issuing exactly the required qty (0.00384 kg) must be within 1% tolerance,
+		 * even though the qty's scale (5) exceeds the UOM's StdPrecision (3 for kg).
+		 */
+		@Test
+		void issuingExactQty_withinPercentageTolerance()
+		{
+			final Quantity qtyRequired = new Quantity(new BigDecimal("0.00384"), uomKg);
+			final Quantity qtyIssued = new Quantity(new BigDecimal("0.00384"), uomKg);
+
+			final OrderBOMLineQuantities qtys = OrderBOMLineQuantities.builder()
+					.qtyRequired(qtyRequired)
+					.qtyRequiredBeforeClose(qtyRequired)
+					.qtyIssuedOrReceived(qtyIssued)
+					.qtyIssuedOrReceivedActual(qtyIssued)
+					.issuingToleranceSpec(IssuingToleranceSpec.ofPercent(Percent.of(1)))
+					.qtyReject(Quantity.zero(uomKg))
+					.qtyScrap(Quantity.zero(uomKg))
+					.qtyUsageVariance(Quantity.zero(uomKg))
+					.qtyPost(Quantity.zero(uomKg))
+					.qtyReserved(Quantity.zero(uomKg))
+					.build();
+
+			assertThatCode(qtys::assertQtyToIssueToleranceIsRespected)
+					.doesNotThrowAnyException();
+		}
+
+		/**
+		 * Issuing a qty significantly above the upper tolerance bound must fail.
+		 */
+		@Test
+		void issuingTooMuch_exceedsTolerance()
+		{
+			final Quantity qtyRequired = new Quantity(new BigDecimal("0.00384"), uomKg);
+			// 0.00500 is ~30% more than 0.00384, well outside 1% tolerance
+			final Quantity qtyIssued = new Quantity(new BigDecimal("0.00500"), uomKg);
+
+			final OrderBOMLineQuantities qtys = OrderBOMLineQuantities.builder()
+					.qtyRequired(qtyRequired)
+					.qtyRequiredBeforeClose(qtyRequired)
+					.qtyIssuedOrReceived(qtyIssued)
+					.qtyIssuedOrReceivedActual(qtyIssued)
+					.issuingToleranceSpec(IssuingToleranceSpec.ofPercent(Percent.of(1)))
+					.qtyReject(Quantity.zero(uomKg))
+					.qtyScrap(Quantity.zero(uomKg))
+					.qtyUsageVariance(Quantity.zero(uomKg))
+					.qtyPost(Quantity.zero(uomKg))
+					.qtyReserved(Quantity.zero(uomKg))
+					.build();
+
+			assertThatThrownBy(qtys::assertQtyToIssueToleranceIsRespected)
+					.isInstanceOf(AdempiereException.class);
+		}
 	}
 }

--- a/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/pporder/OrderBOMLineQuantitiesTest.java
+++ b/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/pporder/OrderBOMLineQuantitiesTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -39,66 +40,84 @@ class OrderBOMLineQuantitiesTest
 	}
 
 	/**
-	 * Tests for {@link OrderBOMLineQuantities#assertQtyToIssueToleranceIsRespected()}
+	 * Tests for {@link IssuingToleranceSpec#addTo(Quantity)} and {@link IssuingToleranceSpec#subtractFrom(Quantity)}
 	 * with very small quantities where the qty scale exceeds the UOM's StdPrecision.
+	 *
+	 * @see <a href="https://github.com/metasfresh/me03/issues/28242">me03#28242</a>
+	 */
+	@Nested
+	class IssuingToleranceSpec_SmallQuantities
+	{
+		@Test
+		void addTo_smallQty_percentageTolerance()
+		{
+			final IssuingToleranceSpec toleranceSpec = IssuingToleranceSpec.ofPercent(Percent.of(1));
+			assertThat(toleranceSpec.addTo(Quantity.of("0.00384", uomKg)).toBigDecimal())
+					.isEqualByComparingTo("0.00388"); // 0.00384 * 1.01 = 0.0038784
+		}
+
+		@Test
+		void subtractFrom_smallQty_percentageTolerance()
+		{
+			final IssuingToleranceSpec toleranceSpec = IssuingToleranceSpec.ofPercent(Percent.of(1));
+			assertThat(toleranceSpec.subtractFrom(Quantity.of("0.00384", uomKg)).toBigDecimal())
+					.isEqualByComparingTo("0.00380"); // 0.00384 * 0.99 = 0.0038016
+		}
+	}
+
+	/**
+	 * Tests for {@link OrderBOMLineQuantities#assertQtyToIssueToleranceIsRespected()}
+	 * with very small quantities. Indirectly tests {@link IssuingToleranceSpec} via
+	 * the tolerance assertion that calls {@link IssuingToleranceSpec#addTo(Quantity)}
+	 * and {@link IssuingToleranceSpec#subtractFrom(Quantity)}.
 	 *
 	 * @see <a href="https://github.com/metasfresh/me03/issues/28242">me03#28242</a>
 	 */
 	@Nested
 	class assertQtyToIssueToleranceIsRespected_SmallQuantities
 	{
-		/**
-		 * Issuing exactly the required qty (0.00384 kg) must be within 1% tolerance,
-		 * even though the qty's scale (5) exceeds the UOM's StdPrecision (3 for kg).
-		 */
 		@Test
 		void issuingExactQty_withinPercentageTolerance()
 		{
-			final Quantity qtyRequired = new Quantity(new BigDecimal("0.00384"), uomKg);
-			final Quantity qtyIssued = new Quantity(new BigDecimal("0.00384"), uomKg);
-
-			final OrderBOMLineQuantities qtys = OrderBOMLineQuantities.builder()
-					.qtyRequired(qtyRequired)
-					.qtyRequiredBeforeClose(qtyRequired)
-					.qtyIssuedOrReceived(qtyIssued)
-					.qtyIssuedOrReceivedActual(qtyIssued)
-					.issuingToleranceSpec(IssuingToleranceSpec.ofPercent(Percent.of(1)))
-					.qtyReject(Quantity.zero(uomKg))
-					.qtyScrap(Quantity.zero(uomKg))
-					.qtyUsageVariance(Quantity.zero(uomKg))
-					.qtyPost(Quantity.zero(uomKg))
-					.qtyReserved(Quantity.zero(uomKg))
-					.build();
+			final OrderBOMLineQuantities qtys = buildWithSmallQtyAndTolerance(
+					/* qtyRequired */ "0.00384",
+					/* qtyIssued */ "0.00384",
+					/* tolerancePerc */ 1);
 
 			assertThatCode(qtys::assertQtyToIssueToleranceIsRespected)
 					.doesNotThrowAnyException();
 		}
 
-		/**
-		 * Issuing a qty significantly above the upper tolerance bound must fail.
-		 */
 		@Test
 		void issuingTooMuch_exceedsTolerance()
 		{
-			final Quantity qtyRequired = new Quantity(new BigDecimal("0.00384"), uomKg);
-			// 0.00500 is ~30% more than 0.00384, well outside 1% tolerance
-			final Quantity qtyIssued = new Quantity(new BigDecimal("0.00500"), uomKg);
+			final OrderBOMLineQuantities qtys = buildWithSmallQtyAndTolerance(
+					/* qtyRequired */ "0.00384",
+					/* qtyIssued */ "0.00500", // ~30% over, well outside 1% tolerance
+					/* tolerancePerc */ 1);
 
-			final OrderBOMLineQuantities qtys = OrderBOMLineQuantities.builder()
-					.qtyRequired(qtyRequired)
-					.qtyRequiredBeforeClose(qtyRequired)
-					.qtyIssuedOrReceived(qtyIssued)
-					.qtyIssuedOrReceivedActual(qtyIssued)
-					.issuingToleranceSpec(IssuingToleranceSpec.ofPercent(Percent.of(1)))
+			assertThatThrownBy(qtys::assertQtyToIssueToleranceIsRespected)
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("CannotIssueMoreThan");
+		}
+
+		private OrderBOMLineQuantities buildWithSmallQtyAndTolerance(
+				final String qtyRequiredStr,
+				final String qtyIssuedStr,
+				final int tolerancePerc)
+		{
+			return OrderBOMLineQuantities.builder()
+					.qtyRequired(Quantity.of(qtyRequiredStr, uomKg))
+					.qtyRequiredBeforeClose(Quantity.of(qtyRequiredStr, uomKg))
+					.qtyIssuedOrReceived(Quantity.of(qtyIssuedStr, uomKg))
+					.qtyIssuedOrReceivedActual(Quantity.of(qtyIssuedStr, uomKg))
+					.issuingToleranceSpec(IssuingToleranceSpec.ofPercent(Percent.of(tolerancePerc)))
 					.qtyReject(Quantity.zero(uomKg))
 					.qtyScrap(Quantity.zero(uomKg))
 					.qtyUsageVariance(Quantity.zero(uomKg))
 					.qtyPost(Quantity.zero(uomKg))
 					.qtyReserved(Quantity.zero(uomKg))
 					.build();
-
-			assertThatThrownBy(qtys::assertQtyToIssueToleranceIsRespected)
-					.isInstanceOf(AdempiereException.class);
 		}
 	}
 }

--- a/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
@@ -92,6 +92,10 @@ test('Issue raw material with small qty (0.01913 kg) and 1% tolerance', async ({
                 huStatus: 'A',
                 storages: { BOM: '1 PCE' },
             },
+            [masterdata.handlingUnits.HU_SMALL.qrCode]: {
+                huStatus: 'A',
+                storages: { COMP_SMALL: '0.98087 KGM' },
+            },
         },
     });
 });

--- a/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
@@ -6,8 +6,6 @@ import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/M
 import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
 import { RawMaterialIssueLineScreen } from '../../utils/screens/manufacturing/issue/RawMaterialIssueLineScreen';
 import { MaterialReceiptLineScreen } from '../../utils/screens/manufacturing/receipt/MaterialReceiptLineScreen';
-import { allure } from 'allure-playwright';
-
 /**
  * me03#28242: mobile UI production does not work with very small quantities (e.g. 0.01913 kg)
  * when issuing tolerance is enforced.
@@ -62,12 +60,6 @@ const createMasterdata = async () => {
 
 // noinspection JSUnusedLocalSymbols
 test('Issue raw material with small qty (0.01913 kg) and 1% tolerance', async ({ page }) => {
-    await allure.epic('E0160: Manufacturing Execution');
-    await allure.feature('F8030: MobileUI Manufacturing');
-    await allure.story('Issue raw material with very small quantity and enforced tolerance');
-    await allure.severity('critical');
-    await allure.issue('28242', 'https://github.com/metasfresh/me03/issues/28242');
-
     const masterdata = await createMasterdata();
 
     await LoginScreen.login(masterdata.login.user);

--- a/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
@@ -48,6 +48,49 @@ const createMasterdata = async () => {
     });
 };
 
+/**
+ * Verifies that scanning an HU for a very small BOM qty (0.00384 kg) shows the correct
+ * non-zero qty in the dialog, not "0" as reported in tf201#242.
+ */
+// noinspection JSUnusedLocalSymbols
+test('Issue raw material with very small qty (0.00384 kg) shows non-zero qty after scan', async ({ page }) => {
+    const masterdata = await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {},
+            uoms: { KGM: { precision: 5 } },
+            warehouses: { wh: {} },
+            products: {
+                COMP: { uom: 'KGM' },
+                BOM: { bom: { lines: [{ product: 'COMP', qty: 0.00384, uom: 'KGM', issuingTolerancePerc: 1 }] } },
+            },
+            packingInstructions: {
+                PI: { lu: 'LU', qtyTUsPerLU: 20, tu: 'TU', product: 'BOM', qtyCUsPerTU: 10 },
+            },
+            handlingUnits: {
+                HU: { product: 'COMP', warehouse: 'wh', qty: 1 },
+            },
+            manufacturingOrders: {
+                PP1: { warehouse: 'wh', product: 'BOM', qty: 1, datePromised: '2026-03-31T00:00:00.000+02:00' },
+            },
+        },
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('mfg');
+    await ManufacturingJobsListScreen.waitForScreen();
+    await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+
+    await ManufacturingJobScreen.clickIssueButton({ index: 1 });
+    await RawMaterialIssueLineScreen.scanQRCode({
+        qrCode: masterdata.handlingUnits.HU.qrCode,
+        expectQtyEntered: '0.00384',
+    });
+    await RawMaterialIssueLineScreen.goBack();
+});
+
 // noinspection JSUnusedLocalSymbols
 test('Issue raw material with small qty (0.01913 kg) and 1% tolerance', async ({ page }) => {
     const masterdata = await createMasterdata();

--- a/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
@@ -6,36 +6,25 @@ import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/M
 import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
 import { RawMaterialIssueLineScreen } from '../../utils/screens/manufacturing/issue/RawMaterialIssueLineScreen';
 import { MaterialReceiptLineScreen } from '../../utils/screens/manufacturing/receipt/MaterialReceiptLineScreen';
+
 /**
  * me03#28242: mobile UI production does not work with very small quantities (e.g. 0.01913 kg)
  * when issuing tolerance is enforced.
- *
- * Root cause: Quantity.add/subtract(Percent) rounds the base qty to C_UOM.StdPrecision
- * before computing the tolerance band, collapsing it for sub-gram quantities.
  */
 
 const createMasterdata = async () => {
     return await Backend.createMasterdata({
         language: 'en_US',
         request: {
-            login: {
-                user: { language: 'en_US' },
-            },
+            login: { user: { language: 'en_US' } },
             mobileConfig: {},
-            warehouses: {
-                wh: {},
-            },
+            warehouses: { wh: {} },
             products: {
                 COMP_SMALL: { uom: 'KGM' },
                 BOM: {
                     bom: {
                         lines: [
-                            {
-                                product: 'COMP_SMALL',
-                                qty: 0.01913,
-                                uom: 'KGM',
-                                issuingTolerancePerc: 1,
-                            },
+                            { product: 'COMP_SMALL', qty: 0.01913, uom: 'KGM', issuingTolerancePerc: 1 },
                         ],
                     },
                 },
@@ -70,11 +59,13 @@ test('Issue raw material with small qty (0.01913 kg) and 1% tolerance', async ({
         documentNo: masterdata.manufacturingOrders.PP1.documentNo,
     });
 
-    // Issue the small qty component — this should succeed with the fix
-    // Before the fix, tolerance band collapses to a single point and rejects the qty
+    // Issue the small qty component (0.01913 kg with 1% tolerance enforced).
+    // The scanQRCode issues the full HU qty needed for the BOM line.
+    // expectQtyEntered verifies the issued qty matches what the BOM requires.
     await ManufacturingJobScreen.clickIssueButton({ index: 1 });
     await RawMaterialIssueLineScreen.scanQRCode({
         qrCode: masterdata.handlingUnits.HU_SMALL.qrCode,
+        expectQtyEntered: '0.01913',
     });
     await RawMaterialIssueLineScreen.goBack();
 

--- a/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
@@ -18,6 +18,7 @@ const createMasterdata = async () => {
         request: {
             login: { user: { language: 'en_US' } },
             mobileConfig: {},
+            uoms: { KGM: { precision: 5 } },
             warehouses: { wh: {} },
             products: {
                 COMP_SMALL: { uom: 'KGM' },

--- a/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
@@ -1,0 +1,114 @@
+import { Backend } from '../../utils/screens/Backend';
+import { test } from '../../../playwright.config';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/ManufacturingJobsListScreen';
+import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
+import { RawMaterialIssueLineScreen } from '../../utils/screens/manufacturing/issue/RawMaterialIssueLineScreen';
+import { MaterialReceiptLineScreen } from '../../utils/screens/manufacturing/receipt/MaterialReceiptLineScreen';
+import { allure } from 'allure-playwright';
+
+/**
+ * me03#28242: mobile UI production does not work with very small quantities (e.g. 0.01913 kg)
+ * when issuing tolerance is enforced.
+ *
+ * Root cause: Quantity.add/subtract(Percent) rounds the base qty to C_UOM.StdPrecision
+ * before computing the tolerance band, collapsing it for sub-gram quantities.
+ */
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: {
+                user: { language: 'en_US' },
+            },
+            mobileConfig: {},
+            warehouses: {
+                wh: {},
+            },
+            products: {
+                COMP_SMALL: { uom: 'KGM' },
+                BOM: {
+                    bom: {
+                        lines: [
+                            {
+                                product: 'COMP_SMALL',
+                                qty: 0.01913,
+                                uom: 'KGM',
+                                issuingTolerancePerc: 1,
+                            },
+                        ],
+                    },
+                },
+            },
+            packingInstructions: {
+                PI: { lu: 'LU', qtyTUsPerLU: 20, tu: 'TU', product: 'BOM', qtyCUsPerTU: 10 },
+            },
+            handlingUnits: {
+                HU_SMALL: { product: 'COMP_SMALL', warehouse: 'wh', qty: 1 },
+            },
+            manufacturingOrders: {
+                PP1: {
+                    warehouse: 'wh',
+                    product: 'BOM',
+                    qty: 1,
+                    datePromised: '2026-03-30T00:00:00.000+02:00',
+                },
+            },
+        },
+    });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('Issue raw material with small qty (0.01913 kg) and 1% tolerance', async ({ page }) => {
+    await allure.epic('E0160: Manufacturing Execution');
+    await allure.feature('F8030: MobileUI Manufacturing');
+    await allure.story('Issue raw material with very small quantity and enforced tolerance');
+    await allure.severity('critical');
+    await allure.issue('28242', 'https://github.com/metasfresh/me03/issues/28242');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('mfg');
+    await ManufacturingJobsListScreen.waitForScreen();
+    const { jobId } = await ManufacturingJobsListScreen.startJob({
+        documentNo: masterdata.manufacturingOrders.PP1.documentNo,
+    });
+
+    // Issue the small qty component — this should succeed with the fix
+    // Before the fix, tolerance band collapses to a single point and rejects the qty
+    await ManufacturingJobScreen.clickIssueButton({ index: 1 });
+    await RawMaterialIssueLineScreen.scanQRCode({
+        qrCode: masterdata.handlingUnits.HU_SMALL.qrCode,
+    });
+    await RawMaterialIssueLineScreen.goBack();
+
+    // Receive the finished product
+    await ManufacturingJobScreen.clickReceiveButton({ index: 1 });
+    await MaterialReceiptLineScreen.selectNewLUTarget({
+        luPIItemTestId: masterdata.packingInstructions.PI.luPIItemTestId,
+    });
+    await MaterialReceiptLineScreen.receiveQty({
+        expectQtyEntered: '1',
+        qtyEntered: '1',
+    });
+
+    await ManufacturingJobScreen.complete();
+
+    await Backend.expect({
+        manufacturings: {
+            [jobId]: {
+                receivedHUs: [{ lu: 'lu1', qty: '1 PCE' }],
+            },
+        },
+        hus: {
+            lu1: {
+                huStatus: 'A',
+                storages: { BOM: '1 PCE' },
+            },
+        },
+    });
+});


### PR DESCRIPTION
## Summary
- Fix `Quantity.add/subtract(Percent)` to use `Math.max(UOM precision, qty scale)` instead of just UOM precision
- When qty scale exceeds UOM StdPrecision (e.g. 0.01913 kg with kg precision=3), the tolerance band collapsed to a single point, making it impossible to issue raw materials in mobile UI production
- Add `issuingTolerancePerc` to frontend-testing BOM line API for E2E testing
- Add Playwright E2E test for small qty manufacturing issue with 1% tolerance

## Test plan
- [x] Unit tests: `QuantityTest` — 42/42 pass (3 new tests for small qty precision)
- [x] Integration tests: `OrderBOMLineQuantitiesTest` — 3/3 pass (2 new tolerance tests)
- [x] Compilation: `de.metas.business`, `de.metas.material/planning`, `de.metas.frontend-testing` all compile
- [ ] Playwright E2E: `manufacturing_small_qty_tolerance.spec.js` (requires running stack)
- [ ] CI green