### PR TITLE
Fix quick-scan on picking job screen for DataWedge IME mode

### DIFF
--- a/e2e/mobile-webui/tests/spec/home_screen.spec.js
+++ b/e2e/mobile-webui/tests/spec/home_screen.spec.js
@@ -63,6 +63,25 @@ test.describe('Scan HU codes', () => {
         await runTest({ masterdata, huBarcode: masterdata.handlingUnits.HU1.huId });
     });
 
+    // Tests the BarcodeScannerComponent in IME mode (Zebra DataWedge text injection)
+    // on the home screen. This is a generic scanner test — not tied to any specific workflow.
+    // The home screen scanner is a visible BarcodeScannerComponent (not hidden like in picking).
+    // noinspection JSUnusedLocalSymbols
+    test('Scan HU QR Code via IME', async ({ page }) => {
+        allure.epic('E0295: Frontend MobileUI');
+        allure.tag('F12000: Frontend MobileUI');
+        allure.tag('F12000');
+        allure.story('Scan HU codes from home screen via IME (Zebra DataWedge)');
+        allure.severity('critical');
+
+        const masterdata = await createMasterdata();
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.scanBarcodeViaIME(masterdata.handlingUnits.HU1.qrCode);
+        await HUManagerScreen.waitForScreen();
+        await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
+    });
+
     // noinspection JSUnusedLocalSymbols
     test('Scan ExternalBarcode', async ({ page }) => {
         // === ALLURE METADATA ===

--- a/e2e/mobile-webui/tests/spec/picking/barcodeScannerModes.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/barcodeScannerModes.spec.js
@@ -1,5 +1,7 @@
 import { test } from "../../../playwright.config";
 import { allure } from 'allure-playwright';
+import { page, FAST_ACTION_TIMEOUT } from "../../utils/common";
+import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
 import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
 import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
@@ -118,6 +120,40 @@ test.describe('Barcode Scanner Input Modes', () => {
         await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU' });
 
         await PickingJobScreen.complete();
+    });
+
+    // Regression test for me03#28834: the hidden barcode scanner on the picking job screen
+    // must use type="text" (not type="hidden") so that Zebra DataWedge IME mode can establish
+    // an InputConnection and inject scanned text. type="hidden" inputs cannot receive focus,
+    // causing DataWedge text injection to silently fail.
+    // noinspection JSUnusedLocalSymbols
+    test('hidden barcode scanner input is IME-compatible (not type=hidden)', async ({ page: _page }) => {
+        allure.epic('E0105: Picking');
+        allure.tag('F00230: MobileUI Picking');
+        allure.tag('F00230');
+        allure.story('Quick-scan hidden input must be type=text for DataWedge IME');
+        allure.severity('critical');
+
+        const masterdata = await createMasterdata();
+
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('picking');
+        await PickingJobsListScreen.waitForScreen();
+        await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+        await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+
+        await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+        await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+
+        // The BarcodeScannerButton renders a hidden BarcodeScannerComponent with isShowInputText=false.
+        // Verify the input element is type="text" (IME-compatible) not type="hidden" (breaks IME).
+        await test.step('Verify hidden scanner input is type=text and inputMode=none', async () => {
+            const scannerInput = page.locator('#input-text');
+            await scannerInput.waitFor({ state: 'attached', timeout: FAST_ACTION_TIMEOUT });
+            await expect(scannerInput).toHaveAttribute('type', 'text');
+            await expect(scannerInput).toHaveAttribute('inputmode', 'none');
+        });
     });
 
 });

--- a/e2e/mobile-webui/tests/spec/picking/barcodeScannerModes.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/barcodeScannerModes.spec.js
@@ -80,8 +80,29 @@ test.describe('Barcode Scanner Input Modes', () => {
         await PickingJobScreen.complete();
     });
 
+    // Tests BarcodeScannerComponent in IME mode (Zebra DataWedge text injection).
+    //
+    // WHY THIS TEST EXISTS (me03#28834):
+    // Zebra MC3300x scanners use DataWedge in IME/InputConnection mode. This means scanned
+    // text is injected via Android's InputConnection.commitText(), NOT via keyboard events.
+    // For InputConnection to work, the barcode input must be:
+    //   - type="text" (NOT type="hidden" — hidden inputs can't receive focus/InputConnection)
+    //   - inputMode="none" (suppresses virtual keyboard while keeping InputConnection alive)
+    //
+    // WHAT THIS TEST VALIDATES:
+    // 1. Input element attributes: verifies the hidden scanner input on the picking job screen
+    //    has type="text" and inputMode="none". This catches regressions where someone changes
+    //    it back to type="hidden" (which would silently break DataWedge IME scanning).
+    // 2. Functional flow: simulates IME text injection via typeViaIME() and verifies the
+    //    full quick-scan path works (scan → auto-resolve line → pick dialog → pick).
+    //
+    // LIMITATION: typeViaIME() uses evaluate() to set the input value directly — this bypasses
+    // the real Android InputConnection. The attribute assertions in step 1 are what actually
+    // guard against the type="hidden" regression. Real InputConnection can only be tested
+    // on hardware (manual test on Zebra MC3300x).
+    //
     // noinspection JSUnusedLocalSymbols
-    test('scan barcode via IME text injection', async ({ page }) => {
+    test('scan barcode via IME text injection', async ({ page: _page }) => {
         allure.epic('E0105: Picking');
         allure.tag('F00230: MobileUI Picking');
         allure.tag('F00230');
@@ -108,10 +129,21 @@ test.describe('Barcode Scanner Input Modes', () => {
 
         await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
 
+        // Verify the hidden scanner input rendered by BarcodeScannerButton has IME-compatible
+        // attributes. This is the critical regression guard — if someone reverts to type="hidden",
+        // the typeViaIME() flow below would still pass (it bypasses InputConnection), but this
+        // assertion would catch it.
+        await test.step('Verify hidden scanner input is IME-compatible (type=text, inputMode=none)', async () => {
+            const scannerInput = page.locator('#input-text');
+            await scannerInput.waitFor({ state: 'attached', timeout: FAST_ACTION_TIMEOUT });
+            await expect(scannerInput).toHaveAttribute('type', 'text');
+            await expect(scannerInput).toHaveAttribute('inputmode', 'none');
+        });
+
         await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '0 TU' });
 
-        // Scan HU via IME
-        await test.step('Pick HU via IME', async () => {
+        // Scan HU via IME directly from the picking job screen (quick-scan without pressing "Scan" button)
+        await test.step('Pick HU via IME (quick-scan from picking job screen)', async () => {
             await BarcodeScannerComponent.typeViaIME(masterdata.handlingUnits.HU1.qrCode);
             await GetQuantityDialog.fillAndPressDone({ expectQtyEntered: '3' });
             await PickingJobScreen.waitForScreen();
@@ -120,40 +152,6 @@ test.describe('Barcode Scanner Input Modes', () => {
         await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU' });
 
         await PickingJobScreen.complete();
-    });
-
-    // Regression test for me03#28834: the hidden barcode scanner on the picking job screen
-    // must use type="text" (not type="hidden") so that Zebra DataWedge IME mode can establish
-    // an InputConnection and inject scanned text. type="hidden" inputs cannot receive focus,
-    // causing DataWedge text injection to silently fail.
-    // noinspection JSUnusedLocalSymbols
-    test('hidden barcode scanner input is IME-compatible (not type=hidden)', async ({ page: _page }) => {
-        allure.epic('E0105: Picking');
-        allure.tag('F00230: MobileUI Picking');
-        allure.tag('F00230');
-        allure.story('Quick-scan hidden input must be type=text for DataWedge IME');
-        allure.severity('critical');
-
-        const masterdata = await createMasterdata();
-
-        await LoginScreen.login(masterdata.login.user);
-        await ApplicationsListScreen.expectVisible();
-        await ApplicationsListScreen.startApplication('picking');
-        await PickingJobsListScreen.waitForScreen();
-        await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
-        await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
-
-        await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
-        await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
-
-        // The BarcodeScannerButton renders a hidden BarcodeScannerComponent with isShowInputText=false.
-        // Verify the input element is type="text" (IME-compatible) not type="hidden" (breaks IME).
-        await test.step('Verify hidden scanner input is type=text and inputMode=none', async () => {
-            const scannerInput = page.locator('#input-text');
-            await scannerInput.waitFor({ state: 'attached', timeout: FAST_ACTION_TIMEOUT });
-            await expect(scannerInput).toHaveAttribute('type', 'text');
-            await expect(scannerInput).toHaveAttribute('inputmode', 'none');
-        });
     });
 
 });

--- a/e2e/mobile-webui/tests/spec/picking/quickscan.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/quickscan.spec.js
@@ -47,14 +47,16 @@ const createMasterdata = async () => {
     });
 };
 
-test.describe('Barcode Scanner Input Modes', () => {
+test.describe('Picking Quick Scan', () => {
 
+    // Quick-scan via keyboard events: scan HU QR code directly from the picking job screen
+    // without pressing the "Scan" button. The system auto-resolves which line the HU belongs to.
     // noinspection JSUnusedLocalSymbols
-    test('scan barcode via keyboard events', async ({ page }) => {
+    test('quick-scan HU via keyboard events', async ({ page }) => {
         allure.epic('E0105: Picking');
         allure.tag('F00230: MobileUI Picking');
         allure.tag('F00230');
-        allure.story('Barcode scanner keyboard input mode');
+        allure.story('Quick-scan HU from picking job screen (keyboard mode)');
         allure.severity('critical');
 
         const masterdata = await createMasterdata();
@@ -102,11 +104,11 @@ test.describe('Barcode Scanner Input Modes', () => {
     // on hardware (manual test on Zebra MC3300x).
     //
     // noinspection JSUnusedLocalSymbols
-    test('scan barcode via IME text injection', async ({ page: _page }) => {
+    test('quick-scan HU via IME text injection', async ({ page: _page }) => {
         allure.epic('E0105: Picking');
         allure.tag('F00230: MobileUI Picking');
         allure.tag('F00230');
-        allure.story('Barcode scanner IME input mode (Zebra DataWedge)');
+        allure.story('Quick-scan HU from picking job screen (IME/DataWedge mode)');
         allure.severity('critical');
 
         const masterdata = await createMasterdata();

--- a/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
@@ -50,4 +50,8 @@ export const ApplicationsListScreen = {
     scanBarcode: async (barcode) => await test.step(`${NAME} - Scan barcode`, async () => {
         await BarcodeScannerComponent.type(barcode);
     }),
+
+    scanBarcodeViaIME: async (barcode) => await test.step(`${NAME} - Scan barcode via IME`, async () => {
+        await BarcodeScannerComponent.typeViaIME(barcode);
+    }),
 }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/assets/BarcodeScannerComponent.scss
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/assets/BarcodeScannerComponent.scss
@@ -23,6 +23,24 @@
     }
   }
 
+  // Visually hidden but focusable input for background barcode scanning.
+  // Used by BarcodeScannerButton to capture DataWedge IME text injection
+  // without showing a visible input field. Must NOT use type="hidden" or
+  // display:none — those break Android InputConnection. (me03#28834)
+  .input-text-offscreen {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    overflow: hidden;
+    pointer-events: none;
+    margin: 0;
+    padding: 0;
+    border: none;
+  }
+
   .loading {
     position: absolute;
     z-index: 999;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
@@ -256,13 +256,19 @@ const BarcodeScannerComponent = ({
   return (
     <div className="barcode-scanner">
       {isProcessing && <Spinner />}
+      {/* IMPORTANT: Always use type="text" — never type="hidden".
+          When isShowInputText=false, the input is visually hidden via CSS (input-text-offscreen)
+          instead of type="hidden". This is critical for Zebra MC3300x DataWedge IME mode:
+          type="hidden" inputs cannot receive focus, so Android InputConnection is never established
+          and DataWedge text injection silently fails. CSS hiding keeps the input focusable and
+          IME-compatible while remaining invisible to the user. (me03#28834) */}
       {!isProcessing && (
         <input
           id="input-text"
           key="input-text"
           ref={inputTextRef}
-          className="input-text"
-          type={isShowInputText ? 'text' : 'hidden'}
+          className={`input-text${isShowInputText ? '' : ' input-text-offscreen'}`}
+          type="text"
           placeholder={inputPlaceholderText || trl('components.BarcodeScannerComponent.scanTextPlaceholder')}
           inputMode={isInputTextReadonly ? 'none' : undefined}
           onFocus={handleInputTextFocus}


### PR DESCRIPTION
## Summary

- Fix the "Schnellscan" (quick-scan) feature on the picking job screen that stopped working on Zebra MC3300x scanners using DataWedge IME mode
- The `BarcodeScannerButton` rendered a hidden `BarcodeScannerComponent` with `type="hidden"` input, which cannot receive focus or establish an Android `InputConnection` — DataWedge text injection silently fails
- Replace `type="hidden"` with CSS-based visual hiding (`position:absolute; opacity:0; 1x1px`) so the input remains `type="text"`, focusable, and IME-compatible
- Add E2E regression test verifying the hidden scanner input has `type="text"` and `inputMode="none"`

## Test plan

- [ ] E2E: `barcodeScannerModes.spec.js` — all 3 tests pass (keyboard, IME, new IME-compatibility assertion)
- [ ] E2E: Picking specs — no regression
- [ ] Manual: Zebra MC3300x hardware test — scan HU QR on picking job screen WITHOUT pressing "Scan" button