### PR TITLE
Fix mobileUI overdelivery prompt not appearing during picking

### DIFF
--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
@@ -253,12 +253,25 @@ public class PickingRestController
 		}
 		final JsonHU hu = hus.get(0);
 
-		return JsonHUInfo.builder()
+		final JsonHUInfo.JsonHUInfoBuilder builder = JsonHUInfo.builder()
 				.id(hu.getId())
 				.unitType(hu.getUnitType())
 				.qtyTUs(hu.getQtyTUs())
-				.huQRCode(hu.getQrCode())
-				.build();
+				.huQRCode(hu.getQrCode());
+
+		// gh#29069: return product qty for overdelivery check
+		final String productNo = request.getProductNo();
+		if (productNo != null && hu.getProducts() != null)
+		{
+			hu.getProducts().stream()
+					.filter(p -> productNo.equals(p.getProductValue()))
+					.findFirst()
+					.ifPresent(p -> builder
+							.productQty(new java.math.BigDecimal(p.getQty()))
+							.productUom(p.getUom()));
+		}
+
+		return builder.build();
 	}
 
 	private HUQRCode toHUQRCode(final @NotNull ScannedCode scannedCode)

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonGetHUInfoByScannedCodeRequest.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonGetHUInfoByScannedCodeRequest.java
@@ -5,10 +5,13 @@ import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
+import javax.annotation.Nullable;
+
 @Value
 @Builder
 @Jacksonized
 public class JsonGetHUInfoByScannedCodeRequest
 {
 	@NonNull String scannedCode;
+	@Nullable String productNo;
 }

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonHUInfo.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonHUInfo.java
@@ -9,6 +9,7 @@ import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 
 @Value
 @Builder
@@ -18,5 +19,7 @@ public class JsonHUInfo
 	@Nullable String id;
 	@NonNull JsonHUType unitType;
 	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) Integer qtyTUs;
+	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) BigDecimal productQty;
+	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) String productUom;
 	@Nullable JsonHUQRCode huQRCode;
 }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/picking.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/picking.js
@@ -152,10 +152,12 @@ export const getClosedLUs = ({ wfProcessId, lineId }) => {
     .then((response) => unboxAxiosResponse(response));
 };
 
-export const getScannedHUQRCodeInfo = ({ qrCode }) => {
-  return axios
-    .post(`${apiBasePath}/picking/hu/byScannedCode`, { scannedCode: qrCode })
-    .then((response) => unboxAxiosResponse(response));
+export const getScannedHUQRCodeInfo = ({ qrCode, productNo = null }) => {
+  const body = { scannedCode: qrCode };
+  if (productNo) {
+    body.productNo = productNo;
+  }
+  return axios.post(`${apiBasePath}/picking/hu/byScannedCode`, body).then((response) => unboxAxiosResponse(response));
 };
 
 export const getNextEligibleLineToPack = ({ wfProcessId, huScannedCode, excludeLineId }) => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
@@ -175,7 +175,9 @@ const ScanHUAndGetQtyComponent = ({
     }
 
     // Qty shall be less than or equal to qtyMax
-    if (resolvedBarcodeData.qtyMax && resolvedBarcodeData.qtyMax > 0) {
+    // NOTE: skip qtyMax validation when over-pick confirmation prompt is enabled,
+    // because the prompt handles the over-delivery scenario instead (gh#29069)
+    if (!getConfirmationPromptForQty && resolvedBarcodeData.qtyMax && resolvedBarcodeData.qtyMax > 0) {
       const { qtyEffective: diff, uomEffective: diffUom } = formatQtyToHumanReadable({
         qty: qtyEntered - resolvedBarcodeData.qtyMax,
         uom,

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickLineScanScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickLineScanScreen.jsx
@@ -93,10 +93,11 @@ const PickLineScanScreen = () => {
       convertScannedBarcodeToResolvedResult({
         scannedBarcode,
         expectedProductId: productId,
+        expectedProductNo: productNo,
         customQRCodeFormats,
         pickingUnit,
       }),
-    [productId, customQRCodeFormats, pickingUnit]
+    [productId, productNo, customQRCodeFormats, pickingUnit]
   );
 
   const onClose = useOnClose({ applicationId, wfProcessId, activity, lineId, next });
@@ -189,6 +190,7 @@ const getPropsFromState = ({ state, wfProcessId, activityId, lineId }) => {
 export const convertScannedBarcodeToResolvedResult = async ({
   scannedBarcode,
   expectedProductId,
+  expectedProductNo,
   customQRCodeFormats,
   pickingUnit,
 }) => {
@@ -225,7 +227,7 @@ export const convertScannedBarcodeToResolvedResult = async ({
     throw trl('activities.picking.notEligibleHUBarcode');
   }
 
-  return convertQRCodeObjectToResolvedResult({ parsedQRCode, pickingUnit, huInfoFromBackend });
+  return convertQRCodeObjectToResolvedResult({ parsedQRCode, pickingUnit, huInfoFromBackend, expectedProductNo });
 };
 
 //
@@ -234,7 +236,12 @@ export const convertScannedBarcodeToResolvedResult = async ({
 //
 //
 
-const convertQRCodeObjectToResolvedResult = async ({ parsedQRCode, pickingUnit, huInfoFromBackend }) => {
+const convertQRCodeObjectToResolvedResult = async ({
+  parsedQRCode,
+  pickingUnit,
+  huInfoFromBackend,
+  expectedProductNo,
+}) => {
   const result = {
     qrCode: parsedQRCode,
   };
@@ -254,18 +261,28 @@ const convertQRCodeObjectToResolvedResult = async ({ parsedQRCode, pickingUnit, 
   result.scannedHU = {
     huUnitType: parsedQRCode.huUnitType,
   };
-  if (parsedQRCode.huUnitType === 'LU' && pickingUnit === PICKING_UNIT_TU) {
-    let huInfo = huInfoFromBackend;
-    if (huInfo == null) {
-      try {
-        huInfo = await getScannedHUQRCodeInfo({ qrCode: toQRCodeString(parsedQRCode) });
-        result.scannedHU.qtyTUs = huInfo.qtyTUs;
-      } catch (error) {
-        console.warn('Failed to get LU info. Ignored', error);
-      }
+
+  // gh#29069: fetch HU info from backend when needed (LU in TU-picking, or whole-TU pick for overdelivery check)
+  let huInfo = huInfoFromBackend;
+  const needsBackendInfo =
+    (parsedQRCode.huUnitType === 'LU' && pickingUnit === PICKING_UNIT_TU) ||
+    parsedQRCode.isTUToBePickedAsWhole === true;
+
+  if (needsBackendInfo && huInfo == null) {
+    try {
+      huInfo = await getScannedHUQRCodeInfo({ qrCode: toQRCodeString(parsedQRCode), productNo: expectedProductNo });
+    } catch (error) {
+      console.warn('Failed to get HU info from backend. Ignored', error);
     }
-    if (huInfo != null) {
+  }
+
+  if (huInfo != null) {
+    if (huInfo.qtyTUs != null) {
       result.scannedHU.qtyTUs = huInfo.qtyTUs;
+    }
+    // gh#29069: use actual product qty from HU as qtyInitial for overdelivery prompt
+    if (huInfo.productQty != null) {
+      result.qtyInitial = parseFloat(huInfo.productQty);
     }
   }
 


### PR DESCRIPTION
## Summary
- The overdelivery confirmation prompt ("Do you really want to pack more than ordered?") was never shown in the mobile UI picking workflow, even with `IsShowConfirmationPromptWhenOverPick=Y`
- **Two root causes fixed:**
  1. **Manual qty entry**: `ScanHUAndGetQtyComponent.validateQtyEntered()` enforces a hard `qtyMax` limit that disables the "Done" button when qty > remaining. This prevents the confirmation prompt from ever being reached. **Fix**: skip `qtyMax` validation when the over-pick confirmation prompt is enabled.
  2. **Whole-TU scanning** (`pickWholeTU=true`): The dialog pre-fills qty = remaining, but the backend picks the actual HU storage qty (which may be higher). The frontend didn't know the HU's actual qty, so it couldn't detect overdelivery. **Fix**: When scanning a whole-TU, the frontend now fetches the HU's actual product qty from the backend via `/hu/byScannedCode` (extended with `productNo` param and `productQty`/`productUom` response fields) and uses it as the initial qty, allowing the prompt to fire.

## Test plan
- [ ] Set `IsShowConfirmationPromptWhenOverPick=Y` in `MobileUI_UserProfile_Picking`
- [ ] **Manual entry**: Create a picking job, enter a quantity greater than remaining - verify the over-pick confirmation prompt appears
- [ ] **Whole-TU scanning**: Scan a TU barcode that contains more product than remaining - verify the prompt appears with the actual HU qty shown
- [ ] Click "Yes" on prompt - pick is submitted
- [ ] Click "No" on prompt - dialog stays, user can cancel
- [ ] With `IsShowConfirmationPromptWhenOverPick=N`: verify manual entry still hard-blocks qty above max (existing behavior)