### PR TITLE
Distributed test report upload + JUnit HTML reports

### DIFF
--- a/.github/actions/upload-report-to-server/action.yml
+++ b/.github/actions/upload-report-to-server/action.yml
@@ -1,0 +1,117 @@
+name: 'Upload Report to Server'
+description: 'Upload an HTML test report to test-reports.metasfresh.com via SSH/rsync'
+
+inputs:
+  report-dir:
+    description: 'Local directory containing the HTML report (must have index.html)'
+    required: true
+  report-type:
+    description: 'Server subdirectory path, e.g. allure/cucumber or junit/backend'
+    required: true
+  branch:
+    description: 'Sanitized branch name'
+    required: true
+  version:
+    description: 'Build version tag'
+    required: true
+  ssh-key:
+    description: 'SSH private key for authentication'
+    required: true
+  server-hostname:
+    description: 'Storagebox hostname'
+    required: true
+  server-user:
+    description: 'Storagebox SSH user'
+    required: true
+  server-ssh-port:
+    description: 'Storagebox SSH port'
+    required: true
+  storagebox-base-path:
+    description: 'Base path on storagebox filesystem'
+    required: true
+
+outputs:
+  skip:
+    description: 'Set to true if upload was skipped (missing key or report)'
+    value: ${{ steps.check.outputs.skip }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check prerequisites
+      id: check
+      shell: bash
+      env:
+        REPORT_DIR: ${{ inputs.report-dir }}
+        SSH_KEY: ${{ inputs.ssh-key }}
+      run: |
+        if [ -z "$SSH_KEY" ]; then
+          echo "::notice::Skipping report upload — ssh-key input is empty"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if [ ! -f "$REPORT_DIR/index.html" ]; then
+          echo "::notice::Skipping report upload — $REPORT_DIR/index.html does not exist"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "skip=false" >> "$GITHUB_OUTPUT"
+
+    - name: Setup SSH
+      if: steps.check.outputs.skip != 'true'
+      shell: bash
+      env:
+        SSH_KEY: ${{ inputs.ssh-key }}
+        SERVER_HOSTNAME: ${{ inputs.server-hostname }}
+        SERVER_USER: ${{ inputs.server-user }}
+        SERVER_SSH_PORT: ${{ inputs.server-ssh-port }}
+      run: |
+        mkdir -p ~/.ssh
+        echo "$SSH_KEY" > ~/.ssh/reports_key
+        chmod 600 ~/.ssh/reports_key
+
+        # Trust both the storagebox and the web server
+        ssh-keyscan -H -p "$SERVER_SSH_PORT" "$SERVER_HOSTNAME" >> ~/.ssh/known_hosts 2>/dev/null
+        ssh-keyscan -H test-reports.metasfresh.com >> ~/.ssh/known_hosts 2>/dev/null
+
+        # Write SSH config with two named hosts
+        cat >> ~/.ssh/config <<EOF
+        Host reports-storage
+          HostName $SERVER_HOSTNAME
+          User $SERVER_USER
+          Port $SERVER_SSH_PORT
+          IdentityFile ~/.ssh/reports_key
+          StrictHostKeyChecking accept-new
+
+        Host reports-server
+          HostName test-reports.metasfresh.com
+          User ci-reports
+          IdentityFile ~/.ssh/reports_key
+          StrictHostKeyChecking accept-new
+        EOF
+
+    - name: Upload report
+      if: steps.check.outputs.skip != 'true'
+      shell: bash
+      env:
+        REPORT_DIR: ${{ inputs.report-dir }}
+        REPORT_TYPE: ${{ inputs.report-type }}
+        BRANCH: ${{ inputs.branch }}
+        VERSION: ${{ inputs.version }}
+        STORAGEBOX_BASE_PATH: ${{ inputs.storagebox-base-path }}
+      run: |
+        STORAGEBOX_PATH="${STORAGEBOX_BASE_PATH}/branches/${BRANCH}/builds/${VERSION}/${REPORT_TYPE}"
+        SERVER_PATH="/var/www/test-reports/branches/${BRANCH}/builds/${VERSION}/${REPORT_TYPE}"
+
+        echo "Creating server directory: $SERVER_PATH"
+        ssh reports-server "mkdir -p '${SERVER_PATH}'"
+
+        echo "Uploading report from ${REPORT_DIR}/ to reports-storage:${STORAGEBOX_PATH}/"
+        rsync -az --delete "${REPORT_DIR}/" "reports-storage:${STORAGEBOX_PATH}/"
+
+        echo "::notice::Report uploaded to https://test-reports.metasfresh.com/branches/${BRANCH}/builds/${VERSION}/${REPORT_TYPE}/"
+
+    - name: Cleanup SSH key
+      if: always() && steps.check.outputs.skip != 'true'
+      shell: bash
+      run: rm -f ~/.ssh/reports_key

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -129,6 +129,48 @@ jobs:
           echo ${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }} >> github_run.txt
           testspace github_run.txt
 
+  # Fast migration CLI build - runs in parallel with java job
+  # This enables db-images to start ~10 minutes earlier
+  migration-cli:
+    runs-on: ${{ vars.RUNNER_HEAVY }}
+    needs: [ init ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: install-envsubst
+        if: env.ACT == 'true'
+        run: |
+          apt-get update && apt-get install -y gettext-base
+      - name: prepare-settings
+        env:
+          METASFRESH_PACKAGES_READ_TOKEN: ${{ secrets.METASFRESH_PACKAGES_READ_TOKEN }}
+        run: |
+          envsubst < docker-builds/mvn/settings.xml > docker-builds/mvn/local-settings.xml
+      - name: prepare-metadata
+        env:
+          GIT_PROPS: ${{ needs.init.outputs.git-properties }}
+        run: |
+          mkdir -p docker-builds/metadata
+          echo -e "$GIT_PROPS" > docker-builds/metadata/git.properties
+          echo "Created git.properties:"
+          cat docker-builds/metadata/git.properties
+      - name: build-migration-cli
+        run: |
+          docker buildx build \
+            --progress=auto \
+            --file docker-builds/Dockerfile.migration-cli \
+            --secret id=mvn-settings,src=docker-builds/mvn/local-settings.xml \
+            --output type=local,dest=./artifacts \
+            .
+      - name: verify-output
+        run: |
+          ls -la artifacts/
+          file artifacts/migration-cli.jar
+      - uses: actions/upload-artifact@v4
+        with:
+          name: migration-cli-jar
+          path: artifacts/migration-cli.jar
+          retention-days: 1
+
   java:
     runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: init
@@ -469,7 +511,28 @@ jobs:
           path: jest/frontend/*.xml
           retention-days: 1
           if-no-files-found: warn
-      # TODO: Upload jest JUnit XML to HTTP report server (source: jest/frontend/*.xml)
+      - name: Generate JUnit HTML for Jest
+        if: always()
+        uses: ./.github/actions/generate-junit-html
+        with:
+          xml-path: jest/frontend/*.xml
+          output-dir: junit-html-jest
+          artifact-name: junit-html-jest
+          report-title: 'JUnit (Jest Frontend)'
+          history-artifact-name: junit-html-history-jest
+      - name: Upload Jest JUnit HTML to server
+        if: always()
+        uses: ./.github/actions/upload-report-to-server
+        with:
+          report-dir: junit-html-jest
+          report-type: junit/jest
+          branch: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          version: ${{ needs.init.outputs.tag-fixed }}
+          ssh-key: ${{ secrets.REPORTS_SERVER_SSH_KEY }}
+          server-hostname: ${{ secrets.TESTREPORTS_HOSTNAME }}
+          server-user: ${{ secrets.TESTREPORTS_USER }}
+          server-ssh-port: ${{ secrets.TESTREPORTS_SSH_PORT }}
+          storagebox-base-path: ${{ secrets.TESTREPORTS_BASE_PATH }}
       - name: assert success
         run: |
           if [ $(cat jest/frontend/jest.exit-code) != 0 ]; then tail -1000 jest/frontend/jest.log && exit 1; fi     # print frontend log and exit if frontend failed
@@ -539,7 +602,7 @@ jobs:
           --tag metasfresh/metas-edi:${{ needs.init.outputs.tag-floating }} \
           --tag metasfresh/metas-edi:${{ needs.init.outputs.tag-fixed }} \
           .
-      # NOTE: metas-db and metas-db-migration-tool are built below in this same job
+      # NOTE: metas-db and metas-db-migration-tool are now built by db-images job
       - name: push-image metasfresh/metas-api:${{ needs.init.outputs.tag-fixed }}
         if: env.ACT != 'true'
         uses: nick-fields/retry@v3
@@ -588,7 +651,7 @@ jobs:
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
           command: docker push --quiet metasfresh/metas-externalsystems:${{ needs.init.outputs.tag-floating }}
-      # NOTE: metas-db and metas-db-migration-tool are built above in this same job
+      # NOTE: metas-db and metas-db-migration-tool push steps moved to db-images job
       - name: push-image metasfresh/metas-edi:${{ needs.init.outputs.tag-fixed }}
         if: env.ACT != 'true'
         uses: nick-fields/retry@v3
@@ -606,6 +669,57 @@ jobs:
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
           command: docker push --quiet metasfresh/metas-edi:${{ needs.init.outputs.tag-floating }}
 
+      - name: produce-summary
+        run: |
+          echo '#### backend images' >> $GITHUB_STEP_SUMMARY
+          echo '* metasfresh/metas-api:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
+          echo '* metasfresh/metas-app:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
+          echo '* metasfresh/metas-externalsystems:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
+          echo '* metasfresh/metas-edi:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
+
+  # db-images: Build database images independently from backend
+  # Now runs in parallel with java job (depends on fast migration-cli job instead)
+  db-images:
+    runs-on: ${{ vars.RUNNER_HEAVY }}
+    needs: [ init, migration-cli ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          username: metasfresh
+          password: ${{ secrets.DOCKERHUB_METASFRESH_RW_TOKEN }}
+      - name: prepare-metadata
+        env:
+          INIT_BUILD_PROPS: ${{ needs.init.outputs.build-info-properties }}
+          INIT_GIT_PROPS: ${{ needs.init.outputs.git-properties }}
+        run: |
+          echo -e "$INIT_BUILD_PROPS" > docker-builds/metadata/build-info.properties
+          echo -e "$INIT_GIT_PROPS" > docker-builds/metadata/git.properties
+      - name: download-migration-cli-jar
+        uses: actions/download-artifact@v4
+        with:
+          name: migration-cli-jar
+          path: .
+      - name: verify-migration-cli-jar
+        run: |
+          ls -la migration-cli.jar
+          file migration-cli.jar
+      - name: aggregate-sql-from-source
+        shell: bash
+        run: |
+          # Aggregate SQL files directly from source code (no Maven dependency)
+          # Preserve intermediate folder structure (e.g., 10-de.metas.adempiere/, 20-de.metas.aggregation/)
+          # Use -print0/read -d '' to handle filenames with spaces
+          mkdir -p migration-sql
+          find backend -path "*/src/main/sql/postgresql/system/*/*.sql" -print0 | while IFS= read -r -d '' sql_file; do
+            intermediate_folder=$(basename "$(dirname "$sql_file")")
+            mkdir -p "migration-sql/$intermediate_folder"
+            cp "$sql_file" "migration-sql/$intermediate_folder/"
+          done
+          SQL_COUNT=$(find migration-sql -name "*.sql" | wc -l)
+          FOLDER_COUNT=$(find migration-sql -mindepth 1 -maxdepth 1 -type d | wc -l)
+          echo "Aggregated $SQL_COUNT SQL migration files in $FOLDER_COUNT intermediate folders"
+          ls -la migration-sql/
       - name: build-db-init
         run: |
           docker buildx build \
@@ -621,10 +735,9 @@ jobs:
         run: |
           docker buildx build \
           --progress=auto \
-          --file docker-builds/Dockerfile.db-migration-tool \
+          --file docker-builds/Dockerfile.db-migration-tool-lite \
           --cache-to type=inline \
           --cache-from metasfresh/metas-db-migration-tool:${{ needs.init.outputs.tag-floating }} \
-          --build-arg REFNAME=${{ needs.init.outputs.tag-fixed }} \
           --tag metasfresh/metas-db-migration-tool:${{ needs.init.outputs.tag-floating }} \
           --tag metasfresh/metas-db-migration-tool:${{ needs.init.outputs.tag-fixed }} \
           .
@@ -662,17 +775,13 @@ jobs:
           command: docker push --quiet metasfresh/metas-db-migration-tool:${{ needs.init.outputs.tag-floating }}
       - name: produce-summary
         run: |
-          echo '#### backend images' >> $GITHUB_STEP_SUMMARY
-          echo '* metasfresh/metas-api:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
-          echo '* metasfresh/metas-app:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
-          echo '* metasfresh/metas-externalsystems:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
-          echo '* metasfresh/metas-edi:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
+          echo '#### db-images' >> $GITHUB_STEP_SUMMARY
           echo '* metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
           echo '* metasfresh/metas-db-migration-tool:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
 
   db-apply-migrations:
     runs-on: ${{ vars.RUNNER_HEAVY }}
-    needs: [ init, backend ]
+    needs: [ init, db-images ]
     env:
       mfversion: ${{ needs.init.outputs.tag-fixed }}
     steps:
@@ -1184,7 +1293,56 @@ jobs:
           path: junit/camel/**/*.xml
           retention-days: 1
           if-no-files-found: warn
-      # TODO: Upload backend+camel JUnit XML to HTTP report server (source: junit/backend/, junit/camel/)
+      - name: Merge backend JUnit XML
+        if: always()
+        run: |
+          mkdir -p junit-merged-backend
+          find junit/commons junit/backend -name '*.xml' -type f -exec cp {} junit-merged-backend/ \;
+          echo "Merged $(ls junit-merged-backend/*.xml 2>/dev/null | wc -l) XML files"
+      - name: Generate JUnit HTML for Backend
+        if: always()
+        uses: ./.github/actions/generate-junit-html
+        with:
+          xml-path: junit-merged-backend/*.xml
+          output-dir: junit-html-backend
+          artifact-name: junit-html-backend
+          report-title: 'JUnit (Backend + Commons)'
+          history-artifact-name: junit-html-history-backend
+      - name: Upload Backend JUnit HTML to server
+        if: always()
+        uses: ./.github/actions/upload-report-to-server
+        with:
+          report-dir: junit-html-backend
+          report-type: junit/backend
+          branch: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          version: ${{ needs.init.outputs.tag-fixed }}
+          ssh-key: ${{ secrets.REPORTS_SERVER_SSH_KEY }}
+          server-hostname: ${{ secrets.TESTREPORTS_HOSTNAME }}
+          server-user: ${{ secrets.TESTREPORTS_USER }}
+          server-ssh-port: ${{ secrets.TESTREPORTS_SSH_PORT }}
+          storagebox-base-path: ${{ secrets.TESTREPORTS_BASE_PATH }}
+      - name: Generate JUnit HTML for Camel
+        if: always()
+        uses: ./.github/actions/generate-junit-html
+        with:
+          xml-path: junit/camel/**/*.xml
+          output-dir: junit-html-camel
+          artifact-name: junit-html-camel
+          report-title: 'JUnit (Camel)'
+          history-artifact-name: junit-html-history-camel
+      - name: Upload Camel JUnit HTML to server
+        if: always()
+        uses: ./.github/actions/upload-report-to-server
+        with:
+          report-dir: junit-html-camel
+          report-type: junit/camel
+          branch: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          version: ${{ needs.init.outputs.tag-fixed }}
+          ssh-key: ${{ secrets.REPORTS_SERVER_SSH_KEY }}
+          server-hostname: ${{ secrets.TESTREPORTS_HOSTNAME }}
+          server-user: ${{ secrets.TESTREPORTS_USER }}
+          server-ssh-port: ${{ secrets.TESTREPORTS_SSH_PORT }}
+          storagebox-base-path: ${{ secrets.TESTREPORTS_BASE_PATH }}
       - name: assert success
         run: |
           if [ $(cat junit/commons/junit.exit-code) != 0 ] || [ $(cat junit/commons/junit.mvn.exit-code) != 0 ]; then tail -1000 junit/commons/junit.log && exit 1; fi      # print commons log and exit if commons failed
@@ -1291,6 +1449,8 @@ jobs:
           mfversion: ${{ needs.init.outputs.tag-fixed }}
           cucumberparams: ${{ matrix.params }}
           TEST_SMTP_HOST: ${{ secrets.TEST_SMTP_HOST }}
+          TEST_SMTP_PORT: "587"
+          TEST_SMTP_STARTTLS: "true"
           TEST_SMTP_FROM: ${{ secrets.TEST_SMTP_FROM }}
           TEST_SMTP_USER: ${{ secrets.TEST_SMTP_USER }}
           TEST_SMTP_PASSWORD: ${{ secrets.TEST_SMTP_PASSWORD }}
@@ -1499,6 +1659,20 @@ jobs:
           retention-days: 30
           history-artifact-name: allure-history-cucumber
           report-title: 'Cucumber BDD'
+      - name: Upload Cucumber Allure report to server
+        if: steps.check_results.outputs.has_results == 'true'
+        uses: ./.github/actions/upload-report-to-server
+        with:
+          report-dir: cucumber-allure-report
+          report-type: allure/cucumber
+          branch: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          version: ${{ needs.init.outputs.tag-fixed }}
+          ssh-key: ${{ secrets.REPORTS_SERVER_SSH_KEY }}
+          server-hostname: ${{ secrets.TESTREPORTS_HOSTNAME }}
+          server-user: ${{ secrets.TESTREPORTS_USER }}
+          server-ssh-port: ${{ secrets.TESTREPORTS_SSH_PORT }}
+          storagebox-base-path: ${{ secrets.TESTREPORTS_BASE_PATH }}
+
 
   health_check:
     name: health check
@@ -1637,8 +1811,6 @@ jobs:
 
       # ===== ALLURE REPORT GENERATION =====
       - name: Generate Allure Report for Mobile
-        if: always()
-        continue-on-error: true  # older branches may not produce Allure results
         uses: ./.github/actions/generate-allure-report
         with:
           results-dir: docker-builds/e2e-tests/allure-results-mobile
@@ -1646,6 +1818,19 @@ jobs:
           artifact-name: allure-report-mobile-webui
           history-artifact-name: allure-history-mobile-webui
           report-title: 'Playwright (Mobile WebUI)'
+      - name: Upload Mobile Allure report to server
+        if: always()
+        uses: ./.github/actions/upload-report-to-server
+        with:
+          report-dir: e2e/mobile-webui/allure-report
+          report-type: allure/mobile-webui
+          branch: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          version: ${{ needs.init.outputs.tag-fixed }}
+          ssh-key: ${{ secrets.REPORTS_SERVER_SSH_KEY }}
+          server-hostname: ${{ secrets.TESTREPORTS_HOSTNAME }}
+          server-user: ${{ secrets.TESTREPORTS_USER }}
+          server-ssh-port: ${{ secrets.TESTREPORTS_SSH_PORT }}
+          storagebox-base-path: ${{ secrets.TESTREPORTS_BASE_PATH }}
       # ===== END ALLURE REPORT GENERATION =====
 
       - name: push-image metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postmobiletest
@@ -1817,6 +2002,20 @@ jobs:
           artifact-name: allure-report-frontend-webui
           history-artifact-name: allure-history-frontend-webui
           report-title: 'Playwright (Frontend WebUI)'
+      - name: Upload Frontend Allure report to server
+        if: steps.check_results.outputs.has_results == 'true'
+        uses: ./.github/actions/upload-report-to-server
+        with:
+          report-dir: e2e/frontend-webui/allure-report
+          report-type: allure/frontend-webui
+          branch: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          version: ${{ needs.init.outputs.tag-fixed }}
+          ssh-key: ${{ secrets.REPORTS_SERVER_SSH_KEY }}
+          server-hostname: ${{ secrets.TESTREPORTS_HOSTNAME }}
+          server-user: ${{ secrets.TESTREPORTS_USER }}
+          server-ssh-port: ${{ secrets.TESTREPORTS_SSH_PORT }}
+          storagebox-base-path: ${{ secrets.TESTREPORTS_BASE_PATH }}
+
 
   # =============================================================================
   # Publish Allure HTML Reports to test-reports.metasfresh.com
@@ -1824,7 +2023,7 @@ jobs:
   publish-test-reports:
     name: publish test reports
     runs-on: ${{ vars.RUNNER_LIGHT }}
-    needs: [ init, cucumber-allure-report, mobile_test, frontend_allure_report ]
+    needs: [ init, cucumber-allure-report, mobile_test, frontend_allure_report, junit, test-frontend ]
     if: always() && needs.init.result == 'success' && needs.init.outputs.skip-publish-reports != 'true'
     permissions:
       actions: write       # trigger reports-cleanup workflow when disk space is low
@@ -1868,89 +2067,99 @@ jobs:
             StrictHostKeyChecking accept-new
           EOF
 
-      - name: Download allure-report-cucumber
-        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
-        uses: actions/download-artifact@v4
-        with:
-          name: allure-report-cucumber
-          path: reports/cucumber
-        continue-on-error: true
-
-      - name: Download allure-report-mobile-webui
-        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
-        uses: actions/download-artifact@v4
-        with:
-          name: allure-report-mobile-webui
-          path: reports/mobile-webui
-        continue-on-error: true
-
-      - name: Download allure-report-frontend-webui
-        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
-        uses: actions/download-artifact@v4
-        with:
-          name: allure-report-frontend-webui
-          path: reports/frontend-webui
-        continue-on-error: true
-
-      - name: Inventory available reports
+      - name: Inventory reports on server
         if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true'
         id: inventory
+        env:
+          BRANCH: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          VERSION: ${{ needs.init.outputs.tag-fixed }}
         run: |
-          REPORTS=""
-          COUNT=0
-          for report_type in cucumber mobile-webui frontend-webui; do
-            if [ -d "reports/${report_type}" ] && [ -f "reports/${report_type}/index.html" ]; then
-              REPORTS="${REPORTS}${report_type} "
-              COUNT=$((COUNT + 1))
+          BUILD_PATH="/var/www/test-reports/branches/${BRANCH}/builds/${VERSION}"
+
+          ALLURE_REPORTS=""
+          ALLURE_COUNT=0
+          for suite in cucumber mobile-webui frontend-webui; do
+            if ssh reports-server "test -f ${BUILD_PATH}/allure/${suite}/index.html" 2>/dev/null; then
+              ALLURE_REPORTS="${ALLURE_REPORTS}${suite} "
+              ALLURE_COUNT=$((ALLURE_COUNT + 1))
             else
-              echo "::notice::No report found for ${report_type}"
+              echo "::notice::No allure report for ${suite}"
             fi
           done
-          echo "reports=${REPORTS}" >> $GITHUB_OUTPUT
-          echo "count=${COUNT}" >> $GITHUB_OUTPUT
-          if [ "$COUNT" -eq 0 ]; then
-            echo "::warning::No Allure report artifacts available — nothing to upload"
-          else
-            echo "Found ${COUNT} report(s): ${REPORTS}"
-          fi
 
-      - name: Upload reports to server
+          JUNIT_REPORTS=""
+          JUNIT_COUNT=0
+          for suite in backend camel jest; do
+            if ssh reports-server "test -f ${BUILD_PATH}/junit/${suite}/index.html" 2>/dev/null; then
+              JUNIT_REPORTS="${JUNIT_REPORTS}${suite} "
+              JUNIT_COUNT=$((JUNIT_COUNT + 1))
+            else
+              echo "::notice::No junit report for ${suite}"
+            fi
+          done
+
+          TOTAL=$((ALLURE_COUNT + JUNIT_COUNT))
+          echo "allure_reports=${ALLURE_REPORTS}" >> $GITHUB_OUTPUT
+          echo "allure_count=${ALLURE_COUNT}" >> $GITHUB_OUTPUT
+          echo "junit_reports=${JUNIT_REPORTS}" >> $GITHUB_OUTPUT
+          echo "junit_count=${JUNIT_COUNT}" >> $GITHUB_OUTPUT
+          echo "count=${TOTAL}" >> $GITHUB_OUTPUT
+          echo "Found ${ALLURE_COUNT} allure + ${JUNIT_COUNT} junit report(s)"
+
+      - name: Generate directory index pages
         if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true' && steps.inventory.outputs.count != '0'
         env:
           BRANCH: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
           VERSION: ${{ needs.init.outputs.tag-fixed }}
-          STORAGEBOX_BASE_PATH: ${{ secrets.TESTREPORTS_BASE_PATH }}
         run: |
-          # Two different base paths — same content, different mount points:
-          #   STORAGEBOX_PATH: used by rsync to reports-storage (storagebox internal path)
-          #   SERVER_PATH:     used by ssh to reports-server (test server mount point)
-          STORAGEBOX_PATH="${STORAGEBOX_BASE_PATH}/branches/${BRANCH}/builds/${VERSION}/allure"
-          SERVER_PATH="/var/www/test-reports/branches/${BRANCH}/builds/${VERSION}/allure"
+          SERVER_PATH="/var/www/test-reports/branches/${BRANCH}/builds/${VERSION}"
 
-          # Create target directories on test server (mkdir needs the server-side path)
-          ssh reports-server "mkdir -p ${SERVER_PATH}"
-
-          for report_type in ${{ steps.inventory.outputs.reports }}; do
-            echo "Uploading ${report_type} report..."
-            rsync -az --delete \
-              "reports/${report_type}/" \
-              "reports-storage:${STORAGEBOX_PATH}/${report_type}/"
-            echo "✓ ${report_type} uploaded"
+          # Allure index
+          ALLURE_LINKS=""
+          for suite in ${{ steps.inventory.outputs.allure_reports }}; do
+            ALLURE_LINKS="${ALLURE_LINKS}<li><a href=\"${suite}/\">${suite}</a></li>"
           done
-
-          # Generate index.html in the allure parent directory so the URL doesn't 403
-          REPORT_LINKS=""
-          for report_type in ${{ steps.inventory.outputs.reports }}; do
-            REPORT_LINKS="${REPORT_LINKS}<li><a href=\"${report_type}/\">${report_type}</a></li>"
-          done
-          ssh reports-server "cat > ${SERVER_PATH}/index.html" <<EOF
+          if [ -n "$ALLURE_LINKS" ]; then
+            ssh reports-server "mkdir -p ${SERVER_PATH}/allure && cat > ${SERVER_PATH}/allure/index.html" <<EOF
           <!DOCTYPE html>
           <html><head><title>Allure Reports — ${VERSION}</title>
           <style>body{font-family:sans-serif;margin:40px}a{color:#0066cc}</style>
           </head><body>
           <h1>Allure Reports</h1>
           <p><strong>Build:</strong> ${VERSION}</p>
-          <ul>${REPORT_LINKS}</ul>
+          <ul>${ALLURE_LINKS}</ul>
+          </body></html>
+          EOF
+          fi
+
+          # JUnit index
+          JUNIT_LINKS=""
+          for suite in ${{ steps.inventory.outputs.junit_reports }}; do
+            JUNIT_LINKS="${JUNIT_LINKS}<li><a href=\"${suite}/\">${suite}</a></li>"
+          done
+          if [ -n "$JUNIT_LINKS" ]; then
+            ssh reports-server "mkdir -p ${SERVER_PATH}/junit && cat > ${SERVER_PATH}/junit/index.html" <<EOF
+          <!DOCTYPE html>
+          <html><head><title>JUnit Reports — ${VERSION}</title>
+          <style>body{font-family:sans-serif;margin:40px}a{color:#0066cc}</style>
+          </head><body>
+          <h1>JUnit Reports</h1>
+          <p><strong>Build:</strong> ${VERSION}</p>
+          <ul>${JUNIT_LINKS}</ul>
+          </body></html>
+          EOF
+          fi
+
+          # Build-level index
+          ssh reports-server "cat > ${SERVER_PATH}/index.html" <<EOF
+          <!DOCTYPE html>
+          <html><head><title>Test Reports — ${VERSION}</title>
+          <style>body{font-family:sans-serif;margin:40px}a{color:#0066cc}h2{margin-top:30px}</style>
+          </head><body>
+          <h1>Test Reports</h1>
+          <p><strong>Build:</strong> ${VERSION}</p>
+          <h2>Allure Reports</h2><ul>${ALLURE_LINKS:-<li>None available</li>}</ul>
+          <h2>JUnit Reports</h2><ul>${JUNIT_LINKS:-<li>None available</li>}</ul>
           <p><a href="https://test-reports.metasfresh.com/">← Back to all reports</a></p>
           </body></html>
           EOF
@@ -2030,6 +2239,64 @@ jobs:
                   failed_steps = [
                       {"name": s.get("name", ""), "status": s.get("status", "")}
                       for s in steps if s.get("status") in ("failed", "broken")
+                  ]
+                  if failed_steps:
+                      failure["failedSteps"] = failed_steps
+
+                  result["failures"].append(failure)
+
+          # JUnit suites (Allure-generated HTML from JUnit XML has same widget structure)
+          junit_dir = os.path.join(build_dir, "junit")
+          junit_suites = ["backend", "camel", "jest"]
+          for suite in junit_suites:
+              suite_dir = os.path.join(junit_dir, suite)
+              summary_file = os.path.join(suite_dir, "widgets", "summary.json")
+              if not os.path.isfile(summary_file):
+                  continue
+
+              with open(summary_file, "r") as f:
+                  summary = json.load(f)
+
+              stats = summary.get("statistic", {})
+              result["suites"][f"junit/{suite}"] = {
+                  "total": stats.get("total", 0),
+                  "passed": stats.get("passed", 0),
+                  "failed": stats.get("failed", 0),
+                  "broken": stats.get("broken", 0),
+                  "skipped": stats.get("skipped", 0)
+              }
+
+              if stats.get("failed", 0) == 0 and stats.get("broken", 0) == 0:
+                  continue
+
+              tc_dir = os.path.join(suite_dir, "data", "test-cases")
+              if not os.path.isdir(tc_dir):
+                  continue
+
+              for tc_file in glob.glob(os.path.join(tc_dir, "*.json")):
+                  with open(tc_file, "r") as f:
+                      try:
+                          tc = json.load(f)
+                      except json.JSONDecodeError:
+                          continue
+
+                  status = tc.get("status", "")
+                  if status not in ("failed", "broken"):
+                      continue
+
+                  failure = {
+                      "suite": f"junit/{suite}",
+                      "name": tc.get("name", ""),
+                      "fullName": tc.get("fullName", ""),
+                      "status": status,
+                      "message": tc.get("statusMessage", ""),
+                      "trace": tc.get("statusTrace", ""),
+                  }
+
+                  steps_list = tc.get("testStage", {}).get("steps", [])
+                  failed_steps = [
+                      {"name": s.get("name", ""), "status": s.get("status", "")}
+                      for s in steps_list if s.get("status") in ("failed", "broken")
                   ]
                   if failed_steps:
                       failure["failedSteps"] = failed_steps
@@ -2148,7 +2415,32 @@ jobs:
                       return a;
                   }
 
-                  function createBuildElement(branchName, build) {
+                  async function discoverReports(basePath) {
+                      var reports = [];
+                      var categories = [
+                          { prefix: 'Allure', dir: '/allure/' },
+                          { prefix: 'JUnit', dir: '/junit/' }
+                      ];
+                      for (var i = 0; i < categories.length; i++) {
+                          var cat = categories[i];
+                          try {
+                              var resp = await fetch(basePath + cat.dir);
+                              if (!resp.ok) continue;
+                              var entries = await resp.json();
+                              entries.forEach(function(entry) {
+                                  if (entry.type === 'directory') {
+                                      reports.push({
+                                          name: cat.prefix + ': ' + entry.name,
+                                          path: cat.dir + entry.name + '/'
+                                      });
+                                  }
+                              });
+                          } catch (e) { console.warn('discoverReports: ' + cat.dir, e.message); }
+                      }
+                      return reports;
+                  }
+
+                  async function createBuildElement(branchName, build) {
                       const buildDiv = document.createElement('div');
                       buildDiv.className = 'build';
 
@@ -2170,23 +2462,22 @@ jobs:
                       linksDiv.className = 'report-links';
 
                       const basePath = '/branches/' + encodeURIComponent(branchName) + '/builds/' + encodeURIComponent(build.version);
+                      const reports = await discoverReports(basePath);
 
-                      const reports = [
-                          { name: 'Frontend', path: '/allure/frontend-webui/' },
-                          { name: 'Mobile', path: '/allure/mobile-webui/' },
-                          { name: 'Cucumber', path: '/allure/cucumber/' }
-                      ];
-
-                      reports.forEach(function(report) {
-                          const link = createLink(basePath + report.path, report.name);
-                          linksDiv.appendChild(link);
-                      });
+                      if (reports.length === 0) {
+                          linksDiv.appendChild(createTextElement('span', 'No reports', 'loading'));
+                      } else {
+                          reports.forEach(function(report) {
+                              const link = createLink(basePath + report.path, report.name);
+                              linksDiv.appendChild(link);
+                          });
+                      }
 
                       buildDiv.appendChild(linksDiv);
                       return buildDiv;
                   }
 
-                  function createBranchElement(branchData) {
+                  async function createBranchElement(branchData) {
                       const branchDiv = document.createElement('div');
                       branchDiv.className = 'branch';
 
@@ -2198,9 +2489,9 @@ jobs:
 
                       // Show all builds (metadata is capped to 3 per branch at publish time)
                       const builds = branchData.builds;
-                      builds.forEach(function(build) {
-                          buildsDiv.appendChild(createBuildElement(branchData.branch, build));
-                      });
+                      for (var i = 0; i < builds.length; i++) {
+                          buildsDiv.appendChild(await createBuildElement(branchData.branch, builds[i]));
+                      }
 
                       branchDiv.appendChild(buildsDiv);
                       return branchDiv;
@@ -2230,7 +2521,7 @@ jobs:
                                   const branchResponse = await fetch('/_metadata/' + file.name);
                                   if (branchResponse.ok) {
                                       const branchData = await branchResponse.json();
-                                      container.appendChild(createBranchElement(branchData));
+                                      container.appendChild(await createBranchElement(branchData));
                                   }
                               } catch (e) {
                                   console.error('Error loading branch:', file.name, e);
@@ -2283,14 +2574,17 @@ jobs:
             exit 0
           fi
 
-          BASE_URL="https://test-reports.metasfresh.com/branches/${BRANCH}/builds/${VERSION}/allure"
+          BUILD_URL="https://test-reports.metasfresh.com/branches/${BRANCH}/builds/${VERSION}"
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Report | Link |" >> $GITHUB_STEP_SUMMARY
           echo "|--------|------|" >> $GITHUB_STEP_SUMMARY
-          for report_type in ${{ steps.inventory.outputs.reports }}; do
-            echo "| ${report_type} | [Open report](${BASE_URL}/${report_type}/) |" >> $GITHUB_STEP_SUMMARY
+          for report_type in ${{ steps.inventory.outputs.allure_reports }}; do
+            echo "| Allure: ${report_type} | [Open report](${BUILD_URL}/allure/${report_type}/) |" >> $GITHUB_STEP_SUMMARY
           done
-          FAILURES_URL="https://test-reports.metasfresh.com/branches/${BRANCH}/builds/${VERSION}/failures.json"
+          for report_type in ${{ steps.inventory.outputs.junit_reports }}; do
+            echo "| JUnit: ${report_type} | [Open report](${BUILD_URL}/junit/${report_type}/) |" >> $GITHUB_STEP_SUMMARY
+          done
+          FAILURES_URL="${BUILD_URL}/failures.json"
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Machine-readable:** [failures.json](${FAILURES_URL})" >> $GITHUB_STEP_SUMMARY
 
@@ -2308,15 +2602,18 @@ jobs:
             exit 0
           fi
 
-          BASE_URL="https://test-reports.metasfresh.com/branches/${BRANCH}/builds/${VERSION}/allure"
+          BUILD_URL="https://test-reports.metasfresh.com/branches/${BRANCH}/builds/${VERSION}"
           REPORT_LINKS=""
-          for report_type in ${{ steps.inventory.outputs.reports }}; do
-            REPORT_LINKS="${REPORT_LINKS}| ${report_type} | [Open report](${BASE_URL}/${report_type}/) |"$'\n'
+          for report_type in ${{ steps.inventory.outputs.allure_reports }}; do
+            REPORT_LINKS="${REPORT_LINKS}| Allure: ${report_type} | [Open report](${BUILD_URL}/allure/${report_type}/) |"$'\n'
+          done
+          for report_type in ${{ steps.inventory.outputs.junit_reports }}; do
+            REPORT_LINKS="${REPORT_LINKS}| JUnit: ${report_type} | [Open report](${BUILD_URL}/junit/${report_type}/) |"$'\n'
           done
 
           MARKER="<!-- allure-reports -->"
           BODY="${MARKER}
-          ### 📊 Allure Test Reports
+          ### 📊 Test Reports
 
           **Build:** \`${VERSION}\`
 

--- a/.github/workflows/reports-cleanup.yml
+++ b/.github/workflows/reports-cleanup.yml
@@ -60,6 +60,21 @@ jobs:
             StrictHostKeyChecking accept-new
           EOF
 
+      - name: Fetch existing GitHub branches
+        if: steps.check-secret.outputs.available == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fetch all branch names from GitHub, sanitize them the same way as cicd.yaml,
+          # and upload to the server so the cleanup script knows which branches still exist.
+          gh api repos/${{ github.repository }}/branches --paginate --jq '.[].name' \
+            | while read -r branch; do
+                echo "$branch" | tr '/' '-' | tr '_' '-' | tr -cd 'a-zA-Z0-9.\n-' | tr '[:upper:]' '[:lower:]' | sed 's/--*/-/g' | sed 's/^-*//' | sed 's/-*$//'
+              done \
+            | sort -u > /tmp/github-branches.txt
+          echo "Found $(wc -l < /tmp/github-branches.txt) branches on GitHub"
+          ssh reports-server "cat > /tmp/github-branches.txt" < /tmp/github-branches.txt
+
       - name: Run cleanup
         if: steps.check-secret.outputs.available == 'true'
         id: cleanup
@@ -74,6 +89,14 @@ jobs:
           MAX_BUILDS_PER_BRANCH = 3
           MAX_BRANCH_AGE_DAYS = 30
           MAX_ORPHAN_BUILD_AGE_DAYS = 7
+          DELETED_BRANCH_GRACE_DAYS = 2
+
+          # Load sanitized branch names from GitHub
+          github_branches = set()
+          gh_branches_file = Path("/tmp/github-branches.txt")
+          if gh_branches_file.exists():
+              github_branches = set(gh_branches_file.read_text().strip().splitlines())
+              print(f"Loaded {len(github_branches)} GitHub branches for existence check")
 
           def get_avail_bytes():
               stat = os.statvfs(str(REPORTS_ROOT))
@@ -134,8 +157,10 @@ jobs:
                       except (json.JSONDecodeError, KeyError):
                           pass
 
-                  # --- Stale branch ---
-                  if newest_ts > 0:
+                  # --- Stale branch (private repos only) ---
+                  # For public reports, branch existence is checked via GitHub API below.
+                  # For private repos we don't have the branch list, so fall back to age.
+                  if label_prefix and newest_ts > 0:
                       age_days = (now - newest_ts) / 86400
                       if age_days > MAX_BRANCH_AGE_DAYS:
                           size = dir_size(branch_dir)
@@ -144,6 +169,23 @@ jobs:
                               metadata_file.unlink()
                           removed_branches.append(
                               f"{label} (stale: {int(age_days)}d, {fmt(size)})"
+                          )
+                          freed += size
+                          continue
+
+                  # --- Deleted branch (no longer exists on GitHub) ---
+                  # Only for public reports (not private repos which use different repos).
+                  # Skip if newest_ts == 0 (no valid timestamps) — let the "No metadata" block handle it.
+                  if not label_prefix and github_branches and branch not in github_branches and newest_ts > 0:
+                      # Grace period: only remove if last build is older than DELETED_BRANCH_GRACE_DAYS
+                      age_days = (now - newest_ts) / 86400
+                      if age_days > DELETED_BRANCH_GRACE_DAYS:
+                          size = dir_size(branch_dir)
+                          shutil.rmtree(branch_dir)
+                          if metadata_file.exists():
+                              metadata_file.unlink()
+                          removed_branches.append(
+                              f"{label} (deleted from GitHub, {int(age_days)}d since last build, {fmt(size)})"
                           )
                           freed += size
                           continue


### PR DESCRIPTION
## Summary

Port of https://github.com/metasfresh/metasfresh/pull/23213 from new_dawn_uat.

- Eliminate slow artifact downloads in publish-test-reports (was 2-11 min, now ~15s)
- Add JUnit HTML reports (backend, camel, jest) to test-reports server
- Landing page discovers reports dynamically
- Cleanup workflow checks GitHub for deleted branches

## Test plan

- [ ] CI passes