### PR TITLE
Port: mobile UI scan field not visible on Android 11 Zebra devices

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/assets/BarcodeScannerComponent.scss
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/assets/BarcodeScannerComponent.scss
@@ -10,8 +10,17 @@
 
   .input-text {
     margin: 10px;
+    padding: 8px 12px;
     font-size: 2em;
     text-align: center;
+    border: 2px solid $grey-lighter;
+    border-radius: 4px;
+    width: calc(100% - 20px);
+
+    &:focus {
+      border-color: $base-mf-green;
+      outline: none;
+    }
   }
 
   .loading {
@@ -39,17 +48,10 @@
   }
 }
 
-.barcode-scanner:has(video) {
-  .input-text {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1;
-    opacity: 0.8;
-  }
-}
-
+// Input is rendered ABOVE the video in normal document flow (not overlaid).
+// Overlaying with position:absolute + z-index does not work reliably on
+// Android 11 WebView due to SurfaceView video compositing (the native video
+// layer ignores CSS z-index and covers overlaid HTML content).
 .barcode-scanner:not(:has(video)) {
   display: flex;
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
@@ -256,7 +256,6 @@ const BarcodeScannerComponent = ({
   return (
     <div className="barcode-scanner">
       {isProcessing && <Spinner />}
-      {isShowVideo && <video key="video" ref={videoRef} width="100%" height="100%" />}
       {!isProcessing && (
         <input
           id="input-text"
@@ -273,6 +272,7 @@ const BarcodeScannerComponent = ({
           data-testid={testId ?? 'qrCode-input'}
         />
       )}
+      {isShowVideo && <video key="video" ref={videoRef} width="100%" height="100%" />}
     </div>
   );
 };


### PR DESCRIPTION
Cherry-pick of `c7000837f6b` from `intensive_care_hotfix`.

Renders the scan text input above the camera viewfinder in normal document flow instead of overlaying with `position: absolute` + `z-index`, which is hidden by Android 11 WebView's native SurfaceView video compositor.

Original PR: https://github.com/metasfresh/metasfresh/pull/23225