### PR TITLE
Fix DESADV export: include unshipped order lines in DesadvLineWithNoPacking

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
@@ -177,9 +177,7 @@ public class EDI_Desadv_JSON_Export_StepDef
 				.as("Expected %d entries in DesadvLineWithNoPacking", expectedRows.size())
 				.isEqualTo(expectedRows.size());
 
-		int index = 0;
-		for (final DataTableRow row : expectedRows)
-		{
+		expectedRows.forEach((row, index) -> {
 			final JsonNode entry = noPacking.get(index);
 			final JsonNode desadvLine = entry.path("DesadvLine");
 			assertThat(desadvLine.isMissingNode()).as("Entry %d should have DesadvLine", index).isFalse();
@@ -209,8 +207,6 @@ public class EDI_Desadv_JSON_Export_StepDef
 						.as("DesadvLineWithNoPacking[%d].IsDeliveryClosed", index)
 						.isEqualTo(expectedIsDeliveryClosed);
 			}
-
-			index++;
-		}
+		});
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
@@ -24,6 +24,7 @@ package de.metas.cucumber.stepdefs.edi;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.context.TestContext;
 import io.cucumber.datatable.DataTable;
@@ -171,13 +172,13 @@ public class EDI_Desadv_JSON_Export_StepDef
 
 		assertThat(noPacking.isArray()).as("DesadvLineWithNoPacking should be an array").isTrue();
 
-		final var expectedRows = DataTableRows.of(dataTable);
+		final DataTableRows expectedRows = DataTableRows.of(dataTable);
 		assertThat(noPacking.size())
 				.as("Expected %d entries in DesadvLineWithNoPacking", expectedRows.size())
 				.isEqualTo(expectedRows.size());
 
 		int index = 0;
-		for (final var row : expectedRows)
+		for (final DataTableRow row : expectedRows)
 		{
 			final JsonNode entry = noPacking.get(index);
 			final JsonNode desadvLine = entry.path("DesadvLine");

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
@@ -149,4 +149,67 @@ public class EDI_Desadv_JSON_Export_StepDef
 			}
 		});
 	}
+
+	/**
+	 * Verifies the {@code DesadvLineWithNoPacking} array in the DESADV JSON export.
+	 * Each row in the DataTable represents an expected entry.
+	 * <p>
+	 * DataTable columns:
+	 * <ul>
+	 *     <li>{@code OrderLine} (required) — expected order line number</li>
+	 *     <li>{@code QtyOrderedInDesadvLineUOM} (required) — expected ordered qty</li>
+	 *     <li>{@code QtyDeliveredInDesadvLineUOM} (required) — expected delivered qty</li>
+	 *     <li>{@code IsDeliveryClosed} (optional) — expected value of IsDeliveryClosed</li>
+	 * </ul>
+	 */
+	@Then("verify DESADV JSON export has DesadvLineWithNoPacking:")
+	public void verifyDesadvLineWithNoPacking(@NonNull final DataTable dataTable) throws Exception
+	{
+		final String responseBody = testContext.getApiResponseBodyAsString();
+		final JsonNode root = objectMapper.readTree(responseBody);
+		final JsonNode noPacking = root.path("metasfresh_DESADV").path("DesadvLineWithNoPacking");
+
+		assertThat(noPacking.isArray()).as("DesadvLineWithNoPacking should be an array").isTrue();
+
+		final var expectedRows = DataTableRows.of(dataTable);
+		assertThat(noPacking.size())
+				.as("Expected %d entries in DesadvLineWithNoPacking", expectedRows.size())
+				.isEqualTo(expectedRows.size());
+
+		int index = 0;
+		for (final var row : expectedRows)
+		{
+			final JsonNode entry = noPacking.get(index);
+			final JsonNode desadvLine = entry.path("DesadvLine");
+			assertThat(desadvLine.isMissingNode()).as("Entry %d should have DesadvLine", index).isFalse();
+
+			final int expectedOrderLine = row.getAsInt("OrderLine");
+			assertThat(desadvLine.path("OrderLine").asInt())
+					.as("DesadvLineWithNoPacking[%d].OrderLine", index)
+					.isEqualTo(expectedOrderLine);
+
+			final int expectedQtyOrdered = row.getAsInt("QtyOrderedInDesadvLineUOM");
+			assertThat(desadvLine.path("QtyOrderedInDesadvLineUOM").asInt())
+					.as("DesadvLineWithNoPacking[%d].QtyOrderedInDesadvLineUOM", index)
+					.isEqualTo(expectedQtyOrdered);
+
+			final int expectedQtyDelivered = row.getAsInt("QtyDeliveredInDesadvLineUOM");
+			assertThat(desadvLine.path("QtyDeliveredInDesadvLineUOM").asInt())
+					.as("DesadvLineWithNoPacking[%d].QtyDeliveredInDesadvLineUOM", index)
+					.isEqualTo(expectedQtyDelivered);
+
+			final Boolean expectedIsDeliveryClosed = row.getAsOptionalBoolean("IsDeliveryClosed").toBooleanOrNull();
+			if (expectedIsDeliveryClosed != null)
+			{
+				assertThat(desadvLine.has("IsDeliveryClosed"))
+						.as("DesadvLineWithNoPacking[%d] should contain IsDeliveryClosed", index)
+						.isTrue();
+				assertThat(desadvLine.path("IsDeliveryClosed").asBoolean())
+						.as("DesadvLineWithNoPacking[%d].IsDeliveryClosed", index)
+						.isEqualTo(expectedIsDeliveryClosed);
+			}
+
+			index++;
+		}
+	}
 }

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
@@ -583,3 +583,106 @@ Feature: EDI DESADV export via postgREST
     Then verify DESADV JSON export has compensation group packing:
       | PackingCount | MainArticleCount | SubArticleCount | IsDeliveryClosed |
       | 1            | 1                | 0               | true             |
+
+  @Id:S0468_040
+  @from:cucumber
+  Scenario: DESADV export includes unshipped order lines in DesadvLineWithNoPacking
+
+    # Two products: one will be shipped, one will NOT be shipped at all
+    Given metasfresh contains M_Products:
+      | Identifier      |
+      | prod_shipped    |
+      | prod_notShipped |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_Product_ID | C_BPartner_ID | M_Product_ID    |
+      | bp_shipped            | customer1     | prod_shipped    |
+      | bp_notShipped         | customer1     | prod_notShipped |
+    And metasfresh contains M_HU_PackingMaterial:
+      | M_HU_PackingMaterial_ID | M_Product_ID | Name        |
+      | pm_shipped              | prod_shipped | pmShipped   |
+    And load M_HU_PackagingCode:
+      | M_HU_PackagingCode_ID | PackagingCode | HU_UnitType |
+      | huPkgCodeLU_ns        | ISO1          | LU          |
+      | huPkgCodeTU_ns        | CART          | TU          |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID     |
+      | huPILU_ns      |
+      | huPITU_ns      |
+      | huPIVirtual_ns |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID     | HU_UnitType | IsCurrent | M_HU_PackagingCode_ID |
+      | huPIVerLU_ns       | huPILU_ns      | LU          | Y         |                       |
+      | huPIVerTU_ns       | huPITU_ns      | TU          | Y         | huPkgCodeTU_ns        |
+      | huPIVerCU_ns       | huPIVirtual_ns | V           | Y         |                       |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID | M_HU_PackingMaterial_ID |
+      | huPiItemLU_ns              | huPIVerLU_ns       | 10  | HU       | huPITU_ns         |                         |
+      | huPiItemTU_ns              | huPIVerTU_ns       | 0   | PM       |                    | pm_shipped              |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID | Qty | ValidFrom  | M_HU_PackagingCode_LU_Fallback_ID | GTIN_LU_PackingMaterial_Fallback |
+      | huPiProd_ns             | huPiItemTU_ns    | prod_shipped | 10  | 2025-01-01 | huPkgCodeLU_ns                    | nsLuGTIN                         |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
+      | salesPLV               | prod_shipped    | 5.00     | PCE      |
+      | salesPLV               | prod_notShipped | 3.00     | PCE      |
+
+    # Order with 2 lines
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | OPT.POReference   |
+      | o_ns       | true    | customer1     | 2025-04-17  | 2025-04-18Z  | partialShipRef    |
+    And metasfresh contains C_OrderLines:
+      | Identifier    | C_Order_ID | M_Product_ID    | QtyEntered | OPT.M_HU_PI_Item_Product_ID |
+      | ol_shipped    | o_ns       | prod_shipped    | 100        | huPiProd_ns                 |
+      | ol_notShipped | o_ns       | prod_notShipped | 50         |                             |
+    And the order identified by o_ns is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier    | C_OrderLine_ID | IsToRecompute |
+      | ss_shipped    | ol_shipped     | N             |
+      | ss_notShipped | ol_notShipped  | N             |
+
+    And setup the SSCC18 code generator with GS1ManufacturerCode 1234567, GS1ExtensionDigit 0 and next sequence number always=1000000.
+
+    # Only ship the first line — the second line is NOT shipped at all
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_shipped                       | D            | true                | false       |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | REST.Context.M_InOut_ID | REST.Context.DocumentNo     |
+      | ss_shipped                       | s_ns                  | shipment_ns_ID          | shipment_ns_DocumentNo      |
+
+    And reset the SSCC18 code generator's next sequence number back to its actual sequence.
+
+    And EDI_Desadv is found:
+      | EDI_Desadv_ID.Identifier | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_ExportStatus | REST.Context |
+      | d_ns                     | customer1                | o_ns                  | P                | d_ns         |
+
+    And the following API_Audit_Config records are created:
+      | Identifier | SeqNo | OPT.Method | OPT.PathPrefix   | IsForceProcessedAsync | IsSynchronousAuditLoggingEnabled | IsWrapApiResponse |
+      | c_ns       | 10    | GET        | api/v2/processes | N                     | Y                                | N                 |
+    And add HTTP headers
+      | Key          | Value                          |
+      | Content-Type | application/json;charset=UTF-8 |
+      | accept       | application/json;charset=UTF-8 |
+
+    When a 'POST' request with the below payload and headers from context is sent to the metasfresh REST-API 'api/v2/processes/M_InOut_EDI_Export_JSON/invoke' and fulfills with '200' status code
+    """
+{
+    "processParameters": [
+    {
+      "name": "M_InOut_ID",
+      "value": "@shipment_ns_ID@"
+    }
+  ]
+}
+    """
+    # The shipped line should be in Packings, the unshipped line should be in DesadvLineWithNoPacking
+    Then verify DESADV JSON export has compensation group packing:
+      | PackingCount | MainArticleCount | SubArticleCount | IsDeliveryClosed |
+      | 1            | 1                | 0               | true             |
+
+    And verify DESADV JSON export has DesadvLineWithNoPacking:
+      | OrderLine | QtyOrderedInDesadvLineUOM | QtyDeliveredInDesadvLineUOM | IsDeliveryClosed |
+      | 20        | 50                        | 0                           | false            |

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5796850_sys_fix_desadv_no_pack_fn_include_unshipped_lines.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5796850_sys_fix_desadv_no_pack_fn_include_unshipped_lines.sql
@@ -1,27 +1,11 @@
-/*
- * #%L
- * de.metas.edi
- * %%
- * Copyright (C) 2025 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
+-- Fix: include unshipped DESADV lines in DesadvLineWithNoPacking
+-- Previously, the function only included lines that had a matching m_inoutline
+-- in the current shipment. Lines with QtyDelivered=0 (not shipped at all) were
+-- excluded because no m_inoutline exists for them.
+-- Now: also include DESADV lines that have no completed shipment line anywhere.
+-- Also fixes IsDeliveryClosed for unshipped lines: returns false when there's
+-- outstanding ordered qty and no delivery tracking row, instead of defaulting to true.
 
--- Function for desadv lines with no pack
--- Ensure edi_desadv_line_object_v is defined and efficient
 CREATE OR REPLACE FUNCTION "de.metas.edi".get_desadv_lines_no_pack_json_fn(p_edi_desadv_id NUMERIC, p_m_inout_id NUMERIC)
     RETURNS JSONB AS $$
 DECLARE


### PR DESCRIPTION
## Summary
- Fixes `get_desadv_lines_no_pack_json_fn` to include DESADV lines that have no shipment line at all (not shipped, QtyDelivered=0) in the `DesadvLineWithNoPacking` array
- Previously, the `EXISTS` filter required a matching `m_inoutline` in the current shipment, silently excluding order lines that were never shipped
- Also fixes `IsDeliveryClosed` for unshipped lines: returns `false` when there's outstanding ordered qty and no delivery tracking row, instead of incorrectly defaulting to `true`

## Test plan
- [ ] New scenario `S0468_040`: Order with 2 lines, only 1 shipped — verifies the unshipped line appears in `DesadvLineWithNoPacking` with `QtyDelivered=0` and `IsDeliveryClosed=false`
- [ ] Existing scenarios S0468_010, S0468_020, S0468_030 still pass (no regression)