### PR TITLE
Fix mobileUI overdelivery prompt not appearing during picking

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/JsonMobileConfigRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/JsonMobileConfigRequest.java
@@ -59,6 +59,7 @@ public class JsonMobileConfigRequest
 		@Nullable Boolean activeWorkplaceRequired;
 		@Nullable Boolean considerOnlyJobScheduledToWorkplace;
 		@Nullable Boolean allowQuickPackAll;
+		@Nullable Boolean showPromptWhenOverPicking;
 
 		@Nullable List<Customer> customers;
 		

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigPickingCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigPickingCommand.java
@@ -147,6 +147,11 @@ class MobileConfigPickingCommand
 
 		builder.displayPickingSlotSuggestions(OptionalBoolean.ofNullableBoolean(from.getDisplayPickingSlotSuggestions()));
 
+		if (from.getShowPromptWhenOverPicking() != null)
+		{
+			builder.isShowConfirmationPromptWhenOverPick(from.getShowPromptWhenOverPicking());
+		}
+
 		return builder.build();
 	}
 

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigPickingCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigPickingCommand.java
@@ -147,10 +147,7 @@ class MobileConfigPickingCommand
 
 		builder.displayPickingSlotSuggestions(OptionalBoolean.ofNullableBoolean(from.getDisplayPickingSlotSuggestions()));
 
-		if (from.getShowPromptWhenOverPicking() != null)
-		{
-			builder.isShowConfirmationPromptWhenOverPick(from.getShowPromptWhenOverPicking());
-		}
+		builder.isShowConfirmationPromptWhenOverPick(from.getShowPromptWhenOverPicking() != null && from.getShowPromptWhenOverPicking());
 
 		return builder.build();
 	}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigPickingCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigPickingCommand.java
@@ -147,7 +147,7 @@ class MobileConfigPickingCommand
 
 		builder.displayPickingSlotSuggestions(OptionalBoolean.ofNullableBoolean(from.getDisplayPickingSlotSuggestions()));
 
-		builder.isShowConfirmationPromptWhenOverPick(from.getShowPromptWhenOverPicking() != null && from.getShowPromptWhenOverPicking());
+		builder.isShowConfirmationPromptWhenOverPick(Boolean.TRUE.equals(from.getShowPromptWhenOverPicking()));
 
 		return builder.build();
 	}

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
@@ -59,10 +59,9 @@ import de.metas.workflow.rest_api.model.WFProcess;
 import de.metas.workflow.rest_api.model.WFProcessId;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.util.Env;
-
-import java.math.BigDecimal;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -74,8 +73,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 import java.util.List;
 
+@Slf4j
 @RequestMapping(MetasfreshRestAPIConstants.ENDPOINT_API_V2 + "/picking")
 @RestController
 @Profile(Profiles.PROFILE_App)
@@ -261,17 +262,25 @@ public class PickingRestController
 				.qtyTUs(hu.getQtyTUs())
 				.huQRCode(hu.getQrCode());
 
-		// gh#29069: return product info for overdelivery detection
+		// Return product info for overdelivery detection (see PickLineScanScreen)
 		final String productNo = request.getProductNo();
-		if (productNo != null && hu.getProducts() != null)
+		if (productNo != null)
 		{
 			hu.getProducts().stream()
 					.filter(p -> productNo.equals(p.getProductValue()))
 					.findFirst()
-					.ifPresent(p -> builder
-							.productNo(p.getProductValue())
-							.productQty(new BigDecimal(p.getQty()))
-							.productUom(p.getUom()));
+					.ifPresent(p -> {
+						builder.productNo(p.getProductValue());
+						try
+						{
+							builder.productQty(new BigDecimal(p.getQty()));
+						}
+						catch (final NumberFormatException e)
+						{
+							log.warn("Cannot parse HU product qty '{}' for product {}. Overdelivery prompt will not fire.", p.getQty(), productNo, e);
+						}
+						builder.productUom(p.getUom());
+					});
 		}
 
 		return builder.build();

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
@@ -61,6 +61,8 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.util.Env;
+
+import java.math.BigDecimal;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -268,7 +270,7 @@ public class PickingRestController
 					.findFirst()
 					.ifPresent(p -> builder
 							.productNo(p.getProductValue())
-							.productQty(new java.math.BigDecimal(p.getQty()))
+							.productQty(new BigDecimal(p.getQty()))
 							.productUom(p.getUom()));
 		}
 

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
@@ -253,12 +253,26 @@ public class PickingRestController
 		}
 		final JsonHU hu = hus.get(0);
 
-		return JsonHUInfo.builder()
+		final JsonHUInfo.JsonHUInfoBuilder builder = JsonHUInfo.builder()
 				.id(hu.getId())
 				.unitType(hu.getUnitType())
 				.qtyTUs(hu.getQtyTUs())
-				.huQRCode(hu.getQrCode())
-				.build();
+				.huQRCode(hu.getQrCode());
+
+		// gh#29069: return product info for overdelivery detection
+		final String productNo = request.getProductNo();
+		if (productNo != null && hu.getProducts() != null)
+		{
+			hu.getProducts().stream()
+					.filter(p -> productNo.equals(p.getProductValue()))
+					.findFirst()
+					.ifPresent(p -> builder
+							.productNo(p.getProductValue())
+							.productQty(new java.math.BigDecimal(p.getQty()))
+							.productUom(p.getUom()));
+		}
+
+		return builder.build();
 	}
 
 	private HUQRCode toHUQRCode(final @NotNull ScannedCode scannedCode)

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonGetHUInfoByScannedCodeRequest.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonGetHUInfoByScannedCodeRequest.java
@@ -5,10 +5,13 @@ import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
+import javax.annotation.Nullable;
+
 @Value
 @Builder
 @Jacksonized
 public class JsonGetHUInfoByScannedCodeRequest
 {
 	@NonNull String scannedCode;
+	@Nullable String productNo;
 }

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonHUInfo.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonHUInfo.java
@@ -21,7 +21,7 @@ public class JsonHUInfo
 	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) Integer qtyTUs;
 	@Nullable JsonHUQRCode huQRCode;
 
-	// gh#29069: product info for overdelivery detection
+	// Product info for overdelivery detection (see PickLineScanScreen)
 	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) String productNo;
 	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) BigDecimal productQty;
 	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) String productUom;

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonHUInfo.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonHUInfo.java
@@ -9,6 +9,7 @@ import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 
 @Value
 @Builder
@@ -19,4 +20,9 @@ public class JsonHUInfo
 	@NonNull JsonHUType unitType;
 	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) Integer qtyTUs;
 	@Nullable JsonHUQRCode huQRCode;
+
+	// gh#29069: product info for overdelivery detection
+	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) String productNo;
+	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) BigDecimal productQty;
+	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) String productUom;
 }

--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
@@ -104,7 +104,7 @@ const createMasterdata_LU_CU = async ({ showPromptWhenOverPicking, orderQtyCUs =
             warehouses: { wh: {} },
             pickingSlots: { slot1: {} },
             products: {
-                P1: { price: 1 },
+                P1: { prices: [{ price: 1 }] },
             },
             packingInstructions: {
                 PI1: { tu: 'TU', product: 'P1', qtyCUsPerTU: 100, lu: 'LU', qtyTUsPerLU: 20 },
@@ -149,7 +149,7 @@ const startPickingJob_LU_CU = async (masterdata) => {
 // noinspection JSUnusedLocalSymbols
 test('LU/TU: over-pick TUs - prompt enabled - confirm Yes', async ({ page }) => {
     allure.epic('E0105: Picking');
-    allure.tag('F00230: MobileUI Picking');
+    allure.feature('F00230: MobileUI Picking');
     allure.tag('F00230');
     allure.story('Over-picking prompt - LU/TU mode, pick more TUs than ordered');
     allure.severity('critical');
@@ -190,7 +190,7 @@ test('LU/TU: over-pick TUs - prompt enabled - confirm Yes', async ({ page }) => 
 // noinspection JSUnusedLocalSymbols
 test('LU/TU: over-pick TUs - prompt enabled - decline', async ({ page }) => {
     allure.epic('E0105: Picking');
-    allure.tag('F00230: MobileUI Picking');
+    allure.feature('F00230: MobileUI Picking');
     allure.tag('F00230');
     allure.story('Over-picking prompt - LU/TU mode, decline overdelivery');
     allure.severity('normal');
@@ -231,7 +231,7 @@ test('LU/TU: over-pick TUs - prompt enabled - decline', async ({ page }) => {
 // noinspection JSUnusedLocalSymbols
 test('LU/TU: pick exact TU qty - prompt enabled - no prompt', async ({ page }) => {
     allure.epic('E0105: Picking');
-    allure.tag('F00230: MobileUI Picking');
+    allure.feature('F00230: MobileUI Picking');
     allure.tag('F00230');
     allure.story('Over-picking prompt - LU/TU mode, exact qty, no prompt fires');
     allure.severity('normal');
@@ -267,7 +267,7 @@ test('LU/TU: pick exact TU qty - prompt enabled - no prompt', async ({ page }) =
 // noinspection JSUnusedLocalSymbols
 test('LU/TU: prompt disabled - regression guard', async ({ page }) => {
     allure.epic('E0105: Picking');
-    allure.tag('F00230: MobileUI Picking');
+    allure.feature('F00230: MobileUI Picking');
     allure.tag('F00230');
     allure.story('Over-picking prompt - LU/TU mode, prompt disabled, pick exact qty');
     allure.severity('normal');
@@ -308,7 +308,7 @@ test('LU/TU: prompt disabled - regression guard', async ({ page }) => {
 // noinspection JSUnusedLocalSymbols
 test('LU/CU: over-pick CUs - prompt enabled - confirm Yes', async ({ page }) => {
     allure.epic('E0105: Picking');
-    allure.tag('F00230: MobileUI Picking');
+    allure.feature('F00230: MobileUI Picking');
     allure.tag('F00230');
     allure.story('Over-picking prompt - LU/CU mode, pick more CUs than ordered');
     allure.severity('critical');
@@ -349,7 +349,7 @@ test('LU/CU: over-pick CUs - prompt enabled - confirm Yes', async ({ page }) => 
 // noinspection JSUnusedLocalSymbols
 test('LU/CU: over-pick CUs - prompt enabled - decline', async ({ page }) => {
     allure.epic('E0105: Picking');
-    allure.tag('F00230: MobileUI Picking');
+    allure.feature('F00230: MobileUI Picking');
     allure.tag('F00230');
     allure.story('Over-picking prompt - LU/CU mode, decline overdelivery');
     allure.severity('normal');
@@ -390,7 +390,7 @@ test('LU/CU: over-pick CUs - prompt enabled - decline', async ({ page }) => {
 // noinspection JSUnusedLocalSymbols
 test('LU/CU: pick exact CU qty - prompt enabled - no prompt', async ({ page }) => {
     allure.epic('E0105: Picking');
-    allure.tag('F00230: MobileUI Picking');
+    allure.feature('F00230: MobileUI Picking');
     allure.tag('F00230');
     allure.story('Over-picking prompt - LU/CU mode, exact qty, no prompt fires');
     allure.severity('normal');
@@ -426,7 +426,7 @@ test('LU/CU: pick exact CU qty - prompt enabled - no prompt', async ({ page }) =
 // noinspection JSUnusedLocalSymbols
 test('LU/CU: prompt disabled - regression guard', async ({ page }) => {
     allure.epic('E0105: Picking');
-    allure.tag('F00230: MobileUI Picking');
+    allure.feature('F00230: MobileUI Picking');
     allure.tag('F00230');
     allure.story('Over-picking prompt - LU/CU mode, prompt disabled, pick exact qty');
     allure.severity('normal');

--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
@@ -14,15 +14,18 @@ import { BarcodeScannerComponent } from '../../utils/components/BarcodeScannerCo
  *
  * Tests for the overdelivery confirmation prompt in mobile UI picking.
  *
- * When IsShowConfirmationPromptWhenOverPick=Y, entering qty > remaining should show a
- * Yes/No confirmation dialog instead of hard-blocking. When the setting is N (default),
- * the existing qtyMax validation blocks quantities above remaining.
+ * When IsShowConfirmationPromptWhenOverPick=Y, entering qty > remaining should show
+ * a Yes/No confirmation dialog instead of hard-blocking.
+ * When the setting is N (default), the existing qtyMax validation blocks qty > remaining.
  *
- * Setup: LU/TU picking — order needs 2 TUs, LU has 20 TUs available.
- * The worker scans the LU and enters the number of TUs to pick.
+ * Covers multiple picking modes: LU/TU (TU picking), LU/CU (CU picking), CU (CU picking).
  */
 
-const createMasterdata = async ({ showPromptWhenOverPicking, orderQtyTUs = 2 }) => {
+//
+// ----- Masterdata helpers -----
+//
+
+const createMasterdata_LU_TU = async ({ showPromptWhenOverPicking, orderQtyTUs = 2 }) => {
     return await Backend.createMasterdata({
         language: 'en_US',
         request: {
@@ -42,9 +45,7 @@ const createMasterdata = async ({ showPromptWhenOverPicking, orderQtyTUs = 2 }) 
             bpartners: { BP1: {} },
             warehouses: { wh: {} },
             pickingSlots: { slot1: {} },
-            products: {
-                P1: { prices: [{ price: 1 }] },
-            },
+            products: { P1: { prices: [{ price: 1 }] } },
             packingInstructions: {
                 PI: { lu: 'LU', qtyTUsPerLU: 20, tu: 'TU', product: 'P1', qtyCUsPerTU: 100 },
             },
@@ -63,7 +64,46 @@ const createMasterdata = async ({ showPromptWhenOverPicking, orderQtyTUs = 2 }) 
     });
 };
 
-const startPickingJob = async (masterdata) => {
+const createMasterdata_LU_CU = async ({ showPromptWhenOverPicking, orderQtyCUs = 10 }) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: 'sales_order',
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_CU'],
+                    shipOnCloseLU: false,
+                    allowCompletingPartialPickingJob: true,
+                    showPromptWhenOverPicking,
+                },
+            },
+            bpartners: { BP1: {} },
+            warehouses: { wh: {} },
+            pickingSlots: { slot1: {} },
+            products: { P1: { price: 1 } },
+            packingInstructions: {
+                LU_CU: { cu: true, lu: 'LU', qtyTUsPerLU: 1 },
+            },
+            handlingUnits: {
+                HU1: { product: 'P1', warehouse: 'wh', qty: 1000, packingInstructions: 'LU_CU' },
+            },
+            salesOrders: {
+                SO1: {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: orderQtyCUs }],
+                },
+            },
+        },
+    });
+};
+
+const startPickingJob_LU_TU = async (masterdata) => {
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('picking');
@@ -74,77 +114,86 @@ const startPickingJob = async (masterdata) => {
     await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
 };
 
+const startPickingJob_LU_CU = async (masterdata) => {
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({
+        qrCode: masterdata.pickingSlots.slot1.qrCode,
+        expectNextScreen: 'PickLineScanScreen',
+        gotoPickingJobScreen: true,
+    });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.LU_CU.luName });
+};
+
+//
+// ----- LU/TU picking mode: scan LU, pick TUs -----
+//
+
 // noinspection JSUnusedLocalSymbols
-test('Over-pick TUs - prompt enabled - confirm Yes', async ({ page }) => {
+test('LU/TU: over-pick TUs - prompt enabled - confirm Yes', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
-    allure.story('Over-picking prompt - pick more TUs than ordered, confirm Yes');
+    allure.story('Over-picking prompt - LU/TU mode, pick more TUs than ordered');
     allure.severity('critical');
 
-    // Order needs 2 TUs, LU has 20 TUs
-    const masterdata = await createMasterdata({ showPromptWhenOverPicking: true, orderQtyTUs: 2 });
-    await startPickingJob(masterdata);
+    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyTUs: 2 });
+    await startPickingJob_LU_TU(masterdata);
 
-    await test.step('Scan LU, enter 5 TUs (more than ordered 2), confirm overdelivery', async () => {
+    await test.step('Scan LU, enter 5 TUs (more than 2 ordered), confirm overdelivery', async () => {
         await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.qrCode);
         await GetQuantityDialog.waitForDialog();
-
-        // Enter 5 TUs > 2 TUs remaining
         await GetQuantityDialog.typeQtyEntered(5);
         await GetQuantityDialog.clickDone();
 
-        // The overdelivery confirmation prompt should appear
         await YesNoDialog.waitForDialog();
         await YesNoDialog.clickYesButton();
 
-        // Pick should succeed
         await PickingJobScreen.waitForScreen();
     });
 });
 
 // noinspection JSUnusedLocalSymbols
-test('Over-pick TUs - prompt enabled - decline', async ({ page }) => {
+test('LU/TU: over-pick TUs - prompt enabled - decline', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
-    allure.story('Over-picking prompt - pick more TUs than ordered, decline');
+    allure.story('Over-picking prompt - LU/TU mode, decline overdelivery');
     allure.severity('normal');
 
-    // Order needs 2 TUs
-    const masterdata = await createMasterdata({ showPromptWhenOverPicking: true, orderQtyTUs: 2 });
-    await startPickingJob(masterdata);
+    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyTUs: 2 });
+    await startPickingJob_LU_TU(masterdata);
 
-    await test.step('Scan LU, enter 5 TUs, decline overdelivery', async () => {
+    await test.step('Scan LU, enter 5 TUs, decline overdelivery, cancel dialog', async () => {
         await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.qrCode);
         await GetQuantityDialog.waitForDialog();
-
         await GetQuantityDialog.typeQtyEntered(5);
         await GetQuantityDialog.clickDone();
 
-        // Decline the overdelivery
         await YesNoDialog.waitForDialog();
         await YesNoDialog.clickNoButton();
 
-        // Should return to the GetQuantityDialog
         await GetQuantityDialog.waitForDialog();
         await GetQuantityDialog.clickCancel();
     });
 });
 
 // noinspection JSUnusedLocalSymbols
-test('Pick exact TU qty - prompt enabled - no prompt', async ({ page }) => {
+test('LU/TU: pick exact TU qty - prompt enabled - no prompt', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
-    allure.story('Over-picking prompt - pick exact TU qty, no prompt');
+    allure.story('Over-picking prompt - LU/TU mode, exact qty, no prompt fires');
     allure.severity('normal');
 
-    // Order needs 2 TUs, pick exactly 2
-    const masterdata = await createMasterdata({ showPromptWhenOverPicking: true, orderQtyTUs: 2 });
-    await startPickingJob(masterdata);
+    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyTUs: 2 });
+    await startPickingJob_LU_TU(masterdata);
 
-    await test.step('Scan LU, pick exactly 2 TUs, no prompt should appear', async () => {
+    await test.step('Scan LU, pick exactly 2 TUs — no prompt should appear', async () => {
         await PickingJobScreen.pickHU({
             qrCode: masterdata.handlingUnits.HU1.qrCode,
             expectQtyEntered: 2,
@@ -154,23 +203,113 @@ test('Pick exact TU qty - prompt enabled - no prompt', async ({ page }) => {
 });
 
 // noinspection JSUnusedLocalSymbols
-test('Over-pick TUs - prompt DISABLED - hard validation blocks', async ({ page }) => {
+test('LU/TU: prompt disabled - regression guard', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
-    allure.story('Over-picking prompt - disabled, hard validation prevents over-entry');
+    allure.story('Over-picking prompt - LU/TU mode, prompt disabled, pick exact qty');
     allure.severity('normal');
 
-    // Order needs 2 TUs, prompt disabled
-    const masterdata = await createMasterdata({ showPromptWhenOverPicking: false, orderQtyTUs: 2 });
-    await startPickingJob(masterdata);
+    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: false, orderQtyTUs: 2 });
+    await startPickingJob_LU_TU(masterdata);
 
-    await test.step('Scan LU, pick exactly 2 TUs (cannot enter more, Done disabled)', async () => {
-        // When prompt is disabled, entering qty > remaining disables the Done button
-        // via qtyMax validation. So just pick the exact amount to verify regression.
+    await test.step('Prompt disabled — pick exact qty, verify existing behavior unchanged', async () => {
         await PickingJobScreen.pickHU({
             qrCode: masterdata.handlingUnits.HU1.qrCode,
             expectQtyEntered: 2,
+        });
+        await PickingJobScreen.waitForScreen();
+    });
+});
+
+//
+// ----- LU/CU picking mode: scan LU, pick CUs -----
+//
+
+// noinspection JSUnusedLocalSymbols
+test('LU/CU: over-pick CUs - prompt enabled - confirm Yes', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - LU/CU mode, pick more CUs than ordered');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata_LU_CU({ showPromptWhenOverPicking: true, orderQtyCUs: 10 });
+    await startPickingJob_LU_CU(masterdata);
+
+    await test.step('Scan LU, enter 25 CUs (more than 10 ordered), confirm overdelivery', async () => {
+        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
+        await GetQuantityDialog.waitForDialog();
+        await GetQuantityDialog.typeQtyEntered(25);
+        await GetQuantityDialog.clickDone();
+
+        await YesNoDialog.waitForDialog();
+        await YesNoDialog.clickYesButton();
+
+        await PickingJobScreen.waitForScreen();
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('LU/CU: over-pick CUs - prompt enabled - decline', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - LU/CU mode, decline overdelivery');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata_LU_CU({ showPromptWhenOverPicking: true, orderQtyCUs: 10 });
+    await startPickingJob_LU_CU(masterdata);
+
+    await test.step('Scan LU, enter 25 CUs, decline overdelivery, cancel dialog', async () => {
+        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
+        await GetQuantityDialog.waitForDialog();
+        await GetQuantityDialog.typeQtyEntered(25);
+        await GetQuantityDialog.clickDone();
+
+        await YesNoDialog.waitForDialog();
+        await YesNoDialog.clickNoButton();
+
+        await GetQuantityDialog.waitForDialog();
+        await GetQuantityDialog.clickCancel();
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('LU/CU: pick exact CU qty - prompt enabled - no prompt', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - LU/CU mode, exact qty, no prompt fires');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata_LU_CU({ showPromptWhenOverPicking: true, orderQtyCUs: 10 });
+    await startPickingJob_LU_CU(masterdata);
+
+    await test.step('Scan LU, pick exactly 10 CUs — no prompt should appear', async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.huId,
+            expectQtyEntered: 10,
+        });
+        await PickingJobScreen.waitForScreen();
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('LU/CU: prompt disabled - regression guard', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - LU/CU mode, prompt disabled, pick exact qty');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata_LU_CU({ showPromptWhenOverPicking: false, orderQtyCUs: 10 });
+    await startPickingJob_LU_CU(masterdata);
+
+    await test.step('Prompt disabled — pick exact qty, verify existing behavior unchanged', async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.huId,
+            expectQtyEntered: 10,
         });
         await PickingJobScreen.waitForScreen();
     });

--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
@@ -10,14 +10,19 @@ import { YesNoDialog } from '../../utils/dialogs/YesNoDialog';
 import { BarcodeScannerComponent } from '../../utils/components/BarcodeScannerComponent';
 
 /**
- * gh#29069: Tests for the overdelivery confirmation prompt in mobile UI picking.
+ * https://github.com/metasfresh/me03/issues/29069
+ *
+ * Tests for the overdelivery confirmation prompt in mobile UI picking.
  *
  * When IsShowConfirmationPromptWhenOverPick=Y, entering qty > remaining should show a
  * Yes/No confirmation dialog instead of hard-blocking. When the setting is N (default),
- * entering qty > remaining should show a validation error (existing behavior).
+ * the existing qtyMax validation blocks quantities above remaining.
+ *
+ * Setup: LU/TU picking — order needs 2 TUs, LU has 20 TUs available.
+ * The worker scans the LU and enters the number of TUs to pick.
  */
 
-const createMasterdata = async ({ showPromptWhenOverPicking }) => {
+const createMasterdata = async ({ showPromptWhenOverPicking, orderQtyTUs = 2 }) => {
     return await Backend.createMasterdata({
         language: 'en_US',
         request: {
@@ -51,7 +56,7 @@ const createMasterdata = async ({ showPromptWhenOverPicking }) => {
                     bpartner: 'BP1',
                     warehouse: 'wh',
                     datePromised: '2025-03-01T00:00:00.000+02:00',
-                    lines: [{ product: 'P1', qty: 10, piItemProduct: 'TU' }],
+                    lines: [{ product: 'P1', qty: orderQtyTUs, piItemProduct: 'TU' }],
                 },
             },
         },
@@ -70,80 +75,102 @@ const startPickingJob = async (masterdata) => {
 };
 
 // noinspection JSUnusedLocalSymbols
-test('CU manual entry - prompt enabled - confirm Yes', async ({ page }) => {
+test('Over-pick TUs - prompt enabled - confirm Yes', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
-    allure.story('Over-picking prompt - CU manual entry, confirm Yes');
+    allure.story('Over-picking prompt - pick more TUs than ordered, confirm Yes');
     allure.severity('critical');
 
-    const masterdata = await createMasterdata({ showPromptWhenOverPicking: true });
+    // Order needs 2 TUs, LU has 20 TUs
+    const masterdata = await createMasterdata({ showPromptWhenOverPicking: true, orderQtyTUs: 2 });
     await startPickingJob(masterdata);
 
-    await test.step('Pick with qty > remaining, confirm overdelivery', async () => {
-        // Scan the HU
+    await test.step('Scan LU, enter 5 TUs (more than ordered 2), confirm overdelivery', async () => {
         await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.qrCode);
         await GetQuantityDialog.waitForDialog();
 
-        // Enter qty > remaining (15 > 10)
-        await GetQuantityDialog.typeQtyEntered(15);
+        // Enter 5 TUs > 2 TUs remaining
+        await GetQuantityDialog.typeQtyEntered(5);
         await GetQuantityDialog.clickDone();
 
         // The overdelivery confirmation prompt should appear
         await YesNoDialog.waitForDialog();
         await YesNoDialog.clickYesButton();
 
-        // Pick should succeed — back to picking job screen
+        // Pick should succeed
         await PickingJobScreen.waitForScreen();
     });
 });
 
 // noinspection JSUnusedLocalSymbols
-test('CU manual entry - prompt enabled - decline', async ({ page }) => {
+test('Over-pick TUs - prompt enabled - decline', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
-    allure.story('Over-picking prompt - CU manual entry, decline');
+    allure.story('Over-picking prompt - pick more TUs than ordered, decline');
     allure.severity('normal');
 
-    const masterdata = await createMasterdata({ showPromptWhenOverPicking: true });
+    // Order needs 2 TUs
+    const masterdata = await createMasterdata({ showPromptWhenOverPicking: true, orderQtyTUs: 2 });
     await startPickingJob(masterdata);
 
-    await test.step('Pick with qty > remaining, decline, then cancel', async () => {
-        // Scan the HU
+    await test.step('Scan LU, enter 5 TUs, decline overdelivery', async () => {
         await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.qrCode);
         await GetQuantityDialog.waitForDialog();
 
-        // Enter qty > remaining (15 > 10)
-        await GetQuantityDialog.typeQtyEntered(15);
+        await GetQuantityDialog.typeQtyEntered(5);
         await GetQuantityDialog.clickDone();
 
         // Decline the overdelivery
         await YesNoDialog.waitForDialog();
         await YesNoDialog.clickNoButton();
 
-        // Should return to the GetQuantityDialog (not closed)
+        // Should return to the GetQuantityDialog
         await GetQuantityDialog.waitForDialog();
-
-        // Cancel the dialog to go back
         await GetQuantityDialog.clickCancel();
     });
 });
 
 // noinspection JSUnusedLocalSymbols
-test('CU manual entry - prompt enabled - qty equal to remaining - no prompt', async ({ page }) => {
+test('Pick exact TU qty - prompt enabled - no prompt', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
-    allure.story('Over-picking prompt - qty equal to remaining, no prompt');
+    allure.story('Over-picking prompt - pick exact TU qty, no prompt');
     allure.severity('normal');
 
-    const masterdata = await createMasterdata({ showPromptWhenOverPicking: true });
+    // Order needs 2 TUs, pick exactly 2
+    const masterdata = await createMasterdata({ showPromptWhenOverPicking: true, orderQtyTUs: 2 });
     await startPickingJob(masterdata);
 
-    await test.step('Pick with qty == remaining, no prompt should appear', async () => {
+    await test.step('Scan LU, pick exactly 2 TUs, no prompt should appear', async () => {
         await PickingJobScreen.pickHU({
             qrCode: masterdata.handlingUnits.HU1.qrCode,
+            expectQtyEntered: 2,
+        });
+        await PickingJobScreen.waitForScreen();
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Over-pick TUs - prompt DISABLED - hard validation blocks', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - disabled, hard validation prevents over-entry');
+    allure.severity('normal');
+
+    // Order needs 2 TUs, prompt disabled
+    const masterdata = await createMasterdata({ showPromptWhenOverPicking: false, orderQtyTUs: 2 });
+    await startPickingJob(masterdata);
+
+    await test.step('Scan LU, pick exactly 2 TUs (cannot enter more, Done disabled)', async () => {
+        // When prompt is disabled, entering qty > remaining disables the Done button
+        // via qtyMax validation. So just pick the exact amount to verify regression.
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.qrCode,
+            expectQtyEntered: 2,
         });
         await PickingJobScreen.waitForScreen();
     });

--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
@@ -28,7 +28,7 @@ const createMasterdata = async ({ showPromptWhenOverPicking }) => {
                     allowPickingAnyCustomer: true,
                     createShipmentPolicy: 'CL',
                     allowPickingAnyHU: true,
-                    pickTo: ['LU_TU', 'TU', 'LU_CU', 'CU'],
+                    pickTo: ['LU_TU'],
                     shipOnCloseLU: false,
                     allowCompletingPartialPickingJob: true,
                     showPromptWhenOverPicking,
@@ -38,20 +38,20 @@ const createMasterdata = async ({ showPromptWhenOverPicking }) => {
             warehouses: { wh: {} },
             pickingSlots: { slot1: {} },
             products: {
-                P1: { price: 1 },
+                P1: { prices: [{ price: 1 }] },
             },
             packingInstructions: {
-                LU_CU: { cu: true, lu: 'LU', qtyTUsPerLU: 1 },
+                PI: { lu: 'LU', qtyTUsPerLU: 20, tu: 'TU', product: 'P1', qtyCUsPerTU: 100 },
             },
             handlingUnits: {
-                HU1: { product: 'P1', warehouse: 'wh', qty: 100, packingInstructions: 'LU_CU' },
+                HU1: { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
             },
             salesOrders: {
                 SO1: {
                     bpartner: 'BP1',
                     warehouse: 'wh',
                     datePromised: '2025-03-01T00:00:00.000+02:00',
-                    lines: [{ product: 'P1', qty: 10 }],
+                    lines: [{ product: 'P1', qty: 10, piItemProduct: 'TU' }],
                 },
             },
         },
@@ -65,12 +65,8 @@ const startPickingJob = async (masterdata) => {
     await PickingJobsListScreen.waitForScreen();
     await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
     await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
-    await PickingJobScreen.scanPickingSlot({
-        qrCode: masterdata.pickingSlots.slot1.qrCode,
-        expectNextScreen: 'PickLineScanScreen',
-        gotoPickingJobScreen: true,
-    });
-    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.LU_CU.luName });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
 };
 
 // noinspection JSUnusedLocalSymbols
@@ -84,9 +80,9 @@ test('CU manual entry - prompt enabled - confirm Yes', async ({ page }) => {
     const masterdata = await createMasterdata({ showPromptWhenOverPicking: true });
     await startPickingJob(masterdata);
 
-    await test.step('Pick CU with qty > remaining, confirm overdelivery', async () => {
+    await test.step('Pick with qty > remaining, confirm overdelivery', async () => {
         // Scan the HU
-        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
+        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.qrCode);
         await GetQuantityDialog.waitForDialog();
 
         // Enter qty > remaining (15 > 10)
@@ -99,7 +95,6 @@ test('CU manual entry - prompt enabled - confirm Yes', async ({ page }) => {
 
         // Pick should succeed — back to picking job screen
         await PickingJobScreen.waitForScreen();
-        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '10 Stk', qtyPicked: '15 Stk', qtyPickedCatchWeight: '' });
     });
 });
 
@@ -114,9 +109,9 @@ test('CU manual entry - prompt enabled - decline', async ({ page }) => {
     const masterdata = await createMasterdata({ showPromptWhenOverPicking: true });
     await startPickingJob(masterdata);
 
-    await test.step('Pick CU with qty > remaining, decline, then cancel', async () => {
+    await test.step('Pick with qty > remaining, decline, then cancel', async () => {
         // Scan the HU
-        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
+        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.qrCode);
         await GetQuantityDialog.waitForDialog();
 
         // Enter qty > remaining (15 > 10)
@@ -136,32 +131,6 @@ test('CU manual entry - prompt enabled - decline', async ({ page }) => {
 });
 
 // noinspection JSUnusedLocalSymbols
-test('CU manual entry - prompt disabled - hard validation blocks', async ({ page }) => {
-    allure.epic('E0105: Picking');
-    allure.tag('F00230: MobileUI Picking');
-    allure.tag('F00230');
-    allure.story('Over-picking prompt - disabled, hard validation blocks');
-    allure.severity('normal');
-
-    const masterdata = await createMasterdata({ showPromptWhenOverPicking: false });
-    await startPickingJob(masterdata);
-
-    await test.step('Pick CU with qty > remaining, expect hard validation error', async () => {
-        // Scan the HU
-        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
-        await GetQuantityDialog.waitForDialog();
-
-        // Enter qty > remaining (15 > 10) — should show validation error, Done button stays enabled
-        // but the qty validation fires on submit
-        await GetQuantityDialog.typeQtyEntered(15);
-        await GetQuantityDialog.clickDone({ expectedError: '5' }); // expects error containing the diff (5 over)
-
-        // Should still be in the dialog (not navigated away)
-        await GetQuantityDialog.clickCancel();
-    });
-});
-
-// noinspection JSUnusedLocalSymbols
 test('CU manual entry - prompt enabled - qty equal to remaining - no prompt', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
@@ -172,11 +141,10 @@ test('CU manual entry - prompt enabled - qty equal to remaining - no prompt', as
     const masterdata = await createMasterdata({ showPromptWhenOverPicking: true });
     await startPickingJob(masterdata);
 
-    await test.step('Pick CU with qty == remaining, no prompt should appear', async () => {
+    await test.step('Pick with qty == remaining, no prompt should appear', async () => {
         await PickingJobScreen.pickHU({
-            qrCode: masterdata.handlingUnits.HU1.huId,
-            expectQtyEntered: 10,
+            qrCode: masterdata.handlingUnits.HU1.qrCode,
         });
-        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '10 Stk', qtyPicked: '10 Stk', qtyPickedCatchWeight: '' });
+        await PickingJobScreen.waitForScreen();
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
@@ -71,9 +71,10 @@ const startPickingJob_LU_TU = async (masterdata) => {
     await ApplicationsListScreen.startApplication('picking');
     await PickingJobsListScreen.waitForScreen();
     await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
-    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
     await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
     await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+    return { pickingJobId };
 };
 
 //
@@ -129,13 +130,14 @@ const startPickingJob_LU_CU = async (masterdata) => {
     await ApplicationsListScreen.startApplication('picking');
     await PickingJobsListScreen.waitForScreen();
     await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
-    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
     await PickingJobScreen.scanPickingSlot({
         qrCode: masterdata.pickingSlots.slot1.qrCode,
         expectNextScreen: 'PickLineScanScreen',
         gotoPickingJobScreen: true,
     });
     await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI1.luName });
+    return { pickingJobId };
 };
 
 //
@@ -152,7 +154,7 @@ test('LU/TU: over-pick TUs - prompt enabled - confirm Yes', async ({ page }) => 
     allure.severity('critical');
 
     const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyCUs: 12 });
-    await startPickingJob_LU_TU(masterdata);
+    const { pickingJobId } = await startPickingJob_LU_TU(masterdata);
 
     await test.step('Scan LU, enter 8 TUs (more than 3 needed), confirm overdelivery', async () => {
         await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.qrCode);
@@ -165,6 +167,19 @@ test('LU/TU: over-pick TUs - prompt enabled - confirm Yes', async ({ page }) => 
         await YesNoDialog.clickYesButton();
 
         await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '8 TU', qtyPickedCatchWeight: '' });
+
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: {
+                            qtyPicked: [{ qtyPicked: '32 PCE', qtyTUs: 8, qtyLUs: 1, processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+        });
     });
 });
 
@@ -248,7 +263,7 @@ test('LU/CU: over-pick CUs - prompt enabled - confirm Yes', async ({ page }) => 
     allure.severity('critical');
 
     const masterdata = await createMasterdata_LU_CU({ showPromptWhenOverPicking: true, orderQtyCUs: 10 });
-    await startPickingJob_LU_CU(masterdata);
+    const { pickingJobId } = await startPickingJob_LU_CU(masterdata);
 
     await test.step('Scan LU, enter 25 CUs (more than 10 ordered), confirm overdelivery', async () => {
         await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
@@ -261,6 +276,22 @@ test('LU/CU: over-pick CUs - prompt enabled - confirm Yes', async ({ page }) => 
         await YesNoDialog.clickYesButton();
 
         await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '10 Stk', qtyPicked: '25 Stk', qtyPickedCatchWeight: '' });
+
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: {
+                            qtyPicked: [{ qtyPicked: '25 PCE', processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+            hus: {
+                [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '975 PCE' } },
+            },
+        });
     });
 });
 

--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
@@ -24,6 +24,7 @@ import { BarcodeScannerComponent } from '../../utils/components/BarcodeScannerCo
 //
 // ----- LU/TU masterdata: 4 CUs per TU, 20 TUs per LU -----
 // Order qty is in CUs. qty=12 with 4 CUs/TU = 3 TUs to pick.
+// HU1 = LU with 20 TUs × 4 CUs = 80 CUs total.
 //
 
 const createMasterdata_LU_TU = async ({ showPromptWhenOverPicking, orderQtyCUs = 12 }) => {
@@ -142,7 +143,7 @@ const startPickingJob_LU_CU = async (masterdata) => {
 
 //
 // ===== LU/TU picking mode: scan LU, pick TUs =====
-// Order: 12 CUs = 3 TUs (4 CUs per TU). LU has 20 TUs.
+// Order: 12 CUs = 3 TUs (4 CUs per TU). LU has 20 TUs (80 CUs).
 //
 
 // noinspection JSUnusedLocalSymbols
@@ -174,10 +175,13 @@ test('LU/TU: over-pick TUs - prompt enabled - confirm Yes', async ({ page }) => 
                 [pickingJobId]: {
                     shipmentSchedules: {
                         P1: {
-                            qtyPicked: [{ qtyPicked: '32 PCE', qtyTUs: 8, qtyLUs: 1, processed: false, shipmentLineId: '-' }],
+                            qtyPicked: [{ qtyPicked: '32 PCE', qtyTUs: 8, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }],
                         },
                     },
                 },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '48 PCE' } },
             },
         });
     });
@@ -192,7 +196,7 @@ test('LU/TU: over-pick TUs - prompt enabled - decline', async ({ page }) => {
     allure.severity('normal');
 
     const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyCUs: 12 });
-    await startPickingJob_LU_TU(masterdata);
+    const { pickingJobId } = await startPickingJob_LU_TU(masterdata);
 
     await test.step('Scan LU, enter 8 TUs, decline overdelivery, cancel dialog', async () => {
         await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.qrCode);
@@ -207,6 +211,21 @@ test('LU/TU: over-pick TUs - prompt enabled - decline', async ({ page }) => {
         await GetQuantityDialog.waitForDialog();
         await GetQuantityDialog.clickCancel();
     });
+
+    await test.step('Verify nothing was picked', async () => {
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [] },
+                    },
+                },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '80 PCE' } },
+            },
+        });
+    });
 });
 
 // noinspection JSUnusedLocalSymbols
@@ -218,7 +237,7 @@ test('LU/TU: pick exact TU qty - prompt enabled - no prompt', async ({ page }) =
     allure.severity('normal');
 
     const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyCUs: 12 });
-    await startPickingJob_LU_TU(masterdata);
+    const { pickingJobId } = await startPickingJob_LU_TU(masterdata);
 
     await test.step('Scan LU, pick exactly 3 TUs — no prompt should appear', async () => {
         await PickingJobScreen.pickHU({
@@ -226,6 +245,22 @@ test('LU/TU: pick exact TU qty - prompt enabled - no prompt', async ({ page }) =
             expectQtyEntered: 3,
         });
         await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });
+
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: {
+                            qtyPicked: [{ qtyPicked: '12 PCE', qtyTUs: 3, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '68 PCE' } },
+            },
+        });
     });
 });
 
@@ -238,7 +273,7 @@ test('LU/TU: prompt disabled - regression guard', async ({ page }) => {
     allure.severity('normal');
 
     const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: false, orderQtyCUs: 12 });
-    await startPickingJob_LU_TU(masterdata);
+    const { pickingJobId } = await startPickingJob_LU_TU(masterdata);
 
     await test.step('Prompt disabled — pick exact qty, verify existing behavior unchanged', async () => {
         await PickingJobScreen.pickHU({
@@ -246,6 +281,22 @@ test('LU/TU: prompt disabled - regression guard', async ({ page }) => {
             expectQtyEntered: 3,
         });
         await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });
+
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: {
+                            qtyPicked: [{ qtyPicked: '12 PCE', qtyTUs: 3, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '68 PCE' } },
+            },
+        });
     });
 });
 
@@ -283,13 +334,13 @@ test('LU/CU: over-pick CUs - prompt enabled - confirm Yes', async ({ page }) => 
                 [pickingJobId]: {
                     shipmentSchedules: {
                         P1: {
-                            qtyPicked: [{ qtyPicked: '25 PCE', processed: false, shipmentLineId: '-' }],
+                            qtyPicked: [{ qtyPicked: '25 PCE', qtyTUs: 1, qtyLUs: 1, vhu: 'vhu1', tu: 'vhu1', lu: 'lu1', processed: false, shipmentLineId: '-' }],
                         },
                     },
                 },
             },
             hus: {
-                [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '975 PCE' } },
+                HU1: { huStatus: 'A', storages: { P1: '975 PCE' } },
             },
         });
     });
@@ -304,7 +355,7 @@ test('LU/CU: over-pick CUs - prompt enabled - decline', async ({ page }) => {
     allure.severity('normal');
 
     const masterdata = await createMasterdata_LU_CU({ showPromptWhenOverPicking: true, orderQtyCUs: 10 });
-    await startPickingJob_LU_CU(masterdata);
+    const { pickingJobId } = await startPickingJob_LU_CU(masterdata);
 
     await test.step('Scan LU, enter 25 CUs, decline overdelivery, cancel dialog', async () => {
         await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
@@ -319,6 +370,21 @@ test('LU/CU: over-pick CUs - prompt enabled - decline', async ({ page }) => {
         await GetQuantityDialog.waitForDialog();
         await GetQuantityDialog.clickCancel();
     });
+
+    await test.step('Verify nothing was picked', async () => {
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [] },
+                    },
+                },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '1000 PCE' } },
+            },
+        });
+    });
 });
 
 // noinspection JSUnusedLocalSymbols
@@ -330,7 +396,7 @@ test('LU/CU: pick exact CU qty - prompt enabled - no prompt', async ({ page }) =
     allure.severity('normal');
 
     const masterdata = await createMasterdata_LU_CU({ showPromptWhenOverPicking: true, orderQtyCUs: 10 });
-    await startPickingJob_LU_CU(masterdata);
+    const { pickingJobId } = await startPickingJob_LU_CU(masterdata);
 
     await test.step('Scan LU, pick exactly 10 CUs — no prompt should appear', async () => {
         await PickingJobScreen.pickHU({
@@ -338,6 +404,22 @@ test('LU/CU: pick exact CU qty - prompt enabled - no prompt', async ({ page }) =
             expectQtyEntered: 10,
         });
         await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '10 Stk', qtyPicked: '10 Stk', qtyPickedCatchWeight: '' });
+
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: {
+                            qtyPicked: [{ qtyPicked: '10 PCE', qtyTUs: 1, qtyLUs: 1, vhu: 'vhu1', tu: 'vhu1', lu: 'lu1', processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '990 PCE' } },
+            },
+        });
     });
 });
 
@@ -350,7 +432,7 @@ test('LU/CU: prompt disabled - regression guard', async ({ page }) => {
     allure.severity('normal');
 
     const masterdata = await createMasterdata_LU_CU({ showPromptWhenOverPicking: false, orderQtyCUs: 10 });
-    await startPickingJob_LU_CU(masterdata);
+    const { pickingJobId } = await startPickingJob_LU_CU(masterdata);
 
     await test.step('Prompt disabled — pick exact qty, verify existing behavior unchanged', async () => {
         await PickingJobScreen.pickHU({
@@ -358,5 +440,21 @@ test('LU/CU: prompt disabled - regression guard', async ({ page }) => {
             expectQtyEntered: 10,
         });
         await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '10 Stk', qtyPicked: '10 Stk', qtyPickedCatchWeight: '' });
+
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: {
+                            qtyPicked: [{ qtyPicked: '10 PCE', qtyTUs: 1, qtyLUs: 1, vhu: 'vhu1', tu: 'vhu1', lu: 'lu1', processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '990 PCE' } },
+            },
+        });
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
@@ -1,0 +1,182 @@
+import { test } from '../../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../../utils/screens/Backend';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { PickingJobsListScreen } from '../../utils/screens/picking/PickingJobsListScreen';
+import { PickingJobScreen } from '../../utils/screens/picking/PickingJobScreen';
+import { GetQuantityDialog } from '../../utils/screens/picking/GetQuantityDialog';
+import { YesNoDialog } from '../../utils/dialogs/YesNoDialog';
+import { BarcodeScannerComponent } from '../../utils/components/BarcodeScannerComponent';
+
+/**
+ * gh#29069: Tests for the overdelivery confirmation prompt in mobile UI picking.
+ *
+ * When IsShowConfirmationPromptWhenOverPick=Y, entering qty > remaining should show a
+ * Yes/No confirmation dialog instead of hard-blocking. When the setting is N (default),
+ * entering qty > remaining should show a validation error (existing behavior).
+ */
+
+const createMasterdata = async ({ showPromptWhenOverPicking }) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: 'sales_order',
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU', 'TU', 'LU_CU', 'CU'],
+                    shipOnCloseLU: false,
+                    allowCompletingPartialPickingJob: true,
+                    showPromptWhenOverPicking,
+                },
+            },
+            bpartners: { BP1: {} },
+            warehouses: { wh: {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                P1: { price: 1 },
+            },
+            packingInstructions: {
+                LU_CU: { cu: true, lu: 'LU', qtyTUsPerLU: 1 },
+            },
+            handlingUnits: {
+                HU1: { product: 'P1', warehouse: 'wh', qty: 100, packingInstructions: 'LU_CU' },
+            },
+            salesOrders: {
+                SO1: {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 10 }],
+                },
+            },
+        },
+    });
+};
+
+const startPickingJob = async (masterdata) => {
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({
+        qrCode: masterdata.pickingSlots.slot1.qrCode,
+        expectNextScreen: 'PickLineScanScreen',
+        gotoPickingJobScreen: true,
+    });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.LU_CU.luName });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('CU manual entry - prompt enabled - confirm Yes', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - CU manual entry, confirm Yes');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata({ showPromptWhenOverPicking: true });
+    await startPickingJob(masterdata);
+
+    await test.step('Pick CU with qty > remaining, confirm overdelivery', async () => {
+        // Scan the HU
+        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
+        await GetQuantityDialog.waitForDialog();
+
+        // Enter qty > remaining (15 > 10)
+        await GetQuantityDialog.typeQtyEntered(15);
+        await GetQuantityDialog.clickDone();
+
+        // The overdelivery confirmation prompt should appear
+        await YesNoDialog.waitForDialog();
+        await YesNoDialog.clickYesButton();
+
+        // Pick should succeed — back to picking job screen
+        await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '10 Stk', qtyPicked: '15 Stk', qtyPickedCatchWeight: '' });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('CU manual entry - prompt enabled - decline', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - CU manual entry, decline');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({ showPromptWhenOverPicking: true });
+    await startPickingJob(masterdata);
+
+    await test.step('Pick CU with qty > remaining, decline, then cancel', async () => {
+        // Scan the HU
+        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
+        await GetQuantityDialog.waitForDialog();
+
+        // Enter qty > remaining (15 > 10)
+        await GetQuantityDialog.typeQtyEntered(15);
+        await GetQuantityDialog.clickDone();
+
+        // Decline the overdelivery
+        await YesNoDialog.waitForDialog();
+        await YesNoDialog.clickNoButton();
+
+        // Should return to the GetQuantityDialog (not closed)
+        await GetQuantityDialog.waitForDialog();
+
+        // Cancel the dialog to go back
+        await GetQuantityDialog.clickCancel();
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('CU manual entry - prompt disabled - hard validation blocks', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - disabled, hard validation blocks');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({ showPromptWhenOverPicking: false });
+    await startPickingJob(masterdata);
+
+    await test.step('Pick CU with qty > remaining, expect hard validation error', async () => {
+        // Scan the HU
+        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
+        await GetQuantityDialog.waitForDialog();
+
+        // Enter qty > remaining (15 > 10) — should show validation error, Done button stays enabled
+        // but the qty validation fires on submit
+        await GetQuantityDialog.typeQtyEntered(15);
+        await GetQuantityDialog.clickDone({ expectedError: '5' }); // expects error containing the diff (5 over)
+
+        // Should still be in the dialog (not navigated away)
+        await GetQuantityDialog.clickCancel();
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('CU manual entry - prompt enabled - qty equal to remaining - no prompt', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - qty equal to remaining, no prompt');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({ showPromptWhenOverPicking: true });
+    await startPickingJob(masterdata);
+
+    await test.step('Pick CU with qty == remaining, no prompt should appear', async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.huId,
+            expectQtyEntered: 10,
+        });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '10 Stk', qtyPicked: '10 Stk', qtyPickedCatchWeight: '' });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
@@ -18,14 +18,15 @@ import { BarcodeScannerComponent } from '../../utils/components/BarcodeScannerCo
  * a Yes/No confirmation dialog instead of hard-blocking.
  * When the setting is N (default), the existing qtyMax validation blocks qty > remaining.
  *
- * Covers multiple picking modes: LU/TU (TU picking), LU/CU (CU picking), CU (CU picking).
+ * Covers LU/TU picking (scan LU, pick TUs) and LU/CU picking (scan LU, pick CUs).
  */
 
 //
-// ----- Masterdata helpers -----
+// ----- LU/TU masterdata: 4 CUs per TU, 20 TUs per LU -----
+// Order qty is in CUs. qty=12 with 4 CUs/TU = 3 TUs to pick.
 //
 
-const createMasterdata_LU_TU = async ({ showPromptWhenOverPicking, orderQtyTUs = 2 }) => {
+const createMasterdata_LU_TU = async ({ showPromptWhenOverPicking, orderQtyCUs = 12 }) => {
     return await Backend.createMasterdata({
         language: 'en_US',
         request: {
@@ -47,7 +48,7 @@ const createMasterdata_LU_TU = async ({ showPromptWhenOverPicking, orderQtyTUs =
             pickingSlots: { slot1: {} },
             products: { P1: { prices: [{ price: 1 }] } },
             packingInstructions: {
-                PI: { lu: 'LU', qtyTUsPerLU: 20, tu: 'TU', product: 'P1', qtyCUsPerTU: 100 },
+                PI: { lu: 'LU', qtyTUsPerLU: 20, tu: 'TU', product: 'P1', qtyCUsPerTU: 4 },
             },
             handlingUnits: {
                 HU1: { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
@@ -57,46 +58,7 @@ const createMasterdata_LU_TU = async ({ showPromptWhenOverPicking, orderQtyTUs =
                     bpartner: 'BP1',
                     warehouse: 'wh',
                     datePromised: '2025-03-01T00:00:00.000+02:00',
-                    lines: [{ product: 'P1', qty: orderQtyTUs, piItemProduct: 'TU' }],
-                },
-            },
-        },
-    });
-};
-
-const createMasterdata_LU_CU = async ({ showPromptWhenOverPicking, orderQtyCUs = 10 }) => {
-    return await Backend.createMasterdata({
-        language: 'en_US',
-        request: {
-            login: { user: { language: 'en_US' } },
-            mobileConfig: {
-                picking: {
-                    aggregationType: 'sales_order',
-                    allowPickingAnyCustomer: true,
-                    createShipmentPolicy: 'CL',
-                    allowPickingAnyHU: true,
-                    pickTo: ['LU_CU'],
-                    shipOnCloseLU: false,
-                    allowCompletingPartialPickingJob: true,
-                    showPromptWhenOverPicking,
-                },
-            },
-            bpartners: { BP1: {} },
-            warehouses: { wh: {} },
-            pickingSlots: { slot1: {} },
-            products: { P1: { price: 1 } },
-            packingInstructions: {
-                LU_CU: { cu: true, lu: 'LU', qtyTUsPerLU: 1 },
-            },
-            handlingUnits: {
-                HU1: { product: 'P1', warehouse: 'wh', qty: 1000, packingInstructions: 'LU_CU' },
-            },
-            salesOrders: {
-                SO1: {
-                    bpartner: 'BP1',
-                    warehouse: 'wh',
-                    datePromised: '2025-03-01T00:00:00.000+02:00',
-                    lines: [{ product: 'P1', qty: orderQtyCUs }],
+                    lines: [{ product: 'P1', qty: orderQtyCUs, piItemProduct: 'TU' }],
                 },
             },
         },
@@ -114,6 +76,53 @@ const startPickingJob_LU_TU = async (masterdata) => {
     await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
 };
 
+//
+// ----- LU/CU masterdata: CU packing, LU with 1000 CUs -----
+// Order qty is in CUs. qty=10, HU has 1000.
+//
+
+const createMasterdata_LU_CU = async ({ showPromptWhenOverPicking, orderQtyCUs = 10 }) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: 'sales_order',
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU', 'TU', 'LU_CU', 'CU'],
+                    shipOnCloseLU: false,
+                    allowCompletingPartialPickingJob: true,
+                    showPromptWhenOverPicking,
+                },
+            },
+            bpartners: { BP1: {} },
+            warehouses: { wh: {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                P1: { price: 1 },
+            },
+            packingInstructions: {
+                PI1: { tu: 'TU', product: 'P1', qtyCUsPerTU: 100, lu: 'LU', qtyTUsPerLU: 20 },
+                LU_CU: { cu: true, lu: 'LU', qtyTUsPerLU: 1 },
+            },
+            handlingUnits: {
+                HU1: { product: 'P1', warehouse: 'wh', qty: 1000, packingInstructions: 'LU_CU' },
+            },
+            salesOrders: {
+                SO1: {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: orderQtyCUs }],
+                },
+            },
+        },
+    });
+};
+
 const startPickingJob_LU_CU = async (masterdata) => {
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
@@ -126,11 +135,12 @@ const startPickingJob_LU_CU = async (masterdata) => {
         expectNextScreen: 'PickLineScanScreen',
         gotoPickingJobScreen: true,
     });
-    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.LU_CU.luName });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI1.luName });
 };
 
 //
-// ----- LU/TU picking mode: scan LU, pick TUs -----
+// ===== LU/TU picking mode: scan LU, pick TUs =====
+// Order: 12 CUs = 3 TUs (4 CUs per TU). LU has 20 TUs.
 //
 
 // noinspection JSUnusedLocalSymbols
@@ -141,13 +151,14 @@ test('LU/TU: over-pick TUs - prompt enabled - confirm Yes', async ({ page }) => 
     allure.story('Over-picking prompt - LU/TU mode, pick more TUs than ordered');
     allure.severity('critical');
 
-    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyTUs: 2 });
+    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyCUs: 12 });
     await startPickingJob_LU_TU(masterdata);
 
-    await test.step('Scan LU, enter 5 TUs (more than 2 ordered), confirm overdelivery', async () => {
+    await test.step('Scan LU, enter 8 TUs (more than 3 needed), confirm overdelivery', async () => {
         await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.qrCode);
         await GetQuantityDialog.waitForDialog();
-        await GetQuantityDialog.typeQtyEntered(5);
+        await GetQuantityDialog.expectQtyEntered(3); // UI suggests 3 TUs (12 CUs / 4 per TU)
+        await GetQuantityDialog.typeQtyEntered(8);
         await GetQuantityDialog.clickDone();
 
         await YesNoDialog.waitForDialog();
@@ -165,13 +176,14 @@ test('LU/TU: over-pick TUs - prompt enabled - decline', async ({ page }) => {
     allure.story('Over-picking prompt - LU/TU mode, decline overdelivery');
     allure.severity('normal');
 
-    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyTUs: 2 });
+    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyCUs: 12 });
     await startPickingJob_LU_TU(masterdata);
 
-    await test.step('Scan LU, enter 5 TUs, decline overdelivery, cancel dialog', async () => {
+    await test.step('Scan LU, enter 8 TUs, decline overdelivery, cancel dialog', async () => {
         await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.qrCode);
         await GetQuantityDialog.waitForDialog();
-        await GetQuantityDialog.typeQtyEntered(5);
+        await GetQuantityDialog.expectQtyEntered(3);
+        await GetQuantityDialog.typeQtyEntered(8);
         await GetQuantityDialog.clickDone();
 
         await YesNoDialog.waitForDialog();
@@ -190,13 +202,13 @@ test('LU/TU: pick exact TU qty - prompt enabled - no prompt', async ({ page }) =
     allure.story('Over-picking prompt - LU/TU mode, exact qty, no prompt fires');
     allure.severity('normal');
 
-    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyTUs: 2 });
+    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyCUs: 12 });
     await startPickingJob_LU_TU(masterdata);
 
-    await test.step('Scan LU, pick exactly 2 TUs — no prompt should appear', async () => {
+    await test.step('Scan LU, pick exactly 3 TUs — no prompt should appear', async () => {
         await PickingJobScreen.pickHU({
             qrCode: masterdata.handlingUnits.HU1.qrCode,
-            expectQtyEntered: 2,
+            expectQtyEntered: 3,
         });
         await PickingJobScreen.waitForScreen();
     });
@@ -210,20 +222,21 @@ test('LU/TU: prompt disabled - regression guard', async ({ page }) => {
     allure.story('Over-picking prompt - LU/TU mode, prompt disabled, pick exact qty');
     allure.severity('normal');
 
-    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: false, orderQtyTUs: 2 });
+    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: false, orderQtyCUs: 12 });
     await startPickingJob_LU_TU(masterdata);
 
     await test.step('Prompt disabled — pick exact qty, verify existing behavior unchanged', async () => {
         await PickingJobScreen.pickHU({
             qrCode: masterdata.handlingUnits.HU1.qrCode,
-            expectQtyEntered: 2,
+            expectQtyEntered: 3,
         });
         await PickingJobScreen.waitForScreen();
     });
 });
 
 //
-// ----- LU/CU picking mode: scan LU, pick CUs -----
+// ===== LU/CU picking mode: scan LU, pick CUs =====
+// Order: 10 CUs. HU has 1000 CUs.
 //
 
 // noinspection JSUnusedLocalSymbols
@@ -240,6 +253,7 @@ test('LU/CU: over-pick CUs - prompt enabled - confirm Yes', async ({ page }) => 
     await test.step('Scan LU, enter 25 CUs (more than 10 ordered), confirm overdelivery', async () => {
         await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
         await GetQuantityDialog.waitForDialog();
+        await GetQuantityDialog.expectQtyEntered(10); // UI suggests 10 CUs (remaining)
         await GetQuantityDialog.typeQtyEntered(25);
         await GetQuantityDialog.clickDone();
 
@@ -264,6 +278,7 @@ test('LU/CU: over-pick CUs - prompt enabled - decline', async ({ page }) => {
     await test.step('Scan LU, enter 25 CUs, decline overdelivery, cancel dialog', async () => {
         await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
         await GetQuantityDialog.waitForDialog();
+        await GetQuantityDialog.expectQtyEntered(10);
         await GetQuantityDialog.typeQtyEntered(25);
         await GetQuantityDialog.clickDone();
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/picking.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/picking.js
@@ -152,12 +152,10 @@ export const getClosedLUs = ({ wfProcessId, lineId }) => {
     .then((response) => unboxAxiosResponse(response));
 };
 
-export const getScannedHUQRCodeInfo = ({ qrCode, productNo = null }) => {
-  const body = { scannedCode: qrCode };
-  if (productNo) {
-    body.productNo = productNo;
-  }
-  return axios.post(`${apiBasePath}/picking/hu/byScannedCode`, body).then((response) => unboxAxiosResponse(response));
+export const getScannedHUQRCodeInfo = ({ qrCode, productNo }) => {
+  return axios
+    .post(`${apiBasePath}/picking/hu/byScannedCode`, { scannedCode: qrCode, productNo })
+    .then((response) => unboxAxiosResponse(response));
 };
 
 export const getNextEligibleLineToPack = ({ wfProcessId, huScannedCode, excludeLineId }) => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/picking.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/picking.js
@@ -152,10 +152,12 @@ export const getClosedLUs = ({ wfProcessId, lineId }) => {
     .then((response) => unboxAxiosResponse(response));
 };
 
-export const getScannedHUQRCodeInfo = ({ qrCode }) => {
-  return axios
-    .post(`${apiBasePath}/picking/hu/byScannedCode`, { scannedCode: qrCode })
-    .then((response) => unboxAxiosResponse(response));
+export const getScannedHUQRCodeInfo = ({ qrCode, productNo = null }) => {
+  const body = { scannedCode: qrCode };
+  if (productNo) {
+    body.productNo = productNo;
+  }
+  return axios.post(`${apiBasePath}/picking/hu/byScannedCode`, body).then((response) => unboxAxiosResponse(response));
 };
 
 export const getNextEligibleLineToPack = ({ wfProcessId, huScannedCode, excludeLineId }) => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
@@ -175,7 +175,9 @@ const ScanHUAndGetQtyComponent = ({
     }
 
     // Qty shall be less than or equal to qtyMax
-    if (resolvedBarcodeData.qtyMax && resolvedBarcodeData.qtyMax > 0) {
+    // NOTE: skip qtyMax validation when over-pick confirmation prompt is enabled,
+    // because the prompt handles the over-delivery scenario instead (gh#29069)
+    if (!getConfirmationPromptForQty && resolvedBarcodeData.qtyMax && resolvedBarcodeData.qtyMax > 0) {
       const { qtyEffective: diff, uomEffective: diffUom } = formatQtyToHumanReadable({
         qty: qtyEntered - resolvedBarcodeData.qtyMax,
         uom,

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
@@ -176,7 +176,7 @@ const ScanHUAndGetQtyComponent = ({
 
     // Qty shall be less than or equal to qtyMax
     // NOTE: skip qtyMax validation when over-pick confirmation prompt is enabled,
-    // because the prompt handles the over-delivery scenario instead (gh#29069)
+    // because the prompt handles the over-delivery scenario instead
     if (!getConfirmationPromptForQty && resolvedBarcodeData.qtyMax && resolvedBarcodeData.qtyMax > 0) {
       const { qtyEffective: diff, uomEffective: diffUom } = formatQtyToHumanReadable({
         qty: qtyEntered - resolvedBarcodeData.qtyMax,

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickLineScanScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickLineScanScreen.jsx
@@ -93,10 +93,12 @@ const PickLineScanScreen = () => {
       convertScannedBarcodeToResolvedResult({
         scannedBarcode,
         expectedProductId: productId,
+        expectedProductNo: productNo,
+        isShowPromptWhenOverPicking,
         customQRCodeFormats,
         pickingUnit,
       }),
-    [productId, customQRCodeFormats, pickingUnit]
+    [productId, productNo, isShowPromptWhenOverPicking, customQRCodeFormats, pickingUnit]
   );
 
   const onClose = useOnClose({ applicationId, wfProcessId, activity, lineId, next });
@@ -189,6 +191,8 @@ const getPropsFromState = ({ state, wfProcessId, activityId, lineId }) => {
 export const convertScannedBarcodeToResolvedResult = async ({
   scannedBarcode,
   expectedProductId,
+  expectedProductNo,
+  isShowPromptWhenOverPicking,
   customQRCodeFormats,
   pickingUnit,
 }) => {
@@ -225,7 +229,13 @@ export const convertScannedBarcodeToResolvedResult = async ({
     throw trl('activities.picking.notEligibleHUBarcode');
   }
 
-  return convertQRCodeObjectToResolvedResult({ parsedQRCode, pickingUnit, huInfoFromBackend });
+  return convertQRCodeObjectToResolvedResult({
+    parsedQRCode,
+    pickingUnit,
+    huInfoFromBackend,
+    expectedProductNo,
+    isShowPromptWhenOverPicking,
+  });
 };
 
 //
@@ -234,7 +244,13 @@ export const convertScannedBarcodeToResolvedResult = async ({
 //
 //
 
-const convertQRCodeObjectToResolvedResult = async ({ parsedQRCode, pickingUnit, huInfoFromBackend }) => {
+const convertQRCodeObjectToResolvedResult = async ({
+  parsedQRCode,
+  pickingUnit,
+  huInfoFromBackend,
+  expectedProductNo,
+  isShowPromptWhenOverPicking,
+}) => {
   const result = {
     qrCode: parsedQRCode,
   };
@@ -254,6 +270,8 @@ const convertQRCodeObjectToResolvedResult = async ({ parsedQRCode, pickingUnit, 
   result.scannedHU = {
     huUnitType: parsedQRCode.huUnitType,
   };
+
+  // Existing behavior: fetch HU info for LU in TU-picking (qtyTUs)
   if (parsedQRCode.huUnitType === 'LU' && pickingUnit === PICKING_UNIT_TU) {
     let huInfo = huInfoFromBackend;
     if (huInfo == null) {
@@ -266,6 +284,23 @@ const convertQRCodeObjectToResolvedResult = async ({ parsedQRCode, pickingUnit, 
     }
     if (huInfo != null) {
       result.scannedHU.qtyTUs = huInfo.qtyTUs;
+    }
+  }
+
+  // gh#29069: For whole-TU picks with overdelivery prompt enabled,
+  // fetch actual product qty from backend so the prompt can detect overdelivery.
+  // The backend picks the full HU storage qty when isPickWholeTU=true,
+  // so we need the actual qty to compare against remaining.
+  if (parsedQRCode.isTUToBePickedAsWhole === true && isShowPromptWhenOverPicking) {
+    try {
+      const huInfo =
+        huInfoFromBackend ??
+        (await getScannedHUQRCodeInfo({ qrCode: toQRCodeString(parsedQRCode), productNo: expectedProductNo }));
+      if (huInfo?.productQty != null) {
+        result.qtyInitial = parseFloat(huInfo.productQty);
+      }
+    } catch (error) {
+      console.warn('Failed to get HU product qty for overdelivery check. Ignored', error);
     }
   }
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickLineScanScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickLineScanScreen.jsx
@@ -287,7 +287,7 @@ const convertQRCodeObjectToResolvedResult = async ({
     }
   }
 
-  // gh#29069: For whole-TU picks with overdelivery prompt enabled,
+  // For whole-TU picks with overdelivery prompt enabled,
   // fetch actual product qty from backend so the prompt can detect overdelivery.
   // The backend picks the full HU storage qty when isPickWholeTU=true,
   // so we need the actual qty to compare against remaining.
@@ -304,7 +304,7 @@ const convertQRCodeObjectToResolvedResult = async ({
     }
   }
 
-  console.log('convertQRCodeObjectToResolvedResult', { result, qrCodeObj: parsedQRCode, pickingUnit });
+  // console.log('convertQRCodeObjectToResolvedResult', { result, qrCodeObj: parsedQRCode, pickingUnit });
   return result;
 };
 


### PR DESCRIPTION
## Summary
- The overdelivery confirmation prompt (`IsShowConfirmationPromptWhenOverPick`) was broken since its introduction — the hard `qtyMax` validation in `ScanHUAndGetQtyComponent` blocked quantities above remaining, preventing the prompt from ever being reached
- **Fix 1**: Skip `qtyMax` validation when the over-pick confirmation prompt is enabled — the prompt itself handles overdelivery
- **Fix 2**: For whole-TU picks (`isTUToBePickedAsWhole`), fetch actual HU product qty from backend via extended `/hu/byScannedCode` endpoint, gated on `isShowPromptWhenOverPicking` being enabled
- Adds `showPromptWhenOverPicking` to the test masterdata API and regression Playwright tests

## Test plan
- [ ] Existing `pick_by_HUId.spec.js` test passes (prompt disabled = no behavior change)
- [ ] New `overPickingPrompt.spec.js` tests pass (4 scenarios: CU manual+prompt confirm, CU manual+prompt decline, prompt disabled hard validation, qty=remaining no prompt)
- [ ] All mobile Playwright tests pass in CI
- [ ] Backend compilation green