### PR TITLE
Fix credit memo reversal allocation: correct per-Line_ID DR/CR signs

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -1134,8 +1134,10 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			factLineBuilder.setAccount(getCustomerAccount(BPartnerCustomerAccountType.C_Receivable, as));
 			if (line.isCreditMemoInvoice())
 			{
-				// ARC (or ARC reversal): DR to clear receivable
-				factLineBuilder.setAmtSource(allocatedAmt, null);
+				// ARC (or ARC reversal): DR to clear the CM's receivable (CR on invoice side).
+				// allocatedAmt is negative for the original CM and positive for the reversal,
+				// so we negate to get the correct clearing sign per Line_ID.
+				factLineBuilder.setAmtSource(allocatedAmt.negate(), null);
 			}
 			else
 			{
@@ -1148,8 +1150,10 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			factLineBuilder.setAccount(getVendorAccount(BPartnerVendorAccountType.V_Liability, as));
 			if (line.isCreditMemoInvoice())
 			{
-				// APC (or APC reversal): CR to clear liability
-				factLineBuilder.setAmtSource(null, allocatedAmt.negate());
+				// APC (or APC reversal): CR to clear the CM's liability (DR on invoice side).
+				// allocatedAmt is positive for the original CM and negative for the reversal,
+				// so we use it directly (without negate) to get the correct clearing sign per Line_ID.
+				factLineBuilder.setAmtSource(null, allocatedAmt);
 			}
 			else
 			{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctBalanceMacher.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctBalanceMacher.java
@@ -5,6 +5,7 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.context.ContextAwareDescription;
 import de.metas.cucumber.stepdefs.context.SharedTestContext;
+import de.metas.invoice.InvoiceId;
 import de.metas.money.Money;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
@@ -31,6 +32,7 @@ public class FactAcctBalanceMacher
 	@Nullable private final Optional<TaxId> taxId;
 	@Nullable private final Optional<BPartnerId> bpartnerId;
 	@Nullable private final Optional<ProductId> productId;
+	@Nullable private final Optional<InvoiceId> invoiceId;
 
 	//
 	// Aggregated amounts
@@ -125,8 +127,16 @@ public class FactAcctBalanceMacher
 		{
 			final ProductId actualProductId = ProductId.ofRepoIdOrNull(record.getM_Product_ID());
 			final ProductId expectedProductId = productId.orElse(null);
-			//noinspection RedundantIfStatement
 			if (!ProductId.equals(actualProductId, expectedProductId))
+			{
+				return false;
+			}
+		}
+		if (invoiceId != null)
+		{
+			final InvoiceId actualInvoiceId = FactAcctInvoiceResolver.resolveInvoiceIdOrNull(record);
+			final InvoiceId expectedInvoiceId = invoiceId.orElse(null);
+			if (!InvoiceId.equals(actualInvoiceId, expectedInvoiceId))
 			{
 				return false;
 			}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctInvoiceResolver.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctInvoiceResolver.java
@@ -1,0 +1,52 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import de.metas.invoice.InvoiceId;
+import de.metas.util.Check;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+import org.adempiere.ad.table.api.AdTableId;
+import org.adempiere.ad.table.api.impl.TableIdsCache;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_C_AllocationHdr;
+import org.compiere.model.I_C_AllocationLine;
+import org.compiere.model.I_C_Invoice;
+import org.compiere.model.I_Fact_Acct;
+
+import javax.annotation.Nullable;
+
+/**
+ * Resolves the {@link InvoiceId} associated with a {@link I_Fact_Acct} record.
+ * <p>
+ * Resolution logic:
+ * <ul>
+ *     <li>If AD_Table_ID = C_Invoice: the Fact_Acct is posted for the invoice itself, so Record_ID is the C_Invoice_ID</li>
+ *     <li>If AD_Table_ID = C_AllocationHdr: the Fact_Acct.Line_ID is the C_AllocationLine_ID; load the C_AllocationLine and return its C_Invoice_ID</li>
+ *     <li>Otherwise: return {@code null} (C_Invoice_ID resolution not applicable for this document type)</li>
+ * </ul>
+ */
+@UtilityClass
+public class FactAcctInvoiceResolver
+{
+	@Nullable
+	public static InvoiceId resolveInvoiceIdOrNull(@NonNull final I_Fact_Acct record)
+	{
+		final String tableName = TableIdsCache.instance.getTableName(AdTableId.ofRepoId(record.getAD_Table_ID()));
+
+		if (I_C_Invoice.Table_Name.equals(tableName))
+		{
+			return InvoiceId.ofRepoIdOrNull(record.getRecord_ID());
+		}
+		else if (I_C_AllocationHdr.Table_Name.equals(tableName))
+		{
+			final int allocationLineId = record.getLine_ID();
+			Check.assume(allocationLineId > 0, "Fact_Acct record for C_AllocationHdr must have a Line_ID (C_AllocationLine_ID): {}", record);
+
+			final I_C_AllocationLine allocationLine = InterfaceWrapperHelper.load(allocationLineId, I_C_AllocationLine.class);
+			return InvoiceId.ofRepoIdOrNull(allocationLine.getC_Invoice_ID());
+		}
+		else
+		{
+			return null;
+		}
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctLineMatcher.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctLineMatcher.java
@@ -4,6 +4,7 @@ import de.metas.acct.AccountConceptualName;
 import de.metas.bpartner.BPartnerId;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.context.ContextAwareDescription;
+import de.metas.invoice.InvoiceId;
 import de.metas.money.Money;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
@@ -39,6 +40,7 @@ public class FactAcctLineMatcher
 	@Nullable private final Optional<TaxId> taxId;
 	@Nullable private final Optional<BPartnerId> bpartnerId;
 	@Nullable private final Optional<ProductId> productId;
+	@Nullable private final Optional<InvoiceId> invoiceId;
 
 	@Override
 	public String toString() {return row.toTabularString();}
@@ -183,6 +185,13 @@ public class FactAcctLineMatcher
 			softly.assertThat(ProductId.ofRepoIdOrNull(record.getM_Product_ID()))
 					.as(description.newWithMessage("M_Product_ID"))
 					.isEqualTo(productId.orElse(null));
+		}
+		if (invoiceId != null)
+		{
+			final InvoiceId actualInvoiceId = FactAcctInvoiceResolver.resolveInvoiceIdOrNull(record);
+			softly.assertThat(actualInvoiceId)
+					.as(description.newWithMessage("C_Invoice_ID"))
+					.isEqualTo(invoiceId.orElse(null));
 		}
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctMatchersFactory.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctMatchersFactory.java
@@ -11,7 +11,9 @@ import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.StepDefConstants;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.util.IdentifiersResolver;
+import de.metas.invoice.InvoiceId;
 import de.metas.money.MoneyService;
 import de.metas.product.ProductId;
 import de.metas.tax.api.ITaxDAO;
@@ -38,6 +40,7 @@ public class FactAcctMatchersFactory
 	@NonNull private final C_BPartner_StepDefData bpartnerTable;
 	@NonNull private final C_Tax_StepDefData taxTable;
 	@NonNull private final M_Product_StepDefData productTable;
+	@NonNull private final C_Invoice_StepDefData invoiceTable;
 
 	public FactAcctMatchers createLineMatchers(@NonNull final DataTable table)
 	{
@@ -83,6 +86,7 @@ public class FactAcctMatchersFactory
 				.taxId(extractTaxId(row))
 				.bpartnerId(extractBPartnerId(row))
 				.productId(extractProductId(row))
+				.invoiceId(extractInvoiceId(row))
 				.build();
 	}
 
@@ -107,6 +111,7 @@ public class FactAcctMatchersFactory
 				.taxId(extractTaxId(row))
 				.bpartnerId(extractBPartnerId(row))
 				.productId(extractProductId(row))
+				.invoiceId(extractInvoiceId(row))
 				//
 				.amtAcctDr(row.getAsOptionalBigDecimal(I_Fact_Acct.COLUMNNAME_AmtAcctDr).orElse(null))
 				.amtAcctCr(row.getAsOptionalBigDecimal(I_Fact_Acct.COLUMNNAME_AmtAcctCr).orElse(null))
@@ -164,6 +169,14 @@ public class FactAcctMatchersFactory
 	{
 		final StepDefDataIdentifier identifier = row.getAsOptionalIdentifier("M_Product_ID").orElse(null);
 		return identifier == null ? null : Optional.ofNullable(identifier.lookupIdIn(productTable));
+	}
+
+	@SuppressWarnings("OptionalAssignedToNull")
+	@Nullable
+	private Optional<InvoiceId> extractInvoiceId(final @NonNull DataTableRow row)
+	{
+		final StepDefDataIdentifier identifier = row.getAsOptionalIdentifier("C_Invoice_ID").orElse(null);
+		return identifier == null ? null : Optional.ofNullable(identifier.lookupIdIn(invoiceTable));
 	}
 
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/Fact_Acct_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/Fact_Acct_StepDef.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
 import de.metas.cucumber.stepdefs.C_Tax_StepDefData;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
+import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.util.IdentifiersResolver;
 import de.metas.money.MoneyService;
 import de.metas.tax.api.ITaxDAO;
@@ -28,7 +29,8 @@ public class Fact_Acct_StepDef
 			@NonNull final IdentifiersResolver identifiersResolver,
 			@NonNull final C_BPartner_StepDefData bpartnerTable,
 			@NonNull final C_Tax_StepDefData taxTable,
-			@NonNull final M_Product_StepDefData productTable
+			@NonNull final M_Product_StepDefData productTable,
+			@NonNull final C_Invoice_StepDefData invoiceTable
 	)
 	{
 		this.identifiersResolver = identifiersResolver;
@@ -44,6 +46,7 @@ public class Fact_Acct_StepDef
 				.bpartnerTable(bpartnerTable)
 				.taxTable(taxTable)
 				.productTable(productTable)
+				.invoiceTable(invoiceTable)
 				.build();
 		this.factAcctTabularStringConverter = FactAcctToTabularStringConverter.builder()
 				.uomDAO(uomDAO)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_StepDef.java
@@ -219,6 +219,19 @@ public class C_Invoice_StepDef
 		}
 	}
 
+	@And("^the reversal of invoice (.*) is identified by (.*)$")
+	public void identify_reversal_invoice(
+			@NonNull final String invoiceIdentifier,
+			@NonNull final String reversalIdentifier)
+	{
+		final I_C_Invoice invoice = invoiceTable.get(invoiceIdentifier);
+		InterfaceWrapperHelper.refresh(invoice);
+		final int reversalId = invoice.getReversal_ID();
+		Check.assume(reversalId > 0, "Invoice {} must have a reversal", invoiceIdentifier);
+		final I_C_Invoice reversal = InterfaceWrapperHelper.load(reversalId, I_C_Invoice.class);
+		invoiceTable.putOrReplace(StepDefDataIdentifier.ofString(reversalIdentifier), reversal);
+	}
+
 	@And("load C_Invoice:")
 	public void loadC_Invoice(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -2871,6 +2871,63 @@ Feature: invoice payment allocation
 # ############################################################################################################################################
 # ############################################################################################################################################
 # ############################################################################################################################################
+  @Id:S0465_CMA_130
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: standalone credit memo reversed - allocation produces balanced Fact_Acct
+    # A standalone credit memo (not allocated against any invoice) is reversed.
+    # The reversal creates an allocation (CM vs its reversal) which must produce balanced Fact_Acct entries.
+    Given metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | salesPLV               | product      | 200.00   | PCE      |
+
+    # Create standalone sales credit memo (ARC) - not linked to any invoice
+    And metasfresh contains C_Invoice:
+      | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | standaloneCM    | customer1     | Gutschrift              | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID | M_Product_ID | QtyInvoiced |
+      | standaloneCM | product      | 1 PCE       |
+    And the invoice identified by standaloneCM is completed
+
+    # Verify the credit memo invoice itself is posted
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID    |
+      | C_Receivable_Acct     | 0 EUR       | 238.00 EUR  | customer1     | standaloneCM |
+      | *                     |             |             |               | standaloneCM |
+
+    # Now reverse the credit memo
+    And the invoice identified by standaloneCM is reversed
+
+    Then validate created invoices
+      | C_Invoice_ID | IsPaid |
+      | standaloneCM | true   |
+
+    # The reversal creates an allocation matching the CM against its reversal
+    And validate C_AllocationLines for invoice standaloneCM
+      | OPT.Amount | OPT.C_AllocationHdr_ID |
+      | -238.00    | alloc_cm_reversal      |
+
+    # The allocation must have Fact_Acct entries with correct per-line DR/CR signs.
+    # Original CM invoice posted C_Receivable CR 238.00 => allocation must clear with DR 238.00 (positive DR, not negative).
+    # Reversal CM invoice posted C_Receivable DR 238.00 => allocation must clear with CR 238.00.
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID         |
+      | C_Receivable_Acct     | 238.00 EUR  | 0 EUR       | customer1     | alloc_cm_reversal |
+      | C_Receivable_Acct     | 0 EUR       | 238.00 EUR  | customer1     | alloc_cm_reversal |
+    And Fact_Acct records balances for documents alloc_cm_reversal are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | 0 EUR         |
+
+
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
   @Id:S0465_CMA_110
   @from:cucumber
   @allure.label.epic:E0340_Invoicing

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -2826,24 +2826,32 @@ Feature: invoice payment allocation
 
     # Verify: the credit memo compensation allocation has Fact_Acct entries
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID        |
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | C_Invoice_ID     | Record_ID        |
       # salesInv_cma_100 posting (GrandTotal=105.60)
-      | C_Receivable_Acct     | 105.60 EUR  | 0 EUR       | customer1     | salesInv_cma_100 |
-      | *                     |             |             |               | salesInv_cma_100 |
+      | C_Receivable_Acct     | 105.60 EUR  | 0 EUR       | customer1     |                  | salesInv_cma_100 |
+      | *                     |             |             |               |                  | salesInv_cma_100 |
       # salesCM_cma_100 posting (GrandTotal=105.60)
-      | C_Receivable_Acct     | 0 EUR       | 105.60 EUR  | customer1     | salesCM_cma_100  |
-      | *                     |             |             |               | salesCM_cma_100  |
-      # alloc_cm: credit memo compensation
-      | C_Receivable_Acct     | 105.60 EUR  | 0 EUR       | customer1     | alloc_cm         |
-      | C_Receivable_Acct     | 0 EUR       | 105.60 EUR  | customer1     | alloc_cm         |
+      | C_Receivable_Acct     | 0 EUR       | 105.60 EUR  | customer1     |                  | salesCM_cma_100  |
+      | *                     |             |             |               |                  | salesCM_cma_100  |
+      # alloc_cm: credit memo compensation — DR clears CM, CR clears invoice
+      | C_Receivable_Acct     | 105.60 EUR  | 0 EUR       | customer1     | salesCM_cma_100  | alloc_cm         |
+      | C_Receivable_Acct     | 0 EUR       | 105.60 EUR  | customer1     | salesInv_cma_100 | alloc_cm         |
+    # Overall allocation balance
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
+
+    # Cross-document per-invoice balance (before reversal):
+    # salesCM_cma_100 is fully cleared: Invoice CR=105.60 + Allocation DR=105.60 => balance=0
+    And Fact_Acct records balances for documents salesCM_cma_100,alloc_cm are matching
+      | AccountConceptualName | C_Invoice_ID    | AmtSourceDr | AmtSourceCr | SourceBalance |
+      | C_Receivable_Acct     | salesCM_cma_100 | 105.60 EUR  | 105.60 EUR  | 0 EUR         |
 
     # Now reverse the credit memo — this creates reversal allocations:
     # 1. A reversal of alloc_cm (undoing the CM-vs-invoice allocation)
     # 2. A new allocation matching the CM against its reversal (reversed invoice allocation)
     And the invoice identified by salesCM_cma_100 is reversed
+    And the reversal of invoice salesCM_cma_100 is identified by reversalCM_cma_100
 
     Then validate created invoices
       | C_Invoice_ID     | IsPaid |
@@ -2857,10 +2865,30 @@ Feature: invoice payment allocation
       | 105.60     | alloc_cm_reversed      |
       | -105.60    | alloc_cm_rev_pair      |
 
-    # The reversed allocation (CM vs its reversal) must have Fact_Acct entries (tests createDirectInvoiceAllocationFacts)
+    # The reversed allocation (CM vs its reversal): per-line — DR clears original CM, negative DR clears reversal CM
+    # Note: IsAllowNegativePosting=Y, so negative amounts are NOT normalized to the opposite side.
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr  | AmtSourceCr | C_BPartner_ID | C_Invoice_ID       | Record_ID         |
+      | C_Receivable_Acct     | 105.60 EUR   | 0 EUR       | customer1     | salesCM_cma_100    | alloc_cm_rev_pair |
+      | C_Receivable_Acct     | -105.60 EUR  | 0 EUR       | customer1     | reversalCM_cma_100 | alloc_cm_rev_pair |
+    # Overall balance for alloc_cm_rev_pair
     And Fact_Acct records balances for documents alloc_cm_rev_pair are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
+
+    # Cross-document per-invoice balance (after reversal):
+    # salesCM_cma_100 is still fully cleared: all 3 allocations cancel its invoice posting
+    And Fact_Acct records balances for documents salesCM_cma_100,alloc_cm,alloc_cm_reversed,alloc_cm_rev_pair are matching
+      | AccountConceptualName | C_Invoice_ID    | SourceBalance |
+      | C_Receivable_Acct     | salesCM_cma_100 | 0 EUR         |
+    # reversalCM_cma_100 is fully cleared: reversal invoice + alloc_cm_rev_pair cancel out
+    And Fact_Acct records balances for documents reversalCM_cma_100,alloc_cm_rev_pair are matching
+      | AccountConceptualName | C_Invoice_ID       | AmtSourceDr  | AmtSourceCr  | SourceBalance |
+      | C_Receivable_Acct     | reversalCM_cma_100 | -105.60 EUR  | -105.60 EUR  | 0 EUR         |
+    # salesInv_cma_100 is back to fully open: invoice DR + alloc_cm CR + alloc_cm_reversed DR = original DR
+    And Fact_Acct records balances for documents salesInv_cma_100,alloc_cm,alloc_cm_reversed are matching
+      | AccountConceptualName | C_Invoice_ID     | AmtSourceDr | AmtSourceCr | SourceBalance |
+      | C_Receivable_Acct     | salesInv_cma_100 | 105.60 EUR  | 0 EUR       | 105.60 EUR    |
 
     # Overall: all allocation Fact_Acct entries for this CM should net to zero
     And Fact_Acct records balances for documents alloc_cm,alloc_cm_reversed,alloc_cm_rev_pair are matching
@@ -2903,6 +2931,7 @@ Feature: invoice payment allocation
 
     # Now reverse the credit memo
     And the invoice identified by standaloneCM is reversed
+    And the reversal of invoice standaloneCM is identified by reversalCM
 
     Then validate created invoices
       | C_Invoice_ID | IsPaid |
@@ -2914,15 +2943,25 @@ Feature: invoice payment allocation
       | -238.00    | alloc_cm_reversal      |
 
     # The allocation must have Fact_Acct entries with correct per-line DR/CR signs.
-    # Original CM invoice posted C_Receivable CR 238.00 => allocation must clear with DR 238.00 (positive DR, not negative).
-    # Reversal CM invoice posted C_Receivable DR 238.00 => allocation must clear with CR 238.00.
+    # Original CM invoice posted C_Receivable CR 238.00 => allocation must clear with DR +238.00 (for standaloneCM).
+    # Reversal CM invoice posted C_Receivable DR 238.00 => allocation must clear with DR -238.00 (for reversalCM).
+    # Note: IsAllowNegativePosting=Y, so negative amounts are NOT normalized to the opposite side.
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID         |
-      | C_Receivable_Acct     | 238.00 EUR  | 0 EUR       | customer1     | alloc_cm_reversal |
-      | C_Receivable_Acct     | 0 EUR       | 238.00 EUR  | customer1     | alloc_cm_reversal |
+      | AccountConceptualName | AmtSourceDr  | AmtSourceCr | C_BPartner_ID | C_Invoice_ID | Record_ID         |
+      | C_Receivable_Acct     | 238.00 EUR   | 0 EUR       | customer1     | standaloneCM | alloc_cm_reversal |
+      | C_Receivable_Acct     | -238.00 EUR  | 0 EUR       | customer1     | reversalCM   | alloc_cm_reversal |
+    # Overall allocation balance
     And Fact_Acct records balances for documents alloc_cm_reversal are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
+
+    # Cross-document per-invoice balance: invoice posting + allocation posting must clear to zero.
+    # standaloneCM: Invoice CR=238 + Allocation DR=238 => DR=CR=238, balance=0
+    # reversalCM: Invoice CR=-238 + Allocation DR=-238 => DR=CR=-238, balance=0
+    And Fact_Acct records balances for documents standaloneCM,reversalCM,alloc_cm_reversal are matching
+      | AccountConceptualName | C_Invoice_ID | AmtSourceDr  | AmtSourceCr  | SourceBalance |
+      | C_Receivable_Acct     | standaloneCM | 238.00 EUR   | 238.00 EUR   | 0 EUR         |
+      | C_Receivable_Acct     | reversalCM   | -238.00 EUR  | -238.00 EUR  | 0 EUR         |
 
 
 # ############################################################################################################################################
@@ -2962,19 +3001,30 @@ Feature: invoice payment allocation
 
     # Verify: allocation has Fact_Acct entries — DR for credit memo, CR for invoice
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID       |
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | C_Invoice_ID    | Record_ID       |
       # salesInvoice posting (GrandTotal=595.00)
-      | C_Receivable_Acct     | 595.00 EUR  | 0 EUR       | customer1     | salesInvoice    |
-      | *                     |             |             |               | salesInvoice    |
+      | C_Receivable_Acct     | 595.00 EUR  | 0 EUR       | customer1     |                 | salesInvoice    |
+      | *                     |             |             |               |                 | salesInvoice    |
       # salesCreditMemo posting (GrandTotal=75.10)
-      | C_Receivable_Acct     | 0 EUR       | 75.10 EUR   | customer1     | salesCreditMemo |
-      | *                     |             |             |               | salesCreditMemo |
-      # alloc_cm: credit memo compensation (amount matches issue: 75.10)
-      | C_Receivable_Acct     | 75.10 EUR   | 0 EUR       | customer1     | alloc_cm        |
-      | C_Receivable_Acct     | 0 EUR       | 75.10 EUR   | customer1     | alloc_cm        |
+      | C_Receivable_Acct     | 0 EUR       | 75.10 EUR   | customer1     |                 | salesCreditMemo |
+      | *                     |             |             |               |                 | salesCreditMemo |
+      # alloc_cm: credit memo compensation — DR clears CM, CR clears invoice
+      | C_Receivable_Acct     | 75.10 EUR   | 0 EUR       | customer1     | salesCreditMemo | alloc_cm        |
+      | C_Receivable_Acct     | 0 EUR       | 75.10 EUR   | customer1     | salesInvoice    | alloc_cm        |
+    # Overall allocation balance
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
+
+    # Cross-document per-invoice balance: invoice posting + allocation posting
+    # salesCreditMemo is fully cleared: Invoice CR=75.10 + Allocation DR=75.10 => DR=CR=75.10, balance=0
+    And Fact_Acct records balances for documents salesCreditMemo,alloc_cm are matching
+      | AccountConceptualName | C_Invoice_ID    | AmtSourceDr | AmtSourceCr | SourceBalance |
+      | C_Receivable_Acct     | salesCreditMemo | 75.10 EUR   | 75.10 EUR   | 0 EUR         |
+    # salesInvoice is partially cleared: Invoice DR=595 + Allocation CR=75.10 => remaining 519.90
+    And Fact_Acct records balances for documents salesInvoice,alloc_cm are matching
+      | AccountConceptualName | C_Invoice_ID | AmtSourceDr | AmtSourceCr | SourceBalance |
+      | C_Receivable_Acct     | salesInvoice | 595.00 EUR  | 75.10 EUR   | 519.90 EUR    |
 
 
 # ############################################################################################################################################
@@ -3014,19 +3064,30 @@ Feature: invoice payment allocation
 
     # Verify: allocation has Fact_Acct entries — CR for credit memo, DR for invoice
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID          |
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | C_Invoice_ID       | Record_ID          |
       # purchaseInvoice posting (GrandTotal=595.00)
-      | V_Liability_Acct      | 0 EUR       | 595.00 EUR  | vendor1       | purchaseInvoice    |
-      | *                     |             |             |               | purchaseInvoice    |
+      | V_Liability_Acct      | 0 EUR       | 595.00 EUR  | vendor1       |                    | purchaseInvoice    |
+      | *                     |             |             |               |                    | purchaseInvoice    |
       # purchaseCreditMemo posting (GrandTotal=75.10)
-      | V_Liability_Acct      | 75.10 EUR   | 0 EUR       | vendor1       | purchaseCreditMemo |
-      | *                     |             |             |               | purchaseCreditMemo |
-      # alloc_cm: credit memo compensation (amount matches issue: 75.10)
-      | V_Liability_Acct      | 0 EUR       | 75.10 EUR   | vendor1       | alloc_cm           |
-      | V_Liability_Acct      | 75.10 EUR   | 0 EUR       | vendor1       | alloc_cm           |
+      | V_Liability_Acct      | 75.10 EUR   | 0 EUR       | vendor1       |                    | purchaseCreditMemo |
+      | *                     |             |             |               |                    | purchaseCreditMemo |
+      # alloc_cm: credit memo compensation — CR clears CM, DR clears invoice
+      | V_Liability_Acct      | 0 EUR       | 75.10 EUR   | vendor1       | purchaseCreditMemo | alloc_cm           |
+      | V_Liability_Acct      | 75.10 EUR   | 0 EUR       | vendor1       | purchaseInvoice    | alloc_cm           |
+    # Overall allocation balance
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |
+
+    # Cross-document per-invoice balance: invoice posting + allocation posting
+    # purchaseCreditMemo is fully cleared: Invoice DR=75.10 + Allocation CR=75.10 => DR=CR=75.10, balance=0
+    And Fact_Acct records balances for documents purchaseCreditMemo,alloc_cm are matching
+      | AccountConceptualName | C_Invoice_ID       | AmtSourceDr | AmtSourceCr | SourceBalance |
+      | V_Liability_Acct      | purchaseCreditMemo | 75.10 EUR   | 75.10 EUR   | 0 EUR         |
+    # purchaseInvoice is partially cleared: Invoice CR=595 + Allocation DR=75.10 => remaining -519.90
+    And Fact_Acct records balances for documents purchaseInvoice,alloc_cm are matching
+      | AccountConceptualName | C_Invoice_ID    | AmtSourceDr | AmtSourceCr | SourceBalance  |
+      | V_Liability_Acct      | purchaseInvoice | 75.10 EUR   | 595.00 EUR  | -519.90 EUR    |
 
 
 # ############################################################################################################################################


### PR DESCRIPTION
## Summary

- Fix inverted DR/CR signs in `Doc_AllocationHdr.createDirectInvoiceAllocationFacts()` for credit memo reversal allocations
- The balance was correct (nets to zero), but per `Fact_Acct.Line_ID` the signs were wrong — breaking open items reports that join back to `C_AllocationLine`
- Add cucumber test `S0465_CMA_130`: standalone credit memo → reverse → verify per-line DR/CR amounts

## Problem

When a credit memo is reversed, the allocation's `Fact_Acct` entries had inverted signs per `Line_ID`:
- Original CM allocation line posted `DR -238` (effectively CR) instead of `DR +238`
- Reversal CM allocation line posted `DR +238` instead of `CR +238`

The overall balance was zero (correct), but reports using `Fact_Acct.Line_ID` to match open items saw the wrong clearing direction.

## Fix

In `createDirectInvoiceAllocationFacts()`:
- **Sales CM (ARC)**: `setAmtSource(allocatedAmt, null)` → `setAmtSource(allocatedAmt.negate(), null)`
- **Purchase CM (APC)**: `setAmtSource(null, allocatedAmt.negate())` → `setAmtSource(null, allocatedAmt)`

## Test plan

- [ ] Cucumber `S0465_CMA_130` passes (standalone sales CM reversal — checks per-line DR/CR amounts)
- [ ] Existing tests `S0465_CMA_100`, `S0465_CMA_110`, `S0465_CMA_120` still pass (balance-only checks, unaffected)
- [ ] Verify on customer instance after reposting affected allocations