### PR TITLE
Improve overPickingPrompt E2E test assertions

### DIFF
--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
@@ -210,6 +210,8 @@ test('LU/TU: over-pick TUs - prompt enabled - decline', async ({ page }) => {
 
         await GetQuantityDialog.waitForDialog();
         await GetQuantityDialog.clickCancel();
+
+        await PickingJobScreen.waitForScreen();
     });
 
     await test.step('Verify nothing was picked', async () => {
@@ -269,11 +271,23 @@ test('LU/TU: prompt disabled - regression guard', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.feature('F00230: MobileUI Picking');
     allure.tag('F00230');
-    allure.story('Over-picking prompt - LU/TU mode, prompt disabled, pick exact qty');
+    allure.story('Over-picking prompt - LU/TU mode, prompt disabled, over-entry blocked + exact qty pick');
     allure.severity('normal');
 
     const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: false, orderQtyCUs: 12 });
     const { pickingJobId } = await startPickingJob_LU_TU(masterdata);
+
+    await test.step('Prompt disabled — enter qty > remaining, Done button blocked, no prompt', async () => {
+        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.qrCode);
+        await GetQuantityDialog.waitForDialog();
+        await GetQuantityDialog.expectQtyEntered(3);
+        await GetQuantityDialog.typeQtyEntered(8);
+        await GetQuantityDialog.expectDoneDisabled();
+        await GetQuantityDialog.expectQtyValidationError('above max');
+        await GetQuantityDialog.clickCancel();
+
+        await PickingJobScreen.waitForScreen();
+    });
 
     await test.step('Prompt disabled — pick exact qty, verify existing behavior unchanged', async () => {
         await PickingJobScreen.pickHU({
@@ -369,6 +383,8 @@ test('LU/CU: over-pick CUs - prompt enabled - decline', async ({ page }) => {
 
         await GetQuantityDialog.waitForDialog();
         await GetQuantityDialog.clickCancel();
+
+        await PickingJobScreen.waitForScreen();
     });
 
     await test.step('Verify nothing was picked', async () => {
@@ -428,11 +444,23 @@ test('LU/CU: prompt disabled - regression guard', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.feature('F00230: MobileUI Picking');
     allure.tag('F00230');
-    allure.story('Over-picking prompt - LU/CU mode, prompt disabled, pick exact qty');
+    allure.story('Over-picking prompt - LU/CU mode, prompt disabled, over-entry blocked + exact qty pick');
     allure.severity('normal');
 
     const masterdata = await createMasterdata_LU_CU({ showPromptWhenOverPicking: false, orderQtyCUs: 10 });
     const { pickingJobId } = await startPickingJob_LU_CU(masterdata);
+
+    await test.step('Prompt disabled — enter qty > remaining, Done button blocked, no prompt', async () => {
+        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
+        await GetQuantityDialog.waitForDialog();
+        await GetQuantityDialog.expectQtyEntered(10);
+        await GetQuantityDialog.typeQtyEntered(25);
+        await GetQuantityDialog.expectDoneDisabled();
+        await GetQuantityDialog.expectQtyValidationError('above max');
+        await GetQuantityDialog.clickCancel();
+
+        await PickingJobScreen.waitForScreen();
+    });
 
     await test.step('Prompt disabled — pick exact qty, verify existing behavior unchanged', async () => {
         await PickingJobScreen.pickHU({

--- a/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
@@ -13,7 +13,7 @@ export const QTY_NOT_FOUND_REASON_IGNORE = 'IgnoreReason';
 
 export const GetQuantityDialog = {
     waitForDialog: async () => await test.step(`${NAME} - Wait for dialog`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     waitToClose: async () => await test.step(`${NAME} - Wait to close`, async () => {
@@ -93,8 +93,7 @@ export const GetQuantityDialog = {
     }),
 
     expectQtyValidationError: async (expectedText) => await test.step(`${NAME} - Expect qty validation error '${expectedText}'`, async () => {
-        const errorMessage = page.locator('#qty-input').locator('..').locator('..').locator('p.help.is-danger');
-        await expect(errorMessage).toContainText(expectedText);
+        await expect(page.getByTestId('qty-validation-error')).toContainText(expectedText);
     }),
 
     clickDone: async ({ expectedError } = {}) => await test.step(`${NAME} - Press OK`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
@@ -84,6 +84,19 @@ export const GetQuantityDialog = {
         await expect(radioButton).toBeChecked();
     }),
 
+    expectDoneDisabled: async () => await test.step(`${NAME} - Expect Done button disabled`, async () => {
+        await expect(page.getByTestId('done-button')).toBeDisabled();
+    }),
+
+    expectDoneEnabled: async () => await test.step(`${NAME} - Expect Done button enabled`, async () => {
+        await expect(page.getByTestId('done-button')).toBeEnabled();
+    }),
+
+    expectQtyValidationError: async (expectedText) => await test.step(`${NAME} - Expect qty validation error '${expectedText}'`, async () => {
+        const errorMessage = page.locator('#qty-input').locator('..').locator('..').locator('p.help.is-danger');
+        await expect(errorMessage).toContainText(expectedText);
+    }),
+
     clickDone: async ({ expectedError } = {}) => await test.step(`${NAME} - Press OK`, async () => {
         let doneButton = page.getByTestId('done-button');
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/QtyInputField.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/QtyInputField.jsx
@@ -88,7 +88,9 @@ const QtyInputField = ({
         />
         {uom && <span className="icon is-small is-right">{uom}</span>}
       </div>
-      <p className="help is-danger">{qtyInfo.notValidMessage}&nbsp;</p>
+      <p data-testid="qty-validation-error" className="help is-danger">
+        {qtyInfo.notValidMessage}&nbsp;
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- **Decline tests**: Assert navigation to PickingJobScreen after declining overdelivery prompt and canceling the dialog (both LU/TU and LU/CU modes)
- **Prompt-disabled regression tests**: Add over-entry blocked assertions — verify Done button is disabled, validation error message shown, and no YesNoDialog appears when entering qty > remaining with prompt disabled
- **GetQuantityDialog screen object**: Add `expectDoneDisabled`, `expectDoneEnabled`, `expectQtyValidationError` helper methods

Follow-up to https://github.com/metasfresh/metasfresh/pull/23307

## Test plan
- [x] All 8 overPickingPrompt tests pass locally (58.8s, Playwright against mf-docker stack build 5.175.3-intensive-care-hotfix.32879)
- [x] CI green