### PR TITLE
Use schema defaults for missing bank accounts

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc.java
@@ -959,7 +959,19 @@ public abstract class Doc<DocLineType extends DocLine<?>>
 		final BankAccountId bpBankAccountId = getBPBankAccountId();
 		if (bpBankAccountId == null)
 		{
-			throw newPostingException().setDetailMessage("No Bank Statement set");
+			// Fallback to account from accounting schema default accounts
+			if (acctType == BankAccountAcctType.RealizedGain_Acct)
+			{
+				return acctSchema.getDefaultAccounts().getRealizedGainAcct();
+			}
+			else if (acctType == BankAccountAcctType.RealizedLoss_Acct)
+			{
+				return acctSchema.getDefaultAccounts().getRealizedLossAcct();
+			}
+			else
+			{
+				throw newPostingException().setDetailMessage("No Bank Account set and no default account available for " + acctType);
+			}
 		}
 
 		return getAccountProvider().getBankAccountAccount(acctSchema.getId(), bpBankAccountId, acctType);


### PR DESCRIPTION
If the BP bank account is null, fall back to the accounting schema's default accounts for RealizedGain_Acct and RealizedLoss_Acct based on acctType. For other acctType values, throw a PostingException with a more specific message. This avoids raising an exception when appropriate default accounts are available.