### PR TITLE
Port: mobile UI scan field not visible on Android 11 Zebra devices

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/assets/BarcodeScannerComponent.scss
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/assets/BarcodeScannerComponent.scss
@@ -9,14 +9,18 @@
   }
 
   .input-text {
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    right: 10px;
+    margin: 10px;
+    padding: 8px 12px;
     font-size: 2em;
-    z-index: 1;
-    opacity: 0.8;
     text-align: center;
+    border: 2px solid $grey-lighter;
+    border-radius: 4px;
+    width: calc(100% - 20px);
+
+    &:focus {
+      border-color: $base-mf-green;
+      outline: none;
+    }
   }
 
   // Visually hidden but focusable input for background barcode scanning.
@@ -59,5 +63,17 @@
     .input-text {
       font-size: 1em;
     }
+  }
+}
+
+// Input is rendered ABOVE the video in normal document flow (not overlaid).
+// Overlaying with position:absolute + z-index does not work reliably on
+// Android 11 WebView due to SurfaceView video compositing (the native video
+// layer ignores CSS z-index and covers overlaid HTML content).
+.barcode-scanner:not(:has(video)) {
+  display: flex;
+
+  .input-text {
+    flex-grow: 1;
   }
 }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
@@ -187,13 +187,14 @@ const BarcodeScannerComponent = ({
   return (
     <div className="barcode-scanner">
       {isProcessing && <Spinner />}
-      <video key="video" ref={videoRef} width="100%" height="100%" />
       {/* IMPORTANT: Always use type="text" — never type="hidden".
           When isShowInputText=false, the input is visually hidden via CSS (input-text-offscreen)
           instead of type="hidden". This is critical for Zebra MC3300x DataWedge IME mode:
           type="hidden" inputs cannot receive focus, so Android InputConnection is never established
           and DataWedge text injection silently fails. CSS hiding keeps the input focusable and
           IME-compatible while remaining invisible to the user. (me03#28834) */}
+      {/* NOTE: Input is rendered BEFORE video to avoid Android 11 WebView SurfaceView
+          compositing issue where the native video layer covers CSS-overlaid content. (me03#28964) */}
       {!isProcessing && (
         <input
           key="input-text"
@@ -207,6 +208,7 @@ const BarcodeScannerComponent = ({
           onKeyUp={handleInputTextKeyPress}
         />
       )}
+      <video key="video" ref={videoRef} width="100%" height="100%" />
     </div>
   );
 };


### PR DESCRIPTION
Cherry-pick of `c7000837f6b` from `intensive_care_hotfix` (with conflict resolution — this branch has an older BarcodeScannerComponent without the `:has()` refactor).

Renders the scan text input above the camera viewfinder in normal document flow instead of overlaying with `position: absolute` + `z-index`.

Original PR: https://github.com/metasfresh/metasfresh/pull/23225
Also ported to: https://github.com/metasfresh/metasfresh/pull/23297 (soft_panda_release)