### PR TITLE
Fix mobile UI qty display precision for small quantities

### DIFF
--- a/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
@@ -5,9 +5,7 @@ import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScre
 import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/ManufacturingJobsListScreen';
 import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
 import { RawMaterialIssueLineScreen } from '../../utils/screens/manufacturing/issue/RawMaterialIssueLineScreen';
-import { RawMaterialIssueLineScanScreen } from '../../utils/screens/manufacturing/issue/RawMaterialIssueLineScanScreen';
 import { MaterialReceiptLineScreen } from '../../utils/screens/manufacturing/receipt/MaterialReceiptLineScreen';
-import { GetQuantityDialog } from '../../utils/screens/picking/GetQuantityDialog';
 
 /**
  * me03#28242: mobile UI production does not work with very small quantities (e.g. 0.01913 kg)
@@ -86,21 +84,13 @@ test('Issue raw material with very small qty (0.00384 kg) shows non-zero qty aft
     await ManufacturingJobsListScreen.waitForScreen();
     await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
 
-    // Decompose scanQRCode to insert display precision assertions
     await ManufacturingJobScreen.clickIssueButton({ index: 1 });
-    await RawMaterialIssueLineScreen.waitForScreen();
-    await RawMaterialIssueLineScreen.clickScanButton();
-    await RawMaterialIssueLineScanScreen.waitForScreen();
-    await RawMaterialIssueLineScanScreen.typeQRCode(masterdata.handlingUnits.HU.qrCode);
-    await GetQuantityDialog.waitForDialog();
-
-    // Verify qty input shows exact value, not 0
-    await GetQuantityDialog.expectQtyEntered('0.00384');
-    // Verify display labels show "3.84 g" (not "4 g" or "0 g")
-    await GetQuantityDialog.expectUserInfoValue({ captionKey: 'general.QtyToPick_Total', expectedValue: '3.84 g' });
-    await GetQuantityDialog.expectUserInfoValue({ captionKey: 'general.QtyToPick', expectedValue: '3.84 g' });
-
-    await GetQuantityDialog.fillAndPressDone({});
+    await RawMaterialIssueLineScreen.scanQRCode({
+        qrCode: masterdata.handlingUnits.HU.qrCode,
+        expectQtyEntered: '0.00384',
+        expectQtyTarget: '3.84 g',
+        expectQtyRemaining: '3.84 g',
+    });
     await RawMaterialIssueLineScreen.goBack();
 });
 
@@ -116,21 +106,13 @@ test('Issue raw material with small qty (0.01913 kg) and 1% tolerance', async ({
         documentNo: masterdata.manufacturingOrders.PP1.documentNo,
     });
 
-    // Decompose scanQRCode to insert display precision assertions
     await ManufacturingJobScreen.clickIssueButton({ index: 1 });
-    await RawMaterialIssueLineScreen.waitForScreen();
-    await RawMaterialIssueLineScreen.clickScanButton();
-    await RawMaterialIssueLineScanScreen.waitForScreen();
-    await RawMaterialIssueLineScanScreen.typeQRCode(masterdata.handlingUnits.HU_SMALL.qrCode);
-    await GetQuantityDialog.waitForDialog();
-
-    // Verify qty input and display labels
-    await GetQuantityDialog.expectQtyEntered('0.01913');
-    await GetQuantityDialog.expectUserInfoValue({ captionKey: 'general.QtyToPick_Total', expectedValue: '19.13 g' });
-    await GetQuantityDialog.expectUserInfoValue({ captionKey: 'general.QtyToPick', expectedValue: '19.13 g' });
-
-    await GetQuantityDialog.fillAndPressDone({});
-    await RawMaterialIssueLineScreen.waitForScreen();
+    await RawMaterialIssueLineScreen.scanQRCode({
+        qrCode: masterdata.handlingUnits.HU_SMALL.qrCode,
+        expectQtyEntered: '0.01913',
+        expectQtyTarget: '19.13 g',
+        expectQtyRemaining: '19.13 g',
+    });
     await RawMaterialIssueLineScreen.goBack();
 
     // Receive the finished product

--- a/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/manufacturing_small_qty_tolerance.spec.js
@@ -5,7 +5,9 @@ import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScre
 import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/ManufacturingJobsListScreen';
 import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
 import { RawMaterialIssueLineScreen } from '../../utils/screens/manufacturing/issue/RawMaterialIssueLineScreen';
+import { RawMaterialIssueLineScanScreen } from '../../utils/screens/manufacturing/issue/RawMaterialIssueLineScanScreen';
 import { MaterialReceiptLineScreen } from '../../utils/screens/manufacturing/receipt/MaterialReceiptLineScreen';
+import { GetQuantityDialog } from '../../utils/screens/picking/GetQuantityDialog';
 
 /**
  * me03#28242: mobile UI production does not work with very small quantities (e.g. 0.01913 kg)
@@ -50,7 +52,8 @@ const createMasterdata = async () => {
 
 /**
  * Verifies that scanning an HU for a very small BOM qty (0.00384 kg) shows the correct
- * non-zero qty in the dialog, not "0" as reported in tf201#242.
+ * non-zero qty in the dialog and displays the correct precision in the info labels.
+ * Covers tf201#242: "zeigt dann nach Scannen die Menge 0 an"
  */
 // noinspection JSUnusedLocalSymbols
 test('Issue raw material with very small qty (0.00384 kg) shows non-zero qty after scan', async ({ page }) => {
@@ -83,11 +86,21 @@ test('Issue raw material with very small qty (0.00384 kg) shows non-zero qty aft
     await ManufacturingJobsListScreen.waitForScreen();
     await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
 
+    // Decompose scanQRCode to insert display precision assertions
     await ManufacturingJobScreen.clickIssueButton({ index: 1 });
-    await RawMaterialIssueLineScreen.scanQRCode({
-        qrCode: masterdata.handlingUnits.HU.qrCode,
-        expectQtyEntered: '0.00384',
-    });
+    await RawMaterialIssueLineScreen.waitForScreen();
+    await RawMaterialIssueLineScreen.clickScanButton();
+    await RawMaterialIssueLineScanScreen.waitForScreen();
+    await RawMaterialIssueLineScanScreen.typeQRCode(masterdata.handlingUnits.HU.qrCode);
+    await GetQuantityDialog.waitForDialog();
+
+    // Verify qty input shows exact value, not 0
+    await GetQuantityDialog.expectQtyEntered('0.00384');
+    // Verify display labels show "3.84 g" (not "4 g" or "0 g")
+    await GetQuantityDialog.expectUserInfoValue({ captionKey: 'general.QtyToPick_Total', expectedValue: '3.84 g' });
+    await GetQuantityDialog.expectUserInfoValue({ captionKey: 'general.QtyToPick', expectedValue: '3.84 g' });
+
+    await GetQuantityDialog.fillAndPressDone({});
     await RawMaterialIssueLineScreen.goBack();
 });
 
@@ -103,14 +116,21 @@ test('Issue raw material with small qty (0.01913 kg) and 1% tolerance', async ({
         documentNo: masterdata.manufacturingOrders.PP1.documentNo,
     });
 
-    // Issue the small qty component (0.01913 kg with 1% tolerance enforced).
-    // The scanQRCode issues the full HU qty needed for the BOM line.
-    // expectQtyEntered verifies the issued qty matches what the BOM requires.
+    // Decompose scanQRCode to insert display precision assertions
     await ManufacturingJobScreen.clickIssueButton({ index: 1 });
-    await RawMaterialIssueLineScreen.scanQRCode({
-        qrCode: masterdata.handlingUnits.HU_SMALL.qrCode,
-        expectQtyEntered: '0.01913',
-    });
+    await RawMaterialIssueLineScreen.waitForScreen();
+    await RawMaterialIssueLineScreen.clickScanButton();
+    await RawMaterialIssueLineScanScreen.waitForScreen();
+    await RawMaterialIssueLineScanScreen.typeQRCode(masterdata.handlingUnits.HU_SMALL.qrCode);
+    await GetQuantityDialog.waitForDialog();
+
+    // Verify qty input and display labels
+    await GetQuantityDialog.expectQtyEntered('0.01913');
+    await GetQuantityDialog.expectUserInfoValue({ captionKey: 'general.QtyToPick_Total', expectedValue: '19.13 g' });
+    await GetQuantityDialog.expectUserInfoValue({ captionKey: 'general.QtyToPick', expectedValue: '19.13 g' });
+
+    await GetQuantityDialog.fillAndPressDone({});
+    await RawMaterialIssueLineScreen.waitForScreen();
     await RawMaterialIssueLineScreen.goBack();
 
     // Receive the finished product

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScreen.js
@@ -18,6 +18,10 @@ export const RawMaterialIssueLineScreen = {
         await expect(containerElement()).toBeVisible();
     }),
 
+    clickScanButton: async () => await test.step(`${NAME} - Click Scan button`, async () => {
+        await page.getByTestId('scanQRCode-button').tap();
+    }),
+
     scanQRCode: async ({ qrCode, expectQtyEntered }) => await test.step(`${NAME} - Scan QR code`, async () => {
         await page.getByTestId('scanQRCode-button').tap();
         await RawMaterialIssueLineScanScreen.waitForScreen();

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScreen.js
@@ -18,14 +18,16 @@ export const RawMaterialIssueLineScreen = {
         await expect(containerElement()).toBeVisible();
     }),
 
-    clickScanButton: async () => await test.step(`${NAME} - Click Scan button`, async () => {
-        await page.getByTestId('scanQRCode-button').tap();
-    }),
-
-    scanQRCode: async ({ qrCode, expectQtyEntered }) => await test.step(`${NAME} - Scan QR code`, async () => {
+    scanQRCode: async ({ qrCode, expectQtyEntered, expectQtyTarget, expectQtyRemaining }) => await test.step(`${NAME} - Scan QR code`, async () => {
         await page.getByTestId('scanQRCode-button').tap();
         await RawMaterialIssueLineScanScreen.waitForScreen();
         await RawMaterialIssueLineScanScreen.typeQRCode(qrCode);
+        if (expectQtyTarget != null) {
+            await GetQuantityDialog.expectUserInfoValue({ captionKey: 'general.QtyToPick_Total', expectedValue: expectQtyTarget });
+        }
+        if (expectQtyRemaining != null) {
+            await GetQuantityDialog.expectUserInfoValue({ captionKey: 'general.QtyToPick', expectedValue: expectQtyRemaining });
+        }
         await GetQuantityDialog.fillAndPressDone({ expectQtyEntered });
         await RawMaterialIssueLineScreen.waitForScreen();
     }),

--- a/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
@@ -24,6 +24,11 @@ export const GetQuantityDialog = {
         await expect(page.locator('#qty-input')).toHaveValue(`${expected}`);
     }),
 
+    expectUserInfoValue: async ({ captionKey, expectedValue }) => await test.step(`${NAME} - Expect ${captionKey} to contain '${expectedValue}'`, async () => {
+        const testId = `userInfo_${captionKey}`;
+        await expect(page.getByTestId(testId)).toContainText(expectedValue);
+    }),
+
     typeQtyEntered: async (qty) => await test.step(`${NAME} - Type QtyEntered '${qty}'`, async () => {
         await page.locator('#qty-input').type(`${qty}`);
     }),

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/qtys.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/qtys.test.js
@@ -1,0 +1,51 @@
+import { countDecimalPlaces } from '../../utils/qtys';
+
+describe('qtys tests', () => {
+  describe('countDecimalPlaces', () => {
+    const expectations = [
+      // [ input, expected ]
+
+      // null/undefined/NaN/Infinity
+      [null, 0],
+      [undefined, 0],
+      [NaN, 0],
+      [Infinity, 0],
+      [-Infinity, 0],
+
+      // integers
+      [0, 0],
+      [1, 0],
+      [10, 0],
+      [100, 0],
+
+      // basic decimals
+      [0.1, 1],
+      [0.01, 2],
+      [0.001, 3],
+      [3.84, 2],
+      [19.125, 3],
+
+      // small quantities (the actual use case)
+      [0.00384, 5],
+      [0.01913, 5],
+      [0.019125, 6],
+
+      // JS strips trailing zeros from numbers, so these are equivalent
+      [1.1, 1], // String(1.10) = "1.1"
+      [0.019125, 6], // String(0.01912500) = "0.019125"
+
+      // string inputs with trailing zeros (from backend JSON)
+      ['0.01912500', 6],
+      ['1.0', 0],
+      ['1.00', 0],
+      ['10.50', 1],
+      ['10.050', 2],
+      ['100', 0],
+      ['0.100', 1],
+    ];
+
+    for (const [input, expected] of expectations) {
+      it(JSON.stringify(input) + ' -> ' + expected, () => expect(countDecimalPlaces(input)).toBe(expected));
+    }
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/qtys.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/qtys.test.js
@@ -54,38 +54,40 @@ describe('qtys tests', () => {
       // [ { qty, uom, precision }, expectedQtyStr, expectedUom ]
 
       // Small kg quantities auto-converted to grams — precision derived from qty decimals minus shift
-      [{ qty: 0.019125, uom: 'kg' }, '19.125', 'g'],    // 6 decimals - 3 shift = 3
-      [{ qty: 0.01913, uom: 'kg' }, '19.13', 'g'],       // 5 decimals - 3 shift = 2
-      [{ qty: 0.00384, uom: 'kg' }, '3.84', 'g'],        // 5 decimals - 3 shift = 2
-      [{ qty: 0.00765, uom: 'kg' }, '7.65', 'g'],        // 5 decimals - 3 shift = 2
-      [{ qty: 0.1, uom: 'kg' }, '100', 'g'],             // 1 decimal - 3 shift = 0 (but >=1 so no conversion) → actually 0.1 < 1 → converts to 100 g, precision max(1-3,0)=0
+      [{ qty: 0.019125, uom: 'kg' }, '19.125', 'g'], // 6 decimals - 3 shift = 3
+      [{ qty: 0.01913, uom: 'kg' }, '19.13', 'g'], // 5 decimals - 3 shift = 2
+      [{ qty: 0.00384, uom: 'kg' }, '3.84', 'g'], // 5 decimals - 3 shift = 2
+      [{ qty: 0.00765, uom: 'kg' }, '7.65', 'g'], // 5 decimals - 3 shift = 2
+      [{ qty: 0.1, uom: 'kg' }, '100', 'g'], // 1 decimal - 3 shift = 0 (but >=1 so no conversion) → actually 0.1 < 1 → converts to 100 g, precision max(1-3,0)=0
 
       // Very small kg → mg conversion
-      [{ qty: 0.0000012, uom: 'kg' }, '1.2', 'mg'],      // 7 decimals, 2 shifts (kg→g→mg) = 7-6=1
+      [{ qty: 0.0000012, uom: 'kg' }, '1.2', 'mg'], // 7 decimals, 2 shifts (kg→g→mg) = 7-6=1
 
       // Normal kg quantities (no conversion, qty >= 1)
-      [{ qty: 100, uom: 'kg' }, '100', 'kg'],            // 0 decimals, no shift
-      [{ qty: 1.5, uom: 'kg' }, '1.5', 'kg'],            // 1 decimal, no shift
-      [{ qty: 2.25, uom: 'kg' }, '2.25', 'kg'],          // 2 decimals, no shift
+      [{ qty: 100, uom: 'kg' }, '100', 'kg'], // 0 decimals, no shift
+      [{ qty: 1.5, uom: 'kg' }, '1.5', 'kg'], // 1 decimal, no shift
+      [{ qty: 2.25, uom: 'kg' }, '2.25', 'kg'], // 2 decimals, no shift
 
       // Non-kg UOM (no conversion possible)
-      [{ qty: 0.5, uom: 'PCE' }, '0.5', 'PCE'],          // 1 decimal, no shift, default precision max(1,4)=4 → but only 1 significant decimal
+      [{ qty: 0.5, uom: 'PCE' }, '0.5', 'PCE'], // 1 decimal, no shift, default precision max(1,4)=4 → but only 1 significant decimal
 
       // Explicit precision overrides derived precision
-      [{ qty: 0.019125, uom: 'kg', precision: 999 }, '19.125', 'g'],  // explicit 999 → shows all
-      [{ qty: 0.019125, uom: 'kg', precision: 1 }, '19.1', 'g'],      // explicit 1 → truncates
+      [{ qty: 0.019125, uom: 'kg', precision: 999 }, '19.125', 'g'], // explicit 999 → shows all
+      [{ qty: 0.019125, uom: 'kg', precision: 1 }, '19.1', 'g'], // explicit 1 → truncates
 
       // Rounding behavior (toFixed uses standard rounding: half-up for most cases)
-      [{ qty: 0.019155, uom: 'kg', precision: 1 }, '19.2', 'g'],     // 19.155 rounded to 1 decimal → 19.2 (rounds up)
-      [{ qty: 0.019145, uom: 'kg', precision: 1 }, '19.1', 'g'],     // 19.145 rounded to 1 decimal → 19.1 (rounds down)
-      [{ qty: 0.019195, uom: 'kg', precision: 1 }, '19.2', 'g'],     // 19.195 rounded to 1 decimal → 19.2 (rounds up)
-      [{ qty: 1.555, uom: 'kg', precision: 2 }, '1.55', 'kg'],       // 1.555 → 1.55 (JS floating-point: 1.555 is stored as 1.554999... so toFixed rounds down)
-      [{ qty: 1.554, uom: 'kg', precision: 2 }, '1.55', 'kg'],       // 1.554 rounded to 2 decimals → 1.55 (rounds down)
-      [{ qty: 0.009999, uom: 'kg', precision: 2 }, '10', 'g'],       // 9.999 g rounded to 2 decimals → 10.00 → "10" (rounds up across boundary)
+      [{ qty: 0.019155, uom: 'kg', precision: 1 }, '19.2', 'g'], // 19.155 rounded to 1 decimal → 19.2 (rounds up)
+      [{ qty: 0.019145, uom: 'kg', precision: 1 }, '19.1', 'g'], // 19.145 rounded to 1 decimal → 19.1 (rounds down)
+      [{ qty: 0.019195, uom: 'kg', precision: 1 }, '19.2', 'g'], // 19.195 rounded to 1 decimal → 19.2 (rounds up)
+      [{ qty: 1.555, uom: 'kg', precision: 2 }, '1.55', 'kg'], // 1.555 → 1.55 (JS floating-point: 1.555 is stored as 1.554999... so toFixed rounds down)
+      [{ qty: 1.554, uom: 'kg', precision: 2 }, '1.55', 'kg'], // 1.554 rounded to 2 decimals → 1.55 (rounds down)
+      [{ qty: 0.009999, uom: 'kg', precision: 2 }, '10', 'g'], // 9.999 g rounded to 2 decimals → 10.00 → "10" (rounds up across boundary)
     ];
 
     for (const [input, expectedQtyStr, expectedUom] of expectations) {
-      const label = `qty=${input.qty} uom=${input.uom}${input.precision != null ? ' precision=' + input.precision : ''} -> "${expectedQtyStr} ${expectedUom}"`;
+      const label = `qty=${input.qty} uom=${input.uom}${
+        input.precision != null ? ' precision=' + input.precision : ''
+      } -> "${expectedQtyStr} ${expectedUom}"`;
       it(label, () => {
         const result = formatQtyToHumanReadable(input);
         expect(result.qtyEffectiveStr).toBe(expectedQtyStr);

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/qtys.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/qtys.test.js
@@ -74,6 +74,14 @@ describe('qtys tests', () => {
       // Explicit precision overrides derived precision
       [{ qty: 0.019125, uom: 'kg', precision: 999 }, '19.125', 'g'],  // explicit 999 → shows all
       [{ qty: 0.019125, uom: 'kg', precision: 1 }, '19.1', 'g'],      // explicit 1 → truncates
+
+      // Rounding behavior (toFixed uses standard rounding: half-up for most cases)
+      [{ qty: 0.019155, uom: 'kg', precision: 1 }, '19.2', 'g'],     // 19.155 rounded to 1 decimal → 19.2 (rounds up)
+      [{ qty: 0.019145, uom: 'kg', precision: 1 }, '19.1', 'g'],     // 19.145 rounded to 1 decimal → 19.1 (rounds down)
+      [{ qty: 0.019195, uom: 'kg', precision: 1 }, '19.2', 'g'],     // 19.195 rounded to 1 decimal → 19.2 (rounds up)
+      [{ qty: 1.555, uom: 'kg', precision: 2 }, '1.55', 'kg'],       // 1.555 → 1.55 (JS floating-point: 1.555 is stored as 1.554999... so toFixed rounds down)
+      [{ qty: 1.554, uom: 'kg', precision: 2 }, '1.55', 'kg'],       // 1.554 rounded to 2 decimals → 1.55 (rounds down)
+      [{ qty: 0.009999, uom: 'kg', precision: 2 }, '10', 'g'],       // 9.999 g rounded to 2 decimals → 10.00 → "10" (rounds up across boundary)
     ];
 
     for (const [input, expectedQtyStr, expectedUom] of expectations) {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/qtys.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/qtys.test.js
@@ -1,4 +1,4 @@
-import { countDecimalPlaces } from '../../utils/qtys';
+import { countDecimalPlaces, formatQtyToHumanReadable } from '../../utils/qtys';
 
 describe('qtys tests', () => {
   describe('countDecimalPlaces', () => {
@@ -46,6 +46,43 @@ describe('qtys tests', () => {
 
     for (const [input, expected] of expectations) {
       it(JSON.stringify(input) + ' -> ' + expected, () => expect(countDecimalPlaces(input)).toBe(expected));
+    }
+  });
+
+  describe('formatQtyToHumanReadable - precision derived from qty decimal places', () => {
+    const expectations = [
+      // [ { qty, uom, precision }, expectedQtyStr, expectedUom ]
+
+      // Small kg quantities auto-converted to grams — precision derived from qty decimals minus shift
+      [{ qty: 0.019125, uom: 'kg' }, '19.125', 'g'],    // 6 decimals - 3 shift = 3
+      [{ qty: 0.01913, uom: 'kg' }, '19.13', 'g'],       // 5 decimals - 3 shift = 2
+      [{ qty: 0.00384, uom: 'kg' }, '3.84', 'g'],        // 5 decimals - 3 shift = 2
+      [{ qty: 0.00765, uom: 'kg' }, '7.65', 'g'],        // 5 decimals - 3 shift = 2
+      [{ qty: 0.1, uom: 'kg' }, '100', 'g'],             // 1 decimal - 3 shift = 0 (but >=1 so no conversion) → actually 0.1 < 1 → converts to 100 g, precision max(1-3,0)=0
+
+      // Very small kg → mg conversion
+      [{ qty: 0.0000012, uom: 'kg' }, '1.2', 'mg'],      // 7 decimals, 2 shifts (kg→g→mg) = 7-6=1
+
+      // Normal kg quantities (no conversion, qty >= 1)
+      [{ qty: 100, uom: 'kg' }, '100', 'kg'],            // 0 decimals, no shift
+      [{ qty: 1.5, uom: 'kg' }, '1.5', 'kg'],            // 1 decimal, no shift
+      [{ qty: 2.25, uom: 'kg' }, '2.25', 'kg'],          // 2 decimals, no shift
+
+      // Non-kg UOM (no conversion possible)
+      [{ qty: 0.5, uom: 'PCE' }, '0.5', 'PCE'],          // 1 decimal, no shift, default precision max(1,4)=4 → but only 1 significant decimal
+
+      // Explicit precision overrides derived precision
+      [{ qty: 0.019125, uom: 'kg', precision: 999 }, '19.125', 'g'],  // explicit 999 → shows all
+      [{ qty: 0.019125, uom: 'kg', precision: 1 }, '19.1', 'g'],      // explicit 1 → truncates
+    ];
+
+    for (const [input, expectedQtyStr, expectedUom] of expectations) {
+      const label = `qty=${input.qty} uom=${input.uom}${input.precision != null ? ' precision=' + input.precision : ''} -> "${expectedQtyStr} ${expectedUom}"`;
+      it(label, () => {
+        const result = formatQtyToHumanReadable(input);
+        expect(result.qtyEffectiveStr).toBe(expectedQtyStr);
+        expect(result.uomEffective).toBe(expectedUom);
+      });
     }
   });
 });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/dialogs/GetQuantityDialog.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/dialogs/GetQuantityDialog.jsx
@@ -277,7 +277,7 @@ const GetQuantityDialog = ({
               userInfo.map((item) => (
                 <tr key={computeKeyFromUserInfoItem(item)}>
                   <th>{computeCaptionFromUserInfoItem(item)}</th>
-                  <td>{item.value}</td>
+                  <td data-testid={computeKeyFromUserInfoItem(item)}>{item.value}</td>
                 </tr>
               ))}
             <tr>
@@ -343,7 +343,7 @@ const GetQuantityDialog = ({
                     userInfo.map((item) => (
                       <tr key={computeKeyFromUserInfoItem(item)}>
                         <th>{computeCaptionFromUserInfoItem(item)}</th>
-                        <td>{item.value}</td>
+                        <td data-testid={computeKeyFromUserInfoItem(item)}>{item.value}</td>
                       </tr>
                     ))}
                   {!hideQtyInput && (

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qtys.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qtys.js
@@ -3,87 +3,102 @@ import { getLanguage } from './translations';
 const MAX_maximumFractionDigits = 20; // ... to avoid "maximumFractionDigits value is out of range"
 
 export const formatQtyToHumanReadableStr = ({ qty, uom, precision = null, tolerance = null }) => {
-  //console.log('formatQtyToHumanReadable', { qty, uom, precision, tolerancePercent });
+    //console.log('formatQtyToHumanReadable', { qty, uom, precision, tolerancePercent });
 
-  const { qtyEffectiveStr, uomEffective } = formatQtyToHumanReadable({ qty, uom, precision });
+    const { qtyEffectiveStr, uomEffective } = formatQtyToHumanReadable({ qty, uom, precision });
 
-  let result = `${qtyEffectiveStr}${uomEffective ? ' ' + uomEffective : ''}`;
+    let result = `${qtyEffectiveStr}${uomEffective ? ' ' + uomEffective : ''}`;
 
-  if (tolerance != null && typeof tolerance === 'object') {
-    if (tolerance.percentage != null) {
-      result += ' ±' + tolerance.percentage + '%';
-    } else if (tolerance.qty != null) {
-      const toleranceQtyStr = formatQtyToHumanReadableStr({
-        qty: tolerance.qty,
-        uom: tolerance.uom,
-      });
-      result += ' ±' + toleranceQtyStr;
+    if (tolerance != null && typeof tolerance === 'object') {
+        if (tolerance.percentage != null) {
+            result += ' ±' + tolerance.percentage + '%';
+        } else if (tolerance.qty != null) {
+            const toleranceQtyStr = formatQtyToHumanReadableStr({
+                qty: tolerance.qty,
+                uom: tolerance.uom,
+            });
+            result += ' ±' + toleranceQtyStr;
+        }
     }
-  }
 
-  // console.log('formatQtyToHumanReadable', {
-  //   result,
-  //   qty,
-  //   uom,
-  //   precision,
-  //   tolerance,
-  //   qtyEffective,
-  //   uomEffective,
-  //   maximumFractionDigits,
-  //   formatOptions,
-  // });
+    // console.log('formatQtyToHumanReadable', {
+    //   result,
+    //   qty,
+    //   uom,
+    //   precision,
+    //   tolerance,
+    //   qtyEffective,
+    //   uomEffective,
+    //   maximumFractionDigits,
+    //   formatOptions,
+    // });
 
-  return result;
+    return result;
+};
+
+const countDecimalPlaces = (num) => {
+    if (num == null || !isFinite(num)) return 0;
+    const str = String(num);
+    const dotIndex = str.indexOf('.');
+    return dotIndex < 0 ? 0 : str.length - dotIndex - 1;
 };
 
 const getDefaultDisplayPrecision = (uom, defaultPrecision = 4) => {
-  if (uom === 'kg') {
-    return 3;
-  } else if (uom === 'g') {
-    return 0;
-  } else if (uom === 'mg') {
-    return 0;
-  } else {
-    return defaultPrecision;
-  }
+    if (uom === 'kg') {
+        return 3;
+    } else if (uom === 'g') {
+        return 0;
+    } else if (uom === 'mg') {
+        return 0;
+    } else {
+        return defaultPrecision;
+    }
 };
 
 export const formatQtyToHumanReadable = ({ qty, uom, precision = null }) => {
-  let qtyEffective = qty ?? 0;
-  let uomEffective = uom;
+    let qtyEffective = qty ?? 0;
+    let uomEffective = uom;
+    let decimalShift = 0;
 
-  while (qtyEffective !== 0 && Math.abs(qtyEffective) < 1) {
-    if (uomEffective === 'kg') {
-      qtyEffective *= 1000;
-      uomEffective = 'g';
-    } else if (uomEffective === 'g') {
-      qtyEffective *= 1000;
-      uomEffective = 'mg';
-    } else {
-      break;
+    while (qtyEffective !== 0 && Math.abs(qtyEffective) < 1) {
+        if (uomEffective === 'kg') {
+            qtyEffective *= 1000;
+            uomEffective = 'g';
+            decimalShift += 3;
+        } else if (uomEffective === 'g') {
+            qtyEffective *= 1000;
+            uomEffective = 'mg';
+            decimalShift += 3;
+        } else {
+            break;
+        }
     }
-  }
 
-  const formatOptions = {
-    useGrouping: false,
-  };
+    const formatOptions = {
+        useGrouping: false,
+    };
 
-  const maximumFractionDigits = Math.min(
-    precision != null ? precision : getDefaultDisplayPrecision(uomEffective),
-    MAX_maximumFractionDigits
-  );
+    let effectivePrecision;
+    if (precision != null) {
+        effectivePrecision = precision;
+    } else {
+        const qtyDecimalPlaces = countDecimalPlaces(qty);
+        effectivePrecision = Math.max(qtyDecimalPlaces - decimalShift, getDefaultDisplayPrecision(uomEffective));
+    }
 
-  qtyEffective = parseFloat(Number(qtyEffective).toFixed(maximumFractionDigits));
+    const maximumFractionDigits = Math.min(effectivePrecision, MAX_maximumFractionDigits);
 
-  if (maximumFractionDigits < MAX_maximumFractionDigits) {
-    formatOptions.minimumFractionDigits = 0;
-    formatOptions.maximumFractionDigits = maximumFractionDigits;
-  }
-  const qtyEffectiveStr = qtyEffective.toLocaleString(getLanguage(), formatOptions);
+    qtyEffective = parseFloat(Number(qtyEffective).toFixed(maximumFractionDigits));
 
-  return {
-    qtyEffectiveStr,
-    qtyEffective,
-    uomEffective,
-  };
+    if (maximumFractionDigits < MAX_maximumFractionDigits) {
+        formatOptions.minimumFractionDigits = 0;
+        formatOptions.maximumFractionDigits = maximumFractionDigits;
+    }
+    const qtyEffectiveStr = qtyEffective.toLocaleString(getLanguage(), formatOptions);
+
+    return {
+        qtyEffectiveStr,
+        qtyEffective,
+        uomEffective,
+    };
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qtys.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qtys.js
@@ -38,7 +38,7 @@ export const formatQtyToHumanReadableStr = ({ qty, uom, precision = null, tolera
 
 const countDecimalPlaces = (num) => {
   if (num == null || !isFinite(num)) return 0;
-  const str = String(num);
+  const str = String(num).replace(/0+$/, '');
   const dotIndex = str.indexOf('.');
   return dotIndex < 0 ? 0 : str.length - dotIndex - 1;
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qtys.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qtys.js
@@ -3,102 +3,102 @@ import { getLanguage } from './translations';
 const MAX_maximumFractionDigits = 20; // ... to avoid "maximumFractionDigits value is out of range"
 
 export const formatQtyToHumanReadableStr = ({ qty, uom, precision = null, tolerance = null }) => {
-    //console.log('formatQtyToHumanReadable', { qty, uom, precision, tolerancePercent });
+  //console.log('formatQtyToHumanReadable', { qty, uom, precision, tolerancePercent });
 
-    const { qtyEffectiveStr, uomEffective } = formatQtyToHumanReadable({ qty, uom, precision });
+  const { qtyEffectiveStr, uomEffective } = formatQtyToHumanReadable({ qty, uom, precision });
 
-    let result = `${qtyEffectiveStr}${uomEffective ? ' ' + uomEffective : ''}`;
+  let result = `${qtyEffectiveStr}${uomEffective ? ' ' + uomEffective : ''}`;
 
-    if (tolerance != null && typeof tolerance === 'object') {
-        if (tolerance.percentage != null) {
-            result += ' ±' + tolerance.percentage + '%';
-        } else if (tolerance.qty != null) {
-            const toleranceQtyStr = formatQtyToHumanReadableStr({
-                qty: tolerance.qty,
-                uom: tolerance.uom,
-            });
-            result += ' ±' + toleranceQtyStr;
-        }
+  if (tolerance != null && typeof tolerance === 'object') {
+    if (tolerance.percentage != null) {
+      result += ' ±' + tolerance.percentage + '%';
+    } else if (tolerance.qty != null) {
+      const toleranceQtyStr = formatQtyToHumanReadableStr({
+        qty: tolerance.qty,
+        uom: tolerance.uom,
+      });
+      result += ' ±' + toleranceQtyStr;
     }
+  }
 
-    // console.log('formatQtyToHumanReadable', {
-    //   result,
-    //   qty,
-    //   uom,
-    //   precision,
-    //   tolerance,
-    //   qtyEffective,
-    //   uomEffective,
-    //   maximumFractionDigits,
-    //   formatOptions,
-    // });
+  // console.log('formatQtyToHumanReadable', {
+  //   result,
+  //   qty,
+  //   uom,
+  //   precision,
+  //   tolerance,
+  //   qtyEffective,
+  //   uomEffective,
+  //   maximumFractionDigits,
+  //   formatOptions,
+  // });
 
-    return result;
+  return result;
 };
 
 const countDecimalPlaces = (num) => {
-    if (num == null || !isFinite(num)) return 0;
-    const str = String(num);
-    const dotIndex = str.indexOf('.');
-    return dotIndex < 0 ? 0 : str.length - dotIndex - 1;
+  if (num == null || !isFinite(num)) return 0;
+  const str = String(num);
+  const dotIndex = str.indexOf('.');
+  return dotIndex < 0 ? 0 : str.length - dotIndex - 1;
 };
 
 const getDefaultDisplayPrecision = (uom, defaultPrecision = 4) => {
-    if (uom === 'kg') {
-        return 3;
-    } else if (uom === 'g') {
-        return 0;
-    } else if (uom === 'mg') {
-        return 0;
-    } else {
-        return defaultPrecision;
-    }
+  if (uom === 'kg') {
+    return 3;
+  } else if (uom === 'g') {
+    return 0;
+  } else if (uom === 'mg') {
+    return 0;
+  } else {
+    return defaultPrecision;
+  }
 };
 
 export const formatQtyToHumanReadable = ({ qty, uom, precision = null }) => {
-    let qtyEffective = qty ?? 0;
-    let uomEffective = uom;
-    let decimalShift = 0;
+  let qtyEffective = qty ?? 0;
+  let uomEffective = uom;
+  let decimalShift = 0;
 
-    while (qtyEffective !== 0 && Math.abs(qtyEffective) < 1) {
-        if (uomEffective === 'kg') {
-            qtyEffective *= 1000;
-            uomEffective = 'g';
-            decimalShift += 3;
-        } else if (uomEffective === 'g') {
-            qtyEffective *= 1000;
-            uomEffective = 'mg';
-            decimalShift += 3;
-        } else {
-            break;
-        }
-    }
-
-    const formatOptions = {
-        useGrouping: false,
-    };
-
-    let effectivePrecision;
-    if (precision != null) {
-        effectivePrecision = precision;
+  while (qtyEffective !== 0 && Math.abs(qtyEffective) < 1) {
+    if (uomEffective === 'kg') {
+      qtyEffective *= 1000;
+      uomEffective = 'g';
+      decimalShift += 3;
+    } else if (uomEffective === 'g') {
+      qtyEffective *= 1000;
+      uomEffective = 'mg';
+      decimalShift += 3;
     } else {
-        const qtyDecimalPlaces = countDecimalPlaces(qty);
-        effectivePrecision = Math.max(qtyDecimalPlaces - decimalShift, getDefaultDisplayPrecision(uomEffective));
+      break;
     }
+  }
 
-    const maximumFractionDigits = Math.min(effectivePrecision, MAX_maximumFractionDigits);
+  const formatOptions = {
+    useGrouping: false,
+  };
 
-    qtyEffective = parseFloat(Number(qtyEffective).toFixed(maximumFractionDigits));
+  let effectivePrecision;
+  if (precision != null) {
+    effectivePrecision = precision;
+  } else {
+    const qtyDecimalPlaces = countDecimalPlaces(qty);
+    effectivePrecision = Math.max(qtyDecimalPlaces - decimalShift, getDefaultDisplayPrecision(uomEffective));
+  }
 
-    if (maximumFractionDigits < MAX_maximumFractionDigits) {
-        formatOptions.minimumFractionDigits = 0;
-        formatOptions.maximumFractionDigits = maximumFractionDigits;
-    }
-    const qtyEffectiveStr = qtyEffective.toLocaleString(getLanguage(), formatOptions);
+  const maximumFractionDigits = Math.min(effectivePrecision, MAX_maximumFractionDigits);
 
-    return {
-        qtyEffectiveStr,
-        qtyEffective,
-        uomEffective,
-    };
+  qtyEffective = parseFloat(Number(qtyEffective).toFixed(maximumFractionDigits));
+
+  if (maximumFractionDigits < MAX_maximumFractionDigits) {
+    formatOptions.minimumFractionDigits = 0;
+    formatOptions.maximumFractionDigits = maximumFractionDigits;
+  }
+  const qtyEffectiveStr = qtyEffective.toLocaleString(getLanguage(), formatOptions);
+
+  return {
+    qtyEffectiveStr,
+    qtyEffective,
+    uomEffective,
+  };
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qtys.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qtys.js
@@ -36,11 +36,13 @@ export const formatQtyToHumanReadableStr = ({ qty, uom, precision = null, tolera
   return result;
 };
 
-const countDecimalPlaces = (num) => {
+export const countDecimalPlaces = (num) => {
   if (num == null || !isFinite(num)) return 0;
-  const str = String(num).replace(/0+$/, '');
+  const str = String(num);
   const dotIndex = str.indexOf('.');
-  return dotIndex < 0 ? 0 : str.length - dotIndex - 1;
+  if (dotIndex < 0) return 0;
+  const decimals = str.substring(dotIndex + 1).replace(/0+$/, '');
+  return decimals.length;
 };
 
 const getDefaultDisplayPrecision = (uom, defaultPrecision = 4) => {


### PR DESCRIPTION
## Summary
- `formatQtyToHumanReadable` now derives precision from the qty's actual decimal places instead of hardcoded per-UOM defaults
- When converting units (kg→g: ×1000), precision adjusts by -3 per conversion step
- Before: `0.019125 kg` → "19 g" (hardcoded g=0 decimals)
- After: `0.019125 kg` → "19.125 g" (derived: 6 decimals - 3 shift = 3)

Follow-up to https://github.com/metasfresh/metasfresh/pull/23232

## Test plan
- [x] Playwright test asserts "Qty to pick (total)" and "Qty to pick" display correct precision
- [ ] CI green
- [ ] Manual verification on https://trueandfairhotfix.metasfresh.com/ after deployment