### PR TITLE
Cucumber tests for allocation accounting fix (reversal scenarios)

### DIFF
--- a/backend/de.metas.acct.base/CLAUDE.md
+++ b/backend/de.metas.acct.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/teo/workspaces/ai/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.acct.base/CLAUDE.md

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -343,7 +343,7 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 	 * not yet compensated for the given accounting schema.
 	 * Only the non-CM line drives the compensation to avoid double-posting.
 	 */
-	public boolean isCreditMemoInvoiceToCompensate(final AcctSchemaId acctSchemaId)
+	public boolean isInvoiceWithCreditMemoCounterLine(final AcctSchemaId acctSchemaId)
 	{
 		if (creditMemoAlreadyCompensated_AcctSchemaIds.contains(acctSchemaId))
 		{

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -401,6 +401,11 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 		return soTrxInvoice;
 	}
 
+	public final boolean isAPI()
+	{
+		return hasInvoiceDocument() && !isSOTrxInvoice() && !isCreditMemoInvoice();
+	}
+
 	/**
 	 * @deprecated Please use {@link #isSOTrxInvoice()}
 	 */

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -133,6 +133,7 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 	private final int m_Counter_AllocationLine_ID;
 	private DocLine_Allocation counterDocLine;
 	private final Set<AcctSchemaId> salesPurchaseInvoiceAlreadyCompensated_AcctSchemaIds = new HashSet<>();
+	private final Set<AcctSchemaId> creditMemoAlreadyCompensated_AcctSchemaIds = new HashSet<>();
 
 	private final PaymentId _paymentId;
 	private final I_C_Payment _payment;
@@ -334,6 +335,46 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 	public void markAsSalesPurchaseInvoiceCompensated(final AcctSchema as)
 	{
 		final boolean added = salesPurchaseInvoiceAlreadyCompensated_AcctSchemaIds.add(as.getId());
+		Check.assume(added, "Line should not be already compensated: {}", this);
+	}
+
+	/**
+	 * @return true if this line is a non-credit-memo invoice with a same-SOTrx credit memo counter-line,
+	 * not yet compensated for the given accounting schema.
+	 * Only the non-CM line drives the compensation to avoid double-posting.
+	 */
+	public boolean isCreditMemoInvoiceToCompensate(final AcctSchemaId acctSchemaId)
+	{
+		if (creditMemoAlreadyCompensated_AcctSchemaIds.contains(acctSchemaId))
+		{
+			return false;
+		}
+
+		if (!hasInvoiceDocument())
+		{
+			return false;
+		}
+
+		// Only the non-credit-memo line drives the compensation
+		if (isCreditMemoInvoice())
+		{
+			return false;
+		}
+
+		final DocLine_Allocation counterLine = getCounterDocLine();
+		if (counterLine == null || !counterLine.hasInvoiceDocument())
+		{
+			return false;
+		}
+
+		// Same SOTrx, counter is credit memo
+		return isSOTrxInvoice() == counterLine.isSOTrxInvoice()
+				&& counterLine.isCreditMemoInvoice();
+	}
+
+	public void markAsCreditMemoInvoiceCompensated(final AcctSchema as)
+	{
+		final boolean added = creditMemoAlreadyCompensated_AcctSchemaIds.add(as.getId());
 		Check.assume(added, "Line should not be already compensated: {}", this);
 	}
 

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -32,7 +32,9 @@ import de.metas.acct.doc.AcctDocRequiredServicesFacade;
 import de.metas.acct.doc.PostingException;
 import de.metas.allocation.api.IAllocationDAO;
 import de.metas.currency.CurrencyConversionContext;
+import de.metas.currency.CurrencyConversionResult;
 import de.metas.currency.CurrencyPrecision;
+import de.metas.currency.ICurrencyBL;
 import de.metas.document.DocBaseType;
 import de.metas.invoice.InvoiceId;
 import de.metas.invoice.InvoiceTax;
@@ -218,15 +220,8 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		}
 		else if (countPayments == 0 && countInvoices > 0)
 		{
-			if (isReversedInvoiceAllocation())
-			{
-				return facts; // nothing to do, analog to isReversedPaymentAllocation()
-			}
-			else
-			{
-				// because we have just one fact line per allocation line
-				fact.setFactTrxLinesStrategy(PerDocumentFactTrxStrategy.instance);
-			}
+			// because we have just one fact line per allocation line
+			fact.setFactTrxLinesStrategy(PerDocumentFactTrxStrategy.instance);
 		}
 
 		for (final DocLine_Allocation line : getDocLines())
@@ -297,6 +292,20 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 				{
 					final AmountSourceAndAcct compensationAmt = createPurchaseSalesInvoiceFacts(fact, line);
 					invoiceTotalAllocatedAmtSourceAndAcctCollector.add(compensationAmt);
+				}
+
+				//
+				// Credit memo compensation (same SOTrx, invoice vs credit memo)
+				{
+					final AmountSourceAndAcct creditMemoCompensationAmt = createCreditMemoCompensationFacts(fact, line);
+					invoiceTotalAllocatedAmtSourceAndAcctCollector.add(creditMemoCompensationAmt);
+				}
+
+				//
+				// Direct allocation for reversed invoice allocations (no payment, no counter-line)
+				{
+					final AmountSourceAndAcct directAllocationAmt = createDirectInvoiceAllocationSource(fact, line);
+					invoiceTotalAllocatedAmtSourceAndAcctCollector.add(directAllocationAmt);
 				}
 
 				//
@@ -407,23 +416,6 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		boolean firstPaymentIsReversalOfSecond = firstPayment.getReversal_ID() == secondPayment.getC_Payment_ID();
 		boolean secondPaymentIsReversalOfFirst = secondPayment.getReversal_ID() == firstPayment.getC_Payment_ID();
 		return firstPaymentIsReversalOfSecond || secondPaymentIsReversalOfFirst;
-	}
-
-	private boolean isReversedInvoiceAllocation()
-	{
-		if (!mightBeReversedAllocation())
-		{
-			return false;
-		}
-
-		// note: the p_lines are not each others' counter doc lines, i.e. DocLine_Allocation.getCounterDocLine() == null and getCounter_AllocationLine_ID == 0
-		final List<DocLine_Allocation> lines = getDocLines();
-		final I_C_Invoice firstInvoice = lines.get(0).getC_Invoice();
-		final I_C_Invoice secondInvoice = lines.get(1).getC_Invoice();
-
-		boolean firstInvoiceIsReversalOfSecond = firstInvoice.getReversal_ID() == secondInvoice.getC_Invoice_ID();
-		boolean secondInvoiceIsReversalOfFirst = secondInvoice.getReversal_ID() == firstInvoice.getC_Invoice_ID();
-		return firstInvoiceIsReversalOfSecond || secondInvoiceIsReversalOfFirst;
 	}
 
 	private boolean mightBeReversedAllocation()
@@ -964,6 +956,139 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		//
 		// Return how much was booked here.
 		return factLine.getAmtSourceAndAcctDrOrCr();
+	}
+
+	/**
+	 * Creates the {@link FactLine} to book the credit memo compensation (same SOTrx, invoice vs credit memo).
+	 * <p>
+	 * When a regular invoice (ARI/API) is allocated against a credit memo (ARC/APC) of the same transaction type
+	 * without any payment, this method creates the clearing entry for the credit memo side.
+	 * The regular invoice's clearing entry is then created by {@link #createInvoiceFacts}.
+	 */
+	private AmountSourceAndAcct createCreditMemoCompensationFacts(final Fact fact, final DocLine_Allocation line)
+	{
+		final AcctSchema as = fact.getAcctSchema();
+
+		if (!line.isCreditMemoInvoiceToCompensate(as.getId()))
+		{
+			return AmountSourceAndAcct.ZERO;
+		}
+
+		Check.assume(!line.hasPaymentDocument(),
+				"Credit memo compensation line shall not have a payment: {}", line);
+
+		final BigDecimal compensationAmtSource = line.getAllocatedAmt();
+		if (compensationAmtSource.signum() == 0)
+		{
+			return AmountSourceAndAcct.ZERO;
+		}
+
+		final DocLine_Allocation counterLine = line.getCounterDocLine();
+		Check.assumeNotNull(counterLine, "counterLine not null");
+
+		// Verify amounts match
+		final BigDecimal counterCompensationAmtSource = counterLine.getAllocatedAmt();
+		if (compensationAmtSource.compareTo(counterCompensationAmtSource.negate()) != 0)
+		{
+			throw newPostingException()
+					.setFact(fact)
+					.setDocLine(line)
+					.setDetailMessage("Counter credit memo shall have matching allocated amount: " + counterLine);
+		}
+
+		if (!as.isAccrual())
+		{
+			throw newPostingException()
+					.setFact(fact)
+					.setDocLine(line)
+					.setDetailMessage("Cash based accounting not supported for credit memo compensation");
+		}
+
+		// Use the counter-invoice's currency conversion context for proper multi-currency handling
+		final CurrencyConversionContext currencyConversionCtx;
+		if (fact.isAccountingCurrency(counterLine.getInvoiceCurrencyId()))
+		{
+			currencyConversionCtx = null;
+		}
+		else
+		{
+			currencyConversionCtx = counterLine.getInvoiceCurrencyConversionCtx();
+		}
+
+		// Create fact line for the counter credit memo
+		final FactLineBuilder factLineBuilder = fact.createLine()
+				.setDocLine(counterLine)
+				.setCurrencyId(getCurrencyId())
+				.setCurrencyConversionCtx(currencyConversionCtx)
+				.orgId(counterLine.getInvoiceOrgId())
+				.bPartnerAndLocationId(counterLine.getInvoiceBPartnerId(), counterLine.getInvoiceBPartnerLocationId())
+				.alsoAddZeroLine();
+
+		if (counterLine.isSOTrxInvoice())
+		{
+			factLineBuilder.setAccount(getCustomerAccount(BPartnerCustomerAccountType.C_Receivable, as));
+			// ARC: DR to clear the credit memo's receivable
+			factLineBuilder.setAmtSource(compensationAmtSource, null);
+		}
+		else
+		{
+			factLineBuilder.setAccount(getVendorAccount(BPartnerVendorAccountType.V_Liability, as));
+			// APC: CR to clear the credit memo's liability
+			factLineBuilder.setAmtSource(null, compensationAmtSource.negate());
+		}
+
+		final FactLine factLine = factLineBuilder.buildAndAddNotNull();
+
+		// Mark both lines as compensated
+		line.markAsCreditMemoInvoiceCompensated(as);
+		counterLine.markAsCreditMemoInvoiceCompensated(as);
+
+		return factLine.getAmtSourceAndAcctDrOrCr();
+	}
+
+	/**
+	 * Creates the source amount for direct invoice allocations (no payment, no counter-line).
+	 * <p>
+	 * This handles reversed invoice allocations where two invoices (e.g., credit memo + its reversal)
+	 * are allocated together without any payment or counter-line linkage.
+	 * The allocated amount flows directly to {@link #createInvoiceFacts} for clearing.
+	 *
+	 * @return the allocated amount as both source and accounting amount (using invoice's FX rate to ensure zero gain/loss)
+	 */
+	private AmountSourceAndAcct createDirectInvoiceAllocationSource(final Fact fact, final DocLine_Allocation line)
+	{
+		if (line.hasPaymentDocument() || line.getCounterDocLine() != null)
+		{
+			return AmountSourceAndAcct.ZERO;
+		}
+
+		final BigDecimal allocatedAmt = line.getAllocatedAmt();
+		if (allocatedAmt.signum() == 0)
+		{
+			return AmountSourceAndAcct.ZERO;
+		}
+
+		// Compute amtAcct using the invoice's conversion context.
+		// This ensures allocationAcctOnPaymentDate equals allocationAcctOnInvoiceDate,
+		// producing zero gain/loss (correct: a reversal is not a realization event).
+		final BigDecimal amtAcct;
+		if (fact.isAccountingCurrency(line.getInvoiceCurrencyId()))
+		{
+			amtAcct = allocatedAmt;
+		}
+		else
+		{
+			final AcctSchema as = fact.getAcctSchema();
+			final ICurrencyBL currencyBL = Services.get(ICurrencyBL.class);
+			final CurrencyConversionResult convResult = currencyBL.convert(
+					line.getInvoiceCurrencyConversionCtx(),
+					allocatedAmt,
+					getCurrencyId(),
+					as.getCurrencyId());
+			amtAcct = convResult.getAmount();
+		}
+
+		return AmountSourceAndAcct.of(allocatedAmt, amtAcct);
 	}
 
 	/**

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -220,8 +220,17 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		}
 		else if (countPayments == 0 && countInvoices > 0)
 		{
-			// because we have just one fact line per allocation line
-			fact.setFactTrxLinesStrategy(PerDocumentFactTrxStrategy.instance);
+			if (mightBeReversedAllocation())
+			{
+				// Reversed invoice allocations produce two DR lines (positive + negative) that net to zero.
+				// PerDocumentFactTrxStrategy doesn't support this pattern, so disable it.
+				fact.setFactTrxLinesStrategy(null);
+			}
+			else
+			{
+				// because we have just one fact line per allocation line
+				fact.setFactTrxLinesStrategy(PerDocumentFactTrxStrategy.instance);
+			}
 		}
 
 		for (final DocLine_Allocation line : getDocLines())
@@ -1049,7 +1058,8 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 	/**
 	 * Creates the source amount for direct invoice allocations (no payment, no counter-line).
 	 * <p>
-	 * This handles reversed invoice allocations where two invoices (e.g., credit memo + its reversal)
+	 * This is a catch-all for any invoice-only allocation line that has no payment and no counter-line.
+	 * The primary use case is reversed invoice allocations where two invoices (e.g., credit memo + its reversal)
 	 * are allocated together without any payment or counter-line linkage.
 	 * The allocated amount flows directly to {@link #createInvoiceFacts} for clearing.
 	 *
@@ -1068,6 +1078,15 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			return AmountSourceAndAcct.ZERO;
 		}
 
+		final AcctSchema as = fact.getAcctSchema();
+		if (!as.isAccrual())
+		{
+			throw newPostingException()
+					.setFact(fact)
+					.setDocLine(line)
+					.setDetailMessage("Cash based accounting not supported for direct invoice allocation");
+		}
+
 		// Compute amtAcct using the invoice's conversion context.
 		// This ensures allocationAcctOnPaymentDate equals allocationAcctOnInvoiceDate,
 		// producing zero gain/loss (correct: a reversal is not a realization event).
@@ -1078,7 +1097,6 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		}
 		else
 		{
-			final AcctSchema as = fact.getAcctSchema();
 			final ICurrencyBL currencyBL = Services.get(ICurrencyBL.class);
 			final CurrencyConversionResult convResult = currencyBL.convert(
 					line.getInvoiceCurrencyConversionCtx(),

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -1119,8 +1119,10 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			factLineBuilder.setAccount(getCustomerAccount(BPartnerCustomerAccountType.C_Receivable, as));
 			if (line.isCreditMemoInvoice())
 			{
-				// ARC (or ARC reversal): DR to clear receivable
-				factLineBuilder.setAmtSource(allocatedAmt, null);
+				// ARC (or ARC reversal): DR to clear the CM's receivable (CR on invoice side).
+				// allocatedAmt is negative for the original CM and positive for the reversal,
+				// so we negate to get the correct clearing sign per Line_ID.
+				factLineBuilder.setAmtSource(allocatedAmt.negate(), null);
 			}
 			else
 			{
@@ -1133,8 +1135,10 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			factLineBuilder.setAccount(getVendorAccount(BPartnerVendorAccountType.V_Liability, as));
 			if (line.isCreditMemoInvoice())
 			{
-				// APC (or APC reversal): CR to clear liability
-				factLineBuilder.setAmtSource(null, allocatedAmt.negate());
+				// APC (or APC reversal): CR to clear the CM's liability (DR on invoice side).
+				// allocatedAmt is positive for the original CM and negative for the reversal,
+				// so we use it directly (without negate) to get the correct clearing sign per Line_ID.
+				factLineBuilder.setAmtSource(null, allocatedAmt);
 			}
 			else
 			{

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -1138,8 +1138,10 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			}
 			else
 			{
-				// API: DR to clear liability
-				factLineBuilder.setAmtSource(allocatedAmt, null);
+				// API (or API reversal): DR to clear the invoice's liability (CR on invoice side).
+				// allocatedAmt is negative for the original invoice and positive for the reversal,
+				// so we negate to get the correct clearing sign per Line_ID.
+				factLineBuilder.setAmtSource(allocatedAmt.negate(), null);
 			}
 		}
 

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -841,12 +841,14 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		{
 			factLineBuilder.setAccount(getCustomerAccount(BPartnerCustomerAccountType.C_Receivable, as));
 
-			// ARC
-			if (line.isCreditMemoInvoice())
+			final DocLine_Allocation counterLine = line.getCounterDocLine();
+
+			// ARC that is not allocated against another invoice
+			if (line.isCreditMemoInvoice() && counterLine == null)
 			{
 				factLineBuilder.setAmtSource(allocationSource, null);
 			}
-			// ARI
+			// ARI or ARC that is allocated against the other invoice
 			else
 			{
 				factLineBuilder.setAmtSource(null, allocationSource);
@@ -864,7 +866,17 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			// API
 			else
 			{
-				factLineBuilder.setAmtSource(allocationSource, null);
+				// API counter-invoice
+				final DocLine_Allocation counterLine = line.getCounterDocLine();
+				if (counterLine != null && counterLine.isAPI())
+				{
+					factLineBuilder.setAmtSource(null, allocationSource);
+				}
+				// other
+				else
+				{
+					factLineBuilder.setAmtSource(allocationSource, null);
+				}
 			}
 		}
 

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -32,9 +32,7 @@ import de.metas.acct.doc.AcctDocRequiredServicesFacade;
 import de.metas.acct.doc.PostingException;
 import de.metas.allocation.api.IAllocationDAO;
 import de.metas.currency.CurrencyConversionContext;
-import de.metas.currency.CurrencyConversionResult;
 import de.metas.currency.CurrencyPrecision;
-import de.metas.currency.ICurrencyBL;
 import de.metas.document.DocBaseType;
 import de.metas.invoice.InvoiceId;
 import de.metas.invoice.InvoiceTax;
@@ -220,17 +218,8 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		}
 		else if (countPayments == 0 && countInvoices > 0)
 		{
-			if (mightBeReversedAllocation())
-			{
-				// Reversed invoice allocations produce two DR lines (positive + negative) that net to zero.
-				// PerDocumentFactTrxStrategy doesn't support this pattern, so disable it.
-				fact.setFactTrxLinesStrategy(null);
-			}
-			else
-			{
-				// because we have just one fact line per allocation line
-				fact.setFactTrxLinesStrategy(PerDocumentFactTrxStrategy.instance);
-			}
+			// because we have just one fact line per allocation line
+			fact.setFactTrxLinesStrategy(PerDocumentFactTrxStrategy.instance);
 		}
 
 		for (final DocLine_Allocation line : getDocLines())
@@ -313,8 +302,7 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 				//
 				// Direct allocation for reversed invoice allocations (no payment, no counter-line)
 				{
-					final AmountSourceAndAcct directAllocationAmt = createDirectInvoiceAllocationSource(fact, line);
-					invoiceTotalAllocatedAmtSourceAndAcctCollector.add(directAllocationAmt);
+					createDirectInvoiceAllocationFacts(fact, line);
 				}
 
 				//
@@ -978,7 +966,7 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 	{
 		final AcctSchema as = fact.getAcctSchema();
 
-		if (!line.isCreditMemoInvoiceToCompensate(as.getId()))
+		if (!line.isInvoiceWithCreditMemoCounterLine(as.getId()))
 		{
 			return AmountSourceAndAcct.ZERO;
 		}
@@ -1056,16 +1044,19 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 	}
 
 	/**
-	 * Creates the source amount for direct invoice allocations (no payment, no counter-line).
+	 * Creates the {@link FactLine} for direct invoice allocations (no payment, no counter-line).
 	 * <p>
-	 * This is a catch-all for any invoice-only allocation line that has no payment and no counter-line.
-	 * The primary use case is reversed invoice allocations where two invoices (e.g., credit memo + its reversal)
+	 * This handles reversed invoice allocations where two invoices (e.g., credit memo + its reversal)
 	 * are allocated together without any payment or counter-line linkage.
-	 * The allocated amount flows directly to {@link #createInvoiceFacts} for clearing.
-	 *
-	 * @return the allocated amount as both source and accounting amount (using invoice's FX rate to ensure zero gain/loss)
+	 * Each line creates its own receivable/liability clearing entry directly.
+	 * <p>
+	 * Tested by S0465_CMA_100 (the reversal part after the credit memo is reversed).
+	 * <p>
+	 * Note: This method creates the final FactLine and returns ZERO so that {@link #createInvoiceFacts}
+	 * does not create a duplicate entry. The FactTrxLinesStrategy is disabled because reversed allocations
+	 * produce two DR lines (positive + negative) that net to zero but violate the 1-DR-N-CR pattern.
 	 */
-	private AmountSourceAndAcct createDirectInvoiceAllocationSource(final Fact fact, final DocLine_Allocation line)
+	private AmountSourceAndAcct createDirectInvoiceAllocationFacts(final Fact fact, final DocLine_Allocation line)
 	{
 		if (line.hasPaymentDocument() || line.getCounterDocLine() != null)
 		{
@@ -1087,26 +1078,63 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 					.setDetailMessage("Cash based accounting not supported for direct invoice allocation");
 		}
 
-		// Compute amtAcct using the invoice's conversion context.
-		// This ensures allocationAcctOnPaymentDate equals allocationAcctOnInvoiceDate,
-		// producing zero gain/loss (correct: a reversal is not a realization event).
-		final BigDecimal amtAcct;
+		// Reversed allocations produce two DR lines (positive + negative) that net to zero.
+		// PerDocumentFactTrxStrategy doesn't support this pattern, so disable it.
+		fact.setFactTrxLinesStrategy(null);
+
+		// Use the invoice's currency conversion context for proper multi-currency handling
+		final CurrencyConversionContext currencyConversionCtx;
 		if (fact.isAccountingCurrency(line.getInvoiceCurrencyId()))
 		{
-			amtAcct = allocatedAmt;
+			currencyConversionCtx = null;
 		}
 		else
 		{
-			final ICurrencyBL currencyBL = Services.get(ICurrencyBL.class);
-			final CurrencyConversionResult convResult = currencyBL.convert(
-					line.getInvoiceCurrencyConversionCtx(),
-					allocatedAmt,
-					getCurrencyId(),
-					as.getCurrencyId());
-			amtAcct = convResult.getAmount();
+			currencyConversionCtx = line.getInvoiceCurrencyConversionCtx();
 		}
 
-		return AmountSourceAndAcct.of(allocatedAmt, amtAcct);
+		// Create the clearing FactLine directly (same pattern as createCreditMemoCompensationFacts)
+		final FactLineBuilder factLineBuilder = fact.createLine()
+				.setDocLine(line)
+				.setCurrencyId(getCurrencyId())
+				.setCurrencyConversionCtx(currencyConversionCtx)
+				.orgId(line.getInvoiceOrgId())
+				.bPartnerAndLocationId(line.getInvoiceBPartnerId(), line.getInvoiceBPartnerLocationId())
+				.alsoAddZeroLine();
+
+		if (line.isSOTrxInvoice())
+		{
+			factLineBuilder.setAccount(getCustomerAccount(BPartnerCustomerAccountType.C_Receivable, as));
+			if (line.isCreditMemoInvoice())
+			{
+				// ARC (or ARC reversal): DR to clear receivable
+				factLineBuilder.setAmtSource(allocatedAmt, null);
+			}
+			else
+			{
+				// ARI: CR to clear receivable
+				factLineBuilder.setAmtSource(null, allocatedAmt);
+			}
+		}
+		else
+		{
+			factLineBuilder.setAccount(getVendorAccount(BPartnerVendorAccountType.V_Liability, as));
+			if (line.isCreditMemoInvoice())
+			{
+				// APC (or APC reversal): CR to clear liability
+				factLineBuilder.setAmtSource(null, allocatedAmt.negate());
+			}
+			else
+			{
+				// API: DR to clear liability
+				factLineBuilder.setAmtSource(allocatedAmt, null);
+			}
+		}
+
+		factLineBuilder.buildAndAdd();
+
+		// Return ZERO so createInvoiceFacts does not create a duplicate entry
+		return AmountSourceAndAcct.ZERO;
 	}
 
 	/**

--- a/backend/de.metas.cucumber/CLAUDE.md
+++ b/backend/de.metas.cucumber/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/teo/workspaces/ai/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.cucumber/CLAUDE.md

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDefData.java
@@ -38,4 +38,5 @@ public class C_BPartner_StepDefData extends StepDefData<I_C_BPartner>
 	{
 		return BPartnerId.ofRepoId(record.getC_BPartner_ID());
 	}
+
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/DataTableRow.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/DataTableRow.java
@@ -22,7 +22,13 @@
 
 package de.metas.cucumber.stepdefs;
 
+import com.google.common.collect.ImmutableList;
+import de.metas.currency.Amount;
+import de.metas.currency.CurrencyCode;
 import de.metas.i18n.ExplainedOptional;
+import de.metas.location.CountryCode;
+import de.metas.money.CurrencyId;
+import de.metas.money.Money;
 import de.metas.quantity.Quantity;
 import de.metas.uom.X12DE355;
 import de.metas.util.Check;
@@ -33,46 +39,87 @@ import de.metas.util.StringUtils;
 import de.metas.util.collections.CollectionUtils;
 import de.metas.util.lang.ReferenceListAwareEnum;
 import de.metas.util.lang.ReferenceListAwareEnums;
+import de.metas.util.lang.RepoIdAware;
+import de.metas.util.text.tabular.Row;
+import de.metas.util.text.tabular.Table;
 import io.cucumber.datatable.DataTable;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
-import lombok.ToString;
+import lombok.Singular;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.I_C_UOM;
 
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 @EqualsAndHashCode
-@ToString
 public class DataTableRow
 {
-	private final int lineNo; // introduced to improve logging/debugging
+	@Getter private final int lineNo; // introduced to improve logging/debugging
 	@NonNull
-	private final Map<String, String> map;
+	private final LinkedHashMap<String, String> map;
 	@Nullable
 	@Setter
 	private String additionalRowIdentifierColumnName;
 
-	DataTableRow(
+	@Builder
+	private DataTableRow(
 			final int lineNo,
-			@NonNull final Map<String, String> map)
+			@NonNull @Singular("_value") final Map<String, String> values)
 	{
 		this.lineNo = lineNo;
-		this.map = map;
+		this.map = new LinkedHashMap<>(values);
 	}
+
+	@SuppressWarnings("unused")
+	public static class DataTableRowBuilder
+	{
+		public DataTableRowBuilder value(final String name, @Nullable final String value)
+		{
+			return _value(name, value);
+		}
+
+		public DataTableRowBuilder value(final String name, final int value)
+		{
+			return value(name, Integer.toString(value));
+		}
+
+		public DataTableRowBuilder value(final String name, final BigDecimal value)
+		{
+			return value(name, value != null ? value.toPlainString() : null);
+		}
+
+		public DataTableRowBuilder value(final String name, final RepoIdAware value)
+		{
+			return value(name, value != null ? Integer.toString(value.getRepoId()) : null);
+		}
+
+		public DataTableRowBuilder value(final String name, final boolean value)
+		{
+			return value(name, StringUtils.ofBoolean(value));
+		}
+	}
+
+	@Override
+	@Deprecated
+	public String toString() {return toTabularString();}
 
 	public static DataTableRow singleRow(@NonNull final DataTable dataTable)
 	{
@@ -109,6 +156,17 @@ public class DataTableRow
 	}
 
 	@NonNull
+	public Optional<List<String>> getAsOptionalCommaSeparatedString(@NonNull final String columnName)
+	{
+		final String columnNameEffective = findEffectiveColumnName(columnName);
+		if (columnNameEffective == null)
+		{
+			return Optional.empty();
+		}
+		return Optional.of(getAsCommaSeparatedString(columnName));
+	}
+
+	@NonNull
 	public List<String> getAsCommaSeparatedString(@NonNull final String columnName)
 	{
 		final String value = getAsString(columnName);
@@ -141,7 +199,7 @@ public class DataTableRow
 		final String columnNameEffective = findEffectiveColumnName(columnName);
 		if (columnNameEffective == null)
 		{
-			return Optional.empty(); // column is missing
+			return Optional.empty(); // the column is missing
 		}
 
 		final String value = map.get(columnNameEffective);
@@ -176,12 +234,24 @@ public class DataTableRow
 		return nameResolved;
 	}
 
-	public ValueAndName suggestValueAndName()
+	public ValueAndName suggestValueAndName(@Nullable final Supplier<String> defaultValueSupplier, @Nullable final Supplier<String> defaultNameSupplier)
 	{
 		final ValueAndName valueAndName = getOptionalValueAndName().orElse(null);
 		if (valueAndName != null)
 		{
 			return valueAndName;
+		}
+
+		if (defaultNameSupplier != null || defaultValueSupplier != null)
+		{
+			final String name = defaultNameSupplier != null ? defaultNameSupplier.get() : null;
+			final String value = defaultValueSupplier != null ? defaultValueSupplier.get() : null;
+
+			final Optional<ValueAndName> valueAndNameFromSupplier = ValueAndName.ofNullableValueAndName(value, name);
+			if (valueAndNameFromSupplier.isPresent())
+			{
+				return valueAndNameFromSupplier.get();
+			}
 		}
 
 		final StepDefDataIdentifier recordIdentifier = getAsOptionalIdentifier().orElse(null);
@@ -191,6 +261,11 @@ public class DataTableRow
 		}
 
 		return ValueAndName.unique();
+	}
+
+	public ValueAndName suggestValueAndName()
+	{
+		return suggestValueAndName(null, null);
 	}
 
 	public ExplainedOptional<ValueAndName> getOptionalValueAndName()
@@ -247,6 +322,13 @@ public class DataTableRow
 				.orElseThrow(() -> new AdempiereException("Missing value for columnName=" + columnName)
 						.appendParametersToMessage()
 						.setParameter("row", map));
+	}
+
+	@Nullable
+	public StepDefDataIdentifier getAsIdentifierOrNull(@NonNull final String columnName)
+	{
+		return getAsOptionalIdentifier(columnName)
+				.orElse(null);
 	}
 
 	@NonNull
@@ -313,23 +395,29 @@ public class DataTableRow
 	}
 
 	@NonNull
-	public OptionalInt getAsOptionalInt(@NonNull final String columnName)
+	public Optional<Integer> getAsOptionalInteger(@NonNull final String columnName)
 	{
 		return getAsOptionalString(columnName)
-				.map(valueStr -> parseOptionalInt(valueStr, columnName))
-				.orElseGet(OptionalInt::empty);
+				.flatMap(valueStr -> parseOptionalInt(valueStr, columnName));
 	}
 
-	private static OptionalInt parseOptionalInt(@Nullable final String valueStr, final String columnInfo)
+	@NonNull
+	public java.util.OptionalInt getAsOptionalInt(@NonNull final String columnName)
+	{
+		final Optional<Integer> opt = getAsOptionalInteger(columnName);
+		return opt.isPresent() ? java.util.OptionalInt.of(opt.get()) : java.util.OptionalInt.empty();
+	}
+
+	private static Optional<Integer> parseOptionalInt(@Nullable final String valueStr, final String columnInfo)
 	{
 		final String valueStrNorm = StringUtils.trimBlankToNull(valueStr);
 		if (valueStrNorm == null)
 		{
-			return OptionalInt.empty();
+			return Optional.empty();
 		}
 
 		final int valueInt = parseInt(valueStrNorm, columnInfo);
-		return OptionalInt.of(valueInt);
+		return Optional.of(valueInt);
 	}
 
 	private static int parseInt(@Nullable final String valueStr, final String columnInfo)
@@ -374,6 +462,16 @@ public class DataTableRow
 				.orElseThrow(() -> new AdempiereException("No value found for " + valueColumnName));
 	}
 
+	public Quantity getAsQuantity(
+			@NonNull final String valueColumnName,
+			@Nullable final String uomColumnName,
+			@Nullable final X12DE355 uomDefaultCode,
+			@NonNull final Function<X12DE355, I_C_UOM> uomMapper)
+	{
+		return getAsOptionalQuantity(valueColumnName, uomColumnName, uomDefaultCode, uomMapper)
+				.orElseThrow(() -> new AdempiereException("No value found for " + valueColumnName));
+	}
+
 	public Optional<Quantity> getAsOptionalQuantity(
 			@NonNull final String valueColumnName,
 			@NonNull final Function<X12DE355, I_C_UOM> uomMapper)
@@ -384,6 +482,15 @@ public class DataTableRow
 	public Optional<Quantity> getAsOptionalQuantity(
 			@NonNull final String valueColumnName,
 			@Nullable final String uomColumnName,
+			@NonNull final Function<X12DE355, I_C_UOM> uomMapper)
+	{
+		return getAsOptionalQuantity(valueColumnName, uomColumnName, null, uomMapper);
+	}
+
+	public Optional<Quantity> getAsOptionalQuantity(
+			@NonNull final String valueColumnName,
+			@Nullable final String uomColumnName,
+			@Nullable final X12DE355 uomDefaultCode,
 			@NonNull final Function<X12DE355, I_C_UOM> uomMapper)
 	{
 		final String valueStr = getAsOptionalString(valueColumnName).map(StringUtils::trimBlankToNull).orElse(null);
@@ -406,14 +513,19 @@ public class DataTableRow
 			uomCode = X12DE355.ofNullableCode(valueStr.substring(spaceIdx).trim());
 		}
 
+		if (uomCode == null && uomColumnName != null)
+		{
+			uomCode = getAsOptionalUOMCode(uomColumnName).orElse(null);
+		}
+
+		if (uomCode == null && uomDefaultCode != null)
+		{
+			uomCode = uomDefaultCode;
+		}
+
 		if (uomCode == null)
 		{
-			if (uomColumnName == null)
-			{
-				throw new AdempiereException("When UOM is not incorporated in `" + valueColumnName + "` then an UOM column name shall be provided");
-			}
-
-			uomCode = getAsUOMCode(uomColumnName);
+			throw new AdempiereException("When UOM is not incorporated in `" + valueColumnName + "` then an UOM column name shall be provided or a default assumed");
 		}
 
 		final I_C_UOM uom = uomMapper.apply(uomCode);
@@ -423,16 +535,116 @@ public class DataTableRow
 	@NonNull
 	public X12DE355 getAsUOMCode(@NonNull final String columnName)
 	{
+		return getAsOptionalUOMCode(columnName)
+				.orElseThrow(() -> new AdempiereException("No value found in column " + columnName));
+	}
+
+	@NonNull
+	public Optional<X12DE355> getAsOptionalUOMCode(@NonNull final String columnName)
+	{
 		String valueStr = getAsOptionalString(columnName).orElse(null);
 		if (valueStr == null && !columnName.endsWith("X12DE355"))
 		{
 			valueStr = getAsOptionalString(columnName + ".X12DE355").orElse(null);
 		}
+		return valueStr != null ? Optional.of(X12DE355.ofCode(valueStr)) : Optional.empty();
+	}
+
+	public CurrencyCode getAsCurrencyCode()
+	{
+		return getAsOptionalCurrencyCode()
+				.orElseThrow(() -> new AdempiereException("No currency code found"));
+	}
+
+	public Optional<CurrencyCode> getAsOptionalCurrencyCode()
+	{
+		return Optionals.firstPresentOfSuppliers(
+						() -> getAsOptionalString("C_Currency.ISO_Code"),
+						() -> getAsOptionalString("C_Currency." + StepDefDataIdentifier.SUFFIX),
+						() -> getAsOptionalString("C_Currency_ID"),
+						() -> getAsOptionalString("currencyCode")
+				)
+				.map(CurrencyCode::ofThreeLetterCode);
+	}
+
+	public Optional<CountryCode> getAsOptionalCountryCode(@NonNull final String columnName)
+	{
+		return Optionals.firstPresentOfSuppliers(
+						() -> getAsOptionalString(columnName),
+						() -> getAsOptionalString(columnName + ".CountryCode")
+				)
+				.map(code -> CountryCode.builder().alpha2(code).alpha3(code).build());
+	}
+
+	public Money getAsMoney(
+			@NonNull final String valueColumnName,
+			@NonNull final Function<CurrencyCode, CurrencyId> currencyCodeMapper)
+	{
+		return getAsOptionalMoney(valueColumnName, currencyCodeMapper)
+				.orElseThrow(() -> new AdempiereException("No value found for " + valueColumnName));
+	}
+
+	public Optional<Money> getAsOptionalMoney(
+			@NonNull final String valueColumnName,
+			@NonNull final Function<CurrencyCode, CurrencyId> currencyCodeMapper)
+	{
+		return getAsOptionalAmount(valueColumnName)
+				.map(amount -> amount.toMoney(currencyCodeMapper));
+	}
+
+	public Optional<Money> getAsOptionalMoney(
+			@NonNull final String valueColumnName,
+			@Nullable final Supplier<CurrencyCode> defaultCurrencyCodeSupplier,
+			@NonNull final Function<CurrencyCode, CurrencyId> currencyCodeMapper)
+	{
+		return getAsOptionalAmount(valueColumnName, defaultCurrencyCodeSupplier)
+				.map(amount -> amount.toMoney(currencyCodeMapper));
+	}
+
+	public Optional<Amount> getAsOptionalAmount(@NonNull final String valueColumnName)
+	{
+		return getAsOptionalAmount(valueColumnName, null);
+	}
+
+	public Optional<Amount> getAsOptionalAmount(@NonNull final String valueColumnName, @Nullable final Supplier<CurrencyCode> defaultCurrencyCodeSupplier)
+	{
+		final String valueStr = getAsOptionalString(valueColumnName).map(StringUtils::trimBlankToNull).orElse(null);
 		if (valueStr == null)
 		{
-			throw new AdempiereException("No value found for " + columnName);
+			return Optional.empty();
 		}
-		return X12DE355.ofCode(valueStr);
+
+		final int spaceIdx = valueStr.indexOf(" ");
+		final BigDecimal valueBD;
+		CurrencyCode currencyCode;
+		if (spaceIdx <= 0)
+		{
+			valueBD = parseBigDecimal(valueStr, valueColumnName);
+			currencyCode = null;
+		}
+		else
+		{
+			valueBD = parseBigDecimal(valueStr.substring(0, spaceIdx), valueColumnName);
+			final String currencyCodeStr = StringUtils.trimBlankToNull(valueStr.substring(spaceIdx));
+			currencyCode = currencyCodeStr != null ? CurrencyCode.ofThreeLetterCode(currencyCodeStr) : null;
+		}
+
+		if (currencyCode == null)
+		{
+			currencyCode = getAsOptionalCurrencyCode().orElse(null);
+		}
+
+		if (currencyCode == null && defaultCurrencyCodeSupplier != null)
+		{
+			currencyCode = defaultCurrencyCodeSupplier.get();
+		}
+
+		if (currencyCode == null)
+		{
+			throw new AdempiereException("No currency code incorporated into `" + valueColumnName + "`: " + valueStr);
+		}
+
+		return Optional.of(Amount.of(valueBD, currencyCode));
 	}
 
 	public LocalDate getAsLocalDate(@NonNull final String columnName)
@@ -460,7 +672,22 @@ public class DataTableRow
 
 	public Timestamp getAsLocalDateTimestamp(@NonNull final String columnName)
 	{
-		return Timestamp.valueOf(getAsLocalDate(columnName).atStartOfDay());
+		return toTimestamp(getAsLocalDate(columnName));
+	}
+
+	private static Timestamp toTimestamp(final LocalDate localDate)
+	{
+		return Timestamp.valueOf(localDate.atStartOfDay());
+	}
+
+	public Optional<Timestamp> getAsOptionalLocalDateTimestamp(@NonNull final String columnName)
+	{
+		return getAsOptionalLocalDate(columnName).map(DataTableRow::toTimestamp);
+	}
+
+	public Optional<Instant> getAsOptionalLocalDateInstant(@NonNull final String columnName)
+	{
+		return getAsOptionalLocalDate(columnName).map(DataTableRow::toInstant);
 	}
 
 	@SuppressWarnings("unused")
@@ -474,14 +701,33 @@ public class DataTableRow
 		return getAsOptionalInstant(columnName).map(Timestamp::from);
 	}
 
+	/**
+	 * Convert the given string. Examples:
+	 * <ul>
+	 *     <li>2007-12-03</li>
+	 *     <li>2007-12-03Z</li>
+	 *     <li>2007-12-03T10:15:30</li>
+	 *     <li>2007-12-03T10:15:30Z</li>
+	 * </ul>
+	 * Append the prefix {@code Z} to indicate that no timezone-conversion shall be done.
+	 * Otherwise, the code assumes the given time is in the TZ returned by {@link ZoneId#systemDefault()} and converts it to UTC from there.
+	 */
 	public Instant getAsInstant(@NonNull final String columnName)
 	{
 		return parseInstant(getAsString(columnName), columnName);
 	}
 
+	/**
+	 * Similar to {@link #getAsInstant(String)}.
+	 */
 	public Optional<Instant> getAsOptionalInstant(@NonNull final String columnName)
 	{
 		return getAsOptionalString(columnName).map(valueStr -> parseInstant(valueStr, columnName));
+	}
+
+	public Optional<Duration> getAsOptionalDuration(@NonNull final String columnName)
+	{
+		return getAsOptionalString(columnName).map(valueStr -> parseDuration(valueStr, columnName));
 	}
 
 	@NonNull
@@ -490,18 +736,20 @@ public class DataTableRow
 		try
 		{
 			if (valueStr.contains("T"))
-			{
+			{ // we have a date+time
 				if (valueStr.endsWith("Z"))
 				{
 					return Instant.parse(valueStr);
 				}
-				else
-				{
-					return toInstant(LocalDateTime.parse(valueStr));
-				}
+				return toInstant(LocalDateTime.parse(valueStr));
 			}
 			else
-			{
+			{ // we have a date
+				if (valueStr.endsWith("Z"))
+				{
+					final String effectiveString = valueStr.replace("Z", "T00:00:00.00Z");
+					return Instant.parse(effectiveString);
+				}
 				return toInstant(LocalDate.parse(valueStr).atStartOfDay());
 			}
 		}
@@ -511,11 +759,29 @@ public class DataTableRow
 		}
 	}
 
+	@NonNull
+	private static Duration parseDuration(@NonNull final String valueStr, final String columnInfo)
+	{
+		try
+		{
+			return Duration.parse(valueStr);
+		}
+		catch (final Exception ex)
+		{
+			throw new AdempiereException("Column `" + columnInfo + "` has invalid Duration `" + valueStr + "`");
+		}
+	}
+
+	private static Instant toInstant(@NonNull final LocalDate ld)
+	{
+		return toInstant(ld.atStartOfDay());
+	}
+
 	private static Instant toInstant(@NonNull final LocalDateTime ldt)
 	{
 		// IMPORTANT: we use JVM timezone instead of SystemTime.zoneId()
-		// because that's the timezone java.sql.Timestamp would use it too,
-		// and because most of currently logic is silently assuming that
+		// because the timezone java.sql.Timestamp would use it too,
+		// and because most of currently the logic is silently assuming that
 		final ZoneId jvmTimeZone = ZoneId.systemDefault();
 		return ldt.atZone(jvmTimeZone).toInstant();
 	}
@@ -523,6 +789,23 @@ public class DataTableRow
 	public Optional<LocalDateTime> getAsOptionalLocalDateTime(@NonNull final String columnName)
 	{
 		return getAsOptionalString(columnName).map(valueStr -> parseLocalDateTime(valueStr, columnName));
+	}
+
+	public Optional<LocalTime> getAsOptionalLocalTime(@NonNull final String columnName)
+	{
+		return getAsOptionalString(columnName).map(valueStr -> parseLocalTime(valueStr, columnName));
+	}
+
+	private LocalTime parseLocalTime(@NonNull final String valueStr, final @NonNull String columnName)
+	{
+		try
+		{
+			return LocalTime.parse(valueStr);
+		}
+		catch (final Exception ex)
+		{
+			throw new AdempiereException("Column `" + columnName + "` has invalid LocalTime `" + valueStr + "`");
+		}
 	}
 
 	@NonNull
@@ -554,5 +837,49 @@ public class DataTableRow
 	{
 		return getAsOptionalEnum(columnName, type)
 				.orElseThrow(() -> new AdempiereException("Missing/invalid `" + type.getSimpleName() + "` of column `" + columnName + "`"));
+	}
+
+	public String toTabularString()
+	{
+		return toTabular().toTabularString();
+	}
+
+	public Table toTabular()
+	{
+		final Table table = new Table();
+		table.addRow(toTabularRow());
+		table.updateHeaderFromRows();
+		//table.removeColumnsWithBlankValues(); // to be decided by the caller
+		return table;
+
+	}
+
+	public Row toTabularRow()
+	{
+		final Row row = new Row();
+		if (lineNo > 0)
+		{
+			row.put("#", lineNo);
+		}
+		row.putAll(map);
+		return row;
+
+	}
+
+	public List<String> getColumnNames()
+	{
+		return ImmutableList.copyOf(map.keySet());
+	}
+
+	public void setValueIfMissing(@NonNull final String columnName, @NonNull final Supplier<String> valueSupplier)
+	{
+		final String existingValue = map.get(columnName);
+		if (existingValue != null)
+		{
+			return;
+		}
+
+		final String newValue = valueSupplier.get();
+		map.put(columnName, newValue);
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/DataTableRows.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/DataTableRows.java
@@ -1,5 +1,6 @@
 package de.metas.cucumber.stepdefs;
 
+import com.google.common.collect.ImmutableList;
 import de.metas.cucumber.stepdefs.context.SharedTestContext;
 import de.metas.util.GuavaCollectors;
 import io.cucumber.datatable.DataTable;
@@ -8,11 +9,13 @@ import lombok.NonNull;
 import lombok.ToString;
 import org.adempiere.exceptions.AdempiereException;
 import org.junit.jupiter.api.function.ThrowingConsumer;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @EqualsAndHashCode
@@ -31,22 +34,37 @@ public class DataTableRows
 		return ofListOfMaps(dataTable.asMaps());
 	}
 
+	public static DataTableRows of(@NonNull final DataTableRow row)
+	{
+		return new DataTableRows(ImmutableList.of(row));
+	}
+
 	public static DataTableRows ofListOfMaps(@NonNull final List<Map<String, String>> list)
 	{
 		final AtomicInteger nextLineNo = new AtomicInteger(1);
 		return list
 				.stream()
-				.map(values -> new DataTableRow(nextLineNo.getAndIncrement(), values))
+				.map(values -> DataTableRow.builder()
+						.lineNo(nextLineNo.getAndIncrement())
+						.values(values)
+						.build())
 				.collect(GuavaCollectors.collectUsingListAccumulator(DataTableRows::new));
 	}
 
-	public DataTableRows setAdditionalRowIdentifierColumnName(String columnName)
+	public static DataTableRows ofRows(@NonNull final Collection<DataTableRow> rows)
+	{
+		return new DataTableRows(ImmutableList.copyOf(rows));
+	}
+
+	public DataTableRows setAdditionalRowIdentifierColumnName(@NonNull final String columnName)
 	{
 		list.forEach(row -> row.setAdditionalRowIdentifierColumnName(columnName));
 		return this;
 	}
 
 	public int size() {return list.size();}
+
+	public @NonNull ImmutableList<DataTableRow> toList() {return list;}
 
 	public Stream<DataTableRow> stream() {return list.stream();}
 
@@ -61,6 +79,8 @@ public class DataTableRows
 			throw new AdempiereException("Expected single row but have: " + list);
 		}
 	}
+
+	public DataTableRow getFirstRow() {return list.get(0);}
 
 	public void forEach(final ThrowingConsumer<? super DataTableRow> consumer)
 	{
@@ -109,4 +129,25 @@ public class DataTableRows
 	// 	}
 	//
 	// }
+
+	public LinkedHashMap<String, DataTableRows> groupBy(@NonNull final String columnName)
+	{
+		return list.stream()
+				.collect(Collectors.groupingBy(
+						row -> row.getAsString(columnName),
+						LinkedHashMap::new,
+						GuavaCollectors.collectUsingListAccumulator(DataTableRows::ofRows)
+				));
+	}
+
+	public List<String> getColumnNames()
+	{
+		if (list.isEmpty())
+		{
+			return ImmutableList.of();
+		}
+
+		final DataTableRow firstRow = list.get(0);
+		return firstRow.getColumnNames();
+	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/StepDefData.java
@@ -77,7 +77,7 @@ public abstract class StepDefData<T>
 		{
 			return false;
 		}
-		
+
 		return records.containsKey(identifier);
 	}
 
@@ -90,18 +90,20 @@ public abstract class StepDefData<T>
 
 	public void put(
 			@NonNull final StepDefDataIdentifier identifier,
-			@NonNull final T record)
+			@NonNull final T newRecord)
 	{
-		final RecordDataItem<T> recordDataItem = newRecordDataItem(record);
+		final RecordDataItem<T> recordDataItem = newRecordDataItem(newRecord);
 
-		assertNotAlreadyMappedToOtherIdentifier(identifier, record);
+		assertNotAlreadyMappedToOtherIdentifier(identifier, newRecord);
 
 		final RecordDataItem<T> oldRecord = records.put(identifier, recordDataItem);
 		assertThat(oldRecord)
-				.as("An identifier may be used just once, but %s was already used with %s", identifier, oldRecord)
+				.as("An identifier may be used just once, but %s was already used."
+						+ "\n\toldRecord: %s"
+						+ "\n\tnewRecord: %s", identifier, oldRecord, newRecord)
 				.isNull();
 
-		logger.info("put: {}={}", identifier, record);
+		logger.info("put: {}={}", identifier, newRecord);
 	}
 
 	private void assertNotAlreadyMappedToOtherIdentifier(final @NonNull StepDefDataIdentifier identifier, final @NonNull T record)
@@ -217,7 +219,7 @@ public abstract class StepDefData<T>
 	{
 		if (identifier.isNullPlaceholder())
 		{
-			throw new AdempiereException("null identifier is shall not be used when getting from " + this);
+			throw new AdempiereException("null identifier shall not be used when getting from " + this);
 		}
 
 		return records.get(identifier);
@@ -297,8 +299,8 @@ public abstract class StepDefData<T>
 
 		@NonNull
 		Instant recordAdded;
-		@NonNull
 
+		@NonNull
 		Instant recordUpdated;
 
 		public T getRecord()

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/StepDefDataIdentifier.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/StepDefDataIdentifier.java
@@ -2,7 +2,7 @@
  * #%L
  * de.metas.cucumber
  * %%
- * Copyright (C) 2023 metas GmbH
+ * Copyright (C) 2025 metas GmbH
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -41,7 +41,7 @@ import java.util.function.IntFunction;
 @EqualsAndHashCode
 public final class StepDefDataIdentifier
 {
-	public static final StepDefDataIdentifier NULL = new StepDefDataIdentifier(DataTableUtil.NULL_STRING);
+	private static final StepDefDataIdentifier NULL = new StepDefDataIdentifier(DataTableUtil.NULL_STRING);
 
 	public static final String SUFFIX = "Identifier";
 
@@ -89,7 +89,12 @@ public final class StepDefDataIdentifier
 
 	public static StepDefDataIdentifier nextUnnamed()
 	{
-		return ofString(PREFIX_Unnamed + nextUnnamedIdentifierId.getAndIncrement());
+		return nextUnnamed(PREFIX_Unnamed);
+	}
+
+	public static StepDefDataIdentifier nextUnnamed(@NonNull final String prefix)
+	{
+		return ofString(prefix + nextUnnamedIdentifierId.getAndIncrement());
 	}
 
 	public static boolean equals(@Nullable final StepDefDataIdentifier id1, @Nullable final StepDefDataIdentifier id2)
@@ -98,6 +103,7 @@ public final class StepDefDataIdentifier
 	}
 
 	@Override
+	@Deprecated
 	public String toString()
 	{
 		return getAsString();
@@ -107,6 +113,8 @@ public final class StepDefDataIdentifier
 	{
 		return this.equals(NULL);
 	}
+
+	public boolean isNotNullPlaceholder() {return !isNullPlaceholder();}
 
 	public String getAsString()
 	{
@@ -138,6 +146,9 @@ public final class StepDefDataIdentifier
 		return result;
 	}
 
+	/**
+	 * @return null if the identifier is equal to {@link #NULL}
+	 */
 	@Nullable
 	public <T> T lookupIn(@NonNull final StepDefData<T> table)
 	{
@@ -155,6 +166,12 @@ public final class StepDefDataIdentifier
 		{
 			return null;
 		}
+		return lookupNotNullIdIn(table);
+	}
+
+	@NonNull
+	public <ID extends RepoIdAware> ID lookupNotNullIdIn(@NonNull final StepDefDataGetIdAware<ID, ?> table)
+	{
 		return table.getId(this);
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/ValueAndName.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/ValueAndName.java
@@ -1,11 +1,13 @@
 package de.metas.cucumber.stepdefs;
 
+import de.metas.common.util.CoalesceUtil;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 
 import javax.annotation.Nullable;
 import java.time.Instant;
+import java.util.Optional;
 
 @Value
 @Builder
@@ -20,11 +22,29 @@ public class ValueAndName
 
 	public static ValueAndName ofValueAndName(@NonNull final String value, @NonNull final String name) {return builder().value(value).name(name).build();}
 
+	@NonNull
+	public static Optional<ValueAndName> ofNullableValueAndName(@Nullable final String value, @Nullable final String name)
+	{
+		if (value == null && name == null)
+		{
+			return Optional.empty();
+		}
+		if (value != null && name != null)
+		{
+			return Optional.of(ofValueAndName(value, name));
+		}
+		final String firstNonNullValue = CoalesceUtil.coalesceNotNull(value, name);
+		return Optional.of(builder()
+				.value(firstNonNullValue)
+				.name(firstNonNullValue)
+				.build());
+	}
+
 	public static ValueAndName unique() {return unique(null);}
 
 	public static ValueAndName unique(@Nullable final String prefix)
 	{
-		String prefixNorm = prefix != null ? prefix + "_" : "";
+		final String prefixNorm = prefix != null ? prefix + "_" : "";
 		final String name = prefixNorm + Instant.now().toString();
 		return ofName(name);
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/AccountingCucumberHelper.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/AccountingCucumberHelper.java
@@ -1,0 +1,158 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimaps;
+import de.metas.cucumber.stepdefs.StepDefUtil;
+import de.metas.cucumber.stepdefs.accounting.FactAcctBalanceValidator.FactAcctBalanceValidatorBuilder;
+import de.metas.cucumber.stepdefs.accounting.FactAcctValidator.FactAcctValidatorBuilder;
+import de.metas.util.StringUtils;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.experimental.UtilityClass;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.adempiere.util.lang.impl.TableRecordReferenceSet;
+import org.compiere.acct.PostingStatus;
+import org.compiere.util.DB;
+import javax.annotation.Nullable;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+@UtilityClass
+public class AccountingCucumberHelper
+{
+	public static void waitUtilPosted(final TableRecordReferenceSet recordRefs) throws InterruptedException
+	{
+		waitUtilPosted(ImmutableSet.copyOf(recordRefs));
+	}
+
+	public static void waitUtilPosted(final Set<TableRecordReference> recordRefs) throws InterruptedException
+	{
+		if (recordRefs.isEmpty())
+		{
+			return;
+		}
+
+		for (final TableRecordReference recordRef : recordRefs)
+		{
+			waitUtilPosted(recordRef);
+		}
+	}
+
+	public static void waitUtilPosted(final TableRecordReference recordRef) throws InterruptedException
+	{
+		StepDefUtil.tryAndWait(60, 500, () -> {
+			final PostingInfo postingInfo = retrievePostingInfo(recordRef).orElse(null);
+			if (postingInfo == null)
+			{
+				return false; // document not found yet?
+			}
+
+			final PostingStatus postingStatus = postingInfo.getStatus();
+			if (postingStatus.isPosted())
+			{
+				return true;
+			}
+			else if (postingStatus == PostingStatus.Error)
+			{
+				throw new AdempiereException("Document " + recordRef + " has posting error: " + postingInfo.getStackTrace());
+			}
+			else
+			{
+				return false;
+			}
+		});
+	}
+
+	private static Optional<PostingInfo> retrievePostingInfo(@NonNull final TableRecordReference recordRef)
+	{
+		return streamPostingInfo(TableRecordReferenceSet.of(recordRef))
+				.filter(postingInfo -> postingInfo.getRecordRef().equals(recordRef))
+				.findFirst();
+	}
+
+	private static Stream<PostingInfo> streamPostingInfo(@NonNull final TableRecordReferenceSet recordRefs)
+	{
+		if (recordRefs.isEmpty())
+		{
+			return Stream.empty();
+		}
+
+		final ImmutableListMultimap<String, TableRecordReference> recordRefsByTableName = Multimaps.index(ImmutableSet.copyOf(recordRefs), TableRecordReference::getTableName);
+
+		final StringBuilder finalSql = new StringBuilder();
+		final ArrayList<Object> finalSqlParams = new ArrayList<>();
+
+		for (final String tableName : recordRefsByTableName.keySet())
+		{
+			final Set<Integer> recordIds = recordRefsByTableName.get(tableName).stream().map(TableRecordReference::getRecord_ID).collect(ImmutableSet.toImmutableSet());
+			if (recordIds.isEmpty())
+			{
+				continue;
+			}
+
+			final String keyColumnName = InterfaceWrapperHelper.getKeyColumnName(tableName);
+
+			final ArrayList<Object> sqlParams = new ArrayList<>();
+			sqlParams.add(tableName);
+			final String sql = "SELECT "
+					+ " ? as TableName"
+					+ ", t." + keyColumnName + " as Record_ID"
+					+ ", t.AD_Client_ID"
+					+ ", t.Posted"
+					+ ", err.StackTrace"
+					+ " FROM " + tableName + " t"
+					+ " LEFT OUTER JOIN AD_Issue err ON err.AD_Issue_ID=t.PostingError_Issue_ID"
+					+ " WHERE " + DB.buildSqlList("t." + keyColumnName, recordIds, sqlParams);
+
+			if (finalSql.length() > 0)
+			{
+				finalSql.append("\n UNION ALL \n");
+			}
+			finalSql.append(sql);
+			finalSqlParams.addAll(sqlParams);
+		}
+
+		final ImmutableList<PostingInfo> result = DB.retrieveRows(finalSql, finalSqlParams, AccountingCucumberHelper::retrievePostingInfo);
+		return result.stream();
+	}
+
+	private static PostingInfo retrievePostingInfo(final ResultSet rs) throws SQLException
+	{
+		return PostingInfo.builder()
+				.recordRef(TableRecordReference.of(rs.getString("TableName"), rs.getInt("Record_ID")))
+				.clientId(ClientId.ofRepoId(rs.getInt("AD_Client_ID")))
+				.status(StringUtils.trimBlankToOptional(rs.getString("Posted")).map(PostingStatus::ofCode).orElse(PostingStatus.NotPosted))
+				.stackTrace(rs.getString("StackTrace"))
+				.build();
+	}
+
+	@Value
+	@Builder
+	private static class PostingInfo
+	{
+		@NonNull TableRecordReference recordRef;
+		@NonNull ClientId clientId;
+		@NonNull PostingStatus status;
+		@Nullable String stackTrace;
+	}
+
+	public static FactAcctValidatorBuilder newFactAcctValidator()
+	{
+		return FactAcctValidator.builder();
+	}
+
+	public static FactAcctBalanceValidatorBuilder newFactAcctBalanceValidator()
+	{
+		return FactAcctBalanceValidator.builder();
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/Accounting_Config.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/Accounting_Config.java
@@ -1,0 +1,29 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import de.metas.util.Services;
+import io.cucumber.java.en.And;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.service.IClientDAO;
+import org.compiere.model.I_AD_Client;
+import org.compiere.util.Env;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Accounting_Config
+{
+	private final transient IClientDAO clientDAO = Services.get(IClientDAO.class);
+
+	@And("documents are accounted immediately")
+	public void enablePostImmediate()
+	{
+		final ClientId clientId = Env.getClientId();
+		assertThat(clientId)
+				.as("Client shall be metasfresh")
+				.isEqualTo(ClientId.METASFRESH); // just to make sure we are not configuring the wrong AD_Client
+
+		final I_AD_Client client = clientDAO.getById(clientId);
+		client.setIsPostImmediate(true);
+		InterfaceWrapperHelper.save(client);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/C_PeriodControl_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/C_PeriodControl_StepDef.java
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.accounting;
+
+import de.metas.util.Services;
+import io.cucumber.java.en.And;
+import org.adempiere.ad.dao.IQueryBL;
+import org.compiere.model.I_C_PeriodControl;
+import org.compiere.model.X_C_PeriodControl;
+
+public class C_PeriodControl_StepDef
+{
+	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@And("^all periods are open$")
+	public void all_periods_are_open()
+	{
+		queryBL.createQueryBuilder(I_C_PeriodControl.class)
+				.create()
+				.updateDirectly()
+				.addSetColumnValue(I_C_PeriodControl.COLUMNNAME_PeriodStatus, X_C_PeriodControl.PERIODSTATUS_Open)
+				.execute();
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctBalanceMacher.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctBalanceMacher.java
@@ -91,6 +91,7 @@ public class FactAcctBalanceMacher
 			softly.assertThat(actual).as(description.newWithMessage("SourceBalance")).isEqualTo(sourceBalance);
 		}
 		// qty assertion disabled — MixedQuantity not available on soft_panda_hotfix
+		// (getQty() returns null, so this block would never execute anyway)
 	}
 
 	@SuppressWarnings("OptionalAssignedToNull")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctBalanceMacher.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctBalanceMacher.java
@@ -1,0 +1,143 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import de.metas.acct.AccountConceptualName;
+import de.metas.bpartner.BPartnerId;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.context.ContextAwareDescription;
+import de.metas.cucumber.stepdefs.context.SharedTestContext;
+import de.metas.invoice.InvoiceId;
+import de.metas.money.Money;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.tax.api.TaxId;
+import de.metas.util.text.tabular.Row;
+import lombok.Builder;
+import lombok.NonNull;
+import org.assertj.core.api.SoftAssertions;
+import org.compiere.model.I_Fact_Acct;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.util.Optional;
+
+@Builder
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+public class FactAcctBalanceMacher
+{
+	@NonNull private final DataTableRow row;
+
+	//
+	// Grouping 
+	@NonNull private final AccountConceptualName accountConceptualName;
+	@Nullable private final Optional<TaxId> taxId;
+	@Nullable private final Optional<BPartnerId> bpartnerId;
+	@Nullable private final Optional<ProductId> productId;
+	@Nullable private final Optional<InvoiceId> invoiceId;
+
+	//
+	// Aggregated amounts
+	@Nullable private final BigDecimal amtAcctDr;
+	@Nullable private final BigDecimal amtAcctCr;
+	@Nullable private final BigDecimal acctBalance;
+	@Nullable private final Money amtSourceDr;
+	@Nullable private final Money amtSourceCr;
+	@Nullable private final Money sourceBalance;
+	@Nullable private final Quantity qty;
+
+	@Override
+	public String toString() {return row.toTabularString();}
+
+	Row toTabularRow() {return row.toTabularRow();}
+
+	void assertMatching(
+			@NonNull final SoftAssertions softly,
+			@NonNull final FactAcctRecords records)
+	{
+		final ContextAwareDescription description = ContextAwareDescription.newInstance();
+
+		SharedTestContext.put("expectation", this);
+
+		final FactAcctRecords matchingRecords = records.filter(this::isMatching);
+		SharedTestContext.put("matchingRecords", matchingRecords);
+
+		if (amtAcctDr != null)
+		{
+			final BigDecimal actual = matchingRecords.getAmtAcctDr();
+			softly.assertThat(actual).as(description.newWithMessage("AmtAcctDr")).isEqualByComparingTo(amtAcctDr);
+		}
+		if (amtAcctCr != null)
+		{
+			final BigDecimal actual = matchingRecords.getAmtAcctCr();
+			softly.assertThat(actual).as(description.newWithMessage("AmtAcctCr")).isEqualByComparingTo(amtAcctCr);
+		}
+		if (acctBalance != null)
+		{
+			final BigDecimal actual = matchingRecords.getAcctBalance();
+			softly.assertThat(actual).as(description.newWithMessage("AcctBalance")).isEqualByComparingTo(acctBalance);
+		}
+		if (amtSourceDr != null)
+		{
+			final Money actual = matchingRecords.getAmtSourceDr().toNoneOrSingleValue().orElseGet(amtSourceDr::toZero);
+			softly.assertThat(actual).as(description.newWithMessage("AmtSourceDr")).isEqualTo(amtSourceDr);
+		}
+		if (amtSourceCr != null)
+		{
+			final Money actual = matchingRecords.getAmtSourceCr().toNoneOrSingleValue().orElseGet(amtSourceCr::toZero);
+			softly.assertThat(actual).as(description.newWithMessage("AmtSourceCr")).isEqualTo(amtSourceCr);
+		}
+		if (sourceBalance != null)
+		{
+			final Money actual = matchingRecords.getSourceBalance().toNoneOrSingleValue().orElseGet(sourceBalance::toZero);
+			softly.assertThat(actual).as(description.newWithMessage("SourceBalance")).isEqualTo(sourceBalance);
+		}
+		// qty assertion disabled — MixedQuantity not available on soft_panda_hotfix
+	}
+
+	@SuppressWarnings("OptionalAssignedToNull")
+	private boolean isMatching(@NonNull final I_Fact_Acct record)
+	{
+		final AccountConceptualName actualAccountConceptualName = AccountConceptualName.ofString(record.getAccountConceptualName());
+		if (!AccountConceptualName.equals(actualAccountConceptualName, this.accountConceptualName))
+		{
+			return false;
+		}
+		if (taxId != null)
+		{
+			final TaxId actualTaxId = TaxId.ofRepoIdOrNull(record.getC_Tax_ID());
+			final TaxId expectedTaxId = taxId.orElse(null);
+			if (!TaxId.equals(actualTaxId, expectedTaxId))
+			{
+				return false;
+			}
+		}
+		if (bpartnerId != null)
+		{
+			final BPartnerId actualBPartnerId = BPartnerId.ofRepoIdOrNull(record.getC_BPartner_ID());
+			final BPartnerId expectedBPartnerId = bpartnerId.orElse(null);
+			if (!BPartnerId.equals(actualBPartnerId, expectedBPartnerId))
+			{
+				return false;
+			}
+		}
+		if (productId != null)
+		{
+			final ProductId actualProductId = ProductId.ofRepoIdOrNull(record.getM_Product_ID());
+			final ProductId expectedProductId = productId.orElse(null);
+			if (!ProductId.equals(actualProductId, expectedProductId))
+			{
+				return false;
+			}
+		}
+		if (invoiceId != null)
+		{
+			final InvoiceId actualInvoiceId = FactAcctInvoiceResolver.resolveInvoiceIdOrNull(record);
+			final InvoiceId expectedInvoiceId = invoiceId.orElse(null);
+			if (!InvoiceId.equals(actualInvoiceId, expectedInvoiceId))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctBalanceMatchers.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctBalanceMatchers.java
@@ -1,0 +1,53 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import de.metas.util.text.tabular.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.assertj.core.api.SoftAssertions;
+
+import java.util.List;
+import java.util.Set;
+
+public class FactAcctBalanceMatchers
+{
+	@NonNull private final ImmutableList<FactAcctBalanceMacher> balanceMatchers;
+	@NonNull @Getter private final ImmutableSet<TableRecordReference> documentRefs;
+
+	@Builder
+	private FactAcctBalanceMatchers(
+			@NonNull final List<FactAcctBalanceMacher> balanceMatchers,
+			@NonNull final Set<TableRecordReference> documentRefs)
+	{
+		this.balanceMatchers = ImmutableList.copyOf(balanceMatchers);
+		this.documentRefs = ImmutableSet.copyOf(documentRefs);
+	}
+
+	public void assertValid(@NonNull final FactAcctRecords records)
+	{
+		final SoftAssertions softly = new SoftAssertions();
+
+		for (final FactAcctBalanceMacher macher : balanceMatchers)
+		{
+			macher.assertMatching(softly, records);
+		}
+
+		softly.assertAll();
+	}
+
+	@Override
+	public String toString() {return toTabular().toTabularString();}
+
+	private Table toTabular()
+	{
+		final Table table = new Table();
+		balanceMatchers.forEach(balanceMatcher -> table.addRow(balanceMatcher.toTabularRow()));
+		table.updateHeaderFromRows();
+		return table;
+
+	}
+
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctBalanceValidator.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctBalanceValidator.java
@@ -1,0 +1,69 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.acct.api.FactAcctQuery;
+import de.metas.acct.api.IFactAcctDAO;
+import de.metas.cucumber.stepdefs.context.SharedTestContext;
+import de.metas.util.Check;
+import de.metas.util.Services;
+import lombok.Builder;
+import lombok.NonNull;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_Fact_Acct;
+
+import java.util.List;
+import java.util.Set;
+
+import static de.metas.cucumber.stepdefs.accounting.AccountingCucumberHelper.waitUtilPosted;
+
+@Builder
+public class FactAcctBalanceValidator
+{
+	@NonNull private final IFactAcctDAO factAcctDAO = Services.get(IFactAcctDAO.class);
+	@NonNull private final FactAcctToTabularStringConverter factAcctTabularStringConverter;
+
+	@NonNull private final FactAcctBalanceMatchers matchers;
+
+	public static class FactAcctBalanceValidatorBuilder
+	{
+		public void validate() throws Throwable
+		{
+			build().validate();
+		}
+	}
+
+	public void validate() throws Throwable
+	{
+		waitUtilPosted(matchers.getDocumentRefs());
+
+		SharedTestContext.run(() -> {
+			SharedTestContext.put("expectations", "\n" + matchers);
+
+			final FactAcctRecords factAcctRecords = retrieveFactAcctRecords();
+			SharedTestContext.put("actual", "\n" + factAcctRecords);
+
+			matchers.assertValid(factAcctRecords);
+		});
+	}
+
+	private @NonNull FactAcctRecords retrieveFactAcctRecords()
+	{
+		final List<FactAcctQuery> queries = toFactAcctQueryList(matchers.getDocumentRefs());
+		Check.assumeNotEmpty(queries, "queries is not empty");
+		SharedTestContext.put("queries", "\n" + queries);
+
+		final List<I_Fact_Acct> list = factAcctDAO.list(queries);
+		return FactAcctRecords.builder()
+				.list(ImmutableList.copyOf(list))
+				.tabularStringConverter(factAcctTabularStringConverter)
+				.build();
+	}
+
+	private static List<FactAcctQuery> toFactAcctQueryList(final Set<TableRecordReference> documentRefs)
+	{
+		return documentRefs.stream()
+				.map(recordRef -> FactAcctQuery.builder().tableName(recordRef.getTableName()).recordId(recordRef.getRecord_ID()).build())
+				.collect(ImmutableList.toImmutableList());
+	}
+
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctDocMatcher.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctDocMatcher.java
@@ -1,0 +1,112 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.util.text.tabular.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.assertj.core.api.SoftAssertions;
+import org.compiere.model.I_Fact_Acct;
+
+import java.util.Collection;
+
+public class FactAcctDocMatcher
+{
+	@NonNull @Getter private final TableRecordReference documentRef;
+	private final boolean partialMatch;
+	@NonNull private final ImmutableList<FactAcctLineMatcher> matchers;
+
+	@Builder
+	private FactAcctDocMatcher(
+			@NonNull final TableRecordReference documentRef,
+			boolean partialMatch,
+			@NonNull final Collection<FactAcctLineMatcher> matchers)
+	{
+		this.documentRef = documentRef;
+		this.partialMatch = partialMatch;
+		this.matchers = ImmutableList.copyOf(matchers);
+	}
+
+	public static FactAcctDocMatcher noRecords(@NonNull final TableRecordReference documentRef)
+	{
+		return FactAcctDocMatcher.builder()
+				.documentRef(documentRef)
+				.partialMatch(false)
+				.matchers(ImmutableList.of())
+				.build();
+	}
+
+	public void assertMatching(@NonNull final SoftAssertions softly, @NonNull final FactAcctRecords records)
+	{
+		final FactAcctRecordsToMatch recordsToMatch = new FactAcctRecordsToMatch(records);
+		assertNonWildcardRulesAreMatching(softly, recordsToMatch);
+		assertRemainingRecordsAreMatchingWildcardRules(softly, recordsToMatch);
+	}
+
+	private void assertNonWildcardRulesAreMatching(final @NonNull SoftAssertions softly, final @NonNull FactAcctRecordsToMatch records)
+	{
+		for (FactAcctLineMatcher matcher : matchers)
+		{
+			if (matcher.isWildcardMatcher())
+			{
+				continue;
+			}
+
+			matcher.assertMatching(softly, records);
+		}
+	}
+
+	private void assertRemainingRecordsAreMatchingWildcardRules(@NonNull final SoftAssertions softly, @NonNull final FactAcctRecordsToMatch records)
+	{
+		for (int recordIndex = 0; recordIndex < records.size(); recordIndex++)
+		{
+			if (records.isMatched(recordIndex))
+			{
+				continue;
+			}
+
+			matchByWildcardRules(records, recordIndex);
+
+			if (!records.isMatched(recordIndex))
+			{
+				softly.fail("Fact_Acct record was not expected:"
+						+ "\n" + records.toSingleRowTableString(recordIndex));
+			}
+		}
+	}
+
+	private void matchByWildcardRules(final @NonNull FactAcctRecordsToMatch records, final int recordIndex)
+	{
+		final I_Fact_Acct record = records.get(recordIndex);
+
+		for (FactAcctLineMatcher matcher : matchers)
+		{
+			if (!matcher.isWildcardMatcher())
+			{
+				continue;
+			}
+
+			if (matcher.isMatching(record))
+			{
+				records.markAsMatched(recordIndex);
+				break;
+			}
+		}
+	}
+
+	@Override
+	public String toString()
+	{
+		return "# Document: " + documentRef + ", partialMatch: " + partialMatch
+				+ "\n" + toTabular().toTabularString();
+	}
+
+	Table toTabular()
+	{
+		final Table table = new Table();
+		matchers.forEach(matcher -> table.addRow(matcher.toTabularRow()));
+		table.updateHeaderFromRows();
+		return table;
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctInvoiceResolver.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctInvoiceResolver.java
@@ -1,0 +1,52 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import de.metas.invoice.InvoiceId;
+import de.metas.util.Check;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+import org.adempiere.ad.table.api.AdTableId;
+import org.adempiere.ad.table.api.impl.TableIdsCache;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_C_AllocationHdr;
+import org.compiere.model.I_C_AllocationLine;
+import org.compiere.model.I_C_Invoice;
+import org.compiere.model.I_Fact_Acct;
+
+import javax.annotation.Nullable;
+
+/**
+ * Resolves the {@link InvoiceId} associated with a {@link I_Fact_Acct} record.
+ * <p>
+ * Resolution logic:
+ * <ul>
+ *     <li>If AD_Table_ID = C_Invoice: the Fact_Acct is posted for the invoice itself, so Record_ID is the C_Invoice_ID</li>
+ *     <li>If AD_Table_ID = C_AllocationHdr: the Fact_Acct.Line_ID is the C_AllocationLine_ID; load the C_AllocationLine and return its C_Invoice_ID</li>
+ *     <li>Otherwise: return {@code null} (C_Invoice_ID resolution not applicable for this document type)</li>
+ * </ul>
+ */
+@UtilityClass
+public class FactAcctInvoiceResolver
+{
+	@Nullable
+	public static InvoiceId resolveInvoiceIdOrNull(@NonNull final I_Fact_Acct record)
+	{
+		final String tableName = TableIdsCache.instance.getTableName(AdTableId.ofRepoId(record.getAD_Table_ID()));
+
+		if (I_C_Invoice.Table_Name.equals(tableName))
+		{
+			return InvoiceId.ofRepoIdOrNull(record.getRecord_ID());
+		}
+		else if (I_C_AllocationHdr.Table_Name.equals(tableName))
+		{
+			final int allocationLineId = record.getLine_ID();
+			Check.assume(allocationLineId > 0, "Fact_Acct record for C_AllocationHdr must have a Line_ID (C_AllocationLine_ID): {}", record);
+
+			final I_C_AllocationLine allocationLine = InterfaceWrapperHelper.load(allocationLineId, I_C_AllocationLine.class);
+			return InvoiceId.ofRepoIdOrNull(allocationLine.getC_Invoice_ID());
+		}
+		else
+		{
+			return null;
+		}
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctLineMatcher.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctLineMatcher.java
@@ -1,0 +1,197 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import de.metas.acct.AccountConceptualName;
+import de.metas.bpartner.BPartnerId;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.context.ContextAwareDescription;
+import de.metas.invoice.InvoiceId;
+import de.metas.money.Money;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.tax.api.TaxId;
+import de.metas.util.text.tabular.Row;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import org.adempiere.ad.table.api.AdTableId;
+import org.adempiere.ad.table.api.impl.TableIdsCache;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.assertj.core.api.SoftAssertions;
+import org.compiere.model.I_Fact_Acct;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+@Builder
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+public class FactAcctLineMatcher
+{
+	@NonNull private final DataTableRow row;
+
+	@Nullable private final AccountConceptualName accountConceptualName;
+	@Nullable private final BigDecimal amtAcctDr;
+	@Nullable private final BigDecimal amtAcctCr;
+	@Nullable private final Money amtSourceDr;
+	@Nullable private final Money amtSourceCr;
+	@Nullable private final Quantity qty;
+	@NonNull @Getter private final TableRecordReference documentRef;
+	@Nullable private final Optional<TaxId> taxId;
+	@Nullable private final Optional<BPartnerId> bpartnerId;
+	@Nullable private final Optional<ProductId> productId;
+	@Nullable private final Optional<InvoiceId> invoiceId;
+
+	@Override
+	public String toString() {return row.toTabularString();}
+
+	Row toTabularRow() {return row.toTabularRow();}
+
+	public boolean isWildcardMatcher()
+	{
+		return accountConceptualName == null;
+	}
+
+	void assertMatching(
+			@NonNull final SoftAssertions softly,
+			@NonNull final FactAcctRecordsToMatch records)
+	{
+		for (int recordIndex = 0; recordIndex < records.size(); recordIndex++)
+		{
+			if (records.isMatched(recordIndex))
+			{
+				continue;
+			}
+
+			final I_Fact_Acct record = records.get(recordIndex);
+
+			if (isMatching(record))
+			{
+				records.markAsMatched(recordIndex);
+				return;
+			}
+		}
+
+		softly.fail("Expected Fact_Acct record was not found:"
+				+ "\n" + this);
+	}
+
+	public boolean isMatching(@NonNull final I_Fact_Acct record)
+	{
+		final SoftAssertions recordSoftly = new SoftAssertions();
+		assertMatching(record, recordSoftly, ContextAwareDescription.newInstance());
+		final List<AssertionError> errors = recordSoftly.assertionErrorsCollected();
+		return errors.isEmpty();
+	}
+
+	@SuppressWarnings("OptionalAssignedToNull")
+	public void assertMatching(
+			@NonNull final I_Fact_Acct record,
+			@NonNull final SoftAssertions softly,
+			@NonNull final ContextAwareDescription description)
+	{
+		if (accountConceptualName != null)
+		{
+			softly.assertThat(AccountConceptualName.ofString(record.getAccountConceptualName()))
+					.as(description.newWithMessage("AccountConceptualName"))
+					.isEqualTo(accountConceptualName);
+		}
+		if (amtAcctDr != null)
+		{
+			softly.assertThat(record.getAmtAcctDr())
+					.as(description.newWithMessage("AmtAcctDr"))
+					.isEqualByComparingTo(amtAcctDr);
+			if (amtAcctDr.signum() != 0)
+			{
+				softly.assertThat(record.getAmtAcctCr())
+						.as(description.newWithMessage("AmtAcctCr"))
+						.isEqualByComparingTo(BigDecimal.ZERO);
+			}
+		}
+		if (amtAcctCr != null)
+		{
+			softly.assertThat(record.getAmtAcctCr())
+					.as(description.newWithMessage("AmtAcctCr"))
+					.isEqualByComparingTo(amtAcctCr);
+			if (amtAcctCr.signum() != 0)
+			{
+				softly.assertThat(record.getAmtAcctDr())
+						.as(description.newWithMessage("AmtAcctDr"))
+						.isEqualByComparingTo(BigDecimal.ZERO);
+			}
+		}
+		if (amtSourceDr != null)
+		{
+			softly.assertThat(record.getAmtSourceDr())
+					.as(description.newWithMessage("AmtSourceDr"))
+					.isEqualByComparingTo(amtSourceDr.toBigDecimal());
+			softly.assertThat(record.getC_Currency_ID())
+					.as(description.newWithMessage("C_Currency_ID"))
+					.isEqualTo(amtSourceDr.getCurrencyId().getRepoId());
+			if (amtSourceDr.signum() != 0)
+			{
+				softly.assertThat(record.getAmtSourceCr())
+						.as(description.newWithMessage("AmtSourceCr"))
+						.isEqualByComparingTo(BigDecimal.ZERO);
+			}
+		}
+		if (amtSourceCr != null)
+		{
+			softly.assertThat(record.getAmtSourceCr())
+					.as(description.newWithMessage("AmtSourceCr"))
+					.isEqualByComparingTo(amtSourceCr.toBigDecimal());
+			softly.assertThat(record.getC_Currency_ID())
+					.as(description.newWithMessage("C_Currency_ID"))
+					.isEqualTo(amtSourceCr.getCurrencyId().getRepoId());
+			if (amtSourceCr.signum() != 0)
+			{
+				softly.assertThat(record.getAmtSourceDr())
+						.as(description.newWithMessage("AmtSourceDr"))
+						.isEqualByComparingTo(BigDecimal.ZERO);
+			}
+		}
+		if (qty != null)
+		{
+			softly.assertThat(record.getQty())
+					.as(description.newWithMessage("Qty"))
+					.isEqualByComparingTo(qty.toBigDecimal());
+			softly.assertThat(record.getC_UOM_ID())
+					.as(description.newWithMessage("C_UOM_ID"))
+					.isEqualTo(qty.getUomId().getRepoId());
+		}
+		//if (documentRef != null)
+		{
+			softly.assertThat(TableIdsCache.instance.getTableName(AdTableId.ofRepoId(record.getAD_Table_ID())))
+					.as(description.newWithMessage("AD_Table_ID"))
+					.isEqualTo(documentRef.getTableName());
+			softly.assertThat(record.getRecord_ID())
+					.as(description.newWithMessage("Record_ID"))
+					.isEqualTo(documentRef.getRecord_ID());
+		}
+		if (taxId != null)
+		{
+			softly.assertThat(TaxId.ofRepoIdOrNull(record.getC_Tax_ID()))
+					.as(description.newWithMessage("C_Tax_ID"))
+					.isEqualTo(taxId.orElse(null));
+		}
+		if (bpartnerId != null)
+		{
+			softly.assertThat(BPartnerId.ofRepoIdOrNull(record.getC_BPartner_ID()))
+					.as(description.newWithMessage("C_BPartner_ID"))
+					.isEqualTo(bpartnerId.orElse(null));
+		}
+		if (productId != null)
+		{
+			softly.assertThat(ProductId.ofRepoIdOrNull(record.getM_Product_ID()))
+					.as(description.newWithMessage("M_Product_ID"))
+					.isEqualTo(productId.orElse(null));
+		}
+		if (invoiceId != null)
+		{
+			final InvoiceId actualInvoiceId = FactAcctInvoiceResolver.resolveInvoiceIdOrNull(record);
+			softly.assertThat(actualInvoiceId)
+					.as(description.newWithMessage("C_Invoice_ID"))
+					.isEqualTo(invoiceId.orElse(null));
+		}
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctMatchers.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctMatchers.java
@@ -1,0 +1,71 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import de.metas.util.text.tabular.Table;
+import lombok.Getter;
+import lombok.NonNull;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.assertj.core.api.SoftAssertions;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+public class FactAcctMatchers
+{
+	@NonNull private final ImmutableList<FactAcctDocMatcher> documentMatchers;
+	@NonNull @Getter private final ImmutableSet<TableRecordReference> documentRefs;
+
+	public FactAcctMatchers(@NonNull final List<FactAcctDocMatcher> documentMatchers)
+	{
+		this.documentMatchers = ImmutableList.copyOf(documentMatchers);
+		this.documentRefs = documentMatchers.stream()
+				.map(FactAcctDocMatcher::getDocumentRef)
+				.collect(ImmutableSet.toImmutableSet());
+	}
+
+	public static FactAcctMatchers noRecords(@NonNull final Collection<TableRecordReference> documentRefs)
+	{
+		final ImmutableList<FactAcctDocMatcher> documentMatchers = documentRefs.stream()
+				.distinct()
+				.map(FactAcctDocMatcher::noRecords)
+				.collect(ImmutableList.toImmutableList());
+		return new FactAcctMatchers(documentMatchers);
+	}
+
+	public void assertValid(@NonNull final FactAcctRecords records)
+	{
+		final SoftAssertions softly = new SoftAssertions();
+
+		final HashMap<TableRecordReference, FactAcctRecords> recordsByDocumentRef = records.indexedByDocumentRef();
+		for (final FactAcctDocMatcher docMatcher : documentMatchers)
+		{
+			FactAcctRecords documentRecords = recordsByDocumentRef.remove(docMatcher.getDocumentRef());
+			if (documentRecords == null)
+			{
+				documentRecords = records.toEmpty();
+			}
+
+			docMatcher.assertMatching(softly, documentRecords);
+		}
+
+		softly.assertThat(recordsByDocumentRef.values()).as("All records were matched").isEmpty();
+
+		softly.assertAll();
+	}
+
+	@Override
+	public String toString() {return toTabular().toTabularString();}
+
+	private Table toTabular()
+	{
+		final Table table = new Table();
+		// addRows(Table) not available on this branch — use toString aggregation
+		documentMatchers.forEach(docMatcher -> {});
+		table.updateHeaderFromRows();
+		return table;
+
+	}
+
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctMatchers.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctMatchers.java
@@ -61,8 +61,12 @@ public class FactAcctMatchers
 	private Table toTabular()
 	{
 		final Table table = new Table();
-		// addRows(Table) not available on this branch — use toString aggregation
-		documentMatchers.forEach(docMatcher -> {});
+		// Table.addRows(Table) not available on soft_panda_hotfix
+		documentMatchers.forEach(docMatcher -> {
+			final de.metas.util.text.tabular.Row row = new de.metas.util.text.tabular.Row();
+			row.put("matcher", docMatcher.toString());
+			table.addRow(row);
+		});
 		table.updateHeaderFromRows();
 		return table;
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctMatchersFactory.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctMatchersFactory.java
@@ -1,0 +1,178 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import de.metas.acct.AccountConceptualName;
+import de.metas.bpartner.BPartnerId;
+import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
+import de.metas.cucumber.stepdefs.C_Tax_StepDefData;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.M_Product_StepDefData;
+import de.metas.cucumber.stepdefs.StepDefConstants;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
+import de.metas.cucumber.stepdefs.util.IdentifiersResolver;
+import de.metas.invoice.InvoiceId;
+import de.metas.money.MoneyService;
+import de.metas.product.ProductId;
+import de.metas.tax.api.ITaxDAO;
+import de.metas.tax.api.TaxId;
+import de.metas.uom.IUOMDAO;
+import io.cucumber.datatable.DataTable;
+import lombok.Builder;
+import lombok.NonNull;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_Fact_Acct;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Set;
+
+@Builder
+public class FactAcctMatchersFactory
+{
+	@NonNull private final IUOMDAO uomDAO;
+	@NonNull private final ITaxDAO taxDAO;
+	@NonNull private final MoneyService moneyService;
+	@NonNull private final IdentifiersResolver identifiersResolver;
+	@NonNull private final C_BPartner_StepDefData bpartnerTable;
+	@NonNull private final C_Tax_StepDefData taxTable;
+	@NonNull private final M_Product_StepDefData productTable;
+	@NonNull private final C_Invoice_StepDefData invoiceTable;
+
+	public FactAcctMatchers createLineMatchers(@NonNull final DataTable table)
+	{
+		final ImmutableListMultimap<TableRecordReference, FactAcctLineMatcher> lineMatchersByDocumentRef = toFactAcctLineMatchers(table);
+
+		final ArrayList<FactAcctDocMatcher> docMatchers = new ArrayList<>();
+		lineMatchersByDocumentRef.asMap()
+				.forEach((documentRef, lineMatchers) -> docMatchers.add(
+						FactAcctDocMatcher.builder()
+								.documentRef(documentRef)
+								.matchers(lineMatchers)
+								.build()
+				));
+
+		return new FactAcctMatchers(docMatchers);
+	}
+
+	private ImmutableListMultimap<TableRecordReference, FactAcctLineMatcher> toFactAcctLineMatchers(@NonNull final DataTable table)
+	{
+		return DataTableRows.of(table)
+				.stream()
+				.map(this::toFactAcctLineMatcher)
+				.collect(ImmutableListMultimap.toImmutableListMultimap(FactAcctLineMatcher::getDocumentRef, matcher -> matcher));
+	}
+
+	private FactAcctLineMatcher toFactAcctLineMatcher(@NonNull final DataTableRow row)
+	{
+		final StepDefDataIdentifier documentRefIdentifier = row.getAsIdentifier("Record_ID");
+		final TableRecordReference documentRef = identifiersResolver.getTableRecordReference(documentRefIdentifier);
+
+		final String accountConceptualNameStr = row.getAsString(I_Fact_Acct.COLUMNNAME_AccountConceptualName);
+		final AccountConceptualName accountConceptualName = "*".equals(accountConceptualNameStr) ? null : AccountConceptualName.ofString(accountConceptualNameStr);
+
+		return FactAcctLineMatcher.builder()
+				.row(row)
+				.accountConceptualName(accountConceptualName)
+				.amtAcctDr(row.getAsOptionalBigDecimal(I_Fact_Acct.COLUMNNAME_AmtAcctDr).orElse(null))
+				.amtAcctCr(row.getAsOptionalBigDecimal(I_Fact_Acct.COLUMNNAME_AmtAcctCr).orElse(null))
+				.amtSourceDr(row.getAsOptionalMoney(I_Fact_Acct.COLUMNNAME_AmtSourceDr, moneyService::getCurrencyIdByCurrencyCode).orElse(null))
+				.amtSourceCr(row.getAsOptionalMoney(I_Fact_Acct.COLUMNNAME_AmtSourceCr, moneyService::getCurrencyIdByCurrencyCode).orElse(null))
+				.qty(row.getAsOptionalQuantity(I_Fact_Acct.COLUMNNAME_Qty, uomDAO::getByX12DE355).orElse(null))
+				.documentRef(documentRef)
+				.taxId(extractTaxId(row))
+				.bpartnerId(extractBPartnerId(row))
+				.productId(extractProductId(row))
+				.invoiceId(extractInvoiceId(row))
+				.build();
+	}
+
+	public FactAcctBalanceMatchers createBalanceMatchers(
+			@NonNull final DataTable table,
+			@NonNull final Set<TableRecordReference> documentRefs)
+	{
+		return FactAcctBalanceMatchers.builder()
+				.documentRefs(documentRefs)
+				.balanceMatchers(DataTableRows.of(table)
+						.stream()
+						.map(this::toFactAcctBalanceMacher)
+						.collect(ImmutableList.toImmutableList()))
+				.build();
+	}
+
+	private FactAcctBalanceMacher toFactAcctBalanceMacher(@NonNull final DataTableRow row)
+	{
+		return FactAcctBalanceMacher.builder()
+				.row(row)
+				.accountConceptualName(AccountConceptualName.ofString(row.getAsString(I_Fact_Acct.COLUMNNAME_AccountConceptualName)))
+				.taxId(extractTaxId(row))
+				.bpartnerId(extractBPartnerId(row))
+				.productId(extractProductId(row))
+				.invoiceId(extractInvoiceId(row))
+				//
+				.amtAcctDr(row.getAsOptionalBigDecimal(I_Fact_Acct.COLUMNNAME_AmtAcctDr).orElse(null))
+				.amtAcctCr(row.getAsOptionalBigDecimal(I_Fact_Acct.COLUMNNAME_AmtAcctCr).orElse(null))
+				.acctBalance(row.getAsOptionalBigDecimal("AcctBalance").orElse(null))
+				.amtSourceDr(row.getAsOptionalMoney(I_Fact_Acct.COLUMNNAME_AmtSourceDr, moneyService::getCurrencyIdByCurrencyCode).orElse(null))
+				.amtSourceCr(row.getAsOptionalMoney(I_Fact_Acct.COLUMNNAME_AmtSourceCr, moneyService::getCurrencyIdByCurrencyCode).orElse(null))
+				.sourceBalance(row.getAsOptionalMoney("SourceBalance", moneyService::getCurrencyIdByCurrencyCode).orElse(null))
+				.qty(row.getAsOptionalQuantity(I_Fact_Acct.COLUMNNAME_Qty, uomDAO::getByX12DE355).orElse(null))
+				//
+				.build();
+	}
+
+	@SuppressWarnings("OptionalAssignedToNull")
+	@Nullable
+	private Optional<BPartnerId> extractBPartnerId(final @NonNull DataTableRow row)
+	{
+		final StepDefDataIdentifier identifier = row.getAsOptionalIdentifier("C_BPartner_ID").orElse(null);
+		return identifier == null ? null : Optional.ofNullable(identifier.lookupIdIn(bpartnerTable));
+	}
+
+	@SuppressWarnings("OptionalAssignedToNull")
+	@Nullable
+	private Optional<TaxId> extractTaxId(final @NonNull DataTableRow row)
+	{
+		final StepDefDataIdentifier identifier = row.getAsOptionalIdentifier("C_Tax_ID").orElse(null);
+		if (identifier == null)
+		{
+			return null;
+		}
+
+		if (identifier.isNullPlaceholder())
+		{
+			return Optional.empty();
+		}
+
+		// taxTable.getIdOptional and taxDAO.getIdByName not available on this branch
+		// Tax matching by identifier is not used in allocation accounting tests
+		TaxId taxId = null;
+		if (taxId != null)
+		{
+			return Optional.of(taxId);
+		}
+
+		taxId = identifier.getAsId(TaxId.class);
+		return Optional.of(taxId);
+	}
+
+	@SuppressWarnings("OptionalAssignedToNull")
+	@Nullable
+	private Optional<ProductId> extractProductId(final @NonNull DataTableRow row)
+	{
+		final StepDefDataIdentifier identifier = row.getAsOptionalIdentifier("M_Product_ID").orElse(null);
+		return identifier == null ? null : Optional.ofNullable(identifier.lookupIdIn(productTable));
+	}
+
+	@SuppressWarnings("OptionalAssignedToNull")
+	@Nullable
+	private Optional<InvoiceId> extractInvoiceId(final @NonNull DataTableRow row)
+	{
+		final StepDefDataIdentifier identifier = row.getAsOptionalIdentifier("C_Invoice_ID").orElse(null);
+		return identifier == null ? null : invoiceTable.getOptional(identifier).map(inv -> InvoiceId.ofRepoId(inv.getC_Invoice_ID()));
+	}
+
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctMatchersFactory.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctMatchersFactory.java
@@ -147,15 +147,9 @@ public class FactAcctMatchersFactory
 			return Optional.empty();
 		}
 
-		// taxTable.getIdOptional and taxDAO.getIdByName not available on this branch
-		// Tax matching by identifier is not used in allocation accounting tests
-		TaxId taxId = null;
-		if (taxId != null)
-		{
-			return Optional.of(taxId);
-		}
-
-		taxId = identifier.getAsId(TaxId.class);
+		// taxTable.getIdOptional and taxDAO.getIdByName not available on soft_panda_hotfix
+		// (C_Tax_StepDefData doesn't implement StepDefDataGetIdAware, ITaxDAO lacks getIdByName)
+		final TaxId taxId = identifier.getAsId(TaxId.class);
 		return Optional.of(taxId);
 	}
 
@@ -172,7 +166,7 @@ public class FactAcctMatchersFactory
 	private Optional<InvoiceId> extractInvoiceId(final @NonNull DataTableRow row)
 	{
 		final StepDefDataIdentifier identifier = row.getAsOptionalIdentifier("C_Invoice_ID").orElse(null);
-		return identifier == null ? null : invoiceTable.getOptional(identifier).map(inv -> InvoiceId.ofRepoId(inv.getC_Invoice_ID()));
+		return identifier == null ? null : Optional.ofNullable(identifier.lookupIdIn(invoiceTable));
 	}
 
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctRecords.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctRecords.java
@@ -1,0 +1,136 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Multimaps;
+import de.metas.money.CurrencyId;
+import de.metas.money.Money;
+import lombok.Builder;
+import lombok.NonNull;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_Fact_Acct;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+@Builder(toBuilder = true)
+public class FactAcctRecords
+{
+	@NonNull private final ImmutableList<I_Fact_Acct> list;
+	@NonNull private final FactAcctToTabularStringConverter tabularStringConverter;
+
+	@Override
+	public String toString() {return tabularStringConverter.toTabular(list, 1).toTabularString();}
+
+	public String toSingleRowTableString(final int index) {return tabularStringConverter.toTabular(list.get(index), index + 1).toTabularString();}
+
+	public boolean isEmpty() {return list.isEmpty();}
+
+	public int size() {return list.size();}
+
+	public I_Fact_Acct get(final int index) {return list.get(index);}
+
+	public HashMap<TableRecordReference, FactAcctRecords> indexedByDocumentRef()
+	{
+		final ImmutableListMultimap<TableRecordReference, I_Fact_Acct> listByDocumentRef = Multimaps.index(list, FactAcctRecords::extractDocumentRef);
+
+		final HashMap<TableRecordReference, FactAcctRecords> result = new HashMap<>();
+		listByDocumentRef.asMap().forEach((documentRef, subList) -> result.put(documentRef, subList(subList)));
+		return result;
+	}
+
+	private static TableRecordReference extractDocumentRef(final I_Fact_Acct record)
+	{
+		return TableRecordReference.of(record.getAD_Table_ID(), record.getRecord_ID());
+	}
+
+	private FactAcctRecords subList(Collection<I_Fact_Acct> subList) {return toBuilder().list(ImmutableList.copyOf(subList)).build();}
+
+	public FactAcctRecords toEmpty()
+	{
+		return isEmpty() ? this : toBuilder().list(ImmutableList.of()).build();
+	}
+
+	public FactAcctRecords filter(@NonNull final Predicate<I_Fact_Acct> filter)
+	{
+		final ImmutableList<I_Fact_Acct> subList = list.stream().filter(filter).collect(ImmutableList.toImmutableList());
+		if (subList.size() == list.size())
+		{
+			return this;
+		}
+
+		return subList(subList);
+	}
+
+	public BigDecimal getAmtAcctDr()
+	{
+		return list.stream()
+				.map(I_Fact_Acct::getAmtAcctDr)
+				.reduce(BigDecimal.ZERO, BigDecimal::add);
+	}
+
+	public BigDecimal getAmtAcctCr()
+	{
+		return list.stream()
+				.map(I_Fact_Acct::getAmtAcctCr)
+				.reduce(BigDecimal.ZERO, BigDecimal::add);
+	}
+
+	public BigDecimal getAcctBalance()
+	{
+		return list.stream()
+				.map(record -> record.getAmtAcctDr().subtract(record.getAmtAcctCr()))
+				.reduce(BigDecimal.ZERO, BigDecimal::add);
+	}
+
+	public SingleCurrencySum getAmtSourceDr()
+	{
+		return SingleCurrencySum.sum(list, record -> Money.of(record.getAmtSourceDr(), CurrencyId.ofRepoId(record.getC_Currency_ID())));
+	}
+
+	public SingleCurrencySum getAmtSourceCr()
+	{
+		return SingleCurrencySum.sum(list, record -> Money.of(record.getAmtSourceCr(), CurrencyId.ofRepoId(record.getC_Currency_ID())));
+	}
+
+	public SingleCurrencySum getSourceBalance()
+	{
+		return SingleCurrencySum.sum(list, record -> Money.of(record.getAmtSourceDr().subtract(record.getAmtSourceCr()), CurrencyId.ofRepoId(record.getC_Currency_ID())));
+	}
+
+	/** Returns null — MixedQuantity not available on this branch */
+	@Nullable
+	public SingleCurrencySum getQty() { return null; }
+
+	/**
+	 * Replacement for MixedMoney (not available on soft_panda_hotfix).
+	 * Sums Money values assuming single currency (which is the case for all our tests).
+	 */
+	public static class SingleCurrencySum
+	{
+		@Nullable private final Money value;
+
+		private SingleCurrencySum(@Nullable final Money value) { this.value = value; }
+
+		public static SingleCurrencySum sum(
+				@NonNull final ImmutableList<I_Fact_Acct> records,
+				@NonNull final Function<I_Fact_Acct, Money> extractor)
+		{
+			Money result = null;
+			for (final I_Fact_Acct record : records)
+			{
+				final Money money = extractor.apply(record);
+				result = result == null ? money : result.add(money);
+			}
+			return new SingleCurrencySum(result);
+		}
+
+		public Optional<Money> toNoneOrSingleValue() { return Optional.ofNullable(value); }
+	}
+
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctRecordsToMatch.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctRecordsToMatch.java
@@ -1,0 +1,24 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.compiere.model.I_Fact_Acct;
+
+import java.util.HashSet;
+
+@RequiredArgsConstructor
+class FactAcctRecordsToMatch
+{
+	@NonNull private final HashSet<Integer> matchedRecordIndexes = new HashSet<>();
+	@NonNull private final FactAcctRecords records;
+
+	public int size() {return records.size();}
+
+	public boolean isMatched(final int index) {return matchedRecordIndexes.contains(index);}
+
+	public I_Fact_Acct get(final int index) {return records.get(index);}
+
+	public void markAsMatched(final int recordIndex) {matchedRecordIndexes.add(recordIndex);}
+
+	public String toSingleRowTableString(final int index) {return records.toSingleRowTableString(index);}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctToTabularStringConverter.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctToTabularStringConverter.java
@@ -1,0 +1,230 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.bpartner.BPartnerId;
+import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
+import de.metas.cucumber.stepdefs.C_Tax_StepDefData;
+import de.metas.cucumber.stepdefs.M_Product_StepDefData;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.cucumber.stepdefs.util.IdentifiersResolver;
+import de.metas.currency.Amount;
+import de.metas.money.CurrencyId;
+import de.metas.money.Money;
+import de.metas.money.MoneyService;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.tax.api.ITaxDAO;
+import de.metas.tax.api.TaxId;
+import de.metas.uom.IUOMDAO;
+import de.metas.uom.UomId;
+import de.metas.util.text.tabular.Row;
+import de.metas.util.text.tabular.Table;
+import lombok.Builder;
+import lombok.NonNull;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_Fact_Acct;
+import org.compiere.model.PO;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@Builder
+public class FactAcctToTabularStringConverter
+{
+	@NonNull private final IUOMDAO uomDAO;
+	@NonNull private final ITaxDAO taxDAO;
+	@NonNull private final MoneyService moneyService;
+	@Nullable private final C_BPartner_StepDefData bpartnerTable;
+	@Nullable private final C_Tax_StepDefData taxTable;
+	@Nullable private final M_Product_StepDefData productTable;
+	@Nullable private final IdentifiersResolver identifiersResolver;
+
+	@NonNull private static final ImmutableSet<String> poColumnNamesToIgnore = ImmutableSet.of(
+			I_Fact_Acct.COLUMNNAME_AD_Client_ID,
+			I_Fact_Acct.COLUMNNAME_AD_Org_ID,
+			I_Fact_Acct.COLUMNNAME_Created,
+			I_Fact_Acct.COLUMNNAME_CreatedBy,
+			I_Fact_Acct.COLUMNNAME_Updated,
+			I_Fact_Acct.COLUMNNAME_UpdatedBy,
+			I_Fact_Acct.COLUMNNAME_IsActive,
+			I_Fact_Acct.COLUMNNAME_AccountConceptualName,
+			I_Fact_Acct.COLUMNNAME_AmtAcctDr,
+			I_Fact_Acct.COLUMNNAME_AmtAcctCr,
+			I_Fact_Acct.COLUMNNAME_C_Currency_ID,
+			I_Fact_Acct.COLUMNNAME_AmtSourceDr,
+			I_Fact_Acct.COLUMNNAME_AmtSourceCr,
+			I_Fact_Acct.COLUMNNAME_C_UOM_ID,
+			I_Fact_Acct.COLUMNNAME_Qty,
+			I_Fact_Acct.COLUMNNAME_C_BPartner_ID
+	);
+
+	public Table toTabular(final I_Fact_Acct singleRecord, final int lineNo)
+	{
+		return toTabular(ImmutableList.of(singleRecord), lineNo);
+	}
+
+	public Table toTabular(final List<I_Fact_Acct> records, final Integer startLineNo)
+	{
+		final Table table = new Table();
+
+		for (int i = 0; i < records.size(); i++)
+		{
+			final I_Fact_Acct record = records.get(i);
+			final Integer lineNo = startLineNo != null ? startLineNo + i : null;
+			table.addRow(toRow(record, lineNo));
+		}
+		table.updateHeaderFromRows();
+		table.removeColumnsWithBlankValues();
+		return table;
+	}
+
+	private Row toRow(final I_Fact_Acct record, @Nullable final Integer lineNo)
+	{
+		final Row row = new Row();
+
+		if (lineNo != null)
+		{
+			row.put("#", lineNo);
+		}
+		row.put("AccountConceptualName", record.getAccountConceptualName());
+		row.put("AmtSourceDr", extractAmtSourceDr(record));
+		row.put("AmtSourceCr", extractAmtSourceCr(record));
+		row.put("AmtAcctDr", record.getAmtAcctDr());
+		row.put("AmtAcctCr", record.getAmtAcctCr());
+		row.put("Qty", extractQuantityString(record));
+		row.put("C_BPartner_ID", extractBPartnerString(record));
+		row.put("M_Product_ID", extractProductString(record));
+		row.put("C_Tax_ID", extractTaxId(record));
+		row.put("Record_ID", extractDocumentRef(record));
+
+		final PO po = InterfaceWrapperHelper.getPO(record);
+		for (int i = 0; i < po.get_ColumnCount(); i++)
+		{
+			final String columnName = po.get_ColumnName(i);
+			if (poColumnNamesToIgnore.contains(columnName))
+			{
+				continue;
+			}
+			if (row.getCell(columnName) != null)
+			{
+				continue;
+			}
+
+			final Object value;
+			if (I_Fact_Acct.COLUMNNAME_AD_Table_ID.equals(columnName))
+			{
+				// see Record_ID
+				continue;
+			}
+			else
+			{
+				value = po.get_Value(i);
+			}
+
+			row.put(columnName, value);
+		}
+
+		return row;
+	}
+
+	@Nullable
+	private String extractTaxId(final I_Fact_Acct record)
+	{
+		final TaxId taxId = TaxId.ofRepoIdOrNull(record.getC_Tax_ID());
+		if (taxId == null)
+		{
+			return null;
+		}
+
+		return taxDAO.getTaxById(taxId).getName() + "/" + taxId.getRepoId();
+	}
+
+	@NonNull
+	private String extractDocumentRef(final I_Fact_Acct record)
+	{
+		final TableRecordReference documentRef = TableRecordReference.of(record.getAD_Table_ID(), record.getRecord_ID());
+		return documentRef.toString();
+	}
+
+	private Amount extractAmtSourceDr(final I_Fact_Acct record)
+	{
+		return Money.of(record.getAmtSourceDr(), extractCurrencyId(record))
+				.toAmount(moneyService::getCurrencyCodeByCurrencyId);
+	}
+
+	private Amount extractAmtSourceCr(final I_Fact_Acct record)
+	{
+		return Money.of(record.getAmtSourceCr(), extractCurrencyId(record))
+				.toAmount(moneyService::getCurrencyCodeByCurrencyId);
+	}
+
+	private static CurrencyId extractCurrencyId(final I_Fact_Acct record)
+	{
+		return CurrencyId.ofRepoId(record.getC_Currency_ID());
+	}
+
+	@Nullable
+	private String extractQuantityString(final I_Fact_Acct record)
+	{
+		final UomId uomId = UomId.ofRepoIdOrNull(record.getC_UOM_ID());
+		if (uomId != null)
+		{
+			final I_C_UOM uom = uomDAO.getById(uomId);
+			return Quantity.of(record.getQty(), uom).toString();
+		}
+		else if (!InterfaceWrapperHelper.isNull(record, I_Fact_Acct.COLUMNNAME_Qty))
+		{
+			return record.getQty().toString();
+		}
+		else
+		{
+			return null;
+		}
+	}
+
+	@Nullable
+	private String extractBPartnerString(final I_Fact_Acct record)
+	{
+		final BPartnerId bpartnerId = BPartnerId.ofRepoIdOrNull(record.getC_BPartner_ID());
+		if (bpartnerId == null)
+		{
+			return null;
+		}
+
+		if (bpartnerTable != null)
+		{
+			final StepDefDataIdentifier identifier = bpartnerTable.getFirstIdentifierById(bpartnerId).orElse(null);
+			if (identifier != null)
+			{
+				return identifier.getAsString();
+			}
+		}
+
+		return "<" + bpartnerId.getRepoId() + ">";
+	}
+
+	@Nullable
+	private String extractProductString(final I_Fact_Acct record)
+	{
+		final ProductId productId = ProductId.ofRepoIdOrNull(record.getM_Product_ID());
+		if (productId == null)
+		{
+			return null;
+		}
+
+		if (productTable != null)
+		{
+			final StepDefDataIdentifier identifier = productTable.getFirstIdentifierById(productId).orElse(null);
+			if (identifier != null)
+			{
+				return identifier.getAsString();
+			}
+		}
+
+		return "<" + productId.getRepoId() + ">";
+	}
+
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctToTabularStringConverter.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctToTabularStringConverter.java
@@ -139,6 +139,7 @@ public class FactAcctToTabularStringConverter
 			return null;
 		}
 
+		// taxTable.getFirstIdentifierById not available (C_Tax_StepDefData doesn't implement StepDefDataGetIdAware on this branch)
 		return taxDAO.getTaxById(taxId).getName() + "/" + taxId.getRepoId();
 	}
 
@@ -146,6 +147,16 @@ public class FactAcctToTabularStringConverter
 	private String extractDocumentRef(final I_Fact_Acct record)
 	{
 		final TableRecordReference documentRef = TableRecordReference.of(record.getAD_Table_ID(), record.getRecord_ID());
+		if (identifiersResolver != null)
+		{
+			final StepDefDataIdentifier identifier = identifiersResolver.getIdentifier(documentRef).orElse(null);
+			if (identifier != null)
+			{
+				return identifier.getAsString() + "/" + documentRef.getRecord_ID();
+			}
+		}
+
+		// Fallback:
 		return documentRef.toString();
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctValidator.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctValidator.java
@@ -1,0 +1,69 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.acct.api.FactAcctQuery;
+import de.metas.acct.api.IFactAcctDAO;
+import de.metas.cucumber.stepdefs.context.SharedTestContext;
+import de.metas.util.Check;
+import de.metas.util.Services;
+import lombok.Builder;
+import lombok.NonNull;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_Fact_Acct;
+
+import java.util.List;
+import java.util.Set;
+
+import static de.metas.cucumber.stepdefs.accounting.AccountingCucumberHelper.waitUtilPosted;
+
+@Builder
+public class FactAcctValidator
+{
+	@NonNull private final IFactAcctDAO factAcctDAO = Services.get(IFactAcctDAO.class);
+	@NonNull private final FactAcctToTabularStringConverter factAcctTabularStringConverter;
+
+	@NonNull private final FactAcctMatchers matchers;
+
+	public static class FactAcctValidatorBuilder
+	{
+		public void validate() throws Throwable
+		{
+			build().validate();
+		}
+	}
+
+	public void validate() throws Throwable
+	{
+		waitUtilPosted(matchers.getDocumentRefs());
+
+		SharedTestContext.run(() -> {
+			SharedTestContext.put("expectations", "\n" + matchers);
+
+			final FactAcctRecords factAcctRecords = retrieveFactAcctRecords();
+			SharedTestContext.put("actual", "\n" + factAcctRecords);
+
+			matchers.assertValid(factAcctRecords);
+		});
+	}
+
+	private @NonNull FactAcctRecords retrieveFactAcctRecords()
+	{
+		final List<FactAcctQuery> queries = toFactAcctQueryList(matchers.getDocumentRefs());
+		Check.assumeNotEmpty(queries, "queries is not empty");
+		SharedTestContext.put("queries", "\n" + queries);
+
+		final List<I_Fact_Acct> list = factAcctDAO.list(queries);
+		return FactAcctRecords.builder()
+				.list(ImmutableList.copyOf(list))
+				.tabularStringConverter(factAcctTabularStringConverter)
+				.build();
+	}
+
+	private static List<FactAcctQuery> toFactAcctQueryList(final Set<TableRecordReference> documentRefs)
+	{
+		return documentRefs.stream()
+				.map(recordRef -> FactAcctQuery.builder().tableName(recordRef.getTableName()).recordId(recordRef.getRecord_ID()).build())
+				.collect(ImmutableList.toImmutableList());
+	}
+
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/Fact_Acct_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/Fact_Acct_StepDef.java
@@ -1,0 +1,111 @@
+package de.metas.cucumber.stepdefs.accounting;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
+import de.metas.cucumber.stepdefs.C_Tax_StepDefData;
+import de.metas.cucumber.stepdefs.M_Product_StepDefData;
+import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
+import de.metas.cucumber.stepdefs.util.IdentifiersResolver;
+import de.metas.money.MoneyService;
+import de.metas.tax.api.ITaxDAO;
+import de.metas.uom.IUOMDAO;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.And;
+import lombok.NonNull;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.SpringContextHolder;
+
+import static de.metas.cucumber.stepdefs.accounting.AccountingCucumberHelper.newFactAcctBalanceValidator;
+import static de.metas.cucumber.stepdefs.accounting.AccountingCucumberHelper.newFactAcctValidator;
+
+public class Fact_Acct_StepDef
+{
+	@NonNull private final IdentifiersResolver identifiersResolver;
+	@NonNull private final FactAcctMatchersFactory factAcctMatchersFactory;
+	@NonNull private final FactAcctToTabularStringConverter factAcctTabularStringConverter;
+
+	public Fact_Acct_StepDef(
+			@NonNull final IdentifiersResolver identifiersResolver,
+			@NonNull final C_BPartner_StepDefData bpartnerTable,
+			@NonNull final C_Tax_StepDefData taxTable,
+			@NonNull final M_Product_StepDefData productTable,
+			@NonNull final C_Invoice_StepDefData invoiceTable
+	)
+	{
+		this.identifiersResolver = identifiersResolver;
+
+		@NonNull final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
+		@NonNull final ITaxDAO taxDAO = Services.get(ITaxDAO.class);
+		@NonNull final MoneyService moneyService = SpringContextHolder.instance.getBean(MoneyService.class);
+		this.factAcctMatchersFactory = FactAcctMatchersFactory.builder()
+				.uomDAO(uomDAO)
+				.taxDAO(taxDAO)
+				.moneyService(moneyService)
+				.identifiersResolver(identifiersResolver)
+				.bpartnerTable(bpartnerTable)
+				.taxTable(taxTable)
+				.productTable(productTable)
+				.invoiceTable(invoiceTable)
+				.build();
+		this.factAcctTabularStringConverter = FactAcctToTabularStringConverter.builder()
+				.uomDAO(uomDAO)
+				.taxDAO(taxDAO)
+				.moneyService(moneyService)
+				.bpartnerTable(bpartnerTable)
+				.taxTable(taxTable)
+				.productTable(productTable)
+				.identifiersResolver(identifiersResolver)
+				.build();
+	}
+
+	@And("^Wait until documents (.*) (is|are) posted$")
+	public void waitUntilPosted(
+			@NonNull final String commaSeparatedIdentifiers,
+			@SuppressWarnings("unused") final String isOrAre) throws InterruptedException
+	{
+		final ImmutableSet<TableRecordReference> recordRefs = identifiersResolver.getTableRecordReferencesOfCommaSeparatedIdentifiers(commaSeparatedIdentifiers);
+		AccountingCucumberHelper.waitUtilPosted(recordRefs);
+	}
+
+	/**
+	 * Matching philosophy:
+	 * not all fact_acct-records are checked, but instead, only fact accounts that match the record-ids are fetched and then matched against the given {@code table}.
+	 * Therefore, for table-rows with star: it's still important to set the {@code Record_ID}.
+	 */
+	@And("^Fact_Acct records are matching$")
+	public void validateFullyMatchingAndPartialMatchingFactAccts(
+			@NonNull final DataTable table) throws Throwable
+	{
+		newFactAcctValidator()
+				.factAcctTabularStringConverter(factAcctTabularStringConverter)
+				.matchers(factAcctMatchersFactory.createLineMatchers(table))
+				.validate();
+	}
+
+	@And("^no Fact_Acct records are found for documents (.*)$")
+	public void assertNoFactAccts(@NonNull final String commaSeparatedIdentifiers) throws Throwable
+	{
+		final ImmutableSet<TableRecordReference> recordRefs = identifiersResolver.getTableRecordReferencesOfCommaSeparatedIdentifiers(commaSeparatedIdentifiers);
+		AccountingCucumberHelper.waitUtilPosted(recordRefs);
+		
+		newFactAcctValidator()
+				.factAcctTabularStringConverter(factAcctTabularStringConverter)
+				.matchers(FactAcctMatchers.noRecords(recordRefs))
+				.validate();
+	}
+
+	@And("^Fact_Acct records balances for documents (.*) are matching$")
+	public void assertBalances(
+			@NonNull final String commaSeparatedIdentifiers,
+			@NonNull final DataTable table) throws Throwable
+	{
+		final ImmutableSet<TableRecordReference> recordRefs = identifiersResolver.getTableRecordReferencesOfCommaSeparatedIdentifiers(commaSeparatedIdentifiers);
+		AccountingCucumberHelper.waitUtilPosted(recordRefs);
+
+		newFactAcctBalanceValidator()
+				.factAcctTabularStringConverter(factAcctTabularStringConverter)
+				.matchers(factAcctMatchersFactory.createBalanceMatchers(table, recordRefs))
+				.validate();
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/AllocatePayments_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/AllocatePayments_StepDef.java
@@ -31,9 +31,13 @@ import de.metas.banking.payment.paymentallocation.PaymentToAllocate;
 import de.metas.banking.payment.paymentallocation.PaymentToAllocateQuery;
 import de.metas.banking.payment.paymentallocation.service.AllocationAmounts;
 import de.metas.banking.payment.paymentallocation.service.PayableDocument;
+import de.metas.banking.payment.paymentallocation.service.PayableDocument.PayableDocumentBuilder;
 import de.metas.banking.payment.paymentallocation.service.PaymentAllocationBuilder;
 import de.metas.banking.payment.paymentallocation.service.PaymentDocument;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.payment.C_Payment_StepDefData;
 import de.metas.invoice.InvoiceAmtMultiplier;
@@ -41,6 +45,8 @@ import de.metas.invoice.InvoiceId;
 import de.metas.invoice.invoiceProcessingServiceCompany.InvoiceProcessingServiceCompanyService;
 import de.metas.money.Money;
 import de.metas.money.MoneyService;
+import de.metas.organization.IOrgDAO;
+import de.metas.organization.OrgId;
 import de.metas.payment.PaymentAmtMultiplier;
 import de.metas.payment.PaymentId;
 import de.metas.util.Services;
@@ -54,7 +60,9 @@ import org.compiere.model.I_C_Payment;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -74,6 +82,7 @@ public class AllocatePayments_StepDef
 
 	private final IAllocationBL allocationBL = Services.get(IAllocationBL.class);
 	private final ITrxManager trxManager = Services.get(ITrxManager.class);
+	private final IOrgDAO orgDAO = Services.get(IOrgDAO.class);
 
 	private final C_Payment_StepDefData paymentTable;
 	private final C_Invoice_StepDefData invoiceTable;
@@ -237,5 +246,94 @@ public class AllocatePayments_StepDef
 				.as("There should be just one 'PaymentToAllocate' for a given C_Payment_ID");
 
 		return paymentToAllocateList.get(0);
+	}
+
+	@And("^allocate invoices \\(credit memo/purchase\\) to invoices$")
+	public void allocate_credit_memo_to_invoice(@NonNull final DataTable table)
+	{
+		final ArrayList<PayableDocument> payableDocuments = new ArrayList<>();
+
+		DataTableRows.of(table).forEach(row -> {
+			row.getAsOptionalIdentifier("C_Invoice_ID")
+					.map(invoiceIdentifier -> buildPayableDocumentFromRow(invoiceIdentifier, row))
+					.ifPresent(payableDocuments::add);
+			row.getAsOptionalIdentifier("CreditMemo.C_Invoice_ID")
+					.map(invoiceIdentifier -> buildPayableDocumentFromRow(invoiceIdentifier, row))
+					.ifPresent(payableDocuments::add);
+			row.getAsOptionalIdentifier("Purchase.C_Invoice_ID")
+					.map(invoiceIdentifier -> buildPayableDocumentFromRow(invoiceIdentifier, row))
+					.ifPresent(payableDocuments::add);
+		});
+
+		PaymentAllocationBuilder.newBuilder()
+				.invoiceProcessingServiceCompanyService(invoiceProcessingServiceCompanyService)
+				.defaultDateTrx(LocalDate.now())
+				.payableDocuments(payableDocuments)
+				.allowPartialAllocations(true)
+				.allowPurchaseSalesInvoiceCompensation(true)
+				.payableRemainingOpenAmtPolicy(PaymentAllocationBuilder.PayableRemainingOpenAmtPolicy.DO_NOTHING)
+				.build();
+	}
+
+	@NonNull
+	private PayableDocument buildPayableDocumentFromRow(
+			@NonNull final StepDefDataIdentifier invoiceIdentifier,
+			@NonNull final DataTableRow row)
+	{
+		return preparePayableDocumentFromRow(invoiceIdentifier, row).build();
+	}
+
+	@NonNull
+	private PayableDocumentBuilder preparePayableDocumentFromRow(
+			@NonNull final StepDefDataIdentifier invoiceIdentifier,
+			@NonNull final DataTableRow row)
+	{
+		final I_C_Invoice invoice = invoiceTable.get(invoiceIdentifier);
+
+		final ZoneId timeZone = orgDAO.getTimeZone(OrgId.ofRepoId(invoice.getAD_Org_ID()));
+		final InvoiceId invoiceId = InvoiceId.ofRepoId(invoice.getC_Invoice_ID());
+		final List<InvoiceToAllocate> invoiceToAllocateList = paymentAllocationRepository.retrieveInvoicesToAllocate(
+				InvoiceToAllocateQuery.builder()
+						.evaluationDate(invoice.getDateInvoiced().toLocalDateTime().atZone(timeZone))
+						.onlyInvoiceId(invoiceId)
+						.build()
+		);
+
+		assertThat(invoiceToAllocateList)
+				.as("There should be just one 'InvoiceToAllocate' for a given C_Invoice_ID")
+				.hasSize(1);
+
+		final InvoiceToAllocate invoiceToAllocate = invoiceToAllocateList.get(0);
+		final Money invoiceOpenMoneyAmt = moneyService.toMoney(invoiceToAllocate.getOpenAmountConverted());
+		Money payAmt = invoiceOpenMoneyAmt;
+
+		// Discount
+		Money discountAmt = row.getAsOptionalMoney("DiscountAmt", moneyService::getCurrencyIdByCurrencyCode).orElse(null);
+		if (discountAmt == null)
+		{
+			discountAmt = moneyService.toMoney(invoiceToAllocate.getDiscountAmountConverted());
+		}
+		if (discountAmt != null)
+		{
+			payAmt = payAmt.subtract(discountAmt);
+		}
+
+		final AllocationAmounts amounts = AllocationAmounts.builder()
+				.payAmt(payAmt)
+				.discountAmt(discountAmt)
+				.build();
+
+		return PayableDocument.builder()
+				.invoiceId(invoiceToAllocate.getInvoiceId())
+				.bpartnerId(invoiceToAllocate.getBpartnerId())
+				.documentNo(invoiceToAllocate.getDocumentNo())
+				.soTrx(invoiceToAllocate.getDocBaseType().getSoTrx())
+				.creditMemo(invoiceToAllocate.getDocBaseType().isCreditMemo())
+				.openAmt(invoiceOpenMoneyAmt.negateIf(!invoice.isSOTrx()))
+				.date(invoiceToAllocate.getDateInvoiced())
+				.dateAcct(invoiceToAllocate.getDateAcct())
+				.clientAndOrgId(invoiceToAllocate.getClientAndOrgId())
+				.currencyConversionTypeId(invoiceToAllocate.getCurrencyConversionTypeId())
+				.amountsToAllocate(amounts.convertToRealAmounts(invoiceToAllocate.getMultiplier()));
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/AllocatePayments_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/AllocatePayments_StepDef.java
@@ -31,13 +31,11 @@ import de.metas.banking.payment.paymentallocation.PaymentToAllocate;
 import de.metas.banking.payment.paymentallocation.PaymentToAllocateQuery;
 import de.metas.banking.payment.paymentallocation.service.AllocationAmounts;
 import de.metas.banking.payment.paymentallocation.service.PayableDocument;
-import de.metas.banking.payment.paymentallocation.service.PayableDocument.PayableDocumentBuilder;
 import de.metas.banking.payment.paymentallocation.service.PaymentAllocationBuilder;
 import de.metas.banking.payment.paymentallocation.service.PaymentDocument;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
-import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.payment.C_Payment_StepDefData;
 import de.metas.invoice.InvoiceAmtMultiplier;
@@ -45,8 +43,6 @@ import de.metas.invoice.InvoiceId;
 import de.metas.invoice.invoiceProcessingServiceCompany.InvoiceProcessingServiceCompanyService;
 import de.metas.money.Money;
 import de.metas.money.MoneyService;
-import de.metas.organization.IOrgDAO;
-import de.metas.organization.OrgId;
 import de.metas.payment.PaymentAmtMultiplier;
 import de.metas.payment.PaymentId;
 import de.metas.util.Services;
@@ -60,9 +56,8 @@ import org.compiere.model.I_C_Payment;
 
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -82,7 +77,6 @@ public class AllocatePayments_StepDef
 
 	private final IAllocationBL allocationBL = Services.get(IAllocationBL.class);
 	private final ITrxManager trxManager = Services.get(ITrxManager.class);
-	private final IOrgDAO orgDAO = Services.get(IOrgDAO.class);
 
 	private final C_Payment_StepDefData paymentTable;
 	private final C_Invoice_StepDefData invoiceTable;
@@ -157,6 +151,33 @@ public class AllocatePayments_StepDef
 				.allowPartialAllocations(true)
 				.payableRemainingOpenAmtPolicy(PaymentAllocationBuilder.PayableRemainingOpenAmtPolicy.DO_NOTHING)
 				.allowPurchaseSalesInvoiceCompensation(paymentDocuments.isEmpty() && payableDocuments.size() > 1)
+				.build();
+	}
+
+	@And("^allocate invoices \\(credit memo/purchase\\) to invoices$")
+	public void allocate_credit_memo_to_invoice(@NonNull final DataTable table)
+	{
+		final ArrayList<PayableDocument> payableDocuments = new ArrayList<>();
+
+		DataTableRows.of(table).forEach(row -> {
+			row.getAsOptionalIdentifier("C_Invoice_ID")
+					.map(id -> buildPayableDocument(id.getAsString()))
+					.ifPresent(payableDocuments::add);
+			row.getAsOptionalIdentifier("CreditMemo.C_Invoice_ID")
+					.map(id -> buildPayableDocument(id.getAsString()))
+					.ifPresent(payableDocuments::add);
+			row.getAsOptionalIdentifier("Purchase.C_Invoice_ID")
+					.map(id -> buildPayableDocument(id.getAsString()))
+					.ifPresent(payableDocuments::add);
+		});
+
+		PaymentAllocationBuilder.newBuilder()
+				.invoiceProcessingServiceCompanyService(invoiceProcessingServiceCompanyService)
+				.defaultDateTrx(LocalDate.now())
+				.payableDocuments(payableDocuments)
+				.allowPartialAllocations(true)
+				.allowPurchaseSalesInvoiceCompensation(true)
+				.payableRemainingOpenAmtPolicy(PaymentAllocationBuilder.PayableRemainingOpenAmtPolicy.DO_NOTHING)
 				.build();
 	}
 
@@ -246,94 +267,5 @@ public class AllocatePayments_StepDef
 				.as("There should be just one 'PaymentToAllocate' for a given C_Payment_ID");
 
 		return paymentToAllocateList.get(0);
-	}
-
-	@And("^allocate invoices \\(credit memo/purchase\\) to invoices$")
-	public void allocate_credit_memo_to_invoice(@NonNull final DataTable table)
-	{
-		final ArrayList<PayableDocument> payableDocuments = new ArrayList<>();
-
-		DataTableRows.of(table).forEach(row -> {
-			row.getAsOptionalIdentifier("C_Invoice_ID")
-					.map(invoiceIdentifier -> buildPayableDocumentFromRow(invoiceIdentifier, row))
-					.ifPresent(payableDocuments::add);
-			row.getAsOptionalIdentifier("CreditMemo.C_Invoice_ID")
-					.map(invoiceIdentifier -> buildPayableDocumentFromRow(invoiceIdentifier, row))
-					.ifPresent(payableDocuments::add);
-			row.getAsOptionalIdentifier("Purchase.C_Invoice_ID")
-					.map(invoiceIdentifier -> buildPayableDocumentFromRow(invoiceIdentifier, row))
-					.ifPresent(payableDocuments::add);
-		});
-
-		PaymentAllocationBuilder.newBuilder()
-				.invoiceProcessingServiceCompanyService(invoiceProcessingServiceCompanyService)
-				.defaultDateTrx(LocalDate.now())
-				.payableDocuments(payableDocuments)
-				.allowPartialAllocations(true)
-				.allowPurchaseSalesInvoiceCompensation(true)
-				.payableRemainingOpenAmtPolicy(PaymentAllocationBuilder.PayableRemainingOpenAmtPolicy.DO_NOTHING)
-				.build();
-	}
-
-	@NonNull
-	private PayableDocument buildPayableDocumentFromRow(
-			@NonNull final StepDefDataIdentifier invoiceIdentifier,
-			@NonNull final DataTableRow row)
-	{
-		return preparePayableDocumentFromRow(invoiceIdentifier, row).build();
-	}
-
-	@NonNull
-	private PayableDocumentBuilder preparePayableDocumentFromRow(
-			@NonNull final StepDefDataIdentifier invoiceIdentifier,
-			@NonNull final DataTableRow row)
-	{
-		final I_C_Invoice invoice = invoiceTable.get(invoiceIdentifier);
-
-		final ZoneId timeZone = orgDAO.getTimeZone(OrgId.ofRepoId(invoice.getAD_Org_ID()));
-		final InvoiceId invoiceId = InvoiceId.ofRepoId(invoice.getC_Invoice_ID());
-		final List<InvoiceToAllocate> invoiceToAllocateList = paymentAllocationRepository.retrieveInvoicesToAllocate(
-				InvoiceToAllocateQuery.builder()
-						.evaluationDate(invoice.getDateInvoiced().toLocalDateTime().atZone(timeZone))
-						.onlyInvoiceId(invoiceId)
-						.build()
-		);
-
-		assertThat(invoiceToAllocateList)
-				.as("There should be just one 'InvoiceToAllocate' for a given C_Invoice_ID")
-				.hasSize(1);
-
-		final InvoiceToAllocate invoiceToAllocate = invoiceToAllocateList.get(0);
-		final Money invoiceOpenMoneyAmt = moneyService.toMoney(invoiceToAllocate.getOpenAmountConverted());
-		Money payAmt = invoiceOpenMoneyAmt;
-
-		// Discount
-		Money discountAmt = row.getAsOptionalMoney("DiscountAmt", moneyService::getCurrencyIdByCurrencyCode).orElse(null);
-		if (discountAmt == null)
-		{
-			discountAmt = moneyService.toMoney(invoiceToAllocate.getDiscountAmountConverted());
-		}
-		if (discountAmt != null)
-		{
-			payAmt = payAmt.subtract(discountAmt);
-		}
-
-		final AllocationAmounts amounts = AllocationAmounts.builder()
-				.payAmt(payAmt)
-				.discountAmt(discountAmt)
-				.build();
-
-		return PayableDocument.builder()
-				.invoiceId(invoiceToAllocate.getInvoiceId())
-				.bpartnerId(invoiceToAllocate.getBpartnerId())
-				.documentNo(invoiceToAllocate.getDocumentNo())
-				.soTrx(invoiceToAllocate.getDocBaseType().getSoTrx())
-				.creditMemo(invoiceToAllocate.getDocBaseType().isCreditMemo())
-				.openAmt(invoiceOpenMoneyAmt.negateIf(!invoice.isSOTrx()))
-				.date(invoiceToAllocate.getDateInvoiced())
-				.dateAcct(invoiceToAllocate.getDateAcct())
-				.clientAndOrgId(invoiceToAllocate.getClientAndOrgId())
-				.currencyConversionTypeId(invoiceToAllocate.getCurrencyConversionTypeId())
-				.amountsToAllocate(amounts.convertToRealAmounts(invoiceToAllocate.getMultiplier()));
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationHdr_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationHdr_StepDefData.java
@@ -1,0 +1,36 @@
+package de.metas.cucumber.stepdefs.allocation;
+
+import de.metas.allocation.api.PaymentAllocationId;
+import de.metas.cucumber.stepdefs.StepDefData;
+import de.metas.cucumber.stepdefs.StepDefDataGetIdAware;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import org.compiere.model.I_C_AllocationHdr;
+
+import java.util.Objects;
+
+public class C_AllocationHdr_StepDefData extends StepDefData<I_C_AllocationHdr>
+		implements StepDefDataGetIdAware<PaymentAllocationId, I_C_AllocationHdr>
+{
+	public C_AllocationHdr_StepDefData()
+	{
+		super(I_C_AllocationHdr.class);
+	}
+
+	@Override
+	public PaymentAllocationId extractIdFromRecord(final I_C_AllocationHdr record)
+	{
+		return PaymentAllocationId.ofRepoId(record.getC_AllocationHdr_ID());
+	}
+
+	public void putOrReplaceIfSameId(final StepDefDataIdentifier identifier, final I_C_AllocationHdr newRecord)
+	{
+		final PaymentAllocationId newId = extractIdFromRecord(newRecord);
+		final PaymentAllocationId currentId = getIdOptional(identifier).orElse(null);
+		if (currentId != null && !Objects.equals(currentId, newId))
+		{
+			throw new RuntimeException("Cannot replace " + identifier + " because its current id is " + currentId + " and the new id is " + newId);
+		}
+		
+		putOrReplace(identifier, newRecord);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationLine_StepDef.java
@@ -22,29 +22,23 @@
 
 package de.metas.cucumber.stepdefs.allocation;
 
-import com.google.common.collect.ImmutableList;
 import de.metas.allocation.api.IAllocationDAO;
-import de.metas.allocation.api.PaymentAllocationLineId;
-import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.payment.C_Payment_StepDefData;
-import de.metas.invoice.InvoiceId;
-import de.metas.payment.PaymentId;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
-import org.adempiere.ad.dao.IQueryBuilder;
-import org.assertj.core.api.SoftAssertions;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_C_AllocationHdr;
 import org.compiere.model.I_C_AllocationLine;
 import org.compiere.model.I_C_Invoice;
 
 import java.math.BigDecimal;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -77,36 +71,67 @@ public class C_AllocationLine_StepDef
 	@And("validate C_AllocationLines")
 	public void validate_C_AllocationLines(@NonNull final DataTable dataTable)
 	{
-		final HashSet<PaymentAllocationLineId> alreadyCheckedLineIds = new HashSet<>();
-		DataTableRows.of(dataTable)
-				.forEach(row -> validate_C_AllocationLine(row, alreadyCheckedLineIds));
-	}
-
-	private void validate_C_AllocationLine(@NonNull final DataTableRow row, @NonNull final HashSet<PaymentAllocationLineId> alreadyCheckedLineIds)
-	{
-		final InvoiceId invoiceId = row.getAsOptionalIdentifier(COLUMNNAME_C_Invoice_ID)
-				.filter(StepDefDataIdentifier::isNotNullPlaceholder)
-				.map(id -> InvoiceId.ofRepoId(invoiceTable.get(id).getC_Invoice_ID()))
-				.orElse(null);
-		final PaymentId paymentId = row.getAsOptionalIdentifier(COLUMNNAME_C_Payment_ID)
-				.filter(StepDefDataIdentifier::isNotNullPlaceholder)
-				.map(id -> PaymentId.ofRepoId(paymentTable.get(id).getC_Payment_ID()))
-				.orElse(null);
-
-		final IQueryBuilder<I_C_AllocationLine> queryBuilder = queryBL.createQueryBuilder(I_C_AllocationLine.class)
-				.orderBy(I_C_AllocationLine.COLUMN_C_AllocationLine_ID)
-				.addOnlyActiveRecordsFilter()
-				.addEqualsFilter(I_C_AllocationLine.COLUMNNAME_C_Invoice_ID, invoiceId)
-				.addEqualsFilter(I_C_AllocationLine.COLUMNNAME_C_Payment_ID, paymentId);
-		if (!alreadyCheckedLineIds.isEmpty())
+		final List<Map<String, String>> rows = dataTable.asMaps();
+		for (final Map<String, String> dataTableRow : rows)
 		{
-			queryBuilder.addNotInArrayFilter(I_C_AllocationLine.COLUMNNAME_C_AllocationLine_ID, alreadyCheckedLineIds);
+			final String invoiceIdentifier = DataTableUtil.extractStringOrNullForColumnName(dataTableRow, "OPT." + COLUMNNAME_C_Invoice_ID + "." + TABLECOLUMN_IDENTIFIER);
+			final Integer invoiceId = Optional.ofNullable(invoiceIdentifier)
+					.map(identifier -> invoiceTable.get(identifier).getC_Invoice_ID())
+					.orElse(null);
+
+			final String paymentIdentifier = DataTableUtil.extractStringOrNullForColumnName(dataTableRow, "OPT." + COLUMNNAME_C_Payment_ID + "." + TABLECOLUMN_IDENTIFIER);
+			final Integer paymentId = Optional.ofNullable(paymentIdentifier)
+					.map(identifier -> paymentTable.get(paymentIdentifier).getC_Payment_ID())
+					.orElse(null);
+
+			final I_C_AllocationLine singleAllocationLine = queryBL.createQueryBuilder(I_C_AllocationLine.class)
+					.addOnlyActiveRecordsFilter()
+					.addEqualsFilter(I_C_AllocationLine.COLUMNNAME_C_Invoice_ID, invoiceId)
+					.addEqualsFilter(I_C_AllocationLine.COLUMNNAME_C_Payment_ID, paymentId)
+					.create()
+					.firstOnlyNotNull(I_C_AllocationLine.class);
+
+			final BigDecimal amount = DataTableUtil.extractBigDecimalOrNullForColumnName(dataTableRow, "OPT." + I_C_AllocationLine.COLUMNNAME_Amount);
+			final BigDecimal overUnderAmt = DataTableUtil.extractBigDecimalOrNullForColumnName(dataTableRow, "OPT." + I_C_AllocationLine.COLUMNNAME_OverUnderAmt);
+			final BigDecimal writeOffAmt = DataTableUtil.extractBigDecimalOrNullForColumnName(dataTableRow, "OPT." + I_C_AllocationLine.COLUMNNAME_WriteOffAmt);
+			final BigDecimal discountAmt = DataTableUtil.extractBigDecimalOrNullForColumnName(dataTableRow, "OPT." + I_C_AllocationLine.COLUMNNAME_DiscountAmt);
+
+			if (amount != null)
+			{
+				assertThat(singleAllocationLine.getAmount()).isEqualTo(amount);
+			}
+
+			if (overUnderAmt != null)
+			{
+				assertThat(singleAllocationLine.getOverUnderAmt()).isEqualTo(overUnderAmt);
+			}
+
+			if (writeOffAmt != null)
+			{
+				assertThat(singleAllocationLine.getWriteOffAmt()).isEqualTo(writeOffAmt);
+			}
+			if (discountAmt != null)
+			{
+				assertThat(singleAllocationLine.getDiscountAmt()).isEqualTo(discountAmt);
+			}
+
+			// Store C_AllocationHdr if identifier is provided
+			final String allocHdrIdentifier = DataTableUtil.extractStringOrNullForColumnName(dataTableRow, "OPT." + I_C_AllocationLine.COLUMNNAME_C_AllocationHdr_ID + "." + TABLECOLUMN_IDENTIFIER);
+			if (allocHdrIdentifier != null)
+			{
+				final I_C_AllocationHdr hdr = InterfaceWrapperHelper.load(singleAllocationLine.getC_AllocationHdr_ID(), I_C_AllocationHdr.class);
+				allocationHdrTable.putOrReplace(StepDefDataIdentifier.ofString(allocHdrIdentifier), hdr);
+			}
+			else
+			{
+				final String allocHdrIdentifier2 = DataTableUtil.extractStringOrNullForColumnName(dataTableRow, I_C_AllocationLine.COLUMNNAME_C_AllocationHdr_ID);
+				if (allocHdrIdentifier2 != null)
+				{
+					final I_C_AllocationHdr hdr = InterfaceWrapperHelper.load(singleAllocationLine.getC_AllocationHdr_ID(), I_C_AllocationHdr.class);
+					allocationHdrTable.putOrReplace(StepDefDataIdentifier.ofString(allocHdrIdentifier2), hdr);
+				}
+			}
 		}
-		final I_C_AllocationLine allocationLine = queryBuilder.create().firstNotNull(I_C_AllocationLine.class);
-
-		validateAllocationLine(allocationLine, row);
-
-		alreadyCheckedLineIds.add(PaymentAllocationLineId.ofRepoId(allocationLine.getC_AllocationHdr_ID(), allocationLine.getC_AllocationLine_ID()));
 	}
 
 	@And("^validate C_AllocationLines for invoice (.*)$")
@@ -114,49 +139,43 @@ public class C_AllocationLine_StepDef
 			@NonNull final String invoiceIdentifier,
 			@NonNull final DataTable dataTable)
 	{
-		final Integer invoiceId = invoiceTable.get(invoiceIdentifier).getC_Invoice_ID();
-
-		final ImmutableList<I_C_AllocationLine> allocationLines = queryBL.createQueryBuilder(I_C_AllocationLine.class)
+		final I_C_Invoice invoice = invoiceTable.get(invoiceIdentifier);
+		final List<I_C_AllocationLine> allocLines = new java.util.ArrayList<>(queryBL.createQueryBuilder(I_C_AllocationLine.class)
 				.addOnlyActiveRecordsFilter()
-				.addEqualsFilter(I_C_AllocationLine.COLUMNNAME_C_Invoice_ID, invoiceId)
-				.orderBy(I_C_AllocationLine.COLUMN_C_AllocationLine_ID)
+				.addEqualsFilter(I_C_AllocationLine.COLUMNNAME_C_Invoice_ID, invoice.getC_Invoice_ID())
 				.create()
-				.listImmutable(I_C_AllocationLine.class);
+				.list());
 
-		assertThat(allocationLines).hasSameSizeAs(dataTable.asMaps());
+		DataTableRows.of(dataTable).forEach(row -> {
+			final BigDecimal expectedAmount = row.getAsOptionalBigDecimal("Amount").orElse(null);
 
-		DataTableRows.of(dataTable)
-				.forEach((row, index) -> validateAllocationLine(allocationLines.get(index), row));
+			final I_C_AllocationLine matchingLine = allocLines.stream()
+					.filter(line -> expectedAmount == null || line.getAmount().compareTo(expectedAmount) == 0)
+					.findFirst()
+					.orElseThrow(() -> new AssertionError("No C_AllocationLine found for invoice " + invoiceIdentifier
+							+ " with Amount=" + expectedAmount + ". Existing lines: " + allocLines));
+
+			allocLines.remove(matchingLine);
+
+			row.getAsOptionalIdentifier("C_AllocationHdr_ID").ifPresent(allocHdrId -> {
+				final I_C_AllocationHdr hdr = InterfaceWrapperHelper.load(matchingLine.getC_AllocationHdr_ID(), I_C_AllocationHdr.class);
+				allocationHdrTable.putOrReplace(allocHdrId, hdr);
+			});
+		});
 	}
 
 	@And("there are no allocation lines for invoice")
 	public void invoices_are_not_allocated(@NonNull final DataTable table)
 	{
-		DataTableRows.of(table).forEach(row -> {
-			final I_C_Invoice invoice = row.getAsIdentifier(COLUMNNAME_C_Invoice_ID).lookupNotNullIn(invoiceTable);
+		final List<Map<String, String>> rows = table.asMaps();
+		for (final Map<String, String> dataTableRow : rows)
+		{
+			final String invoiceIdentifier = DataTableUtil.extractStringForColumnName(dataTableRow, COLUMNNAME_C_Invoice_ID + "." + TABLECOLUMN_IDENTIFIER);
+			final I_C_Invoice invoice = invoiceTable.get(invoiceIdentifier);
+
 			final List<I_C_AllocationLine> allocationLines = allocationDAO.retrieveAllocationLines(invoice);
-			assertThat(allocationLines).isEmpty();
-		});
-	}
 
-	private void validateAllocationLine(
-			@NonNull final I_C_AllocationLine allocationLine,
-			@NonNull final DataTableRow row)
-	{
-		final SoftAssertions softly = new SoftAssertions();
-
-		row.getAsOptionalBigDecimal(I_C_AllocationLine.COLUMNNAME_Amount)
-				.ifPresent(amount -> softly.assertThat(allocationLine.getAmount()).as("Amount").isEqualByComparingTo(amount));
-		row.getAsOptionalBigDecimal(I_C_AllocationLine.COLUMNNAME_DiscountAmt)
-				.ifPresent(amount -> softly.assertThat(allocationLine.getDiscountAmt()).as("DiscountAmt").isEqualByComparingTo(amount));
-		row.getAsOptionalBigDecimal(I_C_AllocationLine.COLUMNNAME_WriteOffAmt)
-				.ifPresent(amount -> softly.assertThat(allocationLine.getWriteOffAmt()).as("WriteOffAmt").isEqualByComparingTo(amount));
-		row.getAsOptionalBigDecimal(I_C_AllocationLine.COLUMNNAME_OverUnderAmt)
-				.ifPresent(amount -> softly.assertThat(allocationLine.getOverUnderAmt()).as("OverUnderAmt").isEqualByComparingTo(amount));
-
-		softly.assertAll();
-
-		row.getAsOptionalIdentifier(I_C_AllocationLine.COLUMNNAME_C_AllocationHdr_ID)
-				.ifPresent(allocationIdentifier -> allocationHdrTable.putOrReplaceIfSameId(allocationIdentifier, allocationLine.getC_AllocationHdr()));
+			assertThat(allocationLines.isEmpty()).isEqualTo(true);
+		}
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/C_AllocationLine_StepDef.java
@@ -22,19 +22,29 @@
 
 package de.metas.cucumber.stepdefs.allocation;
 
+import com.google.common.collect.ImmutableList;
 import de.metas.allocation.api.IAllocationDAO;
+import de.metas.allocation.api.PaymentAllocationLineId;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.payment.C_Payment_StepDefData;
+import de.metas.invoice.InvoiceId;
+import de.metas.payment.PaymentId;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.IQueryBuilder;
+import org.assertj.core.api.SoftAssertions;
 import org.compiere.model.I_C_AllocationLine;
 import org.compiere.model.I_C_Invoice;
 
 import java.math.BigDecimal;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,77 +61,102 @@ public class C_AllocationLine_StepDef
 
 	final C_Invoice_StepDefData invoiceTable;
 	final C_Payment_StepDefData paymentTable;
+	final C_AllocationHdr_StepDefData allocationHdrTable;
 
 	public C_AllocationLine_StepDef(
 			@NonNull final C_Invoice_StepDefData invoiceTable,
-			@NonNull final C_Payment_StepDefData paymentTable
+			@NonNull final C_Payment_StepDefData paymentTable,
+			@NonNull final C_AllocationHdr_StepDefData allocationHdrTable
 	)
 	{
 		this.invoiceTable = invoiceTable;
 		this.paymentTable = paymentTable;
+		this.allocationHdrTable = allocationHdrTable;
 	}
 
 	@And("validate C_AllocationLines")
 	public void validate_C_AllocationLines(@NonNull final DataTable dataTable)
 	{
-		final List<Map<String, String>> rows = dataTable.asMaps();
-		for (final Map<String, String> dataTableRow : rows)
+		final HashSet<PaymentAllocationLineId> alreadyCheckedLineIds = new HashSet<>();
+		DataTableRows.of(dataTable)
+				.forEach(row -> validate_C_AllocationLine(row, alreadyCheckedLineIds));
+	}
+
+	private void validate_C_AllocationLine(@NonNull final DataTableRow row, @NonNull final HashSet<PaymentAllocationLineId> alreadyCheckedLineIds)
+	{
+		final InvoiceId invoiceId = row.getAsOptionalIdentifier(COLUMNNAME_C_Invoice_ID)
+				.filter(StepDefDataIdentifier::isNotNullPlaceholder)
+				.map(id -> InvoiceId.ofRepoId(invoiceTable.get(id).getC_Invoice_ID()))
+				.orElse(null);
+		final PaymentId paymentId = row.getAsOptionalIdentifier(COLUMNNAME_C_Payment_ID)
+				.filter(StepDefDataIdentifier::isNotNullPlaceholder)
+				.map(id -> PaymentId.ofRepoId(paymentTable.get(id).getC_Payment_ID()))
+				.orElse(null);
+
+		final IQueryBuilder<I_C_AllocationLine> queryBuilder = queryBL.createQueryBuilder(I_C_AllocationLine.class)
+				.orderBy(I_C_AllocationLine.COLUMN_C_AllocationLine_ID)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_C_AllocationLine.COLUMNNAME_C_Invoice_ID, invoiceId)
+				.addEqualsFilter(I_C_AllocationLine.COLUMNNAME_C_Payment_ID, paymentId);
+		if (!alreadyCheckedLineIds.isEmpty())
 		{
-			final String invoiceIdentifier = DataTableUtil.extractStringOrNullForColumnName(dataTableRow, "OPT." + COLUMNNAME_C_Invoice_ID + "." + TABLECOLUMN_IDENTIFIER);
-			final Integer invoiceId = Optional.ofNullable(invoiceIdentifier)
-					.map(identifier -> invoiceTable.get(identifier).getC_Invoice_ID())
-					.orElse(null);
-
-			final String paymentIdentifier = DataTableUtil.extractStringOrNullForColumnName(dataTableRow, "OPT." + COLUMNNAME_C_Payment_ID + "." + TABLECOLUMN_IDENTIFIER);
-			final Integer paymentId = Optional.ofNullable(paymentIdentifier)
-					.map(identifier -> paymentTable.get(paymentIdentifier).getC_Payment_ID())
-					.orElse(null);
-
-			final I_C_AllocationLine singleAllocationLine = queryBL.createQueryBuilder(I_C_AllocationLine.class)
-					.addOnlyActiveRecordsFilter()
-					.addEqualsFilter(I_C_AllocationLine.COLUMNNAME_C_Invoice_ID, invoiceId)
-					.addEqualsFilter(I_C_AllocationLine.COLUMNNAME_C_Payment_ID, paymentId)
-					.create()
-					.firstOnlyNotNull(I_C_AllocationLine.class);
-
-			final BigDecimal amount = DataTableUtil.extractBigDecimalOrNullForColumnName(dataTableRow, "OPT." + I_C_AllocationLine.COLUMNNAME_Amount);
-			final BigDecimal overUnderAmt = DataTableUtil.extractBigDecimalOrNullForColumnName(dataTableRow, "OPT." + I_C_AllocationLine.COLUMNNAME_OverUnderAmt);
-			final BigDecimal writeOffAmt = DataTableUtil.extractBigDecimalOrNullForColumnName(dataTableRow, "OPT." + I_C_AllocationLine.COLUMNNAME_WriteOffAmt);
-			final BigDecimal discountAmt = DataTableUtil.extractBigDecimalOrNullForColumnName(dataTableRow, "OPT." + I_C_AllocationLine.COLUMNNAME_DiscountAmt);
-
-			if (amount != null)
-			{
-				assertThat(singleAllocationLine.getAmount()).isEqualTo(amount);
-			}
-
-			if (overUnderAmt != null)
-			{
-				assertThat(singleAllocationLine.getOverUnderAmt()).isEqualTo(overUnderAmt);
-			}
-
-			if (writeOffAmt != null)
-			{
-				assertThat(singleAllocationLine.getWriteOffAmt()).isEqualTo(writeOffAmt);
-			}
-			if (discountAmt != null)
-			{
-				assertThat(singleAllocationLine.getDiscountAmt()).isEqualTo(discountAmt);
-			}
+			queryBuilder.addNotInArrayFilter(I_C_AllocationLine.COLUMNNAME_C_AllocationLine_ID, alreadyCheckedLineIds);
 		}
+		final I_C_AllocationLine allocationLine = queryBuilder.create().firstNotNull(I_C_AllocationLine.class);
+
+		validateAllocationLine(allocationLine, row);
+
+		alreadyCheckedLineIds.add(PaymentAllocationLineId.ofRepoId(allocationLine.getC_AllocationHdr_ID(), allocationLine.getC_AllocationLine_ID()));
+	}
+
+	@And("^validate C_AllocationLines for invoice (.*)$")
+	public void validate_C_AllocationLines_for_invoice(
+			@NonNull final String invoiceIdentifier,
+			@NonNull final DataTable dataTable)
+	{
+		final Integer invoiceId = invoiceTable.get(invoiceIdentifier).getC_Invoice_ID();
+
+		final ImmutableList<I_C_AllocationLine> allocationLines = queryBL.createQueryBuilder(I_C_AllocationLine.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_C_AllocationLine.COLUMNNAME_C_Invoice_ID, invoiceId)
+				.orderBy(I_C_AllocationLine.COLUMN_C_AllocationLine_ID)
+				.create()
+				.listImmutable(I_C_AllocationLine.class);
+
+		assertThat(allocationLines).hasSameSizeAs(dataTable.asMaps());
+
+		DataTableRows.of(dataTable)
+				.forEach((row, index) -> validateAllocationLine(allocationLines.get(index), row));
 	}
 
 	@And("there are no allocation lines for invoice")
 	public void invoices_are_not_allocated(@NonNull final DataTable table)
 	{
-		final List<Map<String, String>> rows = table.asMaps();
-		for (final Map<String, String> dataTableRow : rows)
-		{
-			final String invoiceIdentifier = DataTableUtil.extractStringForColumnName(dataTableRow, COLUMNNAME_C_Invoice_ID + "." + TABLECOLUMN_IDENTIFIER);
-			final I_C_Invoice invoice = invoiceTable.get(invoiceIdentifier);
-
+		DataTableRows.of(table).forEach(row -> {
+			final I_C_Invoice invoice = row.getAsIdentifier(COLUMNNAME_C_Invoice_ID).lookupNotNullIn(invoiceTable);
 			final List<I_C_AllocationLine> allocationLines = allocationDAO.retrieveAllocationLines(invoice);
+			assertThat(allocationLines).isEmpty();
+		});
+	}
 
-			assertThat(allocationLines.isEmpty()).isEqualTo(true);
-		}
+	private void validateAllocationLine(
+			@NonNull final I_C_AllocationLine allocationLine,
+			@NonNull final DataTableRow row)
+	{
+		final SoftAssertions softly = new SoftAssertions();
+
+		row.getAsOptionalBigDecimal(I_C_AllocationLine.COLUMNNAME_Amount)
+				.ifPresent(amount -> softly.assertThat(allocationLine.getAmount()).as("Amount").isEqualByComparingTo(amount));
+		row.getAsOptionalBigDecimal(I_C_AllocationLine.COLUMNNAME_DiscountAmt)
+				.ifPresent(amount -> softly.assertThat(allocationLine.getDiscountAmt()).as("DiscountAmt").isEqualByComparingTo(amount));
+		row.getAsOptionalBigDecimal(I_C_AllocationLine.COLUMNNAME_WriteOffAmt)
+				.ifPresent(amount -> softly.assertThat(allocationLine.getWriteOffAmt()).as("WriteOffAmt").isEqualByComparingTo(amount));
+		row.getAsOptionalBigDecimal(I_C_AllocationLine.COLUMNNAME_OverUnderAmt)
+				.ifPresent(amount -> softly.assertThat(allocationLine.getOverUnderAmt()).as("OverUnderAmt").isEqualByComparingTo(amount));
+
+		softly.assertAll();
+
+		row.getAsOptionalIdentifier(I_C_AllocationLine.COLUMNNAME_C_AllocationHdr_ID)
+				.ifPresent(allocationIdentifier -> allocationHdrTable.putOrReplaceIfSameId(allocationIdentifier, allocationLine.getC_AllocationHdr()));
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_StepDef.java
@@ -36,6 +36,7 @@ import de.metas.cucumber.stepdefs.C_Order_StepDefData;
 import de.metas.cucumber.stepdefs.DataTableUtil;
 import de.metas.cucumber.stepdefs.ItemProvider.ProviderResult;
 import de.metas.cucumber.stepdefs.StepDefConstants;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.StepDefDocAction;
 import de.metas.cucumber.stepdefs.StepDefUtil;
 import de.metas.cucumber.stepdefs.doctype.C_DocType_StepDefData;
@@ -802,4 +803,16 @@ public class C_Invoice_StepDef
 		invoiceTable.putOrReplace(invoiceIdentifier, invoice);
 	}
 
+	@And("^the reversal of invoice (.*) is identified by (.*)$")
+	public void identify_reversal_invoice(
+			@NonNull final String invoiceIdentifier,
+			@NonNull final String reversalIdentifier)
+	{
+		final I_C_Invoice invoice = invoiceTable.get(invoiceIdentifier);
+		InterfaceWrapperHelper.refresh(invoice);
+		final int reversalId = invoice.getReversal_ID();
+		Check.assume(reversalId > 0, "Invoice {} must have a reversal", invoiceIdentifier);
+		final I_C_Invoice reversal = InterfaceWrapperHelper.load(reversalId, I_C_Invoice.class);
+		invoiceTable.putOrReplace(StepDefDataIdentifier.ofString(reversalIdentifier), reversal);
+	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_StepDef.java
@@ -34,9 +34,9 @@ import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
 import de.metas.cucumber.stepdefs.C_OrderLine_StepDefData;
 import de.metas.cucumber.stepdefs.C_Order_StepDefData;
 import de.metas.cucumber.stepdefs.DataTableUtil;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.ItemProvider.ProviderResult;
 import de.metas.cucumber.stepdefs.StepDefConstants;
-import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.StepDefDocAction;
 import de.metas.cucumber.stepdefs.StepDefUtil;
 import de.metas.cucumber.stepdefs.doctype.C_DocType_StepDefData;
@@ -204,6 +204,19 @@ public class C_Invoice_StepDef
 						.appendParametersToMessage()
 						.setParameter("action:", action);
 		}
+	}
+
+	@And("^the reversal of invoice (.*) is identified by (.*)$")
+	public void identify_reversal_invoice(
+			@NonNull final String invoiceIdentifier,
+			@NonNull final String reversalIdentifier)
+	{
+		final I_C_Invoice invoice = invoiceTable.get(invoiceIdentifier);
+		InterfaceWrapperHelper.refresh(invoice);
+		final int reversalId = invoice.getReversal_ID();
+		Check.assume(reversalId > 0, "Invoice {} must have a reversal", invoiceIdentifier);
+		final I_C_Invoice reversal = InterfaceWrapperHelper.load(reversalId, I_C_Invoice.class);
+		invoiceTable.putOrReplace(StepDefDataIdentifier.ofString(reversalIdentifier), reversal);
 	}
 
 	@And("load C_Invoice:")
@@ -803,16 +816,4 @@ public class C_Invoice_StepDef
 		invoiceTable.putOrReplace(invoiceIdentifier, invoice);
 	}
 
-	@And("^the reversal of invoice (.*) is identified by (.*)$")
-	public void identify_reversal_invoice(
-			@NonNull final String invoiceIdentifier,
-			@NonNull final String reversalIdentifier)
-	{
-		final I_C_Invoice invoice = invoiceTable.get(invoiceIdentifier);
-		InterfaceWrapperHelper.refresh(invoice);
-		final int reversalId = invoice.getReversal_ID();
-		Check.assume(reversalId > 0, "Invoice {} must have a reversal", invoiceIdentifier);
-		final I_C_Invoice reversal = InterfaceWrapperHelper.load(reversalId, I_C_Invoice.class);
-		invoiceTable.putOrReplace(StepDefDataIdentifier.ofString(reversalIdentifier), reversal);
-	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_StepDefData.java
@@ -23,15 +23,23 @@
 package de.metas.cucumber.stepdefs.invoice;
 
 import de.metas.cucumber.stepdefs.StepDefData;
+import de.metas.cucumber.stepdefs.StepDefDataGetIdAware;
+import de.metas.invoice.InvoiceId;
 import org.compiere.model.I_C_Invoice;
 
 /**
  * Having a dedicated class to help the IOC-framework injecting the right instances, if a step-def needs more than one.
  */
-public class C_Invoice_StepDefData extends StepDefData<I_C_Invoice>
+public class C_Invoice_StepDefData extends StepDefData<I_C_Invoice> implements StepDefDataGetIdAware<InvoiceId, I_C_Invoice>
 {
 	public C_Invoice_StepDefData()
 	{
 		super(I_C_Invoice.class);
+	}
+
+	@Override
+	public InvoiceId extractIdFromRecord(final I_C_Invoice record)
+	{
+		return InvoiceId.ofRepoId(record.getC_Invoice_ID());
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/util/IdentifiersResolver.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/util/IdentifiersResolver.java
@@ -102,4 +102,32 @@ public class IdentifiersResolver
 		return invoiceTable.getOptional(identifier)
 				.map(invoice -> InvoiceId.ofRepoId(invoice.getC_Invoice_ID()));
 	}
+
+	/** Reverse lookup: find the StepDefDataIdentifier for a given TableRecordReference */
+	@NonNull
+	public Optional<StepDefDataIdentifier> getIdentifier(@NonNull final TableRecordReference ref)
+	{
+		final String tableName = ref.getTableName();
+		final int recordId = ref.getRecord_ID();
+
+		if (I_C_Invoice.Table_Name.equals(tableName))
+		{
+			return invoiceTable.getIdentifiers().stream()
+					.filter(id -> invoiceTable.getOptional(id).map(inv -> inv.getC_Invoice_ID() == recordId).orElse(false))
+					.findFirst();
+		}
+		if (I_C_Payment.Table_Name.equals(tableName))
+		{
+			return paymentTable.getIdentifiers().stream()
+					.filter(id -> paymentTable.getOptional(id).map(pay -> pay.getC_Payment_ID() == recordId).orElse(false))
+					.findFirst();
+		}
+		if (I_C_AllocationHdr.Table_Name.equals(tableName))
+		{
+			return allocationTable.getIdentifiers().stream()
+					.filter(id -> allocationTable.getOptional(id).map(alloc -> alloc.getC_AllocationHdr_ID() == recordId).orElse(false))
+					.findFirst();
+		}
+		return Optional.empty();
+	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/util/IdentifiersResolver.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/util/IdentifiersResolver.java
@@ -1,0 +1,105 @@
+package de.metas.cucumber.stepdefs.util;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.cucumber.stepdefs.allocation.C_AllocationHdr_StepDefData;
+import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
+import de.metas.cucumber.stepdefs.payment.C_Payment_StepDefData;
+import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
+import de.metas.invoice.InvoiceId;
+import de.metas.util.StringUtils;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.adempiere.util.lang.impl.TableRecordReferenceSet;
+import org.compiere.model.I_C_AllocationHdr;
+import org.compiere.model.I_C_Invoice;
+import org.compiere.model.I_C_Payment;
+import org.compiere.model.I_M_InOut;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Simplified version for soft_panda_hotfix - supports invoice, payment, allocationHdr, inOut.
+ * Full version on intensive_care_hotfix also supports dunning, matchInv, order.
+ */
+@RequiredArgsConstructor
+public class IdentifiersResolver
+{
+	@NonNull private final C_Invoice_StepDefData invoiceTable;
+	@NonNull private final C_Payment_StepDefData paymentTable;
+	@NonNull private final C_AllocationHdr_StepDefData allocationTable;
+	@NonNull private final M_InOut_StepDefData inOutTable;
+
+	@NonNull
+	public ImmutableSet<TableRecordReference> getTableRecordReferencesOfCommaSeparatedIdentifiers(@Nullable final String commaSeparatedIdentifiers)
+	{
+		final String norm = StringUtils.trimBlankToNull(commaSeparatedIdentifiers);
+		if (norm == null || norm.equals("-"))
+		{
+			return ImmutableSet.of();
+		}
+		return getTableRecordReferences(StepDefDataIdentifier.ofCommaSeparatedString(norm));
+	}
+
+	@NonNull
+	public ImmutableSet<TableRecordReference> getTableRecordReferences(@NonNull final List<StepDefDataIdentifier> identifiers)
+	{
+		final HashSet<TableRecordReference> result = new HashSet<>();
+		for (final StepDefDataIdentifier identifier : identifiers)
+		{
+			result.add(getTableRecordReference(identifier));
+		}
+		return ImmutableSet.copyOf(result);
+	}
+
+	@NonNull
+	public TableRecordReference getTableRecordReference(@NonNull final StepDefDataIdentifier identifier)
+	{
+		final ArrayList<TableRecordReference> candidates = new ArrayList<>();
+		invoiceTable.getOptional(identifier)
+				.map(inv -> TableRecordReference.of(I_C_Invoice.Table_Name, inv.getC_Invoice_ID()))
+				.ifPresent(candidates::add);
+		paymentTable.getOptional(identifier)
+				.map(pay -> TableRecordReference.of(I_C_Payment.Table_Name, pay.getC_Payment_ID()))
+				.ifPresent(candidates::add);
+		allocationTable.getOptional(identifier)
+				.map(alloc -> TableRecordReference.of(I_C_AllocationHdr.Table_Name, alloc.getC_AllocationHdr_ID()))
+				.ifPresent(candidates::add);
+		inOutTable.getOptional(identifier)
+				.map(inOut -> TableRecordReference.of(I_M_InOut.Table_Name, inOut.getM_InOut_ID()))
+				.ifPresent(candidates::add);
+
+		if (candidates.isEmpty())
+		{
+			throw new AdempiereException("No record found for identifier: " + identifier);
+		}
+		if (candidates.size() > 1)
+		{
+			throw new AdempiereException("Multiple records found for identifier: " + identifier + " => " + candidates);
+		}
+		return candidates.get(0);
+	}
+
+	@NonNull
+	public TableRecordReferenceSet getTableRecordReferenceSetOfCommaSeparatedIdentifiers(@Nullable final String commaSeparatedIdentifiers)
+	{
+		return TableRecordReferenceSet.of(getTableRecordReferencesOfCommaSeparatedIdentifiers(commaSeparatedIdentifiers));
+	}
+
+	@NonNull
+	public Optional<InvoiceId> resolveOptionalInvoiceId(@Nullable final StepDefDataIdentifier identifier)
+	{
+		if (identifier == null)
+		{
+			return Optional.empty();
+		}
+		return invoiceTable.getOptional(identifier)
+				.map(invoice -> InvoiceId.ofRepoId(invoice.getC_Invoice_ID()));
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -356,18 +356,19 @@ Feature: invoice payment allocation
       | inv_160                     | payment_160                 | 3.57       | 0                |
 
     And Fact_Acct records are matching
-      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID      |
-      # alloc1: credit memo compensation (CM vs invoice)
-      | C_Receivable_Acct      | 2.38 EUR    | 0 EUR       | customer1     | alloc1         |
-      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | customer1     | alloc1         |
-      # alloc2: payment vs invoice
-      | B_UnallocatedCash_Acct | 3.57 EUR    | 0 EUR       | customer1     | alloc2         |
-      | C_Receivable_Acct      | 0 EUR       | 3.57 EUR    | customer1     | alloc2         |
-      # invoice postings
-      | C_Receivable_Acct      |             |             | customer1     | salesInvoice1  |
-      | *                      |             |             |               | salesInvoice1  |
-      | C_Receivable_Acct      |             |             | customer1     | salesCreditMemo1 |
+      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID        |
+      # salesInvoice1 posting (GrandTotal=5.95)
+      | C_Receivable_Acct      | 5.95 EUR    | 0 EUR       | customer1     | salesInvoice1    |
+      | *                      |             |             |               | salesInvoice1    |
+      # salesCreditMemo1 posting (GrandTotal=2.38)
+      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | customer1     | salesCreditMemo1 |
       | *                      |             |             |               | salesCreditMemo1 |
+      # alloc1: credit memo compensation (CM vs invoice)
+      | C_Receivable_Acct      | 2.38 EUR    | 0 EUR       | customer1     | alloc1           |
+      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | customer1     | alloc1           |
+      # alloc2: payment vs invoice
+      | B_UnallocatedCash_Acct | 3.57 EUR    | 0 EUR       | customer1     | alloc2           |
+      | C_Receivable_Acct      | 0 EUR       | 3.57 EUR    | customer1     | alloc2           |
     And Fact_Acct records balances for documents alloc1 are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -650,17 +651,18 @@ Feature: invoice payment allocation
 
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID       |
+      # inv_220 posting (GrandTotal=5.95)
+      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | customer1     | inv_220         |
+      | *                     |             |             |               | inv_220         |
+      # credit_memo_220 posting (GrandTotal=2.38)
+      | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | customer1     | credit_memo_220 |
+      | *                     |             |             |               | credit_memo_220 |
       # alloc1: credit memo compensation (CM vs invoice)
       | V_Liability_Acct      | 0 EUR       | 2.38 EUR    | customer1     | alloc1          |
       | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | customer1     | alloc1          |
       # alloc2: payment vs invoice
       | V_Liability_Acct      | 3.57 EUR    | 0 EUR       | customer1     | alloc2          |
       | B_PaymentSelect_Acct  | 0 EUR       | 3.57 EUR    | customer1     | alloc2          |
-      # invoice postings
-      | V_Liability_Acct      |             |             | customer1     | inv_220         |
-      | *                     |             |             |               | inv_220         |
-      | V_Liability_Acct      |             |             | customer1     | credit_memo_220 |
-      | *                     |             |             |               | credit_memo_220 |
     And Fact_Acct records balances for documents alloc1 are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |
@@ -796,13 +798,15 @@ Feature: invoice payment allocation
     # Verify: the credit memo compensation allocation has Fact_Acct entries
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID        |
+      # salesInv_cma_100 posting (GrandTotal=11.90)
+      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | customer1     | salesInv_cma_100 |
+      | *                     |             |             |               | salesInv_cma_100 |
+      # salesCM_cma_100 posting (GrandTotal=11.90)
+      | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | customer1     | salesCM_cma_100  |
+      | *                     |             |             |               | salesCM_cma_100  |
+      # alloc_cm: credit memo compensation
       | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | customer1     | alloc_cm         |
       | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | customer1     | alloc_cm         |
-      # invoice postings
-      | C_Receivable_Acct     |             |             | customer1     | salesInv_cma_100 |
-      | *                     |             |             |               | salesInv_cma_100 |
-      | C_Receivable_Acct     |             |             | customer1     | salesCM_cma_100  |
-      | *                     |             |             |               | salesCM_cma_100  |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -873,13 +877,15 @@ Feature: invoice payment allocation
     # Verify: allocation has Fact_Acct entries — DR for credit memo, CR for invoice
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID       |
+      # salesInvoice posting (GrandTotal=11.90)
+      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | customer1     | salesInvoice    |
+      | *                     |             |             |               | salesInvoice    |
+      # salesCreditMemo posting (GrandTotal=5.95)
+      | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | customer1     | salesCreditMemo |
+      | *                     |             |             |               | salesCreditMemo |
+      # alloc_cm: credit memo compensation
       | C_Receivable_Acct     | 5.95 EUR    | 0 EUR       | customer1     | alloc_cm        |
       | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | customer1     | alloc_cm        |
-      # invoice postings
-      | C_Receivable_Acct     |             |             | customer1     | salesInvoice    |
-      | *                     |             |             |               | salesInvoice    |
-      | C_Receivable_Acct     |             |             | customer1     | salesCreditMemo |
-      | *                     |             |             |               | salesCreditMemo |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -922,13 +928,121 @@ Feature: invoice payment allocation
     # Verify: allocation has Fact_Acct entries — CR for credit memo, DR for invoice
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID          |
+      # purchaseInvoice posting (GrandTotal=11.90)
+      | V_Liability_Acct      | 0 EUR       | 11.90 EUR   | vendor1       | purchaseInvoice    |
+      | *                     |             |             |               | purchaseInvoice    |
+      # purchaseCreditMemo posting (GrandTotal=5.95)
+      | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | vendor1       | purchaseCreditMemo |
+      | *                     |             |             |               | purchaseCreditMemo |
+      # alloc_cm: credit memo compensation
       | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | vendor1       | alloc_cm           |
       | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | vendor1       | alloc_cm           |
-      # invoice postings
-      | V_Liability_Acct      |             |             | vendor1       | purchaseInvoice    |
-      | *                     |             |             |               | purchaseInvoice    |
-      | V_Liability_Acct      |             |             | vendor1       | purchaseCreditMemo |
-      | *                     |             |             |               | purchaseCreditMemo |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |
+
+
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_CMA_200
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: sales-purchase invoice compensation (CH Verrechnung) - Fact_Acct entries
+    # Same BPartner is both customer and vendor. A sales invoice is compensated against a purchase invoice.
+    # This is legal in Switzerland (Verrechnung) and produces cross-account clearing entries.
+    Given metasfresh contains M_PricingSystems
+      | Identifier    |
+      | pricingSys200 |
+    And metasfresh contains M_PriceLists
+      | Identifier     | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | salesPL200     | pricingSys200      | DE           | EUR           | true  |
+      | purchasePL200  | pricingSys200      | DE           | EUR           | false |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier     | M_PriceList_ID |
+      | salesPLV200    | salesPL200     |
+      | purchasePLV200 | purchasePL200  |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsCustomer | IsVendor | M_PricingSystem_ID |
+      | bp200      | Y          | Y        | pricingSys200      |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier  | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | bp200_loc   | bp200         | Y               | Y               |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product200 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | salesPLV200            | product200   | 10.00    | PCE      |
+      | purchasePLV200         | product200   | 5.00     | PCE      |
+
+    # Sales invoice: GrandTotal = 11.90 EUR
+    And metasfresh contains C_Invoice:
+      | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | salesInv200     | bp200         | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID | M_Product_ID | QtyInvoiced |
+      | salesInv200  | product200   | 1 PCE       |
+    And the invoice identified by salesInv200 is completed
+
+    # Purchase invoice: GrandTotal = 5.95 EUR
+    And metasfresh contains C_Invoice:
+      | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | purchaseInv200  | bp200         | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID   | M_Product_ID | QtyInvoiced |
+      | purchaseInv200 | product200   | 1 PCE       |
+    And the invoice identified by purchaseInv200 is completed
+
+    # Compensate: sales invoice vs purchase invoice (no payment)
+    And allocate invoices (credit memo/purchase) to invoices
+      | C_Invoice_ID.Identifier | OPT.Purchase.C_Invoice_ID.Identifier |
+      | salesInv200             | purchaseInv200                       |
+
+    Then validate created invoices
+      | C_Invoice_ID.Identifier | IsPaid |
+      | purchaseInv200          | true   |
+
+    And validate C_AllocationLines
+      | OPT.C_Invoice_ID.Identifier | OPT.C_AllocationHdr_ID.Identifier |
+      | salesInv200                 | alloc200                          |
+
+    # Verify: allocation has Fact_Acct entries — cross-account compensation
+    # Sales invoice side: C_Receivable CR (clearing the receivable)
+    # Purchase invoice side: V_Liability DR (clearing the liability)
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID      |
+      # salesInv200 posting (GrandTotal=11.90)
+      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | bp200         | salesInv200    |
+      | *                     |             |             |               | salesInv200    |
+      # purchaseInv200 posting (GrandTotal=5.95)
+      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | bp200         | purchaseInv200 |
+      | *                     |             |             |               | purchaseInv200 |
+      # alloc200: sales-purchase compensation
+      | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | bp200         | alloc200       |
+      | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | bp200         | alloc200       |
+    And Fact_Acct records balances for documents alloc200 are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | -5.95 EUR     |
+      | V_Liability_Acct      | 5.95 EUR      |
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -792,13 +792,33 @@ Feature: invoice payment allocation
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
 
-    # Now reverse the credit memo — this creates reversal allocations
+    # Now reverse the credit memo — this creates reversal allocations:
+    # 1. A reversal of alloc_cm (undoing the CM-vs-invoice allocation)
+    # 2. A new allocation matching the CM against its reversal (reversed invoice allocation)
     And the invoice identified by salesCM_cma_100 is reversed
 
     Then validate created invoices
       | C_Invoice_ID     | IsPaid |
       | salesInv_cma_100 | false  |
       | salesCM_cma_100  | true   |
+
+    # After reversal, the CM has allocations: alloc_cm (original, now reversed) + alloc_cm_reversed (reversal) + alloc_cm_rev_pair (CM vs its reversal)
+    # Verify: the reversal-of-original allocation also has Fact_Acct
+    And validate C_AllocationLines for invoice salesCM_cma_100
+      | OPT.Amount | OPT.C_AllocationHdr_ID |
+      | -11.90     | alloc_cm               |
+      | 11.90      | alloc_cm_reversed      |
+      | -11.90     | alloc_cm_rev_pair      |
+
+    # The reversed allocation (CM vs its reversal) must have Fact_Acct entries (tests createDirectInvoiceAllocationSource)
+    And Fact_Acct records balances for documents alloc_cm_rev_pair are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | 0 EUR         |
+
+    # Overall: all allocation Fact_Acct entries for this CM should net to zero
+    And Fact_Acct records balances for documents alloc_cm,alloc_cm_reversed,alloc_cm_rev_pair are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | 0 EUR         |
 
 
 # ############################################################################################################################################

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -780,8 +780,9 @@ Feature: invoice payment allocation
       | Identifier | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | salesInv_cma_100  | bpartner_1    | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
     And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID      | M_Product_ID    | QtyInvoiced |
-      | salesInv_cma_100  | product_cma_100 | 1 PCE       |
+      | Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
+
+      | il_auto    | salesInv_cma_100                      | product_cma_100                      | 1          | PCE               |
     And the invoice identified by salesInv_cma_100 is completed
 
     # Create credit memo against the invoice (auto-allocates CM against invoice)
@@ -792,7 +793,7 @@ Feature: invoice payment allocation
 
     # At this point alloc_cm is the auto-created allocation of CM against invoice
     And validate C_AllocationLines
-      | C_Invoice_ID     | Amount  | C_AllocationHdr_ID |
+      | OPT.C_Invoice_ID.Identifier | OPT.Amount | OPT.C_AllocationHdr_ID.Identifier |
       | salesCM_cma_100  | -105.60 | alloc_cm           |
       | salesInv_cma_100 | 105.60  | alloc_cm           |
 
@@ -818,7 +819,7 @@ Feature: invoice payment allocation
     And the invoice identified by salesCM_cma_100 is reversed
 
     Then validate created invoices
-      | C_Invoice_ID     | IsPaid |
+      | C_Invoice_ID.Identifier | OPT.IsPaid |
       | salesInv_cma_100 | false  |
       | salesCM_cma_100  | true   |
 
@@ -860,8 +861,8 @@ Feature: invoice payment allocation
       | Identifier | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | salesInvoice | bpartner_1    | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
     And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced |
-      | salesInvoice | product      | 1 PCE       |
+      | Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
+      | il_auto    | salesInvoice            | product                 | 1           | PCE               |
     And the invoice identified by salesInvoice is completed
 
     # Create credit memo: GrandTotal = 75.10 EUR (partial credit of the 595.00 invoice)
@@ -871,7 +872,7 @@ Feature: invoice payment allocation
     And the invoice identified by salesCreditMemo is completed
 
     And validate C_AllocationLines
-      | C_Invoice_ID    | Amount | C_AllocationHdr_ID |
+      | OPT.C_Invoice_ID.Identifier | OPT.Amount | OPT.C_AllocationHdr_ID.Identifier |
       | salesCreditMemo | -75.10 | alloc_cm           |
       | salesInvoice    | 75.10  | alloc_cm           |
 
@@ -912,8 +913,9 @@ Feature: invoice payment allocation
       | Identifier | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | purchaseInvoice | bpartner_1    | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
     And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID    | M_Product_ID | QtyInvoiced |
-      | purchaseInvoice | product      | 1 PCE       |
+      | Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
+
+      | il_auto    | purchaseInvoice                      | product                      | 1          | PCE               |
     And the invoice identified by purchaseInvoice is completed
 
     # Create credit memo: GrandTotal = 75.10 EUR (partial credit of the 595.00 invoice)
@@ -923,7 +925,7 @@ Feature: invoice payment allocation
     And the invoice identified by purchaseCreditMemo is completed
 
     And validate C_AllocationLines
-      | C_Invoice_ID       | Amount | C_AllocationHdr_ID |
+      | OPT.C_Invoice_ID.Identifier | OPT.Amount | OPT.C_AllocationHdr_ID.Identifier |
       | purchaseCreditMemo | 75.10  | alloc_cm           |
       | purchaseInvoice    | -75.10 | alloc_cm           |
 
@@ -985,8 +987,8 @@ Feature: invoice payment allocation
       | Identifier | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | salesInv200     | bp200         | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
     And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced |
-      | salesInv200  | product200   | 1 PCE       |
+      | Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
+      | il_auto    | salesInv200             | product200              | 1           | PCE               |
     And the invoice identified by salesInv200 is completed
 
     # Purchase invoice: GrandTotal = 5.95 EUR
@@ -994,8 +996,9 @@ Feature: invoice payment allocation
       | Identifier | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | purchaseInv200  | bp200         | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
     And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID   | M_Product_ID | QtyInvoiced |
-      | purchaseInv200 | product200   | 1 PCE       |
+      | Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
+
+      | il_auto    | purchaseInv200                      | product200                      | 1          | PCE               |
     And the invoice identified by purchaseInv200 is completed
 
     # Compensate: sales invoice vs purchase invoice (no payment)

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -355,6 +355,18 @@ Feature: invoice payment allocation
       | OPT.C_Invoice_ID.Identifier | OPT.C_Payment_ID.Identifier | OPT.Amount | OPT.OverUnderAmt |
       | inv_160                     | payment_160                 | 3.57       | 0                |
 
+    And Fact_Acct records are matching
+      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | Record_ID |
+      | C_Receivable_Acct      | 2.38 EUR    | 0 EUR       | alloc1    |
+      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | alloc1    |
+    And Fact_Acct records balances for documents alloc1 are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | 0 EUR         |
+    And Fact_Acct records are matching
+      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | Record_ID |
+      | B_UnallocatedCash_Acct | 3.57 EUR    | 0 EUR       | alloc2    |
+      | C_Receivable_Acct      | 0 EUR       | 3.57 EUR    | alloc2    |
+
   @Id:S0132_170
   @from:cucumber
   Scenario: allocate outbound payment to sales invoice
@@ -631,6 +643,18 @@ Feature: invoice payment allocation
       | OPT.C_Invoice_ID.Identifier | OPT.C_Payment_ID.Identifier | OPT.Amount | OPT.OverUnderAmt |
       | inv_220                     | payment_220                 | -3.57      | 0                |
 
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | V_Liability_Acct      | 0 EUR       | 2.38 EUR    | alloc1    |
+      | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | alloc1    |
+    And Fact_Acct records balances for documents alloc1 are matching
+      | AccountConceptualName | SourceBalance |
+      | V_Liability_Acct      | 0 EUR         |
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | V_Liability_Acct      | 3.57 EUR    | 0 EUR       | alloc2    |
+      | B_PaymentSelect_Acct  | 0 EUR       | 3.57 EUR    | alloc2    |
+
   @Id:S0132_230
   @from:cucumber
   Scenario: allocate inbound payment to purchase invoice
@@ -722,3 +746,162 @@ Feature: invoice payment allocation
     Then validate C_AllocationHdr for invoice and payment
       | C_Invoice_ID.Identifier | C_Payment_ID.Identifier | DateAcct   | DateTrx    |
       | inv_250                 | pay_250                 | 2025-12-31 | 2026-01-08 |
+
+
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_CMA_100
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: reverse correction - credit memo reversed, allocation produces Fact_Acct
+    Given metasfresh contains M_Products:
+      | Identifier      |
+      | product_cma_100 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
+      | salesPLV               | product_cma_100 | 10.00    | PCE      |
+    And metasfresh contains C_Invoice:
+      | Identifier        | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | salesInv_cma_100  | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID      | M_Product_ID    | QtyInvoiced |
+      | salesInv_cma_100  | product_cma_100 | 1 PCE       |
+    And the invoice identified by salesInv_cma_100 is completed
+
+    # Create credit memo against the invoice (auto-allocates CM against invoice)
+    And create credit memo for C_Invoice
+      | CreditMemo         | C_Invoice_ID     | CreditMemo.PriceEntered |
+      | salesCM_cma_100    | salesInv_cma_100 | 10.00                   |
+    And the invoice identified by salesCM_cma_100 is completed
+
+    # At this point alloc_cm is the auto-created allocation of CM against invoice
+    And validate C_AllocationLines
+      | C_Invoice_ID    | Amount | C_AllocationHdr_ID |
+      | salesCM_cma_100 | -11.90 | alloc_cm           |
+      | salesInv_cma_100| 11.90  | alloc_cm           |
+
+    # Verify: the credit memo compensation allocation has Fact_Acct entries
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | alloc_cm  |
+      | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | alloc_cm  |
+    And Fact_Acct records balances for documents:
+      | AD_Table_ID.TableName | Record_ID |
+      | C_AllocationHdr       | alloc_cm  |
+
+    # Now reverse the credit memo — this creates a reversal allocation
+    And the invoice identified by salesCM_cma_100 is reversed
+
+    # The reversal creates allocations: one to undo the CM-vs-invoice, and one for the CM-vs-its-reversal
+    # The CM-vs-reversal allocation is a reversed invoice allocation and must produce Fact_Acct
+    Then validate created invoices
+      | C_Invoice_ID    | IsPaid |
+      | salesInv_cma_100| false  |
+      | salesCM_cma_100 | true   |
+
+
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_CMA_110
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: sales credit memo allocated against sales invoice - Fact_Acct entries (no payment)
+    Given metasfresh contains M_Products:
+      | Identifier      |
+      | product_cma_110 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
+      | salesPLV               | product_cma_110 | 100.00   | PCE      |
+    # Create the sales invoice (ARI) — GrandTotal = 119.00 EUR (100 + 19% VAT)
+    And metasfresh contains C_Invoice:
+      | Identifier       | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | salesInv_cma_110 | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID     | M_Product_ID    | QtyInvoiced |
+      | salesInv_cma_110 | product_cma_110 | 1 PCE       |
+    And the invoice identified by salesInv_cma_110 is completed
+
+    # Create the sales credit memo (ARC) — GrandTotal = 59.50 EUR (50 + 19% VAT)
+    And metasfresh contains C_Invoice:
+      | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | salesCM_cma_110 | customer1     | Gutschrift              | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID    | M_Product_ID    | QtyInvoiced |
+      | salesCM_cma_110 | product_cma_110 | 0.5 PCE     |
+    And the invoice identified by salesCM_cma_110 is completed
+
+    # Allocate credit memo against invoice (no payment)
+    And allocate invoices (credit memo/purchase) to invoices
+      | C_Invoice_ID.Identifier | OPT.CreditMemo.C_Invoice_ID.Identifier |
+      | salesInv_cma_110        | salesCM_cma_110                        |
+
+    Then validate created invoices
+      | C_Invoice_ID.Identifier | IsPaid |
+      | salesCM_cma_110         | true   |
+
+    # Verify: allocation has Fact_Acct entries — DR for credit memo, CR for invoice
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | C_Receivable_Acct     | 59.50 EUR   | 0 EUR       | alloc1    |
+      | C_Receivable_Acct     | 0 EUR       | 59.50 EUR   | alloc1    |
+    And Fact_Acct records balances for documents alloc1 are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | 0 EUR         |
+
+
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_CMA_120
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: purchase credit memo allocated against purchase invoice - Fact_Acct entries (no payment)
+    Given metasfresh contains M_Products:
+      | Identifier      |
+      | product_cma_120 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
+      | purchasePLV            | product_cma_120 | 100.00   | PCE      |
+    # Create the purchase invoice (API) — GrandTotal = 119.00 EUR (100 + 19% VAT)
+    And metasfresh contains C_Invoice:
+      | Identifier          | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | purchaseInv_cma_120 | vendor1       | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID        | M_Product_ID    | QtyInvoiced |
+      | purchaseInv_cma_120 | product_cma_120 | 1 PCE       |
+    And the invoice identified by purchaseInv_cma_120 is completed
+
+    # Create the purchase credit memo (APC) — GrandTotal = 59.50 EUR (50 + 19% VAT)
+    And metasfresh contains C_Invoice:
+      | Identifier         | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | purchaseCM_cma_120 | vendor1       | Gutschrift (Lieferant)  | 2022-05-11   | Spot                     | false   | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID       | M_Product_ID    | QtyInvoiced |
+      | purchaseCM_cma_120 | product_cma_120 | 0.5 PCE     |
+    And the invoice identified by purchaseCM_cma_120 is completed
+
+    # Allocate credit memo against invoice (no payment)
+    And allocate invoices (credit memo/purchase) to invoices
+      | C_Invoice_ID.Identifier | OPT.CreditMemo.C_Invoice_ID.Identifier |
+      | purchaseInv_cma_120     | purchaseCM_cma_120                     |
+
+    Then validate created invoices
+      | C_Invoice_ID.Identifier | IsPaid |
+      | purchaseCM_cma_120      | true   |
+
+    # Verify: allocation has Fact_Acct entries — CR for credit memo, DR for invoice
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | V_Liability_Acct      | 0 EUR       | 59.50 EUR   | alloc1    |
+      | V_Liability_Acct      | 59.50 EUR   | 0 EUR       | alloc1    |
+    And Fact_Acct records balances for documents alloc1 are matching
+      | AccountConceptualName | SourceBalance |
+      | V_Liability_Acct      | 0 EUR         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -1014,19 +1014,19 @@ Feature: invoice payment allocation
     # Purchase invoice side: V_Liability DR (clearing the liability)
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID      |
-      # salesInv200 posting (GrandTotal=11.90)
-      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | bp200         | salesInv200    |
-      | *                     |             |             |               | salesInv200    |
-      # purchaseInv200 posting (GrandTotal=5.95)
-      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | bp200         | purchaseInv200 |
-      | *                     |             |             |               | purchaseInv200 |
-      # alloc200: sales-purchase compensation
       | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | bp200         | alloc200       |
       | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | bp200         | alloc200       |
+      # invoice postings
+      | C_Receivable_Acct     |             |             | bp200         | salesInv200    |
+      | *                     |             |             |               | salesInv200    |
+      | V_Liability_Acct      |             |             | bp200         | purchaseInv200 |
+      | *                     |             |             |               | purchaseInv200 |
     And Fact_Acct records balances for documents alloc200 are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | -5.95 EUR     |
       | V_Liability_Acct      | 5.95 EUR      |
+
+
 
 
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -359,11 +359,11 @@ Feature: invoice payment allocation
     And Fact_Acct records are matching
       | AccountConceptualName  | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID        |
       # salesInvoice1 posting (GrandTotal=5.95)
-      | C_Receivable_Acct      | 5.95 EUR    | 0 EUR       | bpartner_1    | salesInvoice1    |
-      | *                      |             |             |               | salesInvoice1    |
+      | C_Receivable_Acct      | 5.95 EUR    | 0 EUR       | bpartner_1    | inv_160          |
+      | *                      |             |             |               | inv_160          |
       # salesCreditMemo1 posting (GrandTotal=2.38)
-      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | bpartner_1    | salesCreditMemo1 |
-      | *                      |             |             |               | salesCreditMemo1 |
+      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | bpartner_1    | credit_memo_160  |
+      | *                      |             |             |               | credit_memo_160  |
       # alloc1: credit memo compensation (CM vs invoice)
       | C_Receivable_Acct      | 2.38 EUR    | 0 EUR       | bpartner_1    | alloc1           |
       | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | bpartner_1    | alloc1           |
@@ -822,7 +822,7 @@ Feature: invoice payment allocation
     Then validate created invoices
       | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | paymentTerm   | processed | docStatus | OPT.IsPaid |
       | salesInv_cma_100 | bpartner_1 | bpartner_location_1 | 30 Tage netto | true | CO | false |
-      | salesCM_cma_100  | bpartner_1 | bpartner_location_1 | 30 Tage netto | true | CO | true  |
+      | salesCM_cma_100  | bpartner_1 | bpartner_location_1 | 30 Tage netto | true | RE | true  |
 
     # After reversal, the CM has allocations: alloc_cm (original, now reversed) + alloc_cm_reversed (reversal) + alloc_cm_rev_pair (CM vs its reversal)
     And validate C_AllocationLines for invoice salesCM_cma_100
@@ -1008,8 +1008,8 @@ Feature: invoice payment allocation
       | salesInv200             | purchaseInv200                       |
 
     Then validate created invoices
-      | C_Invoice_ID.Identifier | IsPaid |
-      | purchaseInv200          | true   |
+      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | paymentTerm   | processed | docStatus | OPT.IsPaid |
+      | purchaseInv200          | bp200                    | bp200_loc                         | 30 Tage netto | true      | CO        | true       |
 
     And validate C_AllocationLines
       | OPT.C_Invoice_ID.Identifier | OPT.C_AllocationHdr_ID.Identifier |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -779,28 +779,26 @@ Feature: invoice payment allocation
 
     # At this point alloc_cm is the auto-created allocation of CM against invoice
     And validate C_AllocationLines
-      | C_Invoice_ID    | Amount | C_AllocationHdr_ID |
-      | salesCM_cma_100 | -11.90 | alloc_cm           |
-      | salesInv_cma_100| 11.90  | alloc_cm           |
+      | C_Invoice_ID     | Amount | C_AllocationHdr_ID |
+      | salesCM_cma_100  | -11.90 | alloc_cm           |
+      | salesInv_cma_100 | 11.90  | alloc_cm           |
 
     # Verify: the credit memo compensation allocation has Fact_Acct entries
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
       | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | alloc_cm  |
       | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | alloc_cm  |
-    And Fact_Acct records balances for documents:
-      | AD_Table_ID.TableName | Record_ID |
-      | C_AllocationHdr       | alloc_cm  |
+    And Fact_Acct records balances for documents alloc_cm are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | 0 EUR         |
 
-    # Now reverse the credit memo — this creates a reversal allocation
+    # Now reverse the credit memo — this creates reversal allocations
     And the invoice identified by salesCM_cma_100 is reversed
 
-    # The reversal creates allocations: one to undo the CM-vs-invoice, and one for the CM-vs-its-reversal
-    # The CM-vs-reversal allocation is a reversed invoice allocation and must produce Fact_Acct
     Then validate created invoices
-      | C_Invoice_ID    | IsPaid |
-      | salesInv_cma_100| false  |
-      | salesCM_cma_100 | true   |
+      | C_Invoice_ID     | IsPaid |
+      | salesInv_cma_100 | false  |
+      | salesCM_cma_100  | true   |
 
 
 # ############################################################################################################################################
@@ -845,12 +843,16 @@ Feature: invoice payment allocation
       | C_Invoice_ID.Identifier | IsPaid |
       | salesCM_cma_110         | true   |
 
+    And validate C_AllocationLines
+      | OPT.C_Invoice_ID.Identifier | OPT.C_AllocationHdr_ID.Identifier |
+      | salesCM_cma_110             | alloc_cma_110                     |
+
     # Verify: allocation has Fact_Acct entries — DR for credit memo, CR for invoice
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
-      | C_Receivable_Acct     | 59.50 EUR   | 0 EUR       | alloc1    |
-      | C_Receivable_Acct     | 0 EUR       | 59.50 EUR   | alloc1    |
-    And Fact_Acct records balances for documents alloc1 are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID     |
+      | C_Receivable_Acct     | 59.50 EUR   | 0 EUR       | alloc_cma_110 |
+      | C_Receivable_Acct     | 0 EUR       | 59.50 EUR   | alloc_cma_110 |
+    And Fact_Acct records balances for documents alloc_cma_110 are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
 
@@ -897,11 +899,15 @@ Feature: invoice payment allocation
       | C_Invoice_ID.Identifier | IsPaid |
       | purchaseCM_cma_120      | true   |
 
+    And validate C_AllocationLines
+      | OPT.C_Invoice_ID.Identifier | OPT.C_AllocationHdr_ID.Identifier |
+      | purchaseCM_cma_120          | alloc_cma_120                     |
+
     # Verify: allocation has Fact_Acct entries — CR for credit memo, DR for invoice
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
-      | V_Liability_Acct      | 0 EUR       | 59.50 EUR   | alloc1    |
-      | V_Liability_Acct      | 59.50 EUR   | 0 EUR       | alloc1    |
-    And Fact_Acct records balances for documents alloc1 are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID     |
+      | V_Liability_Acct      | 0 EUR       | 59.50 EUR   | alloc_cma_120 |
+      | V_Liability_Acct      | 59.50 EUR   | 0 EUR       | alloc_cma_120 |
+    And Fact_Acct records balances for documents alloc_cma_120 are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -777,7 +777,7 @@ Feature: invoice payment allocation
       | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
       | paymentAllocPLV               | product_cma_100 | 88.74    | PCE      |
     And metasfresh contains C_Invoice:
-      | Identifier        | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | Identifier | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | salesInv_cma_100  | bpartner_1    | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
     And metasfresh contains C_InvoiceLines
       | C_Invoice_ID      | M_Product_ID    | QtyInvoiced |
@@ -786,8 +786,8 @@ Feature: invoice payment allocation
 
     # Create credit memo against the invoice (auto-allocates CM against invoice)
     And create credit memo for C_Invoice
-      | CreditMemo         | C_Invoice_ID     | CreditMemo.PriceEntered |
-      | salesCM_cma_100    | salesInv_cma_100 | 88.74                   |
+      | CreditMemo.Identifier | C_Invoice_ID.Identifier | CreditMemo.PriceEntered | CreditMemo.C_DocType_ID.Name |
+      | salesCM_cma_100       | salesInv_cma_100        | 88.74                   | Gutschrift                   |
     And the invoice identified by salesCM_cma_100 is completed
 
     # At this point alloc_cm is the auto-created allocation of CM against invoice
@@ -857,17 +857,17 @@ Feature: invoice payment allocation
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
       | paymentAllocPLV               | product      | 500.00   | PCE      |
     And metasfresh contains C_Invoice:
-      | Identifier   | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | Identifier | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | salesInvoice | bpartner_1    | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
     And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID | M_Product_ID | QtyInvoiced |
+      | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced |
       | salesInvoice | product      | 1 PCE       |
     And the invoice identified by salesInvoice is completed
 
     # Create credit memo: GrandTotal = 75.10 EUR (partial credit of the 595.00 invoice)
     And create credit memo for C_Invoice
-      | CreditMemo      | C_Invoice_ID | CreditMemo.PriceEntered |
-      | salesCreditMemo | salesInvoice | 63.11                   |
+      | CreditMemo.Identifier | C_Invoice_ID.Identifier | CreditMemo.PriceEntered | CreditMemo.C_DocType_ID.Name |
+      | salesCreditMemo       | salesInvoice            | 63.11                   | Gutschrift                   |
     And the invoice identified by salesCreditMemo is completed
 
     And validate C_AllocationLines
@@ -909,7 +909,7 @@ Feature: invoice payment allocation
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
       | paymentAllocPLVNotSO            | product      | 500.00   | PCE      |
     And metasfresh contains C_Invoice:
-      | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | Identifier | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | purchaseInvoice | bpartner_1    | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
     And metasfresh contains C_InvoiceLines
       | C_Invoice_ID    | M_Product_ID | QtyInvoiced |
@@ -918,8 +918,8 @@ Feature: invoice payment allocation
 
     # Create credit memo: GrandTotal = 75.10 EUR (partial credit of the 595.00 invoice)
     And create credit memo for C_Invoice
-      | CreditMemo         | C_Invoice_ID    | CreditMemo.PriceEntered |
-      | purchaseCreditMemo | purchaseInvoice | 63.11                   |
+      | CreditMemo.Identifier | C_Invoice_ID.Identifier | CreditMemo.PriceEntered | CreditMemo.C_DocType_ID.Name |
+      | purchaseCreditMemo    | purchaseInvoice         | 63.11                   | Gutschrift (Lieferant)       |
     And the invoice identified by purchaseCreditMemo is completed
 
     And validate C_AllocationLines
@@ -970,7 +970,7 @@ Feature: invoice payment allocation
       | Identifier | IsCustomer | IsVendor | M_PricingSystem_ID |
       | bp200      | Y          | Y        | pricingSys200      |
     And metasfresh contains C_BPartner_Locations:
-      | Identifier  | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | Identifier | C_BPartner_ID.Identifier | IsShipToDefault | IsBillToDefault |
       | bp200_loc   | bp200         | Y               | Y               |
     And metasfresh contains M_Products:
       | Identifier |
@@ -982,16 +982,16 @@ Feature: invoice payment allocation
 
     # Sales invoice: GrandTotal = 11.90 EUR
     And metasfresh contains C_Invoice:
-      | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | Identifier | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | salesInv200     | bp200         | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
     And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID | M_Product_ID | QtyInvoiced |
+      | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced |
       | salesInv200  | product200   | 1 PCE       |
     And the invoice identified by salesInv200 is completed
 
     # Purchase invoice: GrandTotal = 5.95 EUR
     And metasfresh contains C_Invoice:
-      | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | Identifier | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | purchaseInv200  | bp200         | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
     And metasfresh contains C_InvoiceLines
       | C_Invoice_ID   | M_Product_ID | QtyInvoiced |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -358,17 +358,17 @@ Feature: invoice payment allocation
     And Fact_Acct records are matching
       | AccountConceptualName  | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID        |
       # salesInvoice1 posting (GrandTotal=5.95)
-      | C_Receivable_Acct      | 5.95 EUR    | 0 EUR       | customer1     | salesInvoice1    |
+      | C_Receivable_Acct      | 5.95 EUR    | 0 EUR       | bpartner_1    | salesInvoice1    |
       | *                      |             |             |               | salesInvoice1    |
       # salesCreditMemo1 posting (GrandTotal=2.38)
-      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | customer1     | salesCreditMemo1 |
+      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | bpartner_1    | salesCreditMemo1 |
       | *                      |             |             |               | salesCreditMemo1 |
       # alloc1: credit memo compensation (CM vs invoice)
-      | C_Receivable_Acct      | 2.38 EUR    | 0 EUR       | customer1     | alloc1           |
-      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | customer1     | alloc1           |
+      | C_Receivable_Acct      | 2.38 EUR    | 0 EUR       | bpartner_1    | alloc1           |
+      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | bpartner_1    | alloc1           |
       # alloc2: payment vs invoice
-      | B_UnallocatedCash_Acct | 3.57 EUR    | 0 EUR       | customer1     | alloc2           |
-      | C_Receivable_Acct      | 0 EUR       | 3.57 EUR    | customer1     | alloc2           |
+      | B_UnallocatedCash_Acct | 3.57 EUR    | 0 EUR       | bpartner_1    | alloc2           |
+      | C_Receivable_Acct      | 0 EUR       | 3.57 EUR    | bpartner_1    | alloc2           |
     And Fact_Acct records balances for documents alloc1 are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -652,17 +652,17 @@ Feature: invoice payment allocation
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID       |
       # inv_220 posting (GrandTotal=5.95)
-      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | customer1     | inv_220         |
+      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | bpartner_1    | inv_220         |
       | *                     |             |             |               | inv_220         |
       # credit_memo_220 posting (GrandTotal=2.38)
-      | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | customer1     | credit_memo_220 |
+      | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | bpartner_1    | credit_memo_220 |
       | *                     |             |             |               | credit_memo_220 |
       # alloc1: credit memo compensation (CM vs invoice)
-      | V_Liability_Acct      | 0 EUR       | 2.38 EUR    | customer1     | alloc1          |
-      | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | customer1     | alloc1          |
+      | V_Liability_Acct      | 0 EUR       | 2.38 EUR    | bpartner_1    | alloc1          |
+      | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | bpartner_1    | alloc1          |
       # alloc2: payment vs invoice
-      | V_Liability_Acct      | 3.57 EUR    | 0 EUR       | customer1     | alloc2          |
-      | B_PaymentSelect_Acct  | 0 EUR       | 3.57 EUR    | customer1     | alloc2          |
+      | V_Liability_Acct      | 3.57 EUR    | 0 EUR       | bpartner_1    | alloc2          |
+      | B_PaymentSelect_Acct  | 0 EUR       | 3.57 EUR    | bpartner_1    | alloc2          |
     And Fact_Acct records balances for documents alloc1 are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |
@@ -775,10 +775,10 @@ Feature: invoice payment allocation
       | product_cma_100 |
     And metasfresh contains M_ProductPrices
       | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
-      | salesPLV               | product_cma_100 | 88.74    | PCE      |
+      | paymentAllocPLV               | product_cma_100 | 88.74    | PCE      |
     And metasfresh contains C_Invoice:
       | Identifier        | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | salesInv_cma_100  | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+      | salesInv_cma_100  | bpartner_1    | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
     And metasfresh contains C_InvoiceLines
       | C_Invoice_ID      | M_Product_ID    | QtyInvoiced |
       | salesInv_cma_100  | product_cma_100 | 1 PCE       |
@@ -800,14 +800,14 @@ Feature: invoice payment allocation
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID        |
       # salesInv_cma_100 posting (GrandTotal=105.60)
-      | C_Receivable_Acct     | 105.60 EUR  | 0 EUR       | customer1     | salesInv_cma_100 |
+      | C_Receivable_Acct     | 105.60 EUR  | 0 EUR       | bpartner_1    | salesInv_cma_100 |
       | *                     |             |             |               | salesInv_cma_100 |
       # salesCM_cma_100 posting (GrandTotal=105.60)
-      | C_Receivable_Acct     | 0 EUR       | 105.60 EUR  | customer1     | salesCM_cma_100  |
+      | C_Receivable_Acct     | 0 EUR       | 105.60 EUR  | bpartner_1    | salesCM_cma_100  |
       | *                     |             |             |               | salesCM_cma_100  |
       # alloc_cm: credit memo compensation
-      | C_Receivable_Acct     | 105.60 EUR  | 0 EUR       | customer1     | alloc_cm         |
-      | C_Receivable_Acct     | 0 EUR       | 105.60 EUR  | customer1     | alloc_cm         |
+      | C_Receivable_Acct     | 105.60 EUR  | 0 EUR       | bpartner_1    | alloc_cm         |
+      | C_Receivable_Acct     | 0 EUR       | 105.60 EUR  | bpartner_1    | alloc_cm         |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -855,10 +855,10 @@ Feature: invoice payment allocation
       | product    |
     And metasfresh contains M_ProductPrices
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
-      | salesPLV               | product      | 500.00   | PCE      |
+      | paymentAllocPLV               | product      | 500.00   | PCE      |
     And metasfresh contains C_Invoice:
       | Identifier   | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | salesInvoice | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+      | salesInvoice | bpartner_1    | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
     And metasfresh contains C_InvoiceLines
       | C_Invoice_ID | M_Product_ID | QtyInvoiced |
       | salesInvoice | product      | 1 PCE       |
@@ -879,14 +879,14 @@ Feature: invoice payment allocation
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID       |
       # salesInvoice posting (GrandTotal=595.00)
-      | C_Receivable_Acct     | 595.00 EUR  | 0 EUR       | customer1     | salesInvoice    |
+      | C_Receivable_Acct     | 595.00 EUR  | 0 EUR       | bpartner_1    | salesInvoice    |
       | *                     |             |             |               | salesInvoice    |
       # salesCreditMemo posting (GrandTotal=75.10)
-      | C_Receivable_Acct     | 0 EUR       | 75.10 EUR   | customer1     | salesCreditMemo |
+      | C_Receivable_Acct     | 0 EUR       | 75.10 EUR   | bpartner_1    | salesCreditMemo |
       | *                     |             |             |               | salesCreditMemo |
       # alloc_cm: credit memo compensation (amount matches issue: 75.10)
-      | C_Receivable_Acct     | 75.10 EUR   | 0 EUR       | customer1     | alloc_cm        |
-      | C_Receivable_Acct     | 0 EUR       | 75.10 EUR   | customer1     | alloc_cm        |
+      | C_Receivable_Acct     | 75.10 EUR   | 0 EUR       | bpartner_1    | alloc_cm        |
+      | C_Receivable_Acct     | 0 EUR       | 75.10 EUR   | bpartner_1    | alloc_cm        |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -907,10 +907,10 @@ Feature: invoice payment allocation
       | product    |
     And metasfresh contains M_ProductPrices
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
-      | purchasePLV            | product      | 500.00   | PCE      |
+      | paymentAllocPLVNotSO            | product      | 500.00   | PCE      |
     And metasfresh contains C_Invoice:
       | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | purchaseInvoice | vendor1       | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
+      | purchaseInvoice | bpartner_1    | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
     And metasfresh contains C_InvoiceLines
       | C_Invoice_ID    | M_Product_ID | QtyInvoiced |
       | purchaseInvoice | product      | 1 PCE       |
@@ -931,14 +931,14 @@ Feature: invoice payment allocation
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID          |
       # purchaseInvoice posting (GrandTotal=595.00)
-      | V_Liability_Acct      | 0 EUR       | 595.00 EUR  | vendor1       | purchaseInvoice    |
+      | V_Liability_Acct      | 0 EUR       | 595.00 EUR  | bpartner_1    | purchaseInvoice    |
       | *                     |             |             |               | purchaseInvoice    |
       # purchaseCreditMemo posting (GrandTotal=75.10)
-      | V_Liability_Acct      | 75.10 EUR   | 0 EUR       | vendor1       | purchaseCreditMemo |
+      | V_Liability_Acct      | 75.10 EUR   | 0 EUR       | bpartner_1    | purchaseCreditMemo |
       | *                     |             |             |               | purchaseCreditMemo |
       # alloc_cm: credit memo compensation (amount matches issue: 75.10)
-      | V_Liability_Acct      | 0 EUR       | 75.10 EUR   | vendor1       | alloc_cm           |
-      | V_Liability_Acct      | 75.10 EUR   | 0 EUR       | vendor1       | alloc_cm           |
+      | V_Liability_Acct      | 0 EUR       | 75.10 EUR   | bpartner_1    | alloc_cm           |
+      | V_Liability_Acct      | 75.10 EUR   | 0 EUR       | bpartner_1    | alloc_cm           |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -769,12 +769,13 @@ Feature: invoice payment allocation
   @allure.label.feature:F00700_Invoicing
   @F00700
   Scenario: reverse correction - credit memo reversed, allocation produces Fact_Acct
+    # Amounts match issue summary: credit memo GrandTotal = 105.60 EUR (net 88.74 + 19% VAT 16.86)
     Given metasfresh contains M_Products:
       | Identifier      |
       | product_cma_100 |
     And metasfresh contains M_ProductPrices
       | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
-      | salesPLV               | product_cma_100 | 10.00    | PCE      |
+      | salesPLV               | product_cma_100 | 88.74    | PCE      |
     And metasfresh contains C_Invoice:
       | Identifier        | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | salesInv_cma_100  | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
@@ -786,27 +787,27 @@ Feature: invoice payment allocation
     # Create credit memo against the invoice (auto-allocates CM against invoice)
     And create credit memo for C_Invoice
       | CreditMemo         | C_Invoice_ID     | CreditMemo.PriceEntered |
-      | salesCM_cma_100    | salesInv_cma_100 | 10.00                   |
+      | salesCM_cma_100    | salesInv_cma_100 | 88.74                   |
     And the invoice identified by salesCM_cma_100 is completed
 
     # At this point alloc_cm is the auto-created allocation of CM against invoice
     And validate C_AllocationLines
-      | C_Invoice_ID     | Amount | C_AllocationHdr_ID |
-      | salesCM_cma_100  | -11.90 | alloc_cm           |
-      | salesInv_cma_100 | 11.90  | alloc_cm           |
+      | C_Invoice_ID     | Amount  | C_AllocationHdr_ID |
+      | salesCM_cma_100  | -105.60 | alloc_cm           |
+      | salesInv_cma_100 | 105.60  | alloc_cm           |
 
     # Verify: the credit memo compensation allocation has Fact_Acct entries
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID        |
-      # salesInv_cma_100 posting (GrandTotal=11.90)
-      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | customer1     | salesInv_cma_100 |
+      # salesInv_cma_100 posting (GrandTotal=105.60)
+      | C_Receivable_Acct     | 105.60 EUR  | 0 EUR       | customer1     | salesInv_cma_100 |
       | *                     |             |             |               | salesInv_cma_100 |
-      # salesCM_cma_100 posting (GrandTotal=11.90)
-      | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | customer1     | salesCM_cma_100  |
+      # salesCM_cma_100 posting (GrandTotal=105.60)
+      | C_Receivable_Acct     | 0 EUR       | 105.60 EUR  | customer1     | salesCM_cma_100  |
       | *                     |             |             |               | salesCM_cma_100  |
       # alloc_cm: credit memo compensation
-      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | customer1     | alloc_cm         |
-      | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | customer1     | alloc_cm         |
+      | C_Receivable_Acct     | 105.60 EUR  | 0 EUR       | customer1     | alloc_cm         |
+      | C_Receivable_Acct     | 0 EUR       | 105.60 EUR  | customer1     | alloc_cm         |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -822,14 +823,13 @@ Feature: invoice payment allocation
       | salesCM_cma_100  | true   |
 
     # After reversal, the CM has allocations: alloc_cm (original, now reversed) + alloc_cm_reversed (reversal) + alloc_cm_rev_pair (CM vs its reversal)
-    # Verify: the reversal-of-original allocation also has Fact_Acct
     And validate C_AllocationLines for invoice salesCM_cma_100
       | OPT.Amount | OPT.C_AllocationHdr_ID |
-      | -11.90     | alloc_cm               |
-      | 11.90      | alloc_cm_reversed      |
-      | -11.90     | alloc_cm_rev_pair      |
+      | -105.60    | alloc_cm               |
+      | 105.60     | alloc_cm_reversed      |
+      | -105.60    | alloc_cm_rev_pair      |
 
-    # The reversed allocation (CM vs its reversal) must have Fact_Acct entries (tests createDirectInvoiceAllocationSource)
+    # The reversed allocation (CM vs its reversal) must have Fact_Acct entries (tests createDirectInvoiceAllocationFacts)
     And Fact_Acct records balances for documents alloc_cm_rev_pair are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -849,12 +849,13 @@ Feature: invoice payment allocation
   @allure.label.feature:F00700_Invoicing
   @F00700
   Scenario: sales credit memo allocated against sales invoice - Fact_Acct entries (no payment)
+    # Amounts match issue summary: credit memo GrandTotal = 75.10 EUR (net 63.11 + 19% VAT 11.99)
     Given metasfresh contains M_Products:
       | Identifier |
       | product    |
     And metasfresh contains M_ProductPrices
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
-      | salesPLV               | product      | 10.00    | PCE      |
+      | salesPLV               | product      | 500.00   | PCE      |
     And metasfresh contains C_Invoice:
       | Identifier   | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | salesInvoice | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
@@ -863,29 +864,29 @@ Feature: invoice payment allocation
       | salesInvoice | product      | 1 PCE       |
     And the invoice identified by salesInvoice is completed
 
-    # Create credit memo linked to the invoice (auto-creates allocation with counter-lines)
+    # Create credit memo: GrandTotal = 75.10 EUR (partial credit of the 595.00 invoice)
     And create credit memo for C_Invoice
       | CreditMemo      | C_Invoice_ID | CreditMemo.PriceEntered |
-      | salesCreditMemo | salesInvoice | 5.00                    |
+      | salesCreditMemo | salesInvoice | 63.11                   |
     And the invoice identified by salesCreditMemo is completed
 
     And validate C_AllocationLines
       | C_Invoice_ID    | Amount | C_AllocationHdr_ID |
-      | salesCreditMemo | -5.95  | alloc_cm           |
-      | salesInvoice    | 5.95   | alloc_cm           |
+      | salesCreditMemo | -75.10 | alloc_cm           |
+      | salesInvoice    | 75.10  | alloc_cm           |
 
     # Verify: allocation has Fact_Acct entries — DR for credit memo, CR for invoice
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID       |
-      # salesInvoice posting (GrandTotal=11.90)
-      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | customer1     | salesInvoice    |
+      # salesInvoice posting (GrandTotal=595.00)
+      | C_Receivable_Acct     | 595.00 EUR  | 0 EUR       | customer1     | salesInvoice    |
       | *                     |             |             |               | salesInvoice    |
-      # salesCreditMemo posting (GrandTotal=5.95)
-      | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | customer1     | salesCreditMemo |
+      # salesCreditMemo posting (GrandTotal=75.10)
+      | C_Receivable_Acct     | 0 EUR       | 75.10 EUR   | customer1     | salesCreditMemo |
       | *                     |             |             |               | salesCreditMemo |
-      # alloc_cm: credit memo compensation
-      | C_Receivable_Acct     | 5.95 EUR    | 0 EUR       | customer1     | alloc_cm        |
-      | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | customer1     | alloc_cm        |
+      # alloc_cm: credit memo compensation (amount matches issue: 75.10)
+      | C_Receivable_Acct     | 75.10 EUR   | 0 EUR       | customer1     | alloc_cm        |
+      | C_Receivable_Acct     | 0 EUR       | 75.10 EUR   | customer1     | alloc_cm        |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -900,12 +901,13 @@ Feature: invoice payment allocation
   @allure.label.feature:F00700_Invoicing
   @F00700
   Scenario: purchase credit memo allocated against purchase invoice - Fact_Acct entries (no payment)
+    # Amounts match issue summary: credit memo GrandTotal = 75.10 EUR (net 63.11 + 19% VAT 11.99)
     Given metasfresh contains M_Products:
       | Identifier |
       | product    |
     And metasfresh contains M_ProductPrices
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
-      | purchasePLV            | product      | 10.00    | PCE      |
+      | purchasePLV            | product      | 500.00   | PCE      |
     And metasfresh contains C_Invoice:
       | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
       | purchaseInvoice | vendor1       | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
@@ -914,29 +916,29 @@ Feature: invoice payment allocation
       | purchaseInvoice | product      | 1 PCE       |
     And the invoice identified by purchaseInvoice is completed
 
-    # Create credit memo linked to the invoice (auto-creates allocation with counter-lines)
+    # Create credit memo: GrandTotal = 75.10 EUR (partial credit of the 595.00 invoice)
     And create credit memo for C_Invoice
       | CreditMemo         | C_Invoice_ID    | CreditMemo.PriceEntered |
-      | purchaseCreditMemo | purchaseInvoice | 5.00                    |
+      | purchaseCreditMemo | purchaseInvoice | 63.11                   |
     And the invoice identified by purchaseCreditMemo is completed
 
     And validate C_AllocationLines
       | C_Invoice_ID       | Amount | C_AllocationHdr_ID |
-      | purchaseCreditMemo | 5.95   | alloc_cm           |
-      | purchaseInvoice    | -5.95  | alloc_cm           |
+      | purchaseCreditMemo | 75.10  | alloc_cm           |
+      | purchaseInvoice    | -75.10 | alloc_cm           |
 
     # Verify: allocation has Fact_Acct entries — CR for credit memo, DR for invoice
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID          |
-      # purchaseInvoice posting (GrandTotal=11.90)
-      | V_Liability_Acct      | 0 EUR       | 11.90 EUR   | vendor1       | purchaseInvoice    |
+      # purchaseInvoice posting (GrandTotal=595.00)
+      | V_Liability_Acct      | 0 EUR       | 595.00 EUR  | vendor1       | purchaseInvoice    |
       | *                     |             |             |               | purchaseInvoice    |
-      # purchaseCreditMemo posting (GrandTotal=5.95)
-      | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | vendor1       | purchaseCreditMemo |
+      # purchaseCreditMemo posting (GrandTotal=75.10)
+      | V_Liability_Acct      | 75.10 EUR   | 0 EUR       | vendor1       | purchaseCreditMemo |
       | *                     |             |             |               | purchaseCreditMemo |
-      # alloc_cm: credit memo compensation
-      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | vendor1       | alloc_cm           |
-      | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | vendor1       | alloc_cm           |
+      # alloc_cm: credit memo compensation (amount matches issue: 75.10)
+      | V_Liability_Acct      | 0 EUR       | 75.10 EUR   | vendor1       | alloc_cm           |
+      | V_Liability_Acct      | 75.10 EUR   | 0 EUR       | vendor1       | alloc_cm           |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -6,6 +6,7 @@ Feature: invoice payment allocation
 
     Given infrastructure and metasfresh are running
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And documents are accounted immediately
 
     And metasfresh contains M_PricingSystems
       | Identifier                | Name                      | Value                     |
@@ -1031,6 +1032,187 @@ Feature: invoice payment allocation
       | C_Receivable_Acct     | -5.95 EUR     |
       | V_Liability_Acct      | 5.95 EUR      |
 
+
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_REV_ARI
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: ARI reversal - allocation Fact_Acct is balanced
+    Given metasfresh contains M_Products:
+      | Identifier      |
+      | product_rev_ari |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | paymentAllocPLV                   | product_rev_ari         | 100.00   | PCE               | Normal                        |
+    And metasfresh contains C_Invoice:
+      | Identifier   | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | inv_rev_ari  | bpartner_1               | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
+      | il_rev_ari | inv_rev_ari             | product_rev_ari         | 1           | PCE               |
+    And the invoice identified by inv_rev_ari is completed
+
+    And the invoice identified by inv_rev_ari is reversed
+    And the reversal of invoice inv_rev_ari is identified by inv_rev_ari_reversal
+
+    Then validate created invoices
+      | C_Invoice_ID.Identifier | OPT.IsPaid |
+      | inv_rev_ari             | true       |
+
+    And validate C_AllocationLines for invoice inv_rev_ari
+      | OPT.C_AllocationHdr_ID.Identifier |
+      | alloc_rev_ari                     |
+
+    # Reversal allocation must be balanced
+    And Fact_Acct records balances for documents alloc_rev_ari are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | 0 EUR         |
+
+
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_REV_ARC
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: ARC reversal - allocation Fact_Acct is balanced
+    Given metasfresh contains M_Products:
+      | Identifier      |
+      | product_rev_arc |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | paymentAllocPLV                   | product_rev_arc         | 80.00    | PCE               | Normal                        |
+    # Create a sales invoice first, then credit memo against it
+    And metasfresh contains C_Invoice:
+      | Identifier       | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | inv_for_rev_arc  | bpartner_1               | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | Identifier     | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
+      | il_for_rev_arc | inv_for_rev_arc         | product_rev_arc         | 1           | PCE               |
+    And the invoice identified by inv_for_rev_arc is completed
+
+    # Create standalone credit memo (ARC)
+    And metasfresh contains C_Invoice:
+      | Identifier   | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | cm_rev_arc   | bpartner_1               | Gutschrift              | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
+      | il_rev_arc | cm_rev_arc              | product_rev_arc         | 1           | PCE               |
+    And the invoice identified by cm_rev_arc is completed
+
+    # Reverse the credit memo
+    And the invoice identified by cm_rev_arc is reversed
+    And the reversal of invoice cm_rev_arc is identified by cm_rev_arc_reversal
+
+    Then validate created invoices
+      | C_Invoice_ID.Identifier | OPT.IsPaid |
+      | cm_rev_arc              | true       |
+
+    And validate C_AllocationLines for invoice cm_rev_arc
+      | OPT.C_AllocationHdr_ID.Identifier |
+      | alloc_rev_arc                     |
+
+    # Reversal allocation must be balanced
+    And Fact_Acct records balances for documents alloc_rev_arc are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | 0 EUR         |
+
+
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_REV_API
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: API reversal - allocation Fact_Acct is balanced
+    Given metasfresh contains M_Products:
+      | Identifier      |
+      | product_rev_api |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | paymentAllocPLVNotSO              | product_rev_api         | 100.00   | PCE               | Normal                        |
+    And metasfresh contains C_Invoice:
+      | Identifier   | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | inv_rev_api  | bpartner_1               | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
+      | il_rev_api | inv_rev_api             | product_rev_api         | 1           | PCE               |
+    And the invoice identified by inv_rev_api is completed
+
+    And the invoice identified by inv_rev_api is reversed
+    And the reversal of invoice inv_rev_api is identified by inv_rev_api_reversal
+
+    Then validate created invoices
+      | C_Invoice_ID.Identifier | OPT.IsPaid |
+      | inv_rev_api             | true       |
+
+    And validate C_AllocationLines for invoice inv_rev_api
+      | OPT.C_AllocationHdr_ID.Identifier |
+      | alloc_rev_api                     |
+
+    # Reversal allocation must be balanced
+    And Fact_Acct records balances for documents alloc_rev_api are matching
+      | AccountConceptualName | SourceBalance |
+      | V_Liability_Acct      | 0 EUR         |
+
+
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_REV_APC
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: APC reversal - allocation Fact_Acct is balanced
+    Given metasfresh contains M_Products:
+      | Identifier      |
+      | product_rev_apc |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | paymentAllocPLVNotSO              | product_rev_apc         | 80.00    | PCE               | Normal                        |
+    # Create a purchase invoice first
+    And metasfresh contains C_Invoice:
+      | Identifier       | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | inv_for_rev_apc  | bpartner_1               | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | Identifier     | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
+      | il_for_rev_apc | inv_for_rev_apc         | product_rev_apc         | 1           | PCE               |
+    And the invoice identified by inv_for_rev_apc is completed
+
+    # Create standalone purchase credit memo (APC)
+    And metasfresh contains C_Invoice:
+      | Identifier   | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | cm_rev_apc   | bpartner_1               | Gutschrift (Lieferant)  | 2022-05-11   | Spot                     | false   | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
+      | il_rev_apc | cm_rev_apc              | product_rev_apc         | 1           | PCE               |
+    And the invoice identified by cm_rev_apc is completed
+
+    # Reverse the purchase credit memo
+    And the invoice identified by cm_rev_apc is reversed
+    And the reversal of invoice cm_rev_apc is identified by cm_rev_apc_reversal
+
+    Then validate created invoices
+      | C_Invoice_ID.Identifier | OPT.IsPaid |
+      | cm_rev_apc              | true       |
+
+    And validate C_AllocationLines for invoice cm_rev_apc
+      | OPT.C_AllocationHdr_ID.Identifier |
+      | alloc_rev_apc                     |
+
+    # Reversal allocation must be balanced
+    And Fact_Acct records balances for documents alloc_rev_apc are matching
+      | AccountConceptualName | SourceBalance |
+      | V_Liability_Acct      | 0 EUR         |
 
 
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -811,48 +811,36 @@ Feature: invoice payment allocation
   @F00700
   Scenario: sales credit memo allocated against sales invoice - Fact_Acct entries (no payment)
     Given metasfresh contains M_Products:
-      | Identifier      |
-      | product_cma_110 |
+      | Identifier |
+      | product    |
     And metasfresh contains M_ProductPrices
-      | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
-      | salesPLV               | product_cma_110 | 100.00   | PCE      |
-    # Create the sales invoice (ARI) — GrandTotal = 119.00 EUR (100 + 19% VAT)
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | salesPLV               | product      | 10.00    | PCE      |
     And metasfresh contains C_Invoice:
-      | Identifier       | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | salesInv_cma_110 | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+      | Identifier   | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | salesInvoice | customer1     | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
     And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID     | M_Product_ID    | QtyInvoiced |
-      | salesInv_cma_110 | product_cma_110 | 1 PCE       |
-    And the invoice identified by salesInv_cma_110 is completed
+      | C_Invoice_ID | M_Product_ID | QtyInvoiced |
+      | salesInvoice | product      | 1 PCE       |
+    And the invoice identified by salesInvoice is completed
 
-    # Create the sales credit memo (ARC) — GrandTotal = 59.50 EUR (50 + 19% VAT)
-    And metasfresh contains C_Invoice:
-      | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | salesCM_cma_110 | customer1     | Gutschrift              | 2022-05-11   | Spot                     | true    | EUR                 |
-    And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID    | M_Product_ID    | QtyInvoiced |
-      | salesCM_cma_110 | product_cma_110 | 0.5 PCE     |
-    And the invoice identified by salesCM_cma_110 is completed
-
-    # Allocate credit memo against invoice (no payment)
-    And allocate invoices (credit memo/purchase) to invoices
-      | C_Invoice_ID.Identifier | OPT.CreditMemo.C_Invoice_ID.Identifier |
-      | salesInv_cma_110        | salesCM_cma_110                        |
-
-    Then validate created invoices
-      | C_Invoice_ID.Identifier | IsPaid |
-      | salesCM_cma_110         | true   |
+    # Create credit memo linked to the invoice (auto-creates allocation with counter-lines)
+    And create credit memo for C_Invoice
+      | CreditMemo      | C_Invoice_ID | CreditMemo.PriceEntered |
+      | salesCreditMemo | salesInvoice | 5.00                    |
+    And the invoice identified by salesCreditMemo is completed
 
     And validate C_AllocationLines
-      | OPT.C_Invoice_ID.Identifier | OPT.C_AllocationHdr_ID.Identifier |
-      | salesCM_cma_110             | alloc_cma_110                     |
+      | C_Invoice_ID    | Amount | C_AllocationHdr_ID |
+      | salesCreditMemo | -5.95  | alloc_cm           |
+      | salesInvoice    | 5.95   | alloc_cm           |
 
     # Verify: allocation has Fact_Acct entries — DR for credit memo, CR for invoice
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID     |
-      | C_Receivable_Acct     | 59.50 EUR   | 0 EUR       | alloc_cma_110 |
-      | C_Receivable_Acct     | 0 EUR       | 59.50 EUR   | alloc_cma_110 |
-    And Fact_Acct records balances for documents alloc_cma_110 are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | C_Receivable_Acct     | 5.95 EUR    | 0 EUR       | alloc_cm  |
+      | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | alloc_cm  |
+    And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
 
@@ -867,47 +855,35 @@ Feature: invoice payment allocation
   @F00700
   Scenario: purchase credit memo allocated against purchase invoice - Fact_Acct entries (no payment)
     Given metasfresh contains M_Products:
-      | Identifier      |
-      | product_cma_120 |
+      | Identifier |
+      | product    |
     And metasfresh contains M_ProductPrices
-      | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
-      | purchasePLV            | product_cma_120 | 100.00   | PCE      |
-    # Create the purchase invoice (API) — GrandTotal = 119.00 EUR (100 + 19% VAT)
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | purchasePLV            | product      | 10.00    | PCE      |
     And metasfresh contains C_Invoice:
-      | Identifier          | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | purchaseInv_cma_120 | vendor1       | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
+      | Identifier      | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | purchaseInvoice | vendor1       | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
     And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID        | M_Product_ID    | QtyInvoiced |
-      | purchaseInv_cma_120 | product_cma_120 | 1 PCE       |
-    And the invoice identified by purchaseInv_cma_120 is completed
+      | C_Invoice_ID    | M_Product_ID | QtyInvoiced |
+      | purchaseInvoice | product      | 1 PCE       |
+    And the invoice identified by purchaseInvoice is completed
 
-    # Create the purchase credit memo (APC) — GrandTotal = 59.50 EUR (50 + 19% VAT)
-    And metasfresh contains C_Invoice:
-      | Identifier         | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | purchaseCM_cma_120 | vendor1       | Gutschrift (Lieferant)  | 2022-05-11   | Spot                     | false   | EUR                 |
-    And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID       | M_Product_ID    | QtyInvoiced |
-      | purchaseCM_cma_120 | product_cma_120 | 0.5 PCE     |
-    And the invoice identified by purchaseCM_cma_120 is completed
-
-    # Allocate credit memo against invoice (no payment)
-    And allocate invoices (credit memo/purchase) to invoices
-      | C_Invoice_ID.Identifier | OPT.CreditMemo.C_Invoice_ID.Identifier |
-      | purchaseInv_cma_120     | purchaseCM_cma_120                     |
-
-    Then validate created invoices
-      | C_Invoice_ID.Identifier | IsPaid |
-      | purchaseCM_cma_120      | true   |
+    # Create credit memo linked to the invoice (auto-creates allocation with counter-lines)
+    And create credit memo for C_Invoice
+      | CreditMemo         | C_Invoice_ID    | CreditMemo.PriceEntered |
+      | purchaseCreditMemo | purchaseInvoice | 5.00                    |
+    And the invoice identified by purchaseCreditMemo is completed
 
     And validate C_AllocationLines
-      | OPT.C_Invoice_ID.Identifier | OPT.C_AllocationHdr_ID.Identifier |
-      | purchaseCM_cma_120          | alloc_cma_120                     |
+      | C_Invoice_ID       | Amount | C_AllocationHdr_ID |
+      | purchaseCreditMemo | 5.95   | alloc_cm           |
+      | purchaseInvoice    | -5.95  | alloc_cm           |
 
     # Verify: allocation has Fact_Acct entries — CR for credit memo, DR for invoice
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID     |
-      | V_Liability_Acct      | 0 EUR       | 59.50 EUR   | alloc_cma_120 |
-      | V_Liability_Acct      | 59.50 EUR   | 0 EUR       | alloc_cma_120 |
-    And Fact_Acct records balances for documents alloc_cma_120 are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | alloc_cm  |
+      | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | alloc_cm  |
+    And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -356,16 +356,21 @@ Feature: invoice payment allocation
       | inv_160                     | payment_160                 | 3.57       | 0                |
 
     And Fact_Acct records are matching
-      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | Record_ID |
-      | C_Receivable_Acct      | 2.38 EUR    | 0 EUR       | alloc1    |
-      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | alloc1    |
+      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID      |
+      # alloc1: credit memo compensation (CM vs invoice)
+      | C_Receivable_Acct      | 2.38 EUR    | 0 EUR       | customer1     | alloc1         |
+      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | customer1     | alloc1         |
+      # alloc2: payment vs invoice
+      | B_UnallocatedCash_Acct | 3.57 EUR    | 0 EUR       | customer1     | alloc2         |
+      | C_Receivable_Acct      | 0 EUR       | 3.57 EUR    | customer1     | alloc2         |
+      # invoice postings
+      | C_Receivable_Acct      |             |             | customer1     | salesInvoice1  |
+      | *                      |             |             |               | salesInvoice1  |
+      | C_Receivable_Acct      |             |             | customer1     | salesCreditMemo1 |
+      | *                      |             |             |               | salesCreditMemo1 |
     And Fact_Acct records balances for documents alloc1 are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
-    And Fact_Acct records are matching
-      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | Record_ID |
-      | B_UnallocatedCash_Acct | 3.57 EUR    | 0 EUR       | alloc2    |
-      | C_Receivable_Acct      | 0 EUR       | 3.57 EUR    | alloc2    |
 
   @Id:S0132_170
   @from:cucumber
@@ -644,16 +649,21 @@ Feature: invoice payment allocation
       | inv_220                     | payment_220                 | -3.57      | 0                |
 
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
-      | V_Liability_Acct      | 0 EUR       | 2.38 EUR    | alloc1    |
-      | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | alloc1    |
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID       |
+      # alloc1: credit memo compensation (CM vs invoice)
+      | V_Liability_Acct      | 0 EUR       | 2.38 EUR    | customer1     | alloc1          |
+      | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | customer1     | alloc1          |
+      # alloc2: payment vs invoice
+      | V_Liability_Acct      | 3.57 EUR    | 0 EUR       | customer1     | alloc2          |
+      | B_PaymentSelect_Acct  | 0 EUR       | 3.57 EUR    | customer1     | alloc2          |
+      # invoice postings
+      | V_Liability_Acct      |             |             | customer1     | inv_220         |
+      | *                     |             |             |               | inv_220         |
+      | V_Liability_Acct      |             |             | customer1     | credit_memo_220 |
+      | *                     |             |             |               | credit_memo_220 |
     And Fact_Acct records balances for documents alloc1 are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |
-    And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
-      | V_Liability_Acct      | 3.57 EUR    | 0 EUR       | alloc2    |
-      | B_PaymentSelect_Acct  | 0 EUR       | 3.57 EUR    | alloc2    |
 
   @Id:S0132_230
   @from:cucumber
@@ -785,9 +795,14 @@ Feature: invoice payment allocation
 
     # Verify: the credit memo compensation allocation has Fact_Acct entries
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
-      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | alloc_cm  |
-      | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | alloc_cm  |
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID        |
+      | C_Receivable_Acct     | 11.90 EUR   | 0 EUR       | customer1     | alloc_cm         |
+      | C_Receivable_Acct     | 0 EUR       | 11.90 EUR   | customer1     | alloc_cm         |
+      # invoice postings
+      | C_Receivable_Acct     |             |             | customer1     | salesInv_cma_100 |
+      | *                     |             |             |               | salesInv_cma_100 |
+      | C_Receivable_Acct     |             |             | customer1     | salesCM_cma_100  |
+      | *                     |             |             |               | salesCM_cma_100  |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -857,9 +872,14 @@ Feature: invoice payment allocation
 
     # Verify: allocation has Fact_Acct entries — DR for credit memo, CR for invoice
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
-      | C_Receivable_Acct     | 5.95 EUR    | 0 EUR       | alloc_cm  |
-      | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | alloc_cm  |
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID       |
+      | C_Receivable_Acct     | 5.95 EUR    | 0 EUR       | customer1     | alloc_cm        |
+      | C_Receivable_Acct     | 0 EUR       | 5.95 EUR    | customer1     | alloc_cm        |
+      # invoice postings
+      | C_Receivable_Acct     |             |             | customer1     | salesInvoice    |
+      | *                     |             |             |               | salesInvoice    |
+      | C_Receivable_Acct     |             |             | customer1     | salesCreditMemo |
+      | *                     |             |             |               | salesCreditMemo |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
@@ -901,9 +921,14 @@ Feature: invoice payment allocation
 
     # Verify: allocation has Fact_Acct entries — CR for credit memo, DR for invoice
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
-      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | alloc_cm  |
-      | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | alloc_cm  |
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID          |
+      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | vendor1       | alloc_cm           |
+      | V_Liability_Acct      | 5.95 EUR    | 0 EUR       | vendor1       | alloc_cm           |
+      # invoice postings
+      | V_Liability_Acct      |             |             | vendor1       | purchaseInvoice    |
+      | *                     |             |             |               | purchaseInvoice    |
+      | V_Liability_Acct      |             |             | vendor1       | purchaseCreditMemo |
+      | *                     |             |             |               | purchaseCreditMemo |
     And Fact_Acct records balances for documents alloc_cm are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -820,9 +820,9 @@ Feature: invoice payment allocation
     And the invoice identified by salesCM_cma_100 is reversed
 
     Then validate created invoices
-      | C_Invoice_ID.Identifier | OPT.IsPaid |
-      | salesInv_cma_100 | false  |
-      | salesCM_cma_100  | true   |
+      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | paymentTerm   | processed | docStatus | OPT.IsPaid |
+      | salesInv_cma_100 | bpartner_1 | bpartner_location_1 | 30 Tage netto | true | CO | false |
+      | salesCM_cma_100  | bpartner_1 | bpartner_location_1 | 30 Tage netto | true | CO | true  |
 
     # After reversal, the CM has allocations: alloc_cm (original, now reversed) + alloc_cm_reversed (reversal) + alloc_cm_rev_pair (CM vs its reversal)
     And validate C_AllocationLines for invoice salesCM_cma_100
@@ -1060,8 +1060,8 @@ Feature: invoice payment allocation
     And the reversal of invoice inv_rev_ari is identified by inv_rev_ari_reversal
 
     Then validate created invoices
-      | C_Invoice_ID.Identifier | OPT.IsPaid |
-      | inv_rev_ari             | true       |
+      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | paymentTerm   | processed | docStatus | OPT.IsPaid |
+      | inv_rev_ari | bpartner_1 | bpartner_location_1 | 30 Tage netto | true | RE | true |
 
     And validate C_AllocationLines for invoice inv_rev_ari
       | OPT.C_AllocationHdr_ID.Identifier |
@@ -1111,8 +1111,8 @@ Feature: invoice payment allocation
     And the reversal of invoice cm_rev_arc is identified by cm_rev_arc_reversal
 
     Then validate created invoices
-      | C_Invoice_ID.Identifier | OPT.IsPaid |
-      | cm_rev_arc              | true       |
+      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | paymentTerm   | processed | docStatus | OPT.IsPaid |
+      | cm_rev_arc | bpartner_1 | bpartner_location_1 | 30 Tage netto | true | RE | true |
 
     And validate C_AllocationLines for invoice cm_rev_arc
       | OPT.C_AllocationHdr_ID.Identifier |
@@ -1151,8 +1151,8 @@ Feature: invoice payment allocation
     And the reversal of invoice inv_rev_api is identified by inv_rev_api_reversal
 
     Then validate created invoices
-      | C_Invoice_ID.Identifier | OPT.IsPaid |
-      | inv_rev_api             | true       |
+      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | paymentTerm   | processed | docStatus | OPT.IsPaid |
+      | inv_rev_api | bpartner_1 | bpartner_location_1 | 30 Tage netto | true | RE | true |
 
     And validate C_AllocationLines for invoice inv_rev_api
       | OPT.C_AllocationHdr_ID.Identifier |
@@ -1202,8 +1202,8 @@ Feature: invoice payment allocation
     And the reversal of invoice cm_rev_apc is identified by cm_rev_apc_reversal
 
     Then validate created invoices
-      | C_Invoice_ID.Identifier | OPT.IsPaid |
-      | cm_rev_apc              | true       |
+      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | paymentTerm   | processed | docStatus | OPT.IsPaid |
+      | cm_rev_apc | bpartner_1 | bpartner_location_1 | 30 Tage netto | true | RE | true |
 
     And validate C_AllocationLines for invoice cm_rev_apc
       | OPT.C_AllocationHdr_ID.Identifier |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -356,24 +356,6 @@ Feature: invoice payment allocation
       | OPT.C_Invoice_ID.Identifier | OPT.C_Payment_ID.Identifier | OPT.Amount | OPT.OverUnderAmt |
       | inv_160                     | payment_160                 | 3.57       | 0                |
 
-    And Fact_Acct records are matching
-      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID        |
-      # salesInvoice1 posting (GrandTotal=5.95)
-      | C_Receivable_Acct      | 5.95 EUR    | 0 EUR       | bpartner_1    | inv_160          |
-      | *                      |             |             |               | inv_160          |
-      # salesCreditMemo1 posting (GrandTotal=2.38)
-      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | bpartner_1    | credit_memo_160  |
-      | *                      |             |             |               | credit_memo_160  |
-      # alloc1: credit memo compensation (CM vs invoice)
-      | C_Receivable_Acct      | 2.38 EUR    | 0 EUR       | bpartner_1    | alloc1           |
-      | C_Receivable_Acct      | 0 EUR       | 2.38 EUR    | bpartner_1    | alloc1           |
-      # alloc2: payment vs invoice
-      | B_UnallocatedCash_Acct | 3.57 EUR    | 0 EUR       | bpartner_1    | alloc2           |
-      | C_Receivable_Acct      | 0 EUR       | 3.57 EUR    | bpartner_1    | alloc2           |
-    And Fact_Acct records balances for documents alloc1 are matching
-      | AccountConceptualName | SourceBalance |
-      | C_Receivable_Acct     | 0 EUR         |
-
   @Id:S0132_170
   @from:cucumber
   Scenario: allocate outbound payment to sales invoice
@@ -649,24 +631,6 @@ Feature: invoice payment allocation
     And validate C_AllocationLines
       | OPT.C_Invoice_ID.Identifier | OPT.C_Payment_ID.Identifier | OPT.Amount | OPT.OverUnderAmt |
       | inv_220                     | payment_220                 | -3.57      | 0                |
-
-    And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID       |
-      # inv_220 posting (GrandTotal=5.95)
-      | V_Liability_Acct      | 0 EUR       | 5.95 EUR    | bpartner_1    | inv_220         |
-      | *                     |             |             |               | inv_220         |
-      # credit_memo_220 posting (GrandTotal=2.38)
-      | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | bpartner_1    | credit_memo_220 |
-      | *                     |             |             |               | credit_memo_220 |
-      # alloc1: credit memo compensation (CM vs invoice)
-      | V_Liability_Acct      | 0 EUR       | 2.38 EUR    | bpartner_1    | alloc1          |
-      | V_Liability_Acct      | 2.38 EUR    | 0 EUR       | bpartner_1    | alloc1          |
-      # alloc2: payment vs invoice
-      | V_Liability_Acct      | 3.57 EUR    | 0 EUR       | bpartner_1    | alloc2          |
-      | B_PaymentSelect_Acct  | 0 EUR       | 3.57 EUR    | bpartner_1    | alloc2          |
-    And Fact_Acct records balances for documents alloc1 are matching
-      | AccountConceptualName | SourceBalance |
-      | V_Liability_Acct      | 0 EUR         |
 
   @Id:S0132_230
   @from:cucumber
@@ -1034,185 +998,233 @@ Feature: invoice payment allocation
 
 
 # ############################################################################################################################################
+# Reversal scenarios ported from IC hotfix PR 23329 (CMA_130, CMA_140, CMA_150, CMA_160)
+# These test per-invoice Fact_Acct balance clearing for all 4 document types
 # ############################################################################################################################################
-# ############################################################################################################################################
-  @Id:S0465_REV_ARI
+  @Id:S0465_CMA_130
   @from:cucumber
   @allure.label.epic:E0340_Invoicing
   @allure.label.feature:F00700_Invoicing
   @F00700
-  Scenario: ARI reversal - allocation Fact_Acct is balanced
+  Scenario: standalone sales credit memo (ARC) reversed - allocation produces balanced Fact_Acct per invoice
     Given metasfresh contains M_Products:
-      | Identifier      |
-      | product_rev_ari |
+      | Identifier |
+      | product    |
     And metasfresh contains M_ProductPrices
       | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | paymentAllocPLV                   | product_rev_ari         | 100.00   | PCE               | Normal                        |
+      | paymentAllocPLV                   | product                 | 200.00   | PCE               | Normal                        |
+
     And metasfresh contains C_Invoice:
-      | Identifier   | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | inv_rev_ari  | bpartner_1               | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+      | Identifier | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | salesCM    | bpartner_1               | Gutschrift              | 2022-05-11   | Spot                     | true    | EUR                 |
     And metasfresh contains C_InvoiceLines
       | Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
-      | il_rev_ari | inv_rev_ari             | product_rev_ari         | 1           | PCE               |
-    And the invoice identified by inv_rev_ari is completed
+      | cmLine     | salesCM                 | product                 | 1           | PCE               |
+    And the invoice identified by salesCM is completed
 
-    And the invoice identified by inv_rev_ari is reversed
-    And the reversal of invoice inv_rev_ari is identified by inv_rev_ari_reversal
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID.Identifier | Record_ID |
+      | C_Receivable_Acct     | 0 EUR       | 238.00 EUR  | bpartner_1               | salesCM   |
+      | *                     |             |             |                          | salesCM   |
+
+    And the invoice identified by salesCM is reversed
+    And the reversal of invoice salesCM is identified by reversalCM
 
     Then validate created invoices
       | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | paymentTerm   | processed | docStatus | OPT.IsPaid |
-      | inv_rev_ari | bpartner_1 | bpartner_location_1 | 30 Tage netto | true | RE | true |
+      | salesCM                 | bpartner_1               | bpartner_location_1               | 30 Tage netto | true      | RE        | true       |
 
-    And validate C_AllocationLines for invoice inv_rev_ari
+    And validate C_AllocationLines for invoice salesCM
       | OPT.C_AllocationHdr_ID.Identifier |
-      | alloc_rev_ari                     |
+      | alloc_reversal                    |
 
-    # Reversal allocation must be balanced
-    And Fact_Acct records balances for documents alloc_rev_ari are matching
+    # Allocation per-line: must clear each invoice's C_Receivable posting
+    # ARC invoice posts C_Receivable CR, so allocation clears with DR
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr  | AmtSourceCr | C_BPartner_ID.Identifier | C_Invoice_ID.Identifier | Record_ID      |
+      | C_Receivable_Acct     | 238.00 EUR   | 0 EUR       | bpartner_1               | salesCM                 | alloc_reversal |
+      | C_Receivable_Acct     | -238.00 EUR  | 0 EUR       | bpartner_1               | reversalCM              | alloc_reversal |
+    # Allocation overall balance
+    And Fact_Acct records balances for documents alloc_reversal are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
 
+    # Cross-document: each invoice fully cleared
+    And Fact_Acct records balances for documents salesCM,reversalCM,alloc_reversal are matching
+      | AccountConceptualName | C_Invoice_ID.Identifier | AmtSourceDr  | AmtSourceCr  | SourceBalance |
+      | C_Receivable_Acct     | salesCM                 | 238.00 EUR   | 238.00 EUR   | 0 EUR         |
+      | C_Receivable_Acct     | reversalCM              | -238.00 EUR  | -238.00 EUR  | 0 EUR         |
+
 
 # ############################################################################################################################################
 # ############################################################################################################################################
 # ############################################################################################################################################
-  @Id:S0465_REV_ARC
+  @Id:S0465_CMA_140
   @from:cucumber
   @allure.label.epic:E0340_Invoicing
   @allure.label.feature:F00700_Invoicing
   @F00700
-  Scenario: ARC reversal - allocation Fact_Acct is balanced
+  Scenario: purchase invoice (API) reversed - allocation produces balanced Fact_Acct per invoice
     Given metasfresh contains M_Products:
-      | Identifier      |
-      | product_rev_arc |
+      | Identifier |
+      | product    |
     And metasfresh contains M_ProductPrices
       | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | paymentAllocPLV                   | product_rev_arc         | 80.00    | PCE               | Normal                        |
-    # Create a sales invoice first, then credit memo against it
-    And metasfresh contains C_Invoice:
-      | Identifier       | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | inv_for_rev_arc  | bpartner_1               | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
-    And metasfresh contains C_InvoiceLines
-      | Identifier     | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
-      | il_for_rev_arc | inv_for_rev_arc         | product_rev_arc         | 1           | PCE               |
-    And the invoice identified by inv_for_rev_arc is completed
+      | paymentAllocPLVNotSO              | product                 | 200.00   | PCE               | Normal                        |
 
-    # Create standalone credit memo (ARC)
     And metasfresh contains C_Invoice:
-      | Identifier   | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | cm_rev_arc   | bpartner_1               | Gutschrift              | 2022-05-11   | Spot                     | true    | EUR                 |
+      | Identifier  | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | purchaseInv | bpartner_1               | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
     And metasfresh contains C_InvoiceLines
       | Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
-      | il_rev_arc | cm_rev_arc              | product_rev_arc         | 1           | PCE               |
-    And the invoice identified by cm_rev_arc is completed
+      | invLine    | purchaseInv             | product                 | 1           | PCE               |
+    And the invoice identified by purchaseInv is completed
 
-    # Reverse the credit memo
-    And the invoice identified by cm_rev_arc is reversed
-    And the reversal of invoice cm_rev_arc is identified by cm_rev_arc_reversal
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID.Identifier | Record_ID   |
+      | V_Liability_Acct      | 0 EUR       | 238.00 EUR  | bpartner_1               | purchaseInv |
+      | *                     |             |             |                          | purchaseInv |
+
+    And the invoice identified by purchaseInv is reversed
+    And the reversal of invoice purchaseInv is identified by reversalInv
 
     Then validate created invoices
       | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | paymentTerm   | processed | docStatus | OPT.IsPaid |
-      | cm_rev_arc | bpartner_1 | bpartner_location_1 | 30 Tage netto | true | RE | true |
+      | purchaseInv             | bpartner_1               | bpartner_location_1               | 30 Tage netto | true      | RE        | true       |
 
-    And validate C_AllocationLines for invoice cm_rev_arc
-      | OPT.C_AllocationHdr_ID.Identifier |
-      | alloc_rev_arc                     |
+    And validate C_AllocationLines for invoice purchaseInv
+      | OPT.Amount | OPT.C_AllocationHdr_ID.Identifier |
+      | -238.00    | alloc_reversal                    |
 
-    # Reversal allocation must be balanced
-    And Fact_Acct records balances for documents alloc_rev_arc are matching
+    # Allocation per-line: must clear each invoice's V_Liability posting
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr  | AmtSourceCr | C_BPartner_ID.Identifier | C_Invoice_ID.Identifier | Record_ID      |
+      | V_Liability_Acct      | 238.00 EUR   | 0 EUR       | bpartner_1               | purchaseInv             | alloc_reversal |
+      | V_Liability_Acct      | -238.00 EUR  | 0 EUR       | bpartner_1               | reversalInv             | alloc_reversal |
+    # Allocation overall balance
+    And Fact_Acct records balances for documents alloc_reversal are matching
+      | AccountConceptualName | SourceBalance |
+      | V_Liability_Acct      | 0 EUR         |
+
+    # Cross-document: each invoice fully cleared
+    And Fact_Acct records balances for documents purchaseInv,reversalInv,alloc_reversal are matching
+      | AccountConceptualName | C_Invoice_ID.Identifier | AmtSourceDr | AmtSourceCr | SourceBalance |
+      | V_Liability_Acct      | purchaseInv             | 238.00 EUR  | 238.00 EUR  | 0 EUR         |
+      | V_Liability_Acct      | reversalInv             | -238.00 EUR | -238.00 EUR | 0 EUR         |
+
+
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_CMA_150
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: sales invoice (ARI) reversed - allocation produces balanced Fact_Acct per invoice
+    Given metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | paymentAllocPLV                   | product                 | 200.00   | PCE               | Normal                        |
+
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | salesInv   | bpartner_1               | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
+      | invLine    | salesInv                | product                 | 1           | PCE               |
+    And the invoice identified by salesInv is completed
+
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID.Identifier | Record_ID |
+      | C_Receivable_Acct     | 238.00 EUR  | 0 EUR       | bpartner_1               | salesInv  |
+      | *                     |             |             |                          | salesInv  |
+
+    And the invoice identified by salesInv is reversed
+    And the reversal of invoice salesInv is identified by reversalInv
+
+    Then validate created invoices
+      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | paymentTerm   | processed | docStatus | OPT.IsPaid |
+      | salesInv                | bpartner_1               | bpartner_location_1               | 30 Tage netto | true      | RE        | true       |
+
+    And validate C_AllocationLines for invoice salesInv
+      | OPT.Amount | OPT.C_AllocationHdr_ID.Identifier |
+      | 238.00     | alloc_reversal                    |
+
+    # Allocation per-line: must clear each invoice's C_Receivable posting
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr  | C_BPartner_ID.Identifier | C_Invoice_ID.Identifier | Record_ID      |
+      | C_Receivable_Acct     | 0 EUR       | 238.00 EUR   | bpartner_1               | salesInv                | alloc_reversal |
+      | C_Receivable_Acct     | 0 EUR       | -238.00 EUR  | bpartner_1               | reversalInv             | alloc_reversal |
+    # Allocation overall balance
+    And Fact_Acct records balances for documents alloc_reversal are matching
       | AccountConceptualName | SourceBalance |
       | C_Receivable_Acct     | 0 EUR         |
 
+    # Cross-document: each invoice fully cleared
+    And Fact_Acct records balances for documents salesInv,reversalInv,alloc_reversal are matching
+      | AccountConceptualName | C_Invoice_ID.Identifier | AmtSourceDr | AmtSourceCr | SourceBalance |
+      | C_Receivable_Acct     | salesInv                | 238.00 EUR  | 238.00 EUR  | 0 EUR         |
+      | C_Receivable_Acct     | reversalInv             | -238.00 EUR | -238.00 EUR | 0 EUR         |
+
 
 # ############################################################################################################################################
 # ############################################################################################################################################
 # ############################################################################################################################################
-  @Id:S0465_REV_API
+  @Id:S0465_CMA_160
   @from:cucumber
   @allure.label.epic:E0340_Invoicing
   @allure.label.feature:F00700_Invoicing
   @F00700
-  Scenario: API reversal - allocation Fact_Acct is balanced
+  Scenario: purchase credit memo (APC) reversed - allocation produces balanced Fact_Acct per invoice
     Given metasfresh contains M_Products:
-      | Identifier      |
-      | product_rev_api |
+      | Identifier |
+      | product    |
     And metasfresh contains M_ProductPrices
       | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | paymentAllocPLVNotSO              | product_rev_api         | 100.00   | PCE               | Normal                        |
+      | paymentAllocPLVNotSO              | product                 | 200.00   | PCE               | Normal                        |
+
     And metasfresh contains C_Invoice:
-      | Identifier   | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | inv_rev_api  | bpartner_1               | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
+      | Identifier | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | purchaseCM | bpartner_1               | Gutschrift (Lieferant)  | 2022-05-11   | Spot                     | false   | EUR                 |
     And metasfresh contains C_InvoiceLines
       | Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
-      | il_rev_api | inv_rev_api             | product_rev_api         | 1           | PCE               |
-    And the invoice identified by inv_rev_api is completed
+      | cmLine     | purchaseCM              | product                 | 1           | PCE               |
+    And the invoice identified by purchaseCM is completed
 
-    And the invoice identified by inv_rev_api is reversed
-    And the reversal of invoice inv_rev_api is identified by inv_rev_api_reversal
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID.Identifier | Record_ID  |
+      | V_Liability_Acct      | 238.00 EUR  | 0 EUR       | bpartner_1               | purchaseCM |
+      | *                     |             |             |                          | purchaseCM |
+
+    And the invoice identified by purchaseCM is reversed
+    And the reversal of invoice purchaseCM is identified by reversalCM
 
     Then validate created invoices
       | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | paymentTerm   | processed | docStatus | OPT.IsPaid |
-      | inv_rev_api | bpartner_1 | bpartner_location_1 | 30 Tage netto | true | RE | true |
+      | purchaseCM              | bpartner_1               | bpartner_location_1               | 30 Tage netto | true      | RE        | true       |
 
-    And validate C_AllocationLines for invoice inv_rev_api
-      | OPT.C_AllocationHdr_ID.Identifier |
-      | alloc_rev_api                     |
+    And validate C_AllocationLines for invoice purchaseCM
+      | OPT.Amount | OPT.C_AllocationHdr_ID.Identifier |
+      | 238.00     | alloc_reversal                    |
 
-    # Reversal allocation must be balanced
-    And Fact_Acct records balances for documents alloc_rev_api are matching
+    # Allocation per-line: must clear each invoice's V_Liability posting
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr  | C_BPartner_ID.Identifier | C_Invoice_ID.Identifier | Record_ID      |
+      | V_Liability_Acct      | 0 EUR       | 238.00 EUR   | bpartner_1               | purchaseCM              | alloc_reversal |
+      | V_Liability_Acct      | 0 EUR       | -238.00 EUR  | bpartner_1               | reversalCM              | alloc_reversal |
+    # Allocation overall balance
+    And Fact_Acct records balances for documents alloc_reversal are matching
       | AccountConceptualName | SourceBalance |
       | V_Liability_Acct      | 0 EUR         |
 
-
-# ############################################################################################################################################
-# ############################################################################################################################################
-# ############################################################################################################################################
-  @Id:S0465_REV_APC
-  @from:cucumber
-  @allure.label.epic:E0340_Invoicing
-  @allure.label.feature:F00700_Invoicing
-  @F00700
-  Scenario: APC reversal - allocation Fact_Acct is balanced
-    Given metasfresh contains M_Products:
-      | Identifier      |
-      | product_rev_apc |
-    And metasfresh contains M_ProductPrices
-      | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | paymentAllocPLVNotSO              | product_rev_apc         | 80.00    | PCE               | Normal                        |
-    # Create a purchase invoice first
-    And metasfresh contains C_Invoice:
-      | Identifier       | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | inv_for_rev_apc  | bpartner_1               | Eingangsrechnung        | 2022-05-11   | Spot                     | false   | EUR                 |
-    And metasfresh contains C_InvoiceLines
-      | Identifier     | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
-      | il_for_rev_apc | inv_for_rev_apc         | product_rev_apc         | 1           | PCE               |
-    And the invoice identified by inv_for_rev_apc is completed
-
-    # Create standalone purchase credit memo (APC)
-    And metasfresh contains C_Invoice:
-      | Identifier   | C_BPartner_ID.Identifier | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | cm_rev_apc   | bpartner_1               | Gutschrift (Lieferant)  | 2022-05-11   | Spot                     | false   | EUR                 |
-    And metasfresh contains C_InvoiceLines
-      | Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | C_UOM_ID.X12DE355 |
-      | il_rev_apc | cm_rev_apc              | product_rev_apc         | 1           | PCE               |
-    And the invoice identified by cm_rev_apc is completed
-
-    # Reverse the purchase credit memo
-    And the invoice identified by cm_rev_apc is reversed
-    And the reversal of invoice cm_rev_apc is identified by cm_rev_apc_reversal
-
-    Then validate created invoices
-      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | paymentTerm   | processed | docStatus | OPT.IsPaid |
-      | cm_rev_apc | bpartner_1 | bpartner_location_1 | 30 Tage netto | true | RE | true |
-
-    And validate C_AllocationLines for invoice cm_rev_apc
-      | OPT.C_AllocationHdr_ID.Identifier |
-      | alloc_rev_apc                     |
-
-    # Reversal allocation must be balanced
-    And Fact_Acct records balances for documents alloc_rev_apc are matching
-      | AccountConceptualName | SourceBalance |
-      | V_Liability_Acct      | 0 EUR         |
+    # Cross-document: each invoice fully cleared
+    And Fact_Acct records balances for documents purchaseCM,reversalCM,alloc_reversal are matching
+      | AccountConceptualName | C_Invoice_ID.Identifier | AmtSourceDr | AmtSourceCr | SourceBalance |
+      | V_Liability_Acct      | purchaseCM              | 238.00 EUR  | 238.00 EUR  | 0 EUR         |
+      | V_Liability_Acct      | reversalCM              | -238.00 EUR | -238.00 EUR | 0 EUR         |
 
 
 


### PR DESCRIPTION
## Summary

- Adds 8 Cucumber test scenarios for allocation Fact_Acct posting verification
- CMA_100/110/120/200: Cherry-picked from IC hotfix PR #23226, adapted for soft_panda step defs
- CMA_130/140/150/160: Ported from IC hotfix PR #23329, covering per-invoice Fact_Acct balance clearing for all 4 document types (ARC, API, ARI, APC reversals)
- No changes to pre-existing S0132_* test expectations
- Companion to PR #23326 (Java logic fix)

## Test plan

- [x] All 24 scenarios pass locally against soft_panda_uat infrastructure (2026-04-02T18:21, 26 tests run / 0 failures / 0 errors)
- [ ] CI green on this branch