### PR TITLE
Fix quick-scan on picking job screen for DataWedge IME mode

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/assets/BarcodeScannerComponent.scss
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/assets/BarcodeScannerComponent.scss
@@ -19,6 +19,24 @@
     text-align: center;
   }
 
+  // Visually hidden but focusable input for background barcode scanning.
+  // Used by BarcodeScannerButton to capture DataWedge IME text injection
+  // without showing a visible input field. Must NOT use type="hidden" or
+  // display:none — those break Android InputConnection. (me03#28834)
+  .input-text-offscreen {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    overflow: hidden;
+    pointer-events: none;
+    margin: 0;
+    padding: 0;
+    border: none;
+  }
+
   .loading {
     position: absolute;
     z-index: 999;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
@@ -188,11 +188,17 @@ const BarcodeScannerComponent = ({
     <div className="barcode-scanner">
       {isProcessing && <Spinner />}
       <video key="video" ref={videoRef} width="100%" height="100%" />
-      {isShowInputText && !isProcessing && (
+      {/* IMPORTANT: Always use type="text" — never type="hidden".
+          When isShowInputText=false, the input is visually hidden via CSS (input-text-offscreen)
+          instead of type="hidden". This is critical for Zebra MC3300x DataWedge IME mode:
+          type="hidden" inputs cannot receive focus, so Android InputConnection is never established
+          and DataWedge text injection silently fails. CSS hiding keeps the input focusable and
+          IME-compatible while remaining invisible to the user. (me03#28834) */}
+      {!isProcessing && (
         <input
           key="input-text"
           ref={inputTextRef}
-          className="input-text"
+          className={`input-text${isShowInputText ? '' : ' input-text-offscreen'}`}
           type="text"
           placeholder={inputPlaceholderText || trl('components.BarcodeScannerComponent.scanTextPlaceholder')}
           onFocus={handleInputTextFocus}


### PR DESCRIPTION
## Summary

Cherry-pick of https://github.com/metasfresh/metasfresh/pull/23264 from `intensive_care_hotfix` to `soft_panda_hotfix`.

- Fix the quick-scan feature on the picking job screen for Zebra MC3300x scanners using DataWedge IME mode
- Replace `type="hidden"` with CSS-based visual hiding so the input remains focusable and InputConnection-compatible
- E2E test files not included (they don't exist on hotfix branches)

## Test plan

- [ ] CI green
- [ ] Frontend code changes only (SCSS + JSX)