### PR TITLE
DESADV: Add QtyCUsPerTU to DesadvLineWithNoPacking

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
@@ -161,6 +161,7 @@ public class EDI_Desadv_JSON_Export_StepDef
 	 *     <li>{@code QtyOrderedInDesadvLineUOM} (required) — expected ordered qty</li>
 	 *     <li>{@code QtyDeliveredInDesadvLineUOM} (required) — expected delivered qty</li>
 	 *     <li>{@code IsDeliveryClosed} (optional) — expected value of IsDeliveryClosed</li>
+	 *     <li>{@code QtyCUsPerTU} (optional) — expected consumer units per traded unit (from order line's QtyItemCapacity)</li>
 	 * </ul>
 	 */
 	@Then("verify DESADV JSON export has DesadvLineWithNoPacking:")
@@ -207,6 +208,15 @@ public class EDI_Desadv_JSON_Export_StepDef
 						.as("DesadvLineWithNoPacking[%d].IsDeliveryClosed", index)
 						.isEqualTo(expectedIsDeliveryClosed);
 			}
+
+			row.getAsOptionalInt("QtyCUsPerTU").ifPresent(expectedQtyCUsPerTU -> {
+				assertThat(entry.has("QtyCUsPerTU"))
+						.as("DesadvLineWithNoPacking[%d] should contain QtyCUsPerTU", index)
+						.isTrue();
+				assertThat(entry.path("QtyCUsPerTU").asInt())
+						.as("DesadvLineWithNoPacking[%d].QtyCUsPerTU", index)
+						.isEqualTo(expectedQtyCUsPerTU);
+			});
 		});
 	}
 }

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
@@ -684,5 +684,5 @@ Feature: EDI DESADV export via postgREST
       | 1            | 1                | 0               | true             |
 
     And verify DESADV JSON export has DesadvLineWithNoPacking:
-      | OrderLine | QtyOrderedInDesadvLineUOM | QtyDeliveredInDesadvLineUOM | IsDeliveryClosed |
-      | 20        | 50                        | 0                           | false            |
+      | OrderLine | QtyOrderedInDesadvLineUOM | QtyDeliveredInDesadvLineUOM | IsDeliveryClosed | QtyCUsPerTU |
+      | 20        | 50                        | 0                           | false            | 0           |

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5797240_sys_desadv_no_pack_add_QtyCUsPerTU.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5797240_sys_desadv_no_pack_add_QtyCUsPerTU.sql
@@ -1,27 +1,8 @@
-/*
- * #%L
- * de.metas.edi
- * %%
- * Copyright (C) 2025 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
+-- Add QtyCUsPerTU to DesadvLineWithNoPacking entries
+-- so that clearing centers (e.g. Migros via Eddyson) can always generate a QTY+59 segment,
+-- even for unshipped/unpacked order lines.
+-- Source: edi_desadvline.QtyItemCapacity (copied from c_orderline.QtyItemCapacity at DESADV creation time)
 
--- Function for desadv lines with no pack
--- Ensure edi_desadv_line_object_v is defined and efficient
 CREATE OR REPLACE FUNCTION "de.metas.edi".get_desadv_lines_no_pack_json_fn(p_edi_desadv_id NUMERIC, p_m_inout_id NUMERIC)
     RETURNS JSONB AS $$
 DECLARE


### PR DESCRIPTION
## Summary
- Adds `QtyCUsPerTU` field to `DesadvLineWithNoPacking` JSON entries, sourced from `edi_desadvline.QtyItemCapacity` (the CU/TU conversion factor from the original order line)
- Enables clearing centers (e.g. Eddyson for Migros) to generate `QTY+59` segments for unshipped/unpacked DESADV lines
- Includes migration script, DDL update, and Cucumber test update

## Context
Migros requires QTY+59 on every DESADV line. Previously, `DesadvLineWithNoPacking` entries (unshipped order lines) did not include this field, making it impossible for the clearing center to generate the required segment.

## Test plan
- [ ] CI passes (migration script + Cucumber test S0468_040)
- [ ] Verify `QtyCUsPerTU` appears in DESADV JSON for unshipped lines