### PR TITLE
Package Licensing: skip IsInfiniteCapacity PI items in fallback chain

### DIFF
--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5797390_sys_gh29099_Package_Licensing_InOut_Report_Skip_InfiniteCapacity.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5797390_sys_gh29099_Package_Licensing_InOut_Report_Skip_InfiniteCapacity.sql
@@ -1,24 +1,7 @@
-/*
- * #%L
- * de.metas.fresh.base
- * %%
- * Copyright (C) 2025 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
+-- gh#29099: Skip IsInfiniteCapacity='Y' PI Item Products in the fallback chain.
+-- When IsInfiniteCapacity is set, the Qty field is meaningless (stale or zero),
+-- so using it as a packaging instruction factor gives wrong Gewerbe weights.
+-- Affects both Tier 1 (InOut line PIIP) and Tier 3 (masterdata default PI).
 
 DROP FUNCTION IF EXISTS report.Package_Licensing_InOut_Report(p_DateFrom              timestamp with time zone,
                                                               p_DateTo                timestamp with time zone,


### PR DESCRIPTION
## Summary
- Tier 1 (`piip_iol.Qty`): wrap in `CASE WHEN IsInfiniteCapacity='N'` — when `IsInfiniteCapacity='Y'`, the Qty field is meaningless/stale
- Tier 3 (masterdata subquery): add `AND IsInfiniteCapacity='N'` filter — same reason
- Follow-up to #23356 based on review feedback

## Impact
Currently defensive — only 1 infinite-capacity PIIP exists in prod data and it has `Qty=0` (already skipped by `NULLIF`). But protects against future data where someone sets `IsInfiniteCapacity='Y'` on a PIIP that has a non-zero Qty.

## Test plan
- [ ] Verify packaging licensing Bewegungsdetails report produces same results (no infinite-capacity PIIPs with non-zero Qty exist currently)
- [ ] Verify CI passes