### PR TITLE
fix landing page report links on test-reports.metasfresh.com

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2426,15 +2426,33 @@ jobs:
                           try {
                               var resp = await fetch(basePath + cat.dir);
                               if (!resp.ok) continue;
-                              var entries = await resp.json();
-                              entries.forEach(function(entry) {
-                                  if (entry.type === 'directory') {
-                                      reports.push({
-                                          name: cat.prefix + ': ' + entry.name,
-                                          path: cat.dir + entry.name + '/'
-                                      });
-                                  }
-                              });
+                              var text = await resp.text();
+                              var entries;
+                              try {
+                                  entries = JSON.parse(text);
+                                  entries.forEach(function(entry) {
+                                      if (entry.type === 'directory') {
+                                          reports.push({
+                                              name: cat.prefix + ': ' + entry.name,
+                                              path: cat.dir + entry.name + '/'
+                                          });
+                                      }
+                                  });
+                              } catch (jsonErr) {
+                                  // index.html served instead of autoindex JSON — parse links
+                                  var parser = new DOMParser();
+                                  var doc = parser.parseFromString(text, 'text/html');
+                                  doc.querySelectorAll('a[href]').forEach(function(a) {
+                                      var href = a.getAttribute('href');
+                                      if (href.endsWith('/') && href !== '../') {
+                                          var name = href.replace(/\/$/, '');
+                                          reports.push({
+                                              name: cat.prefix + ': ' + name,
+                                              path: cat.dir + name + '/'
+                                          });
+                                      }
+                                  });
+                              }
                           } catch (e) { console.warn('discoverReports: ' + cat.dir, e.message); }
                       }
                       return reports;


### PR DESCRIPTION
## Summary
- The landing page at test-reports.metasfresh.com showed "No reports" for every build
- Root cause: `discoverReports()` called `resp.json()` on `/allure/` and `/junit/` paths, but those directories have `index.html` files (generated by the publish job), so nginx serves HTML instead of autoindex JSON
- Fix: try JSON parse first, fall back to extracting `<a href>` links from the HTML index page via `DOMParser`

## Test plan
- [ ] CI passes (workflow file syntax valid)
- [ ] After merge, verify test-reports.metasfresh.com landing page shows report links under each build