### PR TITLE
Fix BPartner Quick Input double-submission crash

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/bpartner/quick_input/service/BPartnerQuickInputService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner/quick_input/service/BPartnerQuickInputService.java
@@ -289,7 +289,12 @@ public class BPartnerQuickInputService
 	public BPartnerId createBPartnerFromTemplate(@NonNull final I_C_BPartner_QuickInput template,
 												 @NonNull final NewRecordContext newRecordContext)
 	{
-		Check.assume(!template.isProcessed(), "{} not already processed", template);
+		if (template.isProcessed())
+		{
+			final int existingBPartnerId = template.getC_BPartner_ID();
+			Check.assume(existingBPartnerId > 0, "Already processed template {} must have a C_BPartner_ID", template);
+			return BPartnerId.ofRepoId(existingBPartnerId);
+		}
 
 		final BooleanWithReason canCreateNewBPartner = Env.getUserRolePermissions()
 				.checkCanCreateNewRecord(

--- a/backend/de.metas.business/src/test/java/de/metas/bpartner/quick_input/service/BPartnerQuickInputServiceCreateFromTemplateTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/bpartner/quick_input/service/BPartnerQuickInputServiceCreateFromTemplateTest.java
@@ -1,0 +1,90 @@
+package de.metas.bpartner.quick_input.service;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.attributes.related.service.BpartnerRelatedRecordsRepository;
+import de.metas.bpartner.attributes.service.BPartnerAttributesRepository;
+import de.metas.bpartner.attributes.service.BPartnerContactAttributesRepository;
+import de.metas.bpartner.composite.repository.BPartnerCompositeRepository;
+import de.metas.bpartner.name.strategy.BPartnerNameAndGreetingStrategies;
+import de.metas.bpartner.name.strategy.BPartnerNameAndGreetingStrategy;
+import de.metas.bpartner.name.strategy.FirstContactBPartnerNameAndGreetingStrategy;
+import de.metas.bpartner.name.strategy.MembershipContactBPartnerNameAndGreetingStrategy;
+import de.metas.bpartner.service.IBPartnerBL;
+import de.metas.bpartner.service.impl.BPartnerBL;
+import de.metas.bpartner.user.role.repository.UserRoleRepository;
+import de.metas.document.NewRecordContext;
+import de.metas.greeting.GreetingRepository;
+import de.metas.organization.OrgId;
+import de.metas.user.UserDefaultAttributesRepository;
+import de.metas.user.UserGroupRepository;
+import de.metas.user.UserId;
+import de.metas.user.UserRepository;
+import org.adempiere.ad.table.MockLogEntriesRepository;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_C_BPartner_QuickInput;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.save;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BPartnerQuickInputServiceCreateFromTemplateTest
+{
+	private BPartnerQuickInputService service;
+
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		SpringContextHolder.registerJUnitBean(IBPartnerBL.class, new BPartnerBL(new UserRepository()));
+		SpringContextHolder.registerJUnitBean(GreetingRepository.class, new GreetingRepository());
+
+		final List<BPartnerNameAndGreetingStrategy> strategies = new ArrayList<>();
+		strategies.add(new FirstContactBPartnerNameAndGreetingStrategy());
+		strategies.add(new MembershipContactBPartnerNameAndGreetingStrategy(new GreetingRepository()));
+		SpringContextHolder.registerJUnitBean(BPartnerNameAndGreetingStrategies.class, new BPartnerNameAndGreetingStrategies(Optional.of(strategies)));
+
+		service = new BPartnerQuickInputService(
+				new BPartnerQuickInputRepository(),
+				new BPartnerQuickInputAttributesRepository(),
+				new BPartnerQuickInputRelatedRecordsRepository(),
+				new BPartnerContactQuickInputAttributesRepository(),
+				new BPartnerNameAndGreetingStrategies(Optional.of(strategies)),
+				new BPartnerCompositeRepository(new BPartnerBL(new UserRepository()), new MockLogEntriesRepository(), new UserRoleRepository()),
+				new BPartnerAttributesRepository(),
+				new BpartnerRelatedRecordsRepository(),
+				new BPartnerContactAttributesRepository(),
+				new UserGroupRepository(),
+				new UserDefaultAttributesRepository());
+	}
+
+	@Test
+	void alreadyProcessedTemplate_returnsExistingBPartnerId()
+	{
+		// Given: a template that was already processed
+		final I_C_BPartner_QuickInput template = newInstance(I_C_BPartner_QuickInput.class);
+		template.setProcessed(true);
+		template.setC_BPartner_ID(12345);
+		save(template);
+
+		final NewRecordContext ctx = NewRecordContext.builder()
+				.loginOrgId(OrgId.ofRepoId(1))
+				.loggedUserId(UserId.ofRepoId(1))
+				.loginLanguage(Env.DEFAULT_LANGUAGE)
+				.build();
+
+		// When: createBPartnerFromTemplate is called again (e.g. double-click)
+		final BPartnerId result = service.createBPartnerFromTemplate(template, ctx);
+
+		// Then: returns the existing BPartner ID without creating a new one
+		assertThat(result).isEqualTo(BPartnerId.ofRepoId(12345));
+	}
+}

--- a/backend/de.metas.business/src/test/java/de/metas/bpartner/quick_input/service/BPartnerQuickInputServiceCreateFromTemplateTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/bpartner/quick_input/service/BPartnerQuickInputServiceCreateFromTemplateTest.java
@@ -23,7 +23,7 @@ import org.adempiere.ad.table.MockLogEntriesRepository;
 import org.adempiere.test.AdempiereTestHelper;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_BPartner_QuickInput;
-import org.compiere.util.Env;
+import org.compiere.util.Language;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -78,7 +78,7 @@ class BPartnerQuickInputServiceCreateFromTemplateTest
 		final NewRecordContext ctx = NewRecordContext.builder()
 				.loginOrgId(OrgId.ofRepoId(1))
 				.loggedUserId(UserId.ofRepoId(1))
-				.loginLanguage(Env.DEFAULT_LANGUAGE)
+				.loginLanguage(Language.getBaseAD_Language())
 				.build();
 
 		// When: createBPartnerFromTemplate is called again (e.g. double-click)

--- a/backend/de.metas.business/src/test/java/de/metas/bpartner/quick_input/service/BPartnerQuickInputServiceCreateFromTemplateTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/bpartner/quick_input/service/BPartnerQuickInputServiceCreateFromTemplateTest.java
@@ -23,7 +23,6 @@ import org.adempiere.ad.table.MockLogEntriesRepository;
 import org.adempiere.test.AdempiereTestHelper;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_BPartner_QuickInput;
-import org.compiere.util.Language;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -78,7 +77,7 @@ class BPartnerQuickInputServiceCreateFromTemplateTest
 		final NewRecordContext ctx = NewRecordContext.builder()
 				.loginOrgId(OrgId.ofRepoId(1))
 				.loggedUserId(UserId.ofRepoId(1))
-				.loginLanguage(Language.getBaseAD_Language())
+				.loginLanguage("de_DE")
 				.build();
 
 		// When: createBPartnerFromTemplate is called again (e.g. double-click)

--- a/frontend/src/__tests__/components/app/Modal.test.js
+++ b/frontend/src/__tests__/components/app/Modal.test.js
@@ -20,6 +20,7 @@ import processResponses from '../../../../test_setup/fixtures/process/responses.
 import hotkeys from '../../../../test_setup/fixtures/hotkeys.json';
 import keymap from '../../../../test_setup/fixtures/keymap.json';
 import thunk from 'redux-thunk';
+import * as GenericActions from '../../../actions/GenericActions';
 const mockStore = configureStore([thunk]);
 
 const getInitialState = function(state = {}) {
@@ -111,5 +112,49 @@ describe('Modal test', () => {
     { attachTo: document.getElementById('container') });
 
     expect(store.getActions()).toEqual(expect.arrayContaining(expectedActions));
+  });
+
+  it('does not call processNewRecord twice when handleClose is invoked rapidly on a new document modal', () => {
+    const processNewRecordSpy = jest
+      .spyOn(GenericActions, 'processNewRecord')
+      .mockReturnValue(new Promise(() => {})); // never resolves — simulates in-flight request
+
+    const newDocProps = {
+      ...fixtures,
+      dataId: 'NEW', // triggers isNewDoc = true
+      modalType: 'window', // not 'process', so handleClose calls closeModal
+      modalSaveStatus: true,
+      dispatch: jest.fn(),
+      printingOptions: {},
+    };
+
+    let modalRef = null;
+    class ModalWithRef extends React.Component {
+      render() {
+        return (
+          <ShortcutProvider hotkeys={hotkeys} keymap={keymap}>
+            <DisconnectedModal
+              ref={(ref) => {
+                modalRef = ref;
+              }}
+              {...newDocProps}
+            />
+          </ShortcutProvider>
+        );
+      }
+    }
+
+    mount(<ModalWithRef />, {
+      attachTo: document.getElementById('container'),
+    });
+
+    // Simulate two rapid handleClose calls (as if Done was clicked twice)
+    modalRef.handleClose();
+    modalRef.handleClose();
+
+    // processNewRecord should only be called once — the second call is blocked by the pending guard
+    expect(processNewRecordSpy).toHaveBeenCalledTimes(1);
+
+    processNewRecordSpy.mockRestore();
   });
 });

--- a/frontend/src/__tests__/components/app/Modal.test.js
+++ b/frontend/src/__tests__/components/app/Modal.test.js
@@ -148,9 +148,16 @@ describe('Modal test', () => {
       attachTo: document.getElementById('container'),
     });
 
-    // Simulate two rapid handleClose calls (as if Done was clicked twice)
-    modalRef.handleClose();
-    modalRef.handleClose();
+    // Simulate two rapid handleClose calls (as if Done was clicked twice).
+    // Each call is wrapped in act() to ensure React flushes setState({ pending: true })
+    // between calls — matching production behavior where each click is a separate DOM event.
+    const { act } = require('react-dom/test-utils');
+    act(() => {
+      modalRef.handleClose();
+    });
+    act(() => {
+      modalRef.handleClose();
+    });
 
     // processNewRecord should only be called once — the second call is blocked by the pending guard
     expect(processNewRecordSpy).toHaveBeenCalledTimes(1);

--- a/frontend/src/components/app/Modal.js
+++ b/frontend/src/components/app/Modal.js
@@ -351,21 +351,28 @@ class Modal extends Component {
     const { isNew, isNewDoc } = this.state;
 
     if (isNewDoc) {
-      processNewRecord('window', windowId, dataId).then((response) => {
-        dispatch(
-          patch(
-            'window',
-            documentType,
-            parentDataId,
-            null,
-            null,
-            triggerField,
-            response.data // it's OK to patch using the newly created record ID (instead of key/caption value)
-          )
-        ).then(() => {
-          this.removeModal();
+      this.setState({ pending: true });
+      processNewRecord('window', windowId, dataId)
+        .then((response) => {
+          dispatch(
+            patch(
+              'window',
+              documentType,
+              parentDataId,
+              null,
+              null,
+              triggerField,
+              response.data // it's OK to patch using the newly created record ID (instead of key/caption value)
+            )
+          ).then(() => {
+            this.removeModal();
+          });
+        })
+        .catch(() => {
+          if (this.mounted) {
+            this.setState({ pending: false });
+          }
         });
-      });
     } else {
       if (closeCallback) {
         closeCallback({
@@ -404,6 +411,11 @@ class Modal extends Component {
    */
   handleClose = () => {
     const { modalSaveStatus, modalType, dispatch } = this.props;
+    const { pending } = this.state;
+
+    if (pending) {
+      return;
+    }
 
     if (modalType === 'process') {
       return this.closeModal(modalSaveStatus);


### PR DESCRIPTION
## Summary

- **Backend**: Replace hard assertion `Check.assume(!isProcessed)` with idempotent early return in `BPartnerQuickInputService.createBPartnerFromTemplate()` — if template is already processed, return existing `C_BPartner_ID`
- **Frontend**: Add `pending` state guard in `Modal.handleClose()` and `closeModal()` to prevent double-click from firing two `processNewRecord` requests

## Root cause

Double-clicking "Done" on the BPartner Quick Input modal sends two `GET /processNewRecord` requests. The backend write lock serializes them, so the first succeeds and the second finds the template already processed — crashing with `AdempiereException: Assumption failure: not already processed`.

## Test plan

- [ ] Backend unit test: `BPartnerQuickInputServiceCreateFromTemplateTest` — verifies already-processed template returns existing BPartnerId
- [ ] Frontend unit test: `Modal.test.js` — verifies rapid double `handleClose()` calls only fire `processNewRecord` once
- [ ] Manual: Open BPartner Quick Input, rapidly double-click Done, verify no error