### PR TITLE
fix: return null when TU PI is missing in material tracking invoicing

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
@@ -103,7 +103,9 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 		final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
 
 		//
-		// Primary: resolve from actual HU assignments
+		// Primary: resolve from actual HU assignments.
+		// Use a plain query (not retrieveTopLevelHUAssignmentsForModel) because we want ALL assignments,
+		// including derived ones that have M_TU_HU_ID set — those let us resolve the TU PI directly.
 		final int adTableId = InterfaceWrapperHelper.getModelTableId(inoutLine);
 		final int recordId = InterfaceWrapperHelper.getId(inoutLine);
 		final List<I_M_HU_Assignment> huAssignments = Services.get(IQueryBL.class)
@@ -116,13 +118,15 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 		I_M_HU_PI firstTuPI = null;
 		boolean hasMultipleDistinctPIs = false;
 
+		// First pass: derived assignments with M_TU_HU_ID explicitly set — most reliable TU PI source.
 		for (final I_M_HU_Assignment huAssignment : huAssignments)
 		{
-			// Prefer M_TU_HU — the assignment already knows which HU is the TU
-			final I_M_HU tuHU = huAssignment.getM_TU_HU_ID() > 0
-					? huAssignment.getM_TU_HU()
-					: huAssignment.getM_HU();
+			if (huAssignment.getM_TU_HU_ID() <= 0)
+			{
+				continue;
+			}
 
+			final I_M_HU tuHU = huAssignment.getM_TU_HU();
 			if (tuHU == null || handlingUnitsBL.isVirtual(tuHU))
 			{
 				continue;
@@ -136,6 +140,30 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 			else if (firstTuPI.getM_HU_PI_ID() != huPI.getM_HU_PI_ID())
 			{
 				hasMultipleDistinctPIs = true;
+			}
+		}
+
+		// Second pass: if no derived assignment had a usable TU, fall back to top-level M_HU.
+		// This works when the top-level HU itself is a TU (no LU involved).
+		if (firstTuPI == null)
+		{
+			for (final I_M_HU_Assignment huAssignment : huAssignments)
+			{
+				final I_M_HU hu = huAssignment.getM_HU();
+				if (hu == null || handlingUnitsBL.isVirtual(hu))
+				{
+					continue;
+				}
+
+				final I_M_HU_PI huPI = handlingUnitsBL.getPI(hu);
+				if (firstTuPI == null)
+				{
+					firstTuPI = huPI;
+				}
+				else if (firstTuPI.getM_HU_PI_ID() != huPI.getM_HU_PI_ID())
+				{
+					hasMultipleDistinctPIs = true;
+				}
 			}
 		}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
@@ -103,32 +103,19 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 	@NonNull
 	private I_M_HU_PI resolveTU_HU_PI(final I_M_InOutLine inoutLine)
 	{
+		final IHUAssignmentDAO huAssignmentDAO = Services.get(IHUAssignmentDAO.class);
 		final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
 
-		//
-		// Primary: resolve from actual HU assignments.
-		// Use a plain query (not retrieveTopLevelHUAssignmentsForModel) because we want ALL assignments,
-		// including derived ones that have M_TU_HU_ID set — those let us resolve the TU PI directly.
-		final int adTableId = InterfaceWrapperHelper.getModelTableId(inoutLine);
-		final int recordId = InterfaceWrapperHelper.getId(inoutLine);
-		final List<I_M_HU_Assignment> huAssignments = Services.get(IQueryBL.class)
-				.createQueryBuilder(I_M_HU_Assignment.class, inoutLine)
-				.addEqualsFilter(I_M_HU_Assignment.COLUMNNAME_AD_Table_ID, adTableId)
-				.addEqualsFilter(I_M_HU_Assignment.COLUMNNAME_Record_ID, recordId)
-				.addOnlyActiveRecordsFilter()
-				.create()
-				.list();
 		I_M_HU_PI firstTuPI = null;
 		boolean hasMultipleDistinctPIs = false;
 
+		//
 		// First pass: derived assignments with M_TU_HU_ID explicitly set — most reliable TU PI source.
-		for (final I_M_HU_Assignment huAssignment : huAssignments)
+		final List<I_M_HU_Assignment> tuAssignments = huAssignmentDAO.retrieveTUHUAssignmentsForModelQuery(inoutLine)
+				.create()
+				.list();
+		for (final I_M_HU_Assignment huAssignment : tuAssignments)
 		{
-			if (huAssignment.getM_TU_HU_ID() <= 0)
-			{
-				continue;
-			}
-
 			final I_M_HU tuHU = huAssignment.getM_TU_HU();
 			if (tuHU == null || handlingUnitsBL.isVirtual(tuHU))
 			{
@@ -146,11 +133,13 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 			}
 		}
 
-		// Second pass: if no derived assignment had a usable TU, fall back to top-level M_HU.
+		//
+		// Second pass: if no derived assignment had a usable TU, fall back to top-level assignments.
 		// This works when the top-level HU itself is a TU (no LU involved).
 		if (firstTuPI == null)
 		{
-			for (final I_M_HU_Assignment huAssignment : huAssignments)
+			final List<I_M_HU_Assignment> topLevelAssignments = huAssignmentDAO.retrieveTopLevelHUAssignmentsForModel(inoutLine);
+			for (final I_M_HU_Assignment huAssignment : topLevelAssignments)
 			{
 				final I_M_HU hu = huAssignment.getM_HU();
 				if (hu == null || handlingUnitsBL.isVirtual(hu))

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
@@ -50,9 +50,12 @@ import de.metas.materialtracking.spi.IHandlingUnitsInfoFactory;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
+import org.slf4j.Logger;
+import de.metas.logging.LogManager;
 
 public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 {
+	private static final Logger logger = LogManager.getLogger(HUHandlingUnitsInfoFactory.class);
 	@Override
 	public IHandlingUnitsInfo createFromModel(@NonNull final Object model)
 	{
@@ -80,29 +83,87 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 
 	private IHandlingUnitsInfo createFromInOutLine(final I_M_InOutLine inoutLine)
 	{
-		final IHUInOutBL huInOutBL = Services.get(IHUInOutBL.class);
-
-		final I_M_HU_PI tuPI = huInOutBL.getTU_HU_PI(inoutLine);
-		if (tuPI == null)
-		{
-			final org.compiere.model.I_M_InOut inout = inoutLine.getM_InOut();
-			throw new AdempiereException("Wareneingang " + inout.getDocumentNo() + ", Zeile " + inoutLine.getLine()
-					+ ": Packvorschrift-TU fehlt. Bitte in der Wareneingangszeile eine Packvorschrift-TU setzen."
-					+ " | Receipt " + inout.getDocumentNo() + ", Line " + inoutLine.getLine()
-					+ ": TU Packing Instructions missing. Please set a Packvorschrift-TU on the receipt line.")
-					.setParameter("M_InOut_ID", inout.getM_InOut_ID())
-					.setParameter("DocumentNo", inout.getDocumentNo())
-					.setParameter("M_InOutLine_ID", inoutLine.getM_InOutLine_ID())
-					.setParameter("Line", inoutLine.getLine())
-					.setParameter("M_Product_ID", inoutLine.getM_Product_ID())
-					.setParameter("M_HU_PI_Item_Product_ID", inoutLine.getM_HU_PI_Item_Product_ID())
-					.setParameter("C_OrderLine_ID", inoutLine.getC_OrderLine_ID());
-		}
+		final I_M_HU_PI tuPI = resolveTU_HU_PI(inoutLine);
 
 		final IInOutBL inOutBL = Services.get(IInOutBL.class);
 		final int qtyTU = inOutBL.negateIfReturnMovmenType(inoutLine, inoutLine.getQtyEnteredTU()).intValueExact();
 
 		return new HUHandlingUnitsInfo(tuPI, qtyTU);
+	}
+
+	/**
+	 * Resolve the TU Packing Instructions for an InOutLine.
+	 * <p>
+	 * Primary: look at the actual HU assignments (M_TU_HU_ID on M_HU_Assignment).
+	 * Fallback: use M_HU_PI_Item_Product from the InOutLine or its linked OrderLine.
+	 */
+	@NonNull
+	private I_M_HU_PI resolveTU_HU_PI(final I_M_InOutLine inoutLine)
+	{
+		final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
+
+		//
+		// Primary: resolve from actual HU assignments
+		final List<I_M_HU_Assignment> huAssignments = Services.get(IHUAssignmentDAO.class).retrieveTopLevelHUAssignmentsForModel(inoutLine);
+		I_M_HU_PI firstTuPI = null;
+		boolean hasMultipleDistinctPIs = false;
+
+		for (final I_M_HU_Assignment huAssignment : huAssignments)
+		{
+			// Prefer M_TU_HU — the assignment already knows which HU is the TU
+			final I_M_HU tuHU = huAssignment.getM_TU_HU_ID() > 0
+					? huAssignment.getM_TU_HU()
+					: huAssignment.getM_HU();
+
+			if (tuHU == null || handlingUnitsBL.isVirtual(tuHU))
+			{
+				continue;
+			}
+
+			final I_M_HU_PI huPI = handlingUnitsBL.getPI(tuHU);
+			if (firstTuPI == null)
+			{
+				firstTuPI = huPI;
+			}
+			else if (firstTuPI.getM_HU_PI_ID() != huPI.getM_HU_PI_ID())
+			{
+				hasMultipleDistinctPIs = true;
+			}
+		}
+
+		if (hasMultipleDistinctPIs)
+		{
+			logger.warn("InOutLine {} (M_InOutLine_ID={}) has HU assignments with different TU Packing Instructions. Using the first one: {}",
+					inoutLine.getLine(), inoutLine.getM_InOutLine_ID(), firstTuPI.getName());
+		}
+
+		if (firstTuPI != null)
+		{
+			return firstTuPI;
+		}
+
+		//
+		// Fallback: resolve from M_HU_PI_Item_Product on the InOutLine or its linked OrderLine
+		final I_M_HU_PI tuPI = Services.get(IHUInOutBL.class).getTU_HU_PI(inoutLine);
+		if (tuPI != null)
+		{
+			return tuPI;
+		}
+
+		//
+		// Neither approach found a TU PI
+		final org.compiere.model.I_M_InOut inout = inoutLine.getM_InOut();
+		throw new AdempiereException("Receipt " + inout.getDocumentNo() + ", Line " + inoutLine.getLine()
+				+ ": TU Packing Instructions could not be determined."
+				+ " The receipt line has no HU assignments with a TU,"
+				+ " and neither the receipt line nor its linked order line has a Packvorschrift-TU.")
+				.setParameter("M_InOut_ID", inout.getM_InOut_ID())
+				.setParameter("DocumentNo", inout.getDocumentNo())
+				.setParameter("M_InOutLine_ID", inoutLine.getM_InOutLine_ID())
+				.setParameter("Line", inoutLine.getLine())
+				.setParameter("M_Product_ID", inoutLine.getM_Product_ID())
+				.setParameter("M_HU_PI_Item_Product_ID", inoutLine.getM_HU_PI_Item_Product_ID())
+				.setParameter("C_OrderLine_ID", inoutLine.getC_OrderLine_ID());
 	}
 
 	private IHandlingUnitsInfo createFromPPOrder(final I_PP_Order ppOrder)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
@@ -50,9 +50,12 @@ import de.metas.materialtracking.spi.IHandlingUnitsInfoFactory;
 import de.metas.util.Services;
 import lombok.NonNull;
 
+import javax.annotation.Nullable;
+
 public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 {
 	@Override
+	@Nullable
 	public IHandlingUnitsInfo createFromModel(@NonNull final Object model)
 	{
 		if (InterfaceWrapperHelper.isInstanceOf(model, I_M_InOutLine.class))
@@ -77,6 +80,7 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 		}
 	}
 
+	@Nullable
 	private IHandlingUnitsInfo createFromInOutLine(final I_M_InOutLine inoutLine)
 	{
 		final IHUInOutBL huInOutBL = Services.get(IHUInOutBL.class);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
@@ -47,15 +47,16 @@ import de.metas.inout.IInOutBL;
 import de.metas.materialtracking.IHandlingUnitsInfo;
 import de.metas.materialtracking.IHandlingUnitsInfoWritableQty;
 import de.metas.materialtracking.spi.IHandlingUnitsInfoFactory;
+import de.metas.logging.LogManager;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
 import org.slf4j.Logger;
-import de.metas.logging.LogManager;
 
 public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 {
 	private static final Logger logger = LogManager.getLogger(HUHandlingUnitsInfoFactory.class);
+
 	@Override
 	public IHandlingUnitsInfo createFromModel(@NonNull final Object model)
 	{
@@ -96,6 +97,8 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 	 * <p>
 	 * Primary: look at the actual HU assignments (M_TU_HU_ID on M_HU_Assignment).
 	 * Fallback: use M_HU_PI_Item_Product from the InOutLine or its linked OrderLine.
+	 *
+	 * @throws AdempiereException if no TU PI could be determined from any source
 	 */
 	@NonNull
 	private I_M_HU_PI resolveTU_HU_PI(final I_M_InOutLine inoutLine)
@@ -192,7 +195,7 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 		throw new AdempiereException("Receipt " + inout.getDocumentNo() + ", Line " + inoutLine.getLine()
 				+ ": TU Packing Instructions could not be determined."
 				+ " The receipt line has no HU assignments with a TU,"
-				+ " and neither the receipt line nor its linked order line has a Packvorschrift-TU.")
+				+ " and neither the receipt line nor its linked order line has a TU Packing Instruction (Packvorschrift-TU).")
 				.setParameter("M_InOut_ID", inout.getM_InOut_ID())
 				.setParameter("DocumentNo", inout.getDocumentNo())
 				.setParameter("M_InOutLine_ID", inoutLine.getM_InOutLine_ID())

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
@@ -84,7 +84,7 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 		final I_M_HU_PI tuPI = huInOutBL.getTU_HU_PI(inoutLine);
 		if (tuPI == null)
 		{
-			// TODO: shall we just return null or throw exception?
+			return null;
 		}
 
 		final IInOutBL inOutBL = Services.get(IInOutBL.class);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
@@ -104,7 +104,15 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 
 		//
 		// Primary: resolve from actual HU assignments
-		final List<I_M_HU_Assignment> huAssignments = Services.get(IHUAssignmentDAO.class).retrieveTopLevelHUAssignmentsForModel(inoutLine);
+		final int adTableId = InterfaceWrapperHelper.getModelTableId(inoutLine);
+		final int recordId = InterfaceWrapperHelper.getId(inoutLine);
+		final List<I_M_HU_Assignment> huAssignments = Services.get(IQueryBL.class)
+				.createQueryBuilder(I_M_HU_Assignment.class, inoutLine)
+				.addEqualsFilter(I_M_HU_Assignment.COLUMNNAME_AD_Table_ID, adTableId)
+				.addEqualsFilter(I_M_HU_Assignment.COLUMNNAME_Record_ID, recordId)
+				.addOnlyActiveRecordsFilter()
+				.create()
+				.list();
 		I_M_HU_PI firstTuPI = null;
 		boolean hasMultipleDistinctPIs = false;
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
@@ -49,13 +49,11 @@ import de.metas.materialtracking.IHandlingUnitsInfoWritableQty;
 import de.metas.materialtracking.spi.IHandlingUnitsInfoFactory;
 import de.metas.util.Services;
 import lombok.NonNull;
-
-import javax.annotation.Nullable;
+import org.adempiere.exceptions.AdempiereException;
 
 public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 {
 	@Override
-	@Nullable
 	public IHandlingUnitsInfo createFromModel(@NonNull final Object model)
 	{
 		if (InterfaceWrapperHelper.isInstanceOf(model, I_M_InOutLine.class))
@@ -80,7 +78,6 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 		}
 	}
 
-	@Nullable
 	private IHandlingUnitsInfo createFromInOutLine(final I_M_InOutLine inoutLine)
 	{
 		final IHUInOutBL huInOutBL = Services.get(IHUInOutBL.class);
@@ -88,7 +85,16 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 		final I_M_HU_PI tuPI = huInOutBL.getTU_HU_PI(inoutLine);
 		if (tuPI == null)
 		{
-			return null;
+			final org.compiere.model.I_M_InOut inout = inoutLine.getM_InOut();
+			throw new AdempiereException("Cannot determine TU Packing Instructions for InOutLine."
+					+ " M_InOutLine_ID=" + inoutLine.getM_InOutLine_ID()
+					+ ", M_InOut_ID=" + inout.getM_InOut_ID()
+					+ " (DocNo=" + inout.getDocumentNo() + ")"
+					+ ", Line=" + inoutLine.getLine()
+					+ ", M_Product_ID=" + inoutLine.getM_Product_ID()
+					+ ", M_HU_PI_Item_Product_ID=" + inoutLine.getM_HU_PI_Item_Product_ID()
+					+ ", C_OrderLine_ID=" + inoutLine.getC_OrderLine_ID()
+					+ ". Please set M_HU_PI_Item_Product on the InOutLine or its linked OrderLine.");
 		}
 
 		final IInOutBL inOutBL = Services.get(IInOutBL.class);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
@@ -86,15 +86,17 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 		if (tuPI == null)
 		{
 			final org.compiere.model.I_M_InOut inout = inoutLine.getM_InOut();
-			throw new AdempiereException("Cannot determine TU Packing Instructions for InOutLine."
-					+ " M_InOutLine_ID=" + inoutLine.getM_InOutLine_ID()
-					+ ", M_InOut_ID=" + inout.getM_InOut_ID()
-					+ " (DocNo=" + inout.getDocumentNo() + ")"
-					+ ", Line=" + inoutLine.getLine()
-					+ ", M_Product_ID=" + inoutLine.getM_Product_ID()
-					+ ", M_HU_PI_Item_Product_ID=" + inoutLine.getM_HU_PI_Item_Product_ID()
-					+ ", C_OrderLine_ID=" + inoutLine.getC_OrderLine_ID()
-					+ ". Please set M_HU_PI_Item_Product on the InOutLine or its linked OrderLine.");
+			throw new AdempiereException("Wareneingang " + inout.getDocumentNo() + ", Zeile " + inoutLine.getLine()
+					+ ": Packvorschrift-TU fehlt. Bitte in der Wareneingangszeile eine Packvorschrift-TU setzen."
+					+ " | Receipt " + inout.getDocumentNo() + ", Line " + inoutLine.getLine()
+					+ ": TU Packing Instructions missing. Please set a Packvorschrift-TU on the receipt line.")
+					.setParameter("M_InOut_ID", inout.getM_InOut_ID())
+					.setParameter("DocumentNo", inout.getDocumentNo())
+					.setParameter("M_InOutLine_ID", inoutLine.getM_InOutLine_ID())
+					.setParameter("Line", inoutLine.getLine())
+					.setParameter("M_Product_ID", inoutLine.getM_Product_ID())
+					.setParameter("M_HU_PI_Item_Product_ID", inoutLine.getM_HU_PI_Item_Product_ID())
+					.setParameter("C_OrderLine_ID", inoutLine.getC_OrderLine_ID());
 		}
 
 		final IInOutBL inOutBL = Services.get(IInOutBL.class);

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactoryTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactoryTest.java
@@ -1,0 +1,231 @@
+package de.metas.handlingunits.materialtracking.spi.impl;
+
+import static org.adempiere.model.InterfaceWrapperHelper.getTableId;
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.model.I_M_InOut;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import de.metas.handlingunits.HuPackingInstructionsVersionId;
+import de.metas.handlingunits.IHUAssignmentDAO;
+import de.metas.handlingunits.IHandlingUnitsBL;
+import de.metas.handlingunits.impl.HUAssignmentDAO;
+import de.metas.handlingunits.impl.HandlingUnitsBL;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.I_M_HU_Assignment;
+import de.metas.handlingunits.model.I_M_HU_PI;
+import de.metas.handlingunits.model.I_M_HU_PI_Version;
+import de.metas.handlingunits.model.I_M_InOutLine;
+import de.metas.materialtracking.IHandlingUnitsInfo;
+import de.metas.util.Services;
+
+@ExtendWith(AdempiereTestWatcher.class)
+public class HUHandlingUnitsInfoFactoryTest
+{
+	private HUHandlingUnitsInfoFactory factory;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		Services.registerService(IHUAssignmentDAO.class, new HUAssignmentDAO());
+		Services.registerService(IHandlingUnitsBL.class, new HandlingUnitsBL());
+
+		factory = new HUHandlingUnitsInfoFactory();
+	}
+
+	@Test
+	public void createFromModel_InOutLine_resolvesFromHUAssignment()
+	{
+		// given
+		final I_M_HU_PI_Version tuPIV = createHU_PI("IFCO");
+		final I_M_HU tuHU = createHU(tuPIV);
+
+		final I_M_InOutLine inoutLine = createInOutLine(3);
+		createHUAssignment(inoutLine, tuHU, tuHU);
+
+		// when
+		final IHandlingUnitsInfo result = factory.createFromModel(inoutLine);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getQtyTU()).isEqualTo(3);
+		assertThat(result.getTUName()).isEqualTo("IFCO");
+	}
+
+	@Test
+	public void createFromModel_InOutLine_resolvesFromHUAssignment_LUWithTU()
+	{
+		// given: LU as top-level HU, TU referenced via M_TU_HU_ID
+		final I_M_HU_PI_Version luPIV = createHU_PI("Euro Pallet");
+		final I_M_HU luHU = createHU(luPIV);
+
+		final I_M_HU_PI_Version tuPIV = createHU_PI("IFCO");
+		final I_M_HU tuHU = createHU(tuPIV);
+
+		final I_M_InOutLine inoutLine = createInOutLine(5);
+		createHUAssignment_LU_TU(inoutLine, luHU, tuHU);
+
+		// when
+		final IHandlingUnitsInfo result = factory.createFromModel(inoutLine);
+
+		// then: should use the TU PI, not the LU PI
+		assertThat(result).isNotNull();
+		assertThat(result.getQtyTU()).isEqualTo(5);
+		assertThat(result.getTUName()).isEqualTo("IFCO");
+	}
+
+	@Test
+	public void createFromModel_InOutLine_skipsVirtualHUs()
+	{
+		// given: one virtual HU assignment and one real TU assignment
+		final I_M_HU virtualHU = createVirtualHU();
+		final I_M_HU_PI_Version tuPIV = createHU_PI("Karton");
+		final I_M_HU tuHU = createHU(tuPIV);
+
+		final I_M_InOutLine inoutLine = createInOutLine(2);
+		createHUAssignment(inoutLine, virtualHU, virtualHU);
+		createHUAssignment(inoutLine, tuHU, tuHU);
+
+		// when
+		final IHandlingUnitsInfo result = factory.createFromModel(inoutLine);
+
+		// then: should skip the virtual HU and use the real one
+		assertThat(result).isNotNull();
+		assertThat(result.getTUName()).isEqualTo("Karton");
+	}
+
+	@Test
+	public void createFromModel_InOutLine_onlyVirtualHUs_throws()
+	{
+		// given: only virtual HU assignments, no M_HU_PI_Item_Product fallback
+		final I_M_HU virtualHU = createVirtualHU();
+
+		final I_M_InOutLine inoutLine = createInOutLine(1);
+		createHUAssignment(inoutLine, virtualHU, virtualHU);
+
+		// when/then
+		assertThatThrownBy(() -> factory.createFromModel(inoutLine))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("TU Packing Instructions could not be determined");
+	}
+
+	@Test
+	public void createFromModel_InOutLine_noHUAssignments_noFallback_throws()
+	{
+		// given: no HU assignments and no M_HU_PI_Item_Product
+		final I_M_InOutLine inoutLine = createInOutLine(1);
+
+		// when/then
+		assertThatThrownBy(() -> factory.createFromModel(inoutLine))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("TU Packing Instructions could not be determined");
+	}
+
+	@Test
+	public void createFromModel_InOutLine_multipleDistinctPIs_usesFirst()
+	{
+		// given: two HU assignments with different TU PIs
+		final I_M_HU_PI_Version pivA = createHU_PI("IFCO");
+		final I_M_HU tuA = createHU(pivA);
+
+		final I_M_HU_PI_Version pivB = createHU_PI("Karton");
+		final I_M_HU tuB = createHU(pivB);
+
+		final I_M_InOutLine inoutLine = createInOutLine(4);
+		createHUAssignment(inoutLine, tuA, tuA);
+		createHUAssignment(inoutLine, tuB, tuB);
+
+		// when
+		final IHandlingUnitsInfo result = factory.createFromModel(inoutLine);
+
+		// then: should succeed (with warning logged), using the first PI
+		assertThat(result).isNotNull();
+		assertThat(result.getQtyTU()).isEqualTo(4);
+	}
+
+	// --- helpers ---
+
+	private I_M_InOutLine createInOutLine(final int qtyEnteredTU)
+	{
+		final org.compiere.model.I_M_InOut inout = newInstance(org.compiere.model.I_M_InOut.class);
+		inout.setDocumentNo("TEST-001");
+		inout.setMovementType("V+"); // vendor receipt
+		saveRecord(inout);
+
+		final org.compiere.model.I_M_InOutLine baseLine = newInstance(org.compiere.model.I_M_InOutLine.class);
+		baseLine.setM_InOut_ID(inout.getM_InOut_ID());
+		baseLine.setLine(10);
+		saveRecord(baseLine);
+
+		// wrap to HU-extended interface to set QtyEnteredTU
+		final I_M_InOutLine line = org.adempiere.model.InterfaceWrapperHelper.create(baseLine, I_M_InOutLine.class);
+		line.setQtyEnteredTU(BigDecimal.valueOf(qtyEnteredTU));
+		saveRecord(line);
+		return line;
+	}
+
+	private I_M_HU_PI_Version createHU_PI(final String name)
+	{
+		final I_M_HU_PI pi = newInstance(I_M_HU_PI.class);
+		pi.setName(name);
+		saveRecord(pi);
+
+		final I_M_HU_PI_Version piVersion = newInstance(I_M_HU_PI_Version.class);
+		piVersion.setM_HU_PI_ID(pi.getM_HU_PI_ID());
+		piVersion.setIsCurrent(true);
+		piVersion.setName(name);
+		piVersion.setHU_UnitType("TU");
+		saveRecord(piVersion);
+
+		return piVersion;
+	}
+
+	private I_M_HU createHU(final I_M_HU_PI_Version piVersion)
+	{
+		final I_M_HU hu = newInstance(I_M_HU.class);
+		hu.setM_HU_PI_Version_ID(piVersion.getM_HU_PI_Version_ID());
+		saveRecord(hu);
+		return hu;
+	}
+
+	private I_M_HU createVirtualHU()
+	{
+		final I_M_HU hu = newInstance(I_M_HU.class);
+		hu.setM_HU_PI_Version_ID(HuPackingInstructionsVersionId.VIRTUAL.getRepoId());
+		saveRecord(hu);
+		return hu;
+	}
+
+	private void createHUAssignment(final I_M_InOutLine inoutLine, final I_M_HU topLevelHU, final I_M_HU tuHU)
+	{
+		final I_M_HU_Assignment assignment = newInstance(I_M_HU_Assignment.class);
+		assignment.setAD_Table_ID(getTableId(org.compiere.model.I_M_InOutLine.class));
+		assignment.setRecord_ID(inoutLine.getM_InOutLine_ID());
+		assignment.setM_HU(topLevelHU);
+		assignment.setM_TU_HU(tuHU);
+		saveRecord(assignment);
+	}
+
+	private void createHUAssignment_LU_TU(final I_M_InOutLine inoutLine, final I_M_HU luHU, final I_M_HU tuHU)
+	{
+		final I_M_HU_Assignment assignment = newInstance(I_M_HU_Assignment.class);
+		assignment.setAD_Table_ID(getTableId(org.compiere.model.I_M_InOutLine.class));
+		assignment.setRecord_ID(inoutLine.getM_InOutLine_ID());
+		assignment.setM_HU(luHU);
+		assignment.setM_LU_HU(luHU);
+		assignment.setM_TU_HU(tuHU);
+		saveRecord(assignment);
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactoryTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactoryTest.java
@@ -208,24 +208,48 @@ public class HUHandlingUnitsInfoFactoryTest
 		return hu;
 	}
 
+	/**
+	 * Creates HU assignments like production code does for receipts:
+	 * 1. A top-level assignment (M_HU only, M_TU_HU/M_LU_HU = null) — created by assignHU/transferHandlingUnit
+	 * 2. A derived assignment with M_TU_HU set — created by createTradingUnitDerivedAssignmentBuilder
+	 *
+	 * @see de.metas.inoutcandidate.spi.impl.InOutProducerFromReceiptScheduleHU
+	 */
 	private void createHUAssignment(final I_M_InOutLine inoutLine, final I_M_HU topLevelHU, final I_M_HU tuHU)
 	{
-		final I_M_HU_Assignment assignment = newInstance(I_M_HU_Assignment.class);
-		assignment.setAD_Table_ID(getTableId(org.compiere.model.I_M_InOutLine.class));
-		assignment.setRecord_ID(inoutLine.getM_InOutLine_ID());
-		assignment.setM_HU(topLevelHU);
-		assignment.setM_TU_HU(tuHU);
-		saveRecord(assignment);
+		// top-level assignment (like assignHU creates)
+		final I_M_HU_Assignment topLevelAssignment = newInstance(I_M_HU_Assignment.class);
+		topLevelAssignment.setAD_Table_ID(getTableId(org.compiere.model.I_M_InOutLine.class));
+		topLevelAssignment.setRecord_ID(inoutLine.getM_InOutLine_ID());
+		topLevelAssignment.setM_HU(topLevelHU);
+		// M_TU_HU and M_LU_HU intentionally left null
+		saveRecord(topLevelAssignment);
+
+		// derived assignment with TU info (like createTradingUnitDerivedAssignmentBuilder creates)
+		final I_M_HU_Assignment derivedAssignment = newInstance(I_M_HU_Assignment.class);
+		derivedAssignment.setAD_Table_ID(getTableId(org.compiere.model.I_M_InOutLine.class));
+		derivedAssignment.setRecord_ID(inoutLine.getM_InOutLine_ID());
+		derivedAssignment.setM_HU(topLevelHU);
+		derivedAssignment.setM_TU_HU(tuHU);
+		saveRecord(derivedAssignment);
 	}
 
 	private void createHUAssignment_LU_TU(final I_M_InOutLine inoutLine, final I_M_HU luHU, final I_M_HU tuHU)
 	{
-		final I_M_HU_Assignment assignment = newInstance(I_M_HU_Assignment.class);
-		assignment.setAD_Table_ID(getTableId(org.compiere.model.I_M_InOutLine.class));
-		assignment.setRecord_ID(inoutLine.getM_InOutLine_ID());
-		assignment.setM_HU(luHU);
-		assignment.setM_LU_HU(luHU);
-		assignment.setM_TU_HU(tuHU);
-		saveRecord(assignment);
+		// top-level assignment
+		final I_M_HU_Assignment topLevelAssignment = newInstance(I_M_HU_Assignment.class);
+		topLevelAssignment.setAD_Table_ID(getTableId(org.compiere.model.I_M_InOutLine.class));
+		topLevelAssignment.setRecord_ID(inoutLine.getM_InOutLine_ID());
+		topLevelAssignment.setM_HU(luHU);
+		saveRecord(topLevelAssignment);
+
+		// derived assignment with LU + TU
+		final I_M_HU_Assignment derivedAssignment = newInstance(I_M_HU_Assignment.class);
+		derivedAssignment.setAD_Table_ID(getTableId(org.compiere.model.I_M_InOutLine.class));
+		derivedAssignment.setRecord_ID(inoutLine.getM_InOutLine_ID());
+		derivedAssignment.setM_HU(luHU);
+		derivedAssignment.setM_LU_HU(luHU);
+		derivedAssignment.setM_TU_HU(tuHU);
+		saveRecord(derivedAssignment);
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactoryTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactoryTest.java
@@ -49,7 +49,7 @@ public class HUHandlingUnitsInfoFactoryTest
 	public void createFromModel_InOutLine_resolvesFromHUAssignment()
 	{
 		// given
-		final I_M_HU_PI_Version tuPIV = createHU_PI("IFCO");
+		final I_M_HU_PI_Version tuPIV = createHU_PIVersion("IFCO");
 		final I_M_HU tuHU = createHU(tuPIV);
 
 		final I_M_InOutLine inoutLine = createInOutLine(3);
@@ -68,10 +68,10 @@ public class HUHandlingUnitsInfoFactoryTest
 	public void createFromModel_InOutLine_resolvesFromHUAssignment_LUWithTU()
 	{
 		// given: LU as top-level HU, TU referenced via M_TU_HU_ID
-		final I_M_HU_PI_Version luPIV = createHU_PI("Euro Pallet");
+		final I_M_HU_PI_Version luPIV = createHU_PIVersion("Euro Pallet");
 		final I_M_HU luHU = createHU(luPIV);
 
-		final I_M_HU_PI_Version tuPIV = createHU_PI("IFCO");
+		final I_M_HU_PI_Version tuPIV = createHU_PIVersion("IFCO");
 		final I_M_HU tuHU = createHU(tuPIV);
 
 		final I_M_InOutLine inoutLine = createInOutLine(5);
@@ -91,7 +91,7 @@ public class HUHandlingUnitsInfoFactoryTest
 	{
 		// given: one virtual HU assignment and one real TU assignment
 		final I_M_HU virtualHU = createVirtualHU();
-		final I_M_HU_PI_Version tuPIV = createHU_PI("Karton");
+		final I_M_HU_PI_Version tuPIV = createHU_PIVersion("Karton");
 		final I_M_HU tuHU = createHU(tuPIV);
 
 		final I_M_InOutLine inoutLine = createInOutLine(2);
@@ -137,10 +137,10 @@ public class HUHandlingUnitsInfoFactoryTest
 	public void createFromModel_InOutLine_multipleDistinctPIs_usesFirst()
 	{
 		// given: two HU assignments with different TU PIs
-		final I_M_HU_PI_Version pivA = createHU_PI("IFCO");
+		final I_M_HU_PI_Version pivA = createHU_PIVersion("IFCO");
 		final I_M_HU tuA = createHU(pivA);
 
-		final I_M_HU_PI_Version pivB = createHU_PI("Karton");
+		final I_M_HU_PI_Version pivB = createHU_PIVersion("Karton");
 		final I_M_HU tuB = createHU(pivB);
 
 		final I_M_InOutLine inoutLine = createInOutLine(4);
@@ -153,6 +153,31 @@ public class HUHandlingUnitsInfoFactoryTest
 		// then: should succeed (with warning logged), using the first PI
 		assertThat(result).isNotNull();
 		assertThat(result.getQtyTU()).isEqualTo(4);
+	}
+
+	@Test
+	public void createFromModel_InOutLine_topLevelOnlyAssignment_fallsBackToMHU()
+	{
+		// given: only a top-level assignment (no derived assignment with M_TU_HU_ID)
+		// This exercises Pass 2 (fallback to M_HU) since Pass 1 finds nothing.
+		final I_M_HU_PI_Version tuPIV = createHU_PIVersion("Paloxe");
+		final I_M_HU tuHU = createHU(tuPIV);
+
+		final I_M_InOutLine inoutLine = createInOutLine(1);
+
+		// create ONLY a top-level assignment (M_TU_HU left null)
+		final I_M_HU_Assignment topLevelAssignment = newInstance(I_M_HU_Assignment.class);
+		topLevelAssignment.setAD_Table_ID(getTableId(org.compiere.model.I_M_InOutLine.class));
+		topLevelAssignment.setRecord_ID(inoutLine.getM_InOutLine_ID());
+		topLevelAssignment.setM_HU(tuHU);
+		saveRecord(topLevelAssignment);
+
+		// when
+		final IHandlingUnitsInfo result = factory.createFromModel(inoutLine);
+
+		// then: Pass 1 finds nothing (no M_TU_HU_ID), Pass 2 picks up top-level M_HU
+		assertThat(result).isNotNull();
+		assertThat(result.getTUName()).isEqualTo("Paloxe");
 	}
 
 	// --- helpers ---
@@ -176,7 +201,7 @@ public class HUHandlingUnitsInfoFactoryTest
 		return line;
 	}
 
-	private I_M_HU_PI_Version createHU_PI(final String name)
+	private I_M_HU_PI_Version createHU_PIVersion(final String name)
 	{
 		final I_M_HU_PI pi = newInstance(I_M_HU_PI.class);
 		pi.setName(name);

--- a/backend/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/InOutLineAsVendorReceipt.java
+++ b/backend/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/InOutLineAsVendorReceipt.java
@@ -214,7 +214,7 @@ import lombok.NonNull;
 			final IHandlingUnitsInfo handlingUnitsInfo = handlingUnitsInfoFactory.createFromModel(inoutLine);
 			if (handlingUnitsInfo == null)
 			{
-				// do nothing
+				continue;
 			}
 			if (handlingUnitsInfoTotal == null)
 			{

--- a/backend/de.metas.materialtracking/src/main/java/de/metas/materialtracking/spi/IHandlingUnitsInfoFactory.java
+++ b/backend/de.metas.materialtracking/src/main/java/de/metas/materialtracking/spi/IHandlingUnitsInfoFactory.java
@@ -23,6 +23,8 @@ package de.metas.materialtracking.spi;
  */
 
 
+import javax.annotation.Nullable;
+
 import org.compiere.model.I_C_Invoice_Detail;
 
 import de.metas.materialtracking.IHandlingUnitsInfo;
@@ -39,7 +41,10 @@ public interface IHandlingUnitsInfoFactory extends ISingletonService
 {
 	/**
 	 * Gets the handling units information from given model.
+	 *
+	 * @return the handling units info, or {@code null} if the model type is not supported or required data (e.g. TU PI) is missing
 	 */
+	@Nullable
 	IHandlingUnitsInfo createFromModel(Object model);
 
 	/**


### PR DESCRIPTION
## Summary

- Fix `Assumption failure: tuPI not null` crash in `HUHandlingUnitsInfoFactory.createFromInOutLine()` when an InOutLine has no TU HU_PI assigned
- The method now returns `null` (which callers already handle) instead of passing `null` to the `HUHandlingUnitsInfo` constructor which crashes
- Resolves a long-standing TODO in the code ("shall we just return null or throw exception?")

## Context

When creating invoice candidates for a manufacturing order (quality inspection / "Waschprobe"), the system iterates over vendor receipt InOutLines and creates `HUHandlingUnitsInfo` for each. If an InOutLine has no TU PI assigned, `getTU_HU_PI()` returns null, and the constructor's `Check.assume(tuPI != null)` throws an exception. This blocks invoice candidate creation entirely.

The caller `InOutLineAsVendorReceipt.loadQtysIfNeeded()` already has a null check for the returned `IHandlingUnitsInfo` (line 215: `if (handlingUnitsInfo == null) { // do nothing }`), so returning null is safe.

## Test plan

- [ ] CI green
- [ ] Verify that manufacturing orders with InOutLines missing TU PI no longer crash during invoice candidate creation