### PR TITLE
fix: return null when TU PI is missing in material tracking invoicing

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
@@ -84,7 +84,7 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 		final I_M_HU_PI tuPI = huInOutBL.getTU_HU_PI(inoutLine);
 		if (tuPI == null)
 		{
-			// TODO: shall we just return null or throw exception?
+			return null;
 		}
 
 		final IInOutBL inOutBL = Services.get(IInOutBL.class);


### PR DESCRIPTION
## Summary

- Fix `Assumption failure: tuPI not null` crash in `HUHandlingUnitsInfoFactory.createFromInOutLine()` when an InOutLine has no TU HU_PI assigned
- The method now returns `null` (which callers already handle) instead of passing `null` to the `HUHandlingUnitsInfo` constructor which crashes
- Same fix as https://github.com/metasfresh/metasfresh/pull/23400 (targeting a customer hotfix branch)

## Test plan

- [ ] CI green
- [ ] Verify that manufacturing orders with InOutLines missing TU PI no longer crash during invoice candidate creation