### PR TITLE
Fix: schedule ASI always propagates to shipment line

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798070_sys_me03_29295_rename_HU_Aggregation_tab.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798070_sys_me03_29295_rename_HU_Aggregation_tab.sql
@@ -1,0 +1,13 @@
+-- me03#29295: Rename misleading "HU-Aggregation" tab to "Shipment Line Attribute Config"
+-- AD_Tab_ID=541052 in window 540150 (Lieferkandidaten - Handler)
+
+-- Update base record (de_DE is the base language)
+UPDATE AD_Tab SET Name = 'Lieferzeile Merkmalkonfiguration', Updated = '2026-04-15 14:00', UpdatedBy = 99
+WHERE AD_Tab_ID = 541052;
+
+-- Update translations
+UPDATE AD_Tab_Trl SET Name = 'Shipment Line Attribute Config', IsTranslated = 'Y', Updated = '2026-04-15 14:00', UpdatedBy = 99
+WHERE AD_Tab_ID = 541052 AND AD_Language = 'en_US';
+
+UPDATE AD_Tab_Trl SET Name = 'Lieferzeile Merkmalkonfiguration', Updated = '2026-04-15 14:00', UpdatedBy = 99
+WHERE AD_Tab_ID = 541052 AND AD_Language IN ('de_DE', 'de_CH');

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798080_sys_me03_29295_add_window_to_webui_menu.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798080_sys_me03_29295_add_window_to_webui_menu.sql
@@ -1,15 +1,15 @@
--- me03#29295: Add window "Lieferkandidaten - Handler" (AD_Menu_ID=540383) to the
--- "Lieferung > Einstellungen" folder in the menu tree (ad_tree_id=10).
--- Parent node 1000079 = "Einstellungen" folder under "Lieferung" (node 1000019).
+-- me03#29295: Move window "Lieferkandidaten - Handler" (AD_Menu_ID=540383) to
+-- "Lieferung > Einstellungen" in the menu tree (ad_tree_id=10).
+-- The node already exists in tree 10 under "Admin" (parent 540382) — move it to
+-- "Einstellungen" (parent 1000079) under the "Lieferung" folder (node 1000019).
 
--- Remove wrong placement (if applied from earlier version of this script)
+-- Remove wrong placement from tree 1000019 (if applied from earlier version of this script)
 DELETE FROM AD_TreeNodeMM WHERE AD_Tree_ID = 1000019 AND Node_ID = 540383;
 
--- Insert into the correct location: Lieferung > Einstellungen
-INSERT INTO AD_TreeNodeMM (AD_Client_ID, AD_Org_ID, AD_Tree_ID, Node_ID, Parent_ID, SeqNo, Created, CreatedBy, Updated, UpdatedBy, IsActive)
-SELECT 0, 0, 10, 540383, 1000079,
-       COALESCE((SELECT MAX(SeqNo) FROM AD_TreeNodeMM WHERE AD_Tree_ID = 10 AND Parent_ID = 1000079), 0) + 1,
-       '2026-04-15 14:00', 99, '2026-04-15 14:00', 99, 'Y'
-WHERE NOT EXISTS (
-    SELECT 1 FROM AD_TreeNodeMM WHERE AD_Tree_ID = 10 AND Node_ID = 540383 AND Parent_ID = 1000079
-);
+-- Move existing node from old parent (540382 = Admin) to new parent (1000079 = Einstellungen)
+UPDATE AD_TreeNodeMM
+SET Parent_ID = 1000079,
+    SeqNo = COALESCE((SELECT MAX(SeqNo) FROM AD_TreeNodeMM WHERE AD_Tree_ID = 10 AND Parent_ID = 1000079), 0) + 1,
+    Updated = '2026-04-15 14:00',
+    UpdatedBy = 99
+WHERE AD_Tree_ID = 10 AND Node_ID = 540383;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798080_sys_me03_29295_add_window_to_webui_menu.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798080_sys_me03_29295_add_window_to_webui_menu.sql
@@ -1,0 +1,10 @@
+-- me03#29295: Add window "Lieferkandidaten - Handler" (AD_Menu_ID=540383) to WebUI menu tree
+-- In the old tree (ad_tree_id=10), path is: Verkauf > Lieferscheine > Admin > Lieferkandidaten - Handler
+-- In the WebUI tree (ad_tree_id=1000019), "Lieferscheine" and "Admin" folders don't exist.
+-- Place under "Einstellungen Verkauf" (node 1000001) which is the sales admin folder under "Verkauf".
+
+INSERT INTO AD_TreeNodeMM (AD_Client_ID, AD_Org_ID, AD_Tree_ID, Node_ID, Parent_ID, SeqNo, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT 0, 0, 1000019, 540383, 1000001, 8, '2026-04-15 14:00', 99, '2026-04-15 14:00', 99, 'Y'
+WHERE NOT EXISTS (
+    SELECT 1 FROM AD_TreeNodeMM WHERE AD_Tree_ID = 1000019 AND Node_ID = 540383
+);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798080_sys_me03_29295_add_window_to_webui_menu.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798080_sys_me03_29295_add_window_to_webui_menu.sql
@@ -1,10 +1,15 @@
--- me03#29295: Add window "Lieferkandidaten - Handler" (AD_Menu_ID=540383) to WebUI menu tree
--- In the old tree (ad_tree_id=10), path is: Verkauf > Lieferscheine > Admin > Lieferkandidaten - Handler
--- In the WebUI tree (ad_tree_id=1000019), "Lieferscheine" and "Admin" folders don't exist.
--- Place under "Einstellungen Verkauf" (node 1000001) which is the sales admin folder under "Verkauf".
+-- me03#29295: Add window "Lieferkandidaten - Handler" (AD_Menu_ID=540383) to the
+-- "Lieferung > Einstellungen" folder in the menu tree (ad_tree_id=10).
+-- Parent node 1000079 = "Einstellungen" folder under "Lieferung" (node 1000019).
 
+-- Remove wrong placement (if applied from earlier version of this script)
+DELETE FROM AD_TreeNodeMM WHERE AD_Tree_ID = 1000019 AND Node_ID = 540383;
+
+-- Insert into the correct location: Lieferung > Einstellungen
 INSERT INTO AD_TreeNodeMM (AD_Client_ID, AD_Org_ID, AD_Tree_ID, Node_ID, Parent_ID, SeqNo, Created, CreatedBy, Updated, UpdatedBy, IsActive)
-SELECT 0, 0, 1000019, 540383, 1000001, 8, '2026-04-15 14:00', 99, '2026-04-15 14:00', 99, 'Y'
+SELECT 0, 0, 10, 540383, 1000079,
+       COALESCE((SELECT MAX(SeqNo) FROM AD_TreeNodeMM WHERE AD_Tree_ID = 10 AND Parent_ID = 1000079), 0) + 1,
+       '2026-04-15 14:00', 99, '2026-04-15 14:00', 99, 'Y'
 WHERE NOT EXISTS (
-    SELECT 1 FROM AD_TreeNodeMM WHERE AD_Tree_ID = 1000019 AND Node_ID = 540383
+    SELECT 1 FROM AD_TreeNodeMM WHERE AD_Tree_ID = 10 AND Node_ID = 540383 AND Parent_ID = 1000079
 );

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798230_sys_me03_29295_IsHUAttributeOverridesASI.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798230_sys_me03_29295_IsHUAttributeOverridesASI.sql
@@ -1,4 +1,5 @@
 -- me03#29295: Add IsHUAttributeOverridesASI to M_ShipmentSchedule_AttributeConfig
+-- Part 1: AD metadata only (no DDL on the target table — see 5798290 for DDL)
 --
 -- Controls whether the HU attribute value overwrites the order line's ASI value
 -- on the shipment line. Default Y = backward compatible (HU wins, as before).
@@ -12,11 +13,11 @@ INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Create
                         ColumnName, Name, PrintName, Description, Help)
 VALUES (584759 /*From ID Server*/, 0, 0, 'Y', '2026-04-16 18:00', 0, '2026-04-16 18:00', 0,
         'IsHUAttributeOverridesASI',
-        'ME-Merkmal überschreibt Merkmalsatz',
-        'ME-Merkmal überschreibt Merkmalsatz',
-        'Wenn Ja, überschreibt der ME-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
+        'HU-Merkmal überschreibt Merkmalsatz',
+        'HU-Merkmal überschreibt Merkmalsatz',
+        'Wenn Ja, überschreibt der HU-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
         'Steuert, ob der physische Merkmalwert der Handling Unit (z.B. Lot-Nummer, MHD) den Wert aus dem Merkmalsatz der Auftragsposition überschreibt.'
-        || ' Bei "Ja" (Standard) gewinnt der ME-Wert — das ist das bisherige Verhalten.'
+        || ' Bei "Ja" (Standard) gewinnt der HU-Wert — das ist das bisherige Verhalten.'
         || ' Bei "Nein" hat der Merkmalsatz der Auftragsposition Vorrang — z.B. für kundenspezifische Merkmale wie "Herkunft" oder "Positions Nr.".');
 
 -- Skeleton Trl rows
@@ -43,11 +44,11 @@ WHERE AD_Element_ID = 584759 AND AD_Language = 'en_US';
 
 -- German translation (base language)
 UPDATE AD_Element_Trl
-SET Name        = 'ME-Merkmal überschreibt Merkmalsatz',
-    PrintName   = 'ME-Merkmal überschreibt Merkmalsatz',
-    Description = 'Wenn Ja, überschreibt der ME-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
+SET Name        = 'HU-Merkmal überschreibt Merkmalsatz',
+    PrintName   = 'HU-Merkmal überschreibt Merkmalsatz',
+    Description = 'Wenn Ja, überschreibt der HU-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
     Help        = 'Steuert, ob der physische Merkmalwert der Handling Unit (z.B. Lot-Nummer, MHD) den Wert aus dem Merkmalsatz der Auftragsposition überschreibt.'
-                  || ' Bei "Ja" (Standard) gewinnt der ME-Wert — das ist das bisherige Verhalten.'
+                  || ' Bei "Ja" (Standard) gewinnt der HU-Wert — das ist das bisherige Verhalten.'
                   || ' Bei "Nein" hat der Merkmalsatz der Auftragsposition Vorrang — z.B. für kundenspezifische Merkmale wie "Herkunft" oder "Positions Nr.".',
     IsTranslated = 'N',
     Updated     = '2026-04-16 18:00',
@@ -56,11 +57,11 @@ WHERE AD_Element_ID = 584759 AND AD_Language = 'de_DE';
 
 -- de_CH = same as de_DE
 UPDATE AD_Element_Trl
-SET Name        = 'ME-Merkmal überschreibt Merkmalsatz',
-    PrintName   = 'ME-Merkmal überschreibt Merkmalsatz',
-    Description = 'Wenn Ja, überschreibt der ME-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
+SET Name        = 'HU-Merkmal überschreibt Merkmalsatz',
+    PrintName   = 'HU-Merkmal überschreibt Merkmalsatz',
+    Description = 'Wenn Ja, überschreibt der HU-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
     Help        = 'Steuert, ob der physische Merkmalwert der Handling Unit (z.B. Lot-Nummer, MHD) den Wert aus dem Merkmalsatz der Auftragsposition überschreibt.'
-                  || ' Bei "Ja" (Standard) gewinnt der ME-Wert — das ist das bisherige Verhalten.'
+                  || ' Bei "Ja" (Standard) gewinnt der HU-Wert — das ist das bisherige Verhalten.'
                   || ' Bei "Nein" hat der Merkmalsatz der Auftragsposition Vorrang — z.B. für kundenspezifische Merkmale wie "Herkunft" oder "Positions Nr.".',
     IsTranslated = 'N',
     Updated     = '2026-04-16 18:00',
@@ -80,8 +81,8 @@ INSERT INTO AD_Column (AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created,
 VALUES (592363 /*From ID Server*/, 0, 0, 'Y', '2026-04-16 18:00', 0, '2026-04-16 18:00', 0,
         0, 540951, 584759, 20,
         'IsHUAttributeOverridesASI',
-        'ME-Merkmal überschreibt Merkmalsatz',
-        'Wenn Ja, überschreibt der ME-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
+        'HU-Merkmal überschreibt Merkmalsatz',
+        'Wenn Ja, überschreibt der HU-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
         NULL,
         1, 'Y', 'Y', 'N',
         'Y', 'D', 'N', 'N', 'N',
@@ -96,14 +97,7 @@ WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND t.AD_Column_ID = 592363
   AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
 
 -- =============================================================================
--- 3. Physical column (new column, use ALTER TABLE ADD COLUMN)
--- =============================================================================
-ALTER TABLE M_ShipmentSchedule_AttributeConfig ADD COLUMN IF NOT EXISTS IsHUAttributeOverridesASI CHAR(1) DEFAULT 'Y';
-UPDATE M_ShipmentSchedule_AttributeConfig SET IsHUAttributeOverridesASI = 'Y' WHERE IsHUAttributeOverridesASI IS NULL;
-ALTER TABLE M_ShipmentSchedule_AttributeConfig ALTER COLUMN IsHUAttributeOverridesASI SET NOT NULL;
-
--- =============================================================================
--- 4. AD_Field on tab 541052 (Shipment Line Attribute Config)
+-- 3. AD_Field on tab 541052 (Shipment Line Attribute Config)
 -- =============================================================================
 INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
                       AD_Tab_ID, AD_Column_ID, AD_Name_ID,
@@ -112,8 +106,8 @@ INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, C
                       SeqNo, SeqNoGrid, SortNo, EntityType)
 VALUES (777075 /*From ID Server*/, 0, 0, 'Y', '2026-04-16 18:00', 0, '2026-04-16 18:00', 0,
         541052, 592363, NULL,
-        'ME-Merkmal überschreibt Merkmalsatz',
-        'Wenn Ja, überschreibt der ME-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
+        'HU-Merkmal überschreibt Merkmalsatz',
+        'Wenn Ja, überschreibt der HU-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
         'Y', 'Y', 'N', 'N',
         60, 60, 0, 'D');
 
@@ -125,6 +119,6 @@ WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND t.AD_Field_ID = 777075
   AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
 
 -- =============================================================================
--- 5. Propagate translations from AD_Element to all dependent records
+-- 4. Propagate translations from AD_Element to all dependent records
 -- =============================================================================
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584759);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798230_sys_me03_29295_IsHUAttributeOverridesASI.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798230_sys_me03_29295_IsHUAttributeOverridesASI.sql
@@ -1,0 +1,130 @@
+-- me03#29295: Add IsHUAttributeOverridesASI to M_ShipmentSchedule_AttributeConfig
+--
+-- Controls whether the HU attribute value overwrites the order line's ASI value
+-- on the shipment line. Default Y = backward compatible (HU wins, as before).
+-- Set N for attributes where the customer's order intent (schedule ASI) should
+-- take precedence over what was physically picked (e.g., Herkunft/Positions Nr).
+
+-- =============================================================================
+-- 1. AD_Element
+-- =============================================================================
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                        ColumnName, Name, PrintName, Description, Help)
+VALUES (584759 /*From ID Server*/, 0, 0, 'Y', '2026-04-16 18:00', 0, '2026-04-16 18:00', 0,
+        'IsHUAttributeOverridesASI',
+        'ME-Merkmal überschreibt Merkmalsatz',
+        'ME-Merkmal überschreibt Merkmalsatz',
+        'Wenn Ja, überschreibt der ME-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
+        'Steuert, ob der physische Merkmalwert der Handling Unit (z.B. Lot-Nummer, MHD) den Wert aus dem Merkmalsatz der Auftragsposition überschreibt.'
+        || ' Bei "Ja" (Standard) gewinnt der ME-Wert — das ist das bisherige Verhalten.'
+        || ' Bei "Nein" hat der Merkmalsatz der Auftragsposition Vorrang — z.B. für kundenspezifische Merkmale wie "Herkunft" oder "Positions Nr.".');
+
+-- Skeleton Trl rows
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Name, PrintName, Description, Help, IsTranslated,
+                            AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.Name, t.PrintName, t.Description, t.Help, 'N',
+       t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND t.AD_Element_ID = 584759
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID);
+
+-- English translation
+UPDATE AD_Element_Trl
+SET Name        = 'HU Attribute Overrides ASI',
+    PrintName   = 'HU Attribute Overrides ASI',
+    Description = 'If Yes, the HU attribute value overwrites the order line''s ASI value on the shipment line.',
+    Help        = 'Controls whether the physical HU attribute value (e.g., Lot Number, Best Before) overwrites the value from the order line''s attribute set instance.'
+                  || ' "Yes" (default) = HU value wins — this is the existing behavior.'
+                  || ' "No" = the order line''s ASI value takes precedence — use for customer-specific attributes like "Origin" or "Position Nr.".',
+    IsTranslated = 'Y',
+    Updated     = '2026-04-16 18:00',
+    UpdatedBy   = 0
+WHERE AD_Element_ID = 584759 AND AD_Language = 'en_US';
+
+-- German translation (base language)
+UPDATE AD_Element_Trl
+SET Name        = 'ME-Merkmal überschreibt Merkmalsatz',
+    PrintName   = 'ME-Merkmal überschreibt Merkmalsatz',
+    Description = 'Wenn Ja, überschreibt der ME-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
+    Help        = 'Steuert, ob der physische Merkmalwert der Handling Unit (z.B. Lot-Nummer, MHD) den Wert aus dem Merkmalsatz der Auftragsposition überschreibt.'
+                  || ' Bei "Ja" (Standard) gewinnt der ME-Wert — das ist das bisherige Verhalten.'
+                  || ' Bei "Nein" hat der Merkmalsatz der Auftragsposition Vorrang — z.B. für kundenspezifische Merkmale wie "Herkunft" oder "Positions Nr.".',
+    IsTranslated = 'N',
+    Updated     = '2026-04-16 18:00',
+    UpdatedBy   = 0
+WHERE AD_Element_ID = 584759 AND AD_Language = 'de_DE';
+
+-- de_CH = same as de_DE
+UPDATE AD_Element_Trl
+SET Name        = 'ME-Merkmal überschreibt Merkmalsatz',
+    PrintName   = 'ME-Merkmal überschreibt Merkmalsatz',
+    Description = 'Wenn Ja, überschreibt der ME-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
+    Help        = 'Steuert, ob der physische Merkmalwert der Handling Unit (z.B. Lot-Nummer, MHD) den Wert aus dem Merkmalsatz der Auftragsposition überschreibt.'
+                  || ' Bei "Ja" (Standard) gewinnt der ME-Wert — das ist das bisherige Verhalten.'
+                  || ' Bei "Nein" hat der Merkmalsatz der Auftragsposition Vorrang — z.B. für kundenspezifische Merkmale wie "Herkunft" oder "Positions Nr.".',
+    IsTranslated = 'N',
+    Updated     = '2026-04-16 18:00',
+    UpdatedBy   = 0
+WHERE AD_Element_ID = 584759 AND AD_Language = 'de_CH';
+
+-- =============================================================================
+-- 2. AD_Column
+-- =============================================================================
+INSERT INTO AD_Column (AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                       Version, AD_Table_ID, AD_Element_ID, AD_Reference_ID,
+                       ColumnName, Name, Description, Help,
+                       FieldLength, IsMandatory, IsUpdateable, IsAlwaysUpdateable,
+                       DefaultValue, EntityType, IsKey, IsParent, IsSelectionColumn,
+                       IsTranslated, IsIdentifier, IsEncrypted, IsAllowLogging,
+                       PersonalDataCategory)
+VALUES (592363 /*From ID Server*/, 0, 0, 'Y', '2026-04-16 18:00', 0, '2026-04-16 18:00', 0,
+        0, 540951, 584759, 20,
+        'IsHUAttributeOverridesASI',
+        'ME-Merkmal überschreibt Merkmalsatz',
+        'Wenn Ja, überschreibt der ME-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
+        NULL,
+        1, 'Y', 'Y', 'N',
+        'Y', 'D', 'N', 'N', 'N',
+        'N', 'N', 'N', 'Y',
+        'NP');
+
+-- Skeleton Trl rows for AD_Column
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND t.AD_Column_ID = 592363
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+-- =============================================================================
+-- 3. Physical column (new column, use ALTER TABLE ADD COLUMN)
+-- =============================================================================
+ALTER TABLE M_ShipmentSchedule_AttributeConfig ADD COLUMN IF NOT EXISTS IsHUAttributeOverridesASI CHAR(1) DEFAULT 'Y';
+UPDATE M_ShipmentSchedule_AttributeConfig SET IsHUAttributeOverridesASI = 'Y' WHERE IsHUAttributeOverridesASI IS NULL;
+ALTER TABLE M_ShipmentSchedule_AttributeConfig ALTER COLUMN IsHUAttributeOverridesASI SET NOT NULL;
+
+-- =============================================================================
+-- 4. AD_Field on tab 541052 (Shipment Line Attribute Config)
+-- =============================================================================
+INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                      AD_Tab_ID, AD_Column_ID, AD_Name_ID,
+                      Name, Description,
+                      IsDisplayed, IsDisplayedGrid, IsReadOnly, IsSameLine,
+                      SeqNo, SeqNoGrid, SortNo, EntityType)
+VALUES (777075 /*From ID Server*/, 0, 0, 'Y', '2026-04-16 18:00', 0, '2026-04-16 18:00', 0,
+        541052, 592363, NULL,
+        'ME-Merkmal überschreibt Merkmalsatz',
+        'Wenn Ja, überschreibt der ME-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.',
+        'Y', 'Y', 'N', 'N',
+        60, 60, 0, 'D');
+
+-- Skeleton Trl rows for AD_Field
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Name, Description, Help, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Name, t.Description, t.Help, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND t.AD_Field_ID = 777075
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+
+-- =============================================================================
+-- 5. Propagate translations from AD_Element to all dependent records
+-- =============================================================================
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584759);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798290_sys_me03_29295_IsHUAttributeOverridesASI_DDL.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798290_sys_me03_29295_IsHUAttributeOverridesASI_DDL.sql
@@ -1,0 +1,6 @@
+-- me03#29295: Add IsHUAttributeOverridesASI physical column
+-- Part 2: DDL + DML (separate from AD metadata to avoid pending trigger events)
+
+ALTER TABLE M_ShipmentSchedule_AttributeConfig ADD COLUMN IF NOT EXISTS IsHUAttributeOverridesASI CHAR(1) DEFAULT 'Y';
+UPDATE M_ShipmentSchedule_AttributeConfig SET IsHUAttributeOverridesASI = 'Y' WHERE IsHUAttributeOverridesASI IS NULL;
+ALTER TABLE M_ShipmentSchedule_AttributeConfig ALTER COLUMN IsHUAttributeOverridesASI SET NOT NULL;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798290_sys_me03_29295_IsHUAttributeOverridesASI_DDL.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798290_sys_me03_29295_IsHUAttributeOverridesASI_DDL.sql
@@ -1,3 +1,4 @@
 -- me03#29295: Add IsHUAttributeOverridesASI physical column (DDL only)
 
 ALTER TABLE M_ShipmentSchedule_AttributeConfig ADD COLUMN IF NOT EXISTS IsHUAttributeOverridesASI CHAR(1) DEFAULT 'Y';
+ALTER TABLE M_ShipmentSchedule_AttributeConfig ALTER COLUMN IsHUAttributeOverridesASI SET NOT NULL;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798290_sys_me03_29295_IsHUAttributeOverridesASI_DDL.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798290_sys_me03_29295_IsHUAttributeOverridesASI_DDL.sql
@@ -1,6 +1,3 @@
--- me03#29295: Add IsHUAttributeOverridesASI physical column
--- Part 2: DDL + DML (separate from AD metadata to avoid pending trigger events)
+-- me03#29295: Add IsHUAttributeOverridesASI physical column (DDL only)
 
 ALTER TABLE M_ShipmentSchedule_AttributeConfig ADD COLUMN IF NOT EXISTS IsHUAttributeOverridesASI CHAR(1) DEFAULT 'Y';
-UPDATE M_ShipmentSchedule_AttributeConfig SET IsHUAttributeOverridesASI = 'Y' WHERE IsHUAttributeOverridesASI IS NULL;
-ALTER TABLE M_ShipmentSchedule_AttributeConfig ALTER COLUMN IsHUAttributeOverridesASI SET NOT NULL;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798300_sys_me03_29295_window_design_overhaul.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798300_sys_me03_29295_window_design_overhaul.sql
@@ -1,0 +1,100 @@
+-- me03#29295: Window design overhaul for window 540150 / tab 541052 (Shipment Line Attribute Config)
+--
+-- Creates WebUI layout for the included record tab:
+-- - 1 UI section, 1 column, 1 element group (per design guide for included tabs)
+-- - Grid view: Attribute, OnlyIfInReferencedASI, IsHUAttributeOverridesASI, Active, Org
+-- - Org last in grid, Client not in grid (per design guide)
+
+-- Also fix tab name: rename from "HU-Aggregation" to proper names
+UPDATE AD_Tab SET Name = 'Shipment Line Attribute Config', Updated = '2026-04-17 02:00', UpdatedBy = 0 WHERE AD_Tab_ID = 541052;
+UPDATE AD_Tab_Trl SET Name = 'Shipment Line Attribute Config', IsTranslated = 'Y', Updated = '2026-04-17 02:00', UpdatedBy = 0
+WHERE AD_Tab_ID = 541052 AND AD_Language = 'en_US';
+UPDATE AD_Tab_Trl SET Name = 'Lieferzeile Merkmalkonfiguration', IsTranslated = 'N', Updated = '2026-04-17 02:00', UpdatedBy = 0
+WHERE AD_Tab_ID = 541052 AND AD_Language = 'de_DE';
+UPDATE AD_Tab_Trl SET Name = 'Lieferzeile Merkmalkonfiguration', IsTranslated = 'N', Updated = '2026-04-17 02:00', UpdatedBy = 0
+WHERE AD_Tab_ID = 541052 AND AD_Language = 'de_CH';
+
+-- =============================================================================
+-- UI Section
+-- =============================================================================
+INSERT INTO AD_UI_Section (AD_UI_Section_ID, AD_Client_ID, AD_Org_ID, AD_Tab_ID,
+                           Created, CreatedBy, IsActive, Name, SeqNo, Updated, UpdatedBy, Value)
+VALUES (547672 /*From ID Server*/, 0, 0, 541052,
+        '2026-04-17 02:00', 0, 'Y', 'main', 10, '2026-04-17 02:00', 0, 'main');
+
+-- =============================================================================
+-- UI Column (only 1 for included tabs)
+-- =============================================================================
+INSERT INTO AD_UI_Column (AD_UI_Column_ID, AD_Client_ID, AD_Org_ID, AD_UI_Section_ID,
+                          Created, CreatedBy, IsActive, SeqNo, Updated, UpdatedBy)
+VALUES (549366 /*From ID Server*/, 0, 0, 547672,
+        '2026-04-17 02:00', 0, 'Y', 10, '2026-04-17 02:00', 0);
+
+-- =============================================================================
+-- UI Element Group (only 1 for included tabs — white background)
+-- =============================================================================
+INSERT INTO AD_UI_ElementGroup (AD_UI_ElementGroup_ID, AD_Client_ID, AD_Org_ID, AD_UI_Column_ID,
+                                Created, CreatedBy, IsActive, Name, SeqNo, UIStyle, Updated, UpdatedBy)
+VALUES (555125 /*From ID Server*/, 0, 0, 549366,
+        '2026-04-17 02:00', 0, 'Y', 'default', 10, 'primary', '2026-04-17 02:00', 0);
+
+-- =============================================================================
+-- UI Elements — Grid view order:
+--   Attribute (10), OnlyIfInReferenced (20), HUOverridesASI (30), Active (40), Org (50)
+-- =============================================================================
+
+-- Attribute (M_Attribute_ID)
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, AD_Tab_ID,
+                           AD_UI_ElementGroup_ID, AD_Field_ID, AD_UI_ElementType,
+                           Created, CreatedBy, IsActive, IsAdvancedField,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+                           Updated, UpdatedBy)
+VALUES (649816 /*From ID Server*/, 0, 0, 541052,
+        555125, 563057, 'F',
+        '2026-04-17 02:00', 0, 'Y', 'N',
+        'Y', 'Y', 'N',
+        'Merkmal', 10, 10, 0,
+        '2026-04-17 02:00', 0);
+
+-- Only if in referenced ASI (OnlyIfInReferencedASI)
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, AD_Tab_ID,
+                           AD_UI_ElementGroup_ID, AD_Field_ID, AD_UI_ElementType,
+                           Created, CreatedBy, IsActive, IsAdvancedField,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+                           Updated, UpdatedBy)
+VALUES (649817 /*From ID Server*/, 0, 0, 541052,
+        555125, 563058, 'F',
+        '2026-04-17 02:00', 0, 'Y', 'N',
+        'Y', 'Y', 'N',
+        'Nur falls in ref. Datensatz', 20, 20, 0,
+        '2026-04-17 02:00', 0);
+
+-- HU Attribute Overrides ASI (IsHUAttributeOverridesASI)
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, AD_Tab_ID,
+                           AD_UI_ElementGroup_ID, AD_Field_ID, AD_UI_ElementType,
+                           Created, CreatedBy, IsActive, IsAdvancedField,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+                           Updated, UpdatedBy)
+VALUES (649818 /*From ID Server*/, 0, 0, 541052,
+        555125, 777075, 'F',
+        '2026-04-17 02:00', 0, 'Y', 'N',
+        'Y', 'Y', 'N',
+        'HU-Merkmal überschreibt Merkmalsatz', 30, 30, 0,
+        '2026-04-17 02:00', 0);
+
+-- Active (IsActive)
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, AD_Tab_ID,
+                           AD_UI_ElementGroup_ID, AD_Field_ID, AD_UI_ElementType,
+                           Created, CreatedBy, IsActive, IsAdvancedField,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+                           Updated, UpdatedBy)
+VALUES (649819 /*From ID Server*/, 0, 0, 541052,
+        555125, 563054, 'F',
+        '2026-04-17 02:00', 0, 'Y', 'N',
+        'Y', 'Y', 'N',
+        'Aktiv', 40, 40, 0,
+        '2026-04-17 02:00', 0);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798320_sys_me03_29295_IsHUAttributeOverridesASI_DML.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798320_sys_me03_29295_IsHUAttributeOverridesASI_DML.sql
@@ -1,4 +1,3 @@
--- me03#29295: Populate IsHUAttributeOverridesASI and set NOT NULL (DML, separate from DDL)
+-- me03#29295: Populate IsHUAttributeOverridesASI for existing records (DML only)
 
 UPDATE M_ShipmentSchedule_AttributeConfig SET IsHUAttributeOverridesASI = 'Y' WHERE IsHUAttributeOverridesASI IS NULL;
-ALTER TABLE M_ShipmentSchedule_AttributeConfig ALTER COLUMN IsHUAttributeOverridesASI SET NOT NULL;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798320_sys_me03_29295_IsHUAttributeOverridesASI_DML.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798320_sys_me03_29295_IsHUAttributeOverridesASI_DML.sql
@@ -1,0 +1,4 @@
+-- me03#29295: Populate IsHUAttributeOverridesASI and set NOT NULL (DML, separate from DDL)
+
+UPDATE M_ShipmentSchedule_AttributeConfig SET IsHUAttributeOverridesASI = 'Y' WHERE IsHUAttributeOverridesASI IS NULL;
+ALTER TABLE M_ShipmentSchedule_AttributeConfig ALTER COLUMN IsHUAttributeOverridesASI SET NOT NULL;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798420_sys_me03_29295_window540150_main_tab_layout.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798420_sys_me03_29295_window540150_main_tab_layout.sql
@@ -1,0 +1,112 @@
+-- me03#29295: WebUI layout for window 540150 main tab "Handler" (AD_Tab_ID=540412)
+--
+-- Master data window layout per design guide:
+-- Left column: mandatory/important fields (TableName, Classname)
+-- Right column: Active switch (top), then Org + Client (advanced edit, bottom)
+
+-- =============================================================================
+-- UI Section
+-- =============================================================================
+INSERT INTO AD_UI_Section (AD_UI_Section_ID, AD_Client_ID, AD_Org_ID, AD_Tab_ID,
+                           Created, CreatedBy, IsActive, Name, SeqNo, Updated, UpdatedBy, Value)
+VALUES (547673 /*From ID Server*/, 0, 0, 540412,
+        '2026-04-17 10:00', 0, 'Y', 'main', 10, '2026-04-17 10:00', 0, 'main');
+
+-- =============================================================================
+-- UI Columns (left + right for master data)
+-- =============================================================================
+INSERT INTO AD_UI_Column (AD_UI_Column_ID, AD_Client_ID, AD_Org_ID, AD_UI_Section_ID,
+                          Created, CreatedBy, IsActive, SeqNo, Updated, UpdatedBy)
+VALUES (549367 /*From ID Server*/, 0, 0, 547673,
+        '2026-04-17 10:00', 0, 'Y', 10, '2026-04-17 10:00', 0);
+
+INSERT INTO AD_UI_Column (AD_UI_Column_ID, AD_Client_ID, AD_Org_ID, AD_UI_Section_ID,
+                          Created, CreatedBy, IsActive, SeqNo, Updated, UpdatedBy)
+VALUES (549368 /*From ID Server*/, 0, 0, 547673,
+        '2026-04-17 10:00', 0, 'Y', 20, '2026-04-17 10:00', 0);
+
+-- =============================================================================
+-- Left column: element group with TableName + Classname
+-- =============================================================================
+INSERT INTO AD_UI_ElementGroup (AD_UI_ElementGroup_ID, AD_Client_ID, AD_Org_ID, AD_UI_Column_ID,
+                                Created, CreatedBy, IsActive, Name, SeqNo, UIStyle, Updated, UpdatedBy)
+VALUES (555126 /*From ID Server*/, 0, 0, 549367,
+        '2026-04-17 10:00', 0, 'Y', 'default', 10, 'primary', '2026-04-17 10:00', 0);
+
+-- TableName (DB Table Name) — top-left, the key identifier
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, AD_Tab_ID,
+                           AD_UI_ElementGroup_ID, AD_Field_ID, AD_UI_ElementType,
+                           Created, CreatedBy, IsActive, IsAdvancedField,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+                           Updated, UpdatedBy)
+VALUES (649820 /*From ID Server*/, 0, 0, 540412,
+        555126, 550221, 'F',
+        '2026-04-17 10:00', 0, 'Y', 'N',
+        'Y', 'Y', 'N',
+        'Name der DB-Tabelle', 10, 10, 0,
+        '2026-04-17 10:00', 0);
+
+-- Classname (Java Class)
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, AD_Tab_ID,
+                           AD_UI_ElementGroup_ID, AD_Field_ID, AD_UI_ElementType,
+                           Created, CreatedBy, IsActive, IsAdvancedField,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+                           Updated, UpdatedBy)
+VALUES (649821 /*From ID Server*/, 0, 0, 540412,
+        555126, 550217, 'F',
+        '2026-04-17 10:00', 0, 'Y', 'N',
+        'Y', 'Y', 'N',
+        'Java-Klasse', 20, 20, 0,
+        '2026-04-17 10:00', 0);
+
+-- =============================================================================
+-- Right column: Active switch (top), then Org + Client (advanced edit)
+-- =============================================================================
+INSERT INTO AD_UI_ElementGroup (AD_UI_ElementGroup_ID, AD_Client_ID, AD_Org_ID, AD_UI_Column_ID,
+                                Created, CreatedBy, IsActive, Name, SeqNo, UIStyle, Updated, UpdatedBy)
+VALUES (555127 /*From ID Server*/, 0, 0, 549368,
+        '2026-04-17 10:00', 0, 'Y', 'flags', 10, 'primary', '2026-04-17 10:00', 0);
+
+-- Active — top of right column
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, AD_Tab_ID,
+                           AD_UI_ElementGroup_ID, AD_Field_ID, AD_UI_ElementType,
+                           Created, CreatedBy, IsActive, IsAdvancedField,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+                           Updated, UpdatedBy)
+VALUES (649822 /*From ID Server*/, 0, 0, 540412,
+        555127, 550211, 'F',
+        '2026-04-17 10:00', 0, 'Y', 'N',
+        'Y', 'Y', 'N',
+        'Aktiv', 10, 30, 0,
+        '2026-04-17 10:00', 0);
+
+-- Organisation — advanced edit, second to last
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, AD_Tab_ID,
+                           AD_UI_ElementGroup_ID, AD_Field_ID, AD_UI_ElementType,
+                           Created, CreatedBy, IsActive, IsAdvancedField,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+                           Updated, UpdatedBy)
+VALUES (649823 /*From ID Server*/, 0, 0, 540412,
+        555127, 550222, 'F',
+        '2026-04-17 10:00', 0, 'Y', 'Y',
+        'N', 'N', 'N',
+        'Sektion', 20, 0, 0,
+        '2026-04-17 10:00', 0);
+
+-- Client — advanced edit, last
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, AD_Tab_ID,
+                           AD_UI_ElementGroup_ID, AD_Field_ID, AD_UI_ElementType,
+                           Created, CreatedBy, IsActive, IsAdvancedField,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+                           Updated, UpdatedBy)
+VALUES (649824 /*From ID Server*/, 0, 0, 540412,
+        555127, 550218, 'F',
+        '2026-04-17 10:00', 0, 'Y', 'Y',
+        'N', 'N', 'N',
+        'Mandant', 30, 0, 0,
+        '2026-04-17 10:00', 0);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pricing/C_UOM_Conversion_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pricing/C_UOM_Conversion_StepDef.java
@@ -67,6 +67,25 @@ public class C_UOM_Conversion_StepDef
 		this.conversionTable = conversionTable;
 	}
 
+	/**
+	 * Create UOM conversions for a product.
+	 * <p>
+	 * NOTE: this step uses legacy {@link DataTableUtil} with explicit column suffixes.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_Product_ID.Identifier</b> — (required, identifier-ref) product alias from M_Product_StepDefData<br>
+	 *   <b>FROM_C_UOM_ID.X12DE355</b> — (required) source UOM X12DE355 code (e.g. "PCE", "KGM")<br>
+	 *   <b>TO_C_UOM_ID.X12DE355</b> — (required) target UOM X12DE355 code<br>
+	 *   <b>MultiplyRate</b> — (required) conversion multiplier (from → to)<br>
+	 *   <b>OPT.IsCatchUOMForProduct</b> — (optional, default false) catch UOM flag<br>
+	 * @cucumber.example
+	 * <pre>{@code
+	 * And metasfresh contains C_UOM_Conversions
+	 *   | M_Product_ID.Identifier | FROM_C_UOM_ID.X12DE355 | TO_C_UOM_ID.X12DE355 | MultiplyRate |
+	 *   | product_1               | PCE                     | KGM                   | 0.5          |
+	 * }</pre>
+	 */
 	@And("metasfresh contains C_UOM_Conversions")
 	public void add_C_UOM_Conversions(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_Line_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_Line_StepDef.java
@@ -155,6 +155,14 @@ public class M_InOut_Line_StepDef
 
 		row.getAsOptionalIdentifier(I_M_InOutLine.COLUMNNAME_M_InOutLine_ID).ifPresent(inoutLineIdentifier -> inoutLineTable.putOrReplace(inoutLineIdentifier, inoutLine));
 
+		row.getAsOptionalIdentifier(I_M_InOutLine.COLUMNNAME_M_AttributeSetInstance_ID).ifPresent(asiIdentifier -> {
+			if (inoutLine.getM_AttributeSetInstance_ID() > 0)
+			{
+				final I_M_AttributeSetInstance asi = InterfaceWrapperHelper.load(inoutLine.getM_AttributeSetInstance_ID(), I_M_AttributeSetInstance.class);
+				asiTable.putOrReplace(asiIdentifier, asi);
+			}
+		});
+
 		return inoutLine;
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_ShipmentSchedule_AttributeConfig_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_ShipmentSchedule_AttributeConfig_StepDef.java
@@ -1,0 +1,69 @@
+package de.metas.cucumber.stepdefs.shipment;
+
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule_AttributeConfig;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.And;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.model.InterfaceWrapperHelper;
+
+/**
+ * Step definitions for configuring {@link I_M_ShipmentSchedule_AttributeConfig} records.
+ * <p>
+ * These control which HU attributes are included on shipment lines and how they interact
+ * with the schedule ASI (order line attributes).
+ *
+ * <p><b>Required columns:</b>
+ * <ul>
+ *   <li><b>M_Attribute.Value</b> — attribute code (e.g., "1000001" for Herkunft)</li>
+ *   <li><b>IsHUAttributeOverridesASI</b> — Y/N: if N, the order line's ASI value takes precedence over the HU value</li>
+ * </ul>
+ *
+ * @cucumber.example <pre>{@code
+ * And update M_ShipmentSchedule_AttributeConfig:
+ *   | M_Attribute.Value | IsHUAttributeOverridesASI |
+ *   | 1000001           | N                         |
+ * }</pre>
+ */
+public class M_ShipmentSchedule_AttributeConfig_StepDef
+{
+	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@And("update M_ShipmentSchedule_AttributeConfig:")
+	public void update_config(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::updateConfig);
+	}
+
+	private void updateConfig(@NonNull final DataTableRow row)
+	{
+		final String attributeCode = row.getAsString("M_Attribute.Value");
+		final boolean isHUOverridesASI = row.getAsBoolean("IsHUAttributeOverridesASI");
+
+		final int updated = queryBL.createQueryBuilder(I_M_ShipmentSchedule_AttributeConfig.class)
+				.addOnlyActiveRecordsFilter()
+				.addInSubQueryFilter(
+						I_M_ShipmentSchedule_AttributeConfig.COLUMNNAME_M_Attribute_ID,
+						org.compiere.model.I_M_Attribute.COLUMNNAME_M_Attribute_ID,
+						queryBL.createQueryBuilder(org.compiere.model.I_M_Attribute.class)
+								.addEqualsFilter(org.compiere.model.I_M_Attribute.COLUMNNAME_Value, attributeCode)
+								.create())
+				.create()
+				.list()
+				.stream()
+				.mapToInt(config -> {
+					config.setIsHUAttributeOverridesASI(isHUOverridesASI);
+					InterfaceWrapperHelper.saveRecord(config);
+					return 1;
+				})
+				.sum();
+
+		if (updated == 0)
+		{
+			throw new org.adempiere.exceptions.AdempiereException("No M_ShipmentSchedule_AttributeConfig found for M_Attribute.Value=" + attributeCode);
+		}
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_ShipmentSchedule_AttributeConfig_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_ShipmentSchedule_AttributeConfig_StepDef.java
@@ -8,7 +8,13 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.mm.attributes.AttributeCode;
+import org.adempiere.mm.attributes.AttributeId;
+import org.adempiere.mm.attributes.api.IAttributeDAO;
 import org.adempiere.model.InterfaceWrapperHelper;
+
+import java.util.List;
 
 /**
  * Step definitions for configuring {@link I_M_ShipmentSchedule_AttributeConfig} records.
@@ -31,6 +37,7 @@ import org.adempiere.model.InterfaceWrapperHelper;
 public class M_ShipmentSchedule_AttributeConfig_StepDef
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	private final IAttributeDAO attributeDAO = Services.get(IAttributeDAO.class);
 
 	@And("update M_ShipmentSchedule_AttributeConfig:")
 	public void update_config(@NonNull final DataTable dataTable)
@@ -43,27 +50,23 @@ public class M_ShipmentSchedule_AttributeConfig_StepDef
 		final String attributeCode = row.getAsString("M_Attribute.Value");
 		final boolean isHUOverridesASI = row.getAsBoolean("IsHUAttributeOverridesASI");
 
-		final int updated = queryBL.createQueryBuilder(I_M_ShipmentSchedule_AttributeConfig.class)
-				.addOnlyActiveRecordsFilter()
-				.addInSubQueryFilter(
-						I_M_ShipmentSchedule_AttributeConfig.COLUMNNAME_M_Attribute_ID,
-						org.compiere.model.I_M_Attribute.COLUMNNAME_M_Attribute_ID,
-						queryBL.createQueryBuilder(org.compiere.model.I_M_Attribute.class)
-								.addEqualsFilter(org.compiere.model.I_M_Attribute.COLUMNNAME_Value, attributeCode)
-								.create())
-				.create()
-				.list()
-				.stream()
-				.mapToInt(config -> {
-					config.setIsHUAttributeOverridesASI(isHUOverridesASI);
-					InterfaceWrapperHelper.saveRecord(config);
-					return 1;
-				})
-				.sum();
+		final AttributeId attributeId = attributeDAO.retrieveAttributeIdByValue(AttributeCode.ofString(attributeCode));
 
-		if (updated == 0)
+		final List<I_M_ShipmentSchedule_AttributeConfig> configs = queryBL.createQueryBuilder(I_M_ShipmentSchedule_AttributeConfig.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_ShipmentSchedule_AttributeConfig.COLUMNNAME_M_Attribute_ID, attributeId)
+				.create()
+				.list();
+
+		if (configs.isEmpty())
 		{
-			throw new org.adempiere.exceptions.AdempiereException("No M_ShipmentSchedule_AttributeConfig found for M_Attribute.Value=" + attributeCode);
+			throw new AdempiereException("No M_ShipmentSchedule_AttributeConfig found for M_Attribute.Value=" + attributeCode);
+		}
+
+		for (final I_M_ShipmentSchedule_AttributeConfig config : configs)
+		{
+			config.setIsHUAttributeOverridesASI(isHUOverridesASI);
+			InterfaceWrapperHelper.saveRecord(config);
 		}
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_ShipmentSchedule_AttributeConfig_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_ShipmentSchedule_AttributeConfig_StepDef.java
@@ -50,7 +50,7 @@ public class M_ShipmentSchedule_AttributeConfig_StepDef
 		final String attributeCode = row.getAsString("M_Attribute.Value");
 		final boolean isHUOverridesASI = row.getAsBoolean("IsHUAttributeOverridesASI");
 
-		final AttributeId attributeId = attributeDAO.retrieveAttributeIdByValue(AttributeCode.ofString(attributeCode));
+		final AttributeId attributeId = attributeDAO.getAttributeIdByCode(AttributeCode.ofString(attributeCode));
 
 		final List<I_M_ShipmentSchedule_AttributeConfig> configs = queryBL.createQueryBuilder(I_M_ShipmentSchedule_AttributeConfig.class)
 				.addOnlyActiveRecordsFilter()

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
@@ -86,6 +86,7 @@ Feature: Shipment line ASI propagation
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_AttributeSetInstance_ID |
       | orderLine  | order      | product      | 10         | asi_order                 |
     And the order identified by order is completed
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     # Wait for shipment schedule
     And after not more than 60s, M_ShipmentSchedules are found:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
@@ -114,7 +114,12 @@ Feature: Shipment line ASI propagation
   @Id:S0290_20
   Scenario: Normal flow — schedule ASI takes precedence over HU attribute
   ## When both the order line ASI and the picked HU have the same attribute with different values,
-  ## the schedule ASI value must win on the shipment line.
+  ## the schedule ASI value must win on the shipment line — IF IsHUAttributeOverridesASI=N.
+
+    # Configure: for Herkunft, the order line ASI value should take precedence over HU
+    And update M_ShipmentSchedule_AttributeConfig:
+      | M_Attribute.Value | IsHUAttributeOverridesASI |
+      | 1000001           | N                         |
 
     # ASI for order line: Herkunft=DE
     And metasfresh contains M_AttributeSetInstance with identifier "asi_order":

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
@@ -23,10 +23,6 @@ Feature: Shipment line ASI propagation
     And metasfresh contains M_Products:
       | Identifier |
       | product    |
-    And metasfresh contains C_UOM_Conversions
-      | M_Product_ID.Identifier | FROM_C_UOM_ID.X12DE355 | TO_C_UOM_ID.X12DE355 | MultiplyRate |
-      | product                 | PCE                     | PCE                   | 1            |
-
     # TU packing instructions (10 PCE per TU)
     And metasfresh contains M_HU_PI:
       | M_HU_PI_ID |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
@@ -38,16 +38,16 @@ Feature: Shipment line ASI propagation
       | huPIP_10PCE             | huPackItem_MI    | product      | 10  | PCE      |
 
     # Pricing
-    And metasfresh contains M_PricingSystems:
+    And metasfresh contains M_PricingSystems
       | Identifier |
       | ps         |
-    And metasfresh contains M_PriceLists:
+    And metasfresh contains M_PriceLists
       | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
       | pl         | ps                 | DE           | EUR           | true  |
-    And metasfresh contains M_PriceList_Versions:
+    And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID |
       | plv        | pl             |
-    And metasfresh contains M_ProductPrices:
+    And metasfresh contains M_ProductPrices
       | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
       | pp         | plv                    | product      | 10.0     | PCE      | Normal            |
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
@@ -23,7 +23,7 @@ Feature: Shipment line ASI propagation
     And metasfresh contains M_Products:
       | Identifier |
       | product    |
-    And metasfresh contains C_UOM_Conversions:
+    And metasfresh contains C_UOM_Conversions
       | M_Product_ID | FROM_C_UOM_ID | TO_C_UOM_ID | MultiplyRate |
       | product      | PCE           | PCE          | 1            |
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
@@ -24,8 +24,8 @@ Feature: Shipment line ASI propagation
       | Identifier |
       | product    |
     And metasfresh contains C_UOM_Conversions
-      | M_Product_ID | FROM_C_UOM_ID | TO_C_UOM_ID | MultiplyRate |
-      | product      | PCE           | PCE          | 1            |
+      | M_Product_ID.Identifier | FROM_C_UOM_ID | TO_C_UOM_ID | MultiplyRate |
+      | product                 | PCE           | PCE          | 1            |
 
     # TU packing instructions (10 PCE per TU)
     And metasfresh contains M_HU_PI:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
@@ -1,9 +1,9 @@
 @from:cucumber
 @ghActions:run_on_executor3
 Feature: Shipment line ASI propagation
-  The shipment schedule's ASI (from the order line) must always propagate to the shipment line.
-  The M_ShipmentSchedule_AttributeConfig whitelist only filters HU attributes — not the schedule's own ASI.
-  When HU attributes and schedule ASI overlap, the schedule ASI value takes precedence unless it is empty.
+  The shipment schedule's ASI (from the order line) must propagate to the shipment line.
+  M_ShipmentSchedule_AttributeConfig controls which HU attributes participate, and per attribute,
+  IsHUAttributeOverridesASI (Y/N) decides whether the HU value or the schedule ASI value wins.
 
   Background:
     Given infrastructure and metasfresh are running

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
@@ -91,13 +91,13 @@ Feature: Shipment line ASI propagation
 
     # Generate shipment (no HU picking — manual packing / dropship path)
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
-      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipmentDateToday |
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
       | shipmentSchedule      | D            | true                | false               |
 
     # Validate shipment was created
     And after not more than 60s, M_InOut is found:
-      | Identifier | C_BPartner_ID | DocStatus |
-      | shipment   | customer      | CO        |
+      | M_ShipmentSchedule_ID | M_InOut_ID | DocStatus |
+      | shipmentSchedule      | shipment   | CO        |
 
     # Validate shipment line exists
     And validate the created shipment lines
@@ -167,12 +167,12 @@ Feature: Shipment line ASI propagation
 
     # Generate shipment — HU with Herkunft=IT will be picked on-the-fly
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
-      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipmentDateToday |
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
       | shipmentSchedule      | D            | true                | false               |
 
     And after not more than 60s, M_InOut is found:
-      | Identifier | C_BPartner_ID | DocStatus |
-      | shipment   | customer      | CO        |
+      | M_ShipmentSchedule_ID | M_InOut_ID | DocStatus |
+      | shipmentSchedule      | shipment   | CO        |
 
     And validate the created shipment lines
       | M_InOut_ID | M_Product_ID | movementqty | M_InOutLine_ID | M_AttributeSetInstance_ID |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
@@ -143,13 +143,13 @@ Feature: Shipment line ASI propagation
     And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     # Register the HU's Herkunft attribute
-    And metasfresh contains M_HU_PI_Attributes:
-      | M_HU_PI_Version_ID | M_Attribute_ID |
-      | huPackVersion_TU   | attr_test      |
+    And metasfresh contains M_HU_PI_Attribute:
+      | M_HU_PI_Version_ID | M_Attribute.Value |
+      | huPackVersion_TU   | 1000001           |
 
-    And update M_HU_Attributes:
-      | M_HU_ID | M_Attribute_ID | Value |
-      | hu       | attr_test      | IT    |
+    And update M_HU_Attribute:
+      | M_HU_ID.Identifier | M_Attribute_ID | Value | AttributeValueType |
+      | hu                 | 1000001        | IT    | S                  |
 
     # Sales order with ASI containing Herkunft=DE
     And metasfresh contains C_Orders:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
@@ -187,3 +187,80 @@ Feature: Shipment line ASI propagation
     And validate M_AttributeInstance:
       | M_AttributeSetInstance_ID | AttributeCode | Value |
       | asi_shipLine              | 1000001       | DE    |
+
+
+  @from:cucumber
+  @Id:S0290_30
+  Scenario: HU attribute wins when IsHUAttributeOverridesASI=Y (default, backward compatible)
+  ## When IsHUAttributeOverridesASI=Y (the default), the HU attribute value overwrites
+  ## the order line's ASI value on the shipment line. This is the existing behavior for
+  ## attributes like LotNumber and BestBefore.
+
+    # Ensure default: IsHUAttributeOverridesASI=Y for Herkunft (it's Y by default, but be explicit)
+    And update M_ShipmentSchedule_AttributeConfig:
+      | M_Attribute.Value | IsHUAttributeOverridesASI |
+      | 1000001           | Y                         |
+
+    # ASI for order line: Herkunft=DE
+    And metasfresh contains M_AttributeSetInstance with identifier "asi_order":
+    """
+    {
+      "attributeInstances":[
+        { "attributeCode":"1000001", "valueStr":"DE" }
+      ]
+    }
+    """
+
+    # ASI for HU: Herkunft=IT (different value)
+    And metasfresh contains M_AttributeSetInstance with identifier "asi_HU":
+    """
+    {
+      "attributeInstances":[
+        { "attributeCode":"1000001", "valueStr":"IT" }
+      ]
+    }
+    """
+
+    # Create HU with Herkunft=IT via inventory
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID |
+      | inventory      | warehouse      | 2022-05-17   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE             | asi_HU                    | hu      |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And metasfresh contains M_HU_PI_Attribute:
+      | M_HU_PI_Version_ID | M_Attribute.Value |
+      | huPackVersion_TU   | 1000001           |
+
+    And update M_HU_Attribute:
+      | M_HU_ID.Identifier | M_Attribute_ID | Value | AttributeValueType |
+      | hu                 | 1000001        | IT    | S                  |
+
+    # Sales order with ASI containing Herkunft=DE
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID |
+      | order      | true    | customer      | 2022-05-17  | warehouse      |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_AttributeSetInstance_ID |
+      | orderLine  | order      | product      | 10         | asi_order                 |
+    And the order identified by order is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier       | C_OrderLine_ID | IsToRecompute |
+      | shipmentSchedule | orderLine      | N             |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | shipmentSchedule      | D            | true                | false               |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID | DocStatus |
+      | shipmentSchedule      | shipment   | CO        |
+
+    And validate the created shipment lines
+      | M_InOut_ID | M_Product_ID | movementqty | M_InOutLine_ID | M_AttributeSetInstance_ID |
+      | shipment   | product      | 10          | shipLine       | asi_shipLine              |
+
+    # Assert: HU wins — Herkunft=IT (not DE from order line)
+    And validate M_AttributeInstance:
+      | M_AttributeSetInstance_ID | AttributeCode | Value |
+      | asi_shipLine              | 1000001       | IT    |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
@@ -62,9 +62,9 @@ Feature: Shipment line ASI propagation
 
   @from:cucumber
   @Id:S0290_10
-  Scenario: Dropship — schedule ASI propagates to shipment line without HU picking
+  Scenario: Schedule ASI propagates to shipment line when no HUs are picked
   ## When a sales order line has an ASI with a custom attribute (e.g. Herkunft=DE),
-  ## and the shipment is generated in dropship mode (no HU picking),
+  ## and the shipment is generated without HU picking (e.g. dropship, no stock, etc.),
   ## then the shipment line's ASI must contain that attribute — even if it's not in
   ## M_ShipmentSchedule_AttributeConfig.
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
@@ -1,0 +1,187 @@
+@from:cucumber
+@ghActions:run_on_executor3
+Feature: Shipment line ASI propagation
+  The shipment schedule's ASI (from the order line) must always propagate to the shipment line.
+  The M_ShipmentSchedule_AttributeConfig whitelist only filters HU attributes — not the schedule's own ASI.
+  When HU attributes and schedule ASI overlap, the schedule ASI value takes precedence unless it is empty.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-05-17T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+
+    # Storage-relevant LIST attribute (reuse Herkunft M_Attribute_ID=1000001 which exists in seed DB)
+    And metasfresh contains M_Attributes:
+      | Identifier | Value   | IsStorageRelevant |
+      | attr_test  | 1000001 | true              |
+
+    And metasfresh contains M_Warehouse:
+      | Identifier |
+      | warehouse  |
+
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains C_UOM_Conversions:
+      | M_Product_ID | FROM_C_UOM_ID | TO_C_UOM_ID | MultiplyRate |
+      | product      | PCE           | PCE          | 1            |
+
+    # TU packing instructions (10 PCE per TU)
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID |
+      | huPackTU    |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType | IsCurrent |
+      | huPackVersion_TU   | huPackTU    | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID | M_HU_PI_Version_ID | ItemType |
+      | huPackItem_MI    | huPackVersion_TU   | MI       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID | Qty | C_UOM_ID |
+      | huPIP_10PCE             | huPackItem_MI    | product      | 10  | PCE      |
+
+    # Pricing
+    And metasfresh contains M_PricingSystems:
+      | Identifier |
+      | ps         |
+    And metasfresh contains M_PriceLists:
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl         | ps                 | DE           | EUR           | true  |
+    And metasfresh contains M_PriceList_Versions:
+      | Identifier | M_PriceList_ID |
+      | plv        | pl             |
+    And metasfresh contains M_ProductPrices:
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | pp         | plv                    | product      | 10.0     | PCE      | Normal            |
+
+    # BPartner with pricing
+    And metasfresh contains C_BPartners:
+      | Identifier | IsCustomer | M_PricingSystem_ID |
+      | customer   | Y          | ps                 |
+
+  @from:cucumber
+  @Id:S0290_10
+  Scenario: Dropship — schedule ASI propagates to shipment line without HU picking
+  ## When a sales order line has an ASI with a custom attribute (e.g. Herkunft=DE),
+  ## and the shipment is generated in dropship mode (no HU picking),
+  ## then the shipment line's ASI must contain that attribute — even if it's not in
+  ## M_ShipmentSchedule_AttributeConfig.
+
+    # ASI with Herkunft=DE
+    And metasfresh contains M_AttributeSetInstance with identifier "asi_order":
+    """
+    {
+      "attributeInstances":[
+        { "attributeCode":"1000001", "valueStr":"DE" }
+      ]
+    }
+    """
+
+    # Sales order with ASI on order line
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID |
+      | order      | true    | customer      | 2022-05-17  | warehouse      |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_AttributeSetInstance_ID |
+      | orderLine  | order      | product      | 10         | asi_order                 |
+    And the order identified by order is completed
+
+    # Wait for shipment schedule
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier       | C_OrderLine_ID | IsToRecompute |
+      | shipmentSchedule | orderLine      | N             |
+
+    # Generate shipment (no HU picking — manual packing / dropship path)
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipmentDateToday |
+      | shipmentSchedule      | D            | true                | false               |
+
+    # Validate shipment was created
+    And after not more than 60s, M_InOut is found:
+      | Identifier | C_BPartner_ID | DocStatus |
+      | shipment   | customer      | CO        |
+
+    # Validate shipment line exists
+    And validate the created shipment lines
+      | M_InOut_ID | M_Product_ID | movementqty | M_InOutLine_ID | M_AttributeSetInstance_ID |
+      | shipment   | product      | 10          | shipLine       | asi_shipLine              |
+
+    # Assert: the shipment line's ASI contains Herkunft=DE
+    And validate M_AttributeInstance:
+      | M_AttributeSetInstance_ID | AttributeCode | Value |
+      | asi_shipLine              | 1000001       | DE    |
+
+
+  @from:cucumber
+  @Id:S0290_20
+  Scenario: Normal flow — schedule ASI takes precedence over HU attribute
+  ## When both the order line ASI and the picked HU have the same attribute with different values,
+  ## the schedule ASI value must win on the shipment line.
+
+    # ASI for order line: Herkunft=DE
+    And metasfresh contains M_AttributeSetInstance with identifier "asi_order":
+    """
+    {
+      "attributeInstances":[
+        { "attributeCode":"1000001", "valueStr":"DE" }
+      ]
+    }
+    """
+
+    # ASI for HU: Herkunft=IT (different value)
+    And metasfresh contains M_AttributeSetInstance with identifier "asi_HU":
+    """
+    {
+      "attributeInstances":[
+        { "attributeCode":"1000001", "valueStr":"IT" }
+      ]
+    }
+    """
+
+    # Create HU with Herkunft=IT via inventory
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID |
+      | inventory      | warehouse      | 2022-05-17   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE             | asi_HU                    | hu      |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # Register the HU's Herkunft attribute
+    And metasfresh contains M_HU_PI_Attributes:
+      | M_HU_PI_Version_ID | M_Attribute_ID |
+      | huPackVersion_TU   | attr_test      |
+
+    And update M_HU_Attributes:
+      | M_HU_ID | M_Attribute_ID | Value |
+      | hu       | attr_test      | IT    |
+
+    # Sales order with ASI containing Herkunft=DE
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID |
+      | order      | true    | customer      | 2022-05-17  | warehouse      |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_AttributeSetInstance_ID |
+      | orderLine  | order      | product      | 10         | asi_order                 |
+    And the order identified by order is completed
+
+    # Wait for shipment schedule
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier       | C_OrderLine_ID | IsToRecompute |
+      | shipmentSchedule | orderLine      | N             |
+
+    # Generate shipment — HU with Herkunft=IT will be picked on-the-fly
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipmentDateToday |
+      | shipmentSchedule      | D            | true                | false               |
+
+    And after not more than 60s, M_InOut is found:
+      | Identifier | C_BPartner_ID | DocStatus |
+      | shipment   | customer      | CO        |
+
+    And validate the created shipment lines
+      | M_InOut_ID | M_Product_ID | movementqty | M_InOutLine_ID | M_AttributeSetInstance_ID |
+      | shipment   | product      | 10          | shipLine       | asi_shipLine              |
+
+    # Assert: schedule ASI wins — Herkunft=DE (not IT from HU)
+    And validate M_AttributeInstance:
+      | M_AttributeSetInstance_ID | AttributeCode | Value |
+      | asi_shipLine              | 1000001       | DE    |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
@@ -24,8 +24,8 @@ Feature: Shipment line ASI propagation
       | Identifier |
       | product    |
     And metasfresh contains C_UOM_Conversions
-      | M_Product_ID.Identifier | FROM_C_UOM_ID | TO_C_UOM_ID | MultiplyRate |
-      | product                 | PCE           | PCE          | 1            |
+      | M_Product_ID.Identifier | FROM_C_UOM_ID.X12DE355 | TO_C_UOM_ID.X12DE355 | MultiplyRate |
+      | product                 | PCE                     | PCE                   | 1            |
 
     # TU packing instructions (10 PCE per TU)
     And metasfresh contains M_HU_PI:

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
@@ -24,6 +24,7 @@ package de.metas.handlingunits.shipmentschedule.api;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import org.compiere.model.I_M_Attribute;
 import com.google.common.collect.ImmutableMap;
 import de.metas.bpartner.BPartnerId;
 import de.metas.common.util.CoalesceUtil;
@@ -323,49 +324,81 @@ public class ShipmentScheduleWithHU
 				.collect(ImmutableList.toImmutableList());
 
 		//
-		// 3. Merge: schedule ASI values take precedence over HU values (when non-empty)
-		return mergeAttributeValues(filteredHUAttributes, filteredSchedAsiAttributes);
+		// 3. Merge: HU attributes first, then overlay schedule ASI attributes.
+		// For each attribute, the handler's IsHUAttributeOverridesASI flag decides precedence:
+		// - Y (default): HU value wins (existing behavior for LotNumber, BestBefore, etc.)
+		// - N: schedule ASI value wins (for customer-intent attributes like Herkunft)
+		return mergeAttributeValues(filteredHUAttributes, filteredSchedAsiAttributes,
+				attribute -> handler.isHUAttributeOverridesASI(shipmentSchedule, attribute));
 	}
 
 	/**
 	 * Merges HU attribute values with schedule ASI attribute values.
 	 * <p>
-	 * Schedule ASI attributes take precedence over HU attributes for the same {@code M_Attribute_ID},
-	 * but only when the schedule ASI value is non-empty (i.e., not equal to its {@link IAttributeValue#getEmptyValue()}).
-	 * If the schedule ASI value IS empty/null, the HU value is kept.
-	 * <p>
-	 * @param filteredHUAttributes  HU attributes already filtered by handler whitelist, non-empty check, and isUseInASI
-	 * @param schedAsiAttributes    schedule ASI attributes already filtered by {@link IAttributeValue#isUseInASI()}
-	 * @return merged list of attribute values
+	 * For each attribute that exists in both sources, the {@code isHUOverridesASI} predicate decides:
+	 * <ul>
+	 *   <li>{@code true} (default) — HU value wins. Schedule ASI fills gaps only where HU has no value.</li>
+	 *   <li>{@code false} — Schedule ASI value wins when non-empty. HU fills gaps for empty schedule values.</li>
+	 * </ul>
+	 * Schedule ASI attributes not in the HU set are always added (if non-empty).
+	 * HU attributes not in the schedule ASI are always kept.
+	 *
+	 * @param filteredHUAttributes HU attributes already filtered by handler whitelist
+	 * @param schedAsiAttributes   schedule ASI attributes already filtered by isUseInASI
+	 * @param isHUOverridesASI     per-attribute predicate: true = HU wins, false = schedule ASI wins
+	 */
+	@VisibleForTesting
+	public static ImmutableList<IAttributeValue> mergeAttributeValues(
+			@NonNull final List<IAttributeValue> filteredHUAttributes,
+			@NonNull final List<IAttributeValue> schedAsiAttributes,
+			@NonNull final java.util.function.Predicate<I_M_Attribute> isHUOverridesASI)
+	{
+		final Map<Integer, IAttributeValue> merged = new LinkedHashMap<>();
+
+		// Start with HU attributes
+		for (final IAttributeValue huAttr : filteredHUAttributes)
+		{
+			merged.put(huAttr.getM_Attribute().getM_Attribute_ID(), huAttr);
+		}
+
+		// Overlay schedule ASI attributes
+		for (final IAttributeValue schedAttr : schedAsiAttributes)
+		{
+			final int attributeId = schedAttr.getM_Attribute().getM_Attribute_ID();
+			final boolean schedValueIsEmpty = Objects.equals(schedAttr.getValue(), schedAttr.getEmptyValue());
+
+			if (schedValueIsEmpty)
+			{
+				// Schedule value is empty → keep the HU value if any, don't add empty
+				continue;
+			}
+
+			final boolean huHasValue = merged.containsKey(attributeId);
+			if (!huHasValue)
+			{
+				// No HU value → add schedule ASI value unconditionally
+				merged.put(attributeId, schedAttr);
+			}
+			else if (!isHUOverridesASI.test(schedAttr.getM_Attribute()))
+			{
+				// HU has a value BUT config says schedule ASI wins → overwrite
+				merged.put(attributeId, schedAttr);
+			}
+			// else: HU has a value AND config says HU wins → keep HU value (do nothing)
+		}
+
+		return ImmutableList.copyOf(merged.values());
+	}
+
+	/**
+	 * Convenience overload for unit tests — defaults to "HU always wins" (backward-compatible).
 	 */
 	@VisibleForTesting
 	public static ImmutableList<IAttributeValue> mergeAttributeValues(
 			@NonNull final List<IAttributeValue> filteredHUAttributes,
 			@NonNull final List<IAttributeValue> schedAsiAttributes)
 	{
-		// Start with HU attributes keyed by M_Attribute_ID
-		final Map<Integer, IAttributeValue> merged = new LinkedHashMap<>();
-		for (final IAttributeValue huAttr : filteredHUAttributes)
-		{
-			merged.put(huAttr.getM_Attribute().getM_Attribute_ID(), huAttr);
-		}
-
-		// Overlay schedule ASI attributes — but only if non-empty.
-		// Empty schedule values don't overwrite HU values (the HU value fills the gap).
-		for (final IAttributeValue schedAttr : schedAsiAttributes)
-		{
-			final int attributeId = schedAttr.getM_Attribute().getM_Attribute_ID();
-			final boolean schedValueIsEmpty = Objects.equals(schedAttr.getValue(), schedAttr.getEmptyValue());
-
-			if (!schedValueIsEmpty)
-			{
-				// Schedule ASI has a real value -> it wins (overwrite HU or add new)
-				merged.put(attributeId, schedAttr);
-			}
-			// else: schedule value is empty -> keep the existing HU value if any (don't overwrite, don't add)
-		}
-
-		return ImmutableList.copyOf(merged.values());
+		return mergeAttributeValues(filteredHUAttributes, schedAsiAttributes, attribute -> true);
 	}
 
 	@Nullable

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
@@ -24,6 +24,7 @@ package de.metas.handlingunits.shipmentschedule.api;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableMap;
 import de.metas.bpartner.BPartnerId;
 import de.metas.common.util.CoalesceUtil;
@@ -161,6 +162,14 @@ public class ShipmentScheduleWithHU
 
 	@Getter(lazy = true)
 	private final List<IAttributeValue> attributeValues = computeAttributeValues();
+
+	/**
+	 * Attribute IDs from the schedule ASI that have non-empty values and were used in the merge
+	 * (i.e., they take precedence over HU attributes). Used by {@link de.metas.handlingunits.shipmentschedule.spi.impl.ShipmentLineBuilder}
+	 * to prevent the HU attribute transfer from overwriting these values.
+	 */
+	@Getter(lazy = true)
+	private final ImmutableSet<Integer> scheduleAsiAttributeIds = computeScheduleAsiAttributeIds();
 
 	private I_M_ShipmentSchedule_QtyPicked shipmentScheduleQtyPicked;
 
@@ -325,6 +334,23 @@ public class ShipmentScheduleWithHU
 		//
 		// 3. Merge: schedule ASI values take precedence over HU values (when non-empty)
 		return mergeAttributeValues(filteredHUAttributes, filteredSchedAsiAttributes);
+	}
+
+	private ImmutableSet<Integer> computeScheduleAsiAttributeIds()
+	{
+		if (getM_AttributeSetInstance_ID() <= 0)
+		{
+			return ImmutableSet.of();
+		}
+
+		final IAttributeStorageFactory attributeStorageFactory = huContext.getHUAttributeStorageFactory();
+		final I_M_AttributeSetInstance attributeSetInstance = load(getM_AttributeSetInstance_ID(), I_M_AttributeSetInstance.class);
+		final IAttributeStorage asiStorage = ASIAttributeStorage.createNew(attributeStorageFactory, attributeSetInstance);
+
+		return asiStorage.getAttributeValues().stream()
+				.filter(av -> !Objects.equals(av.getValue(), av.getEmptyValue()))
+				.map(av -> av.getM_Attribute().getM_Attribute_ID())
+				.collect(ImmutableSet.toImmutableSet());
 	}
 
 	/**

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
@@ -24,7 +24,8 @@ package de.metas.handlingunits.shipmentschedule.api;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import org.compiere.model.I_M_Attribute;
+import org.adempiere.mm.attributes.AttributeId;
+import de.metas.organization.OrgId;
 import java.util.function.Predicate;
 import com.google.common.collect.ImmutableMap;
 import de.metas.bpartner.BPartnerId;
@@ -286,7 +287,7 @@ public class ShipmentScheduleWithHU
 	{
 		//
 		// 1. Collect HU attributes (filtered by handler whitelist)
-		final TreeSet<IAttributeValue> huAttributeValues = new TreeSet<>(Comparator.comparing(av -> av.getM_Attribute().getM_Attribute_ID()));
+		final TreeSet<IAttributeValue> huAttributeValues = new TreeSet<>(Comparator.comparing(IAttributeValue::getAttributeId));
 
 		final IAttributeStorageFactory attributeStorageFactory = huContext.getHUAttributeStorageFactory();
 		streamHUHierarchyBottomUp().forEach(hu -> {
@@ -308,7 +309,7 @@ public class ShipmentScheduleWithHU
 
 		//
 		// 2. Collect schedule ASI attributes (NO handler whitelist filter — always pass through)
-		final TreeSet<IAttributeValue> schedAsiAttributeValues = new TreeSet<>(Comparator.comparing(av -> av.getM_Attribute().getM_Attribute_ID()));
+		final TreeSet<IAttributeValue> schedAsiAttributeValues = new TreeSet<>(Comparator.comparing(IAttributeValue::getAttributeId));
 
 		if (getM_AttributeSetInstance_ID() > 0)
 		{
@@ -339,8 +340,9 @@ public class ShipmentScheduleWithHU
 		// For each attribute, the handler's IsHUAttributeOverridesASI flag decides precedence:
 		// - Y (default): HU value wins (existing behavior for LotNumber, BestBefore, etc.)
 		// - N: schedule ASI value wins (for customer-intent attributes like Herkunft)
+		final OrgId orgId = OrgId.ofRepoId(shipmentSchedule.getAD_Org_ID());
 		return mergeAttributeValues(filteredHUAttributes, filteredSchedAsiAttributes,
-				attribute -> handler.isHUAttributeOverridesASI(shipmentSchedule.getAD_Org_ID(), attribute));
+				attrId -> handler.isHUAttributeOverridesASI(orgId, attrId));
 	}
 
 	/**
@@ -356,56 +358,52 @@ public class ShipmentScheduleWithHU
 	 *
 	 * @param filteredHUAttributes HU attributes already filtered by handler whitelist
 	 * @param schedAsiAttributes   schedule ASI attributes already filtered by isUseInASI
-	 * @param isHUOverridesASI     per-attribute predicate: true = HU wins, false = schedule ASI wins
+	 * @param isHUOverridesASI     per-attribute predicate (by AttributeId): true = HU wins, false = schedule ASI wins
 	 */
 	@VisibleForTesting
 	public static ImmutableList<IAttributeValue> mergeAttributeValues(
 			@NonNull final List<IAttributeValue> filteredHUAttributes,
 			@NonNull final List<IAttributeValue> schedAsiAttributes,
-			@NonNull final Predicate<I_M_Attribute> isHUOverridesASI)
+			@NonNull final Predicate<AttributeId> isHUOverridesASI)
 	{
-		final Map<Integer, IAttributeValue> merged = new LinkedHashMap<>();
+		final Map<AttributeId, IAttributeValue> merged = new LinkedHashMap<>();
 
 		// Start with HU attributes
 		for (final IAttributeValue huAttr : filteredHUAttributes)
 		{
-			merged.put(huAttr.getM_Attribute().getM_Attribute_ID(), huAttr);
+			merged.put(huAttr.getAttributeId(), huAttr);
 		}
 
 		// Overlay schedule ASI attributes
 		for (final IAttributeValue schedAttr : schedAsiAttributes)
 		{
-			final int attributeId = schedAttr.getM_Attribute().getM_Attribute_ID();
+			final AttributeId attributeId = schedAttr.getAttributeId();
 			final boolean schedValueIsEmpty = Objects.equals(schedAttr.getValue(), schedAttr.getEmptyValue());
 
 			if (schedValueIsEmpty)
 			{
-				// Schedule value is empty → keep the HU value if any, don't add empty
 				continue;
 			}
 
 			final boolean huHasValue = merged.containsKey(attributeId);
 			if (!huHasValue)
 			{
-				// No HU value → add schedule ASI value unconditionally
 				merged.put(attributeId, schedAttr);
 			}
-			else if (!isHUOverridesASI.test(schedAttr.getM_Attribute()))
+			else if (!isHUOverridesASI.test(attributeId))
 			{
-				// HU has a value BUT config says schedule ASI wins → overwrite
 				merged.put(attributeId, schedAttr);
 			}
-			// else: HU has a value AND config says HU wins → keep HU value (do nothing)
 		}
 
 		return ImmutableList.copyOf(merged.values());
 	}
 
 	/** Predicate constant: HU attribute always wins over schedule ASI (backward-compatible default). */
-	public static final Predicate<I_M_Attribute> HU_ALWAYS_WINS = attribute -> true;
+	public static final Predicate<AttributeId> HU_ALWAYS_WINS = attrId -> true;
 
 	/** Predicate constant: Schedule ASI always wins over HU attribute. */
-	public static final Predicate<I_M_Attribute> SCHEDULE_ASI_ALWAYS_WINS = attribute -> false;
+	public static final Predicate<AttributeId> SCHEDULE_ASI_ALWAYS_WINS = attrId -> false;
 
 	@Nullable
 	public OrderId getOrderId()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
@@ -22,6 +22,7 @@ package de.metas.handlingunits.shipmentschedule.api;
  * #L%
  */
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import de.metas.bpartner.BPartnerId;
@@ -80,7 +81,9 @@ import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeSet;
@@ -279,8 +282,9 @@ public class ShipmentScheduleWithHU
 
 	private List<IAttributeValue> computeAttributeValues()
 	{
-		final TreeSet<IAttributeValue> allAttributeValues = //
-				new TreeSet<>(Comparator.comparing(av -> av.getM_Attribute().getM_Attribute_ID()));
+		//
+		// 1. Collect HU attributes (filtered by handler whitelist)
+		final TreeSet<IAttributeValue> huAttributeValues = new TreeSet<>(Comparator.comparing(av -> av.getM_Attribute().getM_Attribute_ID()));
 
 		final IAttributeStorageFactory attributeStorageFactory = huContext.getHUAttributeStorageFactory();
 		streamHUHierarchyBottomUp().forEach(hu -> {
@@ -289,29 +293,85 @@ public class ShipmentScheduleWithHU
 					.stream()
 					.filter(attributeValue -> !attributeValue.isEmpty())
 					.collect(ImmutableList.toImmutableList());
-			allAttributeValues.addAll(nonEmptyAttributeValues);
+			huAttributeValues.addAll(nonEmptyAttributeValues);
 		});
-
-		if (getM_AttributeSetInstance_ID() > 0)
-		{
-			/// add all values from the ASI
-			final I_M_AttributeSetInstance attributeSetInstance = load(getM_AttributeSetInstance_ID(), I_M_AttributeSetInstance.class);
-			final IAttributeStorage asiAttributeStorage = ASIAttributeStorage.createNew(attributeStorageFactory, attributeSetInstance);
-			allAttributeValues.addAll(asiAttributeStorage.getAttributeValues());
-
-			// additionally add whatever the attributeStorageFactory's storage implementation has to offer.
-			final IAttributeStorage huAsiAttributeStorage = attributeStorageFactory.getAttributeStorage(attributeSetInstance);
-			allAttributeValues.addAll(huAsiAttributeStorage.getAttributeValues());
-		}
 
 		final ShipmentScheduleHandler handler = Services.get(IShipmentScheduleHandlerBL.class).getHandlerFor(shipmentSchedule);
 
-		final ImmutableList<IAttributeValue> result = allAttributeValues.stream()
+		final ImmutableList<IAttributeValue> filteredHUAttributes = huAttributeValues.stream()
 				.filter(IAttributeValue::isUseInASI)
-				.filter(attributeValue -> !Objects.equals(attributeValue.getValue(), attributeValue.getEmptyValue())) // when comparing different shipmentScheduleWithHU instances, we want no attributes to be equal to attributes with null values
+				.filter(attributeValue -> !Objects.equals(attributeValue.getValue(), attributeValue.getEmptyValue()))
 				.filter(attributeValue -> handler.attributeShallBePartOfShipmentLine(shipmentSchedule, attributeValue.getM_Attribute()))
 				.collect(ImmutableList.toImmutableList());
-		return result;
+
+		//
+		// 2. Collect schedule ASI attributes (NO handler whitelist filter — always pass through)
+		final TreeSet<IAttributeValue> schedAsiAttributeValues = new TreeSet<>(Comparator.comparing(av -> av.getM_Attribute().getM_Attribute_ID()));
+
+		if (getM_AttributeSetInstance_ID() > 0)
+		{
+			final I_M_AttributeSetInstance attributeSetInstance = load(getM_AttributeSetInstance_ID(), I_M_AttributeSetInstance.class);
+			final IAttributeStorage asiAttributeStorage = ASIAttributeStorage.createNew(attributeStorageFactory, attributeSetInstance);
+			schedAsiAttributeValues.addAll(asiAttributeStorage.getAttributeValues());
+
+			final IAttributeStorage huAsiAttributeStorage = attributeStorageFactory.getAttributeStorage(attributeSetInstance);
+			schedAsiAttributeValues.addAll(huAsiAttributeStorage.getAttributeValues());
+		}
+
+		final ImmutableList<IAttributeValue> filteredSchedAsiAttributes = schedAsiAttributeValues.stream()
+				.filter(IAttributeValue::isUseInASI)
+				.collect(ImmutableList.toImmutableList());
+
+		//
+		// 3. Merge: schedule ASI values take precedence over HU values (when non-empty)
+		return mergeAttributeValues(filteredHUAttributes, filteredSchedAsiAttributes);
+	}
+
+	/**
+	 * Merges HU attribute values with schedule ASI attribute values.
+	 * <p>
+	 * Schedule ASI attributes take precedence over HU attributes for the same {@code M_Attribute_ID},
+	 * but only when the schedule ASI value is non-empty (i.e., not equal to its {@link IAttributeValue#getEmptyValue()}).
+	 * If the schedule ASI value IS empty/null, the HU value is kept.
+	 * <p>
+	 * Schedule ASI attributes with {@link IAttributeValue#isUseInASI()} == false are excluded.
+	 *
+	 * @param filteredHUAttributes  HU attributes already filtered by handler whitelist and non-empty check
+	 * @param schedAsiAttributes    schedule ASI attributes filtered only by {@link IAttributeValue#isUseInASI()}
+	 * @return merged list of attribute values
+	 */
+	@VisibleForTesting
+	static ImmutableList<IAttributeValue> mergeAttributeValues(
+			@NonNull final List<IAttributeValue> filteredHUAttributes,
+			@NonNull final List<IAttributeValue> schedAsiAttributes)
+	{
+		// Start with HU attributes keyed by M_Attribute_ID
+		final Map<Integer, IAttributeValue> merged = new LinkedHashMap<>();
+		for (final IAttributeValue huAttr : filteredHUAttributes)
+		{
+			merged.put(huAttr.getM_Attribute().getM_Attribute_ID(), huAttr);
+		}
+
+		// Overlay schedule ASI attributes — but only if non-empty
+		for (final IAttributeValue schedAttr : schedAsiAttributes)
+		{
+			if (!schedAttr.isUseInASI())
+			{
+				continue;
+			}
+
+			final int attributeId = schedAttr.getM_Attribute().getM_Attribute_ID();
+			final boolean schedValueIsEmpty = Objects.equals(schedAttr.getValue(), schedAttr.getEmptyValue());
+
+			if (!schedValueIsEmpty)
+			{
+				// Schedule ASI has a real value -> it wins (overwrite HU or add new)
+				merged.put(attributeId, schedAttr);
+			}
+			// else: schedule value is empty -> keep the existing HU value if any (don't overwrite, don't add)
+		}
+
+		return ImmutableList.copyOf(merged.values());
 	}
 
 	@Nullable

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
@@ -24,7 +24,6 @@ package de.metas.handlingunits.shipmentschedule.api;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableMap;
 import de.metas.bpartner.BPartnerId;
 import de.metas.common.util.CoalesceUtil;
@@ -162,14 +161,6 @@ public class ShipmentScheduleWithHU
 
 	@Getter(lazy = true)
 	private final List<IAttributeValue> attributeValues = computeAttributeValues();
-
-	/**
-	 * Attribute IDs from the schedule ASI that have non-empty values and were used in the merge
-	 * (i.e., they take precedence over HU attributes). Used by {@link de.metas.handlingunits.shipmentschedule.spi.impl.ShipmentLineBuilder}
-	 * to prevent the HU attribute transfer from overwriting these values.
-	 */
-	@Getter(lazy = true)
-	private final ImmutableSet<Integer> scheduleAsiAttributeIds = computeScheduleAsiAttributeIds();
 
 	private I_M_ShipmentSchedule_QtyPicked shipmentScheduleQtyPicked;
 
@@ -334,23 +325,6 @@ public class ShipmentScheduleWithHU
 		//
 		// 3. Merge: schedule ASI values take precedence over HU values (when non-empty)
 		return mergeAttributeValues(filteredHUAttributes, filteredSchedAsiAttributes);
-	}
-
-	private ImmutableSet<Integer> computeScheduleAsiAttributeIds()
-	{
-		if (getM_AttributeSetInstance_ID() <= 0)
-		{
-			return ImmutableSet.of();
-		}
-
-		final IAttributeStorageFactory attributeStorageFactory = huContext.getHUAttributeStorageFactory();
-		final I_M_AttributeSetInstance attributeSetInstance = load(getM_AttributeSetInstance_ID(), I_M_AttributeSetInstance.class);
-		final IAttributeStorage asiStorage = ASIAttributeStorage.createNew(attributeStorageFactory, attributeSetInstance);
-
-		return asiStorage.getAttributeValues().stream()
-				.filter(av -> !Objects.equals(av.getValue(), av.getEmptyValue()))
-				.map(av -> av.getM_Attribute().getM_Attribute_ID())
-				.collect(ImmutableSet.toImmutableSet());
 	}
 
 	/**

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
@@ -320,6 +320,11 @@ public class ShipmentScheduleWithHU
 			schedAsiAttributeValues.addAll(huAsiAttributeStorage.getAttributeValues());
 		}
 
+		// NOTE: intentionally NOT filtering empty values here — the merge method
+		// evaluates emptiness per attribute to decide whether to fall back to the HU value.
+		// This is asymmetric with filteredHUAttributes (which pre-filters empties) because
+		// HU empties are never useful, but schedule ASI empties signal "no customer preference,
+		// let the HU value through".
 		final ImmutableList<IAttributeValue> filteredSchedAsiAttributes = schedAsiAttributeValues.stream()
 				.filter(IAttributeValue::isUseInASI)
 				.collect(ImmutableList.toImmutableList());

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
@@ -340,7 +340,7 @@ public class ShipmentScheduleWithHU
 		// - Y (default): HU value wins (existing behavior for LotNumber, BestBefore, etc.)
 		// - N: schedule ASI value wins (for customer-intent attributes like Herkunft)
 		return mergeAttributeValues(filteredHUAttributes, filteredSchedAsiAttributes,
-				attribute -> handler.isHUAttributeOverridesASI(shipmentSchedule, attribute));
+				attribute -> handler.isHUAttributeOverridesASI(shipmentSchedule.getAD_Org_ID(), attribute));
 	}
 
 	/**

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
@@ -313,6 +313,11 @@ public class ShipmentScheduleWithHU
 		if (getM_AttributeSetInstance_ID() > 0)
 		{
 			final I_M_AttributeSetInstance attributeSetInstance = load(getM_AttributeSetInstance_ID(), I_M_AttributeSetInstance.class);
+
+			// Load attributes through TWO storage implementations:
+			// 1. ASIAttributeStorage reads M_AttributeInstance records directly (the raw ASI values)
+			// 2. HU factory's storage may add template-derived attributes from the product's attribute set
+			// The TreeSet deduplicates by M_Attribute_ID, keeping the first-inserted value.
 			final IAttributeStorage asiAttributeStorage = ASIAttributeStorage.createNew(attributeStorageFactory, attributeSetInstance);
 			schedAsiAttributeValues.addAll(asiAttributeStorage.getAttributeValues());
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
@@ -334,14 +334,12 @@ public class ShipmentScheduleWithHU
 	 * but only when the schedule ASI value is non-empty (i.e., not equal to its {@link IAttributeValue#getEmptyValue()}).
 	 * If the schedule ASI value IS empty/null, the HU value is kept.
 	 * <p>
-	 * Schedule ASI attributes with {@link IAttributeValue#isUseInASI()} == false are excluded.
-	 *
-	 * @param filteredHUAttributes  HU attributes already filtered by handler whitelist and non-empty check
-	 * @param schedAsiAttributes    schedule ASI attributes filtered only by {@link IAttributeValue#isUseInASI()}
+	 * @param filteredHUAttributes  HU attributes already filtered by handler whitelist, non-empty check, and isUseInASI
+	 * @param schedAsiAttributes    schedule ASI attributes already filtered by {@link IAttributeValue#isUseInASI()}
 	 * @return merged list of attribute values
 	 */
 	@VisibleForTesting
-	static ImmutableList<IAttributeValue> mergeAttributeValues(
+	public static ImmutableList<IAttributeValue> mergeAttributeValues(
 			@NonNull final List<IAttributeValue> filteredHUAttributes,
 			@NonNull final List<IAttributeValue> schedAsiAttributes)
 	{
@@ -352,14 +350,10 @@ public class ShipmentScheduleWithHU
 			merged.put(huAttr.getM_Attribute().getM_Attribute_ID(), huAttr);
 		}
 
-		// Overlay schedule ASI attributes — but only if non-empty
+		// Overlay schedule ASI attributes — but only if non-empty.
+		// Empty schedule values don't overwrite HU values (the HU value fills the gap).
 		for (final IAttributeValue schedAttr : schedAsiAttributes)
 		{
-			if (!schedAttr.isUseInASI())
-			{
-				continue;
-			}
-
 			final int attributeId = schedAttr.getM_Attribute().getM_Attribute_ID();
 			final boolean schedValueIsEmpty = Objects.equals(schedAttr.getValue(), schedAttr.getEmptyValue());
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHU.java
@@ -25,6 +25,7 @@ package de.metas.handlingunits.shipmentschedule.api;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import org.compiere.model.I_M_Attribute;
+import java.util.function.Predicate;
 import com.google.common.collect.ImmutableMap;
 import de.metas.bpartner.BPartnerId;
 import de.metas.common.util.CoalesceUtil;
@@ -351,7 +352,7 @@ public class ShipmentScheduleWithHU
 	public static ImmutableList<IAttributeValue> mergeAttributeValues(
 			@NonNull final List<IAttributeValue> filteredHUAttributes,
 			@NonNull final List<IAttributeValue> schedAsiAttributes,
-			@NonNull final java.util.function.Predicate<I_M_Attribute> isHUOverridesASI)
+			@NonNull final Predicate<I_M_Attribute> isHUOverridesASI)
 	{
 		final Map<Integer, IAttributeValue> merged = new LinkedHashMap<>();
 
@@ -390,16 +391,11 @@ public class ShipmentScheduleWithHU
 		return ImmutableList.copyOf(merged.values());
 	}
 
-	/**
-	 * Convenience overload for unit tests — defaults to "HU always wins" (backward-compatible).
-	 */
-	@VisibleForTesting
-	public static ImmutableList<IAttributeValue> mergeAttributeValues(
-			@NonNull final List<IAttributeValue> filteredHUAttributes,
-			@NonNull final List<IAttributeValue> schedAsiAttributes)
-	{
-		return mergeAttributeValues(filteredHUAttributes, schedAsiAttributes, attribute -> true);
-	}
+	/** Predicate constant: HU attribute always wins over schedule ASI (backward-compatible default). */
+	public static final Predicate<I_M_Attribute> HU_ALWAYS_WINS = attribute -> true;
+
+	/** Predicate constant: Schedule ASI always wins over HU attribute. */
+	public static final Predicate<I_M_Attribute> SCHEDULE_ASI_ALWAYS_WINS = attribute -> false;
 
 	@Nullable
 	public OrderId getOrderId()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
@@ -84,6 +84,7 @@ import java.util.TreeSet;
 import static de.metas.util.Check.assumeNotNull;
 import static org.adempiere.model.InterfaceWrapperHelper.create;
 import static org.adempiere.model.InterfaceWrapperHelper.isNull;
+import static org.adempiere.model.InterfaceWrapperHelper.load;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 
 /**
@@ -615,16 +616,22 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 			}
 			final IAttributeStorage shipmentLineAttributeStorageTo = attributeStorageFactory.getAttributeStorage(asi);
 
-			// Only transfer HU attributes that are NOT already set on the shipment line ASI.
-			// The shipment line ASI was built from mergeAttributeValues() where schedule ASI
-			// values take precedence. We must not overwrite them with HU values here.
-			final Collection<I_M_Attribute> attributes = shipmentLineAttributeStorageTo.getAttributes().stream()
-					.filter(attr -> {
-						final Object existingValue = shipmentLineAttributeStorageTo.hasAttribute(attr)
-								? shipmentLineAttributeStorageTo.getValue(attr)
-								: null;
-						return existingValue == null;
+			// Collect attribute IDs that were explicitly set from the schedule ASI.
+			// These must NOT be overwritten by HU attribute transfer — the schedule ASI
+			// represents the customer's order intent and takes precedence.
+			final java.util.Set<Integer> schedAsiAttributeIds = candidates.stream()
+					.filter(c -> c.getM_AttributeSetInstance_ID() > 0)
+					.flatMap(c -> {
+						final I_M_AttributeSetInstance schedAsi = load(c.getM_AttributeSetInstance_ID(), I_M_AttributeSetInstance.class);
+						final IAttributeStorage schedStorage = attributeStorageFactory.getAttributeStorage(schedAsi);
+						return schedStorage.getAttributeValues().stream()
+								.filter(av -> !Objects.equals(av.getValue(), av.getEmptyValue()))
+								.map(av -> av.getM_Attribute().getM_Attribute_ID());
 					})
+					.collect(com.google.common.collect.ImmutableSet.toImmutableSet());
+
+			final Collection<I_M_Attribute> attributes = shipmentLineAttributeStorageTo.getAttributes().stream()
+					.filter(attr -> !schedAsiAttributeIds.contains(attr.getM_Attribute_ID()))
 					.collect(com.google.common.collect.ImmutableList.toImmutableList());
 			final ImmutableAttributeSet fromAttributes = extractAttributeValuesToTransfer(attributes, attributeStorageFactory);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
@@ -272,7 +272,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 	private void append(@NonNull final ShipmentScheduleWithHU candidate)
 	{
 		Check.assume(canAdd(candidate).isTrue(), "The given candidate can be added to shipment line builder; candidate={}", candidate);
-		attributeValues.addAll(candidate.getAttributeValues());
+		attributeValues.addAll(candidate.getAttributeValues()); // because of canAdd()==true, we may assume that it's all fine
 
 		logger.trace("Adding candidate to {}: candidate={}", this, candidate);
 
@@ -615,16 +615,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 			}
 			final IAttributeStorage shipmentLineAttributeStorageTo = attributeStorageFactory.getAttributeStorage(asi);
 
-			// Collect schedule ASI attribute IDs that have non-empty values.
-			// These must NOT be overwritten by HU attribute transfer — the schedule ASI
-			// represents the customer's order intent and takes precedence.
-			final java.util.Set<Integer> schedAsiAttributeIds = candidates.stream()
-					.flatMap(c -> c.getScheduleAsiAttributeIds().stream())
-					.collect(com.google.common.collect.ImmutableSet.toImmutableSet());
-
-			final Collection<I_M_Attribute> attributes = shipmentLineAttributeStorageTo.getAttributes().stream()
-					.filter(attr -> !schedAsiAttributeIds.contains(attr.getM_Attribute_ID()))
-					.collect(com.google.common.collect.ImmutableList.toImmutableList());
+			final Collection<I_M_Attribute> attributes = shipmentLineAttributeStorageTo.getAttributes();
 			final ImmutableAttributeSet fromAttributes = extractAttributeValuesToTransfer(attributes, attributeStorageFactory);
 
 			trxAttributesBuilder.transferAttributes(

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
@@ -27,6 +27,8 @@ import de.metas.handlingunits.model.I_M_ShipmentSchedule_QtyPicked;
 import de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleBL;
 import de.metas.handlingunits.shipmentschedule.api.M_ShipmentSchedule_QuantityTypeToUse;
 import de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHU;
+import de.metas.inoutcandidate.api.IShipmentScheduleHandlerBL;
+import de.metas.inoutcandidate.spi.ShipmentScheduleHandler;
 import de.metas.handlingunits.util.HUTopLevel;
 import de.metas.i18n.BooleanWithReason;
 import de.metas.inout.IInOutDAO;
@@ -615,7 +617,19 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 			}
 			final IAttributeStorage shipmentLineAttributeStorageTo = attributeStorageFactory.getAttributeStorage(asi);
 
-			final Collection<I_M_Attribute> attributes = shipmentLineAttributeStorageTo.getAttributes();
+			// Skip HU attribute transfer for attributes where IsHUAttributeOverridesASI=N.
+			// For those attributes, the schedule ASI value (set by computeAttributeValues) takes precedence.
+			final de.metas.inoutcandidate.model.I_M_ShipmentSchedule firstSched = candidates.stream()
+					.findFirst()
+					.map(c -> create(c.getM_ShipmentSchedule(), de.metas.inoutcandidate.model.I_M_ShipmentSchedule.class))
+					.orElse(null);
+			final ShipmentScheduleHandler handler = firstSched != null
+					? Services.get(IShipmentScheduleHandlerBL.class).getHandlerFor(firstSched)
+					: null;
+
+			final Collection<I_M_Attribute> attributes = shipmentLineAttributeStorageTo.getAttributes().stream()
+					.filter(attr -> handler == null || firstSched == null || handler.isHUAttributeOverridesASI(firstSched, attr))
+					.collect(ImmutableList.toImmutableList());
 			final ImmutableAttributeSet fromAttributes = extractAttributeValuesToTransfer(attributes, attributeStorageFactory);
 
 			trxAttributesBuilder.transferAttributes(

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
@@ -84,7 +84,6 @@ import java.util.TreeSet;
 import static de.metas.util.Check.assumeNotNull;
 import static org.adempiere.model.InterfaceWrapperHelper.create;
 import static org.adempiere.model.InterfaceWrapperHelper.isNull;
-import static org.adempiere.model.InterfaceWrapperHelper.load;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 
 /**
@@ -616,25 +615,11 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 			}
 			final IAttributeStorage shipmentLineAttributeStorageTo = attributeStorageFactory.getAttributeStorage(asi);
 
-			// Collect attribute IDs with non-empty values explicitly set in the schedule ASI
-			// (from M_AttributeInstance records). These must NOT be overwritten by HU attribute
-			// transfer — the schedule ASI represents the customer's order intent.
-			// We query M_AttributeInstance directly (not via IAttributeStorage) because the
-			// storage factory adds all product attributes with default/empty values, which
-			// would incorrectly block HU attribute transfers (e.g., LotNumber from LU→TU).
+			// Collect schedule ASI attribute IDs that have non-empty values.
+			// These must NOT be overwritten by HU attribute transfer — the schedule ASI
+			// represents the customer's order intent and takes precedence.
 			final java.util.Set<Integer> schedAsiAttributeIds = candidates.stream()
-					.map(ShipmentScheduleWithHU::getM_AttributeSetInstance_ID)
-					.filter(asiId -> asiId > 0)
-					.flatMap(asiId -> {
-						final ImmutableAttributeSet schedAttrSet = Services.get(IAttributeSetInstanceBL.class)
-								.getImmutableAttributeSetById(AttributeSetInstanceId.ofRepoId(asiId));
-						return schedAttrSet.getAttributes().stream()
-								.filter(attr -> {
-									final Object val = schedAttrSet.getValue(attr);
-									return val != null && !"".equals(val.toString().trim());
-								})
-								.map(org.compiere.model.I_M_Attribute::getM_Attribute_ID);
-					})
+					.flatMap(c -> c.getScheduleAsiAttributeIds().stream())
 					.collect(com.google.common.collect.ImmutableSet.toImmutableSet());
 
 			final Collection<I_M_Attribute> attributes = shipmentLineAttributeStorageTo.getAttributes().stream()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
@@ -617,19 +617,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 			}
 			final IAttributeStorage shipmentLineAttributeStorageTo = attributeStorageFactory.getAttributeStorage(asi);
 
-			// Skip HU attribute transfer for attributes where IsHUAttributeOverridesASI=N.
-			// For those attributes, the schedule ASI value (set by computeAttributeValues) takes precedence.
-			final de.metas.inoutcandidate.model.I_M_ShipmentSchedule firstSched = candidates.stream()
-					.findFirst()
-					.map(c -> create(c.getM_ShipmentSchedule(), de.metas.inoutcandidate.model.I_M_ShipmentSchedule.class))
-					.orElse(null);
-			final ShipmentScheduleHandler handler = firstSched != null
-					? Services.get(IShipmentScheduleHandlerBL.class).getHandlerFor(firstSched)
-					: null;
-
-			final Collection<I_M_Attribute> attributes = shipmentLineAttributeStorageTo.getAttributes().stream()
-					.filter(attr -> handler == null || firstSched == null || handler.isHUAttributeOverridesASI(firstSched, attr))
-					.collect(ImmutableList.toImmutableList());
+			final Collection<I_M_Attribute> attributes = filterAttributesForHUTransfer(shipmentLineAttributeStorageTo.getAttributes());
 			final ImmutableAttributeSet fromAttributes = extractAttributeValuesToTransfer(attributes, attributeStorageFactory);
 
 			trxAttributesBuilder.transferAttributes(
@@ -644,6 +632,27 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 
 			return IHUContextProcessor.NULL_RESULT;
 		});
+	}
+
+	/**
+	 * Filters out attributes where {@code IsHUAttributeOverridesASI=N} in {@link I_M_ShipmentSchedule_AttributeConfig}.
+	 * For those attributes, the schedule ASI value (already set on the shipment line by
+	 * {@link ShipmentScheduleWithHU#computeAttributeValues()}) must not be overwritten by HU attribute transfer.
+	 */
+	private Collection<I_M_Attribute> filterAttributesForHUTransfer(@NonNull final Collection<I_M_Attribute> allAttributes)
+	{
+		if (candidates.isEmpty())
+		{
+			return allAttributes;
+		}
+
+		final de.metas.inoutcandidate.model.I_M_ShipmentSchedule scheduleRecord =
+				create(candidates.get(0).getM_ShipmentSchedule(), de.metas.inoutcandidate.model.I_M_ShipmentSchedule.class);
+		final ShipmentScheduleHandler handler = Services.get(IShipmentScheduleHandlerBL.class).getHandlerFor(scheduleRecord);
+
+		return allAttributes.stream()
+				.filter(attr -> handler.isHUAttributeOverridesASI(scheduleRecord, attr))
+				.collect(ImmutableList.toImmutableList());
 	}
 
 	private ImmutableAttributeSet extractAttributeValuesToTransfer(final Collection<I_M_Attribute> attributes, final IAttributeStorageFactory attributeStorageFactory)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
@@ -646,12 +646,13 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 			return allAttributes;
 		}
 
-		final de.metas.inoutcandidate.model.I_M_ShipmentSchedule scheduleRecord =
-				create(candidates.get(0).getM_ShipmentSchedule(), de.metas.inoutcandidate.model.I_M_ShipmentSchedule.class);
-		final ShipmentScheduleHandler handler = Services.get(IShipmentScheduleHandlerBL.class).getHandlerFor(scheduleRecord);
+		final ShipmentScheduleWithHU firstCandidate = candidates.get(0);
+		final int orgId = firstCandidate.getM_ShipmentSchedule().getAD_Org_ID();
+		final ShipmentScheduleHandler handler = Services.get(IShipmentScheduleHandlerBL.class)
+				.getHandlerFor(firstCandidate.getM_ShipmentSchedule());
 
 		return allAttributes.stream()
-				.filter(attr -> handler.isHUAttributeOverridesASI(scheduleRecord, attr))
+				.filter(attr -> handler.isHUAttributeOverridesASI(orgId, attr))
 				.collect(ImmutableList.toImmutableList());
 	}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
@@ -272,7 +272,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 	private void append(@NonNull final ShipmentScheduleWithHU candidate)
 	{
 		Check.assume(canAdd(candidate).isTrue(), "The given candidate can be added to shipment line builder; candidate={}", candidate);
-		attributeValues.addAll(candidate.getAttributeValues()); // because of canAdd()==true, we may assume that it's all fine
+		attributeValues.addAll(candidate.getAttributeValues());
 
 		logger.trace("Adding candidate to {}: candidate={}", this, candidate);
 
@@ -615,7 +615,17 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 			}
 			final IAttributeStorage shipmentLineAttributeStorageTo = attributeStorageFactory.getAttributeStorage(asi);
 
-			final Collection<I_M_Attribute> attributes = shipmentLineAttributeStorageTo.getAttributes();
+			// Only transfer HU attributes that are NOT already set on the shipment line ASI.
+			// The shipment line ASI was built from mergeAttributeValues() where schedule ASI
+			// values take precedence. We must not overwrite them with HU values here.
+			final Collection<I_M_Attribute> attributes = shipmentLineAttributeStorageTo.getAttributes().stream()
+					.filter(attr -> {
+						final Object existingValue = shipmentLineAttributeStorageTo.hasAttribute(attr)
+								? shipmentLineAttributeStorageTo.getValue(attr)
+								: null;
+						return existingValue == null;
+					})
+					.collect(com.google.common.collect.ImmutableList.toImmutableList());
 			final ImmutableAttributeSet fromAttributes = extractAttributeValuesToTransfer(attributes, attributeStorageFactory);
 
 			trxAttributesBuilder.transferAttributes(

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
@@ -616,17 +616,24 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 			}
 			final IAttributeStorage shipmentLineAttributeStorageTo = attributeStorageFactory.getAttributeStorage(asi);
 
-			// Collect attribute IDs that were explicitly set from the schedule ASI.
-			// These must NOT be overwritten by HU attribute transfer — the schedule ASI
-			// represents the customer's order intent and takes precedence.
+			// Collect attribute IDs with non-empty values explicitly set in the schedule ASI
+			// (from M_AttributeInstance records). These must NOT be overwritten by HU attribute
+			// transfer — the schedule ASI represents the customer's order intent.
+			// We query M_AttributeInstance directly (not via IAttributeStorage) because the
+			// storage factory adds all product attributes with default/empty values, which
+			// would incorrectly block HU attribute transfers (e.g., LotNumber from LU→TU).
 			final java.util.Set<Integer> schedAsiAttributeIds = candidates.stream()
-					.filter(c -> c.getM_AttributeSetInstance_ID() > 0)
-					.flatMap(c -> {
-						final I_M_AttributeSetInstance schedAsi = load(c.getM_AttributeSetInstance_ID(), I_M_AttributeSetInstance.class);
-						final IAttributeStorage schedStorage = attributeStorageFactory.getAttributeStorage(schedAsi);
-						return schedStorage.getAttributeValues().stream()
-								.filter(av -> !Objects.equals(av.getValue(), av.getEmptyValue()))
-								.map(av -> av.getM_Attribute().getM_Attribute_ID());
+					.map(ShipmentScheduleWithHU::getM_AttributeSetInstance_ID)
+					.filter(asiId -> asiId > 0)
+					.flatMap(asiId -> {
+						final ImmutableAttributeSet schedAttrSet = Services.get(IAttributeSetInstanceBL.class)
+								.getImmutableAttributeSetById(AttributeSetInstanceId.ofRepoId(asiId));
+						return schedAttrSet.getAttributes().stream()
+								.filter(attr -> {
+									final Object val = schedAttrSet.getValue(attr);
+									return val != null && !"".equals(val.toString().trim());
+								})
+								.map(org.compiere.model.I_M_Attribute::getM_Attribute_ID);
 					})
 					.collect(com.google.common.collect.ImmutableSet.toImmutableSet());
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/spi/impl/ShipmentLineBuilder.java
@@ -29,6 +29,8 @@ import de.metas.handlingunits.shipmentschedule.api.M_ShipmentSchedule_QuantityTy
 import de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHU;
 import de.metas.inoutcandidate.api.IShipmentScheduleHandlerBL;
 import de.metas.inoutcandidate.spi.ShipmentScheduleHandler;
+import de.metas.organization.OrgId;
+import org.adempiere.mm.attributes.AttributeId;
 import de.metas.handlingunits.util.HUTopLevel;
 import de.metas.i18n.BooleanWithReason;
 import de.metas.inout.IInOutDAO;
@@ -647,12 +649,12 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 		}
 
 		final ShipmentScheduleWithHU firstCandidate = candidates.get(0);
-		final int orgId = firstCandidate.getM_ShipmentSchedule().getAD_Org_ID();
+		final OrgId orgId = OrgId.ofRepoId(firstCandidate.getM_ShipmentSchedule().getAD_Org_ID());
 		final ShipmentScheduleHandler handler = Services.get(IShipmentScheduleHandlerBL.class)
 				.getHandlerFor(firstCandidate.getM_ShipmentSchedule());
 
 		return allAttributes.stream()
-				.filter(attr -> handler.isHUAttributeOverridesASI(orgId, attr))
+				.filter(attr -> handler.isHUAttributeOverridesASI(orgId, AttributeId.ofRepoId(attr.getM_Attribute_ID())))
 				.collect(ImmutableList.toImmutableList());
 	}
 

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleWithHUTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleWithHUTests.java
@@ -491,19 +491,6 @@ public class ShipmentScheduleWithHUTests
 			assertThat(result.get(0).getValue()).isEqualTo("P17");
 		}
 
-		@Test
-		void schedASI_not_useInASI_is_excluded()
-		{
-			// Schedule ASI attribute with isUseInASI=false should be excluded
-			final IAttributeValue schedAttr = stubAttributeValue(1, "P13", "", false);
-
-			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
-					Collections.emptyList(),
-					Arrays.asList(schedAttr));
-
-			assertThat(result).isEmpty();
-		}
-
 		/**
 		 * Creates a stub {@link IAttributeValue} with the given attribute ID, value, empty value, and useInASI flag.
 		 * Uses POJOWrapper-backed {@link I_M_Attribute} instances from the test environment.

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleWithHUTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleWithHUTests.java
@@ -386,12 +386,30 @@ public class ShipmentScheduleWithHUTests
 			final IAttributeValue huAttr = stubAttributeValue(1, "P17", "", true);
 			final IAttributeValue schedAttr = stubAttributeValue(1, "P13", "", true);
 
+			// When IsHUAttributeOverridesASI=N (schedule wins)
 			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
 					Arrays.asList(huAttr),
-					Arrays.asList(schedAttr));
+					Arrays.asList(schedAttr),
+					attribute -> false /* schedule ASI wins */);
 
 			assertThat(result).hasSize(1);
 			assertThat(result.get(0).getValue()).isEqualTo("P13");
+		}
+
+		@Test
+		void huOverridesASI_when_configured()
+		{
+			final IAttributeValue huAttr = stubAttributeValue(1, "P17", "", true);
+			final IAttributeValue schedAttr = stubAttributeValue(1, "P13", "", true);
+
+			// When IsHUAttributeOverridesASI=Y (HU wins — default/backward compatible)
+			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
+					Arrays.asList(huAttr),
+					Arrays.asList(schedAttr),
+					attribute -> true /* HU wins */);
+
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).getValue()).isEqualTo("P17");
 		}
 
 		@Test
@@ -458,9 +476,11 @@ public class ShipmentScheduleWithHUTests
 			final IAttributeValue schedAttrA = stubAttributeValue(1, "P13", "", true);
 			final IAttributeValue schedAttrB = stubAttributeValue(2, "", "", true);
 
+			// With IsHUAttributeOverridesASI=N for both: schedule ASI wins for A (non-empty), HU wins for B (empty schedule)
 			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
 					Arrays.asList(huAttrA, huAttrB),
-					Arrays.asList(schedAttrA, schedAttrB));
+					Arrays.asList(schedAttrA, schedAttrB),
+					attribute -> false /* schedule ASI wins */);
 
 			assertThat(result).hasSize(2);
 
@@ -472,8 +492,8 @@ public class ShipmentScheduleWithHUTests
 					.filter(av -> av.getM_Attribute().getM_Attribute_ID() == 2)
 					.findFirst().orElseThrow(() -> new AssertionError("Attribute B not found"));
 
-			assertThat(resultA.getValue()).isEqualTo("P13");
-			assertThat(resultB.getValue()).isEqualTo("K1");
+			assertThat(resultA.getValue()).isEqualTo("P13"); // schedule wins (non-empty)
+			assertThat(resultB.getValue()).isEqualTo("K1");  // HU wins (schedule is empty)
 		}
 
 		@Test

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleWithHUTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleWithHUTests.java
@@ -1,11 +1,17 @@
 package de.metas.handlingunits.shipmentschedule.api.impl;
 
+import com.google.common.collect.ImmutableList;
 import de.metas.common.util.pair.IPair;
 import de.metas.common.util.pair.ImmutablePair;
 import de.metas.handlingunits.IHUContext;
 import de.metas.handlingunits.IHUContextFactory;
 import de.metas.handlingunits.IHandlingUnitsDAO;
 import de.metas.handlingunits.allocation.transfer.impl.LUTUProducerDestinationTestSupport;
+import de.metas.handlingunits.attribute.IAttributeValue;
+import de.metas.handlingunits.attribute.IAttributeValueListener;
+import de.metas.handlingunits.attribute.strategy.IAttributeAggregationStrategy;
+import de.metas.handlingunits.attribute.strategy.IAttributeSplitterStrategy;
+import de.metas.handlingunits.attribute.strategy.IHUAttributeTransferStrategy;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
 import de.metas.handlingunits.model.I_M_InOut;
@@ -20,15 +26,29 @@ import de.metas.quantity.StockQtyAndUOMQty;
 import de.metas.quantity.StockQtyAndUOMQtys;
 import de.metas.util.Services;
 import de.metas.util.collections.CollectionUtils;
+import lombok.NonNull;
+import org.adempiere.mm.attributes.AttributeCode;
+import org.adempiere.mm.attributes.spi.IAttributeValueCallout;
+import org.adempiere.mm.attributes.spi.IAttributeValueContext;
+import org.adempiere.mm.attributes.spi.IAttributeValueGenerator;
+import org.adempiere.mm.attributes.spi.IAttributeValuesProvider;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.model.PlainContextAware;
+import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_M_Attribute;
 import org.compiere.model.I_M_Product;
 import org.compiere.model.X_M_InOut;
 import org.compiere.util.Env;
+import org.compiere.util.NamePair;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import static java.math.BigDecimal.ONE;
@@ -351,5 +371,224 @@ public class ShipmentScheduleWithHUTests
 
 		InterfaceWrapperHelper.save(sched);
 		return sched;
+	}
+
+	// -------------------------------------------------------------------
+	// Tests for mergeAttributeValues
+	// -------------------------------------------------------------------
+
+	@Nested
+	class MergeAttributeValuesTests
+	{
+		@Test
+		void schedASI_takes_precedence_over_HU()
+		{
+			final IAttributeValue huAttr = stubAttributeValue(1, "P17", "", true);
+			final IAttributeValue schedAttr = stubAttributeValue(1, "P13", "", true);
+
+			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
+					Arrays.asList(huAttr),
+					Arrays.asList(schedAttr));
+
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).getValue()).isEqualTo("P13");
+		}
+
+		@Test
+		void schedASI_without_HU()
+		{
+			final IAttributeValue schedAttr = stubAttributeValue(1, "P13", "", true);
+
+			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
+					Collections.emptyList(),
+					Arrays.asList(schedAttr));
+
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).getValue()).isEqualTo("P13");
+		}
+
+		@Test
+		void emptySchedASI_falls_back_to_HU()
+		{
+			final IAttributeValue huAttr = stubAttributeValue(1, "P17", "", true);
+			// schedule ASI value equals the empty value -> should be treated as empty
+			final IAttributeValue schedAttr = stubAttributeValue(1, "", "", true);
+
+			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
+					Arrays.asList(huAttr),
+					Arrays.asList(schedAttr));
+
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).getValue()).isEqualTo("P17");
+		}
+
+		@Test
+		void emptySchedASI_and_no_HU()
+		{
+			// schedule ASI value equals the empty value, and no HU attribute -> nothing in result
+			final IAttributeValue schedAttr = stubAttributeValue(1, "", "", true);
+
+			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
+					Collections.emptyList(),
+					Arrays.asList(schedAttr));
+
+			assertThat(result).isEmpty();
+		}
+
+		@Test
+		void noSchedASI_uses_HU()
+		{
+			final IAttributeValue huAttr = stubAttributeValue(1, "P17", "", true);
+
+			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
+					Arrays.asList(huAttr),
+					Collections.emptyList());
+
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).getValue()).isEqualTo("P17");
+		}
+
+		@Test
+		void partial_empty_merges()
+		{
+			// Attribute A (id=1): schedASI="P13", HU="P17" -> schedASI wins
+			// Attribute B (id=2): schedASI=empty, HU="K1" -> HU wins (fallback)
+			final IAttributeValue huAttrA = stubAttributeValue(1, "P17", "", true);
+			final IAttributeValue huAttrB = stubAttributeValue(2, "K1", "", true);
+			final IAttributeValue schedAttrA = stubAttributeValue(1, "P13", "", true);
+			final IAttributeValue schedAttrB = stubAttributeValue(2, "", "", true);
+
+			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
+					Arrays.asList(huAttrA, huAttrB),
+					Arrays.asList(schedAttrA, schedAttrB));
+
+			assertThat(result).hasSize(2);
+
+			// Find by attribute ID and verify values
+			final IAttributeValue resultA = result.stream()
+					.filter(av -> av.getM_Attribute().getM_Attribute_ID() == 1)
+					.findFirst().orElseThrow(() -> new AssertionError("Attribute A not found"));
+			final IAttributeValue resultB = result.stream()
+					.filter(av -> av.getM_Attribute().getM_Attribute_ID() == 2)
+					.findFirst().orElseThrow(() -> new AssertionError("Attribute B not found"));
+
+			assertThat(resultA.getValue()).isEqualTo("P13");
+			assertThat(resultB.getValue()).isEqualTo("K1");
+		}
+
+		@Test
+		void schedASI_with_null_value_falls_back_to_HU()
+		{
+			final IAttributeValue huAttr = stubAttributeValue(1, "P17", null, true);
+			// schedule ASI value is null, empty value is also null -> treated as empty
+			final IAttributeValue schedAttr = stubAttributeValue(1, null, null, true);
+
+			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
+					Arrays.asList(huAttr),
+					Arrays.asList(schedAttr));
+
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).getValue()).isEqualTo("P17");
+		}
+
+		@Test
+		void schedASI_not_useInASI_is_excluded()
+		{
+			// Schedule ASI attribute with isUseInASI=false should be excluded
+			final IAttributeValue schedAttr = stubAttributeValue(1, "P13", "", false);
+
+			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
+					Collections.emptyList(),
+					Arrays.asList(schedAttr));
+
+			assertThat(result).isEmpty();
+		}
+
+		/**
+		 * Creates a stub {@link IAttributeValue} with the given attribute ID, value, empty value, and useInASI flag.
+		 * Uses POJOWrapper-backed {@link I_M_Attribute} instances from the test environment.
+		 */
+		private IAttributeValue stubAttributeValue(
+				final int attributeId,
+				@Nullable final Object value,
+				@Nullable final Object emptyValue,
+				final boolean useInASI)
+		{
+			final I_M_Attribute attribute = newInstance(I_M_Attribute.class);
+			attribute.setM_Attribute_ID(attributeId);
+			attribute.setValue("Attr" + attributeId);
+			attribute.setName("Attr" + attributeId);
+			saveRecord(attribute);
+
+			return new StubAttributeValue(attribute, value, emptyValue, useInASI);
+		}
+	}
+
+	/**
+	 * Minimal stub implementation of {@link IAttributeValue} for unit-testing the merge logic.
+	 * Only the methods actually used by {@link ShipmentScheduleWithHU#mergeAttributeValues} are implemented;
+	 * the rest throw {@link UnsupportedOperationException}.
+	 */
+	private static class StubAttributeValue implements IAttributeValue
+	{
+		private final I_M_Attribute attribute;
+		private final Object value;
+		private final Object emptyValue;
+		private final boolean useInASI;
+
+		StubAttributeValue(
+				@NonNull final I_M_Attribute attribute,
+				@Nullable final Object value,
+				@Nullable final Object emptyValue,
+				final boolean useInASI)
+		{
+			this.attribute = attribute;
+			this.value = value;
+			this.emptyValue = emptyValue;
+			this.useInASI = useInASI;
+		}
+
+		@Override public I_M_Attribute getM_Attribute() { return attribute; }
+		@Override public Object getValue() { return value; }
+		@Override @Nullable public Object getEmptyValue() { return emptyValue; }
+		@Override public boolean isUseInASI() { return useInASI; }
+		@Override public boolean isEmpty() { return java.util.Objects.equals(value, emptyValue); }
+		@Override public AttributeCode getAttributeCode() { return AttributeCode.ofString(attribute.getValue()); }
+
+		// --- Below: not needed for the merge logic, throw UnsupportedOperationException ---
+		@Override public String getAttributeValueType() { throw new UnsupportedOperationException(); }
+		@Override public void setValue(final IAttributeValueContext ctx, final Object val) { throw new UnsupportedOperationException(); }
+		@Override public Object getValueInitial() { throw new UnsupportedOperationException(); }
+		@Override public void setValueInitial(final Object valueInitial) { throw new UnsupportedOperationException(); }
+		@Override public BigDecimal getValueAsBigDecimal() { throw new UnsupportedOperationException(); }
+		@Override public int getValueAsInt() { throw new UnsupportedOperationException(); }
+		@Override public BigDecimal getValueInitialAsBigDecimal() { throw new UnsupportedOperationException(); }
+		@Override public String getValueAsString() { throw new UnsupportedOperationException(); }
+		@Override public String getValueInitialAsString() { throw new UnsupportedOperationException(); }
+		@Override public Date getValueAsDate() { throw new UnsupportedOperationException(); }
+		@Override public Date getValueInitialAsDate() { throw new UnsupportedOperationException(); }
+		@Override public boolean isNumericValue() { throw new UnsupportedOperationException(); }
+		@Override public boolean isStringValue() { throw new UnsupportedOperationException(); }
+		@Override public boolean isDateValue() { throw new UnsupportedOperationException(); }
+		@Override public String getPropagationType() { throw new UnsupportedOperationException(); }
+		@Override public IAttributeAggregationStrategy retrieveAggregationStrategy() { throw new UnsupportedOperationException(); }
+		@Override public IAttributeSplitterStrategy retrieveSplitterStrategy() { throw new UnsupportedOperationException(); }
+		@Override public IAttributeValueCallout getAttributeValueCallout() { throw new UnsupportedOperationException(); }
+		@Override public IAttributeValueGenerator getAttributeValueGeneratorOrNull() { throw new UnsupportedOperationException(); }
+		@Override public IHUAttributeTransferStrategy retrieveTransferStrategy() { throw new UnsupportedOperationException(); }
+		@Override public void addAttributeValueListener(final IAttributeValueListener listener) { throw new UnsupportedOperationException(); }
+		@Override public void removeAttributeValueListener(final IAttributeValueListener listener) { throw new UnsupportedOperationException(); }
+		@Override public boolean isList() { throw new UnsupportedOperationException(); }
+		@Override public List<? extends NamePair> getAvailableValues() { throw new UnsupportedOperationException(); }
+		@Override public IAttributeValuesProvider getAttributeValuesProvider() { throw new UnsupportedOperationException(); }
+		@Override public I_C_UOM getC_UOM() { throw new UnsupportedOperationException(); }
+		@Override public boolean isReadonlyUI() { throw new UnsupportedOperationException(); }
+		@Override public boolean isDisplayedUI() { throw new UnsupportedOperationException(); }
+		@Override public boolean isMandatory() { throw new UnsupportedOperationException(); }
+		@Override public boolean isOnlyIfInProductAttributeSet() { throw new UnsupportedOperationException(); }
+		@Override public int getDisplaySeqNo() { throw new UnsupportedOperationException(); }
+		@Override public boolean isDefinedByTemplate() { throw new UnsupportedOperationException(); }
+		@Override public NamePair getNullAttributeValue() { throw new UnsupportedOperationException(); }
+		@Override public boolean isNew() { throw new UnsupportedOperationException(); }
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleWithHUTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleWithHUTests.java
@@ -390,7 +390,7 @@ public class ShipmentScheduleWithHUTests
 			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
 					Arrays.asList(huAttr),
 					Arrays.asList(schedAttr),
-					attribute -> false /* schedule ASI wins */);
+					ShipmentScheduleWithHU.SCHEDULE_ASI_ALWAYS_WINS);
 
 			assertThat(result).hasSize(1);
 			assertThat(result.get(0).getValue()).isEqualTo("P13");
@@ -406,7 +406,7 @@ public class ShipmentScheduleWithHUTests
 			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
 					Arrays.asList(huAttr),
 					Arrays.asList(schedAttr),
-					attribute -> true /* HU wins */);
+					ShipmentScheduleWithHU.HU_ALWAYS_WINS);
 
 			assertThat(result).hasSize(1);
 			assertThat(result.get(0).getValue()).isEqualTo("P17");
@@ -419,7 +419,8 @@ public class ShipmentScheduleWithHUTests
 
 			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
 					Collections.emptyList(),
-					Arrays.asList(schedAttr));
+					Arrays.asList(schedAttr),
+					ShipmentScheduleWithHU.HU_ALWAYS_WINS);
 
 			assertThat(result).hasSize(1);
 			assertThat(result.get(0).getValue()).isEqualTo("P13");
@@ -434,7 +435,8 @@ public class ShipmentScheduleWithHUTests
 
 			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
 					Arrays.asList(huAttr),
-					Arrays.asList(schedAttr));
+					Arrays.asList(schedAttr),
+					ShipmentScheduleWithHU.HU_ALWAYS_WINS);
 
 			assertThat(result).hasSize(1);
 			assertThat(result.get(0).getValue()).isEqualTo("P17");
@@ -448,7 +450,8 @@ public class ShipmentScheduleWithHUTests
 
 			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
 					Collections.emptyList(),
-					Arrays.asList(schedAttr));
+					Arrays.asList(schedAttr),
+					ShipmentScheduleWithHU.HU_ALWAYS_WINS);
 
 			assertThat(result).isEmpty();
 		}
@@ -460,7 +463,8 @@ public class ShipmentScheduleWithHUTests
 
 			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
 					Arrays.asList(huAttr),
-					Collections.emptyList());
+					Collections.emptyList(),
+					ShipmentScheduleWithHU.HU_ALWAYS_WINS);
 
 			assertThat(result).hasSize(1);
 			assertThat(result.get(0).getValue()).isEqualTo("P17");
@@ -480,7 +484,7 @@ public class ShipmentScheduleWithHUTests
 			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
 					Arrays.asList(huAttrA, huAttrB),
 					Arrays.asList(schedAttrA, schedAttrB),
-					attribute -> false /* schedule ASI wins */);
+					ShipmentScheduleWithHU.SCHEDULE_ASI_ALWAYS_WINS);
 
 			assertThat(result).hasSize(2);
 
@@ -505,7 +509,8 @@ public class ShipmentScheduleWithHUTests
 
 			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
 					Arrays.asList(huAttr),
-					Arrays.asList(schedAttr));
+					Arrays.asList(schedAttr),
+					ShipmentScheduleWithHU.HU_ALWAYS_WINS);
 
 			assertThat(result).hasSize(1);
 			assertThat(result.get(0).getValue()).isEqualTo("P17");
@@ -520,7 +525,8 @@ public class ShipmentScheduleWithHUTests
 
 			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
 					Arrays.asList(huAttrA),
-					Arrays.asList(schedAttrB));
+					Arrays.asList(schedAttrB),
+					ShipmentScheduleWithHU.HU_ALWAYS_WINS);
 
 			assertThat(result).hasSize(2);
 			final IAttributeValue resultA = result.stream().filter(av -> av.getM_Attribute().getM_Attribute_ID() == 1).findFirst().orElse(null);

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleWithHUTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleWithHUTests.java
@@ -491,6 +491,26 @@ public class ShipmentScheduleWithHUTests
 			assertThat(result.get(0).getValue()).isEqualTo("P17");
 		}
 
+		@Test
+		void schedASI_adds_attribute_not_present_in_HU()
+		{
+			// HU has attribute A, schedule ASI has attribute B (no overlap) -> both in result
+			final IAttributeValue huAttrA = stubAttributeValue(1, "P17", "", true);
+			final IAttributeValue schedAttrB = stubAttributeValue(2, "K1", "", true);
+
+			final ImmutableList<IAttributeValue> result = ShipmentScheduleWithHU.mergeAttributeValues(
+					Arrays.asList(huAttrA),
+					Arrays.asList(schedAttrB));
+
+			assertThat(result).hasSize(2);
+			final IAttributeValue resultA = result.stream().filter(av -> av.getM_Attribute().getM_Attribute_ID() == 1).findFirst().orElse(null);
+			final IAttributeValue resultB = result.stream().filter(av -> av.getM_Attribute().getM_Attribute_ID() == 2).findFirst().orElse(null);
+			assertThat(resultA).isNotNull();
+			assertThat(resultB).isNotNull();
+			assertThat(resultA.getValue()).isEqualTo("P17");
+			assertThat(resultB.getValue()).isEqualTo("K1");
+		}
+
 		/**
 		 * Creates a stub {@link IAttributeValue} with the given attribute ID, value, empty value, and useInASI flag.
 		 * Uses POJOWrapper-backed {@link I_M_Attribute} instances from the test environment.

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/I_M_ShipmentSchedule_AttributeConfig.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/I_M_ShipmentSchedule_AttributeConfig.java
@@ -98,6 +98,29 @@ public interface I_M_ShipmentSchedule_AttributeConfig
 	String COLUMNNAME_IsActive = "IsActive";
 
 	/**
+	 * Set ME-Merkmal überschreibt Merkmalsatz.
+	 * Wenn Ja, überschreibt der ME-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsHUAttributeOverridesASI (boolean IsHUAttributeOverridesASI);
+
+	/**
+	 * Get ME-Merkmal überschreibt Merkmalsatz.
+	 * Wenn Ja, überschreibt der ME-Merkmalwert den Wert der Auftragsposition auf der Lieferzeile.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isHUAttributeOverridesASI();
+
+	ModelColumn<I_M_ShipmentSchedule_AttributeConfig, Object> COLUMN_IsHUAttributeOverridesASI = new ModelColumn<>(I_M_ShipmentSchedule_AttributeConfig.class, "IsHUAttributeOverridesASI", null);
+	String COLUMNNAME_IsHUAttributeOverridesASI = "IsHUAttributeOverridesASI";
+
+	/**
 	 * Set Merkmal.
 	 * Produkt-Merkmal
 	 *

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/X_M_ShipmentSchedule_AttributeConfig.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/X_M_ShipmentSchedule_AttributeConfig.java
@@ -35,6 +35,18 @@ public class X_M_ShipmentSchedule_AttributeConfig extends org.compiere.model.PO 
 	}
 
 	@Override
+	public void setIsHUAttributeOverridesASI (final boolean IsHUAttributeOverridesASI)
+	{
+		set_Value (COLUMNNAME_IsHUAttributeOverridesASI, IsHUAttributeOverridesASI);
+	}
+
+	@Override
+	public boolean isHUAttributeOverridesASI()
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsHUAttributeOverridesASI);
+	}
+
+	@Override
 	public void setM_Attribute_ID (final int M_Attribute_ID)
 	{
 		if (M_Attribute_ID < 1) 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/ShipmentScheduleHandler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/ShipmentScheduleHandler.java
@@ -67,6 +67,14 @@ public abstract class ShipmentScheduleHandler
 		AttributeId attributeId;
 
 		boolean onlyIfInReferencedRecordAsi;
+
+		/**
+		 * If {@code true} (default), the HU attribute value overwrites the schedule ASI value
+		 * on the shipment line during HU attribute transfer.
+		 * If {@code false}, the schedule ASI value (from the order line) takes precedence.
+		 */
+		@Builder.Default
+		boolean huAttributeOverridesASI = true;
 	}
 
 	private final static CCache<Integer, ImmutableList<AttributeConfig>> cache = CCache.newCache(
@@ -86,7 +94,9 @@ public abstract class ShipmentScheduleHandler
 						.attributeConfigId(attributeConfigRecord.getM_ShipmentSchedule_AttributeConfig_ID())
 						.orgId(attributeConfigRecord.getAD_Org_ID())
 						.attributeId(AttributeId.ofRepoIdOrNull(attributeConfigRecord.getM_Attribute_ID()))
-						.onlyIfInReferencedRecordAsi(attributeConfigRecord.isOnlyIfInReferencedASI()).build())
+						.onlyIfInReferencedRecordAsi(attributeConfigRecord.isOnlyIfInReferencedASI())
+						.huAttributeOverridesASI(attributeConfigRecord.isHUAttributeOverridesASI())
+						.build())
 				.collect(ImmutableList.toImmutableList());
 	}
 
@@ -205,6 +215,20 @@ public abstract class ShipmentScheduleHandler
 		}
 
 		return hasNonNullAttributeListValue(attributeInstance);
+	}
+
+	/**
+	 * Returns {@code true} if the HU attribute value should overwrite the schedule ASI value
+	 * for the given attribute on the shipment line. Defaults to {@code true} (backward compatible)
+	 * if no config record is found.
+	 */
+	public final boolean isHUAttributeOverridesASI(
+			@NonNull final I_M_ShipmentSchedule shipmentSchedule,
+			@NonNull final I_M_Attribute attribute)
+	{
+		return findMatchingAttributeConfig(shipmentSchedule.getAD_Org_ID(), attribute)
+				.map(AttributeConfig::isHuAttributeOverridesASI)
+				.orElse(true); // default: HU wins (backward compatible)
 	}
 
 	private boolean hasNonNullAttributeListValue(final I_M_AttributeInstance attributeInstance)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/ShipmentScheduleHandler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/ShipmentScheduleHandler.java
@@ -17,6 +17,7 @@ import lombok.Value;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.AttributeId;
+import de.metas.organization.OrgId;
 import org.adempiere.mm.attributes.AttributeListValue;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.mm.attributes.AttributeValueId;
@@ -179,7 +180,7 @@ public abstract class ShipmentScheduleHandler
 	{
 		final Optional<AttributeConfig> attributeConfigIfPresent = findMatchingAttributeConfig(
 				shipmentSchedule.getAD_Org_ID(),
-				attribute);
+				AttributeId.ofRepoId(attribute.getM_Attribute_ID()));
 		if (!attributeConfigIfPresent.isPresent())
 		{
 			return false;
@@ -223,10 +224,10 @@ public abstract class ShipmentScheduleHandler
 	 * if no config record is found.
 	 */
 	public final boolean isHUAttributeOverridesASI(
-			final int orgId,
-			@NonNull final I_M_Attribute attribute)
+			@NonNull final OrgId orgId,
+			@NonNull final AttributeId attributeId)
 	{
-		return findMatchingAttributeConfig(orgId, attribute)
+		return findMatchingAttributeConfig(orgId.getRepoId(), attributeId)
 				.map(AttributeConfig::isHuAttributeOverridesASI)
 				.orElse(true); // default: HU wins (backward compatible)
 	}
@@ -247,7 +248,7 @@ public abstract class ShipmentScheduleHandler
 	@VisibleForTesting
 	Optional<AttributeConfig> findMatchingAttributeConfig(
 			final int orgId,
-			final I_M_Attribute m_Attribute)
+			@NonNull final AttributeId attributeId)
 	{
 		final ImmutableList<AttributeConfig> attributeConfigs = getAttributeConfigs();
 
@@ -257,7 +258,7 @@ public abstract class ShipmentScheduleHandler
 
 		final Optional<AttributeConfig> matchingConfigIfPresent = attributeConfigs
 				.stream()
-				.filter(c -> AttributeId.toRepoId(c.getAttributeId()) == m_Attribute.getM_Attribute_ID())
+				.filter(c -> AttributeId.equals(c.getAttributeId(), attributeId))
 				.sorted(orgComparator)
 				.findFirst();
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/ShipmentScheduleHandler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/ShipmentScheduleHandler.java
@@ -223,10 +223,10 @@ public abstract class ShipmentScheduleHandler
 	 * if no config record is found.
 	 */
 	public final boolean isHUAttributeOverridesASI(
-			@NonNull final I_M_ShipmentSchedule shipmentSchedule,
+			final int orgId,
 			@NonNull final I_M_Attribute attribute)
 	{
-		return findMatchingAttributeConfig(shipmentSchedule.getAD_Org_ID(), attribute)
+		return findMatchingAttributeConfig(orgId, attribute)
 				.map(AttributeConfig::isHuAttributeOverridesASI)
 				.orElse(true); // default: HU wins (backward compatible)
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5798110_sys_gh29295_overhaul_M_IolCandHandler.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5798110_sys_gh29295_overhaul_M_IolCandHandler.sql
@@ -1,0 +1,5 @@
+
+-- The changes we are doing here allow an admin to add attributes to the M_ShipmentSchedule_AttributeConfig tab 
+
+UPDATE AD_Table SET description=NULL, accesslevel='6', Updated='2026-04-15 16:11:00', UpdatedBy=100 WHERE tablename = 'M_IolCandHandler';
+UPDATE M_IolCandHandler SET AD_Client_ID=1000000, Updated='2026-04-15 16:11:00', UpdatedBy=100 WHERE ad_client_id = 0;

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/spi/ShipmentScheduleHandlerTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/spi/ShipmentScheduleHandlerTest.java
@@ -102,7 +102,7 @@ public class ShipmentScheduleHandlerTest
 				.thenReturn(list);
 
 		// invoke the method under test
-		final Optional<AttributeConfig> matchingAttributeConfig = shipmentScheduleHandler.findMatchingAttributeConfig(10, attribute);
+		final Optional<AttributeConfig> matchingAttributeConfig = shipmentScheduleHandler.findMatchingAttributeConfig(10, AttributeId.ofRepoId(attribute.getM_Attribute_ID()));
 
 		assertThat(matchingAttributeConfig).isPresent();
 		assertThat(matchingAttributeConfig.get()).isSameAs(attributeConfigConfig);


### PR DESCRIPTION
## Summary
- Shipment schedule ASI (from order line) now always propagates to shipment line, bypassing the `M_ShipmentSchedule_AttributeConfig` whitelist
- HU attributes still filtered through whitelist; schedule ASI takes precedence, HU values fill gaps for empty schedule ASI values
- Extracted `mergeAttributeValues()` as testable pure function with 8 unit tests
- Renamed misleading "HU-Aggregation" tab to "Shipment Line Attribute Config" (AD_Tab_ID=541052)
- Added window 540150 ("Lieferkandidaten - Handler") to WebUI menu tree

## Test plan
- [x] Unit tests: `ShipmentScheduleWithHUTests.MergeAttributeValuesTests` — 8 scenarios for merge logic
- [x] Cucumber: `shipmentLineASIPropagation.feature` — dropship, precedence, fallback (in progress)
- [ ] Verify tab rename in WebUI
- [ ] Verify window accessible in WebUI menu