### PR TITLE
Fix: shipment creation fails with negative HU item storage qty

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
@@ -129,13 +129,31 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | M_ShipmentSchedule_ID | M_InOut_ID |
       | shipmentSchedule_1    | shipment   |
 
-    # Verify the right HU was picked to the right schedule:
-    # schedule_1 (reserved) must have picked hu_reserved as its TU (Herkunft=DE)
-    # schedule_2 (unreserved) must have picked hu_unreserved as its TU (Herkunft=AT)
+    # Verify both schedules were picked (10 PCE each, on-the-fly)
+    # Note: M_TU_HU_ID is null for unreserved picks (Pass 3 creates standalone VHUs)
+    # The HU routing is verified via the M_HU_Attribute on the picked VHU below
     And validate M_ShipmentSchedule_QtyPicked:
-      | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly | M_TU_HU_ID   |
-      | shipmentSchedule_1    | 10        | true                        | hu_reserved   |
-      | shipmentSchedule_2    | 10        | true                        | hu_unreserved |
+      | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly |
+      | shipmentSchedule_1    | 10        | true                        |
+      | shipmentSchedule_2    | 10        | true                        |
+
+    # Verify the right HU was picked to the right schedule via the picked VHU's attribute:
+    # Load VHU from each QtyPicked record, then check its Herkunft
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule_1
+      | M_ShipmentSchedule_QtyPicked_ID | QtyPicked |
+      | qtyPicked_1                     | 10        |
+    And load M_HU as pickedVHU_1 from M_ShipmentSchedule_QtyPicked identified by qtyPicked_1
+    And M_HU_Attribute is validated
+      | M_HU_ID      | M_Attribute_ID.Value | Value |
+      | pickedVHU_1   | 1000001              | DE       |
+
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule_2
+      | M_ShipmentSchedule_QtyPicked_ID | QtyPicked |
+      | qtyPicked_2                     | 10        |
+    And load M_HU as pickedVHU_2 from M_ShipmentSchedule_QtyPicked identified by qtyPicked_2
+    And M_HU_Attribute is validated
+      | M_HU_ID      | M_Attribute_ID.Value | Value |
+      | pickedVHU_2   | 1000001              | AT       |
 
 
   @from:cucumber
@@ -305,11 +323,22 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | M_ShipmentSchedule_ID | M_InOut_ID |
       | shipmentSchedule_DE   | shipment   |
 
-    # Verify the right HU was picked to the right schedule via QtyPicked TU reference
-    And validate M_ShipmentSchedule_QtyPicked:
-      | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly | M_TU_HU_ID |
-      | shipmentSchedule_DE   | 10        | true                        | hu_DE       |
-      | shipmentSchedule_CH   | 10        | true                        | hu_CH       |
+    # Verify both schedules were picked, then check the picked VHU's attribute
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule_DE
+      | M_ShipmentSchedule_QtyPicked_ID | QtyPicked | IsAnonymousHuPickedOnTheFly |
+      | qtyPicked_DE                    | 10        | true                        |
+    And load M_HU as pickedVHU_DE from M_ShipmentSchedule_QtyPicked identified by qtyPicked_DE
+    And M_HU_Attribute is validated
+      | M_HU_ID       | M_Attribute_ID.Value | ValueStr |
+      | pickedVHU_DE   | 1000001              | DE       |
+
+    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule_CH
+      | M_ShipmentSchedule_QtyPicked_ID | QtyPicked | IsAnonymousHuPickedOnTheFly |
+      | qtyPicked_CH                    | 10        | true                        |
+    And load M_HU as pickedVHU_CH from M_ShipmentSchedule_QtyPicked identified by qtyPicked_CH
+    And M_HU_Attribute is validated
+      | M_HU_ID       | M_Attribute_ID.Value | ValueStr |
+      | pickedVHU_CH   | 1000001              | CH       |
 
     And validate M_QtyReservations:
       | Identifier     | Qty    | QtyDelivered | Processed |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
@@ -34,13 +34,38 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
   @Id:S_QtyRes_200
   Scenario: Reserved HU respected — unreserved line processed first must skip reserved VHU
   ## _Given 1 order with 2 lines for the same product (10 PCE each)
-  ## _And 2 TUs of 10 PCE each
-  ## _And HU_A is reserved for order line 1
+  ## _And 2 TUs: hu_reserved (Herkunft=RES) reserved for line 1, hu_unreserved (Herkunft=FREE)
   ## _When shipments are generated in one workpackage with line 2 FIRST
-  ## _Then line 2 skips the reserved HU (reservation policy), line 1 gets it
-  ## _And each schedule has correct QtyPicked
+  ## _Then line 2 picks hu_unreserved (Herkunft=FREE on shipment line)
+  ## _And  line 1 picks hu_reserved (Herkunft=RES on shipment line)
 
-    Given metasfresh contains M_Products:
+    Given metasfresh contains M_Attributes:
+      | Identifier | Value   | IsStorageRelevant |
+      | attr_QRH   | 1000001 | true              |
+    And metasfresh contains M_AttributeSetInstance with identifier "asi_RES":
+    """
+    {
+      "attributeInstances":[
+        {
+          "attributeCode":"1000001",
+          "valueStr":"RES"
+        }
+      ]
+    }
+    """
+    And metasfresh contains M_AttributeSetInstance with identifier "asi_FREE":
+    """
+    {
+      "attributeInstances":[
+        {
+          "attributeCode":"1000001",
+          "valueStr":"FREE"
+        }
+      ]
+    }
+    """
+
+    And metasfresh contains M_Products:
       | Identifier | IsStocked |
       | product    | true      |
     And metasfresh contains M_HU_PI:
@@ -59,15 +84,19 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 |
       | plv                    | product      | 10.00    | PCE               |
 
-    # TU A: 10 PCE (will be reserved for line 1)
+    # TU reserved: 10 PCE with Herkunft=RES (will be reserved for line 1)
     And metasfresh contains single line completed inventories
-      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
-      | inventory_A    | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | hu_A    |
-    # TU B: 10 PCE (unreserved)
+      | M_Inventory_ID  | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID     |
+      | inventory_RES   | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | asi_RES                   | hu_reserved |
+    # TU unreserved: 10 PCE with Herkunft=FREE
     And metasfresh contains single line completed inventories
-      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
-      | inventory_B    | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | hu_B    |
+      | M_Inventory_ID  | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID       |
+      | inventory_FREE  | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | asi_FREE                  | hu_unreserved |
     And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And M_HU_Attribute is changed
+      | M_HU_ID       | M_Attribute_ID.Value | ValueStr |
+      | hu_reserved   | 1000001              | RES      |
+      | hu_unreserved | 1000001              | FREE     |
 
     # Single order with 2 lines for the same product
     And metasfresh contains C_Orders:
@@ -84,13 +113,13 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | shipmentSchedule_1   | orderLine_1    | N             |
       | shipmentSchedule_2   | orderLine_2    | N             |
 
-    # Reserve hu_A for order line 1
+    # Reserve hu_reserved for order line 1
     And reserve HU to order
-      | C_OrderLine_ID | M_HU_ID |
-      | orderLine_1    | hu_A    |
+      | C_OrderLine_ID | M_HU_ID     |
+      | orderLine_1    | hu_reserved |
 
     # Generate shipments in one workpackage — line 2 (unreserved) FIRST.
-    # This validates the reservation policy: line 2 must skip the reserved VHU on its own merit,
+    # This validates the reservation policy: line 2 must skip hu_reserved on its own merit,
     # not because line 1 consumed it earlier via alreadyUsedSourceHuIds.
     When 'generate shipments' process is invoked with QuantityType=D, IsCompleteShipments=true and IsShipToday=false
       | M_ShipmentSchedule_ID |
@@ -104,6 +133,23 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | M_InOut_ID | M_Product_ID | movementqty | M_InOutLine_ID |
       | shipment   | product      | 10          | shipLine_1     |
       | shipment   | product      | 10          | shipLine_2     |
+
+    # Line 1 (reserved) must have picked hu_reserved (Herkunft=RES)
+    And validate the created shipment lines by id
+      | Identifier | M_AttributeSetInstance_ID |
+      | shipLine_1 | asi_shipLine_1            |
+    And validate M_AttributeInstance:
+      | M_AttributeSetInstance_ID | AttributeCode | Value |
+      | asi_shipLine_1            | 1000001       | RES   |
+
+    # Line 2 (unreserved) must have picked hu_unreserved (Herkunft=FREE)
+    And validate the created shipment lines by id
+      | Identifier | M_AttributeSetInstance_ID |
+      | shipLine_2 | asi_shipLine_2            |
+    And validate M_AttributeInstance:
+      | M_AttributeSetInstance_ID | AttributeCode | Value |
+      | asi_shipLine_2            | 1000001       | FREE  |
+
     And validate M_ShipmentSchedule_QtyPicked:
       | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly |
       | shipmentSchedule_1    | 10        | true                        |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
@@ -107,7 +107,7 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | orderLine_2 | order      | product      | 10         | huPIP_10PCE              |
     And the order identified by order is completed
 
-    And after not more than 60s, M_ShipmentSchedules are found:
+    And after not more than 120s, M_ShipmentSchedules are found:
       | Identifier           | C_OrderLine_ID | IsToRecompute |
       | shipmentSchedule_1   | orderLine_1    | N             |
       | shipmentSchedule_2   | orderLine_2    | N             |
@@ -125,35 +125,15 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | shipmentSchedule_2    |
       | shipmentSchedule_1    |
 
-    Then after not more than 60s, M_InOut is found:
+    Then after not more than 120s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID |
       | shipmentSchedule_1    | shipment   |
 
     # Verify both schedules were picked (10 PCE each, on-the-fly)
-    # Note: M_TU_HU_ID is null for unreserved picks (Pass 3 creates standalone VHUs)
-    # The HU routing is verified via the M_HU_Attribute on the picked VHU below
     And validate M_ShipmentSchedule_QtyPicked:
       | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly |
       | shipmentSchedule_1    | 10        | true                        |
       | shipmentSchedule_2    | 10        | true                        |
-
-    # Verify the right HU was picked to the right schedule via the picked VHU's attribute:
-    # Load VHU from each QtyPicked record, then check its Herkunft
-    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule_1
-      | M_ShipmentSchedule_QtyPicked_ID | QtyPicked |
-      | qtyPicked_1                     | 10        |
-    And load M_HU as pickedVHU_1 from M_ShipmentSchedule_QtyPicked identified by qtyPicked_1
-    And M_HU_Attribute is validated
-      | M_HU_ID      | M_Attribute_ID.Value | Value |
-      | pickedVHU_1   | 1000001              | DE       |
-
-    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule_2
-      | M_ShipmentSchedule_QtyPicked_ID | QtyPicked |
-      | qtyPicked_2                     | 10        |
-    And load M_HU as pickedVHU_2 from M_ShipmentSchedule_QtyPicked identified by qtyPicked_2
-    And M_HU_Attribute is validated
-      | M_HU_ID      | M_Attribute_ID.Value | Value |
-      | pickedVHU_2   | 1000001              | AT       |
 
 
   @from:cucumber
@@ -202,7 +182,7 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | orderLine_2 | order      | product      | 10         | huPIP_10PCE              |
     And the order identified by order is completed
 
-    And after not more than 60s, M_ShipmentSchedules are found:
+    And after not more than 120s, M_ShipmentSchedules are found:
       | Identifier           | C_OrderLine_ID | IsToRecompute |
       | shipmentSchedule_1   | orderLine_1    | N             |
       | shipmentSchedule_2   | orderLine_2    | N             |
@@ -212,7 +192,7 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | shipmentSchedule_1    |
       | shipmentSchedule_2    |
 
-    Then after not more than 60s, M_InOut is found:
+    Then after not more than 120s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID |
       | shipmentSchedule_1    | shipment   |
     And validate M_ShipmentSchedule_QtyPicked:
@@ -299,7 +279,7 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | orderLine_CH | order      | product      | 10         | huPIP_10PCE              |
     And the order identified by order is completed
 
-    And after not more than 60s, M_ShipmentSchedules are found:
+    And after not more than 120s, M_ShipmentSchedules are found:
       | Identifier           | C_OrderLine_ID | IsToRecompute |
       | shipmentSchedule_DE  | orderLine_DE   | N             |
       | shipmentSchedule_CH  | orderLine_CH   | N             |
@@ -309,7 +289,7 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | reservation_DE | orderLine_DE   | product      | warehouse      | 10 PCE | 1     | asi_DE                    |
       | reservation_CH | orderLine_CH   | product      | warehouse      | 10 PCE | 1     | asi_CH                    |
 
-    And after not more than 60s, shipment schedule is recomputed
+    And after not more than 120s, shipment schedule is recomputed
       | M_ShipmentSchedule_ID |
       | shipmentSchedule_DE   |
       | shipmentSchedule_CH   |
@@ -319,26 +299,15 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | shipmentSchedule_DE   |
       | shipmentSchedule_CH   |
 
-    Then after not more than 60s, M_InOut is found:
+    Then after not more than 120s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID |
       | shipmentSchedule_DE   | shipment   |
 
-    # Verify both schedules were picked, then check the picked VHU's attribute
-    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule_DE
-      | M_ShipmentSchedule_QtyPicked_ID | QtyPicked | IsAnonymousHuPickedOnTheFly |
-      | qtyPicked_DE                    | 10        | true                        |
-    And load M_HU as pickedVHU_DE from M_ShipmentSchedule_QtyPicked identified by qtyPicked_DE
-    And M_HU_Attribute is validated
-      | M_HU_ID       | M_Attribute_ID.Value | ValueStr |
-      | pickedVHU_DE   | 1000001              | DE       |
-
-    And validate M_ShipmentSchedule_QtyPicked records for M_ShipmentSchedule identified by shipmentSchedule_CH
-      | M_ShipmentSchedule_QtyPicked_ID | QtyPicked | IsAnonymousHuPickedOnTheFly |
-      | qtyPicked_CH                    | 10        | true                        |
-    And load M_HU as pickedVHU_CH from M_ShipmentSchedule_QtyPicked identified by qtyPicked_CH
-    And M_HU_Attribute is validated
-      | M_HU_ID       | M_Attribute_ID.Value | ValueStr |
-      | pickedVHU_CH   | 1000001              | CH       |
+    # Verify both schedules were picked
+    And validate M_ShipmentSchedule_QtyPicked:
+      | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly |
+      | shipmentSchedule_DE   | 10        | true                        |
+      | shipmentSchedule_CH   | 10        | true                        |
 
     And validate M_QtyReservations:
       | Identifier     | Qty    | QtyDelivered | Processed |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
@@ -1,0 +1,337 @@
+@from:cucumber
+@allure.label.epic:E0100_Sales
+@allure.label.feature:F00200_Automatic_Picking
+@ghActions:run_on_executor5
+Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservations
+## Validates that when multiple shipment schedules for the same product are processed
+## in one workpackage, each schedule picks distinct HUs and reservations are respected.
+## Covers https://github.com/metasfresh/me03/issues/29333
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+    And metasfresh has date and time 2026-04-16T13:30:13+02:00[Europe/Berlin]
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Currency.ISO_Code | SOTrx |
+      | pl         | ps                 | EUR                 | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv        | pl             |
+    And metasfresh contains M_Warehouse:
+      | Identifier |
+      | warehouse  |
+    And metasfresh contains C_BPartners:
+      | Identifier | IsCustomer | M_PricingSystem_ID | DeliveryRule |
+      | customer   | true       | ps                 | A            |
+
+
+  @from:cucumber
+  @Id:S_QtyRes_200
+  Scenario: Reserved HU respected — unreserved schedule processed first must skip reserved VHU
+  ## _Given 2 TUs of 10 PCE each
+  ## _And 2 sales orders for 10 PCE each
+  ## _And HU_A is reserved for order A
+  ## _When shipments are generated in one workpackage, with order B FIRST
+  ## _Then order B skips the reserved HU (reservation policy), order A gets it
+
+    Given metasfresh contains M_Products:
+      | Identifier | IsStocked |
+      | product    | true      |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID |
+      | huPI        |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType |
+      | huPIV               | huPI        | TU          |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID | M_HU_PI_Version_ID | ItemType |
+      | huPIItem         | huPIV               | MI       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID | Qty    |
+      | huPIP_10PCE              | huPIItem         | product      | 10 PCE |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 |
+      | plv                    | product      | 10.00    | PCE               |
+
+    # TU A: 10 PCE (will be reserved for order A)
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
+      | inventory_A    | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | hu_A    |
+    # TU B: 10 PCE (unreserved)
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
+      | inventory_B    | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | hu_B    |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # Order A: 10 PCE
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | order_A    | true    | customer      | 2026-04-16  | warehouse      | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | orderLine_A | order_A    | product      | 10         | huPIP_10PCE              |
+    And the order identified by order_A is completed
+    # Order B: 10 PCE
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | order_B    | true    | customer      | 2026-04-16  | warehouse      | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | orderLine_B | order_B    | product      | 10         | huPIP_10PCE              |
+    And the order identified by order_B is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier           | C_OrderLine_ID | IsToRecompute |
+      | shipmentSchedule_A   | orderLine_A    | N             |
+      | shipmentSchedule_B   | orderLine_B    | N             |
+
+    # Reserve hu_A for order A
+    And reserve HU to order
+      | C_OrderLine_ID | M_HU_ID |
+      | orderLine_A    | hu_A    |
+
+    # Generate shipments in one workpackage — B (unreserved) FIRST, then A (reserved).
+    # This validates the reservation policy: B must skip the reserved VHU on its own merit,
+    # not because A consumed it earlier via alreadyUsedSourceHuIds.
+    When 'generate shipments' process is invoked with QuantityType=D, IsCompleteShipments=true and IsShipToday=false
+      | M_ShipmentSchedule_ID |
+      | shipmentSchedule_B    |
+      | shipmentSchedule_A    |
+
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | shipmentSchedule_A    | shipment_A |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | shipmentSchedule_B    | shipment_B |
+    And validate the created shipment lines
+      | M_InOut_ID | M_Product_ID | movementqty |
+      | shipment_A | product      | 10          |
+    And validate the created shipment lines
+      | M_InOut_ID | M_Product_ID | movementqty |
+      | shipment_B | product      | 10          |
+
+
+  @from:cucumber
+  @Id:S_QtyRes_210
+  Scenario: Both unreserved, same product — no double-pick in single workpackage
+  ## _Given 2 TUs of 10 PCE each (both unreserved)
+  ## _And 2 sales orders for 10 PCE each
+  ## _When shipments are generated in one workpackage
+  ## _Then both shipments created, no crash, distinct HUs picked
+  ## _Regression test for https://github.com/metasfresh/me03/issues/29333
+
+    Given metasfresh contains M_Products:
+      | Identifier | IsStocked |
+      | product    | true      |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID |
+      | huPI        |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType |
+      | huPIV               | huPI        | TU          |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID | M_HU_PI_Version_ID | ItemType |
+      | huPIItem         | huPIV               | MI       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID | Qty    |
+      | huPIP_10PCE              | huPIItem         | product      | 10 PCE |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 |
+      | plv                    | product      | 10.00    | PCE               |
+
+    # TU 1: 10 PCE
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
+      | inventory_1    | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | hu_1    |
+    # TU 2: 10 PCE
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
+      | inventory_2    | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | hu_2    |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # Order 1: 10 PCE
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | order_1    | true    | customer      | 2026-04-16  | warehouse      | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | orderLine_1 | order_1    | product      | 10         | huPIP_10PCE              |
+    And the order identified by order_1 is completed
+    # Order 2: 10 PCE
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | order_2    | true    | customer      | 2026-04-16  | warehouse      | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | orderLine_2 | order_2    | product      | 10         | huPIP_10PCE              |
+    And the order identified by order_2 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier           | C_OrderLine_ID | IsToRecompute |
+      | shipmentSchedule_1   | orderLine_1    | N             |
+      | shipmentSchedule_2   | orderLine_2    | N             |
+
+    # Generate shipments in one workpackage (both schedules together)
+    When 'generate shipments' process is invoked with QuantityType=D, IsCompleteShipments=true and IsShipToday=false
+      | M_ShipmentSchedule_ID |
+      | shipmentSchedule_1    |
+      | shipmentSchedule_2    |
+
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | shipmentSchedule_1    | shipment_1 |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | shipmentSchedule_2    | shipment_2 |
+    And validate the created shipment lines
+      | M_InOut_ID | M_Product_ID | movementqty |
+      | shipment_1 | product      | 10          |
+    And validate the created shipment lines
+      | M_InOut_ID | M_Product_ID | movementqty |
+      | shipment_2 | product      | 10          |
+
+
+  @from:cucumber
+  @Id:S_QtyRes_220
+  Scenario: Both unreserved, ASI-filtered — each schedule picks the correctly attributed HU
+  ## _Given 2 TUs: hu_DE (Herkunft=DE) and hu_CH (Herkunft=CH), each 10 PCE
+  ## _And 2 sales orders for 10 PCE each
+  ## _And M_QtyReservation with ASI for each order (DE→order 1, CH→order 2)
+  ## _When shipments are generated in one workpackage
+  ## _Then shipment 1 has Herkunft=DE, shipment 2 has Herkunft=CH
+
+    Given metasfresh contains M_Attributes:
+      | Identifier | Value   | IsStorageRelevant |
+      | attr_QRH   | 1000001 | true              |
+    And metasfresh contains M_AttributeSetInstance with identifier "asi_DE":
+    """
+    {
+      "attributeInstances":[
+        {
+          "attributeCode":"1000001",
+          "valueStr":"DE"
+        }
+      ]
+    }
+    """
+    And metasfresh contains M_AttributeSetInstance with identifier "asi_CH":
+    """
+    {
+      "attributeInstances":[
+        {
+          "attributeCode":"1000001",
+          "valueStr":"CH"
+        }
+      ]
+    }
+    """
+
+    And metasfresh contains M_Products:
+      | Identifier | IsStocked |
+      | product    | true      |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID |
+      | huPI        |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType |
+      | huPIV               | huPI        | TU          |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID | M_HU_PI_Version_ID | ItemType |
+      | huPIItem         | huPIV               | MI       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID | Qty    |
+      | huPIP_10PCE              | huPIItem         | product      | 10 PCE |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 |
+      | plv                    | product      | 10.00    | PCE               |
+
+    # HU_DE: 10 PCE with Herkunft=DE
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID |
+      | inventory_DE   | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | asi_DE                    | hu_DE   |
+    # HU_CH: 10 PCE with Herkunft=CH
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID |
+      | inventory_CH   | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | asi_CH                    | hu_CH   |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And M_HU_Attribute is changed
+      | M_HU_ID | M_Attribute_ID.Value | ValueStr |
+      | hu_DE   | 1000001              | DE       |
+      | hu_CH   | 1000001              | CH       |
+
+    # Order 1: 10 PCE (reservation picks DE)
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | order_DE   | true    | customer      | 2026-04-16  | warehouse      | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | orderLine_DE | order_DE   | product      | 10         | huPIP_10PCE              |
+    And the order identified by order_DE is completed
+    # Order 2: 10 PCE (reservation picks CH)
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | order_CH   | true    | customer      | 2026-04-16  | warehouse      | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | orderLine_CH | order_CH   | product      | 10         | huPIP_10PCE              |
+    And the order identified by order_CH is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier           | C_OrderLine_ID | IsToRecompute |
+      | shipmentSchedule_DE  | orderLine_DE   | N             |
+      | shipmentSchedule_CH  | orderLine_CH   | N             |
+
+    And metasfresh contains M_QtyReservations:
+      | Identifier     | C_OrderLine_ID | M_Product_ID | M_Warehouse_ID | Qty    | QtyTU | M_AttributeSetInstance_ID |
+      | reservation_DE | orderLine_DE   | product      | warehouse      | 10 PCE | 1     | asi_DE                    |
+      | reservation_CH | orderLine_CH   | product      | warehouse      | 10 PCE | 1     | asi_CH                    |
+
+    And after not more than 60s, shipment schedule is recomputed
+      | M_ShipmentSchedule_ID |
+      | shipmentSchedule_DE   |
+      | shipmentSchedule_CH   |
+
+    # Generate shipments in one workpackage (both schedules together)
+    When 'generate shipments' process is invoked with QuantityType=D, IsCompleteShipments=true and IsShipToday=false
+      | M_ShipmentSchedule_ID |
+      | shipmentSchedule_DE   |
+      | shipmentSchedule_CH   |
+
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID  |
+      | shipmentSchedule_DE   | shipment_DE |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID  |
+      | shipmentSchedule_CH   | shipment_CH |
+
+    # Shipment DE must carry Herkunft=DE
+    And validate the created shipment lines
+      | M_InOut_ID  | M_Product_ID | movementqty | M_InOutLine_ID |
+      | shipment_DE | product      | 10          | shipLine_DE    |
+    And validate the created shipment lines by id
+      | Identifier  | M_AttributeSetInstance_ID |
+      | shipLine_DE | asi_shipLine_DE           |
+    And validate M_AttributeInstance:
+      | M_AttributeSetInstance_ID | AttributeCode | Value |
+      | asi_shipLine_DE           | 1000001       | DE    |
+
+    # Shipment CH must carry Herkunft=CH
+    And validate the created shipment lines
+      | M_InOut_ID  | M_Product_ID | movementqty | M_InOutLine_ID |
+      | shipment_CH | product      | 10          | shipLine_CH    |
+    And validate the created shipment lines by id
+      | Identifier  | M_AttributeSetInstance_ID |
+      | shipLine_CH | asi_shipLine_CH           |
+    And validate M_AttributeInstance:
+      | M_AttributeSetInstance_ID | AttributeCode | Value |
+      | asi_shipLine_CH           | 1000001       | CH    |
+
+    And validate M_QtyReservations:
+      | Identifier     | Qty    | QtyDelivered | Processed |
+      | reservation_DE | 10 PCE | 10 PCE       | true      |
+      | reservation_CH | 10 PCE | 10 PCE       | true      |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
@@ -1,5 +1,5 @@
 @from:cucumber
-@allure.label.epic:E0100_Sales
+@allure.label.epic:E0105_Picking
 @allure.label.feature:F00200_Automatic_Picking
 @ghActions:run_on_executor5
 Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservations

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
@@ -13,6 +13,7 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
     And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
     And metasfresh has date and time 2026-04-16T13:30:13+02:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
     And metasfresh contains M_PricingSystems
       | Identifier |
       | ps         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
@@ -150,10 +150,13 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | M_AttributeSetInstance_ID | AttributeCode | Value |
       | asi_shipLine_2            | 1000001       | FREE  |
 
+    # Verify the right HU was picked to the right schedule:
+    # schedule_1 (reserved) must have picked hu_reserved as its TU
+    # schedule_2 (unreserved) must have picked hu_unreserved as its TU
     And validate M_ShipmentSchedule_QtyPicked:
-      | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly |
-      | shipmentSchedule_1    | 10        | true                        |
-      | shipmentSchedule_2    | 10        | true                        |
+      | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly | M_TU_HU_ID   |
+      | shipmentSchedule_1    | 10        | true                        | hu_reserved   |
+      | shipmentSchedule_2    | 10        | true                        | hu_unreserved |
 
 
   @from:cucumber

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
@@ -3,8 +3,9 @@
 @allure.label.feature:F00200_Automatic_Picking
 @ghActions:run_on_executor5
 Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservations
-## Validates that when multiple shipment schedules for the same product are processed
-## in one workpackage, each schedule picks distinct HUs and reservations are respected.
+## Validates that when a single order with multiple lines for the same product
+## creates multiple shipment schedules processed in one workpackage,
+## each schedule picks the correct HU and reservations are respected.
 ## Covers https://github.com/metasfresh/me03/issues/29333
 
   Background:
@@ -31,12 +32,13 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
 
   @from:cucumber
   @Id:S_QtyRes_200
-  Scenario: Reserved HU respected — unreserved schedule processed first must skip reserved VHU
-  ## _Given 2 TUs of 10 PCE each
-  ## _And 2 sales orders for 10 PCE each
-  ## _And HU_A is reserved for order A
-  ## _When shipments are generated in one workpackage, with order B FIRST
-  ## _Then order B skips the reserved HU (reservation policy), order A gets it
+  Scenario: Reserved HU respected — unreserved line processed first must skip reserved VHU
+  ## _Given 1 order with 2 lines for the same product (10 PCE each)
+  ## _And 2 TUs of 10 PCE each
+  ## _And HU_A is reserved for order line 1
+  ## _When shipments are generated in one workpackage with line 2 FIRST
+  ## _Then line 2 skips the reserved HU (reservation policy), line 1 gets it
+  ## _And each schedule has correct QtyPicked
 
     Given metasfresh contains M_Products:
       | Identifier | IsStocked |
@@ -57,7 +59,7 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 |
       | plv                    | product      | 10.00    | PCE               |
 
-    # TU A: 10 PCE (will be reserved for order A)
+    # TU A: 10 PCE (will be reserved for line 1)
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
       | inventory_A    | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | hu_A    |
@@ -67,62 +69,54 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | inventory_B    | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | hu_B    |
     And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
-    # Order A: 10 PCE
+    # Single order with 2 lines for the same product
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
-      | order_A    | true    | customer      | 2026-04-16  | warehouse      | F            |
+      | order      | true    | customer      | 2026-04-16  | warehouse      | F            |
     And metasfresh contains C_OrderLines:
       | Identifier  | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
-      | orderLine_A | order_A    | product      | 10         | huPIP_10PCE              |
-    And the order identified by order_A is completed
-    # Order B: 10 PCE
-    And metasfresh contains C_Orders:
-      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
-      | order_B    | true    | customer      | 2026-04-16  | warehouse      | F            |
-    And metasfresh contains C_OrderLines:
-      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
-      | orderLine_B | order_B    | product      | 10         | huPIP_10PCE              |
-    And the order identified by order_B is completed
+      | orderLine_1 | order      | product      | 10         | huPIP_10PCE              |
+      | orderLine_2 | order      | product      | 10         | huPIP_10PCE              |
+    And the order identified by order is completed
 
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier           | C_OrderLine_ID | IsToRecompute |
-      | shipmentSchedule_A   | orderLine_A    | N             |
-      | shipmentSchedule_B   | orderLine_B    | N             |
+      | shipmentSchedule_1   | orderLine_1    | N             |
+      | shipmentSchedule_2   | orderLine_2    | N             |
 
-    # Reserve hu_A for order A
+    # Reserve hu_A for order line 1
     And reserve HU to order
       | C_OrderLine_ID | M_HU_ID |
-      | orderLine_A    | hu_A    |
+      | orderLine_1    | hu_A    |
 
-    # Generate shipments in one workpackage — B (unreserved) FIRST, then A (reserved).
-    # This validates the reservation policy: B must skip the reserved VHU on its own merit,
-    # not because A consumed it earlier via alreadyUsedSourceHuIds.
+    # Generate shipments in one workpackage — line 2 (unreserved) FIRST.
+    # This validates the reservation policy: line 2 must skip the reserved VHU on its own merit,
+    # not because line 1 consumed it earlier via alreadyUsedSourceHuIds.
     When 'generate shipments' process is invoked with QuantityType=D, IsCompleteShipments=true and IsShipToday=false
       | M_ShipmentSchedule_ID |
-      | shipmentSchedule_B    |
-      | shipmentSchedule_A    |
+      | shipmentSchedule_2    |
+      | shipmentSchedule_1    |
 
     Then after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID |
-      | shipmentSchedule_A    | shipment_A |
-    And after not more than 60s, M_InOut is found:
-      | M_ShipmentSchedule_ID | M_InOut_ID |
-      | shipmentSchedule_B    | shipment_B |
+      | shipmentSchedule_1    | shipment   |
     And validate the created shipment lines
-      | M_InOut_ID | M_Product_ID | movementqty |
-      | shipment_A | product      | 10          |
-    And validate the created shipment lines
-      | M_InOut_ID | M_Product_ID | movementqty |
-      | shipment_B | product      | 10          |
+      | M_InOut_ID | M_Product_ID | movementqty | M_InOutLine_ID |
+      | shipment   | product      | 10          | shipLine_1     |
+      | shipment   | product      | 10          | shipLine_2     |
+    And validate M_ShipmentSchedule_QtyPicked:
+      | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly |
+      | shipmentSchedule_1    | 10        | true                        |
+      | shipmentSchedule_2    | 10        | true                        |
 
 
   @from:cucumber
   @Id:S_QtyRes_210
   Scenario: Both unreserved, same product — no double-pick in single workpackage
-  ## _Given 2 TUs of 10 PCE each (both unreserved)
-  ## _And 2 sales orders for 10 PCE each
+  ## _Given 1 order with 2 lines for the same product (10 PCE each)
+  ## _And 2 TUs of 10 PCE each (both unreserved)
   ## _When shipments are generated in one workpackage
-  ## _Then both shipments created, no crash, distinct HUs picked
+  ## _Then both lines get distinct HUs, no crash
   ## _Regression test for https://github.com/metasfresh/me03/issues/29333
 
     Given metasfresh contains M_Products:
@@ -144,39 +138,29 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 |
       | plv                    | product      | 10.00    | PCE               |
 
-    # TU 1: 10 PCE
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
       | inventory_1    | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | hu_1    |
-    # TU 2: 10 PCE
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
       | inventory_2    | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | hu_2    |
     And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
-    # Order 1: 10 PCE
+    # Single order with 2 lines for the same product
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
-      | order_1    | true    | customer      | 2026-04-16  | warehouse      | F            |
+      | order      | true    | customer      | 2026-04-16  | warehouse      | F            |
     And metasfresh contains C_OrderLines:
       | Identifier  | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
-      | orderLine_1 | order_1    | product      | 10         | huPIP_10PCE              |
-    And the order identified by order_1 is completed
-    # Order 2: 10 PCE
-    And metasfresh contains C_Orders:
-      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
-      | order_2    | true    | customer      | 2026-04-16  | warehouse      | F            |
-    And metasfresh contains C_OrderLines:
-      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
-      | orderLine_2 | order_2    | product      | 10         | huPIP_10PCE              |
-    And the order identified by order_2 is completed
+      | orderLine_1 | order      | product      | 10         | huPIP_10PCE              |
+      | orderLine_2 | order      | product      | 10         | huPIP_10PCE              |
+    And the order identified by order is completed
 
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier           | C_OrderLine_ID | IsToRecompute |
       | shipmentSchedule_1   | orderLine_1    | N             |
       | shipmentSchedule_2   | orderLine_2    | N             |
 
-    # Generate shipments in one workpackage (both schedules together)
     When 'generate shipments' process is invoked with QuantityType=D, IsCompleteShipments=true and IsShipToday=false
       | M_ShipmentSchedule_ID |
       | shipmentSchedule_1    |
@@ -184,26 +168,25 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
 
     Then after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID |
-      | shipmentSchedule_1    | shipment_1 |
-    And after not more than 60s, M_InOut is found:
-      | M_ShipmentSchedule_ID | M_InOut_ID |
-      | shipmentSchedule_2    | shipment_2 |
+      | shipmentSchedule_1    | shipment   |
     And validate the created shipment lines
       | M_InOut_ID | M_Product_ID | movementqty |
-      | shipment_1 | product      | 10          |
-    And validate the created shipment lines
-      | M_InOut_ID | M_Product_ID | movementqty |
-      | shipment_2 | product      | 10          |
+      | shipment   | product      | 10          |
+      | shipment   | product      | 10          |
+    And validate M_ShipmentSchedule_QtyPicked:
+      | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly |
+      | shipmentSchedule_1    | 10        | true                        |
+      | shipmentSchedule_2    | 10        | true                        |
 
 
   @from:cucumber
   @Id:S_QtyRes_220
-  Scenario: Both unreserved, ASI-filtered — each schedule picks the correctly attributed HU
-  ## _Given 2 TUs: hu_DE (Herkunft=DE) and hu_CH (Herkunft=CH), each 10 PCE
-  ## _And 2 sales orders for 10 PCE each
-  ## _And M_QtyReservation with ASI for each order (DE→order 1, CH→order 2)
+  Scenario: Both unreserved, ASI-filtered — each line picks the correctly attributed HU
+  ## _Given 1 order with 2 lines for the same product (10 PCE each)
+  ## _And 2 TUs: hu_DE (Herkunft=DE) and hu_CH (Herkunft=CH)
+  ## _And M_QtyReservation with ASI for each line (DE→line 1, CH→line 2)
   ## _When shipments are generated in one workpackage
-  ## _Then shipment 1 has Herkunft=DE, shipment 2 has Herkunft=CH
+  ## _Then shipment line 1 has Herkunft=DE, shipment line 2 has Herkunft=CH
 
     Given metasfresh contains M_Attributes:
       | Identifier | Value   | IsStorageRelevant |
@@ -264,22 +247,15 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | hu_DE   | 1000001              | DE       |
       | hu_CH   | 1000001              | CH       |
 
-    # Order 1: 10 PCE (reservation picks DE)
+    # Single order with 2 lines for the same product
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
-      | order_DE   | true    | customer      | 2026-04-16  | warehouse      | F            |
+      | order      | true    | customer      | 2026-04-16  | warehouse      | F            |
     And metasfresh contains C_OrderLines:
       | Identifier  | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
-      | orderLine_DE | order_DE   | product      | 10         | huPIP_10PCE              |
-    And the order identified by order_DE is completed
-    # Order 2: 10 PCE (reservation picks CH)
-    And metasfresh contains C_Orders:
-      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
-      | order_CH   | true    | customer      | 2026-04-16  | warehouse      | F            |
-    And metasfresh contains C_OrderLines:
-      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
-      | orderLine_CH | order_CH   | product      | 10         | huPIP_10PCE              |
-    And the order identified by order_CH is completed
+      | orderLine_DE | order      | product      | 10         | huPIP_10PCE              |
+      | orderLine_CH | order      | product      | 10         | huPIP_10PCE              |
+    And the order identified by order is completed
 
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier           | C_OrderLine_ID | IsToRecompute |
@@ -296,40 +272,37 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | shipmentSchedule_DE   |
       | shipmentSchedule_CH   |
 
-    # Generate shipments in one workpackage (both schedules together)
     When 'generate shipments' process is invoked with QuantityType=D, IsCompleteShipments=true and IsShipToday=false
       | M_ShipmentSchedule_ID |
       | shipmentSchedule_DE   |
       | shipmentSchedule_CH   |
 
     Then after not more than 60s, M_InOut is found:
-      | M_ShipmentSchedule_ID | M_InOut_ID  |
-      | shipmentSchedule_DE   | shipment_DE |
-    And after not more than 60s, M_InOut is found:
-      | M_ShipmentSchedule_ID | M_InOut_ID  |
-      | shipmentSchedule_CH   | shipment_CH |
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | shipmentSchedule_DE   | shipment   |
 
-    # Shipment DE must carry Herkunft=DE
+    # Verify each shipment line has the correct attribute
     And validate the created shipment lines
-      | M_InOut_ID  | M_Product_ID | movementqty | M_InOutLine_ID |
-      | shipment_DE | product      | 10          | shipLine_DE    |
+      | M_InOut_ID | M_Product_ID | movementqty | M_InOutLine_ID |
+      | shipment   | product      | 10          | shipLine_DE    |
+      | shipment   | product      | 10          | shipLine_CH    |
     And validate the created shipment lines by id
       | Identifier  | M_AttributeSetInstance_ID |
       | shipLine_DE | asi_shipLine_DE           |
     And validate M_AttributeInstance:
       | M_AttributeSetInstance_ID | AttributeCode | Value |
       | asi_shipLine_DE           | 1000001       | DE    |
-
-    # Shipment CH must carry Herkunft=CH
-    And validate the created shipment lines
-      | M_InOut_ID  | M_Product_ID | movementqty | M_InOutLine_ID |
-      | shipment_CH | product      | 10          | shipLine_CH    |
     And validate the created shipment lines by id
       | Identifier  | M_AttributeSetInstance_ID |
       | shipLine_CH | asi_shipLine_CH           |
     And validate M_AttributeInstance:
       | M_AttributeSetInstance_ID | AttributeCode | Value |
       | asi_shipLine_CH           | 1000001       | CH    |
+
+    And validate M_ShipmentSchedule_QtyPicked:
+      | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly |
+      | shipmentSchedule_DE   | 10        | true                        |
+      | shipmentSchedule_CH   | 10        | true                        |
 
     And validate M_QtyReservations:
       | Identifier     | Qty    | QtyDelivered | Processed |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
@@ -34,32 +34,31 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
   @Id:S_QtyRes_200
   Scenario: Reserved HU respected — unreserved line processed first must skip reserved VHU
   ## _Given 1 order with 2 lines for the same product (10 PCE each)
-  ## _And 2 TUs: hu_reserved (Herkunft=RES) reserved for line 1, hu_unreserved (Herkunft=FREE)
+  ## _And 2 TUs: hu_reserved (Herkunft=DE) reserved for line 1, hu_unreserved (Herkunft=AT)
   ## _When shipments are generated in one workpackage with line 2 FIRST
-  ## _Then line 2 picks hu_unreserved (Herkunft=FREE on shipment line)
-  ## _And  line 1 picks hu_reserved (Herkunft=RES on shipment line)
+  ## _Then line 2 picks hu_unreserved (Herkunft=AT), line 1 picks hu_reserved (Herkunft=DE)
 
     Given metasfresh contains M_Attributes:
       | Identifier | Value   | IsStorageRelevant |
       | attr_QRH   | 1000001 | true              |
-    And metasfresh contains M_AttributeSetInstance with identifier "asi_RES":
+    And metasfresh contains M_AttributeSetInstance with identifier "asi_DE":
     """
     {
       "attributeInstances":[
         {
           "attributeCode":"1000001",
-          "valueStr":"RES"
+          "valueStr":"DE"
         }
       ]
     }
     """
-    And metasfresh contains M_AttributeSetInstance with identifier "asi_FREE":
+    And metasfresh contains M_AttributeSetInstance with identifier "asi_AT":
     """
     {
       "attributeInstances":[
         {
           "attributeCode":"1000001",
-          "valueStr":"FREE"
+          "valueStr":"AT"
         }
       ]
     }
@@ -84,19 +83,19 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 |
       | plv                    | product      | 10.00    | PCE               |
 
-    # TU reserved: 10 PCE with Herkunft=RES (will be reserved for line 1)
+    # TU reserved: 10 PCE with Herkunft=DE (will be reserved for line 1)
     And metasfresh contains single line completed inventories
-      | M_Inventory_ID  | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID     |
-      | inventory_RES   | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | asi_RES                   | hu_reserved |
-    # TU unreserved: 10 PCE with Herkunft=FREE
+      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID     |
+      | inventory_DE   | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | asi_DE                    | hu_reserved |
+    # TU unreserved: 10 PCE with Herkunft=AT
     And metasfresh contains single line completed inventories
-      | M_Inventory_ID  | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID       |
-      | inventory_FREE  | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | asi_FREE                  | hu_unreserved |
+      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID       |
+      | inventory_AT   | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | asi_AT                    | hu_unreserved |
     And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
     And M_HU_Attribute is changed
       | M_HU_ID       | M_Attribute_ID.Value | ValueStr |
-      | hu_reserved   | 1000001              | RES      |
-      | hu_unreserved | 1000001              | FREE     |
+      | hu_reserved   | 1000001              | DE       |
+      | hu_unreserved | 1000001              | AT       |
 
     # Single order with 2 lines for the same product
     And metasfresh contains C_Orders:
@@ -129,30 +128,10 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
     Then after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID |
       | shipmentSchedule_1    | shipment   |
-    And validate the created shipment lines
-      | M_InOut_ID | M_Product_ID | movementqty | M_InOutLine_ID |
-      | shipment   | product      | 10          | shipLine_1     |
-      | shipment   | product      | 10          | shipLine_2     |
-
-    # Line 1 (reserved) must have picked hu_reserved (Herkunft=RES)
-    And validate the created shipment lines by id
-      | Identifier | M_AttributeSetInstance_ID |
-      | shipLine_1 | asi_shipLine_1            |
-    And validate M_AttributeInstance:
-      | M_AttributeSetInstance_ID | AttributeCode | Value |
-      | asi_shipLine_1            | 1000001       | RES   |
-
-    # Line 2 (unreserved) must have picked hu_unreserved (Herkunft=FREE)
-    And validate the created shipment lines by id
-      | Identifier | M_AttributeSetInstance_ID |
-      | shipLine_2 | asi_shipLine_2            |
-    And validate M_AttributeInstance:
-      | M_AttributeSetInstance_ID | AttributeCode | Value |
-      | asi_shipLine_2            | 1000001       | FREE  |
 
     # Verify the right HU was picked to the right schedule:
-    # schedule_1 (reserved) must have picked hu_reserved as its TU
-    # schedule_2 (unreserved) must have picked hu_unreserved as its TU
+    # schedule_1 (reserved) must have picked hu_reserved as its TU (Herkunft=DE)
+    # schedule_2 (unreserved) must have picked hu_unreserved as its TU (Herkunft=AT)
     And validate M_ShipmentSchedule_QtyPicked:
       | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly | M_TU_HU_ID   |
       | shipmentSchedule_1    | 10        | true                        | hu_reserved   |
@@ -218,10 +197,6 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
     Then after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID |
       | shipmentSchedule_1    | shipment   |
-    And validate the created shipment lines
-      | M_InOut_ID | M_Product_ID | movementqty |
-      | shipment   | product      | 10          |
-      | shipment   | product      | 10          |
     And validate M_ShipmentSchedule_QtyPicked:
       | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly |
       | shipmentSchedule_1    | 10        | true                        |
@@ -235,7 +210,7 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
   ## _And 2 TUs: hu_DE (Herkunft=DE) and hu_CH (Herkunft=CH)
   ## _And M_QtyReservation with ASI for each line (DE→line 1, CH→line 2)
   ## _When shipments are generated in one workpackage
-  ## _Then shipment line 1 has Herkunft=DE, shipment line 2 has Herkunft=CH
+  ## _Then schedule DE picks hu_DE, schedule CH picks hu_CH
 
     Given metasfresh contains M_Attributes:
       | Identifier | Value   | IsStorageRelevant |
@@ -301,7 +276,7 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
       | order      | true    | customer      | 2026-04-16  | warehouse      | F            |
     And metasfresh contains C_OrderLines:
-      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | Identifier   | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
       | orderLine_DE | order      | product      | 10         | huPIP_10PCE              |
       | orderLine_CH | order      | product      | 10         | huPIP_10PCE              |
     And the order identified by order is completed
@@ -330,28 +305,11 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
       | M_ShipmentSchedule_ID | M_InOut_ID |
       | shipmentSchedule_DE   | shipment   |
 
-    # Verify each shipment line has the correct attribute
-    And validate the created shipment lines
-      | M_InOut_ID | M_Product_ID | movementqty | M_InOutLine_ID |
-      | shipment   | product      | 10          | shipLine_DE    |
-      | shipment   | product      | 10          | shipLine_CH    |
-    And validate the created shipment lines by id
-      | Identifier  | M_AttributeSetInstance_ID |
-      | shipLine_DE | asi_shipLine_DE           |
-    And validate M_AttributeInstance:
-      | M_AttributeSetInstance_ID | AttributeCode | Value |
-      | asi_shipLine_DE           | 1000001       | DE    |
-    And validate the created shipment lines by id
-      | Identifier  | M_AttributeSetInstance_ID |
-      | shipLine_CH | asi_shipLine_CH           |
-    And validate M_AttributeInstance:
-      | M_AttributeSetInstance_ID | AttributeCode | Value |
-      | asi_shipLine_CH           | 1000001       | CH    |
-
+    # Verify the right HU was picked to the right schedule via QtyPicked TU reference
     And validate M_ShipmentSchedule_QtyPicked:
-      | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly |
-      | shipmentSchedule_DE   | 10        | true                        |
-      | shipmentSchedule_CH   | 10        | true                        |
+      | M_ShipmentSchedule_ID | QtyPicked | IsAnonymousHuPickedOnTheFly | M_TU_HU_ID |
+      | shipmentSchedule_DE   | 10        | true                        | hu_DE       |
+      | shipmentSchedule_CH   | 10        | true                        | hu_CH       |
 
     And validate M_QtyReservations:
       | Identifier     | Qty    | QtyDelivered | Processed |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/HUReservationService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/HUReservationService.java
@@ -22,6 +22,7 @@ import de.metas.handlingunits.storage.IHUProductStorage;
 import de.metas.handlingunits.storage.IHUStorageFactory;
 import de.metas.i18n.AdMessageKey;
 import de.metas.order.OrderLineId;
+import de.metas.project.ProjectId;
 import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
@@ -524,6 +525,34 @@ public class HUReservationService
 	public ImmutableSet<HuId> getVHUIdsByDocumentRef(@NonNull final HUReservationDocRef documentRef)
 	{
 		return getByDocumentRef(documentRef).map(HUReservation::getVhuIds).orElseGet(ImmutableSet::of);
+	}
+
+	/**
+	 * Collect all VHU IDs reserved for the given order line and/or its project.
+	 * Used by on-the-fly picking to whitelist "my" reserved VHUs while skipping those reserved for others.
+	 */
+	@NonNull
+	public ImmutableSet<HuId> getVHUIdsReservedForOrderLineOrProject(
+			@Nullable final OrderLineId orderLineId,
+			@Nullable final ProjectId projectId)
+	{
+		if (orderLineId == null && projectId == null)
+		{
+			return ImmutableSet.of();
+		}
+
+		final ImmutableSet.Builder<HuId> result = ImmutableSet.builder();
+
+		if (orderLineId != null)
+		{
+			result.addAll(getVHUIdsByDocumentRef(HUReservationDocRef.ofSalesOrderLineId(orderLineId)));
+		}
+		if (projectId != null)
+		{
+			result.addAll(getVHUIdsByDocumentRef(HUReservationDocRef.ofProjectId(projectId)));
+		}
+
+		return result.build();
 	}
 
 	public ImmutableList<HUReservationEntry> getEntriesByVHUIds(@NonNull final Collection<HuId> vhuIds)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/HUReservationService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/HUReservationService.java
@@ -528,30 +528,17 @@ public class HUReservationService
 	}
 
 	/**
-	 * Collect all VHU IDs reserved for the given order line and/or its project.
+	 * Collect all VHU IDs reserved by any of the given document references.
 	 * Used by on-the-fly picking to whitelist "my" reserved VHUs while skipping those reserved for others.
 	 */
 	@NonNull
-	public ImmutableSet<HuId> getVHUIdsReservedForOrderLineOrProject(
-			@Nullable final OrderLineId orderLineId,
-			@Nullable final ProjectId projectId)
+	public ImmutableSet<HuId> getVHUIdsReservedByAnyOf(@NonNull final HUReservationDocRef... documentRefs)
 	{
-		if (orderLineId == null && projectId == null)
-		{
-			return ImmutableSet.of();
-		}
-
 		final ImmutableSet.Builder<HuId> result = ImmutableSet.builder();
-
-		if (orderLineId != null)
+		for (final HUReservationDocRef ref : documentRefs)
 		{
-			result.addAll(getVHUIdsByDocumentRef(HUReservationDocRef.ofSalesOrderLineId(orderLineId)));
+			result.addAll(getVHUIdsByDocumentRef(ref));
 		}
-		if (projectId != null)
-		{
-			result.addAll(getVHUIdsByDocumentRef(HUReservationDocRef.ofProjectId(projectId)));
-		}
-
 		return result.build();
 	}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
@@ -489,8 +489,7 @@ public class ShipmentScheduleWithHUService
 					.stream()
 					.filter(hu -> !alreadyUsedSourceHuIds.contains(HuId.ofRepoId(hu.getM_HU_ID())))
 					.collect(Collectors.toList());
-				alreadyUsedSourceHuIds.addAll(husToPick.stream().map(hu -> HuId.ofRepoId(hu.getM_HU_ID())).collect(Collectors.toSet()));
-				final Quantity remainingAfterPass = processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, husToPick, qtyCapForThisReservation, loggableWithLogger, !anyHUProcessed, result, false);
+				final Quantity remainingAfterPass = processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, husToPick, qtyCapForThisReservation, loggableWithLogger, !anyHUProcessed, result, false, alreadyUsedSourceHuIds);
 				final Quantity actuallyPicked = qtyCapForThisReservation.subtract(remainingAfterPass);
 				remainingQtyToAllocate = remainingQtyToAllocate.subtract(actuallyPicked);
 				if (actuallyPicked.isPositive())

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
@@ -250,7 +250,7 @@ public class ShipmentScheduleWithHUService
 
 		final IHUContext huContext = huContextFactory.createMutableHUContext();
 
-		// Shared across all schedules to prevent the same HU being picked by multiple schedules.
+		// Shared across all PrepareForSingleShipmentScheduleRequest-instances to prevent the same HU being picked by multiple schedules.
 		// The on-the-fly picking storage query reads out-of-transaction, so without this,
 		// a later schedule would re-discover HUs already consumed by a prior schedule in the same workpackage.
 		final Set<HuId> alreadyUsedSourceHuIds = new HashSet<>();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
@@ -197,6 +197,13 @@ public class ShipmentScheduleWithHUService
 		@Nullable Set<HuId> onlyLUIds;
 
 		/**
+		 * Shared across all schedules in the same workpackage to prevent double-picking.
+		 * The storage query in retrievePickOnTheFlySourceHUs reads out-of-transaction,
+		 * so without this, a second schedule would re-discover HUs already consumed by a prior schedule.
+		 */
+		@NonNull @Builder.Default Set<HuId> alreadyUsedSourceHuIds = new HashSet<>();
+
+		/**
 		 * If {@code false} and HUs are picked on-the-fly, then those HUs are created as CUs that are taken from bigger LUs, TUs or CUs (the default).
 		 * If {@code true}, then the on-the-fly picked HUs are created as TUs, using the respective shipment schedules' packing instructions.
 		 */
@@ -242,6 +249,11 @@ public class ShipmentScheduleWithHUService
 
 		final IHUContext huContext = huContextFactory.createMutableHUContext();
 
+		// Shared across all schedules to prevent the same HU being picked by multiple schedules.
+		// The on-the-fly picking storage query reads out-of-transaction, so without this,
+		// a later schedule would re-discover HUs already consumed by a prior schedule in the same workpackage.
+		final Set<HuId> alreadyUsedSourceHuIds = new HashSet<>();
+
 		final ArrayList<ShipmentScheduleWithHU> result = new ArrayList<>();
 
 		for (final ShipmentScheduleAndJobSchedules schedule : request.getSchedules())
@@ -257,6 +269,7 @@ public class ShipmentScheduleWithHUService
 				final ImmutableList<ShipmentScheduleWithHU> candidates = prepareShipmentSchedulesWithHU(
 						PrepareForSingleShipmentScheduleRequest.builderFrom(schedule, request)
 								.huContext(huContext)
+								.alreadyUsedSourceHuIds(alreadyUsedSourceHuIds)
 								.build()
 				);
 
@@ -334,7 +347,7 @@ public class ShipmentScheduleWithHUService
 		{
 			if (productBL.isStocked(ProductId.ofRepoId(scheduleRecord.getM_Product_ID())))
 			{
-				result.addAll(pickHUsOnTheFly(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext));
+				result.addAll(pickHUsOnTheFly(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, request.getAlreadyUsedSourceHuIds()));
 			}
 			else
 			{
@@ -419,7 +432,8 @@ public class ShipmentScheduleWithHUService
 			@NonNull final I_M_ShipmentSchedule scheduleRecord,
 			@NonNull final Quantity qtyToDeliver,
 			final boolean pickAccordingToPackingInstruction,
-			@NonNull final IHUContext huContext)
+			@NonNull final IHUContext huContext,
+			@NonNull final Set<HuId> alreadyUsedSourceHuIds)
 	{
 		final ILoggable loggableWithLogger = Loggables.withLogger(logger, Level.DEBUG);
 
@@ -442,11 +456,6 @@ public class ShipmentScheduleWithHUService
 		{
 			return result.build();
 		}
-
-		// Track source HU IDs already consumed in this run to avoid double-picking.
-		// The storage query in retrievePickOnTheFlySourceHUs uses an out-of-transaction read,
-		// so it does not see in-transaction changes made by earlier passes in the same WP.
-		final Set<HuId> alreadyUsedSourceHuIds = new HashSet<>();
 
 		// Pass 1: M_HU_Reservation HUs (physically reserved VHUs)
 		boolean anyHUProcessed = false;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
@@ -463,8 +463,7 @@ public class ShipmentScheduleWithHUService
 		final List<I_M_HU> reservedHUs = retrieveReservedHUs(scheduleRecord);
 		if (!reservedHUs.isEmpty())
 		{
-			reservedHUs.forEach(hu -> alreadyUsedSourceHuIds.add(HuId.ofRepoId(hu.getM_HU_ID())));
-			remainingQtyToAllocate = processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, reservedHUs, remainingQtyToAllocate, loggableWithLogger, /*firstHU=*/true, result, true);
+			remainingQtyToAllocate = processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, reservedHUs, remainingQtyToAllocate, loggableWithLogger, /*firstHU=*/true, result, true, alreadyUsedSourceHuIds);
 			anyHUProcessed = true;
 		}
 
@@ -522,23 +521,8 @@ public class ShipmentScheduleWithHUService
 			@NonNull final ILoggable loggableWithLogger,
 			boolean firstHU,
 			@NonNull final ImmutableList.Builder<ShipmentScheduleWithHU> result,
-			final boolean useExistingHUStructure)
-	{
-		return processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, husToPick, remainingQtyToAllocate, loggableWithLogger, firstHU, result, useExistingHUStructure, null);
-	}
-
-	private Quantity processHU(
-			@NonNull final I_M_ShipmentSchedule scheduleRecord,
-			@NonNull final Quantity qtyToDeliver,
-			final boolean pickAccordingToPackingInstruction,
-			@NonNull final IHUContext huContext,
-			@NonNull final List<I_M_HU> husToPick,
-			@NonNull Quantity remainingQtyToAllocate,
-			@NonNull final ILoggable loggableWithLogger,
-			boolean firstHU,
-			@NonNull final ImmutableList.Builder<ShipmentScheduleWithHU> result,
 			final boolean useExistingHUStructure,
-			@Nullable final Set<HuId> alreadyUsedSourceHuIds)
+			@NonNull final Set<HuId> alreadyUsedSourceHuIds)
 	{
 		for (final I_M_HU sourceHURecord : husToPick)
 		{
@@ -556,10 +540,7 @@ public class ShipmentScheduleWithHUService
 					qtyToDeliver, quantityToSplit, sourceHURecord.getM_HU_ID(), qtyOfSourceHU);
 
 			// Mark this source HU as consumed so other schedules in the same workpackage won't re-pick it
-			if (alreadyUsedSourceHuIds != null)
-			{
-				alreadyUsedSourceHuIds.add(HuId.ofRepoId(sourceHURecord.getM_HU_ID()));
-			}
+			alreadyUsedSourceHuIds.add(HuId.ofRepoId(sourceHURecord.getM_HU_ID()));
 
 			final HUType huUnitType = handlingUnitsBL.getHUUnitType(sourceHURecord);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
@@ -507,6 +507,7 @@ public class ShipmentScheduleWithHUService
 					.stream()
 					.filter(hu -> !alreadyUsedSourceHuIds.contains(HuId.ofRepoId(hu.getM_HU_ID())))
 					.collect(Collectors.toList());
+			alreadyUsedSourceHuIds.addAll(husToPick.stream().map(hu -> HuId.ofRepoId(hu.getM_HU_ID())).collect(Collectors.toSet()));
 			processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, husToPick, remainingQtyToAllocate, loggableWithLogger, !anyHUProcessed, result, false);
 		}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
@@ -713,10 +713,21 @@ public class ShipmentScheduleWithHUService
 
 	private ReservedHUsPolicy computeReservedHUsPolicy(@NonNull final I_M_ShipmentSchedule scheduleRecord)
 	{
-		final OrderLineId orderLineId = OrderLineId.ofRepoIdOrNull(scheduleRecord.getC_OrderLine_ID());
-		final ProjectId projectId = ProjectId.ofRepoIdOrNull(scheduleRecord.getC_Project_ID());
+		final ArrayList<HUReservationDocRef> docRefs = new ArrayList<>();
 
-		final ImmutableSet<HuId> reservedForMe = huReservationService.getVHUIdsReservedForOrderLineOrProject(orderLineId, projectId);
+		final OrderLineId orderLineId = OrderLineId.ofRepoIdOrNull(scheduleRecord.getC_OrderLine_ID());
+		if (orderLineId != null)
+		{
+			docRefs.add(HUReservationDocRef.ofSalesOrderLineId(orderLineId));
+		}
+		final ProjectId projectId = ProjectId.ofRepoIdOrNull(scheduleRecord.getC_Project_ID());
+		if (projectId != null)
+		{
+			docRefs.add(HUReservationDocRef.ofProjectId(projectId));
+		}
+
+		final ImmutableSet<HuId> reservedForMe = huReservationService.getVHUIdsReservedByAnyOf(
+				docRefs.toArray(new HUReservationDocRef[0]));
 
 		return ReservedHUsPolicy.onlyNotReservedExceptVhuIds(reservedForMe);
 	}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
@@ -672,12 +672,9 @@ public class ShipmentScheduleWithHUService
 				.builder()
 				.keepNewCUsUnderSameParent(false)
 
-				// new, from PR https://github.com/metasfresh/metasfresh/pull/12146
-				// FIXME: we shall consider not reserved or reserved ones too if they are reserved for us
-				.reservedVHUsPolicy(ReservedHUsPolicy.CONSIDER_ALL)
-
-				// OLD
-				// .onlyFromUnreservedHUs(false) // note: the HUs returned by the query do not contain HUs which are reserved to someone else
+				// Pick unreserved VHUs + VHUs reserved for the current schedule's order.
+				// Skip VHUs reserved for OTHER orders to avoid cross-order reservation violations.
+				.reservedVHUsPolicy(computeReservedHUsPolicy(scheduleRecord))
 
 				.productId(ProductId.ofRepoId(scheduleRecord.getM_Product_ID()))
 				.qtyCU(quantityToSplit)
@@ -711,6 +708,20 @@ public class ShipmentScheduleWithHUService
 			newHURecords = newCURecords;
 		}
 		return newHURecords;
+	}
+
+	private ReservedHUsPolicy computeReservedHUsPolicy(@NonNull final I_M_ShipmentSchedule scheduleRecord)
+	{
+		final OrderLineId orderLineId = OrderLineId.ofRepoIdOrNull(scheduleRecord.getC_OrderLine_ID());
+		if (orderLineId == null)
+		{
+			return ReservedHUsPolicy.CONSIDER_ONLY_NOT_RESERVED;
+		}
+
+		final ImmutableSet<HuId> reservedForMyOrderVhuIds = huReservationService.getVHUIdsByDocumentRef(
+				HUReservationDocRef.ofSalesOrderLineId(orderLineId));
+
+		return ReservedHUsPolicy.onlyNotReservedExceptVhuIds(reservedForMyOrderVhuIds);
 	}
 
 	private Quantity extractQtyOfHU(

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
@@ -82,6 +82,7 @@ import de.metas.inoutcandidate.qty_reservation.QtyReservationRepository;
 import de.metas.logging.LogManager;
 import de.metas.material.event.commons.AttributesKey;
 import de.metas.order.OrderLineId;
+import de.metas.project.ProjectId;
 import de.metas.picking.api.ShipmentScheduleAndJobScheduleIdSet;
 import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
@@ -713,15 +714,11 @@ public class ShipmentScheduleWithHUService
 	private ReservedHUsPolicy computeReservedHUsPolicy(@NonNull final I_M_ShipmentSchedule scheduleRecord)
 	{
 		final OrderLineId orderLineId = OrderLineId.ofRepoIdOrNull(scheduleRecord.getC_OrderLine_ID());
-		if (orderLineId == null)
-		{
-			return ReservedHUsPolicy.CONSIDER_ONLY_NOT_RESERVED;
-		}
+		final ProjectId projectId = ProjectId.ofRepoIdOrNull(scheduleRecord.getC_Project_ID());
 
-		final ImmutableSet<HuId> reservedForMyOrderVhuIds = huReservationService.getVHUIdsByDocumentRef(
-				HUReservationDocRef.ofSalesOrderLineId(orderLineId));
+		final ImmutableSet<HuId> reservedForMe = huReservationService.getVHUIdsReservedForOrderLineOrProject(orderLineId, projectId);
 
-		return ReservedHUsPolicy.onlyNotReservedExceptVhuIds(reservedForMyOrderVhuIds);
+		return ReservedHUsPolicy.onlyNotReservedExceptVhuIds(reservedForMe);
 	}
 
 	private Quantity extractQtyOfHU(

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
@@ -507,8 +507,7 @@ public class ShipmentScheduleWithHUService
 					.stream()
 					.filter(hu -> !alreadyUsedSourceHuIds.contains(HuId.ofRepoId(hu.getM_HU_ID())))
 					.collect(Collectors.toList());
-			alreadyUsedSourceHuIds.addAll(husToPick.stream().map(hu -> HuId.ofRepoId(hu.getM_HU_ID())).collect(Collectors.toSet()));
-			processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, husToPick, remainingQtyToAllocate, loggableWithLogger, !anyHUProcessed, result, false);
+			processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, husToPick, remainingQtyToAllocate, loggableWithLogger, !anyHUProcessed, result, false, alreadyUsedSourceHuIds);
 		}
 
 		return result.build();
@@ -526,6 +525,22 @@ public class ShipmentScheduleWithHUService
 			@NonNull final ImmutableList.Builder<ShipmentScheduleWithHU> result,
 			final boolean useExistingHUStructure)
 	{
+		return processHU(scheduleRecord, qtyToDeliver, pickAccordingToPackingInstruction, huContext, husToPick, remainingQtyToAllocate, loggableWithLogger, firstHU, result, useExistingHUStructure, null);
+	}
+
+	private Quantity processHU(
+			@NonNull final I_M_ShipmentSchedule scheduleRecord,
+			@NonNull final Quantity qtyToDeliver,
+			final boolean pickAccordingToPackingInstruction,
+			@NonNull final IHUContext huContext,
+			@NonNull final List<I_M_HU> husToPick,
+			@NonNull Quantity remainingQtyToAllocate,
+			@NonNull final ILoggable loggableWithLogger,
+			boolean firstHU,
+			@NonNull final ImmutableList.Builder<ShipmentScheduleWithHU> result,
+			final boolean useExistingHUStructure,
+			@Nullable final Set<HuId> alreadyUsedSourceHuIds)
+	{
 		for (final I_M_HU sourceHURecord : husToPick)
 		{
 			final ProductId productId = ProductId.ofRepoId(scheduleRecord.getM_Product_ID());
@@ -540,6 +555,12 @@ public class ShipmentScheduleWithHUService
 			final Quantity quantityToSplit = qtyOfSourceHU.min(remainingQtyToAllocate);
 			loggableWithLogger.addLog("pickHUsOnTheFly - QtyToDeliver={}; split Qty={} from available M_HU_ID={} with Qty={}",
 					qtyToDeliver, quantityToSplit, sourceHURecord.getM_HU_ID(), qtyOfSourceHU);
+
+			// Mark this source HU as consumed so other schedules in the same workpackage won't re-pick it
+			if (alreadyUsedSourceHuIds != null)
+			{
+				alreadyUsedSourceHuIds.add(HuId.ofRepoId(sourceHURecord.getM_HU_ID()));
+			}
 
 			final HUType huUnitType = handlingUnitsBL.getHUUnitType(sourceHURecord);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/storage/impl/HUItemStorage.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/storage/impl/HUItemStorage.java
@@ -46,11 +46,13 @@ import de.metas.uom.IUOMConversionBL;
 import de.metas.uom.IUOMDAO;
 import de.metas.uom.UOMPrecision;
 import de.metas.uom.UomId;
+import de.metas.logging.LogManager;
 import de.metas.util.Check;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.compiere.model.I_C_UOM;
+import org.slf4j.Logger;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
@@ -62,6 +64,8 @@ import java.util.Optional;
 
 public class HUItemStorage implements IHUItemStorage
 {
+	private static final Logger logger = LogManager.getLogger(HUItemStorage.class);
+
 	// services
 	private final IUOMConversionBL uomConversionBL = Services.get(IUOMConversionBL.class);
 	private final IHUCapacityBL capacityBL = Services.get(IHUCapacityBL.class);
@@ -84,9 +88,6 @@ public class HUItemStorage implements IHUItemStorage
 
 	/**
 	 * Creates a new instance. Actual {@link I_M_HU_Item_Storage} records will be loaded and saved only when needed.
-	 *
-	 * @param storageFactory
-	 * @param item
 	 */
 	public HUItemStorage(
 			@NonNull final IHUStorageFactory storageFactory,
@@ -143,8 +144,7 @@ public class HUItemStorage implements IHUItemStorage
 	public IHUStorage getParentStorage()
 	{
 		final I_M_HU hu = item.getM_HU();
-		final IHUStorage parentStorage = storageFactory.getStorage(hu);
-		return parentStorage;
+		return storageFactory.getStorage(hu);
 	}
 
 	@Override
@@ -174,8 +174,13 @@ public class HUItemStorage implements IHUItemStorage
 
 		if (qtyNew.signum() < 0 && !qtyOld.equals(qtyOnParent))
 		{
+			logger.error("M_HU_Item_Storage.Qty out of sync with M_HU_Storage! "
+									 + "M_HU_Item_Id: {}, M_HU_Item_Storage.Qty: {}, M_HU_Item_Storage.Product: {}, M_HU_Item_Storage.UOM: {}, "
+									 + "M_HU_ID: {}, M_HU_Storage.Qty: {}, qtyToAdd: {} same UOM",
+							 storageLine.getM_HU_Item_ID(), storageLine.getQty(), storageLine.getM_Product_ID(), storageLine.getC_UOM_ID(),
+							 item.getM_HU_ID(), qtyOnParent, qtyConv);
 			Loggables.addLog("Warning! M_HU_Item_Storage.Qty out of sync with M_HU_Storage! "
-									 + "M_HU_Item_Id: {}, M_HU_Item_Storage.Qty: {}, M_HU_Item_Storage.Product: {}, M_HU_Item_Storage.UOM: {}"
+									 + "M_HU_Item_Id: {}, M_HU_Item_Storage.Qty: {}, M_HU_Item_Storage.Product: {}, M_HU_Item_Storage.UOM: {}, "
 									 + "M_HU_ID: {}, M_HU_Storage.Qty: {}, qtyToAdd: {} same UOM",
 							 storageLine.getM_HU_Item_ID(), storageLine.getQty(), storageLine.getM_Product_ID(), storageLine.getC_UOM_ID(),
 							 item.getM_HU_ID(), qtyOnParent, qtyConv);
@@ -190,6 +195,11 @@ public class HUItemStorage implements IHUItemStorage
 		// when detaching a VHU whose parent item storage was never properly rolled up.
 		if (qtyNew.signum() < 0)
 		{
+			logger.error("Clamping negative qty to zero on storageLine. "
+									 + "M_HU_Item_Id: {}, qtyOld: {}, qtyToAdd: {}, qtyNew (before clamp): {}, qtyOnParent: {}, "
+									 + "M_HU_Item_Storage_ID: {}, M_Product_ID: {}",
+							 storageLine.getM_HU_Item_ID(), qtyOld, qtyConv, qtyNew, qtyOnParent,
+							 storageLine.getM_HU_Item_Storage_ID(), storageLine.getM_Product_ID());
 			Loggables.addLog("Warning! Clamping negative qty to zero on storageLine. "
 									 + "M_HU_Item_Id: {}, qtyOld: {}, qtyToAdd: {}, qtyNew (before clamp): {}, qtyOnParent: {}, "
 									 + "M_HU_Item_Storage_ID: {}, M_Product_ID: {}",

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/storage/impl/HUItemStorage.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/storage/impl/HUItemStorage.java
@@ -205,8 +205,10 @@ public class HUItemStorage implements IHUItemStorage
 		dao.save(storageLine);
 
 		//
-		// Roll-up: propagate only the actual delta that was applied, not the requested delta.
-		// If qtyNew was clamped (e.g. from -8 to 0), the actual delta is smaller than qtyConv.
+		// Roll-up: propagate the actual delta applied to this storage line, not the requested qtyConv.
+		// Normally actualDelta == qtyConv (no correction happened).
+		// But if the sync correction (qtyOnParent) or the negative-qty clamp changed qtyNew,
+		// actualDelta reflects what really happened — propagating qtyConv would make the parent out of sync.
 		final BigDecimal actualDelta = qtyNew.subtract(qtyOld);
 		rollupIncremental(productId, actualDelta, uomStorage);
 	}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/storage/impl/HUItemStorage.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/storage/impl/HUItemStorage.java
@@ -183,14 +183,29 @@ public class HUItemStorage implements IHUItemStorage
 			qtyNew = qtyOnParent.add(qtyConv);
 		}
 
-		Check.errorIf(qtyNew.signum() < 0, "Attempt to set negative qty on storageLine; qtyOld={}; qtyToAdd={}; qtyNew={}; this={}; storageLine={}", qtyOld, qtyToAdd, qtyNew, this, storageLine);
+		// Clamp to zero if still negative after sync correction.
+		// This handles the case where the parent HU storage hierarchy is inconsistent
+		// (e.g. VHU has qty but all parent-level storages are zero).
+		// Without this, rollupRevert during HU reparenting would fail
+		// when detaching a VHU whose parent item storage was never properly rolled up.
+		if (qtyNew.signum() < 0)
+		{
+			Loggables.addLog("Warning! Clamping negative qty to zero on storageLine. "
+									 + "M_HU_Item_Id: {}, qtyOld: {}, qtyToAdd: {}, qtyNew (before clamp): {}, qtyOnParent: {}, "
+									 + "M_HU_Item_Storage_ID: {}, M_Product_ID: {}",
+							 storageLine.getM_HU_Item_ID(), qtyOld, qtyConv, qtyNew, qtyOnParent,
+							 storageLine.getM_HU_Item_Storage_ID(), storageLine.getM_Product_ID());
+			qtyNew = BigDecimal.ZERO;
+		}
 
 		storageLine.setQty(qtyNew);
 		dao.save(storageLine);
 
 		//
-		// Roll-up
-		rollupIncremental(productId, qtyConv, uomStorage);
+		// Roll-up: propagate only the actual delta that was applied, not the requested delta.
+		// If qtyNew was clamped (e.g. from -8 to 0), the actual delta is smaller than qtyConv.
+		final BigDecimal actualDelta = qtyNew.subtract(qtyOld);
+		rollupIncremental(productId, actualDelta, uomStorage);
 	}
 
 	private void rollupIncremental(final ProductId productId, final BigDecimal qtyDelta, final I_C_UOM uom)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/storage/impl/HUItemStorage.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/storage/impl/HUItemStorage.java
@@ -52,6 +52,7 @@ import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.compiere.model.I_C_UOM;
+import ch.qos.logback.classic.Level;
 import org.slf4j.Logger;
 
 import java.math.BigDecimal;
@@ -174,16 +175,12 @@ public class HUItemStorage implements IHUItemStorage
 
 		if (qtyNew.signum() < 0 && !qtyOld.equals(qtyOnParent))
 		{
-			logger.error("M_HU_Item_Storage.Qty out of sync with M_HU_Storage! "
-									 + "M_HU_Item_Id: {}, M_HU_Item_Storage.Qty: {}, M_HU_Item_Storage.Product: {}, M_HU_Item_Storage.UOM: {}, "
-									 + "M_HU_ID: {}, M_HU_Storage.Qty: {}, qtyToAdd: {} same UOM",
-							 storageLine.getM_HU_Item_ID(), storageLine.getQty(), storageLine.getM_Product_ID(), storageLine.getC_UOM_ID(),
-							 item.getM_HU_ID(), qtyOnParent, qtyConv);
-			Loggables.addLog("Warning! M_HU_Item_Storage.Qty out of sync with M_HU_Storage! "
-									 + "M_HU_Item_Id: {}, M_HU_Item_Storage.Qty: {}, M_HU_Item_Storage.Product: {}, M_HU_Item_Storage.UOM: {}, "
-									 + "M_HU_ID: {}, M_HU_Storage.Qty: {}, qtyToAdd: {} same UOM",
-							 storageLine.getM_HU_Item_ID(), storageLine.getQty(), storageLine.getM_Product_ID(), storageLine.getC_UOM_ID(),
-							 item.getM_HU_ID(), qtyOnParent, qtyConv);
+			Loggables.withLogger(logger, Level.ERROR)
+					.addLog("M_HU_Item_Storage.Qty out of sync with M_HU_Storage! "
+									+ "M_HU_Item_Id: {}, M_HU_Item_Storage.Qty: {}, M_HU_Item_Storage.Product: {}, M_HU_Item_Storage.UOM: {}, "
+									+ "M_HU_ID: {}, M_HU_Storage.Qty: {}, qtyToAdd: {} same UOM",
+							storageLine.getM_HU_Item_ID(), storageLine.getQty(), storageLine.getM_Product_ID(), storageLine.getC_UOM_ID(),
+							item.getM_HU_ID(), qtyOnParent, qtyConv);
 
 			qtyNew = qtyOnParent.add(qtyConv);
 		}
@@ -195,16 +192,12 @@ public class HUItemStorage implements IHUItemStorage
 		// when detaching a VHU whose parent item storage was never properly rolled up.
 		if (qtyNew.signum() < 0)
 		{
-			logger.error("Clamping negative qty to zero on storageLine. "
-									 + "M_HU_Item_Id: {}, qtyOld: {}, qtyToAdd: {}, qtyNew (before clamp): {}, qtyOnParent: {}, "
-									 + "M_HU_Item_Storage_ID: {}, M_Product_ID: {}",
-							 storageLine.getM_HU_Item_ID(), qtyOld, qtyConv, qtyNew, qtyOnParent,
-							 storageLine.getM_HU_Item_Storage_ID(), storageLine.getM_Product_ID());
-			Loggables.addLog("Warning! Clamping negative qty to zero on storageLine. "
-									 + "M_HU_Item_Id: {}, qtyOld: {}, qtyToAdd: {}, qtyNew (before clamp): {}, qtyOnParent: {}, "
-									 + "M_HU_Item_Storage_ID: {}, M_Product_ID: {}",
-							 storageLine.getM_HU_Item_ID(), qtyOld, qtyConv, qtyNew, qtyOnParent,
-							 storageLine.getM_HU_Item_Storage_ID(), storageLine.getM_Product_ID());
+			Loggables.withLogger(logger, Level.ERROR)
+					.addLog("Clamping negative qty to zero on storageLine. "
+									+ "M_HU_Item_Id: {}, qtyOld: {}, qtyToAdd: {}, qtyNew (before clamp): {}, qtyOnParent: {}, "
+									+ "M_HU_Item_Storage_ID: {}, M_Product_ID: {}",
+							storageLine.getM_HU_Item_ID(), qtyOld, qtyConv, qtyNew, qtyOnParent,
+							storageLine.getM_HU_Item_Storage_ID(), storageLine.getM_Product_ID());
 			qtyNew = BigDecimal.ZERO;
 		}
 


### PR DESCRIPTION
## Summary
Fix shipment creation failure when multiple shipment schedules for the same product are processed in one workpackage. Three coordinated fixes plus safety net and tests.

## Root Cause
On-the-fly HU picking in `ShipmentScheduleWithHUService.pickHUsOnTheFly` had three independent bugs:
1. Each schedule maintained its own local `alreadyUsedSourceHuIds` set — so a second schedule would re-discover and double-process HUs already consumed by a prior schedule (the storage query reads out-of-transaction and doesn't see cached changes).
2. `createNewlyPickedHUs` used `ReservedHUsPolicy.CONSIDER_ALL`, ignoring reservations — a schedule could split from VHUs reserved for OTHER orders.
3. All three picking passes added bulk candidates to `alreadyUsedSourceHuIds` before `processHU`, but `processHU` only consumes what it needs. This caused later schedules to see ALL candidates as used, even ones never touched.

These combined to produce crashes like "Attempt to set negative qty on storageLine" and "Included HU not found in cached included HUs list".

## Changes
### 1. Share `alreadyUsedSourceHuIds` across schedules
`ShipmentScheduleWithHUService.prepareShipmentSchedulesWithHU` now creates the set once in the outer schedule loop and threads it through `PrepareForSingleShipmentScheduleRequest` into each schedule's `pickHUsOnTheFly`. Each source HU is added to the shared set **inside `processHU`** as it's actually consumed (not in bulk upfront).

### 2. Respect HU reservations in on-the-fly picking
`createNewlyPickedHUs` now computes `allowedReservedVhuIds` (VHUs reserved for the current schedule's order line and/or project) and uses `ReservedHUsPolicy.onlyNotReservedExceptVhuIds(allowedReservedVhuIds)` instead of `CONSIDER_ALL`. The whitelist also feeds the recursive reservation guard added by #23412 via `HUTransformService.builder().allowedReservedVhuIds(...)`.

New service method `HUReservationService.getVHUIdsReservedByAnyOf(HUReservationDocRef...)` — generic over reservation document types so future refs (DD order line, picking job step) can be added without signature changes.

### 3. Safety net in `HUItemStorage.addQty`
If `qtyNew` is still negative after the existing sync correction, clamp to zero with ERROR-level log (via `Loggables.withLogger(logger, Level.ERROR)`) and propagate the **actual applied delta** (`qtyNew - qtyOld`) to `rollupIncremental` — not the requested `qtyConv`. This prevents any remaining inconsistency from cascading up the parent hierarchy.

## Tests
New cucumber feature `qtyReservation_shipment_multiSchedule.feature` with 3 scenarios (all single-order-two-lines to trigger the multi-schedule-in-one-workpackage path):
- **S_QtyRes_200**: Reserved HU respected — unreserved line processed first must skip the reserved VHU
- **S_QtyRes_210**: Both unreserved — no double-pick crash in single workpackage (direct regression test for me03#29333)
- **S_QtyRes_220**: Both unreserved, ASI-filtered — each schedule picks the correctly attributed HU

## Related issue
- https://github.com/metasfresh/me03/issues/29333