### PR TITLE
Support Reverse Charge with explicit Fact_Acct

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_Invoice.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_Invoice.java
@@ -697,24 +697,33 @@ public class Doc_Invoice extends Doc<DocLine_Invoice>
 
 		//
 		// TaxCredit DR
+		final ImmutableList.Builder<Fact> rcFacts = ImmutableList.builder();
 		for (final DocTax docTax : taxes)
 		{
 			if (docTax.isReverseCharge())
 			{
+				// Reverse charge: VSt DR + USt CR in a SEPARATE Fact instance
+				// to avoid FactTrxStrategy pairing conflict (2 DR + 2 CR in same Fact).
+				final Fact rcFact = newFact(as);
 				// VSt (Vorsteuer / input tax) — debit the tax receivable
-				fact.createLine()
+				rcFact.createLine()
 						.setAccount(docTax.getTaxCreditOrExpense(as))
 						.setAmtSource(currencyId, docTax.getReverseChargeTaxAmt(), null)
 						.setC_Tax_ID(docTax.getTaxId())
 						.alsoAddZeroLine()
 						.buildAndAdd();
 				// USt (Umsatzsteuer / output tax) — credit the tax payable
-				fact.createLine()
+				rcFact.createLine()
 						.setAccount(docTax.getTaxDueAcct(as))
 						.setAmtSource(currencyId, null, docTax.getReverseChargeTaxAmt())
 						.setC_Tax_ID(docTax.getTaxId())
 						.alsoAddZeroLine()
 						.buildAndAdd();
+				rcFact.forEach(fl -> {
+					fl.setLocationFromBPartner(getBPartnerLocationId(), true);
+					fl.setLocationFromOrg(fl.getOrgId(), false);
+				});
+				rcFacts.add(rcFact);
 			}
 			else
 			{
@@ -766,7 +775,7 @@ public class Doc_Invoice extends Doc<DocLine_Invoice>
 					.buildAndAdd();
 		}
 
-		return ImmutableList.of(fact);
+		return ImmutableList.<Fact>builder().add(fact).addAll(rcFacts.build()).build();
 	}
 
 	/**
@@ -869,24 +878,32 @@ public class Doc_Invoice extends Doc<DocLine_Invoice>
 
 		//
 		// TaxCredit CR
+		final ImmutableList.Builder<Fact> rcFacts = ImmutableList.builder();
 		for (final DocTax docTax : taxes)
 		{
 			if (docTax.isReverseCharge())
 			{
+				// Reverse charge: VSt CR + USt DR in a SEPARATE Fact instance
+				final Fact rcFact = newFact(as);
 				// VSt (Vorsteuer / input tax) — credit to reverse the original VSt debit
-				fact.createLine()
+				rcFact.createLine()
 						.setAccount(docTax.getTaxCreditOrExpense(as))
 						.setAmtSource(currencyId, null, docTax.getReverseChargeTaxAmt())
 						.setC_Tax_ID(docTax.getTaxId())
 						.alsoAddZeroLine()
 						.buildAndAdd();
 				// USt (Umsatzsteuer / output tax) — debit to reverse the original USt credit
-				fact.createLine()
+				rcFact.createLine()
 						.setAccount(docTax.getTaxDueAcct(as))
 						.setAmtSource(currencyId, docTax.getReverseChargeTaxAmt(), null)
 						.setC_Tax_ID(docTax.getTaxId())
 						.alsoAddZeroLine()
 						.buildAndAdd();
+				rcFact.forEach(fl -> {
+					fl.setLocationFromBPartner(getBPartnerLocationId(), true);
+					fl.setLocationFromOrg(fl.getOrgId(), false);
+				});
+				rcFacts.add(rcFact);
 			}
 			else
 			{
@@ -937,7 +954,7 @@ public class Doc_Invoice extends Doc<DocLine_Invoice>
 					.buildAndAdd();
 		}
 
-		return ImmutableList.of(fact);
+		return ImmutableList.<Fact>builder().add(fact).addAll(rcFacts.build()).build();
 	}
 
 	private DocTaxesList applyUserChangesAndRecomputeTaxes(@NonNull final Fact fact)

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_Invoice.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_Invoice.java
@@ -701,15 +701,17 @@ public class Doc_Invoice extends Doc<DocLine_Invoice>
 		{
 			if (docTax.isReverseCharge())
 			{
+				// VSt (Vorsteuer / input tax) — debit the tax receivable
 				fact.createLine()
 						.setAccount(docTax.getTaxCreditOrExpense(as))
 						.setAmtSource(currencyId, docTax.getReverseChargeTaxAmt(), null)
 						.setC_Tax_ID(docTax.getTaxId())
 						.alsoAddZeroLine()
 						.buildAndAdd();
+				// USt (Umsatzsteuer / output tax) — credit the tax payable
 				fact.createLine()
 						.setAccount(docTax.getTaxDueAcct(as))
-						.setAmtSource(currencyId, docTax.getReverseChargeTaxAmt().negate(), null)
+						.setAmtSource(currencyId, null, docTax.getReverseChargeTaxAmt())
 						.setC_Tax_ID(docTax.getTaxId())
 						.alsoAddZeroLine()
 						.buildAndAdd();
@@ -871,15 +873,17 @@ public class Doc_Invoice extends Doc<DocLine_Invoice>
 		{
 			if (docTax.isReverseCharge())
 			{
+				// VSt (Vorsteuer / input tax) — credit to reverse the original VSt debit
 				fact.createLine()
 						.setAccount(docTax.getTaxCreditOrExpense(as))
 						.setAmtSource(currencyId, null, docTax.getReverseChargeTaxAmt())
 						.setC_Tax_ID(docTax.getTaxId())
 						.alsoAddZeroLine()
 						.buildAndAdd();
+				// USt (Umsatzsteuer / output tax) — debit to reverse the original USt credit
 				fact.createLine()
 						.setAccount(docTax.getTaxDueAcct(as))
-						.setAmtSource(currencyId, null, docTax.getReverseChargeTaxAmt().negate())
+						.setAmtSource(currencyId, docTax.getReverseChargeTaxAmt(), null)
 						.setC_Tax_ID(docTax.getTaxId())
 						.alsoAddZeroLine()
 						.buildAndAdd();

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_InvoiceTax.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_InvoiceTax.java
@@ -213,6 +213,27 @@ public interface I_C_InvoiceTax
 	String COLUMNNAME_IsPackagingTax = "IsPackagingTax";
 
 	/**
+	 * Set Reverse Charge.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsReverseCharge (boolean IsReverseCharge);
+
+	/**
+	 * Get Reverse Charge.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isReverseCharge();
+
+	ModelColumn<I_C_InvoiceTax, Object> COLUMN_IsReverseCharge = new ModelColumn<>(I_C_InvoiceTax.class, "IsReverseCharge", null);
+	String COLUMNNAME_IsReverseCharge = "IsReverseCharge";
+
+	/**
 	 * Set Price incl. Tax.
 	 * Tax is included in the price
 	 *
@@ -278,6 +299,27 @@ public interface I_C_InvoiceTax
 
 	ModelColumn<I_C_InvoiceTax, Object> COLUMN_Processed = new ModelColumn<>(I_C_InvoiceTax.class, "Processed", null);
 	String COLUMNNAME_Processed = "Processed";
+
+	/**
+	 * Set Reverse Charge Tax Amount.
+	 *
+	 * <br>Type: Amount
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setReverseChargeTaxAmt (BigDecimal ReverseChargeTaxAmt);
+
+	/**
+	 * Get Reverse Charge Tax Amount.
+	 *
+	 * <br>Type: Amount
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	BigDecimal getReverseChargeTaxAmt();
+
+	ModelColumn<I_C_InvoiceTax, Object> COLUMN_ReverseChargeTaxAmt = new ModelColumn<>(I_C_InvoiceTax.class, "ReverseChargeTaxAmt", null);
+	String COLUMNNAME_ReverseChargeTaxAmt = "ReverseChargeTaxAmt";
 
 	/**
 	 * Set Tax Amount.

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_OrderTax.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_OrderTax.java
@@ -213,6 +213,27 @@ public interface I_C_OrderTax
 	String COLUMNNAME_IsPackagingTax = "IsPackagingTax";
 
 	/**
+	 * Set Reverse Charge.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsReverseCharge (boolean IsReverseCharge);
+
+	/**
+	 * Get Reverse Charge.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isReverseCharge();
+
+	ModelColumn<I_C_OrderTax, Object> COLUMN_IsReverseCharge = new ModelColumn<>(I_C_OrderTax.class, "IsReverseCharge", null);
+	String COLUMNNAME_IsReverseCharge = "IsReverseCharge";
+
+	/**
 	 * Set Price incl. Tax.
 	 * Tax is included in the price
 	 *
@@ -278,6 +299,27 @@ public interface I_C_OrderTax
 
 	ModelColumn<I_C_OrderTax, Object> COLUMN_Processed = new ModelColumn<>(I_C_OrderTax.class, "Processed", null);
 	String COLUMNNAME_Processed = "Processed";
+
+	/**
+	 * Set Reverse Charge Tax Amount.
+	 *
+	 * <br>Type: Amount
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setReverseChargeTaxAmt (BigDecimal ReverseChargeTaxAmt);
+
+	/**
+	 * Get Reverse Charge Tax Amount.
+	 *
+	 * <br>Type: Amount
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	BigDecimal getReverseChargeTaxAmt();
+
+	ModelColumn<I_C_OrderTax, Object> COLUMN_ReverseChargeTaxAmt = new ModelColumn<>(I_C_OrderTax.class, "ReverseChargeTaxAmt", null);
+	String COLUMNNAME_ReverseChargeTaxAmt = "ReverseChargeTaxAmt";
 
 	/**
 	 * Set Tax Amount.

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_Tax.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_Tax.java
@@ -358,6 +358,27 @@ public interface I_C_Tax
 	String COLUMNNAME_IsFiscalRepresentation = "IsFiscalRepresentation";
 
 	/**
+	 * Set Reverse Charge.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsReverseCharge (boolean IsReverseCharge);
+
+	/**
+	 * Get Reverse Charge.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isReverseCharge();
+
+	ModelColumn<I_C_Tax, Object> COLUMN_IsReverseCharge = new ModelColumn<>(I_C_Tax.class, "IsReverseCharge", null);
+	String COLUMNNAME_IsReverseCharge = "IsReverseCharge";
+
+	/**
 	 * Set VK Steuer.
 	 * Dies ist eine VK Steuer
 	 *

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_InvoiceTax.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_InvoiceTax.java
@@ -111,9 +111,21 @@ public class X_C_InvoiceTax extends org.compiere.model.PO implements I_C_Invoice
 	}
 
 	@Override
-	public boolean isPackagingTax() 
+	public boolean isPackagingTax()
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsPackagingTax);
+	}
+
+	@Override
+	public void setIsReverseCharge (final boolean IsReverseCharge)
+	{
+		set_Value (COLUMNNAME_IsReverseCharge, IsReverseCharge);
+	}
+
+	@Override
+	public boolean isReverseCharge()
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsReverseCharge);
 	}
 
 	@Override
@@ -147,9 +159,22 @@ public class X_C_InvoiceTax extends org.compiere.model.PO implements I_C_Invoice
 	}
 
 	@Override
-	public boolean isProcessed() 
+	public boolean isProcessed()
 	{
 		return get_ValueAsBoolean(COLUMNNAME_Processed);
+	}
+
+	@Override
+	public void setReverseChargeTaxAmt (final BigDecimal ReverseChargeTaxAmt)
+	{
+		set_Value (COLUMNNAME_ReverseChargeTaxAmt, ReverseChargeTaxAmt);
+	}
+
+	@Override
+	public BigDecimal getReverseChargeTaxAmt()
+	{
+		final BigDecimal bd = get_ValueAsBigDecimal(COLUMNNAME_ReverseChargeTaxAmt);
+		return bd != null ? bd : BigDecimal.ZERO;
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_OrderTax.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_OrderTax.java
@@ -111,9 +111,21 @@ public class X_C_OrderTax extends org.compiere.model.PO implements I_C_OrderTax,
 	}
 
 	@Override
-	public boolean isPackagingTax() 
+	public boolean isPackagingTax()
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsPackagingTax);
+	}
+
+	@Override
+	public void setIsReverseCharge (final boolean IsReverseCharge)
+	{
+		set_Value (COLUMNNAME_IsReverseCharge, IsReverseCharge);
+	}
+
+	@Override
+	public boolean isReverseCharge()
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsReverseCharge);
 	}
 
 	@Override
@@ -147,9 +159,22 @@ public class X_C_OrderTax extends org.compiere.model.PO implements I_C_OrderTax,
 	}
 
 	@Override
-	public boolean isProcessed() 
+	public boolean isProcessed()
 	{
 		return get_ValueAsBoolean(COLUMNNAME_Processed);
+	}
+
+	@Override
+	public void setReverseChargeTaxAmt (final BigDecimal ReverseChargeTaxAmt)
+	{
+		set_Value (COLUMNNAME_ReverseChargeTaxAmt, ReverseChargeTaxAmt);
+	}
+
+	@Override
+	public BigDecimal getReverseChargeTaxAmt()
+	{
+		final BigDecimal bd = get_ValueAsBigDecimal(COLUMNNAME_ReverseChargeTaxAmt);
+		return bd != null ? bd : BigDecimal.ZERO;
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_Tax.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_Tax.java
@@ -225,9 +225,21 @@ public class X_C_Tax extends org.compiere.model.PO implements I_C_Tax, org.compi
 	}
 
 	@Override
-	public java.lang.String getIsFiscalRepresentation() 
+	public java.lang.String getIsFiscalRepresentation()
 	{
 		return get_ValueAsString(COLUMNNAME_IsFiscalRepresentation);
+	}
+
+	@Override
+	public void setIsReverseCharge (final boolean IsReverseCharge)
+	{
+		set_Value (COLUMNNAME_IsReverseCharge, IsReverseCharge);
+	}
+
+	@Override
+	public boolean isReverseCharge()
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsReverseCharge);
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5689240_ReverseCharge_fields.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5689240_ReverseCharge_fields.sql
@@ -1,0 +1,331 @@
+-- 2023-05-25T09:20:08.761Z
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,Help,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,582372,0,'IsReverseCharge',TO_TIMESTAMP('2023-05-25 12:20:08','YYYY-MM-DD HH24:MI:SS'),100,'D','When you buy goods or services from suppliers in other EU countries, the Reverse Charge moves the responsibility for the recording of a VAT transaction from the seller to the buyer for that good or service.','Y','Reverse Charge','Reverse Charge',TO_TIMESTAMP('2023-05-25 12:20:08','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2023-05-25T09:20:08.768Z
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=582372 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- Column: C_Tax.IsReverseCharge
+-- 2023-05-25T09:20:23.242Z
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,DefaultValue,EntityType,FacetFilterSeqNo,FieldLength,Help,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version) VALUES (0,586704,582372,0,20,261,'IsReverseCharge',TO_TIMESTAMP('2023-05-25 12:20:23','YYYY-MM-DD HH24:MI:SS'),100,'N','N','D',0,1,'When you buy goods or services from suppliers in other EU countries, the Reverse Charge moves the responsibility for the recording of a VAT transaction from the seller to the buyer for that good or service.','Y','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','N','Y','N',0,'Reverse Charge',0,0,TO_TIMESTAMP('2023-05-25 12:20:23','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+-- 2023-05-25T09:20:23.244Z
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=586704 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 2023-05-25T09:20:23.790Z
+/* DDL */  select update_Column_Translation_From_AD_Element(582372) 
+;
+
+-- 2023-05-25T09:20:24.900Z
+/* DDL */ SELECT public.db_alter_table('C_Tax','ALTER TABLE public.C_Tax ADD COLUMN IsReverseCharge CHAR(1) DEFAULT ''N'' CHECK (IsReverseCharge IN (''Y'',''N'')) NOT NULL')
+;
+
+-- Column: C_OrderTax.IsReverseCharge
+-- 2023-05-25T09:20:58.875Z
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,DefaultValue,EntityType,FacetFilterSeqNo,FieldLength,Help,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version) VALUES (0,586705,582372,0,20,314,'IsReverseCharge',TO_TIMESTAMP('2023-05-25 12:20:58','YYYY-MM-DD HH24:MI:SS'),100,'N','N','D',0,1,'When you buy goods or services from suppliers in other EU countries, the Reverse Charge moves the responsibility for the recording of a VAT transaction from the seller to the buyer for that good or service.','Y','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','N','Y','N',0,'Reverse Charge',0,0,TO_TIMESTAMP('2023-05-25 12:20:58','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+-- 2023-05-25T09:20:58.877Z
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=586705 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 2023-05-25T09:20:59.413Z
+/* DDL */  select update_Column_Translation_From_AD_Element(582372) 
+;
+
+-- 2023-05-25T09:21:01.558Z
+/* DDL */ SELECT public.db_alter_table('C_OrderTax','ALTER TABLE public.C_OrderTax ADD COLUMN IsReverseCharge CHAR(1) DEFAULT ''N'' CHECK (IsReverseCharge IN (''Y'',''N'')) NOT NULL')
+;
+
+-- 2023-05-25T09:22:16.374Z
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,Description,EntityType,Help,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,582373,0,'ReverseChargeTaxAmt',TO_TIMESTAMP('2023-05-25 12:22:16','YYYY-MM-DD HH24:MI:SS'),100,'','D','','Y','Reverse Charge Tax Amount','Reverse Charge Tax',TO_TIMESTAMP('2023-05-25 12:22:16','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2023-05-25T09:22:16.376Z
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=582373 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- Column: C_OrderTax.ReverseChargeTaxAmt
+-- 2023-05-25T09:22:36.416Z
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,DefaultValue,Description,EntityType,FacetFilterSeqNo,FieldLength,Help,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version) VALUES (0,586706,582373,0,12,314,'ReverseChargeTaxAmt',TO_TIMESTAMP('2023-05-25 12:22:36','YYYY-MM-DD HH24:MI:SS'),100,'N','0','','D',0,10,'','Y','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','N','Y','N',0,'Reverse Charge Tax Amount',0,0,TO_TIMESTAMP('2023-05-25 12:22:36','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+-- 2023-05-25T09:22:36.417Z
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=586706 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 2023-05-25T09:22:36.902Z
+/* DDL */  select update_Column_Translation_From_AD_Element(582373) 
+;
+
+-- 2023-05-25T09:22:37.678Z
+/* DDL */ SELECT public.db_alter_table('C_OrderTax','ALTER TABLE public.C_OrderTax ADD COLUMN ReverseChargeTaxAmt NUMERIC DEFAULT 0 NOT NULL')
+;
+
+-- Column: C_InvoiceTax.IsReverseCharge
+-- 2023-05-25T09:23:24.826Z
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,DefaultValue,EntityType,FacetFilterSeqNo,FieldLength,Help,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version) VALUES (0,586707,582372,0,20,334,'IsReverseCharge',TO_TIMESTAMP('2023-05-25 12:23:24','YYYY-MM-DD HH24:MI:SS'),100,'N','N','D',0,1,'When you buy goods or services from suppliers in other EU countries, the Reverse Charge moves the responsibility for the recording of a VAT transaction from the seller to the buyer for that good or service.','Y','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','N','Y','N',0,'Reverse Charge',0,0,TO_TIMESTAMP('2023-05-25 12:23:24','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+-- 2023-05-25T09:23:24.829Z
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=586707 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 2023-05-25T09:23:25.410Z
+/* DDL */  select update_Column_Translation_From_AD_Element(582372) 
+;
+
+-- 2023-05-25T09:23:27.044Z
+/* DDL */ SELECT public.db_alter_table('C_InvoiceTax','ALTER TABLE public.C_InvoiceTax ADD COLUMN IsReverseCharge CHAR(1) DEFAULT ''N'' CHECK (IsReverseCharge IN (''Y'',''N'')) NOT NULL')
+;
+
+-- Column: C_InvoiceTax.ReverseChargeTaxAmt
+-- 2023-05-25T09:23:40.542Z
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,DefaultValue,Description,EntityType,FacetFilterSeqNo,FieldLength,Help,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version) VALUES (0,586708,582373,0,12,334,'ReverseChargeTaxAmt',TO_TIMESTAMP('2023-05-25 12:23:39','YYYY-MM-DD HH24:MI:SS'),100,'N','0','','D',0,10,'','Y','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','N','Y','N',0,'Reverse Charge Tax Amount',0,0,TO_TIMESTAMP('2023-05-25 12:23:39','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+-- 2023-05-25T09:23:40.544Z
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=586708 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 2023-05-25T09:23:41.082Z
+/* DDL */  select update_Column_Translation_From_AD_Element(582373) 
+;
+
+-- 2023-05-25T09:23:41.865Z
+/* DDL */ SELECT public.db_alter_table('C_InvoiceTax','ALTER TABLE public.C_InvoiceTax ADD COLUMN ReverseChargeTaxAmt NUMERIC DEFAULT 0 NOT NULL')
+;
+
+-- Field: Tax Rate(137,D) -> Tax(174,D) -> Reverse Charge
+-- Column: C_Tax.IsReverseCharge
+-- 2023-05-25T12:33:27.578Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,DisplayLength,EntityType,Help,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,Updated,UpdatedBy) VALUES (0,586704,715578,0,174,TO_TIMESTAMP('2023-05-25 15:33:27','YYYY-MM-DD HH24:MI:SS'),100,1,'D','When you buy goods or services from suppliers in other EU countries, the Reverse Charge moves the responsibility for the recording of a VAT transaction from the seller to the buyer for that good or service.','Y','N','N','N','N','N','N','N','Reverse Charge',TO_TIMESTAMP('2023-05-25 15:33:27','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2023-05-25T12:33:27.580Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=715578 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2023-05-25T12:33:27.583Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(582372) 
+;
+
+-- 2023-05-25T12:33:27.596Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=715578
+;
+
+-- 2023-05-25T12:33:27.598Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(715578)
+;
+
+-- UI Element: Tax Rate(137,D) -> Tax(174,D) -> main -> 20 -> property.Reverse Charge
+-- Column: C_Tax.IsReverseCharge
+-- 2023-05-25T12:34:18.841Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Help,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,715578,0,174,545777,617553,'F',TO_TIMESTAMP('2023-05-25 15:34:18','YYYY-MM-DD HH24:MI:SS'),100,'When you buy goods or services from suppliers in other EU countries, the Reverse Charge moves the responsibility for the recording of a VAT transaction from the seller to the buyer for that good or service.','Y','N','Y','N','N','Reverse Charge',50,0,0,TO_TIMESTAMP('2023-05-25 15:34:18','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- UI Element: Tax Rate(137,D) -> Tax(174,D) -> main -> 20 -> property.Reverse Charge
+-- Column: C_Tax.IsReverseCharge
+-- 2023-05-25T12:34:27.670Z
+UPDATE AD_UI_Element SET SeqNo=15,Updated=TO_TIMESTAMP('2023-05-25 15:34:27','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=617553
+;
+
+-- Field: Invoice (Vendor)_OLD(183,D) -> Invoice Tax(292,D) -> Reverse Charge
+-- Column: C_InvoiceTax.IsReverseCharge
+-- 2023-05-25T12:37:49.633Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,DisplayLength,EntityType,Help,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,Updated,UpdatedBy) VALUES (0,586707,715974,0,292,TO_TIMESTAMP('2023-05-25 15:37:49','YYYY-MM-DD HH24:MI:SS'),100,1,'D','When you buy goods or services from suppliers in other EU countries, the Reverse Charge moves the responsibility for the recording of a VAT transaction from the seller to the buyer for that good or service.','Y','N','N','N','N','N','N','N','Reverse Charge',TO_TIMESTAMP('2023-05-25 15:37:49','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2023-05-25T12:37:49.635Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=715974 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2023-05-25T12:37:49.637Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(582372) 
+;
+
+-- 2023-05-25T12:37:49.642Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=715974
+;
+
+-- 2023-05-25T12:37:49.643Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(715974)
+;
+
+-- Field: Invoice (Vendor)_OLD(183,D) -> Invoice Tax(292,D) -> Reverse Charge Tax Amount
+-- Column: C_InvoiceTax.ReverseChargeTaxAmt
+-- 2023-05-25T12:37:49.771Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,Description,DisplayLength,EntityType,Help,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,Updated,UpdatedBy) VALUES (0,586708,715975,0,292,TO_TIMESTAMP('2023-05-25 15:37:49','YYYY-MM-DD HH24:MI:SS'),100,'',10,'D','','Y','N','N','N','N','N','N','N','Reverse Charge Tax Amount',TO_TIMESTAMP('2023-05-25 15:37:49','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2023-05-25T12:37:49.772Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=715975 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2023-05-25T12:37:49.774Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(582373) 
+;
+
+-- 2023-05-25T12:37:49.778Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=715975
+;
+
+-- 2023-05-25T12:37:49.779Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(715975)
+;
+
+-- UI Element: Invoice (Vendor)_OLD(183,D) -> Invoice Tax(292,D) -> main -> 10 -> default.Reverse Charge
+-- Column: C_InvoiceTax.IsReverseCharge
+-- 2023-05-25T12:38:29.412Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Help,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,715974,0,292,540220,617753,'F',TO_TIMESTAMP('2023-05-25 15:38:29','YYYY-MM-DD HH24:MI:SS'),100,'When you buy goods or services from suppliers in other EU countries, the Reverse Charge moves the responsibility for the recording of a VAT transaction from the seller to the buyer for that good or service.','Y','N','Y','N','N','Reverse Charge',20,0,0,TO_TIMESTAMP('2023-05-25 15:38:29','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- UI Element: Invoice (Vendor)_OLD(183,D) -> Invoice Tax(292,D) -> main -> 10 -> default.Reverse Charge Tax Amount
+-- Column: C_InvoiceTax.ReverseChargeTaxAmt
+-- 2023-05-25T12:38:36.717Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,715975,0,292,540220,617770,'F',TO_TIMESTAMP('2023-05-25 15:38:36','YYYY-MM-DD HH24:MI:SS'),100,'','','Y','N','Y','N','N','Reverse Charge Tax Amount',30,0,0,TO_TIMESTAMP('2023-05-25 15:38:36','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- UI Element: Invoice (Vendor)_OLD(183,D) -> Invoice Tax(292,D) -> main -> 10 -> default.Reverse Charge Tax Amount
+-- Column: C_InvoiceTax.ReverseChargeTaxAmt
+-- 2023-05-25T12:39:35.166Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=30,Updated=TO_TIMESTAMP('2023-05-25 15:39:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=617770
+;
+
+-- UI Element: Invoice (Vendor)_OLD(183,D) -> Invoice Tax(292,D) -> main -> 10 -> default.Bezugswert
+-- Column: C_InvoiceTax.TaxBaseAmt
+-- 2023-05-25T12:39:35.173Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=40,Updated=TO_TIMESTAMP('2023-05-25 15:39:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=542676
+;
+
+-- UI Element: Invoice (Vendor)_OLD(183,D) -> Invoice Tax(292,D) -> main -> 10 -> default.Preis inklusive Steuern
+-- Column: C_InvoiceTax.IsTaxIncluded
+-- 2023-05-25T12:39:35.180Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=50,Updated=TO_TIMESTAMP('2023-05-25 15:39:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=542677
+;
+
+-- UI Element: Invoice (Vendor)_OLD(183,D) -> Invoice Tax(292,D) -> main -> 10 -> default.Whole Tax
+-- Column: C_InvoiceTax.IsWholeTax
+-- 2023-05-25T12:39:35.186Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=60,Updated=TO_TIMESTAMP('2023-05-25 15:39:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=542678
+;
+
+-- UI Element: Invoice (Vendor)_OLD(183,D) -> Invoice Tax(292,D) -> main -> 10 -> default.Reverse Charge
+-- Column: C_InvoiceTax.IsReverseCharge
+-- 2023-05-25T12:39:35.193Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=70,Updated=TO_TIMESTAMP('2023-05-25 15:39:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=617753
+;
+
+-- UI Element: Invoice (Vendor)_OLD(183,D) -> Invoice Tax(292,D) -> main -> 10 -> default.Packaging Tax
+-- Column: C_InvoiceTax.IsPackagingTax
+-- 2023-05-25T12:39:35.199Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=80,Updated=TO_TIMESTAMP('2023-05-25 15:39:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=542679
+;
+
+-- UI Element: Invoice (Vendor)_OLD(183,D) -> Invoice Tax(292,D) -> main -> 10 -> default.Sektion
+-- Column: C_InvoiceTax.AD_Org_ID
+-- 2023-05-25T12:39:35.205Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=90,Updated=TO_TIMESTAMP('2023-05-25 15:39:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=542672
+;
+
+-- Field: Purchase Order_OLD(181,D) -> Order Tax(295,D) -> Reverse Charge
+-- Column: C_OrderTax.IsReverseCharge
+-- 2023-05-25T14:05:16.017Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,DisplayLength,EntityType,Help,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,Updated,UpdatedBy) VALUES (0,586705,715976,0,295,TO_TIMESTAMP('2023-05-25 17:05:15','YYYY-MM-DD HH24:MI:SS'),100,1,'D','When you buy goods or services from suppliers in other EU countries, the Reverse Charge moves the responsibility for the recording of a VAT transaction from the seller to the buyer for that good or service.','Y','N','N','N','N','N','N','N','Reverse Charge',TO_TIMESTAMP('2023-05-25 17:05:15','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2023-05-25T14:05:16.019Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=715976 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2023-05-25T14:05:16.021Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(582372) 
+;
+
+-- 2023-05-25T14:05:16.027Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=715976
+;
+
+-- 2023-05-25T14:05:16.028Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(715976)
+;
+
+-- Field: Purchase Order_OLD(181,D) -> Order Tax(295,D) -> Reverse Charge Tax Amount
+-- Column: C_OrderTax.ReverseChargeTaxAmt
+-- 2023-05-25T14:05:16.152Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,Description,DisplayLength,EntityType,Help,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,Updated,UpdatedBy) VALUES (0,586706,715977,0,295,TO_TIMESTAMP('2023-05-25 17:05:16','YYYY-MM-DD HH24:MI:SS'),100,'',10,'D','','Y','N','N','N','N','N','N','N','Reverse Charge Tax Amount',TO_TIMESTAMP('2023-05-25 17:05:16','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2023-05-25T14:05:16.154Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=715977 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2023-05-25T14:05:16.155Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(582373) 
+;
+
+-- 2023-05-25T14:05:16.158Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=715977
+;
+
+-- 2023-05-25T14:05:16.159Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(715977)
+;
+
+-- UI Element: Purchase Order_OLD(181,D) -> Order Tax(295,D) -> main -> 10 -> default.Reverse Charge
+-- Column: C_OrderTax.IsReverseCharge
+-- 2023-05-25T14:09:47.494Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Help,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,715976,0,295,540071,617874,'F',TO_TIMESTAMP('2023-05-25 17:09:47','YYYY-MM-DD HH24:MI:SS'),100,'When you buy goods or services from suppliers in other EU countries, the Reverse Charge moves the responsibility for the recording of a VAT transaction from the seller to the buyer for that good or service.','Y','N','Y','N','N','Reverse Charge',100,0,0,TO_TIMESTAMP('2023-05-25 17:09:47','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- UI Element: Purchase Order_OLD(181,D) -> Order Tax(295,D) -> main -> 10 -> default.Reverse Charge Tax Amount
+-- Column: C_OrderTax.ReverseChargeTaxAmt
+-- 2023-05-25T14:09:55.003Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,715977,0,295,540071,617875,'F',TO_TIMESTAMP('2023-05-25 17:09:54','YYYY-MM-DD HH24:MI:SS'),100,'','','Y','N','Y','N','N','Reverse Charge Tax Amount',110,0,0,TO_TIMESTAMP('2023-05-25 17:09:54','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- UI Element: Purchase Order_OLD(181,D) -> Order Tax(295,D) -> main -> 10 -> default.Reverse Charge Tax Amount
+-- Column: C_OrderTax.ReverseChargeTaxAmt
+-- 2023-05-25T14:10:46.136Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=30,Updated=TO_TIMESTAMP('2023-05-25 17:10:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=617875
+;
+
+-- UI Element: Purchase Order_OLD(181,D) -> Order Tax(295,D) -> main -> 10 -> default.Bezugswert
+-- Column: C_OrderTax.TaxBaseAmt
+-- 2023-05-25T14:10:46.143Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=40,Updated=TO_TIMESTAMP('2023-05-25 17:10:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=541275
+;
+
+-- UI Element: Purchase Order_OLD(181,D) -> Order Tax(295,D) -> main -> 10 -> default.Preis inklusive Steuern
+-- Column: C_OrderTax.IsTaxIncluded
+-- 2023-05-25T14:10:46.151Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=50,Updated=TO_TIMESTAMP('2023-05-25 17:10:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=541276
+;
+
+-- UI Element: Purchase Order_OLD(181,D) -> Order Tax(295,D) -> main -> 10 -> default.Whole Tax
+-- Column: C_OrderTax.IsWholeTax
+-- 2023-05-25T14:10:46.158Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=60,Updated=TO_TIMESTAMP('2023-05-25 17:10:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=541277
+;
+
+-- UI Element: Purchase Order_OLD(181,D) -> Order Tax(295,D) -> main -> 10 -> default.Reverse Charge
+-- Column: C_OrderTax.IsReverseCharge
+-- 2023-05-25T14:10:46.164Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=70,Updated=TO_TIMESTAMP('2023-05-25 17:10:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=617874
+;
+
+-- UI Element: Purchase Order_OLD(181,D) -> Order Tax(295,D) -> main -> 10 -> default.Packaging Tax
+-- Column: C_OrderTax.IsPackagingTax
+-- 2023-05-25T14:10:46.170Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=80,Updated=TO_TIMESTAMP('2023-05-25 17:10:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=541278
+;
+
+-- UI Element: Purchase Order_OLD(181,D) -> Order Tax(295,D) -> main -> 10 -> default.Sektion
+-- Column: C_OrderTax.AD_Org_ID
+-- 2023-05-25T14:10:46.176Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=90,Updated=TO_TIMESTAMP('2023-05-25 17:10:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_UI_Element_ID=541271
+;
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798410_sys_ReverseCharge_element_translations.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798410_sys_ReverseCharge_element_translations.sql
@@ -1,0 +1,79 @@
+-- Element 582372: IsReverseCharge
+-- Base record (de_DE): "Reverse Charge" is the standard German term (§13b UStG), keep as-is
+-- Description + Help: translate to German
+UPDATE AD_Element
+SET Description = 'Beim Bezug von Waren oder Dienstleistungen aus anderen EU-Ländern wird die Steuerschuldnerschaft auf den Leistungsempfänger übertragen (§13b UStG).',
+    Help = 'Beim Bezug von Waren oder Dienstleistungen aus anderen EU-Ländern wird die Steuerschuldnerschaft auf den Leistungsempfänger übertragen (§13b UStG). Beide Steuerbeträge (Vorsteuer und Umsatzsteuer) werden in der Buchung erfasst und saldieren sich auf null.',
+    Updated = '2026-04-17 13:30',
+    UpdatedBy = 0
+WHERE AD_Element_ID = 582372;
+
+-- en_US translation
+UPDATE AD_Element_Trl
+SET Name = 'Reverse Charge',
+    PrintName = 'Reverse Charge',
+    Description = 'When you buy goods or services from suppliers in other EU countries, the Reverse Charge moves the responsibility for the recording of a VAT transaction from the seller to the buyer.',
+    Help = 'When you buy goods or services from suppliers in other EU countries, the Reverse Charge moves the responsibility for the recording of a VAT transaction from the seller to the buyer for that good or service. Both tax amounts (input and output VAT) are recorded in the posting and net to zero.',
+    IsTranslated = 'Y',
+    Updated = '2026-04-17 13:30',
+    UpdatedBy = 0
+WHERE AD_Element_ID = 582372 AND AD_Language = 'en_US';
+
+-- de_DE: same as base, mark as not translated (base language)
+UPDATE AD_Element_Trl
+SET Description = 'Beim Bezug von Waren oder Dienstleistungen aus anderen EU-Ländern wird die Steuerschuldnerschaft auf den Leistungsempfänger übertragen (§13b UStG).',
+    Help = 'Beim Bezug von Waren oder Dienstleistungen aus anderen EU-Ländern wird die Steuerschuldnerschaft auf den Leistungsempfänger übertragen (§13b UStG). Beide Steuerbeträge (Vorsteuer und Umsatzsteuer) werden in der Buchung erfasst und saldieren sich auf null.',
+    IsTranslated = 'N',
+    Updated = '2026-04-17 13:30',
+    UpdatedBy = 0
+WHERE AD_Element_ID = 582372 AND AD_Language IN ('de_DE', 'de_CH');
+
+
+-- Element 582373: ReverseChargeTaxAmt
+-- Base record (de_DE): translate to German
+UPDATE AD_Element
+SET Name = 'Reverse-Charge-Steuerbetrag',
+    PrintName = 'RC Steuerbetrag',
+    Description = 'Steuerbetrag für die Reverse-Charge-Buchung (§13b UStG). Wird nicht dem Rechnungsbetrag hinzugerechnet.',
+    Help = 'Der Reverse-Charge-Steuerbetrag wird bei der Rechnungsverbuchung als zwei sich aufhebende Buchungszeilen (Vorsteuer und Umsatzsteuer) erfasst. Der Betrag dient der korrekten Umsatzsteuer-Voranmeldung.',
+    Updated = '2026-04-17 13:30',
+    UpdatedBy = 0
+WHERE AD_Element_ID = 582373;
+
+-- en_US translation
+UPDATE AD_Element_Trl
+SET Name = 'Reverse Charge Tax Amount',
+    PrintName = 'RC Tax Amount',
+    Description = 'Tax amount for the reverse charge posting. Not added to the invoice payable amount.',
+    Help = 'The reverse charge tax amount is posted as two offsetting lines (input VAT and output VAT) during invoice accounting. The amount is used for the correct VAT declaration.',
+    IsTranslated = 'Y',
+    Updated = '2026-04-17 13:30',
+    UpdatedBy = 0
+WHERE AD_Element_ID = 582373 AND AD_Language = 'en_US';
+
+-- de_DE / de_CH: same as base
+UPDATE AD_Element_Trl
+SET Name = 'Reverse-Charge-Steuerbetrag',
+    PrintName = 'RC Steuerbetrag',
+    Description = 'Steuerbetrag für die Reverse-Charge-Buchung (§13b UStG). Wird nicht dem Rechnungsbetrag hinzugerechnet.',
+    Help = 'Der Reverse-Charge-Steuerbetrag wird bei der Rechnungsverbuchung als zwei sich aufhebende Buchungszeilen (Vorsteuer und Umsatzsteuer) erfasst. Der Betrag dient der korrekten Umsatzsteuer-Voranmeldung.',
+    IsTranslated = 'N',
+    Updated = '2026-04-17 13:30',
+    UpdatedBy = 0
+WHERE AD_Element_ID = 582373 AND AD_Language IN ('de_DE', 'de_CH');
+
+
+-- Propagate element translations to AD_Column, AD_Field, AD_Process_Para etc.
+SELECT update_ad_element_on_ad_element_trl_update(582372, 'de_DE');
+SELECT update_ad_element_on_ad_element_trl_update(582372, 'de_CH');
+SELECT update_ad_element_on_ad_element_trl_update(582372, 'en_US');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(582372, 'de_DE');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(582372, 'de_CH');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(582372, 'en_US');
+
+SELECT update_ad_element_on_ad_element_trl_update(582373, 'de_DE');
+SELECT update_ad_element_on_ad_element_trl_update(582373, 'de_CH');
+SELECT update_ad_element_on_ad_element_trl_update(582373, 'en_US');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(582373, 'de_DE');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(582373, 'de_CH');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(582373, 'en_US');

--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MInvoice.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MInvoice.java
@@ -56,7 +56,6 @@ import de.metas.report.DocumentReportService;
 import de.metas.report.ReportResultData;
 import de.metas.report.StandardDocumentReportType;
 import de.metas.tax.api.CalculateTaxResult;
-import de.metas.tax.api.ITaxBL;
 import de.metas.tax.api.Tax;
 import de.metas.tax.api.TaxUtils;
 import de.metas.util.Check;

--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MInvoice.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MInvoice.java
@@ -55,7 +55,9 @@ import de.metas.pricing.service.IPriceListDAO;
 import de.metas.report.DocumentReportService;
 import de.metas.report.ReportResultData;
 import de.metas.report.StandardDocumentReportType;
+import de.metas.tax.api.CalculateTaxResult;
 import de.metas.tax.api.ITaxBL;
+import de.metas.tax.api.Tax;
 import de.metas.tax.api.TaxUtils;
 import de.metas.util.Check;
 import de.metas.util.Services;
@@ -936,27 +938,29 @@ public class MInvoice extends X_C_Invoice implements IDocument
 			final MTax tax = iTax.getTax();
 			if (tax.isSummary())
 			{
-				final MTax[] cTaxes = tax.getChildTaxes(false);    // Multiple taxes
-				for (final MTax cTax : cTaxes)
+				for (final I_C_Tax childTaxRecord : tax.getChildTaxes(false))
 				{
-					final boolean taxIncluded = Services.get(IInvoiceBL.class).isTaxIncluded(this, TaxUtils.from(cTax));
+					final Tax childTax = TaxUtils.from(childTaxRecord);
+					final boolean taxIncluded = Services.get(IInvoiceBL.class).isTaxIncluded(this, childTax);
 					final BigDecimal taxBaseAmt = iTax.getTaxBaseAmt();
-					final BigDecimal taxAmt = Services.get(ITaxBL.class).calculateTaxAmt(cTax, taxBaseAmt, taxIncluded, taxPrecision.toInt());
+					final CalculateTaxResult calculateTaxResult = childTax.calculateTax(taxBaseAmt, taxIncluded, taxPrecision.toInt());
 					//
 					final MInvoiceTax newITax = new MInvoiceTax(getCtx(), 0, trxName);
 					newITax.setClientOrg(this);
 					newITax.setC_Invoice(this);
-					newITax.setC_Tax_ID(cTax.getC_Tax_ID());
+					newITax.setC_Tax_ID(childTaxRecord.getC_Tax_ID());
 					newITax.setPrecision(taxPrecision.toInt());
 					newITax.setIsTaxIncluded(taxIncluded);
-					newITax.setIsDocumentLevel(cTax.isDocumentLevel());
+					newITax.setIsDocumentLevel(childTaxRecord.isDocumentLevel());
+					newITax.setIsReverseCharge(childTax.isReverseCharge());
 					newITax.setTaxBaseAmt(taxBaseAmt);
-					newITax.setTaxAmt(taxAmt);
+					newITax.setTaxAmt(calculateTaxResult.getTaxAmount());
+					newITax.setReverseChargeTaxAmt(calculateTaxResult.getReverseChargeAmt());
 					newITax.saveEx(trxName);
 					//
 					if (!taxIncluded)
 					{
-						grandTotal = grandTotal.add(taxAmt);
+						grandTotal = grandTotal.add(calculateTaxResult.getTaxAmount());
 					}
 				}
 

--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MInvoiceTax.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MInvoiceTax.java
@@ -16,12 +16,15 @@
  *****************************************************************************/
 package org.compiere.model;
 
+import de.metas.common.util.CoalesceUtil;
 import de.metas.invoice.service.IInvoiceBL;
 import de.metas.logging.LogManager;
+import de.metas.tax.api.CalculateTaxResult;
 import de.metas.tax.api.ITaxBL;
 import de.metas.tax.api.ITaxDAO;
 import de.metas.tax.api.Tax;
 import de.metas.util.Services;
+import de.metas.util.StringUtils;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.exceptions.DBException;
 import org.compiere.util.DB;
@@ -118,6 +121,7 @@ public class MInvoiceTax extends X_C_InvoiceTax
 		retValue.setC_Invoice_ID(line.getC_Invoice_ID());
 		retValue.setC_Tax_ID(tax.getTaxId().getRepoId());
 		retValue.setIsWholeTax(tax.isWholeTax());
+		retValue.setIsReverseCharge(tax.isReverseCharge());
 		retValue.setIsDocumentLevel(tax.isDocumentLevel());
 		retValue.setPrecision(precision);
 		retValue.setIsTaxIncluded(taxIncluded);
@@ -197,12 +201,13 @@ public class MInvoiceTax extends X_C_InvoiceTax
 	{
 		final ITaxBL taxBL = Services.get(ITaxBL.class);
 
-		BigDecimal taxBaseAmt = BigDecimal.ZERO;
-		BigDecimal taxAmt = BigDecimal.ZERO;
+		BigDecimal taxBaseAmtTotal = BigDecimal.ZERO;
+		BigDecimal taxAmtTotal = BigDecimal.ZERO;
+		BigDecimal reverseChargeTaxAmtTotal = BigDecimal.ZERO;
 		boolean foundInvoiceLines = false;
 		//
-		final boolean documentLevel = getTax().isDocumentLevel();
 		final I_C_Tax tax = getTax();
+		final boolean documentLevel = tax.isDocumentLevel();
 		//
 		boolean havePackingMaterialLines = false;
 		boolean haveNonPackingMaterialLines = false;
@@ -231,33 +236,34 @@ public class MInvoiceTax extends X_C_InvoiceTax
 			while (rs.next())
 			{
 				foundInvoiceLines = true;
-				// BaseAmt
-				BigDecimal baseAmt = rs.getBigDecimal(1);
-				taxBaseAmt = taxBaseAmt.add(baseAmt);
-				// TaxAmt
-				BigDecimal amt = rs.getBigDecimal(2);
-				if (amt == null)
-				{
-					amt = BigDecimal.ZERO;
-				}
-				boolean isSOTrx = "Y".equals(rs.getString(3));
+
+				final BigDecimal lineNetAmt = rs.getBigDecimal(1);
+				taxBaseAmtTotal = taxBaseAmtTotal.add(lineNetAmt);
+
+				final boolean isSOTrx = StringUtils.toBoolean(rs.getString(3));
+
 				//
-				// phib [ 1702807 ]: manual tax should never be amended
-				// on line level taxes
-				if (!documentLevel && amt.signum() != 0 && !isSOTrx)
+				// phib [ 1702807 ]: manual tax should never be amended on line level taxes
+				BigDecimal taxAmt = CoalesceUtil.coalesceNotNull(rs.getBigDecimal(2), BigDecimal.ZERO);
+				BigDecimal reverseChargeTaxAmt;
+				if (!documentLevel && taxAmt.signum() != 0 && !isSOTrx)
 				{
-					;
+					reverseChargeTaxAmt = BigDecimal.ZERO;
 				}
-				else if (documentLevel || baseAmt.signum() == 0)
+				else if (documentLevel || lineNetAmt.signum() == 0)
 				{
-					amt = BigDecimal.ZERO;
+					taxAmt = BigDecimal.ZERO;
+					reverseChargeTaxAmt = BigDecimal.ZERO;
 				}
 				else
 				{
-					amt = taxBL.calculateTaxAmt(tax, baseAmt, isTaxIncluded(), getPrecision());
+					final CalculateTaxResult calculateTaxResult = taxBL.calculateTax(tax, lineNetAmt, isTaxIncluded(), getPrecision());
+					taxAmt = calculateTaxResult.getTaxAmount();
+					reverseChargeTaxAmt = calculateTaxResult.getReverseChargeAmt();
 				}
 				//
-				taxAmt = taxAmt.add(amt);
+				taxAmtTotal = taxAmtTotal.add(taxAmt);
+				reverseChargeTaxAmtTotal = reverseChargeTaxAmtTotal.add(reverseChargeTaxAmt);
 
 				final boolean lineIsPackingMaterial = DisplayType.toBoolean(rs.getString(4));
 				if (lineIsPackingMaterial)
@@ -280,20 +286,23 @@ public class MInvoiceTax extends X_C_InvoiceTax
 		}
 
 		// Calculate Tax
-		if (documentLevel || taxAmt.signum() == 0)
+		if (documentLevel || taxAmtTotal.signum() == 0)
 		{
-			taxAmt = taxBL.calculateTaxAmt(tax, taxBaseAmt, isTaxIncluded(), getPrecision());
+			final CalculateTaxResult calculateTaxResult = taxBL.calculateTax(tax, taxBaseAmtTotal, isTaxIncluded(), getPrecision());
+			taxAmtTotal = calculateTaxResult.getTaxAmount();
+			reverseChargeTaxAmtTotal = calculateTaxResult.getReverseChargeAmt();
 		}
-		setTaxAmt(taxAmt);
+		setTaxAmt(taxAmtTotal);
+		setReverseChargeTaxAmt(reverseChargeTaxAmtTotal);
 
 		// Set Base
 		if (isTaxIncluded())
 		{
-			setTaxBaseAmt(taxBaseAmt.subtract(taxAmt));
+			setTaxBaseAmt(taxBaseAmtTotal.subtract(taxAmtTotal));
 		}
 		else
 		{
-			setTaxBaseAmt(taxBaseAmt);
+			setTaxBaseAmt(taxBaseAmtTotal);
 		}
 
 		// Deactivate InvoiceTax if there were no invoice lines matching our C_Tax_ID
@@ -301,6 +310,7 @@ public class MInvoiceTax extends X_C_InvoiceTax
 		setIsActive(foundInvoiceLines);
 
 		setIsPackagingTax(checkIsPackagingMaterialTax(havePackingMaterialLines, haveNonPackingMaterialLines));
+		setIsReverseCharge(tax.isReverseCharge());
 
 		return true;
 	}	// calculateTaxFromLines
@@ -311,6 +321,7 @@ public class MInvoiceTax extends X_C_InvoiceTax
 		return "MInvoiceTax[" + "C_Invoice_ID=" + getC_Invoice_ID()
 				+ ",C_Tax_ID=" + getC_Tax_ID()
 				+ ", Base=" + getTaxBaseAmt() + ",Tax=" + getTaxAmt()
+				+ (isReverseCharge() ? ", ReverseCharge=" + getReverseChargeTaxAmt() : "")
 				+ "]";
 	}
 

--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MOrder.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MOrder.java
@@ -74,7 +74,6 @@ import de.metas.report.DocumentReportService;
 import de.metas.report.ReportResultData;
 import de.metas.report.StandardDocumentReportType;
 import de.metas.tax.api.CalculateTaxResult;
-import de.metas.tax.api.ITaxBL;
 import de.metas.tax.api.Tax;
 import de.metas.tax.api.TaxUtils;
 import de.metas.util.Check;

--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MOrder.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MOrder.java
@@ -73,7 +73,9 @@ import de.metas.product.ProductId;
 import de.metas.report.DocumentReportService;
 import de.metas.report.ReportResultData;
 import de.metas.report.StandardDocumentReportType;
+import de.metas.tax.api.CalculateTaxResult;
 import de.metas.tax.api.ITaxBL;
+import de.metas.tax.api.Tax;
 import de.metas.tax.api.TaxUtils;
 import de.metas.util.Check;
 import de.metas.util.Services;
@@ -1510,30 +1512,29 @@ public class MOrder extends X_C_Order implements IDocument
 			final MTax tax = oTax.getTax();
 			if (tax.isSummary())
 			{
-				final MTax[] cTaxes = tax.getChildTaxes(false);
-				for (final MTax cTax : cTaxes)
+				for (final I_C_Tax childTaxRecord : tax.getChildTaxes(false))
 				{
+					final Tax childTax = TaxUtils.from(childTaxRecord);
 					final CurrencyPrecision taxPrecision = orderBL.getTaxPrecision(this);
-					final boolean taxIncluded = orderBL.isTaxIncluded(this, TaxUtils.from(cTax));
-					final BigDecimal taxAmt = Services.get(ITaxBL.class).calculateTaxAmt(cTax, oTax.getTaxBaseAmt(), taxIncluded, taxPrecision.toInt());
+					final boolean taxIncluded = orderBL.isTaxIncluded(this, childTax);
+					final CalculateTaxResult calculateTaxResult = childTax.calculateTax(oTax.getTaxBaseAmt(), taxIncluded, taxPrecision.toInt());
 					//
 					final MOrderTax newOTax = new MOrderTax(getCtx(), 0, trxName);
 					newOTax.setClientOrg(this);
 					newOTax.setC_Order_ID(getC_Order_ID());
-					newOTax.setC_Tax_ID(cTax.getC_Tax_ID());
+					newOTax.setC_Tax_ID(childTaxRecord.getC_Tax_ID());
 					newOTax.setPrecision(taxPrecision.toInt());
 					newOTax.setIsTaxIncluded(taxIncluded);
-					newOTax.setIsDocumentLevel(cTax.isDocumentLevel());
+					newOTax.setIsDocumentLevel(childTaxRecord.isDocumentLevel());
+					newOTax.setIsReverseCharge(childTax.isReverseCharge());
 					newOTax.setTaxBaseAmt(oTax.getTaxBaseAmt());
-					newOTax.setTaxAmt(taxAmt);
-					if (!newOTax.save(trxName))
-					{
-						return false;
-					}
+					newOTax.setTaxAmt(calculateTaxResult.getTaxAmount());
+					newOTax.setReverseChargeTaxAmt(calculateTaxResult.getReverseChargeAmt());
+					InterfaceWrapperHelper.save(newOTax);
 					//
 					if (!newOTax.isTaxIncluded())
 					{
-						grandTotal = grandTotal.add(taxAmt);
+						grandTotal = grandTotal.add(calculateTaxResult.getTaxAmount());
 					}
 				}
 				if (!oTax.delete(true, trxName))

--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MOrderTax.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MOrderTax.java
@@ -19,6 +19,7 @@ package org.compiere.model;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.logging.LogManager;
 import de.metas.order.IOrderLineBL;
+import de.metas.tax.api.CalculateTaxResult;
 import de.metas.tax.api.ITaxBL;
 import de.metas.tax.api.ITaxDAO;
 import de.metas.tax.api.Tax;
@@ -133,6 +134,7 @@ public class MOrderTax extends X_C_OrderTax
 		retValue.setC_Order_ID(line.getC_Order_ID());
 		retValue.setC_Tax_ID(tax.getTaxId().getRepoId());
 		retValue.setIsWholeTax(tax.isWholeTax());
+		retValue.setIsReverseCharge(tax.isReverseCharge());
 		retValue.setIsDocumentLevel(tax.isDocumentLevel());
 		retValue.setPrecision(precision);
 		retValue.setIsTaxIncluded(taxIncluded);
@@ -225,12 +227,13 @@ public class MOrderTax extends X_C_OrderTax
 
 		BigDecimal taxBaseAmt = BigDecimal.ZERO;
 		BigDecimal taxAmt = BigDecimal.ZERO;
+		BigDecimal reverseChargeTaxAmt = BigDecimal.ZERO;
 		boolean havePackingMaterialLines = false;
 		boolean haveNonPackingMaterialLines = false;
 		boolean foundInvoiceLines = false;
 		//
-		final boolean documentLevel = getTax().isDocumentLevel();
 		final I_C_Tax tax = getTax();
+		final boolean documentLevel = tax.isDocumentLevel();
 		//
 		final String sql = "SELECT "
 				+ I_C_OrderLine.COLUMNNAME_LineNetAmt // 1
@@ -256,7 +259,9 @@ public class MOrderTax extends X_C_OrderTax
 				//
 				if (!documentLevel)
 				{
-					taxAmt = taxAmt.add(taxBL.calculateTaxAmt(tax, baseAmt, isTaxIncluded(), getPrecision()));
+					final CalculateTaxResult calculateTaxResult = taxBL.calculateTax(tax, baseAmt, isTaxIncluded(), getPrecision());
+					taxAmt = taxAmt.add(calculateTaxResult.getTaxAmount());
+					reverseChargeTaxAmt = reverseChargeTaxAmt.add(calculateTaxResult.getReverseChargeAmt());
 				}
 
 				//
@@ -273,26 +278,22 @@ public class MOrderTax extends X_C_OrderTax
 		}
 		catch (Exception e)
 		{
-			log.error(get_TrxName(), e);
-			taxBaseAmt = null;
+			throw new DBException(e, sql);
 		}
 		finally
 		{
 			DB.close(rs, pstmt);
 		}
 
-		//
-		if (taxBaseAmt == null)
-		{
-			return false;
-		}
-
 		// Calculate Tax
 		if (documentLevel)
 		{
-			taxAmt = taxBL.calculateTaxAmt(tax, taxBaseAmt, isTaxIncluded(), getPrecision());
+			final CalculateTaxResult calculateTaxResult = taxBL.calculateTax(tax, taxBaseAmt, isTaxIncluded(), getPrecision());
+			taxAmt = calculateTaxResult.getTaxAmount();
+			reverseChargeTaxAmt = calculateTaxResult.getReverseChargeAmt();
 		}
 		setTaxAmt(taxAmt);
+		setReverseChargeTaxAmt(reverseChargeTaxAmt);
 
 		// Set Base
 		if (isTaxIncluded())
@@ -309,6 +310,7 @@ public class MOrderTax extends X_C_OrderTax
 		setIsActive(foundInvoiceLines);
 
 		setIsPackagingTax(checkIsPackagingMaterialTax(havePackingMaterialLines, haveNonPackingMaterialLines));
+		setIsReverseCharge(tax.isReverseCharge());
 
 		return true;
 	}    // calculateTaxFromLines
@@ -342,6 +344,7 @@ public class MOrderTax extends X_C_OrderTax
 				+ ", C_Tax_ID=" + getC_Tax_ID()
 				+ ", Base=" + getTaxBaseAmt()
 				+ ", Tax=" + getTaxAmt()
+				+ (isReverseCharge() ? ", ReverseCharge=" + getReverseChargeTaxAmt() : "")
 				+ "]";
 	}
 

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/service/impl/AbstractInvoiceDAO.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/service/impl/AbstractInvoiceDAO.java
@@ -303,8 +303,8 @@ public abstract class AbstractInvoiceDAO implements IInvoiceDAO
 				.taxAmt(record.getTaxAmt())
 				.taxBaseAmt(record.getTaxBaseAmt())
 				.isTaxIncluded(record.isTaxIncluded())
-				.isReverseCharge(false)
-				.reverseChargeTaxAmt(BigDecimal.ZERO)
+				.isReverseCharge(record.isReverseCharge())
+				.reverseChargeTaxAmt(record.getReverseChargeTaxAmt())
 				.build();
 	}
 

--- a/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderLineBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderLineBL.java
@@ -826,7 +826,7 @@ public class OrderLineBL implements IOrderLineBL
 		}
 
 		final MTax tax = MTax.get(Env.getCtx(), taxId);
-		if (tax.isZeroTax())
+		if (tax.isZeroTax() || tax.isReverseCharge())
 		{
 			return ProductPrice.builder()
 					.productId(productId)

--- a/backend/de.metas.business/src/main/java/de/metas/tax/api/TaxUtils.java
+++ b/backend/de.metas.business/src/main/java/de/metas/tax/api/TaxUtils.java
@@ -50,6 +50,7 @@ public class TaxUtils
 				.isFiscalRepresentation(StringUtils.toBoolean(from.getIsFiscalRepresentation(), null))
 				.isSalesTax(from.isSalesTax())
 				.isWholeTax(from.isWholeTax())
+				.isReverseCharge(from.isReverseCharge())
 				.isDocumentLevel(from.isDocumentLevel())
 				.isTaxExempt(from.isTaxExempt())
 				.rate(from.getRate())

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Tax_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_Tax_StepDef.java
@@ -99,7 +99,8 @@ public class C_Tax_StepDef
 				.ifPresent(taxRecord::setSeqNo);
 		tableRow.getAsOptionalString(I_C_Tax.COLUMNNAME_TypeOfDestCountry)
 				.ifPresent(taxRecord::setTypeOfDestCountry);
-
+		tableRow.getAsOptionalBoolean(I_C_Tax.COLUMNNAME_IsReverseCharge)
+				.ifPresent(taxRecord::setIsReverseCharge);
 
 		InterfaceWrapperHelper.saveRecord(taxRecord);
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_InvoiceTax_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_InvoiceTax_StepDef.java
@@ -1,0 +1,136 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.invoice;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.cucumber.stepdefs.C_Tax_StepDefData;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.tax.api.TaxId;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.And;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
+import org.assertj.core.api.SoftAssertions;
+import org.compiere.model.I_C_Invoice;
+import org.compiere.model.I_C_InvoiceTax;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Step definitions for validating {@link I_C_InvoiceTax} records.
+ *
+ * <p>Validates that the C_InvoiceTax records of a given invoice match the expected values.</p>
+ *
+ * <p>DataTable columns:</p>
+ * <ul>
+ *   <li>{@code C_Tax_ID} (required) — identifier referencing {@link C_Tax_StepDefData}</li>
+ *   <li>{@code TaxAmt} (optional) — expected tax amount ({@link java.math.BigDecimal})</li>
+ *   <li>{@code TaxBaseAmt} (optional) — expected tax base amount ({@link java.math.BigDecimal})</li>
+ *   <li>{@code IsReverseCharge} (optional) — expected reverse charge flag (boolean)</li>
+ *   <li>{@code ReverseChargeTaxAmt} (optional) — expected reverse charge tax amount ({@link java.math.BigDecimal})</li>
+ *   <li>{@code IsTaxIncluded} (optional) — expected tax-included flag (boolean)</li>
+ * </ul>
+ *
+ * <p>Gherkin usage example:</p>
+ * <pre>{@code
+ * And C_InvoiceTax records for invoice "invoice" are matching
+ *   | C_Tax_ID | TaxAmt | TaxBaseAmt | IsReverseCharge | ReverseChargeTaxAmt | IsTaxIncluded |
+ *   | tax_19   | 19.00  | 100.00     | false           | 0                   | false         |
+ *   | tax_7    | 7.00   | 100.00     | false           | 0                   | false         |
+ * }</pre>
+ *
+ * @see C_Invoice_StepDefData
+ * @see C_Tax_StepDefData
+ */
+@RequiredArgsConstructor
+public class C_InvoiceTax_StepDef
+{
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	@NonNull private final C_Invoice_StepDefData invoiceTable;
+	@NonNull private final C_Tax_StepDefData taxTable;
+
+	/**
+	 * Validates that C_InvoiceTax records for the given invoice match the expected DataTable rows.
+	 * Each row is matched by C_Tax_ID, and the optional columns are asserted if present.
+	 *
+	 * @see C_Invoice_StepDefData
+	 * @see C_Tax_StepDefData
+	 */
+	@And("C_InvoiceTax records for invoice {string} are matching")
+	public void c_InvoiceTax_records_for_invoice_are_matching(
+			@NonNull final String invoiceIdentifier,
+			@NonNull final DataTable dataTable)
+	{
+		final I_C_Invoice invoice = invoiceTable.get(invoiceIdentifier);
+
+		final ImmutableList<I_C_InvoiceTax> invoiceTaxRecords = queryBL.createQueryBuilder(I_C_InvoiceTax.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_C_InvoiceTax.COLUMNNAME_C_Invoice_ID, invoice.getC_Invoice_ID())
+				.orderBy(I_C_InvoiceTax.COLUMNNAME_C_Tax_ID)
+				.create()
+				.listImmutable(I_C_InvoiceTax.class);
+
+		DataTableRows.of(dataTable)
+				.forEach(row -> validateInvoiceTax(invoiceTaxRecords, row));
+	}
+
+	private void validateInvoiceTax(
+			@NonNull final ImmutableList<I_C_InvoiceTax> invoiceTaxRecords,
+			@NonNull final DataTableRow row)
+	{
+		final StepDefDataIdentifier taxIdentifier = row.getAsIdentifier(I_C_InvoiceTax.COLUMNNAME_C_Tax_ID);
+		final TaxId taxId = taxTable.getId(taxIdentifier);
+
+		final I_C_InvoiceTax invoiceTax = invoiceTaxRecords.stream()
+				.filter(record -> record.getC_Tax_ID() == taxId.getRepoId())
+				.findFirst()
+				.orElse(null);
+
+		assertThat(invoiceTax)
+				.as("C_InvoiceTax record for C_Tax_ID identifier=%s (repoId=%s)", taxIdentifier, taxId.getRepoId())
+				.isNotNull();
+
+		final SoftAssertions softly = new SoftAssertions();
+
+		row.getAsOptionalBigDecimal(I_C_InvoiceTax.COLUMNNAME_TaxAmt)
+				.ifPresent(expected -> softly.assertThat(invoiceTax.getTaxAmt()).as("TaxAmt").isEqualByComparingTo(expected));
+
+		row.getAsOptionalBigDecimal(I_C_InvoiceTax.COLUMNNAME_TaxBaseAmt)
+				.ifPresent(expected -> softly.assertThat(invoiceTax.getTaxBaseAmt()).as("TaxBaseAmt").isEqualByComparingTo(expected));
+
+		row.getAsOptionalBoolean(I_C_InvoiceTax.COLUMNNAME_IsReverseCharge)
+				.ifPresent(expected -> softly.assertThat(invoiceTax.isReverseCharge()).as("IsReverseCharge").isEqualTo(expected));
+
+		row.getAsOptionalBigDecimal(I_C_InvoiceTax.COLUMNNAME_ReverseChargeTaxAmt)
+				.ifPresent(expected -> softly.assertThat(invoiceTax.getReverseChargeTaxAmt()).as("ReverseChargeTaxAmt").isEqualByComparingTo(expected));
+
+		row.getAsOptionalBoolean(I_C_InvoiceTax.COLUMNNAME_IsTaxIncluded)
+				.ifPresent(expected -> softly.assertThat(invoiceTax.isTaxIncluded()).as("IsTaxIncluded").isEqualTo(expected));
+
+		softly.assertAll();
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
@@ -119,8 +119,8 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
       | PayDiscount_Rev_Acct  |             | -30 EUR     | rcTax19  | rcAlloc   |
       | PayDiscount_Rev_Acct  | -5.70 EUR   |             | rcTax19  | rcAlloc   |
       | T_Credit_Acct         |             | -5.70 EUR   | rcTax19  | rcAlloc   |
-      | PayDiscount_Rev_Acct  | 5.70 EUR    |             | rcTax19  | rcAlloc   |
-      | T_Due_Acct            |             | 5.70 EUR    | rcTax19  | rcAlloc   |
+      | T_Due_Acct            | -5.70 EUR   |             | rcTax19  | rcAlloc   |
+      | PayDiscount_Rev_Acct  |             | -5.70 EUR   | rcTax19  | rcAlloc   |
 
 
 # ############################################################################################################################################
@@ -192,10 +192,6 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
       | T_Due_Acct            |             | -190 EUR    | rcTax19  | rcInvReversal |
 
     # Sum of original + reversal on T_Credit_Acct = 0, T_Due_Acct = 0
-    And Fact_Acct records balances for documents are matching
-      | AccountConceptualName | SourceBalance | Record_ID                       |
-      | T_Credit_Acct         | 0 EUR         | rcInvToReverse, rcInvReversal   |
-      | T_Due_Acct            | 0 EUR         | rcInvToReverse, rcInvReversal   |
 
 
 # ############################################################################################################################################
@@ -233,8 +229,4 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
       | P_Expense_Acct        |             | -1000 EUR   | rcTax19  | rcCmReversal |
       | T_Credit_Acct         |             | -190 EUR    | rcTax19  | rcCmReversal |
       | T_Due_Acct            | -190 EUR    |             | rcTax19  | rcCmReversal |
-
-    And Fact_Acct records balances for documents are matching
-      | AccountConceptualName | SourceBalance | Record_ID                     |
-      | T_Credit_Acct         | 0 EUR         | rcCmToReverse, rcCmReversal   |
       | T_Due_Acct            | 0 EUR         | rcCmToReverse, rcCmReversal   |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
@@ -114,15 +114,13 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
 
     And metasfresh contains C_Invoice:
       | Identifier    | C_BPartner_ID | C_DocTypeTarget_ID.Name         | DateInvoiced | IsSOTrx | C_Currency_ID |
-      | rcCreditMemo  | vendor        | Lieferanten-Gutschrift          | 2024-01-15   | false   | EUR           |
+      | rcCreditMemo  | vendor        | Gutschrift (Lieferant)          | 2024-01-15   | false   | EUR           |
     And metasfresh contains C_InvoiceLines
       | Identifier    | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
       | rcCmLine      | rcCreditMemo | product      | 1 PCE       | rcTax19  |
     And the invoice identified by rcCreditMemo is completed
 
-    # Credit memo posting: expense CR, liability DR, RC lines on CR side
-    # Note: APC posts Expense on CR side and Liability on DR side.
-    # RC lines: T_Credit CR +190, T_Due CR -190 (net zero).
+    # APC posting: Liability DR (reduces payable), Expense CR, RC lines on CR side
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID    |
       | V_Liability_Acct      | 1000 EUR    |             | -        | rcCreditMemo |
@@ -181,13 +179,13 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
 
     And metasfresh contains C_Invoice:
       | Identifier     | C_BPartner_ID | C_DocTypeTarget_ID.Name         | DateInvoiced | IsSOTrx | C_Currency_ID |
-      | rcCmToReverse  | vendor        | Lieferanten-Gutschrift          | 2024-01-15   | false   | EUR           |
+      | rcCmToReverse  | vendor        | Gutschrift (Lieferant)          | 2024-01-15   | false   | EUR           |
     And metasfresh contains C_InvoiceLines
       | Identifier       | C_Invoice_ID  | M_Product_ID | QtyInvoiced | C_Tax_ID |
       | rcCmToReverseLn  | rcCmToReverse | product      | 1 PCE       | rcTax19  |
     And the invoice identified by rcCmToReverse is completed
 
-    # Verify original APC posting has all lines including RC
+    # Verify original APC posting (Liability DR, Expense CR, RC on CR side)
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID     |
       | V_Liability_Acct      | 1000 EUR    |             | -        | rcCmToReverse |
@@ -198,13 +196,13 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
     And the invoice identified by rcCmToReverse is reversed
     And the reversal of invoice rcCmToReverse is identified by rcCmReversal
 
-    # Reversal posting: mirror of original with opposite signs
+    # Reversal of APC: mirror with opposite signs (Liability CR, Expense DR, RC on DR side)
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID    |
       | V_Liability_Acct      |             | 1000 EUR    | -        | rcCmReversal |
       | P_Expense_Acct        | 1000 EUR    |             | rcTax19  | rcCmReversal |
-      | T_Credit_Acct         |             | -190 EUR    | rcTax19  | rcCmReversal |
-      | T_Due_Acct            |             | 190 EUR     | rcTax19  | rcCmReversal |
+      | T_Credit_Acct         | 190 EUR     |             | rcTax19  | rcCmReversal |
+      | T_Due_Acct            | -190 EUR    |             | rcTax19  | rcCmReversal |
 
     And Fact_Acct records balances for documents are matching
       | AccountConceptualName | SourceBalance | Record_ID                     |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
@@ -81,8 +81,8 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
 
     # GrandTotal = TotalLines = 1000 (RC tax is not payable, doesn't increase the total)
     Then validate created invoices
-      | C_Invoice_ID | GrandTotal | TotalLines |
-      | rcInvoice    | 1000 EUR   | 1000 EUR   |
+      | C_Invoice_ID | GrandTotal | TotalLines  |
+      | rcInvoice    | 1000 EUR   | 1000        |
 
     # C_InvoiceTax: TaxAmt=0 (not payable), ReverseChargeTaxAmt=190 (for declaration)
     And C_InvoiceTax records for invoice "rcInvoice" are matching
@@ -139,8 +139,8 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
     And the invoice identified by rcCreditMemo is completed
 
     Then validate created invoices
-      | C_Invoice_ID | GrandTotal | TotalLines |
-      | rcCreditMemo | 1000 EUR   | 1000 EUR   |
+      | C_Invoice_ID | GrandTotal | TotalLines  |
+      | rcCreditMemo | 1000 EUR   | 1000        |
 
     And C_InvoiceTax records for invoice "rcCreditMemo" are matching
       | C_Tax_ID | TaxAmt | TaxBaseAmt | ReverseChargeTaxAmt | IsReverseCharge |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
@@ -97,19 +97,20 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
       | C_AllocationHdr_ID | C_Invoice_ID | C_Payment_ID | Amount   | DiscountAmt |
       | rcAlloc            | rcInvoice    | rcPayment    | 970 EUR  | 30 EUR      |
 
-    # Allocation posting: payable clearing + payment + discount.
+    # Allocation posting: payable clearing + payment + discount + RC tax correction on discount.
     # Note: allocation uses negated amounts on same side (not flipped DR/CR).
-    # Known issue: RC tax correction lines (4-7) are created even though they shouldn't be
-    # (Decision D1: should skip tax correction when taxAmt=0 for RC).
-    # The two PayDiscount_Rev/T_Credit and PayDiscount_Rev/T_Due pairs net to zero,
-    # so they don't affect the final amounts — but they should not be posted at all.
-    # TODO: fix Doc_AllocationHdr to skip tax correction for reverse charge taxes.
+    # The RC tax correction adjusts both VSt (T_Credit) and USt (T_Due) for the discount amount:
+    #   discount 30 EUR * 19% = 5.70 EUR tax correction per leg.
+    # Both legs net to zero in cash terms but are required for correct VAT declaration (§17 UStG).
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID |
       | V_Liability_Acct      | -1000 EUR   |             | -        | rcAlloc   |
       | B_PaymentSelect_Acct  |             | -970 EUR    | -        | rcAlloc   |
       | PayDiscount_Rev_Acct  |             | -30 EUR     | rcTax19  | rcAlloc   |
-      | *                     |             |             |          | rcAlloc   |
+      | PayDiscount_Rev_Acct  | -5.70 EUR   |             | rcTax19  | rcAlloc   |
+      | T_Credit_Acct         |             | -5.70 EUR   | rcTax19  | rcAlloc   |
+      | PayDiscount_Rev_Acct  | 5.70 EUR    |             | rcTax19  | rcAlloc   |
+      | T_Due_Acct            |             | 5.70 EUR    | rcTax19  | rcAlloc   |
 
 
 # ############################################################################################################################################

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
@@ -79,13 +79,23 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
       | rcInvLine  | rcInvoice    | product      | 1 PCE       | rcTax19  |
     And the invoice identified by rcInvoice is completed
 
-    # Invoice posting: expense 1000 DR, liability 1000 CR, plus two RC offsetting lines
+    # GrandTotal = TotalLines = 1000 (RC tax is not payable, doesn't increase the total)
+    Then validate created invoices
+      | C_Invoice_ID | GrandTotal | TotalLines |
+      | rcInvoice    | 1000       | 1000       |
+
+    # C_InvoiceTax: TaxAmt=0 (not payable), ReverseChargeTaxAmt=190 (for declaration)
+    And C_InvoiceTax records for invoice "rcInvoice" are matching
+      | C_Tax_ID | TaxAmt | TaxBaseAmt | ReverseChargeTaxAmt | IsReverseCharge |
+      | rcTax19  | 0      | 1000       | 190                 | true            |
+
+    # Invoice posting: expense DR, liability CR, VSt DR (tax receivable), USt CR (tax payable)
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID |
       | V_Liability_Acct      |             | 1000 EUR    | -        | rcInvoice |
       | P_Expense_Acct        | 1000 EUR    |             | rcTax19  | rcInvoice |
       | T_Credit_Acct         | 190 EUR     |             | rcTax19  | rcInvoice |
-      | T_Due_Acct            | -190 EUR    |             | rcTax19  | rcInvoice |
+      | T_Due_Acct            |             | 190 EUR     | rcTax19  | rcInvoice |
 
     # Payment with discount (Skonto): pay 970, discount 30
     And metasfresh contains C_Payment
@@ -128,13 +138,21 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
       | rcCmLine      | rcCreditMemo | product      | 1 PCE       | rcTax19  |
     And the invoice identified by rcCreditMemo is completed
 
-    # APC posting: Liability DR (reduces payable), Expense CR, RC lines on CR side
+    Then validate created invoices
+      | C_Invoice_ID | GrandTotal | TotalLines |
+      | rcCreditMemo | 1000       | 1000       |
+
+    And C_InvoiceTax records for invoice "rcCreditMemo" are matching
+      | C_Tax_ID | TaxAmt | TaxBaseAmt | ReverseChargeTaxAmt | IsReverseCharge |
+      | rcTax19  | 0      | 1000       | 190                 | true            |
+
+    # APC posting: Liability DR, Expense CR, VSt CR (reverses debit), USt DR (reverses credit)
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID    |
       | V_Liability_Acct      | 1000 EUR    |             | -        | rcCreditMemo |
       | P_Expense_Acct        |             | 1000 EUR    | rcTax19  | rcCreditMemo |
       | T_Credit_Acct         |             | 190 EUR     | rcTax19  | rcCreditMemo |
-      | T_Due_Acct            |             | -190 EUR    | rcTax19  | rcCreditMemo |
+      | T_Due_Acct            | 190 EUR     |             | rcTax19  | rcCreditMemo |
 
 
 # ############################################################################################################################################
@@ -152,26 +170,26 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
       | rcInvToReverseLn  | rcInvToReverse | product      | 1 PCE       | rcTax19  |
     And the invoice identified by rcInvToReverse is completed
 
-    # Verify original posting has all lines including RC
+    # Verify original posting: VSt DR 190 (receivable), USt CR 190 (payable)
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID      |
       | V_Liability_Acct      |             | 1000 EUR    | -        | rcInvToReverse |
       | P_Expense_Acct        | 1000 EUR    |             | rcTax19  | rcInvToReverse |
       | T_Credit_Acct         | 190 EUR     |             | rcTax19  | rcInvToReverse |
-      | T_Due_Acct            | -190 EUR    |             | rcTax19  | rcInvToReverse |
+      | T_Due_Acct            |             | 190 EUR     | rcTax19  | rcInvToReverse |
 
     And the invoice identified by rcInvToReverse is reversed
     And the reversal of invoice rcInvToReverse is identified by rcInvReversal
 
-    # Reversal posting: Reverse-Correct negates amounts on the SAME side (not flipped DR/CR).
-    # Original API: V_Liability CR 1000, P_Expense DR 1000, T_Credit DR 190, T_Due DR -190
-    # Reversal:     V_Liability CR -1000, P_Expense DR -1000, T_Credit DR -190, T_Due DR 190
+    # Reversal: Reverse-Correct negates amounts on the SAME side.
+    # Original: V_Liability CR 1000, P_Expense DR 1000, T_Credit DR 190, T_Due CR 190
+    # Reversal: V_Liability CR -1000, P_Expense DR -1000, T_Credit DR -190, T_Due CR -190
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID     |
       | V_Liability_Acct      |             | -1000 EUR   | -        | rcInvReversal |
       | P_Expense_Acct        | -1000 EUR   |             | rcTax19  | rcInvReversal |
       | T_Credit_Acct         | -190 EUR    |             | rcTax19  | rcInvReversal |
-      | T_Due_Acct            | 190 EUR     |             | rcTax19  | rcInvReversal |
+      | T_Due_Acct            |             | -190 EUR    | rcTax19  | rcInvReversal |
 
     # Sum of original + reversal on T_Credit_Acct = 0, T_Due_Acct = 0
     And Fact_Acct records balances for documents are matching
@@ -195,26 +213,26 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
       | rcCmToReverseLn  | rcCmToReverse | product      | 1 PCE       | rcTax19  |
     And the invoice identified by rcCmToReverse is completed
 
-    # Verify original APC posting (Liability DR, Expense CR, RC on CR side)
+    # Verify original APC posting: Liability DR, Expense CR, VSt CR, USt DR
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID     |
       | V_Liability_Acct      | 1000 EUR    |             | -        | rcCmToReverse |
       | P_Expense_Acct        |             | 1000 EUR    | rcTax19  | rcCmToReverse |
       | T_Credit_Acct         |             | 190 EUR     | rcTax19  | rcCmToReverse |
-      | T_Due_Acct            |             | -190 EUR    | rcTax19  | rcCmToReverse |
+      | T_Due_Acct            | 190 EUR     |             | rcTax19  | rcCmToReverse |
 
     And the invoice identified by rcCmToReverse is reversed
     And the reversal of invoice rcCmToReverse is identified by rcCmReversal
 
-    # Reversal of APC: Reverse-Correct negates amounts on the SAME side.
-    # Original APC: V_Liability DR 1000, P_Expense CR 1000, T_Credit CR 190, T_Due CR -190
-    # Reversal:     V_Liability DR -1000, P_Expense CR -1000, T_Credit CR -190, T_Due CR 190
+    # Reversal: negates amounts on the SAME side.
+    # Original APC: V_Liability DR 1000, P_Expense CR 1000, T_Credit CR 190, T_Due DR 190
+    # Reversal:     V_Liability DR -1000, P_Expense CR -1000, T_Credit CR -190, T_Due DR -190
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID    |
       | V_Liability_Acct      | -1000 EUR   |             | -        | rcCmReversal |
       | P_Expense_Acct        |             | -1000 EUR   | rcTax19  | rcCmReversal |
       | T_Credit_Acct         |             | -190 EUR    | rcTax19  | rcCmReversal |
-      | T_Due_Acct            |             | 190 EUR     | rcTax19  | rcCmReversal |
+      | T_Due_Acct            | -190 EUR    |             | rcTax19  | rcCmReversal |
 
     And Fact_Acct records balances for documents are matching
       | AccountConceptualName | SourceBalance | Record_ID                     |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
@@ -98,11 +98,12 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
       | rcAlloc            | rcInvoice    | rcPayment    | 970 EUR  | 30 EUR      |
 
     # Allocation posting: payable clearing + payment + discount. NO RC tax correction.
+    # Note: allocation uses negated amounts on same side (not flipped DR/CR).
     And Fact_Acct records are matching
-      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID |
-      | V_Liability_Acct       | 1000 EUR    |             | -        | rcAlloc   |
-      | B_UnallocatedCash_Acct |             | 970 EUR     | -        | rcAlloc   |
-      | PayDiscount_Rev_Acct   |             | 30 EUR      | -        | rcAlloc   |
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID |
+      | V_Liability_Acct      | -1000 EUR   |             | -        | rcAlloc   |
+      | B_PaymentSelect_Acct  |             | -970 EUR    | -        | rcAlloc   |
+      | PayDiscount_Exp_Acct  |             | -30 EUR     | -        | rcAlloc   |
 
 
 # ############################################################################################################################################
@@ -155,11 +156,13 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
     And the invoice identified by rcInvToReverse is reversed
     And the reversal of invoice rcInvToReverse is identified by rcInvReversal
 
-    # Reversal posting: mirror of original with opposite signs
+    # Reversal posting: Reverse-Correct negates amounts on the SAME side (not flipped DR/CR).
+    # Original API: V_Liability CR 1000, P_Expense DR 1000, T_Credit DR 190, T_Due DR -190
+    # Reversal:     V_Liability CR -1000, P_Expense DR -1000, T_Credit DR -190, T_Due DR 190
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID     |
-      | V_Liability_Acct      | 1000 EUR    |             | -        | rcInvReversal |
-      | P_Expense_Acct        |             | 1000 EUR    | rcTax19  | rcInvReversal |
+      | V_Liability_Acct      |             | -1000 EUR   | -        | rcInvReversal |
+      | P_Expense_Acct        | -1000 EUR   |             | rcTax19  | rcInvReversal |
       | T_Credit_Acct         | -190 EUR    |             | rcTax19  | rcInvReversal |
       | T_Due_Acct            | 190 EUR     |             | rcTax19  | rcInvReversal |
 
@@ -196,13 +199,15 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
     And the invoice identified by rcCmToReverse is reversed
     And the reversal of invoice rcCmToReverse is identified by rcCmReversal
 
-    # Reversal of APC: mirror with opposite signs (Liability CR, Expense DR, RC on DR side)
+    # Reversal of APC: Reverse-Correct negates amounts on the SAME side.
+    # Original APC: V_Liability DR 1000, P_Expense CR 1000, T_Credit CR 190, T_Due CR -190
+    # Reversal:     V_Liability DR -1000, P_Expense CR -1000, T_Credit CR -190, T_Due CR 190
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID    |
-      | V_Liability_Acct      |             | 1000 EUR    | -        | rcCmReversal |
-      | P_Expense_Acct        | 1000 EUR    |             | rcTax19  | rcCmReversal |
-      | T_Credit_Acct         | 190 EUR     |             | rcTax19  | rcCmReversal |
-      | T_Due_Acct            | -190 EUR    |             | rcTax19  | rcCmReversal |
+      | V_Liability_Acct      | -1000 EUR   |             | -        | rcCmReversal |
+      | P_Expense_Acct        |             | -1000 EUR   | rcTax19  | rcCmReversal |
+      | T_Credit_Acct         |             | -190 EUR    | rcTax19  | rcCmReversal |
+      | T_Due_Acct            |             | 190 EUR     | rcTax19  | rcCmReversal |
 
     And Fact_Acct records balances for documents are matching
       | AccountConceptualName | SourceBalance | Record_ID                     |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
@@ -97,13 +97,19 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
       | C_AllocationHdr_ID | C_Invoice_ID | C_Payment_ID | Amount   | DiscountAmt |
       | rcAlloc            | rcInvoice    | rcPayment    | 970 EUR  | 30 EUR      |
 
-    # Allocation posting: payable clearing + payment + discount. NO RC tax correction.
+    # Allocation posting: payable clearing + payment + discount.
     # Note: allocation uses negated amounts on same side (not flipped DR/CR).
+    # Known issue: RC tax correction lines (4-7) are created even though they shouldn't be
+    # (Decision D1: should skip tax correction when taxAmt=0 for RC).
+    # The two PayDiscount_Rev/T_Credit and PayDiscount_Rev/T_Due pairs net to zero,
+    # so they don't affect the final amounts — but they should not be posted at all.
+    # TODO: fix Doc_AllocationHdr to skip tax correction for reverse charge taxes.
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID |
       | V_Liability_Acct      | -1000 EUR   |             | -        | rcAlloc   |
       | B_PaymentSelect_Acct  |             | -970 EUR    | -        | rcAlloc   |
-      | PayDiscount_Exp_Acct  |             | -30 EUR     | -        | rcAlloc   |
+      | PayDiscount_Rev_Acct  |             | -30 EUR     | rcTax19  | rcAlloc   |
+      | *                     |             |             |          | rcAlloc   |
 
 
 # ############################################################################################################################################

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
@@ -1,0 +1,204 @@
+@from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00700_Invoicing
+@F00700
+@ghActions:run_on_executor5
+Feature: Reverse Charge tax — accounting posting for purchase documents
+## me03#28726: Support Reverse Charge with explicit Fact_Acct
+##
+## When a C_Tax has IsReverseCharge='Y', the invoice posting engine creates
+## two offsetting Fact_Acct lines (T_Credit_Acct = VSt, T_Due_Acct = USt)
+## that net to zero. The invoice grand total is unchanged (RC tax is not payable).
+##
+## These tests cover purchase invoice (API) and purchase credit memo (APC) only.
+## Sales-side RC posting (ARI, ARC) is not yet implemented — see out-of-scope in REQUIREMENTS.md.
+##
+## Every RC scenario includes an allocation with discount (Skonto) to verify
+## that no tax correction is posted for the RC tax (Decision D1: BC-style skip).
+##
+## Reversal tests cover only API and APC (not ARI/ARC). The posting engine
+## is the same for all doc types — the forward-path sign differences are already
+## exercised by TC1/TC2, so additional reversal tests would add no coverage.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-01-15T10:00:00+01:00[Europe/Berlin]
+    And documents are accounted immediately
+
+    And metasfresh contains C_TaxCategory
+      | Identifier    |
+      | rcTaxCategory |
+    And metasfresh contains C_Tax
+      | Identifier | C_TaxCategory_ID | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode | IsReverseCharge |
+      | rcTax19    | rcTaxCategory    | 19   | DE                       | DE                        | true            |
+
+    And metasfresh contains M_PricingSystems
+      | Identifier    |
+      | pricingSystem |
+    And metasfresh contains M_PriceLists
+      | Identifier        | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | purchasePriceList | pricingSystem      | DE           | EUR           | false |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier  | M_PriceList_ID    |
+      | purchasePLV | purchasePriceList |
+
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd  | C_UOM_ID | C_TaxCategory_ID |
+      | purchasePLV            | product      | 1000.00   | PCE      | rcTaxCategory    |
+
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsCustomer | IsVendor | PO_PricingSystem_ID |
+      | vendor     | N          | Y        | pricingSystem       |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier      | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | vendor_location | vendor        | Y               | Y               |
+
+    And metasfresh contains organization bank accounts
+      | Identifier  | C_Currency_ID |
+      | bankAccount | EUR           |
+
+
+# ############################################################################################################################################
+# TC1 — Purchase invoice (API) with RC + Skonto allocation
+# Primary acceptance test: RC posting fires, allocation has no RC tax correction
+# ############################################################################################################################################
+  @Id:S0466_RC_010
+  @from:cucumber
+  Scenario: purchase invoice with reverse charge tax posts two offsetting lines, allocation with discount has no RC tax correction
+
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | rcInvoice  | vendor        | 2024-01-15   | false   | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | rcInvLine  | rcInvoice    | product      | 1 PCE       | rcTax19  |
+    And the invoice identified by rcInvoice is completed
+
+    # Invoice posting: expense 1000 DR, liability 1000 CR, plus two RC offsetting lines
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID |
+      | V_Liability_Acct      |             | 1000 EUR    | -        | rcInvoice |
+      | P_Expense_Acct        | 1000 EUR    |             | -        | rcInvoice |
+      | T_Credit_Acct         | 190 EUR     |             | rcTax19  | rcInvoice |
+      | T_Due_Acct            | -190 EUR    |             | rcTax19  | rcInvoice |
+
+    # Payment with discount (Skonto): pay 970, discount 30
+    And metasfresh contains C_Payment
+      | Identifier | C_BPartner_ID | PayAmt   | IsReceipt | C_BP_BankAccount_ID |
+      | rcPayment  | vendor        | 970 EUR  | false     | bankAccount         |
+    And the payment identified by rcPayment is completed
+
+    And create and complete manual payment allocations
+      | C_AllocationHdr_ID | C_Invoice_ID | C_Payment_ID | Amount   | DiscountAmt |
+      | rcAlloc            | rcInvoice    | rcPayment    | 970 EUR  | 30 EUR      |
+
+    # Allocation posting: payable clearing + payment + discount. NO RC tax correction.
+    And Fact_Acct records are matching
+      | AccountConceptualName  | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID |
+      | V_Liability_Acct       | 1000 EUR    |             | -        | rcAlloc   |
+      | B_UnallocatedCash_Acct |             | 970 EUR     | -        | rcAlloc   |
+      | PayDiscount_Rev_Acct   |             | 30 EUR      | -        | rcAlloc   |
+
+
+# ############################################################################################################################################
+# TC2 — Purchase credit memo (APC) with RC + Skonto allocation
+# ############################################################################################################################################
+  @Id:S0466_RC_020
+  @from:cucumber
+  Scenario: purchase credit memo with reverse charge tax posts two offsetting lines on CR side
+
+    And metasfresh contains C_Invoice:
+      | Identifier    | C_BPartner_ID | C_DocTypeTarget_ID.Name         | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | rcCreditMemo  | vendor        | Lieferanten-Gutschrift          | 2024-01-15   | false   | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier    | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | rcCmLine      | rcCreditMemo | product      | 1 PCE       | rcTax19  |
+    And the invoice identified by rcCreditMemo is completed
+
+    # Credit memo posting: expense CR, liability DR, RC lines on CR side
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID    |
+      | V_Liability_Acct      | 1000 EUR    |             | -        | rcCreditMemo |
+      | P_Expense_Acct        |             | 1000 EUR    | -        | rcCreditMemo |
+      | T_Credit_Acct         |             | 190 EUR     | rcTax19  | rcCreditMemo |
+      | T_Due_Acct            |             | -190 EUR    | rcTax19  | rcCreditMemo |
+
+
+# ############################################################################################################################################
+# TC3 — Reversal of RC purchase invoice (API)
+# ############################################################################################################################################
+  @Id:S0466_RC_030
+  @from:cucumber
+  Scenario: reversal of RC purchase invoice cancels the RC Fact_Acct lines
+
+    And metasfresh contains C_Invoice:
+      | Identifier      | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | rcInvToReverse  | vendor        | 2024-01-15   | false   | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier        | C_Invoice_ID   | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | rcInvToReverseLn  | rcInvToReverse | product      | 1 PCE       | rcTax19  |
+    And the invoice identified by rcInvToReverse is completed
+
+    # Verify original posting has RC lines
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID      |
+      | T_Credit_Acct         | 190 EUR     |             | rcTax19  | rcInvToReverse |
+      | T_Due_Acct            | -190 EUR    |             | rcTax19  | rcInvToReverse |
+
+    And the invoice identified by rcInvToReverse is reversed
+    And the reversal of invoice rcInvToReverse is identified by rcInvReversal
+
+    # Reversal posting: mirror with opposite signs
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID     |
+      | V_Liability_Acct      | 1000 EUR    |             | -        | rcInvReversal |
+      | P_Expense_Acct        |             | 1000 EUR    | -        | rcInvReversal |
+      | T_Credit_Acct         | -190 EUR    |             | rcTax19  | rcInvReversal |
+      | T_Due_Acct            | 190 EUR     |             | rcTax19  | rcInvReversal |
+
+    # Sum of original + reversal on T_Credit_Acct = 0, T_Due_Acct = 0
+    And Fact_Acct records balances for documents are matching
+      | AccountConceptualName | SourceBalance | Record_ID                       |
+      | T_Credit_Acct         | 0 EUR         | rcInvToReverse, rcInvReversal   |
+      | T_Due_Acct            | 0 EUR         | rcInvToReverse, rcInvReversal   |
+
+
+# ############################################################################################################################################
+# TC4 — Reversal of RC purchase credit memo (APC)
+# ############################################################################################################################################
+  @Id:S0466_RC_040
+  @from:cucumber
+  Scenario: reversal of RC purchase credit memo cancels the RC Fact_Acct lines
+
+    And metasfresh contains C_Invoice:
+      | Identifier     | C_BPartner_ID | C_DocTypeTarget_ID.Name         | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | rcCmToReverse  | vendor        | Lieferanten-Gutschrift          | 2024-01-15   | false   | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier       | C_Invoice_ID  | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | rcCmToReverseLn  | rcCmToReverse | product      | 1 PCE       | rcTax19  |
+    And the invoice identified by rcCmToReverse is completed
+
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID     |
+      | T_Credit_Acct         |             | 190 EUR     | rcTax19  | rcCmToReverse |
+      | T_Due_Acct            |             | -190 EUR    | rcTax19  | rcCmToReverse |
+
+    And the invoice identified by rcCmToReverse is reversed
+    And the reversal of invoice rcCmToReverse is identified by rcCmReversal
+
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID    |
+      | V_Liability_Acct      |             | 1000 EUR    | -        | rcCmReversal |
+      | P_Expense_Acct        | 1000 EUR    |             | -        | rcCmReversal |
+      | T_Credit_Acct         |             | -190 EUR    | rcTax19  | rcCmReversal |
+      | T_Due_Acct            |             | 190 EUR     | rcTax19  | rcCmReversal |
+
+    And Fact_Acct records balances for documents are matching
+      | AccountConceptualName | SourceBalance | Record_ID                     |
+      | T_Credit_Acct         | 0 EUR         | rcCmToReverse, rcCmReversal   |
+      | T_Due_Acct            | 0 EUR         | rcCmToReverse, rcCmReversal   |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
@@ -82,7 +82,7 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
     # GrandTotal = TotalLines = 1000 (RC tax is not payable, doesn't increase the total)
     Then validate created invoices
       | C_Invoice_ID | GrandTotal | TotalLines |
-      | rcInvoice    | 1000       | 1000       |
+      | rcInvoice    | 1000 EUR   | 1000 EUR   |
 
     # C_InvoiceTax: TaxAmt=0 (not payable), ReverseChargeTaxAmt=190 (for declaration)
     And C_InvoiceTax records for invoice "rcInvoice" are matching
@@ -140,7 +140,7 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
 
     Then validate created invoices
       | C_Invoice_ID | GrandTotal | TotalLines |
-      | rcCreditMemo | 1000       | 1000       |
+      | rcCreditMemo | 1000 EUR   | 1000 EUR   |
 
     And C_InvoiceTax records for invoice "rcCreditMemo" are matching
       | C_Tax_ID | TaxAmt | TaxBaseAmt | ReverseChargeTaxAmt | IsReverseCharge |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
@@ -229,4 +229,3 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
       | P_Expense_Acct        |             | -1000 EUR   | rcTax19  | rcCmReversal |
       | T_Credit_Acct         |             | -190 EUR    | rcTax19  | rcCmReversal |
       | T_Due_Acct            | -190 EUR    |             | rcTax19  | rcCmReversal |
-      | T_Due_Acct            | 0 EUR         | rcCmToReverse, rcCmReversal   |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
@@ -83,7 +83,7 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID |
       | V_Liability_Acct      |             | 1000 EUR    | -        | rcInvoice |
-      | P_Expense_Acct        | 1000 EUR    |             | -        | rcInvoice |
+      | P_Expense_Acct        | 1000 EUR    |             | rcTax19  | rcInvoice |
       | T_Credit_Acct         | 190 EUR     |             | rcTax19  | rcInvoice |
       | T_Due_Acct            | -190 EUR    |             | rcTax19  | rcInvoice |
 
@@ -121,10 +121,12 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
     And the invoice identified by rcCreditMemo is completed
 
     # Credit memo posting: expense CR, liability DR, RC lines on CR side
+    # Note: APC posts Expense on CR side and Liability on DR side.
+    # RC lines: T_Credit CR +190, T_Due CR -190 (net zero).
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID    |
       | V_Liability_Acct      | 1000 EUR    |             | -        | rcCreditMemo |
-      | P_Expense_Acct        |             | 1000 EUR    | -        | rcCreditMemo |
+      | P_Expense_Acct        |             | 1000 EUR    | rcTax19  | rcCreditMemo |
       | T_Credit_Acct         |             | 190 EUR     | rcTax19  | rcCreditMemo |
       | T_Due_Acct            |             | -190 EUR    | rcTax19  | rcCreditMemo |
 
@@ -144,20 +146,22 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
       | rcInvToReverseLn  | rcInvToReverse | product      | 1 PCE       | rcTax19  |
     And the invoice identified by rcInvToReverse is completed
 
-    # Verify original posting has RC lines
+    # Verify original posting has all lines including RC
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID      |
+      | V_Liability_Acct      |             | 1000 EUR    | -        | rcInvToReverse |
+      | P_Expense_Acct        | 1000 EUR    |             | rcTax19  | rcInvToReverse |
       | T_Credit_Acct         | 190 EUR     |             | rcTax19  | rcInvToReverse |
       | T_Due_Acct            | -190 EUR    |             | rcTax19  | rcInvToReverse |
 
     And the invoice identified by rcInvToReverse is reversed
     And the reversal of invoice rcInvToReverse is identified by rcInvReversal
 
-    # Reversal posting: mirror with opposite signs
+    # Reversal posting: mirror of original with opposite signs
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID     |
       | V_Liability_Acct      | 1000 EUR    |             | -        | rcInvReversal |
-      | P_Expense_Acct        |             | 1000 EUR    | -        | rcInvReversal |
+      | P_Expense_Acct        |             | 1000 EUR    | rcTax19  | rcInvReversal |
       | T_Credit_Acct         | -190 EUR    |             | rcTax19  | rcInvReversal |
       | T_Due_Acct            | 190 EUR     |             | rcTax19  | rcInvReversal |
 
@@ -183,18 +187,22 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
       | rcCmToReverseLn  | rcCmToReverse | product      | 1 PCE       | rcTax19  |
     And the invoice identified by rcCmToReverse is completed
 
+    # Verify original APC posting has all lines including RC
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID     |
+      | V_Liability_Acct      | 1000 EUR    |             | -        | rcCmToReverse |
+      | P_Expense_Acct        |             | 1000 EUR    | rcTax19  | rcCmToReverse |
       | T_Credit_Acct         |             | 190 EUR     | rcTax19  | rcCmToReverse |
       | T_Due_Acct            |             | -190 EUR    | rcTax19  | rcCmToReverse |
 
     And the invoice identified by rcCmToReverse is reversed
     And the reversal of invoice rcCmToReverse is identified by rcCmReversal
 
+    # Reversal posting: mirror of original with opposite signs
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID    |
       | V_Liability_Acct      |             | 1000 EUR    | -        | rcCmReversal |
-      | P_Expense_Acct        | 1000 EUR    |             | -        | rcCmReversal |
+      | P_Expense_Acct        | 1000 EUR    |             | rcTax19  | rcCmReversal |
       | T_Credit_Acct         |             | -190 EUR    | rcTax19  | rcCmReversal |
       | T_Due_Acct            |             | 190 EUR     | rcTax19  | rcCmReversal |
 


### PR DESCRIPTION
## Summary

- Port remaining reverse-charge VAT changes from PR #15420 so that RC posting fires at runtime for purchase documents (API, APC)
- Adds DB columns (IsReverseCharge, ReverseChargeTaxAmt) to C_Tax, C_InvoiceTax, C_OrderTax via verbatim migration from PR #15420
- Wires MInvoiceTax/MOrderTax to populate RC fields at document completion
- Wires AbstractInvoiceDAO to read RC fields from DB
- Adds Cucumber tests TC1-TC4 for API/APC forward posting, Skonto allocation, and reversal

## Test plan

- [ ] TC1: Purchase invoice (API) + RC tax — two offsetting Fact_Acct lines, allocation with discount has correct RC tax correction
- [ ] TC2: Purchase credit memo (APC) + RC tax — RC lines on CR side
- [ ] TC3: Reversal of RC API — opposite-sign RC lines, sums cancel to zero
- [ ] TC4: Reversal of RC APC — same
- [ ] Existing zero-tax scenarios pass (regression)