### PR TITLE
Add reservation guard logic to `HUTransformService`, including recurs…

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/HUTransformService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/HUTransformService.java
@@ -167,8 +167,16 @@ public class HUTransformService
 
 	@NonNull private final IHUContext huContext;
 	private final ImmutableList<TableRecordReference> referencedObjects;
+	/**
+	 * VHU IDs that are exempt from the reservation guard.
+	 * The caller sets this when it <em>owns</em> the reservation and is explicitly allowed to
+	 * transform those HUs (e.g. shipment picking for the sales order that reserved them).
+	 * Obtain the IDs via {@link de.metas.handlingunits.reservation.HUReservationService#getVHUIdsByDocumentRef}.
+	 */
+	@NonNull private final ImmutableSet<HuId> allowedReservedVhuIds;
 
 	private static final AdMessageKey MSG_HU_PACK_INSTR_MATERIAL_LINE_NOT_FOUND = AdMessageKey.of("HU_PACK_INSTR_MATERIAL_LINE_NOT_FOUND");
+	private static final AdMessageKey MSG_CANNOT_TRANSFORM_RESERVED_HU = AdMessageKey.of("de.metas.handlingunits.CannotTransformReservedHU");
 
 	/**
 	 * Uses {@link IHUContextFactory#createMutableHUContext(Properties, String)} with the given {@code ctx} and {@code trxName} and returns a new {@link HUTransformService} instance with that huContext.
@@ -185,12 +193,14 @@ public class HUTransformService
 			@Nullable final Properties ctx,
 			@Nullable final String trxName,
 			@Nullable final EmptyHUListener emptyHUListener,
-			@Nullable final List<TableRecordReference> referencedObjects)
+			@Nullable final List<TableRecordReference> referencedObjects,
+			@Nullable final Collection<HuId> allowedReservedVhuIds)
 	{
 		this.huQRCodesService = SpringContextHolder.lazyBean(HUQRCodesService.class, huQRCodesService);
 		this.qrCodeConfigurationService = SpringContextHolder.lazyBean(QRCodeConfigurationService.class, null);
 
 		this.referencedObjects = referencedObjects != null ? ImmutableList.copyOf(referencedObjects) : ImmutableList.of();
+		this.allowedReservedVhuIds = allowedReservedVhuIds != null ? ImmutableSet.copyOf(allowedReservedVhuIds) : ImmutableSet.of();
 
 		final IMutableHUContext mutableHUContext = createHUContext(ctx, trxName);
 		if (emptyHUListener != null)
@@ -224,12 +234,14 @@ public class HUTransformService
 	 */
 	@Builder(builderClassName = "BuilderForHUcontext", builderMethodName = "builderForHUcontext")
 	private HUTransformService(@NonNull final IHUContext huContext,
-							   @Nullable final List<TableRecordReference> referencedObjects)
+							   @Nullable final List<TableRecordReference> referencedObjects,
+							   @Nullable final Collection<HuId> allowedReservedVhuIds)
 	{
 		this.huQRCodesService = SpringContextHolder.lazyBean(HUQRCodesService.class);
 		this.qrCodeConfigurationService = SpringContextHolder.lazyBean(QRCodeConfigurationService.class, null);
 
 		this.referencedObjects = referencedObjects != null ? ImmutableList.copyOf(referencedObjects) : ImmutableList.of();
+		this.allowedReservedVhuIds = allowedReservedVhuIds != null ? ImmutableSet.copyOf(allowedReservedVhuIds) : ImmutableSet.of();
 		this.huContext = huContext;
 	}
 
@@ -238,6 +250,59 @@ public class HUTransformService
 		// TODO: in case there were no referenced objects, i think we shall search & retrieve all the referenced documents/lines
 		return referencedObjects;
 	}
+
+	//
+	// =========================================================
+	// Reservation guards
+	// =========================================================
+
+	/**
+	 * Throws {@link AdempiereException} if the given HU itself has {@code IsReserved=Y},
+	 * unless its {@link HuId} is in {@link #allowedReservedVhuIds} (i.e. the caller owns the reservation).
+	 * <p>
+	 * Used for CU-level operations (where the source is the exact VHU being transformed)
+	 * and for TU/LU-level operations that merely re-parent an HU without touching its content
+	 * (e.g. packing a TU onto an LU).  In the latter case checking only the HU's own flag is
+	 * intentional: a TU whose VHU children are reserved can still be moved as a container.
+	 */
+	private void assertNotReserved(@NonNull final I_M_HU hu)
+	{
+		if (!hu.isReserved())
+		{
+			return;
+		}
+		final HuId huId = HuId.ofRepoId(hu.getM_HU_ID());
+		if (allowedReservedVhuIds.contains(huId))
+		{
+			return;
+		}
+		throw new AdempiereException(MSG_CANNOT_TRANSFORM_RESERVED_HU)
+				.appendParametersToMessage()
+				.setParameter("M_HU_ID", hu.getM_HU_ID());
+	}
+
+	/** Convenience overload for a collection of HUs. */
+	private void assertNoneReserved(@NonNull final Collection<I_M_HU> hus)
+	{
+		hus.forEach(this::assertNotReserved);
+	}
+
+	/**
+	 * Throws if the given HU <em>or any of its descendants</em> has {@code IsReserved=Y}.
+	 * <p>
+	 * Used by {@link #husToNewCUs} when the active {@link ReservedHUsPolicy} would include
+	 * reserved VHUs in the extraction (i.e. the policy does not already filter them out).
+	 */
+	private void assertNotReservedRecursively(@NonNull final I_M_HU hu)
+	{
+		assertNotReserved(hu);
+		for (final I_M_HU child : handlingUnitsDAO.retrieveIncludedHUs(hu))
+		{
+			assertNotReservedRecursively(child);
+		}
+	}
+
+	// =========================================================
 
 	private IAllocationRequest createCUAllocationRequest(
 			@NonNull final IHUContext huContext,
@@ -287,6 +352,7 @@ public class HUTransformService
 			@NonNull final I_M_HU cuHU,
 			@NonNull final Quantity qtyCU)
 	{
+		assertNotReserved(cuHU);
 		Check.assume(qtyCU.signum() > 0, "Paramater qtyCU={} needs to be >0; (source-)cuHU={}", qtyCU, cuHU);
 		return cuToNewCU0(cuHU, qtyCU, false);
 	}
@@ -399,6 +465,7 @@ public class HUTransformService
 			@NonNull final Quantity qtyCU,
 			@NonNull final I_M_HU targetTuHU)
 	{
+		assertNotReserved(sourceCuHU);
 		// NOTE: because this method does several non-atomic operations it is important to glue them together in a transaction
 		return trxManager.call(ITrx.TRXNAME_ThreadInherited, () -> cuToExistingTU_InTrx(sourceCuHU, qtyCU, targetTuHU));
 	}
@@ -563,6 +630,7 @@ public class HUTransformService
 			@NonNull final QtyTU qtyTU,
 			@NonNull final I_M_HU luHU)
 	{
+		assertNotReserved(sourceTuHU);
 		LUTUResult result = LUTUResult.EMPTY;
 		final List<I_M_HU> tuHUsToAttachToLU;
 
@@ -670,6 +738,7 @@ public class HUTransformService
 			@NonNull final I_M_HU_PI_Item_Product tuPIItemProduct,
 			final boolean isOwnPackingMaterials)
 	{
+		assertNotReserved(cuHU);
 		final LUTUProducerDestination destination = new LUTUProducerDestination();
 		destination.setTUPI(tuPIItemProduct.getM_HU_PI_Item().getM_HU_PI_Version().getM_HU_PI());
 		destination.setIsHUPlanningReceiptOwnerPM(isOwnPackingMaterials);
@@ -714,6 +783,7 @@ public class HUTransformService
 			@NonNull final I_M_HU sourceTuHU,
 			@NonNull final QtyTU qtyTU)
 	{
+		assertNotReserved(sourceTuHU);
 		final QtyTU availableTUs = getMaximumQtyTU(sourceTuHU);
 		if (qtyTU.compareTo(availableTUs) >= 0) // the caller wants to process the entire sourceTuHU
 		{
@@ -794,6 +864,7 @@ public class HUTransformService
 	 */
 	public TUsList husToNewTUs(@NonNull final HUsToNewTUsRequest newTUsRequest)
 	{
+		assertNoneReserved(newTUsRequest.getSourceHUs());
 		QtyTU qtyTuLeft = newTUsRequest.getQtyTU();
 
 		final ArrayList<TU> result = new ArrayList<>();
@@ -889,6 +960,7 @@ public class HUTransformService
 	 */
 	public LUTUResult luExtractTUs(@NonNull final LUExtractTUsRequest request)
 	{
+		assertNotReserved(request.getSourceLU());
 		@NonNull final LU sourceLU = retrieveLUWithTUs(request.getSourceLU());
 		@NonNull final QtyTU qtyTU = request.getQtyTU();
 		@NonNull final HashSet<HuId> alreadyExtractedTUIds = request.getAlreadyExtractedTUIds() != null
@@ -1110,6 +1182,7 @@ public class HUTransformService
 			@NonNull final QtyTU qtyTU,
 			@NonNull final HuPackingInstructionsId luPIId)
 	{
+		assertNotReserved(sourceTuHU);
 		final HuPackingInstructionsId tuPIId = handlingUnitsBL.getEffectivePackingInstructionsId(sourceTuHU);
 		final BPartnerId bpartnerId = IHandlingUnitsBL.extractBPartnerIdOrNull(sourceTuHU);
 
@@ -1158,6 +1231,7 @@ public class HUTransformService
 			@NonNull final I_M_HU_PI_Item luPIItem,
 			final boolean isOwnPackingMaterials)
 	{
+		assertNotReserved(sourceTuHU);
 		final QtyTU qtyTU_of_sourceTuHU = getMaximumQtyTU(sourceTuHU);
 		if (qtyTU.compareTo(qtyTU_of_sourceTuHU) >= 0 // the complete sourceTuHU shall be processed
 				&& qtyTU_of_sourceTuHU.compareTo(luPIItem.getQty()) <= 0 // the complete sourceTuHU fits onto one pallet
@@ -1438,6 +1512,14 @@ public class HUTransformService
 	 */
 	public HUsToNewCUsResponse husToNewCUs(@NonNull final HUsToNewCUsRequest newCUsRequest)
 	{
+		// If the policy would process reserved VHUs (e.g. CONSIDER_ALL), do a full recursive check
+		// so we fail fast before touching any reserved CU.
+		// If the policy already excludes reserved VHUs (e.g. CONSIDER_ONLY_NOT_RESERVED, as used by
+		// HUReservationService), we skip this check — the policy itself acts as the guard.
+		if (newCUsRequest.getReservedVHUsPolicy().requiresRecursiveReservationGuard())
+		{
+			newCUsRequest.getSourceHUs().forEach(this::assertNotReservedRecursively);
+		}
 		@NonNull Quantity qtyCuLeft = newCUsRequest.getQtyCU();
 
 		final ImmutableList.Builder<I_M_HU> result = ImmutableList.builder();
@@ -1475,6 +1557,7 @@ public class HUTransformService
 		huQRCodesService.get().assertQRCodeAssignedToHU(huQRCode, huId);
 
 		final I_M_HU hu = handlingUnitsBL.getById(huId);
+		assertNotReserved(hu);
 
 		if (handlingUnitsBL.isAggregateHU(hu))
 		{
@@ -1509,6 +1592,12 @@ public class HUTransformService
 		}
 		else
 		{
+			// sourceHU is a VHU — check the policy before attempting the transform,
+			// so that CONSIDER_ONLY_NOT_RESERVED returns empty instead of throwing.
+			if (!singleSourceHuRequest.getReservedVHUsPolicy().isConsiderVHU(sourceHU))
+			{
+				return ImmutableList.of();
+			}
 			return cuToNewCU(sourceHU, singleSourceHuRequest.getQtyCU());
 		}
 	}
@@ -1673,6 +1762,7 @@ public class HUTransformService
 			@NonNull final List<I_M_HU> childCUs,
 			@NonNull final I_M_HU targetTU)
 	{
+		assertNoneReserved(childCUs);
 		final I_M_HU_Item tuMaterialItem = handlingUnitsDAO.retrieveItems(targetTU)
 				.stream()
 				.filter(piItem -> X_M_HU_PI_Item.ITEMTYPE_Material.equals(piItem.getItemType()))
@@ -1726,6 +1816,7 @@ public class HUTransformService
 		}
 
 		final I_M_HU hu = handlingUnitsBL.getById(huId);
+		assertNotReserved(hu);
 		if (handlingUnitsBL.isTopLevel(hu))
 		{
 			return huId;
@@ -1756,6 +1847,7 @@ public class HUTransformService
 			@Nullable final HuPackingInstructionsItemId newLUPackingItem)
 	{
 		final I_M_HU hu = handlingUnitsBL.getById(aggregatedHuId);
+		assertNotReserved(hu);
 
 		if (!handlingUnitsBL.isAggregateHU(hu))
 		{
@@ -1831,7 +1923,11 @@ public class HUTransformService
 					.setParameter("availableQtyTU", availableNrOfTUs.toInt());
 		}
 
-		final List<I_M_HU> extractedTUs = HUTransformService.newInstance().tuToNewTUs(hu, qtyTU).getAllTURecords();
+		final List<I_M_HU> extractedTUs = HUTransformService.builderForHUcontext()
+				.huContext(huContext)
+				.allowedReservedVhuIds(allowedReservedVhuIds)
+				.build()
+				.tuToNewTUs(hu, qtyTU).getAllTURecords();
 		return extractedTUs.stream()
 				.map(I_M_HU::getM_HU_ID)
 				.map(HuId::ofRepoId)
@@ -1849,6 +1945,7 @@ public class HUTransformService
 			@NonNull final List<I_M_HU> tusOrVhus,
 			@Nullable final I_M_HU existingLU)
 	{
+		assertNoneReserved(tusOrVhus);
 		return trxManager.callInThreadInheritedTrx(() -> tusToLU(tusOrVhus, existingLU, null));
 	}
 
@@ -1856,6 +1953,7 @@ public class HUTransformService
 			@NonNull final List<I_M_HU> tusOrVhus,
 			@NonNull final HuId existingLUId)
 	{
+		assertNoneReserved(tusOrVhus);
 		final I_M_HU existingLU = handlingUnitsBL.getById(existingLUId);
 		return trxManager.callInThreadInheritedTrx(() -> tusToLU(tusOrVhus, existingLU, null));
 	}
@@ -1865,6 +1963,7 @@ public class HUTransformService
 			@NonNull final HuId existingLUId)
 	{
 		final List<I_M_HU> tusOrVhus = handlingUnitsBL.getByIds(tusOrVhuIds);
+		assertNoneReserved(tusOrVhus);
 		final I_M_HU existingLU = handlingUnitsBL.getById(existingLUId);
 		return trxManager.callInThreadInheritedTrx(() -> tusToLU(tusOrVhus, existingLU, null));
 	}
@@ -1910,6 +2009,7 @@ public class HUTransformService
 			@NonNull final List<I_M_HU> sourceCuHUs,
 			@NonNull final I_M_HU targetTuHU)
 	{
+		assertNoneReserved(sourceCuHUs);
 		final ImmutableList.Builder<I_M_HU> resultCollector = ImmutableList.builder();
 		sourceCuHUs.forEach(sourceCU -> {
 			final Quantity quantity = getSingleProductStorage(sourceCU).getQtyInStockingUOM();
@@ -1921,6 +2021,7 @@ public class HUTransformService
 
 	public void cusToExistingCU(@NonNull final List<I_M_HU> sourceCuHUs, @NonNull final I_M_HU targetCU)
 	{
+		assertNoneReserved(sourceCuHUs);
 		sourceCuHUs.forEach(sourceCU -> cuToExistingCU(sourceCU, targetCU));
 	}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/ReservedHUsPolicy.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/transfer/ReservedHUsPolicy.java
@@ -20,6 +20,15 @@ public final class ReservedHUsPolicy
 	public static final ReservedHUsPolicy CONSIDER_ALL = builder().vhuReservedStatus(OptionalBoolean.UNKNOWN).build();
 	public static final ReservedHUsPolicy CONSIDER_ONLY_NOT_RESERVED = builder().vhuReservedStatus(OptionalBoolean.FALSE).build();
 
+	/**
+	 * Creates a policy that excludes reserved VHUs but makes an exception for the given IDs.
+	 * <p>
+	 * <b>Important:</b> Because this policy has {@code vhuReservedStatus=FALSE},
+	 * {@link #requiresRecursiveReservationGuard()} returns {@code false}, which skips the recursive
+	 * reservation guard in {@link HUTransformService#husToNewCUs}.
+	 * Callers must therefore also populate {@link HUTransformService#allowedReservedVhuIds}
+	 * with the same IDs to ensure the direct guard ({@code assertNotReserved}) is also bypassed.
+	 */
 	public static ReservedHUsPolicy onlyNotReservedExceptVhuIds(@NonNull final Collection<HuId> vhuIdsToConsiderEvenIfReserved)
 	{
 		return vhuIdsToConsiderEvenIfReserved.isEmpty()
@@ -67,5 +76,21 @@ public final class ReservedHUsPolicy
 	private boolean isHUReservedStatusMatches(@NonNull final I_M_HU vhu)
 	{
 		return vhuReservedStatus.isUnknown() || vhuReservedStatus.isTrue() == vhu.isReserved();
+	}
+
+	/**
+	 * @return true if this policy would potentially process reserved VHUs
+	 *         (i.e., it does NOT explicitly exclude reserved VHUs).
+	 *         Used by {@link HUTransformService} to decide whether a recursive reservation-guard check is needed.
+	 *         <p>
+	 *         <b>Note:</b> This method only inspects {@code vhuReservedStatus} — it does NOT consider
+	 *         {@link #alwaysConsiderVhuIds}. A policy created via {@link #onlyNotReservedExceptVhuIds}
+	 *         returns {@code false} here even though it <em>can</em> process specific reserved VHUs.
+	 *         Those VHUs must also be listed in {@link HUTransformService}'s {@code allowedReservedVhuIds}
+	 *         so they pass the per-method guards.
+	 */
+	public boolean requiresRecursiveReservationGuard()
+	{
+		return vhuReservedStatus.isUnknown() || vhuReservedStatus.isTrue();
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/candidate/commands/PackToHUsProducer.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/candidate/commands/PackToHUsProducer.java
@@ -1,6 +1,7 @@
 package de.metas.handlingunits.picking.candidate.commands;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.common.util.time.SystemTime;
 import de.metas.handlingunits.HUPIItemProduct;
@@ -111,6 +112,7 @@ public class PackToHUsProducer
 		@NonNull TableRecordReference documentRef;
 		boolean checkIfAlreadyPacked;
 		boolean createInventoryForMissingQty;
+		@NonNull @Builder.Default ImmutableSet<HuId> allowedReservedVhuIds = ImmutableSet.of();
 	}
 
 	public LUTUResult packToHU(@NonNull final PackToHURequest request)
@@ -207,12 +209,18 @@ public class PackToHUsProducer
 		else if (packToInfo.getTu().isExistingTU())
 		{
 			final I_M_HU tuRecord = handlingUnitsBL.getById(packToInfo.getTu().getTuIdNotNull());
-			final HUTransformService huTransformService = HUTransformService.newInstance(huContext);
+			final ImmutableSet<HuId> allowedReservedVhuIds = request.getAllowedReservedVhuIds();
+			final HUTransformService huTransformService = HUTransformService.builderForHUcontext()
+					.huContext(huContext)
+					.allowedReservedVhuIds(allowedReservedVhuIds)
+					.build();
 			final I_M_HU cuRecord = huTransformService.huToNewSingleCU(HUTransformService.HUsToNewCUsRequest.builder()
 					.sourceHUs(pickFromHUs.toHUsList())
 					.productId(productId)
 					.qtyCU(qtyPicked)
-					.reservedVHUsPolicy(ReservedHUsPolicy.CONSIDER_ONLY_NOT_RESERVED)
+					.reservedVHUsPolicy(allowedReservedVhuIds.isEmpty()
+							? ReservedHUsPolicy.CONSIDER_ONLY_NOT_RESERVED
+							: ReservedHUsPolicy.onlyNotReservedExceptVhuIds(allowedReservedVhuIds))
 					.build());
 			huTransformService.addCUsToTU(ImmutableList.of(cuRecord), tuRecord);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobCreateCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobCreateCommand.java
@@ -25,6 +25,7 @@ import de.metas.handlingunits.picking.plan.generator.pickFromHUs.PickFromHU;
 import de.metas.handlingunits.picking.plan.model.PickingPlan;
 import de.metas.handlingunits.picking.plan.model.PickingPlanLine;
 import de.metas.handlingunits.picking.plan.model.PickingPlanLineType;
+import de.metas.handlingunits.reservation.HUReservationDocRef;
 import de.metas.i18n.AdMessageKey;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.order.OrderId;
@@ -281,6 +282,10 @@ public class PickingJobCreateCommand
 					.setParameter("plan", plan);
 		}
 
+		// Compute once for all steps (all lines share the same SO line within a ScheduledPackageableList)
+		final ImmutableSet<HuId> allowedReservedVhuIds = huService.getVHUIdsByDocumentRef(
+				HUReservationDocRef.ofSalesOrderLineId(items.getSingleSalesOrderLineId()));
+
 		return PickingJobCreateRepoRequest.Line.builder()
 				.productId(items.getSingleProductId())
 				.huPIItemProductId(items.getSinglePackToHUPIItemProductId())
@@ -290,7 +295,7 @@ public class PickingJobCreateCommand
 				.scheduleId(items.getSingleScheduleIdIfUnique().orElse(null))
 				.catchWeightUomId(items.getSingleCatchWeightUomIdIfUnique().orElse(null))
 				.steps(lines.stream()
-						.map(this::createStepRequest)
+						.map(planLine -> createStepRequest(planLine, allowedReservedVhuIds))
 						.collect(ImmutableList.toImmutableList()))
 				.pickFromAlternatives(plan.getAlternatives()
 						.stream()
@@ -313,14 +318,16 @@ public class PickingJobCreateCommand
 				.build();
 	}
 
-	private PickingJobCreateRepoRequest.Step createStepRequest(@NonNull final PickingPlanLine planLine)
+	private PickingJobCreateRepoRequest.Step createStepRequest(
+			@NonNull final PickingPlanLine planLine,
+			@NonNull final ImmutableSet<HuId> allowedReservedVhuIds)
 	{
 		final PickingPlanLineType type = planLine.getType();
 		switch (type)
 		{
 			case PICK_FROM_HU:
 			{
-				return createStepRequest_PickFromHU(planLine);
+				return createStepRequest_PickFromHU(planLine, allowedReservedVhuIds);
 			}
 			case UNALLOCABLE:
 			{
@@ -335,7 +342,9 @@ public class PickingJobCreateCommand
 		}
 	}
 
-	private PickingJobCreateRepoRequest.Step createStepRequest_PickFromHU(final @NonNull PickingPlanLine planLine)
+	private PickingJobCreateRepoRequest.Step createStepRequest_PickFromHU(
+			final @NonNull PickingPlanLine planLine,
+			final @NonNull ImmutableSet<HuId> allowedReservedVhuIds)
 	{
 		final ProductId productId = planLine.getProductId();
 		final Quantity qtyToPick = planLine.getQty();
@@ -344,7 +353,7 @@ public class PickingJobCreateCommand
 
 		final PickingJobCreateRepoRequest.StepPickFrom mainPickFrom = PickingJobCreateRepoRequest.StepPickFrom.builder()
 				.pickFromLocatorId(pickFromHU.getLocatorId())
-				.pickFromHUId(extractTopLevelCUIfNeeded(pickFromHU.getTopLevelHUId(), productId, qtyToPick))
+				.pickFromHUId(extractTopLevelCUIfNeeded(pickFromHU.getTopLevelHUId(), productId, qtyToPick, allowedReservedVhuIds))
 				.build();
 
 		final ImmutableSet<PickingJobCreateRepoRequest.StepPickFrom> pickFromAlternatives = pickFromHU.getAlternatives()
@@ -380,8 +389,9 @@ public class PickingJobCreateCommand
 	private HuId extractTopLevelCUIfNeeded(
 			@NonNull final HuId pickFromHUId,
 			@NonNull final ProductId productId,
-			@NonNull final Quantity qtyToPick)
+			@NonNull final Quantity qtyToPick,
+			@NonNull final ImmutableSet<HuId> allowedReservedVhuIds)
 	{
-		return huService.extractTopLevelCUIfNeeded(pickFromHUId, productId, qtyToPick);
+		return huService.extractTopLevelCUIfNeeded(pickFromHUId, productId, qtyToPick, allowedReservedVhuIds);
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobUnPickCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobUnPickCommand.java
@@ -27,6 +27,7 @@ import de.metas.handlingunits.picking.job.repository.PickingJobRepository;
 import de.metas.handlingunits.picking.job.service.external.hu.PickingJobHUService;
 import de.metas.handlingunits.picking.job.service.external.shipmentschedule.PickingJobShipmentScheduleService;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
+import de.metas.handlingunits.reservation.HUReservationDocRef;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.Builder;
@@ -230,7 +231,27 @@ public class PickingJobUnPickCommand
 	{
 		return HUTransformService.builder()
 				.huQRCodesService(huService.getHuQRCodesService())
+				.allowedReservedVhuIds(getAllowedReservedVhuIds())
 				.build();
+	}
+
+	/**
+	 * Collects all reserved VHU IDs from all steps being un-picked into a single set.
+	 * This intentionally gives the {@link de.metas.handlingunits.allocation.transfer.HUTransformService}
+	 * wider permission than strictly necessary (i.e. all steps rather than just the current one),
+	 * because the same service instance is reused for the entire un-pick batch and all steps
+	 * are being reversed in the same transaction.
+	 * <p>
+	 * The resulting {@link HUTransformService} instance is single-use: it is created by
+	 * {@link #newHUTransformService()} for this un-pick batch only and must not be reused
+	 * for unrelated operations, as it would carry over the wider VHU exemption.
+	 */
+	private ImmutableSet<HuId> getAllowedReservedVhuIds()
+	{
+		return unpickInstructionsMap.keySet().stream()
+				.map(HUReservationDocRef::ofPickingJobStepId)
+				.flatMap(docRef -> huService.getVHUIdsByDocumentRef(docRef).stream())
+				.collect(ImmutableSet.toImmutableSet());
 	}
 
 	@NonNull

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
@@ -525,6 +525,21 @@ public class PickingJobPickCommand
 		return Optional.ofNullable(this._stepId);
 	}
 
+	private ImmutableSet<HuId> getAllowedReservedVhuIds()
+	{
+		return getReservationDocRef()
+				.map(huService::getVHUIdsByDocumentRef)
+				.orElseGet(ImmutableSet::of);
+	}
+
+	private Optional<HUReservationDocRef> getReservationDocRef()
+	{
+		return Optionals.firstPresentOfSuppliers(
+				() -> getStepIdIfExists().map(HUReservationDocRef::ofPickingJobStepId),
+				() -> getShipmentScheduleInfo().getSalesOrderLineId().map(HUReservationDocRef::ofSalesOrderLineId)
+		);
+	}
+
 	private PickingJobStepId createStep()
 	{
 		final PickingJobStepId newStepId = pickingJobRepository.newPickingJobStepId();
@@ -882,7 +897,9 @@ public class PickingJobPickCommand
 			@NonNull final I_M_HU pickFromHU,
 			@NonNull final QtyTU qtyToPickTUs)
 	{
-		final HUTransformService huTransformService = HUTransformService.newInstance();
+		final HUTransformService huTransformService = HUTransformService.builder()
+				.allowedReservedVhuIds(getAllowedReservedVhuIds())
+				.build();
 
 		final LUPickingTarget pickingTarget = getLUPickingTarget().orElse(null);
 		final LUTUResult result;
@@ -980,6 +997,7 @@ public class PickingJobPickCommand
 						.documentRef(getLineId().toTableRecordReference())
 						.checkIfAlreadyPacked(checkIfAlreadyPacked)
 						.createInventoryForMissingQty(createInventoryForMissingQty)
+						.allowedReservedVhuIds(getAllowedReservedVhuIds())
 						.build()
 		);
 	}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickingJobHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickingJobHUService.java
@@ -270,6 +270,15 @@ public class PickingJobHUService
 			@NonNull final ProductId productId,
 			@NonNull final Quantity qtyToPick)
 	{
+		return extractTopLevelCUIfNeeded(pickFromHUId, productId, qtyToPick, ImmutableSet.of());
+	}
+
+	public HuId extractTopLevelCUIfNeeded(
+			@NonNull final HuId pickFromHUId,
+			@NonNull final ProductId productId,
+			@NonNull final Quantity qtyToPick,
+			@NonNull final ImmutableSet<HuId> allowedReservedVhuIds)
+	{
 		final I_M_HU pickFromHU = handlingUnitsBL.getById(pickFromHUId);
 
 		// Not a top level CU
@@ -289,13 +298,17 @@ public class PickingJobHUService
 			return pickFromHUId;
 		}
 
-		final I_M_HU extractedCU = HUTransformService.newInstance()
+		final I_M_HU extractedCU = HUTransformService.builder()
+				.allowedReservedVhuIds(allowedReservedVhuIds)
+				.build()
 				.huToNewSingleCU(HUTransformService.HUsToNewCUsRequest.builder()
 						.sourceHU(pickFromHU)
 						.productId(productId)
 						.qtyCU(qtyToPick)
 						//.keepNewCUsUnderSameParent(true) // not needed, our HU is top level anyways
-						.reservedVHUsPolicy(ReservedHUsPolicy.CONSIDER_ONLY_NOT_RESERVED)
+						.reservedVHUsPolicy(allowedReservedVhuIds.isEmpty()
+								? ReservedHUsPolicy.CONSIDER_ONLY_NOT_RESERVED
+								: ReservedHUsPolicy.onlyNotReservedExceptVhuIds(allowedReservedVhuIds))
 						.build());
 
 		return HuId.ofRepoId(extractedCU.getM_HU_ID());
@@ -334,6 +347,11 @@ public class PickingJobHUService
 				.collect(ImmutableSet.toImmutableSet());
 
 		huReservationService.deleteReservationsByDocumentRefs(reservationDocRefs);
+	}
+
+	public ImmutableSet<HuId> getVHUIdsByDocumentRef(@NonNull final HUReservationDocRef documentRef)
+	{
+		return huReservationService.getVHUIdsByDocumentRef(documentRef);
 	}
 
 	@Nullable

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
@@ -656,19 +656,30 @@ public class ShipmentScheduleWithHUService
 			final @NonNull I_M_ShipmentSchedule scheduleRecord,
 			final @NonNull I_M_HU sourceHURecord, final @NonNull Quantity quantityToSplit, final boolean pickAccordingToPackingInstruction)
 	{
-		final HUTransformService huTransformService = HUTransformService.newInstance();
+		// Determine which reserved VHUs belong to us (our order line) so the reservation guard lets them through
+		final ImmutableSet<HuId> allowedReservedVhuIds;
+		final OrderLineId orderLineId = OrderLineId.ofRepoIdOrNull(scheduleRecord.getC_OrderLine_ID());
+		if (orderLineId != null)
+		{
+			allowedReservedVhuIds = huReservationService.getVHUIdsByDocumentRef(HUReservationDocRef.ofSalesOrderLineId(orderLineId));
+		}
+		else
+		{
+			allowedReservedVhuIds = ImmutableSet.of();
+		}
+
+		final HUTransformService huTransformService = HUTransformService.builder()
+				.allowedReservedVhuIds(allowedReservedVhuIds)
+				.build();
 
 		// split a part out of the current HU
 		final HUsToNewCUsRequest cuRequest = HUsToNewCUsRequest
 				.builder()
 				.keepNewCUsUnderSameParent(false)
 
-				// new, from PR https://github.com/metasfresh/metasfresh/pull/12146
-				// FIXME: we shall consider not reserved or reserved ones too if they are reserved for us
-				.reservedVHUsPolicy(ReservedHUsPolicy.CONSIDER_ALL)
-
-				// OLD
-				// .onlyFromUnreservedHUs(false) // note: the HUs returned by the query do not contain HUs which are reserved to someone else
+				.reservedVHUsPolicy(allowedReservedVhuIds.isEmpty()
+						? ReservedHUsPolicy.CONSIDER_ONLY_NOT_RESERVED
+						: ReservedHUsPolicy.onlyNotReservedExceptVhuIds(allowedReservedVhuIds))
 
 				.productId(ProductId.ofRepoId(scheduleRecord.getM_Product_ID()))
 				.qtyCU(quantityToSplit)

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5796400_sys_add_CannotTransformReservedHU_AD_Message.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5796400_sys_add_CannotTransformReservedHU_AD_Message.sql
@@ -1,0 +1,11 @@
+-- 2026-04-15
+-- Add AD_Message for HUTransformService reservation guard
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,545700,0,TO_TIMESTAMP('2026-04-15 00:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','Die Handling Unit kann nicht transformiert oder verschoben werden, da sie fuer einen anderen Vorgang reserviert ist.','E',TO_TIMESTAMP('2026-04-15 00:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits.CannotTransformReservedHU')
+;
+
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Message t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=545700 AND NOT EXISTS (SELECT * FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- en_US translation
+UPDATE AD_Message_Trl SET MsgText='Cannot transform or move this handling unit because it is reserved for another process.', IsTranslated='Y' WHERE AD_Message_ID=545700 AND AD_Language='en_US'
+;

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/HUTransformServiceReservationTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/allocation/transfer/HUTransformServiceReservationTests.java
@@ -27,6 +27,7 @@ import de.metas.handlingunits.HUTestHelper;
 import de.metas.handlingunits.HUXmlConverter;
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.IHandlingUnitsDAO;
+import de.metas.handlingunits.QtyTU;
 import de.metas.handlingunits.allocation.impl.HUProducerDestination;
 import de.metas.handlingunits.allocation.transfer.HUTransformService.HUsToNewCUsRequest;
 import de.metas.handlingunits.allocation.transfer.impl.LUTUProducerDestinationTestSupport;
@@ -37,6 +38,8 @@ import de.metas.handlingunits.util.HUTracerInstance;
 import de.metas.quantity.Quantity;
 import de.metas.util.Services;
 import de.metas.util.collections.CollectionUtils;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.compiere.SpringContextHolder;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +52,7 @@ import java.util.List;
 
 import static de.metas.handlingunits.HUAssertions.assertThat;
 import static java.math.BigDecimal.ONE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link HUTransformService} that are especially geared at the sort of use which {@link HUReservationService} makes of it.
@@ -343,5 +347,166 @@ public class HUTransformServiceReservationTests
 		final List<I_M_HU> newCUs = huTransformService.husToNewCUs(husToNewCUsRequest).getNewCUs();
 
 		assertThat(newCUs).isEmpty(); // nothing was extracted, because lu does not contain any salad.
+	}
+
+	// =========================================================
+	// Reservation guard tests
+	// =========================================================
+
+	/**
+	 * A VHU that is directly reserved must not be transformable via cuToNewCU.
+	 */
+	@Test
+	public void cuToNewCU_reservedVHU_shouldThrow()
+	{
+		final LUTUProducerDestinationTestSupport data = testsBase.getData();
+		final I_M_HU cuHU = data.mkRealCUWithTUandQtyCU("10");
+
+		// mark the VHU as reserved
+		cuHU.setIsReserved(true);
+		InterfaceWrapperHelper.save(cuHU);
+
+		assertThatThrownBy(() -> huTransformService.cuToNewCU(cuHU, Quantity.of(ONE, data.helper.uomKg)))
+				.isInstanceOf(AdempiereException.class);
+	}
+
+	/**
+	 * A VHU that is directly reserved must not be moved to another TU.
+	 */
+	@Test
+	public void cuToExistingTU_reservedVHU_shouldThrow()
+	{
+		final LUTUProducerDestinationTestSupport data = testsBase.getData();
+		final I_M_HU cuHU = data.mkRealCUWithTUandQtyCU("10");
+		final I_M_HU targetTU = Services.get(IHandlingUnitsDAO.class).retrieveParent(cuHU);
+
+		cuHU.setIsReserved(true);
+		InterfaceWrapperHelper.save(cuHU);
+
+		assertThatThrownBy(() -> huTransformService.cuToExistingTU(cuHU, Quantity.of(ONE, data.helper.uomKg), targetTU))
+				.isInstanceOf(AdempiereException.class);
+	}
+
+	/**
+	 * husToNewCUs with CONSIDER_ALL policy must fail when a source HU contains a reserved VHU descendant.
+	 */
+	@Test
+	public void husToNewCUs_considerAll_withReservedVHUChild_shouldThrow()
+	{
+		final LUTUProducerDestinationTestSupport data = testsBase.getData();
+		final I_M_HU cuHU = data.mkRealCUWithTUandQtyCU("10");
+		final I_M_HU tuHU = Services.get(IHandlingUnitsDAO.class).retrieveParent(cuHU);
+
+		// mark the inner VHU as reserved (TU itself is NOT reserved)
+		cuHU.setIsReserved(true);
+		InterfaceWrapperHelper.save(cuHU);
+
+		final HUsToNewCUsRequest request = HUsToNewCUsRequest.builder()
+				.sourceHU(tuHU)
+				.productId(data.helper.pTomatoProductId)
+				.qtyCU(Quantity.of(ONE, data.helper.uomKg))
+				.reservedVHUsPolicy(ReservedHUsPolicy.CONSIDER_ALL)
+				.build();
+
+		assertThatThrownBy(() -> huTransformService.husToNewCUs(request))
+				.isInstanceOf(AdempiereException.class);
+	}
+
+	/**
+	 * husToNewCUs with CONSIDER_ONLY_NOT_RESERVED policy must NOT fail even when the source TU
+	 * contains a reserved VHU child — the policy already excludes those VHUs from processing.
+	 * This is the path used by {@link HUReservationService}.
+	 */
+	@Test
+	public void husToNewCUs_considerOnlyNotReserved_withReservedVHUChild_shouldSucceed()
+	{
+		final LUTUProducerDestinationTestSupport data = testsBase.getData();
+		final I_M_HU cuHU = data.mkRealCUWithTUandQtyCU("10");
+		final I_M_HU tuHU = Services.get(IHandlingUnitsDAO.class).retrieveParent(cuHU);
+
+		// mark only the inner VHU as reserved (TU itself is NOT reserved)
+		cuHU.setIsReserved(true);
+		InterfaceWrapperHelper.save(cuHU);
+
+		final HUsToNewCUsRequest request = HUsToNewCUsRequest.builder()
+				.sourceHU(tuHU)
+				.productId(data.helper.pTomatoProductId)
+				.qtyCU(Quantity.of(ONE, data.helper.uomKg))
+				.reservedVHUsPolicy(ReservedHUsPolicy.CONSIDER_ONLY_NOT_RESERVED)
+				.build();
+
+		// The reserved VHU is excluded by the policy, so there is nothing to extract → empty result, no exception
+		final List<I_M_HU> result = huTransformService.husToNewCUs(request).getNewCUs();
+		assertThat(result).isEmpty();
+	}
+
+	/**
+	 * A TU whose VHU children are reserved (but the TU itself is NOT reserved) must be packable
+	 * onto an existing LU — i.e. tuToExistingLU must NOT throw.
+	 * This covers the use-case: "pack a reserved TU on an LU before creating the shipment."
+	 */
+	@Test
+	public void tuToExistingLU_tuWithReservedVHUChild_shouldSucceed()
+	{
+		final LUTUProducerDestinationTestSupport data = testsBase.getData();
+		final I_M_HU cuHU = data.mkRealCUWithTUandQtyCU("10");
+		final I_M_HU sourceTU = Services.get(IHandlingUnitsDAO.class).retrieveParent(cuHU);
+
+		// mark only the inner VHU as reserved — the TU container itself is NOT reserved
+		cuHU.setIsReserved(true);
+		InterfaceWrapperHelper.save(cuHU);
+		assertThat(sourceTU.isReserved()).isFalse();
+
+		// Create a proper LU by using mkAggregateHUWithTotalQtyCU (returns an aggregate VHU inside an LU)
+		final I_M_HU existingLU = handlingUnitsBL.getTopLevelParent(data.mkAggregateHUWithTotalQtyCU("200"));
+
+		// Must NOT throw any reservation-guard exception — the TU itself is not reserved.
+		huTransformService.tuToExistingLU(sourceTU, QtyTU.ONE, existingLU);
+	}
+
+	/**
+	 * A TU that is itself reserved (whole-TU reservation) must NOT be packable onto an LU.
+	 */
+	@Test
+	public void tuToExistingLU_reservedTU_shouldThrow()
+	{
+		final LUTUProducerDestinationTestSupport data = testsBase.getData();
+		final I_M_HU cuHU = data.mkRealCUWithTUandQtyCU("10");
+		final I_M_HU sourceTU = Services.get(IHandlingUnitsDAO.class).retrieveParent(cuHU);
+		final I_M_HU lu = data.createLU(1, 20);
+
+		// mark the TU itself as reserved
+		sourceTU.setIsReserved(true);
+		InterfaceWrapperHelper.save(sourceTU);
+
+		assertThatThrownBy(() -> huTransformService.tuToExistingLU(sourceTU, QtyTU.ONE, lu))
+				.isInstanceOf(AdempiereException.class);
+	}
+
+	/**
+	 * When the caller <em>owns</em> the reservation it passes the reserved VHU IDs via
+	 * {@code allowedReservedVhuIds}. The guard must be bypassed for those specific VHUs,
+	 * so the transformation succeeds (or fails for reasons unrelated to the reservation guard).
+	 * <p>
+	 * Scenario: sales-order picks its own reserved CU (e.g. splits it before creating the shipment).
+	 */
+	@Test
+	public void cuToNewCU_allowedReservedVhuIds_bypassesGuard()
+	{
+		final LUTUProducerDestinationTestSupport data = testsBase.getData();
+		final I_M_HU cuHU = data.mkRealCUWithTUandQtyCU("10");
+
+		// mark the VHU as reserved
+		cuHU.setIsReserved(true);
+		InterfaceWrapperHelper.save(cuHU);
+
+		// Build a service instance that declares this VHU as "allowed" (reservation owner)
+		final de.metas.handlingunits.HuId reservedVhuId = de.metas.handlingunits.HuId.ofRepoId(cuHU.getM_HU_ID());
+		final HUTransformService ownerService = HUTransformService.builderForHUcontext()
+				.huContext(data.helper.getHUContext())
+				.allowedReservedVhuIds(java.util.Collections.singleton(reservedVhuId))
+				.build();
+
+		ownerService.cuToNewCU(cuHU, Quantity.of(ONE, data.helper.uomKg));
 	}
 }


### PR DESCRIPTION
…ive checks, new tests, and AD_Message for reserved HUs (#23412)

* Add reservation guard logic to `HUTransformService`, including recursive checks, new tests, and AD_Message for reserved HUs

* Allow bypassing reservation guard for owned reserved HUs in `HUTransformService` and add corresponding test

* Introduce support for allowing reserved VHUs to pass reservation guard in `HUTransformService`.

* Address code review concerns on reservation guard PR

- Fix bug: propagate allowedReservedVhuIds in splitOutTUsFromAggregated to prevent false guard triggers on nested HUTransformService calls
- Add Javadoc on ReservedHUsPolicy.onlyNotReservedExceptVhuIds documenting the coupling with HUTransformService.allowedReservedVhuIds
- Fix weak test: tuToExistingLU_tuWithReservedVHUChild_shouldSucceed now uses a proper LU fixture instead of passing sourceTU as its own LU
- Fix N+1 queries in PickingJobCreateCommand: compute allowedReservedVhuIds once per line instead of per step
- Document intentional aggregate permission in PickingJobUnPickCommand
- Improve AD_Message: base text in German (de_DE), add en_US translation, message now explains why the HU cannot be transformed



* Refactor reservation guard logic in `HUTransformService` and `ReservedHUsPolicy`

- Rename methods for clarity: `wouldProcessReservedVHU` → `requiresRecursiveReservationGuard`, `assertNotReservedOrHasReservedDescendants` → `assertNotReservedRecursively`
- Remove redundant exception tests in `HUTransformServiceReservationTests`
- Improve test setup for existing LU scenarios with proper fixtures

* Address remaining review findings on reservation guard PR

- Fix latent bug: husToNewCUs VHU else-branch now checks ReservedHUsPolicy.isConsiderVHU before delegating to cuToNewCU, so CONSIDER_ONLY_NOT_RESERVED returns empty instead of throwing
- Improve requiresRecursiveReservationGuard() Javadoc: document that alwaysConsiderVhuIds is not considered and callers must also set allowedReservedVhuIds on HUTransformService
- Clarify PickingJobUnPickCommand.getAllowedReservedVhuIds: note that the HUTransformService instance is single-use per un-pick batch

---------