### PR TITLE
merge/soft_panda_release-to-new_dawn_uat

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
@@ -53,6 +53,8 @@ import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
 import org.slf4j.Logger;
 
+import javax.annotation.Nullable;
+
 public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 {
 	private static final Logger logger = LogManager.getLogger(HUHandlingUnitsInfoFactory.class);
@@ -95,13 +97,60 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 	/**
 	 * Resolve the TU Packing Instructions for an InOutLine.
 	 * <p>
-	 * Primary: look at the actual HU assignments (M_TU_HU_ID on M_HU_Assignment).
-	 * Fallback: use M_HU_PI_Item_Product from the InOutLine or its linked OrderLine.
+	 * Primary: use M_HU_PI_Item_Product from the InOutLine or its linked OrderLine
+	 * (the originally-planned TU PI — preserves prior behavior for all non-rogue lines).
+	 * Fallback: look at the actual HU assignments (M_TU_HU_ID / top-level M_HU),
+	 * used only when the planned TU PI is missing ("rogue" lines that would previously crash).
 	 *
 	 * @throws AdempiereException if no TU PI could be determined from any source
 	 */
 	@NonNull
 	private I_M_HU_PI resolveTU_HU_PI(final I_M_InOutLine inoutLine)
+	{
+		//
+		// Primary: resolve from M_HU_PI_Item_Product on the InOutLine or its linked OrderLine.
+		// This preserves the prior behavior for all lines that used to work.
+		final I_M_HU_PI plannedTuPI = Services.get(IHUInOutBL.class).getTU_HU_PI(inoutLine);
+		if (plannedTuPI != null)
+		{
+			return plannedTuPI;
+		}
+
+		//
+		// Fallback: resolve from actual HU assignments. Only reached when the planned TU PI
+		// is missing (previously caused "Assumption failure: tuPI not null").
+		final I_M_HU_PI actualTuPI = resolveTU_HU_PI_FromHUAssignments(inoutLine);
+		if (actualTuPI != null)
+		{
+			return actualTuPI;
+		}
+
+		//
+		// Neither approach found a TU PI
+		final org.compiere.model.I_M_InOut inout = inoutLine.getM_InOut();
+		throw new AdempiereException("Receipt " + inout.getDocumentNo() + ", Line " + inoutLine.getLine()
+				+ ": TU Packing Instructions could not be determined."
+				+ " Neither the receipt line nor its linked order line has a TU Packing Instruction (Packvorschrift-TU),"
+				+ " and no usable HU assignment was found either.")
+				.setParameter("M_InOut_ID", inout.getM_InOut_ID())
+				.setParameter("DocumentNo", inout.getDocumentNo())
+				.setParameter("M_InOutLine_ID", inoutLine.getM_InOutLine_ID())
+				.setParameter("Line", inoutLine.getLine())
+				.setParameter("M_Product_ID", inoutLine.getM_Product_ID())
+				.setParameter("M_HU_PI_Item_Product_ID", inoutLine.getM_HU_PI_Item_Product_ID())
+				.setParameter("C_OrderLine_ID", inoutLine.getC_OrderLine_ID());
+	}
+
+	/**
+	 * Two-pass resolution from actual HU assignments:
+	 * <ul>
+	 *   <li>Pass 1: derived assignments with M_TU_HU_ID explicitly set (most reliable).</li>
+	 *   <li>Pass 2: top-level M_HU, used when the top-level HU itself is a TU (no LU involved).</li>
+	 * </ul>
+	 * Returns {@code null} if no non-virtual HU could be found.
+	 */
+	@Nullable
+	private I_M_HU_PI resolveTU_HU_PI_FromHUAssignments(final I_M_InOutLine inoutLine)
 	{
 		final IHUAssignmentDAO huAssignmentDAO = Services.get(IHUAssignmentDAO.class);
 		final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
@@ -109,8 +158,7 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 		I_M_HU_PI firstTuPI = null;
 		boolean hasMultipleDistinctPIs = false;
 
-		//
-		// First pass: derived assignments with M_TU_HU_ID explicitly set — most reliable TU PI source.
+		// Pass 1: derived assignments with M_TU_HU_ID set.
 		final List<I_M_HU_Assignment> tuAssignments = huAssignmentDAO.retrieveTUHUAssignmentsForModelQuery(inoutLine)
 				.create()
 				.list();
@@ -133,9 +181,7 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 			}
 		}
 
-		//
-		// Second pass: if no derived assignment had a usable TU, fall back to top-level assignments.
-		// This works when the top-level HU itself is a TU (no LU involved).
+		// Pass 2: fall back to top-level M_HU when no derived assignment had a usable TU.
 		if (firstTuPI == null)
 		{
 			final List<I_M_HU_Assignment> topLevelAssignments = huAssignmentDAO.retrieveTopLevelHUAssignmentsForModel(inoutLine);
@@ -159,39 +205,13 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 			}
 		}
 
-		if (hasMultipleDistinctPIs)
+		if (firstTuPI != null && hasMultipleDistinctPIs)
 		{
 			logger.warn("InOutLine {} (M_InOutLine_ID={}) has HU assignments with different TU Packing Instructions. Using the first one: {}",
 					inoutLine.getLine(), inoutLine.getM_InOutLine_ID(), firstTuPI.getName());
 		}
 
-		if (firstTuPI != null)
-		{
-			return firstTuPI;
-		}
-
-		//
-		// Fallback: resolve from M_HU_PI_Item_Product on the InOutLine or its linked OrderLine
-		final I_M_HU_PI tuPI = Services.get(IHUInOutBL.class).getTU_HU_PI(inoutLine);
-		if (tuPI != null)
-		{
-			return tuPI;
-		}
-
-		//
-		// Neither approach found a TU PI
-		final org.compiere.model.I_M_InOut inout = inoutLine.getM_InOut();
-		throw new AdempiereException("Receipt " + inout.getDocumentNo() + ", Line " + inoutLine.getLine()
-				+ ": TU Packing Instructions could not be determined."
-				+ " The receipt line has no HU assignments with a TU,"
-				+ " and neither the receipt line nor its linked order line has a TU Packing Instruction (Packvorschrift-TU).")
-				.setParameter("M_InOut_ID", inout.getM_InOut_ID())
-				.setParameter("DocumentNo", inout.getDocumentNo())
-				.setParameter("M_InOutLine_ID", inoutLine.getM_InOutLine_ID())
-				.setParameter("Line", inoutLine.getLine())
-				.setParameter("M_Product_ID", inoutLine.getM_Product_ID())
-				.setParameter("M_HU_PI_Item_Product_ID", inoutLine.getM_HU_PI_Item_Product_ID())
-				.setParameter("C_OrderLine_ID", inoutLine.getC_OrderLine_ID());
+		return firstTuPI;
 	}
 
 	private IHandlingUnitsInfo createFromPPOrder(final I_PP_Order ppOrder)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactory.java
@@ -47,11 +47,16 @@ import de.metas.inout.IInOutBL;
 import de.metas.materialtracking.IHandlingUnitsInfo;
 import de.metas.materialtracking.IHandlingUnitsInfoWritableQty;
 import de.metas.materialtracking.spi.IHandlingUnitsInfoFactory;
+import de.metas.logging.LogManager;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.slf4j.Logger;
 
 public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 {
+	private static final Logger logger = LogManager.getLogger(HUHandlingUnitsInfoFactory.class);
+
 	@Override
 	public IHandlingUnitsInfo createFromModel(@NonNull final Object model)
 	{
@@ -79,18 +84,114 @@ public class HUHandlingUnitsInfoFactory implements IHandlingUnitsInfoFactory
 
 	private IHandlingUnitsInfo createFromInOutLine(final I_M_InOutLine inoutLine)
 	{
-		final IHUInOutBL huInOutBL = Services.get(IHUInOutBL.class);
-
-		final I_M_HU_PI tuPI = huInOutBL.getTU_HU_PI(inoutLine);
-		if (tuPI == null)
-		{
-			// TODO: shall we just return null or throw exception?
-		}
+		final I_M_HU_PI tuPI = resolveTU_HU_PI(inoutLine);
 
 		final IInOutBL inOutBL = Services.get(IInOutBL.class);
 		final int qtyTU = inOutBL.negateIfReturnMovmenType(inoutLine, inoutLine.getQtyEnteredTU()).intValueExact();
 
 		return new HUHandlingUnitsInfo(tuPI, qtyTU);
+	}
+
+	/**
+	 * Resolve the TU Packing Instructions for an InOutLine.
+	 * <p>
+	 * Primary: look at the actual HU assignments (M_TU_HU_ID on M_HU_Assignment).
+	 * Fallback: use M_HU_PI_Item_Product from the InOutLine or its linked OrderLine.
+	 *
+	 * @throws AdempiereException if no TU PI could be determined from any source
+	 */
+	@NonNull
+	private I_M_HU_PI resolveTU_HU_PI(final I_M_InOutLine inoutLine)
+	{
+		final IHUAssignmentDAO huAssignmentDAO = Services.get(IHUAssignmentDAO.class);
+		final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
+
+		I_M_HU_PI firstTuPI = null;
+		boolean hasMultipleDistinctPIs = false;
+
+		//
+		// First pass: derived assignments with M_TU_HU_ID explicitly set — most reliable TU PI source.
+		final List<I_M_HU_Assignment> tuAssignments = huAssignmentDAO.retrieveTUHUAssignmentsForModelQuery(inoutLine)
+				.create()
+				.list();
+		for (final I_M_HU_Assignment huAssignment : tuAssignments)
+		{
+			final I_M_HU tuHU = huAssignment.getM_TU_HU();
+			if (tuHU == null || handlingUnitsBL.isVirtual(tuHU))
+			{
+				continue;
+			}
+
+			final I_M_HU_PI huPI = handlingUnitsBL.getPI(tuHU);
+			if (firstTuPI == null)
+			{
+				firstTuPI = huPI;
+			}
+			else if (firstTuPI.getM_HU_PI_ID() != huPI.getM_HU_PI_ID())
+			{
+				hasMultipleDistinctPIs = true;
+			}
+		}
+
+		//
+		// Second pass: if no derived assignment had a usable TU, fall back to top-level assignments.
+		// This works when the top-level HU itself is a TU (no LU involved).
+		if (firstTuPI == null)
+		{
+			final List<I_M_HU_Assignment> topLevelAssignments = huAssignmentDAO.retrieveTopLevelHUAssignmentsForModel(inoutLine);
+			for (final I_M_HU_Assignment huAssignment : topLevelAssignments)
+			{
+				final I_M_HU hu = huAssignment.getM_HU();
+				if (hu == null || handlingUnitsBL.isVirtual(hu))
+				{
+					continue;
+				}
+
+				final I_M_HU_PI huPI = handlingUnitsBL.getPI(hu);
+				if (firstTuPI == null)
+				{
+					firstTuPI = huPI;
+				}
+				else if (firstTuPI.getM_HU_PI_ID() != huPI.getM_HU_PI_ID())
+				{
+					hasMultipleDistinctPIs = true;
+				}
+			}
+		}
+
+		if (hasMultipleDistinctPIs)
+		{
+			logger.warn("InOutLine {} (M_InOutLine_ID={}) has HU assignments with different TU Packing Instructions. Using the first one: {}",
+					inoutLine.getLine(), inoutLine.getM_InOutLine_ID(), firstTuPI.getName());
+		}
+
+		if (firstTuPI != null)
+		{
+			return firstTuPI;
+		}
+
+		//
+		// Fallback: resolve from M_HU_PI_Item_Product on the InOutLine or its linked OrderLine
+		final I_M_HU_PI tuPI = Services.get(IHUInOutBL.class).getTU_HU_PI(inoutLine);
+		if (tuPI != null)
+		{
+			return tuPI;
+		}
+
+		//
+		// Neither approach found a TU PI
+		final org.compiere.model.I_M_InOut inout = inoutLine.getM_InOut();
+		throw new AdempiereException("Receipt " + inout.getDocumentNo() + ", Line " + inoutLine.getLine()
+				+ ": TU Packing Instructions could not be determined."
+				+ " The receipt line has no HU assignments with a TU,"
+				+ " and neither the receipt line nor its linked order line has a TU Packing Instruction (Packvorschrift-TU).")
+				.setParameter("M_InOut_ID", inout.getM_InOut_ID())
+				.setParameter("DocumentNo", inout.getDocumentNo())
+				.setParameter("M_InOutLine_ID", inoutLine.getM_InOutLine_ID())
+				.setParameter("Line", inoutLine.getLine())
+				.setParameter("M_Product_ID", inoutLine.getM_Product_ID())
+				.setParameter("M_HU_PI_Item_Product_ID", inoutLine.getM_HU_PI_Item_Product_ID())
+				.setParameter("C_OrderLine_ID", inoutLine.getC_OrderLine_ID());
 	}
 
 	private IHandlingUnitsInfo createFromPPOrder(final I_PP_Order ppOrder)

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactoryTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactoryTest.java
@@ -1,0 +1,280 @@
+package de.metas.handlingunits.materialtracking.spi.impl;
+
+import static org.adempiere.model.InterfaceWrapperHelper.getTableId;
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.model.I_M_InOut;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import de.metas.handlingunits.HuPackingInstructionsVersionId;
+import de.metas.handlingunits.IHUAssignmentDAO;
+import de.metas.handlingunits.IHandlingUnitsBL;
+import de.metas.handlingunits.impl.HUAssignmentDAO;
+import de.metas.handlingunits.impl.HandlingUnitsBL;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.I_M_HU_Assignment;
+import de.metas.handlingunits.model.I_M_HU_PI;
+import de.metas.handlingunits.model.I_M_HU_PI_Version;
+import de.metas.handlingunits.model.I_M_InOutLine;
+import de.metas.materialtracking.IHandlingUnitsInfo;
+import de.metas.util.Services;
+
+@ExtendWith(AdempiereTestWatcher.class)
+public class HUHandlingUnitsInfoFactoryTest
+{
+	private HUHandlingUnitsInfoFactory factory;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		Services.registerService(IHUAssignmentDAO.class, new HUAssignmentDAO());
+		Services.registerService(IHandlingUnitsBL.class, new HandlingUnitsBL());
+
+		factory = new HUHandlingUnitsInfoFactory();
+	}
+
+	@Test
+	public void createFromModel_InOutLine_resolvesFromHUAssignment()
+	{
+		// given
+		final I_M_HU_PI_Version tuPIV = createHU_PIVersion("IFCO");
+		final I_M_HU tuHU = createHU(tuPIV);
+
+		final I_M_InOutLine inoutLine = createInOutLine(3);
+		createHUAssignment(inoutLine, tuHU, tuHU);
+
+		// when
+		final IHandlingUnitsInfo result = factory.createFromModel(inoutLine);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getQtyTU()).isEqualTo(3);
+		assertThat(result.getTUName()).isEqualTo("IFCO");
+	}
+
+	@Test
+	public void createFromModel_InOutLine_resolvesFromHUAssignment_LUWithTU()
+	{
+		// given: LU as top-level HU, TU referenced via M_TU_HU_ID
+		final I_M_HU_PI_Version luPIV = createHU_PIVersion("Euro Pallet");
+		final I_M_HU luHU = createHU(luPIV);
+
+		final I_M_HU_PI_Version tuPIV = createHU_PIVersion("IFCO");
+		final I_M_HU tuHU = createHU(tuPIV);
+
+		final I_M_InOutLine inoutLine = createInOutLine(5);
+		createHUAssignment_LU_TU(inoutLine, luHU, tuHU);
+
+		// when
+		final IHandlingUnitsInfo result = factory.createFromModel(inoutLine);
+
+		// then: should use the TU PI, not the LU PI
+		assertThat(result).isNotNull();
+		assertThat(result.getQtyTU()).isEqualTo(5);
+		assertThat(result.getTUName()).isEqualTo("IFCO");
+	}
+
+	@Test
+	public void createFromModel_InOutLine_skipsVirtualHUs()
+	{
+		// given: one virtual HU assignment and one real TU assignment
+		final I_M_HU virtualHU = createVirtualHU();
+		final I_M_HU_PI_Version tuPIV = createHU_PIVersion("Karton");
+		final I_M_HU tuHU = createHU(tuPIV);
+
+		final I_M_InOutLine inoutLine = createInOutLine(2);
+		createHUAssignment(inoutLine, virtualHU, virtualHU);
+		createHUAssignment(inoutLine, tuHU, tuHU);
+
+		// when
+		final IHandlingUnitsInfo result = factory.createFromModel(inoutLine);
+
+		// then: should skip the virtual HU and use the real one
+		assertThat(result).isNotNull();
+		assertThat(result.getTUName()).isEqualTo("Karton");
+	}
+
+	@Test
+	public void createFromModel_InOutLine_onlyVirtualHUs_throws()
+	{
+		// given: only virtual HU assignments, no M_HU_PI_Item_Product fallback
+		final I_M_HU virtualHU = createVirtualHU();
+
+		final I_M_InOutLine inoutLine = createInOutLine(1);
+		createHUAssignment(inoutLine, virtualHU, virtualHU);
+
+		// when/then
+		assertThatThrownBy(() -> factory.createFromModel(inoutLine))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("TU Packing Instructions could not be determined");
+	}
+
+	@Test
+	public void createFromModel_InOutLine_noHUAssignments_noFallback_throws()
+	{
+		// given: no HU assignments and no M_HU_PI_Item_Product
+		final I_M_InOutLine inoutLine = createInOutLine(1);
+
+		// when/then
+		assertThatThrownBy(() -> factory.createFromModel(inoutLine))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("TU Packing Instructions could not be determined");
+	}
+
+	@Test
+	public void createFromModel_InOutLine_multipleDistinctPIs_usesFirst()
+	{
+		// given: two HU assignments with different TU PIs
+		final I_M_HU_PI_Version pivA = createHU_PIVersion("IFCO");
+		final I_M_HU tuA = createHU(pivA);
+
+		final I_M_HU_PI_Version pivB = createHU_PIVersion("Karton");
+		final I_M_HU tuB = createHU(pivB);
+
+		final I_M_InOutLine inoutLine = createInOutLine(4);
+		createHUAssignment(inoutLine, tuA, tuA);
+		createHUAssignment(inoutLine, tuB, tuB);
+
+		// when
+		final IHandlingUnitsInfo result = factory.createFromModel(inoutLine);
+
+		// then: should succeed (with warning logged), using the first PI
+		assertThat(result).isNotNull();
+		assertThat(result.getQtyTU()).isEqualTo(4);
+	}
+
+	@Test
+	public void createFromModel_InOutLine_topLevelOnlyAssignment_fallsBackToMHU()
+	{
+		// given: only a top-level assignment (no derived assignment with M_TU_HU_ID)
+		// This exercises Pass 2 (fallback to M_HU) since Pass 1 finds nothing.
+		final I_M_HU_PI_Version tuPIV = createHU_PIVersion("Paloxe");
+		final I_M_HU tuHU = createHU(tuPIV);
+
+		final I_M_InOutLine inoutLine = createInOutLine(1);
+
+		// create ONLY a top-level assignment (M_TU_HU left null)
+		final I_M_HU_Assignment topLevelAssignment = newInstance(I_M_HU_Assignment.class);
+		topLevelAssignment.setAD_Table_ID(getTableId(org.compiere.model.I_M_InOutLine.class));
+		topLevelAssignment.setRecord_ID(inoutLine.getM_InOutLine_ID());
+		topLevelAssignment.setM_HU(tuHU);
+		saveRecord(topLevelAssignment);
+
+		// when
+		final IHandlingUnitsInfo result = factory.createFromModel(inoutLine);
+
+		// then: Pass 1 finds nothing (no M_TU_HU_ID), Pass 2 picks up top-level M_HU
+		assertThat(result).isNotNull();
+		assertThat(result.getTUName()).isEqualTo("Paloxe");
+	}
+
+	// --- helpers ---
+
+	private I_M_InOutLine createInOutLine(final int qtyEnteredTU)
+	{
+		final org.compiere.model.I_M_InOut inout = newInstance(org.compiere.model.I_M_InOut.class);
+		inout.setDocumentNo("TEST-001");
+		inout.setMovementType("V+"); // vendor receipt
+		saveRecord(inout);
+
+		final org.compiere.model.I_M_InOutLine baseLine = newInstance(org.compiere.model.I_M_InOutLine.class);
+		baseLine.setM_InOut_ID(inout.getM_InOut_ID());
+		baseLine.setLine(10);
+		saveRecord(baseLine);
+
+		// wrap to HU-extended interface to set QtyEnteredTU
+		final I_M_InOutLine line = org.adempiere.model.InterfaceWrapperHelper.create(baseLine, I_M_InOutLine.class);
+		line.setQtyEnteredTU(BigDecimal.valueOf(qtyEnteredTU));
+		saveRecord(line);
+		return line;
+	}
+
+	private I_M_HU_PI_Version createHU_PIVersion(final String name)
+	{
+		final I_M_HU_PI pi = newInstance(I_M_HU_PI.class);
+		pi.setName(name);
+		saveRecord(pi);
+
+		final I_M_HU_PI_Version piVersion = newInstance(I_M_HU_PI_Version.class);
+		piVersion.setM_HU_PI_ID(pi.getM_HU_PI_ID());
+		piVersion.setIsCurrent(true);
+		piVersion.setName(name);
+		piVersion.setHU_UnitType("TU");
+		saveRecord(piVersion);
+
+		return piVersion;
+	}
+
+	private I_M_HU createHU(final I_M_HU_PI_Version piVersion)
+	{
+		final I_M_HU hu = newInstance(I_M_HU.class);
+		hu.setM_HU_PI_Version_ID(piVersion.getM_HU_PI_Version_ID());
+		saveRecord(hu);
+		return hu;
+	}
+
+	private I_M_HU createVirtualHU()
+	{
+		final I_M_HU hu = newInstance(I_M_HU.class);
+		hu.setM_HU_PI_Version_ID(HuPackingInstructionsVersionId.VIRTUAL.getRepoId());
+		saveRecord(hu);
+		return hu;
+	}
+
+	/**
+	 * Creates HU assignments like production code does for receipts:
+	 * 1. A top-level assignment (M_HU only, M_TU_HU/M_LU_HU = null) — created by assignHU/transferHandlingUnit
+	 * 2. A derived assignment with M_TU_HU set — created by createTradingUnitDerivedAssignmentBuilder
+	 *
+	 * @see de.metas.inoutcandidate.spi.impl.InOutProducerFromReceiptScheduleHU
+	 */
+	private void createHUAssignment(final I_M_InOutLine inoutLine, final I_M_HU topLevelHU, final I_M_HU tuHU)
+	{
+		// top-level assignment (like assignHU creates)
+		final I_M_HU_Assignment topLevelAssignment = newInstance(I_M_HU_Assignment.class);
+		topLevelAssignment.setAD_Table_ID(getTableId(org.compiere.model.I_M_InOutLine.class));
+		topLevelAssignment.setRecord_ID(inoutLine.getM_InOutLine_ID());
+		topLevelAssignment.setM_HU(topLevelHU);
+		// M_TU_HU and M_LU_HU intentionally left null
+		saveRecord(topLevelAssignment);
+
+		// derived assignment with TU info (like createTradingUnitDerivedAssignmentBuilder creates)
+		final I_M_HU_Assignment derivedAssignment = newInstance(I_M_HU_Assignment.class);
+		derivedAssignment.setAD_Table_ID(getTableId(org.compiere.model.I_M_InOutLine.class));
+		derivedAssignment.setRecord_ID(inoutLine.getM_InOutLine_ID());
+		derivedAssignment.setM_HU(topLevelHU);
+		derivedAssignment.setM_TU_HU(tuHU);
+		saveRecord(derivedAssignment);
+	}
+
+	private void createHUAssignment_LU_TU(final I_M_InOutLine inoutLine, final I_M_HU luHU, final I_M_HU tuHU)
+	{
+		// top-level assignment
+		final I_M_HU_Assignment topLevelAssignment = newInstance(I_M_HU_Assignment.class);
+		topLevelAssignment.setAD_Table_ID(getTableId(org.compiere.model.I_M_InOutLine.class));
+		topLevelAssignment.setRecord_ID(inoutLine.getM_InOutLine_ID());
+		topLevelAssignment.setM_HU(luHU);
+		saveRecord(topLevelAssignment);
+
+		// derived assignment with LU + TU
+		final I_M_HU_Assignment derivedAssignment = newInstance(I_M_HU_Assignment.class);
+		derivedAssignment.setAD_Table_ID(getTableId(org.compiere.model.I_M_InOutLine.class));
+		derivedAssignment.setRecord_ID(inoutLine.getM_InOutLine_ID());
+		derivedAssignment.setM_HU(luHU);
+		derivedAssignment.setM_LU_HU(luHU);
+		derivedAssignment.setM_TU_HU(tuHU);
+		saveRecord(derivedAssignment);
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactoryTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/materialtracking/spi/impl/HUHandlingUnitsInfoFactoryTest.java
@@ -21,9 +21,13 @@ import de.metas.handlingunits.IHUAssignmentDAO;
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.impl.HUAssignmentDAO;
 import de.metas.handlingunits.impl.HandlingUnitsBL;
+import de.metas.handlingunits.inout.IHUInOutBL;
+import de.metas.handlingunits.inout.impl.HUInOutBL;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_Assignment;
 import de.metas.handlingunits.model.I_M_HU_PI;
+import de.metas.handlingunits.model.I_M_HU_PI_Item;
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
 import de.metas.handlingunits.model.I_M_InOutLine;
 import de.metas.materialtracking.IHandlingUnitsInfo;
@@ -41,6 +45,7 @@ public class HUHandlingUnitsInfoFactoryTest
 
 		Services.registerService(IHUAssignmentDAO.class, new HUAssignmentDAO());
 		Services.registerService(IHandlingUnitsBL.class, new HandlingUnitsBL());
+		Services.registerService(IHUInOutBL.class, new HUInOutBL());
 
 		factory = new HUHandlingUnitsInfoFactory();
 	}
@@ -62,6 +67,31 @@ public class HUHandlingUnitsInfoFactoryTest
 		assertThat(result).isNotNull();
 		assertThat(result.getQtyTU()).isEqualTo(3);
 		assertThat(result.getTUName()).isEqualTo("IFCO");
+	}
+
+	@Test
+	public void createFromModel_InOutLine_plannedPI_winsOverHUAssignment()
+	{
+		// given: InOutLine has BOTH a planned TU PI (via M_HU_PI_Item_Product)
+		//        AND HU assignments referencing a different PI.
+		// The fix must prefer the planned PI to preserve prior behavior for non-rogue lines.
+		final I_M_HU_PI_Version plannedPIV = createHU_PIVersion("Paloxe");
+		final I_M_HU_PI_Item_Product plannedPIP = createPIItemProduct(plannedPIV);
+
+		final I_M_HU_PI_Version actualPIV = createHU_PIVersion("Grosspaloxe");
+		final I_M_HU actualTuHU = createHU(actualPIV);
+
+		final I_M_InOutLine inoutLine = createInOutLine(2);
+		inoutLine.setM_HU_PI_Item_Product_ID(plannedPIP.getM_HU_PI_Item_Product_ID());
+		saveRecord(inoutLine);
+		createHUAssignment(inoutLine, actualTuHU, actualTuHU);
+
+		// when
+		final IHandlingUnitsInfo result = factory.createFromModel(inoutLine);
+
+		// then: the planned PI wins — HU assignment is ignored when a planned PI exists
+		assertThat(result).isNotNull();
+		assertThat(result.getTUName()).isEqualTo("Paloxe");
 	}
 
 	@Test
@@ -231,6 +261,23 @@ public class HUHandlingUnitsInfoFactoryTest
 		hu.setM_HU_PI_Version_ID(HuPackingInstructionsVersionId.VIRTUAL.getRepoId());
 		saveRecord(hu);
 		return hu;
+	}
+
+	/**
+	 * Creates an M_HU_PI_Item_Product pointing to a "Material" item of the given PI version.
+	 * This is the metadata that IHUInOutBL.getTU_HU_PI() navigates.
+	 */
+	private I_M_HU_PI_Item_Product createPIItemProduct(final I_M_HU_PI_Version tuPIV)
+	{
+		final I_M_HU_PI_Item piItem = newInstance(I_M_HU_PI_Item.class);
+		piItem.setM_HU_PI_Version_ID(tuPIV.getM_HU_PI_Version_ID());
+		piItem.setItemType("MI");
+		saveRecord(piItem);
+
+		final I_M_HU_PI_Item_Product pip = newInstance(I_M_HU_PI_Item_Product.class);
+		pip.setM_HU_PI_Item_ID(piItem.getM_HU_PI_Item_ID());
+		saveRecord(pip);
+		return pip;
 	}
 
 	/**

--- a/backend/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/InOutLineAsVendorReceipt.java
+++ b/backend/de.metas.materialtracking/src/main/java/de/metas/materialtracking/qualityBasedInvoicing/impl/InOutLineAsVendorReceipt.java
@@ -214,7 +214,7 @@ import lombok.NonNull;
 			final IHandlingUnitsInfo handlingUnitsInfo = handlingUnitsInfoFactory.createFromModel(inoutLine);
 			if (handlingUnitsInfo == null)
 			{
-				// do nothing
+				continue;
 			}
 			if (handlingUnitsInfoTotal == null)
 			{

--- a/backend/de.metas.materialtracking/src/main/java/de/metas/materialtracking/spi/IHandlingUnitsInfoFactory.java
+++ b/backend/de.metas.materialtracking/src/main/java/de/metas/materialtracking/spi/IHandlingUnitsInfoFactory.java
@@ -23,6 +23,8 @@ package de.metas.materialtracking.spi;
  */
 
 
+import javax.annotation.Nullable;
+
 import org.compiere.model.I_C_Invoice_Detail;
 
 import de.metas.materialtracking.IHandlingUnitsInfo;
@@ -39,7 +41,10 @@ public interface IHandlingUnitsInfoFactory extends ISingletonService
 {
 	/**
 	 * Gets the handling units information from given model.
+	 *
+	 * @return the handling units info, or {@code null} if the model type is not supported or required data (e.g. TU PI) is missing
 	 */
+	@Nullable
 	IHandlingUnitsInfo createFromModel(Object model);
 
 	/**


### PR DESCRIPTION
## Summary

Forward-merge `soft_panda_release` → `new_dawn_uat`. Carries the Waschprobe / material-tracking IC-creation fix (tuPI null handling) from soft_panda_hotfix through the merge chain.

### Commits in scope
- `facc9df3357` — fix: return null when TU PI is missing in material tracking invoicing (PR #23400)
- `a99c3e8ab54` — fix: prefer planned TU PI (M_HU_PI_Item_Product) over HU assignment (PR #23444)

### Files changed (4)
- `HUHandlingUnitsInfoFactory.java` (+ test)
- `InOutLineAsVendorReceipt.java`
- `IHandlingUnitsInfoFactory.java`

Java-only diff — no SQL migrations, no DDL — so auto-port / auto-merge applies.

## Test plan
- [ ] CI green