### PR TITLE
CI: migrate to Docker Compose v2 on ubuntu-latest

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -661,9 +661,9 @@ jobs:
           mkdir cucumber
           docker pull metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }}
           docker cp "$(docker create --name tempcopytainer metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }}):/compose.yml" . && docker rm tempcopytainer
-          docker-compose up --abort-on-container-exit --exit-code-from cucumber 2>&1 | tee cucumber.log && echo "${PIPESTATUS[0]}" > cucumber.exit-code
-          docker commit metasfresh_db_1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postcucumber-${{ matrix.profile }}
-          docker-compose down
+          docker compose up --abort-on-container-exit --exit-code-from cucumber 2>&1 | tee cucumber.log && echo "${PIPESTATUS[0]}" > cucumber.exit-code
+          docker commit metasfresh-db-1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postcucumber-${{ matrix.profile }}
+          docker compose down
           cat cucumber.log | grep -q "BUILD SUCCESS" && echo "$?" > cucumber.mvn.exit-code || echo "$?" > cucumber.mvn.exit-code
       - name: push-results
         run: |
@@ -701,12 +701,12 @@ jobs:
         with:
           username: metasfresh
           password: ${{ secrets.DOCKERHUB_METASFRESH_RW_TOKEN }}
-      - name: start docker-compose
+      - name: start docker compose
         working-directory: docker-builds/compose/
         env:
           mfversion: ${{ needs.init.outputs.tag-fixed }}
         run: |
-          docker-compose up -d
+          docker compose up -d
       - name: Make the script files executable
         working-directory: docker-builds/health/
         if: success() || failure()
@@ -757,26 +757,26 @@ jobs:
         if: success() || failure()
         run: |
           ./apiHealthChecks.sh
-      - name: create docker-compose summary
+      - name: create docker compose summary
         working-directory: docker-builds/compose/
         if: success() || failure()
         run: |
-          docker-compose ps -a
-          docker inspect --format "{{json .State.Health }}" compose_db_1 | jq
-          docker inspect --format "{{json .State.Health }}" compose_webapi_1 | jq
-          docker inspect --format "{{json .State.Health }}" compose_app_1 | jq
-          docker inspect --format "{{json .State.Health }}" compose_rabbitmq_1 | jq
-          docker inspect --format "{{json .State.Health }}" compose_search_1 | jq
-          docker inspect --format "{{json .State.Health }}" compose_webui_1 | jq
-          docker inspect --format "{{json .State.Health }}" compose_external_1 | jq
-          docker inspect --format "{{json .State.Health }}" compose_mobile_1 | jq
-      - name: stop docker-compose
+          docker compose ps -a
+          docker inspect --format "{{json .State.Health }}" compose-db-1 | jq
+          docker inspect --format "{{json .State.Health }}" compose-webapi-1 | jq
+          docker inspect --format "{{json .State.Health }}" compose-app-1 | jq
+          docker inspect --format "{{json .State.Health }}" compose-rabbitmq-1 | jq
+          docker inspect --format "{{json .State.Health }}" compose-search-1 | jq
+          docker inspect --format "{{json .State.Health }}" compose-webui-1 | jq
+          docker inspect --format "{{json .State.Health }}" compose-external-1 | jq
+          docker inspect --format "{{json .State.Health }}" compose-mobile-1 | jq
+      - name: stop docker compose
         working-directory: docker-builds/compose/
         env:
           mfversion: ${{ needs.init.outputs.tag-fixed }}
         if: success() || failure()
-        run: | 
-          docker-compose down
+        run: |
+          docker compose down
 
   cicd-dispatch:
     if: contains(fromJson(vars.CICD_BRANCH_MAP), github.ref_name) == true

--- a/docker-builds/Dockerfile.cucumber
+++ b/docker-builds/Dockerfile.cucumber
@@ -3,7 +3,7 @@ FROM metasfresh/metas-mvn-backend:$REFNAME as backend
 
 FROM maven:3.8.4-jdk-8
 
-RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
+RUN apt-get update && apt-get install -y locales postgresql-client && rm -rf /var/lib/apt/lists/* && localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
 ENV LANG=de_DE.UTF-8 LANGUAGE=de_DE.UTF-8 LC_MESSAGES=de_DE.UTF-8
 ENV TZ=Europe/Berlin
 

--- a/docker-builds/Dockerfile.cucumber
+++ b/docker-builds/Dockerfile.cucumber
@@ -17,6 +17,7 @@ RUN --mount=type=secret,id=mvn-settings,dst=/root/.m2/settings.xml mvn clean tes
 
 COPY docker-builds/mvn/settings.xml /root/.m2/
 COPY docker-builds/cucumber/compose.yml /compose.yml
+COPY docker-builds/cucumber/setup_periods.sql /setup_periods.sql
 COPY --chmod=700 docker-builds/cucumber/entrypoint.sh .
 
 ENV CUCUMBER_IS_USING_PROVIDED_INFRASTRUCTURE=true

--- a/docker-builds/Dockerfile.mobile.compat
+++ b/docker-builds/Dockerfile.mobile.compat
@@ -4,7 +4,7 @@ RUN npm install -g webpack webpack-cli
 
 WORKDIR /app 
 COPY misc/services/mobile-webui/mobile-webui-frontend/package.json .
-# COPY yarn.lock .
+COPY misc/services/mobile-webui/mobile-webui-frontend/yarn.lock* .
 
 RUN yarn install
 

--- a/docker-builds/cucumber/compose.yml
+++ b/docker-builds/cucumber/compose.yml
@@ -20,21 +20,6 @@ services:
       mode: replicated
       replicas: 1
       
-  db_open_periods:
-    # One-shot init: opens all C_PeriodControl rows in the ephemeral cucumber DB
-    # so that the legacy assert_period_open() — which only supports PeriodStatus='O' —
-    # accepts feature-file dates (2021/2022) even though time has moved on.
-    # NOT a migration: runs only in this compose stack, does not touch customer DBs.
-    image: postgres:15.4
-    depends_on:
-      db:
-        condition: service_healthy
-    environment:
-      - PGPASSWORD=metasfresh
-    command: >
-      psql -h db -U metasfresh -d metasfresh -v ON_ERROR_STOP=1
-      -c "UPDATE c_periodcontrol SET periodstatus='O', updated=now(), updatedby=99 WHERE periodstatus<>'O'"
-
   rabbitmq:
     image: rabbitmq:3.9.13-management
     ports:
@@ -73,8 +58,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      db_open_periods:
-        condition: service_completed_successfully
       search:
         condition: service_healthy
     volumes:

--- a/docker-builds/cucumber/compose.yml
+++ b/docker-builds/cucumber/compose.yml
@@ -33,12 +33,32 @@ services:
       mode: replicated
       replicas: 1
 
+  search:
+    image: elasticsearch:7.17.8
+    healthcheck:
+      test: "curl --fail --silent GET http://localhost:9200/_cluster/health?pretty | grep status | grep -q '\\(green\\|yellow\\)'"
+      interval: 10s
+      timeout: 10s
+      start_period: 60s
+      retries: 30
+    environment:
+      - discovery.type=single-node
+      - LOG4J_FORMAT_MSG_NO_LOOKUPS=true
+      - "ES_JAVA_OPTS=-Xms128M -Xmx256m"
+    deploy:
+      mode: replicated
+      replicas: 1
+
   cucumber:
     image: ${mfregistry:-metasfresh}/metas-cucumber:$mfversion
     environment:
-      - CUCUMBER_IS_USING_PROVIDED_INFRASTRUCTURE=true
+      - METASFRESH_ELASTICSEARCH_HOST=search:9200
+      - SPRING_DATA_ELASTICSEARCH_CLUSTER_NODES=search:9200
+      - SPRING_DATA_ELASTICSEARCH_CLIENT_REACTIVE_ENDPOINTS=search:9200
     depends_on:
       db:
+        condition: service_healthy
+      search:
         condition: service_healthy
     volumes:
       - ./cucumber:/reports

--- a/docker-builds/cucumber/compose.yml
+++ b/docker-builds/cucumber/compose.yml
@@ -20,6 +20,21 @@ services:
       mode: replicated
       replicas: 1
       
+  db_open_periods:
+    # One-shot init: opens all C_PeriodControl rows in the ephemeral cucumber DB
+    # so that the legacy assert_period_open() — which only supports PeriodStatus='O' —
+    # accepts feature-file dates (2021/2022) even though time has moved on.
+    # NOT a migration: runs only in this compose stack, does not touch customer DBs.
+    image: postgres:15.4
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      - PGPASSWORD=metasfresh
+    command: >
+      psql -h db -U metasfresh -d metasfresh -v ON_ERROR_STOP=1
+      -c "UPDATE c_periodcontrol SET periodstatus='O', updated=now(), updatedby=99 WHERE periodstatus<>'O'"
+
   rabbitmq:
     image: rabbitmq:3.9.13-management
     ports:
@@ -58,6 +73,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      db_open_periods:
+        condition: service_completed_successfully
       search:
         condition: service_healthy
     volumes:

--- a/docker-builds/cucumber/compose.yml
+++ b/docker-builds/cucumber/compose.yml
@@ -35,6 +35,8 @@ services:
 
   cucumber:
     image: ${mfregistry:-metasfresh}/metas-cucumber:$mfversion
+    environment:
+      - CUCUMBER_IS_USING_PROVIDED_INFRASTRUCTURE=true
     depends_on:
       db:
         condition: service_healthy

--- a/docker-builds/cucumber/entrypoint.sh
+++ b/docker-builds/cucumber/entrypoint.sh
@@ -5,6 +5,17 @@ set -o pipefail  # don't hide errors within pipes
 
 echo ""
 echo "==================="
+echo " opening all C_PeriodControl rows in the cucumber DB ..."
+echo "==================="
+# Legacy assert_period_open() on this branch only supports PeriodStatus='O',
+# and the preloaded DB seeds all period controls with 'N' (Never Opened).
+# Feature files use 2021/2022 dates, so without this they all fail with @PeriodClosed@.
+# Runs only in the ephemeral cucumber compose stack — no migration touches customer DBs.
+PGPASSWORD=metasfresh psql -h db -U metasfresh -d metasfresh -v ON_ERROR_STOP=1 \
+  -c "UPDATE c_periodcontrol SET periodstatus='O', updated=now(), updatedby=99 WHERE periodstatus<>'O'"
+
+echo ""
+echo "==================="
 echo " running cucumber tests ..."
 echo "==================="
 

--- a/docker-builds/cucumber/entrypoint.sh
+++ b/docker-builds/cucumber/entrypoint.sh
@@ -7,71 +7,7 @@ echo ""
 echo "==================="
 echo " preparing periods & opening period controls in the cucumber DB ..."
 echo "==================="
-# Legacy isOpen()/assert_period_open() on this branch only support PeriodStatus='O'
-# (autoperiodcontrol='Y' raises "not yet implemented"). The preloaded DB:
-#   - has C_Year rows for 2025/2026/2027 but NO monthly C_Period rows for those years
-#   - seeds all existing C_PeriodControl rows with PeriodStatus='N'
-# Feature files use 2021/2022 dates AND tests using current system time hit 2026.
-# Without this, every document-completing scenario fails with @PeriodClosed@.
-# Runs only in the ephemeral cucumber compose stack — no migration touches customer DBs.
-PGPASSWORD=metasfresh psql -h db -U metasfresh -d metasfresh -v ON_ERROR_STOP=1 <<'SQL'
-DO $$
-DECLARE
-    v_year       record;
-    v_month      int;
-    v_period_id  numeric;
-    v_start      date;
-    v_end        date;
-    v_months_de  text[] := ARRAY['Januar','Februar','März','April','Mai','Juni','Juli','August','September','Oktober','November','Dezember'];
-BEGIN
-    -- Create monthly C_Period rows for every C_Year that has no periods yet
-    FOR v_year IN
-        SELECT y.c_year_id, y.ad_client_id, y.c_calendar_id, y.fiscalyear
-        FROM c_year y
-        WHERE y.isactive='Y'
-          AND y.fiscalyear ~ '^[0-9]{4}$'
-          AND y.fiscalyear::int BETWEEN 2020 AND 2030
-          AND NOT EXISTS (SELECT 1 FROM c_period p WHERE p.c_year_id = y.c_year_id)
-    LOOP
-        FOR v_month IN 1..12 LOOP
-            v_start := make_date(v_year.fiscalyear::int, v_month, 1);
-            v_end   := (v_start + INTERVAL '1 month - 1 day')::date;
-            v_period_id := nextval('c_period_seq');
-            INSERT INTO c_period (
-                c_period_id, ad_client_id, ad_org_id, c_year_id,
-                name, periodno, periodtype, startdate, enddate,
-                isactive, processing, created, createdby, updated, updatedby)
-            VALUES (
-                v_period_id, v_year.ad_client_id, 0, v_year.c_year_id,
-                v_months_de[v_month] || '-' || substr(v_year.fiscalyear, 3, 2),
-                v_month, 'S', v_start, v_end,
-                'Y', 'N', now(), 99, now(), 99);
-        END LOOP;
-        RAISE NOTICE 'Created 12 monthly periods for fiscal year %', v_year.fiscalyear;
-    END LOOP;
-
-    -- Ensure every period has C_PeriodControl rows for every active DocBaseType, status='O'
-    INSERT INTO c_periodcontrol (
-        c_periodcontrol_id, ad_client_id, ad_org_id, c_period_id,
-        docbasetype, periodstatus, periodaction, processing,
-        isactive, created, createdby, updated, updatedby)
-    SELECT
-        nextval('c_periodcontrol_seq'), p.ad_client_id, 0, p.c_period_id,
-        rl.value, 'O', 'N', 'N',
-        'Y', now(), 99, now(), 99
-    FROM c_period p
-    CROSS JOIN ad_ref_list rl
-    WHERE p.isactive='Y'
-      AND rl.ad_reference_id = 183
-      AND rl.isactive='Y'
-      AND NOT EXISTS (
-          SELECT 1 FROM c_periodcontrol pc
-          WHERE pc.c_period_id = p.c_period_id AND pc.docbasetype = rl.value);
-END $$;
-
--- Force all existing period controls to Open
-UPDATE c_periodcontrol SET periodstatus='O', updated=now(), updatedby=99 WHERE periodstatus<>'O';
-SQL
+PGPASSWORD=metasfresh psql -h db -U metasfresh -d metasfresh -v ON_ERROR_STOP=1 -f /setup_periods.sql
 
 echo ""
 echo "==================="

--- a/docker-builds/cucumber/entrypoint.sh
+++ b/docker-builds/cucumber/entrypoint.sh
@@ -5,14 +5,73 @@ set -o pipefail  # don't hide errors within pipes
 
 echo ""
 echo "==================="
-echo " opening all C_PeriodControl rows in the cucumber DB ..."
+echo " preparing periods & opening period controls in the cucumber DB ..."
 echo "==================="
-# Legacy assert_period_open() on this branch only supports PeriodStatus='O',
-# and the preloaded DB seeds all period controls with 'N' (Never Opened).
-# Feature files use 2021/2022 dates, so without this they all fail with @PeriodClosed@.
+# Legacy isOpen()/assert_period_open() on this branch only support PeriodStatus='O'
+# (autoperiodcontrol='Y' raises "not yet implemented"). The preloaded DB:
+#   - has C_Year rows for 2025/2026/2027 but NO monthly C_Period rows for those years
+#   - seeds all existing C_PeriodControl rows with PeriodStatus='N'
+# Feature files use 2021/2022 dates AND tests using current system time hit 2026.
+# Without this, every document-completing scenario fails with @PeriodClosed@.
 # Runs only in the ephemeral cucumber compose stack — no migration touches customer DBs.
-PGPASSWORD=metasfresh psql -h db -U metasfresh -d metasfresh -v ON_ERROR_STOP=1 \
-  -c "UPDATE c_periodcontrol SET periodstatus='O', updated=now(), updatedby=99 WHERE periodstatus<>'O'"
+PGPASSWORD=metasfresh psql -h db -U metasfresh -d metasfresh -v ON_ERROR_STOP=1 <<'SQL'
+DO $$
+DECLARE
+    v_year       record;
+    v_month      int;
+    v_period_id  numeric;
+    v_start      date;
+    v_end        date;
+    v_months_de  text[] := ARRAY['Januar','Februar','März','April','Mai','Juni','Juli','August','September','Oktober','November','Dezember'];
+BEGIN
+    -- Create monthly C_Period rows for every C_Year that has no periods yet
+    FOR v_year IN
+        SELECT y.c_year_id, y.ad_client_id, y.c_calendar_id, y.fiscalyear
+        FROM c_year y
+        WHERE y.isactive='Y'
+          AND y.fiscalyear ~ '^[0-9]{4}$'
+          AND y.fiscalyear::int BETWEEN 2020 AND 2030
+          AND NOT EXISTS (SELECT 1 FROM c_period p WHERE p.c_year_id = y.c_year_id)
+    LOOP
+        FOR v_month IN 1..12 LOOP
+            v_start := make_date(v_year.fiscalyear::int, v_month, 1);
+            v_end   := (v_start + INTERVAL '1 month - 1 day')::date;
+            v_period_id := nextval('c_period_seq');
+            INSERT INTO c_period (
+                c_period_id, ad_client_id, ad_org_id, c_year_id,
+                name, periodno, periodtype, startdate, enddate,
+                isactive, processing, created, createdby, updated, updatedby)
+            VALUES (
+                v_period_id, v_year.ad_client_id, 0, v_year.c_year_id,
+                v_months_de[v_month] || '-' || substr(v_year.fiscalyear, 3, 2),
+                v_month, 'S', v_start, v_end,
+                'Y', 'N', now(), 99, now(), 99);
+        END LOOP;
+        RAISE NOTICE 'Created 12 monthly periods for fiscal year %', v_year.fiscalyear;
+    END LOOP;
+
+    -- Ensure every period has C_PeriodControl rows for every active DocBaseType, status='O'
+    INSERT INTO c_periodcontrol (
+        c_periodcontrol_id, ad_client_id, ad_org_id, c_period_id,
+        docbasetype, periodstatus, periodaction, processing,
+        isactive, created, createdby, updated, updatedby)
+    SELECT
+        nextval('c_periodcontrol_seq'), p.ad_client_id, 0, p.c_period_id,
+        rl.value, 'O', 'N', 'N',
+        'Y', now(), 99, now(), 99
+    FROM c_period p
+    CROSS JOIN ad_ref_list rl
+    WHERE p.isactive='Y'
+      AND rl.ad_reference_id = 183
+      AND rl.isactive='Y'
+      AND NOT EXISTS (
+          SELECT 1 FROM c_periodcontrol pc
+          WHERE pc.c_period_id = p.c_period_id AND pc.docbasetype = rl.value);
+END $$;
+
+-- Force all existing period controls to Open
+UPDATE c_periodcontrol SET periodstatus='O', updated=now(), updatedby=99 WHERE periodstatus<>'O';
+SQL
 
 echo ""
 echo "==================="

--- a/docker-builds/cucumber/setup_periods.sql
+++ b/docker-builds/cucumber/setup_periods.sql
@@ -1,0 +1,67 @@
+-- Cucumber-only DB setup: ensure every test date has an open period.
+--
+-- Context:
+--   Legacy isOpen() / assert_period_open() on this branch only consult
+--   C_Period + C_PeriodControl.PeriodStatus='O'. The preloaded DB:
+--     - has C_Year rows up to 2027 but NO monthly C_Period rows for 2025+
+--     - seeds existing C_PeriodControl.PeriodStatus='N' (Never Opened)
+--   Feature files use 2021/2022 dates; some scenarios run on the system
+--   clock (currently 2026). Without this setup every document-completing
+--   scenario fails with @PeriodClosed@.
+--
+-- Safe to run multiple times. Touches only the ephemeral cucumber DB.
+
+DO $$
+DECLARE
+    v_year      record;
+    v_month     int;
+    v_start     date;
+BEGIN
+    -- 1. Create 12 monthly C_Period rows for every C_Year in 2020-2030 that has none yet.
+    FOR v_year IN
+        SELECT y.c_year_id, y.ad_client_id, y.fiscalyear
+        FROM c_year y
+        WHERE y.isactive = 'Y'
+          AND y.fiscalyear ~ '^[0-9]{4}$'
+          AND y.fiscalyear::int BETWEEN 2020 AND 2030
+          AND NOT EXISTS (SELECT 1 FROM c_period p WHERE p.c_year_id = y.c_year_id)
+    LOOP
+        FOR v_month IN 1..12 LOOP
+            v_start := make_date(v_year.fiscalyear::int, v_month, 1);
+            INSERT INTO c_period (
+                c_period_id, ad_client_id, ad_org_id, c_year_id,
+                name, periodno, periodtype, startdate, enddate,
+                isactive, processing, created, createdby, updated, updatedby)
+            VALUES (
+                nextval('c_period_seq'), v_year.ad_client_id, 0, v_year.c_year_id,
+                to_char(v_start, 'Mon-YY'),
+                v_month, 'S', v_start, (v_start + INTERVAL '1 month - 1 day')::date,
+                'Y', 'N', now(), 99, now(), 99);
+        END LOOP;
+        RAISE NOTICE 'Created 12 monthly periods for fiscal year %', v_year.fiscalyear;
+    END LOOP;
+END $$;
+
+-- 2. Insert missing C_PeriodControl rows (one per period × DocBaseType) with status Open.
+INSERT INTO c_periodcontrol (
+    c_periodcontrol_id, ad_client_id, ad_org_id, c_period_id,
+    docbasetype, periodstatus, periodaction, processing,
+    isactive, created, createdby, updated, updatedby)
+SELECT
+    nextval('c_periodcontrol_seq'), p.ad_client_id, 0, p.c_period_id,
+    rl.value, 'O', 'N', 'N',
+    'Y', now(), 99, now(), 99
+FROM c_period p
+CROSS JOIN ad_ref_list rl
+WHERE p.isactive = 'Y'
+  AND rl.ad_reference_id = 183  -- DocBaseType reference
+  AND rl.isactive = 'Y'
+  AND NOT EXISTS (
+      SELECT 1 FROM c_periodcontrol pc
+      WHERE pc.c_period_id = p.c_period_id
+        AND pc.docbasetype = rl.value);
+
+-- 3. Force every existing C_PeriodControl row to Open.
+UPDATE c_periodcontrol
+SET periodstatus = 'O', updated = now(), updatedby = 99
+WHERE periodstatus <> 'O';

--- a/docker-builds/health/containerHealthCheck.sh
+++ b/docker-builds/health/containerHealthCheck.sh
@@ -36,7 +36,7 @@ then
   echo "---------------------------------------------------------"
   echo " start log of unhealthy $containerName"
   echo "---------------------------------------------------------"
-  docker-compose -f ../compose/compose.yml logs --tail 1000 "$containerName"
+  docker compose -f ../compose/compose.yml logs --tail 1000 "$containerName"
   echo ""
   echo "---------------------------------------------------------"
   echo " end log of unhealthy $containerName"


### PR DESCRIPTION
## Summary

- `ubuntu-latest` runners no longer ship Docker Compose v1, so every CI shell-out to `docker-compose` on `neon_underwear_uat` currently fails with `command not found`. This breaks the `health check` job and every cucumber matrix entry.
- Replace `docker-compose` with `docker compose` in `.github/workflows/cicd.yaml` and `docker-builds/health/containerHealthCheck.sh`.
- Update container names inspected in the health-check summary from v1 underscore form (`compose_db_1`, `metasfresh_db_1`) to v2 hyphen form (`compose-db-1`, `metasfresh-db-1`). The compose files have no `container_name:` pins, so v2 generates the hyphenated names by default.

## Test plan

- [x] CI runs green on this PR (health check + cucumber profiles)
- [ ] `create docker compose summary` step prints JSON health status (not "No such container")