### PR TITLE
ci: pass source_branch to private-extensions auto-update-base-version dispatch

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1701,8 +1701,9 @@ jobs:
         env:
           CICD_RUN_ID: ${{ github.run_id }}
           TAG_FIXED: ${{ needs.init.outputs.tag-fixed }}
+          SOURCE_BRANCH: ${{ github.ref_name }}
           GH_TOKEN: ${{ secrets.CICD_TRIGGER_DISPATCH }}
           CICD_DISPATCH_REPO: ${{ fromJson(vars.CICD_DISPATCH_CONFIG).repo }}
           CICD_DISPATCH_WORKFLOW_FILE: ${{ fromJson(vars.CICD_DISPATCH_CONFIG).workflow_file }}
         run: |
-          gh workflow run "${CICD_DISPATCH_WORKFLOW_FILE}" --repo "${CICD_DISPATCH_REPO}" -f "cicd_run_id=${CICD_RUN_ID}" -f "tag_fixed=${TAG_FIXED}"
+          gh workflow run "${CICD_DISPATCH_WORKFLOW_FILE}" --repo "${CICD_DISPATCH_REPO}" -f "cicd_run_id=${CICD_RUN_ID}" -f "tag_fixed=${TAG_FIXED}" -f "source_branch=${SOURCE_BRANCH}"


### PR DESCRIPTION
Adds the missing `source_branch` argument when dispatching to the private-extensions `auto-update-base-version` workflow.

Without it, the dispatched workflow falls back to its default branch and concurrent dispatches can race on the push, producing `non-fast-forward` rejections. With `source_branch`, each dispatch targets its own branch.

Cherry of the original change on the trunk branch ([97b8136](https://github.com/metasfresh/metasfresh/commit/97b8136df14fdee94e60197a3fcbfb59c79d2f73)).