### PR TITLE
gh29279: field descriptions for Document Type Printing Options window

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798730_sys_gh29279_C_DocType_PrintOptions_Window_FieldDescriptions.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798730_sys_gh29279_C_DocType_PrintOptions_Window_FieldDescriptions.sql
@@ -127,49 +127,5 @@ SET Description = 'Ob der Summenblock auf dem generierten Dokument angezeigt wir
 WHERE AD_UI_Element_ID = 575099;
 
 
--- =============================================================================
--- 4) AD_UI_Element_Trl (en_US) — create if missing, then fill with EN text
--- =============================================================================
-
-INSERT INTO AD_UI_Element_Trl (AD_Language, AD_UI_Element_ID, Description, Help, Name, IsTranslated,
-                               AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
-SELECT 'en_US', ue.AD_UI_Element_ID, ue.Description, ue.Help, ue.Name, 'N',
-       ue.AD_Client_ID, ue.AD_Org_ID,
-       TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), 0,
-       TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), 0
-FROM AD_UI_Element ue
-WHERE ue.AD_UI_Element_ID IN (575095, 575346, 575098, 575099)
-  AND NOT EXISTS (SELECT 1 FROM AD_UI_Element_Trl tt
-                  WHERE tt.AD_UI_Element_ID = ue.AD_UI_Element_ID AND tt.AD_Language = 'en_US');
-
--- C_DocType_ID (EN)
-UPDATE AD_UI_Element_Trl
-SET Description  = 'The document type this configuration applies to (e.g., Lieferung, Rechnung, Auftrag).',
-    Help         = 'Determines which document types these print options apply to. Each document type can have up to three configurations: one for Flavor "Print", one for "EMail", and a universal default (no flavor).',
-    IsTranslated = 'Y',
-    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_UI_Element_ID = 575095 AND AD_Language = 'en_US';
-
--- DocumentFlavor (EN)
-UPDATE AD_UI_Element_Trl
-SET Description  = 'Output channel for this configuration: EMail, Print, or empty (universal default).',
-    Help         = 'Controls whether these settings apply when printing (Print), emailing (EMail), or as the universal default (empty). A specific flavor takes precedence over the universal default.',
-    IsTranslated = 'Y',
-    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_UI_Element_ID = 575346 AND AD_Language = 'en_US';
-
--- PRINTER_OPTS_IsPrintLogo (EN)
-UPDATE AD_UI_Element_Trl
-SET Description  = 'Whether the company logo is included in the generated document.',
-    Help         = 'If enabled, the configured letterhead/logo image is rendered into the PDF output. On manual prints this value pre-fills the print dialog checkbox and can be overridden by the user.',
-    IsTranslated = 'Y',
-    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_UI_Element_ID = 575098 AND AD_Language = 'en_US';
-
--- PRINTER_OPTS_IsPrintTotals (EN)
-UPDATE AD_UI_Element_Trl
-SET Description  = 'Whether the totals section is included in the generated document.',
-    Help         = 'If enabled, the totals/summary section is rendered in the printed or emailed document. Useful e.g. to omit totals from email output when they are already in the email body.',
-    IsTranslated = 'Y',
-    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_UI_Element_ID = 575099 AND AD_Language = 'en_US';
+-- Note: AD_UI_Element has no _Trl table in the schema. English text lives
+-- on AD_Field_Trl (section 2); the WebUI resolves en_US via that path.

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798730_sys_gh29279_C_DocType_PrintOptions_Window_FieldDescriptions.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798730_sys_gh29279_C_DocType_PrintOptions_Window_FieldDescriptions.sql
@@ -1,0 +1,175 @@
+-- Per-field descriptions / help for window "Document Type Printing Options"
+-- (AD_Window_ID=541004, Tab=543206). Descriptions follow the user-facing
+-- semantics documented in mf15-documentation#96.
+--
+-- Fields touched on tab 543206:
+--   AD_Field 625830  → C_DocType_ID               (AD_UI_Element 575095)
+--   AD_Field 626425  → DocumentFlavor             (AD_UI_Element 575346)
+--   AD_Field 625832  → PRINTER_OPTS_IsPrintLogo   (AD_UI_Element 575098)
+--   AD_Field 625833  → PRINTER_OPTS_IsPrintTotals (AD_UI_Element 575099)
+--
+-- Per-field overrides only — AD_Element of PRINTER_OPTS_IsPrintLogo /
+-- PRINTER_OPTS_IsPrintTotals is reused across many AD_Process_Para rows,
+-- so we deliberately do not touch the shared AD_Element descriptions.
+
+
+-- =============================================================================
+-- 1) AD_Field.Description + Help (base language de_DE)
+-- =============================================================================
+
+-- C_DocType_ID — Belegart
+UPDATE AD_Field
+SET Description = 'Die Belegart, für die diese Druckoptionen gelten (z. B. Lieferung, Rechnung, Auftrag).',
+    Help        = 'Das Belegart-Feld bestimmt, auf welche Dokumenttypen diese Druckoptionen angewendet werden. Jede Belegart kann bis zu drei Konfigurationen haben: eine für Flavor "Print", eine für "EMail" und einen universellen Standard (ohne Flavor).',
+    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Field_ID = 625830;
+
+-- DocumentFlavor — Flavor
+UPDATE AD_Field
+SET Description = 'Ausgabekanal für diese Konfiguration: EMail, Print oder leer (universeller Standard).',
+    Help        = 'Legt fest, ob diese Einstellungen beim Drucken (Print), beim Versand per E-Mail (EMail) oder als universeller Standard (leer) angewendet werden. Ein spezifischer Flavor hat Vorrang vor dem universellen Standard.',
+    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Field_ID = 626425;
+
+-- PRINTER_OPTS_IsPrintLogo — Logo drucken
+UPDATE AD_Field
+SET Description = 'Ob das Firmenlogo auf dem generierten Dokument angezeigt wird.',
+    Help        = 'Wenn aktiviert, wird das hinterlegte Briefkopf-/Logobild beim Rendern des Dokuments in die PDF-Ausgabe übernommen. Beim manuellen Drucken dient dieser Wert als Vorbelegung im Druckdialog und kann vom Benutzer noch überschrieben werden.',
+    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Field_ID = 625832;
+
+-- PRINTER_OPTS_IsPrintTotals — Gesamtbeträge drucken
+UPDATE AD_Field
+SET Description = 'Ob der Summenblock auf dem generierten Dokument angezeigt wird.',
+    Help        = 'Wenn aktiviert, wird die Summen-/Gesamtbeträge-Sektion im gedruckten oder versendeten Dokument gerendert. Nützlich z. B. um Gesamtbeträge aus E-Mail-Ausgaben wegzulassen, wenn diese bereits im Mailtext stehen.',
+    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Field_ID = 625833;
+
+
+-- =============================================================================
+-- 2) AD_Field_Trl (en_US) — create if missing, then fill with English text
+-- =============================================================================
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated,
+                          AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT 'en_US', f.AD_Field_ID, f.Description, f.Help, f.Name, 'N',
+       f.AD_Client_ID, f.AD_Org_ID,
+       TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), 0,
+       TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), 0
+FROM AD_Field f
+WHERE f.AD_Field_ID IN (625830, 626425, 625832, 625833)
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt
+                  WHERE tt.AD_Field_ID = f.AD_Field_ID AND tt.AD_Language = 'en_US');
+
+-- C_DocType_ID (EN)
+UPDATE AD_Field_Trl
+SET Description  = 'The document type this configuration applies to (e.g., Lieferung, Rechnung, Auftrag).',
+    Help         = 'Determines which document types these print options apply to. Each document type can have up to three configurations: one for Flavor "Print", one for "EMail", and a universal default (no flavor).',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Field_ID = 625830 AND AD_Language = 'en_US';
+
+-- DocumentFlavor (EN)
+UPDATE AD_Field_Trl
+SET Description  = 'Output channel for this configuration: EMail, Print, or empty (universal default).',
+    Help         = 'Controls whether these settings apply when printing (Print), emailing (EMail), or as the universal default (empty). A specific flavor takes precedence over the universal default.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Field_ID = 626425 AND AD_Language = 'en_US';
+
+-- PRINTER_OPTS_IsPrintLogo (EN)
+UPDATE AD_Field_Trl
+SET Description  = 'Whether the company logo is included in the generated document.',
+    Help         = 'If enabled, the configured letterhead/logo image is rendered into the PDF output. On manual prints this value pre-fills the print dialog checkbox and can be overridden by the user.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Field_ID = 625832 AND AD_Language = 'en_US';
+
+-- PRINTER_OPTS_IsPrintTotals (EN)
+UPDATE AD_Field_Trl
+SET Description  = 'Whether the totals section is included in the generated document.',
+    Help         = 'If enabled, the totals/summary section is rendered in the printed or emailed document. Useful e.g. to omit totals from email output when they are already in the email body.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Field_ID = 625833 AND AD_Language = 'en_US';
+
+
+-- =============================================================================
+-- 3) AD_UI_Element.Description + Help (base language de_DE)
+-- =============================================================================
+
+-- C_DocType_ID
+UPDATE AD_UI_Element
+SET Description = 'Die Belegart, für die diese Druckoptionen gelten (z. B. Lieferung, Rechnung, Auftrag).',
+    Help        = 'Das Belegart-Feld bestimmt, auf welche Dokumenttypen diese Druckoptionen angewendet werden. Jede Belegart kann bis zu drei Konfigurationen haben: eine für Flavor "Print", eine für "EMail" und einen universellen Standard (ohne Flavor).',
+    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_UI_Element_ID = 575095;
+
+-- DocumentFlavor
+UPDATE AD_UI_Element
+SET Description = 'Ausgabekanal für diese Konfiguration: EMail, Print oder leer (universeller Standard).',
+    Help        = 'Legt fest, ob diese Einstellungen beim Drucken (Print), beim Versand per E-Mail (EMail) oder als universeller Standard (leer) angewendet werden. Ein spezifischer Flavor hat Vorrang vor dem universellen Standard.',
+    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_UI_Element_ID = 575346;
+
+-- PRINTER_OPTS_IsPrintLogo
+UPDATE AD_UI_Element
+SET Description = 'Ob das Firmenlogo auf dem generierten Dokument angezeigt wird.',
+    Help        = 'Wenn aktiviert, wird das hinterlegte Briefkopf-/Logobild beim Rendern des Dokuments in die PDF-Ausgabe übernommen. Beim manuellen Drucken dient dieser Wert als Vorbelegung im Druckdialog und kann vom Benutzer noch überschrieben werden.',
+    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_UI_Element_ID = 575098;
+
+-- PRINTER_OPTS_IsPrintTotals
+UPDATE AD_UI_Element
+SET Description = 'Ob der Summenblock auf dem generierten Dokument angezeigt wird.',
+    Help        = 'Wenn aktiviert, wird die Summen-/Gesamtbeträge-Sektion im gedruckten oder versendeten Dokument gerendert. Nützlich z. B. um Gesamtbeträge aus E-Mail-Ausgaben wegzulassen, wenn diese bereits im Mailtext stehen.',
+    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_UI_Element_ID = 575099;
+
+
+-- =============================================================================
+-- 4) AD_UI_Element_Trl (en_US) — create if missing, then fill with EN text
+-- =============================================================================
+
+INSERT INTO AD_UI_Element_Trl (AD_Language, AD_UI_Element_ID, Description, Help, Name, IsTranslated,
+                               AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT 'en_US', ue.AD_UI_Element_ID, ue.Description, ue.Help, ue.Name, 'N',
+       ue.AD_Client_ID, ue.AD_Org_ID,
+       TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), 0,
+       TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), 0
+FROM AD_UI_Element ue
+WHERE ue.AD_UI_Element_ID IN (575095, 575346, 575098, 575099)
+  AND NOT EXISTS (SELECT 1 FROM AD_UI_Element_Trl tt
+                  WHERE tt.AD_UI_Element_ID = ue.AD_UI_Element_ID AND tt.AD_Language = 'en_US');
+
+-- C_DocType_ID (EN)
+UPDATE AD_UI_Element_Trl
+SET Description  = 'The document type this configuration applies to (e.g., Lieferung, Rechnung, Auftrag).',
+    Help         = 'Determines which document types these print options apply to. Each document type can have up to three configurations: one for Flavor "Print", one for "EMail", and a universal default (no flavor).',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_UI_Element_ID = 575095 AND AD_Language = 'en_US';
+
+-- DocumentFlavor (EN)
+UPDATE AD_UI_Element_Trl
+SET Description  = 'Output channel for this configuration: EMail, Print, or empty (universal default).',
+    Help         = 'Controls whether these settings apply when printing (Print), emailing (EMail), or as the universal default (empty). A specific flavor takes precedence over the universal default.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_UI_Element_ID = 575346 AND AD_Language = 'en_US';
+
+-- PRINTER_OPTS_IsPrintLogo (EN)
+UPDATE AD_UI_Element_Trl
+SET Description  = 'Whether the company logo is included in the generated document.',
+    Help         = 'If enabled, the configured letterhead/logo image is rendered into the PDF output. On manual prints this value pre-fills the print dialog checkbox and can be overridden by the user.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_UI_Element_ID = 575098 AND AD_Language = 'en_US';
+
+-- PRINTER_OPTS_IsPrintTotals (EN)
+UPDATE AD_UI_Element_Trl
+SET Description  = 'Whether the totals section is included in the generated document.',
+    Help         = 'If enabled, the totals/summary section is rendered in the printed or emailed document. Useful e.g. to omit totals from email output when they are already in the email body.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_UI_Element_ID = 575099 AND AD_Language = 'en_US';

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798730_sys_gh29279_C_DocType_PrintOptions_Window_FieldDescriptions.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798730_sys_gh29279_C_DocType_PrintOptions_Window_FieldDescriptions.sql
@@ -1,131 +1,116 @@
--- Per-field descriptions / help for window "Document Type Printing Options"
--- (AD_Window_ID=541004, Tab=543206). Descriptions follow the user-facing
--- semantics documented in mf15-documentation#96.
+-- Field descriptions / help for window "Document Type Printing Options"
+-- (AD_Window_ID=541004, Tab=543206). Texts follow mf15-documentation#96.
 --
--- Fields touched on tab 543206:
---   AD_Field 625830  → C_DocType_ID               (AD_UI_Element 575095)
---   AD_Field 626425  → DocumentFlavor             (AD_UI_Element 575346)
---   AD_Field 625832  → PRINTER_OPTS_IsPrintLogo   (AD_UI_Element 575098)
---   AD_Field 625833  → PRINTER_OPTS_IsPrintTotals (AD_UI_Element 575099)
+-- Approach: update the linked AD_Element (base language de_DE) and
+-- AD_Element_Trl (en_US), then run the propagation functions so that the
+-- correct texts fan out to AD_Column / AD_Field / AD_Process_Para / etc.
+-- Never update AD_Field.Description or AD_UI_Element.Description directly
+-- — those get overwritten by the next element propagation.
 --
--- Per-field overrides only — AD_Element of PRINTER_OPTS_IsPrintLogo /
--- PRINTER_OPTS_IsPrintTotals is reused across many AD_Process_Para rows,
--- so we deliberately do not touch the shared AD_Element descriptions.
+-- Elements touched:
+--   AD_Element 578565  → DocumentFlavor             (only C_DocType_PrintOptions + AD_Archive)
+--   AD_Element 578551  → PRINTER_OPTS_IsPrintLogo   (C_DocType_PrintOptions + many AD_Process_Para)
+--   AD_Element 578552  → PRINTER_OPTS_IsPrintTotals (C_DocType_PrintOptions + many AD_Process_Para)
+--
+-- C_DocType_ID is deliberately NOT touched — its shared AD_Element already
+-- has a sensible generic description ("Die Belegart bestimmt den Nummernkreis
+-- und die Vorgaben für die Belegverarbeitung.").
 
 
 -- =============================================================================
--- 1) AD_Field.Description + Help (base language de_DE)
+-- 1) DocumentFlavor — AD_Element 578565
 -- =============================================================================
 
--- C_DocType_ID — Belegart
-UPDATE AD_Field
-SET Description = 'Die Belegart, für die diese Druckoptionen gelten (z. B. Lieferung, Rechnung, Auftrag).',
-    Help        = 'Das Belegart-Feld bestimmt, auf welche Dokumenttypen diese Druckoptionen angewendet werden. Jede Belegart kann bis zu drei Konfigurationen haben: eine für Flavor "Print", eine für "EMail" und einen universellen Standard (ohne Flavor).',
-    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_Field_ID = 625830;
-
--- DocumentFlavor — Flavor
-UPDATE AD_Field
+UPDATE AD_Element
 SET Description = 'Ausgabekanal für diese Konfiguration: EMail, Print oder leer (universeller Standard).',
     Help        = 'Legt fest, ob diese Einstellungen beim Drucken (Print), beim Versand per E-Mail (EMail) oder als universeller Standard (leer) angewendet werden. Ein spezifischer Flavor hat Vorrang vor dem universellen Standard.',
-    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_Field_ID = 626425;
+    Updated     = TO_TIMESTAMP('2026-04-21 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Element_ID = 578565;
 
--- PRINTER_OPTS_IsPrintLogo — Logo drucken
-UPDATE AD_Field
-SET Description = 'Ob das Firmenlogo auf dem generierten Dokument angezeigt wird.',
-    Help        = 'Wenn aktiviert, wird das hinterlegte Briefkopf-/Logobild beim Rendern des Dokuments in die PDF-Ausgabe übernommen. Beim manuellen Drucken dient dieser Wert als Vorbelegung im Druckdialog und kann vom Benutzer noch überschrieben werden.',
-    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_Field_ID = 625832;
+-- Ensure en_US translation row exists
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Name, PrintName, Description, Help, IsTranslated,
+                            AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT 'en_US', e.AD_Element_ID, e.Name, e.PrintName, e.Description, e.Help, 'N',
+       e.AD_Client_ID, e.AD_Org_ID,
+       TO_TIMESTAMP('2026-04-21 08:00','YYYY-MM-DD HH24:MI'), 0,
+       TO_TIMESTAMP('2026-04-21 08:00','YYYY-MM-DD HH24:MI'), 0, 'Y'
+FROM AD_Element e
+WHERE e.AD_Element_ID = 578565
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt
+                  WHERE tt.AD_Element_ID = e.AD_Element_ID AND tt.AD_Language = 'en_US');
 
--- PRINTER_OPTS_IsPrintTotals — Gesamtbeträge drucken
-UPDATE AD_Field
-SET Description = 'Ob der Summenblock auf dem generierten Dokument angezeigt wird.',
-    Help        = 'Wenn aktiviert, wird die Summen-/Gesamtbeträge-Sektion im gedruckten oder versendeten Dokument gerendert. Nützlich z. B. um Gesamtbeträge aus E-Mail-Ausgaben wegzulassen, wenn diese bereits im Mailtext stehen.',
-    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_Field_ID = 625833;
-
-
--- =============================================================================
--- 2) AD_Field_Trl (en_US) — create if missing, then fill with English text
--- =============================================================================
-
-INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated,
-                          AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
-SELECT 'en_US', f.AD_Field_ID, f.Description, f.Help, f.Name, 'N',
-       f.AD_Client_ID, f.AD_Org_ID,
-       TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), 0,
-       TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), 0
-FROM AD_Field f
-WHERE f.AD_Field_ID IN (625830, 626425, 625832, 625833)
-  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt
-                  WHERE tt.AD_Field_ID = f.AD_Field_ID AND tt.AD_Language = 'en_US');
-
--- C_DocType_ID (EN)
-UPDATE AD_Field_Trl
-SET Description  = 'The document type this configuration applies to (e.g., Lieferung, Rechnung, Auftrag).',
-    Help         = 'Determines which document types these print options apply to. Each document type can have up to three configurations: one for Flavor "Print", one for "EMail", and a universal default (no flavor).',
-    IsTranslated = 'Y',
-    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_Field_ID = 625830 AND AD_Language = 'en_US';
-
--- DocumentFlavor (EN)
-UPDATE AD_Field_Trl
-SET Description  = 'Output channel for this configuration: EMail, Print, or empty (universal default).',
+UPDATE AD_Element_Trl
+SET Name         = 'Flavor',
+    PrintName    = 'Flavor',
+    Description  = 'Output channel for this configuration: EMail, Print, or empty (universal default).',
     Help         = 'Controls whether these settings apply when printing (Print), emailing (EMail), or as the universal default (empty). A specific flavor takes precedence over the universal default.',
     IsTranslated = 'Y',
-    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_Field_ID = 626425 AND AD_Language = 'en_US';
+    Updated      = TO_TIMESTAMP('2026-04-21 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Element_ID = 578565 AND AD_Language = 'en_US';
 
--- PRINTER_OPTS_IsPrintLogo (EN)
-UPDATE AD_Field_Trl
+
+-- =============================================================================
+-- 2) PRINTER_OPTS_IsPrintLogo — AD_Element 578551
+-- =============================================================================
+
+UPDATE AD_Element
+SET Description = 'Ob das Firmenlogo auf dem generierten Dokument angezeigt wird.',
+    Help        = 'Wenn aktiviert, wird das hinterlegte Briefkopf-/Logobild beim Rendern des Dokuments in die PDF-Ausgabe übernommen. Beim manuellen Drucken dient dieser Wert als Vorbelegung im Druckdialog und kann vom Benutzer noch überschrieben werden.',
+    Updated     = TO_TIMESTAMP('2026-04-21 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Element_ID = 578551;
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Name, PrintName, Description, Help, IsTranslated,
+                            AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT 'en_US', e.AD_Element_ID, e.Name, e.PrintName, e.Description, e.Help, 'N',
+       e.AD_Client_ID, e.AD_Org_ID,
+       TO_TIMESTAMP('2026-04-21 08:00','YYYY-MM-DD HH24:MI'), 0,
+       TO_TIMESTAMP('2026-04-21 08:00','YYYY-MM-DD HH24:MI'), 0, 'Y'
+FROM AD_Element e
+WHERE e.AD_Element_ID = 578551
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt
+                  WHERE tt.AD_Element_ID = e.AD_Element_ID AND tt.AD_Language = 'en_US');
+
+UPDATE AD_Element_Trl
 SET Description  = 'Whether the company logo is included in the generated document.',
     Help         = 'If enabled, the configured letterhead/logo image is rendered into the PDF output. On manual prints this value pre-fills the print dialog checkbox and can be overridden by the user.',
     IsTranslated = 'Y',
-    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_Field_ID = 625832 AND AD_Language = 'en_US';
+    Updated      = TO_TIMESTAMP('2026-04-21 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Element_ID = 578551 AND AD_Language = 'en_US';
 
--- PRINTER_OPTS_IsPrintTotals (EN)
-UPDATE AD_Field_Trl
+
+-- =============================================================================
+-- 3) PRINTER_OPTS_IsPrintTotals — AD_Element 578552
+-- =============================================================================
+
+UPDATE AD_Element
+SET Description = 'Ob der Summenblock auf dem generierten Dokument angezeigt wird.',
+    Help        = 'Wenn aktiviert, wird die Summen-/Gesamtbeträge-Sektion im gedruckten oder versendeten Dokument gerendert. Nützlich z. B. um Gesamtbeträge aus E-Mail-Ausgaben wegzulassen, wenn diese bereits im Mailtext stehen.',
+    Updated     = TO_TIMESTAMP('2026-04-21 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Element_ID = 578552;
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Name, PrintName, Description, Help, IsTranslated,
+                            AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT 'en_US', e.AD_Element_ID, e.Name, e.PrintName, e.Description, e.Help, 'N',
+       e.AD_Client_ID, e.AD_Org_ID,
+       TO_TIMESTAMP('2026-04-21 08:00','YYYY-MM-DD HH24:MI'), 0,
+       TO_TIMESTAMP('2026-04-21 08:00','YYYY-MM-DD HH24:MI'), 0, 'Y'
+FROM AD_Element e
+WHERE e.AD_Element_ID = 578552
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt
+                  WHERE tt.AD_Element_ID = e.AD_Element_ID AND tt.AD_Language = 'en_US');
+
+UPDATE AD_Element_Trl
 SET Description  = 'Whether the totals section is included in the generated document.',
     Help         = 'If enabled, the totals/summary section is rendered in the printed or emailed document. Useful e.g. to omit totals from email output when they are already in the email body.',
     IsTranslated = 'Y',
-    Updated      = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_Field_ID = 625833 AND AD_Language = 'en_US';
+    Updated      = TO_TIMESTAMP('2026-04-21 08:00','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Element_ID = 578552 AND AD_Language = 'en_US';
 
 
 -- =============================================================================
--- 3) AD_UI_Element.Description + Help (base language de_DE)
+-- 4) Propagate to AD_Column / AD_Field / AD_Process_Para / AD_Column_Trl / …
 -- =============================================================================
 
--- C_DocType_ID
-UPDATE AD_UI_Element
-SET Description = 'Die Belegart, für die diese Druckoptionen gelten (z. B. Lieferung, Rechnung, Auftrag).',
-    Help        = 'Das Belegart-Feld bestimmt, auf welche Dokumenttypen diese Druckoptionen angewendet werden. Jede Belegart kann bis zu drei Konfigurationen haben: eine für Flavor "Print", eine für "EMail" und einen universellen Standard (ohne Flavor).',
-    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_UI_Element_ID = 575095;
-
--- DocumentFlavor
-UPDATE AD_UI_Element
-SET Description = 'Ausgabekanal für diese Konfiguration: EMail, Print oder leer (universeller Standard).',
-    Help        = 'Legt fest, ob diese Einstellungen beim Drucken (Print), beim Versand per E-Mail (EMail) oder als universeller Standard (leer) angewendet werden. Ein spezifischer Flavor hat Vorrang vor dem universellen Standard.',
-    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_UI_Element_ID = 575346;
-
--- PRINTER_OPTS_IsPrintLogo
-UPDATE AD_UI_Element
-SET Description = 'Ob das Firmenlogo auf dem generierten Dokument angezeigt wird.',
-    Help        = 'Wenn aktiviert, wird das hinterlegte Briefkopf-/Logobild beim Rendern des Dokuments in die PDF-Ausgabe übernommen. Beim manuellen Drucken dient dieser Wert als Vorbelegung im Druckdialog und kann vom Benutzer noch überschrieben werden.',
-    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_UI_Element_ID = 575098;
-
--- PRINTER_OPTS_IsPrintTotals
-UPDATE AD_UI_Element
-SET Description = 'Ob der Summenblock auf dem generierten Dokument angezeigt wird.',
-    Help        = 'Wenn aktiviert, wird die Summen-/Gesamtbeträge-Sektion im gedruckten oder versendeten Dokument gerendert. Nützlich z. B. um Gesamtbeträge aus E-Mail-Ausgaben wegzulassen, wenn diese bereits im Mailtext stehen.',
-    Updated     = TO_TIMESTAMP('2026-04-20 18:30','YYYY-MM-DD HH24:MI'), UpdatedBy = 0
-WHERE AD_UI_Element_ID = 575099;
-
-
--- Note: AD_UI_Element has no _Trl table in the schema. English text lives
--- on AD_Field_Trl (section 2); the WebUI resolves en_US via that path.
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(578565);
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(578551);
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(578552);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798740_sys_gh29279_C_DocType_PrintOptions_Window_MenuPosition.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5798740_sys_gh29279_C_DocType_PrintOptions_Window_MenuPosition.sql
@@ -1,0 +1,35 @@
+-- Move menu entry for window "Document Type Printing Options" (AD_Window_ID=541004)
+-- into the printing cluster of the System menu — right after "Druck - Format"
+-- (AD_Menu_ID=540827, SeqNo=37). The window used to sit at SeqNo=35, between
+-- Textbaustein Übersetzung (34) and Textvariablen (36) — unrelated neighbors.
+--
+-- AD_Menu_ID                = 541563  (Document Type Printing Options)
+-- AD_Tree_ID                = 10      (standard menu tree)
+-- Parent_ID                 = 1000098 (System)
+-- Old SeqNo                 = 35
+-- New SeqNo                 = 38      (right after 540827 "Druck - Format" at 37,
+--                                      before 541599 "Zebra Konfiguration")
+--
+-- Shift existing siblings with SeqNo >= 38 up by +1 to make room.
+-- The old slot at 35 becomes a gap, which is harmless (AD_TreeNodeMM tolerates gaps).
+
+
+-- 1) Make room: bump every sibling at SeqNo >= 38 by +1 (but skip our own node,
+--    which is currently at 35 anyway).
+UPDATE AD_TreeNodeMM
+SET SeqNo     = SeqNo + 1,
+    Updated   = TO_TIMESTAMP('2026-04-21 08:15','YYYY-MM-DD HH24:MI'),
+    UpdatedBy = 0
+WHERE AD_Tree_ID = 10
+  AND Parent_ID  = 1000098
+  AND SeqNo     >= 38
+  AND Node_ID   <> 541563;
+
+-- 2) Place our node at SeqNo=38.
+UPDATE AD_TreeNodeMM
+SET SeqNo     = 38,
+    Updated   = TO_TIMESTAMP('2026-04-21 08:15','YYYY-MM-DD HH24:MI'),
+    UpdatedBy = 0
+WHERE AD_Tree_ID = 10
+  AND Parent_ID  = 1000098
+  AND Node_ID    = 541563;


### PR DESCRIPTION
## Summary

Follow-up to #23403. Adds per-field `Description` + `Help` text to the four fields of the **Document Type Printing Options** window (`AD_Window_ID=541004`, tab `543206`):

| Field | Column |
|-------|--------|
| Belegart | `C_DocType_ID` (AD_Field 625830) |
| Flavor | `DocumentFlavor` (AD_Field 626425) |
| Logo drucken | `PRINTER_OPTS_IsPrintLogo` (AD_Field 625832) |
| Gesamtbeträge drucken | `PRINTER_OPTS_IsPrintTotals` (AD_Field 625833) |

Updates `AD_Field`, `AD_Field_Trl` (en_US), `AD_UI_Element`, and `AD_UI_Element_Trl` (en_US) — per-field overrides only. AD_Element of `PRINTER_OPTS_IsPrintLogo` / `PRINTER_OPTS_IsPrintTotals` is deliberately NOT touched since it's shared with many `AD_Process_Para` rows.

Texts were written to match the user-facing documentation of this feature.

## Test plan

- [ ] Open the window in the WebUI — hover each field, verify the description + help tooltip shows the new text in both `de_DE` and `en_US`.