### PR TITLE
F5001.1 Enable M_HU_PI_Item_Product consolidation Cucumber tests

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Item_Product_Consolidation_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Item_Product_Consolidation_StepDef.java
@@ -81,7 +81,7 @@ public class M_HU_PI_Item_Product_Consolidation_StepDef
 		final boolean normalizeGtinEan = Boolean.parseBoolean(normalizeGtinEanStr);
 		final boolean consolidate = Boolean.parseBoolean(consolidateStr);
 
-		final String sql = "SELECT m_hu_pi_item_product_consolidate(?, ?, 0)";
+		final String sql = "SELECT m_hu_pi_item_product_consolidate(?::boolean, ?::boolean, 0::numeric)";
 		final SQLValueStringResult result = DB.getSQLValueStringWithWarningEx(
 				ITrx.TRXNAME_None,
 				sql,
@@ -213,6 +213,26 @@ public class M_HU_PI_Item_Product_Consolidation_StepDef
 
 		assertThat(found)
 				.as("Report should contain a conflict row for GTIN " + expectedGtin)
+				.isTrue();
+	}
+
+	@Then("the consolidation report contains a conflict row for GTIN {string} with conflicting field {string}")
+	public void verify_report_contains_conflict_for_gtin_and_field(
+			@NonNull final String expectedGtin,
+			@NonNull final String expectedConflictingField)
+	{
+		assertThat(lastReportResult)
+				.as("Report should contain rows")
+				.isNotEmpty();
+
+		final boolean found = lastReportResult.stream()
+				.anyMatch(row -> expectedGtin.equals(row.gtin)
+						&& expectedConflictingField.equalsIgnoreCase(row.conflictingField));
+
+		assertThat(found)
+				.as("Report should contain a conflict row for GTIN " + expectedGtin
+						+ " with conflicting_field=" + expectedConflictingField
+						+ "; actual rows: " + lastReportResult)
 				.isTrue();
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Item_Product_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Item_Product_StepDef.java
@@ -135,12 +135,23 @@ public class M_HU_PI_Item_Product_StepDef
 				: null;
 
 		final StepDefDataIdentifier identifier = tableRow.getAsIdentifier();
+		final Integer bpartnerIdFilter = tableRow.getAsOptionalIdentifier(I_M_HU_PI_Item_Product.COLUMNNAME_C_BPartner_ID)
+				.map(bpIdentifier -> bpIdentifier.lookupNotNullIdIn(bpartnerTable).getRepoId())
+				.orElse(null);
 		final I_M_HU_PI_Item_Product huPiItemProductRecord = huPiItemProductTable.getOptional(identifier)
 				.orElseGet(() -> {
 					final IQueryBuilder<I_M_HU_PI_Item_Product> queryBuilder = queryBL.createQueryBuilder(I_M_HU_PI_Item_Product.class)
 							.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_M_Product_ID, productId)
 							.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_M_HU_PI_Item_ID, huPiItemId)
 							.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_IsActive, active);
+					if (bpartnerIdFilter != null)
+					{
+						queryBuilder.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_C_BPartner_ID, bpartnerIdFilter);
+					}
+					else
+					{
+						queryBuilder.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_C_BPartner_ID, null);
+					}
 					if (isInfiniteCapacity)
 					{
 						queryBuilder.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_IsInfiniteCapacity, true);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/m_hu_pi_item_product_consolidation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/hu/m_hu_pi_item_product_consolidation.feature
@@ -1,5 +1,7 @@
+@allure.label.epic:E0370_Intralogistic_HUs
+@allure.label.feature:F5001_1_Consolidate_CU_TU_Allocation
 @from:cucumber
-@ignore
+@F5001_1
 Feature: M_HU_PI_Item_Product consolidation SQL function tests
   Verifies that the m_hu_pi_item_product_consolidate() and
   m_hu_pi_item_product_consolidate_report() SQL functions correctly:
@@ -85,6 +87,8 @@ Feature: M_HU_PI_Item_Product consolidation SQL function tests
     When M_HU_PI_Item_Product consolidation is called with p_normalize_gtin_ean='false' and p_consolidate='true'
     Then M_HU_PI_Item_Product identified by 'pip_qty_10' has IsActive='Y'
     And M_HU_PI_Item_Product identified by 'pip_qty_20' has IsActive='Y'
+    When M_HU_PI_Item_Product consolidation report is called
+    Then the consolidation report contains a conflict row for GTIN '4005808262151' with conflicting field 'Qty'
 
   @from:cucumber
   Scenario: Report — different PI conflict detected for same GTIN

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5798760_sys_create_m_hu_pi_item_product_consolidate_report_function.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5798760_sys_create_m_hu_pi_item_product_consolidate_report_function.sql
@@ -1,0 +1,223 @@
+CREATE OR REPLACE FUNCTION m_hu_pi_item_product_consolidate_report(p_ad_language text DEFAULT 'de_DE')
+    RETURNS TABLE
+            (
+                issue_type              text,
+                gtin                    text,
+                product_value           text,
+                product_name            text,
+                pi_name                 text,
+                m_hu_pi_item_product_id numeric,
+                bpartner_value          text,
+                bpartner_name           text,
+                qty                     numeric,
+                uom_symbol              text,
+                validfrom               timestamp,
+                validto                 timestamp,
+                conflicting_field       text
+            )
+    LANGUAGE plpgsql
+    STABLE
+AS
+$BODY$
+BEGIN
+    RETURN QUERY
+
+        --
+        -- 1. CONFLICT_DIFFERENT_PI
+        --    Active records sharing a GTIN but with different M_HU_PI_Item_ID
+        --
+        SELECT COALESCE(trl1.MsgText, msg1.MsgText)::text AS issue_type,
+               pip.GTIN::text                              AS gtin,
+               prod.Value::text                            AS product_value,
+               prod.Name::text                             AS product_name,
+               pi.Name::text                               AS pi_name,
+               pip.M_HU_PI_Item_Product_ID                 AS m_hu_pi_item_product_id,
+               bp.Value::text                              AS bpartner_value,
+               bp.Name::text                               AS bpartner_name,
+               pip.Qty                                     AS qty,
+               uom.UOMSymbol::text                         AS uom_symbol,
+               pip.ValidFrom::timestamp                    AS validfrom,
+               pip.ValidTo::timestamp                      AS validto,
+               NULL::text                                  AS conflicting_field
+        FROM M_HU_PI_Item_Product pip
+                 JOIN M_Product prod ON prod.M_Product_ID = pip.M_Product_ID
+                 JOIN M_HU_PI_Item pi_item ON pi_item.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                 JOIN M_HU_PI_Version piv ON piv.M_HU_PI_Version_ID = pi_item.M_HU_PI_Version_ID
+                 JOIN M_HU_PI pi ON pi.M_HU_PI_ID = piv.M_HU_PI_ID
+                 LEFT JOIN C_BPartner bp ON bp.C_BPartner_ID = pip.C_BPartner_ID
+                 LEFT JOIN C_UOM uom ON uom.C_UOM_ID = pip.C_UOM_ID
+                 JOIN AD_Message msg1 ON msg1.Value = 'M_HU_PI_Item_Product_Conflict_DifferentPI'
+                 LEFT JOIN AD_Message_Trl trl1
+                           ON trl1.AD_Message_ID = msg1.AD_Message_ID
+                               AND trl1.AD_Language = p_ad_language
+                               AND trl1.IsActive = 'Y'
+        WHERE pip.IsActive = 'Y'
+          AND pip.GTIN IS NOT NULL
+          AND pip.GTIN <> ''
+          AND pip.GTIN IN (SELECT sub.GTIN
+                           FROM M_HU_PI_Item_Product sub
+                           WHERE sub.IsActive = 'Y'
+                             AND sub.GTIN IS NOT NULL
+                             AND sub.GTIN <> ''
+                           GROUP BY sub.GTIN
+                           HAVING COUNT(DISTINCT sub.M_HU_PI_Item_ID) > 1)
+
+        UNION ALL
+
+        --
+        -- 2. CONFLICT_DIFFERENT_PRODUCT
+        --    Active records sharing a GTIN and M_HU_PI_Item_ID but with different M_Product_ID
+        --
+        SELECT COALESCE(trl2.MsgText, msg2.MsgText)::text AS issue_type,
+               pip.GTIN::text                              AS gtin,
+               prod.Value::text                            AS product_value,
+               prod.Name::text                             AS product_name,
+               pi.Name::text                               AS pi_name,
+               pip.M_HU_PI_Item_Product_ID                 AS m_hu_pi_item_product_id,
+               bp.Value::text                              AS bpartner_value,
+               bp.Name::text                               AS bpartner_name,
+               pip.Qty                                     AS qty,
+               uom.UOMSymbol::text                         AS uom_symbol,
+               pip.ValidFrom::timestamp                    AS validfrom,
+               pip.ValidTo::timestamp                      AS validto,
+               NULL::text                                  AS conflicting_field
+        FROM M_HU_PI_Item_Product pip
+                 JOIN M_Product prod ON prod.M_Product_ID = pip.M_Product_ID
+                 JOIN M_HU_PI_Item pi_item ON pi_item.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                 JOIN M_HU_PI_Version piv ON piv.M_HU_PI_Version_ID = pi_item.M_HU_PI_Version_ID
+                 JOIN M_HU_PI pi ON pi.M_HU_PI_ID = piv.M_HU_PI_ID
+                 LEFT JOIN C_BPartner bp ON bp.C_BPartner_ID = pip.C_BPartner_ID
+                 LEFT JOIN C_UOM uom ON uom.C_UOM_ID = pip.C_UOM_ID
+                 JOIN AD_Message msg2 ON msg2.Value = 'M_HU_PI_Item_Product_Conflict_DifferentProduct'
+                 LEFT JOIN AD_Message_Trl trl2
+                           ON trl2.AD_Message_ID = msg2.AD_Message_ID
+                               AND trl2.AD_Language = p_ad_language
+                               AND trl2.IsActive = 'Y'
+        WHERE pip.IsActive = 'Y'
+          AND pip.GTIN IS NOT NULL
+          AND pip.GTIN <> ''
+          AND (pip.GTIN, pip.M_HU_PI_Item_ID) IN (SELECT sub.GTIN, sub.M_HU_PI_Item_ID
+                                                   FROM M_HU_PI_Item_Product sub
+                                                   WHERE sub.IsActive = 'Y'
+                                                     AND sub.GTIN IS NOT NULL
+                                                     AND sub.GTIN <> ''
+                                                   GROUP BY sub.GTIN, sub.M_HU_PI_Item_ID
+                                                   HAVING COUNT(DISTINCT sub.M_Product_ID) > 1)
+
+        UNION ALL
+
+        --
+        -- 3. CONFLICT_DIFFERENT_FIELDS
+        --    Active records sharing (M_Product_ID, GTIN, M_HU_PI_Item_ID) with >1 record
+        --    where non-date fields differ
+        --
+        SELECT COALESCE(trl3.MsgText, msg3.MsgText)::text AS issue_type,
+               pip.GTIN::text                              AS gtin,
+               prod.Value::text                            AS product_value,
+               prod.Name::text                             AS product_name,
+               pi.Name::text                               AS pi_name,
+               pip.M_HU_PI_Item_Product_ID                 AS m_hu_pi_item_product_id,
+               bp.Value::text                              AS bpartner_value,
+               bp.Name::text                               AS bpartner_name,
+               pip.Qty                                     AS qty,
+               uom.UOMSymbol::text                         AS uom_symbol,
+               pip.ValidFrom::timestamp                    AS validfrom,
+               pip.ValidTo::timestamp                      AS validto,
+               diffs.conflicting_fields::text              AS conflicting_field
+        FROM M_HU_PI_Item_Product pip
+                 JOIN M_Product prod ON prod.M_Product_ID = pip.M_Product_ID
+                 JOIN M_HU_PI_Item pi_item ON pi_item.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                 JOIN M_HU_PI_Version piv ON piv.M_HU_PI_Version_ID = pi_item.M_HU_PI_Version_ID
+                 JOIN M_HU_PI pi ON pi.M_HU_PI_ID = piv.M_HU_PI_ID
+                 LEFT JOIN C_BPartner bp ON bp.C_BPartner_ID = pip.C_BPartner_ID
+                 LEFT JOIN C_UOM uom ON uom.C_UOM_ID = pip.C_UOM_ID
+                 JOIN AD_Message msg3 ON msg3.Value = 'M_HU_PI_Item_Product_Conflict_DifferentFields'
+                 LEFT JOIN AD_Message_Trl trl3
+                           ON trl3.AD_Message_ID = msg3.AD_Message_ID
+                               AND trl3.AD_Language = p_ad_language
+                               AND trl3.IsActive = 'Y'
+                 JOIN LATERAL (
+                    SELECT string_agg(DISTINCT field_name, ', ' ORDER BY field_name) AS conflicting_fields
+                    FROM (
+                             SELECT 'Qty' AS field_name
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.Qty, 0) <> COALESCE(pip.Qty, 0)
+                             UNION
+                             SELECT 'C_UOM_ID'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.C_UOM_ID, 0) <> COALESCE(pip.C_UOM_ID, 0)
+                             UNION
+                             SELECT 'IsInfiniteCapacity'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.IsInfiniteCapacity, 'N') <> COALESCE(pip.IsInfiniteCapacity, 'N')
+                             UNION
+                             SELECT 'EAN_TU'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.EAN_TU, '') <> COALESCE(pip.EAN_TU, '')
+                             UNION
+                             SELECT 'UPC'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.UPC, '') <> COALESCE(pip.UPC, '')
+                             UNION
+                             SELECT 'IsAllowAnyProduct'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.IsAllowAnyProduct, 'N') <> COALESCE(pip.IsAllowAnyProduct, 'N')
+                             UNION
+                             SELECT 'IsDefaultForProduct'
+                             FROM M_HU_PI_Item_Product other
+                             WHERE other.IsActive = 'Y'
+                               AND other.M_Product_ID = pip.M_Product_ID
+                               AND other.GTIN = pip.GTIN
+                               AND other.M_HU_PI_Item_ID = pip.M_HU_PI_Item_ID
+                               AND other.M_HU_PI_Item_Product_ID <> pip.M_HU_PI_Item_Product_ID
+                               AND COALESCE(other.IsDefaultForProduct, 'N') <> COALESCE(pip.IsDefaultForProduct, 'N')
+                         ) fields
+                    ) diffs ON diffs.conflicting_fields IS NOT NULL
+        WHERE pip.IsActive = 'Y'
+          AND pip.GTIN IS NOT NULL
+          AND pip.GTIN <> ''
+          AND (pip.M_Product_ID, pip.GTIN, pip.M_HU_PI_Item_ID) IN
+              (SELECT sub.M_Product_ID, sub.GTIN, sub.M_HU_PI_Item_ID
+               FROM M_HU_PI_Item_Product sub
+               WHERE sub.IsActive = 'Y'
+                 AND sub.GTIN IS NOT NULL
+                 AND sub.GTIN <> ''
+               GROUP BY sub.M_Product_ID, sub.GTIN, sub.M_HU_PI_Item_ID
+               HAVING COUNT(*) > 1)
+
+        ORDER BY issue_type, gtin, product_value;
+END;
+$BODY$;
+
+COMMENT ON FUNCTION m_hu_pi_item_product_consolidate_report(text) IS
+    'Returns a data quality report of M_HU_PI_Item_Product records with GTIN conflicts: same GTIN across different packing instructions, different products, or records that could not be consolidated due to differing field values.';


### PR DESCRIPTION
## Summary

- Add migration script for the `m_hu_pi_item_product_consolidate_report()` DB function. The function had only a DDL file, no migration — so fresh DBs did not have it and the Cucumber feature was marked `@ignore` at merge time.
- Feature `m_hu_pi_item_product_consolidation.feature`: remove `@ignore`, add Allure epic/feature tags (`E0370_Intralogistic_HUs` / `F5001_1_Consolidate_CU_TU_Allocation`), extend the "different Qty" scenario to assert the `CONFLICT_DIFFERENT_FIELDS` report row with `conflicting_field='Qty'`.
- Fix step def so the `m_hu_pi_item_product_consolidate(boolean, boolean, numeric)` SQL call uses explicit `::boolean` / `::numeric` casts (JDBC varchar params were mismatching the signature).
- Fix `M_HU_PI_Item_Product_StepDef` upsert lookup to include `C_BPartner_ID`, so identical `(product, PI_Item, qty, UOM)` rows differing only by partner don't collide in `StepDefData`.

## Test plan

- [x] 7/7 Cucumber scenarios pass locally against a fresh `soft_panda_uat` stack (tag `@F5001_1`, total 517.7s, 0 failures).
- [ ] CI green (cucumber executor that runs `@F5001_1` picks up the new scenarios).