### PR TITLE
Fix a duplicated AD_Reference_ID

### DIFF
--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788030_sys_gh28014_C_Period_Ordered_Asc_reference.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788030_sys_gh28014_C_Period_Ordered_Asc_reference.sql
@@ -17,7 +17,7 @@
 INSERT INTO AD_Reference (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive,
                           Created, CreatedBy, Updated, UpdatedBy,
                           Name, Description, ValidationType, EntityType, IsOrderByValue)
-VALUES (542086, 0, 0, 'Y',
+VALUES (542058, 0, 0, 'Y',
         TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'), 100, TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'), 100,
         'C_Period Ordered (asc)', 'C_Period ordered by StartDate ascending — use when year is already filtered', 'T', 'de.metas.fresh', 'N');
 
@@ -32,7 +32,7 @@ FROM AD_Language l, AD_Reference t
 WHERE l.IsActive = 'Y'
   AND l.IsSystemLanguage = 'Y'
   AND l.IsBaseLanguage = 'N'
-  AND t.AD_Reference_ID = 542086
+  AND t.AD_Reference_ID = 542058
   AND NOT EXISTS (
       SELECT 1 FROM AD_Reference_Trl tt
       WHERE tt.AD_Language = l.AD_Language
@@ -44,15 +44,15 @@ INSERT INTO AD_Ref_Table (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive,
                           Created, CreatedBy, Updated, UpdatedBy,
                           AD_Table_ID, AD_Key, AD_Display, OrderByClause, WhereClause,
                           IsValueDisplayed, EntityType)
-VALUES (542086, 0, 0, 'Y',
+VALUES (542058, 0, 0, 'Y',
         TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'), 100, TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'), 100,
         145, 837, null, 'C_Period.StartDate', null,
         'N', 'de.metas.fresh');
 
 -- Step 3: Switch process parameters that have a sibling C_Year_ID parameter
--- from 540658 (desc) to 542086 (asc)
+-- from 540658 (desc) to 542058 (asc)
 UPDATE AD_Process_Para pp
-SET AD_Reference_Value_ID = 542086,
+SET AD_Reference_Value_ID = 542058,
     Updated               = TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'),
     UpdatedBy             = 100
 WHERE pp.AD_Reference_Value_ID = 540658

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788030_sys_gh28014_C_Period_Ordered_Asc_reference.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788030_sys_gh28014_C_Period_Ordered_Asc_reference.sql
@@ -17,7 +17,7 @@
 INSERT INTO AD_Reference (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive,
                           Created, CreatedBy, Updated, UpdatedBy,
                           Name, Description, ValidationType, EntityType, IsOrderByValue)
-VALUES (542058, 0, 0, 'Y',
+VALUES (542086, 0, 0, 'Y',
         TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'), 100, TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'), 100,
         'C_Period Ordered (asc)', 'C_Period ordered by StartDate ascending — use when year is already filtered', 'T', 'de.metas.fresh', 'N');
 
@@ -32,7 +32,7 @@ FROM AD_Language l, AD_Reference t
 WHERE l.IsActive = 'Y'
   AND l.IsSystemLanguage = 'Y'
   AND l.IsBaseLanguage = 'N'
-  AND t.AD_Reference_ID = 542058
+  AND t.AD_Reference_ID = 542086
   AND NOT EXISTS (
       SELECT 1 FROM AD_Reference_Trl tt
       WHERE tt.AD_Language = l.AD_Language
@@ -44,15 +44,15 @@ INSERT INTO AD_Ref_Table (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive,
                           Created, CreatedBy, Updated, UpdatedBy,
                           AD_Table_ID, AD_Key, AD_Display, OrderByClause, WhereClause,
                           IsValueDisplayed, EntityType)
-VALUES (542058, 0, 0, 'Y',
+VALUES (542086, 0, 0, 'Y',
         TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'), 100, TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'), 100,
         145, 837, null, 'C_Period.StartDate', null,
         'N', 'de.metas.fresh');
 
 -- Step 3: Switch process parameters that have a sibling C_Year_ID parameter
--- from 540658 (desc) to 542058 (asc)
+-- from 540658 (desc) to 542086 (asc)
 UPDATE AD_Process_Para pp
-SET AD_Reference_Value_ID = 542058,
+SET AD_Reference_Value_ID = 542086,
     Updated               = TO_TIMESTAMP('2026-02-21', 'YYYY-MM-DD'),
     UpdatedBy             = 100
 WHERE pp.AD_Reference_Value_ID = 540658

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788032_sys_gh28014_fix_AD_Reference_ID.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788032_sys_gh28014_fix_AD_Reference_ID.sql
@@ -9,5 +9,6 @@
 --
 
 UPDATE AD_Reference SET AD_Reference_ID=542058 WHERE AD_Reference_ID=542051;
+UPDATE AD_Reference_Trl SET AD_Reference_ID=542058 WHERE AD_Reference_ID=542051;
 UPDATE AD_Ref_Table SET AD_Reference_ID=542058 WHERE AD_Reference_ID=542051;
 UPDATE AD_Process_Para SET AD_Reference_Value_ID=542058 WHERE AD_Reference_Value_ID=542051;

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788032_sys_gh28014_fix_AD_Reference_ID.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788032_sys_gh28014_fix_AD_Reference_ID.sql
@@ -1,12 +1,13 @@
 
 --
--- 5788030_sys_gh28014_C_Period_Ordered_Asc_reference.sql originally created an AD_reference with ID=542058
+-- 5788030_sys_gh28014_C_Period_Ordered_Asc_reference.sql originally created an AD_reference with ID=542051
 -- That ID was "guessed". Now, a later script 5789650_sys_ReceiveUnitType_List.sql dies to insert a different AD_reference with the same ID and fails.
 --
 -- Fix:
--- 1st: update 5788030_sys_gh28014_C_Period_Ordered_Asc_reference to use a legit AD_Reference_ID=542086 instead of 542058
--- 2nd: add this file to update DBs where the SQL with the wrong ID was already applied     
+-- 1st: DONE EARLIER: 5788030_sys_gh28014_C_Period_Ordered_Asc_reference to use a legit AD_Reference_ID=542058 instead of 542051 in commit 69e4f9b8
+-- 2nd: NOW: add this file to update DBs where the SQL with the wrong ID was already applied     
 --
-UPDATE AD_Reference SET AD_Reference_ID=542086 WHERE AD_Reference_ID=542058;
-UPDATE AD_Ref_Table SET AD_Reference_ID=542086 WHERE AD_Reference_ID=542058;
-UPDATE AD_Process_Para SET AD_Reference_Value_ID=542086 WHERE AD_Reference_Value_ID=542058;
+
+UPDATE AD_Reference SET AD_Reference_ID=542058 WHERE AD_Reference_ID=542051;
+UPDATE AD_Ref_Table SET AD_Reference_ID=542058 WHERE AD_Reference_ID=542051;
+UPDATE AD_Process_Para SET AD_Reference_Value_ID=542058 WHERE AD_Reference_Value_ID=542051;

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788032_sys_gh28014_fix_AD_Reference_ID.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5788032_sys_gh28014_fix_AD_Reference_ID.sql
@@ -1,0 +1,12 @@
+
+--
+-- 5788030_sys_gh28014_C_Period_Ordered_Asc_reference.sql originally created an AD_reference with ID=542058
+-- That ID was "guessed". Now, a later script 5789650_sys_ReceiveUnitType_List.sql dies to insert a different AD_reference with the same ID and fails.
+--
+-- Fix:
+-- 1st: update 5788030_sys_gh28014_C_Period_Ordered_Asc_reference to use a legit AD_Reference_ID=542086 instead of 542058
+-- 2nd: add this file to update DBs where the SQL with the wrong ID was already applied     
+--
+UPDATE AD_Reference SET AD_Reference_ID=542086 WHERE AD_Reference_ID=542058;
+UPDATE AD_Ref_Table SET AD_Reference_ID=542086 WHERE AD_Reference_ID=542058;
+UPDATE AD_Process_Para SET AD_Reference_Value_ID=542086 WHERE AD_Reference_Value_ID=542058;


### PR DESCRIPTION
`5788030_sys_gh28014_C_Period_Ordered_Asc_reference.sql` originally created an AD_reference with ID=542051
That ID was "guessed". Now, a later script 5789650_sys_ReceiveUnitType_List.sql dies to insert a different AD_reference with the same ID and fails.

Fix:
- 1st: DONE EARLIER: 5788030_sys_gh28014_C_Period_Ordered_Asc_reference to use a legit AD_Reference_ID=542058 instead of 542051 in commit 69e4f9b8
- 2nd: DONE HERE: add this file to update DBs where the SQL with the wrong ID was already applied     
