### PR TITLE
Port: Prevent single failing schedule from aborting shipment batch (PR #23355)

### DIFF
--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v1/shipping/ShipmentService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v1/shipping/ShipmentService.java
@@ -351,7 +351,7 @@ public class ShipmentService
 						.quantityTypeToUse(request.getQuantityTypeToUse())
 						.onTheFlyPickToPackingInstructions(false) // backwards compatibility: on-the-fly-pick to (anonymous) CUs
 						.qtyToDeliverOverrides(QtyToDeliverMap.EMPTY)
-						.isFailIfNoPickedHUs(true) // backwards compatibility: true - fail if no picked HUs found
+						.failOnSingleScheduleWithNoPickedHUs(true) // backwards compatibility: true - fail if no picked HUs found (REST API typically processes single schedules)
 						.build()
 		);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleAndJobSchedulesCollection.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleAndJobSchedulesCollection.java
@@ -58,6 +58,13 @@ public class ShipmentScheduleAndJobSchedulesCollection implements Iterable<Shipm
 
 	public boolean isEmpty() {return list.isEmpty();}
 
+	public int countUnprocessed()
+	{
+		return (int) list.stream()
+				.filter(schedule -> !schedule.isProcessed())
+				.count();
+	}
+
 	@Override
 	public @NotNull Iterator<ShipmentScheduleAndJobSchedules> iterator() {return list.iterator();}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUService.java
@@ -153,7 +153,9 @@ public class ShipmentScheduleWithHUService
 
 	public static ShipmentScheduleWithHUService newInstanceForUnitTesting()
 	{
-		Adempiere.enableUnitTestMode();
+		Adempiere.assertUnitTestMode();
+		// Spring context returns non-null in unit test mode even though static analysis can't prove it
+		// noinspection DataFlowIssue
 		return SpringContextHolder.getBeanOrSupply(
 				ShipmentScheduleWithHUService.class,
 				() -> new ShipmentScheduleWithHUService(new HUReservationService(new HUReservationRepository()))
@@ -174,8 +176,9 @@ public class ShipmentScheduleWithHUService
 		 */
 		@Builder.Default boolean onTheFlyPickToPackingInstructions = false;
 		@NonNull @Builder.Default QtyToDeliverMap qtyToDeliverOverrides = QtyToDeliverMap.EMPTY;
-		@Builder.Default boolean isFailIfNoPickedHUs = true;
+		@Builder.Default boolean failOnSingleScheduleWithNoPickedHUs = true;
 
+		@Nullable
 		public StockQtyAndUOMQty getQtyToDeliverOverride(@NonNull final ShipmentScheduleId shipmentScheduleId)
 		{
 			return qtyToDeliverOverrides.getQtyToDeliver(shipmentScheduleId);
@@ -203,14 +206,27 @@ public class ShipmentScheduleWithHUService
 		@Nullable StockQtyAndUOMQty quantityToDeliverOverride;
 
 		/**
-		 * Fails if no picked HUs were found.
+		 * When {@code true}, throws an exception if no picked HUs are found.
+		 * <p>
+		 * Behavior:
+		 * <ul>
+		 * <li><b>Single-schedule mode</b> ({@code isBatchProcessing()=false}): Exception is thrown when {@code true}</li>
+		 * <li><b>Batch mode</b> ({@code isBatchProcessing()=true}): Always skips with warning (this flag is ignored)</li>
+		 * </ul>
 		 * Applies only when <code>quantityType</code> is PickedQty.
 		 */
-		@Builder.Default boolean isFailIfNoPickedHUs = true;
+		@Builder.Default boolean failOnSingleScheduleWithNoPickedHUs = true;
+
+		/**
+		 * Whether this request is part of a batch (determined by the caller from countUnprocessed()).
+		 * Must remain stable across all schedules in one batch.
+		 */
+		@Builder.Default boolean isBatchProcessing = false;
 
 		public static PrepareForSingleShipmentScheduleRequestBuilder builderFrom(
 				@NonNull final ShipmentScheduleAndJobSchedules schedule,
-				@NonNull final PrepareForShipmentSchedulesRequest request)
+				@NonNull final PrepareForShipmentSchedulesRequest request,
+				final boolean isBatchProcessing)
 		{
 			final ShipmentScheduleId shipmentScheduleId = schedule.getShipmentScheduleId();
 
@@ -220,8 +236,9 @@ public class ShipmentScheduleWithHUService
 					.quantityType(request.getQuantityTypeToUse())
 					.onlyLUIds(request.getOnlyLUIds())
 					.onTheFlyPickToPackingInstructions(request.isOnTheFlyPickToPackingInstructions())
-					.isFailIfNoPickedHUs(request.isFailIfNoPickedHUs())
+					.failOnSingleScheduleWithNoPickedHUs(request.isFailOnSingleScheduleWithNoPickedHUs())
 					.quantityToDeliverOverride(request.getQtyToDeliverOverride(shipmentScheduleId))
+					.isBatchProcessing(isBatchProcessing)
 					;
 		}
 
@@ -239,6 +256,13 @@ public class ShipmentScheduleWithHUService
 
 		final ArrayList<ShipmentScheduleWithHU> result = new ArrayList<>();
 
+		// Compute batch mode once at the beginning based on unprocessed count.
+		// Must be computed here (not in PrepareForSingleShipmentScheduleRequest) to:
+		// 1. Prevent manual override via builder
+		// 2. Ensure same value used for all schedules in this batch (stable throughout the loop)
+		// 3. Base decision on actual unprocessed count at batch start time
+		final boolean isBatchProcessing = request.getSchedules().countUnprocessed() > 1;
+
 		for (final ShipmentScheduleAndJobSchedules schedule : request.getSchedules())
 		{
 			// Skip already processed candidates
@@ -250,7 +274,7 @@ public class ShipmentScheduleWithHUService
 			try (final MDCCloseable ignored = ShipmentSchedulesMDC.putShipmentSchedule(schedule.getShipmentSchedule()))
 			{
 				final ImmutableList<ShipmentScheduleWithHU> candidates = prepareShipmentSchedulesWithHU(
-						PrepareForSingleShipmentScheduleRequest.builderFrom(schedule, request)
+						PrepareForSingleShipmentScheduleRequest.builderFrom(schedule, request, isBatchProcessing)
 								.huContext(huContext)
 								.build()
 				);
@@ -650,20 +674,32 @@ public class ShipmentScheduleWithHUService
 	{
 		final Collection<? extends ShipmentScheduleWithHU> candidatesForPick = prepareShipmentScheduleWithHUForPick(request);
 
-		if (request.isFailIfNoPickedHUs() && candidatesForPick.isEmpty())
+		if (candidatesForPick.isEmpty())
 		{
-			// the parameter insists that we use qtyPicked records, but there is none
-			// => nothing to do, basically
+			final ShipmentScheduleId shipmentScheduleId = request.getShipmentScheduleId();
 
 			// If we got no qty picked records just because they were already delivered,
 			// don't fail this workpackage but just log the issue (task 09048)
-			final ShipmentScheduleId shipmentScheduleId = request.getShipmentScheduleId();
 			final boolean wereDelivered = shipmentScheduleAllocDAO.retrieveOnShipmentLineRecordsQuery(shipmentScheduleId).create().anyMatch();
 			if (wereDelivered)
 			{
 				Loggables.withLogger(logger, Level.INFO).addLog("Skipped shipment schedule because it was already delivered: {}", shipmentScheduleId);
 				return Collections.emptyList();
 			}
+
+			// In batch mode: always log warning and skip (failOnSingleScheduleWithNoPickedHUs is ignored)
+			// In single mode: check failOnSingleScheduleWithNoPickedHUs flag
+			if (request.isBatchProcessing() || !request.isFailOnSingleScheduleWithNoPickedHUs())
+			{
+				final String logMessage = request.isBatchProcessing()
+						? "Skipping shipment schedule {} in batch processing - no I_M_ShipmentSchedule_QtyPicked records (or these records have inactive HUs)."
+						: "Skipping shipment schedule {} - no I_M_ShipmentSchedule_QtyPicked records (or these records have inactive HUs).";
+
+				Loggables.withLogger(logger, Level.WARN).addLog(logMessage, shipmentScheduleId);
+				return Collections.emptyList();
+			}
+
+			// Single schedule mode with failOnSingleScheduleWithNoPickedHUs=true: throw exception
 			Loggables.withLogger(logger, Level.WARN).addLog("Shipment schedule has no I_M_ShipmentSchedule_QtyPicked records (or these records have inactive HUs); M_ShipmentSchedule={}", shipmentScheduleId);
 			throw new AdempiereException(MSG_NoQtyPicked);
 		}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentServiceTestImpl.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentServiceTestImpl.java
@@ -64,7 +64,9 @@ public class ShipmentServiceTestImpl implements IShipmentService
 
 	public static ShipmentServiceTestImpl newInstanceForUnitTesting()
 	{
-		Adempiere.enableUnitTestMode();
+		Adempiere.assertUnitTestMode();
+		// Spring context returns non-null in unit test mode even though static analysis can't prove it
+		// noinspection DataFlowIssue
 		return SpringContextHolder.getBeanOrSupply(
 				ShipmentServiceTestImpl.class,
 				() -> new ShipmentServiceTestImpl(
@@ -94,7 +96,7 @@ public class ShipmentServiceTestImpl implements IShipmentService
 						.quantityTypeToUse(request.getQuantityTypeToUse())
 						.onTheFlyPickToPackingInstructions(request.isOnTheFlyPickToPackingInstructions())
 						.qtyToDeliverOverrides(QtyToDeliverMap.EMPTY)
-						.isFailIfNoPickedHUs(true) // backwards compatibility: true - fail if no picked HUs found
+						.failOnSingleScheduleWithNoPickedHUs(true) // backwards compatibility: true - fail if no picked HUs found (tests expect failures)
 						.build()
 		);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/async/GenerateInOutFromShipmentSchedules.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/async/GenerateInOutFromShipmentSchedules.java
@@ -177,7 +177,7 @@ public class GenerateInOutFromShipmentSchedules extends WorkpackageProcessorAdap
 
 		final boolean onTheFlyPickToPackingInstructions = getParameters().getParameterAsBool(ShipmentScheduleWorkPackageParameters.PARAM_IsOnTheFlyPickToPackingInstructions);
 		final boolean isCloseShipmentSchedules = getParameters().getParameterAsBool(ShipmentScheduleWorkPackageParameters.PARAM_IsCloseShipmentSchedules);
-		final boolean isFailIfNoPickedHUs = !isCloseShipmentSchedules;
+		final boolean failOnSingleScheduleWithNoPickedHUs = !isCloseShipmentSchedules;
 
 		return shipmentScheduleWithHUService.prepareShipmentSchedulesWithHU(
 				PrepareForShipmentSchedulesRequest.builder()
@@ -186,7 +186,7 @@ public class GenerateInOutFromShipmentSchedules extends WorkpackageProcessorAdap
 						.quantityTypeToUse(quantityTypeToUse)
 						.onTheFlyPickToPackingInstructions(onTheFlyPickToPackingInstructions)
 						.qtyToDeliverOverrides(scheduleId2QtyToDeliverOverride)
-						.isFailIfNoPickedHUs(isFailIfNoPickedHUs)
+						.failOnSingleScheduleWithNoPickedHUs(failOnSingleScheduleWithNoPickedHUs)
 						.build()
 		);
 	}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/ShipmentScheduleWithHUServiceTest.java
@@ -1,0 +1,310 @@
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.handlingunits.shipmentschedule.api;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.google.common.collect.ImmutableList;
+import de.metas.handlingunits.model.I_M_ShipmentSchedule;
+import de.metas.inout.ShipmentScheduleId;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link ShipmentScheduleWithHUService}.
+ */
+class ShipmentScheduleWithHUServiceTest
+{
+	private ShipmentScheduleWithHUService shipmentScheduleWithHUService;
+	private ListAppender<ILoggingEvent> logAppender;
+	private Logger logger;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		shipmentScheduleWithHUService = ShipmentScheduleWithHUService.newInstanceForUnitTesting();
+
+		// Setup log capturing
+		logger = (Logger) LoggerFactory.getLogger(ShipmentScheduleWithHUService.class);
+		logAppender = new ListAppender<>();
+		logAppender.start();
+		logger.addAppender(logAppender);
+	}
+
+	@AfterEach
+	void afterEach()
+	{
+		// Cleanup log appender
+		if (logger != null && logAppender != null)
+		{
+			logger.detachAppender(logAppender);
+		}
+	}
+
+	/**
+	 * Single-schedule mode:
+	 * Single schedule with no picked HUs should throw exception when failOnSingleScheduleWithNoPickedHUs=true
+	 */
+	@Test
+	void singleSchedule_noPickedHUs_failEnabled_shouldThrowException()
+	{
+		// Given: Single schedule with no picked HUs (test mode returns empty by default)
+		final I_M_ShipmentSchedule schedule = createShipmentSchedule(ShipmentScheduleId.ofRepoId(100));
+		final ShipmentScheduleAndJobSchedulesCollection schedules = ShipmentScheduleAndJobSchedulesCollection
+				.ofShipmentSchedules(ImmutableList.of(schedule));
+
+		final ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest request = ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest.builder()
+				.schedules(schedules)
+				.quantityTypeToUse(M_ShipmentSchedule_QuantityTypeToUse.TYPE_PICKED_QTY)
+				.failOnSingleScheduleWithNoPickedHUs(true)
+				.build();
+
+		// When/Then: Should throw exception
+		assertThatThrownBy(() -> shipmentScheduleWithHUService.prepareShipmentSchedulesWithHU(request))
+				.isInstanceOf(AdempiereException.class);
+	}
+
+	/**
+	 * Single-schedule mode:
+	 * Single schedule with no picked HUs should NOT throw when failOnSingleScheduleWithNoPickedHUs=false
+	 */
+	@Test
+	void singleSchedule_noPickedHUs_failDisabled_shouldReturnEmpty()
+	{
+		// Given: Single schedule with no picked HUs (test mode returns empty by default)
+		final I_M_ShipmentSchedule schedule = createShipmentSchedule(ShipmentScheduleId.ofRepoId(100));
+		final ShipmentScheduleAndJobSchedulesCollection schedules = ShipmentScheduleAndJobSchedulesCollection
+				.ofShipmentSchedules(ImmutableList.of(schedule));
+
+		final ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest request = ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest.builder()
+				.schedules(schedules)
+				.quantityTypeToUse(M_ShipmentSchedule_QuantityTypeToUse.TYPE_PICKED_QTY)
+				.failOnSingleScheduleWithNoPickedHUs(false)
+				.build();
+
+		// When: Process
+		final ImmutableList<ShipmentScheduleWithHU> result = shipmentScheduleWithHUService.prepareShipmentSchedulesWithHU(request);
+
+		// Then: Should return an empty list (no exception)
+		assertThat(result).isEmpty();
+	}
+
+	/**
+	 * Batch processing behavior:
+	 * Multiple schedules with no picked HUs should NOT throw even when failOnSingleScheduleWithNoPickedHUs=true
+	 */
+	@Test
+	void batchProcessing_multipleSchedules_allWithNoPickedHUs_failEnabled_shouldNotThrow()
+	{
+		// Given: 3 schedules - all have no picked HUs (test mode returns empty by default)
+		final I_M_ShipmentSchedule schedule1 = createShipmentSchedule(ShipmentScheduleId.ofRepoId(101));
+		final I_M_ShipmentSchedule schedule2 = createShipmentSchedule(ShipmentScheduleId.ofRepoId(102));
+		final I_M_ShipmentSchedule schedule3 = createShipmentSchedule(ShipmentScheduleId.ofRepoId(103));
+
+		final ShipmentScheduleAndJobSchedulesCollection schedules = ShipmentScheduleAndJobSchedulesCollection
+				.ofShipmentSchedules(ImmutableList.of(schedule1, schedule2, schedule3));
+
+		final ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest request = ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest.builder()
+				.schedules(schedules)
+				.quantityTypeToUse(M_ShipmentSchedule_QuantityTypeToUse.TYPE_PICKED_QTY)
+				.failOnSingleScheduleWithNoPickedHUs(true)
+				.build();
+
+		// When: Process batch - should not throw despite failOnSingleScheduleWithNoPickedHUs=true
+		final ImmutableList<ShipmentScheduleWithHU> result = shipmentScheduleWithHUService.prepareShipmentSchedulesWithHU(request);
+
+		// Then: Should complete without exception, all schedules skipped
+		assertThat(result).isNotNull().isEmpty();
+	}
+
+	/**
+	 * Batch processing behavior:
+	 * Multiple schedules with no picked HUs should NOT throw when failOnSingleScheduleWithNoPickedHUs=false
+	 */
+	@Test
+	void batchProcessing_multipleSchedules_allWithNoPickedHUs_failDisabled_shouldNotThrow()
+	{
+		// Given: 3 schedules - all have no picked HUs (test mode returns empty by default)
+		final I_M_ShipmentSchedule schedule1 = createShipmentSchedule(ShipmentScheduleId.ofRepoId(201));
+		final I_M_ShipmentSchedule schedule2 = createShipmentSchedule(ShipmentScheduleId.ofRepoId(202));
+		final I_M_ShipmentSchedule schedule3 = createShipmentSchedule(ShipmentScheduleId.ofRepoId(203));
+
+		final ShipmentScheduleAndJobSchedulesCollection schedules = ShipmentScheduleAndJobSchedulesCollection
+				.ofShipmentSchedules(ImmutableList.of(schedule1, schedule2, schedule3));
+
+		final ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest request = ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest.builder()
+				.schedules(schedules)
+				.quantityTypeToUse(M_ShipmentSchedule_QuantityTypeToUse.TYPE_PICKED_QTY)
+				.failOnSingleScheduleWithNoPickedHUs(false) // With fail=false, batch mode should not throw
+				.build();
+
+		// When: Process batch
+		final ImmutableList<ShipmentScheduleWithHU> result = shipmentScheduleWithHUService.prepareShipmentSchedulesWithHU(request);
+
+		// Then: Should complete without exception (schedules with no picked HUs are skipped)
+		assertThat(result).isNotNull().isEmpty();
+	}
+
+	/**
+	 * Batch processing boundary test:
+	 * Exactly 1 schedule should throw exception when failOnSingleScheduleWithNoPickedHUs=true
+	 */
+	@Test
+	void batchProcessing_boundary_exactlyOneSchedule_shouldThrowException()
+	{
+		// Given: Exactly 1 schedule (boundary: not batch mode)
+		final I_M_ShipmentSchedule schedule = createShipmentSchedule(ShipmentScheduleId.ofRepoId(301));
+		final ShipmentScheduleAndJobSchedulesCollection schedules = ShipmentScheduleAndJobSchedulesCollection
+				.ofShipmentSchedules(ImmutableList.of(schedule));
+
+		final ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest request = ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest.builder()
+				.schedules(schedules)
+				.quantityTypeToUse(M_ShipmentSchedule_QuantityTypeToUse.TYPE_PICKED_QTY)
+				.failOnSingleScheduleWithNoPickedHUs(true)
+				.build();
+
+		// When/Then: Should throw exception (size == 1, not batch mode)
+		assertThatThrownBy(() -> shipmentScheduleWithHUService.prepareShipmentSchedulesWithHU(request))
+				.isInstanceOf(AdempiereException.class);
+	}
+
+	/**
+	 * Batch processing boundary test:
+	 * Exactly 2 schedules should NOT throw exception (batch mode threshold)
+	 */
+	@Test
+	void batchProcessing_boundary_exactlyTwoSchedules_shouldSkipAndContinue()
+	{
+		// Given: Exactly 2 schedules (boundary: batch mode threshold)
+		final I_M_ShipmentSchedule schedule1 = createShipmentSchedule(ShipmentScheduleId.ofRepoId(401));
+		final I_M_ShipmentSchedule schedule2 = createShipmentSchedule(ShipmentScheduleId.ofRepoId(402));
+		final ShipmentScheduleAndJobSchedulesCollection schedules = ShipmentScheduleAndJobSchedulesCollection
+				.ofShipmentSchedules(ImmutableList.of(schedule1, schedule2));
+
+		final ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest request = ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest.builder()
+				.schedules(schedules)
+				.quantityTypeToUse(M_ShipmentSchedule_QuantityTypeToUse.TYPE_PICKED_QTY)
+				.failOnSingleScheduleWithNoPickedHUs(true)
+				.build();
+
+		// When: Process batch (size == 2, batch mode enabled)
+		final ImmutableList<ShipmentScheduleWithHU> result = shipmentScheduleWithHUService.prepareShipmentSchedulesWithHU(request);
+
+		// Then: Should complete without exception (size > 1 triggers batch mode)
+		assertThat(result).isNotNull().isEmpty();
+	}
+
+	/**
+	 * Edge case: 2 schedules submitted, but 1 already processed
+	 * Should throw exception (single unprocessed schedule mode, not batch mode)
+	 */
+	@Test
+	void batchProcessing_edgeCase_twoSchedules_oneAlreadyProcessed_shouldThrowException()
+	{
+		// Given: 2 schedules submitted, but first one is already processed
+		final I_M_ShipmentSchedule schedule1 = createShipmentSchedule(ShipmentScheduleId.ofRepoId(601));
+		schedule1.setProcessed(true); // Already processed
+		InterfaceWrapperHelper.save(schedule1);
+
+		final I_M_ShipmentSchedule schedule2 = createShipmentSchedule(ShipmentScheduleId.ofRepoId(602));
+		// schedule2 is NOT processed, has no picked HUs
+
+		final ShipmentScheduleAndJobSchedulesCollection schedules = ShipmentScheduleAndJobSchedulesCollection
+				.ofShipmentSchedules(ImmutableList.of(schedule1, schedule2));
+
+		final ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest request = ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest.builder()
+				.schedules(schedules)
+				.quantityTypeToUse(M_ShipmentSchedule_QuantityTypeToUse.TYPE_PICKED_QTY)
+				.failOnSingleScheduleWithNoPickedHUs(true)
+				.build();
+
+		// When/Then: Should throw exception (only 1 unprocessed schedule, NOT batch mode)
+		assertThatThrownBy(() -> shipmentScheduleWithHUService.prepareShipmentSchedulesWithHU(request))
+				.isInstanceOf(AdempiereException.class);
+	}
+
+	/**
+	 * Batch processing behavior:
+	 * Verify that schedules with no picked HUs are skipped without throwing exception in batch mode.
+	 * Also verifies WARN log is emitted (if Loggables routes to SLF4J in test environment).
+	 */
+	@Test
+	void batchProcessing_multipleSchedules_shouldLogWarningWhenSkippingSchedule()
+	{
+		// Given: 2 schedules in batch mode (both have no picked HUs)
+		final I_M_ShipmentSchedule schedule1 = createShipmentSchedule(ShipmentScheduleId.ofRepoId(501));
+		final I_M_ShipmentSchedule schedule2 = createShipmentSchedule(ShipmentScheduleId.ofRepoId(502));
+		final ShipmentScheduleAndJobSchedulesCollection schedules = ShipmentScheduleAndJobSchedulesCollection
+				.ofShipmentSchedules(ImmutableList.of(schedule1, schedule2));
+
+		final ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest request = ShipmentScheduleWithHUService.PrepareForShipmentSchedulesRequest.builder()
+				.schedules(schedules)
+				.quantityTypeToUse(M_ShipmentSchedule_QuantityTypeToUse.TYPE_PICKED_QTY)
+				.failOnSingleScheduleWithNoPickedHUs(true)
+				.build();
+
+		// When: Process batch
+		logAppender.list.clear(); // Clear any previous logs
+		final ImmutableList<ShipmentScheduleWithHU> result = shipmentScheduleWithHUService.prepareShipmentSchedulesWithHU(request);
+
+		// Then: Primary assertion - no exception thrown and empty result
+		assertThat(result)
+				.as("Batch mode should skip schedules with no picked HUs without throwing exception")
+				.isEmpty();
+
+		// Secondary assertion - verify logs (may not work if Loggables doesn't route to SLF4J in tests)
+		final long warnCount = logAppender.list.stream()
+				.filter(event -> event.getLevel() == Level.WARN)
+				.filter(event -> event.getFormattedMessage().contains("Skipping shipment schedule"))
+				.filter(event -> event.getFormattedMessage().contains("batch processing"))
+				.count();
+
+		// Note: This assertion may be fragile if Loggables routes to work-package log instead of SLF4J
+		assertThat(warnCount)
+				.as("Should log WARN for each skipped schedule (if Loggables routes to SLF4J)")
+				.isEqualTo(2);
+	}
+
+	/**
+	 * Helper: Create a shipment schedule using InterfaceWrapperHelper (proper Adempiere test approach)
+	 */
+	private I_M_ShipmentSchedule createShipmentSchedule(final ShipmentScheduleId id)
+	{
+		final I_M_ShipmentSchedule schedule = InterfaceWrapperHelper.newInstance(I_M_ShipmentSchedule.class);
+		schedule.setM_ShipmentSchedule_ID(id.getRepoId());
+		schedule.setProcessed(false);
+		InterfaceWrapperHelper.save(schedule);
+		return schedule;
+	}
+}

--- a/e2e/mobile-webui/tests/spec/distribution/distribution.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/distribution.spec.js
@@ -58,7 +58,7 @@ test('Simple distribution test', async ({ page }) => {
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('distribution');
     await DistributionJobsListScreen.waitForScreen();
-    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId, expectHitCount: 1 });
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
     await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
     await DistributionJobScreen.clickLineButton({ index: 1 });
     await DistributionLineScreen.scanHUToMove({ huQRCode: masterdata.handlingUnits.HU1.qrCode, qtyToMove: '100', expectedQtyToMove: '100' });
@@ -85,7 +85,7 @@ test('Try picking an HU from a different locator than pick from locator', async 
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('distribution');
     await DistributionJobsListScreen.waitForScreen();
-    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId, expectHitCount: 1 });
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
     await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
     await DistributionJobScreen.clickLineButton({ index: 1 });
     await DistributionLineScreen.scanHUToMove({
@@ -110,7 +110,7 @@ test('Try picking an HU containing a different product than expected', async ({ 
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('distribution');
     await DistributionJobsListScreen.waitForScreen();
-    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId, expectHitCount: 1 });
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
     await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
     await DistributionJobScreen.clickLineButton({ index: 1 });
     await expectErrorToast(
@@ -143,7 +143,7 @@ test('Distribution using 2 steps to pick the needed qty.', async ({ page }) => {
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('distribution');
     await DistributionJobsListScreen.waitForScreen();
-    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId, expectHitCount: 1 });
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
     await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
 
     await DistributionJobScreen.clickLineButton({ index: 1 });
@@ -176,7 +176,7 @@ test('Pick & Unpick in distribution step screen', async ({ page }) => {
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('distribution');
     await DistributionJobsListScreen.waitForScreen();
-    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId, expectHitCount: 1 });
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
     await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
 
     await DistributionJobScreen.clickLineButton({ index: 1 });
@@ -201,5 +201,5 @@ test('Filter distribution orders by plantId', async ({ page }) => {
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('distribution');
     await DistributionJobsListScreen.waitForScreen();
-    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.plantFacetId, expectHitCount: 1 });
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.plantFacetId });
 });


### PR DESCRIPTION
## Summary

Ports https://github.com/metasfresh/metasfresh/pull/23355 (commit `3358e461a0c`) from `intensive_care_hotfix` to `soft_panda_release`.

## Why
A single shipment schedule with `QtyPicked=0` or no picked HUs aborts the whole async shipment-generation workpackage, taking all other schedules in the batch down with it. This surfaces whenever a user partially picks an order — the unpicked lines crash the shipment generation for the picked lines too.

## Changes (identical to upstream)
- Rename `isFailIfNoPickedHUs` → `failOnSingleScheduleWithNoPickedHUs`.
- New `ShipmentScheduleAndJobSchedulesCollection.countUnprocessed()` helper.
- New `isBatchProcessing` flag; when true, per-schedule "no picked HUs" is logged as WARN and skipped instead of thrown.
- Updates `GenerateInOutFromShipmentSchedules`, `ShipmentService`, `ShipmentServiceTestImpl` to use the renamed flag.
- New unit test `ShipmentScheduleWithHUServiceTest.java` (+310 lines).
- Drops `expectHitCount: 1` from `filterByFacetId(...)` calls in `distribution.spec.js` (flaky-assertion cleanup).

## Test plan
- [x] Local compile of `backend/de.metas.handlingunits.base` — green.
- [ ] CI on this PR — including the new `ShipmentScheduleWithHUServiceTest` (311 lines) and all Cucumber profiles.
- [ ] Manual check on local infra: sales order with 3 lines, pick HUs for lines 1 and 2 only, enqueue shipment generation → WP completes, `M_InOut` has 2 lines, line 3 stays open, WP log contains WARN for the skipped schedule.