### PR TITLE
Fix misleading MobileUI_UserProfile_Picking FieldNames

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799030_sys_gh29258_IsAllowSkippingRejectedReason_labels.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799030_sys_gh29258_IsAllowSkippingRejectedReason_labels.sql
@@ -7,8 +7,8 @@
 
 -- AD_Element (base / de_DE)
 UPDATE AD_Element
-   SET Name         = 'Ohne Grund',
-       PrintName    = 'Ohne Grund',
+   SET Name         = 'Unterkomm. ohne Grund erl.',
+       PrintName    = 'Unterkomm. ohne Grund erl.',
        Description  = 'Wenn aktiviert kann der Kommissionierer eine geringere Menge ohne Angabe eines Grundes erfassen (der Dropdown erhält eine zusätzliche Option «Ohne Grund»).',
        Updated      = now(),
        UpdatedBy    = 100
@@ -16,8 +16,8 @@ UPDATE AD_Element
 
 -- AD_Element_Trl: de_DE, de_CH — keep same German text, untranslated flag
 UPDATE AD_Element_Trl
-   SET Name         = 'Ohne Grund',
-       PrintName    = 'Ohne Grund',
+   SET Name         = 'Unterkomm. ohne Grund erl.',
+       PrintName    = 'Unterkomm. ohne Grund erl.',
        Description  = 'Wenn aktiviert kann der Kommissionierer eine geringere Menge ohne Angabe eines Grundes erfassen (der Dropdown erhält eine zusätzliche Option «Ohne Grund»).',
        IsTranslated = 'N',
        Updated      = now(),
@@ -27,8 +27,8 @@ UPDATE AD_Element_Trl
 
 -- AD_Element_Trl: en_US — proper English translation
 UPDATE AD_Element_Trl
-   SET Name         = 'Without reason',
-       PrintName    = 'Without reason',
+   SET Name         = 'Allow under-pick w/o reason',
+       PrintName    = 'Allow under-pick w/o reason',
        Description  = 'When enabled, the picker can record a lower quantity without specifying a reason (the dropdown gets an additional «Without reason» option).',
        IsTranslated = 'Y',
        Updated      = now(),
@@ -38,8 +38,8 @@ UPDATE AD_Element_Trl
 
 -- AD_Element_Trl: fr_CH — keep the placeholder consistent with the German base
 UPDATE AD_Element_Trl
-   SET Name         = 'Ohne Grund',
-       PrintName    = 'Ohne Grund',
+   SET Name         = 'Unterkomm. ohne Grund erl.',
+       PrintName    = 'Unterkomm. ohne Grund erl.',
        Description  = 'Wenn aktiviert kann der Kommissionierer eine geringere Menge ohne Angabe eines Grundes erfassen (der Dropdown erhält eine zusätzliche Option «Ohne Grund»).',
        IsTranslated = 'N',
        Updated      = now(),
@@ -50,7 +50,7 @@ UPDATE AD_Element_Trl
 -- AD_Column: MobileUI_UserProfile_Picking.IsAllowSkippingRejectedReason (id 588938)
 -- AD_Column: MobileUI_UserProfile_Picking_Job.IsAllowSkippingRejectedReason (id 589655)
 UPDATE AD_Column
-   SET Name        = 'Ohne Grund',
+   SET Name        = 'Unterkomm. ohne Grund erl.',
        Description = 'Wenn aktiviert kann der Kommissionierer eine geringere Menge ohne Angabe eines Grundes erfassen (der Dropdown erhält eine zusätzliche Option «Ohne Grund»).',
        Updated     = now(),
        UpdatedBy   = 100

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799030_sys_gh29258_IsAllowSkippingRejectedReason_labels.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799030_sys_gh29258_IsAllowSkippingRejectedReason_labels.sql
@@ -1,0 +1,57 @@
+-- me03#29258: The AD_Element 583236 / IsAllowSkippingRejectedReason carried a
+-- misleading label "Abweichende Menge erlauben" and a description that claimed
+-- it controlled under-picking. In fact it only adds an "Ohne Grund" option to
+-- the rejection-reason dropdown so the picker does not have to choose a reason
+-- when picking a lower quantity. Renaming the checkbox + description + both
+-- AD_Column records to match the actual behavior.
+
+-- AD_Element (base / de_DE)
+UPDATE AD_Element
+   SET Name         = 'Ohne Grund',
+       PrintName    = 'Ohne Grund',
+       Description  = 'Wenn aktiviert kann der Kommissionierer eine geringere Menge ohne Angabe eines Grundes erfassen (der Dropdown erhält eine zusätzliche Option «Ohne Grund»).',
+       Updated      = now(),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 583236;
+
+-- AD_Element_Trl: de_DE, de_CH — keep same German text, untranslated flag
+UPDATE AD_Element_Trl
+   SET Name         = 'Ohne Grund',
+       PrintName    = 'Ohne Grund',
+       Description  = 'Wenn aktiviert kann der Kommissionierer eine geringere Menge ohne Angabe eines Grundes erfassen (der Dropdown erhält eine zusätzliche Option «Ohne Grund»).',
+       IsTranslated = 'N',
+       Updated      = now(),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 583236
+   AND AD_Language IN ('de_DE', 'de_CH');
+
+-- AD_Element_Trl: en_US — proper English translation
+UPDATE AD_Element_Trl
+   SET Name         = 'Without reason',
+       PrintName    = 'Without reason',
+       Description  = 'When enabled, the picker can record a lower quantity without specifying a reason (the dropdown gets an additional «Without reason» option).',
+       IsTranslated = 'Y',
+       Updated      = now(),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 583236
+   AND AD_Language = 'en_US';
+
+-- AD_Element_Trl: fr_CH — keep the placeholder consistent with the German base
+UPDATE AD_Element_Trl
+   SET Name         = 'Ohne Grund',
+       PrintName    = 'Ohne Grund',
+       Description  = 'Wenn aktiviert kann der Kommissionierer eine geringere Menge ohne Angabe eines Grundes erfassen (der Dropdown erhält eine zusätzliche Option «Ohne Grund»).',
+       IsTranslated = 'N',
+       Updated      = now(),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 583236
+   AND AD_Language = 'fr_CH';
+
+-- AD_Column: MobileUI_UserProfile_Picking.IsAllowSkippingRejectedReason (id 588938)
+-- AD_Column: MobileUI_UserProfile_Picking_Job.IsAllowSkippingRejectedReason (id 589655)
+UPDATE AD_Column
+   SET Name        = 'Ohne Grund',
+       Description = 'Wenn aktiviert kann der Kommissionierer eine geringere Menge ohne Angabe eines Grundes erfassen (der Dropdown erhält eine zusätzliche Option «Ohne Grund»).',
+       Updated     = now(),
+       UpdatedBy   = 100
+ WHERE AD_Column_ID IN (588938, 589655);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799050_sys_gh29258_IsConsiderSalesOrderCapacity_labels.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799050_sys_gh29258_IsConsiderSalesOrderCapacity_labels.sql
@@ -1,0 +1,60 @@
+-- me03#29258: AD_Element 583235 / IsConsiderSalesOrderCapacity had a label
+-- ("CU-TU Menge aus Auftrag verwenden") and a description ("Wenn nicht
+-- aktiviert wird die Mengenzuordnung bei TU Catch Weight aus den Stammdaten
+-- des Produkts genommen") that do not describe what the flag does in code.
+--
+-- Actual behavior (PickingJobPickCommand.computeQtyToPickCUs): when ON, CUs
+-- taken from a scanned TU are capped to the remaining to-pick qty (partial
+-- TU possible). When OFF, always picks the full TU capacity. The flag
+-- operates on the CU side only; it does NOT cap the TU count itself.
+
+-- AD_Element (base / de_DE)
+UPDATE AD_Element
+   SET Name         = 'TU-Inhalt auf Restm. kappen',
+       PrintName    = 'TU-Inhalt auf Restm. kappen',
+       Description  = 'Wenn aktiviert, wird beim TU-Scan die CU-Menge auf die noch offene Auftragsmenge gekappt (eine TU kann damit teilweise entnommen werden). Wenn deaktiviert, wird immer die volle TU-Kapazität entnommen, auch wenn das die Auftragsmenge übersteigt.',
+       Updated      = now(),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 583235;
+
+-- AD_Element_Trl: de_DE, de_CH
+UPDATE AD_Element_Trl
+   SET Name         = 'TU-Inhalt auf Restm. kappen',
+       PrintName    = 'TU-Inhalt auf Restm. kappen',
+       Description  = 'Wenn aktiviert, wird beim TU-Scan die CU-Menge auf die noch offene Auftragsmenge gekappt (eine TU kann damit teilweise entnommen werden). Wenn deaktiviert, wird immer die volle TU-Kapazität entnommen, auch wenn das die Auftragsmenge übersteigt.',
+       IsTranslated = 'N',
+       Updated      = now(),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 583235
+   AND AD_Language IN ('de_DE', 'de_CH');
+
+-- AD_Element_Trl: en_US
+UPDATE AD_Element_Trl
+   SET Name         = 'Cap TU content to remaining qty',
+       PrintName    = 'Cap TU content to remaining qty',
+       Description  = 'When enabled, the CU quantity taken from a scanned TU is capped to the remaining order qty (a TU may be picked partially). When disabled, the full TU capacity is always picked, even if that exceeds the order qty.',
+       IsTranslated = 'Y',
+       Updated      = now(),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 583235
+   AND AD_Language = 'en_US';
+
+-- AD_Element_Trl: fr_CH — keep placeholder consistent with the German base
+UPDATE AD_Element_Trl
+   SET Name         = 'TU-Inhalt auf Restm. kappen',
+       PrintName    = 'TU-Inhalt auf Restm. kappen',
+       Description  = 'Wenn aktiviert, wird beim TU-Scan die CU-Menge auf die noch offene Auftragsmenge gekappt (eine TU kann damit teilweise entnommen werden). Wenn deaktiviert, wird immer die volle TU-Kapazität entnommen, auch wenn das die Auftragsmenge übersteigt.',
+       IsTranslated = 'N',
+       Updated      = now(),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 583235
+   AND AD_Language = 'fr_CH';
+
+-- AD_Column: MobileUI_UserProfile_Picking.IsConsiderSalesOrderCapacity (id 588937)
+-- AD_Column: MobileUI_UserProfile_Picking_Job.IsConsiderSalesOrderCapacity (id 589658)
+UPDATE AD_Column
+   SET Name        = 'TU-Inhalt auf Restm. kappen',
+       Description = 'Wenn aktiviert, wird beim TU-Scan die CU-Menge auf die noch offene Auftragsmenge gekappt (eine TU kann damit teilweise entnommen werden). Wenn deaktiviert, wird immer die volle TU-Kapazität entnommen, auch wenn das die Auftragsmenge übersteigt.',
+       Updated     = now(),
+       UpdatedBy   = 100
+ WHERE AD_Column_ID IN (588937, 589658);

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -109,7 +109,7 @@ const translations = {
       switchToQrCodeInput: 'Scannen',
       skip: 'Überspringen',
       scanTargetHU: 'Ziel HU scannen',
-      qtyRejectedIgnoreReason: 'Keinen Grund eintragen',
+      qtyRejectedIgnoreReason: 'Ohne Grund',
       qrcode: {
         missingQty: 'Der gescannte QR-Code enthält keine Mengenangaben!',
         differentUOM: 'Der gescannte QR UOM stimmt nicht mit dem Ziel überein!',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -106,7 +106,7 @@ const translations = {
       switchToQrCodeInput: 'Scan',
       skip: 'Skip',
       scanTargetHU: 'Scan target HU',
-      qtyRejectedIgnoreReason: 'Do not record a reason',
+      qtyRejectedIgnoreReason: 'Without reason',
       qrcode: {
         missingQty: 'The scanned QR contains no qty information!',
         differentUOM: 'The scanned QR UOM does not match the target!',


### PR DESCRIPTION
## Summary

Two `MobileUI_UserProfile_Picking` flags shipped with labels and descriptions that do not describe what they actually do. Customers ticked them expecting different behavior (see me03#29258 — sp80 customer report).

This PR corrects the AD metadata labels + descriptions and (for one of them) the corresponding frontend dropdown label so the admin form matches what the picker sees.

No column is dropped or renamed at the DB level — only the display labels change.

## Changes

### Migration 1 — `5799030_sys_gh29258_IsAllowSkippingRejectedReason_labels.sql`

`AD_Element 583236 / IsAllowSkippingRejectedReason` previously shipped with the label **"Abweichende Menge erlauben"** plus a description that claimed it controls whether under-picking is allowed. Both were wrong: under-picking is always allowed independent of this flag. The flag only adds an **"Ohne Grund"** entry to the rejection-reason dropdown in the picking dialog, so the picker can record a lower quantity without having to choose a specific rejection reason.

Updates `AD_Element` + 2 `AD_Column` rows (`MobileUI_UserProfile_Picking`, `MobileUI_UserProfile_Picking_Job`) + all `AD_Element_Trl` rows (de_DE, de_CH, en_US, fr_CH):

| | Before | After |
|---|---|---|
| DE name/printname | `Abweichende Menge erlauben` | `Unterkomm. ohne Grund erl.` |
| DE description | `Wenn aktiviert darf eine geringere Menge kommissioniert werden. Es taucht dann eine weitere Option im Kommissionierdialog auf.` | `Wenn aktiviert kann der Kommissionierer eine geringere Menge ohne Angabe eines Grundes erfassen (der Dropdown erhält eine zusätzliche Option «Ohne Grund»).` |
| EN name/printname | `Allow picking with no rejected qty reason` | `Allow under-pick w/o reason` |
| EN description | `If activated, a smaller quantity may be picked. An additional option then appears in the picking dialog.` | `When enabled, the picker can record a lower quantity without specifying a reason (the dropdown gets an additional «Without reason» option).` |

### Mobile frontend (translations) — matches the renamed dropdown option

`translations_de.js` / `translations_en.js` — renames the dropdown entry the picker sees so admin and picker see the same short form:

| | Before | After |
|---|---|---|
| DE | `Keinen Grund eintragen` | `Ohne Grund` |
| EN | `Do not record a reason` | `Without reason` |

### Migration 2 — `5799050_sys_gh29258_IsConsiderSalesOrderCapacity_labels.sql`

`AD_Element 583235 / IsConsiderSalesOrderCapacity` previously shipped with the label **"CU-TU Menge aus Auftrag verwenden"** and a description about TU Catch Weight master-data, neither of which matches the actual behavior.

What the flag actually does (`PickingJobPickCommand.computeQtyToPickCUs()`): it is a CU-level clamp for TU-scan picks. When **ON**, the CU qty taken from a scanned TU is capped to the remaining to-pick qty (so a TU can be picked partially). When **OFF**, the full TU capacity is always picked, even if that overdelivers the order. The flag operates on the CU side only — it does **not** cap the TU count itself.

Updates `AD_Element` + 2 `AD_Column` rows (`MobileUI_UserProfile_Picking`, `MobileUI_UserProfile_Picking_Job`) + all `AD_Element_Trl` rows (de_DE, de_CH, en_US, fr_CH):

| | Before | After |
|---|---|---|
| DE name/printname | `CU-TU Menge aus Auftrag verwenden` | `TU-Inhalt auf Restm. kappen` |
| DE description | `Wenn nicht aktiviert wird die Mengenzuordnung bei TU Catch Weight aus den Stammdaten des Produkts genommen` | `Wenn aktiviert, wird beim TU-Scan die CU-Menge auf die noch offene Auftragsmenge gekappt (eine TU kann damit teilweise entnommen werden). Wenn deaktiviert, wird immer die volle TU-Kapazität entnommen, auch wenn das die Auftragsmenge übersteigt.` |
| EN name/printname | `Consider sales order capacity` | `Cap TU content to remaining qty` |
| EN description | `If not activated, the quantity allocation for TU Catch Weight is taken from the master data of the product` | `When enabled, the CU quantity taken from a scanned TU is capped to the remaining order qty (a TU may be picked partially). When disabled, the full TU capacity is always picked, even if that exceeds the order qty.` |

## Test plan
- [x] CI — green (Merge Gate passed)
- [ ] Manual sanity: open the MobileUI Picking Profile window and confirm the two renamed checkboxes + descriptions
- [ ] Manual sanity: in the mobile picker's GetQuantityDialog, confirm the rejection-reason dropdown shows `Ohne Grund` / `Without reason` when the `IsAllowSkippingRejectedReason` flag is enabled
