### PR TITLE
Port: Fix mobileUI overdelivery prompt not appearing during picking (PR #23307)

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/JsonMobileConfigRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/JsonMobileConfigRequest.java
@@ -59,6 +59,7 @@ public class JsonMobileConfigRequest
 		@Nullable Boolean activeWorkplaceRequired;
 		@Nullable Boolean considerOnlyJobScheduledToWorkplace;
 		@Nullable Boolean allowQuickPackAll;
+		@Nullable Boolean showPromptWhenOverPicking;
 
 		@Nullable List<Customer> customers;
 		

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigPickingCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigPickingCommand.java
@@ -147,6 +147,8 @@ class MobileConfigPickingCommand
 
 		builder.displayPickingSlotSuggestions(OptionalBoolean.ofNullableBoolean(from.getDisplayPickingSlotSuggestions()));
 
+		builder.isShowConfirmationPromptWhenOverPick(Boolean.TRUE.equals(from.getShowPromptWhenOverPicking()));
+
 		return builder.build();
 	}
 

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
@@ -59,6 +59,7 @@ import de.metas.workflow.rest_api.model.WFProcess;
 import de.metas.workflow.rest_api.model.WFProcessId;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.util.Env;
 import org.jetbrains.annotations.NotNull;
@@ -72,8 +73,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 import java.util.List;
 
+@Slf4j
 @RequestMapping(MetasfreshRestAPIConstants.ENDPOINT_API_V2 + "/picking")
 @RestController
 @Profile(Profiles.PROFILE_App)
@@ -253,12 +256,34 @@ public class PickingRestController
 		}
 		final JsonHU hu = hus.get(0);
 
-		return JsonHUInfo.builder()
+		final JsonHUInfo.JsonHUInfoBuilder builder = JsonHUInfo.builder()
 				.id(hu.getId())
 				.unitType(hu.getUnitType())
 				.qtyTUs(hu.getQtyTUs())
-				.huQRCode(hu.getQrCode())
-				.build();
+				.huQRCode(hu.getQrCode());
+
+		// Return product info for overdelivery detection (see PickLineScanScreen)
+		final String productNo = request.getProductNo();
+		if (productNo != null)
+		{
+			hu.getProducts().stream()
+					.filter(p -> productNo.equals(p.getProductValue()))
+					.findFirst()
+					.ifPresent(p -> {
+						builder.productNo(p.getProductValue());
+						try
+						{
+							builder.productQty(new BigDecimal(p.getQty()));
+						}
+						catch (final NumberFormatException e)
+						{
+							log.warn("Cannot parse HU product qty '{}' for product {}. Overdelivery prompt will not fire.", p.getQty(), productNo, e);
+						}
+						builder.productUom(p.getUom());
+					});
+		}
+
+		return builder.build();
 	}
 
 	private HUQRCode toHUQRCode(final @NotNull ScannedCode scannedCode)

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonGetHUInfoByScannedCodeRequest.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonGetHUInfoByScannedCodeRequest.java
@@ -5,10 +5,13 @@ import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
+import javax.annotation.Nullable;
+
 @Value
 @Builder
 @Jacksonized
 public class JsonGetHUInfoByScannedCodeRequest
 {
 	@NonNull String scannedCode;
+	@Nullable String productNo;
 }

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonHUInfo.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonHUInfo.java
@@ -9,6 +9,7 @@ import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 
 @Value
 @Builder
@@ -19,4 +20,9 @@ public class JsonHUInfo
 	@NonNull JsonHUType unitType;
 	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) Integer qtyTUs;
 	@Nullable JsonHUQRCode huQRCode;
+
+	// Product info for overdelivery detection (see PickLineScanScreen)
+	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) String productNo;
+	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) BigDecimal productQty;
+	@Nullable @JsonInclude(JsonInclude.Include.NON_NULL) String productUom;
 }

--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
@@ -1,0 +1,460 @@
+import { test } from '../../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../../utils/screens/Backend';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { PickingJobsListScreen } from '../../utils/screens/picking/PickingJobsListScreen';
+import { PickingJobScreen } from '../../utils/screens/picking/PickingJobScreen';
+import { GetQuantityDialog } from '../../utils/screens/picking/GetQuantityDialog';
+import { YesNoDialog } from '../../utils/dialogs/YesNoDialog';
+import { BarcodeScannerComponent } from '../../utils/components/BarcodeScannerComponent';
+
+/**
+ * https://github.com/metasfresh/me03/issues/29069
+ *
+ * Tests for the overdelivery confirmation prompt in mobile UI picking.
+ *
+ * When IsShowConfirmationPromptWhenOverPick=Y, entering qty > remaining should show
+ * a Yes/No confirmation dialog instead of hard-blocking.
+ * When the setting is N (default), the existing qtyMax validation blocks qty > remaining.
+ *
+ * Covers LU/TU picking (scan LU, pick TUs) and LU/CU picking (scan LU, pick CUs).
+ */
+
+//
+// ----- LU/TU masterdata: 4 CUs per TU, 20 TUs per LU -----
+// Order qty is in CUs. qty=12 with 4 CUs/TU = 3 TUs to pick.
+// HU1 = LU with 20 TUs × 4 CUs = 80 CUs total.
+//
+
+const createMasterdata_LU_TU = async ({ showPromptWhenOverPicking, orderQtyCUs = 12 }) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: 'sales_order',
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                    shipOnCloseLU: false,
+                    allowCompletingPartialPickingJob: true,
+                    showPromptWhenOverPicking,
+                },
+            },
+            bpartners: { BP1: {} },
+            warehouses: { wh: {} },
+            pickingSlots: { slot1: {} },
+            products: { P1: { prices: [{ price: 1 }] } },
+            packingInstructions: {
+                PI: { lu: 'LU', qtyTUsPerLU: 20, tu: 'TU', product: 'P1', qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                HU1: { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
+            },
+            salesOrders: {
+                SO1: {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: orderQtyCUs, piItemProduct: 'TU' }],
+                },
+            },
+        },
+    });
+};
+
+const startPickingJob_LU_TU = async (masterdata) => {
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+    return { pickingJobId };
+};
+
+//
+// ----- LU/CU masterdata: CU packing, LU with 1000 CUs -----
+// Order qty is in CUs. qty=10, HU has 1000.
+//
+
+const createMasterdata_LU_CU = async ({ showPromptWhenOverPicking, orderQtyCUs = 10 }) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: 'sales_order',
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU', 'TU', 'LU_CU', 'CU'],
+                    shipOnCloseLU: false,
+                    allowCompletingPartialPickingJob: true,
+                    showPromptWhenOverPicking,
+                },
+            },
+            bpartners: { BP1: {} },
+            warehouses: { wh: {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                P1: { prices: [{ price: 1 }] },
+            },
+            packingInstructions: {
+                PI1: { tu: 'TU', product: 'P1', qtyCUsPerTU: 100, lu: 'LU', qtyTUsPerLU: 20 },
+                LU_CU: { cu: true, lu: 'LU', qtyTUsPerLU: 1 },
+            },
+            handlingUnits: {
+                HU1: { product: 'P1', warehouse: 'wh', qty: 1000, packingInstructions: 'LU_CU' },
+            },
+            salesOrders: {
+                SO1: {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: orderQtyCUs }],
+                },
+            },
+        },
+    });
+};
+
+const startPickingJob_LU_CU = async (masterdata) => {
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({
+        qrCode: masterdata.pickingSlots.slot1.qrCode,
+        expectNextScreen: 'PickLineScanScreen',
+        gotoPickingJobScreen: true,
+    });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI1.luName });
+    return { pickingJobId };
+};
+
+//
+// ===== LU/TU picking mode: scan LU, pick TUs =====
+// Order: 12 CUs = 3 TUs (4 CUs per TU). LU has 20 TUs (80 CUs).
+//
+
+// noinspection JSUnusedLocalSymbols
+test('LU/TU: over-pick TUs - prompt enabled - confirm Yes', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - LU/TU mode, pick more TUs than ordered');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyCUs: 12 });
+    const { pickingJobId } = await startPickingJob_LU_TU(masterdata);
+
+    await test.step('Scan LU, enter 8 TUs (more than 3 needed), confirm overdelivery', async () => {
+        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.qrCode);
+        await GetQuantityDialog.waitForDialog();
+        await GetQuantityDialog.expectQtyEntered(3); // UI suggests 3 TUs (12 CUs / 4 per TU)
+        await GetQuantityDialog.typeQtyEntered(8);
+        await GetQuantityDialog.clickDone();
+
+        await YesNoDialog.waitForDialog();
+        await YesNoDialog.clickYesButton();
+
+        await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '8 TU', qtyPickedCatchWeight: '' });
+
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: {
+                            qtyPicked: [{ qtyPicked: '32 PCE', qtyTUs: 8, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '48 PCE' } },
+            },
+        });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('LU/TU: over-pick TUs - prompt enabled - decline', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - LU/TU mode, decline overdelivery');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyCUs: 12 });
+    const { pickingJobId } = await startPickingJob_LU_TU(masterdata);
+
+    await test.step('Scan LU, enter 8 TUs, decline overdelivery, cancel dialog', async () => {
+        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.qrCode);
+        await GetQuantityDialog.waitForDialog();
+        await GetQuantityDialog.expectQtyEntered(3);
+        await GetQuantityDialog.typeQtyEntered(8);
+        await GetQuantityDialog.clickDone();
+
+        await YesNoDialog.waitForDialog();
+        await YesNoDialog.clickNoButton();
+
+        await GetQuantityDialog.waitForDialog();
+        await GetQuantityDialog.clickCancel();
+    });
+
+    await test.step('Verify nothing was picked', async () => {
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [] },
+                    },
+                },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '80 PCE' } },
+            },
+        });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('LU/TU: pick exact TU qty - prompt enabled - no prompt', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - LU/TU mode, exact qty, no prompt fires');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: true, orderQtyCUs: 12 });
+    const { pickingJobId } = await startPickingJob_LU_TU(masterdata);
+
+    await test.step('Scan LU, pick exactly 3 TUs — no prompt should appear', async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.qrCode,
+            expectQtyEntered: 3,
+        });
+        await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });
+
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: {
+                            qtyPicked: [{ qtyPicked: '12 PCE', qtyTUs: 3, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '68 PCE' } },
+            },
+        });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('LU/TU: prompt disabled - regression guard', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - LU/TU mode, prompt disabled, pick exact qty');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata_LU_TU({ showPromptWhenOverPicking: false, orderQtyCUs: 12 });
+    const { pickingJobId } = await startPickingJob_LU_TU(masterdata);
+
+    await test.step('Prompt disabled — pick exact qty, verify existing behavior unchanged', async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.qrCode,
+            expectQtyEntered: 3,
+        });
+        await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });
+
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: {
+                            qtyPicked: [{ qtyPicked: '12 PCE', qtyTUs: 3, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '68 PCE' } },
+            },
+        });
+    });
+});
+
+//
+// ===== LU/CU picking mode: scan LU, pick CUs =====
+// Order: 10 CUs. HU has 1000 CUs.
+//
+
+// noinspection JSUnusedLocalSymbols
+test('LU/CU: over-pick CUs - prompt enabled - confirm Yes', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - LU/CU mode, pick more CUs than ordered');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata_LU_CU({ showPromptWhenOverPicking: true, orderQtyCUs: 10 });
+    const { pickingJobId } = await startPickingJob_LU_CU(masterdata);
+
+    await test.step('Scan LU, enter 25 CUs (more than 10 ordered), confirm overdelivery', async () => {
+        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
+        await GetQuantityDialog.waitForDialog();
+        await GetQuantityDialog.expectQtyEntered(10); // UI suggests 10 CUs (remaining)
+        await GetQuantityDialog.typeQtyEntered(25);
+        await GetQuantityDialog.clickDone();
+
+        await YesNoDialog.waitForDialog();
+        await YesNoDialog.clickYesButton();
+
+        await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '10 Stk', qtyPicked: '25 Stk', qtyPickedCatchWeight: '' });
+
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: {
+                            qtyPicked: [{ qtyPicked: '25 PCE', qtyTUs: 1, qtyLUs: 1, vhu: 'vhu1', tu: 'vhu1', lu: 'lu1', processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '975 PCE' } },
+            },
+        });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('LU/CU: over-pick CUs - prompt enabled - decline', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - LU/CU mode, decline overdelivery');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata_LU_CU({ showPromptWhenOverPicking: true, orderQtyCUs: 10 });
+    const { pickingJobId } = await startPickingJob_LU_CU(masterdata);
+
+    await test.step('Scan LU, enter 25 CUs, decline overdelivery, cancel dialog', async () => {
+        await BarcodeScannerComponent.type(masterdata.handlingUnits.HU1.huId);
+        await GetQuantityDialog.waitForDialog();
+        await GetQuantityDialog.expectQtyEntered(10);
+        await GetQuantityDialog.typeQtyEntered(25);
+        await GetQuantityDialog.clickDone();
+
+        await YesNoDialog.waitForDialog();
+        await YesNoDialog.clickNoButton();
+
+        await GetQuantityDialog.waitForDialog();
+        await GetQuantityDialog.clickCancel();
+    });
+
+    await test.step('Verify nothing was picked', async () => {
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [] },
+                    },
+                },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '1000 PCE' } },
+            },
+        });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('LU/CU: pick exact CU qty - prompt enabled - no prompt', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - LU/CU mode, exact qty, no prompt fires');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata_LU_CU({ showPromptWhenOverPicking: true, orderQtyCUs: 10 });
+    const { pickingJobId } = await startPickingJob_LU_CU(masterdata);
+
+    await test.step('Scan LU, pick exactly 10 CUs — no prompt should appear', async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.huId,
+            expectQtyEntered: 10,
+        });
+        await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '10 Stk', qtyPicked: '10 Stk', qtyPickedCatchWeight: '' });
+
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: {
+                            qtyPicked: [{ qtyPicked: '10 PCE', qtyTUs: 1, qtyLUs: 1, vhu: 'vhu1', tu: 'vhu1', lu: 'lu1', processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '990 PCE' } },
+            },
+        });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('LU/CU: prompt disabled - regression guard', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - LU/CU mode, prompt disabled, pick exact qty');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata_LU_CU({ showPromptWhenOverPicking: false, orderQtyCUs: 10 });
+    const { pickingJobId } = await startPickingJob_LU_CU(masterdata);
+
+    await test.step('Prompt disabled — pick exact qty, verify existing behavior unchanged', async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.huId,
+            expectQtyEntered: 10,
+        });
+        await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '10 Stk', qtyPicked: '10 Stk', qtyPickedCatchWeight: '' });
+
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: {
+                            qtyPicked: [{ qtyPicked: '10 PCE', qtyTUs: 1, qtyLUs: 1, vhu: 'vhu1', tu: 'vhu1', lu: 'lu1', processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+            hus: {
+                HU1: { huStatus: 'A', storages: { P1: '990 PCE' } },
+            },
+        });
+    });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/picking.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/picking.js
@@ -152,9 +152,9 @@ export const getClosedLUs = ({ wfProcessId, lineId }) => {
     .then((response) => unboxAxiosResponse(response));
 };
 
-export const getScannedHUQRCodeInfo = ({ qrCode }) => {
+export const getScannedHUQRCodeInfo = ({ qrCode, productNo }) => {
   return axios
-    .post(`${apiBasePath}/picking/hu/byScannedCode`, { scannedCode: qrCode })
+    .post(`${apiBasePath}/picking/hu/byScannedCode`, { scannedCode: qrCode, productNo })
     .then((response) => unboxAxiosResponse(response));
 };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
@@ -175,7 +175,9 @@ const ScanHUAndGetQtyComponent = ({
     }
 
     // Qty shall be less than or equal to qtyMax
-    if (resolvedBarcodeData.qtyMax && resolvedBarcodeData.qtyMax > 0) {
+    // NOTE: skip qtyMax validation when over-pick confirmation prompt is enabled,
+    // because the prompt handles the over-delivery scenario instead
+    if (!getConfirmationPromptForQty && resolvedBarcodeData.qtyMax && resolvedBarcodeData.qtyMax > 0) {
       const { qtyEffective: diff, uomEffective: diffUom } = formatQtyToHumanReadable({
         qty: qtyEntered - resolvedBarcodeData.qtyMax,
         uom,

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickLineScanScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickLineScanScreen.jsx
@@ -93,10 +93,12 @@ const PickLineScanScreen = () => {
       convertScannedBarcodeToResolvedResult({
         scannedBarcode,
         expectedProductId: productId,
+        expectedProductNo: productNo,
+        isShowPromptWhenOverPicking,
         customQRCodeFormats,
         pickingUnit,
       }),
-    [productId, customQRCodeFormats, pickingUnit]
+    [productId, productNo, isShowPromptWhenOverPicking, customQRCodeFormats, pickingUnit]
   );
 
   const onClose = useOnClose({ applicationId, wfProcessId, activity, lineId, next });
@@ -189,6 +191,8 @@ const getPropsFromState = ({ state, wfProcessId, activityId, lineId }) => {
 export const convertScannedBarcodeToResolvedResult = async ({
   scannedBarcode,
   expectedProductId,
+  expectedProductNo,
+  isShowPromptWhenOverPicking,
   customQRCodeFormats,
   pickingUnit,
 }) => {
@@ -225,7 +229,13 @@ export const convertScannedBarcodeToResolvedResult = async ({
     throw trl('activities.picking.notEligibleHUBarcode');
   }
 
-  return convertQRCodeObjectToResolvedResult({ parsedQRCode, pickingUnit, huInfoFromBackend });
+  return convertQRCodeObjectToResolvedResult({
+    parsedQRCode,
+    pickingUnit,
+    huInfoFromBackend,
+    expectedProductNo,
+    isShowPromptWhenOverPicking,
+  });
 };
 
 //
@@ -234,7 +244,13 @@ export const convertScannedBarcodeToResolvedResult = async ({
 //
 //
 
-const convertQRCodeObjectToResolvedResult = async ({ parsedQRCode, pickingUnit, huInfoFromBackend }) => {
+const convertQRCodeObjectToResolvedResult = async ({
+  parsedQRCode,
+  pickingUnit,
+  huInfoFromBackend,
+  expectedProductNo,
+  isShowPromptWhenOverPicking,
+}) => {
   const result = {
     qrCode: parsedQRCode,
   };
@@ -254,6 +270,8 @@ const convertQRCodeObjectToResolvedResult = async ({ parsedQRCode, pickingUnit, 
   result.scannedHU = {
     huUnitType: parsedQRCode.huUnitType,
   };
+
+  // Existing behavior: fetch HU info for LU in TU-picking (qtyTUs)
   if (parsedQRCode.huUnitType === 'LU' && pickingUnit === PICKING_UNIT_TU) {
     let huInfo = huInfoFromBackend;
     if (huInfo == null) {
@@ -269,7 +287,24 @@ const convertQRCodeObjectToResolvedResult = async ({ parsedQRCode, pickingUnit, 
     }
   }
 
-  console.log('convertQRCodeObjectToResolvedResult', { result, qrCodeObj: parsedQRCode, pickingUnit });
+  // For whole-TU picks with overdelivery prompt enabled,
+  // fetch actual product qty from backend so the prompt can detect overdelivery.
+  // The backend picks the full HU storage qty when isPickWholeTU=true,
+  // so we need the actual qty to compare against remaining.
+  if (parsedQRCode.isTUToBePickedAsWhole === true && isShowPromptWhenOverPicking) {
+    try {
+      const huInfo =
+        huInfoFromBackend ??
+        (await getScannedHUQRCodeInfo({ qrCode: toQRCodeString(parsedQRCode), productNo: expectedProductNo }));
+      if (huInfo?.productQty != null) {
+        result.qtyInitial = parseFloat(huInfo.productQty);
+      }
+    } catch (error) {
+      console.warn('Failed to get HU product qty for overdelivery check. Ignored', error);
+    }
+  }
+
+  // console.log('convertQRCodeObjectToResolvedResult', { result, qrCodeObj: parsedQRCode, pickingUnit });
   return result;
 };
 


### PR DESCRIPTION
## Summary

Ports https://github.com/metasfresh/metasfresh/pull/23307 (commit `1f4a4f0f1ae`) from `intensive_care_hotfix` to `soft_panda_release`. No conflicts on cherry-pick.

## Why
Addresses bug #1 of the sp80 customer report (me03#29258 — *"Überlieferung nicht über mobileUI möglich trotzdem entsprechender konfig im mobileui Picking Profile"*). The upstream PR's investigation matches ours exactly:

> The overdelivery confirmation prompt (`IsShowConfirmationPromptWhenOverPick`) was broken since its introduction — the hard `qtyMax` validation in `ScanHUAndGetQtyComponent` blocked quantities above remaining, preventing the prompt from ever being reached.

## What the port brings in (identical to upstream)
- **Fix 1**: `ScanHUAndGetQtyComponent.jsx` — skip the hard `qtyMax` validation when the over-pick confirmation prompt handler is provided. The prompt itself then gates overdelivery.
- **Fix 2**: `PickLineScanScreen.jsx` + `PickingRestController.java` — for whole-TU picks (`isTUToBePickedAsWhole`), fetch the actual HU product qty from the backend via an extended `/hu/byScannedCode` endpoint, gated on `isShowPromptWhenOverPicking`.
- Extends the test masterdata API (`JsonMobileConfigRequest.java`, `MobileConfigPickingCommand.java`) with a `showPromptWhenOverPicking` toggle.
- New Playwright regression test `e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js` (460 lines, 8 tests).

## Effect on the customer
With this port on `soft_panda_release`, checking `IsShowConfirmationPromptWhenOverPick=Y` on the mobileUI picking profile becomes the actual "allow over-pick" switch. The picker sees a confirmation prompt instead of the hard `"1 TU über max"` block.

## Test plan
- [x] Local compile of `backend/de.metas.picking.rest-api` — green.
- [x] CI on this PR (full cucumber, frontend-webui, mobile test suites including the new `overPickingPrompt.spec.js`).
- [ ] Manual on a local mobileUI picking profile: tick `IsShowConfirmationPromptWhenOverPick=Y`, pick 1 TU over ordered → confirmation dialog, not hard block.