### PR TITLE
Rename IsShowConfirmationPromptWhenOverPick labels (me03#29258)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799100_sys_gh29258_IsShowConfirmationPromptWhenOverPick_labels.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799100_sys_gh29258_IsShowConfirmationPromptWhenOverPick_labels.sql
@@ -19,7 +19,7 @@
 UPDATE AD_Element
    SET Name         = 'Überkomm. mit Rückfrage erl.',
        PrintName    = 'Überkomm. mit Rückfrage erl.',
-       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überkomm. über eine Rückfrage bestätigen. Wenn deaktiviert, wird die Überkomm. im Frontend hart geblockt («N über max»).',
+       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überkommissionierung über eine Rückfrage bestätigen. Wenn deaktiviert, wird die Überkommissionierung  blockiert («N über max»).',
        Updated      = now(),
        UpdatedBy    = 100
  WHERE AD_Element_ID = 583289;
@@ -28,7 +28,7 @@ UPDATE AD_Element
 UPDATE AD_Element_Trl
    SET Name         = 'Überkomm. mit Rückfrage erl.',
        PrintName    = 'Überkomm. mit Rückfrage erl.',
-       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überkomm. über eine Rückfrage bestätigen. Wenn deaktiviert, wird die Überkomm. im Frontend hart geblockt («N über max»).',
+       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überkommissionierung über eine Rückfrage bestätigen. Wenn deaktiviert, wird die Überkommissionierung  blockiert («N über max»).',
        IsTranslated = 'N',
        Updated      = now(),
        UpdatedBy    = 100
@@ -50,7 +50,7 @@ UPDATE AD_Element_Trl
 UPDATE AD_Element_Trl
    SET Name         = 'Überkomm. mit Rückfrage erl.',
        PrintName    = 'Überkomm. mit Rückfrage erl.',
-       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überkomm. über eine Rückfrage bestätigen. Wenn deaktiviert, wird die Überkomm. im Frontend hart geblockt («N über max»).',
+       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überkommissionierung über eine Rückfrage bestätigen. Wenn deaktiviert, wird die Überkommissionierung  blockiert («N über max»).',
        IsTranslated = 'N',
        Updated      = now(),
        UpdatedBy    = 100
@@ -61,7 +61,7 @@ UPDATE AD_Element_Trl
 -- AD_Column: MobileUI_UserProfile_Picking_Job.IsShowConfirmationPromptWhenOverPick (id 589660)
 UPDATE AD_Column
    SET Name        = 'Überkomm. mit Rückfrage erl.',
-       Description = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überkomm. über eine Rückfrage bestätigen. Wenn deaktiviert, wird die Überkomm. im Frontend hart geblockt («N über max»).',
+       Description = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überkommissionierung über eine Rückfrage bestätigen. Wenn deaktiviert, wird die Überkommissionierung  blockiert («N über max»).',
        Updated     = now(),
        UpdatedBy   = 100
  WHERE AD_Column_ID IN (589168, 589660);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799100_sys_gh29258_IsShowConfirmationPromptWhenOverPick_labels.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799100_sys_gh29258_IsShowConfirmationPromptWhenOverPick_labels.sql
@@ -1,0 +1,67 @@
+-- me03#29258: AD_Element 583289 / IsShowConfirmationPromptWhenOverPick
+-- shipped with the label "Rückfragen bei Überkommissionierung" (DE) and
+-- "Ask User when Over Picking" (EN) and no description. Both labels imply
+-- the flag only controls whether a confirmation prompt is shown, but it
+-- actually gates whether over-picking is allowed at all:
+--
+--   Flag ON  -> over-picking is allowed; the picker must confirm via prompt
+--   Flag OFF -> over-picking is hard-blocked in the frontend ("N über max")
+--
+-- Wiring: PickLineScanScreen.jsx line 143 and PickStepScanScreen.jsx line 74
+--   getConfirmationPromptForQty={isShowPromptWhenOverPicking ? getConfirmationPromptForQty : undefined}
+-- ScanHUAndGetQtyComponent.jsx line 177 skips the hard qtyMax check iff the
+-- prompt handler is provided.
+--
+-- This migration renames labels only; neither the column name nor code
+-- changes, so existing profile values are preserved.
+
+-- AD_Element (base / de_DE)
+UPDATE AD_Element
+   SET Name         = 'Überpicken mit Rückfrage erl.',
+       PrintName    = 'Überpicken mit Rückfrage erl.',
+       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überentnahme über eine Rückfrage bestätigen. Wenn deaktiviert, wird eine Überentnahme im Frontend hart geblockt («N über max»).',
+       Updated      = now(),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 583289;
+
+-- AD_Element_Trl: de_DE, de_CH — same German text
+UPDATE AD_Element_Trl
+   SET Name         = 'Überpicken mit Rückfrage erl.',
+       PrintName    = 'Überpicken mit Rückfrage erl.',
+       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überentnahme über eine Rückfrage bestätigen. Wenn deaktiviert, wird eine Überentnahme im Frontend hart geblockt («N über max»).',
+       IsTranslated = 'N',
+       Updated      = now(),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 583289
+   AND AD_Language IN ('de_DE', 'de_CH');
+
+-- AD_Element_Trl: en_US
+UPDATE AD_Element_Trl
+   SET Name         = 'Allow over-pick with prompt',
+       PrintName    = 'Allow over-pick with prompt',
+       Description  = 'When enabled, the picker can record more than the ordered qty; the over-delivery must be confirmed via a prompt. When disabled, over-picking is hard-blocked in the frontend ("N above max").',
+       IsTranslated = 'Y',
+       Updated      = now(),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 583289
+   AND AD_Language = 'en_US';
+
+-- AD_Element_Trl: fr_CH — keep placeholder consistent with the German base
+UPDATE AD_Element_Trl
+   SET Name         = 'Überpicken mit Rückfrage erl.',
+       PrintName    = 'Überpicken mit Rückfrage erl.',
+       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überentnahme über eine Rückfrage bestätigen. Wenn deaktiviert, wird eine Überentnahme im Frontend hart geblockt («N über max»).',
+       IsTranslated = 'N',
+       Updated      = now(),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 583289
+   AND AD_Language = 'fr_CH';
+
+-- AD_Column: MobileUI_UserProfile_Picking.IsShowConfirmationPromptWhenOverPick (id 589168)
+-- AD_Column: MobileUI_UserProfile_Picking_Job.IsShowConfirmationPromptWhenOverPick (id 589660)
+UPDATE AD_Column
+   SET Name        = 'Überpicken mit Rückfrage erl.',
+       Description = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überentnahme über eine Rückfrage bestätigen. Wenn deaktiviert, wird eine Überentnahme im Frontend hart geblockt («N über max»).',
+       Updated     = now(),
+       UpdatedBy   = 100
+ WHERE AD_Column_ID IN (589168, 589660);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799100_sys_gh29258_IsShowConfirmationPromptWhenOverPick_labels.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799100_sys_gh29258_IsShowConfirmationPromptWhenOverPick_labels.sql
@@ -17,18 +17,18 @@
 
 -- AD_Element (base / de_DE)
 UPDATE AD_Element
-   SET Name         = 'Überpicken mit Rückfrage erl.',
-       PrintName    = 'Überpicken mit Rückfrage erl.',
-       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überentnahme über eine Rückfrage bestätigen. Wenn deaktiviert, wird eine Überentnahme im Frontend hart geblockt («N über max»).',
+   SET Name         = 'Überkomm. mit Rückfrage erl.',
+       PrintName    = 'Überkomm. mit Rückfrage erl.',
+       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überkomm. über eine Rückfrage bestätigen. Wenn deaktiviert, wird die Überkomm. im Frontend hart geblockt («N über max»).',
        Updated      = now(),
        UpdatedBy    = 100
  WHERE AD_Element_ID = 583289;
 
 -- AD_Element_Trl: de_DE, de_CH — same German text
 UPDATE AD_Element_Trl
-   SET Name         = 'Überpicken mit Rückfrage erl.',
-       PrintName    = 'Überpicken mit Rückfrage erl.',
-       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überentnahme über eine Rückfrage bestätigen. Wenn deaktiviert, wird eine Überentnahme im Frontend hart geblockt («N über max»).',
+   SET Name         = 'Überkomm. mit Rückfrage erl.',
+       PrintName    = 'Überkomm. mit Rückfrage erl.',
+       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überkomm. über eine Rückfrage bestätigen. Wenn deaktiviert, wird die Überkomm. im Frontend hart geblockt («N über max»).',
        IsTranslated = 'N',
        Updated      = now(),
        UpdatedBy    = 100
@@ -48,9 +48,9 @@ UPDATE AD_Element_Trl
 
 -- AD_Element_Trl: fr_CH — keep placeholder consistent with the German base
 UPDATE AD_Element_Trl
-   SET Name         = 'Überpicken mit Rückfrage erl.',
-       PrintName    = 'Überpicken mit Rückfrage erl.',
-       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überentnahme über eine Rückfrage bestätigen. Wenn deaktiviert, wird eine Überentnahme im Frontend hart geblockt («N über max»).',
+   SET Name         = 'Überkomm. mit Rückfrage erl.',
+       PrintName    = 'Überkomm. mit Rückfrage erl.',
+       Description  = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überkomm. über eine Rückfrage bestätigen. Wenn deaktiviert, wird die Überkomm. im Frontend hart geblockt («N über max»).',
        IsTranslated = 'N',
        Updated      = now(),
        UpdatedBy    = 100
@@ -60,8 +60,8 @@ UPDATE AD_Element_Trl
 -- AD_Column: MobileUI_UserProfile_Picking.IsShowConfirmationPromptWhenOverPick (id 589168)
 -- AD_Column: MobileUI_UserProfile_Picking_Job.IsShowConfirmationPromptWhenOverPick (id 589660)
 UPDATE AD_Column
-   SET Name        = 'Überpicken mit Rückfrage erl.',
-       Description = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überentnahme über eine Rückfrage bestätigen. Wenn deaktiviert, wird eine Überentnahme im Frontend hart geblockt («N über max»).',
+   SET Name        = 'Überkomm. mit Rückfrage erl.',
+       Description = 'Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überkomm. über eine Rückfrage bestätigen. Wenn deaktiviert, wird die Überkomm. im Frontend hart geblockt («N über max»).',
        Updated     = now(),
        UpdatedBy   = 100
  WHERE AD_Column_ID IN (589168, 589660);


### PR DESCRIPTION
## Summary

Third in the me03#29258 naming overhaul series (after https://github.com/metasfresh/metasfresh/pull/23558). `AD_Element 583289 / IsShowConfirmationPromptWhenOverPick` shipped with labels that undersell its effect: the existing *"Rückfragen bei Überkommissionierung"* / *"Ask User when Over Picking"* suggest the flag only toggles a prompt, when in fact it gates whether over-picking is allowed at all.

## What the flag really does

| State | Behavior |
|---|---|
| **ON** | Over-picking is allowed. The frontend skips the hard `qtyMax` check and shows a confirmation prompt (`overPickConfirmationPrompt`). Picker confirms → over-pick is accepted. |
| **OFF** | Over-picking is hard-blocked. The frontend shows `"N über max"` / `"N above max"` and refuses the input. |

Wiring (verified):
- `PickLineScanScreen.jsx:143` / `PickStepScanScreen.jsx:74`: `getConfirmationPromptForQty={isShowPromptWhenOverPicking ? getConfirmationPromptForQty : undefined}`
- `ScanHUAndGetQtyComponent.jsx:177`: skips the hard `qtyMax` check iff the prompt handler is provided.

## Changes — migration `5799100_sys_gh29258_IsShowConfirmationPromptWhenOverPick_labels.sql`

Labels only — column name and code are unchanged, so existing profile values are preserved.

| | Before | After |
|---|---|---|
| DE name/printname | `Rückfragen bei Überkommissionierung` | `Überkomm. mit Rückfrage erl.` |
| DE description | *(empty)* | `Wenn aktiviert, darf der Kommissionierer mehr als die Auftragsmenge erfassen und muss die Überkommissionierung über eine Rückfrage bestätigen. Wenn deaktiviert, wird die Überkommissionierung  blockiert («N über max»).` |
| EN name/printname | `Ask User when Over Picking` | `Allow over-pick with prompt` |
| EN description | *(empty)* | `When enabled, the picker can record more than the ordered qty; the over-delivery must be confirmed via a prompt. When disabled, over-picking is hard-blocked in the frontend ("N above max").` |

Updates: `AD_Element` + 2 `AD_Column` rows (`MobileUI_UserProfile_Picking`, `MobileUI_UserProfile_Picking_Job`) + all `AD_Element_Trl` rows (de_DE, de_CH, en_US, fr_CH).

## Test plan
- [ ] CI db-apply-migrations applies `5799100` cleanly
- [ ] Manual sanity: open the MobileUI Picking Profile window and confirm the renamed checkbox + description
