### PR TITLE
v2 OLCand lookup: skip HUPI/BPartner_Product rows pointing to inactive M_Product

### DIFF
--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/product/ExternalIdentifierProductLookupService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/product/ExternalIdentifierProductLookupService.java
@@ -38,6 +38,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.dao.ICompositeQueryFilter;
 import org.adempiere.ad.dao.IQueryBL;
+import org.compiere.model.IQuery;
 import org.compiere.model.I_C_BPartner_Product;
 import org.compiere.model.I_M_Product;
 import org.springframework.stereotype.Service;
@@ -92,6 +93,14 @@ public class ExternalIdentifierProductLookupService
 			@NonNull final ExternalIdentifier productIdentifier)
 	{
 		final String gtin = productIdentifier.asGTIN();
+
+		// Only consider HUPI / BPartner_Product rows that point to an active M_Product.
+		// The consolidation process (F5001.1) can leave an M_Product inactive while keeping
+		// its HUPI/BPartner_Product rows active — those rows must NOT be matched by incoming OLCands.
+		final IQuery<I_M_Product> activeProducts = queryBL.createQueryBuilder(I_M_Product.class)
+				.addOnlyActiveRecordsFilter()
+				.create();
+
 		final ICompositeQueryFilter<I_M_HU_PI_Item_Product> hupiFilter = queryBL.createCompositeQueryFilter(I_M_HU_PI_Item_Product.class)
 				.setJoinOr()
 				.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_GTIN, gtin)
@@ -101,7 +110,7 @@ public class ExternalIdentifierProductLookupService
 		final I_M_HU_PI_Item_Product hupi = queryBL.createQueryBuilder(I_M_HU_PI_Item_Product.class)
 				.addOnlyActiveRecordsFilter()
 				.filter(hupiFilter)
-				.addNotNull(I_M_HU_PI_Item_Product.COLUMNNAME_M_Product_ID)
+				.addInSubQueryFilter(I_M_HU_PI_Item_Product.COLUMNNAME_M_Product_ID, I_M_Product.COLUMNNAME_M_Product_ID, activeProducts)
 				.orderBy(I_M_HU_PI_Item_Product.COLUMNNAME_M_HU_PI_Item_Product_ID)
 				.create().first();
 		if (hupi != null)
@@ -121,7 +130,7 @@ public class ExternalIdentifierProductLookupService
 		final I_C_BPartner_Product bpp = queryBL.createQueryBuilder(I_C_BPartner_Product.class)
 				.addOnlyActiveRecordsFilter()
 				.filter(bppFilter)
-				.addNotNull(I_C_BPartner_Product.COLUMNNAME_M_Product_ID)
+				.addInSubQueryFilter(I_C_BPartner_Product.COLUMNNAME_M_Product_ID, I_M_Product.COLUMNNAME_M_Product_ID, activeProducts)
 				.orderBy(I_C_BPartner_Product.COLUMNNAME_C_BPartner_Product_ID)
 				.create().first();
 		if (bpp != null)

--- a/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v2/product/ExternalIdentifierProductLookupServiceTest.java
+++ b/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v2/product/ExternalIdentifierProductLookupServiceTest.java
@@ -294,6 +294,85 @@ public class ExternalIdentifierProductLookupServiceTest
 	}
 
 	@Test
+	void lookupProductByGTIN_skips_HU_PI_Item_Product_when_referenced_M_Product_is_inactive()
+	{
+		// given: an active HUPI pointing to a deactivated M_Product
+		final I_M_Product inactiveProduct = InterfaceWrapperHelper.newInstance(I_M_Product.class);
+		inactiveProduct.setValue("inactive-product");
+		inactiveProduct.setIsActive(false);
+		InterfaceWrapperHelper.save(inactiveProduct);
+
+		final I_M_HU_PI_Item_Product hupiItemProduct = InterfaceWrapperHelper.newInstance(I_M_HU_PI_Item_Product.class);
+		hupiItemProduct.setM_Product_ID(inactiveProduct.getM_Product_ID());
+		hupiItemProduct.setGTIN("12345678");
+		hupiItemProduct.setIsActive(true);
+		InterfaceWrapperHelper.save(hupiItemProduct);
+
+		// when
+		final ExternalIdentifier identifier = ExternalIdentifier.of("gtin-12345678");
+		final Optional<ProductAndHUPIItemProductId> result = productLookupService.lookupProductByGTIN(identifier);
+
+		// then: HUPI is NOT matched because its M_Product is inactive — no other candidate either
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void lookupProductByGTIN_falls_through_when_HU_PI_Item_Product_refs_inactive_product_but_another_active_product_has_GTIN()
+	{
+		// given: one HUPI points to an inactive M_Product (= the stale PI row the consolidation
+		// process forgot to deactivate), and a *different*, active M_Product carries the GTIN.
+		final I_M_Product inactiveProduct = InterfaceWrapperHelper.newInstance(I_M_Product.class);
+		inactiveProduct.setValue("inactive-product");
+		inactiveProduct.setIsActive(false);
+		InterfaceWrapperHelper.save(inactiveProduct);
+
+		final I_M_HU_PI_Item_Product hupiItemProduct = InterfaceWrapperHelper.newInstance(I_M_HU_PI_Item_Product.class);
+		hupiItemProduct.setM_Product_ID(inactiveProduct.getM_Product_ID());
+		hupiItemProduct.setGTIN("12345678");
+		hupiItemProduct.setIsActive(true);
+		InterfaceWrapperHelper.save(hupiItemProduct);
+
+		final I_M_Product activeProduct = InterfaceWrapperHelper.newInstance(I_M_Product.class);
+		activeProduct.setValue("active-product");
+		activeProduct.setGTIN("12345678");
+		activeProduct.setIsActive(true);
+		InterfaceWrapperHelper.save(activeProduct);
+
+		// when
+		final ExternalIdentifier identifier = ExternalIdentifier.of("gtin-12345678");
+		final Optional<ProductAndHUPIItemProductId> result = productLookupService.lookupProductByGTIN(identifier);
+
+		// then: the stale HUPI is skipped, BPartner_Product step finds nothing,
+		// and the direct M_Product lookup returns the active product (without a specific HUPI).
+		assertThat(result).isPresent();
+		assertThat(result.get().getProductId()).isEqualTo(ProductId.ofRepoId(activeProduct.getM_Product_ID()));
+		assertThat(result.get().getHupiItemProductId()).isEqualTo(HUPIItemProductId.VIRTUAL_HU);
+	}
+
+	@Test
+	void lookupProductByGTIN_skips_C_BPartner_Product_when_referenced_M_Product_is_inactive()
+	{
+		// given: an active BPartner_Product pointing to a deactivated M_Product
+		final I_M_Product inactiveProduct = InterfaceWrapperHelper.newInstance(I_M_Product.class);
+		inactiveProduct.setValue("inactive-product");
+		inactiveProduct.setIsActive(false);
+		InterfaceWrapperHelper.save(inactiveProduct);
+
+		final I_C_BPartner_Product bpartnerProduct = InterfaceWrapperHelper.newInstance(I_C_BPartner_Product.class);
+		bpartnerProduct.setM_Product_ID(inactiveProduct.getM_Product_ID());
+		bpartnerProduct.setGTIN("11223344");
+		bpartnerProduct.setIsActive(true);
+		InterfaceWrapperHelper.save(bpartnerProduct);
+
+		// when
+		final ExternalIdentifier identifier = ExternalIdentifier.of("gtin-11223344");
+		final Optional<ProductAndHUPIItemProductId> result = productLookupService.lookupProductByGTIN(identifier);
+
+		// then: BPartner_Product is NOT matched because its M_Product is inactive
+		assertThat(result).isEmpty();
+	}
+
+	@Test
 	void lookupProductByGTIN_prioritizes_HU_PI_Item_Product_over_M_Product()
 	{
 		// given


### PR DESCRIPTION
## Summary

`ExternalIdentifierProductLookupService.lookupProductByGTIN()` (v2 REST API path used by incoming JSON `C_OLCand`s) filters `M_HU_PI_Item_Product` and `C_BPartner_Product` rows by their own `IsActive='Y'` but does not check the referenced `M_Product`'s `IsActive` flag.

After the consolidation process (F5001.1), an `M_Product` can be deactivated while its HUPI / BPartner_Product rows remain active — incoming OLCand JSON would then be matched to a deactivated product.

Fix: add an `addInSubQueryFilter` on active `M_Product`s to the HUPI and `C_BPartner_Product` lookups. The direct `M_Product` fallback was already correct.

Label `ops:without_review_approval` + `ops:auto_squash_merge` + `branch:soft_panda_release` apply here.

## Test plan

- [x] 3 new unit tests in `ExternalIdentifierProductLookupServiceTest`:
  - `lookupProductByGTIN_skips_HU_PI_Item_Product_when_referenced_M_Product_is_inactive` — active HUPI + inactive product → empty
  - `lookupProductByGTIN_falls_through_when_HU_PI_Item_Product_refs_inactive_product_but_another_active_product_has_GTIN` — active HUPI with stale FK + separate active product carrying same GTIN → direct M_Product match
  - `lookupProductByGTIN_skips_C_BPartner_Product_when_referenced_M_Product_is_inactive` — active BPP + inactive product → empty
- [ ] CI green

## Related

- Follow-up to #22890 (F5001.1 consolidation) and #23533 / #23552 (test enablement + Excel header localization).
- Customer repo needs a one-time data cleanup (committed separately into sp80 as `5799120_cli_gh28837_deactivate_stale_hupi.sql`) to deactivate any HUPI rows whose `M_Product` was already deactivated before this lookup fix.