### PR TITLE
mobileui picking: surface failed complete confirmations with retry panel

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/confirmation.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/confirmation.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { apiBasePath } from '../constants';
 import { unboxAxiosResponse } from '../utils';
 
-const DEFAULT_TIMEOUT_MILLIS = 20000;
+export const DEFAULT_TIMEOUT_MILLIS = 20000;
 
 /**
  * @method userConfirmation

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/confirmation.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/confirmation.js
@@ -10,7 +10,7 @@ const DEFAULT_TIMEOUT_MILLIS = 20000;
  *
  * The Zebra scanner on flaky wifi regularly drops the TCP connection mid-roam; without an explicit timeout,
  * axios hangs forever and the operator is left with no signal that their "Fertigstellen" press didn't reach
- * the backend (me03#29027). The timeout ensures the promise eventually rejects so the UI can surface the
+ * the backend. The timeout ensures the promise eventually rejects so the UI can surface the
  * failure and let the operator retry.
  */
 export function postUserConfirmation({ wfProcessId, activityId, timeoutMillis }) {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/confirmation.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/confirmation.js
@@ -2,14 +2,20 @@ import axios from 'axios';
 import { apiBasePath } from '../constants';
 import { unboxAxiosResponse } from '../utils';
 
+const DEFAULT_TIMEOUT_MILLIS = 20000;
+
 /**
  * @method userConfirmation
  * @summary Post confirmation to the server after a dialog is shown (see ConfirmationButton/ConfirmActivity component)
- * @param {object} `token` - The token to use for authentication
- * @returns
+ *
+ * The Zebra scanner on flaky wifi regularly drops the TCP connection mid-roam; without an explicit timeout,
+ * axios hangs forever and the operator is left with no signal that their "Fertigstellen" press didn't reach
+ * the backend (me03#29027). The timeout ensures the promise eventually rejects so the UI can surface the
+ * failure and let the operator retry.
  */
-export function postUserConfirmation({ wfProcessId, activityId }) {
+export function postUserConfirmation({ wfProcessId, activityId, timeoutMillis }) {
+  const timeout = Number.isFinite(timeoutMillis) && timeoutMillis > 0 ? timeoutMillis : DEFAULT_TIMEOUT_MILLIS;
   return axios
-    .post(`${apiBasePath}/userWorkflows/wfProcess/${wfProcessId}/${activityId}/userConfirmation`)
+    .post(`${apiBasePath}/userWorkflows/wfProcess/${wfProcessId}/${activityId}/userConfirmation`, null, { timeout })
     .then((response) => unboxAxiosResponse(response));
 }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx
@@ -84,13 +84,13 @@ const ConfirmActivity = ({
           <div className="buttons">
             <ButtonWithIndicator
               testId="confirm-activity-error-retry"
-              caption={trl('activities.confirmButton.error.retry')}
+              captionKey="activities.confirmButton.error.retry"
               disabled={isProcessing}
               onClick={sendConfirmation}
             />
             <ButtonWithIndicator
               testId="confirm-activity-error-cancel"
-              caption={trl('activities.confirmButton.error.cancel')}
+              captionKey="activities.confirmButton.error.cancel"
               disabled={isProcessing}
               onClick={onCancelError}
             />

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { postUserConfirmation } from '../../../api/confirmation';
 import ConfirmButton from '../../../components/buttons/ConfirmButton';
 import ButtonWithIndicator from '../../../components/buttons/ButtonWithIndicator';
-import { extractUserFriendlyErrorMessageFromAxiosError } from '../../../utils/toast';
+import { extractUserFriendlyErrorMessageFromAxiosError, toastError } from '../../../utils/toast';
 import { useDispatch } from 'react-redux';
 import { appLaunchersLocation } from '../../../routes/launchers';
 import { setActivityProcessing, updateWFProcess } from '../../../actions/WorkflowActions';
@@ -45,6 +45,10 @@ const ConfirmActivity = ({
         }
       })
       .catch((axiosError) => {
+        // A server response means the backend rejected the operation (e.g. "all steps must be completed");
+        // retrying the same payload won't help, and there is automation that asserts on the toast.
+        // Only surface the inline retry panel for network-layer failures (timeout / no response at all).
+        const isNetworkFailure = !axiosError?.response;
         const message = extractUserFriendlyErrorMessageFromAxiosError({ axiosError });
         uiTrace.trace({
           eventName: 'confirmationFailed',
@@ -52,9 +56,14 @@ const ConfirmActivity = ({
           activityId,
           httpStatus: axiosError?.response?.status ?? null,
           axiosCode: axiosError?.code ?? null,
+          isNetworkFailure,
           message,
         });
-        setErrorMessage(message);
+        if (isNetworkFailure) {
+          setErrorMessage(message);
+        } else {
+          toastError({ axiosError });
+        }
       })
       .finally(() => dispatch(setActivityProcessing({ wfProcessId, activityId, processing: false })));
   };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import { postUserConfirmation } from '../../../api/confirmation';
+import { DEFAULT_TIMEOUT_MILLIS, postUserConfirmation } from '../../../api/confirmation';
 import ConfirmButton from '../../../components/buttons/ConfirmButton';
 import ButtonWithIndicator from '../../../components/buttons/ButtonWithIndicator';
 import { extractUserFriendlyErrorMessageFromAxiosError, toastError } from '../../../utils/toast';
@@ -11,8 +11,6 @@ import { useMobileNavigation } from '../../../hooks/useMobileNavigation';
 import { usePositiveNumberSetting } from '../../../reducers/settings';
 import { trl } from '../../../utils/translations';
 import * as uiTrace from '../../../utils/ui_trace';
-
-const DEFAULT_TIMEOUT_MILLIS = 20000;
 
 const ConfirmActivity = ({
   applicationId,
@@ -29,17 +27,22 @@ const ConfirmActivity = ({
   const dispatch = useDispatch();
   const history = useMobileNavigation();
   const [errorMessage, setErrorMessage] = useState(null);
+  // Synchronous guard: isProcessing only re-flows via Redux on the next render,
+  // so a fast double-tap on Retry would otherwise send two requests.
+  const sendingRef = useRef(false);
 
   // Overridable via AD_SysConfig mobileui.frontend.api.completeConfirmation.timeoutMillis
   const timeoutMillis = usePositiveNumberSetting('api.completeConfirmation.timeoutMillis', DEFAULT_TIMEOUT_MILLIS);
 
   const sendConfirmation = () => {
+    if (sendingRef.current) return;
+    sendingRef.current = true;
     setErrorMessage(null);
     dispatch(setActivityProcessing({ wfProcessId, activityId, processing: true }));
     postUserConfirmation({ wfProcessId, activityId, timeoutMillis })
       .then((wfProcess) => {
-        uiTrace.trace({ eventName: 'confirmationPosted', wfProcessId, activityId });
         dispatch(updateWFProcess({ wfProcess }));
+        uiTrace.trace({ eventName: 'confirmationPosted', wfProcessId, activityId });
         if (isLastActivity) {
           history.push(appLaunchersLocation({ applicationId }));
         }
@@ -65,7 +68,10 @@ const ConfirmActivity = ({
           toastError({ axiosError });
         }
       })
-      .finally(() => dispatch(setActivityProcessing({ wfProcessId, activityId, processing: false })));
+      .finally(() => {
+        sendingRef.current = false;
+        dispatch(setActivityProcessing({ wfProcessId, activityId, processing: false }));
+      });
   };
 
   const onCancelError = () => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx
@@ -1,12 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { postUserConfirmation } from '../../../api/confirmation';
 import ConfirmButton from '../../../components/buttons/ConfirmButton';
-import { toastError } from '../../../utils/toast';
+import ButtonWithIndicator from '../../../components/buttons/ButtonWithIndicator';
+import { extractUserFriendlyErrorMessageFromAxiosError } from '../../../utils/toast';
 import { useDispatch } from 'react-redux';
 import { appLaunchersLocation } from '../../../routes/launchers';
 import { setActivityProcessing, updateWFProcess } from '../../../actions/WorkflowActions';
 import { useMobileNavigation } from '../../../hooks/useMobileNavigation';
+import { usePositiveNumberSetting } from '../../../reducers/settings';
+import { trl } from '../../../utils/translations';
+import * as uiTrace from '../../../utils/ui_trace';
+
+const DEFAULT_TIMEOUT_MILLIS = 20000;
 
 const ConfirmActivity = ({
   applicationId,
@@ -22,19 +28,39 @@ const ConfirmActivity = ({
 }) => {
   const dispatch = useDispatch();
   const history = useMobileNavigation();
-  const onUserConfirmed = () => {
+  const [errorMessage, setErrorMessage] = useState(null);
+
+  // Overridable via AD_SysConfig mobileui.frontend.api.completeConfirmation.timeoutMillis
+  const timeoutMillis = usePositiveNumberSetting('api.completeConfirmation.timeoutMillis', DEFAULT_TIMEOUT_MILLIS);
+
+  const sendConfirmation = () => {
+    setErrorMessage(null);
     dispatch(setActivityProcessing({ wfProcessId, activityId, processing: true }));
-    postUserConfirmation({ wfProcessId, activityId })
+    postUserConfirmation({ wfProcessId, activityId, timeoutMillis })
       .then((wfProcess) => {
+        uiTrace.trace({ eventName: 'confirmationPosted', wfProcessId, activityId });
         dispatch(updateWFProcess({ wfProcess }));
-      })
-      .then(() => {
         if (isLastActivity) {
           history.push(appLaunchersLocation({ applicationId }));
         }
       })
-      .catch((axiosError) => toastError({ axiosError }))
+      .catch((axiosError) => {
+        const message = extractUserFriendlyErrorMessageFromAxiosError({ axiosError });
+        uiTrace.trace({
+          eventName: 'confirmationFailed',
+          wfProcessId,
+          activityId,
+          httpStatus: axiosError?.response?.status ?? null,
+          axiosCode: axiosError?.code ?? null,
+          message,
+        });
+        setErrorMessage(message);
+      })
       .finally(() => dispatch(setActivityProcessing({ wfProcessId, activityId, processing: false })));
+  };
+
+  const onCancelError = () => {
+    setErrorMessage(null);
   };
 
   return (
@@ -44,11 +70,33 @@ const ConfirmActivity = ({
         caption={caption}
         promptQuestion={promptQuestion}
         userInstructions={userInstructions}
-        isUserEditable={isUserEditable}
+        isUserEditable={isUserEditable && !errorMessage}
         isProcessing={isProcessing}
         completeStatus={completeStatus}
-        onUserConfirmed={onUserConfirmed}
+        onUserConfirmed={sendConfirmation}
       />
+      {errorMessage && (
+        <div className="notification is-danger mt-3" data-testid="confirm-activity-error-panel">
+          <p className="mb-3">
+            <strong>{trl('activities.confirmButton.error.title')}</strong>
+          </p>
+          <p className="mb-3">{errorMessage}</p>
+          <div className="buttons">
+            <ButtonWithIndicator
+              testId="confirm-activity-error-retry"
+              caption={trl('activities.confirmButton.error.retry')}
+              disabled={isProcessing}
+              onClick={sendConfirmation}
+            />
+            <ButtonWithIndicator
+              testId="confirm-activity-error-cancel"
+              caption={trl('activities.confirmButton.error.cancel')}
+              disabled={isProcessing}
+              onClick={onCancelError}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
@@ -37,6 +37,11 @@ export const useKeyboardBarcodeReader = ({
       if (event.ctrlKey || event.metaKey) {
         return;
       }
+      // Composition / IME events, some browser extensions and Chrome autofill dispatch
+      // keydown-like events with event.key === undefined. Bail out before any .length access.
+      if (event.key == null) {
+        return;
+      }
       // Allow altKey for printable characters (Zebra MC3300x firmware sets altKey=true on scanner keystrokes)
       if (event.altKey && event.key.length !== 1) {
         return;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -155,6 +155,11 @@ const translations = {
       },
       abort: 'Rückgängig',
       notFound: 'Nicht gefunden',
+      error: {
+        title: 'Bestätigung konnte nicht gesendet werden',
+        retry: 'Erneut senden',
+        cancel: 'Abbrechen',
+      },
     },
     mfg: {
       ProductName: 'Produkt',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -152,6 +152,11 @@ const translations = {
       },
       abort: 'Abort',
       notFound: 'Not found',
+      error: {
+        title: 'Could not send confirmation',
+        retry: 'Retry',
+        cancel: 'Cancel',
+      },
     },
     mfg: {
       ProductName: 'Product Name',


### PR DESCRIPTION
## Summary

Warehouse operators using mobile picking on flaky wifi could silently lose
the `POST /userWorkflows/wfProcess/{id}/{activityId}/userConfirmation` call
that completes a picking job: `axios.post` had no timeout, the request
stalled forever, and the eventual failure was only surfaced as a toast
that the operator usually missed. Server-side the job stayed resumable,
leaving the sales order in an indeterminate state until the office
intervened.

## Changes

- **Timeout on `postUserConfirmation`** — 20 s default, overridable via
  `mobileui.frontend.api.completeConfirmation.timeoutMillis` sysconfig.
- **Persistent retry panel in `ConfirmActivity` for network failures** —
  when the request times out or the scanner can't reach the backend at
  all, the operator now sees a red inline error panel with a client-side
  message plus an explicit **Retry** / **Cancel** pair (instead of a
  disappearing toast). Retry reuses the same `wfProcessId` / `activityId`,
  no re-scan needed. Backend rejections (server responded with 4xx/5xx,
  e.g. "all steps must be completed") still surface via the existing
  toast, since retrying the same payload wouldn't help.
- **Idempotency note** — `PickingJobCompleteCommand#execute` already
  short-circuits when `docStatus.isCompleted()`, so retrying a call that
  actually did reach the backend the first time is safe and returns the
  already-completed job.
- **New UI-trace events** `confirmationPosted` / `confirmationFailed`
  with `wfProcessId`, `activityId`, HTTP status, axios code, and an
  `isNetworkFailure` flag. Future "the button didn't do anything"
  investigations become searchable in `ui_trace`.
- **Translations** — `activities.confirmButton.error.{title,retry,cancel}`
  added for `de_DE` and `en_US`.

## Out of scope (intentional)

- `x-ui-trace-id` header propagation on mutating mobile endpoints —
  separate PR against `new_dawn_uat` after this hotfix merges.
- Playwright E2E reproducing the picking profile with a simulated network
  flake on `/complete` — to be added as a follow-up.

## Test plan

- [x] Manual: pick a job on a mobile browser, press Fertigstellen / Ja,
      verify the call still completes normally.
- [x] Manual: intercept `/complete/userConfirmation` in devtools (block /
      delay > 20 s), press Ja, verify the red retry panel appears with a
      clear message and Retry re-sends the call successfully.
- [ ] Manual: trigger a backend rejection (e.g. press Ja on a partial
      pick with `allowCompletingPartialPickingJob=N`), verify the error
      still surfaces as a toast (no inline panel for this case).
- [x] Manual: verify `confirmationPosted` / `confirmationFailed` events
      arrive in `ui_trace` with the `isNetworkFailure` flag set correctly.
- [x] `yarn lint` is clean on changed files.