### PR TITLE
gh29361: TC-S10b — verify API+Skonto parity via payment-based allocation (R8b)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/AllocatePayments_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/AllocatePayments_StepDef.java
@@ -22,6 +22,7 @@
 
 package de.metas.cucumber.stepdefs.allocation;
 
+import com.google.common.collect.ImmutableSet;
 import de.metas.allocation.api.IAllocationBL;
 import de.metas.banking.payment.paymentallocation.InvoiceToAllocate;
 import de.metas.banking.payment.paymentallocation.InvoiceToAllocateQuery;
@@ -189,18 +190,24 @@ public class AllocatePayments_StepDef
 			final StepDefDataIdentifier allocIdentifier = row.getAsIdentifier("C_AllocationHdr_ID");
 			final I_C_Payment payment = paymentTable.get(row.getAsIdentifier(COLUMNNAME_C_Payment_ID));
 
-			final I_C_AllocationLine allocLine = queryBL.createQueryBuilder(I_C_AllocationLine.class)
+			final List<I_C_AllocationLine> allocLines = queryBL.createQueryBuilder(I_C_AllocationLine.class)
 					.addEqualsFilter(I_C_AllocationLine.COLUMNNAME_C_Payment_ID, payment.getC_Payment_ID())
 					.addOnlyActiveRecordsFilter()
 					.orderBy(I_C_AllocationLine.COLUMNNAME_C_AllocationLine_ID)
 					.create()
-					.first();
+					.list();
 
-			assertThat(allocLine)
-					.as("Expected exactly one active C_AllocationLine carrying payment C_Payment_ID=%s", payment.getC_Payment_ID())
-					.isNotNull();
+			final ImmutableSet<Integer> distinctHdrIds = allocLines.stream()
+					.map(I_C_AllocationLine::getC_AllocationHdr_ID)
+					.collect(ImmutableSet.toImmutableSet());
 
-			final I_C_AllocationHdr hdr = InterfaceWrapperHelper.load(allocLine.getC_AllocationHdr_ID(), I_C_AllocationHdr.class);
+			assertThat(distinctHdrIds)
+					.as("Expected exactly one C_AllocationHdr linked to payment C_Payment_ID=%s via its C_AllocationLine(s). "
+							+ "Found %s distinct hdr id(s) across %s allocation line(s): %s",
+							payment.getC_Payment_ID(), distinctHdrIds.size(), allocLines.size(), distinctHdrIds)
+					.hasSize(1);
+
+			final I_C_AllocationHdr hdr = InterfaceWrapperHelper.load(distinctHdrIds.iterator().next(), I_C_AllocationHdr.class);
 			allocationHdrTable.putOrReplace(allocIdentifier, hdr);
 		});
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/AllocatePayments_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/allocation/AllocatePayments_StepDef.java
@@ -40,6 +40,7 @@ import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.cucumber.stepdefs.allocation.C_AllocationHdr_StepDefData;
 import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.payment.C_Payment_StepDefData;
 import de.metas.invoice.InvoiceAmtMultiplier;
@@ -57,10 +58,14 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.SpringContextHolder;
+import org.compiere.model.I_C_AllocationHdr;
+import org.compiere.model.I_C_AllocationLine;
 import org.compiere.model.I_C_Invoice;
 import org.compiere.model.I_C_Payment;
 
@@ -94,6 +99,9 @@ public class AllocatePayments_StepDef
 	@NonNull private final C_Payment_StepDefData paymentTable;
 	@NonNull private final C_Invoice_StepDefData invoiceTable;
 	@NonNull private final C_BPartner_StepDefData bpartnerTable;
+	@NonNull private final C_AllocationHdr_StepDefData allocationHdrTable;
+
+	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 	@And("^apply (.*) to invoices$")
 	public void apply_write_off_or_discount_to_invoice(final String processToApply, @NonNull final DataTable table)
@@ -152,6 +160,49 @@ public class AllocatePayments_StepDef
 		final PaymentAllocationResult result = paymentAllocationBuilder.build();
 
 		DataTableRows.of(table).forEach(row -> updateServiceInvoiceIdentifier(row, result));
+	}
+
+	/**
+	 * Registers the {@link I_C_AllocationHdr} generated for a completed {@link I_C_Payment}
+	 * into {@link C_AllocationHdr_StepDefData} so later steps can reference it by identifier.
+	 * Intended for scenarios where the allocation is built indirectly via
+	 * {@link PaymentAllocationBuilder} (path P) and no allocation identifier is otherwise
+	 * known. Looks up the C_AllocationHdr via the C_AllocationLine that carries this payment.
+	 *
+	 * <p><b>Required columns</b>:
+	 * <ul>
+	 *     <li>{@code C_Payment_ID} — identifier of a previously registered payment</li>
+	 *     <li>{@code C_AllocationHdr_ID} — identifier under which the looked-up allocation hdr is registered</li>
+	 * </ul>
+	 *
+	 * <p><b>Gherkin usage example</b>:
+	 * <pre>{@code
+	 * And register C_AllocationHdr from C_Payment:
+	 *   | C_Payment_ID | C_AllocationHdr_ID |
+	 *   | payment      | alloc              |
+	 * }</pre>
+	 */
+	@And("register C_AllocationHdr from C_Payment:")
+	public void registerAllocationHdrFromPayment(@NonNull final DataTable table)
+	{
+		DataTableRows.of(table).forEach(row -> {
+			final StepDefDataIdentifier allocIdentifier = row.getAsIdentifier("C_AllocationHdr_ID");
+			final I_C_Payment payment = paymentTable.get(row.getAsIdentifier(COLUMNNAME_C_Payment_ID));
+
+			final I_C_AllocationLine allocLine = queryBL.createQueryBuilder(I_C_AllocationLine.class)
+					.addEqualsFilter(I_C_AllocationLine.COLUMNNAME_C_Payment_ID, payment.getC_Payment_ID())
+					.addOnlyActiveRecordsFilter()
+					.orderBy(I_C_AllocationLine.COLUMNNAME_C_AllocationLine_ID)
+					.create()
+					.first();
+
+			assertThat(allocLine)
+					.as("Expected exactly one active C_AllocationLine carrying payment C_Payment_ID=%s", payment.getC_Payment_ID())
+					.isNotNull();
+
+			final I_C_AllocationHdr hdr = InterfaceWrapperHelper.load(allocLine.getC_AllocationHdr_ID(), I_C_AllocationHdr.class);
+			allocationHdrTable.putOrReplace(allocIdentifier, hdr);
+		});
 	}
 
 	private void updateServiceInvoiceIdentifier(final DataTableRow row, final PaymentAllocationResult result)

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/tax_declaration/tax_accounting_report.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/tax_declaration/tax_accounting_report.feature
@@ -694,6 +694,96 @@ Feature: Tax Accounting Report ("Mehrwertsteuer-Verprobung 3")
 
 
 # ############################################################################################################################################
+# TC-S10b — Purchase invoice (API) + Skonto via payment-based path (PaymentAllocationBuilder)
+# ############################################################################################################################################
+# Mirror of TC-S10 but the allocation is built indirectly via `PaymentAllocationBuilder`
+# (path P — payment + auto-allocation) instead of the discount-only `C_AllocationHdr_Builder`
+# (path D). Both paths must produce the same Fact_Acct rows and the same report output per
+# §17(1)(2) UStG — the §17 obligation is on the underlying transaction, not the UI workflow
+# that created the allocation.
+#
+# An older observation (pre-direction-signed DiscountAmt) showed path P emitting TaxAmt = −3.80
+# on T_Credit_Acct while path D emitted +3.80 for the same API + Skonto scenario. The direction-
+# signed DiscountAmt shipped on this issue likely already resolved it; this scenario is the
+# empirical check (green = confirmed resolved; red = concrete finding).
+  @Id:S0467_TAR_100b
+  @from:cucumber
+  Scenario: purchase invoice + Skonto via payment-based allocation produces the same tax-correction row as the discount-only path
+
+    And metasfresh contains C_TaxCategory
+      | Identifier  |
+      | taxCategory |
+    And metasfresh contains C_Tax
+      | Identifier | C_TaxCategory_ID | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
+      | tax19      | taxCategory      | 19   | DE                       | DE                        |
+    And metasfresh contains C_VAT_Codes:
+      | Identifier | C_Tax_ID | IsSOTrx |
+      | purchase19 | tax19    | N       |
+      | sales19    | tax19    | Y       |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | purchasePLV            | product      | 100.00   | PCE      | taxCategory      |
+
+    And metasfresh contains organization bank accounts
+      | Identifier      | C_Currency_ID |
+      | org_EUR_account | EUR           |
+
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoice    | vendor        | 2024-01-15   | false   | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceL1  | invoice      | product      | 7 PCE       | tax19    |
+      | invoiceL2  | invoice      | product      | 3 PCE       | tax19    |
+    And the invoice identified by invoice is completed
+
+    # AP payment (we pay vendor): invoice gross = 1190 EUR, we keep 23.80 as Skonto → PayAmt = 1166.20.
+    And metasfresh contains C_Payment
+      | Identifier | C_BPartner_ID | PayAmt      | IsReceipt | C_BP_BankAccount_ID |
+      | payment    | vendor        | 1166.20 EUR | false     | org_EUR_account     |
+    And the payment identified by payment is completed
+
+    # Path P: PaymentAllocationBuilder produces an allocation that combines the payment with the discount.
+    And allocate payments to invoices
+      | C_Invoice_ID | C_Payment_ID | DiscountAmt |
+      | invoice      | payment      | 23.80 EUR   |
+
+    # Register the resulting allocationHdr so Fact_Acct assertions can reference it by identifier.
+    And register C_AllocationHdr from C_Payment:
+      | C_Payment_ID | C_AllocationHdr_ID |
+      | payment      | alloc              |
+
+    And Wait until documents invoice, alloc are posted
+
+    # Expected Fact_Acct rows: identical to TC-S10 (path D). Invoice posts T_Credit DR 190;
+    # allocation posts T_Credit CR 3.80. Net balance +186.20 per §17(1)(2) UStG.
+    # C_VAT_Code on both legs = purchase19 (IsSOTrx=N) — purchase/input side.
+    And Fact_Acct records are matching
+      | AccountConceptualName | AmtAcctDr | AmtAcctCr | C_Tax_ID | C_VAT_Code_ID | Record_ID |
+      | T_Credit_Acct         | 190       |           | tax19    | purchase19    | invoice   |
+      | *                     |           |           |          |               | invoice   |
+      | T_Credit_Acct         |           | 3.80      | tax19    | purchase19    | alloc     |
+      | *                     |           |           |          |               | alloc     |
+    And Fact_Acct records balances for documents invoice,alloc are matching
+      | AccountConceptualName | AcctBalance | C_Tax_ID |
+      | T_Credit_Acct         | 186.20      | tax19    |
+
+    # Expected report output: identical to TC-S10. If these assertions pass, R8b is confirmed
+    # resolved by the direction-signed DiscountAmt convention shipped in PR 23496.
+    Then report_taxaccounts for C_Tax "tax19" between "2024-01-01" and "2024-01-31" returns:
+      | Level | C_VAT_Code_ID | AccountConceptualName | NetAmt_SUM | TaxAmt_SUM | NetAmt | TaxAmt | C_BPartner_ID | DocumentNo |
+      | 1     | purchase19    |                       | 980        | 186.20     |        |        | -             | -          |
+      | 2     | purchase19    | T_Credit_Acct         | 980        | 186.20     |        |        | -             | -          |
+      | 3     | purchase19    | T_Credit_Acct         | 980        | 186.20     |        |        | -             | -          |
+      | 4     | purchase19    | T_Credit_Acct         |            |            | -20    | -3.80  | vendor        | alloc      |
+      | 4     | purchase19    | T_Credit_Acct         |            |            | 1000   | 190    | vendor        | invoice    |
+      | ReCap | purchase19    |                       | 980        | 186.20     |        |        | -             | -          |
+
+
+# ############################################################################################################################################
 # TC-S11 — Purchase credit memo (APC) + discount-only allocation
 # ############################################################################################################################################
 # Purchase credit memo posts T_Credit_Acct Cr=190 (reversing the receivable). When the vendor refunds


### PR DESCRIPTION
## Summary

Adds scenario **TC-S10b** that mirrors TC-S10 (API + Skonto, path D — discount-only allocation via `C_AllocationHdr_Builder`) but builds the allocation indirectly via `PaymentAllocationBuilder` (path P — payment + auto-allocation). Both paths must produce the same Fact_Acct rows and the same report output per §17(1)(2) UStG.

An older snapshot (pre-PR 23496) showed path P emitting `TaxAmt = −3.80` on `T_Credit_Acct` while path D emitted `+3.80` for the same input. The direction-signed `DiscountAmt` convention shipped in PR 23496 likely resolved the divergence; **TC-S10b confirms empirically — passes on first run, proving path P and path D now agree.**

Tracked on me03#29361 as R8b.

## Changes

- `tax_accounting_report.feature` — new scenario TC-S10b, tagged `@Id:S0467_TAR_100b`.
- `AllocatePayments_StepDef.java` — new step `register C_AllocationHdr from C_Payment:` that looks up the allocation hdr generated by `PaymentAllocationBuilder` and registers it in `C_AllocationHdr_StepDefData` so Fact_Acct assertions can reference it by identifier.

## Test plan

- [x] Local: TC-S10b green first run.
- [x] Local: full `tax_accounting_report.feature` — 17/17 green (16 existing + TC-S10b).
- [ ] CI green.