### PR TITLE
Port mobileui picking retry panel to new_dawn_uat (cherry-pick of #23579)

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/confirmation.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/confirmation.js
@@ -2,14 +2,20 @@ import axios from 'axios';
 import { apiBasePath } from '../constants';
 import { unboxAxiosResponse } from '../utils';
 
+export const DEFAULT_TIMEOUT_MILLIS = 20000;
+
 /**
  * @method userConfirmation
  * @summary Post confirmation to the server after a dialog is shown (see ConfirmationButton/ConfirmActivity component)
- * @param {object} `token` - The token to use for authentication
- * @returns
+ *
+ * The Zebra scanner on flaky wifi regularly drops the TCP connection mid-roam; without an explicit timeout,
+ * axios hangs forever and the operator is left with no signal that their "Fertigstellen" press didn't reach
+ * the backend. The timeout ensures the promise eventually rejects so the UI can surface the
+ * failure and let the operator retry.
  */
-export function postUserConfirmation({ wfProcessId, activityId }) {
+export function postUserConfirmation({ wfProcessId, activityId, timeoutMillis }) {
+  const timeout = Number.isFinite(timeoutMillis) && timeoutMillis > 0 ? timeoutMillis : DEFAULT_TIMEOUT_MILLIS;
   return axios
-    .post(`${apiBasePath}/userWorkflows/wfProcess/${wfProcessId}/${activityId}/userConfirmation`)
+    .post(`${apiBasePath}/userWorkflows/wfProcess/${wfProcessId}/${activityId}/userConfirmation`, null, { timeout })
     .then((response) => unboxAxiosResponse(response));
 }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx
@@ -1,12 +1,16 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import { postUserConfirmation } from '../../../api/confirmation';
+import { DEFAULT_TIMEOUT_MILLIS, postUserConfirmation } from '../../../api/confirmation';
 import ConfirmButton from '../../../components/buttons/ConfirmButton';
-import { toastError } from '../../../utils/toast';
+import ButtonWithIndicator from '../../../components/buttons/ButtonWithIndicator';
+import { extractUserFriendlyErrorMessageFromAxiosError, toastError } from '../../../utils/toast';
 import { useDispatch } from 'react-redux';
 import { appLaunchersLocation } from '../../../routes/launchers';
 import { setActivityProcessing, updateWFProcess } from '../../../actions/WorkflowActions';
 import { useMobileNavigation } from '../../../hooks/useMobileNavigation';
+import { usePositiveNumberSetting } from '../../../reducers/settings';
+import { trl } from '../../../utils/translations';
+import * as uiTrace from '../../../utils/ui_trace';
 
 const ConfirmActivity = ({
   applicationId,
@@ -22,19 +26,56 @@ const ConfirmActivity = ({
 }) => {
   const dispatch = useDispatch();
   const history = useMobileNavigation();
-  const onUserConfirmed = () => {
+  const [errorMessage, setErrorMessage] = useState(null);
+  // Synchronous guard: isProcessing only re-flows via Redux on the next render,
+  // so a fast double-tap on Retry would otherwise send two requests.
+  const sendingRef = useRef(false);
+
+  // Overridable via AD_SysConfig mobileui.frontend.api.completeConfirmation.timeoutMillis
+  const timeoutMillis = usePositiveNumberSetting('api.completeConfirmation.timeoutMillis', DEFAULT_TIMEOUT_MILLIS);
+
+  const sendConfirmation = () => {
+    if (sendingRef.current) return;
+    sendingRef.current = true;
+    setErrorMessage(null);
     dispatch(setActivityProcessing({ wfProcessId, activityId, processing: true }));
-    postUserConfirmation({ wfProcessId, activityId })
+    postUserConfirmation({ wfProcessId, activityId, timeoutMillis })
       .then((wfProcess) => {
         dispatch(updateWFProcess({ wfProcess }));
-      })
-      .then(() => {
+        uiTrace.trace({ eventName: 'confirmationPosted', wfProcessId, activityId });
         if (isLastActivity) {
           history.push(appLaunchersLocation({ applicationId }));
         }
       })
-      .catch((axiosError) => toastError({ axiosError }))
-      .finally(() => dispatch(setActivityProcessing({ wfProcessId, activityId, processing: false })));
+      .catch((axiosError) => {
+        // A server response means the backend rejected the operation (e.g. "all steps must be completed");
+        // retrying the same payload won't help, and there is automation that asserts on the toast.
+        // Only surface the inline retry panel for network-layer failures (timeout / no response at all).
+        const isNetworkFailure = !axiosError?.response;
+        const message = extractUserFriendlyErrorMessageFromAxiosError({ axiosError });
+        uiTrace.trace({
+          eventName: 'confirmationFailed',
+          wfProcessId,
+          activityId,
+          httpStatus: axiosError?.response?.status ?? null,
+          axiosCode: axiosError?.code ?? null,
+          isNetworkFailure,
+          message,
+        });
+        if (isNetworkFailure) {
+          setErrorMessage(message);
+        } else {
+          toastError({ axiosError });
+        }
+      })
+      .finally(() => {
+        sendingRef.current = false;
+        dispatch(setActivityProcessing({ wfProcessId, activityId, processing: false }));
+      });
+  };
+
+  const onCancelError = () => {
+    setErrorMessage(null);
   };
 
   return (
@@ -44,11 +85,33 @@ const ConfirmActivity = ({
         caption={caption}
         promptQuestion={promptQuestion}
         userInstructions={userInstructions}
-        isUserEditable={isUserEditable}
+        isUserEditable={isUserEditable && !errorMessage}
         isProcessing={isProcessing}
         completeStatus={completeStatus}
-        onUserConfirmed={onUserConfirmed}
+        onUserConfirmed={sendConfirmation}
       />
+      {errorMessage && (
+        <div className="notification is-danger mt-3" data-testid="confirm-activity-error-panel">
+          <p className="mb-3">
+            <strong>{trl('activities.confirmButton.error.title')}</strong>
+          </p>
+          <p className="mb-3">{errorMessage}</p>
+          <div className="buttons">
+            <ButtonWithIndicator
+              testId="confirm-activity-error-retry"
+              captionKey="activities.confirmButton.error.retry"
+              disabled={isProcessing}
+              onClick={sendConfirmation}
+            />
+            <ButtonWithIndicator
+              testId="confirm-activity-error-cancel"
+              captionKey="activities.confirmButton.error.cancel"
+              disabled={isProcessing}
+              onClick={onCancelError}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
@@ -37,6 +37,11 @@ export const useKeyboardBarcodeReader = ({
       if (event.ctrlKey || event.metaKey) {
         return;
       }
+      // Composition / IME events, some browser extensions and Chrome autofill dispatch
+      // keydown-like events with event.key === undefined. Bail out before any .length access.
+      if (event.key == null) {
+        return;
+      }
       // Allow altKey for printable characters (Zebra MC3300x firmware sets altKey=true on scanner keystrokes)
       if (event.altKey && event.key.length !== 1) {
         return;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -155,6 +155,11 @@ const translations = {
       },
       abort: 'Rückgängig',
       notFound: 'Nicht gefunden',
+      error: {
+        title: 'Bestätigung konnte nicht gesendet werden',
+        retry: 'Erneut senden',
+        cancel: 'Abbrechen',
+      },
     },
     mfg: {
       ProductName: 'Produkt',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -152,6 +152,11 @@ const translations = {
       },
       abort: 'Abort',
       notFound: 'Not found',
+      error: {
+        title: 'Could not send confirmation',
+        retry: 'Retry',
+        cancel: 'Cancel',
+      },
     },
     mfg: {
       ProductName: 'Product Name',


### PR DESCRIPTION
## Summary

Cherry-pick of the squash-merge commit from [#23579](https://github.com/metasfresh/metasfresh/pull/23579) (originally merged into `intensive_care_hotfix`) onto `new_dawn_uat`, so the picking retry-panel fix is available on the shared UAT line.

## Source

- Original PR: https://github.com/metasfresh/metasfresh/pull/23579
- Source branch: `intensive_care_hotfix`
- Squash-merge commit: `f6cfcbb0869f740b168e903a861656bf2fe289a9`
- `intensive_care_hotfix` CI run covering that commit: green ([run 24822427506](https://github.com/metasfresh/metasfresh/actions/runs/24822427506))

Cherry-pick applied cleanly (two auto-merges in `translations_de.js` / `translations_en.js`).

## What it fixes

Mobile picking on flaky wifi could silently lose the `completeUserConfirmation` call. `axios.post` had no timeout, the request stalled forever, and the eventual failure only surfaced as a toast the operator usually missed — leaving the sales order in an indeterminate state.

This PR:

- Adds a 20 s timeout on `postUserConfirmation` (overridable via `mobileui.frontend.api.completeConfirmation.timeoutMillis` sysconfig).
- Adds a persistent retry panel in `ConfirmActivity` for network failures (times out / unreachable backend) with explicit **Retry** / **Cancel**. Retry reuses the same `wfProcessId` / `activityId` — no re-scan. Backend 4xx/5xx still go via the existing toast.
- Relies on existing idempotency in `PickingJobCompleteCommand#execute` (short-circuits when `docStatus.isCompleted()`).
- Emits new `confirmationPosted` / `confirmationFailed` UI-trace events with HTTP status, axios code, and `isNetworkFailure` flag.

## Files changed

```
misc/services/mobile-webui/mobile-webui-frontend/src/api/confirmation.js
misc/services/mobile-webui/mobile-webui-frontend/src/components/activities/confirmButton/ConfirmActivity.jsx
misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
```

Frontend only — no backend Java, no SQL migrations, no API-contract changes.