### PR TITLE
Revert: cherry-pick of #23579 to new_dawn_uat (#23586)

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/confirmation.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/confirmation.js
@@ -2,20 +2,14 @@ import axios from 'axios';
 import { apiBasePath } from '../constants';
 import { unboxAxiosResponse } from '../utils';
 
-export const DEFAULT_TIMEOUT_MILLIS = 20000;
-
 /**
  * @method userConfirmation
  * @summary Post confirmation to the server after a dialog is shown (see ConfirmationButton/ConfirmActivity component)
- *
- * The Zebra scanner on flaky wifi regularly drops the TCP connection mid-roam; without an explicit timeout,
- * axios hangs forever and the operator is left with no signal that their "Fertigstellen" press didn't reach
- * the backend. The timeout ensures the promise eventually rejects so the UI can surface the
- * failure and let the operator retry.
+ * @param {object} `token` - The token to use for authentication
+ * @returns
  */
-export function postUserConfirmation({ wfProcessId, activityId, timeoutMillis }) {
-  const timeout = Number.isFinite(timeoutMillis) && timeoutMillis > 0 ? timeoutMillis : DEFAULT_TIMEOUT_MILLIS;
+export function postUserConfirmation({ wfProcessId, activityId }) {
   return axios
-    .post(`${apiBasePath}/userWorkflows/wfProcess/${wfProcessId}/${activityId}/userConfirmation`, null, { timeout })
+    .post(`${apiBasePath}/userWorkflows/wfProcess/${wfProcessId}/${activityId}/userConfirmation`)
     .then((response) => unboxAxiosResponse(response));
 }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx
@@ -1,16 +1,12 @@
-import React, { useRef, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { DEFAULT_TIMEOUT_MILLIS, postUserConfirmation } from '../../../api/confirmation';
+import { postUserConfirmation } from '../../../api/confirmation';
 import ConfirmButton from '../../../components/buttons/ConfirmButton';
-import ButtonWithIndicator from '../../../components/buttons/ButtonWithIndicator';
-import { extractUserFriendlyErrorMessageFromAxiosError, toastError } from '../../../utils/toast';
+import { toastError } from '../../../utils/toast';
 import { useDispatch } from 'react-redux';
 import { appLaunchersLocation } from '../../../routes/launchers';
 import { setActivityProcessing, updateWFProcess } from '../../../actions/WorkflowActions';
 import { useMobileNavigation } from '../../../hooks/useMobileNavigation';
-import { usePositiveNumberSetting } from '../../../reducers/settings';
-import { trl } from '../../../utils/translations';
-import * as uiTrace from '../../../utils/ui_trace';
 
 const ConfirmActivity = ({
   applicationId,
@@ -26,56 +22,19 @@ const ConfirmActivity = ({
 }) => {
   const dispatch = useDispatch();
   const history = useMobileNavigation();
-  const [errorMessage, setErrorMessage] = useState(null);
-  // Synchronous guard: isProcessing only re-flows via Redux on the next render,
-  // so a fast double-tap on Retry would otherwise send two requests.
-  const sendingRef = useRef(false);
-
-  // Overridable via AD_SysConfig mobileui.frontend.api.completeConfirmation.timeoutMillis
-  const timeoutMillis = usePositiveNumberSetting('api.completeConfirmation.timeoutMillis', DEFAULT_TIMEOUT_MILLIS);
-
-  const sendConfirmation = () => {
-    if (sendingRef.current) return;
-    sendingRef.current = true;
-    setErrorMessage(null);
+  const onUserConfirmed = () => {
     dispatch(setActivityProcessing({ wfProcessId, activityId, processing: true }));
-    postUserConfirmation({ wfProcessId, activityId, timeoutMillis })
+    postUserConfirmation({ wfProcessId, activityId })
       .then((wfProcess) => {
         dispatch(updateWFProcess({ wfProcess }));
-        uiTrace.trace({ eventName: 'confirmationPosted', wfProcessId, activityId });
+      })
+      .then(() => {
         if (isLastActivity) {
           history.push(appLaunchersLocation({ applicationId }));
         }
       })
-      .catch((axiosError) => {
-        // A server response means the backend rejected the operation (e.g. "all steps must be completed");
-        // retrying the same payload won't help, and there is automation that asserts on the toast.
-        // Only surface the inline retry panel for network-layer failures (timeout / no response at all).
-        const isNetworkFailure = !axiosError?.response;
-        const message = extractUserFriendlyErrorMessageFromAxiosError({ axiosError });
-        uiTrace.trace({
-          eventName: 'confirmationFailed',
-          wfProcessId,
-          activityId,
-          httpStatus: axiosError?.response?.status ?? null,
-          axiosCode: axiosError?.code ?? null,
-          isNetworkFailure,
-          message,
-        });
-        if (isNetworkFailure) {
-          setErrorMessage(message);
-        } else {
-          toastError({ axiosError });
-        }
-      })
-      .finally(() => {
-        sendingRef.current = false;
-        dispatch(setActivityProcessing({ wfProcessId, activityId, processing: false }));
-      });
-  };
-
-  const onCancelError = () => {
-    setErrorMessage(null);
+      .catch((axiosError) => toastError({ axiosError }))
+      .finally(() => dispatch(setActivityProcessing({ wfProcessId, activityId, processing: false })));
   };
 
   return (
@@ -85,33 +44,11 @@ const ConfirmActivity = ({
         caption={caption}
         promptQuestion={promptQuestion}
         userInstructions={userInstructions}
-        isUserEditable={isUserEditable && !errorMessage}
+        isUserEditable={isUserEditable}
         isProcessing={isProcessing}
         completeStatus={completeStatus}
-        onUserConfirmed={sendConfirmation}
+        onUserConfirmed={onUserConfirmed}
       />
-      {errorMessage && (
-        <div className="notification is-danger mt-3" data-testid="confirm-activity-error-panel">
-          <p className="mb-3">
-            <strong>{trl('activities.confirmButton.error.title')}</strong>
-          </p>
-          <p className="mb-3">{errorMessage}</p>
-          <div className="buttons">
-            <ButtonWithIndicator
-              testId="confirm-activity-error-retry"
-              captionKey="activities.confirmButton.error.retry"
-              disabled={isProcessing}
-              onClick={sendConfirmation}
-            />
-            <ButtonWithIndicator
-              testId="confirm-activity-error-cancel"
-              captionKey="activities.confirmButton.error.cancel"
-              disabled={isProcessing}
-              onClick={onCancelError}
-            />
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
@@ -37,11 +37,6 @@ export const useKeyboardBarcodeReader = ({
       if (event.ctrlKey || event.metaKey) {
         return;
       }
-      // Composition / IME events, some browser extensions and Chrome autofill dispatch
-      // keydown-like events with event.key === undefined. Bail out before any .length access.
-      if (event.key == null) {
-        return;
-      }
       // Allow altKey for printable characters (Zebra MC3300x firmware sets altKey=true on scanner keystrokes)
       if (event.altKey && event.key.length !== 1) {
         return;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -155,11 +155,6 @@ const translations = {
       },
       abort: 'Rückgängig',
       notFound: 'Nicht gefunden',
-      error: {
-        title: 'Bestätigung konnte nicht gesendet werden',
-        retry: 'Erneut senden',
-        cancel: 'Abbrechen',
-      },
     },
     mfg: {
       ProductName: 'Produkt',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -152,11 +152,6 @@ const translations = {
       },
       abort: 'Abort',
       notFound: 'Not found',
-      error: {
-        title: 'Could not send confirmation',
-        retry: 'Retry',
-        cancel: 'Cancel',
-      },
     },
     mfg: {
       ProductName: 'Product Name',


### PR DESCRIPTION
Reverts [#23586](https://github.com/metasfresh/metasfresh/pull/23586) (cherry-pick of #23579) on `new_dawn_uat`.

## Why

Premature cherry-pick. The picking retry-panel fix should reach `new_dawn_uat` through the normal forward-merge chain (`intensive_care_hotfix → intensive_care_release → new_dawn_uat`), not as an isolated cherry-pick.

## What this does

Plain `git revert` of squash commit `81b80de251a80ec0ef681de72b1caeaae8dde3e0` — restores the five files to their pre-cherry-pick content. No effect on `intensive_care_hotfix`; the original PR #23579 remains merged there.