### PR TITLE
gh29361: zero C_InvoiceTax.ReverseChargeTaxAmt on sales invoices

### DIFF
--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MInvoiceTax.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MInvoiceTax.java
@@ -208,6 +208,9 @@ public class MInvoiceTax extends X_C_InvoiceTax
 		//
 		final I_C_Tax tax = getTax();
 		final boolean documentLevel = tax.isDocumentLevel();
+		// me03#29361: SOTrx is uniform for all lines of an invoice. Capture once outside
+		// the loop so we can zero a document-level RC recomputation below too.
+		boolean invoiceIsSOTrx = false;
 		//
 		boolean havePackingMaterialLines = false;
 		boolean haveNonPackingMaterialLines = false;
@@ -241,6 +244,7 @@ public class MInvoiceTax extends X_C_InvoiceTax
 				taxBaseAmtTotal = taxBaseAmtTotal.add(lineNetAmt);
 
 				final boolean isSOTrx = StringUtils.toBoolean(rs.getString(3));
+				invoiceIsSOTrx = isSOTrx;
 
 				//
 				// phib [ 1702807 ]: manual tax should never be amended on line level taxes
@@ -260,6 +264,15 @@ public class MInvoiceTax extends X_C_InvoiceTax
 					final CalculateTaxResult calculateTaxResult = taxBL.calculateTax(tax, lineNetAmt, isTaxIncluded(), getPrecision());
 					taxAmt = calculateTaxResult.getTaxAmount();
 					reverseChargeTaxAmt = calculateTaxResult.getReverseChargeAmt();
+				}
+
+				// me03#29361: RC declaration obligation belongs to the buyer, not the supplier.
+				// On a sales invoice (supplier's books) §13b does not produce a declarable
+				// reverse-charge amount — both KZ 84/85 and KZ 67 are the customer's boxes.
+				// Zero any RC amount that Tax.calculateTax() may have produced for SOTrx rows.
+				if (isSOTrx)
+				{
+					reverseChargeTaxAmt = BigDecimal.ZERO;
 				}
 				//
 				taxAmtTotal = taxAmtTotal.add(taxAmt);
@@ -291,6 +304,13 @@ public class MInvoiceTax extends X_C_InvoiceTax
 			final CalculateTaxResult calculateTaxResult = taxBL.calculateTax(tax, taxBaseAmtTotal, isTaxIncluded(), getPrecision());
 			taxAmtTotal = calculateTaxResult.getTaxAmount();
 			reverseChargeTaxAmtTotal = calculateTaxResult.getReverseChargeAmt();
+		}
+		// me03#29361: zero any RC amount on sales invoices (buyer declares, not supplier).
+		// Safety-net after the document-level recomputation above, which otherwise
+		// overwrites the per-line zeroing done inside the loop.
+		if (invoiceIsSOTrx)
+		{
+			reverseChargeTaxAmtTotal = BigDecimal.ZERO;
 		}
 		setTaxAmt(taxAmtTotal);
 		setReverseChargeTaxAmt(reverseChargeTaxAmtTotal);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
@@ -3,18 +3,27 @@
 @allure.label.feature:F00700_Invoicing
 @F00700
 @ghActions:run_on_executor5
-Feature: Reverse Charge tax — accounting posting for purchase documents
+Feature: Reverse Charge tax — accounting posting for purchase and sales documents
 ## me03#28726: Support Reverse Charge with explicit Fact_Acct
+## me03#29361: zero C_InvoiceTax.ReverseChargeTaxAmt on sales invoices
 ##
-## When a C_Tax has IsReverseCharge='Y', the invoice posting engine creates
-## two offsetting Fact_Acct lines (T_Credit_Acct = VSt, T_Due_Acct = USt)
-## that net to zero. The invoice grand total is unchanged (RC tax is not payable).
+## Purchase side (API / APC): when a C_Tax has IsReverseCharge='Y', the invoice
+## posting engine creates two offsetting Fact_Acct lines (T_Credit_Acct = VSt,
+## T_Due_Acct = USt) that net to zero. The invoice grand total is unchanged
+## (RC tax is not payable). C_InvoiceTax records carry TaxAmt=0 and
+## ReverseChargeTaxAmt=base*rate — the latter is what the buyer declares on
+## KZ 84/85 and KZ 67.
 ##
-## These tests cover purchase invoice (API) and purchase credit memo (APC) only.
-## Sales-side RC posting (ARI, ARC) is not yet implemented — see out-of-scope in REQUIREMENTS.md.
+## Sales side (ARI / ARC): the RC declaration obligation attaches to the buyer,
+## not the supplier. A supplier's sales invoice with an RC-flagged tax therefore
+## must NOT carry a ReverseChargeTaxAmt — C_InvoiceTax.ReverseChargeTaxAmt is
+## zero (same as TaxAmt). The invoice is a net-only invoice from the supplier's
+## perspective; whether/how the Fact_Acct posting engine emits tax lines on
+## the sales branches is tracked as a separate follow-up.
 ##
-## Every RC scenario includes an allocation with discount (Skonto) to verify
-## that no tax correction is posted for the RC tax (Decision D1: BC-style skip).
+## Every purchase RC scenario (TC1/TC2) includes an allocation with discount
+## (Skonto) to verify that no tax correction is posted for the RC tax
+## (Decision D1: BC-style skip).
 ##
 ## Reversal tests cover only API and APC (not ARI/ARC). The posting engine
 ## is the same for all doc types — the forward-path sign differences are already
@@ -40,9 +49,11 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
     And metasfresh contains M_PriceLists
       | Identifier        | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
       | purchasePriceList | pricingSystem      | DE           | EUR           | false |
+      | salesPriceList    | pricingSystem      | DE           | EUR           | true  |
     And metasfresh contains M_PriceList_Versions
       | Identifier  | M_PriceList_ID    |
       | purchasePLV | purchasePriceList |
+      | salesPLV    | salesPriceList    |
 
     And metasfresh contains M_Products:
       | Identifier |
@@ -50,13 +61,16 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
     And metasfresh contains M_ProductPrices
       | M_PriceList_Version_ID | M_Product_ID | PriceStd  | C_UOM_ID | C_TaxCategory_ID |
       | purchasePLV            | product      | 1000.00   | PCE      | rcTaxCategory    |
+      | salesPLV               | product      | 1000.00   | PCE      | rcTaxCategory    |
 
     And metasfresh contains C_BPartners without locations:
-      | Identifier | IsCustomer | IsVendor | PO_PricingSystem_ID |
-      | vendor     | N          | Y        | pricingSystem       |
+      | Identifier | IsCustomer | IsVendor | M_PricingSystem_ID | PO_PricingSystem_ID |
+      | vendor     | N          | Y        |                    | pricingSystem       |
+      | customer   | Y          | N        | pricingSystem      |                     |
     And metasfresh contains C_BPartner_Locations:
-      | Identifier      | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
-      | vendor_location | vendor        | Y               | Y               |
+      | Identifier        | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | vendor_location   | vendor        | Y               | Y               |
+      | customer_location | customer      | Y               | Y               |
 
     And metasfresh contains organization bank accounts
       | Identifier  | C_Currency_ID |
@@ -229,3 +243,58 @@ Feature: Reverse Charge tax — accounting posting for purchase documents
       | P_Expense_Acct        |             | -1000 EUR   | rcTax19  | rcCmReversal |
       | T_Credit_Acct         |             | -190 EUR    | rcTax19  | rcCmReversal |
       | T_Due_Acct            | -190 EUR    |             | rcTax19  | rcCmReversal |
+
+
+# ############################################################################################################################################
+# TC5 — Sales invoice (ARI) with RC tax — supplier must not carry a ReverseChargeTaxAmt
+# me03#29361: the §13b declaration obligation is the buyer's; the supplier's C_InvoiceTax
+# record therefore carries TaxAmt=0 AND ReverseChargeTaxAmt=0. Before the fix,
+# MInvoiceTax.calculateTaxFromLines stored a non-zero ReverseChargeTaxAmt on SOTrx rows
+# (fell through to Tax.calculateTax(), which returns amount*rate regardless of SOTrx).
+# ############################################################################################################################################
+  @Id:S0466_RC_050
+  @from:cucumber
+  Scenario: sales invoice with reverse charge tax has ReverseChargeTaxAmt=0 on C_InvoiceTax
+
+    And metasfresh contains C_Invoice:
+      | Identifier   | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | rcSalesInv   | customer      | 2024-01-15   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier    | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | rcSalesInvLn  | rcSalesInv   | product      | 1 PCE       | rcTax19  |
+    And the invoice identified by rcSalesInv is completed
+
+    # GrandTotal = TotalLines = 1000 (net only — RC tax is not payable, supplier issues net invoice)
+    Then validate created invoices
+      | C_Invoice_ID | GrandTotal | TotalLines |
+      | rcSalesInv   | 1000 EUR   | 1000       |
+
+    # Key invariant: on a sales invoice, C_InvoiceTax.ReverseChargeTaxAmt MUST be 0.
+    # The supplier does not declare the RC amount — the customer does (KZ 84/85 + KZ 67).
+    And C_InvoiceTax records for invoice "rcSalesInv" are matching
+      | C_Tax_ID | TaxAmt | TaxBaseAmt | ReverseChargeTaxAmt | IsReverseCharge |
+      | rcTax19  | 0      | 1000       | 0                   | true            |
+
+
+# ############################################################################################################################################
+# TC6 — Sales credit memo (ARC) with RC tax — same invariant as TC5
+# ############################################################################################################################################
+  @Id:S0466_RC_060
+  @from:cucumber
+  Scenario: sales credit memo with reverse charge tax has ReverseChargeTaxAmt=0 on C_InvoiceTax
+
+    And metasfresh contains C_Invoice:
+      | Identifier    | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | rcSalesCm     | customer      | Gutschrift              | 2024-01-15   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier   | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | rcSalesCmLn  | rcSalesCm    | product      | 1 PCE       | rcTax19  |
+    And the invoice identified by rcSalesCm is completed
+
+    Then validate created invoices
+      | C_Invoice_ID | GrandTotal | TotalLines |
+      | rcSalesCm    | 1000 EUR   | 1000       |
+
+    And C_InvoiceTax records for invoice "rcSalesCm" are matching
+      | C_Tax_ID | TaxAmt | TaxBaseAmt | ReverseChargeTaxAmt | IsReverseCharge |
+      | rcTax19  | 0      | 1000       | 0                   | true            |


### PR DESCRIPTION
## Summary

- Enforce the invariant that a sales invoice (IsSOTrx=Y) never carries a non-zero `C_InvoiceTax.ReverseChargeTaxAmt` when the tax is reverse-charge — the §13b declaration obligation belongs to the buyer (KZ 84/85 on base, KZ 67 on tax), not the supplier.
- Before this PR: `MInvoiceTax.calculateTaxFromLines` zeroed the per-line RC amount inside the loop but then the document-level "Calculate Tax" block unconditionally recomputed `reverseChargeTaxAmtTotal = base * rate` via `Tax.calculateTax()`, overwriting the zero. `Tax.calculateTax()` is SOTrx-unaware by design.
- Fix: capture `IsSOTrx` once (uniform across all lines of an invoice) and zero the RC total both inside the loop and after the document-level recomputation, right before `setReverseChargeTaxAmt`. Minimal surface; no API change.

## Test plan

- [x] New cucumber scenarios in `invoice_reverseCharge_accounting.feature`:
  - **TC5** (`@Id:S0466_RC_050`) — sales invoice (ARI) with RC tax → asserts `C_InvoiceTax.TaxAmt = 0` AND `ReverseChargeTaxAmt = 0`.
  - **TC6** (`@Id:S0466_RC_060`) — sales credit memo (ARC) with RC tax → same invariant.
- [x] Existing purchase scenarios (TC1 ARI+Skonto, TC2 APC, TC3 ARI reversal, TC4 APC reversal) pass unchanged — all 6 scenarios green locally.
- [x] Local run (`run-cucumber-feature.sh invoice_reverseCharge_accounting deep_tundra_uat`, 2026-04-23): `All 6 scenarios passed`.
- [ ] CI green on full cucumber + junit suites.

## Out of scope (tracked as follow-ups)

- `Doc_Invoice.createFacts_Sales{Invoice,CreditMemo}` has no `isReverseCharge()` guard on the `T_Due_Acct` FactLine creation. After this PR the FactLine is posted with a zero amount (harmless, cosmetic). Proper suppression belongs in a separate change.
- `MOrderTax.calculateTaxFromLines` has the same SOTrx blind spot. `C_OrderTax` is not declaration-facing, so fixing it is lower priority but worth mirroring for consistency.