### PR TITLE
mobileui picking: Playwright coverage for network-flake retry panel

### DIFF
--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -7,9 +7,10 @@ import { PickingJobStepScreen } from "../../utils/screens/picking/PickingJobStep
 import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
 import { Backend } from "../../utils/screens/Backend";
 import { LoginScreen } from "../../utils/screens/LoginScreen";
-import { expectErrorToast } from '../../utils/common';
+import { expectErrorToast, VERY_SLOW_ACTION_TIMEOUT } from '../../utils/common';
 import { QTY_NOT_FOUND_REASON_NOT_FOUND } from '../../utils/screens/picking/GetQuantityDialog';
 import { SelectPickTargetLUScreen } from '../../utils/screens/picking/ReopenLUScreen';
+import { ConfirmActivityErrorPanel } from '../../utils/components/ConfirmActivityErrorPanel';
 
 const createMasterdata = async ({
                                     language = 'en_US',
@@ -362,6 +363,73 @@ test.describe('Picking Job Completion', () => {
             qtyNotFoundReason: QTY_NOT_FOUND_REASON_NOT_FOUND,
         });
         await PickingJobScreen.complete()
+    });
+
+    // noinspection JSUnusedLocalSymbols
+    test('Network failure on complete shows retry panel; Retry then succeeds', async ({ page }) => {
+        // === ALLURE METADATA ===
+        allure.epic('E0105: Picking');
+        allure.tag('F00230: MobileUI Picking');
+        allure.tag('F00230');
+        allure.story('Picking job completion recovers from network flake');
+        allure.severity('normal');
+
+        const masterdata = await createMasterdata({ allowCompletingPartialPickingJob: true });
+
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('picking');
+        await PickingJobsListScreen.waitForScreen();
+        await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+        await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+        await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+        await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '3' });
+
+        const confirmationRoute = '**/userWorkflows/wfProcess/**/userConfirmation';
+        await test.step('Block userConfirmation to simulate a network failure', async () => {
+            await page.route(confirmationRoute, route => route.abort('failed'));
+        });
+
+        await PickingJobScreen.completeExpectingNetworkError();
+
+        await test.step('Release the block and retry', async () => {
+            await page.unroute(confirmationRoute);
+        });
+        await ConfirmActivityErrorPanel.clickRetry();
+        await PickingJobsListScreen.waitForScreen({ timeout: VERY_SLOW_ACTION_TIMEOUT });
+    });
+
+    // noinspection JSUnusedLocalSymbols
+    test('Cancel on retry panel hides it and leaves the job resumable', async ({ page }) => {
+        // === ALLURE METADATA ===
+        allure.epic('E0105: Picking');
+        allure.tag('F00230: MobileUI Picking');
+        allure.tag('F00230');
+        allure.story('Picking job completion recovers from network flake');
+        allure.severity('normal');
+
+        const masterdata = await createMasterdata({ allowCompletingPartialPickingJob: true });
+
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('picking');
+        await PickingJobsListScreen.waitForScreen();
+        await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+        await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+        await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+        await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '3' });
+
+        const confirmationRoute = '**/userWorkflows/wfProcess/**/userConfirmation';
+        await page.route(confirmationRoute, route => route.abort('failed'));
+
+        await PickingJobScreen.completeExpectingNetworkError();
+        await ConfirmActivityErrorPanel.clickCancel();
+        await ConfirmActivityErrorPanel.waitForPanelDetached();
+
+        // Clean up the route interception so it doesn't affect follow-on steps if the test is extended later.
+        await page.unroute(confirmationRoute);
     });
 
 });

--- a/e2e/mobile-webui/tests/utils/components/ConfirmActivityErrorPanel.js
+++ b/e2e/mobile-webui/tests/utils/components/ConfirmActivityErrorPanel.js
@@ -1,0 +1,22 @@
+import { FAST_ACTION_TIMEOUT, page, SLOW_ACTION_TIMEOUT, step } from "../common";
+
+const NAME = 'ConfirmActivityErrorPanel';
+const containerElement = () => page.getByTestId('confirm-activity-error-panel');
+
+export const ConfirmActivityErrorPanel = {
+    waitForPanel: async () => await step(`${NAME} - Wait for panel`, async () => {
+        await containerElement().waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+    }),
+
+    waitForPanelDetached: async () => await step(`${NAME} - Wait for panel detached`, async () => {
+        await containerElement().waitFor({ state: 'detached', timeout: FAST_ACTION_TIMEOUT });
+    }),
+
+    clickRetry: async () => await step(`${NAME} - Click Retry`, async () => {
+        await page.getByTestId('confirm-activity-error-retry').tap();
+    }),
+
+    clickCancel: async () => await step(`${NAME} - Click Cancel`, async () => {
+        await page.getByTestId('confirm-activity-error-cancel').tap();
+    }),
+};

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
@@ -12,6 +12,7 @@ import { PickLineScanScreen } from './PickLineScanScreen';
 import { PickingJobLineScreen } from './PickingJobLineScreen';
 import { test } from '../../../../playwright.config';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
+import { ConfirmActivityErrorPanel } from '../../components/ConfirmActivityErrorPanel';
 
 const NAME = 'PickingJobScreen';
 /** @returns {import('@playwright/test').Locator} */
@@ -228,6 +229,13 @@ export const PickingJobScreen = {
         await YesNoDialog.waitForDialog();
         await YesNoDialog.clickYesButton();
         await PickingJobsListScreen.waitForScreen({ timeout: VERY_SLOW_ACTION_TIMEOUT });
+    }),
+
+    completeExpectingNetworkError: async () => await step(`${NAME} - Complete, expect network-error retry panel`, async () => {
+        await page.locator('#last-confirm-button').tap();
+        await YesNoDialog.waitForDialog();
+        await YesNoDialog.clickYesButton();
+        await ConfirmActivityErrorPanel.waitForPanel();
     }),
 
     goBack: async () => await test.step(`${NAME} - Go back`, async () => {


### PR DESCRIPTION
## Summary

Adds Playwright end-to-end coverage for the mobileUI picking retry panel introduced in [#23579](https://github.com/metasfresh/metasfresh/pull/23579), so the retry-on-network-failure path is regression-protected.

The feature itself reached `new_dawn_uat` via the forward-merge chain `intensive_care_hotfix → intensive_care_release → new_dawn_uat` (PR [#23584](https://github.com/metasfresh/metasfresh/pull/23584) → PR [#23515](https://github.com/metasfresh/metasfresh/pull/23515), merge commit `1cc4a4567ff`). This PR simply adds the tests against that now-present code.

## Scenarios added

Both sit under the existing `Picking Job Completion` describe block in `picking.spec.js`:

1. **Network failure on complete shows retry panel; Retry then succeeds** — abort the `userConfirmation` request via `page.route`, assert the inline retry panel appears, unroute, tap **Retry**, and verify the retried call reaches the backend and the screen transitions to the launchers list.
2. **Cancel on retry panel hides it and leaves the job resumable** — abort the request, assert the panel appears, tap **Cancel**, and assert the panel unmounts.

## Supporting plumbing

- New page-object `ConfirmActivityErrorPanel.js` (selectors for the error message, Retry, and Cancel controls).
- `PickingJobScreen.completeExpectingNetworkError()` — variant of `complete()` that taps Fertigstellen + Yes and waits for the retry panel instead of the launchers list.

## Scope

E2E-only. No backend Java, no SQL migrations, no API-contract changes. Three files under `e2e/frontend-webui/tests/`:

```
e2e/frontend-webui/tests/spec/picking/picking.spec.js
e2e/frontend-webui/tests/utils/components/ConfirmActivityErrorPanel.js
e2e/frontend-webui/tests/utils/screens/picking/PickingJobScreen.js
```