### PR TITLE
mobileui: propagate X-Ui-Trace-Id on every mutating API request

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/index.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/index.js
@@ -8,6 +8,7 @@ import { load } from 'redux-localstorage-simple';
 import { setupCounterpart } from './utils/translations';
 import { setupOfflineModeDetector } from './services/offlineModeDetector';
 import { setupServiceWorker } from './services/serviceWorker/serviceWorkerRegistration';
+import { installMutatingApiTraceIdInterceptor } from './utils/ui_trace/mutatingApiInterceptor';
 
 import './assets/index.scss';
 import '@fortawesome/fontawesome-free/js/all.min';
@@ -16,6 +17,7 @@ import { logErrorToBackend } from './api/applications';
 import ErrorScreen from './components/ErrorScreen';
 
 setupCounterpart();
+installMutatingApiTraceIdInterceptor();
 
 export const globalStore = store(load());
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/ui_trace/mutatingApiInterceptor.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/ui_trace/mutatingApiInterceptor.js
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import { v4 as uuidv4 } from 'uuid';
+
+const HEADER_UITraceId = 'X-Ui-Trace-Id';
+const MUTATING_METHODS = new Set(['post', 'put', 'delete', 'patch']);
+
+/**
+ * Ensures every mutating mobile-UI request carries an X-Ui-Trace-Id header so the
+ * backend's api_request_audit table can be correlated back to the frontend action
+ * that triggered it. If traceFunction already pinned a trace id onto
+ * axios.defaults.headers.common, that id is kept as-is so the request and the
+ * surrounding frontend uiTrace event share the same id. Otherwise, a fresh UUID
+ * is generated for this single request; that id will only appear in backend
+ * audit, which is still enough to identify the individual request.
+ *
+ * Intentionally does NOT emit a uiTrace event — mutating mobile endpoints fire
+ * frequently enough that one event per call would drown ui_trace. The caller
+ * that wants a semantic frontend trail should emit its own event (see
+ * ConfirmActivity.jsx for an example).
+ */
+export const installMutatingApiTraceIdInterceptor = () => {
+  axios.interceptors.request.use((config) => {
+    const method = (config.method || 'get').toLowerCase();
+    if (!MUTATING_METHODS.has(method)) {
+      return config;
+    }
+    const alreadySet = config.headers?.[HEADER_UITraceId] ?? axios.defaults.headers.common?.[HEADER_UITraceId];
+    if (alreadySet) {
+      return config;
+    }
+    config.headers = config.headers || {};
+    config.headers[HEADER_UITraceId] = uuidv4();
+    return config;
+  });
+};


### PR DESCRIPTION
## Summary

Follow-up to [#23579](https://github.com/metasfresh/metasfresh/pull/23579) (listed as out-of-scope there): every mutating mobile-webui request (POST / PUT / DELETE / PATCH) now carries an `X-Ui-Trace-Id` header, so the frontend `uiTrace` event and the backend `api_request_audit` entry share the same trace id.

## Behavior

- If `traceFunction` has already pinned a trace id on `axios.defaults.headers.common`, that id is kept as-is for the request (same id used by the surrounding frontend `uiTrace` event and the backend audit entry).
- Otherwise a fresh UUID is generated for the single request.
- GET requests are not tagged — the interceptor only fires for mutating verbs.

## Why no uiTrace event from the interceptor

Mutating mobile endpoints fire too often for "one event per call" to stay searchable. Callers that want a semantic frontend trail continue to emit their own events — `confirmationPosted` / `confirmationFailed` in `ConfirmActivity` (introduced in #23579) are the current reference.

## Scope

Frontend only. 2 files under `misc/services/mobile-webui/mobile-webui-frontend/`:

```
src/index.js                                   (2-line change — register the interceptor)
src/utils/ui_trace/mutatingApiInterceptor.js   (new, 35 lines)
```

No backend Java, no SQL migrations, no API-contract changes.