### PR TITLE
Add AD_SysConfig record for mobileui.frontend.api.completeConfirmation.timeoutMillis

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799400_sys_me03_29027_sysconfig_completeConfirmation_timeoutMillis.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799400_sys_me03_29027_sysconfig_completeConfirmation_timeoutMillis.sql
@@ -1,0 +1,17 @@
+-- SysConfig Name: mobileui.frontend.api.completeConfirmation.timeoutMillis
+-- SysConfig Value: 20000
+-- Timeout (in milliseconds) for the completion confirmation API call on the Mobile UI
+-- picking workflow. When the request takes longer than this, an inline retry panel
+-- is shown with Retry / Cancel instead of a short-lived toast. Default: 20000 (20s).
+-- Read on the frontend via usePositiveNumberSetting('api.completeConfirmation.timeoutMillis', ...).
+INSERT INTO AD_SysConfig (AD_Client_ID, AD_Org_ID, AD_SysConfig_ID, ConfigurationLevel,
+                          Created, CreatedBy, Updated, UpdatedBy,
+                          EntityType, IsActive, Name, Value, Description)
+VALUES (0, 0, 541805 /*From ID Server*/, 'S',
+        TO_TIMESTAMP('2026-04-23 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        TO_TIMESTAMP('2026-04-23 14:00', 'YYYY-MM-DD HH24:MI'), 0,
+        'D', 'Y',
+        'mobileui.frontend.api.completeConfirmation.timeoutMillis',
+        '20000',
+        'Timeout in milliseconds for the completion confirmation API call on the Mobile UI picking workflow. When the request takes longer than this, an inline retry panel is shown (Retry / Cancel) instead of a short-lived toast. Default: 20000 (20s).')
+;


### PR DESCRIPTION
## Summary

Follow-up to [#23579](https://github.com/metasfresh/metasfresh/pull/23579) — that PR introduced the sysconfig key `mobileui.frontend.api.completeConfirmation.timeoutMillis` (read by `ConfirmActivity.jsx` via `usePositiveNumberSetting`) but did not ship the corresponding `AD_SysConfig` row. Without this row, administrators cannot see or tune the timeout in the **System Configurator** window; the feature works but the setting is invisible.

This migration creates the row with the default matching the frontend fallback.

## Record

| Field | Value |
|-------|-------|
| `Name` | `mobileui.frontend.api.completeConfirmation.timeoutMillis` |
| `Value` | `20000` |
| `ConfigurationLevel` | `S` (System) |
| `EntityType` | `D` (Dictionary) |
| `AD_SysConfig_ID` | `541805` (from central ID server) |

The `ConfigurationLevel=S` matches sibling `mobileui.frontend.*` sysconfigs (e.g. `mobileui.frontend.barcodeScanner.useCamera`, `mobileui.frontend.barcodeScanner.scanDuplicatesIntervalMillis`).

## Scope

Single AD_SysConfig row, no DDL, no behavior change. Once merged, the auto-port workflow carries the migration through `intensive_care_release → new_dawn_uat`.