### PR TITLE
Port gh29279: Resolve @SQL= default values in print option descriptors

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/GridField.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/GridField.java
@@ -670,46 +670,29 @@ public class GridField
 		 * (b) SQL Statement (for data integity & consistency)
 		 */
 		String defStr = "";
-		if (m_vo.DefaultValue.startsWith("@SQL="))
+		if (DB.isSqlDefaultValue(m_vo.DefaultValue))
 		{
-			String sql = m_vo.DefaultValue.substring(5);			// w/o tag
-			// sql = Env.parseContext(ctx, m_vo.WindowNo, sql, false, true); // replace variables
-			// hengsin, capture unparseable error to avoid subsequent sql exception
-			sql = Env.parseContext(ctx, m_vo.WindowNo, sql, false, false);	// replace variables
-			if (sql.equals(""))
+			String sql = m_vo.DefaultValue.substring(DB.SQL_DEFAULT_VALUE_PREFIX.length());
+			// Use window-specific context for @Variable@ resolution (not global context)
+			sql = Env.parseContext(ctx, m_vo.WindowNo, sql, false, false);
+			if (Check.isBlank(sql))
 			{
-				log.warn("(" + m_vo.getColumnName() + ") - Default SQL variable parse failed: "
-						+ m_vo.DefaultValue);
+				log.warn("({}) - Default SQL variable parse failed: {}", m_vo.getColumnName(), m_vo.DefaultValue);
 			}
 			else
 			{
-				PreparedStatement stmt = null;
-				ResultSet rs = null;
 				try
 				{
-					stmt = DB.prepareStatement(sql, ITrx.TRXNAME_None);
-					rs = stmt.executeQuery();
-					if (rs.next())
-					{
-						defStr = rs.getString(1);
-					}
-					else
-					{
-						log.warn("(" + m_vo.getColumnName() + ") - no Result: " + sql);
-					}
+					defStr = DB.getSQLValueStringEx(ITrx.TRXNAME_None, sql);
 				}
-				catch (SQLException e)
+				catch (final Exception e)
 				{
-					log.warn("(" + m_vo.getColumnName() + ") " + sql, e);
-				}
-				finally
-				{
-					DB.close(rs, stmt);
+					log.warn("({}) {}", m_vo.getColumnName(), sql, e);
 				}
 			}
 			if (defStr != null && defStr.length() > 0)
 			{
-				log.debug("[SQL] " + m_vo.getColumnName() + "=" + defStr);
+				log.debug("[SQL] {}={}", m_vo.getColumnName(), defStr);
 				return createDefault(defStr);
 			}
 		}	// SQL Statement
@@ -717,7 +700,7 @@ public class GridField
 		/**
 		 * (c) Field DefaultValue === similar code in AStartRPDialog.getDefault ===
 		 */
-		if (!m_vo.DefaultValue.equals("") && !m_vo.DefaultValue.startsWith("@SQL="))
+		if (!m_vo.DefaultValue.equals("") && !DB.isSqlDefaultValue(m_vo.DefaultValue))
 		{
 			defStr = "";		// problem is with texts like 'sss;sss'
 			// It is one or more variables/constants

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/copy/ValueToCopy.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/model/copy/ValueToCopy.java
@@ -165,42 +165,26 @@ public class ValueToCopy
 		//(b) SQL Statement (for data integity & consistency)
 		//
 		String defStr = "";
-		if (defaultLogic.startsWith("@SQL="))
+		if (DB.isSqlDefaultValue(defaultLogic))
 		{
-			String sql = defaultLogic.substring(5); // w/o tag
-
+			String sql = defaultLogic.substring(DB.SQL_DEFAULT_VALUE_PREFIX.length());
+			// Use PO-specific context for @Variable@ resolution (not global context)
 			final Evaluatee evaluatee = Evaluatees.composeNotNulls(po, parentPO);
 			sql = Evaluator.parseContext(evaluatee, sql);
-			if (sql == null || Check.isBlank(sql))
+			if (Check.isBlank(sql))
 			{
 				log.warn("({}) - Default SQL variable parse failed: {}", columnName, defaultLogic);
 			}
 			else
 			{
-				PreparedStatement pstmt = null;
-				ResultSet rs = null;
 				try
 				{
-					pstmt = DB.prepareStatement(sql, po.get_TrxName());
-					rs = pstmt.executeQuery();
-					if (rs.next())
-					{
-						defStr = rs.getString(1);
-					}
-					else
-					{
-						log.warn("({}) - no Result: {}", columnName, sql);
-					}
+					defStr = DB.getSQLValueStringEx(po.get_TrxName(), sql);
 				}
-				catch (final SQLException e)
+				catch (final DBException e)
 				{
-					throw new DBException(e, sql)
-							.setParameter("columnName", columnName)
+					throw e.setParameter("columnName", columnName)
 							.appendParametersToMessage();
-				}
-				finally
-				{
-					DB.close(rs, pstmt);
 				}
 			}
 			if (defStr == null && parentPO != null && parentPO.get_ColumnIndex(columnName) >= 0)
@@ -217,7 +201,7 @@ public class ValueToCopy
 		//
 		//(c) Field DefaultValue === similar code in AStartRPDialog.getDefault ===
 		//
-		if (!Check.isBlank(defaultLogic) && !defaultLogic.startsWith("@SQL="))
+		if (!Check.isBlank(defaultLogic) && !DB.isSqlDefaultValue(defaultLogic))
 		{
 			// It is one or more variables/constants
 			final StringTokenizer st = new StringTokenizer(defaultLogic, ",;", false);

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/DB.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/DB.java
@@ -1234,6 +1234,66 @@ public class DB
 		return result.getReturnedValue();
 	}
 
+	// --- @SQL= default value resolution utilities ---
+
+	public static final String SQL_DEFAULT_VALUE_PREFIX = "@SQL=";
+
+	/**
+	 * Returns {@code true} if the given default value string starts with the {@code @SQL=} prefix,
+	 * indicating it should be resolved by executing the embedded SQL query.
+	 */
+	public static boolean isSqlDefaultValue(@Nullable final String defaultValue)
+	{
+		return defaultValue != null && defaultValue.startsWith(SQL_DEFAULT_VALUE_PREFIX);
+	}
+
+	/**
+	 * Resolves a default value that may start with {@code @SQL=}.
+	 * <ul>
+	 * <li>If it starts with {@code @SQL=}: strips the prefix, resolves any {@code @Variable@} or
+	 * {@code @Variable/default@} context placeholders using the global context ({@link Env#getCtx()}),
+	 * executes the SQL, and returns the first column of the first row as a String.</li>
+	 * <li>If it does NOT start with {@code @SQL=}: returns the value as-is (passthrough).</li>
+	 * <li>On parse or SQL error: logs a warning and returns {@code null}.</li>
+	 * </ul>
+	 * <p>
+	 * For callers that have a specific window or document context for {@code @Variable@} resolution
+	 * (e.g., {@link org.compiere.model.GridField}), resolve the variables first using
+	 * {@link Env#parseContext} and then call {@link #getSQLValueStringEx} directly.
+	 *
+	 * @see de.metas.ui.web.window.descriptor.factory.standard.DefaultValueExpressionsFactory
+	 * for the deferred-evaluation variant used by WebUI document fields
+	 * (compiles SQL into IStringExpression, evaluates with live document context at render time)
+	 */
+	@Nullable
+	public static String resolveSqlDefaultValue(@Nullable final String defaultValue)
+	{
+		if (!isSqlDefaultValue(defaultValue))
+		{
+			return defaultValue;
+		}
+
+		final String sqlTemplate = defaultValue.substring(SQL_DEFAULT_VALUE_PREFIX.length());
+
+		// Resolve @Variable@ and @Variable/default@ placeholders using global context
+		final String sql = Env.parseContext(Env.getCtx(), Env.WINDOW_MAIN, sqlTemplate, false, false);
+		if (Check.isBlank(sql))
+		{
+			log.warn("@SQL= default value: variable parse failed: {}", defaultValue);
+			return null;
+		}
+
+		try
+		{
+			return getSQLValueStringEx(ITrx.TRXNAME_None, sql);
+		}
+		catch (final Exception ex)
+		{
+			log.warn("Failed to resolve @SQL= default value: {}", defaultValue, ex);
+			return null;
+		}
+	}
+
 	public SQLValueStringResult getSQLValueStringWithWarningEx(@Nullable final String trxName, final String sql, final Object... params)
 	{
 		String retValue = null;

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/report/DocumentPrintOptionDescriptorsRepository.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/report/DocumentPrintOptionDescriptorsRepository.java
@@ -32,6 +32,7 @@ import de.metas.util.StringUtils;
 import lombok.NonNull;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_AD_Process_Para;
+import org.compiere.util.DB;
 import org.springframework.stereotype.Repository;
 
 import javax.annotation.Nullable;
@@ -75,7 +76,7 @@ public class DocumentPrintOptionDescriptorsRepository
 				.internalName(parameterName)
 				.name(trls.getColumnTrl(I_AD_Process_Para.COLUMNNAME_Name, processPara.getName()))
 				.description(trls.getColumnTrl(I_AD_Process_Para.COLUMNNAME_Description, processPara.getDescription()))
-				.defaultValue(StringUtils.toBoolean(processPara.getDefaultValue()))
+				.defaultValue(StringUtils.toBoolean(DB.resolveSqlDefaultValue(processPara.getDefaultValue())))
 				.build();
 	}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/compiere/util/DBSqlDefaultValueTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/compiere/util/DBSqlDefaultValueTest.java
@@ -1,0 +1,68 @@
+package org.compiere.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DBSqlDefaultValueTest
+{
+	@Test
+	void isSqlDefaultValue_null_returnsFalse()
+	{
+		assertThat(DB.isSqlDefaultValue(null)).isFalse();
+	}
+
+	@Test
+	void isSqlDefaultValue_emptyString_returnsFalse()
+	{
+		assertThat(DB.isSqlDefaultValue("")).isFalse();
+	}
+
+	@Test
+	void isSqlDefaultValue_plainValue_returnsFalse()
+	{
+		assertThat(DB.isSqlDefaultValue("Y")).isFalse();
+	}
+
+	@Test
+	void isSqlDefaultValue_contextVariable_returnsFalse()
+	{
+		assertThat(DB.isSqlDefaultValue("@AD_Client_ID@")).isFalse();
+	}
+
+	@Test
+	void isSqlDefaultValue_sqlPrefix_returnsTrue()
+	{
+		assertThat(DB.isSqlDefaultValue("@SQL=SELECT 1")).isTrue();
+	}
+
+	@Test
+	void isSqlDefaultValue_sqlPrefixWithVariable_returnsTrue()
+	{
+		assertThat(DB.isSqlDefaultValue("@SQL=SELECT 1 WHERE AD_Client_ID=@AD_Client_ID@")).isTrue();
+	}
+
+	@Test
+	void resolveSqlDefaultValue_null_returnsNull()
+	{
+		assertThat(DB.resolveSqlDefaultValue(null)).isNull();
+	}
+
+	@Test
+	void resolveSqlDefaultValue_plainValue_returnsAsIs()
+	{
+		assertThat(DB.resolveSqlDefaultValue("Y")).isEqualTo("Y");
+	}
+
+	@Test
+	void resolveSqlDefaultValue_emptyString_returnsEmptyString()
+	{
+		assertThat(DB.resolveSqlDefaultValue("")).isEqualTo("");
+	}
+
+	@Test
+	void resolveSqlDefaultValue_contextVariable_returnsAsIs()
+	{
+		assertThat(DB.resolveSqlDefaultValue("@AD_Client_ID@")).isEqualTo("@AD_Client_ID@");
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/process/AD_Process_Create_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/process/AD_Process_Create_StepDef.java
@@ -1,0 +1,65 @@
+package de.metas.cucumber.stepdefs.process;
+
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_AD_Process;
+import org.compiere.model.X_AD_Process;
+
+/**
+ * Step definitions for creating {@link I_AD_Process} records in tests.
+ *
+ * <p>Required columns:
+ * <ul>
+ *   <li>{@code Value} — process value (unique identifier)</li>
+ *   <li>{@code Name} — display name</li>
+ * </ul>
+ *
+ * <p>Optional columns:
+ * <ul>
+ *   <li>{@code Type} — process type (default: {@code Java}). See {@link X_AD_Process} TYPE_* constants.</li>
+ *   <li>{@code AccessLevel} — access level (default: {@code 3} = Client+Organization). See {@link X_AD_Process} ACCESSLEVEL_* constants.</li>
+ *   <li>{@code Classname} — Java class implementing the process</li>
+ *   <li>{@code Identifier} — test-local reference for cross-step lookups</li>
+ * </ul>
+ *
+ * <p>Example:
+ * <pre>{@code
+ * Given metasfresh contains AD_Processes:
+ *   | Identifier | Value            | Name              |
+ *   | process    | TestPrintProcess | Test Print Process |
+ * }</pre>
+ */
+@RequiredArgsConstructor
+public class AD_Process_Create_StepDef
+{
+	@NonNull private final AD_Process_StepDefData processTable;
+
+	/**
+	 * Creates one or more {@link I_AD_Process} records from the given data table.
+	 *
+	 * @see AD_Process_Para_StepDef for creating process parameters
+	 */
+	@Given("metasfresh contains AD_Processes:")
+	public void metasfresh_contains_ad_processes(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::createAD_Process);
+	}
+
+	private void createAD_Process(@NonNull final DataTableRow row)
+	{
+		final I_AD_Process process = InterfaceWrapperHelper.newInstance(I_AD_Process.class);
+		process.setValue(row.getAsString(I_AD_Process.COLUMNNAME_Value));
+		process.setName(row.getAsString(I_AD_Process.COLUMNNAME_Name));
+		process.setType(row.getAsOptionalString(I_AD_Process.COLUMNNAME_Type).orElse(X_AD_Process.TYPE_Java));
+		process.setAccessLevel(row.getAsOptionalString(I_AD_Process.COLUMNNAME_AccessLevel).orElse(X_AD_Process.ACCESSLEVEL_ClientPlusOrganization));
+		row.getAsOptionalString(I_AD_Process.COLUMNNAME_Classname).ifPresent(process::setClassname);
+		InterfaceWrapperHelper.saveRecord(process);
+
+		row.getAsOptionalIdentifier().ifPresent(id -> processTable.putOrReplace(id, process));
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/process/AD_Process_Para_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/process/AD_Process_Para_StepDef.java
@@ -1,0 +1,76 @@
+package de.metas.cucumber.stepdefs.process;
+
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_AD_Process;
+import org.compiere.model.I_AD_Process_Para;
+
+/**
+ * Step definitions for creating {@link I_AD_Process_Para} records in tests.
+ *
+ * <p>Required columns:
+ * <ul>
+ *   <li>{@code AD_Process_ID} — identifier referencing the parent {@link I_AD_Process} (from {@link AD_Process_Create_StepDef})</li>
+ *   <li>{@code ColumnName} — parameter column name (e.g. {@code PRINTER_OPTS_IsPrintLogo})</li>
+ *   <li>{@code Name} — display name</li>
+ * </ul>
+ *
+ * <p>Optional columns:
+ * <ul>
+ *   <li>{@code SeqNo} — sequence number (default: auto-incrementing from 10)</li>
+ *   <li>{@code FieldLength} — field length (default: 0)</li>
+ *   <li>{@code DefaultValue} — default value string; supports {@code @SQL=} expressions</li>
+ *   <li>{@code AD_Reference_ID} — reference type (e.g. 20 for Yes-No)</li>
+ *   <li>{@code Description} — parameter description</li>
+ *   <li>{@code Identifier} — test-local reference for cross-step lookups</li>
+ * </ul>
+ *
+ * <p>Example:
+ * <pre>{@code
+ * Given metasfresh contains AD_Process_Paras:
+ *   | Identifier | AD_Process_ID | ColumnName               | Name       | DefaultValue | AD_Reference_ID |
+ *   | param      | process       | PRINTER_OPTS_IsPrintLogo | Print Logo | Y            | 20              |
+ * }</pre>
+ */
+@RequiredArgsConstructor
+public class AD_Process_Para_StepDef
+{
+	@NonNull private final AD_Process_StepDefData processTable;
+	@NonNull private final AD_Process_Para_StepDefData processParaTable;
+
+	private int nextSeqNo = 10;
+
+	/**
+	 * Creates one or more {@link I_AD_Process_Para} records from the given data table.
+	 * The parent process must have been created first via {@link AD_Process_Create_StepDef}.
+	 */
+	@Given("metasfresh contains AD_Process_Paras:")
+	public void metasfresh_contains_ad_process_paras(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::createAD_ProcessPara);
+	}
+
+	private void createAD_ProcessPara(@NonNull final DataTableRow row)
+	{
+		final I_AD_Process process = processTable.get(row.getAsIdentifier(I_AD_Process_Para.COLUMNNAME_AD_Process_ID));
+
+		final I_AD_Process_Para para = InterfaceWrapperHelper.newInstance(I_AD_Process_Para.class);
+		para.setAD_Process_ID(process.getAD_Process_ID());
+		para.setSeqNo(row.getAsOptionalInt(I_AD_Process_Para.COLUMNNAME_SeqNo).orElse(nextSeqNo));
+		nextSeqNo += 10;
+		para.setColumnName(row.getAsString(I_AD_Process_Para.COLUMNNAME_ColumnName));
+		para.setName(row.getAsString(I_AD_Process_Para.COLUMNNAME_Name));
+		para.setFieldLength(row.getAsOptionalInt(I_AD_Process_Para.COLUMNNAME_FieldLength).orElse(0));
+		row.getAsOptionalString(I_AD_Process_Para.COLUMNNAME_DefaultValue).ifPresent(para::setDefaultValue);
+		row.getAsOptionalString(I_AD_Process_Para.COLUMNNAME_Description).ifPresent(para::setDescription);
+		row.getAsOptionalInt(I_AD_Process_Para.COLUMNNAME_AD_Reference_ID).ifPresent(para::setAD_Reference_ID);
+		InterfaceWrapperHelper.saveRecord(para);
+
+		row.getAsOptionalIdentifier().ifPresent(id -> processParaTable.putOrReplace(id, para));
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/process/AD_Process_Para_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/process/AD_Process_Para_StepDefData.java
@@ -1,0 +1,13 @@
+package de.metas.cucumber.stepdefs.process;
+
+import de.metas.cucumber.stepdefs.StepDefData;
+
+import org.compiere.model.I_AD_Process_Para;
+
+public class AD_Process_Para_StepDefData extends StepDefData<I_AD_Process_Para>
+{
+	public AD_Process_Para_StepDefData()
+	{
+		super(I_AD_Process_Para.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/process/AD_Process_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/process/AD_Process_StepDefData.java
@@ -1,0 +1,13 @@
+package de.metas.cucumber.stepdefs.process;
+
+import de.metas.cucumber.stepdefs.StepDefData;
+
+import org.compiere.model.I_AD_Process;
+
+public class AD_Process_StepDefData extends StepDefData<I_AD_Process>
+{
+	public AD_Process_StepDefData()
+	{
+		super(I_AD_Process.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/report/DocumentPrintOption_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/report/DocumentPrintOption_StepDef.java
@@ -1,0 +1,82 @@
+package de.metas.cucumber.stepdefs.report;
+
+import de.metas.cucumber.stepdefs.process.AD_Process_StepDefData;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.process.AdProcessId;
+import de.metas.report.DocumentPrintOptionDescriptor;
+import de.metas.report.DocumentPrintOptionDescriptorsList;
+import de.metas.report.DocumentPrintOptionDescriptorsRepository;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Then;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.compiere.model.I_AD_Process;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Step definitions for verifying document print option descriptors resolved by
+ * {@link DocumentPrintOptionDescriptorsRepository}.
+ *
+ * <p>Verifies that print option defaults (including {@code @SQL=} expressions) are
+ * correctly resolved from {@code AD_Process_Para.DefaultValue}.
+ *
+ * <p>Example:
+ * <pre>{@code
+ * Then the print option descriptors for AD_Process "process" include:
+ *   | OptionName               | DefaultValue |
+ *   | PRINTER_OPTS_IsPrintLogo | true         |
+ * }</pre>
+ */
+@RequiredArgsConstructor
+public class DocumentPrintOption_StepDef
+{
+	@NonNull private final AD_Process_StepDefData processTable;
+	@NonNull private final DocumentPrintOptionDescriptorsRepository printOptionDescriptorsRepository;
+
+	/**
+	 * Verifies that the print option descriptors for the given process match expectations.
+	 *
+	 * <p>Required columns:
+	 * <ul>
+	 *   <li>{@code OptionName} — internal name of the print option (e.g. {@code PRINTER_OPTS_IsPrintLogo})</li>
+	 *   <li>{@code DefaultValue} — expected resolved default ({@code true} or {@code false})</li>
+	 * </ul>
+	 *
+	 * @param processIdentifierStr identifier of the AD_Process (from {@link de.metas.cucumber.stepdefs.process.AD_Process_Create_StepDef})
+	 */
+	@Then("the print option descriptors for AD_Process {string} include:")
+	public void the_print_option_descriptors_include(
+			@NonNull final String processIdentifierStr,
+			@NonNull final DataTable dataTable)
+	{
+		final I_AD_Process process = processTable.get(StepDefDataIdentifier.ofString(processIdentifierStr));
+		final AdProcessId processId = AdProcessId.ofRepoId(process.getAD_Process_ID());
+
+		final DocumentPrintOptionDescriptorsList descriptors = printOptionDescriptorsRepository.getPrintingOptionDescriptors(processId);
+
+		DataTableRows.of(dataTable).forEach(row -> assertPrintOption(descriptors, row));
+	}
+
+	private static void assertPrintOption(
+			@NonNull final DocumentPrintOptionDescriptorsList descriptors,
+			@NonNull final DataTableRow row)
+	{
+		final String optionName = row.getAsString("OptionName");
+		final boolean expectedDefaultValue = row.getAsBoolean("DefaultValue");
+
+		final DocumentPrintOptionDescriptor descriptor = descriptors.getOptions().stream()
+				.filter(d -> optionName.equals(d.getInternalName()))
+				.findFirst()
+				.orElse(null);
+
+		assertThat(descriptor)
+				.as("Print option descriptor for '%s' should exist", optionName)
+				.isNotNull();
+		assertThat(descriptor.getDefaultValue())
+				.as("Print option '%s' default value", optionName)
+				.isEqualTo(expectedDefaultValue);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/report/documentPrintOptionDefaults.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/report/documentPrintOptionDefaults.feature
@@ -1,0 +1,31 @@
+@from:cucumber
+@ghActions:run_on_executor1
+Feature: Document Print Option defaults resolve @SQL= expressions
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+
+  @from:cucumber
+  Scenario: AD_Process_Para with static default Y resolves to true
+    Given metasfresh contains AD_Processes:
+      | Identifier | Value            | Name              |
+      | process    | TestPrintProcess | Test Print Process |
+    And metasfresh contains AD_Process_Paras:
+      | Identifier | AD_Process_ID | ColumnName               | Name       | DefaultValue | AD_Reference_ID |
+      | param      | process       | PRINTER_OPTS_IsPrintLogo | Print Logo | Y            | 20              |
+    Then the print option descriptors for AD_Process "process" include:
+      | OptionName               | DefaultValue |
+      | PRINTER_OPTS_IsPrintLogo | true         |
+
+  @from:cucumber
+  Scenario: AD_Process_Para with @SQL= default resolves correctly
+    Given metasfresh contains AD_Processes:
+      | Identifier | Value              | Name                |
+      | process    | TestPrintProcSQL   | Test Print Proc SQL |
+    And metasfresh contains AD_Process_Paras:
+      | Identifier | AD_Process_ID | ColumnName               | Name       | DefaultValue                                           | AD_Reference_ID |
+      | param      | process       | PRINTER_OPTS_IsPrintLogo | Print Logo | @SQL=SELECT 'Y' FROM AD_System FETCH FIRST 1 ROW ONLY | 20              |
+    Then the print option descriptors for AD_Process "process" include:
+      | OptionName               | DefaultValue |
+      | PRINTER_OPTS_IsPrintLogo | true         |

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/DefaultValueExpressionsFactory.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/factory/standard/DefaultValueExpressionsFactory.java
@@ -21,6 +21,7 @@ import org.adempiere.ad.expression.api.impl.DateStringExpressionSupport.DateStri
 import org.adempiere.ad.expression.api.impl.IntegerStringExpressionSupport.IntegerStringExpression;
 import org.adempiere.ad.expression.api.impl.SysDateDateExpression;
 import org.adempiere.mm.attributes.api.AttributeConstants;
+import org.compiere.util.DB;
 import org.compiere.util.DisplayType;
 import org.compiere.util.TimeUtil;
 import org.slf4j.Logger;
@@ -213,10 +214,11 @@ public class DefaultValueExpressionsFactory
 		{
 			return Optional.of(IStringExpression.NULL);
 		}
-		// If it's a SQL expression => compile it as SQL expression
-		else if (defaultValueStr.startsWith("@SQL="))
+		// If it's a SQL expression => compile it as SQL expression (deferred evaluation with document context).
+		// For immediate evaluation without document context, see DB.resolveSqlDefaultValue()
+		else if (DB.isSqlDefaultValue(defaultValueStr))
 		{
-			final String sqlTemplate = defaultValueStr.substring(5).trim();
+			final String sqlTemplate = defaultValueStr.substring(DB.SQL_DEFAULT_VALUE_PREFIX.length()).trim();
 			final IStringExpression sqlTemplateStringExpression = expressionFactory.compile(sqlTemplate, IStringExpression.class);
 			return Optional.of(SqlDefaultValueExpression.of(sqlTemplateStringExpression, fieldValueClass));
 		}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlDefaultValueExpression.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlDefaultValueExpression.java
@@ -57,6 +57,14 @@ import lombok.NonNull;
  */
 
 @JsonSerialize(using = JsonStringExpressionSerializer.class)
+/**
+ * Deferred SQL default value expression for WebUI document fields.
+ * The SQL template (with {@code @Variable@} placeholders) is compiled at descriptor build time
+ * and evaluated at document render time using the live document context.
+ *
+ * @see DB#resolveSqlDefaultValue(String) for the immediate-execution variant
+ * used by print option descriptors and other non-document contexts
+ */
 public final class SqlDefaultValueExpression<V> implements IExpression<V>
 {
 	public static <V> SqlDefaultValueExpression<?> of(


### PR DESCRIPTION
Cherry-pick of #23403 (squash commit df55efb9) from new_dawn_uat.

Fixes the same @SQL= bug that broke kh202's Logo drucken. Without this fix, any `AD_Process_Para.DefaultValue` rewritten by private-ext migration 5783321 to `@SQL=SELECT getDefaultValue_ProcessPara(...)` is passed to `StringUtils.toBoolean()` as a raw string and returns false — print logos disappear.

The env file `misc/dev-support/docker/infrastructure/env-files/keen_hawk_uat.env` from the original commit was dropped (keen_hawk-specific).

## Test plan

- Automated: `DBSqlDefaultValueTest` + cucumber `documentPrintOptionDefaults.feature` carried over from the source.