### PR TITLE
ci: run auto-update-base-version on the target branch (me03#29386)

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2669,10 +2669,24 @@ jobs:
           CICD_DISPATCH_REPO: ${{ fromJson(vars.CICD_DISPATCH_CONFIG).repo }}
           CICD_DISPATCH_WORKFLOW_FILE: ${{ fromJson(vars.CICD_DISPATCH_CONFIG).workflow_file }}
         run: |
-          # --ref "${SOURCE_BRANCH}" runs the downstream workflow ON the target
-          # branch, not on the private-extensions default branch. Without it,
-          # the workflow starts on new_dawn_uat, does an in-process
-          # `git checkout ${SOURCE_BRANCH}` and EndBug/add-and-commit sends the
-          # commit object to origin but the branch ref update is silently
-          # dropped — resulting in an orphan commit. See me03#29386.
-          gh workflow run "${CICD_DISPATCH_WORKFLOW_FILE}" --repo "${CICD_DISPATCH_REPO}" --ref "${SOURCE_BRANCH}" -f "cicd_run_id=${CICD_RUN_ID}" -f "tag_fixed=${TAG_FIXED}" -f "source_branch=${SOURCE_BRANCH}"
+          # Run the downstream workflow ON the target branch (via --ref) when
+          # that branch exists in private-extensions, otherwise fall back to
+          # running it on the PE default branch so its `check-branch` step can
+          # take the "branch doesn't exist → dispatch directly to me03" path.
+          #
+          # Without --ref when the branch DOES exist, the workflow starts on
+          # new_dawn_uat, does an in-process `git checkout ${SOURCE_BRANCH}`,
+          # and `EndBug/add-and-commit` sends the commit object to origin but
+          # the branch ref update is silently dropped — resulting in an orphan
+          # commit. See me03#29386.
+          #
+          # With --ref when the branch DOES NOT exist, `gh workflow run` fails
+          # with "could not find a reference" and the workflow never runs,
+          # breaking the fallback-to-default dispatch path.
+          REF_ARGS=()
+          if gh api "repos/${CICD_DISPATCH_REPO}/branches/${SOURCE_BRANCH}" --jq .name >/dev/null 2>&1; then
+            REF_ARGS+=(--ref "${SOURCE_BRANCH}")
+          else
+            echo "Branch '${SOURCE_BRANCH}' not found in ${CICD_DISPATCH_REPO}; running workflow on default branch so its fallback path activates."
+          fi
+          gh workflow run "${CICD_DISPATCH_WORKFLOW_FILE}" --repo "${CICD_DISPATCH_REPO}" "${REF_ARGS[@]}" -f "cicd_run_id=${CICD_RUN_ID}" -f "tag_fixed=${TAG_FIXED}" -f "source_branch=${SOURCE_BRANCH}"

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2669,4 +2669,10 @@ jobs:
           CICD_DISPATCH_REPO: ${{ fromJson(vars.CICD_DISPATCH_CONFIG).repo }}
           CICD_DISPATCH_WORKFLOW_FILE: ${{ fromJson(vars.CICD_DISPATCH_CONFIG).workflow_file }}
         run: |
-          gh workflow run "${CICD_DISPATCH_WORKFLOW_FILE}" --repo "${CICD_DISPATCH_REPO}" -f "cicd_run_id=${CICD_RUN_ID}" -f "tag_fixed=${TAG_FIXED}" -f "source_branch=${SOURCE_BRANCH}"
+          # --ref "${SOURCE_BRANCH}" runs the downstream workflow ON the target
+          # branch, not on the private-extensions default branch. Without it,
+          # the workflow starts on new_dawn_uat, does an in-process
+          # `git checkout ${SOURCE_BRANCH}` and EndBug/add-and-commit sends the
+          # commit object to origin but the branch ref update is silently
+          # dropped — resulting in an orphan commit. See me03#29386.
+          gh workflow run "${CICD_DISPATCH_WORKFLOW_FILE}" --repo "${CICD_DISPATCH_REPO}" --ref "${SOURCE_BRANCH}" -f "cicd_run_id=${CICD_RUN_ID}" -f "tag_fixed=${TAG_FIXED}" -f "source_branch=${SOURCE_BRANCH}"


### PR DESCRIPTION
Fixes the last known issue from the dispatch-chain repair (me03#29386).

## Problem

The `cicd-dispatch` job triggers `auto-update-base-version.yaml` on `mf15-private-extensions` via
```
gh workflow run auto-update-base-version.yaml -f source_branch=${SOURCE_BRANCH} …
```
With no `--ref`, GitHub always runs that workflow on PE's default branch (`new_dawn_uat`). The workflow then uses an in-process `git checkout ${SOURCE_BRANCH}` followed by `EndBug/add-and-commit@v9` to commit and push `docker-builds/version.base.info`. On any branch other than the workflow's native branch, this sends the commit object to origin (so the SHA is fetchable) but the branch ref update is silently dropped, leaving the target branch unchanged while the dispatch reports `committed: true`.

Observed on 2026-04-22: after the pilot on `epic_party_hotfix`, the dispatch ran successfully, commit `424d66e` was created and stored, customer dispatch propagated correctly — but `mf15-private-extensions/epic_party_hotfix:docker-builds/version.base.info` stayed at the pre-pilot value. See the me03 issue for the full trace.

## Fix

Add `--ref "${SOURCE_BRANCH}"` so the downstream workflow runs on the target branch natively. `actions/checkout@v4` then provides the right git credentials for that branch and the push succeeds normally.

This is the parent-level equivalent of https://github.com/metasfresh/mf15-private-extensions/pull/20 (which fixed the PE→PE hop inside `auto-update-base-version.yaml`).

## Test plan

- [ ] CI green on this PR
- [ ] After merge, trigger a fresh build on any non-default PE-connected metasfresh branch (e.g. `epic_party_hotfix`) and verify the resulting commit lands on that branch's ref in mf15-private-extensions
- [ ] Verify `gh run list --workflow auto-update-base-version.yaml --branch <that_branch>` actually shows a run on that branch (not on `new_dawn_uat`)