### PR TITLE
Restore mobile retry panel accidentally dropped by #23582

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/confirmation.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/confirmation.js
@@ -2,14 +2,20 @@ import axios from 'axios';
 import { apiBasePath } from '../constants';
 import { unboxAxiosResponse } from '../utils';
 
+export const DEFAULT_TIMEOUT_MILLIS = 20000;
+
 /**
  * @method userConfirmation
  * @summary Post confirmation to the server after a dialog is shown (see ConfirmationButton/ConfirmActivity component)
- * @param {object} `token` - The token to use for authentication
- * @returns
+ *
+ * The Zebra scanner on flaky wifi regularly drops the TCP connection mid-roam; without an explicit timeout,
+ * axios hangs forever and the operator is left with no signal that their "Fertigstellen" press didn't reach
+ * the backend. The timeout ensures the promise eventually rejects so the UI can surface the
+ * failure and let the operator retry.
  */
-export function postUserConfirmation({ wfProcessId, activityId }) {
+export function postUserConfirmation({ wfProcessId, activityId, timeoutMillis }) {
+  const timeout = Number.isFinite(timeoutMillis) && timeoutMillis > 0 ? timeoutMillis : DEFAULT_TIMEOUT_MILLIS;
   return axios
-    .post(`${apiBasePath}/userWorkflows/wfProcess/${wfProcessId}/${activityId}/userConfirmation`)
+    .post(`${apiBasePath}/userWorkflows/wfProcess/${wfProcessId}/${activityId}/userConfirmation`, null, { timeout })
     .then((response) => unboxAxiosResponse(response));
 }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx
@@ -1,12 +1,16 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import { postUserConfirmation } from '../../../api/confirmation';
+import { DEFAULT_TIMEOUT_MILLIS, postUserConfirmation } from '../../../api/confirmation';
 import ConfirmButton from '../../../components/buttons/ConfirmButton';
-import { toastError } from '../../../utils/toast';
+import ButtonWithIndicator from '../../../components/buttons/ButtonWithIndicator';
+import { extractUserFriendlyErrorMessageFromAxiosError, toastError } from '../../../utils/toast';
 import { useDispatch } from 'react-redux';
 import { appLaunchersLocation } from '../../../routes/launchers';
 import { setActivityProcessing, updateWFProcess } from '../../../actions/WorkflowActions';
 import { useMobileNavigation } from '../../../hooks/useMobileNavigation';
+import { usePositiveNumberSetting } from '../../../reducers/settings';
+import { trl } from '../../../utils/translations';
+import * as uiTrace from '../../../utils/ui_trace';
 
 const ConfirmActivity = ({
   applicationId,
@@ -22,19 +26,56 @@ const ConfirmActivity = ({
 }) => {
   const dispatch = useDispatch();
   const history = useMobileNavigation();
-  const onUserConfirmed = () => {
+  const [errorMessage, setErrorMessage] = useState(null);
+  // Synchronous guard: isProcessing only re-flows via Redux on the next render,
+  // so a fast double-tap on Retry would otherwise send two requests.
+  const sendingRef = useRef(false);
+
+  // Overridable via AD_SysConfig mobileui.frontend.api.completeConfirmation.timeoutMillis
+  const timeoutMillis = usePositiveNumberSetting('api.completeConfirmation.timeoutMillis', DEFAULT_TIMEOUT_MILLIS);
+
+  const sendConfirmation = () => {
+    if (sendingRef.current) return;
+    sendingRef.current = true;
+    setErrorMessage(null);
     dispatch(setActivityProcessing({ wfProcessId, activityId, processing: true }));
-    postUserConfirmation({ wfProcessId, activityId })
+    postUserConfirmation({ wfProcessId, activityId, timeoutMillis })
       .then((wfProcess) => {
         dispatch(updateWFProcess({ wfProcess }));
-      })
-      .then(() => {
+        uiTrace.trace({ eventName: 'confirmationPosted', wfProcessId, activityId });
         if (isLastActivity) {
           history.push(appLaunchersLocation({ applicationId }));
         }
       })
-      .catch((axiosError) => toastError({ axiosError }))
-      .finally(() => dispatch(setActivityProcessing({ wfProcessId, activityId, processing: false })));
+      .catch((axiosError) => {
+        // A server response means the backend rejected the operation (e.g. "all steps must be completed");
+        // retrying the same payload won't help, and there is automation that asserts on the toast.
+        // Only surface the inline retry panel for network-layer failures (timeout / no response at all).
+        const isNetworkFailure = !axiosError?.response;
+        const message = extractUserFriendlyErrorMessageFromAxiosError({ axiosError });
+        uiTrace.trace({
+          eventName: 'confirmationFailed',
+          wfProcessId,
+          activityId,
+          httpStatus: axiosError?.response?.status ?? null,
+          axiosCode: axiosError?.code ?? null,
+          isNetworkFailure,
+          message,
+        });
+        if (isNetworkFailure) {
+          setErrorMessage(message);
+        } else {
+          toastError({ axiosError });
+        }
+      })
+      .finally(() => {
+        sendingRef.current = false;
+        dispatch(setActivityProcessing({ wfProcessId, activityId, processing: false }));
+      });
+  };
+
+  const onCancelError = () => {
+    setErrorMessage(null);
   };
 
   return (
@@ -44,11 +85,33 @@ const ConfirmActivity = ({
         caption={caption}
         promptQuestion={promptQuestion}
         userInstructions={userInstructions}
-        isUserEditable={isUserEditable}
+        isUserEditable={isUserEditable && !errorMessage}
         isProcessing={isProcessing}
         completeStatus={completeStatus}
-        onUserConfirmed={onUserConfirmed}
+        onUserConfirmed={sendConfirmation}
       />
+      {errorMessage && (
+        <div className="notification is-danger mt-3" data-testid="confirm-activity-error-panel">
+          <p className="mb-3">
+            <strong>{trl('activities.confirmButton.error.title')}</strong>
+          </p>
+          <p className="mb-3">{errorMessage}</p>
+          <div className="buttons">
+            <ButtonWithIndicator
+              testId="confirm-activity-error-retry"
+              captionKey="activities.confirmButton.error.retry"
+              disabled={isProcessing}
+              onClick={sendConfirmation}
+            />
+            <ButtonWithIndicator
+              testId="confirm-activity-error-cancel"
+              captionKey="activities.confirmButton.error.cancel"
+              disabled={isProcessing}
+              onClick={onCancelError}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
@@ -37,6 +37,11 @@ export const useKeyboardBarcodeReader = ({
       if (event.ctrlKey || event.metaKey) {
         return;
       }
+      // Composition / IME events, some browser extensions and Chrome autofill dispatch
+      // keydown-like events with event.key === undefined. Bail out before any .length access.
+      if (event.key == null) {
+        return;
+      }
       // Allow altKey for printable characters (Zebra MC3300x firmware sets altKey=true on scanner keystrokes)
       if (event.altKey && event.key.length !== 1) {
         return;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -155,6 +155,11 @@ const translations = {
       },
       abort: 'Rückgängig',
       notFound: 'Nicht gefunden',
+      error: {
+        title: 'Bestätigung konnte nicht gesendet werden',
+        retry: 'Erneut senden',
+        cancel: 'Abbrechen',
+      },
     },
     mfg: {
       ProductName: 'Produkt',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -152,6 +152,11 @@ const translations = {
       },
       abort: 'Abort',
       notFound: 'Not found',
+      error: {
+        title: 'Could not send confirmation',
+        retry: 'Retry',
+        cancel: 'Cancel',
+      },
     },
     mfg: {
       ProductName: 'Product Name',


### PR DESCRIPTION
## Summary

- Restore 5 mobile-webui-frontend files that were silently reverted by [#23582](https://github.com/metasfresh/metasfresh/pull/23582) (a tax-reporting PR), re-bringing the `confirm-activity-error-panel` component.
- Files are byte-identical to their state at commit `f29dff50534` (merge of [#23591](https://github.com/metasfresh/metasfresh/pull/23591)), which was the correct post-merge tree.
- Unblocks the `mobile test` CI job on `new_dawn_uat` — two Playwright scenarios under *Picking Job Completion* that assert the retry panel appears on network failure.

## Why a tax-reporting PR reverted mobile-webui code

1. [#23582](https://github.com/metasfresh/metasfresh/pull/23582) branch (`new_dawn_uat_TaxAccountingReportTotalAmt`) was opened when `new_dawn_uat` had the retry panel ([#23586](https://github.com/metasfresh/metasfresh/pull/23586)).
2. During the PR's life, the author merged `new_dawn_uat` into their branch **while the panel was in its reverted window** ([#23587](https://github.com/metasfresh/metasfresh/pull/23587)) — pulling the revert into the feature branch.
3. `new_dawn_uat` subsequently re-added the panel via the `intensive_care_release → new_dawn_uat` merge ([#23515](https://github.com/metasfresh/metasfresh/pull/23515)). The feature branch was **never re-synced** after that.
4. GitHub's **squash merge** emits one commit whose diff = (feature-tip content vs current base). Because the feature tip lacked the retry panel and the base had it, the squash silently bundled "delete 5 mobile-webui-frontend files" into the tax-reporting commit — files [#23582](https://github.com/metasfresh/metasfresh/pull/23582) never intended to touch.

## Files restored (all identical to `f29dff50534`)

- `misc/services/mobile-webui/mobile-webui-frontend/src/api/confirmation.js`
- `misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/confirmButton/ConfirmActivity.jsx`
- `misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js`
- `misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js`
- `misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js`

## Test plan

- [ ] `mobile test` CI job passes on `new_dawn_uat_RestoreRetryPanel`
- [ ] Specifically: `picking.spec.js` scenarios *"Network failure on complete shows retry panel; Retry then succeeds"* and *"Cancel on retry panel hides it and leaves the job resumable"* (F00230) go green
- [ ] No changes to tax-reporting code from [#23582](https://github.com/metasfresh/metasfresh/pull/23582) — that logic stays intact (verified: `git log f29dff50534..HEAD` on the 5 touched paths shows only `b75e1559f47`)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>