### PR TITLE
Send mail via Microsoft Graph from the user's mailbox, not the server's

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/mailboxes/Mailbox.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/mailboxes/Mailbox.java
@@ -132,6 +132,7 @@ public class Mailbox
 				final MicrosoftGraphConfig microsoftGraphConfig = getMicrosoftGraphConfigNotNull();
 				return ExplainedOptional.of(
 						toBuilder()
+								.email(userEmail)
 								.microsoftGraphConfig(microsoftGraphConfig.withDefaultReplyTo(userEmail))
 								.build()
 				);

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/email/mailboxes/MailboxTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/email/mailboxes/MailboxTest.java
@@ -1,0 +1,67 @@
+package de.metas.email.mailboxes;
+
+import de.metas.email.EMailAddress;
+import de.metas.i18n.ExplainedOptional;
+import de.metas.user.UserId;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MailboxTest
+{
+	private static final EMailAddress SERVER_EMAIL = EMailAddress.ofString("server@example.com");
+	private static final EMailAddress USER_EMAIL = EMailAddress.ofString("user@example.com");
+
+	@Test
+	void mergeFrom_microsoftGraph_setsFromAndReplyToToUserEmail()
+	{
+		final Mailbox serverMailbox = Mailbox.builder()
+				.type(MailboxType.MICROSOFT_GRAPH)
+				.email(SERVER_EMAIL)
+				.microsoftGraphConfig(MicrosoftGraphConfig.builder()
+						.clientId("client-id")
+						.tenantId("tenant-id")
+						.clientSecret("client-secret")
+						.build())
+				.build();
+
+		final UserEMailConfig userConfig = UserEMailConfig.builder()
+				.userId(UserId.ofRepoId(123))
+				.email(USER_EMAIL)
+				.build();
+
+		final ExplainedOptional<Mailbox> result = serverMailbox.mergeFrom(userConfig);
+
+		assertThat(result.isPresent()).isTrue();
+		final Mailbox merged = result.get();
+		assertThat(merged.getEmail()).isEqualTo(USER_EMAIL);
+		assertThat(merged.getMicrosoftGraphConfigNotNull().getDefaultReplyTo()).isEqualTo(USER_EMAIL);
+		// server-level Graph credentials must remain unchanged (single tenant-wide app)
+		assertThat(merged.getMicrosoftGraphConfigNotNull().getClientId()).isEqualTo("client-id");
+		assertThat(merged.getMicrosoftGraphConfigNotNull().getTenantId()).isEqualTo("tenant-id");
+		assertThat(merged.getMicrosoftGraphConfigNotNull().getClientSecret()).isEqualTo("client-secret");
+	}
+
+	@Test
+	void mergeFrom_microsoftGraph_userWithoutEmail_returnsEmpty()
+	{
+		final Mailbox serverMailbox = Mailbox.builder()
+				.type(MailboxType.MICROSOFT_GRAPH)
+				.email(SERVER_EMAIL)
+				.microsoftGraphConfig(MicrosoftGraphConfig.builder()
+						.clientId("client-id")
+						.tenantId("tenant-id")
+						.clientSecret("client-secret")
+						.build())
+				.build();
+
+		final UserEMailConfig userConfig = UserEMailConfig.builder()
+				.userId(UserId.ofRepoId(123))
+				.email(null)
+				.build();
+
+		final ExplainedOptional<Mailbox> result = serverMailbox.mergeFrom(userConfig);
+
+		assertThat(result.isPresent()).isFalse();
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes the From-address bug when a logged-in user sends mail through Microsoft Graph (e.g. ALT-E from a sales order).
- Before this PR: the recipient sees the server mailbox in the `From` header and the user's address only in `Reply-To`.
- After this PR: the user's address is used in `From` (and `Reply-To`), matching the existing SMTP behaviour.

## Root cause
`Mailbox.mergeFrom(UserEMailConfig)` for `MailboxType.MICROSOFT_GRAPH` only stored the user's email as `defaultReplyTo` and kept the server mailbox's `email` unchanged. `MicrosoftGraphMailSender.newUserRequest` then issued `POST /users/{server-mailbox}/sendMail` regardless of who was logged in. The SMTP branch already did the right thing (replacing `mailbox.email` with the user's email).

## Change
One-line addition in `Mailbox.java`: in the `MICROSOFT_GRAPH` branch of `mergeFrom`, set `.email(userEmail)` on the merged mailbox, mirroring the SMTP branch. Plus a unit test covering both the merge and the no-user-email fallback (which still throws `MailboxNotFoundException` upstream).

## Azure / customer-side prerequisite
For the recipient to actually receive the mail, the customer's Azure app registration needs `Mail.Send` **application** permission AND an `ApplicationAccessPolicy` allowing the app to send-as each metasfresh user's mailbox. Otherwise Graph returns 403. This is unchanged by this PR (already required to use Graph at all).

## Test plan
- [x] Unit tests added: `MailboxTest.mergeFrom_microsoftGraph_setsFromAndReplyToToUserEmail` and `..._userWithoutEmail_returnsEmpty`. Both pass locally.
- [x] Module compiles: `de.metas.adempiere.adempiere.base`.
- [ ] Manual UAT on a customer instance with Graph configured: send from a sales order and verify the recipient's `From` header equals the logged-in user's `AD_User.EMail`.