### PR TITLE
Revert "Add `APProFormaInvoice` to `DocBaseType` enum"

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/DocBaseType.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/DocBaseType.java
@@ -60,7 +60,6 @@ public enum DocBaseType implements ReferenceListAwareEnum
 	BillOfMaterialVersion(X_C_DocType.DOCBASETYPE_BOMFormula),
 	CostRevaluation(X_C_DocType.DOCBASETYPE_CostRevaluation),
 	AnalysisReport(X_C_DocType.DOCBASETYPE_AnalysisReport),
-	APProFormaInvoice(X_C_DocType.DOCBASETYPE_APProFormaInvoice),
 	;
 
 	public static final int AD_REFERENCE_ID = X_C_DocType.DOCBASETYPE_AD_Reference_ID;


### PR DESCRIPTION
Reverts metasfresh/metasfresh#23665 because the value was already added in: #23165