### PR TITLE
fix(webui): cap toString reason and self-heal sticky-error documents on child invalidation

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentCollection.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentCollection.java
@@ -601,6 +601,37 @@ public class DocumentCollection
 		}
 	}
 
+	/**
+	 * Decides whether the cached root document should be evicted when one of its children gets
+	 * invalidated.
+	 *
+	 * <p>Historically this was gated purely on {@link DocumentToInvalidate#isInvalidateDocument()},
+	 * which the dispatcher only sets for whole-table invalidations. For a specific child-record
+	 * invalidation (the common case when a single child row is inserted/updated/deleted
+	 * externally), the gate stays false and the cached parent keeps its in-memory state.
+	 *
+	 * <p>That is fine for a happy-path parent — the child collection is flagged stale and the
+	 * frontend refreshes it on its own. It is NOT fine when the cached parent is in error state,
+	 * because a child-state change is a strong signal that the condition that produced the error
+	 * may now be gone. Without this escape hatch, the sticky error (and its potentially huge
+	 * {@code reason} string) survives until the document is evicted by LRU or by an admin cache
+	 * reset with {@code forgetNotSavedDocuments=true}.
+	 *
+	 * <p>Pure boolean signature on purpose so it can be unit-tested without needing to mock
+	 * {@link Document} (which is final and has a non-trivial constructor).
+	 */
+	static boolean shouldInvalidateRootOnChildInvalidation(
+			final boolean callerRequestedFullInvalidation,
+			final boolean rootHasSaveError,
+			final boolean rootValidStatusIsValid)
+	{
+		if (callerRequestedFullInvalidation)
+		{
+			return true;
+		}
+		return rootHasSaveError || !rootValidStatusIsValid;
+	}
+
 	private void invalidate(@NonNull final DocumentToInvalidate documentToInvalidate)
 	{
 		final ImmutableList<DocumentEntityDescriptor> entityDescriptors = getCachedWindowIdsForTableName(documentToInvalidate.getTableName())
@@ -651,7 +682,11 @@ public class DocumentCollection
 				// Invalidate the root document
 				// NOTE: avoid invalidating if the document is new (and not saved) because in that case we will lose the document and we will never be able to recover.
 				// As a symptom the user will get 404 or similar in his browser and the document will vanish completely.
-				if (documentToInvalidate.isInvalidateDocument() && !rootDocument.isNew())
+				if (shouldInvalidateRootOnChildInvalidation(
+						documentToInvalidate.isInvalidateDocument(),
+						rootDocument.getSaveStatus().isError(),
+						rootDocument.getValidStatus().isValid())
+						&& !rootDocument.isNew())
 				{
 					rootDocuments.invalidate(rootDocumentKey);
 				}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentSaveStatus.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentSaveStatus.java
@@ -108,6 +108,21 @@ public final class DocumentSaveStatus
 	@Override
 	public String toString()
 	{
+		// Bound reason to avoid exponential growth when an exception message is built
+		// from Document.toString() (which embeds this saveStatus). Without the cap, each
+		// successive error re-embeds the previous reason -> O(2^n) string size, easily
+		// reaching 100+ MB in the JSON response.
+		final String reasonStr;
+		if (reason == null)
+		{
+			reasonStr = null;
+		}
+		else
+		{
+			final String s = String.valueOf(reason);
+			final int max = 200;
+			reasonStr = s.length() <= max ? s : s.substring(0, max) + "...(+" + (s.length() - max) + " chars)";
+		}
 		return MoreObjects.toStringHelper(this)
 				.omitNullValues()
 				.add("saved", saved ? true : null)
@@ -115,7 +130,7 @@ public final class DocumentSaveStatus
 				.add("deleted", deleted ? true : null)
 				.add("hasChangesToBeSaved", hasChangesToBeSaved ? true : null)
 				.add("error", error ? true : null)
-				.add("reason", reason)
+				.add("reason", reasonStr)
 				.toString();
 	}
 

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentSaveStatus.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentSaveStatus.java
@@ -37,6 +37,36 @@ import javax.annotation.Nullable;
 @EqualsAndHashCode
 public final class DocumentSaveStatus
 {
+	/**
+	 * Maximum number of chars rendered for {@code reason} inside {@link #toString()} (and inside
+	 * {@link DocumentValidStatus#toString()}, which uses the same cap).
+	 *
+	 * <p>Bounds the toString output so an exception message built from {@code Document.toString()}
+	 * (which embeds save status / valid status) cannot grow exponentially when that message then
+	 * becomes the next {@code reason}. Without the cap each successive error doubles the stored
+	 * reason — easily reaching 100+ MB JSON responses.
+	 *
+	 * <p>5000 chars is a balance: enough headroom for a normal exception message that includes a
+	 * one-level {@code Document{...}} snapshot for debugging, yet small enough that even a fully
+	 * nested toString output stays under ~5 KB and the doubling chain is severed.
+	 */
+	public static final int TOSTRING_REASON_MAX_CHARS = 5000;
+
+	@Nullable
+	static String truncateReasonForToString(@Nullable final ITranslatableString reason)
+	{
+		if (reason == null)
+		{
+			return null;
+		}
+		final String s = String.valueOf(reason);
+		if (s.length() <= TOSTRING_REASON_MAX_CHARS)
+		{
+			return s;
+		}
+		return s.substring(0, TOSTRING_REASON_MAX_CHARS) + "...(+" + (s.length() - TOSTRING_REASON_MAX_CHARS) + " chars)";
+	}
+
 	public static DocumentSaveStatus unknown(boolean isPresentInDatabase)
 	{
 		return builder().hasChangesToBeSaved(true).isPresentInDatabase(isPresentInDatabase).error(false).reason(TranslatableStrings.anyLanguage("not yet checked")).build();
@@ -108,21 +138,6 @@ public final class DocumentSaveStatus
 	@Override
 	public String toString()
 	{
-		// Bound reason to avoid exponential growth when an exception message is built
-		// from Document.toString() (which embeds this saveStatus). Without the cap, each
-		// successive error re-embeds the previous reason -> O(2^n) string size, easily
-		// reaching 100+ MB in the JSON response.
-		final String reasonStr;
-		if (reason == null)
-		{
-			reasonStr = null;
-		}
-		else
-		{
-			final String s = String.valueOf(reason);
-			final int max = 200;
-			reasonStr = s.length() <= max ? s : s.substring(0, max) + "...(+" + (s.length() - max) + " chars)";
-		}
 		return MoreObjects.toStringHelper(this)
 				.omitNullValues()
 				.add("saved", saved ? true : null)
@@ -130,7 +145,7 @@ public final class DocumentSaveStatus
 				.add("deleted", deleted ? true : null)
 				.add("hasChangesToBeSaved", hasChangesToBeSaved ? true : null)
 				.add("error", error ? true : null)
-				.add("reason", reasonStr)
+				.add("reason", truncateReasonForToString(reason))
 				.toString();
 	}
 

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentValidStatus.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentValidStatus.java
@@ -107,12 +107,10 @@ public final class DocumentValidStatus
 
 			if (!TranslatableStrings.isBlank(reason))
 			{
-				// Bound reason to avoid exponential growth when an exception message is built
-				// from Document.toString() (which embeds this validStatus).
-				final String s = String.valueOf(reason);
-				final int max = 200;
-				final String reasonStr = s.length() <= max ? s : s.substring(0, max) + "...(+" + (s.length() - max) + " chars)";
-				sb.append("('").append(reasonStr).append("')");
+				// Bound the rendered reason to avoid exponential growth when an exception message
+				// is built from Document.toString() (which embeds this validStatus). See
+				// DocumentSaveStatus#TOSTRING_REASON_MAX_CHARS for rationale.
+				sb.append("('").append(DocumentSaveStatus.truncateReasonForToString(reason)).append("')");
 			}
 
 			toString = this._toString = sb.toString();

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentValidStatus.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentValidStatus.java
@@ -107,7 +107,12 @@ public final class DocumentValidStatus
 
 			if (!TranslatableStrings.isBlank(reason))
 			{
-				sb.append("('").append(reason).append("')");
+				// Bound reason to avoid exponential growth when an exception message is built
+				// from Document.toString() (which embeds this validStatus).
+				final String s = String.valueOf(reason);
+				final int max = 200;
+				final String reasonStr = s.length() <= max ? s : s.substring(0, max) + "...(+" + (s.length() - max) + " chars)";
+				sb.append("('").append(reasonStr).append("')");
 			}
 
 			toString = this._toString = sb.toString();

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/window/model/DocumentCollectionShouldInvalidateRootTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/window/model/DocumentCollectionShouldInvalidateRootTest.java
@@ -1,0 +1,59 @@
+package de.metas.ui.web.window.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link DocumentCollection#shouldInvalidateRootOnChildInvalidation(boolean, boolean, boolean)}.
+ *
+ * Covers the scenario where a child record is invalidated externally and the cached root
+ * document is in error state — the root must be evicted so the next read loads a clean
+ * document from the repository, otherwise the sticky error (and its potentially huge
+ * {@code reason} string) survives indefinitely.
+ */
+class DocumentCollectionShouldInvalidateRootTest
+{
+	@Test
+	void happyPath_noErrors_noFullInvalidationRequested_keepsRootCached()
+	{
+		assertThat(DocumentCollection.shouldInvalidateRootOnChildInvalidation(
+				false, // callerRequestedFullInvalidation
+				false, // rootHasSaveError
+				true   // rootValidStatusIsValid
+		)).isFalse();
+	}
+
+	@Test
+	void fullInvalidationRequested_alwaysEvictsRoot()
+	{
+		assertThat(DocumentCollection.shouldInvalidateRootOnChildInvalidation(true, false, true)).isTrue();
+		assertThat(DocumentCollection.shouldInvalidateRootOnChildInvalidation(true, true, false)).isTrue();
+	}
+
+	@Test
+	void rootInSaveErrorState_childInvalidation_evictsRoot()
+	{
+		assertThat(DocumentCollection.shouldInvalidateRootOnChildInvalidation(
+				false, // callerRequestedFullInvalidation
+				true,  // rootHasSaveError
+				true   // rootValidStatusIsValid — irrelevant once saveError is true
+		)).isTrue();
+	}
+
+	@Test
+	void rootValidStatusInvalid_childInvalidation_evictsRoot()
+	{
+		assertThat(DocumentCollection.shouldInvalidateRootOnChildInvalidation(
+				false, // callerRequestedFullInvalidation
+				false, // rootHasSaveError
+				false  // rootValidStatusIsValid = false
+		)).isTrue();
+	}
+
+	@Test
+	void bothErrorFlagsSet_evictsRoot()
+	{
+		assertThat(DocumentCollection.shouldInvalidateRootOnChildInvalidation(false, true, false)).isTrue();
+	}
+}

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/window/model/DocumentStatusReasonTruncationTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/window/model/DocumentStatusReasonTruncationTest.java
@@ -18,18 +18,17 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class DocumentStatusReasonTruncationTest
 {
-	/** Max length applied inside the toString() methods. Must match the value used in the production code. */
-	private static final int EXPECTED_REASON_CAP = 200;
-
 	/** Slack for the other toString parts (flags, prefix/suffix, truncation marker). */
 	private static final int TOSTRING_OVERHEAD = 500;
 
 	private static String longMessage()
 	{
-		// 10 000 chars — well above the cap and large enough to detect any unbounded
-		// embedding in a single-iteration test.
-		final StringBuilder sb = new StringBuilder(10_000);
-		for (int i = 0; i < 10_000; i++)
+		// Well above the cap and large enough to detect any unbounded embedding in a
+		// single-iteration test. Sized relative to the production cap so a future bump
+		// to TOSTRING_REASON_MAX_CHARS keeps the test meaningful.
+		final int len = DocumentSaveStatus.TOSTRING_REASON_MAX_CHARS * 2;
+		final StringBuilder sb = new StringBuilder(len);
+		for (int i = 0; i < len; i++)
 		{
 			sb.append('x');
 		}
@@ -49,7 +48,7 @@ class DocumentStatusReasonTruncationTest
 
 		assertThat(s.length())
 				.as("DocumentSaveStatus.toString() must cap reason to avoid recursive blow-up")
-				.isLessThan(EXPECTED_REASON_CAP + TOSTRING_OVERHEAD);
+				.isLessThan(DocumentSaveStatus.TOSTRING_REASON_MAX_CHARS + TOSTRING_OVERHEAD);
 
 		assertThat(s)
 				.as("truncation marker must be present when reason exceeds cap")
@@ -68,7 +67,7 @@ class DocumentStatusReasonTruncationTest
 
 		assertThat(s.length())
 				.as("DocumentValidStatus.toString() must cap reason to avoid recursive blow-up")
-				.isLessThan(EXPECTED_REASON_CAP + TOSTRING_OVERHEAD);
+				.isLessThan(DocumentSaveStatus.TOSTRING_REASON_MAX_CHARS + TOSTRING_OVERHEAD);
 
 		assertThat(s)
 				.as("truncation marker must be present when reason exceeds cap")

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/window/model/DocumentStatusReasonTruncationTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/window/model/DocumentStatusReasonTruncationTest.java
@@ -1,0 +1,102 @@
+package de.metas.ui.web.window.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link DocumentSaveStatus#toString()} and
+ * {@link DocumentValidStatus#toString()} cap their {@code reason} portion, so the
+ * {@code toString()} of an enclosing {@link Document} cannot trigger exponential
+ * growth when an exception message is built from {@code document.toString()} and
+ * then becomes the next {@code reason}.
+ *
+ * Regression test: a poisoned document can accumulate thousands of recursively-nested
+ * {@code Document{...}} snapshots in {@code validStatus.reason} / {@code saveStatus.reason},
+ * producing 100+ MB JSON responses. Capping the reason inside {@code toString()} breaks
+ * the doubling feedback loop.
+ */
+class DocumentStatusReasonTruncationTest
+{
+	/** Max length applied inside the toString() methods. Must match the value used in the production code. */
+	private static final int EXPECTED_REASON_CAP = 200;
+
+	/** Slack for the other toString parts (flags, prefix/suffix, truncation marker). */
+	private static final int TOSTRING_OVERHEAD = 500;
+
+	private static String longMessage()
+	{
+		// 10 000 chars — well above the cap and large enough to detect any unbounded
+		// embedding in a single-iteration test.
+		final StringBuilder sb = new StringBuilder(10_000);
+		for (int i = 0; i < 10_000; i++)
+		{
+			sb.append('x');
+		}
+		return sb.toString();
+	}
+
+	@Test
+	void documentSaveStatus_toString_bounds_reason_length()
+	{
+		final String bigMessage = longMessage();
+
+		final DocumentSaveStatus status = DocumentSaveStatus.error(
+				new RuntimeException(bigMessage),
+				DocumentSaveStatus.savedJustLoaded());
+
+		final String s = status.toString();
+
+		assertThat(s.length())
+				.as("DocumentSaveStatus.toString() must cap reason to avoid recursive blow-up")
+				.isLessThan(EXPECTED_REASON_CAP + TOSTRING_OVERHEAD);
+
+		assertThat(s)
+				.as("truncation marker must be present when reason exceeds cap")
+				.contains("...(+")
+				.contains("chars)");
+	}
+
+	@Test
+	void documentValidStatus_toString_bounds_reason_length()
+	{
+		final String bigMessage = longMessage();
+
+		final DocumentValidStatus status = DocumentValidStatus.invalid(new RuntimeException(bigMessage));
+
+		final String s = status.toString();
+
+		assertThat(s.length())
+				.as("DocumentValidStatus.toString() must cap reason to avoid recursive blow-up")
+				.isLessThan(EXPECTED_REASON_CAP + TOSTRING_OVERHEAD);
+
+		assertThat(s)
+				.as("truncation marker must be present when reason exceeds cap")
+				.contains("...(+")
+				.contains("chars)");
+	}
+
+	@Test
+	void documentSaveStatus_toString_keeps_short_reason_intact()
+	{
+		final DocumentSaveStatus status = DocumentSaveStatus.error(
+				new RuntimeException("short reason"),
+				DocumentSaveStatus.savedJustLoaded());
+
+		assertThat(status.toString())
+				.as("short reasons must pass through unchanged")
+				.contains("short reason")
+				.doesNotContain("...(+");
+	}
+
+	@Test
+	void documentValidStatus_toString_keeps_short_reason_intact()
+	{
+		final DocumentValidStatus status = DocumentValidStatus.invalid(new RuntimeException("short reason"));
+
+		assertThat(status.toString())
+				.as("short reasons must pass through unchanged")
+				.contains("short reason")
+				.doesNotContain("...(+");
+	}
+}


### PR DESCRIPTION
## Summary

Two-commit fix for a product window occasionally returning a 100+ MB REST response that rendered the page blank.

### What was happening

When a child Document fails to load (e.g. its underlying PO is missing in the database), webapi code throws a `DBException` whose message is built by interpolating the parent Document. `Document.toString()` embeds `saveStatus` and `validStatus`, whose `toString()`s in turn embed their `reason` field. That exception message is then stored back as the new `reason`, and the cycle repeats: each subsequent error doubles the stored reason because the whole previous toString output is re-embedded.

After ~20 cycles the reason string exceeds 100 MB. The JSON window response balloons to the same size, frontend chokes, page is blank.

### Conditions for the bug to manifest

1. Parent root Document is cached in `DocumentCollection.rootDocuments`.
2. A child row gets deleted externally (other tab/session, save-time interceptor, trigger, cascade).
3. Subsequent save / refresh attempts fail with `No PO found` and the exception message embeds `document.toString()`, seeding the recursion.
4. The cached parent's `saveStatus.hasChangesToBeSaved=true`, so default `cacheReset(false)` deliberately skips it (to protect unsaved work).
5. User keeps interacting with the same window through retries instead of closing it / waiting for LRU eviction / waiting for a webapi restart.

When all five align, the reason grows exponentially. Until now the only way out was an admin `cacheReset?forgetNotSavedDocuments=true`, which calls `rootDocuments.invalidateAll()` unconditionally.

## Commits

### 1. `fix(webui): cap reason in Document*Status toString to avoid O(2^n) growth`

Truncate `reason` to the first 200 chars inside `DocumentSaveStatus.toString()` and `DocumentValidStatus.toString()`. Short reasons pass through unchanged; long ones get a `...(+<n> chars)` suffix so truncation is visible in logs.

The stored reason can still grow via callers, but the rendered toString output is bounded — so any exception message built from `document.toString()` stays bounded too, and the doubling chain is severed at the rendering step.

Defensive cap; does not fix the exception sites that interpolate `document.toString()` in their messages.

### 2. `fix(webui): evict cached root document when child invalidation meets error state`

Cache invalidation for a specific child record (INSERT/UPDATE/DELETE on an included table) was only marking the parent's included-documents collection as stale — it did NOT evict the parent from `rootDocuments`. For a happy-path parent that's fine: the frontend refreshes the tab and the user sees current data.

It is NOT fine when the cached parent is already in `saveStatus.error` / `validStatus.invalid` state. The error condition that produced the failure may have been caused by the very child state that just became stale, but the sticky error survives indefinitely: next read serves the cached parent as-is, since `forRootDocumentReadonly` does not call `refreshFromRepositoryIfStaled` (only the writable path does). Until now the only way to clear this was an admin `cacheReset?forgetNotSavedDocuments=true` or LRU eviction.

Fix: when a child-record invalidation arrives for a cached parent that is already in error state, evict the parent. Next read loads a clean document from the repository and recomputes the status against current DB state.

- Happy-path parents are not evicted — behaviour unchanged for the common case (no extra DB load).
- Documents that have not been persisted yet (`isNew()`) are still protected against eviction (existing safety).
- Decision logic extracted into a pure boolean helper `DocumentCollection.shouldInvalidateRootOnChildInvalidation` so it can be unit-tested without mocking the final `Document` class.

## Test plan

- [x] `DocumentStatusReasonTruncationTest` — covers both classes for short and long reasons (truncation marker visible, length capped).
- [x] `DocumentCollectionShouldInvalidateRootTest` — covers all four boolean combinations of the eviction decision (happy path, full-invalidation requested, save-error, validStatus-invalid).
- [x] CI green.
- [x] Manual verification in the affected environment: hotswap of commit 1 stopped further growth; `cacheReset?forgetNotSavedDocuments=true` cleared the already-poisoned in-memory document; product window loads cleanly afterwards. With commit 2, future occurrences should self-heal on the next child-invalidation event without requiring an admin cache reset.

## Notes

- Commit 1 does NOT shrink an already-large reason in memory. After deploying, in-flight poisoned documents are evicted by commit 2 on the next child invalidation, by LRU eviction, or by a webapi restart. The plain `cacheReset` continues to skip them (it protects unsaved work); `cacheReset?forgetNotSavedDocuments=true` remains the manual escape hatch.
- The exception sites that build their message from `document.toString()` (e.g. `DBException("No PO found for " + document)` patterns) are the ultimate root cause. Fixing those is a larger hunt; the toString cap is the right safety net regardless.
