### PR TITLE
ci: fix silent failure of nightly reports-cleanup workflow (gh29466)

### DIFF
--- a/.github/workflows/reports-cleanup.yml
+++ b/.github/workflows/reports-cleanup.yml
@@ -58,6 +58,8 @@ jobs:
             User ci-reports
             IdentityFile ~/.ssh/reports_key
             StrictHostKeyChecking accept-new
+            ServerAliveInterval 30
+            ServerAliveCountMax 10
           EOF
 
       - name: Fetch existing GitHub branches
@@ -79,7 +81,8 @@ jobs:
         if: steps.check-secret.outputs.available == 'true'
         id: cleanup
         run: |
-          ssh reports-server "python3 -" <<'PYEOF' | tee /tmp/cleanup-output.txt
+          set -o pipefail
+          ssh reports-server "python3 -u -" <<'PYEOF' | tee /tmp/cleanup-output.txt
           import json, os, shutil, time, sys
           from pathlib import Path
           from datetime import datetime, timezone
@@ -300,6 +303,11 @@ jobs:
         if: steps.check-secret.outputs.available == 'true'
         run: |
           OUTPUT="/tmp/cleanup-output.txt"
+          if ! grep -q '^BEFORE_AVAIL=' "$OUTPUT"; then
+            echo "::error::Cleanup script produced no BEFORE_AVAIL marker — the SSH session was likely truncated before the script finished. Check the 'Run cleanup' step output."
+            cat "$OUTPUT" || true
+            exit 1
+          fi
           BEFORE=$(grep 'BEFORE_AVAIL=' "$OUTPUT" | cut -d= -f2)
           AFTER=$(grep 'AFTER_AVAIL=' "$OUTPUT" | cut -d= -f2)
           FREED=$(grep 'FREED=' "$OUTPUT" | cut -d= -f2)


### PR DESCRIPTION
## Summary

Fixes https://github.com/metasfresh/me03/issues/29466 (parent: https://github.com/metasfresh/mf15/issues/4069). Every nightly run of `reports-cleanup.yml` reports success, yet `test-reports.metasfresh.com` keeps filling up.

Inspection of run https://github.com/metasfresh/metasfresh/actions/runs/24947503001 shows the entire stdout of the **Run cleanup** step is:

```
##[group]Run ssh reports-server "python3 -" <<'PYEOF' | tee /tmp/cleanup-output.txt
shell: /usr/bin/bash -e {0}
##[endgroup]
client_loop: send disconnect: Broken pipe
```

— SSH dropped after ~4 min 18 s of silent processing, but the step still reports success because:

- shell is `bash -e` without `pipefail` → `tee` masks SSH's non-zero exit;
- Python stdout is block-buffered through the SSH pipe → no `print(...)` ever reaches `tee`, so the buffered progress is lost when the session is interrupted;
- the **Step summary** step then `grep`s an empty file, prints `Disk before / after / Space freed = unknown`, and exits 0.

Likely tipping factor: https://github.com/metasfresh/metasfresh/pull/23006 (commit https://github.com/metasfresh/metasfresh/commit/5b40e17e9c34076bd487c6529dcd2c5f6cc12d7a) extended cleanup to private-repo trees, increasing per-run runtime past the SSH idle-timeout window.

## Defense-in-depth fix (workflow-only)

- **`ServerAliveInterval 30` + `ServerAliveCountMax 10`** in the reports-server SSH config — keeps the connection alive across long-running Python work, defeats NAT/firewall idle timeouts.
- **`set -o pipefail`** in the Run cleanup step — SSH non-zero exits no longer hidden by `tee`.
- **`python3 -u -`** instead of `python3 -` — unbuffered stdout, so every `print(...)` appears in real time. Diagnostic both for healthy runs and for partial-run forensics.
- **Fail loudly in Step summary** if `BEFORE_AVAIL=` is missing from the cleanup output — prevents a future regression from silently reporting "unknown" values as a green build.

No change to which directories are kept or removed.

## Test plan

- [x] YAML validates (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- [ ] Merge → `gh workflow run reports-cleanup.yml --repo metasfresh/metasfresh` → confirm Run cleanup step shows real `BEFORE_AVAIL=`/`FREED=` lines and Step summary prints non-`unknown` values.
- [ ] Confirm disk usage on `test-reports.metasfresh.com` actually drops after the manual run.

## Pending — needs human

- The workflow can now succeed, but the existing backlog of stale data on `test-reports.metasfresh.com` may make even the fixed run slow. If the first manual run after merge hits the new `pipefail` and times out, a one-off human SSH cleanup may be required (workspace policy: SSH to test-reports is human-only). Tracked in `ai-work/29466/pending-questions.md`.
- Should this be ported to `*_hotfix` / `*_release` branches? Their cicd.yaml publishes to the same server, but they have their own copy of the workflow file and may not have https://github.com/metasfresh/metasfresh/pull/23006 anyway. Awaiting confirmation.