### PR TITLE
ci: make reports-cleanup race-tolerant against parallel publish (gh29466)

### DIFF
--- a/.github/workflows/reports-cleanup.yml
+++ b/.github/workflows/reports-cleanup.yml
@@ -108,9 +108,20 @@ jobs:
           def dir_size(path):
               total = 0
               for entry in path.rglob("*"):
-                  if entry.is_file():
-                      total += entry.stat().st_size
+                  try:
+                      if entry.is_file():
+                          total += entry.stat().st_size
+                  except FileNotFoundError:
+                      # File vanished between rglob and stat — concurrent publish.
+                      pass
               return total
+
+          def _ignore_missing(func, path, exc):
+              # rmtree onexc handler — concurrent cicd publish jobs can unlink files
+              # while we walk the tree, racing shutil.rmtree's readdir+unlink window.
+              # Treat missing entries as already-cleaned; re-raise everything else.
+              if not isinstance(exc, FileNotFoundError):
+                  raise exc
 
           def fmt(size_bytes):
               for unit in ("B", "KB", "MB", "GB"):
@@ -167,9 +178,9 @@ jobs:
                       age_days = (now - newest_ts) / 86400
                       if age_days > MAX_BRANCH_AGE_DAYS:
                           size = dir_size(branch_dir)
-                          shutil.rmtree(branch_dir)
+                          shutil.rmtree(branch_dir, onexc=_ignore_missing)
                           if metadata_file.exists():
-                              metadata_file.unlink()
+                              metadata_file.unlink(missing_ok=True)
                           removed_branches.append(
                               f"{label} (stale: {int(age_days)}d, {fmt(size)})"
                           )
@@ -184,9 +195,9 @@ jobs:
                       age_days = (now - newest_ts) / 86400
                       if age_days > DELETED_BRANCH_GRACE_DAYS:
                           size = dir_size(branch_dir)
-                          shutil.rmtree(branch_dir)
+                          shutil.rmtree(branch_dir, onexc=_ignore_missing)
                           if metadata_file.exists():
-                              metadata_file.unlink()
+                              metadata_file.unlink(missing_ok=True)
                           removed_branches.append(
                               f"{label} (deleted from GitHub, {int(age_days)}d since last build, {fmt(size)})"
                           )
@@ -201,9 +212,9 @@ jobs:
                           dir_age = 999
                       if dir_age > MAX_ORPHAN_BUILD_AGE_DAYS:
                           size = dir_size(branch_dir)
-                          shutil.rmtree(branch_dir)
+                          shutil.rmtree(branch_dir, onexc=_ignore_missing)
                           if metadata_file.exists():
-                              metadata_file.unlink()
+                              metadata_file.unlink(missing_ok=True)
                           removed_branches.append(
                               f"{label} (no metadata, {int(dir_age)}d old, {fmt(size)})"
                           )
@@ -221,7 +232,7 @@ jobs:
                           ev_path = builds_dir / ev_ver
                           if ev_path.is_dir():
                               size = dir_size(ev_path)
-                              shutil.rmtree(ev_path)
+                              shutil.rmtree(ev_path, onexc=_ignore_missing)
                               removed_builds.append(
                                   f"{label}/{ev_ver} (over cap, {fmt(size)})"
                               )
@@ -241,7 +252,7 @@ jobs:
                                   build_age = 999
                               if build_age > MAX_ORPHAN_BUILD_AGE_DAYS:
                                   size = dir_size(build_dir)
-                                  shutil.rmtree(build_dir)
+                                  shutil.rmtree(build_dir, onexc=_ignore_missing)
                                   removed_builds.append(
                                       f"{label}/{version} ({int(build_age)}d, {fmt(size)})"
                                   )
@@ -249,9 +260,9 @@ jobs:
 
                   # --- Remove empty branch directory ---
                   if builds_dir.exists() and not any(builds_dir.iterdir()):
-                      shutil.rmtree(branch_dir)
+                      shutil.rmtree(branch_dir, onexc=_ignore_missing)
                       if metadata_file.exists():
-                          metadata_file.unlink()
+                          metadata_file.unlink(missing_ok=True)
                       removed_branches.append(f"{label} (empty after pruning)")
 
               # --- Orphaned metadata files ---
@@ -259,14 +270,20 @@ jobs:
                   for meta_file in sorted(metadata_dir.glob("*.json")):
                       branch = meta_file.stem
                       if not (branches_dir / branch).exists():
-                          meta_file.unlink()
+                          meta_file.unlink(missing_ok=True)
                           orphaned_meta.append(f"{label_prefix}{branch}" if label_prefix else branch)
 
+          tree_errors = []
+
+          def safe_cleanup(branches_dir, metadata_dir, label_prefix=""):
+              try:
+                  cleanup_report_tree(branches_dir, metadata_dir, label_prefix)
+              except Exception as e:
+                  tree_errors.append(f"{label_prefix or '<public>'}: {type(e).__name__}: {e}")
+                  print(f"WARN: cleanup_report_tree({label_prefix or '<public>'}) failed: {e}", flush=True)
+
           # === Clean public reports ===
-          cleanup_report_tree(
-              REPORTS_ROOT / "branches",
-              REPORTS_ROOT / "_metadata"
-          )
+          safe_cleanup(REPORTS_ROOT / "branches", REPORTS_ROOT / "_metadata")
 
           # === Clean private repo reports ===
           private_root = REPORTS_ROOT / "_private"
@@ -275,10 +292,10 @@ jobs:
                   if not repo_dir.is_dir():
                       continue
                   repo_name = repo_dir.name
-                  cleanup_report_tree(
+                  safe_cleanup(
                       repo_dir / "branches",
                       repo_dir / "_metadata",
-                      label_prefix=f"_private/{repo_name}/"
+                      label_prefix=f"_private/{repo_name}/",
                   )
 
           after = get_avail_bytes()
@@ -297,6 +314,11 @@ jobs:
               print(f"ORPHANED_METADATA={len(orphaned_meta)}")
               for m in orphaned_meta:
                   print(f"  META: {m}")
+          if tree_errors:
+              print(f"TREE_ERRORS={len(tree_errors)}")
+              for err in tree_errors:
+                  print(f"  TREE_ERROR: {err}")
+              sys.exit(1)
           PYEOF
 
       - name: Step summary


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/metasfresh/metasfresh/pull/23705 (already merged) for https://github.com/metasfresh/me03/issues/29466.

PR #23705 unmasked the silent failure. The very first manual run after that merge — https://github.com/metasfresh/metasfresh/actions/runs/24948750500/job/73054856965 — exposed the underlying bug:

```
Loaded 304 GitHub branches for existence check
Traceback (most recent call last):
  File "<stdin>", line 181, in <module>
  File "<stdin>", line 102, in cleanup_report_tree
  File "/usr/lib/python3.12/shutil.py", line 785, in rmtree
    _rmtree_safe_fd(fd, path, onexc)
  ...
FileNotFoundError: [Errno 2] No such file or directory: '1b8af88f94023d10.json'
```

**Root cause**: a parallel cicd publish job uploads new reports while the cleanup walks the same tree. `shutil.rmtree`'s readdir+unlink window is racy — if a file is deleted by another process between the two, `os.unlink` raises `FileNotFoundError` and the whole script aborts. This was always there; PR #23705 just made it visible.

## Changes

- `_ignore_missing(func, path, exc)` helper passed as `onexc=` to every `shutil.rmtree(...)` call. Re-raises anything other than `FileNotFoundError`; treats missing entries as already-cleaned.
- `Path.unlink(missing_ok=True)` for metadata-file deletes (same race surface, smaller blast radius).
- `dir_size()`'s rglob/stat per entry wrapped with `try/except FileNotFoundError`.
- New `safe_cleanup(...)` wrapper around `cleanup_report_tree(...)` so a failure in the public tree no longer poisons private-repo cleanup, and vice versa. Errors are collected in `tree_errors[]`.
- If `tree_errors` is non-empty at the end, `sys.exit(1)` — the run goes red on real failures while still reporting partial progress.

No change to retention thresholds or the decision tree for what gets removed.

## Pre-merge validation

Per the policy from the previous round, dispatched the workflow against this branch ref *before* opening the PR:

```
gh workflow run reports-cleanup.yml \
  --ref new_dawn_uat_FixReportsCleanupRaceCondition \
  --repo metasfresh/metasfresh
```

Run: https://github.com/metasfresh/metasfresh/actions/runs/24948899577 — **in progress** as of opening this PR. Will update with the result before requesting integration.

## Test plan

- [ ] Pre-merge dispatch run https://github.com/metasfresh/metasfresh/actions/runs/24948899577 ends green, with non-empty `BRANCHES_REMOVED=`/`BUILDS_PRUNED=` lines and a positive `FREED=`.
- [ ] `df -h /var/www/test-reports/` on the server shows freed space matches the workflow's reported `FREED=`.
- [ ] Subsequent nightly runs stay green even while cicd publish jobs are running concurrently.