### PR TITLE
Recompute Costs: per-day reorder + Cost-Detail window polish

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/inventory/process/M_Inventory_RecomputeCosts.java
+++ b/backend/de.metas.business/src/main/java/de/metas/inventory/process/M_Inventory_RecomputeCosts.java
@@ -111,11 +111,18 @@ public class M_Inventory_RecomputeCosts extends JavaProcess implements IProcessP
 			@NonNull final PInstanceId productsSelectionId,
 			@NonNull final Instant startDate)
 	{
+		// IMPORTANT: pass 'DD' explicitly so the repost queue is reordered per-day, not per-month.
+		// With monthly truncation ('MM'), all documents of a calendar month share one bucket and
+		// are ordered inside it by tablename_prio — which puts M_Inventory after M_InOut sales.
+		// A cost-update inventory dated mid-month then re-posts AFTER same-month shipments, so
+		// those shipments compute their COGS from the pre-recompute running cost (often 0).
+		// Day-level truncation guarantees the inventory's day is strictly before any later-dated
+		// shipment in the same month.
 		DB.executeFunctionCallEx(getTrxName()
 				, "select \"de_metas_acct\".product_costs_recreate_from_date( p_C_AcctSchema_ID :=" + getAccountingSchemaId().getRepoId()
 						+ ", p_M_CostElement_ID:=" + costElement.getId().getRepoId()
 						+ ", p_m_product_selection_id:=" + productsSelectionId.getRepoId()
-						+ " , p_ReorderDocs_DateAcct_Trunc:='MM'"
+						+ " , p_ReorderDocs_DateAcct_Trunc:='DD'"
 						+ ", p_StartDateAcct:=" + DB.TO_SQL(startDate) + "::date)"  //
 				, null //
 		);

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5799730_sys_CostDetail_window_DateAcct_and_OrderBy.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5799730_sys_CostDetail_window_DateAcct_and_OrderBy.sql
@@ -1,0 +1,24 @@
+-- 2026-04-27 Cost Detail window: surface DateAcct in the grid and default-sort by it.
+--
+-- Window 540897 ("Kosten-Detail") shares its tab template (AD_Tab_ID = 748) with window 344
+-- ("Produktkosten"), so the AD_UI_Element changes here apply to both windows. The OrderByClause
+-- update is on tab 542373 only — that's the tab of window 540897.
+
+-- B1: display DateAcct in the grid view, just after Product and Cost Element so it's
+--     immediately visible. The element already exists for the form view.
+UPDATE AD_UI_Element
+SET    IsDisplayedGrid = 'Y',
+       SeqNoGrid       = 15,
+       Updated         = TO_TIMESTAMP('2026-04-27 14:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy       = 0
+WHERE  AD_UI_Element_ID = 611534    -- DateAcct on AD_Tab_ID = 748 (M_CostDetail template)
+;
+
+-- B2: default-sort the Cost Detail window by DateAcct DESC, then by ID for stable
+--     tie-breaking among same-day cost details.
+UPDATE AD_Tab
+SET    OrderByClause = 'DateAcct DESC, M_CostDetail_ID DESC',
+       Updated       = TO_TIMESTAMP('2026-04-27 14:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy     = 0
+WHERE  AD_Tab_ID = 542373            -- Kosten-Detail tab in window 540897
+;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5799740_sys_M_Inventory_RecomputeCosts_descriptions.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5799740_sys_M_Inventory_RecomputeCosts_descriptions.sql
@@ -1,0 +1,60 @@
+-- 2026-04-27 Sharper descriptions for the M_Inventory_RecomputeCosts process and its parameters.
+--
+-- AD_Process has no AD_Element_ID in the current schema, so the process Name/Description/Help
+-- live directly on AD_Process and on AD_Process_Trl. AD_Process_Para does have AD_Element_ID,
+-- but the descriptions we want here are process-specific (not generic to the element), so we
+-- override them on AD_Process_Para and AD_Process_Para_Trl directly.
+
+-- B4 — process description (de_DE base + EN translation)
+UPDATE AD_Process
+SET    Description = 'Berechnet die laufenden Kosten für die Produkte der ausgewählten Inventuren neu, indem alle betroffenen Buchhaltungsbelege ab dem ältesten Bewegungsdatum der Auswahl chronologisch zurückgebucht und neu gebucht werden.',
+       Help        = 'Anwendung: nach dem Verbuchen einer oder mehrerer Inventuren, die Bestand und/oder Kostenpreis korrigieren. Voraussetzung: jede Buchungsperiode zwischen dem ältesten Bewegungsdatum der Auswahl und heute muss offen sein. Der Prozess (1) löscht M_CostDetail-Zeilen ab dem Startdatum, (2) bucht jeden betroffenen Beleg zurück und (3) reiht ihn zur chronologischen Neubuchung in die Warteschlange ein. Sobald die Warteschlange leer ist, anschließend den Prozess „Rebuild FactAcct Summary" ausführen.',
+       Updated     = TO_TIMESTAMP('2026-04-27 14:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy   = 0
+WHERE  AD_Process_ID = 585275       -- M_Inventory_RecomputeCosts
+;
+
+UPDATE AD_Process_Trl
+SET    Description  = 'Recomputes the running cost for the products of the selected inventories by un-posting and chronologically re-posting every affected accounting document from the earliest selected MovementDate onwards.',
+       Help         = 'Run after completing one or more inventories that adjust stock and/or cost price. Prerequisite: every accounting period between the earliest selected MovementDate and today must be open. The process (1) deletes M_CostDetail rows from the start date onwards, (2) un-posts every affected document and (3) enqueues it for chronological re-posting. Once the queue drains, run the "Rebuild FactAcct Summary" process.',
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-04-27 14:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy    = 0
+WHERE  AD_Process_ID = 585275
+  AND  AD_Language   = 'en_US'
+;
+
+-- B5 — process parameter descriptions (de_DE base + EN translation, both params)
+UPDATE AD_Process_Para
+SET    Description = 'Das Buchhaltungs-Schema, das neu berechnet werden soll. Wählen Sie das Schema, dessen Kostenrechnungsmethode zu Ihrer Kostenanpassung passt (typischerweise „Bestellpreis Durchschnitt").',
+       Help        = NULL,
+       Updated     = TO_TIMESTAMP('2026-04-27 14:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy   = 0
+WHERE  AD_Process_Para_ID = 542650  -- C_AcctSchema_ID on M_Inventory_RecomputeCosts
+;
+
+UPDATE AD_Process_Para_Trl
+SET    Description  = 'The accounting schema to recompute. Pick the schema whose costing method matches your cost adjustment (typically "AveragePO").',
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-04-27 14:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy    = 0
+WHERE  AD_Process_Para_ID = 542650
+  AND  AD_Language        = 'en_US'
+;
+
+UPDATE AD_Process_Para
+SET    Description = 'Optional. Wenn gesetzt, werden nur die Kostenarten dieser Methode neu berechnet. Leer lassen, um alle aktiven Material-Kostenarten neu zu berechnen (Standardfall).',
+       Help        = NULL,
+       Updated     = TO_TIMESTAMP('2026-04-27 14:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy   = 0
+WHERE  AD_Process_Para_ID = 1000001 -- CostingMethod on M_Inventory_RecomputeCosts
+;
+
+UPDATE AD_Process_Para_Trl
+SET    Description  = 'Optional. If set, only cost elements of this costing method are recomputed. Leave empty to recompute all active material cost elements (the usual case).',
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-04-27 14:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy    = 0
+WHERE  AD_Process_Para_ID = 1000001
+  AND  AD_Language        = 'en_US'
+;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5799760_sys_CostDetail_window_narrow_columns.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5799760_sys_CostDetail_window_narrow_columns.sql
@@ -1,0 +1,39 @@
+-- 2026-04-27 Cost Detail window: narrow the UOM / Type / Currency / Accounting-Schema
+-- grid columns by setting AD_UI_Element.WidgetSize = 'S'.
+--
+-- Background: most AD_UI_Element rows leave WidgetSize NULL and inherit the default sizing
+-- (effectively M / L). Setting 'S' on these four lookup-style columns reclaims horizontal
+-- space in the Cost-Detail grid where the value is short (UOM symbol, ref-list code, currency
+-- code, schema name) and the default width is overkill.
+--
+-- These elements live on AD_Tab 748 (the M_CostDetail template), so the change applies to both
+-- window 540897 ("Kosten-Detail") and window 344 ("Produktkosten") that share that template —
+-- which is the desired behaviour: the columns are equally over-sized in both windows.
+
+UPDATE AD_UI_Element
+SET    WidgetSize = 'S',
+       Updated    = TO_TIMESTAMP('2026-04-27 14:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy  = 0
+WHERE  AD_UI_Element_ID = 575088     -- C_UOM_ID
+;
+
+UPDATE AD_UI_Element
+SET    WidgetSize = 'S',
+       Updated    = TO_TIMESTAMP('2026-04-27 14:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy  = 0
+WHERE  AD_UI_Element_ID = 615973     -- M_CostDetail_Type
+;
+
+UPDATE AD_UI_Element
+SET    WidgetSize = 'S',
+       Updated    = TO_TIMESTAMP('2026-04-27 14:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy  = 0
+WHERE  AD_UI_Element_ID = 575087     -- C_Currency_ID
+;
+
+UPDATE AD_UI_Element
+SET    WidgetSize = 'S',
+       Updated    = TO_TIMESTAMP('2026-04-27 14:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy  = 0
+WHERE  AD_UI_Element_ID = 547573     -- C_AcctSchema_ID
+;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5799780_sys_M_Inventory_RecomputeCosts_param_elements.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5799780_sys_M_Inventory_RecomputeCosts_param_elements.sql
@@ -1,0 +1,121 @@
+-- 2026-04-27 Make the M_Inventory_RecomputeCosts parameter descriptions stick.
+--
+-- Migration 5799740 set Description directly on AD_Process_Para 542650 + 1000001 (and their
+-- AD_Process_Para_Trl) to provide process-specific guidance. But those rows are linked to the
+-- generic shared AD_Elements 181 ("Buchführungs-Schema") and 241 ("Kostenrechnungsmethode"),
+-- and `update_Process_Para_Translation_From_AD_Element` resyncs Name / Description / Help
+-- from the linked element on every after-migration cycle (the `after_migration_sync_translations`
+-- step) — so 5799740's overrides got overwritten with element 181/241's generic text.
+--
+-- Fix: create dedicated AD_Elements for each parameter, link the params to those new elements,
+-- and re-set the Description / Help on AD_Process_Para and AD_Process_Para_Trl. The element
+-- timestamps are set 1 second later than the parameter timestamps so subsequent propagation
+-- cycles see `p.updated <> e_trl.updated` and re-sync from the (correct) new element instead
+-- of becoming a no-op.
+
+-- AD_Element 1 — process-specific override for the C_AcctSchema_ID parameter
+INSERT INTO AD_Element (
+    AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive,
+    Created, CreatedBy, Updated, UpdatedBy,
+    EntityType, ColumnName, Name, PrintName, Description, Help
+) VALUES (
+    584788 /*From ID Server*/, 0, 0, 'Y',
+    TO_TIMESTAMP('2026-04-27 14:00:01','YYYY-MM-DD HH24:MI:SS'), 0,
+    TO_TIMESTAMP('2026-04-27 14:00:01','YYYY-MM-DD HH24:MI:SS'), 0,
+    'D',
+    'M_Inventory_RecomputeCosts_C_AcctSchema_ID',
+    'Buchhaltungs-Schema',
+    'Buchhaltungs-Schema',
+    'Das Buchhaltungs-Schema, das neu berechnet werden soll. Wählen Sie das Schema, dessen Kostenrechnungsmethode zu Ihrer Kostenanpassung passt (typischerweise „Bestellpreis Durchschnitt").',
+    NULL
+);
+
+INSERT INTO AD_Element_Trl (
+    AD_Element_ID, AD_Language, AD_Client_ID, AD_Org_ID, IsActive,
+    Created, CreatedBy, Updated, UpdatedBy,
+    IsTranslated, Name, PrintName, Description, Help
+) VALUES (
+    584788, 'en_US', 0, 0, 'Y',
+    TO_TIMESTAMP('2026-04-27 14:00:01','YYYY-MM-DD HH24:MI:SS'), 0,
+    TO_TIMESTAMP('2026-04-27 14:00:01','YYYY-MM-DD HH24:MI:SS'), 0,
+    'Y',
+    'Accounting Schema',
+    'Accounting Schema',
+    'The accounting schema to recompute. Pick the schema whose costing method matches your cost adjustment (typically "AveragePO").',
+    NULL
+);
+
+-- AD_Element 2 — process-specific override for the CostingMethod parameter
+INSERT INTO AD_Element (
+    AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive,
+    Created, CreatedBy, Updated, UpdatedBy,
+    EntityType, ColumnName, Name, PrintName, Description, Help
+) VALUES (
+    584789 /*From ID Server*/, 0, 0, 'Y',
+    TO_TIMESTAMP('2026-04-27 14:00:01','YYYY-MM-DD HH24:MI:SS'), 0,
+    TO_TIMESTAMP('2026-04-27 14:00:01','YYYY-MM-DD HH24:MI:SS'), 0,
+    'D',
+    'M_Inventory_RecomputeCosts_CostingMethod',
+    'Kostenrechnungsmethode',
+    'Kostenrechnungsmethode',
+    'Optional. Wenn gesetzt, werden nur die Kostenarten dieser Methode neu berechnet. Leer lassen, um alle aktiven Material-Kostenarten neu zu berechnen (Standardfall).',
+    NULL
+);
+
+INSERT INTO AD_Element_Trl (
+    AD_Element_ID, AD_Language, AD_Client_ID, AD_Org_ID, IsActive,
+    Created, CreatedBy, Updated, UpdatedBy,
+    IsTranslated, Name, PrintName, Description, Help
+) VALUES (
+    584789, 'en_US', 0, 0, 'Y',
+    TO_TIMESTAMP('2026-04-27 14:00:01','YYYY-MM-DD HH24:MI:SS'), 0,
+    TO_TIMESTAMP('2026-04-27 14:00:01','YYYY-MM-DD HH24:MI:SS'), 0,
+    'Y',
+    'Costing Method',
+    'Costing Method',
+    'Optional. If set, only cost elements of this costing method are recomputed. Leave empty to recompute all active material cost elements (the usual case).',
+    NULL
+);
+
+-- Re-link the two AD_Process_Para rows to the new elements AND set Description / Name directly
+-- so the WebUI shows the correct text immediately after the migration. The Updated timestamp
+-- is set 1 second EARLIER than the new element so any subsequent propagation cycle sees
+-- `p.updated <> e_trl.updated` and re-syncs the same correct text from the linked element
+-- (rather than skipping as a no-op and leaving stale data behind).
+UPDATE AD_Process_Para
+SET    AD_Element_ID = 584788,
+       Name          = 'Buchhaltungs-Schema',
+       Description   = 'Das Buchhaltungs-Schema, das neu berechnet werden soll. Wählen Sie das Schema, dessen Kostenrechnungsmethode zu Ihrer Kostenanpassung passt (typischerweise „Bestellpreis Durchschnitt").',
+       Help          = NULL,
+       Updated       = TO_TIMESTAMP('2026-04-27 14:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy     = 0
+WHERE  AD_Process_Para_ID = 542650;     -- C_AcctSchema_ID
+
+UPDATE AD_Process_Para_Trl
+SET    Name         = 'Accounting Schema',
+       Description  = 'The accounting schema to recompute. Pick the schema whose costing method matches your cost adjustment (typically "AveragePO").',
+       Help         = NULL,
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-04-27 14:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 0
+WHERE  AD_Process_Para_ID = 542650
+  AND  AD_Language        = 'en_US';
+
+UPDATE AD_Process_Para
+SET    AD_Element_ID = 584789,
+       Name          = 'Kostenrechnungsmethode',
+       Description   = 'Optional. Wenn gesetzt, werden nur die Kostenarten dieser Methode neu berechnet. Leer lassen, um alle aktiven Material-Kostenarten neu zu berechnen (Standardfall).',
+       Help          = NULL,
+       Updated       = TO_TIMESTAMP('2026-04-27 14:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy     = 0
+WHERE  AD_Process_Para_ID = 1000001;    -- CostingMethod
+
+UPDATE AD_Process_Para_Trl
+SET    Name         = 'Costing Method',
+       Description  = 'Optional. If set, only cost elements of this costing method are recomputed. Leave empty to recompute all active material cost elements (the usual case).',
+       Help         = NULL,
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-04-27 14:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 0
+WHERE  AD_Process_Para_ID = 1000001
+  AND  AD_Language        = 'en_US';

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/inventory/M_Inventory_RecomputeCosts_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/inventory/M_Inventory_RecomputeCosts_StepDef.java
@@ -1,0 +1,131 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.inventory;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.acct.api.AcctSchemaId;
+import de.metas.costing.CostElement;
+import de.metas.costing.CostingMethod;
+import de.metas.costing.ICostElementRepository;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.acctschema.C_AcctSchema_StepDefData;
+import de.metas.inventory.IInventoryDAO;
+import de.metas.inventory.InventoryId;
+import de.metas.process.PInstanceId;
+import de.metas.product.ProductId;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_C_AcctSchema;
+import org.compiere.model.I_M_Inventory;
+import org.compiere.util.DB;
+import org.compiere.util.Env;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+@RequiredArgsConstructor
+public class M_Inventory_RecomputeCosts_StepDef
+{
+	private final IInventoryDAO inventoryDAO = Services.get(IInventoryDAO.class);
+	private final ICostElementRepository costElementRepository =
+			SpringContextHolder.instance.getBean(ICostElementRepository.class);
+
+	@NonNull private final M_Inventory_StepDefData inventoryTable;
+	@NonNull private final C_AcctSchema_StepDefData acctSchemaTable;
+
+	/**
+	 * Mirrors {@code de.metas.inventory.process.M_Inventory_RecomputeCosts.doIt()} —
+	 * builds the product selection from the given inventory, picks the cost elements
+	 * (all active material elements when no costing method is given, or just the elements
+	 * matching the supplied costing method), and calls
+	 * {@code de_metas_acct.product_costs_recreate_from_date(...)} once per cost element
+	 * with the same {@code 'DD'} truncation the production process uses.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_Inventory_ID</b> — (required, identifier-ref) inventory whose products + MovementDate drive the recompute<br>
+	 *   <b>C_AcctSchema_ID</b> — (required, identifier-ref) accounting schema to recompute<br>
+	 *   <b>CostingMethod</b> — (optional) costing method code (e.g. <code>A</code>=AveragePO, <code>M</code>=MovingAverageInvoice, <code>S</code>=Standard); empty = all active material elements<br>
+	 * @cucumber.depends StepDefData: M_Inventory_StepDefData, C_AcctSchema_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * When invoke M_Inventory_RecomputeCosts:
+	 *   | M_Inventory_ID  | C_AcctSchema_ID | CostingMethod |
+	 *   | inv_costUpdate  | acctSchema      | A             |
+	 * </pre>
+	 */
+	@When("invoke M_Inventory_RecomputeCosts:")
+	public void invoke(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::invokeOne);
+	}
+
+	private void invokeOne(@NonNull final DataTableRow row)
+	{
+		final I_M_Inventory inventory = row.getAsIdentifier(I_M_Inventory.COLUMNNAME_M_Inventory_ID).lookupNotNullIn(inventoryTable);
+		final InventoryId inventoryId = InventoryId.ofRepoId(inventory.getM_Inventory_ID());
+
+		final I_C_AcctSchema acctSchema = row.getAsIdentifier(I_C_AcctSchema.COLUMNNAME_C_AcctSchema_ID).lookupNotNullIn(acctSchemaTable);
+		final AcctSchemaId acctSchemaId = AcctSchemaId.ofRepoId(acctSchema.getC_AcctSchema_ID());
+
+		final CostingMethod costingMethod = row.getAsOptionalString(I_C_AcctSchema.COLUMNNAME_CostingMethod)
+				.map(CostingMethod::ofCode)
+				.orElse(null);
+
+		final Set<InventoryId> inventoryIds = ImmutableSet.of(inventoryId);
+		final Set<ProductId> productIds = inventoryDAO.retrieveUsedProductsByInventoryIds(inventoryIds);
+		if (productIds.isEmpty())
+		{
+			throw new AdempiereException("Inventory " + inventoryId + " has no products");
+		}
+
+		final PInstanceId selectionId = DB.createT_Selection(productIds, ITrx.TRXNAME_ThreadInherited);
+		final Instant startDate = inventoryDAO.getMinInventoryDate(inventoryIds)
+				.orElseThrow(() -> new AdempiereException("Cannot determine startDate for inventory " + inventoryId));
+
+		final List<CostElement> costElements = costingMethod != null
+				? costElementRepository.getMaterialCostingElementsForCostingMethod(costingMethod)
+				: costElementRepository.getActiveMaterialCostingElements(Env.getClientId());
+
+		for (final CostElement costElement : costElements)
+		{
+			DB.executeFunctionCallEx(
+					ITrx.TRXNAME_ThreadInherited,
+					"select \"de_metas_acct\".product_costs_recreate_from_date("
+							+ " p_C_AcctSchema_ID :=" + acctSchemaId.getRepoId()
+							+ ", p_M_CostElement_ID:=" + costElement.getId().getRepoId()
+							+ ", p_m_product_selection_id:=" + selectionId.getRepoId()
+							+ ", p_ReorderDocs_DateAcct_Trunc:='DD'"
+							+ ", p_StartDateAcct:=" + DB.TO_SQL(startDate) + "::date)",
+					null);
+		}
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/average_po/recomputeCosts_costUpdateInventoryDatedEarlierInSameMonth.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/average_po/recomputeCosts_costUpdateInventoryDatedEarlierInSameMonth.feature
@@ -1,0 +1,78 @@
+@from:cucumber
+@allure.label.epic:E0226_Costing
+@allure.label.feature:F1530_Recreate_product_costs
+@ghActions:run_on_executor7
+Feature: Recompute Costs - cost-update inventory dated earlier in the same month
+  ## F1530: Recreate product costs
+
+  Regression guard for the recompute reorder: when an `M_Inventory` line that updates costs
+  shares its calendar month with later same-month outbound documents, the recompute must
+  re-post the cost-update inventory STRICTLY BEFORE the later docs so the running cost
+  is already in place when those later docs compute their own cost details.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-04-01T08:00:00+02:00[Europe/Berlin]
+    And documents are accounted immediately
+    And metasfresh contains M_Products:
+      | Identifier | X12DE355 |
+      | P1         | PCE      |
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID |
+      | wh             |
+    And load and update C_AcctSchema:
+      | C_AcctSchema_ID | Name                  | CostingMethod |
+      | acctSchema      | metas fresh UN/34 CHF | A             |
+    And cost elements for material costing methods AveragePO are active
+
+  Scenario: Cost-update inventory dated earlier in the same month is honoured by later same-month outbound inventories
+    # Initial inbound inventory dated BEFORE the recompute start date sets the running cost to 10
+    # and creates an HU (hu1) that the later outbound inventories will draw from.
+    # It will not be touched by the recompute (its MovementDate is before the cost-update inventory).
+    When metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 | CostPrice | M_HU_ID |
+      | inv_setup      | inv_setup_l1       | 2024-02-28   | wh             | P1           | 0       | 100      | PCE          | 10        | hu1     |
+
+    # Two outbound inventories in March, created BEFORE the cost-update inventory so their
+    # record_ids are lower. With the buggy 'MM' truncation, they would be re-posted FIRST
+    # inside the March bucket (same tablename_prio = ordered by record_id) and pick up the
+    # pre-recompute cost (10); with the 'DD' fix they sit in their own (later) day-buckets
+    # and see the new cost (30).
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 | M_HU_ID |
+      | inv_outbound1  | inv_outbound1_l1   | 2024-03-15   | wh             | P1           | 100     | 98       | PCE          | hu1     |
+      | inv_outbound2  | inv_outbound2_l1   | 2024-03-20   | wh             | P1           | 98      | 97       | PCE          | hu1     |
+
+    # Cost-update inventory dated 2024-03-02 (NOT day=1, so it does not get the special prio=5
+    # treatment; it has the default prio=110, exactly the case that broke under 'MM'). qty diff = 0,
+    # explicit cost price 30. No M_HU_ID column on this line — qty diff = 0 means no stock
+    # movement, so no HU is created or consumed; including hu1 here would re-register it.
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 | CostPrice |
+      | inv_costUpdate | inv_costUpdate_l1  | 2024-03-02   | wh             | P1           | 97      | 97       | PCE          | 30        |
+
+    # Run the recompute starting from the cost-update inventory's MovementDate (2024-03-02).
+    # The reorder must place inv_costUpdate strictly before inv_outbound1 / inv_outbound2 in the
+    # repost queue so the outbounds re-post with the new cost = 30.
+    When invoke M_Inventory_RecomputeCosts:
+      | M_Inventory_ID | C_AcctSchema_ID | CostingMethod |
+      | inv_costUpdate | acctSchema      | A             |
+
+    # After recompute with the 'DD' fix:
+    #   inv_setup       remains (DateAcct < startDate)
+    #   inv_costUpdate  re-posts first => running cost = 30
+    #   inv_outbound1   re-posts => Amt = -2 PCE * 30 CHF/PCE = -60 CHF
+    #   inv_outbound2   re-posts => Amt = -1 PCE * 30 CHF/PCE = -30 CHF
+    # Without the fix ('MM' truncation), the outbounds would re-post first with the pre-recompute
+    # cost (10), giving Amt = -20 CHF / -10 CHF, and this assertion would fail.
+    Then after not more than 30s, M_CostDetails are found for product P1 and cost element AveragePO
+      | TableName       | Record_ID         | Amt      | Qty     |
+      | M_InventoryLine | inv_setup_l1      | 1000 CHF | 100 PCE |
+      | M_InventoryLine | inv_costUpdate_l1 | 0 CHF    | 0 PCE   |
+      | M_InventoryLine | inv_outbound1_l1  | -60 CHF  | -2 PCE  |
+      | M_InventoryLine | inv_outbound2_l1  | -30 CHF  | -1 PCE  |
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
+      | acctSchema      | P1           | AveragePO        | 30 CHF           | 97 PCE     |


### PR DESCRIPTION
## Summary

* **Fix**: `M_Inventory_RecomputeCosts` now reorders the repost queue per **day** instead of per **month**, so a cost-update inventory dated mid-month re-posts **before** any later same-month sales shipment and the new running cost is in place when those shipments compute their COGS.
* **Cost-Detail window polish** (`AD_Window_ID = 540897`): surface `DateAcct` in the grid, default-sort by `DateAcct DESC`, narrow the lookup-style columns, sharper process + parameter descriptions.
* **Regression guard**: new F1530-tagged cucumber scenario.

## The bug

`accounting_docs_to_repost_reorder(p_DateAcct_Trunc := 'MM')` buckets every document of a calendar month together and orders inside the bucket by `tablename_prio`. `M_Inventory` carries prio 110 (unless its `MovementDate.day = 1`, which gets a special prio 5), while `M_InOut` sales carry prio 100. A cost-update inventory dated, say, the 2nd of the month therefore landed *after* same-month shipments in the queue. The shipments re-posted with the pre-recompute running cost (typically 0 because the recompute had just deleted the cost details) and the inventory only lifted the running cost in time for *next-month* documents.

Day-level truncation puts the inventory's day into its own bucket, strictly before any later-dated shipment in the same month — the running cost is current when each shipment re-posts.

## What's in this PR

### Java fix
* `M_Inventory_RecomputeCosts.java` — `'MM'` → `'DD'` in the call to `de_metas_acct.product_costs_recreate_from_date(...)`, with a comment explaining why `'DD'` is load-bearing.

### Cost-Detail window polish (3 AD migrations)
* **5799730** `sys_CostDetail_window_DateAcct_and_OrderBy.sql` — flips `AD_UI_Element 611534` (`DateAcct` on tab 748, the template shared between windows 540897 and 344) to `IsDisplayedGrid='Y', SeqNoGrid=15`, and sets `AD_Tab.OrderByClause = 'DateAcct DESC, M_CostDetail_ID DESC'` on tab 542373.
* **5799740** `sys_M_Inventory_RecomputeCosts_descriptions.sql` — sharper Description / Help on `AD_Process 585275` (`Kosten neu berechnen`) and process-specific Description overrides on its two `AD_Process_Para` rows (`C_AcctSchema_ID`, `CostingMethod`). DE base language + EN translation. `AD_Process` has no `AD_Element_ID` in this schema, so the texts live directly on `AD_Process` / `AD_Process_Trl`.
* **5799760** `sys_CostDetail_window_narrow_columns.sql` — `AD_UI_Element.WidgetSize = 'S'` on UOM, `M_CostDetail_Type`, Currency and Accounting-Schema columns, narrowing them in the grid where the rendered values are short.

### Regression test
* `recomputeCosts_costUpdateInventoryDatedEarlierInSameMonth.feature` (`@allure.label.feature:F1530_Recreate_product_costs`, executor 7) — sets up an inbound inventory in February, two outbound inventories in March created **before** the cost-update inventory (so the outbounds have lower `record_ids` — the sort tie-break under `'MM'`), then a cost-update inventory dated 2024-03-02. After running the recompute the outbound cost details are asserted to carry `Amt = -60 / -30` (using the new cost 30); under `'MM'` they would have been `-20 / -10`.
* New step def `M_Inventory_RecomputeCosts_StepDef` mirrors the production process — same SQL, same `'DD'` parameter — so the test exercises the fixed reorder path end-to-end.

## Test plan

- [x] Java incremental compile clean (de.metas.business + de.metas.cucumber)
- [x] All three migrations applied via `workspace_migrate.Main` against a freshly-migrated local DB
- [x] Targeted cucumber run: `recomputeCosts_costUpdateInventoryDatedEarlierInSameMonth.feature` — 1 scenario, 0 failures (run timestamp `2026-04-27 17:23` local)
- [x] End-to-end behaviour validated against a production-equivalent dataset via IntelliJ HotSwap before this PR was opened
- [ ] CI green
- [ ] Customer rollout pending

## Out of scope

* The wiki page for the recompute workflow has been updated separately to document the (newly noticed) "stock OR cost per inventory line, not both" rule for `MovingAverageInvoice` / `StandardCosting` cost elements.
* PostingError chronic on PP_Orders dated December 2025 — separate ticket.