### PR TITLE
ci(mergify): upgrade configuration to current format

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -142,7 +142,6 @@ pull_request_rules:
       label:
         add:
           - "branch:{{base}}"
-      delete_head_branch: {}
 
   - name: Block direct merges between protected branches (use auto-port instead)
     conditions:
@@ -198,3 +197,5 @@ pull_request_rules:
       queue:
         name: merge-queue
 
+merge_protections_settings:
+  reporting_method: check-runs


### PR DESCRIPTION
Hand-crafted replacement for the auto-generated PR https://github.com/metasfresh/metasfresh/pull/23234 (now closed), which would have broken the YAML on merge.

## What this does

Applies the two changes Mergify is requiring before **2026-07-31**:

- Removes the deprecated `delete_head_branch:` action. The repo's "Automatically delete head branches" setting handles head-branch cleanup natively.
- Explicitly sets `merge_protections_settings.reporting_method: check-runs` to preserve current reporting behaviour (Mergify's default changes from `check-runs` to `deployments` after the deadline).

## Why not the auto-generated PR

The Mergify-generated PR https://github.com/metasfresh/metasfresh/pull/23234 stripped the YAML anchor *definitions* (`&ALL_BASE_BRANCHES`, `&PROJECT_BRANCHES_UAT`, `&PROJECT_BRANCHES_HOTFIX`, `&PROJECT_BRANCHES_RELEASE`) but left the `*ALL_BASE_BRANCHES` aliases at lines 153, 181, 193 intact. Merging that diff would have produced unparseable YAML.

This PR keeps all anchors and aliases as-is and only applies the two real, required changes.

## Validation

- `python -c "import yaml; yaml.safe_load(open('.mergify.yml'))"` → OK
- Diff is two lines: one `delete_head_branch: {}` removed, two-line `merge_protections_settings` block added