### PR TITLE
Port: gh29279 SqlDefaultValueExpression supports RepoIdAware → keen_hawk_hotfix

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/report/documentPrintOptionDefaults.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/report/documentPrintOptionDefaults.feature
@@ -7,6 +7,7 @@ Feature: Document Print Option defaults resolve @SQL= expressions
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
 
   @from:cucumber
+  @Id:F36025_static_default_resolves
   Scenario: AD_Process_Para with static default Y resolves to true
     Given metasfresh contains AD_Processes:
       | Identifier | Value            | Name              |
@@ -19,6 +20,7 @@ Feature: Document Print Option defaults resolve @SQL= expressions
       | PRINTER_OPTS_IsPrintLogo | true         |
 
   @from:cucumber
+  @Id:F36025_sql_default_resolves
   Scenario: AD_Process_Para with @SQL= default resolves correctly
     Given metasfresh contains AD_Processes:
       | Identifier | Value              | Name                |

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlDefaultValueExpression.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/SqlDefaultValueExpression.java
@@ -32,6 +32,8 @@ import de.metas.logging.LogManager;
 import de.metas.ui.web.window.datatypes.LookupValue.IntegerLookupValue;
 import de.metas.ui.web.window.datatypes.LookupValue.StringLookupValue;
 import de.metas.util.Check;
+import de.metas.util.lang.RepoIdAware;
+import de.metas.util.lang.RepoIdAwares;
 import lombok.NonNull;
 
 /*
@@ -117,6 +119,16 @@ public final class SqlDefaultValueExpression<V> implements IExpression<V>
 				|| StringLookupValue.class.equals(valueClass))
 		{
 			return new SqlDefaultValueExpression<>(stringExpression, String.class, (rs) -> rs.getString(1));
+		}
+		// Any RepoIdAware (e.g. WebuiImageId, BPartnerId, ...): read the int and wrap via the typed factory.
+		else if (RepoIdAware.class.isAssignableFrom(valueClass))
+		{
+			@SuppressWarnings("unchecked")
+			final Class<RepoIdAware> repoIdClass = (Class<RepoIdAware>)valueClass;
+			return new SqlDefaultValueExpression<>(stringExpression, repoIdClass, (rs) -> {
+				final int repoId = rs.getInt(1);
+				return rs.wasNull() ? null : RepoIdAwares.ofRepoId(repoId, repoIdClass);
+			});
 		}
 
 		throw ExpressionCompileException.newWithPlainMessage("Value type " + valueClass + " is not supported by " + SqlDefaultValueExpression.class);

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/window/descriptor/sql/SqlDefaultValueExpressionTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/window/descriptor/sql/SqlDefaultValueExpressionTest.java
@@ -1,0 +1,52 @@
+package de.metas.ui.web.window.descriptor.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import org.adempiere.ad.expression.api.IStringExpression;
+import org.adempiere.ad.expression.exceptions.ExpressionCompileException;
+import org.junit.jupiter.api.Test;
+
+import de.metas.ui.web.upload.WebuiImageId;
+import de.metas.util.lang.RepoIdAware;
+
+/**
+ * Type-handling coverage for {@link SqlDefaultValueExpression#of(IStringExpression, Class)}.
+ * <p>
+ * Regression: process parameters typed as a {@link RepoIdAware} (e.g. {@link WebuiImageId}) used to fail
+ * with {@code ExpressionCompileException("Value type ... is not supported")} when their default was
+ * rewritten by {@code mf15-private-extensions/5783321_UpdateDefaultValues.sql} to {@code @SQL=...}.
+ * The fix accepts any {@link RepoIdAware} subclass and wraps the int from the result set via the
+ * typed {@code ofRepoId} factory.
+ * <p>
+ * The deserialization lambda itself requires DB access to test end-to-end; here we cover the type
+ * acceptance path which is what the regression hinges on.
+ */
+class SqlDefaultValueExpressionTest
+{
+	private static final IStringExpression FAKE_SQL = mock(IStringExpression.class);
+
+	@Test
+	void of_supports_RepoIdAware_subclass_WebuiImageId()
+	{
+		final SqlDefaultValueExpression<?> expr = SqlDefaultValueExpression.of(FAKE_SQL, WebuiImageId.class);
+		assertThat(expr).isNotNull();
+		assertThat(expr.getValueClass()).isEqualTo(WebuiImageId.class);
+	}
+
+	@Test
+	void of_unsupported_value_type_still_throws()
+	{
+		// A value class that is neither RepoIdAware nor in the explicit type list should still throw —
+		// graceful degradation is intentional, blanket acceptance is not.
+		assertThatThrownBy(() -> SqlDefaultValueExpression.of(FAKE_SQL, NotARepoId.class))
+				.isInstanceOf(ExpressionCompileException.class)
+				.hasMessageContaining("not supported by");
+	}
+
+	/** Plain class — neither in the explicit list nor a {@link RepoIdAware}. */
+	private static final class NotARepoId
+	{
+	}
+}


### PR DESCRIPTION
## Summary

Cherry-pick of https://github.com/metasfresh/metasfresh/commit/88886882526ddbcf80b1372bc7ad6eea3dbb8cd4 (https://github.com/metasfresh/metasfresh/pull/23736) from `new_dawn_uat`.

Adds `RepoIdAware` value-class support to `SqlDefaultValueExpression.of(...)` so process parameters typed as e.g. `WebuiImageId` (DisplayType.Image, AD_Reference_ID=32) no longer fail with `ExpressionCompileException("Value type ... is not supported")` when their default is rewritten to `@SQL=...` by `mf15-private-extensions/5783321_UpdateDefaultValues.sql`.

Surfaced as a dt204 health-check failure but latent on every customer branch that has `5783321` applied. Urgent for keen_hawk_hotfix to unblock further rollouts.

## Test plan

- [x] SqlDefaultValueExpressionTest — 2 green locally (compile + unit-test gates of pre-push validation hook satisfied)
- [ ] CI green