### PR TITLE
Recompute Costs: post-rollout fixes — DE descriptions + DateAcct filter

### DIFF
--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5400270_sys_M_Inventory_RecomputeCosts_descriptions_de.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5400270_sys_M_Inventory_RecomputeCosts_descriptions_de.sql
@@ -1,0 +1,41 @@
+-- 2026-04-28 Push the German texts of M_Inventory_RecomputeCosts process + parameters into
+-- the de_DE / de_CH translation rows.
+--
+-- Migration 5799740 set Description / Help on AD_Process 585275 (base) and AD_Process_Para
+-- 542650 / 1000001 (base). It also set the en_US AD_Process_Trl. But the German trl rows
+-- (de_DE, de_CH) on AD_Process_Trl and AD_Process_Para_Trl still carried the pre-fix generic
+-- text ("Berechnen Sie die Kosten ...", "Stammdaten für Buchhaltung", "Gibt an, wie die
+-- Kosten berechnet werden"). The WebUI serves de_CH users from the de_CH trl row directly
+-- (IsTranslated=Y), so they kept seeing the old text after the fix.
+--
+-- This migration fills both German trl rows with the new Description / Help.
+
+-- AD_Process_Trl — German rows for M_Inventory_RecomputeCosts (AD_Process_ID = 585275)
+UPDATE AD_Process_Trl
+SET    Description  = 'Berechnet die laufenden Kosten für die Produkte der ausgewählten Inventuren neu, indem alle betroffenen Buchhaltungsbelege ab dem ältesten Bewegungsdatum der Auswahl chronologisch zurückgebucht und neu gebucht werden.',
+       Help         = 'Anwendung: nach dem Verbuchen einer oder mehrerer Inventuren, die Bestand und/oder Kostenpreis korrigieren. Voraussetzung: jede Buchungsperiode zwischen dem ältesten Bewegungsdatum der Auswahl und heute muss offen sein. Der Prozess (1) löscht M_CostDetail-Zeilen ab dem Startdatum, (2) bucht jeden betroffenen Beleg zurück und (3) reiht ihn zur chronologischen Neubuchung in die Warteschlange ein. Sobald die Warteschlange leer ist, anschließend den Prozess „Rebuild FactAcct Summary" ausführen.',
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-04-28 06:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy    = 0
+WHERE  AD_Process_ID = 585275
+  AND  AD_Language   IN ('de_DE','de_CH');
+
+-- AD_Process_Para_Trl — German rows for the C_AcctSchema_ID parameter (AD_Process_Para_ID = 542650)
+UPDATE AD_Process_Para_Trl
+SET    Description  = 'Das Buchhaltungs-Schema, das neu berechnet werden soll. Wählen Sie das Schema, dessen Kostenrechnungsmethode zu Ihrer Kostenanpassung passt (typischerweise „Bestellpreis Durchschnitt").',
+       Help         = NULL,
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-04-28 06:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy    = 0
+WHERE  AD_Process_Para_ID = 542650
+  AND  AD_Language        IN ('de_DE','de_CH');
+
+-- AD_Process_Para_Trl — German rows for the CostingMethod parameter (AD_Process_Para_ID = 1000001)
+UPDATE AD_Process_Para_Trl
+SET    Description  = 'Optional. Wenn gesetzt, werden nur die Kostenarten dieser Methode neu berechnet. Leer lassen, um alle aktiven Material-Kostenarten neu zu berechnen (Standardfall).',
+       Help         = NULL,
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-04-28 06:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy    = 0
+WHERE  AD_Process_Para_ID = 1000001
+  AND  AD_Language        IN ('de_DE','de_CH');

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5400280_sys_CostDetail_window_DateAcct_filter.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5400280_sys_CostDetail_window_DateAcct_filter.sql
@@ -1,0 +1,16 @@
+-- 2026-04-28 Make DateAcct (M_CostDetail.DateAcct) a date-range filter in the Cost-Detail
+-- window's grid view.
+--
+-- Migration 5799730 surfaced DateAcct in the grid (AD_UI_Element.IsDisplayedGrid='Y'), but
+-- AD_Column.IsSelectionColumn was still 'N' so the column did not appear in the filter panel.
+-- For a Date column (AD_Reference_ID = 15) we also want IsRangeFilter='Y' so the WebUI
+-- renders the standard from/to date-range widget.
+
+UPDATE AD_Column
+SET    IsSelectionColumn    = 'Y',
+       SelectionColumnSeqNo = 15,             -- between M_Product_ID (10) and M_CostElement_ID (20)
+       IsRangeFilter        = 'Y',
+       Updated              = TO_TIMESTAMP('2026-04-28 06:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy            = 0
+WHERE  AD_Column_ID = 584019                 -- DateAcct on M_CostDetail (AD_Table_ID = 808)
+;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5400290_sys_CostDetail_window_DateAcct_narrow.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5400290_sys_CostDetail_window_DateAcct_narrow.sql
@@ -1,0 +1,13 @@
+-- 2026-04-29 Cost-Detail window: narrow the DateAcct grid column to match
+-- the UOM / Type / Currency / Acct-Schema columns already narrowed by 5799760.
+--
+-- AD_UI_Element 611534 = DateAcct on AD_Tab 748 (M_CostDetail template).
+-- The change applies to both window 540897 ("Kosten-Detail") and window 344
+-- ("Produktkosten") that share the template — same as 5799760.
+
+UPDATE AD_UI_Element
+SET    WidgetSize = 'S',
+       Updated    = TO_TIMESTAMP('2026-04-29 06:00','YYYY-MM-DD HH24:MI'),
+       UpdatedBy  = 0
+WHERE  AD_UI_Element_ID = 611534                     -- DateAcct
+;


### PR DESCRIPTION
## Summary

Two follow-ups after #23750 was rolled out to the customer hotfix instance:

1. **`Kosten neu berechnen` Description / Help — German trl rows.** #23750 updated `AD_Process` (base) and the `en_US` `AD_Process_Trl`. The de_DE / de_CH `AD_Process_Trl` and `AD_Process_Para_Trl` rows still carried the original generic text with `IsTranslated='Y'`, so German-speaking users kept seeing the old description in the process dialog.
2. **`DateAcct` not filterable.** #23750 surfaced `DateAcct` in the Cost-Detail grid via `AD_UI_Element`, but `AD_Column.IsSelectionColumn = 'N'` so the column did not appear in the filter panel.

## Changes

### `5400270_sys_M_Inventory_RecomputeCosts_descriptions_de.sql`
Sets the new German `Description` / `Help` on:
- `AD_Process_Trl` for `AD_Process_ID = 585275`, languages `de_DE` + `de_CH`
- `AD_Process_Para_Trl` for `AD_Process_Para_ID = 542650` (`C_AcctSchema_ID`), languages `de_DE` + `de_CH`
- `AD_Process_Para_Trl` for `AD_Process_Para_ID = 1000001` (`CostingMethod`), languages `de_DE` + `de_CH`

All German rows are flipped to `IsTranslated = 'Y'` so the WebUI uses them directly without a fallback.

### `5400280_sys_CostDetail_window_DateAcct_filter.sql`
On `AD_Column 584019` (`M_CostDetail.DateAcct`):
- `IsSelectionColumn = 'Y'`
- `SelectionColumnSeqNo = 15` (between `M_Product_ID` = 10 and `M_CostElement_ID` = 20)
- `IsRangeFilter = 'Y'` so the WebUI renders a from/to date-range widget

## Test plan

- [x] Both migrations applied via `workspace_migrate.Main` against the freshly-templated local `intensive_care_uat` DB; verified target rows hold the new content.
- [ ] CI green
- [ ] Customer rollout (the existing recompute regression test in #23750 already covers the costing logic; these follow-ups are pure AD metadata)

## Out of scope (separate, wiki-only)

The customer also asked whether `Rebuild_FactAcctSummary` truly needs to be run after `M_Inventory_RecomputeCosts`. Answer: **no, not strictly** — the `fact_acct_log_tg_fn` trigger + `FactAcctLogService` incremental aggregation keep `Fact_Acct_Summary` in sync automatically as `Fact_Acct` rows are deleted/inserted by the un-post / re-post cycle. `Rebuild_FactAcctSummary` is a complete-rebuild safety net (truncates + re-aggregates from `Fact_Acct`), useful as a sanity check after large operations but not a required step. The wiki page will be updated to soften that step from "must run" to "recommended sanity check".