### PR TITLE
Fix C_PaySelectionLine.C_BP_BankAccount_ID val_rule — drop @C_Order_ID@ branch (29368 follow-up)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5800140_C_PaySelectionLine_BPBankAccount_ValRule_drop_C_Order_ID.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5800140_C_PaySelectionLine_BPBankAccount_ValRule_drop_C_Order_ID.sql
@@ -1,0 +1,13 @@
+-- me03 #29368 — drop the `@C_Order_ID@` branch from the C_PaySelectionLine.C_BP_BankAccount_ID
+-- validation rule. After iter-2, pay-selection lines reference invoices only (regular + proforma);
+-- C_PaySelectionLine no longer carries a C_Order_ID column, so the `UNION select ... from C_Order`
+-- subselect references a context variable that is never resolved. Window health check fails:
+--     "No context variable `C_Order_ID` found in C_PaySelection/206.C_PaySelectionLine/353.C_BP_BankAccount_ID.LookupDescriptor."
+-- The line always has C_Invoice_ID set, so the invoice branch alone covers both the regular- and
+-- proforma-invoice cases.
+
+UPDATE AD_Val_Rule
+SET Code    = 'C_BP_BankAccount.C_BPartner_ID=@C_BPartner_ID@ /* the invoice''s currency needs to match the account''s currency */ AND C_BP_BankAccount.C_Currency_ID=(select i.C_Currency_ID from C_Invoice i where i.C_Invoice_ID=@C_Invoice_ID@) AND (C_BP_BankAccount.BPBankAcctUse = ''B'' OR C_BP_BankAccount.BPBankAcctUse = ''@PaymentRule@'' /*Allow selection of NON-Standard types of usage like "Provision", because we can''t know if they make sense or not*/ OR C_BP_BankAccount.BPBankAcctUse NOT IN (''B'',''D'',''N'',''T'') )',
+    Updated = TO_TIMESTAMP('2026-04-28 21:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy = 100
+WHERE AD_Val_Rule_ID = 540104;


### PR DESCRIPTION
## Summary

- After https://github.com/metasfresh/me03/issues/29368 (iter-2), `C_PaySelectionLine` no longer carries `C_Order_ID` — pay-selection lines reference invoices only (regular + proforma).
- Validation rule `AD_Val_Rule_ID=540104` (`C_PaySelectionLine.C_BP_BankAccount_ID`) still referenced `@C_Order_ID@` via a `UNION ... C_Order` subselect, causing the window health check to fail with `No context variable \`C_Order_ID\` found in C_PaySelection/206.C_PaySelectionLine/353.C_BP_BankAccount_ID.LookupDescriptor`.
- The line always has `C_Invoice_ID` set, so the `C_Invoice` currency branch alone covers both regular- and proforma-invoice cases.

## Test plan

- [x] Migration `5800140` applied locally → `AD_Val_Rule.Code` updated, no `@C_Order_ID@` reference.
- [x] Window health check on local webapi: `countErrors: 0` across all 827 windows (including window 206 — Pay Selection).
- [x] Functional check via `application-dictionary §16` (SELECT-1-FROM-context-table pattern with real values from `C_PaySelectionLine_ID=1000020`): returns the expected vendor EUR bank account.
- [ ] CI green