### PR TITLE
Port: webui make table columns resizable by user (F50000) to task_force_hotfix

### DIFF
--- a/e2e/frontend-webui/tests/spec/column-resize.spec.js
+++ b/e2e/frontend-webui/tests/spec/column-resize.spec.js
@@ -1,0 +1,226 @@
+import { test } from '../../playwright.config';
+import { expect } from '@playwright/test';
+import { allure } from 'allure-playwright';
+import { getPage, SLOW_ACTION_TIMEOUT } from '../utils/common';
+
+const FRONTEND_BASE_URL =
+  process.env.FRONTEND_BASE_URL || 'http://localhost:3000';
+
+/**
+ * Column Resize test suite for metasfresh web UI.
+ * Tests the ability to resize table columns by dragging column header borders.
+ *
+ * Features tested:
+ * - F50000: Resizable Table Columns
+ */
+test.describe('Column Resize', () => {
+  test.beforeEach(async ({ page }) => {
+    // Login directly with default credentials
+    await page.goto(`${FRONTEND_BASE_URL}/login`);
+    await page.locator('.login-container').waitFor({
+      state: 'visible',
+      timeout: SLOW_ACTION_TIMEOUT,
+    });
+
+    await page.locator('input[name="username"]').fill('metasfresh');
+    await page.locator('input[name="password"]').fill('metasfresh');
+    await page.locator('.btn-meta-success').click();
+
+    // Handle role selection: if a second login step appears, click through it
+    try {
+      await page.waitForURL((url) => !url.toString().includes('/login'), {
+        timeout: 5000,
+      });
+    } catch {
+      // Role selection step - click the confirm button again
+      const confirmBtn = page.locator('.btn-meta-success');
+      if (await confirmBtn.isVisible()) {
+        await confirmBtn.click();
+      }
+      await page.waitForURL((url) => !url.toString().includes('/login'), {
+        timeout: SLOW_ACTION_TIMEOUT,
+      });
+    }
+  });
+
+  test('Drag to resize a column in document list', async ({ page }) => {
+    allure.epic('E0200: WebUI Table Features');
+    allure.tag('F50000: Resizable Table Columns');
+    allure.tag('F50000');
+    allure.story('Drag-to-resize column width');
+    allure.severity('critical');
+
+    // Navigate to Business Partners list view (window 123)
+    await page.goto(`${FRONTEND_BASE_URL}/window/123`);
+
+    // Wait for table to load
+    await page.locator('.js-table').waitFor({
+      state: 'visible',
+      timeout: SLOW_ACTION_TIMEOUT,
+    });
+
+    // Wait for at least one row
+    await page
+      .locator('.js-table tbody tr')
+      .first()
+      .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+    // Find the first column header with a resize handle
+    const resizeHandle = page.locator('.column-resize-handle').first();
+    await expect(resizeHandle).toBeAttached();
+
+    // Get the parent th element's width
+    const th = page.locator('thead th:has(.column-resize-handle)').first();
+    const initialBox = await th.boundingBox();
+    const initialWidth = initialBox.width;
+    console.log(`Initial column width: ${initialWidth}px`);
+
+    // Get the resize handle position
+    const handleBox = await resizeHandle.boundingBox();
+    const startX = handleBox.x + handleBox.width / 2;
+    const startY = handleBox.y + handleBox.height / 2;
+
+    // Drag the resize handle 100px to the right
+    const dragDistance = 100;
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX + dragDistance, startY, { steps: 10 });
+    await page.mouse.up();
+
+    await page.waitForTimeout(300);
+
+    // Verify the column width increased
+    const newBox = await th.boundingBox();
+    const newWidth = newBox.width;
+    console.log(`New column width: ${newWidth}px`);
+
+    expect(newWidth).toBeGreaterThan(initialWidth + 50);
+    console.log(
+      `Column resized from ${initialWidth}px to ${newWidth}px`
+    );
+  });
+
+  test('Column width persists after page reload', async ({ page }) => {
+    allure.epic('E0200: WebUI Table Features');
+    allure.tag('F50000: Resizable Table Columns');
+    allure.tag('F50000');
+    allure.story('Column width persistence');
+    allure.severity('critical');
+
+    // Navigate to Business Partners list view
+    await page.goto(`${FRONTEND_BASE_URL}/window/123`);
+
+    // Wait for table
+    await page.locator('.js-table').waitFor({
+      state: 'visible',
+      timeout: SLOW_ACTION_TIMEOUT,
+    });
+    await page
+      .locator('.js-table tbody tr')
+      .first()
+      .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+    // Resize a column
+    const resizeHandle = page.locator('.column-resize-handle').first();
+    const th = page.locator('thead th:has(.column-resize-handle)').first();
+
+    const handleBox = await resizeHandle.boundingBox();
+    const startX = handleBox.x + handleBox.width / 2;
+    const startY = handleBox.y + handleBox.height / 2;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX + 80, startY, { steps: 10 });
+    await page.mouse.up();
+
+    await page.waitForTimeout(300);
+
+    const resizedBox = await th.boundingBox();
+    const resizedWidth = resizedBox.width;
+    console.log(`Width after resize: ${resizedWidth}px`);
+
+    // Reload the page
+    await page.reload();
+
+    // Wait for table to reload
+    await page.locator('.js-table').waitFor({
+      state: 'visible',
+      timeout: SLOW_ACTION_TIMEOUT,
+    });
+    await page
+      .locator('.js-table tbody tr')
+      .first()
+      .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+    // Check width is preserved (5px tolerance)
+    const afterReloadBox = await page
+      .locator('thead th:has(.column-resize-handle)')
+      .first()
+      .boundingBox();
+    const afterReloadWidth = afterReloadBox.width;
+    console.log(`Width after reload: ${afterReloadWidth}px`);
+
+    expect(Math.abs(afterReloadWidth - resizedWidth)).toBeLessThan(5);
+    console.log('Column width persisted across page reload');
+  });
+
+  test('Double-click resize handle resets column width', async ({ page }) => {
+    allure.epic('E0200: WebUI Table Features');
+    allure.tag('F50000: Resizable Table Columns');
+    allure.tag('F50000');
+    allure.story('Double-click to reset column width');
+    allure.severity('normal');
+
+    // Navigate to Business Partners list view
+    await page.goto(`${FRONTEND_BASE_URL}/window/123`);
+
+    // Wait for table
+    await page.locator('.js-table').waitFor({
+      state: 'visible',
+      timeout: SLOW_ACTION_TIMEOUT,
+    });
+    await page
+      .locator('.js-table tbody tr')
+      .first()
+      .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+    // Capture original width
+    const th = page.locator('thead th:has(.column-resize-handle)').first();
+    const originalBox = await th.boundingBox();
+    const originalWidth = originalBox.width;
+    console.log(`Original width: ${originalWidth}px`);
+
+    // Resize the column
+    const resizeHandle = page.locator('.column-resize-handle').first();
+    const handleBox = await resizeHandle.boundingBox();
+    const startX = handleBox.x + handleBox.width / 2;
+    const startY = handleBox.y + handleBox.height / 2;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX + 150, startY, { steps: 10 });
+    await page.mouse.up();
+
+    await page.waitForTimeout(300);
+
+    const resizedBox = await th.boundingBox();
+    expect(resizedBox.width).toBeGreaterThan(originalWidth);
+    console.log(`Resized width: ${resizedBox.width}px`);
+
+    // Double-click the resize handle to reset
+    const newHandleBox = await resizeHandle.boundingBox();
+    await page.mouse.dblclick(
+      newHandleBox.x + newHandleBox.width / 2,
+      newHandleBox.y + newHandleBox.height / 2
+    );
+
+    await page.waitForTimeout(300);
+
+    // Verify width is back near the original (10px tolerance)
+    const resetBox = await th.boundingBox();
+    console.log(`Width after reset: ${resetBox.width}px`);
+
+    expect(Math.abs(resetBox.width - originalWidth)).toBeLessThan(10);
+    console.log('Column width reset by double-click');
+  });
+});

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -125,6 +125,35 @@ const devServer = new WebpackDevServer(
     },
     hot: true,
     historyApiFallback: true,
+    // Proxy is opt-in: set API_PROXY_TARGET to enable proxying /rest and /stomp
+    // to a local backend (e.g., API_PROXY_TARGET=http://localhost:8080).
+    // Without this, config.js determines the backend URL (default for human devs).
+    ...(process.env.API_PROXY_TARGET
+      ? {
+          proxy: [
+            {
+              context: ['/rest', '/stomp'],
+              target: process.env.API_PROXY_TARGET,
+              changeOrigin: false,
+              ws: true,
+              cookieDomainRewrite: '',
+              cookiePathRewrite: '/',
+              onProxyRes: function (proxyRes) {
+                var setCookie = proxyRes.headers['set-cookie'];
+                if (setCookie) {
+                  proxyRes.headers['set-cookie'] = setCookie.map(function (
+                    cookie
+                  ) {
+                    return cookie
+                      .replace(/;\s*SameSite=[^;]*/gi, '')
+                      .replace(/;\s*Secure/gi, '');
+                  });
+                }
+              },
+            },
+          ],
+        }
+      : {}),
 
     // Enhanced dev middleware options
     devMiddleware: {

--- a/frontend/src/__tests__/components/table/TableHeader.test.js
+++ b/frontend/src/__tests__/components/table/TableHeader.test.js
@@ -22,13 +22,15 @@ describe('TableHeader', () => {
     const html = wrapperTableCMenu.html();
 
     expect(html).not.toContain(`<th class="indent"></th>`);
-    // Updated expectations to include data-testid attributes
-    expect(html).toContain(`<th class="td-sm" data-testid="column-R_Request_ID">Request</th>`);
-    expect(html).toContain(`<th class="td-lg" data-testid="column-R_RequestType_ID">Request Type</th>`);
-    expect(html).toContain(`<th class="td-md" data-testid="column-Created">Created</th>`);
-    expect(html).toContain(`<th class="td-lg" data-testid="column-CreatedBy">Created By</th>`);
-    expect(html).toContain(`<th class="td-lg" data-testid="column-Summary">Summary</th>`);
-    expect(html).toContain(`<th class="td-md" data-testid="column-AD_Org_ID">Organisation</th>`);
+    // Check column headers with data-testid and resize handles
+    expect(html).toContain(`data-testid="column-R_Request_ID">Request`);
+    expect(html).toContain(`data-testid="column-R_RequestType_ID">Request Type`);
+    expect(html).toContain(`data-testid="column-Created">Created`);
+    expect(html).toContain(`data-testid="column-CreatedBy">Created By`);
+    expect(html).toContain(`data-testid="column-Summary">Summary`);
+    expect(html).toContain(`data-testid="column-AD_Org_ID">Organisation`);
+    // Verify resize handles are present
+    expect(html).toContain(`column-resize-handle`);
   });
 
   it('should have indent present', () => {

--- a/frontend/src/assets/css/table.scss
+++ b/frontend/src/assets/css/table.scss
@@ -160,6 +160,24 @@
   th {
     font-weight: 500;
     position: relative;
+
+    .column-resize-handle {
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 5px;
+      cursor: col-resize;
+      z-index: 3;
+
+      &:hover {
+        background-color: rgba(255, 255, 255, 0.3);
+      }
+    }
+
+    &.column-resizing {
+      background-color: lighten($brand-color-secondary, 10%);
+    }
   }
 
   td {

--- a/frontend/src/components/table/Table.js
+++ b/frontend/src/components/table/Table.js
@@ -8,6 +8,10 @@ import {
   handleCopy,
   isShowCommentsMarker,
 } from '../../utils/tableHelpers';
+import {
+  loadColumnWidths,
+  saveColumnWidths,
+} from '../../utils/columnWidthStorage';
 import TableHeader from './TableHeader';
 import TableRow from './TableRow';
 import Spinner from '../app/SpinnerOverlay';
@@ -24,6 +28,7 @@ class Table extends PureComponent {
     this.state = {
       listenOnKeys: true,
       tableRefreshToggle: false,
+      columnWidths: {},
     };
     this.multiSelectionStartIdx = null;
   }
@@ -31,16 +36,30 @@ class Table extends PureComponent {
   componentDidMount() {
     this._isMounted = true;
     this.initialPaddingBottom = 100;
+
+    // Load persisted column widths
+    const { windowId, viewId } = this.props;
+    const columnWidths = loadColumnWidths(windowId, viewId);
+    if (Object.keys(columnWidths).length > 0) {
+      this.setState({ columnWidths });
+    }
+
     if (this.props.autofocus && this.table) {
       this.table.focus();
     }
   }
 
   componentDidUpdate(prevProps) {
-    const { mainTable, open, rows } = this.props;
+    const { mainTable, open, rows, windowId, viewId } = this.props;
 
     if (!this._isMounted) {
       return;
+    }
+
+    // Reload column widths if window/view changed
+    if (windowId !== prevProps.windowId || viewId !== prevProps.viewId) {
+      const columnWidths = loadColumnWidths(windowId, viewId);
+      this.setState({ columnWidths });
     }
 
     if (
@@ -76,6 +95,35 @@ class Table extends PureComponent {
 
   setTfootRef = (ref) => {
     this.tfoot = ref;
+  };
+
+  handleColumnResize = (fieldName, width) => {
+    this.setState((prevState) => ({
+      columnWidths: {
+        ...prevState.columnWidths,
+        [fieldName]: Math.round(width),
+      },
+    }));
+  };
+
+  handleColumnResizeEnd = () => {
+    const { windowId, viewId } = this.props;
+    const { columnWidths } = this.state;
+    saveColumnWidths(windowId, viewId, columnWidths);
+  };
+
+  handleColumnResetWidth = (fieldName) => {
+    this.setState(
+      (prevState) => {
+        const newWidths = { ...prevState.columnWidths };
+        delete newWidths[fieldName];
+        return { columnWidths: newWidths };
+      },
+      () => {
+        const { windowId, viewId } = this.props;
+        saveColumnWidths(windowId, viewId, this.state.columnWidths);
+      }
+    );
   };
 
   getCurrentRowIndex = (arrowOrientation) => {
@@ -368,7 +416,7 @@ class Table extends PureComponent {
       onFastInlineEdit,
       isShowComments,
     } = this.props;
-    const { listenOnKeys } = this.state;
+    const { listenOnKeys, columnWidths } = this.state;
 
     if (!rows.length || !columns.length) {
       return null;
@@ -411,6 +459,7 @@ class Table extends PureComponent {
           tableId,
           listenOnKeys,
           isShowComments,
+          columnWidths,
         }}
         cols={columns}
         key={`row-${i}${viewId ? `-${viewId}` : ''}`}
@@ -508,6 +557,7 @@ class Table extends PureComponent {
       setActiveSort,
       pending,
     } = this.props;
+    const { columnWidths } = this.state;
 
     return (
       <div
@@ -553,10 +603,14 @@ class Table extends PureComponent {
                 docId,
                 viewId,
                 setActiveSort,
+                columnWidths,
               }}
               cols={columns}
               windowType={windowId}
               deselect={onDeselectAll}
+              onColumnResize={this.handleColumnResize}
+              onColumnResizeEnd={this.handleColumnResizeEnd}
+              onColumnResetWidth={this.handleColumnResetWidth}
             />
           </thead>
           <tbody>{this.renderTableBody()}</tbody>

--- a/frontend/src/components/table/TableCell.js
+++ b/frontend/src/components/table/TableCell.js
@@ -183,6 +183,7 @@ class TableCell extends PureComponent {
       tableCellData,
       colIndex,
       updateRow,
+      columnWidth,
     } = this.props;
     const docId = `${this.props.docId}`;
     const { tooltipToggled } = this.state;
@@ -190,7 +191,15 @@ class TableCell extends PureComponent {
     const tdTitle = getTdTitle({ item, description });
     const isOpenDatePicker = isEdited && item.widgetType === 'Date';
     const isDateField = checkIfDateField({ item });
-    let style = cellExtended ? { height: extendLongText * 20 } : {};
+    const style = cellExtended ? { height: extendLongText * 20 } : {};
+    const tdStyle = columnWidth
+      ? {
+          ...style,
+          width: `${columnWidth}px`,
+          minWidth: `${columnWidth}px`,
+          maxWidth: `${columnWidth}px`,
+        }
+      : undefined;
 
     return (
       <td
@@ -207,13 +216,14 @@ class TableCell extends PureComponent {
             'cell-disabled': isReadonly,
             'cell-mandatory': isMandatory,
           },
-          getSizeClass(item),
+          { [getSizeClass(item)]: !columnWidth },
           item.widgetType,
           {
             'pulse-on': updatedRow,
             'pulse-off': !updatedRow,
           }
         )}
+        style={tdStyle}
         data-cy={`cell-${property}`}
       >
         {hasComments && (
@@ -335,6 +345,7 @@ TableCell.propTypes = {
   handleFocusAction: PropTypes.func,
   tableCellData: PropTypes.object,
   tableId: PropTypes.string.isRequired,
+  columnWidth: PropTypes.number,
 };
 
 export default TableCell;

--- a/frontend/src/components/table/TableHeader.js
+++ b/frontend/src/components/table/TableHeader.js
@@ -5,13 +5,18 @@ import PropTypes from 'prop-types';
 import { shouldRenderColumn, getSizeClass } from '../../utils/tableHelpers';
 import { getTableId } from '../../reducers/tables';
 
+const MIN_COLUMN_WIDTH = 50;
+
 export default class TableHeader extends PureComponent {
   constructor(props) {
     super(props);
 
     this.state = {
       fields: {},
+      resizing: null, // { index, startX, startWidth }
     };
+
+    this.thRefs = {};
   }
 
   static getDerivedStateFromProps(props) {
@@ -28,6 +33,11 @@ export default class TableHeader extends PureComponent {
     }
 
     return null;
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousemove', this.handleResizeMove);
+    document.removeEventListener('mouseup', this.handleResizeEnd);
   }
 
   handleClick = (field, sortable) => {
@@ -76,6 +86,63 @@ export default class TableHeader extends PureComponent {
     deselect();
   };
 
+  handleResizeStart = (e, fieldName) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const th = this.thRefs[fieldName];
+    if (!th) return;
+
+    const startWidth = th.getBoundingClientRect().width;
+
+    this.setState({
+      resizing: { fieldName, startX: e.clientX, startWidth },
+    });
+
+    document.addEventListener('mousemove', this.handleResizeMove);
+    document.addEventListener('mouseup', this.handleResizeEnd);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  };
+
+  handleResizeMove = (e) => {
+    const { resizing } = this.state;
+    if (!resizing) return;
+
+    const { onColumnResize } = this.props;
+    const diff = e.clientX - resizing.startX;
+    const newWidth = Math.max(MIN_COLUMN_WIDTH, resizing.startWidth + diff);
+
+    if (onColumnResize) {
+      onColumnResize(resizing.fieldName, newWidth);
+    }
+  };
+
+  handleResizeEnd = () => {
+    const { onColumnResizeEnd } = this.props;
+
+    document.removeEventListener('mousemove', this.handleResizeMove);
+    document.removeEventListener('mouseup', this.handleResizeEnd);
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+
+    this.setState({ resizing: null });
+
+    if (onColumnResizeEnd) {
+      onColumnResizeEnd();
+    }
+  };
+
+  handleResizeDoubleClick = (e, fieldName) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const { onColumnResetWidth } = this.props;
+    if (onColumnResetWidth) {
+      onColumnResetWidth(fieldName);
+    }
+  };
+
   renderSorting = (field, caption, sortable, description) => {
     const { fields } = this.state;
     const fieldSorting = fields[field];
@@ -104,7 +171,8 @@ export default class TableHeader extends PureComponent {
   };
 
   renderCols = (cols) => {
-    const { onSortTable } = this.props;
+    const { onSortTable, columnWidths } = this.props;
+    const { resizing } = this.state;
 
     return (
       cols &&
@@ -114,11 +182,31 @@ export default class TableHeader extends PureComponent {
           const fieldName =
             item.fields && item.fields[0] ? item.fields[0].field : null;
           const dataTestId = fieldName ? `column-${fieldName}` : undefined;
+          const customWidth =
+            fieldName && columnWidths ? columnWidths[fieldName] : null;
+
+          const style = customWidth
+            ? {
+                width: `${customWidth}px`,
+                minWidth: `${customWidth}px`,
+                maxWidth: `${customWidth}px`,
+              }
+            : {};
 
           return (
             <th
               key={index}
-              className={getSizeClass(item)}
+              ref={(el) => {
+                if (fieldName) this.thRefs[fieldName] = el;
+              }}
+              className={classnames(
+                { [getSizeClass(item)]: !customWidth },
+                {
+                  'column-resizing':
+                    resizing && resizing.fieldName === fieldName,
+                }
+              )}
+              style={style}
               data-testid={dataTestId}
             >
               {onSortTable
@@ -129,6 +217,16 @@ export default class TableHeader extends PureComponent {
                     item.description
                   )
                 : item.caption}
+              {fieldName && (
+                <div
+                  className="column-resize-handle"
+                  data-testid={`resize-handle-${fieldName}`}
+                  onMouseDown={(e) => this.handleResizeStart(e, fieldName)}
+                  onDoubleClick={(e) =>
+                    this.handleResizeDoubleClick(e, fieldName)
+                  }
+                />
+              )}
             </th>
           );
         }
@@ -160,4 +258,8 @@ TableHeader.propTypes = {
   cols: PropTypes.any,
   indentSupported: PropTypes.any,
   setActiveSort: PropTypes.func,
+  columnWidths: PropTypes.object,
+  onColumnResize: PropTypes.func,
+  onColumnResizeEnd: PropTypes.func,
+  onColumnResetWidth: PropTypes.func,
 };

--- a/frontend/src/components/table/TableRow.js
+++ b/frontend/src/components/table/TableRow.js
@@ -513,6 +513,7 @@ class TableRow extends PureComponent {
       changeListenOnFalse,
       fieldsByName,
       isShowComments,
+      columnWidths,
     } = this.props;
     const {
       edited,
@@ -561,6 +562,11 @@ class TableRow extends PureComponent {
               widgetData
             );
 
+            const columnWidth =
+              columnWidths && columnWidths[property]
+                ? columnWidths[property]
+                : null;
+
             return (
               <TableCell
                 {...{
@@ -596,6 +602,7 @@ class TableRow extends PureComponent {
                   tableCellData,
                   description,
                   updateHeight,
+                  columnWidth,
                 }}
                 ref={(c) => {
                   if (c && isSelected) {
@@ -787,6 +794,7 @@ TableRow.propTypes = {
   navigationActive: PropTypes.bool,
   isModal: PropTypes.bool,
   isShowComments: PropTypes.bool,
+  columnWidths: PropTypes.object,
 };
 
 export default TableRow;

--- a/frontend/src/utils/columnWidthStorage.js
+++ b/frontend/src/utils/columnWidthStorage.js
@@ -1,0 +1,52 @@
+const STORAGE_KEY_PREFIX = 'columnWidths_';
+
+/**
+ * @method getStorageKey
+ * @summary Generate a localStorage key for the given window/view
+ */
+function getStorageKey(windowId, viewProfileId) {
+  return `${STORAGE_KEY_PREFIX}${windowId}${
+    viewProfileId ? `_${viewProfileId}` : ''
+  }`;
+}
+
+/**
+ * @method loadColumnWidths
+ * @summary Load persisted column widths from localStorage
+ * @param {string} windowId
+ * @param {string} [viewProfileId]
+ * @returns {object} Map of fieldName -> width in pixels
+ */
+export function loadColumnWidths(windowId, viewProfileId) {
+  if (!windowId) return {};
+
+  try {
+    const key = getStorageKey(windowId, viewProfileId);
+    const stored = localStorage.getItem(key);
+    return stored ? JSON.parse(stored) : {};
+  } catch (e) {
+    return {};
+  }
+}
+
+/**
+ * @method saveColumnWidths
+ * @summary Save column widths to localStorage
+ * @param {string} windowId
+ * @param {string} [viewProfileId]
+ * @param {object} widths - Map of fieldName -> width in pixels
+ */
+export function saveColumnWidths(windowId, viewProfileId, widths) {
+  if (!windowId) return;
+
+  try {
+    const key = getStorageKey(windowId, viewProfileId);
+    if (Object.keys(widths).length === 0) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, JSON.stringify(widths));
+    }
+  } catch (e) {
+    // localStorage might be full or unavailable
+  }
+}


### PR DESCRIPTION
Port of https://github.com/metasfresh/metasfresh/pull/22435 from `new_dawn_uat` to `task_force_hotfix`.

Cherry-pick of squash merge `ac970a6c6a1984c5c7d51fba3f250613571b4c23`. Clean cherry-pick (one auto-merge in `frontend/src/components/table/TableRow.js`, no conflicts).

Tracks https://github.com/metasfresh/me03/issues/29367 (port issue) and https://github.com/metasfresh/me03/issues/27257 (parent / source).

Files changed (frontend + e2e only — no backend, no SQL migrations, no AD changes):

- `e2e/frontend-webui/tests/spec/column-resize.spec.js`
- `frontend/server.js`
- `frontend/src/__tests__/components/table/TableHeader.test.js`
- `frontend/src/assets/css/table.scss`
- `frontend/src/components/table/Table.js`
- `frontend/src/components/table/TableCell.js`
- `frontend/src/components/table/TableHeader.js`
- `frontend/src/components/table/TableRow.js`
- `frontend/src/utils/columnWidthStorage.js`

Local pre-push validation:
- `yarn lint`: 0 errors, 24 acceptable PropTypes warnings
- `yarn test --testPathPattern='TableHeader' --watchAll=false`: 3/3 passed
- Frontend lint config diff between `task_force_hotfix` and `new_dawn_uat`: empty