### PR TITLE
fix(shipment): consolidate aggregate-HU QtyPicked rows during reversal (me03#29561)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
@@ -362,6 +362,9 @@ public class C_Order_StepDef
 			order.setDatePromised(Timestamp.from(datePromisedToBeSet));
 		}
 
+		tableRow.getAsOptionalInstant(I_C_Order.COLUMNNAME_DateAcct)
+				.ifPresent(dateAcct -> order.setDateAcct(Timestamp.from(dateAcct)));
+
 		if (EmptyUtil.isNotBlank(poReference))
 		{
 			order.setPOReference(poReference);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/reversedShipment.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/reversedShipment.feature
@@ -13,6 +13,7 @@ Feature: reversed shipment
     And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
 
   @from:cucumber
+  @Id:S29561_10
   Scenario: we can create and complete a shipment, then reserve/correct it and check the hu's status
     Given metasfresh has date and time 2021-12-16T13:30:13+01:00[Europe/Berlin]
     And metasfresh contains M_Products:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/reversedShipment.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/reversedShipment.feature
@@ -100,3 +100,99 @@ Feature: reversed shipment
     And after not more than 60 seconds metasfresh has MD_Stock data
       | M_Product_ID.Identifier | QtyOnHand |
       | p_1                     | 0         |
+
+  @from:cucumber
+  @Id:S29561_20
+  Scenario: aggregate-HU shipment can be reversed and re-shipped without duplicate QtyPicked rows
+  ## me03#29561: when a shipment whose allocation is an aggregate HU (one VHU representing N TUs)
+  ## is reversed, the HU-trx snapshot replay emits N trx lines through the same VHU. Without
+  ## consolidation in ShipmentScheduleHUTrxListener, that produces N identical
+  ## M_ShipmentSchedule_QtyPicked rows that collide on the M_ShipmentSchedule_QtyPicked_UI partial
+  ## unique index when the next shipment is generated. This scenario fails on the second
+  ## 'generate shipments' step without the fix.
+    Given metasfresh has date and time 2024-06-03T13:30:13+02:00[Europe/Berlin]
+    And metasfresh contains M_Products:
+      | Identifier | Name           |
+      | p_agg      | hu_product_agg |
+    # Set up a self-contained DE→DE 0% tax. The customer-preloaded sp80 DB only
+    # has CH-domestic and DE→CH taxes for active categories with InternalName, so we
+    # can't rely on a built-in tax for our DE-customer scenario.
+    And metasfresh contains C_TaxCategory
+      | Identifier  | Name           | InternalName |
+      | tcAggS29561 | tc_agg_S29561  | aggS29561    |
+    And metasfresh contains C_Tax
+      | Identifier | Name        | C_TaxCategory_ID | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode | ValidFrom  |
+      | taxAgg     | tax_agg_de  | tcAggS29561      | 0    | DE                       | DE                        | 2024-01-01 |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                       | Value                       | OPT.IsActive |
+      | ps_agg     | hu_pricing_system_name_agg | hu_pricing_system_value_agg | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                   | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_agg     | ps_agg                        | DE                        | EUR                 | hu_price_list_name_agg | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name                  | ValidFrom  |
+      | plv_agg    | pl_agg                    | hu_salesOrder-PLV-agg | 2024-01-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_agg     | plv_agg                           | p_agg                   | 10.0     | PCE               | aggS29561                     |
+    And metasfresh contains C_BPartners:
+      | Identifier      | Name               | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.InvoiceRule |
+      | endcustomer_agg | hu_endcustomer_agg | N            | Y              | ps_agg                        | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_agg      | 0123456789012 | endcustomer_agg          | Y                   | Y                   |
+    # HU Packing Instruction hierarchy: LU holds up to 10 TU, each TU holds 2 PCE
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID |
+      | pi_LU_agg  |
+      | pi_TU_agg  |
+      | pi_VHU_agg |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType | IsCurrent |
+      | piv_LU_agg         | pi_LU_agg  | LU          | Y         |
+      | piv_TU_agg         | pi_TU_agg  | TU          | Y         |
+      | piv_VHU_agg        | pi_VHU_agg | V           | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID |
+      | pii_LU_agg      | piv_LU_agg         | 10  | HU       | pi_TU_agg         |
+      | pii_TU_agg      | piv_TU_agg         | 0   | PM       |                   |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | pip_agg                 | pii_TU_agg      | p_agg                   | 2   | 2024-01-01 |
+    # Order 12 PCE → 6 TUs of 2 PCE each → on-the-fly picking creates an aggregate HU
+    # (1 VHU record representing 6 logical TUs). The reverse replays 6 trx lines through that VHU.
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.DateAcct | OPT.POReference | M_Warehouse_ID |
+      | o_agg      | true    | endcustomer_agg          | 2024-06-03  | 2024-06-03   | po_ref_agg      | 540008         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered | M_HU_PI_Item_Product_ID.Identifier |
+      | ol_agg     | o_agg                 | p_agg                   | 12         | pip_agg                            |
+    When the order identified by o_agg is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_agg    | ol_agg                    | N             |
+    # === First shipment: aggregate HU created on-the-fly ===
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_agg                          | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_agg                          | s_agg_1               | CO            |
+    # === Reverse shipment ===
+    And perform shipment document action
+      | M_InOut_ID.Identifier | DocAction |
+      | s_agg_1               | RC        |
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_agg    | ol_agg                    | N             |
+    # === Re-ship: this step fails without the fix ===
+    # The reversal replayed N=6 trx lines through the aggregate VHU. Without
+    # ShipmentScheduleHUTrxListener consolidating them, there are N duplicate
+    # QtyPicked rows, and 'generate shipments' fails with a partial unique
+    # index violation on M_ShipmentSchedule_QtyPicked_UI when binding M_InOutLine_ID.
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_agg                          | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | s_s_agg                          | s_agg_2               | CO            |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleBL.java
@@ -53,6 +53,27 @@ public interface IHUShipmentScheduleBL extends ISingletonService
 	ShipmentScheduleWithHU addQtyPickedAndUpdateHU(AddQtyPickedRequest request);
 
 	/**
+	 * Try to add the request's qty into a single existing un-shipped {@link I_M_ShipmentSchedule_QtyPicked}
+	 * row for the same {@code (M_ShipmentSchedule_ID, VHU_ID)} pair instead of creating a new row.
+	 * <p>
+	 * Scope is intentionally narrow — only HU-trx-listener-shaped picks are eligible:
+	 * the request must have no {@code PickingJobScheduleId}, must not be marked as
+	 * {@code anonymousHuPickedOnTheFly}, and the HU must be a virtual HU. The candidate
+	 * row is also filtered to {@code M_Picking_Job_Schedule_ID IS NULL} and
+	 * {@code IsAnonymousHuPickedOnTheFly = N} so that genuine multi-job picks on the same
+	 * VHU are never collapsed.
+	 * <p>
+	 * Used by {@code ShipmentScheduleHUTrxListener.trxLineProcessed} to defuse the duplicate-row
+	 * pattern produced when an aggregate HU's snapshot is replayed (one VHU node receives
+	 * multiple HU-trx lines in one transaction). See me03#29561.
+	 *
+	 * @return {@code true} if a matching row was found and the qty was merged into it (caller
+	 *         should skip the regular new-row path); {@code false} otherwise (caller should fall
+	 *         through to {@link #addQtyPickedAndUpdateHU(AddQtyPickedRequest)}).
+	 */
+	boolean tryMergeQtyPickedIntoExistingForVHU(AddQtyPickedRequest request);
+
+	/**
 	 * Creates a producer which will create shipments ({@link I_M_InOut}) from {@link ShipmentScheduleWithHU}s.
 	 */
 	IInOutProducerFromShipmentScheduleWithHU createInOutProducerFromShipmentSchedule();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleDAO.java
@@ -22,6 +22,7 @@ package de.metas.handlingunits.shipmentschedule.api;
  * #L%
  */
 
+import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_ShipmentSchedule_QtyPicked;
 import de.metas.inout.ShipmentScheduleId;
@@ -46,4 +47,14 @@ public interface IHUShipmentScheduleDAO extends ISingletonService
 	IQueryBuilder<I_M_ShipmentSchedule_QtyPicked> retrieveSchedsQtyPickedForVHUQuery(I_M_HU vhu);
 
 	List<ShipmentScheduleWithHU> retrieveShipmentSchedulesWithHUsFromHUs(List<I_M_HU> hus);
+
+	/**
+	 * Active, un-shipped (M_InOutLine_ID IS NULL), non-job-schedule, non-anonymous-on-the-fly QtyPicked rows
+	 * for the given (schedule, VHU) pair. Used by {@code ShipmentScheduleHUTrxListener} to consolidate
+	 * sibling rows produced when an aggregate HU's snapshot is replayed and routes multiple HU-trx lines
+	 * through the same VHU. See me03#29561.
+	 */
+	List<I_M_ShipmentSchedule_QtyPicked> retrieveMergeableListenerQtyPickedForVHU(
+			@NonNull ShipmentScheduleId shipmentScheduleId,
+			@NonNull HuId vhuId);
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -1,5 +1,6 @@
 package de.metas.handlingunits.shipmentschedule.api.impl;
 
+import ch.qos.logback.classic.Level;
 import com.google.common.collect.ImmutableList;
 import de.metas.adempiere.gui.search.IHUPackingAwareBL;
 import de.metas.adempiere.gui.search.impl.ShipmentScheduleHUPackingAware;
@@ -60,9 +61,11 @@ import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
 import de.metas.product.ProductId;
 import de.metas.project.ProjectId;
 import de.metas.quantity.Quantity;
+import de.metas.quantity.StockQtyAndUOMQty;
 import de.metas.shipping.model.I_M_ShipperTransportation;
 import de.metas.uom.UomId;
 import de.metas.util.Check;
+import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
@@ -212,6 +215,100 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 		huContext.flush();
 
 		return ShipmentScheduleWithHU.ofShipmentScheduleQtyPicked(qtyPickedRecord, huContext);
+	}
+
+	@Override
+	public boolean tryMergeQtyPickedIntoExistingForVHU(@NonNull final AddQtyPickedRequest request)
+	{
+		// Eligibility — only HU-trx-listener-shaped picks may be merged.
+		// Order: cheapest request-shape guards first; HU lookup last.
+		final ShipmentScheduleAndJobScheduleId scheduleId = request.getScheduleId();
+		if (scheduleId.getJobScheduleId() != null)
+		{
+			return false;
+		}
+		if (request.isAnonymousHuPickedOnTheFly())
+		{
+			return false;
+		}
+
+		// Catch-weight merging is not supported here — fall through to create-new so each
+		// catch reading keeps its own row.
+		final StockQtyAndUOMQty qtyToAdd = request.getQtyPicked();
+		if (qtyToAdd.isUOMQtySet())
+		{
+			return false;
+		}
+
+		// Only merge strictly positive allocations. Negative qty represents an un-allocation
+		// (see ShipmentScheduleHUTrxListener#trxLineProcessed Javadoc) and must remain its own
+		// audit row so the netting is visible — silently subtracting from a sibling can drive
+		// a row to zero/negative and mask a stock discrepancy.
+		if (qtyToAdd.getStockQty().signum() <= 0)
+		{
+			return false;
+		}
+
+		final I_M_HU vhu = request.getHu();
+		if (!handlingUnitsBL.isVirtual(vhu))
+		{
+			return false;
+		}
+
+		final HuId vhuId = HuId.ofRepoId(vhu.getM_HU_ID());
+		final List<I_M_ShipmentSchedule_QtyPicked> candidates = huShipmentScheduleDAO.retrieveMergeableListenerQtyPickedForVHU(
+				scheduleId.getShipmentScheduleId(),
+				vhuId);
+
+		if (candidates.isEmpty())
+		{
+			return false;
+		}
+		if (candidates.size() > 1)
+		{
+			// Pre-existing duplicates — not our job to silently collapse them. Log and fall through;
+			// the new-row path will leave the duplicates intact for human inspection.
+			Loggables.withLogger(logger, Level.WARN).addLog(
+					"tryMergeQtyPickedIntoExistingForVHU: found {} pre-existing un-shipped QtyPicked rows for shipmentScheduleId={} vhuId={} — falling through to create-new",
+					candidates.size(), scheduleId.getShipmentScheduleId(), vhuId);
+			return false;
+		}
+
+		final I_M_ShipmentSchedule_QtyPicked existing = candidates.get(0);
+		// Defensive: even though the request carries no catch UOM (guard above), reject merging
+		// into a row that was previously written with one. Could only happen if a different code
+		// path bypassed the request-side guard; better to fall through than risk arithmetic that
+		// loses the catch reading.
+		final BigDecimal existingCatchQty = existing.getQtyDeliveredCatch();
+		if (existing.getCatch_UOM_ID() > 0 || (existingCatchQty != null && existingCatchQty.signum() != 0))
+		{
+			return false;
+		}
+
+		existing.setQtyPicked(existing.getQtyPicked().add(qtyToAdd.getStockQty().toBigDecimal()));
+		final IHUContext huContext = request.getHuContext();
+		ShipmentScheduleWithHU.ofShipmentScheduleQtyPicked(existing, huContext).updateQtyTUAndQtyLU();
+		saveRecord(existing);
+
+		// Drive the same HU side-effects as the create-new path. On the well-formed reversal
+		// flow the topLevelHU is already Picked with the right partner/location (the FIRST
+		// trx-line in the same transaction went through addQtyPickedAndUpdateHU), so each call
+		// is a verified no-op:
+		//   - HUStatusBL.setHUStatus returns early when status is unchanged
+		//   - PO setters with equal values do not produce an UPDATE
+		// Re-running them here is a safety net for edge cases where the first row's flow
+		// didn't reach this point (e.g. a row pre-existed from a prior session).
+		final LUTUCUPair husPair = handlingUnitsBL.getTopLevelParentAsLUTUCUPair(vhu);
+		final I_M_HU topLevelHU = husPair.getTopLevelHU();
+		setHUStatusToPicked(topLevelHU);
+		setHUPartnerAndLocationFromSched(topLevelHU, getShipmentSchedule(request));
+		handlingUnitsDAO.saveHU(topLevelHU);
+		huContext.flush();
+
+		Loggables.withLogger(logger, Level.DEBUG).addLog(
+				"tryMergeQtyPickedIntoExistingForVHU: merged qty={} into M_ShipmentSchedule_QtyPicked_ID={} (shipmentScheduleId={} vhuId={})",
+				qtyToAdd.getStockQty(), existing.getM_ShipmentSchedule_QtyPicked_ID(), scheduleId.getShipmentScheduleId(), vhuId);
+		return true;
 	}
 
 	private de.metas.inoutcandidate.model.I_M_ShipmentSchedule getShipmentSchedule(final AddQtyPickedRequest request)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO.java
@@ -1,6 +1,7 @@
 package de.metas.handlingunits.shipmentschedule.api.impl;
 
 import com.google.common.base.Preconditions;
+import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHUContextFactory;
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.IMutableHUContext;
@@ -145,6 +146,23 @@ public class HUShipmentScheduleDAO implements IHUShipmentScheduleDAO
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_VHU_ID, vhu.getM_HU_ID())
 				.orderBy(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_ShipmentSchedule_QtyPicked_ID);
+	}
+
+	@Override
+	public List<I_M_ShipmentSchedule_QtyPicked> retrieveMergeableListenerQtyPickedForVHU(
+			@NonNull final ShipmentScheduleId shipmentScheduleId,
+			@NonNull final HuId vhuId)
+	{
+		return queryBL.createQueryBuilder(I_M_ShipmentSchedule_QtyPicked.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_ShipmentSchedule_ID, shipmentScheduleId)
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_VHU_ID, vhuId)
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_InOutLine_ID, null)
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_Picking_Job_Schedule_ID, null)
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_IsAnonymousHuPickedOnTheFly, false)
+				.orderBy(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_ShipmentSchedule_QtyPicked_ID)
+				.create()
+				.list();
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleHUTrxListener.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleHUTrxListener.java
@@ -100,7 +100,7 @@ public final class ShipmentScheduleHUTrxListener implements IHUTrxListener
 		//
 		// Link VHU to shipment schedule
 		final IHUShipmentScheduleBL huShipmentScheduleBL = Services.get(IHUShipmentScheduleBL.class);
-		huShipmentScheduleBL.addQtyPickedAndUpdateHU(AddQtyPickedRequest.builder()
+		final AddQtyPickedRequest request = AddQtyPickedRequest.builder()
 				.shipmentSchedule(shipmentSchedule)
 				.qtyPicked(CatchWeightHelper.extractQtys(
 						huContext,
@@ -111,7 +111,19 @@ public final class ShipmentScheduleHUTrxListener implements IHUTrxListener
 				.hu(vhu)
 				.huContext(huContext)
 				.anonymousHuPickedOnTheFly(false)
-				.build());
+				.build();
+
+		// On aggregate-HU snapshot replay (e.g. shipment reversal), the same VHU node receives
+		// multiple HU-trx lines in one transaction. Without consolidation, that produces N
+		// QtyPicked rows that share the same (VHU, TU, LU, QtyLU, QtyTU, QtyPicked) tuple and
+		// later collide on the M_ShipmentSchedule_QtyPicked_UI partial unique index when the
+		// next shipment is generated. See me03#29561.
+		if (huShipmentScheduleBL.tryMergeQtyPickedIntoExistingForVHU(request))
+		{
+			return;
+		}
+
+		huShipmentScheduleBL.addQtyPickedAndUpdateHU(request);
 	}
 
 	@Nullable

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL_tryMergeQtyPickedIntoExistingForVHU_Test.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL_tryMergeQtyPickedIntoExistingForVHU_Test.java
@@ -1,0 +1,159 @@
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2015 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package de.metas.handlingunits.shipmentschedule.api.impl;
+
+import de.metas.handlingunits.IHUContext;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.shipmentschedule.api.AddQtyPickedRequest;
+import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.picking.api.PickingJobScheduleId;
+import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.quantity.StockQtyAndUOMQty;
+import de.metas.uom.UomId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Cheap-guard tests for {@link HUShipmentScheduleBL#tryMergeQtyPickedIntoExistingForVHU(AddQtyPickedRequest)}.
+ *
+ * <p>The merge predicate has multiple early returns based on request shape (no HU lookup,
+ * no DAO query, no side effects). Those are the contract the listener relies on for
+ * non-listener-shaped picks to fall through to {@code addQtyPickedAndUpdateHU}. This test
+ * locks each one in so we don't accidentally widen the merge scope in a future refactor.</p>
+ *
+ * <p>Happy-path coverage (qty actually summed into an existing row) requires HU machinery
+ * and is exercised by the cucumber {@code reversedShipment.feature} scenario.</p>
+ */
+class HUShipmentScheduleBL_tryMergeQtyPickedIntoExistingForVHU_Test
+{
+	private static final int VHU_ID = 1_111_111;
+
+	private HUShipmentScheduleBL bl;
+	private I_M_ShipmentSchedule schedule;
+	private I_M_HU vhu;
+	private I_C_UOM uom;
+	private IHUContext huContext;
+
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+		bl = new HUShipmentScheduleBL();
+
+		schedule = InterfaceWrapperHelper.newInstance(I_M_ShipmentSchedule.class);
+		schedule.setM_Product_ID(7777);
+		InterfaceWrapperHelper.saveRecord(schedule);
+
+		vhu = InterfaceWrapperHelper.newInstance(I_M_HU.class);
+		InterfaceWrapperHelper.saveRecord(vhu);
+
+		uom = InterfaceWrapperHelper.newInstance(I_C_UOM.class);
+		uom.setUOMSymbol("PCE");
+		InterfaceWrapperHelper.saveRecord(uom);
+
+		huContext = mock(IHUContext.class);
+	}
+
+	@Test
+	void rejects_when_pickingJobScheduleId_is_set()
+	{
+		final AddQtyPickedRequest request = baseRequestBuilder(positiveStockQty(BigDecimal.TEN))
+				.scheduleId(ShipmentScheduleAndJobScheduleId.of(
+						ShipmentScheduleId.ofRepoId(schedule.getM_ShipmentSchedule_ID()),
+						PickingJobScheduleId.ofRepoId(8_888)))
+				.cachedShipmentSchedule(null)
+				.build();
+
+		assertThat(bl.tryMergeQtyPickedIntoExistingForVHU(request)).isFalse();
+	}
+
+	@Test
+	void rejects_when_anonymous_on_the_fly_is_set()
+	{
+		final AddQtyPickedRequest request = baseRequestBuilder(positiveStockQty(BigDecimal.TEN))
+				.anonymousHuPickedOnTheFly(true)
+				.build();
+
+		assertThat(bl.tryMergeQtyPickedIntoExistingForVHU(request)).isFalse();
+	}
+
+	@Test
+	void rejects_when_request_carries_catch_weight()
+	{
+		final StockQtyAndUOMQty qtyWithCatch = StockQtyAndUOMQty.builder()
+				.productId(ProductId.ofRepoId(schedule.getM_Product_ID()))
+				.stockQty(Quantity.of(BigDecimal.TEN, uom))
+				.uomQty(Quantity.of(new BigDecimal("9.7"), uom))
+				.build();
+		final AddQtyPickedRequest request = baseRequestBuilder(qtyWithCatch).build();
+
+		assertThat(bl.tryMergeQtyPickedIntoExistingForVHU(request)).isFalse();
+	}
+
+	@Test
+	void rejects_when_qty_is_zero()
+	{
+		final AddQtyPickedRequest request = baseRequestBuilder(positiveStockQty(BigDecimal.ZERO)).build();
+
+		assertThat(bl.tryMergeQtyPickedIntoExistingForVHU(request)).isFalse();
+	}
+
+	@Test
+	void rejects_when_qty_is_negative()
+	{
+		// Un-allocation (negative trx-line qty) must remain its own audit row so the netting is visible.
+		final AddQtyPickedRequest request = baseRequestBuilder(positiveStockQty(new BigDecimal("-2"))).build();
+
+		assertThat(bl.tryMergeQtyPickedIntoExistingForVHU(request)).isFalse();
+	}
+
+	private AddQtyPickedRequest.AddQtyPickedRequestBuilder baseRequestBuilder(final StockQtyAndUOMQty qty)
+	{
+		return AddQtyPickedRequest.builder()
+				.scheduleId(ShipmentScheduleAndJobScheduleId.ofShipmentScheduleId(
+						ShipmentScheduleId.ofRepoId(schedule.getM_ShipmentSchedule_ID())))
+				.cachedShipmentSchedule(schedule)
+				.qtyPicked(qty)
+				.hu(vhu)
+				.huContext(huContext)
+				.anonymousHuPickedOnTheFly(false);
+	}
+
+	private StockQtyAndUOMQty positiveStockQty(final BigDecimal amount)
+	{
+		return StockQtyAndUOMQty.builder()
+				.productId(ProductId.ofRepoId(schedule.getM_Product_ID()))
+				.stockQty(Quantity.of(amount, uom))
+				.build();
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO_retrieveMergeableListenerQtyPickedForVHU_Test.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO_retrieveMergeableListenerQtyPickedForVHU_Test.java
@@ -1,0 +1,151 @@
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2015 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package de.metas.handlingunits.shipmentschedule.api.impl;
+
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.model.I_M_ShipmentSchedule_QtyPicked;
+import de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleDAO;
+import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.util.Services;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link IHUShipmentScheduleDAO#retrieveMergeableListenerQtyPickedForVHU(ShipmentScheduleId, HuId)}.
+ *
+ * <p>Pinpoint the predicate filters that scope the merge to listener-shaped picks (no job schedule,
+ * not anonymous-on-the-fly, un-shipped, active). See me03#29561.</p>
+ */
+class HUShipmentScheduleDAO_retrieveMergeableListenerQtyPickedForVHU_Test
+{
+	private static final int VHU_ID_1 = 1_111_111;
+	private static final int VHU_ID_2 = 2_222_222;
+	private static final int OTHER_INOUT_LINE_ID = 9_999;
+	private static final int OTHER_PICKING_JOB_SCHEDULE_ID = 8_888;
+
+	private IHUShipmentScheduleDAO dao;
+
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+		dao = Services.get(IHUShipmentScheduleDAO.class);
+	}
+
+	@Test
+	void empty_when_no_rows_for_schedule_and_vhu()
+	{
+		final ShipmentScheduleId scheduleId = createSchedule();
+		final HuId vhuId = HuId.ofRepoId(VHU_ID_1);
+
+		assertThat(dao.retrieveMergeableListenerQtyPickedForVHU(scheduleId, vhuId)).isEmpty();
+	}
+
+	@Test
+	void returns_only_active_unshipped_listener_rows_for_the_given_schedule_and_vhu()
+	{
+		final ShipmentScheduleId schedule = createSchedule();
+		final ShipmentScheduleId otherSchedule = createSchedule();
+		final HuId vhuId = HuId.ofRepoId(VHU_ID_1);
+		final HuId otherVhuId = HuId.ofRepoId(VHU_ID_2);
+
+		// Eligible listener row — should be returned.
+		final I_M_ShipmentSchedule_QtyPicked eligibleRow = newRow(schedule, VHU_ID_1, b -> {});
+
+		// Same VHU + schedule but bound to a shipment line → already shipped, not mergeable.
+		newRow(schedule, VHU_ID_1, b -> b.setM_InOutLine_ID(OTHER_INOUT_LINE_ID));
+
+		// Same VHU + schedule but inactive → not mergeable.
+		newRow(schedule, VHU_ID_1, b -> b.setIsActive(false));
+
+		// Same VHU + schedule but tied to a picking-job schedule → genuine mobile pick, not listener-shaped.
+		newRow(schedule, VHU_ID_1, b -> b.setM_Picking_Job_Schedule_ID(OTHER_PICKING_JOB_SCHEDULE_ID));
+
+		// Same VHU + schedule but flagged anonymous-on-the-fly → on-the-fly path, not listener-shaped.
+		newRow(schedule, VHU_ID_1, b -> b.setIsAnonymousHuPickedOnTheFly(true));
+
+		// Different schedule — not for our pair.
+		newRow(otherSchedule, VHU_ID_1, b -> {});
+
+		// Different VHU — not for our pair.
+		newRow(schedule, VHU_ID_2, b -> {});
+
+		final List<I_M_ShipmentSchedule_QtyPicked> result =
+				dao.retrieveMergeableListenerQtyPickedForVHU(schedule, vhuId);
+
+		assertThat(result).extracting(I_M_ShipmentSchedule_QtyPicked::getM_ShipmentSchedule_QtyPicked_ID)
+				.containsExactly(eligibleRow.getM_ShipmentSchedule_QtyPicked_ID());
+
+		// Sanity-check: the second VHU truly has its own row in the DB (so the filter, not absence, excludes it).
+		assertThat(dao.retrieveMergeableListenerQtyPickedForVHU(schedule, otherVhuId)).hasSize(1);
+	}
+
+	@Test
+	void returns_multiple_when_multiple_listener_rows_exist_for_same_pair()
+	{
+		// This is the pre-existing-duplicates case: the BL method will then *not* auto-merge
+		// (it logs a warning and falls through). The DAO honestly reports both.
+		final ShipmentScheduleId schedule = createSchedule();
+		final HuId vhuId = HuId.ofRepoId(VHU_ID_1);
+
+		newRow(schedule, VHU_ID_1, b -> {});
+		newRow(schedule, VHU_ID_1, b -> {});
+
+		assertThat(dao.retrieveMergeableListenerQtyPickedForVHU(schedule, vhuId)).hasSize(2);
+	}
+
+	private ShipmentScheduleId createSchedule()
+	{
+		final I_M_ShipmentSchedule sched = InterfaceWrapperHelper.newInstance(I_M_ShipmentSchedule.class);
+		InterfaceWrapperHelper.saveRecord(sched);
+		return ShipmentScheduleId.ofRepoId(sched.getM_ShipmentSchedule_ID());
+	}
+
+	@FunctionalInterface
+	private interface RowCustomizer
+	{
+		void apply(I_M_ShipmentSchedule_QtyPicked row);
+	}
+
+	private I_M_ShipmentSchedule_QtyPicked newRow(
+			final ShipmentScheduleId scheduleId,
+			final int vhuId,
+			final RowCustomizer customizer)
+	{
+		final I_M_ShipmentSchedule_QtyPicked row = InterfaceWrapperHelper.newInstance(I_M_ShipmentSchedule_QtyPicked.class);
+		row.setM_ShipmentSchedule_ID(scheduleId.getRepoId());
+		row.setVHU_ID(vhuId);
+		row.setIsActive(true);
+		// All other relevant filter columns default to NULL/false in the in-memory DB,
+		// which matches the "eligible listener row" baseline.
+		customizer.apply(row);
+		InterfaceWrapperHelper.saveRecord(row);
+		return row;
+	}
+}

--- a/misc/dev-support/docker/infrastructure/env-files/soft_panda_uat.env
+++ b/misc/dev-support/docker/infrastructure/env-files/soft_panda_uat.env
@@ -15,7 +15,7 @@
 BRANCH_NAME=soft_panda_uat
 
 DB_PORT=32432
-DB_DOCKER_IMG=ghcr.io/metasfresh/sp80/metasfresh-db:5.175-soft-panda-uat-preloaded
+DB_DOCKER_IMG=ghcr.io/metasfresh/sp80/metasfresh-db:5.175-soft-panda-hotfix-preloaded
 
 RABBITMQ_PORT=32672
 RABBITMQ_MGMT_PORT=32673

--- a/misc/dev-support/docker/infrastructure/env-files/soft_panda_uat.env
+++ b/misc/dev-support/docker/infrastructure/env-files/soft_panda_uat.env
@@ -15,7 +15,7 @@
 BRANCH_NAME=soft_panda_uat
 
 DB_PORT=32432
-DB_DOCKER_IMG=ghcr.io/metasfresh/sp80/metasfresh-db:5.175-soft-panda-hotfix-preloaded
+DB_DOCKER_IMG=ghcr.io/metasfresh/sp80/metasfresh-db:5.175-soft-panda-release-preloaded
 
 RABBITMQ_PORT=32672
 RABBITMQ_MGMT_PORT=32673


### PR DESCRIPTION
## Summary

Fix duplicate `M_ShipmentSchedule_QtyPicked` rows produced during reversal of an aggregate-HU shipment, which since sp80#2314's partial unique index `M_ShipmentSchedule_QtyPicked_UI` cause the next shipment generation to fail with the doubled-quantity error.

## Root cause

`ShipmentScheduleHUTrxListener.trxLineProcessed` emits one `M_ShipmentSchedule_QtyPicked` row per `M_HU_Trx_Line`. For an **aggregate HU** (a single VHU representing N logical TUs), the snapshot replay during `MInOut.reverseCorrectIt()` routes N trx lines through the *same* VHU, producing N rows with identical `(VHU, TU, LU, QtyLU, QtyTU, QtyPicked)`. When the next shipment is generated and writes the same `M_InOutLine_ID` onto all of them, the partial unique index correctly catches the duplicate.

Forward picking always splits a fresh VHU per trx line, so this pattern was historically impossible — the listener never defended against it.

## Fix

`ShipmentScheduleHUTrxListener.trxLineProcessed` now consults a new BL helper `tryMergeQtyPickedIntoExistingForVHU(AddQtyPickedRequest)` before delegating to `addQtyPickedAndUpdateHU`. If a single un-shipped active row already exists for the same `(M_ShipmentSchedule_ID, VHU_ID)` pair AND the request is listener-shaped, the qty is added into that row instead of creating a duplicate. Otherwise the call falls through to the existing create-new path.

The merge predicate is intentionally narrow:
- request: `M_Picking_Job_Schedule_ID` must be NULL, `IsAnonymousHuPickedOnTheFly` must be `false`, qty must carry no catch-weight, qty must be **strictly positive** (negative qty is an un-allocation and stays its own audit row), HU must be virtual.
- candidate row: `M_InOutLine_ID IS NULL`, `IsActive = Y`, `M_Picking_Job_Schedule_ID IS NULL`, `IsAnonymousHuPickedOnTheFly = N`, no catch UOM/qty.
- exactly one candidate → merge; zero → fall through; two or more → log a warning and fall through (don't auto-collapse pre-existing duplicates — surface them for human inspection).

## Files

- `IHUShipmentScheduleBL.java` / `HUShipmentScheduleBL.java` — new `tryMergeQtyPickedIntoExistingForVHU` method.
- `IHUShipmentScheduleDAO.java` / `HUShipmentScheduleDAO.java` — new `retrieveMergeableListenerQtyPickedForVHU` query.
- `ShipmentScheduleHUTrxListener.java` — early-return on successful merge.
- `HUShipmentScheduleDAO_retrieveMergeableListenerQtyPickedForVHU_Test.java` — DAO predicate coverage (3 scenarios: empty, all filters, multiple-existing).
- `HUShipmentScheduleBL_tryMergeQtyPickedIntoExistingForVHU_Test.java` — request-shape guard coverage (5 scenarios: job-schedule, anonymous-on-the-fly, catch-weight, zero qty, negative qty).
- `reversedShipment.feature` — new `S29561_20` cucumber scenario reproducing me03#29561 end-to-end (aggregate HU, ship → reverse → re-ship). Existing happy-path scenario tagged `S29561_10`.

## Test plan

- [x] `de.metas.handlingunits.base` unit tests: 846 passed, 22 skipped, 0 failed.
- [x] DAO + BL unit tests for the new method (8 new test cases, all passing).
- [ ] Cucumber `reversedShipment.feature` (incl. new aggregate-HU scenario) green locally — running.
- [ ] Cucumber `reversedShipmentClearsBPartner.feature` green locally — pending.
- [ ] CI to run the full Cucumber + unit suites.

## Known follow-up

A theoretical race exists if two reversals of *different* shipments touch the **same VHU + same shipment schedule** concurrently — both transactions could see "no candidate row" and INSERT, producing two duplicate un-shipped rows that the merge can only catch on a *third* trx line in one of them. In practice a shipment-line is mutated by one user/process at a time, so this scenario is near-impossible — but worth a note for future maintainers. No protection added in this PR.
