### PR TITLE
Create one PO line per PurchaseCandidate

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/order/OrderFactory.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/OrderFactory.java
@@ -43,7 +43,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 
@@ -193,16 +192,6 @@ public class OrderFactory
 			final OrderLineBuilder orderLineBuilder = new OrderLineBuilder(this);
 			orderLineBuilders.add(orderLineBuilder);
 			return orderLineBuilder;
-		}
-	}
-
-	public Optional<OrderLineBuilder> orderLineByProductAndUom(final ProductId productId, final UomId uomId)
-	{
-		try (final MDCCloseable ignored = TableRecordMDC.putTableRecordReference(order))
-		{
-			return orderLineBuilders.stream()
-					.filter(orderLineBuilder -> orderLineBuilder.isProductAndUomMatching(productId, uomId))
-					.findFirst();
 		}
 	}
 

--- a/backend/de.metas.business/src/main/java/de/metas/order/OrderLineBuilder.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/OrderLineBuilder.java
@@ -296,12 +296,6 @@ public class OrderLineBuilder
 		return this;
 	}
 
-	public boolean isProductAndUomMatching(@Nullable final ProductId productId, @Nullable final UomId uomId)
-	{
-		return ProductId.equals(getProductId(), productId)
-				&& UomId.equals(getUomId(), uomId);
-	}
-
 	public OrderLineBuilder description(@Nullable final String description)
 	{
 		this.description = description;

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemFactory.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemFactory.java
@@ -18,7 +18,6 @@ import de.metas.order.event.OrderUserNotifications.NotificationRequest;
 import de.metas.organization.IOrgDAO;
 import de.metas.organization.OrgId;
 import de.metas.purchasecandidate.purchaseordercreation.remotepurchaseitem.PurchaseOrderItem;
-import de.metas.uom.UomId;
 import de.metas.user.UserId;
 import de.metas.util.Services;
 import lombok.Builder;
@@ -126,10 +125,7 @@ import java.util.Set;
 	public void addCandidate(@NonNull final PurchaseOrderItem purchaseOrderItem)
 	{
 		final OrderLineBuilder orderLineBuilder = orderFactory
-				.orderLineByProductAndUom(
-						purchaseOrderItem.getProductId(),
-						UomId.ofRepoId(purchaseOrderItem.getUomId()))
-				.orElseGet(orderFactory::newOrderLine)
+				.newOrderLine()
 				.productId(purchaseOrderItem.getProductId());
 
 		orderLineBuilder.addQty(purchaseOrderItem.getPurchasedQty());

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemFactory.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemFactory.java
@@ -122,6 +122,12 @@ import java.util.Set;
 		this.userNotifications = userNotifications;
 	}
 
+	/**
+	 * Adds {@code purchaseOrderItem} as a new, independent order line.
+	 * Each call creates a fresh {@link OrderLineBuilder} — candidates are never merged,
+	 * preserving the invariant required by
+	 * {@code UC_C_PurchaseCandidate_Alloc_C_OrderLinePO_ID}: one purchase candidate per PO line.
+	 */
 	public void addCandidate(@NonNull final PurchaseOrderItem purchaseOrderItem)
 	{
 		final OrderLineBuilder orderLineBuilder = orderFactory

--- a/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemsAggregatorTest.java
+++ b/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemsAggregatorTest.java
@@ -61,6 +61,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstanceOutOfTrx;
 import static org.adempiere.model.InterfaceWrapperHelper.save;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
 
 /*
  * #%L
@@ -257,11 +258,11 @@ public class PurchaseOrderFromItemsAggregatorTest
 		final List<I_C_OrderLine> lines = Services.get(IOrderDAO.class)
 				.retrieveOrderLines(OrderId.ofRepoId(purchaseOrder.getC_Order_ID()));
 
-		assertThat(lines).hasSize(2);
-		assertThat(lines).extracting(I_C_OrderLine::getM_AttributeSetInstance_ID)
-				.containsExactlyInAnyOrder(41, 42);
-		assertThat(lines).extracting(I_C_OrderLine::getQtyEntered)
-				.containsExactly(TEN.toBigDecimal(), TEN.toBigDecimal());
+		assertThat(lines)
+				.extracting(I_C_OrderLine::getM_AttributeSetInstance_ID, I_C_OrderLine::getQtyEntered)
+				.containsExactlyInAnyOrder(
+						tuple(41, TEN.toBigDecimal()),
+						tuple(42, TEN.toBigDecimal()));
 	}
 
 	@Test
@@ -298,6 +299,8 @@ public class PurchaseOrderFromItemsAggregatorTest
 				.retrieveOrderLines(OrderId.ofRepoId(purchaseOrder.getC_Order_ID()));
 
 		assertThat(lines).hasSize(2);
+		assertThat(lines).extracting(I_C_OrderLine::getM_AttributeSetInstance_ID)
+				.containsExactlyInAnyOrder(40, 40);
 	}
 
 	@Test
@@ -351,8 +354,11 @@ public class PurchaseOrderFromItemsAggregatorTest
 		final ProductAndCategoryAndManufacturerId product =
 				ProductAndCategoryAndManufacturerId.of(productRecord.getM_Product_ID(), 30, 35);
 
+		// Two forecast-driven candidates with NO SO link, all other dimensions identical
+		// (same product, same UOM, same ASI). Each must still produce its own PO line —
+		// confirms Approach B's structural invariant for the forecast path.
 		final PurchaseCandidate candA = buildCandidate(vendor, productRecord, product, 40, /*salesOrderAndLineId=*/ null, now);
-		final PurchaseCandidate candB = buildCandidate(vendor, productRecord, product, 41, /*salesOrderAndLineId=*/ null, now);
+		final PurchaseCandidate candB = buildCandidate(vendor, productRecord, product, 40, /*salesOrderAndLineId=*/ null, now);
 
 		final I_C_Order purchaseOrder = runAggregator(ImmutableList.of(candA, candB));
 
@@ -360,6 +366,8 @@ public class PurchaseOrderFromItemsAggregatorTest
 				.retrieveOrderLines(OrderId.ofRepoId(purchaseOrder.getC_Order_ID()));
 
 		assertThat(lines).hasSize(2);
+		assertThat(lines).extracting(I_C_OrderLine::getM_AttributeSetInstance_ID)
+				.containsExactlyInAnyOrder(40, 40);
 	}
 
 	private PurchaseCandidate buildCandidate(

--- a/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemsAggregatorTest.java
+++ b/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemsAggregatorTest.java
@@ -264,6 +264,104 @@ public class PurchaseOrderFromItemsAggregatorTest
 				.containsExactly(TEN.toBigDecimal(), TEN.toBigDecimal());
 	}
 
+	@Test
+	public void sameAsi_differentSoLines_yieldsTwoOrderLines()
+	{
+		final ZonedDateTime now = SystemTime.asZonedDateTime();
+
+		final I_C_Order salesOrder = newInstance(I_C_Order.class);
+		save(salesOrder);
+
+		final I_C_BPartner vendor = newInstance(I_C_BPartner.class);
+		vendor.setValue("Vendor");
+		vendor.setName("Vendor");
+		save(vendor);
+
+		final I_M_Product productRecord = newInstance(I_M_Product.class);
+		productRecord.setC_UOM_ID(EACH.getC_UOM_ID());
+		saveRecord(productRecord);
+		final ProductAndCategoryAndManufacturerId product =
+				ProductAndCategoryAndManufacturerId.of(productRecord.getM_Product_ID(), 30, 35);
+
+		final PurchaseCandidate candA = buildCandidate(vendor, productRecord, product,
+				/*asiRepoId=*/ 40,
+				OrderAndLineId.ofRepoIds(salesOrder.getC_Order_ID(), 50),
+				now);
+		final PurchaseCandidate candB = buildCandidate(vendor, productRecord, product,
+				/*asiRepoId=*/ 40,
+				OrderAndLineId.ofRepoIds(salesOrder.getC_Order_ID(), 51),
+				now);
+
+		final I_C_Order purchaseOrder = runAggregator(ImmutableList.of(candA, candB));
+
+		final List<I_C_OrderLine> lines = Services.get(IOrderDAO.class)
+				.retrieveOrderLines(OrderId.ofRepoId(purchaseOrder.getC_Order_ID()));
+
+		assertThat(lines).hasSize(2);
+	}
+
+	@Test
+	public void sameAsi_sameSoLine_stillYieldsTwoOrderLines()
+	{
+		final ZonedDateTime now = SystemTime.asZonedDateTime();
+
+		final I_C_Order salesOrder = newInstance(I_C_Order.class);
+		save(salesOrder);
+
+		final I_C_BPartner vendor = newInstance(I_C_BPartner.class);
+		vendor.setValue("Vendor");
+		vendor.setName("Vendor");
+		save(vendor);
+
+		final I_M_Product productRecord = newInstance(I_M_Product.class);
+		productRecord.setC_UOM_ID(EACH.getC_UOM_ID());
+		saveRecord(productRecord);
+		final ProductAndCategoryAndManufacturerId product =
+				ProductAndCategoryAndManufacturerId.of(productRecord.getM_Product_ID(), 30, 35);
+
+		final OrderAndLineId soLine = OrderAndLineId.ofRepoIds(salesOrder.getC_Order_ID(), 50);
+		final PurchaseCandidate candA = buildCandidate(vendor, productRecord, product, 40, soLine, now);
+		final PurchaseCandidate candB = buildCandidate(vendor, productRecord, product, 40, soLine, now);
+
+		final I_C_Order purchaseOrder = runAggregator(ImmutableList.of(candA, candB));
+
+		final List<I_C_OrderLine> lines = Services.get(IOrderDAO.class)
+				.retrieveOrderLines(OrderId.ofRepoId(purchaseOrder.getC_Order_ID()));
+
+		// The unique constraint UC_C_PurchaseCandidate_Alloc_C_OrderLinePO_ID demands one PCand per PO line.
+		// Approach B preserves this invariant even for the edge case "two PCands referencing the same SO line".
+		assertThat(lines).hasSize(2);
+	}
+
+	@Test
+	public void forecastDriven_nullSoLine_yieldsTwoOrderLines()
+	{
+		final ZonedDateTime now = SystemTime.asZonedDateTime();
+
+		// no salesOrder needed — forecast-driven candidates have no SO link
+
+		final I_C_BPartner vendor = newInstance(I_C_BPartner.class);
+		vendor.setValue("Vendor");
+		vendor.setName("Vendor");
+		save(vendor);
+
+		final I_M_Product productRecord = newInstance(I_M_Product.class);
+		productRecord.setC_UOM_ID(EACH.getC_UOM_ID());
+		saveRecord(productRecord);
+		final ProductAndCategoryAndManufacturerId product =
+				ProductAndCategoryAndManufacturerId.of(productRecord.getM_Product_ID(), 30, 35);
+
+		final PurchaseCandidate candA = buildCandidate(vendor, productRecord, product, 40, /*salesOrderAndLineId=*/ null, now);
+		final PurchaseCandidate candB = buildCandidate(vendor, productRecord, product, 41, /*salesOrderAndLineId=*/ null, now);
+
+		final I_C_Order purchaseOrder = runAggregator(ImmutableList.of(candA, candB));
+
+		final List<I_C_OrderLine> lines = Services.get(IOrderDAO.class)
+				.retrieveOrderLines(OrderId.ofRepoId(purchaseOrder.getC_Order_ID()));
+
+		assertThat(lines).hasSize(2);
+	}
+
 	private PurchaseCandidate buildCandidate(
 			@NonNull final I_C_BPartner vendor,
 			@NonNull final I_M_Product productRecord,

--- a/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemsAggregatorTest.java
+++ b/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemsAggregatorTest.java
@@ -1,5 +1,6 @@
 package de.metas.purchasecandidate.purchaseordercreation.localorder;
 
+import com.google.common.collect.ImmutableList;
 import de.metas.adempiere.model.I_M_Product;
 import de.metas.attachments.AttachmentEntryService;
 import de.metas.bpartner.BPartnerId;
@@ -13,8 +14,10 @@ import de.metas.document.references.zoom_into.NullCustomizedWindowInfoMapReposit
 import de.metas.email.MailService;
 import de.metas.notification.INotificationRepository;
 import de.metas.notification.impl.NotificationRepository;
+import de.metas.order.IOrderDAO;
 import de.metas.order.IOrderLineBL;
 import de.metas.order.OrderAndLineId;
+import de.metas.order.OrderId;
 import de.metas.order.OrderLinePriceUpdateRequest;
 import de.metas.order.impl.OrderLineBL;
 import de.metas.order.impl.OrderLineDetailRepository;
@@ -37,6 +40,7 @@ import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.SpringContextHolder;
+import de.metas.interfaces.I_C_OrderLine;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_UOM;
@@ -45,8 +49,10 @@ import org.compiere.util.TimeUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -215,5 +221,106 @@ public class PurchaseOrderFromItemsAggregatorTest
 		// assertThat(purchaseOrder.getC_Currency_ID()).isGreaterThan(0);
 
 		assertThat(orderLineBL.updatePricesCallCount).isEqualTo(1);
+	}
+
+	@Test
+	public void differentAsi_yieldsTwoOrderLines()
+	{
+		final ZonedDateTime now = SystemTime.asZonedDateTime();
+
+		final I_C_Order salesOrder = newInstance(I_C_Order.class);
+		save(salesOrder);
+
+		final I_C_BPartner vendor = newInstance(I_C_BPartner.class);
+		vendor.setValue("Vendor");
+		vendor.setName("Vendor");
+		save(vendor);
+
+		final I_M_Product productRecord = newInstance(I_M_Product.class);
+		productRecord.setC_UOM_ID(EACH.getC_UOM_ID());
+		saveRecord(productRecord);
+		final ProductAndCategoryAndManufacturerId product =
+				ProductAndCategoryAndManufacturerId.of(productRecord.getM_Product_ID(), 30, 35);
+
+		// two PCands: same product + uom + vendor, but DIFFERENT ASI ids
+		final PurchaseCandidate candA = buildCandidate(vendor, productRecord, product,
+				/*asiRepoId=*/ 41,
+				OrderAndLineId.ofRepoIds(salesOrder.getC_Order_ID(), 50),
+				now);
+		final PurchaseCandidate candB = buildCandidate(vendor, productRecord, product,
+				/*asiRepoId=*/ 42,
+				OrderAndLineId.ofRepoIds(salesOrder.getC_Order_ID(), 51),
+				now);
+
+		final I_C_Order purchaseOrder = runAggregator(ImmutableList.of(candA, candB));
+
+		final List<I_C_OrderLine> lines = Services.get(IOrderDAO.class)
+				.retrieveOrderLines(OrderId.ofRepoId(purchaseOrder.getC_Order_ID()));
+
+		assertThat(lines).hasSize(2);
+		assertThat(lines).extracting(I_C_OrderLine::getM_AttributeSetInstance_ID)
+				.containsExactlyInAnyOrder(41, 42);
+		assertThat(lines).extracting(I_C_OrderLine::getQtyEntered)
+				.containsExactly(TEN.toBigDecimal(), TEN.toBigDecimal());
+	}
+
+	private PurchaseCandidate buildCandidate(
+			@NonNull final I_C_BPartner vendor,
+			@NonNull final I_M_Product productRecord,
+			@NonNull final ProductAndCategoryAndManufacturerId product,
+			final int attributeSetInstanceRepoId,
+			@Nullable final OrderAndLineId salesOrderAndLineId,
+			@NonNull final ZonedDateTime purchaseDatePromised)
+	{
+		final VendorProductInfo vendorProductInfo = VendorProductInfo.builder()
+				.product(product)
+				.attributeSetInstanceId(AttributeSetInstanceId.ofRepoId(attributeSetInstanceRepoId))
+				.vendorId(BPartnerId.ofRepoId(vendor.getC_BPartner_ID()))
+				.defaultVendor(false)
+				.vendorProductNo("productNo")
+				.vendorProductName("productName")
+				.pricingConditions(PricingConditions.builder()
+						.validFrom(TimeUtil.asInstant(Timestamp.valueOf("2017-01-01 10:10:10.0")))
+						.build())
+				.build();
+
+		return PurchaseCandidate.builder()
+				.groupReference(DemandGroupReference.EMPTY)
+				.orgId(OrgId.ofRepoId(Env.CTXVALUE_AD_Org_ID_Any))
+				.purchaseDatePromised(purchaseDatePromised)
+				.vendorId(vendorProductInfo.getVendorId())
+				.aggregatePOs(vendorProductInfo.isAggregatePOs())
+				.productId(vendorProductInfo.getProductId())
+				.attributeSetInstanceId(vendorProductInfo.getAttributeSetInstanceId())
+				.vendorProductNo(vendorProductInfo.getVendorProductNo())
+				.qtyToPurchase(TEN)
+				.salesOrderAndLineIdOrNull(salesOrderAndLineId)
+				.warehouseId(WarehouseId.ofRepoId(60))
+				.profitInfoOrNull(PurchaseCandidateTestTool.createPurchaseProfitInfo())
+				.dimension(dimension)
+				.build();
+	}
+
+	private I_C_Order runAggregator(final List<PurchaseCandidate> candidates)
+	{
+		final PurchaseOrderFromItemsAggregator aggregator = PurchaseOrderFromItemsAggregator.newInstance();
+
+		Services.get(ITrxManager.class).runInNewTrx(() -> {
+			for (final PurchaseCandidate candidate : candidates)
+			{
+				aggregator.add(PurchaseOrderItem.builder()
+						.purchaseCandidate(candidate)
+						.datePromised(candidate.getPurchaseDatePromised())
+						.purchasedQty(TEN)
+						.remotePurchaseOrderId(NullVendorGatewayInvoker.NO_REMOTE_PURCHASE_ID)
+						.dimension(dimension)
+						.build());
+			}
+			aggregator.closeAllGroups();
+		});
+
+		final List<I_C_Order> createdPurchaseOrders = aggregator.getCreatedPurchaseOrders();
+		assertThat(createdPurchaseOrders).hasSize(1);
+		return createdPurchaseOrders.get(0);
 	}
 }

--- a/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemsAggregatorTest.java
+++ b/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/purchaseordercreation/localorder/PurchaseOrderFromItemsAggregatorTest.java
@@ -12,6 +12,7 @@ import de.metas.document.dimension.OrderLineDimensionFactory;
 import de.metas.document.engine.DocStatus;
 import de.metas.document.references.zoom_into.NullCustomizedWindowInfoMapRepository;
 import de.metas.email.MailService;
+import de.metas.interfaces.I_C_OrderLine;
 import de.metas.notification.INotificationRepository;
 import de.metas.notification.impl.NotificationRepository;
 import de.metas.order.IOrderDAO;
@@ -40,7 +41,6 @@ import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.SpringContextHolder;
-import de.metas.interfaces.I_C_OrderLine;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_UOM;
@@ -176,8 +176,8 @@ public class PurchaseOrderFromItemsAggregatorTest
 				.vendorProductNo("productNo")
 				.vendorProductName("productName")
 				.pricingConditions(PricingConditions.builder()
-										   .validFrom(TimeUtil.asInstant(Timestamp.valueOf("2017-01-01 10:10:10.0")))
-										   .build())
+						.validFrom(TimeUtil.asInstant(Timestamp.valueOf("2017-01-01 10:10:10.0")))
+						.build())
 				.build();
 
 		final PurchaseCandidate purchaseCandidate = PurchaseCandidate.builder()


### PR DESCRIPTION
## Summary

Restores the 1-PCand-to-1-PO-line invariant required by the unique constraint `UC_C_PurchaseCandidate_Alloc_C_OrderLinePO_ID`. `PurchaseOrderFromItemFactory#addCandidate` no longer looks up an existing line by `(productId, uomId)`; each `PurchaseOrderItem` now produces a fresh `OrderLineBuilder`.

Fixes https://github.com/metasfresh/me03/issues/29575.

## Root cause

When two purchase candidates shared the same `(product, uom)` but differed in `M_AttributeSetInstance_ID` (typical for dropship cases — each SO line carries its own per-customer/lot ASI), the previous lookup-and-merge silently overwrote the per-candidate ASI / HUPI / `qtyEnteredTU` and summed the quantities, then violated `UC_C_PurchaseCandidate_Alloc_C_OrderLinePO_ID` when both `C_PurchaseCandidate_Alloc` rows tried to point at the same `C_OrderLinePO_ID`.

The 2018 migration that introduced the unique constraint already documented the intent: *"Each purchase order line can't have more than one purchase candidate."* The fix aligns the aggregation code with that long-standing invariant.

## Behaviour change

Multiple purchase candidates with identical product/UOM are no longer merged into a single PO line. They each produce a dedicated PO line. This applies to all flows (SO-driven, forecast-driven, manual `Create Purchase Orders`).

The cucumber feature files exercising the PCand → PO creation path (dropship, packing-and-attributes, project-to-SO, auto-create-from-product-planning, supply-required-via-purchase, simulation) all assert 1-PCand→1-PO-line and are unaffected by the change.

## Tests

Four new unit tests in `PurchaseOrderFromItemsAggregatorTest`:

- `differentAsi_yieldsTwoOrderLines` — regression test for the bug; asserts both ASI identity and qty per line via `tuple` form.
- `sameAsi_differentSoLines_yieldsTwoOrderLines` — documents the deliberate behaviour change.
- `sameAsi_sameSoLine_stillYieldsTwoOrderLines` — confirms the structural invariant for the partial-purchase edge case.
- `forecastDriven_nullSoLine_yieldsTwoOrderLines` — same-ASI, null SO line; stresses the forecast-driven path.

## Dead code removed

`OrderFactory#orderLineByProductAndUom` and `OrderLineBuilder#isProductAndUomMatching` had only this one caller in the backend. They are deleted.