### PR TITLE
Add UniqueProductPriceFallbackRule for unique tagged-only price records

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/pricing/rules/price_list_version/PriceListVersionPricingRule.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/rules/price_list_version/PriceListVersionPricingRule.java
@@ -55,7 +55,8 @@ public class PriceListVersionPricingRule implements IPricingRule
 		this.includedPricingRules = AggregatedPricingRule.ofNullables(
 				createPricingRule(PriceListVersionConfiguration.getHUPricingRuleFactory()),
 				new AttributePricing(),
-				new MainProductPriceRule()
+				new MainProductPriceRule(),
+				new UniqueProductPriceFallbackRule()
 		);
 	}
 

--- a/backend/de.metas.business/src/main/java/de/metas/pricing/rules/price_list_version/UniqueProductPriceFallbackRule.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/rules/price_list_version/UniqueProductPriceFallbackRule.java
@@ -1,0 +1,192 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.pricing.rules.price_list_version;
+
+import ch.qos.logback.classic.Level;
+import de.metas.handlingunits.HUPIItemProductId;
+import de.metas.i18n.BooleanWithReason;
+import de.metas.i18n.ITranslatableString;
+import de.metas.i18n.TranslatableStrings;
+import de.metas.logging.LogManager;
+import de.metas.money.CurrencyId;
+import de.metas.pricing.IPackingMaterialAware;
+import de.metas.pricing.IPricingContext;
+import de.metas.pricing.IPricingResult;
+import de.metas.pricing.InvoicableQtyBasedOn;
+import de.metas.pricing.PriceListVersionId;
+import de.metas.pricing.service.IPriceListDAO;
+import de.metas.pricing.service.ProductPrices;
+import de.metas.pricing.service.ProductScalePriceService;
+import de.metas.pricing.tax.ProductTaxCategoryService;
+import de.metas.product.IProductBL;
+import de.metas.product.IProductDAO;
+import de.metas.product.ProductCategoryId;
+import de.metas.product.ProductId;
+import de.metas.uom.UomId;
+import de.metas.util.Loggables;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_M_PriceList;
+import org.compiere.model.I_M_PriceList_Version;
+import org.compiere.model.I_M_ProductPrice;
+import org.slf4j.Logger;
+
+import java.util.List;
+
+/**
+ * Last-resort fallback after {@link MainProductPriceRule}.
+ *
+ * <p>If the product has <b>exactly one</b> active, valid {@link I_M_ProductPrice} on the
+ * effective price-list-version, that single record is used as the price - regardless of
+ * {@code M_HU_PI_Item_Product_ID} or {@code IsAttributeDependant}. This handles the case
+ * where a customer maintains a single tagged price row per product on a PLV without a
+ * separate "baseline" sibling that the strict rules require.
+ *
+ * <p>Zero or multiple candidates -> no-op (genuinely missing or ambiguous; existing strict
+ * semantics keep applying).
+ *
+ * <p>See https://github.com/metasfresh/me03/issues/29144 (Spavetti / sp80).
+ */
+class UniqueProductPriceFallbackRule extends AbstractPriceListBasedRule
+{
+	private static final Logger logger = LogManager.getLogger(UniqueProductPriceFallbackRule.class);
+
+	private final IPriceListDAO priceListsRepo = Services.get(IPriceListDAO.class);
+	private final IProductDAO productsRepo = Services.get(IProductDAO.class);
+	private final IProductBL productsService = Services.get(IProductBL.class);
+
+	private final ProductTaxCategoryService productTaxCategoryService = SpringContextHolder.instance.getBean(ProductTaxCategoryService.class);
+	private final ProductScalePriceService productScalePriceService = SpringContextHolder.instance.getBean(ProductScalePriceService.class);
+
+	@Override
+	public void calculate(@NonNull final IPricingContext pricingCtx, @NonNull final IPricingResult result)
+	{
+		if (!applies(pricingCtx, result))
+		{
+			return;
+		}
+
+		final I_M_PriceList_Version plv = pricingCtx.getM_PriceList_Version();
+		if (plv == null || !plv.isActive())
+		{
+			return;
+		}
+
+		final ProductId productId = pricingCtx.getProductId();
+
+		// Query without IsAttributeDependant / M_HU_PI_Item_Product_ID filtering.
+		// dontMatchAttributes() puts the query in IGNORE mode so neither the IsAttributeDependant
+		// flag nor the registered HUPIItemProductMatcher_None main-matcher is applied.
+		final List<I_M_ProductPrice> candidates = ProductPrices.newQuery(plv)
+				.setProductId(productId)
+				.onlyValidPrices(true)
+				.dontMatchAttributes()
+				.list(I_M_ProductPrice.class);
+
+		if (candidates.size() != 1)
+		{
+			Loggables.withLogger(logger, Level.DEBUG).addLog(
+					"UniqueProductPriceFallbackRule - skip; productId={} on plv={} has {} candidates",
+					productId, plv.getM_PriceList_Version_ID(), candidates.size());
+			return;
+		}
+
+		final I_M_ProductPrice productPrice = candidates.get(0);
+
+		final ProductScalePriceService.ProductPriceSettings productPriceSettings =
+				productScalePriceService.getProductPriceSettings(productPrice, pricingCtx.getQuantity());
+		if (productPriceSettings == null)
+		{
+			Loggables.withLogger(logger, Level.DEBUG).addLog(
+					"UniqueProductPriceFallbackRule - skip; no ProductPriceSettings for qty={} M_ProductPrice_ID={}",
+					pricingCtx.getQty(), productPrice.getM_ProductPrice_ID());
+			return;
+		}
+
+		final PriceListVersionId resultPriceListVersionId = PriceListVersionId.ofRepoId(productPrice.getM_PriceList_Version_ID());
+		final I_M_PriceList priceList = priceListsRepo.getById(plv.getM_PriceList_ID());
+		final ProductCategoryId productCategoryId = productsRepo.retrieveProductCategoryByProductId(productId);
+
+		result.setPriceStd(productPriceSettings.getPriceStd());
+		result.setPriceList(productPriceSettings.getPriceList());
+		result.setPriceLimit(productPriceSettings.getPriceLimit());
+		result.setCurrencyId(CurrencyId.ofRepoId(priceList.getC_Currency_ID()));
+		result.setProductId(productId);
+		result.setProductCategoryId(productCategoryId);
+		result.setPriceEditable(productPrice.isPriceEditable());
+		result.setDiscountEditable(result.isDiscountEditable() && productPrice.isDiscountEditable());
+		result.setEnforcePriceLimit(extractEnforcePriceLimit(priceList));
+		result.setTaxIncluded(priceList.isTaxIncluded());
+		result.setTaxCategoryId(productTaxCategoryService.getTaxCategoryId(productPrice));
+		result.setPriceListVersionId(resultPriceListVersionId);
+		result.setPriceUomId(getProductPriceUomId(productPrice, productId));
+		result.setInvoicableQtyBasedOn(InvoicableQtyBasedOn.ofNullableCodeOrNominal(productPrice.getInvoicableQtyBasedOn()));
+		result.setCalculated(true);
+
+		// Propagate the packing material if the unique record carries one.
+		// Mirrors AttributePricing.setResultForProductPriceAttribute.
+		InterfaceWrapperHelper.getRepoIdOptional(productPrice, IPackingMaterialAware.COLUMNNAME_M_HU_PI_Item_Product_ID, HUPIItemProductId::ofRepoId)
+				.ifPresent(result::setPackingMaterialId);
+
+		// BOM override - keep parity with MainProductPriceRule.
+		BOMPriceCalculator.builder()
+				.bomProductId(productId)
+				.asiAware(pricingCtx.getAttributeSetInstanceAware().orElse(null))
+				.priceListVersion(plv)
+				.calculate()
+				.ifPresent(bomPrices -> updatePricingResultFromBOMPrices(result, bomPrices));
+	}
+
+	private BooleanWithReason extractEnforcePriceLimit(@NonNull final I_M_PriceList priceList)
+	{
+		final ITranslatableString reason = TranslatableStrings.builder()
+				.appendADElement("M_PriceList_ID")
+				.append(": ")
+				.append(priceList.getName())
+				.build();
+
+		return priceList.isEnforcePriceLimit()
+				? BooleanWithReason.trueBecause(reason)
+				: BooleanWithReason.falseBecause(reason);
+	}
+
+	private UomId getProductPriceUomId(@NonNull final I_M_ProductPrice productPrice, @NonNull final ProductId productId)
+	{
+		final UomId productPriceUomId = UomId.ofRepoIdOrNull(productPrice.getC_UOM_ID());
+		if (productPriceUomId != null)
+		{
+			return productPriceUomId;
+		}
+
+		return productsService.getStockUOMId(productId);
+	}
+
+	private static void updatePricingResultFromBOMPrices(@NonNull final IPricingResult to, @NonNull final BOMPrices from)
+	{
+		to.setPriceStd(from.getPriceStd());
+		to.setPriceList(from.getPriceList());
+		to.setPriceLimit(from.getPriceLimit());
+	}
+}

--- a/backend/de.metas.business/src/test/java/de/metas/pricing/rules/price_list_version/UniqueProductPriceFallbackRuleTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/pricing/rules/price_list_version/UniqueProductPriceFallbackRuleTest.java
@@ -1,0 +1,137 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.pricing.rules.price_list_version;
+
+import de.metas.pricing.IPricingResult;
+import de.metas.pricing.service.impl.ASIBuilder;
+import de.metas.pricing.service.impl.PricingTestHelper;
+import de.metas.pricing.tax.ProductTaxCategoryRepository;
+import de.metas.pricing.tax.ProductTaxCategoryService;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_M_ProductPrice;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for {@link UniqueProductPriceFallbackRule}.
+ *
+ * <p>Background — me03 issue 29144 ("Fehlermeldung Produkt nicht auf Preisliste trotz Eintrag",
+ * Spavetti / sp80): the strict three-rule pipeline (HU, attribute, main) leaves the result
+ * uncalculated when the only candidate price for a product carries
+ * {@code IsAttributeDependant = Y} or {@code M_HU_PI_Item_Product_ID} set, because
+ * {@link MainProductPriceRule}'s filters reject it. The new fallback engages only after the
+ * strict rules have failed and only when the data is unambiguous (exactly one active+valid
+ * {@code M_ProductPrice}).
+ *
+ * <p>The packing-material variant ({@code M_HU_PI_Item_Product_ID}) is exercised in
+ * {@code de.metas.handlingunits.base} where {@code de.metas.handlingunits.model.I_M_ProductPrice}
+ * exposes the column setter. This class covers the {@code IsAttributeDependant} variant, which is
+ * sufficient to verify the fallback's flag-agnostic uniqueness logic.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+class UniqueProductPriceFallbackRuleTest
+{
+	private PricingTestHelper helper;
+
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+		helper = new PricingTestHelper();
+		SpringContextHolder.registerJUnitBean(new ProductTaxCategoryService(new ProductTaxCategoryRepository()));
+	}
+
+	private I_M_ProductPrice newBaselinePrice(final int amount)
+	{
+		return helper.newProductPriceBuilder().setPrice(amount).build();
+	}
+
+	private I_M_ProductPrice newAttributeDependentPrice(final int amount, final String countryValue)
+	{
+		return helper.newProductPriceBuilder()
+				.setASI(ASIBuilder.newInstance()
+						.setAttribute(helper.attr_Country, countryValue)
+						.build())
+				.setPrice(amount)
+				.build();
+	}
+
+	@Test
+	@DisplayName("Single attribute-dependent price, no order-line ASI → fallback uses it")
+	void uniqueRecord_attributeDependent_isPickedUp()
+	{
+		newAttributeDependentPrice(11, "DE");
+
+		final IPricingResult result = helper.calculatePrice(helper.createPricingContext());
+
+		assertThat(result.isCalculated()).as("calculated").isTrue();
+		assertThat(result.getPriceStd()).as("PriceStd").isEqualByComparingTo(BigDecimal.valueOf(11));
+	}
+
+	@Test
+	@DisplayName("Tagged + baseline siblings → MainProductPriceRule wins on baseline; fallback skipped")
+	void taggedPlusBaseline_baselineWins()
+	{
+		newAttributeDependentPrice(10, "DE");
+		newBaselinePrice(20);
+
+		final IPricingResult result = helper.calculatePrice(helper.createPricingContext());
+
+		assertThat(result.isCalculated()).as("calculated").isTrue();
+		assertThat(result.getPriceStd())
+				.as("PriceStd should match the baseline, not the tagged record")
+				.isEqualByComparingTo(BigDecimal.valueOf(20));
+	}
+
+	@Test
+	@DisplayName("Two tagged records, no baseline → uniqueness gate skips, result stays uncalculated")
+	void twoTaggedRecords_uniquenessGateSkips()
+	{
+		newAttributeDependentPrice(10, "DE");
+		newAttributeDependentPrice(15, "CH");
+
+		final IPricingResult result = helper.calculatePrice(helper.createPricingContext());
+
+		assertThat(result.isCalculated())
+				.as("calculated; the fallback must NOT silently disambiguate two tagged records")
+				.isFalse();
+	}
+
+	@Test
+	@DisplayName("No M_ProductPrice records → result stays uncalculated (existing behaviour preserved)")
+	void noRecords_resultUncalculated()
+	{
+		// no M_ProductPrice rows created
+		final IPricingResult result = helper.calculatePrice(helper.createPricingContext());
+
+		assertThat(result.isCalculated()).as("calculated").isFalse();
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/pricing/spi/impl/UniqueProductPriceFallbackRule_HUTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/pricing/spi/impl/UniqueProductPriceFallbackRule_HUTest.java
@@ -1,0 +1,109 @@
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.handlingunits.pricing.spi.impl;
+
+import de.metas.pricing.IEditablePricingContext;
+import de.metas.pricing.IPricingResult;
+import de.metas.pricing.tax.ProductTaxCategoryRepository;
+import de.metas.pricing.tax.ProductTaxCategoryService;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.SpringContextHolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * Customer-shape regression tests for the {@code UniqueProductPriceFallbackRule}.
+ *
+ * <p>me03 issue 29144 (Spavetti / sp80): the customer's only {@code M_ProductPrice} for the
+ * product carries {@code M_HU_PI_Item_Product_ID}. The order line has no packing-material
+ * context, so {@code HUPricing} cannot match, {@code AttributePricing} skips, and
+ * {@code MainProductPriceRule}'s {@code HUPIItemProductMatcher_None} excludes the tagged record
+ * — leaving the result uncalculated and raising "Produkt nicht auf Preisliste".
+ *
+ * <p>The new fallback fires after the strict trio fails and accepts the unique tagged record.
+ *
+ * <p>The flag-agnostic uniqueness logic is also exercised in
+ * {@code de.metas.business / UniqueProductPriceFallbackRuleTest} via the
+ * {@code IsAttributeDependant} variant; this test class focuses on the
+ * {@code M_HU_PI_Item_Product_ID} variant since the column lives on the HU-extended interface.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class UniqueProductPriceFallbackRule_HUTest
+{
+	private HUPricingTestHelper helper;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+		helper = new HUPricingTestHelper();
+		SpringContextHolder.registerJUnitBean(new ProductTaxCategoryService(new ProductTaxCategoryRepository()));
+	}
+
+	@Test
+	@DisplayName("Single packing-tagged price, order line without packing context → fallback uses it")
+	public void uniquePackingTaggedPrice_isPickedUp()
+	{
+		helper.newProductPriceBuilder()
+				.setM_HU_PI_Item_Product(helper.defaultPIItemProduct1)
+				.setPrice(7)
+				.build();
+
+		final IEditablePricingContext pricingCtx = helper.createPricingContext();
+		// no setReferencedObject → no packing material, no ASI on the order line
+
+		final IPricingResult result = helper.calculatePrice(pricingCtx);
+
+		assertThat(result.isCalculated()).as("calculated").isTrue();
+		assertThat(result.getPriceStd()).as("PriceStd").isEqualByComparingTo(BigDecimal.valueOf(7));
+	}
+
+	@Test
+	@DisplayName("Two packing-tagged prices (PI1, PI2), no order-line context → uniqueness gate skips")
+	public void twoPackingTaggedPrices_uniquenessGateSkips()
+	{
+		helper.newProductPriceBuilder()
+				.setM_HU_PI_Item_Product(helper.defaultPIItemProduct1)
+				.setPrice(7)
+				.build();
+		helper.newProductPriceBuilder()
+				.setM_HU_PI_Item_Product(helper.defaultPIItemProduct2)
+				.setPrice(11)
+				.build();
+
+		final IEditablePricingContext pricingCtx = helper.createPricingContext();
+
+		final IPricingResult result = helper.calculatePrice(pricingCtx);
+
+		assertThat(result.isCalculated())
+				.as("calculated; the fallback must NOT silently pick one of two tagged records")
+				.isFalse();
+	}
+}


### PR DESCRIPTION
## Summary

When a product has exactly one active+valid `M_ProductPrice` on the effective
price-list-version but the row carries `M_HU_PI_Item_Product_ID` or
`IsAttributeDependant = Y`, the strict three-rule pipeline (`HUPricing`,
`AttributePricing`, `MainProductPriceRule`) leaves the pricing result
uncalculated. `MainProductPriceRule`'s baseline filters
(`IsAttributeDependant = N` plus the registered `HUPIItemProductMatcher_None`)
reject the lone tagged record, so pricing fails with `ProductNotOnPriceListException`
even when the customer's intent is *"this is the price for this product"*.

This PR adds `UniqueProductPriceFallbackRule` as the fourth sub-rule of
`PriceListVersionPricingRule`, running after `MainProductPriceRule` inside
the existing base-PLV walk loop. The rule queries `M_ProductPrice` for
`(PLV, product)` with no flag filtering and engages **only when exactly one
candidate exists**. Zero or multiple candidates → no-op, so the existing
strict semantics keep applying when the data is ambiguous.