### PR TITLE
Distinguish destroyed HU from product mismatch in QR resolver

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
@@ -32,6 +32,7 @@ class PickFromHUQRCodeResolveCommand
 	private final static AdMessageKey ERR_LMQ_LotNoNotFound = AdMessageKey.of("de.metas.handlingunits.picking.job.L_M_QR_CODE_ERROR_MSG");
 	private final static AdMessageKey ERR_NoLotNoFoundForQRCode = AdMessageKey.of("de.metas.handlingunits.picking.job.QR_CODE_EXTERNAL_LOT_ERROR_MSG");
 	public final static AdMessageKey ERR_QR_ProductNotMatching = AdMessageKey.of("de.metas.handlingunits.picking.job.QR_CODE_PRODUCT_ERROR_MSG");
+	public final static AdMessageKey ERR_QR_HU_Destroyed = AdMessageKey.of("de.metas.handlingunits.picking.job.QR_CODE_HU_DESTROYED_ERROR_MSG");
 
 	// services
 	@NonNull private final PickingJobProductService productService;
@@ -54,6 +55,11 @@ class PickFromHUQRCodeResolveCommand
 		{
 			final HUQRCode huQRCode = (HUQRCode)pickFromHUQRCode;
 			final HuId huId = huService.getHuIdByQRCode(huQRCode);
+			// Destroyed HUs have empty storage, so containsProduct below would give a misleading "product not matching" error.
+			if (huService.isDestroyed(huId))
+			{
+				return ExplainedOptional.emptyBecause(ERR_QR_HU_Destroyed);
+			}
 			if (!huService.containsProduct(huId, productId))
 			{
 				return ExplainedOptional.emptyBecause(ERR_QR_ProductNotMatching);

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5800850_msg_QR_CODE_HU_DESTROYED_ERROR_MSG.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5800850_msg_QR_CODE_HU_DESTROYED_ERROR_MSG.sql
@@ -2,7 +2,7 @@
 -- Value: de.metas.handlingunits.picking.job.QR_CODE_HU_DESTROYED_ERROR_MSG
 -- 2026-05-05 12:00
 INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
-VALUES (0,545677 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-05 12:00','YYYY-MM-DD HH24:MI'),0,'D','Y','HU wurde zerstört. Bitte neuen QR-Code anfordern.','E','QR_CODE_HU_DESTROYED',TO_TIMESTAMP('2026-05-05 12:00','YYYY-MM-DD HH24:MI'),0,'de.metas.handlingunits.picking.job.QR_CODE_HU_DESTROYED_ERROR_MSG')
+VALUES (0,545677 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-05 12:00','YYYY-MM-DD HH24:MI'),0,'D','Y','HU wurde bereits zerstört.','E','QR_CODE_HU_DESTROYED',TO_TIMESTAMP('2026-05-05 12:00','YYYY-MM-DD HH24:MI'),0,'de.metas.handlingunits.picking.job.QR_CODE_HU_DESTROYED_ERROR_MSG')
 ;
 
 -- 2026-05-05 12:00
@@ -15,7 +15,7 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.
 
 -- en_US translation
 -- 2026-05-05 12:00
-UPDATE AD_Message_Trl SET IsTranslated='Y', MsgText='HU was destroyed. Please request a new QR code.', Updated=TO_TIMESTAMP('2026-05-05 12:00','YYYY-MM-DD HH24:MI'), UpdatedBy=0
+UPDATE AD_Message_Trl SET IsTranslated='Y', MsgText='HU was already destroyed.', Updated=TO_TIMESTAMP('2026-05-05 12:00','YYYY-MM-DD HH24:MI'), UpdatedBy=0
 WHERE AD_Language='en_US' AND AD_Message_ID=545677
 ;
 

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5800850_msg_QR_CODE_HU_DESTROYED_ERROR_MSG.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5800850_msg_QR_CODE_HU_DESTROYED_ERROR_MSG.sql
@@ -1,0 +1,26 @@
+-- me03#29347 — distinguish destroyed-HU from product-mismatch when scanning a QR during picking.
+-- Value: de.metas.handlingunits.picking.job.QR_CODE_HU_DESTROYED_ERROR_MSG
+-- 2026-05-05 12:00
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545677 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-05 12:00','YYYY-MM-DD HH24:MI'),0,'D','Y','HU wurde zerstört. Bitte neuen QR-Code anfordern.','E','QR_CODE_HU_DESTROYED',TO_TIMESTAMP('2026-05-05 12:00','YYYY-MM-DD HH24:MI'),0,'de.metas.handlingunits.picking.job.QR_CODE_HU_DESTROYED_ERROR_MSG')
+;
+
+-- 2026-05-05 12:00
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545677
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- en_US translation
+-- 2026-05-05 12:00
+UPDATE AD_Message_Trl SET IsTranslated='Y', MsgText='HU was destroyed. Please request a new QR code.', Updated=TO_TIMESTAMP('2026-05-05 12:00','YYYY-MM-DD HH24:MI'), UpdatedBy=0
+WHERE AD_Language='en_US' AND AD_Message_ID=545677
+;
+
+-- de_DE / de_CH inherit base text via AD_Message; flag as translated so the UI shows them.
+-- 2026-05-05 12:00
+UPDATE AD_Message_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-05 12:00','YYYY-MM-DD HH24:MI'), UpdatedBy=0
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545677
+;


### PR DESCRIPTION
## Summary

When a picker scans a QR sticker whose HU was destroyed, the QR-to-HU
assignment still resolves (`M_HU_QRCode_Assignment` is not cleared on
destroy), but `M_HU_Storage` is empty for the picking line's product.
Without this change, `PickingJobHUService.containsProduct(huId, productId)`
returns `false` and the user sees the misleading
**"Produkt passt nicht" / "Product not matching"** error — sending them
to search the shelf for a different product instead of recognising
the sticker is stale.

This change branches on `huService.isDestroyed(huId)` before the
`containsProduct` check and surfaces a dedicated AD_Message
(`de.metas.handlingunits.picking.job.QR_CODE_HU_DESTROYED_ERROR_MSG`,
ErrorCode `QR_CODE_HU_DESTROYED`):

- **DE**: `HU wurde bereits zerstört.`
- **EN**: `HU was already destroyed.`

Wording is purely informative — picker training covers the response
("find a different sticker for this product on the shelf", or
escalate). Earlier draft included "Bitte neuen QR-Code anfordern" /
"Please request a new QR code" but that left the picker hanging
(they're not authorised to print QR codes and the right action varies
by situation).

## Root cause confirmation

For the customer report, the HU was destroyed on **2026-03-16 19:21:56 CET**
and the failing API request arrived **2026-04-16 13:55:11 CEST** — a
~1-month gap. The QR sticker physically outlived the HU.

## Issue

https://github.com/metasfresh/me03/issues/29347

## Changes

- `PickFromHUQRCodeResolveCommand.java` — new constant `ERR_QR_HU_Destroyed` and an extra `if (huService.isDestroyed(huId))` branch before the existing `containsProduct` check.
- `5800850_msg_QR_CODE_HU_DESTROYED_ERROR_MSG.sql` — AD_Message + translations (de_DE, de_CH, en_US) + AD_Message_Trl fan-out (covers both `IsSystemLanguage='Y'` and `IsBaseLanguage='Y'`).

## Local validation

- Compile: green (`backend/de.metas.handlingunits.base` + reactor deps)
- Migrations: `5800850` applied locally against `intensive_care_uat`; AD_Message + Trl + AD_MigrationScript registry verified
- Unit tests: 665 run, 0 failures, 22 skipped (none related to this path; the resolver class has no pre-existing test scaffold — would need 50+ lines of mock setup for a 4-line branch, deferred and noted in `ai-work/29347/pending-questions.md`)

## Test plan

- [ ] CI green on `metasfresh` repo
- [ ] UAT scenario: destroy an HU → scan its (still-printed) QR sticker on a picking line for the product the HU previously held → verify the new dedicated message appears (DE + EN), not "Produkt passt nicht"
- [ ] UAT scenario: scan a valid HU QR for a wrong-product line → verify the existing "Produkt passt nicht" still appears (regression check)

## Follow-ups (separate PRs)

- https://github.com/metasfresh/metasfresh/pull/23827 — enrich `ERR_QR_ProductNotMatching` with expected product name.
- https://github.com/metasfresh/metasfresh/pull/23828 — clear/deactivate `M_HU_QRCode_Assignment` when an HU is destroyed (removes the precondition for this PR's failure mode).
- https://github.com/metasfresh/mf15/issues/4101 — audit of catch-weight lot-number divergence (no separate fix needed).