### PR TITLE
Enrich QR product-mismatch error with expected product name

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
@@ -15,6 +15,7 @@ import de.metas.handlingunits.qrcodes.model.IHUQRCode;
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.BooleanWithReason;
 import de.metas.i18n.ExplainedOptional;
+import de.metas.i18n.TranslatableStrings;
 import de.metas.product.ProductId;
 import lombok.Builder;
 import lombok.NonNull;
@@ -56,7 +57,8 @@ class PickFromHUQRCodeResolveCommand
 			final HuId huId = huService.getHuIdByQRCode(huQRCode);
 			if (!huService.containsProduct(huId, productId))
 			{
-				return ExplainedOptional.emptyBecause(ERR_QR_ProductNotMatching);
+				return ExplainedOptional.emptyBecause(
+						TranslatableStrings.adMessage(ERR_QR_ProductNotMatching, productService.getProductNameTrl(productId)));
 			}
 
 			return ExplainedOptional.of(HUInfo.ofHuIdAndQRCode(huId, huQRCode));
@@ -162,11 +164,7 @@ class PickFromHUQRCodeResolveCommand
 			final ProductId gs1ProductId = productService.getProductIdByGTINStrictlyNotNull(gtin, ClientId.METASFRESH);
 			if (!ProductId.equals(expectedProductId, gs1ProductId))
 			{
-				return BooleanWithReason.falseBecause(ERR_QR_ProductNotMatching);
-				// throw new AdempiereException(ERR_QR_ProductNotMatching)
-				// 		.setParameter("GTIN", gtin)
-				// 		.setParameter("expected", expectedProductId)
-				// 		.setParameter("actual", gs1ProductId);
+				return BooleanWithReason.falseBecause(ERR_QR_ProductNotMatching, productService.getProductNameTrl(expectedProductId));
 			}
 		}
 
@@ -181,13 +179,7 @@ class PickFromHUQRCodeResolveCommand
 		final EAN13 ean13 = pickFromQRCode.unbox();
 		if (!productService.isValidEAN13Product(ean13, expectedProductId, customerId))
 		{
-			return BooleanWithReason.falseBecause(ERR_QR_ProductNotMatching);
-			// final String expectedProductNo = productService.getProductValue(expectedProductId);
-			// final EAN13ProductCode ean13ProductNo = ean13.getProductNo();
-			// throw new AdempiereException(ERR_QR_ProductNotMatching)
-			// 		.setParameter("ean13ProductNo", ean13ProductNo)
-			// 		.setParameter("expectedProductNo", expectedProductNo)
-			// 		.setParameter("expectedProductId", expectedProductId);
+			return BooleanWithReason.falseBecause(ERR_QR_ProductNotMatching, productService.getProductNameTrl(expectedProductId));
 		}
 
 		return BooleanWithReason.TRUE;
@@ -203,11 +195,7 @@ class PickFromHUQRCodeResolveCommand
 		final String expectedProductNo = productService.getProductValue(expectedProductId);
 		if (!Objects.equals(qrCodeProductNo, expectedProductNo))
 		{
-			return BooleanWithReason.falseBecause(ERR_QR_ProductNotMatching);
-			// throw new AdempiereException(ERR_QR_ProductNotMatching)
-			// 		.setParameter("qrCodeProductNo", qrCodeProductNo)
-			// 		.setParameter("expectedProductNo", expectedProductNo)
-			// 		.setParameter("expectedProductId", expectedProductId);
+			return BooleanWithReason.falseBecause(ERR_QR_ProductNotMatching, productService.getProductNameTrl(expectedProductId));
 		}
 
 		return BooleanWithReason.TRUE;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/product/PickingJobProductService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/product/PickingJobProductService.java
@@ -69,6 +69,11 @@ public class PickingJobProductService
 		return productBL.getProductValue(productId);
 	}
 
+	public ITranslatableString getProductNameTrl(@NonNull final ProductId productId)
+	{
+		return productBL.getProductNameTrl(productId);
+	}
+
 	public boolean isValidEAN13Product(@NonNull final EAN13 ean13, @NonNull final ProductId expectedProductId, @Nullable final BPartnerId bpartnerId)
 	{
 		return productBL.isValidEAN13Product(ean13, expectedProductId, bpartnerId);

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5800870_msg_QR_CODE_PRODUCT_ERROR_MSG_enriched.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5800870_msg_QR_CODE_PRODUCT_ERROR_MSG_enriched.sql
@@ -1,0 +1,45 @@
+-- me03#29347 follow-up (a) — enrich existing AD_Message
+-- de.metas.handlingunits.picking.job.QR_CODE_PRODUCT_ERROR_MSG (AD_Message_ID=545477)
+-- with a {0} placeholder for the expected product name, so the picker sees what was supposed
+-- to be scanned instead of the bare "Produkt passt nicht".
+
+-- Update base text (German)
+-- 2026-05-05 13:00
+UPDATE AD_Message
+SET MsgText='Produkt passt nicht. Erwartet: {0}',
+    Updated=TO_TIMESTAMP('2026-05-05 13:00','YYYY-MM-DD HH24:MI'),
+    UpdatedBy=0
+WHERE AD_Message_ID=545477
+;
+
+-- Update de_DE / de_CH translations (same German text as base)
+-- 2026-05-05 13:00
+UPDATE AD_Message_Trl
+SET MsgText='Produkt passt nicht. Erwartet: {0}',
+    IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-05-05 13:00','YYYY-MM-DD HH24:MI'),
+    UpdatedBy=0
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545477
+;
+
+-- Update en_US translation
+-- 2026-05-05 13:00
+UPDATE AD_Message_Trl
+SET MsgText='Product not matching. Expected: {0}',
+    IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-05-05 13:00','YYYY-MM-DD HH24:MI'),
+    UpdatedBy=0
+WHERE AD_Language='en_US' AND AD_Message_ID=545477
+;
+
+-- Defensive: catch any other AD_Message_Trl row still on the old base text (e.g. fr_CH and
+-- any other language fanned out from the original 5737500 script that no one ever localised).
+-- They should fall back to the new German base text rather than render "{0}"-less.
+-- Leave IsTranslated='N' so the row is still flagged as not-actually-translated.
+-- 2026-05-05 13:00
+UPDATE AD_Message_Trl
+SET MsgText='Produkt passt nicht. Erwartet: {0}',
+    Updated=TO_TIMESTAMP('2026-05-05 13:00','YYYY-MM-DD HH24:MI'),
+    UpdatedBy=0
+WHERE AD_Message_ID=545477 AND MsgText='Produkt passt nicht'
+;


### PR DESCRIPTION
## Summary

The existing error **'Produkt passt nicht' / 'Product not matching'**
tells the picker that a QR scan didn't match the picking line, but
doesn't say what was supposed to be scanned. For shelf layouts that
put similar products near each other, the picker has to step out of
the mobile flow to check the order — the most common workflow on
customer floors.

This change enriches the existing AD_Message
(`de.metas.handlingunits.picking.job.QR_CODE_PRODUCT_ERROR_MSG`,
AD_Message_ID 545477) with a `{0}` placeholder for the expected
product name. New text:

- **DE**: `Produkt passt nicht. Erwartet: {0}`
- **EN**: `Product not matching. Expected: {0}`

All four call sites that surface this error are updated to pass the
translatable product name: `HUQRCode`, `GS1HUQRCode`, `EAN13HUQRCode`,
`CustomHUQRCode`.

## Issue

https://github.com/metasfresh/me03/issues/29347 — follow-up (a) to
https://github.com/metasfresh/metasfresh/pull/23826 (PR1, destroyed-HU
detection).

## Scope decision

Only the **expected** name is added (single `{0}` parameter). The
original analysis suggested also showing what the HU actually contains,
but that only applies cleanly to the `HUQRCode` branch (the other
three branches don't have a resolved HU at error time). Punted to a
future refinement if the team wants it.

## Defensive translation update

The migration also catches any `AD_Message_Trl` row still on the old
base text — e.g. `fr_CH` and any other language fanned out from
`5737500` that was never localised — so they fall back to the new
German base text rather than render with a missing placeholder.
`IsTranslated` stays at `'N'` for those rows since the row is German
text, not an actual translation.

## Drive-by cleanup

Removed three pre-existing commented-out `throw new
AdempiereException(ERR_QR_ProductNotMatching)` blocks in the three
`validateQRCode_*` helper methods. The parameterised return
introduced here realises what those comments hinted at, so they
are no longer load-bearing.

## Local validation

- Compile: green (`backend/de.metas.handlingunits.base`)
- Migrations: `5800870` applied locally against `intensive_care_uat`; `AD_Message` + `AD_Message_Trl` (de_DE, de_CH, en_US, fr_CH) verified — fr_CH catches the defensive UPDATE
- Unit tests: 665 run, 0 failures, 22 skipped

## Relationship to PR1

https://github.com/metasfresh/metasfresh/pull/23826 (destroyed-HU
detection) and this PR both touch `PickFromHUQRCodeResolveCommand.execute()`'s
`HUQRCode` branch but at different lines — PR1 adds an `isDestroyed`
check **before** the `containsProduct` check; this PR enriches the
return **inside** the `containsProduct` block. Trivial merge resolution
when both land.

## Test plan

- [ ] CI green on `metasfresh` repo
- [ ] UAT scenario: scan a QR sticker for the wrong picking line → verify the message includes the expected product name (DE + EN)
- [ ] UAT scenario: scan via GS1 / EAN13 / Custom QR with mismatched product → same enriched message