### PR TITLE
Clear M_HU_QRCode_Assignment when HU is destroyed

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/interceptor/M_HU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/interceptor/M_HU.java
@@ -1,0 +1,51 @@
+package de.metas.handlingunits.qrcodes.interceptor;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.X_M_HU;
+import de.metas.handlingunits.qrcodes.model.HUQRCode;
+import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.ad.modelvalidator.annotations.ModelChange;
+import org.compiere.model.ModelValidator;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Interceptor(I_M_HU.class)
+@Component
+@RequiredArgsConstructor
+public class M_HU
+{
+	@NonNull private final HUQRCodesService huQRCodesService;
+
+	/**
+	 * When an HU is destroyed, drop the QR-code-to-HU assignment so future scans of the
+	 * (still physically printed) sticker fail with a clear "unknown QR code" message rather
+	 * than resolving to an HU with empty storage.
+	 */
+	@ModelChange(timings = ModelValidator.TYPE_BEFORE_CHANGE, ifColumnsChanged = I_M_HU.COLUMNNAME_HUStatus)
+	public void removeQRCodeAssignmentsOnDestroy(@NonNull final I_M_HU hu)
+	{
+		if (!X_M_HU.HUSTATUS_Destroyed.equals(hu.getHUStatus()))
+		{
+			return;
+		}
+
+		final HuId huId = HuId.ofRepoId(hu.getM_HU_ID());
+		final List<HUQRCode> qrCodes = huQRCodesService.getExistingQRCodesByHuId(huId);
+		if (qrCodes.isEmpty())
+		{
+			return;
+		}
+
+		final ImmutableSet<HuId> huIdSet = ImmutableSet.of(huId);
+		for (final HUQRCode qrCode : qrCodes)
+		{
+			huQRCodesService.removeAssignment(qrCode, huIdSet);
+		}
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/interceptor/M_HU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/interceptor/M_HU.java
@@ -1,10 +1,8 @@
 package de.metas.handlingunits.qrcodes.interceptor;
 
-import com.google.common.collect.ImmutableSet;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.X_M_HU;
-import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +10,6 @@ import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.compiere.model.ModelValidator;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Interceptor(I_M_HU.class)
 @Component
@@ -23,29 +19,20 @@ public class M_HU
 	@NonNull private final HUQRCodesService huQRCodesService;
 
 	/**
-	 * When an HU is destroyed, drop the QR-code-to-HU assignment so future scans of the
-	 * (still physically printed) sticker fail with a clear "unknown QR code" message rather
-	 * than resolving to an HU with empty storage.
+	 * When an HU is destroyed, deactivate (soft-delete) the QR-code-to-HU assignment so future
+	 * scans of the (still physically printed) sticker fail with a clear "unknown QR code" message
+	 * rather than resolving to an HU with empty storage. The row is kept around for traceability
+	 * (Updated / UpdatedBy show when and by whom it was deactivated); scan-time lookups already
+	 * filter on IsActive='Y'.
 	 */
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_CHANGE, ifColumnsChanged = I_M_HU.COLUMNNAME_HUStatus)
-	public void removeQRCodeAssignmentsOnDestroy(@NonNull final I_M_HU hu)
+	public void deactivateQRCodeAssignmentsOnDestroy(@NonNull final I_M_HU hu)
 	{
 		if (!X_M_HU.HUSTATUS_Destroyed.equals(hu.getHUStatus()))
 		{
 			return;
 		}
 
-		final HuId huId = HuId.ofRepoId(hu.getM_HU_ID());
-		final List<HUQRCode> qrCodes = huQRCodesService.getExistingQRCodesByHuId(huId);
-		if (qrCodes.isEmpty())
-		{
-			return;
-		}
-
-		final ImmutableSet<HuId> huIdSet = ImmutableSet.of(huId);
-		for (final HUQRCode qrCode : qrCodes)
-		{
-			huQRCodesService.removeAssignment(qrCode, huIdSet);
-		}
+		huQRCodesService.deactivateAssignmentsByHuId(HuId.ofRepoId(hu.getM_HU_ID()));
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesRepository.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesRepository.java
@@ -138,6 +138,24 @@ public class HUQRCodesRepository
 		removeAssignment(existingRecord, huIdsToRemove);
 	}
 
+	/**
+	 * Soft-delete: set {@code IsActive='N'} on every active {@code M_HU_QRCode_Assignment} row pointing at
+	 * the given HU, preserving the row for audit/traceability. All scan-time lookup paths already filter on
+	 * {@code IsActive='Y'} via {@code addOnlyActiveRecordsFilter()}, so deactivated rows stop resolving.
+	 */
+	public void deactivateAssignmentsByHuId(@NonNull final HuId huId)
+	{
+		queryBL.createQueryBuilder(I_M_HU_QRCode_Assignment.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_HU_QRCode_Assignment.COLUMNNAME_M_HU_ID, huId)
+				.create()
+				.stream()
+				.forEach(assignment -> {
+					assignment.setIsActive(false);
+					InterfaceWrapperHelper.save(assignment);
+				});
+	}
+
 	public boolean isQRCodeAssignedToHU(@NonNull final HUQRCode qrCode, @NonNull final HuId huId)
 	{
 		return getHUAssignmentByQRCode(qrCode)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -292,12 +292,12 @@ public class HUQRCodesService
 	}
 
 	/**
-	 * Read-only counterpart of {@link #getQRCodesByHuId(HuId)} — never auto-generates a QR code.
-	 * Use from cleanup paths (e.g. on HU destroy) where creating a new QR code would be wrong.
+	 * Soft-delete every active {@code M_HU_QRCode_Assignment} row pointing at the given HU.
+	 * Preserves the row for audit/traceability; existing scan-time lookups already filter on {@code IsActive='Y'}.
 	 */
-	public List<HUQRCode> getExistingQRCodesByHuId(@NonNull final HuId huId)
+	public void deactivateAssignmentsByHuId(@NonNull final HuId huId)
 	{
-		return huQRCodesRepository.getQRCodesByHuId(huId);
+		huQRCodesRepository.deactivateAssignmentsByHuId(huId);
 	}
 
 	private List<HUQRCode> getOrCreateQRCodesByHuId(@NonNull final HuId huId, boolean isGenerateQRCodesIfMissing)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -291,6 +291,15 @@ public class HUQRCodesService
 		return getOrCreateQRCodesByHuId(huId, isGenerateQRCodesIfMissing());
 	}
 
+	/**
+	 * Read-only counterpart of {@link #getQRCodesByHuId(HuId)} — never auto-generates a QR code.
+	 * Use from cleanup paths (e.g. on HU destroy) where creating a new QR code would be wrong.
+	 */
+	public List<HUQRCode> getExistingQRCodesByHuId(@NonNull final HuId huId)
+	{
+		return huQRCodesRepository.getQRCodesByHuId(huId);
+	}
+
 	private List<HUQRCode> getOrCreateQRCodesByHuId(@NonNull final HuId huId, boolean isGenerateQRCodesIfMissing)
 	{
 		if (isGenerateQRCodesIfMissing)


### PR DESCRIPTION
## Summary

When an HU is destroyed, `M_HU_QRCode_Assignment` is currently left
intact, so a stale physically printed sticker still resolves to the
(now empty / inactive) HU on re-scan. That's the failure mode that
triggered this issue chain (scan a month-old sticker → backend
resolves to a destroyed HU → 'Produkt passt nicht').
https://github.com/metasfresh/metasfresh/pull/23826 catches this at
scan time and surfaces a clearer error; this PR removes the failure
mode entirely by deactivating the QR-to-HU link when the HU's
`HUStatus` flips to `Destroyed`.

## Implementation

A `BEFORE_CHANGE` model interceptor on `I_M_HU.HUStatus`. When the
new status is `Destroyed`, the interceptor calls
`HUQRCodesService.deactivateAssignmentsByHuId(huId)`, which sets
`IsActive='N'` on every active `M_HU_QRCode_Assignment` row pointing
at that HU.

**Soft-delete, not physical delete.** Per code-review feedback:
preserving the row keeps an audit trail (`Updated` / `UpdatedBy`
show when and by whom the assignment was deactivated) and leaves a
path open for reversibility on a `D → A` transition (a follow-up
that re-activates the row becomes a one-line change). All scan-time
lookup paths already filter on `IsActive='Y'` via
`addOnlyActiveRecordsFilter()`, so deactivated rows stop resolving
without any change to the read side.

This replaces an earlier draft of this PR that used the existing
hard-delete `removeAssignment` API. The hard-delete path is still
used by `HUTransformService` and `HUPPOrderBL` for user-initiated
explicit reassignments — those are out of scope here.

The implementation is now a single bulk operation: query the
assignment table directly by `M_HU_ID`, set `IsActive='N'` on each
match. No need to enumerate QR codes first; no need for a read-only
companion of `getQRCodesByHuId` (the read-only workaround in the
earlier draft was needed only because the QR-code enumeration path
auto-creates a fresh QR code when `GenerateQRCodeIfMissing=Y`).

Same trigger condition and timing as the existing sibling interceptor
at `de.metas.handlingunits.picking.interceptor.M_HU` (which removes
the HU from picking-slot queues on destroy).

## Issue

https://github.com/metasfresh/me03/issues/29347 — follow-up (c) to
https://github.com/metasfresh/metasfresh/pull/23826 (PR1, destroyed-HU
detection) and
https://github.com/metasfresh/metasfresh/pull/23827 (PR2, enriched
product-mismatch error).

## Local validation

- Compile: green (`backend/de.metas.handlingunits.base`)
- Unit tests: 665 run, 0 failures, 22 skipped
- No new tests for the interceptor — no scaffold exists for sibling interceptors (`picking.interceptor.M_HU`, `inventory.interceptor.M_Inventory`) and the behaviour is testable end-to-end via Cucumber/Playwright. Customer UAT will exercise it.

## Relationship to PR1 / PR2

The three PRs in this issue chain are independent in source — each branches from `intensive_care_hotfix` directly:

- https://github.com/metasfresh/metasfresh/pull/23826 (PR1, destroy detection)
- https://github.com/metasfresh/metasfresh/pull/23827 (PR2, enriched mismatch error)
- this PR (PR3, deactivate assignment on destroy)

After all three are integrated, the destroy-detection branch (PR1) becomes a defensive backstop — PR3 removes the precondition for it to fire. PR1 still earns its keep for HUs destroyed by code paths that pre-date this interceptor (legacy stickers in the wild) and for any future code path that bypasses the model interceptor.

## Test plan

- [ ] CI green on `metasfresh` repo
- [ ] UAT: destroy an HU → verify the corresponding `M_HU_QRCode_Assignment` row is now `IsActive='N'` (not deleted)
- [ ] UAT: scan the now-stale QR sticker → verify the response is "QR code not found" (not the new "HU destroyed" message from PR1, since the assignment is no longer active before scan time)
- [ ] UAT regression: ordinary picking flows unaffected — destroy events for non-stickered HUs still complete cleanly