### PR TITLE
Surface destroyed-HU error even when QR assignment is soft-deleted

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
@@ -55,19 +55,35 @@ class PickFromHUQRCodeResolveCommand
 		else if (pickFromHUQRCode instanceof HUQRCode)
 		{
 			final HUQRCode huQRCode = (HUQRCode)pickFromHUQRCode;
-			final HuId huId = huService.getHuIdByQRCode(huQRCode);
-			// Destroyed HUs have empty storage, so containsProduct below would give a misleading "product not matching" error.
-			if (huService.isDestroyed(huId))
+			final HuId activeHuId = huService.getHuIdByQRCodeIfExists(huQRCode).orElse(null);
+			if (activeHuId == null)
+			{
+				// No active assignment. The destroy interceptor (M_HU.deactivateQRCodeAssignmentsOnDestroy)
+				// soft-deletes assignments when an HU is destroyed, so check the inactive set as well: if
+				// the QR resolves to a destroyed HU, surface the dedicated message instead of the generic
+				// "no HU attached" exception. Anything else (genuinely unknown QR, or inactive assignment
+				// pointing at a still-alive HU) falls through to the existing throwing variant.
+				final HuId inactiveHuId = huService.getHuIdByQRCodeIncludingInactiveIfExists(huQRCode).orElse(null);
+				if (inactiveHuId != null && huService.isDestroyed(inactiveHuId))
+				{
+					return ExplainedOptional.emptyBecause(ERR_QR_HU_Destroyed);
+				}
+				huService.getHuIdByQRCode(huQRCode); // throws AdempiereException — see HUQRCodesService.java
+				throw new IllegalStateException("unreachable");
+			}
+
+			// Legacy backstop: assignment still active but HU was destroyed before the destroy interceptor was deployed.
+			if (huService.isDestroyed(activeHuId))
 			{
 				return ExplainedOptional.emptyBecause(ERR_QR_HU_Destroyed);
 			}
-			if (!huService.containsProduct(huId, productId))
+			if (!huService.containsProduct(activeHuId, productId))
 			{
 				return ExplainedOptional.emptyBecause(
 						TranslatableStrings.adMessage(ERR_QR_ProductNotMatching, productService.getProductNameTrl(productId)));
 			}
 
-			return ExplainedOptional.of(HUInfo.ofHuIdAndQRCode(huId, huQRCode));
+			return ExplainedOptional.of(HUInfo.ofHuIdAndQRCode(activeHuId, huQRCode));
 		}
 		else if (pickFromHUQRCode instanceof LMQRCode)
 		{

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickingJobHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickingJobHUService.java
@@ -212,6 +212,10 @@ public class PickingJobHUService
 
 	public HuId getHuIdByQRCode(final HUQRCode huQRCode) {return huQRCodesService.getHuIdByQRCode(huQRCode);}
 
+	public Optional<HuId> getHuIdByQRCodeIfExists(final HUQRCode huQRCode) {return huQRCodesService.getHuIdByQRCodeIfExists(huQRCode);}
+
+	public Optional<HuId> getHuIdByQRCodeIncludingInactiveIfExists(final HUQRCode huQRCode) {return huQRCodesService.getHuIdByQRCodeIncludingInactiveIfExists(huQRCode);}
+
 	public HuId createInventoryForMissingQty(@NonNull final CreateVirtualInventoryWithQtyReq req) {return inventoryService.createInventoryForMissingQty(req);}
 
 	public PickFromHUsSupplier newPickFromHUsSupplier()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesRepository.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesRepository.java
@@ -139,6 +139,23 @@ public class HUQRCodesRepository
 	}
 
 	/**
+	 * Read-only counterpart of {@link #getHUAssignmentByQRCode(HUQRCode)} that also returns rows whose
+	 * {@code M_HU_QRCode_Assignment.IsActive='N'}. Use from cleanup / forensic paths (e.g. detecting a
+	 * stale sticker scan after the HU was destroyed and the assignment soft-deleted by the destroy
+	 * interceptor). Returns the most recent assignment first when several exist.
+	 */
+	public Optional<HuId> getHuIdByQRCodeIncludingInactive(@NonNull final HUQRCode huQRCode)
+	{
+		return getByUniqueId(huQRCode.getId())
+				.flatMap(record -> queryBL.createQueryBuilder(I_M_HU_QRCode_Assignment.class)
+						.addEqualsFilter(I_M_HU_QRCode_Assignment.COLUMNNAME_M_HU_QRCode_ID, record.getM_HU_QRCode_ID())
+						.orderByDescending(I_M_HU_QRCode_Assignment.COLUMNNAME_M_HU_QRCode_Assignment_ID)
+						.create()
+						.firstOptional(I_M_HU_QRCode_Assignment.class)
+						.map(assignment -> HuId.ofRepoId(assignment.getM_HU_ID())));
+	}
+
+	/**
 	 * Soft-delete: set {@code IsActive='N'} on every active {@code M_HU_QRCode_Assignment} row pointing at
 	 * the given HU, preserving the row for audit/traceability. All scan-time lookup paths already filter on
 	 * {@code IsActive='Y'} via {@code addOnlyActiveRecordsFilter()}, so deactivated rows stop resolving.

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -210,6 +210,17 @@ public class HUQRCodesService
 				.map(HUQRCodeAssignment::getSingleHUId);
 	}
 
+	/**
+	 * Variant of {@link #getHuIdByQRCodeIfExists(HUQRCode)} that also resolves through soft-deleted
+	 * assignments. Use when a stale sticker scan needs to surface a more specific cause than the
+	 * generic "no HU attached" exception (e.g. the HU was destroyed and the destroy interceptor
+	 * deactivated the assignment).
+	 */
+	public Optional<HuId> getHuIdByQRCodeIncludingInactiveIfExists(@NonNull final HUQRCode qrCode)
+	{
+		return huQRCodesRepository.getHuIdByQRCodeIncludingInactive(qrCode);
+	}
+
 	public Optional<HUQRCodeAssignment> getHUAssignmentByQRCode(@NonNull final HUQRCode huQRCode)
 	{
 		return huQRCodesRepository.getHUAssignmentByQRCode(huQRCode);


### PR DESCRIPTION
## Summary

Follow-up to the three integrated PRs:

- https://github.com/metasfresh/metasfresh/pull/23826 — destroyed-HU detection
- https://github.com/metasfresh/metasfresh/pull/23827 — enriched product-mismatch error
- https://github.com/metasfresh/metasfresh/pull/23828 — deactivate `M_HU_QRCode_Assignment` on HU destroy

After PR3 is in effect, every **new** destroy soft-deletes the assignment row (`IsActive='N'`). The scan-time lookup `HUQRCodesService.getHuIdByQRCode` then returns empty and throws the generic `No HU attached to QR Code <code>` exception — so the dedicated `HU wurde bereits zerstört.` message added by PR1 only ever fires for **legacy** stickers (HUs destroyed before the interceptor was deployed) and for exotic code paths that bypass the interceptor. Going forward, pickers would see the technical "no HU attached" exception instead of the friendlier "HU was already destroyed" message.

This PR closes that gap. In `PickFromHUQRCodeResolveCommand.execute()`'s `HUQRCode` branch, when the active-only lookup returns empty, fall back to a query that also considers soft-deleted assignments. If that resolves to a destroyed HU, surface the dedicated `ERR_QR_HU_Destroyed` message. Anything else (genuinely unknown QR, or inactive assignment pointing at a still-alive HU) still reaches the existing `getHuIdByQRCode` exception path.

The legacy-backstop branch (active assignment + destroyed HU) is preserved as-is — it still earns its keep until all stale stickers age out.