### PR TITLE
Port build fix from new_dawn_uat: exclude *.md from jasper resource copy

### DIFF
--- a/misc/dev-support/bootstrap-scripts/mvn_build.sh
+++ b/misc/dev-support/bootstrap-scripts/mvn_build.sh
@@ -54,7 +54,9 @@ SKIP_MIGRATION_SCRIPTS_TEST="${SKIP_MIGRATION_SCRIPTS_TEST:-true}"
 BACKEND_PARAMS="-DSKIP_MIGRATION_SCRIPTS_TEST=${SKIP_MIGRATION_SCRIPTS_TEST}"
 
 # Default Maven goals (used if no goals provided as arguments)
-DEFAULT_GOALS='clean install'
+# Incremental build by default (no clean) for faster development cycles
+# Use --clean flag or pass "clean install" explicitly for full clean builds
+DEFAULT_GOALS='install'
 
 # ============================================================================
 # Functions
@@ -103,6 +105,8 @@ IMPORTANT - FULL BUILD DURATION:
 
 OPTIONS:
     -h, --help              Show this help message
+    --clean                 Clean before building (adds 'clean' goal)
+                            By default, builds are incremental (no clean)
     --deps-only             Build only core dependencies (parent-pom, de-metas-common)
                             Fast option for installing dependencies (~2-3 minutes)
     --skip-tests            Skip running tests (adds -DskipTests)
@@ -113,12 +117,13 @@ MAVEN_GOALS:
     Examples: "test", "clean install", "verify", "package"
 
 EXAMPLES:
-    $(basename "$0")                          # Default: clean install (full build)
+    $(basename "$0")                          # Default: incremental install (no clean)
+    $(basename "$0") --clean                  # Full clean install
     $(basename "$0") --deps-only              # Install only dependencies (parent-pom, de-metas-common)
     $(basename "$0") test                     # Run tests only
     $(basename "$0") clean verify             # Clean and verify
-    $(basename "$0") --skip-tests install     # Install without tests
-    $(basename "$0") --parallel clean install # Parallel build
+    $(basename "$0") --skip-tests             # Install without tests
+    $(basename "$0") --parallel --clean       # Parallel clean build
 
 ENVIRONMENT VARIABLES:
     JAVA8_HOME                      Java 8 installation for parent-pom, de-metas-common, backend
@@ -145,12 +150,17 @@ EOF
 MAVEN_GOALS=""
 SKIP_TESTS=""
 DEPS_ONLY=false
+DO_CLEAN=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
         -h|--help)
             show_help
             exit 0
+            ;;
+        --clean)
+            DO_CLEAN=true
+            shift
             ;;
         --deps-only)
             DEPS_ONLY=true
@@ -175,6 +185,11 @@ done
 # Use default goals if none provided
 if [ -z "$MAVEN_GOALS" ]; then
     MAVEN_GOALS="$DEFAULT_GOALS"
+fi
+
+# Prepend 'clean' if --clean flag was used
+if [ "$DO_CLEAN" = true ]; then
+    MAVEN_GOALS="clean $MAVEN_GOALS"
 fi
 
 # If deps-only mode, force skip tests and skip test compilation

--- a/misc/parent-pom/pom.xml
+++ b/misc/parent-pom/pom.xml
@@ -804,6 +804,7 @@ Failure to find de.metas:de.metas.parent:pom:(1.0.0,3) in (URL ...) was cached i
                                             <directory>src/main/jasperreports</directory>
                                             <excludes>
                                                 <exclude>**/*.jrxml</exclude>
+                                                <exclude>**/*.md</exclude>
                                             </excludes>
                                         </resource>
                                     </resources>


### PR DESCRIPTION
Cherry-pick of d3350bc018a (https://github.com/metasfresh/metasfresh/pull/22132) from new_dawn_uat. Two coupled changes:

1. **`misc/parent-pom/pom.xml`** — exclude `**/*.md` from the `jasperreports` resource-copy block. Fixes Windows symlink failures when `maven-resources-plugin:copy-resources` tries to copy the symlinked CLAUDE.md files into target/jasper. Markdown files have no business in the jasper output anyway.

2. **`misc/dev-support/bootstrap-scripts/mvn_build.sh`** — switch the default from \`clean install\` to \`install\` so local incremental builds are fast. \`--clean\` flag added for explicit clean builds. Aligns with metasfresh CLAUDE.md's "Clean Builds Require User Approval" rule.

Verified locally on this workspace: \`./misc/dev-support/bootstrap-scripts/mvn_build.sh\` runs to BUILD SUCCESS where it previously failed at \`de.metas.fresh.base\` with "A required privilege is not held by the client".

Discovered while running https://github.com/metasfresh/me03/issues/29671 — the symlink crash was blocking local validation for the terminology cleanup work on the same workspace.