### PR TITLE
Don't override CreateShipmentPolicy in close-LU shipment generation

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentCandidate.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentCandidate.java
@@ -29,12 +29,12 @@ public class PickingShipmentCandidate
 			@NonNull final PickingShipmentCandidateKey key,
 			@Nullable final Set<HuId> onlyLUIds,
 			@Nullable final CreateShipmentPolicy createShipmentPolicy,
-			final boolean waitForShipments)
+			@Nullable final Boolean waitForShipments)
 	{
 		this.key = key;
 		this.onlyLUIds = onlyLUIds != null ? ImmutableSet.copyOf(onlyLUIds) : ImmutableSet.of();
 		this.createShipmentPolicy = createShipmentPolicy != null ? createShipmentPolicy : CreateShipmentPolicy.CREATE_COMPLETE_CLOSE;
-		this.waitForShipments = waitForShipments;
+		this.waitForShipments = waitForShipments != null ? waitForShipments : false;
 		if (!this.createShipmentPolicy.isCreateShipment())
 		{
 			throw new AdempiereException("Invalid create shipment policy option: " + this.createShipmentPolicy);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentCandidate.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentCandidate.java
@@ -20,6 +20,7 @@ public class PickingShipmentCandidate
 	@NonNull @Delegate private final PickingShipmentCandidateKey key;
 	@NonNull @Getter private final ImmutableSet<HuId> onlyLUIds;
 	@NonNull @Getter private final CreateShipmentPolicy createShipmentPolicy;
+	@Getter private final boolean waitForShipments;
 
 	@NonNull private final HashSet<ShipmentScheduleId> shipmentScheduleIds = new HashSet<>();
 
@@ -27,11 +28,13 @@ public class PickingShipmentCandidate
 	private PickingShipmentCandidate(
 			@NonNull final PickingShipmentCandidateKey key,
 			@Nullable final Set<HuId> onlyLUIds,
-			@Nullable final CreateShipmentPolicy createShipmentPolicy)
+			@Nullable final CreateShipmentPolicy createShipmentPolicy,
+			final boolean waitForShipments)
 	{
 		this.key = key;
 		this.onlyLUIds = onlyLUIds != null ? ImmutableSet.copyOf(onlyLUIds) : ImmutableSet.of();
 		this.createShipmentPolicy = createShipmentPolicy != null ? createShipmentPolicy : CreateShipmentPolicy.CREATE_COMPLETE_CLOSE;
+		this.waitForShipments = waitForShipments;
 		if (!this.createShipmentPolicy.isCreateShipment())
 		{
 			throw new AdempiereException("Invalid create shipment policy option: " + this.createShipmentPolicy);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentService.java
@@ -42,20 +42,21 @@ public class PickingShipmentService
 
 	public void createShipmentIfNeeded(final PickingJob pickingJob)
 	{
-		prepareShipmentCandidates(pickingJob, ImmutableSet.of(), null)
+		prepareShipmentCandidates(pickingJob, ImmutableSet.of(), null, false)
 				.forEach(this::createShipment);
 	}
 
 	public void createShipmentForLUs(@NonNull final PickingJob pickingJob, @NonNull final Set<HuId> luIds)
 	{
-		prepareShipmentCandidates(pickingJob, ImmutableSet.copyOf(luIds), CreateShipmentPolicy.CREATE_COMPLETE_CLOSE)
+		prepareShipmentCandidates(pickingJob, ImmutableSet.copyOf(luIds), null, true)
 				.forEach(this::createShipment);
 	}
 
 	private Collection<PickingShipmentCandidate> prepareShipmentCandidates(
 			@NonNull final PickingJob pickingJob,
 			@NonNull final ImmutableSet<HuId> onlyLUIds,
-			@Nullable final CreateShipmentPolicy createShipmentPolicyOverride
+			@Nullable final CreateShipmentPolicy createShipmentPolicyOverride,
+			final boolean waitForShipments
 	)
 	{
 		final LinkedHashMap<PickingShipmentCandidateKey, PickingShipmentCandidate> shipmentCandidates = new LinkedHashMap<>();
@@ -78,6 +79,7 @@ public class PickingShipmentService
 						.key(key)
 						.onlyLUIds(onlyLUIds)
 						.createShipmentPolicy(createShipmentPolicyEffective)
+						.waitForShipments(waitForShipments)
 						.build();
 				shipmentCandidates.put(key, shipmentCandidate);
 			}
@@ -106,8 +108,7 @@ public class PickingShipmentService
 				.onTheFlyPickToPackingInstructions(true)
 				.isCompleteShipment(createShipmentPolicy.isCreateAndCompleteShipment())
 				.isCloseShipmentSchedules(createShipmentPolicy.isCloseShipmentSchedules())
-				// since we are not going to immediately create invoices, we want to move on and to not wait for shipments
-				.waitForShipments(false)
+				.waitForShipments(shipmentCandidate.isWaitForShipments())
 				.build());
 	}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentService.java
@@ -84,10 +84,7 @@ public class PickingShipmentService
 				shipmentCandidates.put(key, shipmentCandidate);
 			}
 
-			if (shipmentCandidate != null)
-			{
-				shipmentCandidate.addLine(line);
-			}
+			shipmentCandidate.addLine(line);
 		}
 
 		return shipmentCandidates.values();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentService.java
@@ -2,6 +2,7 @@ package de.metas.handlingunits.picking.job.shipment;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import de.metas.bpartner.BPartnerId;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileRepository;
@@ -66,10 +67,7 @@ public class PickingShipmentService
 			PickingShipmentCandidate shipmentCandidate = shipmentCandidates.get(key);
 			if (shipmentCandidate == null)
 			{
-				final CreateShipmentPolicy createShipmentPolicyEffective = CoalesceUtil.coalesceNotNull(
-						createShipmentPolicyOverride,
-						() -> configRepository.getPickingJobOptions(key.getCustomerId()).getCreateShipmentPolicy()
-				);
+				final CreateShipmentPolicy createShipmentPolicyEffective = resolveCreateShipmentPolicy(key.getCustomerId(), createShipmentPolicyOverride);
 				if (!createShipmentPolicyEffective.isCreateShipment())
 				{
 					continue;
@@ -88,6 +86,17 @@ public class PickingShipmentService
 		}
 
 		return shipmentCandidates.values();
+	}
+
+	@VisibleForTesting
+	@NonNull
+	CreateShipmentPolicy resolveCreateShipmentPolicy(
+			@NonNull final BPartnerId customerId,
+			@Nullable final CreateShipmentPolicy override)
+	{
+		return CoalesceUtil.coalesceNotNull(
+				override,
+				() -> configRepository.getPickingJobOptions(customerId).getCreateShipmentPolicy());
 	}
 
 	private void createShipment(@NonNull final PickingShipmentCandidate shipmentCandidate)

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentCandidateTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentCandidateTest.java
@@ -1,0 +1,76 @@
+package de.metas.handlingunits.picking.job.shipment;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.handlingunits.picking.job.service.CreateShipmentPolicy;
+import org.adempiere.exceptions.AdempiereException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression coverage for the contract that {@link PickingShipmentCandidate} carries the
+ * customer-configured {@link CreateShipmentPolicy} and the synchronous-wait flag through to
+ * {@link PickingShipmentService#createShipment(PickingShipmentCandidate)} unchanged. The earlier
+ * bug (me03 issue 27448) was that the service layer was forcing {@code CREATE_COMPLETE_CLOSE}
+ * regardless of the configured policy.
+ */
+class PickingShipmentCandidateTest
+{
+	private static final PickingShipmentCandidateKey KEY = new PickingShipmentCandidateKey(BPartnerId.ofRepoId(1));
+
+	@Test
+	void createShipmentPolicy_isPreserved_whenConfigured()
+	{
+		final PickingShipmentCandidate candidate = PickingShipmentCandidate.builder()
+				.key(KEY)
+				.createShipmentPolicy(CreateShipmentPolicy.CREATE_AND_COMPLETE)
+				.build();
+
+		assertThat(candidate.getCreateShipmentPolicy()).isEqualTo(CreateShipmentPolicy.CREATE_AND_COMPLETE);
+	}
+
+	@Test
+	void createShipmentPolicy_defaultsTo_CREATE_COMPLETE_CLOSE_whenNull()
+	{
+		final PickingShipmentCandidate candidate = PickingShipmentCandidate.builder()
+				.key(KEY)
+				.build();
+
+		assertThat(candidate.getCreateShipmentPolicy()).isEqualTo(CreateShipmentPolicy.CREATE_COMPLETE_CLOSE);
+	}
+
+	@Test
+	void createShipmentPolicy_DO_NOT_CREATE_isRejected()
+	{
+		assertThatThrownBy(() -> PickingShipmentCandidate.builder()
+				.key(KEY)
+				.createShipmentPolicy(CreateShipmentPolicy.DO_NOT_CREATE)
+				.build())
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("Invalid create shipment policy");
+	}
+
+	@Test
+	void waitForShipments_defaultsToFalse_whenNotSet()
+	{
+		final PickingShipmentCandidate candidate = PickingShipmentCandidate.builder()
+				.key(KEY)
+				.createShipmentPolicy(CreateShipmentPolicy.CREATE_AND_COMPLETE)
+				.build();
+
+		assertThat(candidate.isWaitForShipments()).isFalse();
+	}
+
+	@Test
+	void waitForShipments_isTrue_whenExplicitlySet()
+	{
+		final PickingShipmentCandidate candidate = PickingShipmentCandidate.builder()
+				.key(KEY)
+				.createShipmentPolicy(CreateShipmentPolicy.CREATE_AND_COMPLETE)
+				.waitForShipments(true)
+				.build();
+
+		assertThat(candidate.isWaitForShipments()).isTrue();
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentServiceTest.java
@@ -1,0 +1,96 @@
+package de.metas.handlingunits.picking.job.shipment;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileRepository;
+import de.metas.handlingunits.picking.config.mobileui.PickingJobOptions;
+import de.metas.handlingunits.picking.job.service.CreateShipmentPolicy;
+import de.metas.handlingunits.shipmentschedule.api.IShipmentService;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Service-level regression coverage for me03 issue 27448.
+ * <p>
+ * Original bug: {@link PickingShipmentService#createShipmentForLUs} hardcoded the
+ * {@link CreateShipmentPolicy} to {@link CreateShipmentPolicy#CREATE_COMPLETE_CLOSE} regardless
+ * of what the customer's mobile-picking profile had configured. The fix removes that override
+ * so the customer-configured policy is honoured.
+ * <p>
+ * The DTO checks in {@link PickingShipmentCandidateTest} would have passed even with the bug
+ * in place — only an assertion on the policy resolution itself catches the regression.
+ */
+class PickingShipmentServiceTest
+{
+	private static final BPartnerId CUSTOMER_ID = BPartnerId.ofRepoId(1);
+
+	private static PickingJobOptions optionsWith(final CreateShipmentPolicy policy)
+	{
+		return PickingJobOptions.builder()
+				.createShipmentPolicy(policy)
+				.build();
+	}
+
+	private static PickingShipmentService newServiceWithConfiguredPolicy(final CreateShipmentPolicy configuredPolicy)
+	{
+		final MobileUIPickingUserProfileRepository profileRepo = mock(MobileUIPickingUserProfileRepository.class);
+		when(profileRepo.getPickingJobOptions(CUSTOMER_ID)).thenReturn(optionsWith(configuredPolicy));
+		return new PickingShipmentService(profileRepo, mock(IShipmentService.class));
+	}
+
+	@Test
+	void resolveCreateShipmentPolicy_returnsConfiguredPolicy_whenOverrideIsNull()
+	{
+		final PickingShipmentService service = newServiceWithConfiguredPolicy(CreateShipmentPolicy.CREATE_AND_COMPLETE);
+
+		final CreateShipmentPolicy resolved = service.resolveCreateShipmentPolicy(CUSTOMER_ID, null);
+
+		assertThat(resolved)
+				.as("close-LU path passes override=null and must therefore use the customer-configured policy — me03#27448 regression guard")
+				.isEqualTo(CreateShipmentPolicy.CREATE_AND_COMPLETE);
+	}
+
+	@Test
+	void resolveCreateShipmentPolicy_returnsCREATE_COMPLETE_CLOSE_whenCustomerConfiguredSo()
+	{
+		final PickingShipmentService service = newServiceWithConfiguredPolicy(CreateShipmentPolicy.CREATE_COMPLETE_CLOSE);
+
+		final CreateShipmentPolicy resolved = service.resolveCreateShipmentPolicy(CUSTOMER_ID, null);
+
+		assertThat(resolved).isEqualTo(CreateShipmentPolicy.CREATE_COMPLETE_CLOSE);
+	}
+
+	@Test
+	void resolveCreateShipmentPolicy_returnsCREATE_DRAFT_whenCustomerConfiguredSo()
+	{
+		final PickingShipmentService service = newServiceWithConfiguredPolicy(CreateShipmentPolicy.CREATE_DRAFT);
+
+		final CreateShipmentPolicy resolved = service.resolveCreateShipmentPolicy(CUSTOMER_ID, null);
+
+		assertThat(resolved).isEqualTo(CreateShipmentPolicy.CREATE_DRAFT);
+	}
+
+	@Test
+	void resolveCreateShipmentPolicy_returnsDO_NOT_CREATE_whenCustomerConfiguredSo()
+	{
+		final PickingShipmentService service = newServiceWithConfiguredPolicy(CreateShipmentPolicy.DO_NOT_CREATE);
+
+		final CreateShipmentPolicy resolved = service.resolveCreateShipmentPolicy(CUSTOMER_ID, null);
+
+		assertThat(resolved).isEqualTo(CreateShipmentPolicy.DO_NOT_CREATE);
+	}
+
+	@Test
+	void resolveCreateShipmentPolicy_overrideTakesPrecedence_overConfiguredPolicy()
+	{
+		final PickingShipmentService service = newServiceWithConfiguredPolicy(CreateShipmentPolicy.CREATE_AND_COMPLETE);
+
+		final CreateShipmentPolicy resolved = service.resolveCreateShipmentPolicy(CUSTOMER_ID, CreateShipmentPolicy.CREATE_COMPLETE_CLOSE);
+
+		assertThat(resolved)
+				.as("an explicit override must win over the customer profile (the contract that makes the override parameter useful)")
+				.isEqualTo(CreateShipmentPolicy.CREATE_COMPLETE_CLOSE);
+	}
+}


### PR DESCRIPTION
## Summary

`PickingShipmentService.createShipmentForLUs` was passing `CreateShipmentPolicy.CREATE_COMPLETE_CLOSE` as the `createShipmentPolicyOverride` to `prepareShipmentCandidates`. Inside that helper, the override always wins over the customer-configured policy on `MobileUI_UserProfile_Picking.CreateShipmentPolicy` (the `CoalesceUtil.coalesceNotNull` picks the non-null override first), so every per-LU "OK and close LU" on mobile picking closed the shipment schedule — even on partial picks.

## Changes

- `PickingShipmentService.createShipmentForLUs` now passes `null` as the override → customer-configured `CreateShipmentPolicy` flows through. Customers who want auto-close on per-LU close keep `CREATE_COMPLETE_CLOSE`; those who want per-LU shipments without auto-close use `CREATE_AND_COMPLETE`.

- New `boolean waitForShipments` field threaded via `PickingShipmentCandidate`:
  - `createShipmentForLUs` (per-step close-LU) → `waitForShipments=true`. The shipment workpackage runs synchronously so `M_ShipmentSchedule.QtyDelivered` is current before control returns to the picker, preventing the next picking session from reading stale `QtyToDeliver`.
  - `createShipmentIfNeeded` (picking-job-complete) → `waitForShipments=false` (existing behavior preserved).

## Files

- `backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentCandidate.java`
- `backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/shipment/PickingShipmentService.java`