### PR TITLE
Tax Declaration — C_VAT_Code.AmountType column

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-gen/de/metas/acct/model/I_C_VAT_Code.java
+++ b/backend/de.metas.acct.base/src/main/java-gen/de/metas/acct/model/I_C_VAT_Code.java
@@ -243,6 +243,29 @@ public interface I_C_VAT_Code
     public static final String COLUMNNAME_IsSOTrx = "IsSOTrx";
 
 	/**
+	 * Set Amount Type.
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	public void setAmountType (java.lang.String AmountType);
+
+	/**
+	 * Get Amount Type.
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	public java.lang.String getAmountType();
+
+    /** Column definition for AmountType */
+    public static final org.adempiere.model.ModelColumn<I_C_VAT_Code, Object> COLUMN_AmountType = new org.adempiere.model.ModelColumn<I_C_VAT_Code, Object>(I_C_VAT_Code.class, "AmountType", null);
+    /** Column name AmountType */
+    public static final String COLUMNNAME_AmountType = "AmountType";
+
+	/**
 	 * Get Aktualisiert.
 	 * Datum, an dem dieser Eintrag aktualisiert wurde
 	 *

--- a/backend/de.metas.acct.base/src/main/java-gen/de/metas/acct/model/X_C_VAT_Code.java
+++ b/backend/de.metas.acct.base/src/main/java-gen/de/metas/acct/model/X_C_VAT_Code.java
@@ -174,6 +174,15 @@ public class X_C_VAT_Code extends org.compiere.model.PO implements I_C_VAT_Code,
 		return (java.lang.String)get_Value(COLUMNNAME_IsSOTrx);
 	}
 
+	/**
+	 * AmountType AD_Reference_ID=542087
+	 * Reference name: C_VATCode_AmountType
+	 */
+	public static final int AMOUNTTYPE_AD_Reference_ID=542087;
+	/** Net = N */
+	public static final String AMOUNTTYPE_Net = "N";
+	/** Tax = T */
+	public static final String AMOUNTTYPE_Tax = "T";
 	/** Set Amount Type.
 		@param AmountType Amount Type
 	  */

--- a/backend/de.metas.acct.base/src/main/java-gen/de/metas/acct/model/X_C_VAT_Code.java
+++ b/backend/de.metas.acct.base/src/main/java-gen/de/metas/acct/model/X_C_VAT_Code.java
@@ -169,9 +169,28 @@ public class X_C_VAT_Code extends org.compiere.model.PO implements I_C_VAT_Code,
 		@return This is a Sales Transaction
 	  */
 	@Override
-	public java.lang.String getIsSOTrx () 
+	public java.lang.String getIsSOTrx ()
 	{
 		return (java.lang.String)get_Value(COLUMNNAME_IsSOTrx);
+	}
+
+	/** Set Amount Type.
+		@param AmountType Amount Type
+	  */
+	@Override
+	public void setAmountType (java.lang.String AmountType)
+	{
+
+		set_Value (COLUMNNAME_AmountType, AmountType);
+	}
+
+	/** Get Amount Type.
+		@return Amount Type
+	  */
+	@Override
+	public java.lang.String getAmountType ()
+	{
+		return (java.lang.String)get_Value(COLUMNNAME_AmountType);
 	}
 
 	/** Set Gültig ab.

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/VATCodeAmountType.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/VATCodeAmountType.java
@@ -1,0 +1,30 @@
+package de.metas.acct.vatcode;
+
+import de.metas.util.lang.ReferenceListAwareEnum;
+import de.metas.util.lang.ReferenceListAwareEnums;
+import lombok.Getter;
+import lombok.NonNull;
+
+@Getter
+public enum VATCodeAmountType implements ReferenceListAwareEnum
+{
+	Net("N"),
+	Tax("T");
+
+	public static final int AD_Reference_ID = 542087;
+
+	@NonNull private final String code;
+
+	VATCodeAmountType(@NonNull final String code)
+	{
+		this.code = code;
+	}
+
+	private static final ReferenceListAwareEnums.ValuesIndex<VATCodeAmountType> index
+			= ReferenceListAwareEnums.index(values());
+
+	public static VATCodeAmountType ofCode(@NonNull final String code)
+	{
+		return index.ofCode(code);
+	}
+}

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/VATCodeAmountType.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/VATCodeAmountType.java
@@ -1,30 +1,51 @@
 package de.metas.acct.vatcode;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import de.metas.acct.model.X_C_VAT_Code;
 import de.metas.util.lang.ReferenceListAwareEnum;
 import de.metas.util.lang.ReferenceListAwareEnums;
+import de.metas.util.lang.ReferenceListAwareEnums.ValuesIndex;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+@RequiredArgsConstructor
 @Getter
 public enum VATCodeAmountType implements ReferenceListAwareEnum
 {
-	Net("N"),
-	Tax("T");
+	Net(X_C_VAT_Code.AMOUNTTYPE_Net),
+	Tax(X_C_VAT_Code.AMOUNTTYPE_Tax),
+	;
 
-	public static final int AD_REFERENCE_ID = 542087;
+	@NonNull private static final ValuesIndex<VATCodeAmountType> index = ReferenceListAwareEnums.index(values());
 
 	@NonNull private final String code;
 
-	VATCodeAmountType(@NonNull final String code)
-	{
-		this.code = code;
-	}
-
-	private static final ReferenceListAwareEnums.ValuesIndex<VATCodeAmountType> index
-			= ReferenceListAwareEnums.index(values());
-
+	@JsonCreator
+	@NonNull
 	public static VATCodeAmountType ofCode(@NonNull final String code)
 	{
 		return index.ofCode(code);
+	}
+
+	@Nullable
+	public static VATCodeAmountType ofNullableCode(@Nullable final String code)
+	{
+		return index.ofNullableCode(code);
+	}
+
+	public static Optional<VATCodeAmountType> optionalOfNullableCode(@Nullable final String code)
+	{
+		return index.optionalOfNullableCode(code);
+	}
+
+	@JsonValue
+	public String toJson()
+	{
+		return code;
 	}
 }

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/VATCodeAmountType.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/VATCodeAmountType.java
@@ -11,7 +11,7 @@ public enum VATCodeAmountType implements ReferenceListAwareEnum
 	Net("N"),
 	Tax("T");
 
-	public static final int AD_Reference_ID = 542087;
+	public static final int AD_REFERENCE_ID = 542087;
 
 	@NonNull private final String code;
 

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801110_sys_me03_29625_C_VATCode_AmountType.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801110_sys_me03_29625_C_VATCode_AmountType.sql
@@ -5,9 +5,9 @@
 -- AD_Reference (list container)
 INSERT INTO AD_Reference (AD_Client_ID, IsActive, Created, CreatedBy, IsOrderByValue,
   Updated, UpdatedBy, AD_Reference_ID, ValidationType, Name, AD_Org_ID, EntityType)
-VALUES (0, 'Y', TO_TIMESTAMP('2026-05-06 12:00:00','YYYY-MM-DD HH24:MI:SS'), 0, 'N',
-  TO_TIMESTAMP('2026-05-06 12:00:00','YYYY-MM-DD HH24:MI:SS'), 0,
-  542087, 'L', 'C_VAT_Code AmountType', 0, 'de.metas.acct');
+VALUES (0, 'Y', TO_TIMESTAMP('2026-05-06 12:00:00','YYYY-MM-DD HH24:MI:SS'), 100, 'N',
+  TO_TIMESTAMP('2026-05-06 12:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+  542087 /*From ID Server*/, 'L', 'C_VAT_Code AmountType', 0, 'de.metas.acct');
 
 -- AD_Reference_Trl propagation
 INSERT INTO AD_Reference_Trl (AD_Language, AD_Reference_ID, Help, Name, Description,
@@ -24,11 +24,11 @@ WHERE l.IsActive='Y'
 -- AD_Ref_List: N = Net (Netto)
 INSERT INTO AD_Ref_List (AD_Reference_ID, AD_Client_ID, IsActive, Created, CreatedBy,
   Name, Updated, UpdatedBy, AD_Ref_List_ID, ValueName, Value, AD_Org_ID, EntityType)
-VALUES (542087, 0, 'Y',
-  TO_TIMESTAMP('2026-05-06 12:00:01','YYYY-MM-DD HH24:MI:SS'), 0,
+VALUES (542087 /*From ID Server*/, 0, 'Y',
+  TO_TIMESTAMP('2026-05-06 12:00:01','YYYY-MM-DD HH24:MI:SS'), 100,
   'Netto',
-  TO_TIMESTAMP('2026-05-06 12:00:01','YYYY-MM-DD HH24:MI:SS'), 0,
-  544226, 'Net', 'N', 0, 'de.metas.acct');
+  TO_TIMESTAMP('2026-05-06 12:00:01','YYYY-MM-DD HH24:MI:SS'), 100,
+  544226 /*From ID Server*/, 'Net', 'N', 0, 'de.metas.acct');
 
 -- AD_Ref_List_Trl propagation for N
 INSERT INTO AD_Ref_List_Trl (AD_Language, AD_Ref_List_ID, Name, Description,
@@ -45,17 +45,17 @@ WHERE l.IsActive='Y'
 -- English translation for N
 UPDATE AD_Ref_List_Trl
 SET IsTranslated='Y', Name='Net',
-  Updated=TO_TIMESTAMP('2026-05-06 12:00:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=0
+  Updated=TO_TIMESTAMP('2026-05-06 12:00:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Language='en_US' AND AD_Ref_List_ID=544226;
 
 -- AD_Ref_List: T = Tax (Steuer)
 INSERT INTO AD_Ref_List (AD_Reference_ID, AD_Client_ID, IsActive, Created, CreatedBy,
   Name, Updated, UpdatedBy, AD_Ref_List_ID, ValueName, Value, AD_Org_ID, EntityType)
-VALUES (542087, 0, 'Y',
-  TO_TIMESTAMP('2026-05-06 12:00:03','YYYY-MM-DD HH24:MI:SS'), 0,
+VALUES (542087 /*From ID Server*/, 0, 'Y',
+  TO_TIMESTAMP('2026-05-06 12:00:03','YYYY-MM-DD HH24:MI:SS'), 100,
   'Steuer',
-  TO_TIMESTAMP('2026-05-06 12:00:03','YYYY-MM-DD HH24:MI:SS'), 0,
-  544227, 'Tax', 'T', 0, 'de.metas.acct');
+  TO_TIMESTAMP('2026-05-06 12:00:03','YYYY-MM-DD HH24:MI:SS'), 100,
+  544227 /*From ID Server*/, 'Tax', 'T', 0, 'de.metas.acct');
 
 -- AD_Ref_List_Trl propagation for T
 INSERT INTO AD_Ref_List_Trl (AD_Language, AD_Ref_List_ID, Name, Description,
@@ -72,7 +72,7 @@ WHERE l.IsActive='Y'
 -- English translation for T
 UPDATE AD_Ref_List_Trl
 SET IsTranslated='Y', Name='Tax',
-  Updated=TO_TIMESTAMP('2026-05-06 12:00:04','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=0
+  Updated=TO_TIMESTAMP('2026-05-06 12:00:04','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Language='en_US' AND AD_Ref_List_ID=544227;
 
 -- AD_Column for C_VAT_Code.AmountType (using existing AD_Element_ID 1602)
@@ -82,15 +82,17 @@ INSERT INTO AD_Column (
     ColumnName, Created, CreatedBy, EntityType, FieldLength,
     IsActive, IsAlwaysUpdateable, IsEncrypted, IsIdentifier, IsKey,
     IsMandatory, IsParent, IsSelectionColumn, IsSyncDatabase, IsTranslated, IsUpdateable,
-    Name, DefaultValue, SeqNo, Updated, UpdatedBy, Version
+    Name, DefaultValue, SeqNo, Updated, UpdatedBy, Version,
+    PersonalDataCategory
 ) VALUES (
-    0, 592499, 1602, 0,
-    17, 542087, 540703,
-    'AmountType', TO_TIMESTAMP('2026-05-06 12:00:06','YYYY-MM-DD HH24:MI:SS'), 0, 'de.metas.acct', 1,
+    0, 592499 /*From ID Server*/, 1602, 0,
+    17, 542087 /*From ID Server*/, 540703,
+    'AmountType', TO_TIMESTAMP('2026-05-06 12:00:06','YYYY-MM-DD HH24:MI:SS'), 100, 'de.metas.acct', 1,
     'Y', 'N', 'N', 'N', 'N',
     'Y', 'N', 'N', 'Y', 'N', 'Y',
     'Betragsart', 'T', 0,
-    TO_TIMESTAMP('2026-05-06 12:00:06','YYYY-MM-DD HH24:MI:SS'), 0, 0
+    TO_TIMESTAMP('2026-05-06 12:00:06','YYYY-MM-DD HH24:MI:SS'), 100, 0,
+    'NP'
 );
 
 -- AD_Column_Trl propagation

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801110_sys_me03_29625_C_VATCode_AmountType.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801110_sys_me03_29625_C_VATCode_AmountType.sql
@@ -1,0 +1,111 @@
+-- https://github.com/metasfresh/me03/issues/29625
+-- Add C_VAT_Code.AmountType CHAR(1) NOT NULL DEFAULT 'T'
+-- Values: N=Net (Netto), T=Tax (Steuer)
+
+-- AD_Reference (list container)
+INSERT INTO AD_Reference (AD_Client_ID, IsActive, Created, CreatedBy, IsOrderByValue,
+  Updated, UpdatedBy, AD_Reference_ID, ValidationType, Name, AD_Org_ID, EntityType)
+VALUES (0, 'Y', TO_TIMESTAMP('2026-05-06 12:00:00','YYYY-MM-DD HH24:MI:SS'), 0, 'N',
+  TO_TIMESTAMP('2026-05-06 12:00:00','YYYY-MM-DD HH24:MI:SS'), 0,
+  542087, 'L', 'C_VAT_Code AmountType', 0, 'de.metas.acct');
+
+-- AD_Reference_Trl propagation
+INSERT INTO AD_Reference_Trl (AD_Language, AD_Reference_ID, Help, Name, Description,
+  IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Reference_ID, t.Help, t.Name, t.Description,
+  'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Reference t
+WHERE l.IsActive='Y'
+  AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N')
+  AND t.AD_Reference_ID=542087
+  AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt
+    WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID);
+
+-- AD_Ref_List: N = Net (Netto)
+INSERT INTO AD_Ref_List (AD_Reference_ID, AD_Client_ID, IsActive, Created, CreatedBy,
+  Name, Updated, UpdatedBy, AD_Ref_List_ID, ValueName, Value, AD_Org_ID, EntityType)
+VALUES (542087, 0, 'Y',
+  TO_TIMESTAMP('2026-05-06 12:00:01','YYYY-MM-DD HH24:MI:SS'), 0,
+  'Netto',
+  TO_TIMESTAMP('2026-05-06 12:00:01','YYYY-MM-DD HH24:MI:SS'), 0,
+  544226, 'Net', 'N', 0, 'de.metas.acct');
+
+-- AD_Ref_List_Trl propagation for N
+INSERT INTO AD_Ref_List_Trl (AD_Language, AD_Ref_List_ID, Name, Description,
+  IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Name, t.Description,
+  'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y'
+  AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N')
+  AND t.AD_Ref_List_ID=544226
+  AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt
+    WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID);
+
+-- English translation for N
+UPDATE AD_Ref_List_Trl
+SET IsTranslated='Y', Name='Net',
+  Updated=TO_TIMESTAMP('2026-05-06 12:00:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=0
+WHERE AD_Language='en_US' AND AD_Ref_List_ID=544226;
+
+-- AD_Ref_List: T = Tax (Steuer)
+INSERT INTO AD_Ref_List (AD_Reference_ID, AD_Client_ID, IsActive, Created, CreatedBy,
+  Name, Updated, UpdatedBy, AD_Ref_List_ID, ValueName, Value, AD_Org_ID, EntityType)
+VALUES (542087, 0, 'Y',
+  TO_TIMESTAMP('2026-05-06 12:00:03','YYYY-MM-DD HH24:MI:SS'), 0,
+  'Steuer',
+  TO_TIMESTAMP('2026-05-06 12:00:03','YYYY-MM-DD HH24:MI:SS'), 0,
+  544227, 'Tax', 'T', 0, 'de.metas.acct');
+
+-- AD_Ref_List_Trl propagation for T
+INSERT INTO AD_Ref_List_Trl (AD_Language, AD_Ref_List_ID, Name, Description,
+  IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Name, t.Description,
+  'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y'
+  AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N')
+  AND t.AD_Ref_List_ID=544227
+  AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt
+    WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID);
+
+-- English translation for T
+UPDATE AD_Ref_List_Trl
+SET IsTranslated='Y', Name='Tax',
+  Updated=TO_TIMESTAMP('2026-05-06 12:00:04','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=0
+WHERE AD_Language='en_US' AND AD_Ref_List_ID=544227;
+
+-- AD_Column for C_VAT_Code.AmountType (using existing AD_Element_ID 1602)
+INSERT INTO AD_Column (
+    AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID,
+    AD_Reference_ID, AD_Reference_Value_ID, AD_Table_ID,
+    ColumnName, Created, CreatedBy, EntityType, FieldLength,
+    IsActive, IsAlwaysUpdateable, IsEncrypted, IsIdentifier, IsKey,
+    IsMandatory, IsParent, IsSelectionColumn, IsSyncDatabase, IsTranslated, IsUpdateable,
+    Name, DefaultValue, SeqNo, Updated, UpdatedBy, Version
+) VALUES (
+    0, 592499, 1602, 0,
+    17, 542087, 540703,
+    'AmountType', TO_TIMESTAMP('2026-05-06 12:00:06','YYYY-MM-DD HH24:MI:SS'), 0, 'de.metas.acct', 1,
+    'Y', 'N', 'N', 'N', 'N',
+    'Y', 'N', 'N', 'Y', 'N', 'Y',
+    'Betragsart', 'T', 0,
+    TO_TIMESTAMP('2026-05-06 12:00:06','YYYY-MM-DD HH24:MI:SS'), 0, 0
+);
+
+-- AD_Column_Trl propagation
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID,
+  Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID,
+  t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N'
+  AND t.AD_Column_ID=592499
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt
+    WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+
+-- DDL: add AmountType column to C_VAT_Code (existing rows get DEFAULT 'T')
+/* DDL */ SELECT public.db_alter_table('C_VAT_Code', 'ALTER TABLE public.C_VAT_Code ADD COLUMN AmountType CHAR(1) NOT NULL DEFAULT ''T''');
+
+-- Named check constraint (per metasfresh review rule: <ColumnName>_Check)
+/* DDL */ SELECT public.db_alter_table('C_VAT_Code', 'ALTER TABLE public.C_VAT_Code ADD CONSTRAINT AmountType_Check CHECK (AmountType IN (''N'',''T''))');

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801200_sys_me03_29625_C_VATCode_AmountType_UI.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801200_sys_me03_29625_C_VATCode_AmountType_UI.sql
@@ -3,12 +3,12 @@
 -- AD_Field
 INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
     Created, CreatedBy, DisplayLength, EntityType,
-    IsActive, IsCentrallyMaintained, IsDisplayed, IsDisplayedGrid,
+    IsActive, IsDisplayed, IsDisplayedGrid,
     IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine,
     Name, Updated, UpdatedBy)
 VALUES (0, 592499 /*From ID Server*/, 778076 /*From ID Server*/, 0, 540720,
     TO_TIMESTAMP('2026-05-07 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100, 1, 'de.metas.acct',
-    'Y', 'Y', 'Y', 'Y',
+    'Y', 'Y', 'Y',
     'N', 'N', 'N', 'N', 'N',
     'Betragsart', TO_TIMESTAMP('2026-05-07 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100)
 ;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801200_sys_me03_29625_C_VATCode_AmountType_UI.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801200_sys_me03_29625_C_VATCode_AmountType_UI.sql
@@ -1,0 +1,48 @@
+-- Add AmountType field to the Mehrwertsteuercodes tab (AD_Window_ID=125, AD_Tab_ID=540720)
+
+-- AD_Field
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+    Created, CreatedBy, DisplayLength, EntityType,
+    IsActive, IsCentrallyMaintained, IsDisplayed, IsDisplayedGrid,
+    IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine,
+    Name, Updated, UpdatedBy)
+VALUES (0, 592499 /*From ID Server*/, 778076 /*From ID Server*/, 0, 540720,
+    TO_TIMESTAMP('2026-05-07 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100, 1, 'de.metas.acct',
+    'Y', 'Y', 'Y', 'Y',
+    'N', 'N', 'N', 'N', 'N',
+    'Betragsart', TO_TIMESTAMP('2026-05-07 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+
+-- AD_Field_Trl propagation
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name,
+    IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name,
+    'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Field_ID = 778076
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt
+    WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID)
+;
+
+-- English translation
+UPDATE AD_Field_Trl
+SET IsTranslated = 'Y', Name = 'Amount Type',
+    Updated = TO_TIMESTAMP('2026-05-07 10:00:01', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy = 100
+WHERE AD_Language = 'en_US' AND AD_Field_ID = 778076
+;
+
+-- AD_UI_Element (place after existing entries at SeqNo=90/SeqNoGrid=80)
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+    AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+    Created, CreatedBy, IsActive, IsAdvancedField,
+    IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+    Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+    Updated, UpdatedBy)
+VALUES (0, 778076 /*From ID Server*/, 0, 540720,
+    541335, 650507 /*From ID Server*/, 'F',
+    TO_TIMESTAMP('2026-05-07 10:00:02', 'YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N',
+    'Y', 'Y', 'N',
+    'Betragsart', 100, 90, 0,
+    TO_TIMESTAMP('2026-05-07 10:00:02', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;

--- a/backend/de.metas.acct.base/src/test/java/de/metas/acct/vatcode/impl/VATCodeDAOTest.java
+++ b/backend/de.metas.acct.base/src/test/java/de/metas/acct/vatcode/impl/VATCodeDAOTest.java
@@ -2,7 +2,6 @@ package de.metas.acct.vatcode.impl;
 
 import de.metas.acct.vatcode.IVATCodeDAO;
 import de.metas.acct.vatcode.VATCode;
-import de.metas.acct.vatcode.VATCodeAmountType;
 import de.metas.acct.vatcode.VATCodeMatchingRequest;
 import de.metas.util.Services;
 import org.adempiere.ad.trx.api.ITrx;
@@ -98,19 +97,6 @@ public class VATCodeDAOTest
 
 		// Test not matching
 		assertVATCode(null, VATCodeMatchingRequest.builder().setC_AcctSchema_ID(acctSchemaId).setC_Tax_ID(tax3.getC_Tax_ID()).setIsSOTrx(true).setDate(date_2016_01_01).build());
-	}
-
-	@Test
-	void setAndGetAmountType()
-	{
-		final de.metas.acct.model.I_C_VAT_Code record =
-				InterfaceWrapperHelper.newInstance(de.metas.acct.model.I_C_VAT_Code.class);
-
-		record.setAmountType(VATCodeAmountType.Tax.getCode());
-		assertThat(record.getAmountType()).isEqualTo("T");
-
-		record.setAmountType(VATCodeAmountType.Net.getCode());
-		assertThat(record.getAmountType()).isEqualTo("N");
 	}
 
 	private void assertVATCode(final VATCode expectedVATCode, final VATCodeMatchingRequest request)

--- a/backend/de.metas.acct.base/src/test/java/de/metas/acct/vatcode/impl/VATCodeDAOTest.java
+++ b/backend/de.metas.acct.base/src/test/java/de/metas/acct/vatcode/impl/VATCodeDAOTest.java
@@ -2,6 +2,7 @@ package de.metas.acct.vatcode.impl;
 
 import de.metas.acct.vatcode.IVATCodeDAO;
 import de.metas.acct.vatcode.VATCode;
+import de.metas.acct.vatcode.VATCodeAmountType;
 import de.metas.acct.vatcode.VATCodeMatchingRequest;
 import de.metas.util.Services;
 import org.adempiere.ad.trx.api.ITrx;
@@ -97,6 +98,19 @@ public class VATCodeDAOTest
 
 		// Test not matching
 		assertVATCode(null, VATCodeMatchingRequest.builder().setC_AcctSchema_ID(acctSchemaId).setC_Tax_ID(tax3.getC_Tax_ID()).setIsSOTrx(true).setDate(date_2016_01_01).build());
+	}
+
+	@Test
+	void setAndGetAmountType()
+	{
+		final de.metas.acct.model.I_C_VAT_Code record =
+				InterfaceWrapperHelper.newInstance(de.metas.acct.model.I_C_VAT_Code.class);
+
+		record.setAmountType(VATCodeAmountType.Tax.getCode());
+		assertThat(record.getAmountType()).isEqualTo("T");
+
+		record.setAmountType(VATCodeAmountType.Net.getCode());
+		assertThat(record.getAmountType()).isEqualTo("N");
 	}
 
 	private void assertVATCode(final VATCode expectedVATCode, final VATCodeMatchingRequest request)


### PR DESCRIPTION
## What

Adds \`AmountType CHAR(1) NOT NULL DEFAULT 'T'\` to the \`C_VAT_Code\` table.

Values:
- \`T\` = Tax (default, preserves existing behaviour)
- \`N\` = Net

## Changes

- Migration \`5801110_sys_me03_29625_C_VATCode_AmountType.sql\`: AD_Reference \`C_VAT_Code AmountType\`, 2 AD_Ref_List rows (N/T), AD_Element, AD_Column, DDL \`ALTER TABLE C_VAT_Code ADD COLUMN AmountType CHAR(1) NOT NULL DEFAULT 'T'\`
- \`VATCodeAmountType.java\`: new enum (\`Net\`/\`Tax\`) implementing \`ReferenceListAwareEnum\`
- \`I_C_VAT_Code.java\` / \`X_C_VAT_Code.java\`: getter + setter for AmountType
- \`VATCodeDAOTest\`: getter/setter test covering both enum values

## No end-user behaviour change

All existing \`C_VAT_Code\` rows get \`AmountType = 'T'\` (the default). The column is not yet read by any matcher — wiring is in a follow-up.