### PR TITLE
Workstation / Workplace / Plant terminology cleanup (me03#29671)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5801060_sys_me03_29671_ManufacturingResourceType_Labels.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5801060_sys_me03_29671_ManufacturingResourceType_Labels.sql
@@ -1,0 +1,39 @@
+-- me03#29671: Normalize ManufacturingResourceType label terminology (EN + DE)
+-- Reference inventory: ai-work/29671/ad-label-inventory.md
+-- Terminology locked: ai-work/29671/terminology.md
+
+-- AD_Ref_List: ManufacturingResourceType=ES — set EN Name to "External System"
+-- 2026-05-06T10:15:00Z
+UPDATE AD_Ref_List SET Name='External System', Updated=TO_TIMESTAMP('2026-05-06 10:15:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=0 WHERE AD_Ref_List_ID=543704;
+
+-- AD_Ref_List: ManufacturingResourceType=PL — set EN Name to "Production Line"
+-- 2026-05-06T10:15:01Z
+UPDATE AD_Ref_List SET Name='Production Line', Updated=TO_TIMESTAMP('2026-05-06 10:15:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=0 WHERE AD_Ref_List_ID=53244;
+
+-- AD_Ref_List_Trl (de_DE) for PL — Linie → Produktionslinie
+-- 2026-05-06T10:15:02Z
+UPDATE AD_Ref_List_Trl SET Name='Produktionslinie', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-06 10:15:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=0 WHERE AD_Ref_List_ID=53244 AND AD_Language='de_DE';
+
+-- AD_Ref_List_Trl (de_CH) for PL — Linie → Produktionslinie
+-- 2026-05-06T10:15:03Z
+UPDATE AD_Ref_List_Trl SET Name='Produktionslinie', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-06 10:15:03','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=0 WHERE AD_Ref_List_ID=53244 AND AD_Language='de_CH';
+
+-- AD_Ref_List: ManufacturingResourceType=PT — set EN Name to "Plant"
+-- 2026-05-06T10:15:04Z
+UPDATE AD_Ref_List SET Name='Plant', Updated=TO_TIMESTAMP('2026-05-06 10:15:04','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=0 WHERE AD_Ref_List_ID=53245;
+
+-- AD_Ref_List: ManufacturingResourceType=WC — set EN Name to "Work Center"
+-- 2026-05-06T10:15:05Z
+UPDATE AD_Ref_List SET Name='Work Center', Updated=TO_TIMESTAMP('2026-05-06 10:15:05','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=0 WHERE AD_Ref_List_ID=53246;
+
+-- AD_Ref_List_Trl (de_DE) for WC — Abteilung → Arbeitsbereich
+-- 2026-05-06T10:15:06Z
+UPDATE AD_Ref_List_Trl SET Name='Arbeitsbereich', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-06 10:15:06','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=0 WHERE AD_Ref_List_ID=53246 AND AD_Language='de_DE';
+
+-- AD_Ref_List_Trl (de_CH) for WC — Abteilung → Arbeitsbereich
+-- 2026-05-06T10:15:07Z
+UPDATE AD_Ref_List_Trl SET Name='Arbeitsbereich', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-06 10:15:07','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=0 WHERE AD_Ref_List_ID=53246 AND AD_Language='de_CH';
+
+-- AD_Ref_List: ManufacturingResourceType=WS — set EN Name to "Workstation"
+-- 2026-05-06T10:15:08Z
+UPDATE AD_Ref_List SET Name='Workstation', Updated=TO_TIMESTAMP('2026-05-06 10:15:08','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=0 WHERE AD_Ref_List_ID=53247;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5801100_sys_me03_29671_IsScanResourceRequired_Workstation_Labels.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5801100_sys_me03_29671_IsScanResourceRequired_Workstation_Labels.sql
@@ -1,0 +1,73 @@
+-- me03#29671: rename "Arbeitsplatz-Scan erforderlich" → "Arbeitsstation-Scan erforderlich"
+-- and add German translations for PP_Workstation_UserAssign.
+--
+-- Background: The AD_Element 581714 (`IsScanResourceRequired`) flag drives the
+-- *workstation* (S_Resource type WS, "Arbeitsstation") scan dialog and the strict
+-- WorkStation_ID launcher filter — NOT the Arbeitsplatz / C_Workplace flow. The
+-- previous migration 5794900_sys_gh28943 set the German label to "Arbeitsplatz-Scan",
+-- which collided with the C_Workplace concept and confused configurators (root
+-- cause of part of me03#29671). The English en_US Trl is already correct
+-- ("Workstation Scan Required") and is left untouched.
+--
+-- Locked terminology source-of-truth: ai-work/29671/terminology.md
+--   Arbeitsstation = S_Resource type WS = Workstation (one word)
+--   Arbeitsplatz   = C_Workplace        = Workplace
+
+--
+-- Block 1: AD_Element 581714 IsScanResourceRequired — base + de_DE + de_CH
+--
+
+UPDATE AD_Element
+SET Name='Arbeitsstation-Scan erforderlich',
+    PrintName='Arbeitsstation-Scan erforderlich',
+    Description='Benutzer muss vor der Produktionsarbeit zuerst einen Arbeitsstation-QR-Code scannen. Es werden nur Aufträge der zugewiesenen Arbeitsstation angezeigt.',
+    Updated='2026-05-06 16:30',
+    UpdatedBy=100
+WHERE AD_Element_ID=581714;
+
+UPDATE AD_Element_Trl
+SET Name='Arbeitsstation-Scan erforderlich',
+    PrintName='Arbeitsstation-Scan erforderlich',
+    Description='Benutzer muss vor der Produktionsarbeit zuerst einen Arbeitsstation-QR-Code scannen. Es werden nur Aufträge der zugewiesenen Arbeitsstation angezeigt.',
+    IsTranslated='Y',
+    Updated='2026-05-06 16:30',
+    UpdatedBy=100
+WHERE AD_Element_ID=581714 AND AD_Language='de_DE';
+
+UPDATE AD_Element_Trl
+SET Name='Arbeitsstation-Scan erforderlich',
+    PrintName='Arbeitsstation-Scan erforderlich',
+    Description='Benutzer muss vor der Produktionsarbeit zuerst einen Arbeitsstation-QR-Code scannen. Es werden nur Aufträge der zugewiesenen Arbeitsstation angezeigt.',
+    IsTranslated='Y',
+    Updated='2026-05-06 16:30',
+    UpdatedBy=100
+WHERE AD_Element_ID=581714 AND AD_Language='de_CH';
+
+-- Propagate to AD_Column / AD_Field / AD_Tab / AD_Window via the standard helpers.
+SELECT update_Column_Translation_From_AD_Element(581714);
+SELECT update_FieldTranslation_From_AD_Name_Element(581714);
+
+--
+-- Block 2: AD_Element 583021 PP_Workstation_UserAssign_ID — add missing German
+-- translations. Currently all four languages still hold the English fallback
+-- "Workstation User Assignment". en_US/fr_CH stay as-is; only DE is filled.
+--
+
+UPDATE AD_Element_Trl
+SET Name='Arbeitsstation-Benutzerzuweisung',
+    PrintName='Arbeitsstation-Benutzerzuweisung',
+    IsTranslated='Y',
+    Updated='2026-05-06 16:30',
+    UpdatedBy=100
+WHERE AD_Element_ID=583021 AND AD_Language='de_DE';
+
+UPDATE AD_Element_Trl
+SET Name='Arbeitsstation-Benutzerzuweisung',
+    PrintName='Arbeitsstation-Benutzerzuweisung',
+    IsTranslated='Y',
+    Updated='2026-05-06 16:30',
+    UpdatedBy=100
+WHERE AD_Element_ID=583021 AND AD_Language='de_CH';
+
+SELECT update_Column_Translation_From_AD_Element(583021);
+SELECT update_FieldTranslation_From_AD_Name_Element(583021);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5801120_sys_me03_29671_Workstation_Workplace_Plant_Descriptions.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5801120_sys_me03_29671_Workstation_Workplace_Plant_Descriptions.sql
@@ -1,0 +1,223 @@
+-- me03#29671: add (or rewrite) descriptions on Workstation / Workplace / Plant /
+-- Resource elements + the 5 ManufacturingResourceType list values, so configurers
+-- get a useful tooltip in the WebUI without having to consult mf15-documentation
+-- issue #113.
+--
+-- Locked terminology source-of-truth: ai-work/29671/terminology.md
+-- Companion mf15-doc: https://github.com/metasfresh/mf15-documentation/issues/113
+--
+-- Pattern: for each AD_Element, set Description on the base + de_DE/de_CH/en_US
+-- Trls (IsTranslated='Y' so the Trls don't fall back to base), then call the
+-- standard helper to propagate to AD_Column / AD_Field. AD_Ref_List values are
+-- updated directly (no helper function for them).
+
+--
+-- 1. IsManufacturingResource (AD_Element 53232) — flag on S_Resource
+--
+
+UPDATE AD_Element
+SET Description='Markiert die Ressource als für die Produktion relevant. Nur entsprechend markierte S_Resource-Datensätze erscheinen in den Produktionsmodul-Auswahllisten und können vom Mobile-UI als Arbeitsstation gescannt werden.',
+    Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=53232;
+
+UPDATE AD_Element_Trl
+SET Description='Markiert die Ressource als für die Produktion relevant. Nur entsprechend markierte S_Resource-Datensätze erscheinen in den Produktionsmodul-Auswahllisten und können vom Mobile-UI als Arbeitsstation gescannt werden.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=53232 AND AD_Language='de_DE';
+
+UPDATE AD_Element_Trl
+SET Description='Markiert die Ressource als für die Produktion relevant. Nur entsprechend markierte S_Resource-Datensätze erscheinen in den Produktionsmodul-Auswahllisten und können vom Mobile-UI als Arbeitsstation gescannt werden.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=53232 AND AD_Language='de_CH';
+
+UPDATE AD_Element_Trl
+SET Description='Marks the resource as relevant for manufacturing. Only S_Resource records flagged accordingly appear in the manufacturing module''s selection lists and can be scanned as a Workstation in MobileUI.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=53232 AND AD_Language='en_US';
+
+SELECT update_Column_Translation_From_AD_Element(53232);
+SELECT update_FieldTranslation_From_AD_Name_Element(53232);
+
+--
+-- 2. ManufacturingResourceType (AD_Element 53233) — type discriminator
+--
+
+UPDATE AD_Element
+SET Description='Art der Produktions-Ressource: Arbeitsstation (physisches scanbares Gerät), Arbeitsbereich (Aggregat innerhalb einer Produktionsstätte), Produktionsstätte (Werk), Produktionslinie oder Externes System.',
+    Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=53233;
+
+UPDATE AD_Element_Trl
+SET Description='Art der Produktions-Ressource: Arbeitsstation (physisches scanbares Gerät), Arbeitsbereich (Aggregat innerhalb einer Produktionsstätte), Produktionsstätte (Werk), Produktionslinie oder Externes System.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=53233 AND AD_Language='de_DE';
+
+UPDATE AD_Element_Trl
+SET Description='Art der Produktions-Ressource: Arbeitsstation (physisches scanbares Gerät), Arbeitsbereich (Aggregat innerhalb einer Produktionsstätte), Produktionsstätte (Werk), Produktionslinie oder Externes System.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=53233 AND AD_Language='de_CH';
+
+UPDATE AD_Element_Trl
+SET Description='Type of manufacturing resource: Workstation (physical scannable device), Work Center (aggregate within a Plant), Plant (manufacturing site), Production Line, or External System.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=53233 AND AD_Language='en_US';
+
+SELECT update_Column_Translation_From_AD_Element(53233);
+SELECT update_FieldTranslation_From_AD_Name_Element(53233);
+
+--
+-- 3. WorkStation_ID (AD_Element 583018) — FK to S_Resource type WS used on PP_Order
+--
+
+UPDATE AD_Element
+SET Description='Die Arbeitsstation, an der dieser Produktionsauftrag bearbeitet werden soll. In der MobileUI-Produktion erscheinen nur Aufträge, deren Arbeitsstation der vom Bediener gescannten entspricht.',
+    Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=583018;
+
+UPDATE AD_Element_Trl
+SET Description='Die Arbeitsstation, an der dieser Produktionsauftrag bearbeitet werden soll. In der MobileUI-Produktion erscheinen nur Aufträge, deren Arbeitsstation der vom Bediener gescannten entspricht.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=583018 AND AD_Language='de_DE';
+
+UPDATE AD_Element_Trl
+SET Description='Die Arbeitsstation, an der dieser Produktionsauftrag bearbeitet werden soll. In der MobileUI-Produktion erscheinen nur Aufträge, deren Arbeitsstation der vom Bediener gescannten entspricht.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=583018 AND AD_Language='de_CH';
+
+UPDATE AD_Element_Trl
+SET Description='The Workstation at which this manufacturing order is to be processed. In MobileUI Manufacturing, only orders whose Workstation matches the one scanned by the operator are shown.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=583018 AND AD_Language='en_US';
+
+SELECT update_Column_Translation_From_AD_Element(583018);
+SELECT update_FieldTranslation_From_AD_Name_Element(583018);
+
+--
+-- 4. PP_Workstation_UserAssign_ID (AD_Element 583021) — user↔workstation assignment
+--
+
+UPDATE AD_Element
+SET Description='Aktive Zuordnung eines Benutzers zu einer Arbeitsstation. Wird beim Scannen einer Arbeitsstation in der MobileUI-Produktion gesetzt und steuert anschließend, welche Aufträge dem Benutzer angezeigt werden.',
+    Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=583021;
+
+UPDATE AD_Element_Trl
+SET Description='Aktive Zuordnung eines Benutzers zu einer Arbeitsstation. Wird beim Scannen einer Arbeitsstation in der MobileUI-Produktion gesetzt und steuert anschließend, welche Aufträge dem Benutzer angezeigt werden.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=583021 AND AD_Language='de_DE';
+
+UPDATE AD_Element_Trl
+SET Description='Aktive Zuordnung eines Benutzers zu einer Arbeitsstation. Wird beim Scannen einer Arbeitsstation in der MobileUI-Produktion gesetzt und steuert anschließend, welche Aufträge dem Benutzer angezeigt werden.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=583021 AND AD_Language='de_CH';
+
+UPDATE AD_Element_Trl
+SET Description='Active assignment of a user to a Workstation. Created when the user scans a Workstation in MobileUI Manufacturing and afterwards drives which orders are shown to the user.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=583021 AND AD_Language='en_US';
+
+SELECT update_Column_Translation_From_AD_Element(583021);
+SELECT update_FieldTranslation_From_AD_Name_Element(583021);
+
+--
+-- 5. C_Workplace_ID (AD_Element 582772) — REWRITE the misleading existing description
+--
+
+UPDATE AD_Element
+SET Description='Logischer Bereich in einem Lager, dem eine oder mehrere Arbeitsstationen zugeordnet sein können. Ein Bediener meldet sich pro Schicht an genau einem Arbeitsplatz an. Über das zugehörige Lager (M_Warehouse_ID) wird der Lagerort der dort verrichteten Arbeit bestimmt.',
+    Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=582772;
+
+UPDATE AD_Element_Trl
+SET Description='Logischer Bereich in einem Lager, dem eine oder mehrere Arbeitsstationen zugeordnet sein können. Ein Bediener meldet sich pro Schicht an genau einem Arbeitsplatz an. Über das zugehörige Lager (M_Warehouse_ID) wird der Lagerort der dort verrichteten Arbeit bestimmt.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=582772 AND AD_Language='de_DE';
+
+UPDATE AD_Element_Trl
+SET Description='Logischer Bereich in einem Lager, dem eine oder mehrere Arbeitsstationen zugeordnet sein können. Ein Bediener meldet sich pro Schicht an genau einem Arbeitsplatz an. Über das zugehörige Lager (M_Warehouse_ID) wird der Lagerort der dort verrichteten Arbeit bestimmt.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=582772 AND AD_Language='de_CH';
+
+UPDATE AD_Element_Trl
+SET Description='Logical area within a warehouse, to which one or more Workstations can be assigned. An operator logs into exactly one Workplace per shift. The associated warehouse (M_Warehouse_ID) drives the storage location of the work performed there.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Element_ID=582772 AND AD_Language='en_US';
+
+SELECT update_Column_Translation_From_AD_Element(582772);
+SELECT update_FieldTranslation_From_AD_Name_Element(582772);
+
+--
+-- 6. AD_Ref_List values for ManufacturingResourceType (AD_Reference 53223)
+--    — descriptions per value, in EN base + de_DE/de_CH Trls.
+--    No helper function for AD_Ref_List; direct UPDATE only.
+--
+
+-- ES (AD_Ref_List 543704) -- External System
+UPDATE AD_Ref_List
+SET Description='External System: External system integration (e.g. Shopware, Alberta, external controller). Configured via ExternalSystem_Config_ID.',
+    Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=543704;
+UPDATE AD_Ref_List_Trl
+SET Description='Externes System: Integration eines externen Systems (z. B. Shopware, Alberta, externe Steuerung). Wird über ExternalSystem_Config_ID konfiguriert.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=543704 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl
+SET Description='Externes System: Integration eines externen Systems (z. B. Shopware, Alberta, externe Steuerung). Wird über ExternalSystem_Config_ID konfiguriert.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=543704 AND AD_Language='de_CH';
+
+-- PL (AD_Ref_List 53244) -- Production Line
+UPDATE AD_Ref_List
+SET Description='Production Line: Production line within a Work Center.',
+    Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53244;
+UPDATE AD_Ref_List_Trl
+SET Description='Produktionslinie: Produktionslinie innerhalb eines Arbeitsbereichs.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53244 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl
+SET Description='Produktionslinie: Produktionslinie innerhalb eines Arbeitsbereichs.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53244 AND AD_Language='de_CH';
+
+-- PT (AD_Ref_List 53245) -- Plant
+UPDATE AD_Ref_List
+SET Description='Plant: Manufacturing site. PP_Order.S_Resource_ID points at a Plant.',
+    Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53245;
+UPDATE AD_Ref_List_Trl
+SET Description='Produktionsstätte: Standort der Fertigung. PP_Order.S_Resource_ID verweist auf eine Produktionsstätte.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53245 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl
+SET Description='Produktionsstätte: Standort der Fertigung. PP_Order.S_Resource_ID verweist auf eine Produktionsstätte.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53245 AND AD_Language='de_CH';
+
+-- WC (AD_Ref_List 53246) -- Work Center
+UPDATE AD_Ref_List
+SET Description='Work Center: Aggregate or department within a Plant. Groups multiple Workstations under one logical unit.',
+    Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53246;
+UPDATE AD_Ref_List_Trl
+SET Description='Arbeitsbereich: Aggregat oder Abteilung innerhalb einer Produktionsstätte. Fasst mehrere Arbeitsstationen zu einer logischen Einheit zusammen.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53246 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl
+SET Description='Arbeitsbereich: Aggregat oder Abteilung innerhalb einer Produktionsstätte. Fasst mehrere Arbeitsstationen zu einer logischen Einheit zusammen.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53246 AND AD_Language='de_CH';
+
+-- WS (AD_Ref_List 53247) -- Workstation
+UPDATE AD_Ref_List
+SET Description='Workstation: Physical scannable device within a Workplace (printer, scale, machine). Operators identify themselves by scanning the Workstation''s QR code.',
+    Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53247;
+UPDATE AD_Ref_List_Trl
+SET Description='Arbeitsstation: Physisches scanbares Gerät innerhalb eines Arbeitsplatzes (Drucker, Waage, Maschine). Bediener identifizieren sich durch Scannen des Arbeitsstation-QR-Codes.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53247 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl
+SET Description='Arbeitsstation: Physisches scanbares Gerät innerhalb eines Arbeitsplatzes (Drucker, Waage, Maschine). Bediener identifizieren sich durch Scannen des Arbeitsstation-QR-Codes.',
+    IsTranslated='Y', Updated='2026-05-06 17:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53247 AND AD_Language='de_CH';

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5801130_sys_me03_29671_Backfill_ManufacturingResourceType_de_DE_Trl.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5801130_sys_me03_29671_Backfill_ManufacturingResourceType_de_DE_Trl.sql
@@ -1,0 +1,45 @@
+-- me03#29671 follow-up to 5801120: AD_Ref_List values PL, PT, WC, WS for
+-- AD_Reference 53223 (ManufacturingResourceType) had no de_DE translation row,
+-- so the de_DE description UPDATEs in 5801120 were silent no-ops. ES already
+-- had a de_DE row, so its description landed.
+--
+-- Fix: call add_missing_translations() to backfill any missing _Trl rows across
+-- the database, then re-apply the de_DE description UPDATEs for the four codes.
+
+SELECT add_missing_translations();
+
+-- PL (AD_Ref_List 53244) -- Produktionslinie
+UPDATE AD_Ref_List_Trl
+SET Description='Produktionslinie: Produktionslinie innerhalb eines Arbeitsbereichs.',
+    IsTranslated='Y', Updated='2026-05-06 17:30', UpdatedBy=100
+WHERE AD_Ref_List_ID=53244 AND AD_Language='de_DE';
+
+-- PT (AD_Ref_List 53245) -- Produktionsstätte
+UPDATE AD_Ref_List_Trl
+SET Description='Produktionsstätte: Standort der Fertigung. PP_Order.S_Resource_ID verweist auf eine Produktionsstätte.',
+    IsTranslated='Y', Updated='2026-05-06 17:30', UpdatedBy=100
+WHERE AD_Ref_List_ID=53245 AND AD_Language='de_DE';
+
+-- WC (AD_Ref_List 53246) -- Arbeitsbereich
+UPDATE AD_Ref_List_Trl
+SET Description='Arbeitsbereich: Aggregat oder Abteilung innerhalb einer Produktionsstätte. Fasst mehrere Arbeitsstationen zu einer logischen Einheit zusammen.',
+    IsTranslated='Y', Updated='2026-05-06 17:30', UpdatedBy=100
+WHERE AD_Ref_List_ID=53246 AND AD_Language='de_DE';
+
+-- WS (AD_Ref_List 53247) -- Arbeitsstation
+UPDATE AD_Ref_List_Trl
+SET Description='Arbeitsstation: Physisches scanbares Gerät innerhalb eines Arbeitsplatzes (Drucker, Waage, Maschine). Bediener identifizieren sich durch Scannen des Arbeitsstation-QR-Codes.',
+    IsTranslated='Y', Updated='2026-05-06 17:30', UpdatedBy=100
+WHERE AD_Ref_List_ID=53247 AND AD_Language='de_DE';
+
+-- Also re-apply Names that the previous Phase-1 migration set on AD_Ref_List
+-- (EN base) so the newly-created de_DE rows carry the right base Name too.
+-- (For consistency with 5801060_sys_me03_29671_ManufacturingResourceType_Labels.sql.)
+UPDATE AD_Ref_List_Trl SET Name='Produktionslinie',  IsTranslated='Y', Updated='2026-05-06 17:30', UpdatedBy=100
+WHERE AD_Ref_List_ID=53244 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Name='Produktionsstätte', IsTranslated='Y', Updated='2026-05-06 17:30', UpdatedBy=100
+WHERE AD_Ref_List_ID=53245 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Name='Arbeitsbereich',    IsTranslated='Y', Updated='2026-05-06 17:30', UpdatedBy=100
+WHERE AD_Ref_List_ID=53246 AND AD_Language='de_DE';
+UPDATE AD_Ref_List_Trl SET Name='Arbeitsstation',    IsTranslated='Y', Updated='2026-05-06 17:30', UpdatedBy=100
+WHERE AD_Ref_List_ID=53247 AND AD_Language='de_DE';

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5801140_sys_me03_29671_ManufacturingResourceType_en_US_Trl.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5801140_sys_me03_29671_ManufacturingResourceType_en_US_Trl.sql
@@ -1,0 +1,44 @@
+-- me03#29671 follow-up: AD_Ref_List values for AD_Reference 53223
+-- (ManufacturingResourceType) — sync the en_US Trl Names + Descriptions to the
+-- locked terminology. Earlier migrations updated AD_Ref_List.Name (base) and
+-- AD_Ref_List.Description (base) but did not touch the en_US Trl rows, which is
+-- what an en_US user actually sees in the WebUI.
+
+-- Names (one-line per row) — fix "Work Station" → "Workstation"; ensure the
+-- other four match the locked terms even if already correct.
+UPDATE AD_Ref_List_Trl SET Name='External System',  IsTranslated='Y', Updated='2026-05-06 17:45', UpdatedBy=100
+WHERE AD_Ref_List_ID=543704 AND AD_Language='en_US';
+UPDATE AD_Ref_List_Trl SET Name='Production Line',  IsTranslated='Y', Updated='2026-05-06 17:45', UpdatedBy=100
+WHERE AD_Ref_List_ID=53244  AND AD_Language='en_US';
+UPDATE AD_Ref_List_Trl SET Name='Plant',            IsTranslated='Y', Updated='2026-05-06 17:45', UpdatedBy=100
+WHERE AD_Ref_List_ID=53245  AND AD_Language='en_US';
+UPDATE AD_Ref_List_Trl SET Name='Work Center',      IsTranslated='Y', Updated='2026-05-06 17:45', UpdatedBy=100
+WHERE AD_Ref_List_ID=53246  AND AD_Language='en_US';
+UPDATE AD_Ref_List_Trl SET Name='Workstation',      IsTranslated='Y', Updated='2026-05-06 17:45', UpdatedBy=100
+WHERE AD_Ref_List_ID=53247  AND AD_Language='en_US';
+
+-- Descriptions
+UPDATE AD_Ref_List_Trl
+SET Description='External System: External system integration (e.g. Shopware, Alberta, external controller). Configured via ExternalSystem_Config_ID.',
+    IsTranslated='Y', Updated='2026-05-06 17:45', UpdatedBy=100
+WHERE AD_Ref_List_ID=543704 AND AD_Language='en_US';
+
+UPDATE AD_Ref_List_Trl
+SET Description='Production Line: Production line within a Work Center.',
+    IsTranslated='Y', Updated='2026-05-06 17:45', UpdatedBy=100
+WHERE AD_Ref_List_ID=53244 AND AD_Language='en_US';
+
+UPDATE AD_Ref_List_Trl
+SET Description='Plant: Manufacturing site. PP_Order.S_Resource_ID points at a Plant.',
+    IsTranslated='Y', Updated='2026-05-06 17:45', UpdatedBy=100
+WHERE AD_Ref_List_ID=53245 AND AD_Language='en_US';
+
+UPDATE AD_Ref_List_Trl
+SET Description='Work Center: Aggregate or department within a Plant. Groups multiple Workstations under one logical unit.',
+    IsTranslated='Y', Updated='2026-05-06 17:45', UpdatedBy=100
+WHERE AD_Ref_List_ID=53246 AND AD_Language='en_US';
+
+UPDATE AD_Ref_List_Trl
+SET Description='Workstation: Physical scannable device within a Workplace (printer, scale, machine). Operators identify themselves by scanning the Workstation''s QR code.',
+    IsTranslated='Y', Updated='2026-05-06 17:45', UpdatedBy=100
+WHERE AD_Ref_List_ID=53247 AND AD_Language='en_US';

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5801160_sys_me03_29671_Fix_WS_description_optional_Workplace.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5801160_sys_me03_29671_Fix_WS_description_optional_Workplace.sql
@@ -1,0 +1,29 @@
+-- me03#29671 follow-up: the WS (Workstation) AD_Ref_List description previously
+-- said "innerhalb eines Arbeitsplatzes" / "within a Workplace", implying that a
+-- Workstation must always live inside a Workplace. That is incorrect: the
+-- S_Resource.C_Workplace_ID link is optional. A Workstation may stand alone or
+-- be linked to at most one Workplace at a time.
+
+-- AD_Ref_List 53247 (WS) — base (EN) description
+UPDATE AD_Ref_List
+SET Description='Workstation: Physical scannable device (printer, scale, machine) at which an operator performs manufacturing work. Optionally assigned to a Workplace via C_Workplace_ID. Operators identify themselves by scanning the Workstation''s QR code.',
+    Updated='2026-05-06 18:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53247;
+
+-- AD_Ref_List_Trl en_US
+UPDATE AD_Ref_List_Trl
+SET Description='Workstation: Physical scannable device (printer, scale, machine) at which an operator performs manufacturing work. Optionally assigned to a Workplace via C_Workplace_ID. Operators identify themselves by scanning the Workstation''s QR code.',
+    IsTranslated='Y', Updated='2026-05-06 18:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53247 AND AD_Language='en_US';
+
+-- AD_Ref_List_Trl de_DE
+UPDATE AD_Ref_List_Trl
+SET Description='Arbeitsstation: Physisches scanbares Gerät (Drucker, Waage, Maschine), an dem ein Bediener Produktionsarbeit verrichtet. Optional einem Arbeitsplatz zugeordnet (C_Workplace_ID). Bediener identifizieren sich durch Scannen des Arbeitsstation-QR-Codes.',
+    IsTranslated='Y', Updated='2026-05-06 18:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53247 AND AD_Language='de_DE';
+
+-- AD_Ref_List_Trl de_CH
+UPDATE AD_Ref_List_Trl
+SET Description='Arbeitsstation: Physisches scanbares Gerät (Drucker, Waage, Maschine), an dem ein Bediener Produktionsarbeit verrichtet. Optional einem Arbeitsplatz zugeordnet (C_Workplace_ID). Bediener identifizieren sich durch Scannen des Arbeitsstation-QR-Codes.',
+    IsTranslated='Y', Updated='2026-05-06 18:00', UpdatedBy=100
+WHERE AD_Ref_List_ID=53247 AND AD_Language='de_CH';


### PR DESCRIPTION
Cleans up the metasfresh AD-metadata around the production-resource hierarchy that the customer hit in https://github.com/metasfresh/me03/issues/29671. The trap was that the German UI labeled both \`C_Workplace\` (a logical area in a warehouse) and \`S_Resource\` of \`ManufacturingResourceType='WS'\` (a physical scannable device) as "Arbeitsplatz". This PR locks the terminology and applies it across `AD_Ref_List`, `AD_Element`, and the propagated `AD_Column` / `AD_Field` rows.

Locked terminology — see https://github.com/metasfresh/mf15-documentation/issues/113 for the full doc:

| DB | DE | EN |
|---|---|---|
| \`C_Workplace\` | Arbeitsplatz | Workplace |
| \`S_Resource\` type \`WS\` | **Arbeitsstation** | **Workstation** *(one word)* |
| \`S_Resource\` type \`PT\` | Produktionsstätte | Plant |
| \`S_Resource\` type \`WC\` | Arbeitsbereich | Work Center *(two words)* |
| \`S_Resource\` type \`PL\` | Produktionslinie | Production Line |
| \`S_Resource\` type \`ES\` | Externes System | External System |

## Migrations

- \`5801060\` — AD_Ref_List Names for the 5 \`ManufacturingResourceType\` values, EN+DE. Notably WC was "Abteilung", PL was "Linie" — both wrong even in DE.
- \`5801100\` — \`IsScanResourceRequired\` (AD_Element 581714): rename DE label "Arbeitsplatz-Scan erforderlich" → "Arbeitsstation-Scan erforderlich" + matching description. The flag drives the Workstation scan, not the Workplace flow. Plus DE translation for \`PP_Workstation_UserAssign_ID\` (583021), previously English fallback.
- \`5801120\` — descriptions on six AD_Element rows (\`IsManufacturingResource\`, \`ManufacturingResourceType\`, \`WorkStation_ID\`, \`PP_Workstation_UserAssign_ID\`, \`C_Workplace_ID\`) + AD_Ref_List base descriptions for the 5 list values. Configurers now see meaningful tooltips without consulting the doc issue.
- \`5801130\` — backfills missing \`de_DE\` Trl rows for AD_Ref_List 53244/53245/53246/53247 via \`add_missing_translations()\`, then re-applies DE Names + Descriptions.
- \`5801140\` — syncs \`en_US\` Trl Names + Descriptions for the 5 list values; notably WS \`en_US\` Trl was still "Work Station" (two words).
- \`5801160\` — fixes the WS description so it reflects that the \`C_Workplace_ID\` link is **optional** ("at which an operator performs manufacturing work") rather than implying spatial containment ("within a Workplace").

All applied locally on \`intensive_care.uat_env\` and verified — every cell of the 5×2 dropdown matrix matches the locked terminology, and \`update_Column_Translation_From_AD_Element\` propagated the descriptions into AD_Column and AD_Field for all six elements.

## Out of scope

- DB-level table/column renames (e.g., \`PP_Workstation_UserAssign\` keeps its name).
- Code-level enum consolidation (\`de.metas.business.resource.ManufacturingResourceType\` vs \`de.metas.material.planning.ManufacturingResourceType\`).
- Toast-transparency improvement for the generic "uups…" mobile-webui error — separate me03 issue.
- Test gap analysis follow-ups — queued, see https://github.com/metasfresh/me03/issues/29671 for the plan.