### PR TITLE
Propagate price attributes when UniqueProductPriceFallbackRule matches

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/pricing/rules/price_list_version/UniqueProductPriceFallbackRule.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/rules/price_list_version/UniqueProductPriceFallbackRule.java
@@ -34,6 +34,7 @@ import de.metas.pricing.IPricingContext;
 import de.metas.pricing.IPricingResult;
 import de.metas.pricing.InvoicableQtyBasedOn;
 import de.metas.pricing.PriceListVersionId;
+import de.metas.pricing.attributebased.IAttributePricingBL;
 import de.metas.pricing.service.IPriceListDAO;
 import de.metas.pricing.service.ProductPrices;
 import de.metas.pricing.service.ProductScalePriceService;
@@ -76,6 +77,7 @@ class UniqueProductPriceFallbackRule extends AbstractPriceListBasedRule
 	private final IPriceListDAO priceListsRepo = Services.get(IPriceListDAO.class);
 	private final IProductDAO productsRepo = Services.get(IProductDAO.class);
 	private final IProductBL productsService = Services.get(IProductBL.class);
+	private final IAttributePricingBL attributePricingBL = Services.get(IAttributePricingBL.class);
 
 	private final ProductTaxCategoryService productTaxCategoryService = SpringContextHolder.instance.getBean(ProductTaxCategoryService.class);
 	private final ProductScalePriceService productScalePriceService = SpringContextHolder.instance.getBean(ProductScalePriceService.class);
@@ -145,8 +147,11 @@ class UniqueProductPriceFallbackRule extends AbstractPriceListBasedRule
 		result.setInvoicableQtyBasedOn(InvoicableQtyBasedOn.ofNullableCodeOrNominal(productPrice.getInvoicableQtyBasedOn()));
 		result.setCalculated(true);
 
-		// Propagate the packing material if the unique record carries one.
-		// Mirrors AttributePricing.setResultForProductPriceAttribute.
+		// Propagate the price's attribute set and packing material into the pricing result so
+		// downstream consumers (order line, invoice candidate) inherit the same ASI / packing
+		// dimensions as the price record we matched. Mirrors
+		// AttributePricing.setResultForProductPriceAttribute.
+		result.addPricingAttributes(attributePricingBL.extractPricingAttributes(productPrice));
 		InterfaceWrapperHelper.getRepoIdOptional(productPrice, IPackingMaterialAware.COLUMNNAME_M_HU_PI_Item_Product_ID, HUPIItemProductId::ofRepoId)
 				.ifPresent(result::setPackingMaterialId);
 

--- a/backend/de.metas.business/src/test/java/de/metas/pricing/rules/price_list_version/UniqueProductPriceFallbackRuleTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/pricing/rules/price_list_version/UniqueProductPriceFallbackRuleTest.java
@@ -27,6 +27,7 @@ import de.metas.pricing.service.impl.ASIBuilder;
 import de.metas.pricing.service.impl.PricingTestHelper;
 import de.metas.pricing.tax.ProductTaxCategoryRepository;
 import de.metas.pricing.tax.ProductTaxCategoryService;
+import org.adempiere.mm.attributes.AttributeListValue;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
 import org.compiere.SpringContextHolder;
@@ -74,7 +75,7 @@ class UniqueProductPriceFallbackRuleTest
 		return helper.newProductPriceBuilder().setPrice(amount).build();
 	}
 
-	private I_M_ProductPrice newAttributeDependentPrice(final int amount, final String countryValue)
+	private I_M_ProductPrice newAttributeDependentPrice(final int amount, final AttributeListValue countryValue)
 	{
 		return helper.newProductPriceBuilder()
 				.setASI(ASIBuilder.newInstance()
@@ -85,22 +86,26 @@ class UniqueProductPriceFallbackRuleTest
 	}
 
 	@Test
-	@DisplayName("Single attribute-dependent price, no order-line ASI → fallback uses it")
+	@DisplayName("Single attribute-dependent price, no order-line ASI → fallback uses it and propagates attributes")
 	void uniqueRecord_attributeDependent_isPickedUp()
 	{
-		newAttributeDependentPrice(11, "DE");
+		newAttributeDependentPrice(11, helper.attr_Country_DE);
 
 		final IPricingResult result = helper.calculatePrice(helper.createPricingContext());
 
 		assertThat(result.isCalculated()).as("calculated").isTrue();
 		assertThat(result.getPriceStd()).as("PriceStd").isEqualByComparingTo(BigDecimal.valueOf(11));
+		assertThat(result.getPricingAttributes())
+				.as("the price's attribute set must be propagated to the pricing result")
+				.extracting(pa -> pa.getAttributeValue() == null ? null : pa.getAttributeValue().getId())
+				.containsExactly(helper.attr_Country_DE.getId());
 	}
 
 	@Test
 	@DisplayName("Tagged + baseline siblings → MainProductPriceRule wins on baseline; fallback skipped")
 	void taggedPlusBaseline_baselineWins()
 	{
-		newAttributeDependentPrice(10, "DE");
+		newAttributeDependentPrice(10, helper.attr_Country_DE);
 		newBaselinePrice(20);
 
 		final IPricingResult result = helper.calculatePrice(helper.createPricingContext());
@@ -109,14 +114,17 @@ class UniqueProductPriceFallbackRuleTest
 		assertThat(result.getPriceStd())
 				.as("PriceStd should match the baseline, not the tagged record")
 				.isEqualByComparingTo(BigDecimal.valueOf(20));
+		assertThat(result.getPricingAttributes())
+				.as("baseline path must not propagate attributes (the price has none)")
+				.isEmpty();
 	}
 
 	@Test
 	@DisplayName("Two tagged records, no baseline → uniqueness gate skips, result stays uncalculated")
 	void twoTaggedRecords_uniquenessGateSkips()
 	{
-		newAttributeDependentPrice(10, "DE");
-		newAttributeDependentPrice(15, "CH");
+		newAttributeDependentPrice(10, helper.attr_Country_DE);
+		newAttributeDependentPrice(15, helper.attr_Country_CH);
 
 		final IPricingResult result = helper.calculatePrice(helper.createPricingContext());
 


### PR DESCRIPTION
## Summary

Follow-up to the previous PR. Customer feedback after integration: when
`UniqueProductPriceFallbackRule` engages on an attribute-dependent price
record, the matched record's attributes must flow into the pricing result
so downstream consumers (order line, invoice candidate) inherit the same
ASI dimensions as the price — same contract `AttributePricing` already
honours via `setResultForProductPriceAttribute`.

The fallback now calls
`result.addPricingAttributes(attributePricingBL.extractPricingAttributes(productPrice))`
right after `setCalculated(true)`, mirroring the strict attribute-pricing
path. The packing-material propagation that was already there is kept.
For the baseline-only path the propagated list is naturally empty (no ASI
on the record), so the existing baseline behaviour is unchanged.

## Test plan

- [x] `UniqueProductPriceFallbackRuleTest.uniqueRecord_attributeDependent_isPickedUp`
  now asserts `result.getPricingAttributes()` carries the price's ASI
  attributes (`Country = DE`).
- [x] `UniqueProductPriceFallbackRuleTest.taggedPlusBaseline_baselineWins`
  asserts the baseline path still produces an empty pricing-attributes
  list.
- [x] Full module suites green for `de.metas.handlingunits.base` (840/840).
- [x] Pricing-related tests in `de.metas.business` green; pre-existing
  unrelated failures (`CustomsInvoiceServiceTest`, `FreightCostTest`,
  `MPaymentTest$computeAllocationAmt`) unchanged baseline.
- [ ] CI green on the full pipeline.