### PR TITLE
Include M_HU_ID in destroyed-HU error message

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
@@ -66,7 +66,8 @@ class PickFromHUQRCodeResolveCommand
 				final HuId inactiveHuId = huService.getHuIdByQRCodeIncludingInactiveIfExists(huQRCode).orElse(null);
 				if (inactiveHuId != null && huService.isDestroyed(inactiveHuId))
 				{
-					return ExplainedOptional.emptyBecause(ERR_QR_HU_Destroyed);
+					return ExplainedOptional.emptyBecause(
+							TranslatableStrings.adMessage(ERR_QR_HU_Destroyed, inactiveHuId.getRepoId()));
 				}
 				huService.getHuIdByQRCode(huQRCode); // throws AdempiereException — see HUQRCodesService.java
 				throw new IllegalStateException("unreachable");
@@ -75,7 +76,8 @@ class PickFromHUQRCodeResolveCommand
 			// Legacy backstop: assignment still active but HU was destroyed before the destroy interceptor was deployed.
 			if (huService.isDestroyed(activeHuId))
 			{
-				return ExplainedOptional.emptyBecause(ERR_QR_HU_Destroyed);
+				return ExplainedOptional.emptyBecause(
+						TranslatableStrings.adMessage(ERR_QR_HU_Destroyed, activeHuId.getRepoId()));
 			}
 			if (!huService.containsProduct(activeHuId, productId))
 			{

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5801170_msg_QR_CODE_HU_DESTROYED_ERROR_MSG_with_huId.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5801170_msg_QR_CODE_HU_DESTROYED_ERROR_MSG_with_huId.sql
@@ -1,0 +1,43 @@
+-- me03#29347 follow-up — include the M_HU_ID (also the user-facing search key) in the
+-- destroyed-HU error message so the picker can hand the number to a supervisor / look it up
+-- in the WebUI HU window without further detective work.
+
+-- Update base text (German)
+-- 2026-05-06 14:00
+UPDATE AD_Message
+SET MsgText='HU {0} wurde bereits zerstört.',
+    Updated=TO_TIMESTAMP('2026-05-06 14:00','YYYY-MM-DD HH24:MI'),
+    UpdatedBy=0
+WHERE AD_Message_ID=545677
+;
+
+-- Update de_DE / de_CH translations (same German text as base)
+-- 2026-05-06 14:00
+UPDATE AD_Message_Trl
+SET MsgText='HU {0} wurde bereits zerstört.',
+    IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-05-06 14:00','YYYY-MM-DD HH24:MI'),
+    UpdatedBy=0
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545677
+;
+
+-- Update en_US translation
+-- 2026-05-06 14:00
+UPDATE AD_Message_Trl
+SET MsgText='HU {0} was already destroyed.',
+    IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-05-06 14:00','YYYY-MM-DD HH24:MI'),
+    UpdatedBy=0
+WHERE AD_Language='en_US' AND AD_Message_ID=545677
+;
+
+-- Defensive: catch any other AD_Message_Trl row still on the prior placeholder-less text
+-- (e.g. fr_CH and any other language fanned out from 5800850 that was never localised).
+-- Leave IsTranslated='N' so the row is still flagged as not-actually-translated.
+-- 2026-05-06 14:00
+UPDATE AD_Message_Trl
+SET MsgText='HU {0} wurde bereits zerstört.',
+    Updated=TO_TIMESTAMP('2026-05-06 14:00','YYYY-MM-DD HH24:MI'),
+    UpdatedBy=0
+WHERE AD_Message_ID=545677 AND MsgText='HU wurde bereits zerstört.'
+;


### PR DESCRIPTION
## Summary

Follow-up to the four already-integrated PRs in the QR-code destroyed-HU detection chain:

- https://github.com/metasfresh/metasfresh/pull/23826 — destroyed-HU detection (legacy backstop)
- https://github.com/metasfresh/metasfresh/pull/23827 — enriched product-mismatch error
- https://github.com/metasfresh/metasfresh/pull/23828 — deactivate `M_HU_QRCode_Assignment` on HU destroy
- https://github.com/metasfresh/metasfresh/pull/23841 — surface destroyed-HU error even when the assignment is soft-deleted

The destroyed-HU error currently surfaces `HU wurde bereits zerstört.` / `HU was already destroyed.` with no identifier — the picker has nothing to hand to a supervisor or punch into the WebUI HU window for forensics. This adds the `M_HU_ID` (also the user-facing search key in the HU window) as parameter `{0}`:

- **DE**: `HU 12345 wurde bereits zerstört.`
- **EN**: `HU 12345 was already destroyed.`

## Files

- `5801170_msg_QR_CODE_HU_DESTROYED_ERROR_MSG_with_huId.sql` — UPDATEs AD_Message_ID=545677 base text + de_DE / de_CH / en_US Trl rows + a defensive UPDATE for any other Trl row still on the prior placeholder-less text (e.g. fr_CH).
- `PickFromHUQRCodeResolveCommand.java` — both call sites of `ERR_QR_HU_Destroyed` in the `HUQRCode` branch (the post-deactivation fallback and the legacy backstop) now pass `huId.getRepoId()` via `TranslatableStrings.adMessage(...)`.

## Local validation

- Compile: green (`backend/de.metas.handlingunits.base` + reactor deps)
- Migrations: `5801170` applied locally; AD_Message + AD_Message_Trl (de_DE, de_CH, en_US, fr_CH) verified to carry the `{0}` placeholder
- Unit tests: 676 run, 0 failures, 22 skipped