### PR TITLE
DO NOT INTEGRATE — RED proof: blank-barcode bug in BarcodeScannerComponent (gh29025)

### DIFF
--- a/e2e/mobile-webui/tests/spec/humanager/scan.spec.js
+++ b/e2e/mobile-webui/tests/spec/humanager/scan.spec.js
@@ -4,6 +4,7 @@ import { Backend } from "../../utils/screens/Backend";
 import { LoginScreen } from "../../utils/screens/LoginScreen";
 import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
 import { HUManagerScreen } from '../../utils/screens/huManager/HUManagerScreen';
+import { step } from '../../utils/common';
 
 const createMasterdata = async ({ externalBarcode } = {}) => {
     return await Backend.createMasterdata({
@@ -76,4 +77,30 @@ test('Scan by ExternalBarcode attribute', async ({ page }) => {
     await HUManagerScreen.waitForScreen();
     await HUManagerScreen.scanHUQRCode({ huQRCode: externalBarcode });
     await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Spurious Enter without barcode does not trigger blank API call', async ({ page }) => {
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5120');
+    allure.story('HU Manager - Scan Methods');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('huManager');
+    await HUManagerScreen.waitForScreen();
+
+    // step() races the action against ErrorToast.waitToPopup — if a toast fires, test fails.
+    // Bug (before fix): blank Enter → backend → AdempiereException("code is blank") → toast.
+    await step('Spurious Enter should not cause an error', async () => {
+        await page.evaluate(() => {
+            const input = document.querySelector('#input-text');
+            if (input) {
+                input.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', bubbles: true }));
+            }
+        });
+        await page.waitForTimeout(1500);
+    });
 });


### PR DESCRIPTION
## ⛔ DO NOT INTEGRATE

This branch exists solely as a **RED-phase proof** for the TDD cycle of the blank-barcode bug fix.

It contains **only the Playwright regression test** — the fix is intentionally absent. The test **must fail** here to prove the bug existed before the fix was applied.

**The real fix lives in:** https://github.com/metasfresh/metasfresh/pull/23848

---

## What this proves

CI run https://github.com/metasfresh/metasfresh/actions/runs/25481248106 on this branch ran the mobile test suite against the unfixed code. Result: **1 failed, 131 passed**.

### Failure output

\`\`\`
  1) [Mobile Chrome] › tests/spec/humanager/scan.spec.js:83:5
     › Spurious Enter without barcode does not trigger blank API call
     › Spurious Enter should not cause an error

     Error: Unexpected error toast detected: Please try again

        at utils/common.js:44

      42 |                     const textContent = await toastLocator.textContent();
      43 |                     // console.log(`Error toast detected...`)
    > 44 |                     throw new Error('Unexpected error toast detected: ' + textContent);
         |                           ^
      45 |                 },
      46 |                 999_000
      47 |             ),
          at /app/tests/utils/common.js:44:27
          at /app/tests/utils/dialogs/ErrorToast.js:16:17
          at runAndWatchForErrors (/app/tests/utils/common.js:33:16)
          at /app/tests/spec/humanager/scan.spec.js:97:5

  1 failed
    [Mobile Chrome] › tests/spec/humanager/scan.spec.js:83:5
    › Spurious Enter without barcode does not trigger blank API call
  131 passed (15.8m)
\`\`\`

A spurious Enter keystroke with an empty barcode input forwarded a blank string to the backend → backend rejected it → error toast \`Please try again\` fired → \`step()\` wrapper caught the toast and failed the test.

The 3 pre-existing scan tests all passed — only the new regression test failed, confirming the bug is exactly as expected.

Allure report: https://test-reports.metasfresh.com/branches/soft-panda-release-gh29025-red-proof/builds/5.175-soft-panda-release-gh29025-red-proof.34625/allure/mobile-webui/

---

## GREEN proof

The same test **passes** on https://github.com/metasfresh/metasfresh/pull/23848 (CI run https://github.com/metasfresh/metasfresh/actions/runs/25461444125) — the blank guard silently discards the empty Enter, no API call is made, no error toast fires.

---

**Do not merge.** Close this PR once https://github.com/metasfresh/metasfresh/pull/23848 is merged.