### PR TITLE
ci(mergify): allow_inplace_checks on both queue_rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -37,11 +37,13 @@ merge_protections:
 queue_rules:
   - name: squash-queue
     merge_method: squash
+    allow_inplace_checks: true
     merge_conditions:
       - check-success=Merge Gate
 
   - name: merge-queue
     merge_method: merge
+    allow_inplace_checks: true
     merge_conditions:
       - check-success=Merge Gate
 


### PR DESCRIPTION
## Summary

Add `allow_inplace_checks: true` to both `queue_rules` in `.mergify.yml`. With this, when a PR is already at the train tip (i.e. rebased on top of the queue base), mergify reuses the PR's own cicd run instead of creating a fresh `mergify/merge-queue/<sha>` (+ `tmp-mergify/merge-queue/<sha>`) branch pair and running cicd from scratch on those.

## Why

Today, every PR that goes through the queue triggers an extra full cicd run on a `mergify/merge-queue/<sha>` branch even when the PR's own checks were green seconds earlier. When the train rebases (because a new commit landed on `new_dawn_uat`), the cycle repeats and the previous merge-queue cicd run is **not** cancelled — that's the source of the runner-pool pile-up we observed today (multiple `tmp-mergify/...` shas with running cicds even though mergify had moved on to a new train sha).

`speculative_checks` is left at its default of 1 — we don't want parallel speculative trains, just less re-running of the same checks.

## Risk

`allow_inplace_checks` only takes effect when the PR is already up-to-date with the train base. If the PR needs a rebase / new commits from the base, mergify still creates the merge-queue branch and runs cicd from scratch, so the integration-safety property of the queue is preserved.

## Test plan

- [ ] After merge, watch the next 3–5 PRs that go through the queue. Expect: most of them will NOT spawn a `mergify/merge-queue/<sha>` cicd run; the PR-level cicd is reused.
- [ ] If any PR triggers a fresh merge-queue cicd, that's expected — it means the PR was behind and needed a rebase.