### PR TITLE
ci(mergify): drop deprecated allow_inplace_checks, set max_parallel_checks=1

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -34,16 +34,17 @@ merge_protections:
     success_conditions:
       - check-success=Merge Gate
 
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: squash-queue
     merge_method: squash
-    allow_inplace_checks: true
     merge_conditions:
       - check-success=Merge Gate
 
   - name: merge-queue
     merge_method: merge
-    allow_inplace_checks: true
     merge_conditions:
       - check-success=Merge Gate
 


### PR DESCRIPTION
## Summary

Replaces the per-queue `allow_inplace_checks: true` lines added in https://github.com/metasfresh/metasfresh/pull/23891 with the modern equivalent.

Mergify deprecated `allow_inplace_checks` (their bot flagged it on PR #23891). Per current mergify docs, in-place checks are now **auto-computed** and enabled when:
- `merge_queue.max_parallel_checks == 1`
- every `queue_rules` entry has `batch_size == 1` (default)
- every queue's CI is single-step (already the case)

So this PR:

1. **Removes** the deprecated `allow_inplace_checks: true` lines from both queue rules.
2. **Adds** a top-level `merge_queue:` block with `max_parallel_checks: 1`.

## Behavioural intent

Same as #23891: when a PR is at the train tip, reuse the PR's own green cicd run instead of spawning a fresh `mergify/merge-queue/<sha>` (+ `tmp-mergify/...`) cicd cycle. `max_parallel_checks: 1` also keeps the queue to a single train at a time, which matches what we already observed in practice and avoids the orphan-tmp-branch CI pile-up seen on 2026-05-07 (multiple in-flight cicd runs on dead train shas after rebases).

## Diff

```yaml
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: squash-queue
     merge_method: squash
-    allow_inplace_checks: true
     merge_conditions:
       - check-success=Merge Gate

   - name: merge-queue
     merge_method: merge
-    allow_inplace_checks: true
     merge_conditions:
       - check-success=Merge Gate
```

## Test plan

- [ ] After merge, watch the next 3–5 PRs going through the queue. Expect: most do NOT spawn a separate `mergify/merge-queue/<sha>` cicd run; the PR's own cicd is reused.
- [ ] Mergify-bot does not re-flag any deprecated keys on this PR.