### PR TITLE
[29625] Fix AmountType field position in Mehrwertsteuercodes tab

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801390_sys_me03_29625_C_VATCode_AmountType_UI_FixSeqNo.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801390_sys_me03_29625_C_VATCode_AmountType_UI_FixSeqNo.sql
@@ -1,0 +1,7 @@
+UPDATE AD_UI_Element
+SET    SeqNo     = 15,
+       SeqNoGrid = 15,
+       Updated   = TO_TIMESTAMP('2026-05-08 09:00', 'YYYY-MM-DD HH24:MI'),
+       UpdatedBy = 100
+WHERE  AD_UI_Element_ID = 650507
+;


### PR DESCRIPTION
## Summary

- Move `Betragsart` (AmountType, `AD_UI_Element_ID=650507`) to `SeqNo=15` / `SeqNoGrid=15` in the Mehrwertsteuercodes sub-tab so it appears directly after the `Steuer` (Tax) field (`SeqNo=10`) in both form view and grid view.