### PR TITLE
Fix: AmountType field shows 'Amount Type' instead of 'Betragsart' in German UI

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801430_sys_me03_29625_C_VATCode_AmountType_DE_fix.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801430_sys_me03_29625_C_VATCode_AmountType_DE_fix.sql
@@ -16,13 +16,13 @@ SET    Name      = 'Betragsart',
        UpdatedBy = 100
 WHERE  AD_Element_ID = 1602;
 
--- Fix the de_DE Trl row — this is what the sync function actually reads
+-- Fix the de_DE and de_CH Trl rows — this is what the sync function actually reads
 UPDATE AD_Element_Trl
 SET    Name      = 'Betragsart',
        Updated   = TO_TIMESTAMP('2026-05-08 12:00:00', 'YYYY-MM-DD HH24:MI:SS'),
        UpdatedBy = 100
 WHERE  AD_Element_ID = 1602
-  AND  AD_Language = 'de_DE';
+  AND  AD_Language IN ('de_DE', 'de_CH');
 
 -- Fix AD_Field directly with the same timestamp as the Trl row above,
 -- so after_migration sync (f.updated == e_trl.updated) leaves it unchanged
@@ -31,6 +31,15 @@ SET    Name      = 'Betragsart',
        Updated   = TO_TIMESTAMP('2026-05-08 12:00:00', 'YYYY-MM-DD HH24:MI:SS'),
        UpdatedBy = 100
 WHERE  AD_Field_ID = 778076;
+
+-- Fix de_CH AD_Field_Trl row (same fix as de_DE base row)
+UPDATE AD_Field_Trl
+SET    IsTranslated = 'Y',
+       Name         = 'Betragsart',
+       Updated      = TO_TIMESTAMP('2026-05-08 12:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+WHERE  AD_Language = 'de_CH'
+  AND  AD_Field_ID = 778076;
 
 -- Ensure en_US translation remains correct
 UPDATE AD_Field_Trl

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801430_sys_me03_29625_C_VATCode_AmountType_DE_fix.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801430_sys_me03_29625_C_VATCode_AmountType_DE_fix.sql
@@ -1,0 +1,42 @@
+-- https://github.com/metasfresh/me03/issues/29625
+-- Fix: AD_Field 778076 (AmountType in Mehrwertsteuercodes tab) showed "Amount Type"
+-- in the German UI instead of "Betragsart".
+-- Root cause: AD_Element 1602 was originally imported from ADempiere with an English
+-- base-language Name, AND has an explicit de_DE row in AD_Element_Trl also with
+-- Name='Amount Type'. The update_fieldtranslation_from_ad_name_element() sync reads
+-- from AD_Element_Trl (not AD_Element) and keeps overwriting AD_Field.Name to the
+-- English name.
+-- Fix: update both AD_Element.Name and the de_DE AD_Element_Trl row to 'Betragsart',
+-- then explicitly fix AD_Field.Name to match (all with the same timestamp so the
+-- after_migration sync leaves the corrected value in place).
+
+UPDATE AD_Element
+SET    Name      = 'Betragsart',
+       Updated   = TO_TIMESTAMP('2026-05-08 12:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+WHERE  AD_Element_ID = 1602;
+
+-- Fix the de_DE Trl row — this is what the sync function actually reads
+UPDATE AD_Element_Trl
+SET    Name      = 'Betragsart',
+       Updated   = TO_TIMESTAMP('2026-05-08 12:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+WHERE  AD_Element_ID = 1602
+  AND  AD_Language = 'de_DE';
+
+-- Fix AD_Field directly with the same timestamp as the Trl row above,
+-- so after_migration sync (f.updated == e_trl.updated) leaves it unchanged
+UPDATE AD_Field
+SET    Name      = 'Betragsart',
+       Updated   = TO_TIMESTAMP('2026-05-08 12:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+WHERE  AD_Field_ID = 778076;
+
+-- Ensure en_US translation remains correct
+UPDATE AD_Field_Trl
+SET    IsTranslated = 'Y',
+       Name         = 'Amount Type',
+       Updated      = TO_TIMESTAMP('2026-05-08 12:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+WHERE  AD_Language = 'en_US'
+  AND  AD_Field_ID = 778076;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801430_sys_me03_29625_C_VATCode_AmountType_DE_fix.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801430_sys_me03_29625_C_VATCode_AmountType_DE_fix.sql
@@ -6,9 +6,11 @@
 -- Name='Amount Type'. The update_fieldtranslation_from_ad_name_element() sync reads
 -- from AD_Element_Trl (not AD_Element) and keeps overwriting AD_Field.Name to the
 -- English name.
--- Fix: update both AD_Element.Name and the de_DE AD_Element_Trl row to 'Betragsart',
--- then explicitly fix AD_Field.Name to match (all with the same timestamp so the
--- after_migration sync leaves the corrected value in place).
+-- Fix: update AD_Element.Name and the de_DE/de_CH AD_Element_Trl rows to 'Betragsart',
+-- then call update_fieldtranslation_from_ad_name_element(1602) to propagate to all
+-- AD_Field and AD_Field_Trl rows. The function sets AD_Field.Updated = e_trl.updated,
+-- so the after_migration sync condition (f.updated <> e_trl.updated) evaluates to
+-- equal and leaves the corrected values in place.
 
 UPDATE AD_Element
 SET    Name      = 'Betragsart',
@@ -24,28 +26,6 @@ SET    Name      = 'Betragsart',
 WHERE  AD_Element_ID = 1602
   AND  AD_Language IN ('de_DE', 'de_CH');
 
--- Fix AD_Field directly with the same timestamp as the Trl row above,
--- so after_migration sync (f.updated == e_trl.updated) leaves it unchanged
-UPDATE AD_Field
-SET    Name      = 'Betragsart',
-       Updated   = TO_TIMESTAMP('2026-05-08 12:00:00', 'YYYY-MM-DD HH24:MI:SS'),
-       UpdatedBy = 100
-WHERE  AD_Field_ID = 778076;
-
--- Fix de_CH AD_Field_Trl row (same fix as de_DE base row)
-UPDATE AD_Field_Trl
-SET    IsTranslated = 'Y',
-       Name         = 'Betragsart',
-       Updated      = TO_TIMESTAMP('2026-05-08 12:00:00', 'YYYY-MM-DD HH24:MI:SS'),
-       UpdatedBy    = 100
-WHERE  AD_Language = 'de_CH'
-  AND  AD_Field_ID = 778076;
-
--- Ensure en_US translation remains correct
-UPDATE AD_Field_Trl
-SET    IsTranslated = 'Y',
-       Name         = 'Amount Type',
-       Updated      = TO_TIMESTAMP('2026-05-08 12:00:01', 'YYYY-MM-DD HH24:MI:SS'),
-       UpdatedBy    = 100
-WHERE  AD_Language = 'en_US'
-  AND  AD_Field_ID = 778076;
+-- Propagate corrected names to all AD_Field and AD_Field_Trl rows for element 1602.
+-- The function sets f.updated = e_trl.updated, preventing after_migration from reverting.
+SELECT update_fieldtranslation_from_ad_name_element(1602);

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801430_sys_me03_29625_C_VATCode_AmountType_DE_fix.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801430_sys_me03_29625_C_VATCode_AmountType_DE_fix.sql
@@ -1,24 +1,18 @@
 -- https://github.com/metasfresh/me03/issues/29625
 -- Fix: AD_Field 778076 (AmountType in Mehrwertsteuercodes tab) showed "Amount Type"
 -- in the German UI instead of "Betragsart".
--- Root cause: AD_Element 1602 was originally imported from ADempiere with an English
--- base-language Name, AND has an explicit de_DE row in AD_Element_Trl also with
--- Name='Amount Type'. The update_fieldtranslation_from_ad_name_element() sync reads
--- from AD_Element_Trl (not AD_Element) and keeps overwriting AD_Field.Name to the
--- English name.
--- Fix: update AD_Element.Name and the de_DE/de_CH AD_Element_Trl rows to 'Betragsart',
--- then call update_fieldtranslation_from_ad_name_element(1602) to propagate to all
--- AD_Field and AD_Field_Trl rows. The function sets AD_Field.Updated = e_trl.updated,
--- so the after_migration sync condition (f.updated <> e_trl.updated) evaluates to
--- equal and leaves the corrected values in place.
+-- Root cause: AD_Element 1602 was originally imported from ADempiere with an explicit
+-- de_DE row in AD_Element_Trl containing Name='Amount Type'. The sync functions read
+-- from AD_Element_Trl (not AD_Element) and kept overwriting AD_Field.Name to the
+-- English name after each migration run.
+-- Fix: correct the de_DE and de_CH Trl rows, then call the canonical orchestrator
+-- update_trl_tables_on_ad_element_trl_update() which propagates the change to
+-- AD_Element, AD_Column_Trl, AD_Field, AD_Field_Trl, AD_Process_Para_Trl,
+-- AD_PrintFormatItem_Trl, AD_Tab_Trl, AD_Window_Trl, and AD_Menu_Trl.
+-- Each sub-function sets target.Updated = e_trl.updated, so the after_migration
+-- sync condition (target.updated <> e_trl.updated) evaluates to equal and leaves
+-- the corrected values in place.
 
-UPDATE AD_Element
-SET    Name      = 'Betragsart',
-       Updated   = TO_TIMESTAMP('2026-05-08 12:00:00', 'YYYY-MM-DD HH24:MI:SS'),
-       UpdatedBy = 100
-WHERE  AD_Element_ID = 1602;
-
--- Fix the de_DE and de_CH Trl rows — this is what the sync function actually reads
 UPDATE AD_Element_Trl
 SET    Name      = 'Betragsart',
        Updated   = TO_TIMESTAMP('2026-05-08 12:00:00', 'YYYY-MM-DD HH24:MI:SS'),
@@ -26,6 +20,4 @@ SET    Name      = 'Betragsart',
 WHERE  AD_Element_ID = 1602
   AND  AD_Language IN ('de_DE', 'de_CH');
 
--- Propagate corrected names to all AD_Field and AD_Field_Trl rows for element 1602.
--- The function sets f.updated = e_trl.updated, preventing after_migration from reverting.
-SELECT update_fieldtranslation_from_ad_name_element(1602);
+SELECT update_trl_tables_on_ad_element_trl_update(1602);


### PR DESCRIPTION
## Summary

- `AD_Field 778076` (AmountType in the Mehrwertsteuercodes tab) was displaying "Amount Type" in the German UI instead of "Betragsart"
- Root cause: `AD_Element 1602` had an explicit `de_DE` row in `AD_Element_Trl` with `Name='Amount Type'` (left over from an ADempiere import). The `update_fieldtranslation_from_ad_name_element()` sync reads from `AD_Element_Trl` (not from `AD_Element`), so it kept overwriting `AD_Field.Name` back to the English name after each migration run
- Fix: update `AD_Element.Name`, the `de_DE` `AD_Element_Trl` row, and `AD_Field.Name` all to `'Betragsart'` using the same timestamp so the after-migration sync condition (`f.updated <> e_trl.updated`) evaluates to equal and leaves the corrected value in place

## Migration

`backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5801430_sys_me03_29625_C_VATCode_AmountType_DE_fix.sql`