### PR TITLE
Tax Declaration — fix Skonto (payment discount) VAT code AmountType on discount and write-off legs

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -30,7 +30,6 @@ import de.metas.acct.api.TaxCorrectionType;
 import de.metas.acct.doc.AcctDocContext;
 import de.metas.acct.doc.AcctDocRequiredServicesFacade;
 import de.metas.acct.doc.PostingException;
-import de.metas.acct.vatcode.IVATCodeDAO;
 import de.metas.allocation.api.IAllocationDAO;
 import de.metas.currency.CurrencyConversionContext;
 import de.metas.currency.CurrencyPrecision;
@@ -1558,9 +1557,9 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 									.buildAndAdd();
 							if (discountFl != null)
 							{
-								final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
-										.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId())
-										.orElseGet(line::isSOTrx);
+								final boolean netIsSOTrx = services
+										.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId(), taxId)
+										.orElseGet(line::isSOTrxInvoice);
 								discountFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 							}
 
@@ -1586,9 +1585,9 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 									.buildAndAdd();
 							if (discountFl != null)
 							{
-								final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
-										.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId())
-										.orElseGet(line::isSOTrx);
+								final boolean netIsSOTrx = services
+										.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId(), taxId)
+										.orElseGet(line::isSOTrxInvoice);
 								discountFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 							}
 
@@ -1640,9 +1639,9 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 									.buildAndAdd();
 							if (discountFl != null)
 							{
-								final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
-										.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId())
-										.orElseGet(line::isSOTrx);
+								final boolean netIsSOTrx = services
+										.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId(), taxId)
+										.orElseGet(line::isSOTrxInvoice);
 								discountFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 							}
 
@@ -1669,9 +1668,9 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 									.buildAndAdd();
 							if (discountFl != null)
 							{
-								final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
-										.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId())
-										.orElseGet(line::isSOTrx);
+								final boolean netIsSOTrx = services
+										.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId(), taxId)
+										.orElseGet(line::isSOTrxInvoice);
 								discountFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 							}
 
@@ -1705,9 +1704,9 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 								.buildAndAdd();
 						if (writeOffFl != null)
 						{
-							final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
-									.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId())
-									.orElseGet(line::isSOTrx);
+							final boolean netIsSOTrx = services
+									.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId(), taxId)
+									.orElseGet(line::isSOTrxInvoice);
 							writeOffFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 						}
 
@@ -1753,9 +1752,9 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 								.buildAndAdd();
 						if (writeOffFl != null)
 						{
-							final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
-									.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId())
-									.orElseGet(line::isSOTrx);
+							final boolean netIsSOTrx = services
+									.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId(), taxId)
+									.orElseGet(line::isSOTrxInvoice);
 							writeOffFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 						}
 					}

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -1549,13 +1549,16 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 						if (isDiscountExpense)
 						{
 							// DR
-							fact.createLine()
+							final FactLine discountFl = fact.createLine()
 									.setDocLine(line)
 									.setAccount(discountAcct)
 									.setAmt(taxAmtAdjustment, null)
-									.setC_Tax_ID(taxId).vatCode(taxFactAcct.getVATCode())
 									.additionalDescription(description)
 									.buildAndAdd();
+							if (discountFl != null)
+							{
+								discountFl.setTaxIdAndUpdateVatCode(taxId, VATCodeAmountType.Net);
+							}
 
 							// CR
 							fact.createLine()
@@ -1571,13 +1574,16 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 						else
 						{
 							// DR
-							fact.createLine()
+							final FactLine discountFl = fact.createLine()
 									.setDocLine(line)
 									.setAccount(discountAcct)
 									.setAmt(taxAmtAdjustment.negate(), null)
-									.setC_Tax_ID(taxId).vatCode(taxFactAcct.getVATCode())
 									.additionalDescription(description)
 									.buildAndAdd();
+							if (discountFl != null)
+							{
+								discountFl.setTaxIdAndUpdateVatCode(taxId, VATCodeAmountType.Net);
+							}
 
 							// CR
 							fact.createLine()
@@ -1619,13 +1625,16 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 									.buildAndAdd();
 
 							// CR
-							fact.createLine()
+							final FactLine discountFl = fact.createLine()
 									.setDocLine(line)
 									.setAccount(discountAcct)
 									.setAmt(null, taxAmtAdjustment)
-									.setC_Tax_ID(taxId).vatCode(taxFactAcct.getVATCode())
 									.additionalDescription(description)
 									.buildAndAdd();
+							if (discountFl != null)
+							{
+								discountFl.setTaxIdAndUpdateVatCode(taxId, VATCodeAmountType.Net);
+							}
 
 						}
 						// Discount revenue
@@ -1642,13 +1651,16 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 									.buildAndAdd();
 
 							// CR
-							fact.createLine()
+							final FactLine discountFl = fact.createLine()
 									.setDocLine(line)
 									.setAccount(discountAcct)
 									.setAmt(null, taxAmtAdjustment.negate())
-									.setC_Tax_ID(taxId).vatCode(taxFactAcct.getVATCode())
 									.additionalDescription(description)
 									.buildAndAdd();
+							if (discountFl != null)
+							{
+								discountFl.setTaxIdAndUpdateVatCode(taxId, VATCodeAmountType.Net);
+							}
 
 						}
 					}
@@ -1672,13 +1684,16 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 						result.add(fact);
 
 						//DR
-						fact.createLine()
+						final FactLine writeOffFl = fact.createLine()
 								.setDocLine(line)
 								.setAccount(writeOffAccount)
 								.setAmt(taxAmtAdjustment, null)
-								.setC_Tax_ID(taxId).vatCode(taxFactAcct.getVATCode())
 								.additionalDescription(description)
 								.buildAndAdd();
+						if (writeOffFl != null)
+						{
+							writeOffFl.setTaxIdAndUpdateVatCode(taxId, VATCodeAmountType.Net);
+						}
 
 						// CR
 						fact.createLine()
@@ -1714,13 +1729,16 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 								.buildAndAdd();
 
 						// CR
-						fact.createLine()
+						final FactLine writeOffFl = fact.createLine()
 								.setDocLine(line)
 								.setAccount(writeOffAccount)
 								.setAmt(null, amountCMAdjusted)
-								.setC_Tax_ID(taxId).vatCode(taxFactAcct.getVATCode())
 								.additionalDescription(description)
 								.buildAndAdd();
+						if (writeOffFl != null)
+						{
+							writeOffFl.setTaxIdAndUpdateVatCode(taxId, VATCodeAmountType.Net);
+						}
 					}
 				}
 			}                // WriteOff

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -1559,7 +1559,7 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 							if (discountFl != null)
 							{
 								final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
-										.findIsSOTrxByCode(taxFactAcct.getVATCode())
+										.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId())
 										.orElseGet(line::isSOTrx);
 								discountFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 							}
@@ -1587,7 +1587,7 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 							if (discountFl != null)
 							{
 								final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
-										.findIsSOTrxByCode(taxFactAcct.getVATCode())
+										.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId())
 										.orElseGet(line::isSOTrx);
 								discountFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 							}
@@ -1641,7 +1641,7 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 							if (discountFl != null)
 							{
 								final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
-										.findIsSOTrxByCode(taxFactAcct.getVATCode())
+										.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId())
 										.orElseGet(line::isSOTrx);
 								discountFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 							}
@@ -1670,7 +1670,7 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 							if (discountFl != null)
 							{
 								final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
-										.findIsSOTrxByCode(taxFactAcct.getVATCode())
+										.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId())
 										.orElseGet(line::isSOTrx);
 								discountFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 							}
@@ -1706,7 +1706,7 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 						if (writeOffFl != null)
 						{
 							final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
-									.findIsSOTrxByCode(taxFactAcct.getVATCode())
+									.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId())
 									.orElseGet(line::isSOTrx);
 							writeOffFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 						}
@@ -1754,7 +1754,7 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 						if (writeOffFl != null)
 						{
 							final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
-									.findIsSOTrxByCode(taxFactAcct.getVATCode())
+									.findIsSOTrxByCode(taxFactAcct.getVATCode(), as.getId())
 									.orElseGet(line::isSOTrx);
 							writeOffFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 						}

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -30,6 +30,7 @@ import de.metas.acct.api.TaxCorrectionType;
 import de.metas.acct.doc.AcctDocContext;
 import de.metas.acct.doc.AcctDocRequiredServicesFacade;
 import de.metas.acct.doc.PostingException;
+import de.metas.acct.vatcode.IVATCodeDAO;
 import de.metas.allocation.api.IAllocationDAO;
 import de.metas.currency.CurrencyConversionContext;
 import de.metas.currency.CurrencyPrecision;
@@ -1557,7 +1558,10 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 									.buildAndAdd();
 							if (discountFl != null)
 							{
-								discountFl.setTaxIdAndUpdateVatCode(taxId, VATCodeAmountType.Net);
+								final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
+										.findIsSOTrxByCode(taxFactAcct.getVATCode())
+										.orElseGet(line::isSOTrx);
+								discountFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 							}
 
 							// CR
@@ -1582,7 +1586,10 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 									.buildAndAdd();
 							if (discountFl != null)
 							{
-								discountFl.setTaxIdAndUpdateVatCode(taxId, VATCodeAmountType.Net);
+								final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
+										.findIsSOTrxByCode(taxFactAcct.getVATCode())
+										.orElseGet(line::isSOTrx);
+								discountFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 							}
 
 							// CR
@@ -1633,7 +1640,10 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 									.buildAndAdd();
 							if (discountFl != null)
 							{
-								discountFl.setTaxIdAndUpdateVatCode(taxId, VATCodeAmountType.Net);
+								final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
+										.findIsSOTrxByCode(taxFactAcct.getVATCode())
+										.orElseGet(line::isSOTrx);
+								discountFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 							}
 
 						}
@@ -1659,7 +1669,10 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 									.buildAndAdd();
 							if (discountFl != null)
 							{
-								discountFl.setTaxIdAndUpdateVatCode(taxId, VATCodeAmountType.Net);
+								final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
+										.findIsSOTrxByCode(taxFactAcct.getVATCode())
+										.orElseGet(line::isSOTrx);
+								discountFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 							}
 
 						}
@@ -1692,7 +1705,10 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 								.buildAndAdd();
 						if (writeOffFl != null)
 						{
-							writeOffFl.setTaxIdAndUpdateVatCode(taxId, VATCodeAmountType.Net);
+							final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
+									.findIsSOTrxByCode(taxFactAcct.getVATCode())
+									.orElseGet(line::isSOTrx);
+							writeOffFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 						}
 
 						// CR
@@ -1737,7 +1753,10 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 								.buildAndAdd();
 						if (writeOffFl != null)
 						{
-							writeOffFl.setTaxIdAndUpdateVatCode(taxId, VATCodeAmountType.Net);
+							final boolean netIsSOTrx = Services.get(IVATCodeDAO.class)
+									.findIsSOTrxByCode(taxFactAcct.getVATCode())
+									.orElseGet(line::isSOTrx);
+							writeOffFl.setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net);
 						}
 					}
 				}

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -692,7 +692,7 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 				}
 				if (fl != null)
 				{
-					fl.setTaxIdAndUpdateVatCode(taxId, VATCodeAmountType.Tax);
+					fl.setTaxIdAndUpdateVatCode(taxId, VATCodeAmountType.Net);
 					if (payment != null)
 					{
 						fl.setAD_Org_ID(payment.getAD_Org_ID());

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/doc/AcctDocRequiredServicesFacade.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/doc/AcctDocRequiredServicesFacade.java
@@ -481,6 +481,10 @@ public class AcctDocRequiredServicesFacade
 			@NonNull final AcctSchemaId acctSchemaId,
 			@NonNull final TaxId taxId)
 	{
+		if (vatCode == null || vatCode.isEmpty())
+		{
+			return Optional.empty();
+		}
 		return vatCodeDAO.findIsSOTrxByCode(vatCode, acctSchemaId, taxId);
 	}
 

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/doc/AcctDocRequiredServicesFacade.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/doc/AcctDocRequiredServicesFacade.java
@@ -485,7 +485,7 @@ public class AcctDocRequiredServicesFacade
 		{
 			return Optional.empty();
 		}
-		return vatCodeDAO.findIsSOTrxByCode(VATCode.ofCode(vatCode), acctSchemaId, taxId);
+		return vatCodeDAO.findIsSOTrxByCode(vatCode, acctSchemaId, taxId);
 	}
 
 	public Dimension extractDimensionFromModel(final Object model)

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/doc/AcctDocRequiredServicesFacade.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/doc/AcctDocRequiredServicesFacade.java
@@ -7,6 +7,7 @@ import de.metas.acct.accounts.AccountProvider;
 import de.metas.acct.accounts.AccountProviderFactory;
 import de.metas.acct.api.AccountId;
 import de.metas.acct.api.AcctSchema;
+import de.metas.acct.api.AcctSchemaId;
 import de.metas.acct.api.DocumentPostMultiRequest;
 import de.metas.acct.api.FactAcctId;
 import de.metas.acct.api.IAccountDAO;
@@ -473,6 +474,14 @@ public class AcctDocRequiredServicesFacade
 	public Optional<VATCode> findVATCode(final VATCodeMatchingRequest request)
 	{
 		return vatCodeDAO.findVATCode(request);
+	}
+
+	public Optional<Boolean> findIsSOTrxByCode(
+			@Nullable final String vatCode,
+			@NonNull final AcctSchemaId acctSchemaId,
+			@NonNull final TaxId taxId)
+	{
+		return vatCodeDAO.findIsSOTrxByCode(vatCode, acctSchemaId, taxId);
 	}
 
 	public Dimension extractDimensionFromModel(final Object model)

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/doc/AcctDocRequiredServicesFacade.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/doc/AcctDocRequiredServicesFacade.java
@@ -485,7 +485,7 @@ public class AcctDocRequiredServicesFacade
 		{
 			return Optional.empty();
 		}
-		return vatCodeDAO.findIsSOTrxByCode(vatCode, acctSchemaId, taxId);
+		return vatCodeDAO.findIsSOTrxByCode(VATCode.ofCode(vatCode), acctSchemaId, taxId);
 	}
 
 	public Dimension extractDimensionFromModel(final Object model)

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/IVATCodeDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/IVATCodeDAO.java
@@ -60,11 +60,11 @@ public interface IVATCodeDAO extends ISingletonService
 	VATCode createVATCode(@NonNull CreateVATCodeRequest request);
 
 	/**
-	 * Returns the IsSOTrx flag of the C_VAT_Code record that matches the given VATCode.
+	 * Returns the IsSOTrx flag of the C_VAT_Code record that has the given VATCode string.
 	 * Used to derive the correct IsSOTrx for Net VAT code lookup when the tax leg's IsSOTrx
 	 * differs from the document's (e.g. reverse-charge T_Due_Acct within a purchase allocation).
 	 *
 	 * @return Optional.empty() if no record found or if the record's IsSOTrx is blank
 	 */
-	Optional<Boolean> findIsSOTrxByCode(@NonNull VATCode vatCode, @NonNull AcctSchemaId acctSchemaId, @NonNull TaxId taxId);
+	Optional<Boolean> findIsSOTrxByCode(@NonNull String vatCode, @NonNull AcctSchemaId acctSchemaId, @NonNull TaxId taxId);
 }

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/IVATCodeDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/IVATCodeDAO.java
@@ -67,5 +67,5 @@ public interface IVATCodeDAO extends ISingletonService
 	 *
 	 * @return Optional.empty() if vatCode is null/empty or no record found
 	 */
-	Optional<Boolean> findIsSOTrxByCode(@Nullable String vatCode, @NonNull AcctSchemaId acctSchemaId);
+	Optional<Boolean> findIsSOTrxByCode(@Nullable String vatCode, @NonNull AcctSchemaId acctSchemaId, @NonNull TaxId taxId);
 }

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/IVATCodeDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/IVATCodeDAO.java
@@ -7,7 +7,6 @@ import de.metas.tax.api.VatCodeId;
 import de.metas.util.ISingletonService;
 import lombok.NonNull;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
 
 /*
@@ -65,7 +64,7 @@ public interface IVATCodeDAO extends ISingletonService
 	 * Used to derive the correct IsSOTrx for Net VAT code lookup when the tax leg's IsSOTrx
 	 * differs from the document's (e.g. reverse-charge T_Due_Acct within a purchase allocation).
 	 *
-	 * @return Optional.empty() if vatCode is null/empty or no record found
+	 * @return Optional.empty() if no record found or if the record's IsSOTrx is blank
 	 */
-	Optional<Boolean> findIsSOTrxByCode(@Nullable String vatCode, @NonNull AcctSchemaId acctSchemaId, @NonNull TaxId taxId);
+	Optional<Boolean> findIsSOTrxByCode(@NonNull String vatCode, @NonNull AcctSchemaId acctSchemaId, @NonNull TaxId taxId);
 }

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/IVATCodeDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/IVATCodeDAO.java
@@ -60,11 +60,11 @@ public interface IVATCodeDAO extends ISingletonService
 	VATCode createVATCode(@NonNull CreateVATCodeRequest request);
 
 	/**
-	 * Returns the IsSOTrx flag of the C_VAT_Code record that has the given VATCode string.
+	 * Returns the IsSOTrx flag of the C_VAT_Code record that matches the given VATCode.
 	 * Used to derive the correct IsSOTrx for Net VAT code lookup when the tax leg's IsSOTrx
 	 * differs from the document's (e.g. reverse-charge T_Due_Acct within a purchase allocation).
 	 *
 	 * @return Optional.empty() if no record found or if the record's IsSOTrx is blank
 	 */
-	Optional<Boolean> findIsSOTrxByCode(@NonNull String vatCode, @NonNull AcctSchemaId acctSchemaId, @NonNull TaxId taxId);
+	Optional<Boolean> findIsSOTrxByCode(@NonNull VATCode vatCode, @NonNull AcctSchemaId acctSchemaId, @NonNull TaxId taxId);
 }

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/IVATCodeDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/IVATCodeDAO.java
@@ -7,6 +7,7 @@ import de.metas.tax.api.VatCodeId;
 import de.metas.util.ISingletonService;
 import lombok.NonNull;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 /*
@@ -66,5 +67,5 @@ public interface IVATCodeDAO extends ISingletonService
 	 *
 	 * @return Optional.empty() if vatCode is null/empty or no record found
 	 */
-	Optional<Boolean> findIsSOTrxByCode(@javax.annotation.Nullable String vatCode);
+	Optional<Boolean> findIsSOTrxByCode(@Nullable String vatCode, @NonNull AcctSchemaId acctSchemaId);
 }

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/IVATCodeDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/IVATCodeDAO.java
@@ -58,4 +58,13 @@ public interface IVATCodeDAO extends ISingletonService
 	 */
 	@NonNull
 	VATCode createVATCode(@NonNull CreateVATCodeRequest request);
+
+	/**
+	 * Returns the IsSOTrx flag of the C_VAT_Code record that has the given VATCode string.
+	 * Used to derive the correct IsSOTrx for Net VAT code lookup when the tax leg's IsSOTrx
+	 * differs from the document's (e.g. reverse-charge T_Due_Acct within a purchase allocation).
+	 *
+	 * @return Optional.empty() if vatCode is null/empty or no record found
+	 */
+	Optional<Boolean> findIsSOTrxByCode(@javax.annotation.Nullable String vatCode);
 }

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/VATCode.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/VATCode.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
 
+import javax.annotation.Nullable;
+
 /*
  * #%L
  * de.metas.acct.base
@@ -38,13 +40,19 @@ public final class VATCode
 		return new VATCode(code, VatCodeId.ofRepoId(vatCodeId));
 	}
 
+	public static VATCode ofCode(@NonNull final String code)
+	{
+		return new VATCode(code, null);
+	}
+
 	@Getter
 	private final String code;
 
 	@Getter
+	@Nullable
 	private final VatCodeId vatCodeId;
 
-	private VATCode(final String code, @NonNull final VatCodeId vatCodeId)
+	private VATCode(final String code, @Nullable final VatCodeId vatCodeId)
 	{
 		Check.assumeNotEmpty(code, "code not empty");
 		this.code = code;

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/VATCode.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/VATCode.java
@@ -7,8 +7,6 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
 
-import javax.annotation.Nullable;
-
 /*
  * #%L
  * de.metas.acct.base
@@ -40,19 +38,13 @@ public final class VATCode
 		return new VATCode(code, VatCodeId.ofRepoId(vatCodeId));
 	}
 
-	public static VATCode ofCode(@NonNull final String code)
-	{
-		return new VATCode(code, null);
-	}
-
 	@Getter
 	private final String code;
 
 	@Getter
-	@Nullable
 	private final VatCodeId vatCodeId;
 
-	private VATCode(final String code, @Nullable final VatCodeId vatCodeId)
+	private VATCode(final String code, @NonNull final VatCodeId vatCodeId)
 	{
 		Check.assumeNotEmpty(code, "code not empty");
 		this.code = code;

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/impl/VATCodeDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/impl/VATCodeDAO.java
@@ -163,7 +163,7 @@ public class VATCodeDAO implements IVATCodeDAO
 				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_VATCode, vatCode)
 				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_C_Tax_ID, taxId)
 				.create()
-				.firstOptional()
+				.firstOnlyOptional()
 				.map(r -> X_C_VAT_Code.ISSOTRX_Yes.equals(r.getIsSOTrx()));
 	}
 
@@ -239,7 +239,7 @@ public class VATCodeDAO implements IVATCodeDAO
 				.addColumn(I_C_VAT_Code.COLUMN_ValidFrom, Direction.Descending, Nulls.Last)
 				.addColumn(I_C_VAT_Code.COLUMN_ValidTo, Direction.Descending, Nulls.Last)
 				.addColumn(I_C_VAT_Code.COLUMN_IsSOTrx, Direction.Ascending, Nulls.Last)
-				.addColumn(I_C_VAT_Code.COLUMN_C_VAT_Code_ID)
+				.addColumn(I_C_VAT_Code.COLUMN_C_VAT_Code_ID, Direction.Descending, Nulls.Last)
 				.endOrderBy()
 				//
 				.create()

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/impl/VATCodeDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/impl/VATCodeDAO.java
@@ -15,6 +15,7 @@ import de.metas.tax.api.TaxId;
 import de.metas.tax.api.VatCodeId;
 import de.metas.util.Services;
 import lombok.NonNull;
+import javax.annotation.Nullable;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryOrderBy.Direction;
 import org.adempiere.ad.dao.IQueryOrderBy.Nulls;
@@ -150,7 +151,7 @@ public class VATCodeDAO implements IVATCodeDAO
 	}
 
 	@Override
-	public Optional<Boolean> findIsSOTrxByCode(@javax.annotation.Nullable final String vatCode)
+	public Optional<Boolean> findIsSOTrxByCode(@Nullable final String vatCode, @NonNull final AcctSchemaId acctSchemaId)
 	{
 		if (vatCode == null || vatCode.isEmpty())
 		{
@@ -158,6 +159,7 @@ public class VATCodeDAO implements IVATCodeDAO
 		}
 		return queryBL.createQueryBuilder(I_C_VAT_Code.class, Env.getCtx(), ITrx.TRXNAME_ThreadInherited)
 				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_C_AcctSchema_ID, acctSchemaId)
 				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_VATCode, vatCode)
 				.create()
 				.firstOptional()

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/impl/VATCodeDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/impl/VATCodeDAO.java
@@ -151,20 +151,23 @@ public class VATCodeDAO implements IVATCodeDAO
 	}
 
 	@Override
-	public Optional<Boolean> findIsSOTrxByCode(@Nullable final String vatCode, @NonNull final AcctSchemaId acctSchemaId, @NonNull final TaxId taxId)
+	public Optional<Boolean> findIsSOTrxByCode(@NonNull final String vatCode, @NonNull final AcctSchemaId acctSchemaId, @NonNull final TaxId taxId)
 	{
-		if (vatCode == null || vatCode.isEmpty())
-		{
-			return Optional.empty();
-		}
-		return queryBL.createQueryBuilder(I_C_VAT_Code.class, Env.getCtx(), ITrx.TRXNAME_ThreadInherited)
+		return queryBL.createQueryBuilder(I_C_VAT_Code.class)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_C_AcctSchema_ID, acctSchemaId)
 				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_VATCode, vatCode)
 				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_C_Tax_ID, taxId)
 				.create()
 				.firstOnlyOptional()
-				.map(r -> X_C_VAT_Code.ISSOTRX_Yes.equals(r.getIsSOTrx()));
+				.flatMap(r -> {
+					final String isSOTrxStr = r.getIsSOTrx();
+					if (isSOTrxStr == null || isSOTrxStr.isEmpty())
+					{
+						return Optional.empty();
+					}
+					return Optional.of(X_C_VAT_Code.ISSOTRX_Yes.equals(isSOTrxStr));
+				});
 	}
 
 	/**

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/impl/VATCodeDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/impl/VATCodeDAO.java
@@ -151,12 +151,12 @@ public class VATCodeDAO implements IVATCodeDAO
 	}
 
 	@Override
-	public Optional<Boolean> findIsSOTrxByCode(@NonNull final VATCode vatCode, @NonNull final AcctSchemaId acctSchemaId, @NonNull final TaxId taxId)
+	public Optional<Boolean> findIsSOTrxByCode(@NonNull final String vatCode, @NonNull final AcctSchemaId acctSchemaId, @NonNull final TaxId taxId)
 	{
 		return queryBL.createQueryBuilder(I_C_VAT_Code.class)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_C_AcctSchema_ID, acctSchemaId)
-				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_VATCode, vatCode.getCode())
+				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_VATCode, vatCode)
 				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_C_Tax_ID, taxId)
 				.create()
 				.firstOnlyOptional()

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/impl/VATCodeDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/impl/VATCodeDAO.java
@@ -149,6 +149,21 @@ public class VATCodeDAO implements IVATCodeDAO
 		return VATCode.of(record.getVATCode(), record.getC_VAT_Code_ID());
 	}
 
+	@Override
+	public Optional<Boolean> findIsSOTrxByCode(@javax.annotation.Nullable final String vatCode)
+	{
+		if (vatCode == null || vatCode.isEmpty())
+		{
+			return Optional.empty();
+		}
+		return queryBL.createQueryBuilder(I_C_VAT_Code.class, Env.getCtx(), ITrx.TRXNAME_ThreadInherited)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_VATCode, vatCode)
+				.create()
+				.firstOptional()
+				.map(r -> X_C_VAT_Code.ISSOTRX_Yes.equals(r.getIsSOTrx()));
+	}
+
 	/**
 	 * @return true if the given {@link I_C_VAT_Code} is matching our request.
 	 */

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/impl/VATCodeDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/impl/VATCodeDAO.java
@@ -15,7 +15,6 @@ import de.metas.tax.api.TaxId;
 import de.metas.tax.api.VatCodeId;
 import de.metas.util.Services;
 import lombok.NonNull;
-import javax.annotation.Nullable;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryOrderBy.Direction;
 import org.adempiere.ad.dao.IQueryOrderBy.Nulls;
@@ -28,6 +27,7 @@ import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 import org.slf4j.Logger;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -151,7 +151,7 @@ public class VATCodeDAO implements IVATCodeDAO
 	}
 
 	@Override
-	public Optional<Boolean> findIsSOTrxByCode(@Nullable final String vatCode, @NonNull final AcctSchemaId acctSchemaId)
+	public Optional<Boolean> findIsSOTrxByCode(@Nullable final String vatCode, @NonNull final AcctSchemaId acctSchemaId, @NonNull final TaxId taxId)
 	{
 		if (vatCode == null || vatCode.isEmpty())
 		{
@@ -161,6 +161,7 @@ public class VATCodeDAO implements IVATCodeDAO
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_C_AcctSchema_ID, acctSchemaId)
 				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_VATCode, vatCode)
+				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_C_Tax_ID, taxId)
 				.create()
 				.firstOptional()
 				.map(r -> X_C_VAT_Code.ISSOTRX_Yes.equals(r.getIsSOTrx()));

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/impl/VATCodeDAO.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/vatcode/impl/VATCodeDAO.java
@@ -151,12 +151,12 @@ public class VATCodeDAO implements IVATCodeDAO
 	}
 
 	@Override
-	public Optional<Boolean> findIsSOTrxByCode(@NonNull final String vatCode, @NonNull final AcctSchemaId acctSchemaId, @NonNull final TaxId taxId)
+	public Optional<Boolean> findIsSOTrxByCode(@NonNull final VATCode vatCode, @NonNull final AcctSchemaId acctSchemaId, @NonNull final TaxId taxId)
 	{
 		return queryBL.createQueryBuilder(I_C_VAT_Code.class)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_C_AcctSchema_ID, acctSchemaId)
-				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_VATCode, vatCode)
+				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_VATCode, vatCode.getCode())
 				.addEqualsFilter(I_C_VAT_Code.COLUMNNAME_C_Tax_ID, taxId)
 				.create()
 				.firstOnlyOptional()

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -185,7 +185,7 @@ Feature: invoice payment allocation
   @from:cucumber
   @allure.label.epic:E0340_Invoicing
   @allure.label.feature:F00700_Invoicing
-  Scenario: sales invoice with VAT codes — allocation discount tax correction has Tax-AmountType VAT code
+  Scenario: allocation discount: PayDiscount_Exp_Acct carries Net VAT code, T_Due_Acct carries Tax VAT code (§17 UStG)
 
     Given metasfresh has date and time 2022-05-11T08:00:00+02:00[Europe/Berlin]
     And metasfresh contains C_TaxCategory
@@ -232,10 +232,14 @@ Feature: invoice payment allocation
       | C_AllocationHdr_ID | C_Invoice_ID | C_Payment_ID | Amount     | DiscountAmt |
       | alloc              | invoice      | payment      | 107.10 EUR | 11.90 EUR   |
 
-    # Key assertion: the T_Due_Acct tax correction leg on the allocation must carry the Tax-AmountType VAT code
+    # §17 UStG: PayDiscount gross leg and offset leg → Net VAT code (Bemessungsgrundlage reduced)
+    # T_Due_Acct correction → Tax VAT code (Steuerbetrag corrected)
+    # Net contribution to N-bucket: 11.90 − 1.90 = 10.00 EUR ✓
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID | C_VAT_Code_ID |
+      | PayDiscount_Exp_Acct  | 11.90 EUR   |             | tax19    | alloc     | sales19_N     |
       | T_Due_Acct            | 1.90 EUR    |             | tax19    | alloc     | sales19_T     |
+      | PayDiscount_Exp_Acct  |             | 1.90 EUR    | tax19    | alloc     | sales19_N     |
       | *                     |             |             |          | alloc     |               |
 
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -435,8 +435,8 @@ Feature: invoice payment allocation
     # Gross write-off leg (2.90 EUR) has no VAT code (createInvoiceWriteOffFacts does not set one)
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID | C_VAT_Code_ID |
-      | WriteOff_Acct         | 2.90 EUR    |             |          | alloc3    |               |
-      | C_Receivable_Acct     |             | 2.90 EUR    |          | alloc3    |               |
+      | WriteOff_Acct         | 2.90 EUR    |             |          | alloc3    | null          |
+      | C_Receivable_Acct     |             | 2.90 EUR    |          | alloc3    | null          |
       | T_Due_Acct            | 0.46 EUR    |             | tax1     | alloc3    | tax1_T        |
       | WriteOff_Acct         |             | 0.46 EUR    | tax1     | alloc3    | tax1_N        |
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -435,8 +435,8 @@ Feature: invoice payment allocation
     # Gross write-off leg (2.90 EUR) has no VAT code (createInvoiceWriteOffFacts does not set one)
     And Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID | C_VAT_Code_ID |
-      | WriteOff_Acct         | 2.90 EUR    |             |          | alloc3    | null          |
-      | C_Receivable_Acct     |             | 2.90 EUR    |          | alloc3    | null          |
+      | WriteOff_Acct         | 2.90 EUR    |             |          | alloc3    | -             |
+      | C_Receivable_Acct     |             | 2.90 EUR    |          | alloc3    | -             |
       | T_Due_Acct            | 0.46 EUR    |             | tax1     | alloc3    | tax1_T        |
       | WriteOff_Acct         |             | 0.46 EUR    | tax1     | alloc3    | tax1_N        |
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -380,6 +380,10 @@ Feature: invoice payment allocation
       | Identifier | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
       | invl_120_1 | inv_120_1    | product_120  | 1 PCE       | tax1     |
       | invl_120_2 | inv_120_2    | product_120  | 1 PCE       | tax1     |
+    And metasfresh contains C_VAT_Codes:
+      | Identifier | C_Tax_ID | IsSOTrx | AmountType |
+      | tax1_N     | tax1     | Y       | N          |
+      | tax1_T     | tax1     | Y       | T          |
     And the invoice identified by inv_120_1 is completed
     And the invoice identified by inv_120_2 is completed
 
@@ -427,12 +431,14 @@ Feature: invoice payment allocation
     And validate C_AllocationLines
       | C_Invoice_ID | Amount | WriteOffAmt | C_AllocationHdr_ID |
       | inv_120_2    | 0      | 2.9         | alloc3             |
+    # §17 UStG: WriteOff offset leg → Net VAT code; T_Due correction → Tax VAT code
+    # Gross write-off leg (2.90 EUR) has no VAT code (createInvoiceWriteOffFacts does not set one)
     And Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID |
-      | WriteOff_Acct         | 2.90 EUR    |             |          | alloc3    |
-      | C_Receivable_Acct     |             | 2.90 EUR    |          | alloc3    |
-      | T_Due_Acct            | 0.46 EUR    |             | tax1     | alloc3    |
-      | WriteOff_Acct         |             | 0.46 EUR    | tax1     | alloc3    |
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID | C_VAT_Code_ID |
+      | WriteOff_Acct         | 2.90 EUR    |             |          | alloc3    |               |
+      | C_Receivable_Acct     |             | 2.90 EUR    |          | alloc3    |               |
+      | T_Due_Acct            | 0.46 EUR    |             | tax1     | alloc3    | tax1_T        |
+      | WriteOff_Acct         |             | 0.46 EUR    | tax1     | alloc3    | tax1_N        |
 
 
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoice_reverseCharge_accounting.feature
@@ -48,6 +48,7 @@ Feature: Reverse Charge tax — accounting posting for purchase and sales docume
       | purchase19_N | rcTax19  | N       | N          |
       | purchase19_T | rcTax19  | N       | T          |
       | sales19_T    | rcTax19  | Y       | T          |
+      | sales19_N    | rcTax19  | Y       | N          |
 
     And metasfresh contains M_PricingSystems
       | Identifier    |
@@ -136,11 +137,11 @@ Feature: Reverse Charge tax — accounting posting for purchase and sales docume
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_Tax_ID | Record_ID | C_VAT_Code_ID |
       | V_Liability_Acct      | -1000 EUR   |             | -        | rcAlloc   | -             |
       | B_PaymentSelect_Acct  |             | -970 EUR    | -        | rcAlloc   | -             |
-      | PayDiscount_Rev_Acct  |             | -30 EUR     | rcTax19  | rcAlloc   | purchase19_T  |
-      | PayDiscount_Rev_Acct  | -5.70 EUR   |             | rcTax19  | rcAlloc   | purchase19_T  |
+      | PayDiscount_Rev_Acct  |             | -30 EUR     | rcTax19  | rcAlloc   | purchase19_N  |
+      | PayDiscount_Rev_Acct  | -5.70 EUR   |             | rcTax19  | rcAlloc   | purchase19_N  |
       | T_Credit_Acct         |             | -5.70 EUR   | rcTax19  | rcAlloc   | purchase19_T  |
       | T_Due_Acct            | -5.70 EUR   |             | rcTax19  | rcAlloc   | sales19_T     |
-      | PayDiscount_Rev_Acct  |             | -5.70 EUR   | rcTax19  | rcAlloc   | sales19_T     |
+      | PayDiscount_Rev_Acct  |             | -5.70 EUR   | rcTax19  | rcAlloc   | sales19_N     |
 
 
 # ############################################################################################################################################


### PR DESCRIPTION
## Summary

Fixes incorrect `VATCodeAmountType` assignment on payment discount (Skonto) and write-off legs in `Doc_AllocationHdr`.

**Why:** §17 Abs. 1 UStG (Entgeltminderung) requires the Bemessungsgrundlage (net base) to be reduced when Skonto is taken. The net discount amount must flow into the Net VAT code bucket. Before this fix, all discount legs were tagged Tax, leaving the Net bucket uncorrected.

**Changes to `Doc_AllocationHdr.java`:**
- Line 695 (`createInvoiceDiscountFacts`): `VATCodeAmountType.Tax` → `Net` on the PayDiscount gross leg.
- Lines 1556, 1578, 1626, 1649 (`Doc_AllocationTax.createEntries`, discount offset legs): replaced `.setC_Tax_ID(taxId).vatCode(taxFactAcct.getVATCode())` with `setTaxIdAndUpdateVatCode(taxId, netIsSOTrx, VATCodeAmountType.Net)`.
- Lines 1679, 1721 (`Doc_AllocationTax.createEntries`, write-off offset legs): same fix.
- Tax correction legs on `taxAcct` (T_Due/T_Credit) are unchanged.

**RC edge case fix (`IVATCodeDAO.findIsSOTrxByCode`):**
- Reverse-charge purchase invoices have a `T_Due_Acct` leg with `IsSOTrx=Y` inside a CMA document where `isSOTrx()` is always false. Added `IVATCodeDAO.findIsSOTrxByCode(vatCode, acctSchemaId)` to derive the correct `IsSOTrx` from the original invoice tax leg's stored VATCode string.

## Test plan
- [x] `de.metas.acct.base` — BUILD SUCCESS
- [x] `invoice_reverseCharge_accounting.feature` — 6/6 PASS (fixed wrong PayDiscount VAT codes)
- [x] `invoicePaymentAllocation.feature` @Id:S0465_100_020 — 1/1 PASS (extended with explicit Net assertions)
- [x] `invoicePaymentAllocation.feature` @Id:S0465_120 — 1/1 PASS (write-off scenario extended with Net VAT code assertions)