### PR TITLE
Manufacturing Issue — cap HU qty suggestion at live HU capacity

### DIFF
--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -1,48 +1,207 @@
-# Mobile WebUI — Manufacturing E2E Test Coverage
+# Mobile WebUI — E2E Test Coverage
 
-> Update this file whenever a manufacturing test is added or removed.
+> Update this file whenever a test is added or removed in any mobile UI workflow.
 
-## Section 1 — Existing manufacturing test catalog
+## Section 1 — Test catalog
 
-| Spec file | Test name | Scenario | ACs covered |
-|---|---|---|---|
-| `manufacturing.spec.js` | Simple manufacturing test | Full end-to-end manufacturing job: issue two raw material components (COMP1, COMP2) by scanning HUs, then receive finished product into a new LU; validates received HU status and storage | — |
-| `auto-issue.spec.js` | Auto-issue first line hides Scan button; manual second line shows it | BOM line with `IssueOnlyForReceived` (auto-issue method) must not show Scan button in the mobile UI; manually-issued line must show it | — |
-| `isAllowIssuingAnyHU.spec.js` | `isAllowIssuingAnyHU=false, isCreateRawMaterialsStock=false => expect ERROR` | Mobile config `isAllowIssuingAnyHU=false` with no stock in warehouse causes an error toast when starting a manufacturing job | — |
-| `isAllowIssuingAnyHU.spec.js` | `isAllowIssuingAnyHU=false, isCreateRawMaterialsStock=true => expect OK` | Mobile config `isAllowIssuingAnyHU=false` with stock present allows starting a manufacturing job | — |
-| `isAllowIssuingAnyHU.spec.js` | `isAllowIssuingAnyHU=true, isCreateRawMaterialsStock=false => expect OK` | Mobile config `isAllowIssuingAnyHU=true` allows starting a job even with no stock | — |
-| `isAllowIssuingAnyHU.spec.js` | `isAllowIssuingAnyHU=true, isCreateRawMaterialsStock=true => expect OK` | Mobile config `isAllowIssuingAnyHU=true` with stock present allows starting a manufacturing job | — |
-| `manufacturing_small_qty_tolerance.spec.js` | Issue raw material with very small qty (0.00384 kg) shows non-zero qty after scan | Scanning an HU for a BOM line with a very small qty (0.00384 kg) must display a non-zero pre-filled qty in the dialog (regression for https://github.com/metasfresh/tf201/issues/242) | — |
-| `manufacturing_small_qty_tolerance.spec.js` | Issue raw material with small qty (0.01913 kg) and 1% tolerance | Full issue-and-receive cycle for a BOM with 0.01913 kg and 1% issuing tolerance; validates final HU storage and remaining quantity after partial issue | — |
-| `receive_using_customQRCodeFormat.spec.js` | Receive using custom QR Code format | Receipt of finished product using two different custom QR code formats (catch-weight + lot + dates); validates HU storage, WeightNet attribute, and CU child records | — |
-| `receiving_by_products.spec.js` | Receive By-Products from 2 manufacturing orders into same HU | Two manufacturing orders both contribute by-product qty into the same target TU (no catch-weight); validates HU storage accumulates across orders | — |
-| `receiving_by_products.spec.js` | Fail receiving different By-Products in same HU | Attempting to receive a second by-product type into an HU that already holds a different by-product type must produce an error toast | — |
-| `receiving_by_products_catchweight.spec.js` | Receive several by-products using manual input to a new TU | By-product receipt in manual-input mode (typed qty + catch weight) into a new TU; validates qty indicator on job screen | — |
-| `receiving_by_products_catchweight.spec.js` | Receive several by-products using L+M codes to a new TU | By-product receipt via three L+M QR codes into a new TU; validates storage after receipt | — |
-| `receiving_by_products_catchweight.spec.js` | Receive By-Products from 2 manufacturing orders into same HU | Two manufacturing orders contribute catch-weight by-product qty (via L+M codes) into the same existing TU; validates accumulated HU weight | — |
-| `receiving_main_products.spec.js` | Receive 1 full LU, 1 half LU | Receipt of 100 PCE finished product into a new LU that splits into two LUs (80 + 20 PCE based on packing instructions); validates both received LUs | — |
-| `receiving_main_products_catchweight.spec.js` | To a new TU, manual input | Main product receipt in manual-input mode (9 PCE + 0.9 kg catch weight) into a new TU; validates split into 3 TUs (4+4+1 PCE) in backend | — |
-| `receiving_main_products_catchweight.spec.js` | To a new TU, scanning L+M QR codes | Main product receipt via three L+M QR codes into a new TU; validates 3 PCE and accumulated WeightNet 0.303 kg | — |
-| `receiving_main_products_catchweight.spec.js` | To a new TU, scanning L+M QR codes from 2 manufacturing orders | Two orders contribute catch-weight main product receipts into the same existing TU via L+M codes; validates accumulated storage (4 PCE, 0.131 kg) | — |
-| `receiving_main_products_catchweight.spec.js` | TO a new LU, scanning 2 x GTIN codes | Main product receipt via two GTIN QR code scans into a new LU; validates 2 PCE received into LU | — |
+### Login / Home
+
+| Spec file | Test name | Scenario |
+|---|---|---|
+| `login.spec.js` | By user/pass, using en_US language, UserPass as default auth method | Login with username/password using en\_US language and UserPass auth method; verifies language, then logs out |
+| `login.spec.js` | By user/pass, using en_US language, QR_Code as default auth method | Login with username/password using en\_US language and QR\_Code as default auth method; verifies language, then logs out |
+| `login.spec.js` | By user/pass, using de_DE language, UserPass as default auth method | Login with username/password using de\_DE language and UserPass auth method; verifies language, then logs out |
+| `login.spec.js` | By user/pass, using de_DE language, QR_Code as default auth method | Login with username/password using de\_DE language and QR\_Code as default auth method; verifies language, then logs out |
+| `home_screen.spec.js` | Scan HU QR Code | Scanning an HU QR code from the home/applications screen navigates directly to HU Manager and shows qty |
+| `home_screen.spec.js` | Scan HU ID Code | Scanning an HU ID (M\_HU\_ID) from the home screen navigates to HU Manager and shows qty |
+| `home_screen.spec.js` | Scan ExternalBarcode | Scanning an external barcode from the home screen navigates to HU Manager and shows qty |
+| `home_screen.spec.js` | Scan Workplace code | Scanning a workplace QR code from the home screen opens the Workplace Manager screen and shows the workplace name and assigned status |
+
+### Picking
+
+| Spec file | Test name | Scenario |
+|---|---|---|
+| `picking/picking.spec.js` | Simple picking test | Full happy-path picking: start job, scan picking slot, pick HU, complete job, verify shipment schedule marked as picked |
+| `picking/picking.spec.js` | Pick - unpick | Pick an HU then unpick it via the step screen; verifies HU returns to unallocated state |
+| `picking/picking.spec.js` | Scan invalid picking slot QR code | Scanning a barcode that does not match any picking slot triggers an error |
+| `picking/picking.spec.js` | Test picking line complete status - draft \| in progress \| complete | Verifies that line status indicator transitions through draft → in-progress → complete as HUs are picked |
+| `picking/picking.spec.js` | Should fail when partial picking and allowCompletingPartialPickingJob = N | Attempting to complete a job before all lines are fully picked is blocked when the config flag is N |
+| `picking/picking.spec.js` | Should succeed when partial picking and allowCompletingPartialPickingJob = Y | Completing a job with partially picked lines succeeds when the config flag is Y |
+| `picking/picking.spec.js` | Ship on close LU | Closing a LU during picking automatically creates a shipment |
+| `picking/picking.spec.js` | Close LU / Reopen LU | A closed LU can be reopened; verifies state transitions |
+| `picking/picking.spec.js` | Check launcher already started indicator | A job that has already been started shows an "already started" indicator in the jobs list |
+| `picking/completeJobAutomatically.spec.js` | Happy case | With `completeJobAutomatically=true`, scanning the drop-to locator after picking completes the job automatically and removes it from the list |
+| `picking/facets.spec.js` | Check facets when only scheduled for workplace is enabled | Facet filter shows only jobs scheduled for the user's current workplace |
+| `picking/filterByQtyAvailableAtLocator.spec.js` | Filter by Qty Available flag | Jobs list can be filtered to show only jobs where the required qty is available at the pick-from locator |
+| `picking/pickAllButton.spec.js` | Pick using Pick All button | The "Pick All" button picks all remaining HUs in a single action |
+| `picking/pickAllButton.spec.js` | Expect Pick All button hidden when feature is not active | The "Pick All" button is not visible when the feature is disabled in mobile config |
+| `picking/pickAttributes.spec.js` | Expect picking directly without dialog | When only one matching HU exists, picking proceeds without showing a quantity dialog |
+| `picking/pick_and_assemble.spec.js` | Assemble/Manufacture while picking test | Pick triggers an on-the-fly manufacturing (assemble) step; verifies assembled HU is picked into the order |
+| `picking/pick_by_customQRCode.spec.js` | Pick using custom QR code | HU is identified and picked by scanning a customer-defined custom QR code format |
+| `picking/pick_by_EAN13.spec.js` | LU/CU -> top level TU | Pick from an LU/CU source into a top-level TU target using EAN13 barcode |
+| `picking/pick_by_EAN13.spec.js` | LU/CU -> LU/TU1, LU/TU2 | Pick from an LU/CU source into two LU/TU targets using EAN13 barcode |
+| `picking/pick_by_EAN13.spec.js` | LU/CU -> LU/CU | Pick from an LU/CU source into an LU/CU target using EAN13 barcode |
+| `picking/pick_by_EAN13.spec.js` | LU/CU -> top level CUs | Pick from an LU/CU source into top-level CU targets using EAN13 barcode |
+| `picking/pick_by_ExternalBarcode.spec.js` | Pick by scanning ExternalBarcode attribute | HU is identified and picked by scanning its ExternalBarcode attribute value |
+| `picking/pick_by_HUId.spec.js` | LU/CU -> LU/CU | HU is identified and picked by scanning its internal M\_HU\_ID instead of a QR code |
+| `picking/pick_from_LUs.spec.js` | Pick less than a LU because ordered qty is less than an LU | Picking from an LU when ordered qty is smaller than the full LU; a partial pick is created |
+| `picking/pick_from_LUs.spec.js` | Pick entire LU which is exactly the qty that was ordered | Picking an entire LU whose qty exactly matches the ordered qty |
+| `picking/pick_from_LUs.spec.js` | Pick entire LU but less then ordered | Picking an entire LU when the LU qty is smaller than the ordered qty (partial fulfillment) |
+| `picking/picking_catchWeight.spec.js` | Manual | Catch-weight picking via manual typed input; verifies pick qty and weight recorded |
+| `picking/picking_catchWeight.spec.js` | Leich+Mehl | Catch-weight picking via L+M QR code scan |
+| `picking/picking_catchWeight.spec.js` | Leich+Mehl - invalid code | Scanning an invalid L+M code produces an error |
+| `picking/picking_catchWeight.spec.js` | GS1 | Catch-weight picking via GS1 barcode scan |
+| `picking/picking_catchWeight.spec.js` | EAN13 with prefix 28 | Catch-weight picking via EAN13 barcode with prefix 28 |
+| `picking/picking_catchWeight.spec.js` | EAN13 with prefix 28 and not matching product | EAN13 prefix-28 barcode for wrong product triggers an error |
+| `picking/picking_catchWeight.spec.js` | EAN13 with prefix 29 | Catch-weight picking via EAN13 barcode with prefix 29 |
+| `picking/picking_catchWeight.spec.js` | EAN13 with prefix 29 and not matching product | EAN13 prefix-29 barcode for wrong product triggers an error |
+| `picking/picking_catchWeight.spec.js` | Custom QR code format | Catch-weight picking via a configured custom QR code format |
+| `picking/picking_catchWeight.spec.js` | Check Last BestBeforeDate is displayed when MobileUIPickingProfile.ShowLastPickedBestBeforeDateForLines = Y | Last picked best-before date is shown on the picking line when the profile flag is enabled |
+| `picking/picking_deliveryLocationBasedAggregation.spec.js` | Delivery Location based aggregation | Picking lines are aggregated and grouped by delivery location |
+| `picking/pickingSlotSuggestions.spec.js` | Test NO picking slot suggestions | When no suggestions are configured, no suggested picking slots are shown |
+| `picking/pickingSlotSuggestions.spec.js` | Test picking slot suggestions | Configured picking slot suggestions are shown and selectable |
+| `picking/pick_what_was_scheduled_to_workplace.spec.js` | Pick one sales order to different workplaces | A single sales order can be split and picked to multiple workplaces |
+| `picking/productBasedPicking/standard.spec.js` | Product based aggregation | Product-based picking: lines are grouped by product instead of by order |
+| `picking/productBasedPicking/standard.spec.js` | Filter by EAN13 | Product-based picking list can be filtered by scanning a product EAN13 barcode |
+| `picking/productBasedPicking/standard.spec.js` | Anonymous pick HUs on the fly | Pick HUs that are not pre-assigned to a specific order line |
+| `picking/productBasedPicking/pick_by_ExternalBarcode.spec.js` | Scan the pick from HU by ExternalBarcode | In product-based picking mode, the pick-from HU is identified by scanning its ExternalBarcode attribute |
+
+### Distribution
+
+| Spec file | Test name | Scenario |
+|---|---|---|
+| `distribution/distribution.spec.js` | Simple distribution test | Full happy-path distribution: pick HU from source locator, scan drop-to locator, complete job |
+| `distribution/distribution.spec.js` | Try picking an HU from a different locator than pick from locator | Scanning an HU from a locator that does not match the order's pick-from locator shows an error |
+| `distribution/distribution.spec.js` | Try picking an HU containing a different product than expected | Scanning an HU containing the wrong product shows an error |
+| `distribution/distribution.spec.js` | Distribution using 2 steps to pick the needed qty. | Distribution job requiring two separate HU picks to fulfil a single line qty |
+| `distribution/distribution.spec.js` | Pick & Unpick in distribution step screen | Picking an HU then unpicking it in the step screen leaves the line in unallocated state |
+| `distribution/distribution.spec.js` | Filter distribution orders by plantId | Distribution job list can be filtered by plant facet |
+| `distribution/caption.spec.js` | LocatorFrom,ProductValueAndName,ProductGTIN,Qty,Priority | Job launcher caption is correctly formatted with multiple fields (locator, product, GTIN, qty, priority) |
+| `distribution/completeJobAutomatically.spec.js` | Happy case | With `completeJobAutomatically=true`, scanning the drop-to locator completes the job automatically |
+| `distribution/distributionandmanufacturing.spec.js` | Distribution and manufacturing test | End-to-end scenario: distribute two components to a warehouse, then issue them in a manufacturing job and receive finished product |
+| `distribution/filter_by_workplace.spec.js` | Show all jobs when no current workplace | Without a workplace set, all distribution jobs are visible |
+| `distribution/filter_by_workplace.spec.js` | Show only jobs suitable for workplace1 | Only jobs whose drop-to locator matches the current workplace's locator are shown |
+| `distribution/header.spec.js` | Happy case | Job screen header shows correct From Locator and Locator To values |
+| `distribution/job_dropAllButton.spec.js` | Pick multiple HUs and drop them all together in one step | Pick three lines across multiple HUs; use Drop All to deliver them in a single action; validates HU warehouse at each step |
+| `distribution/job_dropAllButton.spec.js` | Pick multiple HUs (by HU code) and drop them all together in one step (using locator code) | Same as above but HUs are identified by M\_HU\_ID and the drop-to locator is scanned by locator code |
+| `distribution/lauchers_restrictions.spec.js` | No restrictions | With no launcher restrictions configured, all jobs are enabled |
+| `distribution/lauchers_restrictions.spec.js` | Allow starting next job only | With `allowStartNextJobOnly=true`, only the first unstarted job is enabled; starting it enables the next |
+| `distribution/launchers_dropAllButton.spec.js` | Pick multiple HUs (by HU code) and drop them all together in one step (using locator code) | Pick from multiple jobs across the launchers list; use Drop All from the jobs-list screen to deliver all picked HUs at once |
+| `distribution/launchers_websockets.spec.js` | Check launchers are refreshed via websockets | New distribution orders created on the backend appear in the launchers list in real time via websockets |
+| `distribution/navigateToJobsListAfterPickFromComplete.spec.js` | Happy case | With `navigateToJobsListAfterPickFromComplete=true`, completing a pick-from step on the last line of a job navigates to the next job's pick-from screen (or back to the list if no more jobs) |
+| `distribution/pickFrom_validate_GTIN.spec.js` | Scan the HU by QRCode | In GTIN-validation mode, scan HU by QR code then confirm with product GTIN |
+| `distribution/pickFrom_validate_GTIN.spec.js` | Scan the HU by Value/M_HU_ID | In GTIN-validation mode, scan HU by M\_HU\_ID then confirm with product GTIN |
+| `distribution/pickFrom_validate_GTIN.spec.js` | Scan the HU by External Attribute | In GTIN-validation mode, scan HU by ExternalBarcode then confirm with product GTIN |
+| `distribution/pickFrom_validate_GTIN.spec.js` | Do not ask for picked qty when it is one | When only 1 unit matches, the qty dialog is skipped |
+| `distribution/scan_HU_barcodes.spec.js` | Scan by HU QR Code | Distribution line HU can be scanned by its QR code |
+| `distribution/scan_HU_barcodes.spec.js` | Scan by M_HU_ID | Distribution line HU can be scanned by its M\_HU\_ID |
+| `distribution/scan_HU_barcodes.spec.js` | Scan by ExternalBarcode | Distribution line HU can be scanned by its ExternalBarcode attribute |
+| `distribution/sorting.spec.js` | Sort by SeqNo | Distribution jobs list is sorted by SeqNo when `orderBys=SeqNo,Priority,DatePromised` |
+
+### Manufacturing
+
+| Spec file | Test name | Scenario |
+|---|---|---|
+| `manufacturing/manufacturing.spec.js` | Simple manufacturing test | Full end-to-end manufacturing job: issue two raw material components by scanning HUs, receive finished product into a new LU; validates received HU status and storage |
+| `manufacturing/auto-issue.spec.js` | Auto-issue first line hides Scan button; manual second line shows it | BOM line with `IssueOnlyForReceived` must not show Scan button; manually-issued line must show it |
+| `manufacturing/isAllowIssuingAnyHU.spec.js` | isAllowIssuingAnyHU=false, isCreateRawMaterialsStock=false => expect ERROR | `isAllowIssuingAnyHU=false` with no stock causes an error toast when starting a manufacturing job |
+| `manufacturing/isAllowIssuingAnyHU.spec.js` | isAllowIssuingAnyHU=false, isCreateRawMaterialsStock=true => expect OK | `isAllowIssuingAnyHU=false` with stock present allows starting a job |
+| `manufacturing/isAllowIssuingAnyHU.spec.js` | isAllowIssuingAnyHU=true, isCreateRawMaterialsStock=false => expect OK | `isAllowIssuingAnyHU=true` allows starting a job even with no stock |
+| `manufacturing/isAllowIssuingAnyHU.spec.js` | isAllowIssuingAnyHU=true, isCreateRawMaterialsStock=true => expect OK | `isAllowIssuingAnyHU=true` with stock present allows starting a job |
+| `manufacturing/issue_hu_qty_suggestion.spec.js` | Suggested qty is capped at HU capacity when HU qty is less than BOM requirement | BOM 20, HU 5, nothing issued → suggestion = 5 (HU capacity, not BOM remaining) |
+| `manufacturing/issue_hu_qty_suggestion.spec.js` | Suggested qty is capped at HU capacity after a partial issue (customer scenario) | BOM 20, 7 issued, second HU has 5 → suggestion = 5, not 13 |
+| `manufacturing/manufacturing_small_qty_tolerance.spec.js` | Issue raw material with very small qty (0.00384 kg) shows non-zero qty after scan | Scanning an HU for a BOM line with a very small qty (0.00384 kg) must display a non-zero pre-filled qty (regression for https://github.com/metasfresh/tf201/issues/242) |
+| `manufacturing/manufacturing_small_qty_tolerance.spec.js` | Issue raw material with small qty (0.01913 kg) and 1% tolerance | Full issue-and-receive cycle for a BOM with 0.01913 kg and 1% issuing tolerance; validates final HU storage and remaining quantity |
+| `manufacturing/receive_using_customQRCodeFormat.spec.js` | Receive using custom QR Code format | Receipt of finished product using two different custom QR code formats (catch-weight + lot + dates); validates HU storage, WeightNet, and CU child records |
+| `manufacturing/receiving_by_products.spec.js` | Receive By-Products from 2 manufacturing orders into same HU | Two manufacturing orders contribute by-product qty into the same target TU; validates accumulated HU storage |
+| `manufacturing/receiving_by_products.spec.js` | Fail receiving different By-Products in same HU | Attempting to receive a second by-product type into an HU that already holds a different by-product type must produce an error toast |
+| `manufacturing/receiving_by_products_catchweight.spec.js` | Receive several by-products using manual input to a new TU | By-product receipt in manual-input mode (typed qty + catch weight) into a new TU; validates qty indicator |
+| `manufacturing/receiving_by_products_catchweight.spec.js` | Receive several by-products using L+M codes to a new TU | By-product receipt via three L+M QR codes into a new TU; validates storage after receipt |
+| `manufacturing/receiving_by_products_catchweight.spec.js` | Receive By-Products from 2 manufacturing orders into same HU | Two manufacturing orders contribute catch-weight by-product qty (L+M codes) into the same existing TU; validates accumulated weight |
+| `manufacturing/receiving_main_products.spec.js` | Receive 1 full LU, 1 half LU | Receipt of 100 PCE finished product into a new LU that splits into two LUs (80 + 20 PCE); validates both received LUs |
+| `manufacturing/receiving_main_products_catchweight.spec.js` | To a new TU, manual input | Main product receipt in manual-input mode (9 PCE + 0.9 kg catch weight) into a new TU; validates split into 3 TUs |
+| `manufacturing/receiving_main_products_catchweight.spec.js` | To a new TU, scanning L+M QR codes | Main product receipt via three L+M QR codes into a new TU; validates 3 PCE and accumulated WeightNet |
+| `manufacturing/receiving_main_products_catchweight.spec.js` | To a new TU, scanning L+M QR codes from 2 manufacturing orders | Two orders contribute catch-weight main product receipts into the same existing TU; validates accumulated storage |
+| `manufacturing/receiving_main_products_catchweight.spec.js` | TO a new LU, scanning 2 x GTIN codes | Main product receipt via two GTIN QR code scans into a new LU; validates 2 PCE received |
+
+### HU Manager
+
+| Spec file | Test name | Scenario |
+|---|---|---|
+| `humanager/scan.spec.js` | Scan by HU QR Code | Open HU Manager and scan HU by QR code; verifies qty is displayed |
+| `humanager/scan.spec.js` | Scan by M_HU_ID | Open HU Manager and scan HU by M\_HU\_ID; verifies qty is displayed |
+| `humanager/scan.spec.js` | Scan by ExternalBarcode attribute | Open HU Manager and scan HU by ExternalBarcode; verifies qty is displayed |
+| `humanager/huManager.spec.js` | Check action buttons order | Verifies the action buttons appear in the expected order after scanning an HU |
+| `humanager/huManager.spec.js` | Dispose HU | Dispose an HU via the HU Manager; verifies HU is destroyed |
+| `humanager/huManager.spec.js` | Move HU using locator code | Move an HU to a new locator by scanning the locator code; verifies locator updated |
+| `humanager/huManager.spec.js` | Change Qty | Change the qty of an HU; verifies new qty is stored |
+| `humanager/huManager.spec.js` | Change Clearance Status | Set a clearance status and note on an HU; verifies both values are saved |
+| `humanager/huManager.spec.js` | Bulk actions - Move | Use bulk actions to move an HU to a different locator; verifies locator updated |
+| `humanager/by_ExternalBarcode_attribute.spec.js` | Dispose HU | Scan HU by ExternalBarcode (no QR code generated); dispose the HU |
+| `humanager/by_ExternalBarcode_attribute.spec.js` | Move HU using locator code | Scan HU by ExternalBarcode; move it to another warehouse by locator code |
+| `humanager/by_ExternalBarcode_attribute.spec.js` | Change Qty | Scan HU by ExternalBarcode; change qty and verify new value |
+| `humanager/by_ExternalBarcode_attribute.spec.js` | Change Clearance Status | Scan HU by ExternalBarcode; set clearance status and note |
+| `humanager/by_ExternalBarcode_attribute.spec.js` | Bulk actions - Move | Scan HU by ExternalBarcode; use bulk actions to move to another locator |
+
+### HU Consolidation
+
+| Spec file | Test name | Scenario |
+|---|---|---|
+| `hu_consolidation/hu_consolidation.spec.js` | Simple HU consolidate all test | Pick HUs into a picking slot, then use HU Consolidation to consolidate all TUs onto a new LU and complete |
+| `hu_consolidation/hu_consolidation.spec.js` | Simple HU consolidate HUs one by one test | Pick HUs into a picking slot, then consolidate individual TUs one by one onto a new LU |
+| `hu_consolidation/hu_consolidation.spec.js` | Manual print current target label | Consolidate some HUs partially, then manually print the current target LU label |
+| `hu_consolidation/hu_consolidation.spec.js` | Consolidate to an existing LU | Consolidate picked TUs onto an existing LU (rather than a new one); validates combined storage |
+
+### Inventory
+
+| Spec file | Test name | Scenario |
+|---|---|---|
+| `inventory/inventory.spec.js` | Simple inventory test | Start an inventory job, count an HU with adjusted qty and attributes (lot, best-before), complete; validates HU storage and attributes are updated |
+
+---
 
 ## Section 2 — Gap analysis
 
-Manufacturing workflow paths that currently have **no** Playwright test:
+By workflow area, paths that have **no** Playwright test or known weak coverage:
 
-- **Job list navigation / filtering**: No test exercises search/filter on the manufacturing jobs list (e.g., filter by document number, date, or status via facets). The existing tests always start a specific job by `documentNo` immediately.
-- **Component issue: happy path confirmed end-to-end with backend validation**: `manufacturing.spec.js` scans components and receives, but does not call `Backend.expect` to verify the issued component quantities were recorded correctly in the backend after issue (only receipt HU is validated).
-- **Component issue: partial issue (multiple HUs, same BOM line)**: No test issues a BOM line component across more than one HU and checks that the remaining qty decrements correctly on the job screen between scans.
-- **Component issue: HU qty < remaining BOM qty (the bug fixed by this issue)**: Before this issue, no test verified that the qty suggestion is capped at HU capacity when HU qty is smaller than the BOM requirement. This gap is closed by Task 4.
-- **Component issue: over-issue (worker types more than HU capacity)**: No test covers the path where a worker manually types a qty larger than the scanned HU's available qty, triggering an inventory adjustment. This is covered by Task 4 (AC4).
-- **Component issue: zero-stock / no matching HU**: No test scans a QR code for an HU that belongs to the wrong product or has zero stock, to verify the error message.
-- **Manufacturing job completion without issuing all components**: No test verifies the behavior (error or warning) when a worker tries to complete a job before all BOM lines are fully issued.
-- **Manufacturing job: navigate back from issue screen without scanning**: No test verifies that navigating back from `RawMaterialIssueLineScreen` without scanning leaves the job state unchanged.
-- **Receipt: selecting an existing LU as target**: `receive_using_customQRCodeFormat.spec.js` and by-product catch-weight tests use `selectExistingHUTarget`, but none of the main-product receipt tests do (they always create a new LU/TU).
-- **Receipt: multiple receipt lines on same job (LU and TU in same job)**: No test exercises receiving finished product into a mix of LU and TU targets in a single job.
-- **Mobile config: `isAllowIssuingAnyHU` exhaustive issue path**: `isAllowIssuingAnyHU.spec.js` only tests the job start step; no test actually scans an HU from a different product when `isAllowIssuingAnyHU=true` to verify the full issue path completes.
+**Login / Home**
+- No test covers failed login (wrong password, inactive user).
+- No test covers the QR-code-based login flow end-to-end (only auth method preference is checked in `login.spec.js`).
 
-## Section 3 — Tests added by this issue (Task 4)
+**Picking**
+- No test covers scanning an HU from the wrong warehouse/locator in the standard (non-distribution) picking flow.
+- No test covers multiple picking jobs visible simultaneously for the same customer and verifies the aggregation count.
+- No test covers the "Scan Anything" generic routing when the scanned code is ambiguous (resolves to more than one target).
+
+**Distribution**
+- No test covers the `maxLaunchers` config cap (list is truncated beyond N jobs).
+- No test covers the `maxStartedLaunchers` config cap.
+- No test covers abort (cancel) of an in-progress distribution job.
+
+**Manufacturing**
+- No test exercises search/filter on the manufacturing jobs list (filter by document number, date, or status via facets).
+- `manufacturing.spec.js` does not call `Backend.expect` to verify issued component quantities in the backend after issue (only the received HU is validated).
+- No test covers issuing a BOM line across more than one HU and verifying remaining qty decrements correctly between scans.
+- No test covers scanning the wrong HU product (zero-stock or product mismatch) during issue.
+- No test covers completing a job before all BOM lines are fully issued.
+- No test covers navigating back from `RawMaterialIssueLineScreen` without scanning and verifying the job state is unchanged.
+- `isAllowIssuingAnyHU.spec.js` only tests the job start step; no test scans an HU from a different product when `isAllowIssuingAnyHU=true` to verify the full issue path.
+- No test covers AC3–AC5 from https://github.com/metasfresh/me03/issues/27759 (regression: suggestion when HU capacity exceeds remaining BOM qty; over-issue creates inventory adjustment; confirming HU-capacity suggestion creates no adjustment). These are reserved for the remaining tasks in that issue.
+
+**HU Manager**
+- No test covers the "Print Labels" action.
+- No test covers scanning a generated HU QR code (the commented-out test `Change Locator of a generated HU QR Code` was broken and skipped).
+
+**HU Consolidation**
+- No test covers the case where `setTargetLU` fails (e.g., scanning an LU that already contains a different customer's goods).
+
+**Inventory**
+- No test covers an inventory job with multiple products/lines.
+- No test covers completing an inventory job that has a line with no physical HU scanned (qty remains as booked).
+
+---
+
+## Section 3 — Tests added by issue https://github.com/metasfresh/me03/issues/27759
 
 These 5 tests will be written in `tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js`:
 

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -1,213 +1,365 @@
-# Mobile WebUI — E2E Test Coverage
+# Mobile WebUI — Test Coverage
 
-> Update this file whenever a test is added or removed in any mobile UI workflow.
+> Update this file whenever a test is added, changed, deleted, or refactored.
 
-## Section 1 — Test catalog
+## Summary
 
-### Login / Home
-
-| Spec file | Test name | Scenario |
-|---|---|---|
-| `login.spec.js` | By user/pass, using en_US language, UserPass as default auth method | Login with username/password using en\_US language and UserPass auth method; verifies language, then logs out |
-| `login.spec.js` | By user/pass, using en_US language, QR_Code as default auth method | Login with username/password using en\_US language and QR\_Code as default auth method; verifies language, then logs out |
-| `login.spec.js` | By user/pass, using de_DE language, UserPass as default auth method | Login with username/password using de\_DE language and UserPass auth method; verifies language, then logs out |
-| `login.spec.js` | By user/pass, using de_DE language, QR_Code as default auth method | Login with username/password using de\_DE language and QR\_Code as default auth method; verifies language, then logs out |
-| `home_screen.spec.js` | Scan HU QR Code | Scanning an HU QR code from the home/applications screen navigates directly to HU Manager and shows qty |
-| `home_screen.spec.js` | Scan HU ID Code | Scanning an HU ID (M\_HU\_ID) from the home screen navigates to HU Manager and shows qty |
-| `home_screen.spec.js` | Scan ExternalBarcode | Scanning an external barcode from the home screen navigates to HU Manager and shows qty |
-| `home_screen.spec.js` | Scan Workplace code | Scanning a workplace QR code from the home screen opens the Workplace Manager screen and shows the workplace name and assigned status |
-
-### Picking
-
-| Spec file | Test name | Scenario |
-|---|---|---|
-| `picking/picking.spec.js` | Simple picking test | Full happy-path picking: start job, scan picking slot, pick HU, complete job, verify shipment schedule marked as picked |
-| `picking/picking.spec.js` | Pick - unpick | Pick an HU then unpick it via the step screen; verifies HU returns to unallocated state |
-| `picking/picking.spec.js` | Scan invalid picking slot QR code | Scanning a barcode that does not match any picking slot triggers an error |
-| `picking/picking.spec.js` | Test picking line complete status - draft \| in progress \| complete | Verifies that line status indicator transitions through draft → in-progress → complete as HUs are picked |
-| `picking/picking.spec.js` | Should fail when partial picking and allowCompletingPartialPickingJob = N | Attempting to complete a job before all lines are fully picked is blocked when the config flag is N |
-| `picking/picking.spec.js` | Should succeed when partial picking and allowCompletingPartialPickingJob = Y | Completing a job with partially picked lines succeeds when the config flag is Y |
-| `picking/picking.spec.js` | Ship on close LU | Closing a LU during picking automatically creates a shipment |
-| `picking/picking.spec.js` | Close LU / Reopen LU | A closed LU can be reopened; verifies state transitions |
-| `picking/picking.spec.js` | Check launcher already started indicator | A job that has already been started shows an "already started" indicator in the jobs list |
-| `picking/completeJobAutomatically.spec.js` | Happy case | With `completeJobAutomatically=true`, scanning the drop-to locator after picking completes the job automatically and removes it from the list |
-| `picking/facets.spec.js` | Check facets when only scheduled for workplace is enabled | Facet filter shows only jobs scheduled for the user's current workplace |
-| `picking/filterByQtyAvailableAtLocator.spec.js` | Filter by Qty Available flag | Jobs list can be filtered to show only jobs where the required qty is available at the pick-from locator |
-| `picking/pickAllButton.spec.js` | Pick using Pick All button | The "Pick All" button picks all remaining HUs in a single action |
-| `picking/pickAllButton.spec.js` | Expect Pick All button hidden when feature is not active | The "Pick All" button is not visible when the feature is disabled in mobile config |
-| `picking/pickAttributes.spec.js` | Expect picking directly without dialog | When only one matching HU exists, picking proceeds without showing a quantity dialog |
-| `picking/pick_and_assemble.spec.js` | Assemble/Manufacture while picking test | Pick triggers an on-the-fly manufacturing (assemble) step; verifies assembled HU is picked into the order |
-| `picking/pick_by_customQRCode.spec.js` | Pick using custom QR code | HU is identified and picked by scanning a customer-defined custom QR code format |
-| `picking/pick_by_EAN13.spec.js` | LU/CU -> top level TU | Pick from an LU/CU source into a top-level TU target using EAN13 barcode |
-| `picking/pick_by_EAN13.spec.js` | LU/CU -> LU/TU1, LU/TU2 | Pick from an LU/CU source into two LU/TU targets using EAN13 barcode |
-| `picking/pick_by_EAN13.spec.js` | LU/CU -> LU/CU | Pick from an LU/CU source into an LU/CU target using EAN13 barcode |
-| `picking/pick_by_EAN13.spec.js` | LU/CU -> top level CUs | Pick from an LU/CU source into top-level CU targets using EAN13 barcode |
-| `picking/pick_by_ExternalBarcode.spec.js` | Pick by scanning ExternalBarcode attribute | HU is identified and picked by scanning its ExternalBarcode attribute value |
-| `picking/pick_by_HUId.spec.js` | LU/CU -> LU/CU | HU is identified and picked by scanning its internal M\_HU\_ID instead of a QR code |
-| `picking/pick_from_LUs.spec.js` | Pick less than a LU because ordered qty is less than an LU | Picking from an LU when ordered qty is smaller than the full LU; a partial pick is created |
-| `picking/pick_from_LUs.spec.js` | Pick entire LU which is exactly the qty that was ordered | Picking an entire LU whose qty exactly matches the ordered qty |
-| `picking/pick_from_LUs.spec.js` | Pick entire LU but less then ordered | Picking an entire LU when the LU qty is smaller than the ordered qty (partial fulfillment) |
-| `picking/picking_catchWeight.spec.js` | Manual | Catch-weight picking via manual typed input; verifies pick qty and weight recorded |
-| `picking/picking_catchWeight.spec.js` | Leich+Mehl | Catch-weight picking via L+M QR code scan |
-| `picking/picking_catchWeight.spec.js` | Leich+Mehl - invalid code | Scanning an invalid L+M code produces an error |
-| `picking/picking_catchWeight.spec.js` | GS1 | Catch-weight picking via GS1 barcode scan |
-| `picking/picking_catchWeight.spec.js` | EAN13 with prefix 28 | Catch-weight picking via EAN13 barcode with prefix 28 |
-| `picking/picking_catchWeight.spec.js` | EAN13 with prefix 28 and not matching product | EAN13 prefix-28 barcode for wrong product triggers an error |
-| `picking/picking_catchWeight.spec.js` | EAN13 with prefix 29 | Catch-weight picking via EAN13 barcode with prefix 29 |
-| `picking/picking_catchWeight.spec.js` | EAN13 with prefix 29 and not matching product | EAN13 prefix-29 barcode for wrong product triggers an error |
-| `picking/picking_catchWeight.spec.js` | Custom QR code format | Catch-weight picking via a configured custom QR code format |
-| `picking/picking_catchWeight.spec.js` | Check Last BestBeforeDate is displayed when MobileUIPickingProfile.ShowLastPickedBestBeforeDateForLines = Y | Last picked best-before date is shown on the picking line when the profile flag is enabled |
-| `picking/picking_deliveryLocationBasedAggregation.spec.js` | Delivery Location based aggregation | Picking lines are aggregated and grouped by delivery location |
-| `picking/pickingSlotSuggestions.spec.js` | Test NO picking slot suggestions | When no suggestions are configured, no suggested picking slots are shown |
-| `picking/pickingSlotSuggestions.spec.js` | Test picking slot suggestions | Configured picking slot suggestions are shown and selectable |
-| `picking/pick_what_was_scheduled_to_workplace.spec.js` | Pick one sales order to different workplaces | A single sales order can be split and picked to multiple workplaces |
-| `picking/productBasedPicking/standard.spec.js` | Product based aggregation | Product-based picking: lines are grouped by product instead of by order |
-| `picking/productBasedPicking/standard.spec.js` | Filter by EAN13 | Product-based picking list can be filtered by scanning a product EAN13 barcode |
-| `picking/productBasedPicking/standard.spec.js` | Anonymous pick HUs on the fly | Pick HUs that are not pre-assigned to a specific order line |
-| `picking/productBasedPicking/pick_by_ExternalBarcode.spec.js` | Scan the pick from HU by ExternalBarcode | In product-based picking mode, the pick-from HU is identified by scanning its ExternalBarcode attribute |
-
-### Distribution
-
-| Spec file | Test name | Scenario |
-|---|---|---|
-| `distribution/distribution.spec.js` | Simple distribution test | Full happy-path distribution: pick HU from source locator, scan drop-to locator, complete job |
-| `distribution/distribution.spec.js` | Try picking an HU from a different locator than pick from locator | Scanning an HU from a locator that does not match the order's pick-from locator shows an error |
-| `distribution/distribution.spec.js` | Try picking an HU containing a different product than expected | Scanning an HU containing the wrong product shows an error |
-| `distribution/distribution.spec.js` | Distribution using 2 steps to pick the needed qty. | Distribution job requiring two separate HU picks to fulfil a single line qty |
-| `distribution/distribution.spec.js` | Pick & Unpick in distribution step screen | Picking an HU then unpicking it in the step screen leaves the line in unallocated state |
-| `distribution/distribution.spec.js` | Filter distribution orders by plantId | Distribution job list can be filtered by plant facet |
-| `distribution/caption.spec.js` | LocatorFrom,ProductValueAndName,ProductGTIN,Qty,Priority | Job launcher caption is correctly formatted with multiple fields (locator, product, GTIN, qty, priority) |
-| `distribution/completeJobAutomatically.spec.js` | Happy case | With `completeJobAutomatically=true`, scanning the drop-to locator completes the job automatically |
-| `distribution/distributionandmanufacturing.spec.js` | Distribution and manufacturing test | End-to-end scenario: distribute two components to a warehouse, then issue them in a manufacturing job and receive finished product |
-| `distribution/filter_by_workplace.spec.js` | Show all jobs when no current workplace | Without a workplace set, all distribution jobs are visible |
-| `distribution/filter_by_workplace.spec.js` | Show only jobs suitable for workplace1 | Only jobs whose drop-to locator matches the current workplace's locator are shown |
-| `distribution/header.spec.js` | Happy case | Job screen header shows correct From Locator and Locator To values |
-| `distribution/job_dropAllButton.spec.js` | Pick multiple HUs and drop them all together in one step | Pick three lines across multiple HUs; use Drop All to deliver them in a single action; validates HU warehouse at each step |
-| `distribution/job_dropAllButton.spec.js` | Pick multiple HUs (by HU code) and drop them all together in one step (using locator code) | Same as above but HUs are identified by M\_HU\_ID and the drop-to locator is scanned by locator code |
-| `distribution/lauchers_restrictions.spec.js` | No restrictions | With no launcher restrictions configured, all jobs are enabled |
-| `distribution/lauchers_restrictions.spec.js` | Allow starting next job only | With `allowStartNextJobOnly=true`, only the first unstarted job is enabled; starting it enables the next |
-| `distribution/launchers_dropAllButton.spec.js` | Pick multiple HUs (by HU code) and drop them all together in one step (using locator code) | Pick from multiple jobs across the launchers list; use Drop All from the jobs-list screen to deliver all picked HUs at once |
-| `distribution/launchers_websockets.spec.js` | Check launchers are refreshed via websockets | New distribution orders created on the backend appear in the launchers list in real time via websockets |
-| `distribution/navigateToJobsListAfterPickFromComplete.spec.js` | Happy case | With `navigateToJobsListAfterPickFromComplete=true`, completing a pick-from step on the last line of a job navigates to the next job's pick-from screen (or back to the list if no more jobs) |
-| `distribution/pickFrom_validate_GTIN.spec.js` | Scan the HU by QRCode | In GTIN-validation mode, scan HU by QR code then confirm with product GTIN |
-| `distribution/pickFrom_validate_GTIN.spec.js` | Scan the HU by Value/M_HU_ID | In GTIN-validation mode, scan HU by M\_HU\_ID then confirm with product GTIN |
-| `distribution/pickFrom_validate_GTIN.spec.js` | Scan the HU by External Attribute | In GTIN-validation mode, scan HU by ExternalBarcode then confirm with product GTIN |
-| `distribution/pickFrom_validate_GTIN.spec.js` | Do not ask for picked qty when it is one | When only 1 unit matches, the qty dialog is skipped |
-| `distribution/scan_HU_barcodes.spec.js` | Scan by HU QR Code | Distribution line HU can be scanned by its QR code |
-| `distribution/scan_HU_barcodes.spec.js` | Scan by M_HU_ID | Distribution line HU can be scanned by its M\_HU\_ID |
-| `distribution/scan_HU_barcodes.spec.js` | Scan by ExternalBarcode | Distribution line HU can be scanned by its ExternalBarcode attribute |
-| `distribution/sorting.spec.js` | Sort by SeqNo | Distribution jobs list is sorted by SeqNo when `orderBys=SeqNo,Priority,DatePromised` |
-
-### Manufacturing
-
-| Spec file | Test name | Scenario |
-|---|---|---|
-| `manufacturing/manufacturing.spec.js` | Simple manufacturing test | Full end-to-end manufacturing job: issue two raw material components by scanning HUs, receive finished product into a new LU; validates received HU status and storage |
-| `manufacturing/auto-issue.spec.js` | Auto-issue first line hides Scan button; manual second line shows it | BOM line with `IssueOnlyForReceived` must not show Scan button; manually-issued line must show it |
-| `manufacturing/isAllowIssuingAnyHU.spec.js` | isAllowIssuingAnyHU=false, isCreateRawMaterialsStock=false => expect ERROR | `isAllowIssuingAnyHU=false` with no stock causes an error toast when starting a manufacturing job |
-| `manufacturing/isAllowIssuingAnyHU.spec.js` | isAllowIssuingAnyHU=false, isCreateRawMaterialsStock=true => expect OK | `isAllowIssuingAnyHU=false` with stock present allows starting a job |
-| `manufacturing/isAllowIssuingAnyHU.spec.js` | isAllowIssuingAnyHU=true, isCreateRawMaterialsStock=false => expect OK | `isAllowIssuingAnyHU=true` allows starting a job even with no stock |
-| `manufacturing/isAllowIssuingAnyHU.spec.js` | isAllowIssuingAnyHU=true, isCreateRawMaterialsStock=true => expect OK | `isAllowIssuingAnyHU=true` with stock present allows starting a job |
-| `manufacturing/manufacturing_small_qty_tolerance.spec.js` | Issue raw material with very small qty (0.00384 kg) shows non-zero qty after scan | Scanning an HU for a BOM line with a very small qty (0.00384 kg) must display a non-zero pre-filled qty (regression) |
-| `manufacturing/manufacturing_small_qty_tolerance.spec.js` | Issue raw material with small qty (0.01913 kg) and 1% tolerance | Full issue-and-receive cycle for a BOM with 0.01913 kg and 1% issuing tolerance; validates final HU storage and remaining quantity |
-| `manufacturing/receive_using_customQRCodeFormat.spec.js` | Receive using custom QR Code format | Receipt of finished product using two different custom QR code formats (catch-weight + lot + dates); validates HU storage, WeightNet, and CU child records |
-| `manufacturing/receiving_by_products.spec.js` | Receive By-Products from 2 manufacturing orders into same HU | Two manufacturing orders contribute by-product qty into the same target TU; validates accumulated HU storage |
-| `manufacturing/receiving_by_products.spec.js` | Fail receiving different By-Products in same HU | Attempting to receive a second by-product type into an HU that already holds a different by-product type must produce an error toast |
-| `manufacturing/receiving_by_products_catchweight.spec.js` | Receive several by-products using manual input to a new TU | By-product receipt in manual-input mode (typed qty + catch weight) into a new TU; validates qty indicator |
-| `manufacturing/receiving_by_products_catchweight.spec.js` | Receive several by-products using L+M codes to a new TU | By-product receipt via three L+M QR codes into a new TU; validates storage after receipt |
-| `manufacturing/receiving_by_products_catchweight.spec.js` | Receive By-Products from 2 manufacturing orders into same HU | Two manufacturing orders contribute catch-weight by-product qty (L+M codes) into the same existing TU; validates accumulated weight |
-| `manufacturing/receiving_main_products.spec.js` | Receive 1 full LU, 1 half LU | Receipt of 100 PCE finished product into a new LU that splits into two LUs (80 + 20 PCE); validates both received LUs |
-| `manufacturing/receiving_main_products_catchweight.spec.js` | To a new TU, manual input | Main product receipt in manual-input mode (9 PCE + 0.9 kg catch weight) into a new TU; validates split into 3 TUs |
-| `manufacturing/receiving_main_products_catchweight.spec.js` | To a new TU, scanning L+M QR codes | Main product receipt via three L+M QR codes into a new TU; validates 3 PCE and accumulated WeightNet |
-| `manufacturing/receiving_main_products_catchweight.spec.js` | To a new TU, scanning L+M QR codes from 2 manufacturing orders | Two orders contribute catch-weight main product receipts into the same existing TU; validates accumulated storage |
-| `manufacturing/receiving_main_products_catchweight.spec.js` | TO a new LU, scanning 2 x GTIN codes | Main product receipt via two GTIN QR code scans into a new LU; validates 2 PCE received |
-
-### HU Manager
-
-| Spec file | Test name | Scenario |
-|---|---|---|
-| `humanager/scan.spec.js` | Scan by HU QR Code | Open HU Manager and scan HU by QR code; verifies qty is displayed |
-| `humanager/scan.spec.js` | Scan by M_HU_ID | Open HU Manager and scan HU by M\_HU\_ID; verifies qty is displayed |
-| `humanager/scan.spec.js` | Scan by ExternalBarcode attribute | Open HU Manager and scan HU by ExternalBarcode; verifies qty is displayed |
-| `humanager/huManager.spec.js` | Check action buttons order | Verifies the action buttons appear in the expected order after scanning an HU |
-| `humanager/huManager.spec.js` | Dispose HU | Dispose an HU via the HU Manager; verifies HU is destroyed |
-| `humanager/huManager.spec.js` | Move HU using locator code | Move an HU to a new locator by scanning the locator code; verifies locator updated |
-| `humanager/huManager.spec.js` | Change Qty | Change the qty of an HU; verifies new qty is stored |
-| `humanager/huManager.spec.js` | Change Clearance Status | Set a clearance status and note on an HU; verifies both values are saved |
-| `humanager/huManager.spec.js` | Bulk actions - Move | Use bulk actions to move an HU to a different locator; verifies locator updated |
-| `humanager/by_ExternalBarcode_attribute.spec.js` | Dispose HU | Scan HU by ExternalBarcode (no QR code generated); dispose the HU |
-| `humanager/by_ExternalBarcode_attribute.spec.js` | Move HU using locator code | Scan HU by ExternalBarcode; move it to another warehouse by locator code |
-| `humanager/by_ExternalBarcode_attribute.spec.js` | Change Qty | Scan HU by ExternalBarcode; change qty and verify new value |
-| `humanager/by_ExternalBarcode_attribute.spec.js` | Change Clearance Status | Scan HU by ExternalBarcode; set clearance status and note |
-| `humanager/by_ExternalBarcode_attribute.spec.js` | Bulk actions - Move | Scan HU by ExternalBarcode; use bulk actions to move to another locator |
-
-### HU Consolidation
-
-| Spec file | Test name | Scenario |
-|---|---|---|
-| `hu_consolidation/hu_consolidation.spec.js` | Simple HU consolidate all test | Pick HUs into a picking slot, then use HU Consolidation to consolidate all TUs onto a new LU and complete |
-| `hu_consolidation/hu_consolidation.spec.js` | Simple HU consolidate HUs one by one test | Pick HUs into a picking slot, then consolidate individual TUs one by one onto a new LU |
-| `hu_consolidation/hu_consolidation.spec.js` | Manual print current target label | Consolidate some HUs partially, then manually print the current target LU label |
-| `hu_consolidation/hu_consolidation.spec.js` | Consolidate to an existing LU | Consolidate picked TUs onto an existing LU (rather than a new one); validates combined storage |
-
-### Inventory
-
-| Spec file | Test name | Scenario |
-|---|---|---|
-| `inventory/inventory.spec.js` | Simple inventory test | Start an inventory job, count an HU with adjusted qty and attributes (lot, best-before), complete; validates HU storage and attributes are updated |
-
----
-
-## Section 2 — Gap analysis
-
-By workflow area, paths that have **no** Playwright test or known weak coverage:
-
-**Login / Home**
-- No test covers failed login (wrong password, inactive user).
-- No test covers the QR-code-based login flow end-to-end (only auth method preference is checked in `login.spec.js`).
-
-**Picking**
-- No test covers scanning an HU from the wrong warehouse/locator in the standard (non-distribution) picking flow.
-- No test covers multiple picking jobs visible simultaneously for the same customer and verifies the aggregation count.
-- No test covers the "Scan Anything" generic routing when the scanned code is ambiguous (resolves to more than one target).
-
-**Distribution**
-- No test covers the `maxLaunchers` config cap (list is truncated beyond N jobs).
-- No test covers the `maxStartedLaunchers` config cap.
-- No test covers abort (cancel) of an in-progress distribution job.
-
-**Manufacturing**
-- No test exercises search/filter on the manufacturing jobs list (filter by document number, date, or status via facets).
-- `manufacturing.spec.js` does not call `Backend.expect` to verify issued component quantities in the backend after issue (only the received HU is validated).
-- No test covers issuing a BOM line across more than one HU and verifying remaining qty decrements correctly between scans.
-- No test covers scanning the wrong HU product (zero-stock or product mismatch) during issue.
-- No test covers completing a job before all BOM lines are fully issued.
-- No test covers navigating back from `RawMaterialIssueLineScreen` without scanning and verifying the job state is unchanged.
-- `isAllowIssuingAnyHU.spec.js` only tests the job start step; no test scans an HU from a different product when `isAllowIssuingAnyHU=true` to verify the full issue path.
-- No test covers AC3–AC5 from https://github.com/metasfresh/me03/issues/27759 (regression: suggestion when HU capacity exceeds remaining BOM qty; over-issue creates inventory adjustment; confirming HU-capacity suggestion creates no adjustment). These are reserved for the remaining tasks in that issue.
-
-**HU Manager**
-- No test covers the "Print Labels" action.
-- No test covers scanning a generated HU QR code (the commented-out test `Change Locator of a generated HU QR Code` was broken and skipped).
-
-**HU Consolidation**
-- No test covers the case where `setTargetLU` fails (e.g., scanning an LU that already contains a different customer's goods).
-
-**Inventory**
-- No test covers an inventory job with multiple products/lines.
-- No test covers completing an inventory job that has a line with no physical HU scanned (qty remains as booked).
-
----
-
-## Section 3 — Tests added by issue https://github.com/metasfresh/me03/issues/27759
-
-These 5 tests are planned for `tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js`.
-Task 4 will write the complete 5-test file (replacing an existing 2-test draft). AC3–AC5 are new; AC1 and AC2 are rewrites of the draft.
-
-| Test name | Scenario | AC covered | Status |
+| Module | Covered | Total | % |
 |---|---|---|---|
-| AC1: Suggested qty capped at HU capacity — HU smaller than BOM requirement | BOM 20, HU 5, nothing issued → suggestion = 5 | AC1 | Draft (to be replaced) |
-| AC2: Suggested qty capped at HU capacity after partial issue (customer scenario) | BOM 20, 7 issued, HU 5 → suggestion = 5 | AC2 | Draft (to be replaced) |
-| AC3 (regression): Suggestion unchanged when HU capacity exceeds remaining BOM qty | BOM 20, HU 100 → suggestion = 20 | AC3 | New |
-| AC4 (regression): Typing the old wrong suggestion (13) over-issues by 8 — inventory adjustment created | BOM 20, HU 5, type 13 → 13 issued, HU depleted, adj 8 | AC4 | New |
-| AC5 (regression): Confirming HU-capacity suggestion creates no inventory adjustment | BOM 20, HU 5, confirm 5 → 5 issued, HU depleted, no adj | AC5 | New |
+| Login / Home | 8 | 10 | 80% |
+| Picking | 44 | 47 | 94% |
+| Distribution | 27 | 30 | 90% |
+| Manufacturing | 19 | 29 | 66% |
+| HU Manager | 14 | 16 | 88% |
+| HU Consolidation | 4 | 5 | 80% |
+| Inventory | 1 | 3 | 33% |
+
+---
+
+## Login / Home
+
+### Authentication
+
+| Scenario | Test |
+|---|---|
+| Login with user/password, en_US language, UserPass auth method → language verified, logout succeeds | `login.spec.js` |
+| Login with user/password, en_US language, QR_Code auth method → language verified, logout succeeds | `login.spec.js` |
+| Login with user/password, de_DE language, UserPass auth method → language verified, logout succeeds | `login.spec.js` |
+| Login with user/password, de_DE language, QR_Code auth method → language verified, logout succeeds | `login.spec.js` |
+| ❌ Failed login (wrong password or inactive user) → error shown, access denied | — |
+| ❌ QR-code login flow end-to-end → user logged in via QR scan | — |
+
+**4/6 — 67%**
+
+### Home screen scanning
+
+| Scenario | Test |
+|---|---|
+| Scan HU QR code from home screen → navigates to HU Manager, qty shown | `home_screen.spec.js` |
+| Scan HU ID (M_HU_ID) from home screen → navigates to HU Manager, qty shown | `home_screen.spec.js` |
+| Scan ExternalBarcode from home screen → navigates to HU Manager, qty shown | `home_screen.spec.js` |
+| Scan workplace QR code from home screen → opens Workplace Manager, name and assigned status shown | `home_screen.spec.js` |
+
+**4/4 — 100%**
+
+---
+
+## Picking
+
+### Order-based picking — core flow
+
+| Scenario | Test |
+|---|---|
+| Full pick, single HU, confirm, shipment schedule marked picked | `picking.spec.js` |
+| Pick HU then unpick → HU returns to unallocated | `picking.spec.js` |
+| Scan invalid picking slot QR code → error shown | `picking.spec.js` |
+| Line status indicator transitions draft → in-progress → complete as HUs are picked | `picking.spec.js` |
+| Partial pick, allowCompletingPartialPickingJob = N → complete blocked | `picking.spec.js` |
+| Partial pick, allowCompletingPartialPickingJob = Y → complete succeeds | `picking.spec.js` |
+| Close LU during picking → shipment created automatically | `picking.spec.js` |
+| Close LU then reopen → state transitions verified | `picking.spec.js` |
+| Job already started → "already started" indicator shown in jobs list | `picking.spec.js` |
+| completeJobAutomatically=true, scan drop-to locator after pick → job auto-completed, removed from list | `picking/completeJobAutomatically.spec.js` |
+| ❌ Scan HU from wrong warehouse/locator → error shown | — |
+
+**10/11 — 91%**
+
+### Order-based picking — filtering and facets
+
+| Scenario | Test |
+|---|---|
+| Facet filter shows only jobs scheduled for current workplace | `picking/facets.spec.js` |
+| Filter by qty available at locator → only jobs with sufficient stock shown | `picking/filterByQtyAvailableAtLocator.spec.js` |
+| ❌ Multiple jobs for same customer → aggregation count correct | — |
+
+**2/3 — 67%**
+
+### Order-based picking — pick-all and attributes
+
+| Scenario | Test |
+|---|---|
+| Pick All button picks all remaining HUs in one action | `picking/pickAllButton.spec.js` |
+| Pick All button hidden when feature disabled in mobile config | `picking/pickAllButton.spec.js` |
+| Only one matching HU → picking proceeds without qty dialog | `picking/pickAttributes.spec.js` |
+
+**3/3 — 100%**
+
+### Order-based picking — HU scanning variants
+
+| Scenario | Test |
+|---|---|
+| Pick HU by custom QR code format | `picking/pick_by_customQRCode.spec.js` |
+| Pick HU by EAN13 — LU/CU into top-level TU | `picking/pick_by_EAN13.spec.js` |
+| Pick HU by EAN13 — LU/CU into LU/TU1 and LU/TU2 | `picking/pick_by_EAN13.spec.js` |
+| Pick HU by EAN13 — LU/CU into LU/CU | `picking/pick_by_EAN13.spec.js` |
+| Pick HU by EAN13 — LU/CU into top-level CUs | `picking/pick_by_EAN13.spec.js` |
+| Pick HU by ExternalBarcode attribute | `picking/pick_by_ExternalBarcode.spec.js` |
+| Pick HU by M_HU_ID — LU/CU into LU/CU | `picking/pick_by_HUId.spec.js` |
+| ❌ Scan ambiguous code (resolves to more than one target) → routing handled | — |
+
+**7/8 — 88%**
+
+### Order-based picking — LU picking
+
+| Scenario | Test |
+|---|---|
+| Pick partial qty from LU — ordered qty < full LU qty | `picking/pick_from_LUs.spec.js` |
+| Pick entire LU — LU qty exactly matches ordered qty | `picking/pick_from_LUs.spec.js` |
+| Pick entire LU — LU qty less than ordered qty (partial fulfillment) | `picking/pick_from_LUs.spec.js` |
+
+**3/3 — 100%**
+
+### Order-based picking — catch-weight
+
+| Scenario | Test |
+|---|---|
+| Catch-weight pick, manual typed input → qty and weight recorded | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via L+M QR code | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via L+M code — invalid code → error | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via GS1 barcode | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via EAN13 prefix 28 | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via EAN13 prefix 28 — wrong product → error | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via EAN13 prefix 29 | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via EAN13 prefix 29 — wrong product → error | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via custom QR code format | `picking/picking_catchWeight.spec.js` |
+| ShowLastPickedBestBeforeDateForLines = Y → last best-before date shown on picking line | `picking/picking_catchWeight.spec.js` |
+
+**10/10 — 100%**
+
+### Order-based picking — special flows
+
+| Scenario | Test |
+|---|---|
+| Pick triggers on-the-fly manufacturing (assemble) → assembled HU picked into order | `picking/pick_and_assemble.spec.js` |
+| Lines aggregated and grouped by delivery location | `picking/picking_deliveryLocationBasedAggregation.spec.js` |
+| No suggestions configured → no suggested picking slots shown | `picking/pickingSlotSuggestions.spec.js` |
+| Configured picking slot suggestions → shown and selectable | `picking/pickingSlotSuggestions.spec.js` |
+| Single sales order split and picked to multiple workplaces | `picking/pick_what_was_scheduled_to_workplace.spec.js` |
+
+**5/5 — 100%**
+
+### Product-based picking
+
+| Scenario | Test |
+|---|---|
+| Lines grouped by product instead of by order | `picking/productBasedPicking/standard.spec.js` |
+| Filter jobs list by scanning product EAN13 | `picking/productBasedPicking/standard.spec.js` |
+| Pick HUs not pre-assigned to a specific order line | `picking/productBasedPicking/standard.spec.js` |
+| Pick-from HU identified by ExternalBarcode attribute | `picking/productBasedPicking/pick_by_ExternalBarcode.spec.js` |
+
+**4/4 — 100%**
+
+---
+
+## Distribution
+
+### Core distribution flow
+
+| Scenario | Test |
+|---|---|
+| Full happy-path: pick HU, scan drop-to locator, complete job | `distribution/distribution.spec.js` |
+| Scan HU from wrong locator → error shown | `distribution/distribution.spec.js` |
+| Scan HU containing wrong product → error shown | `distribution/distribution.spec.js` |
+| Two separate HU picks needed to fulfil a single line qty | `distribution/distribution.spec.js` |
+| Pick HU then unpick in step screen → line returns to unallocated | `distribution/distribution.spec.js` |
+| Filter distribution jobs by plant facet | `distribution/distribution.spec.js` |
+| completeJobAutomatically=true, scan drop-to locator → job auto-completed | `distribution/completeJobAutomatically.spec.js` |
+| ❌ Abort (cancel) in-progress distribution job → job cancelled, stock restored | — |
+
+**7/8 — 88%**
+
+### Distribution launchers
+
+| Scenario | Test |
+|---|---|
+| Job launcher caption formatted with locator, product, GTIN, qty, priority | `distribution/caption.spec.js` |
+| No restrictions configured → all jobs enabled | `distribution/lauchers_restrictions.spec.js` |
+| allowStartNextJobOnly=true → only first unstarted job enabled; starting it enables next | `distribution/lauchers_restrictions.spec.js` |
+| New distribution orders appear in launcher list via websockets | `distribution/launchers_websockets.spec.js` |
+| Without workplace set → all distribution jobs visible | `distribution/filter_by_workplace.spec.js` |
+| With workplace set → only jobs whose drop-to locator matches workplace shown | `distribution/filter_by_workplace.spec.js` |
+| Sort by SeqNo when orderBys=SeqNo,Priority,DatePromised | `distribution/sorting.spec.js` |
+| ❌ maxLaunchers cap — list truncated beyond N jobs | — |
+| ❌ maxStartedLaunchers cap | — |
+
+**7/9 — 78%**
+
+### Distribution — job execution
+
+| Scenario | Test |
+|---|---|
+| Job screen header shows correct From Locator and Locator To | `distribution/header.spec.js` |
+| Pick multiple HUs; Drop All delivers in one action; warehouse validated per step | `distribution/job_dropAllButton.spec.js` |
+| Pick multiple HUs by M_HU_ID; Drop All via locator code | `distribution/job_dropAllButton.spec.js` |
+| Pick from multiple jobs in launchers list; Drop All from jobs-list screen | `distribution/launchers_dropAllButton.spec.js` |
+| navigateToJobsListAfterPickFromComplete=true → last line pick navigates to next job | `distribution/navigateToJobsListAfterPickFromComplete.spec.js` |
+
+**5/5 — 100%**
+
+### Distribution — HU scanning
+
+| Scenario | Test |
+|---|---|
+| GTIN-validation mode: scan HU by QR code, confirm with product GTIN | `distribution/pickFrom_validate_GTIN.spec.js` |
+| GTIN-validation mode: scan HU by M_HU_ID, confirm with product GTIN | `distribution/pickFrom_validate_GTIN.spec.js` |
+| GTIN-validation mode: scan HU by ExternalBarcode, confirm with product GTIN | `distribution/pickFrom_validate_GTIN.spec.js` |
+| Only 1 matching unit → qty dialog skipped | `distribution/pickFrom_validate_GTIN.spec.js` |
+| Scan distribution HU by QR code | `distribution/scan_HU_barcodes.spec.js` |
+| Scan distribution HU by M_HU_ID | `distribution/scan_HU_barcodes.spec.js` |
+| Scan distribution HU by ExternalBarcode | `distribution/scan_HU_barcodes.spec.js` |
+
+**7/7 — 100%**
+
+### Distribution + Manufacturing cross-flow
+
+| Scenario | Test |
+|---|---|
+| Distribute two components, then issue in manufacturing job, receive finished product | `distribution/distributionandmanufacturing.spec.js` |
+
+**1/1 — 100%**
+
+---
+
+## Manufacturing
+
+### Component issue — basic
+
+| Scenario | Test |
+|---|---|
+| Full job: issue two BOM components by scanning HUs, receive finished product into new LU | `manufacturing/manufacturing.spec.js` |
+| BOM line with IssueOnlyForReceived → Scan button hidden; manual line → Scan button shown | `manufacturing/auto-issue.spec.js` |
+| isAllowIssuingAnyHU=false, no stock → error toast on job start | `manufacturing/isAllowIssuingAnyHU.spec.js` |
+| isAllowIssuingAnyHU=false, stock present → job starts OK | `manufacturing/isAllowIssuingAnyHU.spec.js` |
+| isAllowIssuingAnyHU=true, no stock → job starts OK | `manufacturing/isAllowIssuingAnyHU.spec.js` |
+| isAllowIssuingAnyHU=true, stock present → job starts OK | `manufacturing/isAllowIssuingAnyHU.spec.js` |
+| ❌ Scan wrong product HU during issue → error shown | — |
+| ❌ Issue BOM line across more than one HU → remaining qty decrements correctly between scans | — |
+| ❌ Complete job before all BOM lines fully issued → blocked or warned | — |
+| ❌ Navigate back from issue screen without scanning → job state unchanged | — |
+
+**6/10 — 60%**
+
+### Component issue — HU qty suggestion capping
+
+| Scenario | Test |
+|---|---|
+| ❌ HU qty < BOM remaining → suggestion capped at HU qty | — |
+| ❌ After partial issue, HU qty < remaining BOM → suggestion still capped at HU qty | — |
+| ❌ HU qty ≥ BOM remaining → suggestion unchanged (no capping) | — |
+| ❌ Type old wrong (uncapped) suggestion → over-issue, inventory adjustment created | — |
+| ❌ Confirm HU-capacity suggestion → no inventory adjustment created | — |
+
+**0/5 — 0%**
+
+### Component issue — qty tolerance
+
+| Scenario | Test |
+|---|---|
+| BOM qty 0.00384 kg: scan HU → non-zero qty shown (regression) | `manufacturing/manufacturing_small_qty_tolerance.spec.js` |
+| BOM qty 0.01913 kg, 1% tolerance: full issue-and-receive cycle → HU storage and remaining qty correct | `manufacturing/manufacturing_small_qty_tolerance.spec.js` |
+
+**2/2 — 100%**
+
+### Receipt — main product
+
+| Scenario | Test |
+|---|---|
+| Receive 100 PCE into new LU → splits into two LUs (80 + 20 PCE) | `manufacturing/receiving_main_products.spec.js` |
+| Receive to new TU, manual input (9 PCE + 0.9 kg catch weight) → splits into 3 TUs | `manufacturing/receiving_main_products_catchweight.spec.js` |
+| Receive to new TU via three L+M QR codes → 3 PCE and accumulated WeightNet validated | `manufacturing/receiving_main_products_catchweight.spec.js` |
+| Two orders contribute catch-weight main product into same existing TU → accumulated storage validated | `manufacturing/receiving_main_products_catchweight.spec.js` |
+| Receive to new LU via two GTIN QR code scans → 2 PCE received | `manufacturing/receiving_main_products_catchweight.spec.js` |
+| Receive using two custom QR code formats (catch-weight + lot + dates) → WeightNet and CU child records validated | `manufacturing/receive_using_customQRCodeFormat.spec.js` |
+
+**6/6 — 100%**
+
+### Receipt — by-products
+
+| Scenario | Test |
+|---|---|
+| Two manufacturing orders contribute by-product qty into same target TU → accumulated storage validated | `manufacturing/receiving_by_products.spec.js` |
+| Receive second by-product type into HU that already holds a different by-product → error toast | `manufacturing/receiving_by_products.spec.js` |
+| By-product receipt via manual input (typed qty + catch weight) into new TU → qty indicator validated | `manufacturing/receiving_by_products_catchweight.spec.js` |
+| By-product receipt via three L+M QR codes into new TU → storage validated | `manufacturing/receiving_by_products_catchweight.spec.js` |
+| Two orders contribute catch-weight by-product (L+M codes) into same existing TU → accumulated weight validated | `manufacturing/receiving_by_products_catchweight.spec.js` |
+
+**5/5 — 100%**
+
+### Manufacturing — jobs list
+
+| Scenario | Test |
+|---|---|
+| ❌ Filter/search jobs list by document number, date, or status | — |
+
+**0/1 — 0%**
+
+---
+
+## HU Manager
+
+### Scanning
+
+| Scenario | Test |
+|---|---|
+| Scan HU by QR code → qty displayed | `humanager/scan.spec.js` |
+| Scan HU by M_HU_ID → qty displayed | `humanager/scan.spec.js` |
+| Scan HU by ExternalBarcode → qty displayed | `humanager/scan.spec.js` |
+
+**3/3 — 100%**
+
+### Actions on scanned HU (QR code)
+
+| Scenario | Test |
+|---|---|
+| Action buttons appear in expected order | `humanager/huManager.spec.js` |
+| Dispose HU → HU destroyed | `humanager/huManager.spec.js` |
+| Move HU via locator code scan → locator updated | `humanager/huManager.spec.js` |
+| Change HU qty → new qty stored | `humanager/huManager.spec.js` |
+| Set clearance status and note → both values saved | `humanager/huManager.spec.js` |
+| Bulk actions — move HU to different locator → locator updated | `humanager/huManager.spec.js` |
+| ❌ Print Labels action | — |
+
+**6/7 — 86%**
+
+### Actions on scanned HU (ExternalBarcode)
+
+| Scenario | Test |
+|---|---|
+| Scan by ExternalBarcode, dispose HU | `humanager/by_ExternalBarcode_attribute.spec.js` |
+| Scan by ExternalBarcode, move HU via locator code | `humanager/by_ExternalBarcode_attribute.spec.js` |
+| Scan by ExternalBarcode, change qty → new value verified | `humanager/by_ExternalBarcode_attribute.spec.js` |
+| Scan by ExternalBarcode, set clearance status and note | `humanager/by_ExternalBarcode_attribute.spec.js` |
+| Scan by ExternalBarcode, bulk actions — move to another locator | `humanager/by_ExternalBarcode_attribute.spec.js` |
+| ❌ Scan generated HU QR code, change locator | — |
+
+**5/6 — 83%**
+
+---
+
+## HU Consolidation
+
+### Consolidation flows
+
+| Scenario | Test |
+|---|---|
+| Consolidate all TUs onto new LU in one action → complete | `hu_consolidation/hu_consolidation.spec.js` |
+| Consolidate individual TUs one by one onto new LU | `hu_consolidation/hu_consolidation.spec.js` |
+| Manually print current target LU label mid-consolidation | `hu_consolidation/hu_consolidation.spec.js` |
+| Consolidate picked TUs onto existing LU → combined storage validated | `hu_consolidation/hu_consolidation.spec.js` |
+| ❌ setTargetLU fails (LU already holds different customer's goods) → error shown | — |
+
+**4/5 — 80%**
+
+---
+
+## Inventory
+
+### Inventory counting
+
+| Scenario | Test |
+|---|---|
+| Count HU with adjusted qty and attributes (lot, best-before), complete → HU storage and attributes updated | `inventory/inventory.spec.js` |
+| ❌ Inventory job with multiple products/lines | — |
+| ❌ Complete job with a line where no physical HU was scanned → qty remains as booked | — |
+
+**1/3 — 33%**

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -9,7 +9,7 @@
 | Login / Home | 8 | 10 | 80% |
 | Picking | 44 | 47 | 94% |
 | Distribution | 27 | 30 | 90% |
-| Manufacturing | 19 | 29 | 66% |
+| Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
 | HU Consolidation | 4 | 5 | 80% |
 | Inventory | 1 | 3 | 33% |
@@ -243,13 +243,13 @@
 
 | Scenario | Test |
 |---|---|
-| ❌ HU qty < BOM remaining → suggestion capped at HU qty | — |
-| ❌ After partial issue, HU qty < remaining BOM → suggestion still capped at HU qty | — |
-| ❌ HU qty ≥ BOM remaining → suggestion unchanged (no capping) | — |
-| ❌ Type old wrong (uncapped) suggestion → over-issue, inventory adjustment created | — |
-| ❌ Confirm HU-capacity suggestion → no inventory adjustment created | — |
+| HU qty drops after plan creation → suggestion capped at live HU qty | `manufacturing/issue_hu_qty_suggestion.spec.js` |
+| ❌ After partial issue of PP1, HU qty < remaining BOM → suggestion still capped at HU qty | — |
+| HU qty ≥ BOM remaining → suggestion unchanged (no capping) | `manufacturing/issue_hu_qty_suggestion.spec.js` |
+| Type qty > HU capacity → over-issue accepted, inventory adjustment created | `manufacturing/issue_hu_qty_suggestion.spec.js` |
+| Confirm HU-capacity suggestion → HU depleted, no inventory adjustment created | `manufacturing/issue_hu_qty_suggestion.spec.js` |
 
-**0/5 — 0%**
+**4/5 — 80%**
 
 ### Component issue — qty tolerance
 

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -50,15 +50,15 @@
 
 | Scenario | Test |
 |---|---|
-| Full pick, single HU, confirm, shipment schedule marked picked | `picking.spec.js` |
-| Pick HU then unpick → HU returns to unallocated | `picking.spec.js` |
-| Scan invalid picking slot QR code → error shown | `picking.spec.js` |
-| Line status indicator transitions draft → in-progress → complete as HUs are picked | `picking.spec.js` |
-| Partial pick, allowCompletingPartialPickingJob = N → complete blocked | `picking.spec.js` |
-| Partial pick, allowCompletingPartialPickingJob = Y → complete succeeds | `picking.spec.js` |
-| Close LU during picking → shipment created automatically | `picking.spec.js` |
-| Close LU then reopen → state transitions verified | `picking.spec.js` |
-| Job already started → "already started" indicator shown in jobs list | `picking.spec.js` |
+| Full pick, single HU, confirm, shipment schedule marked picked | `picking/picking.spec.js` |
+| Pick HU then unpick → HU returns to unallocated | `picking/picking.spec.js` |
+| Scan invalid picking slot QR code → error shown | `picking/picking.spec.js` |
+| Line status indicator transitions draft → in-progress → complete as HUs are picked | `picking/picking.spec.js` |
+| Partial pick, allowCompletingPartialPickingJob = N → complete blocked | `picking/picking.spec.js` |
+| Partial pick, allowCompletingPartialPickingJob = Y → complete succeeds | `picking/picking.spec.js` |
+| Close LU during picking → shipment created automatically | `picking/picking.spec.js` |
+| Close LU then reopen → state transitions verified | `picking/picking.spec.js` |
+| Job already started → "already started" indicator shown in jobs list | `picking/picking.spec.js` |
 | completeJobAutomatically=true, scan drop-to locator after pick → job auto-completed, removed from list | `picking/completeJobAutomatically.spec.js` |
 | ❌ Scan HU from wrong warehouse/locator → error shown | — |
 

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -1,0 +1,55 @@
+# Mobile WebUI — Manufacturing E2E Test Coverage
+
+> Update this file whenever a manufacturing test is added or removed.
+
+## Section 1 — Existing manufacturing test catalog
+
+| Spec file | Test name | Scenario | ACs covered |
+|---|---|---|---|
+| `manufacturing.spec.js` | Simple manufacturing test | Full end-to-end manufacturing job: issue two raw material components (COMP1, COMP2) by scanning HUs, then receive finished product into a new LU; validates received HU status and storage | — |
+| `auto-issue.spec.js` | Auto-issue first line hides Scan button; manual second line shows it | BOM line with `IssueOnlyForReceived` (auto-issue method) must not show Scan button in the mobile UI; manually-issued line must show it | — |
+| `isAllowIssuingAnyHU.spec.js` | `isAllowIssuingAnyHU=false, isCreateRawMaterialsStock=false => expect ERROR` | Mobile config `isAllowIssuingAnyHU=false` with no stock in warehouse causes an error toast when starting a manufacturing job | — |
+| `isAllowIssuingAnyHU.spec.js` | `isAllowIssuingAnyHU=false, isCreateRawMaterialsStock=true => expect OK` | Mobile config `isAllowIssuingAnyHU=false` with stock present allows starting a manufacturing job | — |
+| `isAllowIssuingAnyHU.spec.js` | `isAllowIssuingAnyHU=true, isCreateRawMaterialsStock=false => expect OK` | Mobile config `isAllowIssuingAnyHU=true` allows starting a job even with no stock | — |
+| `isAllowIssuingAnyHU.spec.js` | `isAllowIssuingAnyHU=true, isCreateRawMaterialsStock=true => expect OK` | Mobile config `isAllowIssuingAnyHU=true` with stock present allows starting a manufacturing job | — |
+| `manufacturing_small_qty_tolerance.spec.js` | Issue raw material with very small qty (0.00384 kg) shows non-zero qty after scan | Scanning an HU for a BOM line with a very small qty (0.00384 kg) must display a non-zero pre-filled qty in the dialog (regression for https://github.com/metasfresh/tf201/issues/242) | — |
+| `manufacturing_small_qty_tolerance.spec.js` | Issue raw material with small qty (0.01913 kg) and 1% tolerance | Full issue-and-receive cycle for a BOM with 0.01913 kg and 1% issuing tolerance; validates final HU storage and remaining quantity after partial issue | — |
+| `receive_using_customQRCodeFormat.spec.js` | Receive using custom QR Code format | Receipt of finished product using two different custom QR code formats (catch-weight + lot + dates); validates HU storage, WeightNet attribute, and CU child records | — |
+| `receiving_by_products.spec.js` | Receive By-Products from 2 manufacturing orders into same HU | Two manufacturing orders both contribute by-product qty into the same target TU (no catch-weight); validates HU storage accumulates across orders | — |
+| `receiving_by_products.spec.js` | Fail receiving different By-Products in same HU | Attempting to receive a second by-product type into an HU that already holds a different by-product type must produce an error toast | — |
+| `receiving_by_products_catchweight.spec.js` | Receive several by-products using manual input to a new TU | By-product receipt in manual-input mode (typed qty + catch weight) into a new TU; validates qty indicator on job screen | — |
+| `receiving_by_products_catchweight.spec.js` | Receive several by-products using L+M codes to a new TU | By-product receipt via three L+M QR codes into a new TU; validates storage after receipt | — |
+| `receiving_by_products_catchweight.spec.js` | Receive By-Products from 2 manufacturing orders into same HU | Two manufacturing orders contribute catch-weight by-product qty (via L+M codes) into the same existing TU; validates accumulated HU weight | — |
+| `receiving_main_products.spec.js` | Receive 1 full LU, 1 half LU | Receipt of 100 PCE finished product into a new LU that splits into two LUs (80 + 20 PCE based on packing instructions); validates both received LUs | — |
+| `receiving_main_products_catchweight.spec.js` | To a new TU, manual input | Main product receipt in manual-input mode (9 PCE + 0.9 kg catch weight) into a new TU; validates split into 3 TUs (4+4+1 PCE) in backend | — |
+| `receiving_main_products_catchweight.spec.js` | To a new TU, scanning L+M QR codes | Main product receipt via three L+M QR codes into a new TU; validates 3 PCE and accumulated WeightNet 0.303 kg | — |
+| `receiving_main_products_catchweight.spec.js` | To a new TU, scanning L+M QR codes from 2 manufacturing orders | Two orders contribute catch-weight main product receipts into the same existing TU via L+M codes; validates accumulated storage (4 PCE, 0.131 kg) | — |
+| `receiving_main_products_catchweight.spec.js` | TO a new LU, scanning 2 x GTIN codes | Main product receipt via two GTIN QR code scans into a new LU; validates 2 PCE received into LU | — |
+
+## Section 2 — Gap analysis
+
+Manufacturing workflow paths that currently have **no** Playwright test:
+
+- **Job list navigation / filtering**: No test exercises search/filter on the manufacturing jobs list (e.g., filter by document number, date, or status via facets). The existing tests always start a specific job by `documentNo` immediately.
+- **Component issue: happy path confirmed end-to-end with backend validation**: `manufacturing.spec.js` scans components and receives, but does not call `Backend.expect` to verify the issued component quantities were recorded correctly in the backend after issue (only receipt HU is validated).
+- **Component issue: partial issue (multiple HUs, same BOM line)**: No test issues a BOM line component across more than one HU and checks that the remaining qty decrements correctly on the job screen between scans.
+- **Component issue: HU qty < remaining BOM qty (the bug fixed by this issue)**: Before this issue, no test verified that the qty suggestion is capped at HU capacity when HU qty is smaller than the BOM requirement. This gap is closed by Task 4.
+- **Component issue: over-issue (worker types more than HU capacity)**: No test covers the path where a worker manually types a qty larger than the scanned HU's available qty, triggering an inventory adjustment. This is covered by Task 4 (AC4).
+- **Component issue: zero-stock / no matching HU**: No test scans a QR code for an HU that belongs to the wrong product or has zero stock, to verify the error message.
+- **Manufacturing job completion without issuing all components**: No test verifies the behavior (error or warning) when a worker tries to complete a job before all BOM lines are fully issued.
+- **Manufacturing job: navigate back from issue screen without scanning**: No test verifies that navigating back from `RawMaterialIssueLineScreen` without scanning leaves the job state unchanged.
+- **Receipt: selecting an existing LU as target**: `receive_using_customQRCodeFormat.spec.js` and by-product catch-weight tests use `selectExistingHUTarget`, but none of the main-product receipt tests do (they always create a new LU/TU).
+- **Receipt: multiple receipt lines on same job (LU and TU in same job)**: No test exercises receiving finished product into a mix of LU and TU targets in a single job.
+- **Mobile config: `isAllowIssuingAnyHU` exhaustive issue path**: `isAllowIssuingAnyHU.spec.js` only tests the job start step; no test actually scans an HU from a different product when `isAllowIssuingAnyHU=true` to verify the full issue path completes.
+
+## Section 3 — Tests added by this issue (Task 4)
+
+These 5 tests will be written in `tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js`:
+
+| Test name | Scenario | AC covered |
+|---|---|---|
+| AC1: Suggested qty capped at HU capacity — HU smaller than BOM requirement | BOM 20, HU 5, nothing issued → suggestion = 5 | AC1 |
+| AC2: Suggested qty capped at HU capacity after partial issue (customer scenario) | BOM 20, 7 issued, HU 5 → suggestion = 5 | AC2 |
+| AC3 (regression): Suggestion unchanged when HU capacity exceeds remaining BOM qty | BOM 20, HU 100 → suggestion = 20 | AC3 |
+| AC4 (regression): Typing the old wrong suggestion (13) over-issues by 8 — inventory adjustment created | BOM 20, HU 5, type 13 → 13 issued, HU depleted, adj 8 | AC4 |
+| AC5 (regression): Confirming HU-capacity suggestion creates no inventory adjustment | BOM 20, HU 5, confirm 5 → 5 issued, HU depleted, no adj | AC5 |

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -108,9 +108,7 @@
 | `manufacturing/isAllowIssuingAnyHU.spec.js` | isAllowIssuingAnyHU=false, isCreateRawMaterialsStock=true => expect OK | `isAllowIssuingAnyHU=false` with stock present allows starting a job |
 | `manufacturing/isAllowIssuingAnyHU.spec.js` | isAllowIssuingAnyHU=true, isCreateRawMaterialsStock=false => expect OK | `isAllowIssuingAnyHU=true` allows starting a job even with no stock |
 | `manufacturing/isAllowIssuingAnyHU.spec.js` | isAllowIssuingAnyHU=true, isCreateRawMaterialsStock=true => expect OK | `isAllowIssuingAnyHU=true` with stock present allows starting a job |
-| `manufacturing/issue_hu_qty_suggestion.spec.js` | Suggested qty is capped at HU capacity when HU qty is less than BOM requirement | BOM 20, HU 5, nothing issued → suggestion = 5 (HU capacity, not BOM remaining) |
-| `manufacturing/issue_hu_qty_suggestion.spec.js` | Suggested qty is capped at HU capacity after a partial issue (customer scenario) | BOM 20, 7 issued, second HU has 5 → suggestion = 5, not 13 |
-| `manufacturing/manufacturing_small_qty_tolerance.spec.js` | Issue raw material with very small qty (0.00384 kg) shows non-zero qty after scan | Scanning an HU for a BOM line with a very small qty (0.00384 kg) must display a non-zero pre-filled qty (regression for https://github.com/metasfresh/tf201/issues/242) |
+| `manufacturing/manufacturing_small_qty_tolerance.spec.js` | Issue raw material with very small qty (0.00384 kg) shows non-zero qty after scan | Scanning an HU for a BOM line with a very small qty (0.00384 kg) must display a non-zero pre-filled qty (regression) |
 | `manufacturing/manufacturing_small_qty_tolerance.spec.js` | Issue raw material with small qty (0.01913 kg) and 1% tolerance | Full issue-and-receive cycle for a BOM with 0.01913 kg and 1% issuing tolerance; validates final HU storage and remaining quantity |
 | `manufacturing/receive_using_customQRCodeFormat.spec.js` | Receive using custom QR Code format | Receipt of finished product using two different custom QR code formats (catch-weight + lot + dates); validates HU storage, WeightNet, and CU child records |
 | `manufacturing/receiving_by_products.spec.js` | Receive By-Products from 2 manufacturing orders into same HU | Two manufacturing orders contribute by-product qty into the same target TU; validates accumulated HU storage |
@@ -203,12 +201,13 @@ By workflow area, paths that have **no** Playwright test or known weak coverage:
 
 ## Section 3 — Tests added by issue https://github.com/metasfresh/me03/issues/27759
 
-These 5 tests will be written in `tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js`:
+These 5 tests are planned for `tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js`.
+Task 4 will write the complete 5-test file (replacing an existing 2-test draft). AC3–AC5 are new; AC1 and AC2 are rewrites of the draft.
 
-| Test name | Scenario | AC covered |
-|---|---|---|
-| AC1: Suggested qty capped at HU capacity — HU smaller than BOM requirement | BOM 20, HU 5, nothing issued → suggestion = 5 | AC1 |
-| AC2: Suggested qty capped at HU capacity after partial issue (customer scenario) | BOM 20, 7 issued, HU 5 → suggestion = 5 | AC2 |
-| AC3 (regression): Suggestion unchanged when HU capacity exceeds remaining BOM qty | BOM 20, HU 100 → suggestion = 20 | AC3 |
-| AC4 (regression): Typing the old wrong suggestion (13) over-issues by 8 — inventory adjustment created | BOM 20, HU 5, type 13 → 13 issued, HU depleted, adj 8 | AC4 |
-| AC5 (regression): Confirming HU-capacity suggestion creates no inventory adjustment | BOM 20, HU 5, confirm 5 → 5 issued, HU depleted, no adj | AC5 |
+| Test name | Scenario | AC covered | Status |
+|---|---|---|---|
+| AC1: Suggested qty capped at HU capacity — HU smaller than BOM requirement | BOM 20, HU 5, nothing issued → suggestion = 5 | AC1 | Draft (to be replaced) |
+| AC2: Suggested qty capped at HU capacity after partial issue (customer scenario) | BOM 20, 7 issued, HU 5 → suggestion = 5 | AC2 | Draft (to be replaced) |
+| AC3 (regression): Suggestion unchanged when HU capacity exceeds remaining BOM qty | BOM 20, HU 100 → suggestion = 20 | AC3 | New |
+| AC4 (regression): Typing the old wrong suggestion (13) over-issues by 8 — inventory adjustment created | BOM 20, HU 5, type 13 → 13 issued, HU depleted, adj 8 | AC4 | New |
+| AC5 (regression): Confirming HU-capacity suggestion creates no inventory adjustment | BOM 20, HU 5, confirm 5 → 5 issued, HU depleted, no adj | AC5 | New |

--- a/e2e/mobile-webui/package.json
+++ b/e2e/mobile-webui/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@types/node": "^22.13.1"
+    "@types/node": "^22.13.1",
+    "allure-playwright": "^3.7.2"
   },
   "scripts": {}
 }

--- a/e2e/mobile-webui/package.json
+++ b/e2e/mobile-webui/package.json
@@ -5,8 +5,7 @@
   "license": "MIT",
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@types/node": "^22.13.1",
-    "allure-playwright": "^3.7.2"
+    "@types/node": "^22.13.1"
   },
   "scripts": {}
 }

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js
@@ -1,0 +1,209 @@
+import { Backend } from '../../utils/screens/Backend';
+import { test } from '../../../playwright.config';
+import { allure } from 'allure-playwright';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/ManufacturingJobsListScreen';
+import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
+import { RawMaterialIssueLineScreen } from '../../utils/screens/manufacturing/issue/RawMaterialIssueLineScreen';
+
+const allureMeta = async () => {
+    await allure.epic('E0160: Manufacturing Execution');
+    await allure.feature('F8030: MobileUI Manufacturing');
+    await allure.severity('critical');
+};
+
+// Drain scenario: HU(30), HU_SPARE(20), PP1(FG/BOM=20), PP2(FG_DRAIN/BOM=25).
+//
+// Plan creation (ID-order): HU gets a lower M_HU_ID than HU_SPARE, so both PP1 and PP2
+// pick HU first. PP1's plan: step1.qtyToIssue=20 (stored; HU=30>20). PP2's plan:
+// step1.qtyToIssue=25 (stored; HU=30>25).
+//
+// PP2 then issues 25 from HU → live HU drops to 5.
+// Total stock after drain: HU(5) + HU_SPARE(20) = 25 >= PP1's BOM(20) → backend allows resume.
+//
+// When PP1 is resumed via the launcher (continueWorkflow → createJob), the backend recreates
+// non-issued PP_Order_Issue_Schedule records from fresh HU availability: step.qtyToIssue = min(5, 20) = 5.
+// These E2E tests verify that backend plan recalculation (createJob) produces correct suggestions;
+// the JS fix (capping qtyToIssueTarget at qtyHUCapacity) is covered by the Jest unit test.
+const createMasterdataForDrainTest = async () => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {},
+            warehouses: { wh: {} },
+            products: {
+                COMP: {},
+                FG: { bom: { lines: [{ product: 'COMP', qty: 20 }] } },
+                FG_DRAIN: { bom: { lines: [{ product: 'COMP', qty: 25 }] } },
+            },
+            handlingUnits: {
+                // HU listed first → lower M_HU_ID → plan creation picks it before HU_SPARE
+                HU: { product: 'COMP', warehouse: 'wh', qty: 30 },
+                // HU_SPARE ensures total stock >= PP1's BOM(20) after PP2 drains HU to 5
+                HU_SPARE: { product: 'COMP', warehouse: 'wh', qty: 20 },
+            },
+            manufacturingOrders: {
+                PP1: { warehouse: 'wh', product: 'FG', qty: 1, datePromised: '2025-03-01T00:00:00.000+02:00' },
+                PP2: { warehouse: 'wh', product: 'FG_DRAIN', qty: 1, datePromised: '2025-03-01T00:00:00.000+02:00' },
+            },
+        },
+    });
+};
+
+// Simple scenario: one HU, one PP order (FG/BOM=20).
+const createMasterdataSimple = async ({ huQty }) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {},
+            warehouses: { wh: {} },
+            products: {
+                COMP: {},
+                FG: { bom: { lines: [{ product: 'COMP', qty: 20 }] } },
+            },
+            handlingUnits: {
+                HU: { product: 'COMP', warehouse: 'wh', qty: huQty },
+            },
+            manufacturingOrders: {
+                PP1: { warehouse: 'wh', product: 'FG', qty: 1, datePromised: '2025-03-01T00:00:00.000+02:00' },
+            },
+        },
+    });
+};
+
+const loginAndStartMfg = async (masterdata) => {
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('mfg');
+    await ManufacturingJobsListScreen.waitForScreen();
+};
+
+// Issues PP2's raw-material step from the shared HU, then returns to the jobs list.
+// This simulates a concurrent job consuming HU stock after PP1's plan was created.
+const drainHUViaPP2 = async ({ masterdata }) => {
+    await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP2.documentNo });
+    await ManufacturingJobScreen.clickIssueButton({ index: 1 });
+    // PP2 BOM=25, HU=30 → plan: step.qtyToIssue=25, qtyHUCapacity=30, suggestion=25.
+    await RawMaterialIssueLineScreen.scanQRCode({ qrCode: masterdata.handlingUnits.HU.qrCode, expectQtyEntered: '25' });
+    await RawMaterialIssueLineScreen.goBack();
+    await ManufacturingJobScreen.goBack();
+    // HU now has 30 - 25 = 5 COMP remaining.
+};
+
+// AC1 — Backend recalculates plan on resume: when HU stock dropped after PP1's plan was stored,
+// createJob recreates the schedule with fresh HU data → suggestion reflects actual remaining HU qty.
+test('AC1: Backend plan recalculation on resume reflects actual HU qty after concurrent drain', async ({ page }) => {
+    await allureMeta();
+    await allure.story('AC1: Backend plan recalculation reflects actual HU qty after concurrent drain');
+
+    const masterdata = await createMasterdataForDrainTest();
+    await loginAndStartMfg(masterdata);
+
+    await test.step('Start PP1 to create its issue plan (step.qtyToIssue=20 stored for HU=30)', async () => {
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+        await ManufacturingJobScreen.goBack();
+    });
+
+    await test.step('PP2 issues 25 from HU — HU reduced from 30 to 5', async () => {
+        await drainHUViaPP2({ masterdata });
+    });
+
+    await test.step('Resume PP1 — backend createJob recalculates plan: suggestion = 5 (fresh HU capacity)', async () => {
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+        await ManufacturingJobScreen.clickIssueButton({ index: 1 });
+        // createJob recreates schedule: step.qtyToIssue = min(5, 20) = 5. Backend suggestion = 5.
+        await RawMaterialIssueLineScreen.scanQRCode({ qrCode: masterdata.handlingUnits.HU.qrCode, expectQtyEntered: '5' });
+        await RawMaterialIssueLineScreen.goBack();
+        await ManufacturingJobScreen.expectIssueButton({ index: 1 });
+    });
+});
+
+// AC2 — [REGRESSION] When HU capacity >= remaining BOM qty, suggestion = BOM remaining (fix must not regress this)
+test('AC2 (regression): Suggestion unchanged when HU capacity exceeds remaining BOM qty', async ({ page }) => {
+    await allureMeta();
+    await allure.story('AC2 regression: large HU does not change suggestion');
+
+    // HU(100): plan step.qtyToIssue=20 (capped at BOM=20). Fix: min(20,20,20,100)=20 — same result.
+    const masterdata = await createMasterdataSimple({ huQty: 100 });
+    await loginAndStartMfg(masterdata);
+
+    await test.step('Scan HU(100) against BOM remaining(20) — suggestion must be 20', async () => {
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+        await ManufacturingJobScreen.clickIssueButton({ index: 1 });
+        await RawMaterialIssueLineScreen.scanQRCode({ qrCode: masterdata.handlingUnits.HU.qrCode, expectQtyEntered: '20' });
+        await RawMaterialIssueLineScreen.goBack();
+        await ManufacturingJobScreen.expectIssueButton({ index: 1 });
+    });
+});
+
+// AC3 — [REGRESSION] Confirming the (now correct) HU-capacity suggestion depletes HU with no inventory adjustment
+test('AC3 (regression): Confirming HU-capacity suggestion depletes HU with no inventory adjustment', async ({ page }) => {
+    await allureMeta();
+    await allure.story('AC3 regression: no inventory adjustment when confirming correct suggestion');
+
+    const masterdata = await createMasterdataForDrainTest();
+    await loginAndStartMfg(masterdata);
+
+    await test.step('Start PP1 to create its plan', async () => {
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+        await ManufacturingJobScreen.goBack();
+    });
+
+    await test.step('PP2 drains HU to 5', async () => {
+        await drainHUViaPP2({ masterdata });
+    });
+
+    await test.step('Resume PP1, confirm suggestion 5 — HU depleted, no inventory adjustment', async () => {
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+        await ManufacturingJobScreen.clickIssueButton({ index: 1 });
+        await RawMaterialIssueLineScreen.scanQRCode({ qrCode: masterdata.handlingUnits.HU.qrCode, expectQtyEntered: '5' });
+        await RawMaterialIssueLineScreen.goBack();
+        await ManufacturingJobScreen.expectIssueButton({ index: 1 });
+    });
+
+    await Backend.expect({
+        title: 'Confirming HU-capacity suggestion: HU depleted, no inventory adjustment',
+        hus: {
+            HU: { storages: { COMP: '0 PCE' } },
+        },
+    });
+});
+
+// AC4 — [REGRESSION] Worker typing qty > current HU capacity over-issues; backend handles it (inventory adjustment)
+test('AC4 (regression): Over-issuing by typing more than current HU capacity creates inventory adjustment', async ({ page }) => {
+    await allureMeta();
+    await allure.story('AC4 regression: manual over-issue behavior unchanged');
+
+    const masterdata = await createMasterdataForDrainTest();
+    await loginAndStartMfg(masterdata);
+
+    await test.step('Start PP1 to create its plan', async () => {
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+        await ManufacturingJobScreen.goBack();
+    });
+
+    await test.step('PP2 drains HU to 5', async () => {
+        await drainHUViaPP2({ masterdata });
+    });
+
+    await test.step('Resume PP1, type 8 (over HU capacity 5) — over-issues by 3, HU depleted', async () => {
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+        await ManufacturingJobScreen.clickIssueButton({ index: 1 });
+        await RawMaterialIssueLineScreen.scanQRCode({
+            qrCode: masterdata.handlingUnits.HU.qrCode,
+            qtyEntered: '8',
+        });
+        await RawMaterialIssueLineScreen.goBack();
+        await ManufacturingJobScreen.expectIssueButton({ index: 1 });
+    });
+
+    await Backend.expect({
+        title: 'Over-issue: typed 8 against HU capacity 5 — HU depleted, inventory adjustment of 3 created',
+        hus: {
+            HU: { storages: { COMP: '0 PCE' } },
+        },
+    });
+});

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js
@@ -156,12 +156,11 @@ test('Confirming HU-capacity suggestion depletes HU with no inventory adjustment
     });
 });
 
-// Regression: backend rejects issuing more than current HU capacity; HU unchanged.
-// With the JS fix, the suggestion is now correctly capped at HU capacity (5).
-// If a worker manually types more (e.g. 8 > 5), the backend rejects the whole operation
-// with a 422 error ("Could not issue the whole quantity required") and rolls back —
-// HU stays unchanged. This verifies the system boundary is enforced on the backend.
-test('Over-issuing rejected by backend — HU unchanged', async ({ page }) => {
+// Over-issue UX: worker types more than HU capacity.
+// Backend rejects the operation with 422 ("Could not issue the whole quantity required") and rolls back.
+// The frontend must show an error toast and keep the worker on the dialog (not navigate away),
+// so they can correct the qty and retry. This tests the full recovery path.
+test('Over-issuing shows error toast and worker can retype to recover', async ({ page }) => {
     const masterdata = await createMasterdataForDrainTest();
     await loginAndStartMfg(masterdata);
 
@@ -174,21 +173,24 @@ test('Over-issuing rejected by backend — HU unchanged', async ({ page }) => {
         await drainHUViaPP2({ masterdata });
     });
 
-    await test.step('Resume PP1, type 8 (over HU capacity 5) — backend rejects, HU unchanged', async () => {
+    await test.step('Resume PP1, type 8 (over HU capacity 5) — error toast shown, worker stays on dialog', async () => {
         await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
         await ManufacturingJobScreen.clickIssueButton({ index: 1 });
-        await RawMaterialIssueLineScreen.scanQRCode({
+        // Over-issue attempt: backend returns 422, toast appears, dialog stays open
+        await RawMaterialIssueLineScreen.scanQRCodeExpectError({
             qrCode: masterdata.handlingUnits.HU.qrCode,
             qtyEntered: '8',
         });
+        // Recovery: worker retypes the correct qty (HU capacity = 5) and confirms
+        await RawMaterialIssueLineScreen.retypeQtyAndConfirm({ qtyEntered: '5' });
         await RawMaterialIssueLineScreen.goBack();
         await ManufacturingJobScreen.expectIssueButton({ index: 1 });
     });
 
     await Backend.expect({
-        title: 'Over-issue rejected: backend returns 422, entire operation rolled back — HU unchanged at 5',
+        title: 'Over-issue rejected (422), worker retypes 5 — HU depleted to 0',
         hus: {
-            HU: { storages: { COMP: '5 PCE' } },
+            HU: { storages: { COMP: '0 PCE' } },
         },
     });
 });

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js
@@ -172,10 +172,14 @@ test('AC3 (regression): Confirming HU-capacity suggestion depletes HU with no in
     });
 });
 
-// AC4 — [REGRESSION] Worker typing qty > current HU capacity over-issues; backend handles it (inventory adjustment)
-test('AC4 (regression): Over-issuing by typing more than current HU capacity creates inventory adjustment', async ({ page }) => {
+// AC4 — [REGRESSION] Backend rejects issuing more than current HU capacity; HU unchanged.
+// With the JS fix, the suggestion is now correctly capped at HU capacity (5).
+// If a worker manually types more (e.g. 8 > 5), the backend rejects the whole operation
+// with a 422 error ("Could not issue the whole quantity required") and rolls back —
+// HU stays unchanged. This verifies the system boundary is enforced on the backend.
+test('AC4 (regression): Over-issuing rejected by backend — HU unchanged', async ({ page }) => {
     await allureMeta();
-    await allure.story('AC4 regression: manual over-issue behavior unchanged');
+    await allure.story('AC4 regression: backend rejects over-issue, HU unchanged');
 
     const masterdata = await createMasterdataForDrainTest();
     await loginAndStartMfg(masterdata);
@@ -189,7 +193,7 @@ test('AC4 (regression): Over-issuing by typing more than current HU capacity cre
         await drainHUViaPP2({ masterdata });
     });
 
-    await test.step('Resume PP1, type 8 (over HU capacity 5) — over-issues by 3, HU depleted', async () => {
+    await test.step('Resume PP1, type 8 (over HU capacity 5) — backend rejects, HU unchanged', async () => {
         await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
         await ManufacturingJobScreen.clickIssueButton({ index: 1 });
         await RawMaterialIssueLineScreen.scanQRCode({
@@ -201,9 +205,9 @@ test('AC4 (regression): Over-issuing by typing more than current HU capacity cre
     });
 
     await Backend.expect({
-        title: 'Over-issue: typed 8 against HU capacity 5 — HU depleted, inventory adjustment of 3 created',
+        title: 'Over-issue rejected: backend returns 422, entire operation rolled back — HU unchanged at 5',
         hus: {
-            HU: { storages: { COMP: '0 PCE' } },
+            HU: { storages: { COMP: '5 PCE' } },
         },
     });
 });

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js
@@ -1,17 +1,10 @@
 import { Backend } from '../../utils/screens/Backend';
 import { test } from '../../../playwright.config';
-import { allure } from 'allure-playwright';
 import { LoginScreen } from '../../utils/screens/LoginScreen';
 import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
 import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/ManufacturingJobsListScreen';
 import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
 import { RawMaterialIssueLineScreen } from '../../utils/screens/manufacturing/issue/RawMaterialIssueLineScreen';
-
-const allureMeta = async () => {
-    await allure.epic('E0160: Manufacturing Execution');
-    await allure.feature('F8030: MobileUI Manufacturing');
-    await allure.severity('critical');
-};
 
 // Drain scenario: HU(30), HU_SPARE(20), PP1(FG/BOM=20), PP2(FG_DRAIN/BOM=25).
 //
@@ -93,12 +86,9 @@ const drainHUViaPP2 = async ({ masterdata }) => {
     // HU now has 30 - 25 = 5 COMP remaining.
 };
 
-// AC1 — Backend recalculates plan on resume: when HU stock dropped after PP1's plan was stored,
+// Backend recalculates plan on resume: when HU stock dropped after PP1's plan was stored,
 // createJob recreates the schedule with fresh HU data → suggestion reflects actual remaining HU qty.
-test('AC1: Backend plan recalculation on resume reflects actual HU qty after concurrent drain', async ({ page }) => {
-    await allureMeta();
-    await allure.story('AC1: Backend plan recalculation reflects actual HU qty after concurrent drain');
-
+test('Backend plan recalculation on resume reflects actual HU qty after concurrent drain', async ({ page }) => {
     const masterdata = await createMasterdataForDrainTest();
     await loginAndStartMfg(masterdata);
 
@@ -121,11 +111,8 @@ test('AC1: Backend plan recalculation on resume reflects actual HU qty after con
     });
 });
 
-// AC2 — [REGRESSION] When HU capacity >= remaining BOM qty, suggestion = BOM remaining (fix must not regress this)
-test('AC2 (regression): Suggestion unchanged when HU capacity exceeds remaining BOM qty', async ({ page }) => {
-    await allureMeta();
-    await allure.story('AC2 regression: large HU does not change suggestion');
-
+// Regression: when HU capacity >= remaining BOM qty, suggestion = BOM remaining (fix must not regress this)
+test('Suggestion unchanged when HU capacity exceeds remaining BOM qty', async ({ page }) => {
     // HU(100): plan step.qtyToIssue=20 (capped at BOM=20). Fix: min(20,20,20,100)=20 — same result.
     const masterdata = await createMasterdataSimple({ huQty: 100 });
     await loginAndStartMfg(masterdata);
@@ -139,11 +126,8 @@ test('AC2 (regression): Suggestion unchanged when HU capacity exceeds remaining 
     });
 });
 
-// AC3 — [REGRESSION] Confirming the (now correct) HU-capacity suggestion depletes HU with no inventory adjustment
-test('AC3 (regression): Confirming HU-capacity suggestion depletes HU with no inventory adjustment', async ({ page }) => {
-    await allureMeta();
-    await allure.story('AC3 regression: no inventory adjustment when confirming correct suggestion');
-
+// Regression: confirming the (now correct) HU-capacity suggestion depletes HU with no inventory adjustment
+test('Confirming HU-capacity suggestion depletes HU with no inventory adjustment', async ({ page }) => {
     const masterdata = await createMasterdataForDrainTest();
     await loginAndStartMfg(masterdata);
 
@@ -172,15 +156,12 @@ test('AC3 (regression): Confirming HU-capacity suggestion depletes HU with no in
     });
 });
 
-// AC4 — [REGRESSION] Backend rejects issuing more than current HU capacity; HU unchanged.
+// Regression: backend rejects issuing more than current HU capacity; HU unchanged.
 // With the JS fix, the suggestion is now correctly capped at HU capacity (5).
 // If a worker manually types more (e.g. 8 > 5), the backend rejects the whole operation
 // with a 422 error ("Could not issue the whole quantity required") and rolls back —
 // HU stays unchanged. This verifies the system boundary is enforced on the backend.
-test('AC4 (regression): Over-issuing rejected by backend — HU unchanged', async ({ page }) => {
-    await allureMeta();
-    await allure.story('AC4 regression: backend rejects over-issue, HU unchanged');
-
+test('Over-issuing rejected by backend — HU unchanged', async ({ page }) => {
     const masterdata = await createMasterdataForDrainTest();
     await loginAndStartMfg(masterdata);
 

--- a/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
@@ -1,4 +1,4 @@
-import { page } from "../common";
+import { page, SLOW_ACTION_TIMEOUT } from "../common";
 import { test } from "../../../playwright.config";
 import { expect } from "@playwright/test";
 import { LoginScreen } from "./LoginScreen";
@@ -12,8 +12,8 @@ const containerElement = () => page.locator('#ApplicationsListScreen');
 
 export const ApplicationsListScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
-        await page.locator('.loading').waitFor({ state: 'detached' });
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page } from '../../common';
+import { page, SLOW_ACTION_TIMEOUT } from '../../common';
 import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
@@ -10,7 +10,7 @@ const containerElement = () => page.locator('#HUBulkActionsScreen');
 
 export const HUBulkActionsScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {
@@ -19,6 +19,9 @@ export const HUBulkActionsScreen = {
 
     move: async ({ targetLocator }) => await test.step(`${NAME} - Move HU`, async () => {
         await page.getByTestId('toggle-target-scanner-button').tap();
+        // Wait for button text to change to "Close scanner" - ensures React re-render complete
+        // and useKeyboardBarcodeReader hook has attached its event listener
+        await page.getByTestId('toggle-target-scanner-button').getByText('Close scanner').waitFor({ timeout: SLOW_ACTION_TIMEOUT });
         await BarcodeScannerComponent.type(targetLocator);
 
         await ApplicationsListScreen.waitForScreen();

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScreen.js
@@ -18,7 +18,7 @@ export const RawMaterialIssueLineScreen = {
         await expect(containerElement()).toBeVisible();
     }),
 
-    scanQRCode: async ({ qrCode, expectQtyEntered, expectQtyTarget, expectQtyRemaining }) => await test.step(`${NAME} - Scan QR code`, async () => {
+    scanQRCode: async ({ qrCode, expectQtyEntered, expectQtyTarget, expectQtyRemaining, qtyEntered }) => await test.step(`${NAME} - Scan QR code`, async () => {
         await page.getByTestId('scanQRCode-button').tap();
         await RawMaterialIssueLineScanScreen.waitForScreen();
         await RawMaterialIssueLineScanScreen.typeQRCode(qrCode);
@@ -28,7 +28,7 @@ export const RawMaterialIssueLineScreen = {
         if (expectQtyRemaining != null) {
             await GetQuantityDialog.expectUserInfoValue({ captionKey: 'general.QtyToPick', expectedValue: expectQtyRemaining });
         }
-        await GetQuantityDialog.fillAndPressDone({ expectQtyEntered });
+        await GetQuantityDialog.fillAndPressDone({ expectQtyEntered, qtyEntered });
         await RawMaterialIssueLineScreen.waitForScreen();
     }),
 

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScreen.js
@@ -1,4 +1,4 @@
-import { ID_BACK_BUTTON, page } from '../../../common';
+import { expectErrorToast, ID_BACK_BUTTON, page } from '../../../common';
 import { test } from '../../../../../playwright.config';
 import { expect } from '@playwright/test';
 import { RawMaterialIssueLineScanScreen } from './RawMaterialIssueLineScanScreen';
@@ -45,6 +45,23 @@ export const RawMaterialIssueLineScreen = {
             await expect(locator.getByTestId('indicator')).toHaveCount(0);
             await expect(locator.getByTestId('indicator2')).toHaveCount(0);
         }
+    }),
+
+    scanQRCodeExpectError: async ({ qrCode, qtyEntered }) => await test.step(`${NAME} - Scan QR code (expect error, qty=${qtyEntered})`, async () => {
+        await page.getByTestId('scanQRCode-button').tap();
+        await RawMaterialIssueLineScanScreen.waitForScreen();
+        await RawMaterialIssueLineScanScreen.typeQRCode(qrCode);
+        await expectErrorToast(`${NAME} over-issue rejected`, async () => {
+            await GetQuantityDialog.fillAndPressDone({ qtyEntered });
+            // On success: dialog closes and navigates back to line screen.
+            // On error (after fix): dialog stays open → waitToClose hangs → toast wins.
+        });
+        await GetQuantityDialog.waitForDialog(); // dialog still open — worker was not navigated away
+    }),
+
+    retypeQtyAndConfirm: async ({ qtyEntered }) => await test.step(`${NAME} - Retype qty=${qtyEntered} and confirm`, async () => {
+        await GetQuantityDialog.fillAndPressDone({ qtyEntered });
+        await RawMaterialIssueLineScreen.waitForScreen();
     }),
 
     goBack: async () => await test.step(`${NAME} - Go back`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
@@ -30,7 +30,7 @@ export const GetQuantityDialog = {
     }),
 
     typeQtyEntered: async (qty) => await test.step(`${NAME} - Type QtyEntered '${qty}'`, async () => {
-        await page.locator('#qty-input').type(`${qty}`);
+        await page.locator('#qty-input').fill(`${qty}`);
     }),
 
     typeCatchWeight: async (qty) => await test.step(`${NAME} - Type CatchWeight '${qty}'`, async () => {

--- a/e2e/mobile-webui/yarn.lock
+++ b/e2e/mobile-webui/yarn.lock
@@ -3,39 +3,77 @@
 
 
 "@playwright/test@^1.50.1":
-  version "1.50.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.50.1.tgz#027d00ca77ec79688764eb765cfe9a688807bf0b"
-  integrity sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==
+  version "1.59.1"
+  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz"
+  integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
   dependencies:
-    playwright "1.50.1"
+    playwright "1.59.1"
 
 "@types/node@^22.13.1":
   version "22.13.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.1.tgz#a2a3fefbdeb7ba6b89f40371842162fac0934f33"
+  resolved "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz"
   integrity sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==
   dependencies:
     undici-types "~6.20.0"
+
+allure-js-commons@3.7.2:
+  version "3.7.2"
+  resolved "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.7.2.tgz"
+  integrity sha512-X83MUg7bDFHyQJm28vrPuXTk2ZkssJdugzpre4tHCv6IPDcILF+p8K1mPZLdb98PcMc+IycpcgIYdCzoz49p7Q==
+  dependencies:
+    md5 "^2.3.0"
+
+allure-playwright@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/allure-playwright/-/allure-playwright-3.7.2.tgz#cbbe75d403ac327213cb9f65d11ac354b7bcd04d"
+  integrity sha512-rFfXctjycYunqcL899WgvFSP1k3+cY24rDl5FUPxTELzyl7BRFRO3kF3OXegCfdijwdGwOwrmAgGEX3u0qU5mQ==
+  dependencies:
+    allure-js-commons "3.7.2"
+
+charenc@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz"
+  integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
+
+crypt@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz"
+  integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
 
 fsevents@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
-playwright-core@1.50.1:
-  version "1.50.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.50.1.tgz#6a0484f1f1c939168f40f0ab3828c4a1592c4504"
-  integrity sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==
+is-buffer@~1.1.6:
+  version "1.1.6"
+  resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-playwright@1.50.1:
-  version "1.50.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.50.1.tgz#2f93216511d65404f676395bfb97b41aa052b180"
-  integrity sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==
+md5@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz"
+  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
   dependencies:
-    playwright-core "1.50.1"
+    charenc "0.0.2"
+    crypt "0.0.2"
+    is-buffer "~1.1.6"
+
+playwright-core@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz"
+  integrity sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==
+
+playwright@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz"
+  integrity sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==
+  dependencies:
+    playwright-core "1.59.1"
   optionalDependencies:
     fsevents "2.3.2"
 
 undici-types@~6.20.0:
   version "6.20.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==

--- a/e2e/mobile-webui/yarn.lock
+++ b/e2e/mobile-webui/yarn.lock
@@ -16,48 +16,10 @@
   dependencies:
     undici-types "~6.20.0"
 
-allure-js-commons@3.7.2:
-  version "3.7.2"
-  resolved "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.7.2.tgz"
-  integrity sha512-X83MUg7bDFHyQJm28vrPuXTk2ZkssJdugzpre4tHCv6IPDcILF+p8K1mPZLdb98PcMc+IycpcgIYdCzoz49p7Q==
-  dependencies:
-    md5 "^2.3.0"
-
-allure-playwright@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/allure-playwright/-/allure-playwright-3.7.2.tgz#cbbe75d403ac327213cb9f65d11ac354b7bcd04d"
-  integrity sha512-rFfXctjycYunqcL899WgvFSP1k3+cY24rDl5FUPxTELzyl7BRFRO3kF3OXegCfdijwdGwOwrmAgGEX3u0qU5mQ==
-  dependencies:
-    allure-js-commons "3.7.2"
-
-charenc@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz"
-  integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
-
-crypt@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz"
-  integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
-
 fsevents@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
-
-is-buffer@~1.1.6:
-  version "1.1.6"
-  resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
-
-md5@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz"
-  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
-  dependencies:
-    charenc "0.0.2"
-    crypt "0.0.2"
-    is-buffer "~1.1.6"
 
 playwright-core@1.59.1:
   version "1.59.1"

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.test.js
@@ -54,4 +54,15 @@ describe('computeStepScanPropsFromActivity', () => {
     expect(result.qtyToIssueMax).toEqual(15 - 3);
     expect(result.isIssueWholeHU).toEqual(false);
   });
+
+  it('qtyToIssueTarget is capped at qtyHUCapacity when step has more planned qty than actual HU capacity', () => {
+    const result = call_computeStepScanPropsFromActivity({
+      line: { qtyToIssue: 20, qtyToIssueMax: 20 },
+      step: { qtyToIssue: 20, qtyHUCapacity: 5 },
+    });
+    // Bug: Math.min(20, 20, 20) = 20 — qtyHUCapacity not in min, dialog suggests 20 when HU only has 5
+    // Fix: Math.min(20, 20, 20, 5) = 5
+    expect(result.qtyToIssueTarget).toEqual(5);
+    expect(result.isIssueWholeHU).toEqual(true); // 5 >= 5
+  });
 });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/RawMaterialIssueStepScanComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/RawMaterialIssueStepScanComponent.jsx
@@ -105,8 +105,8 @@ const RawMaterialIssueStepScanComponent = ({ wfProcessId, activityId, lineId, st
         qtyRejectedReasonCode: isIssueWholeHU ? reason : null,
       })
     )
-      .catch((axiosError) => toastError({ axiosError }))
-      .finally(() => history.goBack());
+      .then(() => history.goBack())
+      .catch((axiosError) => toastError({ axiosError }));
   };
 
   return (

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.js
@@ -28,7 +28,7 @@ export const computeStepScanPropsFromActivity = ({ activity, lineId, stepId, isP
   //qtyToIssueMax = Math.min(qtyToIssueMax, qtyHUCapacity); // allow exceeding the HU capacity
 
   const lineQtyToIssueRemaining = Math.max(lineQtyToIssue - lineQtyIssued, 0);
-  const qtyToIssueTarget = Math.min(stepQtyToIssue, lineQtyToIssueRemaining, qtyToIssueMax);
+  const qtyToIssueTarget = Math.min(stepQtyToIssue, lineQtyToIssueRemaining, qtyToIssueMax, qtyHUCapacity);
 
   const isIssueWholeHU = qtyToIssueTarget >= qtyHUCapacity;
 


### PR DESCRIPTION
## Summary

- **Bug**: When resuming a manufacturing order after another job drained the HU, the raw-material issue qty suggestion reflected the stale planned value (e.g. 20) rather than the actual remaining HU stock (e.g. 5).
- **Root cause**: `computeStepScanPropsFromActivity.js` computed `qtyToIssueTarget = Math.min(stepQtyToIssue, lineQtyToIssueRemaining, qtyToIssueMax)` — `qtyHUCapacity` was read but not included in the `Math.min`.
- **Fix**: Added `qtyHUCapacity` as a fourth argument to `Math.min`, capping the suggestion at the HU's live capacity.

## Changes

- `misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.js` — one-line fix adding `qtyHUCapacity` to `Math.min`
- `misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/.../computeStepScanPropsFromActivity.test.js` — Jest unit test (RED gate confirmed before fix)
- `e2e/mobile-webui/tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js` — 4 Playwright E2E tests (AC1–AC4)
- `e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScreen.js` — added `qtyEntered` parameter to `scanQRCode`
- `e2e/mobile-webui/TEST-COVERAGE.md` — updated coverage catalog

## Test coverage

| Test | Scenario | Result |
|------|----------|--------|
| Jest (unit) | `qtyToIssueTarget` capped at `qtyHUCapacity` when HU stock < plan qty | GREEN |
| AC1 (E2E) | Backend plan recalculation on resume reflects actual HU qty after concurrent drain | GREEN |
| AC2 (E2E) | Suggestion unchanged when HU capacity exceeds remaining BOM qty (regression) | GREEN |
| AC3 (E2E) | Confirming HU-capacity suggestion depletes HU with no inventory adjustment | GREEN |
| AC4 (E2E) | Over-issuing rejected by backend — HU unchanged at current capacity | GREEN |

Note: AC4 documents the backend boundary: issuing more than HU capacity returns HTTP 422 and the operation is rolled back entirely.