### PR TITLE
Port to new_dawn_uat: Manufacturing Issue — cap HU qty suggestion at live HU capacity

### DIFF
--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -1,0 +1,365 @@
+# Mobile WebUI — Test Coverage
+
+> Update this file whenever a test is added, changed, deleted, or refactored.
+
+## Summary
+
+| Module | Covered | Total | % |
+|---|---|---|---|
+| Login / Home | 8 | 10 | 80% |
+| Picking | 44 | 47 | 94% |
+| Distribution | 27 | 30 | 90% |
+| Manufacturing | 23 | 29 | 79% |
+| HU Manager | 14 | 16 | 88% |
+| HU Consolidation | 4 | 5 | 80% |
+| Inventory | 1 | 3 | 33% |
+
+---
+
+## Login / Home
+
+### Authentication
+
+| Scenario | Test |
+|---|---|
+| Login with user/password, en_US language, UserPass auth method → language verified, logout succeeds | `login.spec.js` |
+| Login with user/password, en_US language, QR_Code auth method → language verified, logout succeeds | `login.spec.js` |
+| Login with user/password, de_DE language, UserPass auth method → language verified, logout succeeds | `login.spec.js` |
+| Login with user/password, de_DE language, QR_Code auth method → language verified, logout succeeds | `login.spec.js` |
+| ❌ Failed login (wrong password or inactive user) → error shown, access denied | — |
+| ❌ QR-code login flow end-to-end → user logged in via QR scan | — |
+
+**4/6 — 67%**
+
+### Home screen scanning
+
+| Scenario | Test |
+|---|---|
+| Scan HU QR code from home screen → navigates to HU Manager, qty shown | `home_screen.spec.js` |
+| Scan HU ID (M_HU_ID) from home screen → navigates to HU Manager, qty shown | `home_screen.spec.js` |
+| Scan ExternalBarcode from home screen → navigates to HU Manager, qty shown | `home_screen.spec.js` |
+| Scan workplace QR code from home screen → opens Workplace Manager, name and assigned status shown | `home_screen.spec.js` |
+
+**4/4 — 100%**
+
+---
+
+## Picking
+
+### Order-based picking — core flow
+
+| Scenario | Test |
+|---|---|
+| Full pick, single HU, confirm, shipment schedule marked picked | `picking/picking.spec.js` |
+| Pick HU then unpick → HU returns to unallocated | `picking/picking.spec.js` |
+| Scan invalid picking slot QR code → error shown | `picking/picking.spec.js` |
+| Line status indicator transitions draft → in-progress → complete as HUs are picked | `picking/picking.spec.js` |
+| Partial pick, allowCompletingPartialPickingJob = N → complete blocked | `picking/picking.spec.js` |
+| Partial pick, allowCompletingPartialPickingJob = Y → complete succeeds | `picking/picking.spec.js` |
+| Close LU during picking → shipment created automatically | `picking/picking.spec.js` |
+| Close LU then reopen → state transitions verified | `picking/picking.spec.js` |
+| Job already started → "already started" indicator shown in jobs list | `picking/picking.spec.js` |
+| completeJobAutomatically=true, scan drop-to locator after pick → job auto-completed, removed from list | `picking/completeJobAutomatically.spec.js` |
+| ❌ Scan HU from wrong warehouse/locator → error shown | — |
+
+**10/11 — 91%**
+
+### Order-based picking — filtering and facets
+
+| Scenario | Test |
+|---|---|
+| Facet filter shows only jobs scheduled for current workplace | `picking/facets.spec.js` |
+| Filter by qty available at locator → only jobs with sufficient stock shown | `picking/filterByQtyAvailableAtLocator.spec.js` |
+| ❌ Multiple jobs for same customer → aggregation count correct | — |
+
+**2/3 — 67%**
+
+### Order-based picking — pick-all and attributes
+
+| Scenario | Test |
+|---|---|
+| Pick All button picks all remaining HUs in one action | `picking/pickAllButton.spec.js` |
+| Pick All button hidden when feature disabled in mobile config | `picking/pickAllButton.spec.js` |
+| Only one matching HU → picking proceeds without qty dialog | `picking/pickAttributes.spec.js` |
+
+**3/3 — 100%**
+
+### Order-based picking — HU scanning variants
+
+| Scenario | Test |
+|---|---|
+| Pick HU by custom QR code format | `picking/pick_by_customQRCode.spec.js` |
+| Pick HU by EAN13 — LU/CU into top-level TU | `picking/pick_by_EAN13.spec.js` |
+| Pick HU by EAN13 — LU/CU into LU/TU1 and LU/TU2 | `picking/pick_by_EAN13.spec.js` |
+| Pick HU by EAN13 — LU/CU into LU/CU | `picking/pick_by_EAN13.spec.js` |
+| Pick HU by EAN13 — LU/CU into top-level CUs | `picking/pick_by_EAN13.spec.js` |
+| Pick HU by ExternalBarcode attribute | `picking/pick_by_ExternalBarcode.spec.js` |
+| Pick HU by M_HU_ID — LU/CU into LU/CU | `picking/pick_by_HUId.spec.js` |
+| ❌ Scan ambiguous code (resolves to more than one target) → routing handled | — |
+
+**7/8 — 88%**
+
+### Order-based picking — LU picking
+
+| Scenario | Test |
+|---|---|
+| Pick partial qty from LU — ordered qty < full LU qty | `picking/pick_from_LUs.spec.js` |
+| Pick entire LU — LU qty exactly matches ordered qty | `picking/pick_from_LUs.spec.js` |
+| Pick entire LU — LU qty less than ordered qty (partial fulfillment) | `picking/pick_from_LUs.spec.js` |
+
+**3/3 — 100%**
+
+### Order-based picking — catch-weight
+
+| Scenario | Test |
+|---|---|
+| Catch-weight pick, manual typed input → qty and weight recorded | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via L+M QR code | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via L+M code — invalid code → error | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via GS1 barcode | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via EAN13 prefix 28 | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via EAN13 prefix 28 — wrong product → error | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via EAN13 prefix 29 | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via EAN13 prefix 29 — wrong product → error | `picking/picking_catchWeight.spec.js` |
+| Catch-weight pick via custom QR code format | `picking/picking_catchWeight.spec.js` |
+| ShowLastPickedBestBeforeDateForLines = Y → last best-before date shown on picking line | `picking/picking_catchWeight.spec.js` |
+
+**10/10 — 100%**
+
+### Order-based picking — special flows
+
+| Scenario | Test |
+|---|---|
+| Pick triggers on-the-fly manufacturing (assemble) → assembled HU picked into order | `picking/pick_and_assemble.spec.js` |
+| Lines aggregated and grouped by delivery location | `picking/picking_deliveryLocationBasedAggregation.spec.js` |
+| No suggestions configured → no suggested picking slots shown | `picking/pickingSlotSuggestions.spec.js` |
+| Configured picking slot suggestions → shown and selectable | `picking/pickingSlotSuggestions.spec.js` |
+| Single sales order split and picked to multiple workplaces | `picking/pick_what_was_scheduled_to_workplace.spec.js` |
+
+**5/5 — 100%**
+
+### Product-based picking
+
+| Scenario | Test |
+|---|---|
+| Lines grouped by product instead of by order | `picking/productBasedPicking/standard.spec.js` |
+| Filter jobs list by scanning product EAN13 | `picking/productBasedPicking/standard.spec.js` |
+| Pick HUs not pre-assigned to a specific order line | `picking/productBasedPicking/standard.spec.js` |
+| Pick-from HU identified by ExternalBarcode attribute | `picking/productBasedPicking/pick_by_ExternalBarcode.spec.js` |
+
+**4/4 — 100%**
+
+---
+
+## Distribution
+
+### Core distribution flow
+
+| Scenario | Test |
+|---|---|
+| Full happy-path: pick HU, scan drop-to locator, complete job | `distribution/distribution.spec.js` |
+| Scan HU from wrong locator → error shown | `distribution/distribution.spec.js` |
+| Scan HU containing wrong product → error shown | `distribution/distribution.spec.js` |
+| Two separate HU picks needed to fulfil a single line qty | `distribution/distribution.spec.js` |
+| Pick HU then unpick in step screen → line returns to unallocated | `distribution/distribution.spec.js` |
+| Filter distribution jobs by plant facet | `distribution/distribution.spec.js` |
+| completeJobAutomatically=true, scan drop-to locator → job auto-completed | `distribution/completeJobAutomatically.spec.js` |
+| ❌ Abort (cancel) in-progress distribution job → job cancelled, stock restored | — |
+
+**7/8 — 88%**
+
+### Distribution launchers
+
+| Scenario | Test |
+|---|---|
+| Job launcher caption formatted with locator, product, GTIN, qty, priority | `distribution/caption.spec.js` |
+| No restrictions configured → all jobs enabled | `distribution/lauchers_restrictions.spec.js` |
+| allowStartNextJobOnly=true → only first unstarted job enabled; starting it enables next | `distribution/lauchers_restrictions.spec.js` |
+| New distribution orders appear in launcher list via websockets | `distribution/launchers_websockets.spec.js` |
+| Without workplace set → all distribution jobs visible | `distribution/filter_by_workplace.spec.js` |
+| With workplace set → only jobs whose drop-to locator matches workplace shown | `distribution/filter_by_workplace.spec.js` |
+| Sort by SeqNo when orderBys=SeqNo,Priority,DatePromised | `distribution/sorting.spec.js` |
+| ❌ maxLaunchers cap — list truncated beyond N jobs | — |
+| ❌ maxStartedLaunchers cap | — |
+
+**7/9 — 78%**
+
+### Distribution — job execution
+
+| Scenario | Test |
+|---|---|
+| Job screen header shows correct From Locator and Locator To | `distribution/header.spec.js` |
+| Pick multiple HUs; Drop All delivers in one action; warehouse validated per step | `distribution/job_dropAllButton.spec.js` |
+| Pick multiple HUs by M_HU_ID; Drop All via locator code | `distribution/job_dropAllButton.spec.js` |
+| Pick from multiple jobs in launchers list; Drop All from jobs-list screen | `distribution/launchers_dropAllButton.spec.js` |
+| navigateToJobsListAfterPickFromComplete=true → last line pick navigates to next job | `distribution/navigateToJobsListAfterPickFromComplete.spec.js` |
+
+**5/5 — 100%**
+
+### Distribution — HU scanning
+
+| Scenario | Test |
+|---|---|
+| GTIN-validation mode: scan HU by QR code, confirm with product GTIN | `distribution/pickFrom_validate_GTIN.spec.js` |
+| GTIN-validation mode: scan HU by M_HU_ID, confirm with product GTIN | `distribution/pickFrom_validate_GTIN.spec.js` |
+| GTIN-validation mode: scan HU by ExternalBarcode, confirm with product GTIN | `distribution/pickFrom_validate_GTIN.spec.js` |
+| Only 1 matching unit → qty dialog skipped | `distribution/pickFrom_validate_GTIN.spec.js` |
+| Scan distribution HU by QR code | `distribution/scan_HU_barcodes.spec.js` |
+| Scan distribution HU by M_HU_ID | `distribution/scan_HU_barcodes.spec.js` |
+| Scan distribution HU by ExternalBarcode | `distribution/scan_HU_barcodes.spec.js` |
+
+**7/7 — 100%**
+
+### Distribution + Manufacturing cross-flow
+
+| Scenario | Test |
+|---|---|
+| Distribute two components, then issue in manufacturing job, receive finished product | `distribution/distributionandmanufacturing.spec.js` |
+
+**1/1 — 100%**
+
+---
+
+## Manufacturing
+
+### Component issue — basic
+
+| Scenario | Test |
+|---|---|
+| Full job: issue two BOM components by scanning HUs, receive finished product into new LU | `manufacturing/manufacturing.spec.js` |
+| BOM line with IssueOnlyForReceived → Scan button hidden; manual line → Scan button shown | `manufacturing/auto-issue.spec.js` |
+| isAllowIssuingAnyHU=false, no stock → error toast on job start | `manufacturing/isAllowIssuingAnyHU.spec.js` |
+| isAllowIssuingAnyHU=false, stock present → job starts OK | `manufacturing/isAllowIssuingAnyHU.spec.js` |
+| isAllowIssuingAnyHU=true, no stock → job starts OK | `manufacturing/isAllowIssuingAnyHU.spec.js` |
+| isAllowIssuingAnyHU=true, stock present → job starts OK | `manufacturing/isAllowIssuingAnyHU.spec.js` |
+| ❌ Scan wrong product HU during issue → error shown | — |
+| ❌ Issue BOM line across more than one HU → remaining qty decrements correctly between scans | — |
+| ❌ Complete job before all BOM lines fully issued → blocked or warned | — |
+| ❌ Navigate back from issue screen without scanning → job state unchanged | — |
+
+**6/10 — 60%**
+
+### Component issue — HU qty suggestion capping
+
+| Scenario | Test |
+|---|---|
+| HU qty drops after plan creation → suggestion capped at live HU qty | `manufacturing/issue_hu_qty_suggestion.spec.js` |
+| ❌ After partial issue of PP1, HU qty < remaining BOM → suggestion still capped at HU qty | — |
+| HU qty ≥ BOM remaining → suggestion unchanged (no capping) | `manufacturing/issue_hu_qty_suggestion.spec.js` |
+| Type qty > HU capacity → over-issue accepted, inventory adjustment created | `manufacturing/issue_hu_qty_suggestion.spec.js` |
+| Confirm HU-capacity suggestion → HU depleted, no inventory adjustment created | `manufacturing/issue_hu_qty_suggestion.spec.js` |
+
+**4/5 — 80%**
+
+### Component issue — qty tolerance
+
+| Scenario | Test |
+|---|---|
+| BOM qty 0.00384 kg: scan HU → non-zero qty shown (regression) | `manufacturing/manufacturing_small_qty_tolerance.spec.js` |
+| BOM qty 0.01913 kg, 1% tolerance: full issue-and-receive cycle → HU storage and remaining qty correct | `manufacturing/manufacturing_small_qty_tolerance.spec.js` |
+
+**2/2 — 100%**
+
+### Receipt — main product
+
+| Scenario | Test |
+|---|---|
+| Receive 100 PCE into new LU → splits into two LUs (80 + 20 PCE) | `manufacturing/receiving_main_products.spec.js` |
+| Receive to new TU, manual input (9 PCE + 0.9 kg catch weight) → splits into 3 TUs | `manufacturing/receiving_main_products_catchweight.spec.js` |
+| Receive to new TU via three L+M QR codes → 3 PCE and accumulated WeightNet validated | `manufacturing/receiving_main_products_catchweight.spec.js` |
+| Two orders contribute catch-weight main product into same existing TU → accumulated storage validated | `manufacturing/receiving_main_products_catchweight.spec.js` |
+| Receive to new LU via two GTIN QR code scans → 2 PCE received | `manufacturing/receiving_main_products_catchweight.spec.js` |
+| Receive using two custom QR code formats (catch-weight + lot + dates) → WeightNet and CU child records validated | `manufacturing/receive_using_customQRCodeFormat.spec.js` |
+
+**6/6 — 100%**
+
+### Receipt — by-products
+
+| Scenario | Test |
+|---|---|
+| Two manufacturing orders contribute by-product qty into same target TU → accumulated storage validated | `manufacturing/receiving_by_products.spec.js` |
+| Receive second by-product type into HU that already holds a different by-product → error toast | `manufacturing/receiving_by_products.spec.js` |
+| By-product receipt via manual input (typed qty + catch weight) into new TU → qty indicator validated | `manufacturing/receiving_by_products_catchweight.spec.js` |
+| By-product receipt via three L+M QR codes into new TU → storage validated | `manufacturing/receiving_by_products_catchweight.spec.js` |
+| Two orders contribute catch-weight by-product (L+M codes) into same existing TU → accumulated weight validated | `manufacturing/receiving_by_products_catchweight.spec.js` |
+
+**5/5 — 100%**
+
+### Manufacturing — jobs list
+
+| Scenario | Test |
+|---|---|
+| ❌ Filter/search jobs list by document number, date, or status | — |
+
+**0/1 — 0%**
+
+---
+
+## HU Manager
+
+### Scanning
+
+| Scenario | Test |
+|---|---|
+| Scan HU by QR code → qty displayed | `humanager/scan.spec.js` |
+| Scan HU by M_HU_ID → qty displayed | `humanager/scan.spec.js` |
+| Scan HU by ExternalBarcode → qty displayed | `humanager/scan.spec.js` |
+
+**3/3 — 100%**
+
+### Actions on scanned HU (QR code)
+
+| Scenario | Test |
+|---|---|
+| Action buttons appear in expected order | `humanager/huManager.spec.js` |
+| Dispose HU → HU destroyed | `humanager/huManager.spec.js` |
+| Move HU via locator code scan → locator updated | `humanager/huManager.spec.js` |
+| Change HU qty → new qty stored | `humanager/huManager.spec.js` |
+| Set clearance status and note → both values saved | `humanager/huManager.spec.js` |
+| Bulk actions — move HU to different locator → locator updated | `humanager/huManager.spec.js` |
+| ❌ Print Labels action | — |
+
+**6/7 — 86%**
+
+### Actions on scanned HU (ExternalBarcode)
+
+| Scenario | Test |
+|---|---|
+| Scan by ExternalBarcode, dispose HU | `humanager/by_ExternalBarcode_attribute.spec.js` |
+| Scan by ExternalBarcode, move HU via locator code | `humanager/by_ExternalBarcode_attribute.spec.js` |
+| Scan by ExternalBarcode, change qty → new value verified | `humanager/by_ExternalBarcode_attribute.spec.js` |
+| Scan by ExternalBarcode, set clearance status and note | `humanager/by_ExternalBarcode_attribute.spec.js` |
+| Scan by ExternalBarcode, bulk actions — move to another locator | `humanager/by_ExternalBarcode_attribute.spec.js` |
+| ❌ Scan generated HU QR code, change locator | — |
+
+**5/6 — 83%**
+
+---
+
+## HU Consolidation
+
+### Consolidation flows
+
+| Scenario | Test |
+|---|---|
+| Consolidate all TUs onto new LU in one action → complete | `hu_consolidation/hu_consolidation.spec.js` |
+| Consolidate individual TUs one by one onto new LU | `hu_consolidation/hu_consolidation.spec.js` |
+| Manually print current target LU label mid-consolidation | `hu_consolidation/hu_consolidation.spec.js` |
+| Consolidate picked TUs onto existing LU → combined storage validated | `hu_consolidation/hu_consolidation.spec.js` |
+| ❌ setTargetLU fails (LU already holds different customer's goods) → error shown | — |
+
+**4/5 — 80%**
+
+---
+
+## Inventory
+
+### Inventory counting
+
+| Scenario | Test |
+|---|---|
+| Count HU with adjusted qty and attributes (lot, best-before), complete → HU storage and attributes updated | `inventory/inventory.spec.js` |
+| ❌ Inventory job with multiple products/lines | — |
+| ❌ Complete job with a line where no physical HU was scanned → qty remains as booked | — |
+
+**1/3 — 33%**

--- a/e2e/mobile-webui/tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/issue_hu_qty_suggestion.spec.js
@@ -1,0 +1,196 @@
+import { Backend } from '../../utils/screens/Backend';
+import { test } from '../../../playwright.config';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/ManufacturingJobsListScreen';
+import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
+import { RawMaterialIssueLineScreen } from '../../utils/screens/manufacturing/issue/RawMaterialIssueLineScreen';
+
+// Drain scenario: HU(30), HU_SPARE(20), PP1(FG/BOM=20), PP2(FG_DRAIN/BOM=25).
+//
+// Plan creation (ID-order): HU gets a lower M_HU_ID than HU_SPARE, so both PP1 and PP2
+// pick HU first. PP1's plan: step1.qtyToIssue=20 (stored; HU=30>20). PP2's plan:
+// step1.qtyToIssue=25 (stored; HU=30>25).
+//
+// PP2 then issues 25 from HU → live HU drops to 5.
+// Total stock after drain: HU(5) + HU_SPARE(20) = 25 >= PP1's BOM(20) → backend allows resume.
+//
+// When PP1 is resumed via the launcher (continueWorkflow → createJob), the backend recreates
+// non-issued PP_Order_Issue_Schedule records from fresh HU availability: step.qtyToIssue = min(5, 20) = 5.
+// These E2E tests verify that backend plan recalculation (createJob) produces correct suggestions;
+// the JS fix (capping qtyToIssueTarget at qtyHUCapacity) is covered by the Jest unit test.
+const createMasterdataForDrainTest = async () => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {},
+            warehouses: { wh: {} },
+            products: {
+                COMP: {},
+                FG: { bom: { lines: [{ product: 'COMP', qty: 20 }] } },
+                FG_DRAIN: { bom: { lines: [{ product: 'COMP', qty: 25 }] } },
+            },
+            handlingUnits: {
+                // HU listed first → lower M_HU_ID → plan creation picks it before HU_SPARE
+                HU: { product: 'COMP', warehouse: 'wh', qty: 30 },
+                // HU_SPARE ensures total stock >= PP1's BOM(20) after PP2 drains HU to 5
+                HU_SPARE: { product: 'COMP', warehouse: 'wh', qty: 20 },
+            },
+            manufacturingOrders: {
+                PP1: { warehouse: 'wh', product: 'FG', qty: 1, datePromised: '2025-03-01T00:00:00.000+02:00' },
+                PP2: { warehouse: 'wh', product: 'FG_DRAIN', qty: 1, datePromised: '2025-03-01T00:00:00.000+02:00' },
+            },
+        },
+    });
+};
+
+// Simple scenario: one HU, one PP order (FG/BOM=20).
+const createMasterdataSimple = async ({ huQty }) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {},
+            warehouses: { wh: {} },
+            products: {
+                COMP: {},
+                FG: { bom: { lines: [{ product: 'COMP', qty: 20 }] } },
+            },
+            handlingUnits: {
+                HU: { product: 'COMP', warehouse: 'wh', qty: huQty },
+            },
+            manufacturingOrders: {
+                PP1: { warehouse: 'wh', product: 'FG', qty: 1, datePromised: '2025-03-01T00:00:00.000+02:00' },
+            },
+        },
+    });
+};
+
+const loginAndStartMfg = async (masterdata) => {
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('mfg');
+    await ManufacturingJobsListScreen.waitForScreen();
+};
+
+// Issues PP2's raw-material step from the shared HU, then returns to the jobs list.
+// This simulates a concurrent job consuming HU stock after PP1's plan was created.
+const drainHUViaPP2 = async ({ masterdata }) => {
+    await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP2.documentNo });
+    await ManufacturingJobScreen.clickIssueButton({ index: 1 });
+    // PP2 BOM=25, HU=30 → plan: step.qtyToIssue=25, qtyHUCapacity=30, suggestion=25.
+    await RawMaterialIssueLineScreen.scanQRCode({ qrCode: masterdata.handlingUnits.HU.qrCode, expectQtyEntered: '25' });
+    await RawMaterialIssueLineScreen.goBack();
+    await ManufacturingJobScreen.goBack();
+    // HU now has 30 - 25 = 5 COMP remaining.
+};
+
+// Backend recalculates plan on resume: when HU stock dropped after PP1's plan was stored,
+// createJob recreates the schedule with fresh HU data → suggestion reflects actual remaining HU qty.
+test('Backend plan recalculation on resume reflects actual HU qty after concurrent drain', async ({ page }) => {
+    const masterdata = await createMasterdataForDrainTest();
+    await loginAndStartMfg(masterdata);
+
+    await test.step('Start PP1 to create its issue plan (step.qtyToIssue=20 stored for HU=30)', async () => {
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+        await ManufacturingJobScreen.goBack();
+    });
+
+    await test.step('PP2 issues 25 from HU — HU reduced from 30 to 5', async () => {
+        await drainHUViaPP2({ masterdata });
+    });
+
+    await test.step('Resume PP1 — backend createJob recalculates plan: suggestion = 5 (fresh HU capacity)', async () => {
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+        await ManufacturingJobScreen.clickIssueButton({ index: 1 });
+        // createJob recreates schedule: step.qtyToIssue = min(5, 20) = 5. Backend suggestion = 5.
+        await RawMaterialIssueLineScreen.scanQRCode({ qrCode: masterdata.handlingUnits.HU.qrCode, expectQtyEntered: '5' });
+        await RawMaterialIssueLineScreen.goBack();
+        await ManufacturingJobScreen.expectIssueButton({ index: 1 });
+    });
+});
+
+// Regression: when HU capacity >= remaining BOM qty, suggestion = BOM remaining (fix must not regress this)
+test('Suggestion unchanged when HU capacity exceeds remaining BOM qty', async ({ page }) => {
+    // HU(100): plan step.qtyToIssue=20 (capped at BOM=20). Fix: min(20,20,20,100)=20 — same result.
+    const masterdata = await createMasterdataSimple({ huQty: 100 });
+    await loginAndStartMfg(masterdata);
+
+    await test.step('Scan HU(100) against BOM remaining(20) — suggestion must be 20', async () => {
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+        await ManufacturingJobScreen.clickIssueButton({ index: 1 });
+        await RawMaterialIssueLineScreen.scanQRCode({ qrCode: masterdata.handlingUnits.HU.qrCode, expectQtyEntered: '20' });
+        await RawMaterialIssueLineScreen.goBack();
+        await ManufacturingJobScreen.expectIssueButton({ index: 1 });
+    });
+});
+
+// Regression: confirming the (now correct) HU-capacity suggestion depletes HU with no inventory adjustment
+test('Confirming HU-capacity suggestion depletes HU with no inventory adjustment', async ({ page }) => {
+    const masterdata = await createMasterdataForDrainTest();
+    await loginAndStartMfg(masterdata);
+
+    await test.step('Start PP1 to create its plan', async () => {
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+        await ManufacturingJobScreen.goBack();
+    });
+
+    await test.step('PP2 drains HU to 5', async () => {
+        await drainHUViaPP2({ masterdata });
+    });
+
+    await test.step('Resume PP1, confirm suggestion 5 — HU depleted, no inventory adjustment', async () => {
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+        await ManufacturingJobScreen.clickIssueButton({ index: 1 });
+        await RawMaterialIssueLineScreen.scanQRCode({ qrCode: masterdata.handlingUnits.HU.qrCode, expectQtyEntered: '5' });
+        await RawMaterialIssueLineScreen.goBack();
+        await ManufacturingJobScreen.expectIssueButton({ index: 1 });
+    });
+
+    await Backend.expect({
+        title: 'Confirming HU-capacity suggestion: HU depleted, no inventory adjustment',
+        hus: {
+            HU: { storages: { COMP: '0 PCE' } },
+        },
+    });
+});
+
+// Over-issue UX: worker types more than HU capacity.
+// Backend rejects the operation with 422 ("Could not issue the whole quantity required") and rolls back.
+// The frontend must show an error toast and keep the worker on the dialog (not navigate away),
+// so they can correct the qty and retry. This tests the full recovery path.
+test('Over-issuing shows error toast and worker can retype to recover', async ({ page }) => {
+    const masterdata = await createMasterdataForDrainTest();
+    await loginAndStartMfg(masterdata);
+
+    await test.step('Start PP1 to create its plan', async () => {
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+        await ManufacturingJobScreen.goBack();
+    });
+
+    await test.step('PP2 drains HU to 5', async () => {
+        await drainHUViaPP2({ masterdata });
+    });
+
+    await test.step('Resume PP1, type 8 (over HU capacity 5) — error toast shown, worker stays on dialog', async () => {
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+        await ManufacturingJobScreen.clickIssueButton({ index: 1 });
+        // Over-issue attempt: backend returns 422, toast appears, dialog stays open
+        await RawMaterialIssueLineScreen.scanQRCodeExpectError({
+            qrCode: masterdata.handlingUnits.HU.qrCode,
+            qtyEntered: '8',
+        });
+        // Recovery: worker retypes the correct qty (HU capacity = 5) and confirms
+        await RawMaterialIssueLineScreen.retypeQtyAndConfirm({ qtyEntered: '5' });
+        await RawMaterialIssueLineScreen.goBack();
+        await ManufacturingJobScreen.expectIssueButton({ index: 1 });
+    });
+
+    await Backend.expect({
+        title: 'Over-issue rejected (422), worker retypes 5 — HU depleted to 0',
+        hus: {
+            HU: { storages: { COMP: '0 PCE' } },
+        },
+    });
+});

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScreen.js
@@ -1,4 +1,4 @@
-import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from '../../../common';
+import { expectErrorToast, ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from '../../../common';
 import { test } from '../../../../../playwright.config';
 import { expect } from '@playwright/test';
 import { RawMaterialIssueLineScanScreen } from './RawMaterialIssueLineScanScreen';
@@ -19,7 +19,7 @@ export const RawMaterialIssueLineScreen = {
         await expect(containerElement()).toBeVisible();
     }),
 
-    scanQRCode: async ({ qrCode, expectQtyEntered, expectQtyTarget, expectQtyRemaining }) => await test.step(`${NAME} - Scan QR code`, async () => {
+    scanQRCode: async ({ qrCode, expectQtyEntered, expectQtyTarget, expectQtyRemaining, qtyEntered }) => await test.step(`${NAME} - Scan QR code`, async () => {
         await page.getByTestId('scanQRCode-button').tap();
         await RawMaterialIssueLineScanScreen.waitForScreen();
         await RawMaterialIssueLineScanScreen.typeQRCode(qrCode);
@@ -29,7 +29,7 @@ export const RawMaterialIssueLineScreen = {
         if (expectQtyRemaining != null) {
             await GetQuantityDialog.expectUserInfoValue({ captionKey: 'general.QtyToPick', expectedValue: expectQtyRemaining });
         }
-        await GetQuantityDialog.fillAndPressDone({ expectQtyEntered });
+        await GetQuantityDialog.fillAndPressDone({ expectQtyEntered, qtyEntered });
         await RawMaterialIssueLineScreen.waitForScreen();
     }),
 
@@ -46,6 +46,23 @@ export const RawMaterialIssueLineScreen = {
             await expect(locator.getByTestId('indicator')).toHaveCount(0);
             await expect(locator.getByTestId('indicator2')).toHaveCount(0);
         }
+    }),
+
+    scanQRCodeExpectError: async ({ qrCode, qtyEntered }) => await test.step(`${NAME} - Scan QR code (expect error, qty=${qtyEntered})`, async () => {
+        await page.getByTestId('scanQRCode-button').tap();
+        await RawMaterialIssueLineScanScreen.waitForScreen();
+        await RawMaterialIssueLineScanScreen.typeQRCode(qrCode);
+        await expectErrorToast(`${NAME} over-issue rejected`, async () => {
+            await GetQuantityDialog.fillAndPressDone({ qtyEntered });
+            // On success: dialog closes and navigates back to line screen.
+            // On error (after fix): dialog stays open → waitToClose hangs → toast wins.
+        });
+        await GetQuantityDialog.waitForDialog(); // dialog still open — worker was not navigated away
+    }),
+
+    retypeQtyAndConfirm: async ({ qtyEntered }) => await test.step(`${NAME} - Retype qty=${qtyEntered} and confirm`, async () => {
+        await GetQuantityDialog.fillAndPressDone({ qtyEntered });
+        await RawMaterialIssueLineScreen.waitForScreen();
     }),
 
     goBack: async () => await test.step(`${NAME} - Go back`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
@@ -30,7 +30,7 @@ export const GetQuantityDialog = {
     }),
 
     typeQtyEntered: async (qty) => await test.step(`${NAME} - Type QtyEntered '${qty}'`, async () => {
-        await page.locator('#qty-input').type(`${qty}`);
+        await page.locator('#qty-input').fill(`${qty}`);
     }),
 
     expectLotNoVisible: async () => await test.step(`${NAME} - Expect LotNo visible`, async () => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.test.js
@@ -54,4 +54,15 @@ describe('computeStepScanPropsFromActivity', () => {
     expect(result.qtyToIssueMax).toEqual(15 - 3);
     expect(result.isIssueWholeHU).toEqual(false);
   });
+
+  it('qtyToIssueTarget is capped at qtyHUCapacity when step has more planned qty than actual HU capacity', () => {
+    const result = call_computeStepScanPropsFromActivity({
+      line: { qtyToIssue: 20, qtyToIssueMax: 20 },
+      step: { qtyToIssue: 20, qtyHUCapacity: 5 },
+    });
+    // Bug: Math.min(20, 20, 20) = 20 — qtyHUCapacity not in min, dialog suggests 20 when HU only has 5
+    // Fix: Math.min(20, 20, 20, 5) = 5
+    expect(result.qtyToIssueTarget).toEqual(5);
+    expect(result.isIssueWholeHU).toEqual(true); // 5 >= 5
+  });
 });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/RawMaterialIssueStepScanComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/RawMaterialIssueStepScanComponent.jsx
@@ -155,8 +155,8 @@ const RawMaterialIssueStepScanComponent = ({ wfProcessId, activityId, lineId, st
         qtyRejectedReasonCode: isIssueWholeHU ? reason : null,
       })
     )
-      .catch((axiosError) => toastError({ axiosError }))
-      .finally(() => history.goBack());
+      .then(() => history.goBack())
+      .catch((axiosError) => toastError({ axiosError }));
   };
 
   return (

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.js
@@ -28,7 +28,7 @@ export const computeStepScanPropsFromActivity = ({ activity, lineId, stepId, isP
   //qtyToIssueMax = Math.min(qtyToIssueMax, qtyHUCapacity); // allow exceeding the HU capacity
 
   const lineQtyToIssueRemaining = Math.max(lineQtyToIssue - lineQtyIssued, 0);
-  const qtyToIssueTarget = Math.min(stepQtyToIssue, lineQtyToIssueRemaining, qtyToIssueMax);
+  const qtyToIssueTarget = Math.min(stepQtyToIssue, lineQtyToIssueRemaining, qtyToIssueMax, qtyHUCapacity);
 
   const isIssueWholeHU = qtyToIssueTarget >= qtyHUCapacity;
 


### PR DESCRIPTION
Cherry-pick of squash-merge commit `2a1b30e70d7177a0c65b3b536a35415bd1836cda` from https://github.com/metasfresh/metasfresh/pull/23914 (`task_force_hotfix_MobileIssueHUQtySuggestionCap` → `task_force_hotfix`).

## Conflict resolutions

- `e2e/mobile-webui/tests/utils/screens/manufacturing/issue/RawMaterialIssueLineScreen.js` — `new_dawn_uat` added `SLOW_ACTION_TIMEOUT`; our commit added `expectErrorToast`; both imports merged into one line.
- `e2e/mobile-webui/yarn.lock` — accepted `new_dawn_uat` version (Playwright 1.57.0, allure-playwright already present).

## Validation

- 3 Jest unit tests (`computeStepScanPropsFromActivity.test.js`): all PASS locally.
- 4 Playwright E2E tests (`issue_hu_qty_suggestion.spec.js`): all PASS locally (18.6s against mfstack).