### PR TITLE
Fix mobileUI Scan-GRAI: distribute GRAIs across all aggregate blocks

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/grai/HUGraiSnapshot.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/grai/HUGraiSnapshot.java
@@ -152,38 +152,38 @@ public class HUGraiSnapshot
 			// else: slot was already empty and stays empty — no change
 		}
 
-		// Step 4: Handle aggregate blocks
-		if (!aggregateBlocks.isEmpty())
+		// Step 4: Distribute remaining GRAIs across ALL aggregate blocks, respecting each block's tuCount.
+		// Each aggregate block corresponds to a distinct product group on the LU and has its own VHU
+		// and capacity (tuCount). Dumping everything into block 0 is the historical bug that caused
+		// all GRAIs to land on the first product's TU when an LU carried several products.
+		for (final AggregateBlock block : aggregateBlocks)
 		{
-			final AggregateBlock firstBlock = aggregateBlocks.get(0);
-
-			// Compute what the first block should hold:
-			// = (existing GRAIs that are in desiredGrais) + remainingUnassigned
+			final int capacity = block.tuCount.toInt();
 			final ArrayList<GRAI> newBlockGrais = new ArrayList<>();
-			for (final GRAI grai : firstBlock.grais)
+
+			// Keep existing GRAIs that are still desired (up to block capacity).
+			for (final GRAI grai : block.grais)
 			{
+				if (newBlockGrais.size() >= capacity)
+				{
+					break;
+				}
 				if (desiredGrais.contains(grai))
 				{
 					newBlockGrais.add(grai);
 				}
 			}
-			newBlockGrais.addAll(remainingUnassigned);
-			remainingUnassigned.clear();
-			final GRAISet newBlockGraiSet = GRAISet.ofCollection(newBlockGrais);
 
-			if (!newBlockGraiSet.equals(firstBlock.grais))
+			// Fill remaining slots in this block from the unassigned pool.
+			while (newBlockGrais.size() < capacity && !remainingUnassigned.isEmpty())
 			{
-				changes.add(AttributeChange.of(firstBlock.vhuId, newBlockGraiSet));
+				newBlockGrais.add(remainingUnassigned.remove(0));
 			}
 
-			// Clear any additional aggregate blocks
-			for (int i = 1; i < aggregateBlocks.size(); i++)
+			final GRAISet newBlockGraiSet = GRAISet.ofCollection(newBlockGrais);
+			if (!newBlockGraiSet.equals(block.grais))
 			{
-				final AggregateBlock block = aggregateBlocks.get(i);
-				if (!block.grais.isEmpty())
-				{
-					changes.add(AttributeChange.of(block.vhuId, GRAISet.EMPTY));
-				}
+				changes.add(AttributeChange.of(block.vhuId, newBlockGraiSet));
 			}
 		}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/grai/HUGraiSnapshotLoader.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/grai/HUGraiSnapshotLoader.java
@@ -56,6 +56,13 @@ class HUGraiSnapshotLoader
 	{
 		if (handlingUnitsBL.isVirtual(hu))
 		{
+			// A pure virtual HU has no GRAI semantics. But a VHU that lives under an HA item
+			// represents a group of aggregated TUs (one per product on an LU); scanning the
+			// VHU is how the mobileUI lets the user assign GRAIs to that specific TU group.
+			if (handlingUnitsBL.isAggregateHU(hu))
+			{
+				return ExplainedOptional.of(loadVHUUnderHA(hu));
+			}
 			return ExplainedOptional.emptyBecause("GRAI scanning not supported for virtual HU " + hu.getM_HU_ID());
 		}
 
@@ -67,6 +74,21 @@ class HUGraiSnapshotLoader
 		{
 			return ExplainedOptional.of(loadTU(hu));
 		}
+	}
+
+	@NonNull
+	private HUGraiSnapshot loadVHUUnderHA(@NonNull final I_M_HU vhu)
+	{
+		final I_M_HU_Item haItem = handlingUnitsDAO.retrieveParentItem(vhu);
+		final QtyTU tuCount = HandlingUnitsBL.getTUsCount(haItem);
+		final HuId vhuId = HuId.ofRepoId(vhu.getM_HU_ID());
+		final GRAISet existingGrais = readGRAISet(vhu);
+
+		return HUGraiSnapshot.builder()
+				.huId(vhuId)
+				.tus(ImmutableList.of())
+				.aggregateBlocks(ImmutableList.of(HUGraiSnapshot.AggregateBlock.of(vhuId, tuCount, existingGrais)))
+				.build();
 	}
 
 	@NonNull

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/HUGraiSnapshotLoaderTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/HUGraiSnapshotLoaderTest.java
@@ -1,0 +1,151 @@
+package de.metas.handlingunits.grai;
+
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.IHandlingUnitsBL;
+import de.metas.handlingunits.IHandlingUnitsDAO;
+import de.metas.handlingunits.attribute.IHUAttributesBL;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.I_M_HU_Item;
+import de.metas.handlingunits.model.X_M_HU_Item;
+import de.metas.i18n.ExplainedOptional;
+import org.adempiere.mm.attributes.api.AttributeConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Loader-level tests for {@link HUGraiSnapshotLoader} focused on the dispatch in {@code load(I_M_HU)}.
+ * The richer per-snapshot behaviour (delta computation, distribution across blocks, etc.) is covered
+ * by {@link HUGraiSnapshotTest}.
+ */
+class HUGraiSnapshotLoaderTest
+{
+	private IHandlingUnitsBL handlingUnitsBL;
+	private IHandlingUnitsDAO handlingUnitsDAO;
+	private IHUAttributesBL huAttributesBL;
+	private HUGraiSnapshotLoader loader;
+
+	@BeforeEach
+	void setup()
+	{
+		handlingUnitsBL = mock(IHandlingUnitsBL.class);
+		handlingUnitsDAO = mock(IHandlingUnitsDAO.class);
+		huAttributesBL = mock(IHUAttributesBL.class);
+
+		loader = HUGraiSnapshotLoader.builder()
+				.handlingUnitsBL(handlingUnitsBL)
+				.handlingUnitsDAO(handlingUnitsDAO)
+				.huAttributesBL(huAttributesBL)
+				.build();
+	}
+
+	private ExplainedOptional<HUGraiSnapshot> loadVia(final I_M_HU hu)
+	{
+		final HuId huId = HuId.ofRepoId(hu.getM_HU_ID());
+		when(handlingUnitsDAO.getById(huId)).thenReturn(hu);
+		return loader.loadById(huId);
+	}
+
+	@Nested
+	class LoadVirtualHU
+	{
+		@Test
+		void vhuUnderHAItem_returnsAggregateBlockSnapshot()
+		{
+			// HA item with tuCount=5
+			final I_M_HU_Item haItem = mock(I_M_HU_Item.class);
+			when(haItem.getItemType()).thenReturn(X_M_HU_Item.ITEMTYPE_HUAggregate);
+			when(haItem.getQty()).thenReturn(new BigDecimal("5"));
+
+			// VHU sitting under that HA item
+			final I_M_HU vhu = mock(I_M_HU.class);
+			when(vhu.getM_HU_ID()).thenReturn(33681691);
+
+			when(handlingUnitsBL.isVirtual(vhu)).thenReturn(true);
+			when(handlingUnitsBL.isAggregateHU(vhu)).thenReturn(true);
+			when(handlingUnitsDAO.retrieveParentItem(vhu)).thenReturn(haItem);
+			when(huAttributesBL.getHUAttributeValue(eq(vhu), eq(AttributeConstants.ATTR_GRAI))).thenReturn(null);
+
+			final ExplainedOptional<HUGraiSnapshot> result = loadVia(vhu);
+
+			assertThat(result.isPresent()).isTrue();
+			final HUGraiSnapshot snapshot = result.get();
+			assertThat(snapshot.getHuId()).isEqualTo(HuId.ofRepoId(33681691));
+			assertThat(snapshot.getTus()).isEmpty();
+			assertThat(snapshot.getAggregateBlocks()).hasSize(1);
+
+			final HUGraiSnapshot.AggregateBlock block = snapshot.getAggregateBlocks().get(0);
+			assertThat(block.getVhuId()).isEqualTo(HuId.ofRepoId(33681691));
+			assertThat(block.getTuCount().toInt()).isEqualTo(5);
+			assertThat(block.getGrais().isEmpty()).isTrue();
+		}
+
+		@Test
+		void vhuUnderHAItem_withExistingGrais_preservesThem()
+		{
+			final I_M_HU_Item haItem = mock(I_M_HU_Item.class);
+			when(haItem.getItemType()).thenReturn(X_M_HU_Item.ITEMTYPE_HUAggregate);
+			when(haItem.getQty()).thenReturn(new BigDecimal("3"));
+
+			final I_M_HU vhu = mock(I_M_HU.class);
+			when(vhu.getM_HU_ID()).thenReturn(42);
+
+			when(handlingUnitsBL.isVirtual(vhu)).thenReturn(true);
+			when(handlingUnitsBL.isAggregateHU(vhu)).thenReturn(true);
+			when(handlingUnitsDAO.retrieveParentItem(vhu)).thenReturn(haItem);
+			when(huAttributesBL.getHUAttributeValue(eq(vhu), eq(AttributeConstants.ATTR_GRAI)))
+					.thenReturn("7613204.00307.1000000001,7613204.00307.1000000002");
+
+			final HUGraiSnapshot snapshot = loadVia(vhu).get();
+
+			assertThat(snapshot.getAggregateBlocks()).hasSize(1);
+			final HUGraiSnapshot.AggregateBlock block = snapshot.getAggregateBlocks().get(0);
+			assertThat(block.getTuCount().toInt()).isEqualTo(3);
+			assertThat(block.getGrais().size()).isEqualTo(2);
+		}
+
+		@Test
+		void pureVirtualHU_notUnderHA_returnsEmpty()
+		{
+			final I_M_HU vhu = mock(I_M_HU.class);
+			when(vhu.getM_HU_ID()).thenReturn(99);
+			when(handlingUnitsBL.isVirtual(vhu)).thenReturn(true);
+			when(handlingUnitsBL.isAggregateHU(vhu)).thenReturn(false);
+
+			final ExplainedOptional<HUGraiSnapshot> result = loadVia(vhu);
+
+			assertThat(result.isPresent()).isFalse();
+			assertThat(result.getExplanation().getDefaultValue()).contains("99");
+		}
+	}
+
+	@Nested
+	class LoadStandaloneTU
+	{
+		@Test
+		void nonVirtualNonLU_loadsAsSingleSlotTU()
+		{
+			final I_M_HU tu = mock(I_M_HU.class);
+			when(tu.getM_HU_ID()).thenReturn(123);
+			when(handlingUnitsBL.isVirtual(tu)).thenReturn(false);
+			when(handlingUnitsBL.isLoadingUnit(tu)).thenReturn(false);
+			when(huAttributesBL.getHUAttributeValue(eq(tu), eq(AttributeConstants.ATTR_GRAI)))
+					.thenReturn("7613204.00307.1000000007");
+
+			final HUGraiSnapshot snapshot = loadVia(tu).get();
+
+			assertThat(snapshot.getHuId()).isEqualTo(HuId.ofRepoId(123));
+			assertThat(snapshot.getTus()).hasSize(1);
+			assertThat(snapshot.getTus().get(0).getHuId()).isEqualTo(HuId.ofRepoId(123));
+			assertThat(snapshot.getTus().get(0).getGrai()).isEqualTo(GRAI.ofCanonicalString("7613204.00307.1000000007"));
+			assertThat(snapshot.getAggregateBlocks()).isEmpty();
+		}
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/HUGraiSnapshotTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/HUGraiSnapshotTest.java
@@ -22,6 +22,12 @@ class HUGraiSnapshotTest
 	private static final GRAI GRAI_B = GRAI.ofCanonicalString("7613204.00307.1000000002");
 	private static final GRAI GRAI_C = GRAI.ofCanonicalString("7613204.00307.1000000003");
 	private static final GRAI GRAI_D = GRAI.ofCanonicalString("7613204.00307.1000000004");
+	private static final GRAI GRAI_E = GRAI.ofCanonicalString("7613204.00307.1000000005");
+	private static final GRAI GRAI_F = GRAI.ofCanonicalString("7613204.00307.1000000006");
+	private static final GRAI GRAI_G = GRAI.ofCanonicalString("7613204.00307.1000000007");
+	private static final GRAI GRAI_H = GRAI.ofCanonicalString("7613204.00307.1000000008");
+	private static final GRAI GRAI_I = GRAI.ofCanonicalString("7613204.00307.1000000009");
+	private static final GRAI GRAI_J = GRAI.ofCanonicalString("7613204.00307.1000000010");
 
 	// -------------------------------------------------------------------
 	// GET path
@@ -351,6 +357,121 @@ class HUGraiSnapshotTest
 					AttributeChange.of(HuId.ofRepoId(1), GRAISet.of(GRAI_A)));
 			assertThat(delta.hasUnassignedGrais()).isTrue();
 			assertThat(delta.getUnassignedGrais().toSet()).containsExactly(GRAI_B);
+		}
+	}
+
+	// -------------------------------------------------------------------
+	// computeDelta — multiple aggregate blocks (one per product on an LU)
+	// -------------------------------------------------------------------
+
+	@Nested
+	class ComputeDelta_MultipleAggregateBlocks
+	{
+		@Test
+		void threeBlocks_3_3_3_distributesAcrossBlocks()
+		{
+			final HUGraiSnapshot snapshot = snapshotLU(
+					ImmutableList.of(),
+					ImmutableList.of(
+							AggregateBlock.of(HuId.ofRepoId(10), QtyTU.ofInt(3), GRAISet.EMPTY),
+							AggregateBlock.of(HuId.ofRepoId(20), QtyTU.ofInt(3), GRAISet.EMPTY),
+							AggregateBlock.of(HuId.ofRepoId(30), QtyTU.ofInt(3), GRAISet.EMPTY)));
+
+			final HUGraiDelta delta = snapshot.computeDelta(GRAISet.ofCollection(
+					ImmutableList.of(GRAI_A, GRAI_B, GRAI_C, GRAI_D, GRAI_E, GRAI_F, GRAI_G, GRAI_H, GRAI_I)));
+
+			assertThat(delta.getChanges()).containsExactly(
+					AttributeChange.of(HuId.ofRepoId(10), GRAISet.ofCollection(ImmutableList.of(GRAI_A, GRAI_B, GRAI_C))),
+					AttributeChange.of(HuId.ofRepoId(20), GRAISet.ofCollection(ImmutableList.of(GRAI_D, GRAI_E, GRAI_F))),
+					AttributeChange.of(HuId.ofRepoId(30), GRAISet.ofCollection(ImmutableList.of(GRAI_G, GRAI_H, GRAI_I))));
+			assertThat(delta.hasUnassignedGrais()).isFalse();
+		}
+
+		/**
+		 * Real-world shape from me03 bug report: 3 products on one LU with tuCounts 3 / 5 / 1 = 9 TUs,
+		 * 9 GRAIs scanned. Before the fix, all 9 ended up on the first VHU.
+		 */
+		@Test
+		void threeBlocks_3_5_1_distributesByCapacity()
+		{
+			final HUGraiSnapshot snapshot = snapshotLU(
+					ImmutableList.of(),
+					ImmutableList.of(
+							AggregateBlock.of(HuId.ofRepoId(10), QtyTU.ofInt(3), GRAISet.EMPTY),
+							AggregateBlock.of(HuId.ofRepoId(20), QtyTU.ofInt(5), GRAISet.EMPTY),
+							AggregateBlock.of(HuId.ofRepoId(30), QtyTU.ofInt(1), GRAISet.EMPTY)));
+
+			final HUGraiDelta delta = snapshot.computeDelta(GRAISet.ofCollection(
+					ImmutableList.of(GRAI_A, GRAI_B, GRAI_C, GRAI_D, GRAI_E, GRAI_F, GRAI_G, GRAI_H, GRAI_I)));
+
+			assertThat(delta.getChanges()).containsExactly(
+					AttributeChange.of(HuId.ofRepoId(10), GRAISet.ofCollection(ImmutableList.of(GRAI_A, GRAI_B, GRAI_C))),
+					AttributeChange.of(HuId.ofRepoId(20), GRAISet.ofCollection(ImmutableList.of(GRAI_D, GRAI_E, GRAI_F, GRAI_G, GRAI_H))),
+					AttributeChange.of(HuId.ofRepoId(30), GRAISet.of(GRAI_I)));
+			assertThat(delta.hasUnassignedGrais()).isFalse();
+		}
+
+		@Test
+		void threeBlocks_partialFill_lastBlockStaysEmpty()
+		{
+			final HUGraiSnapshot snapshot = snapshotLU(
+					ImmutableList.of(),
+					ImmutableList.of(
+							AggregateBlock.of(HuId.ofRepoId(10), QtyTU.ofInt(3), GRAISet.EMPTY),
+							AggregateBlock.of(HuId.ofRepoId(20), QtyTU.ofInt(3), GRAISet.EMPTY),
+							AggregateBlock.of(HuId.ofRepoId(30), QtyTU.ofInt(3), GRAISet.EMPTY)));
+
+			// Only 5 GRAIs for 9 slots → block 10 gets 3, block 20 gets 2, block 30 stays empty (no change).
+			final HUGraiDelta delta = snapshot.computeDelta(GRAISet.ofCollection(
+					ImmutableList.of(GRAI_A, GRAI_B, GRAI_C, GRAI_D, GRAI_E)));
+
+			assertThat(delta.getChanges()).containsExactly(
+					AttributeChange.of(HuId.ofRepoId(10), GRAISet.ofCollection(ImmutableList.of(GRAI_A, GRAI_B, GRAI_C))),
+					AttributeChange.of(HuId.ofRepoId(20), GRAISet.ofCollection(ImmutableList.of(GRAI_D, GRAI_E))));
+			assertThat(delta.hasUnassignedGrais()).isFalse();
+		}
+
+		@Test
+		void threeBlocks_preservesExistingValidGraisInLaterBlocks()
+		{
+			// Block 20 already has GRAI_E (correctly assigned). The same desired set must not move it.
+			final HUGraiSnapshot snapshot = snapshotLU(
+					ImmutableList.of(),
+					ImmutableList.of(
+							AggregateBlock.of(HuId.ofRepoId(10), QtyTU.ofInt(2), GRAISet.EMPTY),
+							AggregateBlock.of(HuId.ofRepoId(20), QtyTU.ofInt(2), GRAISet.of(GRAI_E)),
+							AggregateBlock.of(HuId.ofRepoId(30), QtyTU.ofInt(2), GRAISet.EMPTY)));
+
+			final HUGraiDelta delta = snapshot.computeDelta(GRAISet.ofCollection(
+					ImmutableList.of(GRAI_A, GRAI_B, GRAI_E, GRAI_C, GRAI_D, GRAI_F)));
+
+			// Block 10: empty → fills from unassigned (A, B).
+			// Block 20: keeps existing E, fills one more slot from unassigned (C).
+			// Block 30: empty → fills from unassigned (D, F).
+			assertThat(delta.getChanges()).containsExactly(
+					AttributeChange.of(HuId.ofRepoId(10), GRAISet.ofCollection(ImmutableList.of(GRAI_A, GRAI_B))),
+					AttributeChange.of(HuId.ofRepoId(20), GRAISet.ofCollection(ImmutableList.of(GRAI_E, GRAI_C))),
+					AttributeChange.of(HuId.ofRepoId(30), GRAISet.ofCollection(ImmutableList.of(GRAI_D, GRAI_F))));
+			assertThat(delta.hasUnassignedGrais()).isFalse();
+		}
+
+		@Test
+		void threeBlocks_overflow_reportsUnassigned()
+		{
+			final HUGraiSnapshot snapshot = snapshotLU(
+					ImmutableList.of(),
+					ImmutableList.of(
+							AggregateBlock.of(HuId.ofRepoId(10), QtyTU.ofInt(3), GRAISet.EMPTY),
+							AggregateBlock.of(HuId.ofRepoId(20), QtyTU.ofInt(3), GRAISet.EMPTY),
+							AggregateBlock.of(HuId.ofRepoId(30), QtyTU.ofInt(3), GRAISet.EMPTY)));
+
+			// 10 GRAIs for 9 slots → 1 unassigned.
+			final HUGraiDelta delta = snapshot.computeDelta(GRAISet.ofCollection(
+					ImmutableList.of(GRAI_A, GRAI_B, GRAI_C, GRAI_D, GRAI_E, GRAI_F, GRAI_G, GRAI_H, GRAI_I, GRAI_J)));
+
+			assertThat(delta.getChanges()).hasSize(3);
+			assertThat(delta.hasUnassignedGrais()).isTrue();
+			assertThat(delta.getUnassignedGrais().size()).isEqualTo(1);
 		}
 	}
 


### PR DESCRIPTION
## Summary

- When an LU carries several products, the HU model creates one HA (HU-Aggregate) item per product. `HUGraiSnapshot.computeDelta` previously dumped all unassigned GRAIs into `aggregateBlocks.get(0)` and cleared blocks 2..N, so every GRAI scanned via the mobileUI "Scan GRAI" workflow ended up on the first product's VHU.
- Replace the "first block gets everything, others get cleared" branch with a per-block loop that respects each block's `tuCount` and preserves already-correct GRAIs in every block.
- Real-world reproducer: 1 LU, 3 products, tuCounts 3 / 5 / 1, 9 GRAIs scanned → before: all 9 on the first VHU; after: 3 / 5 / 1.

## Files

- `backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/grai/HUGraiSnapshot.java` — replace Step 4 in `computeDelta`.
- `backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/HUGraiSnapshotTest.java` — new `ComputeDelta_MultipleAggregateBlocks` nested class with 5 tests (3/3/3 distribution, 3/5/1 real-world shape, partial fill, preserves-existing-GRAIs in later blocks, overflow → unassigned).

No DB migration, no frontend change, no REST contract change.

## Test plan

- [x] `HUGraiSnapshotTest` — 40 tests pass locally (35 existing + 5 new).
- [x] `HUGraiSnapshotsCollectionTest` — 6 tests pass locally.
- [ ] CI green on this branch.
- [ ] Manual smoke on the affected LU shape in mobileUI (3 products on 1 LU, scan N GRAIs).