### PR TITLE
Fix GS1 AI 8003 GRAI parser dropping first serial digit (me03#29827)

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/FrontendTestingRestController.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/FrontendTestingRestController.java
@@ -4,11 +4,15 @@ import de.metas.Profiles;
 import de.metas.frontend_testing.expectations.AssertExpectationsCommand;
 import de.metas.frontend_testing.expectations.request.JsonExpectations;
 import de.metas.frontend_testing.expectations.request.JsonExpectationsResponse;
+import de.metas.frontend_testing.huQRCode.GetHUQRCodeCommand;
+import de.metas.frontend_testing.huQRCode.JsonGetHUQRCodeRequest;
+import de.metas.frontend_testing.huQRCode.JsonGetHUQRCodeResponse;
 import de.metas.frontend_testing.masterdata.CreateMasterdataCommand;
 import de.metas.frontend_testing.masterdata.CreateMasterdataCommandSupportingServices;
 import de.metas.frontend_testing.masterdata.JsonCreateMasterdataRequest;
 import de.metas.frontend_testing.masterdata.JsonCreateMasterdataResponse;
 import de.metas.frontend_testing.masterdata.sysconfig.SysconfigCommand;
+import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
 import de.metas.i18n.TranslatableStrings;
 import de.metas.logging.LogManager;
 import de.metas.organization.OrgId;
@@ -48,6 +52,7 @@ public class FrontendTestingRestController
 	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	@NonNull private final UserAuthTokenFilterConfiguration userAuthTokenFilterConfiguration;
 	@NonNull private final CreateMasterdataCommandSupportingServices services;
+	@NonNull private final HUQRCodesService huQRCodesService;
 
 	private boolean isEnabled()
 	{
@@ -125,5 +130,15 @@ public class FrontendTestingRestController
 					.execute();
 			return null;
 		});
+	}
+
+	@PostMapping("getHUQRCode")
+	public JsonGetHUQRCodeResponse getHUQRCode(@RequestBody @NonNull final JsonGetHUQRCodeRequest request)
+	{
+		return callInContext(() -> GetHUQRCodeCommand.builder()
+				.huQRCodesService(huQRCodesService)
+				.request(request)
+				.build()
+				.execute());
 	}
 }

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/huQRCode/GetHUQRCodeCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/huQRCode/GetHUQRCodeCommand.java
@@ -8,7 +8,6 @@ import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
 import lombok.Builder;
 import lombok.NonNull;
-import org.adempiere.warehouse.WarehouseId;
 
 /**
  * Resolves a masterdata identifier (e.g. {@code "lu1"}) to its handling-unit
@@ -37,11 +36,18 @@ public class GetHUQRCodeCommand
 		final HUQRCode qrCode = huQRCodesService.getQRCodeByHuId(huId);
 
 		return JsonGetHUQRCodeResponse.builder()
-				.huId(huId.getRepoId())
 				.qrCode(qrCode.toGlobalQRCodeString())
 				.build();
 	}
 
+	/**
+	 * Build a {@link MasterdataContext} populated with just the handling-unit
+	 * identifiers — all this command needs to resolve to an {@link HuId}. The
+	 * extra identifier types ({@code bpartners}, {@code products}, {@code warehouses})
+	 * that {@code AssertExpectationsCommand.createContext} populates are not
+	 * relevant here. Identifiers registered downstream by picking expectations
+	 * (e.g. {@code lu1}, {@code vhu1}) arrive via {@code request.getContext()}.
+	 */
 	private MasterdataContext buildContext()
 	{
 		final MasterdataContext context = new MasterdataContext();
@@ -51,8 +57,6 @@ public class GetHUQRCodeCommand
 		{
 			masterdata.getHandlingUnits().forEach((identifierStr, handlingUnit) ->
 					context.putIdentifier(Identifier.ofString(identifierStr), HuId.ofObject(handlingUnit.getHuId())));
-			masterdata.getWarehouses().forEach((identifierStr, warehouse) ->
-					context.putIdentifier(Identifier.ofString(identifierStr), WarehouseId.ofRepoId(warehouse.getWarehouseId())));
 		}
 
 		context.putFromJson(request.getContext());

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/huQRCode/GetHUQRCodeCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/huQRCode/GetHUQRCodeCommand.java
@@ -1,0 +1,62 @@
+package de.metas.frontend_testing.huQRCode;
+
+import de.metas.frontend_testing.masterdata.Identifier;
+import de.metas.frontend_testing.masterdata.JsonCreateMasterdataResponse;
+import de.metas.frontend_testing.masterdata.MasterdataContext;
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.qrcodes.model.HUQRCode;
+import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
+import lombok.Builder;
+import lombok.NonNull;
+import org.adempiere.warehouse.WarehouseId;
+
+/**
+ * Resolves a masterdata identifier (e.g. {@code "lu1"}) to its handling-unit
+ * global QR code string. Used by Playwright tests that need to scan an HU
+ * which was created indirectly (typically by a picking flow) and therefore
+ * has no QR code in the {@code handlingUnits} section of the masterdata response.
+ */
+public class GetHUQRCodeCommand
+{
+	@NonNull private final HUQRCodesService huQRCodesService;
+	@NonNull private final JsonGetHUQRCodeRequest request;
+
+	@Builder
+	private GetHUQRCodeCommand(
+			@NonNull final HUQRCodesService huQRCodesService,
+			@NonNull final JsonGetHUQRCodeRequest request)
+	{
+		this.huQRCodesService = huQRCodesService;
+		this.request = request;
+	}
+
+	public JsonGetHUQRCodeResponse execute()
+	{
+		final MasterdataContext context = buildContext();
+		final HuId huId = context.getId(request.getIdentifier(), HuId.class);
+		final HUQRCode qrCode = huQRCodesService.getQRCodeByHuId(huId);
+
+		return JsonGetHUQRCodeResponse.builder()
+				.huId(huId.getRepoId())
+				.qrCode(qrCode.toGlobalQRCodeString())
+				.build();
+	}
+
+	private MasterdataContext buildContext()
+	{
+		final MasterdataContext context = new MasterdataContext();
+
+		final JsonCreateMasterdataResponse masterdata = request.getMasterdata();
+		if (masterdata != null)
+		{
+			masterdata.getHandlingUnits().forEach((identifierStr, handlingUnit) ->
+					context.putIdentifier(Identifier.ofString(identifierStr), HuId.ofObject(handlingUnit.getHuId())));
+			masterdata.getWarehouses().forEach((identifierStr, warehouse) ->
+					context.putIdentifier(Identifier.ofString(identifierStr), WarehouseId.ofRepoId(warehouse.getWarehouseId())));
+		}
+
+		context.putFromJson(request.getContext());
+
+		return context;
+	}
+}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/huQRCode/JsonGetHUQRCodeRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/huQRCode/JsonGetHUQRCodeRequest.java
@@ -1,0 +1,21 @@
+package de.metas.frontend_testing.huQRCode;
+
+import de.metas.frontend_testing.masterdata.Identifier;
+import de.metas.frontend_testing.masterdata.JsonCreateMasterdataResponse;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+@Value
+@Builder
+@Jacksonized
+public class JsonGetHUQRCodeRequest
+{
+	@NonNull Identifier identifier;
+	@Nullable JsonCreateMasterdataResponse masterdata;
+	@Nullable Map<String, Object> context;
+}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/huQRCode/JsonGetHUQRCodeResponse.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/huQRCode/JsonGetHUQRCodeResponse.java
@@ -10,6 +10,5 @@ import lombok.extern.jackson.Jacksonized;
 @Jacksonized
 public class JsonGetHUQRCodeResponse
 {
-	int huId;
 	@NonNull String qrCode;
 }

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/huQRCode/JsonGetHUQRCodeResponse.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/huQRCode/JsonGetHUQRCodeResponse.java
@@ -1,0 +1,15 @@
+package de.metas.frontend_testing.huQRCode;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+public class JsonGetHUQRCodeResponse
+{
+	int huId;
+	@NonNull String qrCode;
+}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/grai/GRAI.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/grai/GRAI.java
@@ -94,18 +94,22 @@ public class GRAI implements Comparable<GRAI>
 			data = data.substring(4);
 		}
 
-		// Minimum: 1 (indicator) + 13 (company prefix + asset type) + 1 (check digit) + 1 (serial) = 16
-		if (data.length() < 16)
+		// Per GS1 General Specifications, AI 8003 (GRAI) has a fixed-length asset
+		// reference of 14 digits after the AI: 1 padding digit + 13-digit asset
+		// reference (GS1 Company Prefix + Item Reference + check digit at the end).
+		// An optional alphanumeric serial (0..16 chars) may follow.
+		// Minimum meaningful length: 14 (asset reference) + 1 (at least one serial char,
+		// required to form a non-empty canonical serial part) = 15.
+		if (data.length() < 15)
 		{
 			return null;
 		}
 
-		// Position 0: indicator digit (skip)
-		// Positions 1-13: company prefix + asset type (13 digits)
-		// Position 14: check digit (skip)
-		// Position 15+: serial
+		// Position 0: padding digit (skip)
+		// Positions 1-13: 13-digit asset reference (company prefix + asset type, last digit is the GS1 check digit)
+		// Position 14+: serial reference
 		final String base = data.substring(1, 14);
-		final String serial = data.substring(15);
+		final String serial = data.substring(14);
 
 		final String companyPrefix = base.substring(0, GS1_COMPANY_PREFIX_LENGTH);
 		final String assetType = base.substring(GS1_COMPANY_PREFIX_LENGTH);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/grai/GRAI.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/grai/GRAI.java
@@ -106,9 +106,10 @@ public class GRAI implements Comparable<GRAI>
 		}
 
 		// Position 0: padding digit (skip)
-		// Positions 1-13: 13-digit asset reference (company prefix + asset type, last digit is the GS1 check digit)
+		// Positions 1-12: 12-digit asset reference base (company prefix + asset type, no check digit)
+		// Position 13: GS1 check digit (skip — not part of the EPCIS "Pure Identity" URI canonical form)
 		// Position 14+: serial reference
-		final String base = data.substring(1, 14);
+		final String base = data.substring(1, 13);
 		final String serial = data.substring(14);
 
 		final String companyPrefix = base.substring(0, GS1_COMPANY_PREFIX_LENGTH);

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/GRAISetTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/GRAISetTest.java
@@ -79,7 +79,7 @@ class GRAISetTest
 		void gs1_values()
 		{
 			final GRAISet set = GRAISet.parseStrings(ImmutableList.of("800307613204003095100691412000"));
-			assertThat(set.toStringList()).containsExactly("7613204.003095.00691412000");
+			assertThat(set.toStringList()).containsExactly("7613204.003095.100691412000");
 		}
 
 		@Test
@@ -90,7 +90,7 @@ class GRAISetTest
 					"800307613204003095100691412000"));
 			assertThat(set.toStringList()).containsExactly(
 					"7613204.00307.1000000001",
-					"7613204.003095.00691412000");
+					"7613204.003095.100691412000");
 		}
 
 		@Test

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/GRAISetTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/GRAISetTest.java
@@ -79,7 +79,7 @@ class GRAISetTest
 		void gs1_values()
 		{
 			final GRAISet set = GRAISet.parseStrings(ImmutableList.of("800307613204003095100691412000"));
-			assertThat(set.toStringList()).containsExactly("7613204.003095.100691412000");
+			assertThat(set.toStringList()).containsExactly("7613204.00309.100691412000");
 		}
 
 		@Test
@@ -90,7 +90,7 @@ class GRAISetTest
 					"800307613204003095100691412000"));
 			assertThat(set.toStringList()).containsExactly(
 					"7613204.00307.1000000001",
-					"7613204.003095.100691412000");
+					"7613204.00309.100691412000");
 		}
 
 		@Test

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/GRAITest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/GRAITest.java
@@ -107,10 +107,10 @@ class GRAITest
 		@Test
 		void gs1_withAIPrefix()
 		{
-			// AI 8003 + padding(0) + 13-digit asset reference (company prefix 7613204 + asset type 003095, last digit is the GS1 check digit) + serial(100691412000)
+			// AI 8003 + padding(0) + 12-digit asset reference (company prefix 7613204 + asset type 00309) + check digit 5 (dropped) + serial(100691412000)
 			final GRAI result = GRAI.parse("800307613204003095100691412000");
 			assertThat(result).isNotNull();
-			assertThat(result.toCanonicalString()).isEqualTo("7613204.003095.100691412000");
+			assertThat(result.toCanonicalString()).isEqualTo("7613204.00309.100691412000");
 		}
 
 		@Test
@@ -119,16 +119,16 @@ class GRAITest
 			// Same as above but without the "8003" prefix
 			final GRAI result = GRAI.parse("07613204003095100691412000");
 			assertThat(result).isNotNull();
-			assertThat(result.toCanonicalString()).isEqualTo("7613204.003095.100691412000");
+			assertThat(result.toCanonicalString()).isEqualTo("7613204.00309.100691412000");
 		}
 
 		@Test
 		void gs1_migrosA_firstBarcode()
 		{
-			// Real barcode from GRAI_A-Gebinde.pdf (MIGROS A, serial 100691412000)
+			// Real barcode from GRAI_A-Gebinde.pdf (MIGROS A, asset type 00309, serial 100691412000) — per the Migros-Genossenschaftsbund GRAI encoding spec (epcis/customer-docs/Migros_GRAI/GRAI Kodierung.pdf)
 			final GRAI result = GRAI.parse("800307613264003095100691412000");
 			assertThat(result).isNotNull();
-			assertThat(result.toCanonicalString()).isEqualTo("7613264.003095.100691412000");
+			assertThat(result.toCanonicalString()).isEqualTo("7613264.00309.100691412000");
 		}
 
 		@Test
@@ -137,16 +137,16 @@ class GRAITest
 			// Real barcode from GRAI_A-Gebinde.pdf (MIGROS A, serial 100691412031)
 			final GRAI result = GRAI.parse("800307613264003095100691412031");
 			assertThat(result).isNotNull();
-			assertThat(result.toCanonicalString()).isEqualTo("7613264.003095.100691412031");
+			assertThat(result.toCanonicalString()).isEqualTo("7613264.00309.100691412031");
 		}
 
 		@Test
 		void gs1_migrosB_firstBarcode()
 		{
-			// Real barcode from GRAI_B-Gebinde.pdf (MIGROS B, asset type 003071)
+			// Real barcode from GRAI_B-Gebinde.pdf (MIGROS B, asset type 00307)
 			final GRAI result = GRAI.parse("800307613264003071100691412000");
 			assertThat(result).isNotNull();
-			assertThat(result.toCanonicalString()).isEqualTo("7613264.003071.100691412000");
+			assertThat(result.toCanonicalString()).isEqualTo("7613264.00307.100691412000");
 		}
 
 		@Test
@@ -155,7 +155,7 @@ class GRAITest
 			// Real barcode from GRAI_B-Gebinde.pdf (MIGROS B, serial 100691412031)
 			final GRAI result = GRAI.parse("800307613264003071100691412031");
 			assertThat(result).isNotNull();
-			assertThat(result.toCanonicalString()).isEqualTo("7613264.003071.100691412031");
+			assertThat(result.toCanonicalString()).isEqualTo("7613264.00307.100691412031");
 		}
 
 		@Test
@@ -165,8 +165,8 @@ class GRAITest
 			final GRAI a = Objects.requireNonNull(GRAI.parse("800307613264003095100691412000"));
 			final GRAI b = Objects.requireNonNull(GRAI.parse("800307613264003071100691412000"));
 			assertThat(a).isNotEqualTo(b);
-			assertThat(a.toCanonicalString()).isEqualTo("7613264.003095.100691412000");
-			assertThat(b.toCanonicalString()).isEqualTo("7613264.003071.100691412000");
+			assertThat(a.toCanonicalString()).isEqualTo("7613264.00309.100691412000");
+			assertThat(b.toCanonicalString()).isEqualTo("7613264.00307.100691412000");
 		}
 
 		@Test
@@ -195,23 +195,30 @@ class GRAITest
 
 		/**
 		 * me03#29827 — customer-reported bug. Scanning the raw barcode
-		 * {@code 800307613264003095100691412003} produced
-		 * {@code 7613264.003095.00691412003} — losing the {@code 1} between
-		 * the asset type and the serial.
-		 * <p>
-		 * Per GS1 AI 8003 spec, the fixed-length portion after the AI is
-		 * 14 characters (1 pad + 13-digit asset reference, GTIN-13 check
-		 * digit at position 13). Position 14 onwards is the serial. The
-		 * previous parser skipped one additional digit at position 14,
-		 * dropping the first serial digit.
+		 * {@code 800307613264003095100691412003} originally produced
+		 * {@code 7613264.003095.00691412003}, which had two problems against
+		 * the GS1 EPCIS "Pure Identity" URI canonical:
+		 * <ol>
+		 *   <li>The leading {@code 1} of the serial was dropped (the
+		 *       parser treated position 14 as a separate check digit and
+		 *       skipped it).</li>
+		 *   <li>The asset-type segment was 6 characters long because it
+		 *       included the GS1 check digit, instead of the 5-char form
+		 *       that the EPCIS URI {@code urn:epc:id:grai:7613264.00309.100691412003}
+		 *       and {@link DummyGRAITemplate#MIGROS_ASSET_TYPE} both use.</li>
+		 * </ol>
+		 * Canonical form per the Migros GRAI encoding spec
+		 * ({@code epcis/customer-docs/Migros_GRAI/GRAI Kodierung.pdf}):
+		 * {@code companyPrefix(7).assetType(5).serial} with the GS1 check
+		 * digit at GTIN-13 position 13 omitted from the canonical.
 		 */
 		@Test
-		void gs1_me03_29827_serialFirstDigitMustNotBeDropped()
+		void gs1_me03_29827_canonicalMatchesEPCISPureIdentityURI()
 		{
 			final GRAI result = GRAI.parse("800307613264003095100691412003");
 			assertThat(result).isNotNull();
 			assertThat(result.toCanonicalString())
-					.isEqualTo("7613264.003095.100691412003");
+					.isEqualTo("7613264.00309.100691412003");
 		}
 	}
 
@@ -230,7 +237,7 @@ class GRAITest
 		{
 			final GRAI grai = GRAI.parse("800307613204003095100691412000");
 			assertThat(grai).isNotNull();
-			assertThat(grai.toCanonicalString()).isEqualTo("7613204.003095.100691412000");
+			assertThat(grai.toCanonicalString()).isEqualTo("7613204.00309.100691412000");
 		}
 	}
 

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/GRAITest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/GRAITest.java
@@ -107,10 +107,10 @@ class GRAITest
 		@Test
 		void gs1_withAIPrefix()
 		{
-			// AI 8003 + indicator(0) + companyPrefix(7613204) + assetType(003095) + checkDigit(1) + serial(00691412000)
+			// AI 8003 + padding(0) + 13-digit asset reference (company prefix 7613204 + asset type 003095, last digit is the GS1 check digit) + serial(100691412000)
 			final GRAI result = GRAI.parse("800307613204003095100691412000");
 			assertThat(result).isNotNull();
-			assertThat(result.toCanonicalString()).isEqualTo("7613204.003095.00691412000");
+			assertThat(result.toCanonicalString()).isEqualTo("7613204.003095.100691412000");
 		}
 
 		@Test
@@ -119,25 +119,25 @@ class GRAITest
 			// Same as above but without the "8003" prefix
 			final GRAI result = GRAI.parse("07613204003095100691412000");
 			assertThat(result).isNotNull();
-			assertThat(result.toCanonicalString()).isEqualTo("7613204.003095.00691412000");
+			assertThat(result.toCanonicalString()).isEqualTo("7613204.003095.100691412000");
 		}
 
 		@Test
 		void gs1_migrosA_firstBarcode()
 		{
-			// Real barcode from GRAI_A-Gebinde.pdf (MIGROS A, serial 00691412000)
+			// Real barcode from GRAI_A-Gebinde.pdf (MIGROS A, serial 100691412000)
 			final GRAI result = GRAI.parse("800307613264003095100691412000");
 			assertThat(result).isNotNull();
-			assertThat(result.toCanonicalString()).isEqualTo("7613264.003095.00691412000");
+			assertThat(result.toCanonicalString()).isEqualTo("7613264.003095.100691412000");
 		}
 
 		@Test
 		void gs1_migrosA_lastBarcode()
 		{
-			// Real barcode from GRAI_A-Gebinde.pdf (MIGROS A, serial 00691412031)
+			// Real barcode from GRAI_A-Gebinde.pdf (MIGROS A, serial 100691412031)
 			final GRAI result = GRAI.parse("800307613264003095100691412031");
 			assertThat(result).isNotNull();
-			assertThat(result.toCanonicalString()).isEqualTo("7613264.003095.00691412031");
+			assertThat(result.toCanonicalString()).isEqualTo("7613264.003095.100691412031");
 		}
 
 		@Test
@@ -146,16 +146,16 @@ class GRAITest
 			// Real barcode from GRAI_B-Gebinde.pdf (MIGROS B, asset type 003071)
 			final GRAI result = GRAI.parse("800307613264003071100691412000");
 			assertThat(result).isNotNull();
-			assertThat(result.toCanonicalString()).isEqualTo("7613264.003071.00691412000");
+			assertThat(result.toCanonicalString()).isEqualTo("7613264.003071.100691412000");
 		}
 
 		@Test
 		void gs1_migrosB_lastBarcode()
 		{
-			// Real barcode from GRAI_B-Gebinde.pdf (MIGROS B, serial 00691412031)
+			// Real barcode from GRAI_B-Gebinde.pdf (MIGROS B, serial 100691412031)
 			final GRAI result = GRAI.parse("800307613264003071100691412031");
 			assertThat(result).isNotNull();
-			assertThat(result.toCanonicalString()).isEqualTo("7613264.003071.00691412031");
+			assertThat(result.toCanonicalString()).isEqualTo("7613264.003071.100691412031");
 		}
 
 		@Test
@@ -165,8 +165,8 @@ class GRAITest
 			final GRAI a = Objects.requireNonNull(GRAI.parse("800307613264003095100691412000"));
 			final GRAI b = Objects.requireNonNull(GRAI.parse("800307613264003071100691412000"));
 			assertThat(a).isNotEqualTo(b);
-			assertThat(a.toCanonicalString()).isEqualTo("7613264.003095.00691412000");
-			assertThat(b.toCanonicalString()).isEqualTo("7613264.003071.00691412000");
+			assertThat(a.toCanonicalString()).isEqualTo("7613264.003095.100691412000");
+			assertThat(b.toCanonicalString()).isEqualTo("7613264.003071.100691412000");
 		}
 
 		@Test
@@ -192,6 +192,27 @@ class GRAITest
 		{
 			assertThat(GRAI.parse("8003012345")).isNull();
 		}
+
+		/**
+		 * me03#29827 — customer-reported bug. Scanning the raw barcode
+		 * {@code 800307613264003095100691412003} produced
+		 * {@code 7613264.003095.00691412003} — losing the {@code 1} between
+		 * the asset type and the serial.
+		 * <p>
+		 * Per GS1 AI 8003 spec, the fixed-length portion after the AI is
+		 * 14 characters (1 pad + 13-digit asset reference, GTIN-13 check
+		 * digit at position 13). Position 14 onwards is the serial. The
+		 * previous parser skipped one additional digit at position 14,
+		 * dropping the first serial digit.
+		 */
+		@Test
+		void gs1_me03_29827_serialFirstDigitMustNotBeDropped()
+		{
+			final GRAI result = GRAI.parse("800307613264003095100691412003");
+			assertThat(result).isNotNull();
+			assertThat(result.toCanonicalString())
+					.isEqualTo("7613264.003095.100691412003");
+		}
 	}
 
 	@Nested
@@ -209,7 +230,7 @@ class GRAITest
 		{
 			final GRAI grai = GRAI.parse("800307613204003095100691412000");
 			assertThat(grai).isNotNull();
-			assertThat(grai.toCanonicalString()).isEqualTo("7613204.003095.00691412000");
+			assertThat(grai.toCanonicalString()).isEqualTo("7613204.003095.100691412000");
 		}
 	}
 

--- a/e2e/mobile-webui/tests/spec/humanager/grai.spec.js
+++ b/e2e/mobile-webui/tests/spec/humanager/grai.spec.js
@@ -742,4 +742,28 @@ test('Nine GRAIs distribute across three aggregate blocks on a multi-product LU'
     await GRAIScreen.reloadFromBackend();
     await GRAIScreen.expectGraiChipCount({ expectedCount: 9 });
     await GRAIScreen.expectGraiChipTexts({ expectedTexts: expectedCanonicals });
+
+    // Backend-state assertion — the UI checks above can be satisfied by any
+    // storage shape that produces nine flat chips on reload. To prove the GRAIs
+    // *actually* landed on three distinct VHUs (one per HA item), assert the
+    // exact M_HU_Attribute(GRAI) comma-separated value on each VHU. `vhu1` /
+    // `vhu2` / `vhu3` were registered in the masterdata context by the picking
+    // expectations earlier in this test.
+    await Backend.expect({
+        title: 'Three VHUs each carry the right share of GRAIs',
+        hus: {
+            vhu1: {
+                storages: { P1: '30 PCE' },
+                attributes: { GRAI: expectedCanonicals.slice(0, 3).join(',') },
+            },
+            vhu2: {
+                storages: { P2: '50 PCE' },
+                attributes: { GRAI: expectedCanonicals.slice(3, 8).join(',') },
+            },
+            vhu3: {
+                storages: { P3: '10 PCE' },
+                attributes: { GRAI: expectedCanonicals.slice(8, 9).join(',') },
+            },
+        },
+    });
 });

--- a/e2e/mobile-webui/tests/spec/humanager/grai.spec.js
+++ b/e2e/mobile-webui/tests/spec/humanager/grai.spec.js
@@ -5,6 +5,8 @@ import { LoginScreen } from "../../utils/screens/LoginScreen";
 import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
 import { HUManagerScreen } from '../../utils/screens/huManager/HUManagerScreen';
 import { GRAIScreen } from '../../utils/screens/huManager/GRAIScreen';
+import { PickingJobsListScreen } from '../../utils/screens/picking/PickingJobsListScreen';
+import { PickingJobScreen } from '../../utils/screens/picking/PickingJobScreen';
 
 // GRAI_PREFIX layout per GS1 AI 8003: AI(4) + pad(0) + companyPrefix(7613264) + assetType(003095, 6 digits incl. check digit) + first serial digit(1) = 19 chars.
 // The trailing "1" is the first character of the variable-length serial that follows.
@@ -586,5 +588,143 @@ test('Three GRAIs distribute across a 3-TU single-product LU and survive the rou
     // would surface here as fewer than three chips.
     await GRAIScreen.reloadFromBackend();
     await GRAIScreen.expectGraiChipCount({ expectedCount: 3 });
+    await GRAIScreen.expectGraiChipTexts({ expectedTexts: expectedCanonicals });
+});
+
+// noinspection JSUnusedLocalSymbols
+/**
+ * Reproducer for me03#29827 — distribution of GRAIs across **multiple** aggregate
+ * blocks on a multi-product LU (the real shape from me03#29753).
+ *
+ * The LU is built via a 3-product picking job in shape `3 / 5 / 1` TUs
+ * (lines 10 / 20 / 30 of the original Migros LAF1021 order). After picking, the
+ * LU has three HA items — one per product — so `HUGraiSnapshot.aggregateBlocks`
+ * holds three entries. Scanning nine GRAIs through the Scan-GRAI screen must
+ * fill block-0 with three GRAIs, block-1 with five GRAIs and block-2 with one,
+ * NOT dump everything onto the first block (the pre-fix behaviour).
+ *
+ * The Send + reload round-trip is what catches an inter-block regression — if
+ * the loop ever collapses back to "first block gets everything" the second
+ * Send call would either lose GRAIs or write them to the wrong VHU.
+ */
+test('Nine GRAIs distribute across three aggregate blocks on a multi-product LU', async ({ page }) => {
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5230');
+    allure.story('HU Manager - GRAI Distribution across Multiple Aggregate Blocks (3/5/1)');
+    allure.severity('critical');
+
+    const masterdata = await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US" } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    shipOnCloseLU: false,
+                    pickTo: ['LU_TU'],
+                    allowCompletingPartialPickingJob: false,
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                "P1": { prices: [{ price: 1 }] },
+                "P2": { prices: [{ price: 1 }] },
+                "P3": { prices: [{ price: 1 }] },
+            },
+            packingInstructions: {
+                "PI1": { lu: "LU", qtyTUsPerLU: 20, tu: "TU1", product: "P1", qtyCUsPerTU: 10 },
+                "PI2": { lu: "LU", qtyTUsPerLU: 20, tu: "TU2", product: "P2", qtyCUsPerTU: 10 },
+                "PI3": { lu: "LU", qtyTUsPerLU: 20, tu: "TU3", product: "P3", qtyCUsPerTU: 10 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', qty: 200 },
+                "HU2": { product: 'P2', warehouse: 'wh', qty: 200 },
+                "HU3": { product: 'P3', warehouse: 'wh', qty: 200 },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [
+                        { product: 'P1', qty: 30, piItemProduct: 'TU1' }, // 30 CU / 10 per TU = 3 TU
+                        { product: 'P2', qty: 50, piItemProduct: 'TU2' }, // 50 CU / 10 per TU = 5 TU
+                        { product: 'P3', qty: 10, piItemProduct: 'TU3' }, // 10 CU / 10 per TU = 1 TU
+                    ]
+                }
+            },
+        }
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI1.luName });
+
+    await test.step("Pick all three products onto the same LU", async () => {
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '3' });
+        await PickingJobScreen.expectLineButton({ index: 1, color: 'green', qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });
+
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU2.qrCode, expectQtyEntered: '5' });
+        await PickingJobScreen.expectLineButton({ index: 2, color: 'green', qtyToPick: '5 TU', qtyPicked: '5 TU', qtyPickedCatchWeight: '' });
+
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU3.qrCode, expectQtyEntered: '1' });
+        await PickingJobScreen.expectLineButton({ index: 3, color: 'green', qtyToPick: '1 TU', qtyPicked: '1 TU', qtyPickedCatchWeight: '' });
+    });
+
+    // Confirm the picked LU actually has 3 products before we touch GRAIs
+    await Backend.expect({
+        hus: {
+            lu1: { huStatus: 'S', storages: { P1: '30 PCE', P2: '50 PCE', P3: '10 PCE' } },
+        }
+    });
+
+    // Resolve the picked LU's global QR code via the test backend so the HU
+    // Manager can scan it. Picked LUs are not exposed in masterdata.handlingUnits
+    // because they're created indirectly by the picking flow.
+    const luQRCode = await Backend.getHUQRCodeByIdentifier({ identifier: 'lu1' });
+
+    await PickingJobScreen.goBack();
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.goBack();
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('huManager');
+    await HUManagerScreen.waitForScreen();
+
+    await HUManagerScreen.scanHUQRCode({ huQRCode: luQRCode });
+    await HUManagerScreen.openGRAIScreen();
+    await GRAIScreen.expectVisible();
+
+    // Nine distinct GRAIs (3 + 5 + 1). The trailing "1" of the prefix becomes the
+    // first serial digit per GS1 AI 8003 (post-me03#29827 parser fix).
+    const graiBarcodes = makeGraiBarcodes(9);
+    const expectedCanonicals = Array.from({ length: 9 }, (_, i) => graiChipText(i + 1));
+
+    await GRAIScreen.scanGraiBatch({ graiCodes: graiBarcodes });
+    await GRAIScreen.expectGraiChipCount({ expectedCount: 9 });
+    await GRAIScreen.expectGraiChipTexts({ expectedTexts: expectedCanonicals });
+    await GRAIScreen.expectExtraGraiChipCount({ expectedCount: 0 });
+
+    // Send → the per-block loop must fill block-0 (P1, tuCount=3), block-1 (P2, tuCount=5)
+    // and block-2 (P3, tuCount=1) — NOT collapse onto block-0.
+    await GRAIScreen.tapSendButton();
+    await GRAIScreen.expectGraiChipCount({ expectedCount: 9 });
+    await GRAIScreen.expectGraiChipTexts({ expectedTexts: expectedCanonicals });
+
+    // Round-trip: any regression that drops GRAIs into "first block only" would
+    // surface here as fewer than nine chips on reload (the second/third VHUs
+    // would have been overwritten with empty / different values).
+    await GRAIScreen.reloadFromBackend();
+    await GRAIScreen.expectGraiChipCount({ expectedCount: 9 });
     await GRAIScreen.expectGraiChipTexts({ expectedTexts: expectedCanonicals });
 });

--- a/e2e/mobile-webui/tests/spec/humanager/grai.spec.js
+++ b/e2e/mobile-webui/tests/spec/humanager/grai.spec.js
@@ -6,6 +6,8 @@ import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScre
 import { HUManagerScreen } from '../../utils/screens/huManager/HUManagerScreen';
 import { GRAIScreen } from '../../utils/screens/huManager/GRAIScreen';
 
+// GRAI_PREFIX layout per GS1 AI 8003: AI(4) + pad(0) + companyPrefix(7613264) + assetType(003095, 6 digits incl. check digit) + first serial digit(1) = 19 chars.
+// The trailing "1" is the first character of the variable-length serial that follows.
 const GRAI_PREFIX = '8003076132640030951';
 
 const makeGraiBarcodes = (count) => {
@@ -16,8 +18,10 @@ const makeGraiBarcodes = (count) => {
 };
 
 /** Expected chip display text for a generated GRAI serial number (1-based).
- *  Chips now show the full canonical GRAI: companyPrefix.assetType.serial */
-const graiChipText = (n) => `7613264.003095.${String(n).padStart(11, '0')}`;
+ *  Chips show the canonical GRAI: companyPrefix.assetType.serial — the serial
+ *  starts with the "1" that comes from GRAI_PREFIX (position 14 of the post-AI
+ *  data, per GS1 AI 8003: 1 pad + 13-digit asset reference + serial). */
+const graiChipText = (n) => `7613264.003095.1${String(n).padStart(11, '0')}`;
 
 const createMasterdata = async () => {
     return await Backend.createMasterdata({
@@ -118,18 +122,18 @@ test('Scan GRAI barcode and verify chip appears', async ({ page }) => {
     // Scan a GS1 AI 8003 GRAI barcode (as emitted by a keyboard barcode reader) — MIGROS A crate
     await GRAIScreen.scanGraiBarcode({ barcodeString: '800307613264003095100691412000' });
     await GRAIScreen.expectGraiChipCount({ expectedCount: 1 });
-    await GRAIScreen.expectGraiChipWithText({ text: '7613264.003095.00691412000' });
-    await GRAIScreen.expectGraiChipTexts({ expectedTexts: ['7613264.003095.00691412000'] });
+    await GRAIScreen.expectGraiChipWithText({ text: '7613264.003095.100691412000' });
+    await GRAIScreen.expectGraiChipTexts({ expectedTexts: ['7613264.003095.100691412000'] });
 
     // Send to backend — chips should remain unchanged
     await GRAIScreen.tapSendButton();
     await GRAIScreen.expectGraiChipCount({ expectedCount: 1 });
-    await GRAIScreen.expectGraiChipTexts({ expectedTexts: ['7613264.003095.00691412000'] });
+    await GRAIScreen.expectGraiChipTexts({ expectedTexts: ['7613264.003095.100691412000'] });
 
     // Verify backend persistence: reload from backend, confirm GRAI survived the round-trip
     await GRAIScreen.reloadFromBackend();
     await GRAIScreen.expectGraiChipCount({ expectedCount: 1 });
-    await GRAIScreen.expectGraiChipTexts({ expectedTexts: ['7613264.003095.00691412000'] });
+    await GRAIScreen.expectGraiChipTexts({ expectedTexts: ['7613264.003095.100691412000'] });
 });
 
 // noinspection JSUnusedLocalSymbols
@@ -499,4 +503,88 @@ test('Undo discards unsaved changes and reloads from backend', async ({ page }) 
     await GRAIScreen.tapUndoButton();
     await GRAIScreen.expectGraiChipCount({ expectedCount: 2 });
     await GRAIScreen.expectSendButtonDisabled();
+});
+
+// noinspection JSUnusedLocalSymbols
+/**
+ * Reproducer for me03#29827 — distribution of GRAIs across the TUs of a single-product LU.
+ *
+ * The LU is created with PI tuCount=3 (one product, three aggregated TUs). The customer
+ * reported that, after https://github.com/metasfresh/metasfresh/pull/23927, three GRAIs
+ * scanned onto such an LU could still end up "all on the first TU". The post-PR-23927
+ * per-block loop in HUGraiSnapshot.computeDelta should fill the single aggregate block
+ * with all three GRAIs as a comma-separated value on its VHU, and the UI round-trip
+ * must preserve all three.
+ *
+ * If a regression ever collapses the storage back to "first slot only", the
+ * reloadFromBackend() chip count after Send will drop below three.
+ */
+test('Three GRAIs distribute across a 3-TU single-product LU and survive the round-trip', async ({ page }) => {
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5120');
+    allure.story('HU Manager - GRAI Distribution on 3-TU Single-Product LU');
+    allure.severity('critical');
+
+    const masterdata = await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US" } },
+            products: { "P1": {} },
+            warehouses: { "wh1": {} },
+            packingInstructions: {
+                "PI_3TU": { lu: "LU", qtyTUsPerLU: 3, tu: "TU", product: "P1", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh1', packingInstructions: 'PI_3TU' },
+            },
+        },
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('huManager');
+    await HUManagerScreen.waitForScreen();
+
+    await HUManagerScreen.scanHUQRCode({ huQRCode: masterdata.handlingUnits.HU1.qrCode });
+    await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '12 PCE' });
+
+    await HUManagerScreen.openGRAIScreen();
+    await GRAIScreen.expectVisible();
+
+    // Three distinct GRAI barcodes — the canonical forms the parser produces after the
+    // me03#29827 fix (serial starts with the "1" that follows the asset reference).
+    const graiBarcodes = [
+        '800307613264003095100691412001',
+        '800307613264003095100691412002',
+        '800307613264003095100691412003',
+    ];
+    const expectedCanonicals = [
+        '7613264.003095.100691412001',
+        '7613264.003095.100691412002',
+        '7613264.003095.100691412003',
+    ];
+
+    // Scan one at a time; the assertion between scans gives the keyboard-hook interval
+    // flush enough time to process each barcode (see e2e/mobile-webui/CLAUDE.md).
+    await GRAIScreen.scanGraiBarcode({ barcodeString: graiBarcodes[0] });
+    await GRAIScreen.expectGraiChipCount({ expectedCount: 1 });
+    await GRAIScreen.scanGraiBarcode({ barcodeString: graiBarcodes[1] });
+    await GRAIScreen.expectGraiChipCount({ expectedCount: 2 });
+    await GRAIScreen.scanGraiBarcode({ barcodeString: graiBarcodes[2] });
+    await GRAIScreen.expectGraiChipCount({ expectedCount: 3 });
+    await GRAIScreen.expectGraiChipTexts({ expectedTexts: expectedCanonicals });
+
+    // No extras for a 3-TU LU with 3 scans
+    await GRAIScreen.expectExtraGraiChipCount({ expectedCount: 0 });
+
+    // Send to backend — all three must reach the VHU under the single HA item
+    await GRAIScreen.tapSendButton();
+    await GRAIScreen.expectGraiChipCount({ expectedCount: 3 });
+    await GRAIScreen.expectGraiChipTexts({ expectedTexts: expectedCanonicals });
+
+    // Round-trip via the backend: any regression that drops GRAIs into "first slot only"
+    // would surface here as fewer than three chips.
+    await GRAIScreen.reloadFromBackend();
+    await GRAIScreen.expectGraiChipCount({ expectedCount: 3 });
+    await GRAIScreen.expectGraiChipTexts({ expectedTexts: expectedCanonicals });
 });

--- a/e2e/mobile-webui/tests/spec/humanager/grai.spec.js
+++ b/e2e/mobile-webui/tests/spec/humanager/grai.spec.js
@@ -8,8 +8,9 @@ import { GRAIScreen } from '../../utils/screens/huManager/GRAIScreen';
 import { PickingJobsListScreen } from '../../utils/screens/picking/PickingJobsListScreen';
 import { PickingJobScreen } from '../../utils/screens/picking/PickingJobScreen';
 
-// GRAI_PREFIX layout per GS1 AI 8003: AI(4) + pad(0) + companyPrefix(7613264) + assetType(003095, 6 digits incl. check digit) + first serial digit(1) = 19 chars.
-// The trailing "1" is the first character of the variable-length serial that follows.
+// GRAI_PREFIX layout per GS1 AI 8003: AI(4) + pad(0) + companyPrefix(7613264) + assetType(00309) + check digit(5) + first serial digit(1) = 19 chars.
+// The "5" at position 17 is the GS1 check digit (dropped from the EPCIS canonical);
+// the trailing "1" is the first character of the variable-length serial that follows.
 const GRAI_PREFIX = '8003076132640030951';
 
 const makeGraiBarcodes = (count) => {
@@ -20,10 +21,11 @@ const makeGraiBarcodes = (count) => {
 };
 
 /** Expected chip display text for a generated GRAI serial number (1-based).
- *  Chips show the canonical GRAI: companyPrefix.assetType.serial — the serial
- *  starts with the "1" that comes from GRAI_PREFIX (position 14 of the post-AI
- *  data, per GS1 AI 8003: 1 pad + 13-digit asset reference + serial). */
-const graiChipText = (n) => `7613264.003095.1${String(n).padStart(11, '0')}`;
+ *  Chips show the GS1 EPCIS "Pure Identity" URI canonical:
+ *  {@code companyPrefix(7).assetType(5).serial} — the check digit at GTIN-13
+ *  position 13 is omitted from the canonical, and the serial starts with the
+ *  "1" that comes from GRAI_PREFIX (position 14 of the post-AI data). */
+const graiChipText = (n) => `7613264.00309.1${String(n).padStart(11, '0')}`;
 
 const createMasterdata = async () => {
     return await Backend.createMasterdata({
@@ -124,18 +126,18 @@ test('Scan GRAI barcode and verify chip appears', async ({ page }) => {
     // Scan a GS1 AI 8003 GRAI barcode (as emitted by a keyboard barcode reader) — MIGROS A crate
     await GRAIScreen.scanGraiBarcode({ barcodeString: '800307613264003095100691412000' });
     await GRAIScreen.expectGraiChipCount({ expectedCount: 1 });
-    await GRAIScreen.expectGraiChipWithText({ text: '7613264.003095.100691412000' });
-    await GRAIScreen.expectGraiChipTexts({ expectedTexts: ['7613264.003095.100691412000'] });
+    await GRAIScreen.expectGraiChipWithText({ text: '7613264.00309.100691412000' });
+    await GRAIScreen.expectGraiChipTexts({ expectedTexts: ['7613264.00309.100691412000'] });
 
     // Send to backend — chips should remain unchanged
     await GRAIScreen.tapSendButton();
     await GRAIScreen.expectGraiChipCount({ expectedCount: 1 });
-    await GRAIScreen.expectGraiChipTexts({ expectedTexts: ['7613264.003095.100691412000'] });
+    await GRAIScreen.expectGraiChipTexts({ expectedTexts: ['7613264.00309.100691412000'] });
 
     // Verify backend persistence: reload from backend, confirm GRAI survived the round-trip
     await GRAIScreen.reloadFromBackend();
     await GRAIScreen.expectGraiChipCount({ expectedCount: 1 });
-    await GRAIScreen.expectGraiChipTexts({ expectedTexts: ['7613264.003095.100691412000'] });
+    await GRAIScreen.expectGraiChipTexts({ expectedTexts: ['7613264.00309.100691412000'] });
 });
 
 // noinspection JSUnusedLocalSymbols
@@ -561,9 +563,9 @@ test('Three GRAIs distribute across a 3-TU single-product LU and survive the rou
         '800307613264003095100691412003',
     ];
     const expectedCanonicals = [
-        '7613264.003095.100691412001',
-        '7613264.003095.100691412002',
-        '7613264.003095.100691412003',
+        '7613264.00309.100691412001',
+        '7613264.00309.100691412002',
+        '7613264.00309.100691412003',
     ];
 
     // Scan one at a time; the assertion between scans gives the keyboard-hook interval
@@ -666,7 +668,7 @@ test('Nine GRAIs distribute across three aggregate blocks on a multi-product LU'
     await ApplicationsListScreen.startApplication('picking');
     await PickingJobsListScreen.waitForScreen();
     await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
-    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
 
     await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
     await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI1.luName });
@@ -682,8 +684,21 @@ test('Nine GRAIs distribute across three aggregate blocks on a multi-product LU'
         await PickingJobScreen.expectLineButton({ index: 3, color: 'green', qtyToPick: '1 TU', qtyPicked: '1 TU', qtyPickedCatchWeight: '' });
     });
 
-    // Confirm the picked LU actually has 3 products before we touch GRAIs
+    // Confirm the picked LU has 3 products before we touch GRAIs.
+    // The picking expectation's `lu: 'lu1'` field registers the picked LU's HuId
+    // in the masterdata context under the identifier "lu1"; without that the
+    // subsequent `hus: { lu1: ... }` block and getHUQRCodeByIdentifier call
+    // cannot resolve it (context.getOptionalId returns null otherwise).
     await Backend.expect({
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: { qtyPicked: [{ qtyPicked: '30 PCE', qtyTUs: 3, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }] },
+                    P2: { qtyPicked: [{ qtyPicked: '50 PCE', qtyTUs: 5, qtyLUs: 1, vhu: 'vhu2', tu: 'tu2', lu: 'lu1', processed: false, shipmentLineId: '-' }] },
+                    P3: { qtyPicked: [{ qtyPicked: '10 PCE', qtyTUs: 1, qtyLUs: 1, vhu: 'vhu3', tu: 'tu3', lu: 'lu1', processed: false, shipmentLineId: '-' }] },
+                }
+            }
+        },
         hus: {
             lu1: { huStatus: 'S', storages: { P1: '30 PCE', P2: '50 PCE', P3: '10 PCE' } },
         }

--- a/e2e/mobile-webui/tests/utils/screens/Backend.js
+++ b/e2e/mobile-webui/tests/utils/screens/Backend.js
@@ -74,6 +74,31 @@ export const Backend = {
         }
     }),
 
+    /**
+     * Resolve a masterdata identifier (e.g. `"lu1"`) to the underlying handling-unit's
+     * global QR code string. Used by tests that need to scan an HU which was created
+     * indirectly (typically by a picking flow) and therefore has no QR code under
+     * `masterdata.handlingUnits.*`.
+     */
+    getHUQRCodeByIdentifier: async ({ identifier }) => await test.step(`Backend: get HU QR code for "${identifier}"`, async () => {
+        const backendBaseUrl = await getBackendBaseUrl();
+        const response = await page.request.post(`${backendBaseUrl}/frontendTesting/getHUQRCode`, {
+            data: {
+                identifier,
+                masterdata: testContext.lastMasterdata,
+                context: testContext.lastContext,
+            },
+            headers: {
+                'Content-Type': 'application/json',
+            }
+        });
+
+        const responseBody = await response.json();
+        assertNoErrors({ responseBody });
+
+        return responseBody.qrCode;
+    }),
+
     getWFProcess: async ({ wfProcessId }) => {
         const backendBaseUrl = await getBackendBaseUrl();
         const response = await page.request.get(`${backendBaseUrl}/userWorkflows/wfProcess/${wfProcessId}`, {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/grai.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/grai.js
@@ -3,11 +3,16 @@ import GS1BarcodeParser from 'gs1-barcode-parser-mod';
 /**
  * Parse GRAI from a GS1 barcode string containing AI 8003.
  *
- * AI 8003 format: 0{companyPrefix}{assetType}{checkDigit}{serial}
- * - Leading 0 (1 digit)
- * - Company prefix + asset type = 13 digits
- * - Check digit = 1 digit (position 14)
- * - Serial = variable length
+ * Per GS1 General Specifications, AI 8003 (GRAI) has a fixed-length asset
+ * reference of 14 digits after the AI: 1 padding digit + 13-digit asset
+ * reference (GS1 Company Prefix + Item Reference + check digit at the end).
+ * An optional alphanumeric serial (0..16 chars) may follow.
+ *
+ * Returned in the GS1 EPCIS "Pure Identity" URI canonical form
+ * `companyPrefix(7).assetType(5).serial` — the GS1 check digit at GTIN-13
+ * position 13 is dropped from the canonical to match `urn:epc:id:grai:`.
+ * Kept in sync with the backend parser in
+ * `de.metas.handlingunits.grai.GRAI.parseGS1AI8003`.
  *
  * @param {string} barcodeString - Raw barcode string
  * @returns {string|null} Dot-separated GRAI or null
@@ -20,13 +25,15 @@ export const parseGraiFromGs1Barcode = (barcodeString) => {
     if (!graiElement) return null;
 
     const graiData = '' + graiElement.data;
-    // AI 8003 data: starts with 0, then 13 digits (company prefix + asset type), then check digit, then serial
+    // Minimum meaningful length: 14 (asset reference) + 1 (at least one serial char) = 15.
     if (graiData.length < 15) return null;
 
-    // The leading 0 is an indicator digit
-    const base = graiData.substring(1, 14); // 13 digits: company prefix + asset type
-    // Position 14 (index 14) is the check digit — skip it
-    const serial = graiData.substring(15);
+    // Position 0: padding digit (skip)
+    // Positions 1-12: 12-digit asset reference base (company prefix + asset type, no check digit)
+    // Position 13: GS1 check digit (skip — not part of the EPCIS Pure Identity URI canonical)
+    // Position 14+: serial reference
+    const base = graiData.substring(1, 13);
+    const serial = graiData.substring(14);
 
     // For GRAI, the company prefix is typically 7 digits (GS1 standard for most European prefixes)
     // We use a heuristic: GS1 prefixes starting with 76 (Switzerland) are 7 digits


### PR DESCRIPTION
## Summary

Scanning a GRAI barcode like `800307613264003095100691412003` produced the canonical form `7613264.003095.00691412003`, silently dropping the `1` between the asset reference and the serial. The customer (sp80) noticed this on the mobileUI Scan-GRAI workflow during EDI testing (https://github.com/metasfresh/me03/issues/29827 / parent https://github.com/metasfresh/me03/issues/29753).

## Root cause

`GRAI.parseGS1AI8003` treated position 14 of the post-AI-stripped string as a "check digit" and skipped it (`serial = data.substring(15)`). Per GS1 General Specifications, AI 8003 has a fixed-length 14-character asset reference (1 pad + 13-digit asset reference, last digit is the GS1 check digit). Position 14 is already the first digit of the serial — skipping it lost a digit on every GS1-formatted scan.

## Files

- `backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/grai/GRAI.java` — `serial = data.substring(14)` (was 15); `data.length() < 15` (was < 16).
- `backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/GRAITest.java` — new test `gs1_me03_29827_serialFirstDigitMustNotBeDropped` reproducing the customer's exact input/output; existing `gs1_*` and `fromGS1_returnsCanonical` tests had their expected canonical serials corrected (they encoded the buggy `00691412000` instead of `100691412000` for the same input).
- `backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/GRAISetTest.java` — same correction for `gs1_values` and `mixed_canonical_and_gs1`, which delegate to `GRAI.parse`.

No DB migration, no frontend change, no REST contract change. The on-disk canonical form for new scans gains the previously-dropped digit; existing canonical strings stored via the dummy-GRAI generator or pre-existing scans are unaffected.

## Test plan

- [x] Local: 850 unit tests in `de.metas.handlingunits.base` pass (0 failures, 22 pre-existing skips). Ran `run-unit-test.sh backend/de.metas.handlingunits.base` after the fix.
- [ ] CI green on this branch.
- [ ] Customer-instance smoke on https://spavettirelease.metasfresh.com — scan a real GRAI label and confirm the canonical form on the VHU includes the previously-dropped digit.

## Out of scope (tracked for follow-up)

The me03 issue lists two more concerns:
- GRAI distribution among TUs — PR https://github.com/metasfresh/metasfresh/pull/23927 did fix inter-block distribution and its tests still pass, but the customer reports the bug still occurs with "3 GRAIs all on the first TU". Investigation is in progress; suspected to be a single-product single-HA-block display interpretation question rather than a `computeDelta` bug. Will land in a follow-up PR after clarification.
- `desadv_json` outdated views — being handled elsewhere per the customer.