### PR TITLE
Extend report Bestandsprüfung Rohware

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/material_cockpit_bom_demand_report.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/material_cockpit_bom_demand_report.sql
@@ -6,15 +6,17 @@ CREATE OR REPLACE FUNCTION material_cockpit_bom_demand_report(
 )
     RETURNS TABLE
             (
-                parent_product            text,
-                parent_qty_reserved       numeric,
-                bom_line                  text,
-                component_product         text,
-                bom_qty_per_unit          numeric,
+                parent_product             text,
+                parent_qty_reserved        numeric,
+                bom_line                   text,
+                component_product          text,
+                bom_qty_per_unit           numeric,
                 total_component_qty_needed numeric,
-                total_on_hand_qty         numeric,
-                shortage                  numeric,
-                UOMSymbol                text
+                total_on_hand_qty          numeric,
+                total_reserved_qty         numeric,
+                total_ordered_qty          numeric,
+                shortage                   numeric,
+                UOMSymbol                  text
             )
 AS
 $$
@@ -52,44 +54,129 @@ BEGIN
                    AND (pb.validto IS NULL OR pb.validto >= NOW())
                  ORDER BY pb.m_product_id, pb.validfrom DESC
              ),
+             -- Expands BOM recursively via PP_Product_BOM_Recursive and accumulates
+             -- quantities along each path (e.g. qty_D1_per_A = qty_C1_per_A * qty_D1_per_C1).
              bom_components AS (
-                 SELECT pd.product_info                                    AS parent_product_info,
-                        pd.qtyReserved                                     AS parent_qty_res,
-                        bl.line::text                                      AS b_line,
-                        (p_comp.Value || '_' || p_comp.Name)::text         AS c_info,
-                        bl.qtybom                                          AS q_per_unit,
-                        (bl.qtybom * pd.qtyReserved)                       AS t_needed,
-                        uom.UOMSymbol::text                                AS uom,
-                        p_comp.m_product_id                                AS c_id
+                 SELECT pd.product_info                             AS parent_product_info,
+                        pd.qtyReserved                             AS parent_qty_res,
+                        r.line_text                                AS b_line,
+                        r.sort_path                                AS sort_path,
+                        (p_comp.Value || '_' || p_comp.Name)::text AS c_info,
+                        r.acc_qty                                  AS q_per_unit,
+                        (r.acc_qty * pd.qtyReserved)               AS t_needed,
+                        r.uom_symbol::text                         AS uom,
+                        r.component_product_id                     AS c_id
                  FROM product_demand pd
                           INNER JOIN active_boms ab ON pd.m_product_id = ab.m_product_id
-                          INNER JOIN pp_product_bomline bl ON ab.pp_product_bom_id = bl.pp_product_bom_id
-                          INNER JOIN m_product p_comp ON bl.m_product_id = p_comp.m_product_id
-                          LEFT JOIN c_uom uom ON bl.c_uom_id = uom.c_uom_id
-                 WHERE bl.IsActive = 'Y'
-                   AND bl.componenttype = 'CO'
-                   AND COALESCE(bl.qtybom, 0) <> 0
-                   AND bl.validfrom <= NOW()
-                   AND (bl.validto IS NULL OR bl.validto >= NOW())
+                          CROSS JOIN LATERAL (
+                     -- bom_all: all BOM nodes (depth>=2 = components, not the root product)
+                     -- filtered to fixed-quantity lines only (IsQtyPercentage='N')
+                     WITH RECURSIVE
+                         bom_all AS (
+                             SELECT rec.Line       AS line_text,
+                                    rec.M_Product_ID,
+                                    rec.QtyBOM,
+                                    rec.UOMSymbol,
+                                    rec.depth,
+                                    rec.path
+                             FROM PP_Product_BOM_Recursive(ab.pp_product_bom_id, NULL) rec
+                             WHERE rec.depth >= 2
+                               AND rec.IsQtyPercentage = 'N'
+                               AND COALESCE(rec.QtyBOM, 0) <> 0
+                         ),
+                         -- accumulated: walks the path top-down, multiplying QtyBOM at each level
+                         -- so acc_qty for D1 (under C1 under A) = qty_C1_per_A * qty_D1_per_C1
+                         accumulated(line_text, component_product_id, uom_symbol, sort_path, acc_qty) AS (
+                             -- base: direct children of the root BOM (depth=2)
+                             SELECT ba.line_text, ba.M_Product_ID, ba.UOMSymbol, ba.path,
+                                    ba.QtyBOM
+                             FROM bom_all ba
+                             WHERE ba.depth = 2
+
+                             UNION ALL
+
+                             -- recursive: each deeper level multiplies its parent's accumulated qty
+                             SELECT ba.line_text, ba.M_Product_ID, ba.UOMSymbol, ba.path,
+                                    a.acc_qty * ba.QtyBOM
+                             FROM bom_all ba
+                                      INNER JOIN accumulated a
+                                                 ON ba.path[1:array_length(ba.path, 1) - 1] = a.sort_path
+                         )
+                     SELECT acc.line_text,
+                            acc.component_product_id,
+                            acc.uom_symbol,
+                            acc.sort_path,
+                            acc.acc_qty
+                     FROM accumulated acc
+                     ) r
+                          INNER JOIN m_product p_comp ON r.component_product_id = p_comp.m_product_id
              ),
+             -- Aggregate demand across all BOM paths per component.
+             -- A component can appear in multiple sub-BOMs (e.g. D1 under both C1 and C2).
+             -- Summing t_needed gives the correct total demand; bom_line lists all paths.
+             component_demand AS (
+                 SELECT bc.parent_product_info,
+                        bc.parent_qty_res,
+                        STRING_AGG(bc.b_line, ', ' ORDER BY bc.sort_path) AS b_line,
+                        MIN(bc.sort_path)                                  AS first_sort_path,
+                        bc.c_info,
+                        bc.c_id,
+                        bc.uom,
+                        SUM(bc.q_per_unit)                                 AS q_per_unit,
+                        SUM(bc.t_needed)                                   AS t_needed
+                 FROM bom_components bc
+                 GROUP BY bc.parent_product_info, bc.parent_qty_res, bc.c_info, bc.c_id, bc.uom
+             ),
+             -- Global stock, reservations, and open PO/MO quantities per component product.
+             -- Reserved = qty committed via sales orders (qtyReserved)
+             --          + production order candidates (qtyToProduce)
+             --          + open manufacturing orders (PP_Order docstatus CO/IP, not yet issued).
+             -- Ordered  = qty incoming from purchase orders without goods receipt (qtyToMove).
              global_stock AS (
-                 SELECT v.m_product_id,
-                        SUM(v.qtyStock) AS total_qty_stock
-                 FROM QtyDemand_QtySupply_V v
-                 GROUP BY v.m_product_id
+                 SELECT src.m_product_id,
+                        SUM(src.qty_stock)    AS total_qty_stock,
+                        SUM(src.qty_reserved) AS total_reserved,
+                        SUM(src.qty_ordered)  AS total_ordered
+                 FROM (
+                          -- stock, SO reservations, PP_Order_Candidate demand, PO incoming
+                          SELECT v.m_product_id,
+                                 COALESCE(v.qtyStock, 0)                                   AS qty_stock,
+                                 COALESCE(v.qtyReserved, 0) + COALESCE(v.qtyToProduce, 0) AS qty_reserved,
+                                 COALESCE(v.qtyToMove, 0)                                  AS qty_ordered
+                          FROM QtyDemand_QtySupply_V v
+
+                          UNION ALL
+
+                          -- raw material demand from confirmed/in-progress manufacturing orders
+                          SELECT pobl.m_product_id,
+                                 0                                                                             AS qty_stock,
+                                 GREATEST(pobl.qtyrequiered - COALESCE(pobl.qtydelivered, 0), 0)              AS qty_reserved,
+                                 0                                                                             AS qty_ordered
+                          FROM pp_order po
+                                   INNER JOIN pp_order_bomline pobl ON pobl.pp_order_id = po.pp_order_id
+                          WHERE po.docstatus IN ('CO', 'IP')
+                            AND po.isactive = 'Y'
+                            AND pobl.isactive = 'Y'
+                      ) src
+                 GROUP BY src.m_product_id
              )
-        SELECT bc.parent_product_info,
-               bc.parent_qty_res,
-               bc.b_line,
-               bc.c_info,
-               bc.q_per_unit,
-               bc.t_needed,
+        SELECT cd.parent_product_info,
+               cd.parent_qty_res,
+               cd.b_line,
+               cd.c_info,
+               cd.q_per_unit,
+               cd.t_needed,
                COALESCE(gs.total_qty_stock, 0),
-               GREATEST(bc.t_needed - COALESCE(gs.total_qty_stock, 0), 0),
-               bc.uom
-        FROM bom_components bc
-                 LEFT JOIN global_stock gs ON bc.c_id = gs.m_product_id
-        ORDER BY bc.parent_product_info, bc.b_line::numeric;
+               COALESCE(gs.total_reserved, 0),
+               COALESCE(gs.total_ordered, 0),
+               -- shortage = demand - available, where available = stock - reserved + ordered
+               GREATEST(cd.t_needed - (COALESCE(gs.total_qty_stock, 0)
+                                           - COALESCE(gs.total_reserved, 0)
+                   + COALESCE(gs.total_ordered, 0)), 0) AS shortage,
+               cd.uom
+        FROM component_demand cd
+                 LEFT JOIN global_stock gs ON cd.c_id = gs.m_product_id
+        ORDER BY cd.parent_product_info, cd.first_sort_path;
 END;
 $$
     LANGUAGE plpgsql;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/material_cockpit_bom_demand_report.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/material_cockpit_bom_demand_report.sql
@@ -157,6 +157,18 @@ BEGIN
                           WHERE po.docstatus IN ('CO', 'IP')
                             AND po.isactive = 'Y'
                             AND pobl.isactive = 'Y'
+
+                          UNION ALL
+
+                          -- supply from confirmed/in-progress manufacturing orders (product being produced)
+                          -- counts as incoming supply for the semi-finished/component product
+                          SELECT po.m_product_id,
+                                 0                                                                             AS qty_stock,
+                                 0                                                                             AS qty_reserved,
+                                 GREATEST(po.qtyordered - COALESCE(po.qtydelivered, 0), 0)                    AS qty_ordered
+                          FROM pp_order po
+                          WHERE po.docstatus IN ('CO', 'IP')
+                            AND po.isactive = 'Y'
                       ) src
                  GROUP BY src.m_product_id
              )

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/material_cockpit_bom_demand_report.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/material_cockpit_bom_demand_report.sql
@@ -129,7 +129,7 @@ BEGIN
              ),
              -- Global stock, reservations, and open PO/MO quantities per component product.
              -- Reserved = qty committed via sales orders (qtyReserved)
-             --          + production order candidates (qtyToProduce)
+             --          + production order (qtyToProduce)
              --          + open manufacturing orders (PP_Order docstatus CO/IP, not yet issued).
              -- Ordered  = qty incoming from purchase orders without goods receipt (qtyToMove).
              global_stock AS (
@@ -138,7 +138,7 @@ BEGIN
                         SUM(src.qty_reserved) AS total_reserved,
                         SUM(src.qty_ordered)  AS total_ordered
                  FROM (
-                          -- stock, SO reservations, PP_Order_Candidate demand, PO incoming
+                          -- stock, SO reservations, PP_Order demand, PO incoming
                           SELECT v.m_product_id,
                                  COALESCE(v.qtyStock, 0)                                   AS qty_stock,
                                  COALESCE(v.qtyReserved, 0) + COALESCE(v.qtyToProduce, 0) AS qty_reserved,

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5802400_sys_Material_Cockpit2_BOM_Demand_Report_Extension.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5802400_sys_Material_Cockpit2_BOM_Demand_Report_Extension.sql
@@ -1,0 +1,200 @@
+DROP FUNCTION IF EXISTS material_cockpit_bom_demand_report(varchar, varchar);
+
+CREATE OR REPLACE FUNCTION material_cockpit_bom_demand_report(
+    p_qtydemand_qtysupply_v_ids varchar,
+    p_uuid                      varchar
+)
+    RETURNS TABLE
+            (
+                parent_product             text,
+                parent_qty_reserved        numeric,
+                bom_line                   text,
+                component_product          text,
+                bom_qty_per_unit           numeric,
+                total_component_qty_needed numeric,
+                total_on_hand_qty          numeric,
+                total_reserved_qty         numeric,
+                total_ordered_qty          numeric,
+                shortage                   numeric,
+                UOMSymbol                  text
+            )
+AS
+$$
+BEGIN
+    RETURN QUERY
+        WITH selected_ids AS (
+            SELECT CASE
+                       WHEN p_qtydemand_qtysupply_v_ids = 'all' THEN
+                           ARRAY(
+                                   SELECT s.intkey1
+                                   FROM t_webui_viewselection s
+                                   WHERE s.uuid = p_uuid
+                           )::int[]
+                                                                ELSE
+                           REGEXP_SPLIT_TO_ARRAY(p_qtydemand_qtysupply_v_ids, ',')::int[]
+                   END AS ids
+        ),
+             product_demand AS (
+                 SELECT v.m_product_id,
+                        (v.ProductValue || '_' || v.ProductName)::text AS product_info,
+                        SUM(v.qtyReserved)                             AS qtyReserved
+                 FROM QtyDemand_QtySupply_V v
+                          CROSS JOIN selected_ids si
+                 WHERE v.QtyDemand_QtySupply_V_ID = ANY (si.ids)
+                 GROUP BY v.m_product_id, v.ProductValue, v.ProductName
+                 HAVING SUM(v.qtyReserved) > 0
+             ),
+             active_boms AS (
+                 SELECT DISTINCT ON (pb.m_product_id) pb.m_product_id,
+                                                      pb.pp_product_bom_id
+                 FROM pp_product_bom pb
+                 WHERE pb.IsActive = 'Y'
+                   AND pb.docstatus = 'CO'
+                   AND pb.validfrom <= NOW()
+                   AND (pb.validto IS NULL OR pb.validto >= NOW())
+                 ORDER BY pb.m_product_id, pb.validfrom DESC
+             ),
+             -- Expands BOM recursively via PP_Product_BOM_Recursive and accumulates
+             -- quantities along each path (e.g. qty_D1_per_A = qty_C1_per_A * qty_D1_per_C1).
+             bom_components AS (
+                 SELECT pd.product_info                             AS parent_product_info,
+                        pd.qtyReserved                             AS parent_qty_res,
+                        r.line_text                                AS b_line,
+                        r.sort_path                                AS sort_path,
+                        (p_comp.Value || '_' || p_comp.Name)::text AS c_info,
+                        r.acc_qty                                  AS q_per_unit,
+                        (r.acc_qty * pd.qtyReserved)               AS t_needed,
+                        r.uom_symbol::text                         AS uom,
+                        r.component_product_id                     AS c_id
+                 FROM product_demand pd
+                          INNER JOIN active_boms ab ON pd.m_product_id = ab.m_product_id
+                          CROSS JOIN LATERAL (
+                     -- bom_all: all BOM nodes (depth>=2 = components, not the root product)
+                     -- filtered to fixed-quantity lines only (IsQtyPercentage='N')
+                     WITH RECURSIVE
+                         bom_all AS (
+                             SELECT rec.Line       AS line_text,
+                                    rec.M_Product_ID,
+                                    rec.QtyBOM,
+                                    rec.UOMSymbol,
+                                    rec.depth,
+                                    rec.path
+                             FROM PP_Product_BOM_Recursive(ab.pp_product_bom_id, NULL) rec
+                             WHERE rec.depth >= 2
+                               AND rec.IsQtyPercentage = 'N'
+                               AND COALESCE(rec.QtyBOM, 0) <> 0
+                         ),
+                         -- accumulated: walks the path top-down, multiplying QtyBOM at each level
+                         -- so acc_qty for D1 (under C1 under A) = qty_C1_per_A * qty_D1_per_C1
+                         accumulated(line_text, component_product_id, uom_symbol, sort_path, acc_qty) AS (
+                             -- base: direct children of the root BOM (depth=2)
+                             SELECT ba.line_text, ba.M_Product_ID, ba.UOMSymbol, ba.path,
+                                    ba.QtyBOM
+                             FROM bom_all ba
+                             WHERE ba.depth = 2
+
+                             UNION ALL
+
+                             -- recursive: each deeper level multiplies its parent's accumulated qty
+                             SELECT ba.line_text, ba.M_Product_ID, ba.UOMSymbol, ba.path,
+                                    a.acc_qty * ba.QtyBOM
+                             FROM bom_all ba
+                                      INNER JOIN accumulated a
+                                                 ON ba.path[1:array_length(ba.path, 1) - 1] = a.sort_path
+                         )
+                     SELECT acc.line_text,
+                            acc.component_product_id,
+                            acc.uom_symbol,
+                            acc.sort_path,
+                            acc.acc_qty
+                     FROM accumulated acc
+                     ) r
+                          INNER JOIN m_product p_comp ON r.component_product_id = p_comp.m_product_id
+             ),
+             -- Aggregate demand across all BOM paths per component.
+             -- A component can appear in multiple sub-BOMs (e.g. D1 under both C1 and C2).
+             -- Summing t_needed gives the correct total demand; bom_line lists all paths.
+             component_demand AS (
+                 SELECT bc.parent_product_info,
+                        bc.parent_qty_res,
+                        STRING_AGG(bc.b_line, ', ' ORDER BY bc.sort_path) AS b_line,
+                        MIN(bc.sort_path)                                  AS first_sort_path,
+                        bc.c_info,
+                        bc.c_id,
+                        bc.uom,
+                        SUM(bc.q_per_unit)                                 AS q_per_unit,
+                        SUM(bc.t_needed)                                   AS t_needed
+                 FROM bom_components bc
+                 GROUP BY bc.parent_product_info, bc.parent_qty_res, bc.c_info, bc.c_id, bc.uom
+             ),
+             -- Global stock, reservations, and open PO/MO quantities per component product.
+             -- Reserved = qty committed via sales orders (qtyReserved)
+             --          + production order candidates (qtyToProduce)
+             --          + open manufacturing orders (PP_Order docstatus CO/IP, not yet issued).
+             -- Ordered  = qty incoming from purchase orders without goods receipt (qtyToMove).
+             global_stock AS (
+                 SELECT src.m_product_id,
+                        SUM(src.qty_stock)    AS total_qty_stock,
+                        SUM(src.qty_reserved) AS total_reserved,
+                        SUM(src.qty_ordered)  AS total_ordered
+                 FROM (
+                          -- stock, SO reservations, PP_Order_Candidate demand, PO incoming
+                          SELECT v.m_product_id,
+                                 COALESCE(v.qtyStock, 0)                                   AS qty_stock,
+                                 COALESCE(v.qtyReserved, 0) + COALESCE(v.qtyToProduce, 0) AS qty_reserved,
+                                 COALESCE(v.qtyToMove, 0)                                  AS qty_ordered
+                          FROM QtyDemand_QtySupply_V v
+
+                          UNION ALL
+
+                          -- raw material demand from confirmed/in-progress manufacturing orders
+                          SELECT pobl.m_product_id,
+                                 0                                                                             AS qty_stock,
+                                 GREATEST(pobl.qtyrequiered - COALESCE(pobl.qtydelivered, 0), 0)              AS qty_reserved,
+                                 0                                                                             AS qty_ordered
+                          FROM pp_order po
+                                   INNER JOIN pp_order_bomline pobl ON pobl.pp_order_id = po.pp_order_id
+                          WHERE po.docstatus IN ('CO', 'IP')
+                            AND po.isactive = 'Y'
+                            AND pobl.isactive = 'Y'
+
+                          UNION ALL
+
+                          -- supply from confirmed/in-progress manufacturing orders (product being produced)
+                          -- counts as incoming supply for the semi-finished/component product
+                          SELECT po.m_product_id,
+                                 0                                                                             AS qty_stock,
+                                 0                                                                             AS qty_reserved,
+                                 GREATEST(po.qtyordered - COALESCE(po.qtydelivered, 0), 0)                    AS qty_ordered
+                          FROM pp_order po
+                          WHERE po.docstatus IN ('CO', 'IP')
+                            AND po.isactive = 'Y'
+                      ) src
+                 GROUP BY src.m_product_id
+             )
+        SELECT cd.parent_product_info,
+               cd.parent_qty_res,
+               cd.b_line,
+               cd.c_info,
+               cd.q_per_unit,
+               cd.t_needed,
+               COALESCE(gs.total_qty_stock, 0),
+               COALESCE(gs.total_reserved, 0),
+               COALESCE(gs.total_ordered, 0),
+               -- shortage = demand - available, where available = stock - reserved + ordered
+               GREATEST(cd.t_needed - (COALESCE(gs.total_qty_stock, 0)
+                                           - COALESCE(gs.total_reserved, 0)
+                   + COALESCE(gs.total_ordered, 0)), 0) AS shortage,
+               cd.uom
+        FROM component_demand cd
+                 LEFT JOIN global_stock gs ON cd.c_id = gs.m_product_id
+        ORDER BY cd.parent_product_info, cd.first_sort_path;
+END;
+$$
+    LANGUAGE plpgsql;
+
+-- -- With WebUI selection
+-- SELECT * FROM material_cockpit_bom_demand_report('all', 'your-uuid-here');
+--
+-- -- With explicit IDs
+-- SELECT * FROM material_cockpit_bom_demand_report('123456,789012', NULL);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5802400_sys_Material_Cockpit2_BOM_Demand_Report_Extension.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5802400_sys_Material_Cockpit2_BOM_Demand_Report_Extension.sql
@@ -129,7 +129,7 @@ BEGIN
              ),
              -- Global stock, reservations, and open PO/MO quantities per component product.
              -- Reserved = qty committed via sales orders (qtyReserved)
-             --          + production order candidates (qtyToProduce)
+             --          + production order (qtyToProduce)
              --          + open manufacturing orders (PP_Order docstatus CO/IP, not yet issued).
              -- Ordered  = qty incoming from purchase orders without goods receipt (qtyToMove).
              global_stock AS (
@@ -138,7 +138,7 @@ BEGIN
                         SUM(src.qty_reserved) AS total_reserved,
                         SUM(src.qty_ordered)  AS total_ordered
                  FROM (
-                          -- stock, SO reservations, PP_Order_Candidate demand, PO incoming
+                          -- stock, SO reservations, PP_Order demand, PO incoming
                           SELECT v.m_product_id,
                                  COALESCE(v.qtyStock, 0)                                   AS qty_stock,
                                  COALESCE(v.qtyReserved, 0) + COALESCE(v.qtyToProduce, 0) AS qty_reserved,

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5802410_sys_PP_Product_BOM_Recursive_Improvement.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5802410_sys_PP_Product_BOM_Recursive_Improvement.sql
@@ -1,0 +1,111 @@
+drop function if exists PP_Product_BOM_Recursive(numeric, varchar);
+create or replace function PP_Product_BOM_Recursive(p_PP_Product_BOM_ID numeric, p_ad_language varchar)
+returns table
+(
+	Line text,
+	Parent_Line text,
+	ProductValue varchar,
+	ProductName varchar,
+	QtyBOM numeric,
+	Percentage numeric,
+	UOMSymbol varchar,
+	--
+	depth integer,
+	M_Product_ID numeric,
+	IsQtyPercentage char(1),
+	C_UOM_ID numeric,
+    path integer[]
+)
+as
+$BODY$
+--
+	with recursive bomNode as (
+		(
+			select
+				array[1::integer] as path,
+				null::integer[] as parent_path,
+				1 as depth,
+				bomProduct.Value as ProductValue,
+				coalesce(pt.Name, bomProduct.Name) as ProductName,
+				bomProduct.M_Product_ID,
+				bomProduct.IsBOM,
+				bom.PP_Product_BOM_ID,
+				'N'::char(1) as IsQtyPercentage,
+				round(1::numeric, uom.StdPrecision) as QtyBOM,
+				null::numeric as Percentage,
+				COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
+				uom.C_UOM_ID,
+				-- tracks M_Product_IDs whose BOMs have been entered, to detect cycles
+				ARRAY[bomProduct.M_Product_ID::integer] as visited_product_ids
+			from PP_Product_BOM bom
+			inner join M_Product bomProduct on bomProduct.M_Product_ID=bom.M_Product_ID
+			LEFT OUTER JOIN M_Product_Trl pt    ON bomProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
+       AND pt.isActive = 'Y'
+			left outer join C_UOM uom on uom.C_UOM_ID=coalesce(bom.C_UOM_ID, bomProduct.C_UOM_ID)
+			LEFT OUTER JOIN C_UOM_Trl uomt ON uom.C_UOM_ID = uomt.C_UOM_ID AND uomt.IsActive='Y' and uomt.AD_Language = p_ad_language
+			where
+			bom.PP_Product_BOM_ID=PP_Product_BOM_Recursive.p_PP_Product_BOM_ID
+		)
+		--
+		union all
+		--
+		(
+			select
+				parent.path || (row_number() over (partition by bomLine.PP_Product_BOM_ID order by bomLine.PP_Product_BOMLine_ID))::integer as path,
+				parent.path as parent_path,
+				parent.depth + 1 as depth,
+				bomLineProduct.Value as ProductValue,
+				coalesce(pt.Name, bomLineProduct.Name) as ProductName,
+				bomLineProduct.M_Product_ID,
+				bomLineProduct.IsBOM,
+				-- guard against cycles: only look up the sub-BOM if this product
+				-- has not already been expanded as a BOM root in the current path
+				(case when bomLineProduct.IsBOM='Y'
+				      AND NOT (bomLineProduct.M_Product_ID::integer = ANY(parent.visited_product_ids))
+					then (select bom.PP_Product_BOM_ID from PP_Product_BOM bom
+						where bom.M_Product_ID=bomLineProduct.M_Product_ID
+						and bom.IsActive='Y'
+                        AND (bom.validto >= NOW() OR bom.validto IS NULL)
+                        ORDER BY bom.validfrom DESC, bom.PP_Product_BOM_ID DESC
+						limit 1)
+					else null
+					end)::numeric(10,0) as PP_Product_BOM_ID,
+				bomLine.IsQtyPercentage,
+				(case when bomLine.IsQtyPercentage='N' then round(bomLine.QtyBOM, uom.StdPrecision) else null end) as QtyBOM,
+				(case when bomLine.IsQtyPercentage='Y' then round(bomLine.QtyBatch, 2) else null end) as Percentage,
+				COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
+				uom.C_UOM_ID,
+				parent.visited_product_ids || bomLineProduct.M_Product_ID::integer as visited_product_ids
+			from bomNode parent
+			inner join PP_Product_BOMLine bomLine on bomLine.PP_Product_BOM_ID=parent.PP_Product_BOM_ID
+			inner join M_Product bomLineProduct on bomLineProduct.M_Product_ID = bomLine.M_Product_ID
+			LEFT OUTER JOIN M_Product_Trl pt    ON bomLineProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
+       AND pt.isActive = 'Y'
+			left outer join C_UOM uom on uom.C_UOM_ID=bomLine.C_UOM_ID
+			LEFT OUTER JOIN C_UOM_Trl uomt ON bomLine.C_UOM_ID = uomt.C_UOM_ID AND uomt.IsActive='Y' and uomt.AD_Language = p_ad_language
+			where bomLine.IsActive='Y'
+			order by bomLine.PP_Product_BOMLine_ID
+		)
+	)
+	--
+	select
+		array_to_string(n.path, '.')||'.' as Line,
+		array_to_string(n.parent_path, '.')||'.' as Parent_Line,
+		n.ProductValue,
+		n.ProductName,
+		n.QtyBOM,
+		n.Percentage,
+		n.UOMSymbol,
+		--
+		n.depth,
+		n.M_Product_ID,
+		n.IsQtyPercentage,
+		n.C_UOM_ID,
+        n.path
+	from bomNode n
+	order by path
+	;
+$BODY$
+LANGUAGE sql STABLE
+COST 100;
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5802410_sys_PP_Product_BOM_Recursive_Improvement.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5802410_sys_PP_Product_BOM_Recursive_Improvement.sql
@@ -1,111 +1,105 @@
 drop function if exists PP_Product_BOM_Recursive(numeric, varchar);
 create or replace function PP_Product_BOM_Recursive(p_PP_Product_BOM_ID numeric, p_ad_language varchar)
-returns table
-(
-	Line text,
-	Parent_Line text,
-	ProductValue varchar,
-	ProductName varchar,
-	QtyBOM numeric,
-	Percentage numeric,
-	UOMSymbol varchar,
-	--
-	depth integer,
-	M_Product_ID numeric,
-	IsQtyPercentage char(1),
-	C_UOM_ID numeric,
-    path integer[]
-)
+    returns table
+            (
+                Line text,
+                Parent_Line text,
+                ProductValue varchar,
+                ProductName varchar,
+                QtyBOM numeric,
+                Percentage numeric,
+                UOMSymbol varchar,
+                --
+                depth integer,
+                M_Product_ID numeric,
+                IsQtyPercentage char(1),
+                C_UOM_ID numeric,
+                path integer[]
+            )
 as
 $BODY$
+    --
+with recursive bomNode as (
+    (
+        select
+            array[1::integer] as path,
+            null::integer[] as parent_path,
+            1 as depth,
+            bomProduct.Value as ProductValue,
+            coalesce(pt.Name, bomProduct.Name) as ProductName,
+            bomProduct.M_Product_ID,
+            bomProduct.IsBOM,
+            bom.PP_Product_BOM_ID,
+            'N'::char(1) as IsQtyPercentage,
+            round(1::numeric, uom.StdPrecision) as QtyBOM,
+            null::numeric as Percentage,
+            COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
+            uom.C_UOM_ID
+        from PP_Product_BOM bom
+                 inner join M_Product bomProduct on bomProduct.M_Product_ID=bom.M_Product_ID
+                 LEFT OUTER JOIN M_Product_Trl pt    ON bomProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
+            AND pt.isActive = 'Y'
+                 left outer join C_UOM uom on uom.C_UOM_ID=coalesce(bom.C_UOM_ID, bomProduct.C_UOM_ID)
+                 LEFT OUTER JOIN C_UOM_Trl uomt ON uom.C_UOM_ID = uomt.C_UOM_ID AND uomt.IsActive='Y' and uomt.AD_Language = p_ad_language
+        where
+            bom.PP_Product_BOM_ID=PP_Product_BOM_Recursive.p_PP_Product_BOM_ID
+    )
+    --
+    union all
+    --
+    (
+        select
+            parent.path || (row_number() over (partition by bomLine.PP_Product_BOM_ID order by bomLine.PP_Product_BOMLine_ID))::integer as path,
+            parent.path as parent_path,
+            parent.depth + 1 as depth,
+            bomLineProduct.Value as ProductValue,
+            coalesce(pt.Name, bomLineProduct.Name) as ProductName,
+            bomLineProduct.M_Product_ID,
+            bomLineProduct.IsBOM,
+            (case when bomLineProduct.IsBOM='Y'
+                      then (select bom.PP_Product_BOM_ID from PP_Product_BOM bom
+                            where bom.M_Product_ID=bomLineProduct.M_Product_ID
+                              and bom.IsActive='Y'
+                              AND (bom.validto >= NOW() OR bom.validto IS NULL)
+                            ORDER BY bom.validfrom DESC, bom.PP_Product_BOM_ID DESC
+                            limit 1)
+                      else null
+             end)::numeric(10,0) as PP_Product_BOM_ID,
+            bomLine.IsQtyPercentage,
+            (case when bomLine.IsQtyPercentage='N' then round(bomLine.QtyBOM, uom.StdPrecision) else null end) as QtyBOM,
+            (case when bomLine.IsQtyPercentage='Y' then round(bomLine.QtyBatch, 2) else null end) as Percentage,
+            COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
+            uom.C_UOM_ID
+        from bomNode parent
+                 inner join PP_Product_BOMLine bomLine on bomLine.PP_Product_BOM_ID=parent.PP_Product_BOM_ID
+                 inner join M_Product bomLineProduct on bomLineProduct.M_Product_ID = bomLine.M_Product_ID
+                 LEFT OUTER JOIN M_Product_Trl pt    ON bomLineProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
+            AND pt.isActive = 'Y'
+                 left outer join C_UOM uom on uom.C_UOM_ID=bomLine.C_UOM_ID
+                 LEFT OUTER JOIN C_UOM_Trl uomt ON bomLine.C_UOM_ID = uomt.C_UOM_ID AND uomt.IsActive='Y' and uomt.AD_Language = p_ad_language
+        where bomLine.IsActive='Y'
+        order by bomLine.PP_Product_BOMLine_ID
+    )
+)
 --
-	with recursive bomNode as (
-		(
-			select
-				array[1::integer] as path,
-				null::integer[] as parent_path,
-				1 as depth,
-				bomProduct.Value as ProductValue,
-				coalesce(pt.Name, bomProduct.Name) as ProductName,
-				bomProduct.M_Product_ID,
-				bomProduct.IsBOM,
-				bom.PP_Product_BOM_ID,
-				'N'::char(1) as IsQtyPercentage,
-				round(1::numeric, uom.StdPrecision) as QtyBOM,
-				null::numeric as Percentage,
-				COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
-				uom.C_UOM_ID,
-				-- tracks M_Product_IDs whose BOMs have been entered, to detect cycles
-				ARRAY[bomProduct.M_Product_ID::integer] as visited_product_ids
-			from PP_Product_BOM bom
-			inner join M_Product bomProduct on bomProduct.M_Product_ID=bom.M_Product_ID
-			LEFT OUTER JOIN M_Product_Trl pt    ON bomProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
-       AND pt.isActive = 'Y'
-			left outer join C_UOM uom on uom.C_UOM_ID=coalesce(bom.C_UOM_ID, bomProduct.C_UOM_ID)
-			LEFT OUTER JOIN C_UOM_Trl uomt ON uom.C_UOM_ID = uomt.C_UOM_ID AND uomt.IsActive='Y' and uomt.AD_Language = p_ad_language
-			where
-			bom.PP_Product_BOM_ID=PP_Product_BOM_Recursive.p_PP_Product_BOM_ID
-		)
-		--
-		union all
-		--
-		(
-			select
-				parent.path || (row_number() over (partition by bomLine.PP_Product_BOM_ID order by bomLine.PP_Product_BOMLine_ID))::integer as path,
-				parent.path as parent_path,
-				parent.depth + 1 as depth,
-				bomLineProduct.Value as ProductValue,
-				coalesce(pt.Name, bomLineProduct.Name) as ProductName,
-				bomLineProduct.M_Product_ID,
-				bomLineProduct.IsBOM,
-				-- guard against cycles: only look up the sub-BOM if this product
-				-- has not already been expanded as a BOM root in the current path
-				(case when bomLineProduct.IsBOM='Y'
-				      AND NOT (bomLineProduct.M_Product_ID::integer = ANY(parent.visited_product_ids))
-					then (select bom.PP_Product_BOM_ID from PP_Product_BOM bom
-						where bom.M_Product_ID=bomLineProduct.M_Product_ID
-						and bom.IsActive='Y'
-                        AND (bom.validto >= NOW() OR bom.validto IS NULL)
-                        ORDER BY bom.validfrom DESC, bom.PP_Product_BOM_ID DESC
-						limit 1)
-					else null
-					end)::numeric(10,0) as PP_Product_BOM_ID,
-				bomLine.IsQtyPercentage,
-				(case when bomLine.IsQtyPercentage='N' then round(bomLine.QtyBOM, uom.StdPrecision) else null end) as QtyBOM,
-				(case when bomLine.IsQtyPercentage='Y' then round(bomLine.QtyBatch, 2) else null end) as Percentage,
-				COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
-				uom.C_UOM_ID,
-				parent.visited_product_ids || bomLineProduct.M_Product_ID::integer as visited_product_ids
-			from bomNode parent
-			inner join PP_Product_BOMLine bomLine on bomLine.PP_Product_BOM_ID=parent.PP_Product_BOM_ID
-			inner join M_Product bomLineProduct on bomLineProduct.M_Product_ID = bomLine.M_Product_ID
-			LEFT OUTER JOIN M_Product_Trl pt    ON bomLineProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
-       AND pt.isActive = 'Y'
-			left outer join C_UOM uom on uom.C_UOM_ID=bomLine.C_UOM_ID
-			LEFT OUTER JOIN C_UOM_Trl uomt ON bomLine.C_UOM_ID = uomt.C_UOM_ID AND uomt.IsActive='Y' and uomt.AD_Language = p_ad_language
-			where bomLine.IsActive='Y'
-			order by bomLine.PP_Product_BOMLine_ID
-		)
-	)
-	--
-	select
-		array_to_string(n.path, '.')||'.' as Line,
-		array_to_string(n.parent_path, '.')||'.' as Parent_Line,
-		n.ProductValue,
-		n.ProductName,
-		n.QtyBOM,
-		n.Percentage,
-		n.UOMSymbol,
-		--
-		n.depth,
-		n.M_Product_ID,
-		n.IsQtyPercentage,
-		n.C_UOM_ID,
-        n.path
-	from bomNode n
-	order by path
-	;
+select
+    array_to_string(n.path, '.')||'.' as Line,
+    array_to_string(n.parent_path, '.')||'.' as Parent_Line,
+    n.ProductValue,
+    n.ProductName,
+    n.QtyBOM,
+    n.Percentage,
+    n.UOMSymbol,
+    --
+    n.depth,
+    n.M_Product_ID,
+    n.IsQtyPercentage,
+    n.C_UOM_ID,
+    n.path
+from bomNode n
+order by path
+    ;
 $BODY$
-LANGUAGE sql STABLE
-COST 100;
+    LANGUAGE sql STABLE
+                 COST 100;
 

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5802420_sys_Elements_For_Report.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5802420_sys_Elements_For_Report.sql
@@ -1,0 +1,18 @@
+-- Run mode: SWING_CLIENT
+
+-- 2026-05-13T17:34:35.220Z
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,584867,0,'total_reserved_qty',TO_TIMESTAMP('2026-05-13 17:34:33.507000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','Reservierte Menge','Reservierte Menge',TO_TIMESTAMP('2026-05-13 17:34:33.507000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-05-13T17:34:35.520Z
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=584867 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- 2026-05-13T17:35:24.304Z
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,584868,0,'total_ordered_qty',TO_TIMESTAMP('2026-05-13 17:35:23.810000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','Bestellte Menge','Bestellte Menge',TO_TIMESTAMP('2026-05-13 17:35:23.810000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-05-13T17:35:24.419Z
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=584868 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/ddl/functions/PP_Product_BOM_Recursive.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/ddl/functions/PP_Product_BOM_Recursive.sql
@@ -34,7 +34,9 @@ $BODY$
 				round(1::numeric, uom.StdPrecision) as QtyBOM,
 				null::numeric as Percentage,
 				COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
-				uom.C_UOM_ID
+				uom.C_UOM_ID,
+				-- tracks M_Product_IDs whose BOMs have been entered, to detect cycles
+				ARRAY[bomProduct.M_Product_ID::integer] as visited_product_ids
 			from PP_Product_BOM bom
 			inner join M_Product bomProduct on bomProduct.M_Product_ID=bom.M_Product_ID
 			LEFT OUTER JOIN M_Product_Trl pt    ON bomProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
@@ -56,11 +58,13 @@ $BODY$
 				coalesce(pt.Name, bomLineProduct.Name) as ProductName,
 				bomLineProduct.M_Product_ID,
 				bomLineProduct.IsBOM,
+				-- guard against cycles: only look up the sub-BOM if this product
+				-- has not already been expanded as a BOM root in the current path
 				(case when bomLineProduct.IsBOM='Y'
+				      AND NOT (bomLineProduct.M_Product_ID::integer = ANY(parent.visited_product_ids))
 					then (select bom.PP_Product_BOM_ID from PP_Product_BOM bom
 						where bom.M_Product_ID=bomLineProduct.M_Product_ID
 						and bom.IsActive='Y'
-						and bom.Value=bomLineProduct.Value
                         AND (bom.validto >= NOW() OR bom.validto IS NULL)
                         ORDER BY bom.validfrom DESC, bom.PP_Product_BOM_ID DESC
 						limit 1)
@@ -70,7 +74,8 @@ $BODY$
 				(case when bomLine.IsQtyPercentage='N' then round(bomLine.QtyBOM, uom.StdPrecision) else null end) as QtyBOM,
 				(case when bomLine.IsQtyPercentage='Y' then round(bomLine.QtyBatch, 2) else null end) as Percentage,
 				COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
-				uom.C_UOM_ID
+				uom.C_UOM_ID,
+				parent.visited_product_ids || bomLineProduct.M_Product_ID::integer as visited_product_ids
 			from bomNode parent
 			inner join PP_Product_BOMLine bomLine on bomLine.PP_Product_BOM_ID=parent.PP_Product_BOM_ID
 			inner join M_Product bomLineProduct on bomLineProduct.M_Product_ID = bomLine.M_Product_ID

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/ddl/functions/PP_Product_BOM_Recursive.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/ddl/functions/PP_Product_BOM_Recursive.sql
@@ -1,105 +1,105 @@
 drop function if exists PP_Product_BOM_Recursive(numeric, varchar);
 create or replace function PP_Product_BOM_Recursive(p_PP_Product_BOM_ID numeric, p_ad_language varchar)
-    returns table
-            (
-                Line text,
-                Parent_Line text,
-                ProductValue varchar,
-                ProductName varchar,
-                QtyBOM numeric,
-                Percentage numeric,
-                UOMSymbol varchar,
-                --
-                depth integer,
-                M_Product_ID numeric,
-                IsQtyPercentage char(1),
-                C_UOM_ID numeric,
-                path integer[]
-            )
+returns table
+(
+	Line text,
+	Parent_Line text,
+	ProductValue varchar,
+	ProductName varchar,
+	QtyBOM numeric,
+	Percentage numeric,
+	UOMSymbol varchar,
+	--
+	depth integer,
+	M_Product_ID numeric,
+	IsQtyPercentage char(1),
+	C_UOM_ID numeric,
+    path integer[]
+)
 as
 $BODY$
-    --
-with recursive bomNode as (
-    (
-        select
-            array[1::integer] as path,
-            null::integer[] as parent_path,
-            1 as depth,
-            bomProduct.Value as ProductValue,
-            coalesce(pt.Name, bomProduct.Name) as ProductName,
-            bomProduct.M_Product_ID,
-            bomProduct.IsBOM,
-            bom.PP_Product_BOM_ID,
-            'N'::char(1) as IsQtyPercentage,
-            round(1::numeric, uom.StdPrecision) as QtyBOM,
-            null::numeric as Percentage,
-            COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
-            uom.C_UOM_ID
-        from PP_Product_BOM bom
-                 inner join M_Product bomProduct on bomProduct.M_Product_ID=bom.M_Product_ID
-                 LEFT OUTER JOIN M_Product_Trl pt    ON bomProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
-            AND pt.isActive = 'Y'
-                 left outer join C_UOM uom on uom.C_UOM_ID=coalesce(bom.C_UOM_ID, bomProduct.C_UOM_ID)
-                 LEFT OUTER JOIN C_UOM_Trl uomt ON uom.C_UOM_ID = uomt.C_UOM_ID AND uomt.IsActive='Y' and uomt.AD_Language = p_ad_language
-        where
-            bom.PP_Product_BOM_ID=PP_Product_BOM_Recursive.p_PP_Product_BOM_ID
-    )
-    --
-    union all
-    --
-    (
-        select
-            parent.path || (row_number() over (partition by bomLine.PP_Product_BOM_ID order by bomLine.PP_Product_BOMLine_ID))::integer as path,
-            parent.path as parent_path,
-            parent.depth + 1 as depth,
-            bomLineProduct.Value as ProductValue,
-            coalesce(pt.Name, bomLineProduct.Name) as ProductName,
-            bomLineProduct.M_Product_ID,
-            bomLineProduct.IsBOM,
-            (case when bomLineProduct.IsBOM='Y'
-                      then (select bom.PP_Product_BOM_ID from PP_Product_BOM bom
-                            where bom.M_Product_ID=bomLineProduct.M_Product_ID
-                              and bom.IsActive='Y'
-                              AND (bom.validto >= NOW() OR bom.validto IS NULL)
-                            ORDER BY bom.validfrom DESC, bom.PP_Product_BOM_ID DESC
-                            limit 1)
-                      else null
-             end)::numeric(10,0) as PP_Product_BOM_ID,
-            bomLine.IsQtyPercentage,
-            (case when bomLine.IsQtyPercentage='N' then round(bomLine.QtyBOM, uom.StdPrecision) else null end) as QtyBOM,
-            (case when bomLine.IsQtyPercentage='Y' then round(bomLine.QtyBatch, 2) else null end) as Percentage,
-            COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
-            uom.C_UOM_ID
-        from bomNode parent
-                 inner join PP_Product_BOMLine bomLine on bomLine.PP_Product_BOM_ID=parent.PP_Product_BOM_ID
-                 inner join M_Product bomLineProduct on bomLineProduct.M_Product_ID = bomLine.M_Product_ID
-                 LEFT OUTER JOIN M_Product_Trl pt    ON bomLineProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
-            AND pt.isActive = 'Y'
-                 left outer join C_UOM uom on uom.C_UOM_ID=bomLine.C_UOM_ID
-                 LEFT OUTER JOIN C_UOM_Trl uomt ON bomLine.C_UOM_ID = uomt.C_UOM_ID AND uomt.IsActive='Y' and uomt.AD_Language = p_ad_language
-        where bomLine.IsActive='Y'
-        order by bomLine.PP_Product_BOMLine_ID
-    )
-)
 --
-select
-    array_to_string(n.path, '.')||'.' as Line,
-    array_to_string(n.parent_path, '.')||'.' as Parent_Line,
-    n.ProductValue,
-    n.ProductName,
-    n.QtyBOM,
-    n.Percentage,
-    n.UOMSymbol,
-    --
-    n.depth,
-    n.M_Product_ID,
-    n.IsQtyPercentage,
-    n.C_UOM_ID,
-    n.path
-from bomNode n
-order by path
-    ;
+	with recursive bomNode as (
+		(
+			select
+				array[1::integer] as path,
+				null::integer[] as parent_path,
+				1 as depth,
+				bomProduct.Value as ProductValue,
+				coalesce(pt.Name, bomProduct.Name) as ProductName,
+				bomProduct.M_Product_ID,
+				bomProduct.IsBOM,
+				bom.PP_Product_BOM_ID,
+				'N'::char(1) as IsQtyPercentage,
+				round(1::numeric, uom.StdPrecision) as QtyBOM,
+				null::numeric as Percentage,
+				COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
+				uom.C_UOM_ID
+			from PP_Product_BOM bom
+			inner join M_Product bomProduct on bomProduct.M_Product_ID=bom.M_Product_ID
+			LEFT OUTER JOIN M_Product_Trl pt    ON bomProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
+       AND pt.isActive = 'Y'
+			left outer join C_UOM uom on uom.C_UOM_ID=coalesce(bom.C_UOM_ID, bomProduct.C_UOM_ID)
+			LEFT OUTER JOIN C_UOM_Trl uomt ON uom.C_UOM_ID = uomt.C_UOM_ID AND uomt.IsActive='Y' and uomt.AD_Language = p_ad_language
+			where
+			bom.PP_Product_BOM_ID=PP_Product_BOM_Recursive.p_PP_Product_BOM_ID
+		)
+		--
+		union all
+		--
+		(
+			select
+				parent.path || (row_number() over (partition by bomLine.PP_Product_BOM_ID order by bomLine.PP_Product_BOMLine_ID))::integer as path,
+				parent.path as parent_path,
+				parent.depth + 1 as depth,
+				bomLineProduct.Value as ProductValue,
+				coalesce(pt.Name, bomLineProduct.Name) as ProductName,
+				bomLineProduct.M_Product_ID,
+				bomLineProduct.IsBOM,
+				(case when bomLineProduct.IsBOM='Y'
+					then (select bom.PP_Product_BOM_ID from PP_Product_BOM bom
+						where bom.M_Product_ID=bomLineProduct.M_Product_ID
+						and bom.IsActive='Y'
+                        AND (bom.validto >= NOW() OR bom.validto IS NULL)
+                        ORDER BY bom.validfrom DESC, bom.PP_Product_BOM_ID DESC
+						limit 1)
+					else null
+					end)::numeric(10,0) as PP_Product_BOM_ID,
+				bomLine.IsQtyPercentage,
+				(case when bomLine.IsQtyPercentage='N' then round(bomLine.QtyBOM, uom.StdPrecision) else null end) as QtyBOM,
+				(case when bomLine.IsQtyPercentage='Y' then round(bomLine.QtyBatch, 2) else null end) as Percentage,
+				COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
+				uom.C_UOM_ID
+			from bomNode parent
+			inner join PP_Product_BOMLine bomLine on bomLine.PP_Product_BOM_ID=parent.PP_Product_BOM_ID
+			inner join M_Product bomLineProduct on bomLineProduct.M_Product_ID = bomLine.M_Product_ID
+			LEFT OUTER JOIN M_Product_Trl pt    ON bomLineProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
+       AND pt.isActive = 'Y'
+			left outer join C_UOM uom on uom.C_UOM_ID=bomLine.C_UOM_ID
+			LEFT OUTER JOIN C_UOM_Trl uomt ON bomLine.C_UOM_ID = uomt.C_UOM_ID AND uomt.IsActive='Y' and uomt.AD_Language = p_ad_language
+			where bomLine.IsActive='Y'
+			order by bomLine.PP_Product_BOMLine_ID
+		)
+	)
+	--
+	select
+		array_to_string(n.path, '.')||'.' as Line,
+		array_to_string(n.parent_path, '.')||'.' as Parent_Line,
+		n.ProductValue,
+		n.ProductName,
+		n.QtyBOM,
+		n.Percentage,
+		n.UOMSymbol,
+		--
+		n.depth,
+		n.M_Product_ID,
+		n.IsQtyPercentage,
+		n.C_UOM_ID,
+        n.path
+	from bomNode n
+	order by path
+	;
 $BODY$
-    LANGUAGE sql STABLE
-                 COST 100;
+LANGUAGE sql STABLE
+COST 100;
 

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/ddl/functions/PP_Product_BOM_Recursive.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/ddl/functions/PP_Product_BOM_Recursive.sql
@@ -1,111 +1,105 @@
 drop function if exists PP_Product_BOM_Recursive(numeric, varchar);
 create or replace function PP_Product_BOM_Recursive(p_PP_Product_BOM_ID numeric, p_ad_language varchar)
-returns table
-(
-	Line text,
-	Parent_Line text,
-	ProductValue varchar,
-	ProductName varchar,
-	QtyBOM numeric,
-	Percentage numeric,
-	UOMSymbol varchar,
-	--
-	depth integer,
-	M_Product_ID numeric,
-	IsQtyPercentage char(1),
-	C_UOM_ID numeric,
-    path integer[]
-)
+    returns table
+            (
+                Line text,
+                Parent_Line text,
+                ProductValue varchar,
+                ProductName varchar,
+                QtyBOM numeric,
+                Percentage numeric,
+                UOMSymbol varchar,
+                --
+                depth integer,
+                M_Product_ID numeric,
+                IsQtyPercentage char(1),
+                C_UOM_ID numeric,
+                path integer[]
+            )
 as
 $BODY$
+    --
+with recursive bomNode as (
+    (
+        select
+            array[1::integer] as path,
+            null::integer[] as parent_path,
+            1 as depth,
+            bomProduct.Value as ProductValue,
+            coalesce(pt.Name, bomProduct.Name) as ProductName,
+            bomProduct.M_Product_ID,
+            bomProduct.IsBOM,
+            bom.PP_Product_BOM_ID,
+            'N'::char(1) as IsQtyPercentage,
+            round(1::numeric, uom.StdPrecision) as QtyBOM,
+            null::numeric as Percentage,
+            COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
+            uom.C_UOM_ID
+        from PP_Product_BOM bom
+                 inner join M_Product bomProduct on bomProduct.M_Product_ID=bom.M_Product_ID
+                 LEFT OUTER JOIN M_Product_Trl pt    ON bomProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
+            AND pt.isActive = 'Y'
+                 left outer join C_UOM uom on uom.C_UOM_ID=coalesce(bom.C_UOM_ID, bomProduct.C_UOM_ID)
+                 LEFT OUTER JOIN C_UOM_Trl uomt ON uom.C_UOM_ID = uomt.C_UOM_ID AND uomt.IsActive='Y' and uomt.AD_Language = p_ad_language
+        where
+            bom.PP_Product_BOM_ID=PP_Product_BOM_Recursive.p_PP_Product_BOM_ID
+    )
+    --
+    union all
+    --
+    (
+        select
+            parent.path || (row_number() over (partition by bomLine.PP_Product_BOM_ID order by bomLine.PP_Product_BOMLine_ID))::integer as path,
+            parent.path as parent_path,
+            parent.depth + 1 as depth,
+            bomLineProduct.Value as ProductValue,
+            coalesce(pt.Name, bomLineProduct.Name) as ProductName,
+            bomLineProduct.M_Product_ID,
+            bomLineProduct.IsBOM,
+            (case when bomLineProduct.IsBOM='Y'
+                      then (select bom.PP_Product_BOM_ID from PP_Product_BOM bom
+                            where bom.M_Product_ID=bomLineProduct.M_Product_ID
+                              and bom.IsActive='Y'
+                              AND (bom.validto >= NOW() OR bom.validto IS NULL)
+                            ORDER BY bom.validfrom DESC, bom.PP_Product_BOM_ID DESC
+                            limit 1)
+                      else null
+             end)::numeric(10,0) as PP_Product_BOM_ID,
+            bomLine.IsQtyPercentage,
+            (case when bomLine.IsQtyPercentage='N' then round(bomLine.QtyBOM, uom.StdPrecision) else null end) as QtyBOM,
+            (case when bomLine.IsQtyPercentage='Y' then round(bomLine.QtyBatch, 2) else null end) as Percentage,
+            COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
+            uom.C_UOM_ID
+        from bomNode parent
+                 inner join PP_Product_BOMLine bomLine on bomLine.PP_Product_BOM_ID=parent.PP_Product_BOM_ID
+                 inner join M_Product bomLineProduct on bomLineProduct.M_Product_ID = bomLine.M_Product_ID
+                 LEFT OUTER JOIN M_Product_Trl pt    ON bomLineProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
+            AND pt.isActive = 'Y'
+                 left outer join C_UOM uom on uom.C_UOM_ID=bomLine.C_UOM_ID
+                 LEFT OUTER JOIN C_UOM_Trl uomt ON bomLine.C_UOM_ID = uomt.C_UOM_ID AND uomt.IsActive='Y' and uomt.AD_Language = p_ad_language
+        where bomLine.IsActive='Y'
+        order by bomLine.PP_Product_BOMLine_ID
+    )
+)
 --
-	with recursive bomNode as (
-		(
-			select
-				array[1::integer] as path,
-				null::integer[] as parent_path,
-				1 as depth,
-				bomProduct.Value as ProductValue,
-				coalesce(pt.Name, bomProduct.Name) as ProductName,
-				bomProduct.M_Product_ID,
-				bomProduct.IsBOM,
-				bom.PP_Product_BOM_ID,
-				'N'::char(1) as IsQtyPercentage,
-				round(1::numeric, uom.StdPrecision) as QtyBOM,
-				null::numeric as Percentage,
-				COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
-				uom.C_UOM_ID,
-				-- tracks M_Product_IDs whose BOMs have been entered, to detect cycles
-				ARRAY[bomProduct.M_Product_ID::integer] as visited_product_ids
-			from PP_Product_BOM bom
-			inner join M_Product bomProduct on bomProduct.M_Product_ID=bom.M_Product_ID
-			LEFT OUTER JOIN M_Product_Trl pt    ON bomProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
-       AND pt.isActive = 'Y'
-			left outer join C_UOM uom on uom.C_UOM_ID=coalesce(bom.C_UOM_ID, bomProduct.C_UOM_ID)
-			LEFT OUTER JOIN C_UOM_Trl uomt ON uom.C_UOM_ID = uomt.C_UOM_ID AND uomt.IsActive='Y' and uomt.AD_Language = p_ad_language
-			where
-			bom.PP_Product_BOM_ID=PP_Product_BOM_Recursive.p_PP_Product_BOM_ID
-		)
-		--
-		union all
-		--
-		(
-			select
-				parent.path || (row_number() over (partition by bomLine.PP_Product_BOM_ID order by bomLine.PP_Product_BOMLine_ID))::integer as path,
-				parent.path as parent_path,
-				parent.depth + 1 as depth,
-				bomLineProduct.Value as ProductValue,
-				coalesce(pt.Name, bomLineProduct.Name) as ProductName,
-				bomLineProduct.M_Product_ID,
-				bomLineProduct.IsBOM,
-				-- guard against cycles: only look up the sub-BOM if this product
-				-- has not already been expanded as a BOM root in the current path
-				(case when bomLineProduct.IsBOM='Y'
-				      AND NOT (bomLineProduct.M_Product_ID::integer = ANY(parent.visited_product_ids))
-					then (select bom.PP_Product_BOM_ID from PP_Product_BOM bom
-						where bom.M_Product_ID=bomLineProduct.M_Product_ID
-						and bom.IsActive='Y'
-                        AND (bom.validto >= NOW() OR bom.validto IS NULL)
-                        ORDER BY bom.validfrom DESC, bom.PP_Product_BOM_ID DESC
-						limit 1)
-					else null
-					end)::numeric(10,0) as PP_Product_BOM_ID,
-				bomLine.IsQtyPercentage,
-				(case when bomLine.IsQtyPercentage='N' then round(bomLine.QtyBOM, uom.StdPrecision) else null end) as QtyBOM,
-				(case when bomLine.IsQtyPercentage='Y' then round(bomLine.QtyBatch, 2) else null end) as Percentage,
-				COALESCE(uom.UOMSymbol, uomt.UOMSymbol) as UOMSymbol,
-				uom.C_UOM_ID,
-				parent.visited_product_ids || bomLineProduct.M_Product_ID::integer as visited_product_ids
-			from bomNode parent
-			inner join PP_Product_BOMLine bomLine on bomLine.PP_Product_BOM_ID=parent.PP_Product_BOM_ID
-			inner join M_Product bomLineProduct on bomLineProduct.M_Product_ID = bomLine.M_Product_ID
-			LEFT OUTER JOIN M_Product_Trl pt    ON bomLineProduct.M_Product_ID = pt.M_Product_ID AND pt.AD_Language =p_ad_language
-       AND pt.isActive = 'Y'
-			left outer join C_UOM uom on uom.C_UOM_ID=bomLine.C_UOM_ID
-			LEFT OUTER JOIN C_UOM_Trl uomt ON bomLine.C_UOM_ID = uomt.C_UOM_ID AND uomt.IsActive='Y' and uomt.AD_Language = p_ad_language
-			where bomLine.IsActive='Y'
-			order by bomLine.PP_Product_BOMLine_ID
-		)
-	)
-	--
-	select
-		array_to_string(n.path, '.')||'.' as Line,
-		array_to_string(n.parent_path, '.')||'.' as Parent_Line,
-		n.ProductValue,
-		n.ProductName,
-		n.QtyBOM,
-		n.Percentage,
-		n.UOMSymbol,
-		--
-		n.depth,
-		n.M_Product_ID,
-		n.IsQtyPercentage,
-		n.C_UOM_ID,
-        n.path
-	from bomNode n
-	order by path
-	;
+select
+    array_to_string(n.path, '.')||'.' as Line,
+    array_to_string(n.parent_path, '.')||'.' as Parent_Line,
+    n.ProductValue,
+    n.ProductName,
+    n.QtyBOM,
+    n.Percentage,
+    n.UOMSymbol,
+    --
+    n.depth,
+    n.M_Product_ID,
+    n.IsQtyPercentage,
+    n.C_UOM_ID,
+    n.path
+from bomNode n
+order by path
+    ;
 $BODY$
-LANGUAGE sql STABLE
-COST 100;
+    LANGUAGE sql STABLE
+                 COST 100;
 


### PR DESCRIPTION
Requirements were: 


* Report "Bestandsprüfung Rohware" run form material cockpit v2 shall be extended with the following info:
    - Which raw materials are reserved through sales  orders, production orders => Reserved
    - Which raw materials are in transit due to purchase orders without goods receipt => Ordered
    - Shortage: (In stock - reserved + ordered) - Demand

   * In the sql function ``material_cockpit_bom_demand_report``, use this function: ``PP_Product_BOM_Recursive``
   * The test case that has to work is: 
      * finished product A has components C1, C2, C3
      * C1 is a bom itself, having the components D1, D2, D3
   * => When called for product A, the function should return the quantities for all C1, C2, C3, D1, D2, D3
