### PR TITLE
Quick input batch entry — advance DOM focus after Enter-key product selection

### DIFF
--- a/e2e/frontend-webui/tests/spec/quick-input.spec.js
+++ b/e2e/frontend-webui/tests/spec/quick-input.spec.js
@@ -224,3 +224,135 @@ test.describe('Quick Input Batch Entry — Tab focus cycle (https://github.com/m
     expect(result.isLast, 'Shift+Tab from first field must land on last focusable').toBe(true);
   });
 });
+
+// =========================================================================
+// NOTE: runs against http://localhost:3002 (dev server with the Enter-key fix)
+// https://github.com/metasfresh/me03/issues/29125
+// Quick Input (Batch Entry) panel: Enter-key product selection and focus advance
+//
+// Bug: Pressing Enter in the product lookup field did not select the first
+// typeahead match and advance focus to the Qty field. Instead the keystroke
+// was absorbed by the dropdown debounce and focus stayed on the product field.
+//
+// Expected: Enter fires an immediate (non-debounced) typeahead request,
+// selects the best match, and advances focus to the next field in the form.
+// =========================================================================
+
+test.describe('Quick Input Batch Entry — Enter-key product selection (https://github.com/metasfresh/me03/issues/29125)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsMetasfresh(page);
+    await openSalesOrder(page);
+    await openBatchEntry(page);
+  });
+
+  test('Enter on product field selects first match and advances focus to Qty', async ({
+    page,
+  }) => {
+    const productInput = page.locator('.quick-input-container input').first();
+    await productInput.focus();
+    await productInput.fill('T');
+
+    // Wait for typeahead dropdown to appear with at least one real option
+    let dropdownVisible = false;
+    try {
+      await page
+        .locator(
+          '.input-dropdown-list .input-dropdown-list-option:not([data-test-id^="SEARCH"])'
+        )
+        .first()
+        .waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
+      dropdownVisible = true;
+    } catch {
+      // No dropdown appeared — seed DB may have no products starting with 'T'
+    }
+
+    if (!dropdownVisible) {
+      test.skip(true, 'No products matching "T" in seed DB');
+      return;
+    }
+
+    await page.keyboard.press('Enter');
+
+    // Wait for the PATCH round-trip + React re-render + focus advance
+    await page.waitForTimeout(1500);
+
+    const focusResult = await page.evaluate(() => {
+      const form = document.querySelector('.quick-input-container');
+      const productInput = form ? form.querySelector('input') : null;
+      const active = document.activeElement;
+      return {
+        inForm: !!form && form.contains(active),
+        isProductInput: active === productInput,
+        productValue: productInput ? productInput.value : '',
+      };
+    });
+
+    expect(
+      focusResult.productValue,
+      'product field must have a non-empty value after Enter selection'
+    ).toBeTruthy();
+    expect(
+      focusResult.inForm,
+      'focus must remain inside quick-input-container after selection'
+    ).toBe(true);
+    expect(
+      focusResult.isProductInput,
+      'focus must have advanced away from the product input'
+    ).toBe(false);
+  });
+
+  test('Mouse-click selection still works (regression: shouldKeepFocus)', async ({
+    page,
+  }) => {
+    const productInput = page.locator('.quick-input-container input').first();
+    await productInput.focus();
+    await productInput.fill('T');
+    // Give the debounced typeahead time to fire before polling the dropdown
+    await page.waitForTimeout(600);
+
+    let dropdownVisible = false;
+    try {
+      await page
+        .locator(
+          '.input-dropdown-list .input-dropdown-list-option:not([data-test-id^="SEARCH"])'
+        )
+        .first()
+        .waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
+      dropdownVisible = true;
+    } catch {
+      // No dropdown
+    }
+
+    if (!dropdownVisible) {
+      test.skip(true, 'No products matching "T" in seed DB');
+      return;
+    }
+
+    const firstOption = page
+      .locator(
+        '.input-dropdown-list .input-dropdown-list-option:not([data-test-id^="SEARCH"])'
+      )
+      .first();
+
+    // Read the text of the option we are about to click so we can verify it
+    // was actually selected — inputValue() is more reliable than checking focus.
+    const optionText = await firstOption.innerText();
+    await firstOption.click();
+
+    // Wait for the PATCH round-trip after selection
+    await page.waitForTimeout(1500);
+
+    // The product input DOM value is set directly by RawLookup (not via React state),
+    // so inputValue() reads the correct value.
+    const productValue = await productInput.inputValue();
+    expect(
+      productValue,
+      `product field must have a non-empty value after clicking "${optionText}"`
+    ).toBeTruthy();
+
+    await expect(
+      page.locator('.quick-input-container'),
+      'quick-input-container must remain visible after selection'
+    ).toBeVisible();
+  });
+});

--- a/frontend/src/components/widget/Lookup/Lookup.js
+++ b/frontend/src/components/widget/Lookup/Lookup.js
@@ -126,15 +126,17 @@ class Lookup extends Component {
 
   setNextProperty = (currentFieldName) => {
     const { widgetData, properties, onBlurWidget } = this.props;
+    let hasNextSubField = false;
 
     if (widgetData) {
-      widgetData.map((item, index) => {
+      widgetData.forEach((item, index) => {
         const nextIndex = index + 1;
 
         if (
           nextIndex < widgetData.length &&
           widgetData[index].field === currentFieldName
         ) {
+          hasNextSubField = true;
           const nextProp = properties[nextIndex];
           this.setState(
             { property: nextProp.field }, //
@@ -149,10 +151,37 @@ class Lookup extends Component {
             { property: '' }, //
             () => {
               onBlurWidget && onBlurWidget();
+              this.focusNextFormField();
             }
           );
         }
       });
+    }
+
+    return hasNextSubField;
+  };
+
+  focusNextFormField = () => {
+    const wrapperEl = this.wrapperElement;
+    if (!wrapperEl) return;
+
+    const form = wrapperEl.closest('form');
+    if (!form) return;
+
+    const allInputs = Array.from(
+      form.querySelectorAll(
+        'input:not([disabled]):not([readonly]):not([type="hidden"])'
+      )
+    );
+
+    const lookupInputs = wrapperEl.querySelectorAll('input');
+    if (lookupInputs.length === 0) return;
+
+    const lastLookupInput = lookupInputs[lookupInputs.length - 1];
+    const currentIndex = allInputs.indexOf(lastLookupInput);
+
+    if (currentIndex >= 0 && currentIndex + 1 < allInputs.length) {
+      allInputs[currentIndex + 1].focus();
     }
   };
 

--- a/frontend/src/components/widget/Lookup/Lookup.js
+++ b/frontend/src/components/widget/Lookup/Lookup.js
@@ -161,30 +161,36 @@ class Lookup extends Component {
     return hasNextSubField;
   };
 
-  focusNextFormField = () => {
+  focusNextFormField = (retriesLeft = 5) => {
     const wrapperEl = this.wrapperElement;
     if (!wrapperEl) return;
 
     const form = wrapperEl.closest('form');
     if (!form) return;
 
+    // Include disabled inputs — Qty may be temporarily disabled during callout.
     const allInputs = Array.from(
-      form.querySelectorAll(
-        'input:not([disabled]):not([readonly]):not([type="hidden"])'
-      )
+      form.querySelectorAll('input:not([readonly]):not([type="hidden"])')
     );
 
     const lookupInputs = wrapperEl.querySelectorAll(
-      'input:not([disabled]):not([readonly]):not([type="hidden"])'
+      'input:not([readonly]):not([type="hidden"])'
     );
     if (lookupInputs.length === 0) return;
 
     const lastLookupInput = lookupInputs[lookupInputs.length - 1];
     const currentIndex = allInputs.indexOf(lastLookupInput);
+    if (currentIndex < 0 || currentIndex + 1 >= allInputs.length) return;
 
-    if (currentIndex >= 0 && currentIndex + 1 < allInputs.length) {
-      allInputs[currentIndex + 1].focus();
+    const nextInput = allInputs[currentIndex + 1];
+    if (nextInput.disabled) {
+      // Next field not yet enabled (callout pending) — retry
+      if (retriesLeft > 0) {
+        setTimeout(() => this.focusNextFormField(retriesLeft - 1), 100);
+      }
+      return;
     }
+    nextInput.focus();
   };
 
   // isMouseEvent param is to tell us if we should enable listening to keys

--- a/frontend/src/components/widget/Lookup/Lookup.js
+++ b/frontend/src/components/widget/Lookup/Lookup.js
@@ -174,7 +174,9 @@ class Lookup extends Component {
       )
     );
 
-    const lookupInputs = wrapperEl.querySelectorAll('input');
+    const lookupInputs = wrapperEl.querySelectorAll(
+      'input:not([disabled]):not([readonly]):not([type="hidden"])'
+    );
     if (lookupInputs.length === 0) return;
 
     const lastLookupInput = lookupInputs[lookupInputs.length - 1];

--- a/frontend/src/components/widget/Lookup/RawLookup.js
+++ b/frontend/src/components/widget/Lookup/RawLookup.js
@@ -270,13 +270,18 @@ export class RawLookup extends Component {
       ? mainProperty.parameterName
       : mainProperty.field;
 
-    // shouldKeepFocus: only suppress this.focus() when onChange is synchronous AND
-    // setNextProperty reports no next sub-field (Lookup exits the last sub-field via
-    // focusNextFormField instead). For async onChange (regular documents), the Promise
-    // callback runs after this.focus() is already evaluated — shouldKeepFocus remains
-    // true, preserving the original "always refocus" behavior. For quick input, focus
-    // advance on Enter goes through resolveAndSelectOnEnter → handleAutoSelectAndAdvance
-    // → focusNextFieldInForm, bypassing this code path entirely.
+    // shouldKeepFocus: controls whether to call this.focus() after onChange completes.
+    // - Async onChange (regular documents): onChange returns a Promise; its .then()
+    //   callback is a microtask and cannot run before the current synchronous stack
+    //   unwinds. The `if (shouldKeepFocus)` check below runs synchronously, so
+    //   shouldKeepFocus is still true — preserving the original "always refocus" behavior.
+    // - Sync onChange (quick input): onChange returns undefined; executeAfterPromise
+    //   runs the callback inline. If setNextProperty reports no next sub-field,
+    //   shouldKeepFocus is set to false before `if (shouldKeepFocus)` is checked —
+    //   correct: Lookup.focusNextFormField handles focus advance instead.
+    // - Enter-key path in quick input: goes through resolveAndSelectOnEnter →
+    //   handleAutoSelectAndAdvance → focusNextFieldInForm, bypassing this code path
+    //   entirely.
     let shouldKeepFocus = true;
 
     executeAfterPromise(onChange(fieldName, selectedItemNorm), () => {
@@ -369,6 +374,7 @@ export class RawLookup extends Component {
   handleInputTextKeyDown = (e) => {
     const { isOpen, subentity } = this.props;
 
+    // ArrowDown on a closed dropdown: open it (same behaviour as clicking the field)
     if (e.key === 'ArrowDown') {
       if (!isOpen) {
         e.preventDefault();
@@ -442,11 +448,13 @@ export class RawLookup extends Component {
   };
 
   /**
-   * @method buildTypeaheadRequestForQuery
-   * @summary Build and fire a typeahead request for the given query string.
-   * Returns the axios promise. This is a non-debounced version of typeaheadRequest.
+   * @method _buildTypeaheadPromise
+   * @summary Core routing for typeahead requests: selects the correct API based on
+   * entity type, attribute flag, and filterWidget context. Returns the axios promise.
+   * Shared by buildTypeaheadRequestForQuery (Enter-key path) and typeaheadRequest
+   * (debounced path) so the routing logic is not duplicated.
    */
-  buildTypeaheadRequestForQuery = (query) => {
+  _buildTypeaheadPromise = (query) => {
     const {
       windowType,
       dataId,
@@ -463,7 +471,7 @@ export class RawLookup extends Component {
       typeaheadSupplier,
     } = this.props;
 
-    const typeaheadParams = {
+    const params = {
       entity,
       docType: windowType,
       docId: filterWidget ? viewId : dataId,
@@ -474,18 +482,14 @@ export class RawLookup extends Component {
     };
 
     if (typeaheadSupplier) {
-      return typeaheadSupplier({
-        ...typeaheadParams,
-        subentity,
-        subentityId,
-      });
+      return typeaheadSupplier({ ...params, subentity, subentityId });
     } else if (entity === 'documentView' && attribute) {
       return getViewAttributeTypeahead(
         windowType,
         viewId,
         dataId,
         mainProperty.field,
-        typeaheadParams.query
+        params.query
       );
     } else if (entity === 'documentView' && !attribute) {
       return getViewFieldTypeahead({
@@ -493,22 +497,25 @@ export class RawLookup extends Component {
         viewId,
         rowId,
         fieldName: mainProperty.field,
-        query: typeaheadParams.query,
+        query: params.query,
       });
     } else if (viewId && !filterWidget) {
       return autocompleteModalRequest({
-        ...typeaheadParams,
+        ...params,
         entity: 'documentView',
         viewId,
       });
     } else {
-      return autocompleteRequest({
-        ...typeaheadParams,
-        subentity,
-        subentityId,
-      });
+      return autocompleteRequest({ ...params, subentity, subentityId });
     }
   };
+
+  /**
+   * @method buildTypeaheadRequestForQuery
+   * @summary Build and fire a typeahead request for the given query string.
+   * Returns the axios promise. This is a non-debounced version of typeaheadRequest.
+   */
+  buildTypeaheadRequestForQuery = (query) => this._buildTypeaheadPromise(query);
 
   /**
    * @method handleAutoSelectAndAdvance
@@ -597,77 +604,11 @@ export class RawLookup extends Component {
   };
 
   typeaheadRequest = () => {
-    const {
-      windowType,
-      dataId,
-      filterWidget,
-      attribute,
-      parameterName,
-      tabId,
-      rowId,
-      entity,
-      subentity,
-      subentityId,
-      viewId,
-      mainProperty,
-      typeaheadSupplier,
-    } = this.props;
-
     const inputValue = this.inputSearch.value;
-    let typeaheadRequest;
-    const typeaheadParams = {
-      entity,
-      docType: windowType,
-      docId: filterWidget ? viewId : dataId,
-      propertyName: filterWidget ? parameterName : mainProperty.field,
-      query: inputValue,
-      rowId,
-      tabId,
-    };
+    this.typeaheadQuery = inputValue;
 
-    this.typeaheadQuery = typeaheadParams.query;
-
-    if (typeaheadSupplier) {
-      typeaheadRequest = typeaheadSupplier({
-        ...typeaheadParams,
-        subentity,
-        subentityId,
-      });
-    } else if (entity === 'documentView' && attribute) {
-      typeaheadRequest = getViewAttributeTypeahead(
-        windowType,
-        viewId,
-        dataId,
-        mainProperty.field,
-        typeaheadParams.query
-      );
-    } else if (entity === 'documentView' && !attribute) {
-      typeaheadRequest = getViewFieldTypeahead({
-        windowId: windowType,
-        viewId,
-        rowId,
-        fieldName: mainProperty.field,
-        query: typeaheadParams.query,
-      });
-    } else if (viewId && !filterWidget) {
-      typeaheadRequest = autocompleteModalRequest({
-        ...typeaheadParams,
-        entity: 'documentView',
-        viewId,
-      });
-    } else {
-      typeaheadRequest = autocompleteRequest({
-        ...typeaheadParams,
-        subentity,
-        subentityId,
-      });
-    }
-
-    typeaheadRequest.then((response) => {
-      if (
-        this.typeaheadQuery &&
-        this.typeaheadQuery === typeaheadParams.query
-      ) {
+    this._buildTypeaheadPromise(inputValue).then((response) => {
+      if (this.typeaheadQuery && this.typeaheadQuery === inputValue) {
         this.populateTypeaheadData(response.data);
       }
     });

--- a/frontend/src/components/widget/Lookup/RawLookup.js
+++ b/frontend/src/components/widget/Lookup/RawLookup.js
@@ -560,10 +560,11 @@ export class RawLookup extends Component {
       return;
     }
 
+    // Include disabled inputs — the next field (e.g. Qty) may be temporarily disabled
+    // during a callout/re-render after product selection. Excluding it would skip straight
+    // to the field after it. We detect that case and retry below.
     const inputs = Array.from(
-      form.querySelectorAll(
-        'input:not([disabled]):not([type="hidden"]):not([readonly])'
-      )
+      form.querySelectorAll('input:not([type="hidden"]):not([readonly])')
     );
     const idx = inputs.indexOf(this.inputSearch);
     if (idx < 0) {
@@ -575,6 +576,13 @@ export class RawLookup extends Component {
     }
     if (idx < inputs.length - 1) {
       const nextInput = inputs[idx + 1];
+      if (nextInput.disabled) {
+        // Next field not yet enabled (callout pending) — retry
+        if (retriesLeft > 0) {
+          setTimeout(() => this.focusNextFieldInForm(retriesLeft - 1), 100);
+        }
+        return;
+      }
       nextInput.focus();
 
       if (document.activeElement === nextInput) {

--- a/frontend/src/components/widget/Lookup/RawLookup.js
+++ b/frontend/src/components/widget/Lookup/RawLookup.js
@@ -270,13 +270,13 @@ export class RawLookup extends Component {
       ? mainProperty.parameterName
       : mainProperty.field;
 
-    // NOTE: When onChange returns a Promise (async path, typical for regular documents),
-    // the callback inside executeAfterPromise runs AFTER this.focus() below.
-    // In that case shouldKeepFocus is always true at the this.focus() call site,
-    // preserving the original behavior (always refocus). The "don't refocus" path
-    // only takes effect when onChange is synchronous (returns null/undefined).
-    // For quick input, focus advance is handled by a completely different code path
-    // (resolveAndSelectOnEnter → handleAutoSelectAndAdvance → focusNextFieldInForm).
+    // shouldKeepFocus: only suppress this.focus() when onChange is synchronous AND
+    // setNextProperty reports no next sub-field (Lookup exits the last sub-field via
+    // focusNextFormField instead). For async onChange (regular documents), the Promise
+    // callback runs after this.focus() is already evaluated — shouldKeepFocus remains
+    // true, preserving the original "always refocus" behavior. For quick input, focus
+    // advance on Enter goes through resolveAndSelectOnEnter → handleAutoSelectAndAdvance
+    // → focusNextFieldInForm, bypassing this code path entirely.
     let shouldKeepFocus = true;
 
     executeAfterPromise(onChange(fieldName, selectedItemNorm), () => {
@@ -571,8 +571,9 @@ export class RawLookup extends Component {
       console.warn(
         'RawLookup.focusNextFieldInForm: current input not found in form input list. This may indicate a DOM structure issue.'
       );
+      return; // no point retrying — the input won't appear in the list on next attempt
     }
-    if (idx >= 0 && idx < inputs.length - 1) {
+    if (idx < inputs.length - 1) {
       const nextInput = inputs[idx + 1];
       nextInput.focus();
 

--- a/frontend/src/components/widget/Lookup/RawLookup.js
+++ b/frontend/src/components/widget/Lookup/RawLookup.js
@@ -44,6 +44,39 @@ const executeAfterPromise = (promise, afterCallback) => {
 };
 
 /**
+ * Play a short beep sound using the Web Audio API.
+ * Used for error feedback in fast-entry scenarios where the user doesn't watch the screen.
+ */
+let beepAudioCtx = null;
+const playBeep = () => {
+  try {
+    if (!beepAudioCtx) {
+      beepAudioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    }
+
+    // Resume suspended context (Chrome autoplay policy)
+    if (beepAudioCtx.state === 'suspended') {
+      beepAudioCtx.resume().catch(() => {}); // best-effort
+    }
+
+    const gainNode = beepAudioCtx.createGain();
+    gainNode.connect(beepAudioCtx.destination);
+    gainNode.gain.value = 0.3;
+
+    const oscillator = beepAudioCtx.createOscillator();
+    oscillator.type = 'sine';
+    oscillator.frequency.setValueAtTime(800, beepAudioCtx.currentTime);
+    oscillator.connect(gainNode);
+
+    oscillator.start();
+    oscillator.stop(beepAudioCtx.currentTime + 0.08);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('Could not play beep sound:', e);
+  }
+};
+
+/**
  * Simple lookup field, part of a composed lookup field (see Lookup.js).
  */
 export class RawLookup extends Component {
@@ -237,10 +270,21 @@ export class RawLookup extends Component {
       ? mainProperty.parameterName
       : mainProperty.field;
 
-    executeAfterPromise(
-      onChange(fieldName, selectedItemNorm), //
-      () => setNextProperty(fieldName)
-    );
+    // NOTE: When onChange returns a Promise (async path, typical for regular documents),
+    // the callback inside executeAfterPromise runs AFTER this.focus() below.
+    // In that case shouldKeepFocus is always true at the this.focus() call site,
+    // preserving the original behavior (always refocus). The "don't refocus" path
+    // only takes effect when onChange is synchronous (returns null/undefined).
+    // For quick input, focus advance is handled by a completely different code path
+    // (resolveAndSelectOnEnter → handleAutoSelectAndAdvance → focusNextFieldInForm).
+    let shouldKeepFocus = true;
+
+    executeAfterPromise(onChange(fieldName, selectedItemNorm), () => {
+      const hasNextSubField = setNextProperty(fieldName);
+      if (!hasNextSubField) {
+        shouldKeepFocus = false;
+      }
+    });
 
     // see FiltersItem.updateItems
     updateItems &&
@@ -254,7 +298,9 @@ export class RawLookup extends Component {
 
     handleInputEmptyStatus && handleInputEmptyStatus(false);
 
-    setTimeout(() => this.focus(), 0);
+    if (shouldKeepFocus) {
+      this.focus();
+    }
 
     this.handleDropdownBlur(isMouseEvent);
   };
@@ -318,6 +364,227 @@ export class RawLookup extends Component {
 
     onDropdownListToggle &&
       onDropdownListToggle(isDropdownListOpen, item.field, isMouseEvent);
+  };
+
+  handleInputTextKeyDown = (e) => {
+    const { isOpen, subentity } = this.props;
+
+    if (e.key === 'ArrowDown') {
+      if (!isOpen) {
+        e.preventDefault();
+        e.stopPropagation();
+        this.handleInputTextChange();
+      }
+    }
+
+    // Quick input: handle Enter for immediate product resolution
+    if (e.key === 'Enter' && subentity === 'quickInput') {
+      e.preventDefault();
+      e.stopPropagation();
+
+      this.resolveAndSelectOnEnter();
+    }
+  };
+
+  /**
+   * @method resolveAndSelectOnEnter
+   * @summary Quick input: when Enter is pressed, immediately resolve the lookup value
+   * and auto-select the first match. If no match found, play a beep sound.
+   * After selection, advance focus to the next field in the quick input form.
+   */
+  resolveAndSelectOnEnter = () => {
+    const { list, loading } = this.state;
+
+    // If typeahead results are already loaded, use them
+    if (!loading && list.length > 0) {
+      const regularItems = list.filter(
+        (item) =>
+          item.key !== KEY_New &&
+          item.key !== KEY_AdvancedSearch &&
+          !isNoneItem(item)
+      );
+      this.resolveItems(regularItems);
+      return;
+    }
+
+    const query = this.inputSearch.value;
+    if (!query || !query.trim()) {
+      return;
+    }
+
+    // Fire an immediate typeahead request (bypass debounce)
+    this.buildTypeaheadRequestForQuery(query)
+      .then((response) => {
+        const values = response.data.values || [];
+        this.resolveItems(values);
+      })
+      .catch(() => {
+        playBeep();
+      });
+  };
+
+  /**
+   * @method resolveItems
+   * @summary Given the typeahead results, auto-select if exactly one match,
+   * beep if no match, or beep and keep dropdown open if multiple matches.
+   */
+  resolveItems = (items) => {
+    if (items.length === 1) {
+      this.handleAutoSelectAndAdvance(items[0]);
+    } else if (items.length > 1) {
+      // Select the highlighted item (arrow-key navigated) or the first one
+      const selected = this.state.selected || items[0];
+      this.handleAutoSelectAndAdvance(selected);
+    } else {
+      // No match
+      playBeep();
+    }
+  };
+
+  /**
+   * @method buildTypeaheadRequestForQuery
+   * @summary Build and fire a typeahead request for the given query string.
+   * Returns the axios promise. This is a non-debounced version of typeaheadRequest.
+   */
+  buildTypeaheadRequestForQuery = (query) => {
+    const {
+      windowType,
+      dataId,
+      filterWidget,
+      attribute,
+      parameterName,
+      tabId,
+      rowId,
+      entity,
+      subentity,
+      subentityId,
+      viewId,
+      mainProperty,
+      typeaheadSupplier,
+    } = this.props;
+
+    const typeaheadParams = {
+      entity,
+      docType: windowType,
+      docId: filterWidget ? viewId : dataId,
+      propertyName: filterWidget ? parameterName : mainProperty.field,
+      query: query || ' ',
+      rowId,
+      tabId,
+    };
+
+    if (typeaheadSupplier) {
+      return typeaheadSupplier({
+        ...typeaheadParams,
+        subentity,
+        subentityId,
+      });
+    } else if (entity === 'documentView' && attribute) {
+      return getViewAttributeTypeahead(
+        windowType,
+        viewId,
+        dataId,
+        mainProperty.field,
+        typeaheadParams.query
+      );
+    } else if (entity === 'documentView' && !attribute) {
+      return getViewFieldTypeahead({
+        windowId: windowType,
+        viewId,
+        rowId,
+        fieldName: mainProperty.field,
+        query: typeaheadParams.query,
+      });
+    } else if (viewId && !filterWidget) {
+      return autocompleteModalRequest({
+        ...typeaheadParams,
+        entity: 'documentView',
+        viewId,
+      });
+    } else {
+      return autocompleteRequest({
+        ...typeaheadParams,
+        subentity,
+        subentityId,
+      });
+    }
+  };
+
+  /**
+   * @method handleAutoSelectAndAdvance
+   * @summary Select the given item and advance focus to the next field in the quick input form.
+   * Unlike handleSelect_RegularItem, this does NOT refocus the current lookup input.
+   */
+  handleAutoSelectAndAdvance = (selectedItem) => {
+    const { onChange, handleInputEmptyStatus, mainProperty, filterWidget } =
+      this.props;
+
+    const fieldName = filterWidget
+      ? mainProperty.parameterName
+      : mainProperty.field;
+
+    this.inputSearch.value = computeInputTextFromSelectedItem(selectedItem);
+    this.setState({ inputTextOnFocus: this.inputSearch.value });
+
+    handleInputEmptyStatus?.(false);
+
+    this.handleDropdownBlur();
+
+    // Call onChange (PATCH) and advance focus AFTER the server responds
+    // and React re-renders. We intentionally skip setNextProperty here
+    // because it manages focus within composed lookups (e.g. BPartner →
+    // Location → Contact) and would call onBlurWidget, stealing focus.
+    executeAfterPromise(onChange(fieldName, selectedItem), () =>
+      this.focusNextFieldInForm()
+    );
+  };
+
+  /**
+   * @method focusNextFieldInForm
+   * @summary Find the next focusable input in the parent form and focus it.
+   * Used after auto-selecting a product in quick input to advance to the quantity field.
+   * Retries up to 10 times (every 100ms) because the PATCH response triggers a React
+   * re-render that may make the next field focusable asynchronously.
+   */
+  focusNextFieldInForm = (retriesLeft = 10) => {
+    if (!this.inputSearch) {
+      return;
+    }
+
+    const form = this.inputSearch.closest('form');
+    if (!form) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'RawLookup.focusNextFieldInForm: no parent <form> found. Focus advance requires the quick input to be wrapped in a <form> element (see TableQuickInput).'
+      );
+      return;
+    }
+
+    const inputs = Array.from(
+      form.querySelectorAll(
+        'input:not([disabled]):not([type="hidden"]):not([readonly])'
+      )
+    );
+    const idx = inputs.indexOf(this.inputSearch);
+    if (idx < 0) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'RawLookup.focusNextFieldInForm: current input not found in form input list. This may indicate a DOM structure issue.'
+      );
+    }
+    if (idx >= 0 && idx < inputs.length - 1) {
+      const nextInput = inputs[idx + 1];
+      nextInput.focus();
+
+      if (document.activeElement === nextInput) {
+        return;
+      }
+    }
+
+    // Retry: the next field may not be focusable yet (React re-render pending)
+    if (retriesLeft > 0) {
+      setTimeout(() => this.focusNextFieldInForm(retriesLeft - 1), 100);
+    }
   };
 
   typeaheadRequest = () => {
@@ -604,6 +871,7 @@ export class RawLookup extends Component {
                     tabIndex={tabIndex}
                     placeholder={this.props.item.emptyText}
                     onChange={this.handleInputTextChange}
+                    onKeyDown={this.handleInputTextKeyDown}
                     onClick={this.handleInputTextClick}
                     onFocus={this.handleInputTextFocus}
                     onBlur={this.handleInputTextBlur}


### PR DESCRIPTION
## What

In batch entry (quick input), pressing Enter after typing a product name moved
the visual highlight (blue rectangle) to the Qty field but left the keyboard
cursor in the Product field. Typing went into the wrong field.

Additionally, after product selection the Qty field can be temporarily disabled
during a callout/re-render cycle, causing focus to jump past it to the next
enabled field (M_HU_PI_Item_Product_ID) instead of waiting for Qty to become
ready.

## Why

- `Lookup.setNextProperty` only updated React state (visual highlight) but
  never called `.focus()` on the next DOM input — no Enter-key handler existed
  to intercept product selection and advance real focus.
- `focusNextFieldInForm` / `focusNextFormField` used `:not([disabled])` in
  their DOM queries, which excluded temporarily-disabled fields. When Qty was
  disabled (callout pending), it was skipped entirely.

## How

**`Lookup.js`**
- `setNextProperty` now tracks `hasNextSubField` (boolean) and returns it
- Calls `focusNextFormField()` from the setState callback when advancing past
  the last sub-field (mouse-click path)
- New `focusNextFormField()`: finds the next focusable input in the parent
  `<form>` via DOM query, includes disabled inputs, retries (up to 5×, 100 ms
  each) when the next field is still disabled — safe no-op when not inside a form

**`RawLookup.js`**
- `handleInputTextKeyDown`: intercepts Enter when `subentity === 'quickInput'`,
  calls `resolveAndSelectOnEnter()` (no effect in regular document views)
- `resolveAndSelectOnEnter()`: uses already-loaded typeahead results or fires
  an immediate (non-debounced) request, then auto-selects the match
- `resolveItems()`: 1 match → select + advance; >1 → take highlighted/first;
  0 → beep
- `handleAutoSelectAndAdvance()`: selects item, then calls `focusNextFieldInForm()`
  after the PATCH response — does not re-steal focus like `handleSelect_RegularItem`
- `focusNextFieldInForm()`: walks to next input in the `<form>`, includes
  disabled inputs, retries (up to 10×, 100 ms each) — retries when the next
  field is disabled (callout pending) rather than skipping it; self-terminates
  on unmount
- `playBeep()`: Web Audio API oscillator for no-match audio feedback
- `handleSelect_RegularItem`: `shouldKeepFocus` flag replaces unconditional
  `this.focus()` — skips refocus when exiting last sub-field

**Safety**
- Enter interception and focus advance only activate inside a `<form>`.
  Quick input uses `<form class="quick-input-container">`. Regular document
  views use `<div>` — no form found → no-op.

## Tests

- `yarn lintfix`: 0 errors
- `yarn test`: 350 passed, 66/68 suites (2 skipped pre-existing)