### PR TITLE
InvoiceRule Manual: add Description on the ref-list entry

### DIFF
--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5802600_sys_InvoiceRule_Manual_Description.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5802600_sys_InvoiceRule_Manual_Description.sql
@@ -1,0 +1,19 @@
+-- 2026-05-13T20:00:00.000Z
+-- InvoiceRule Manual — Add a meaningful Description on the ref-list entry so users see in the dropdown tooltip what 'Manuell' actually means (and how it differs from 'Nach Lieferung')
+UPDATE AD_Ref_List SET Description='Wie ''Nach Lieferung'', erfordert aber die ausdrückliche Freigabe des Benutzers, bevor der Kandidat fakturiert wird.',Updated=TO_TIMESTAMP('2026-05-13 20:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Ref_List_ID=544228
+;
+
+-- 2026-05-13T20:00:01.000Z
+-- InvoiceRule Manual — Propagate the new Description into the seed _Trl rows (matches what AD_Ref_List_Trl was seeded as 'N' = not yet translated)
+UPDATE AD_Ref_List_Trl SET Description='Wie ''Nach Lieferung'', erfordert aber die ausdrückliche Freigabe des Benutzers, bevor der Kandidat fakturiert wird.',Updated=TO_TIMESTAMP('2026-05-13 20:00:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Ref_List_ID=544228 AND AD_Language IN ('de_DE','de_CH','nl_NL')
+;
+
+-- 2026-05-13T20:00:02.000Z
+-- InvoiceRule Manual — English description
+UPDATE AD_Ref_List_Trl SET Description='Like ''After Delivery'', but requires express user permission before the candidate is invoiced.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-13 20:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Ref_List_ID=544228
+;
+
+-- 2026-05-13T20:00:03.000Z
+-- InvoiceRule Manual — Backfill description for any other active languages (idempotent)
+SELECT add_missing_translations()
+;


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/metasfresh/metasfresh/pull/23923. Adds a `Description` to the new `InvoiceRule.Manual` ref-list entry (AD_Ref_List 544228) so the dropdown tooltip in *Geschäftspartner*, *Auftrag*, *Auftragsposition* and *Rechnungs-Kandidat* explains the rule.

Without a Description, *Manuell* is just a label and the difference from *Nach Lieferung* (which auto-invoices once delivered) is not self-evident.

## Wording

- **DE** (`de_DE` / `de_CH` / `nl_NL`): *Wie 'Nach Lieferung', erfordert aber die ausdrückliche Freigabe des Benutzers, bevor der Kandidat fakturiert wird.*
- **EN** (`en_US`): *Like 'After Delivery', but requires express user permission before the candidate is invoiced.*

## Migration script

`backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5802600_sys_InvoiceRule_Manual_Description.sql`

- `UPDATE AD_Ref_List.Description` (German base)
- `UPDATE AD_Ref_List_Trl.Description` for `de_DE` / `de_CH` / `nl_NL`
- `UPDATE AD_Ref_List_Trl` for `en_US` with the English text + `IsTranslated='Y'`
- `SELECT add_missing_translations()` to backfill any other active languages

## Test plan

- [ ] CI green (no Java changes — SQL-only migration)
- [ ] After deploy, open *Geschäftspartner* on the UAT instance and confirm the *Rechnungsstellungsregel* dropdown shows the German description for *Manuell* on hover / when the value is selected
- [ ] Switch UI language to English and confirm the English description is shown