### PR TITLE
Restore Allure reports publishing on inner_silence_uat

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -18,6 +18,7 @@ jobs:
       build-info-properties: ${{ steps.build-info-properties.outputs.content }}
       git-properties: ${{ steps.git-properties.outputs.content }}
       base-version-matrix: ${{ steps.base-version-matrix.outputs.matrix }}
+      branch-sanitized-gh-pages: ${{ steps.sanitize-branch-gh-pages.outputs.value }}
       skip-testspace: ${{ steps.skip-checks.outputs.skip-testspace }}
       skip-publish-reports: ${{ steps.skip-checks.outputs.skip-publish-reports }}
     steps:
@@ -50,6 +51,13 @@ jobs:
           GIT_REF: ${{ github.ref_name }}
         run: |
           echo "refname=$(echo ""$GIT_REF"" | sed -r 's/([^a-zA-Z0-9.]+)/-/g' | sed -r 's/(^-|-$)//g')" >> $GITHUB_OUTPUT
+      - name: sanitize-branch-for-gh-pages
+        id: sanitize-branch-gh-pages
+        env:
+          GIT_REF: ${{ github.ref_name }}
+        run: |
+          SANITIZED=$(echo "$GIT_REF" | tr '/' '-' | tr '_' '-' | tr -cd 'a-zA-Z0-9.-' | tr '[:upper:]' '[:lower:]' | sed 's/--*/-/g' | sed 's/^-*//' | sed 's/-*$//')
+          echo "value=${SANITIZED}" >> $GITHUB_OUTPUT
       - name: define-build-info-properties
         id: build-info-properties
         env:


### PR DESCRIPTION
## Problem

No Allure reports are being published from the `inner_silence_uat` branch (works fine on `new_dawn_uat`). Example failing job: https://github.com/metasfresh/metasfresh/actions/runs/25874220805/job/76039530364

## Root cause

`.github/workflows/cicd.yaml` on `inner_silence_uat` still references `needs.init.outputs.branch-sanitized-gh-pages` in three places of the `publish-reports` job (env `BRANCH:` for upload / branch-metadata / summary steps), but the `init` job no longer declares that output nor the step that computes it. With `BRANCH=""` the conditional upload/metadata/summary steps silently skip, and nothing lands on `test-reports.metasfresh.com`.

The branches have diverged and are not expected to be reunited, so this is a surgical add-only fix rather than a full sync.

## Fix

Restore in the `init` job of `.github/workflows/cicd.yaml`:

- step `sanitize-branch-for-gh-pages` (id `sanitize-branch-gh-pages`) that maps `github.ref_name` to a gh-pages-safe slug
- output declaration `branch-sanitized-gh-pages`

+8 lines, nothing else touched.

## Test plan

- [x] CI on this PR runs to green
- [ ] `publish-reports` job no longer skips the upload steps
- [ ] Allure report appears at `https://test-reports.metasfresh.com/branches/<sanitized-branch>/builds/<version>/allure/` after merge to `inner_silence_uat`