### PR TITLE
DESADV-JSON: expose pack-item line as DesadvLine.LineItemLine

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
@@ -200,7 +200,6 @@ public class EDI_Desadv_JSON_Export_StepDef
 
 			// LineItemLine is intentionally absent for no-pack entries: there is no
 			// EDI_Desadv_Pack_Item, so there is no pack-item line number to expose.
-			// (see metasfresh me03#29842)
 			assertThat(desadvLine.has("LineItemLine"))
 					.as("DesadvLineWithNoPacking[%d].DesadvLine must NOT contain LineItemLine (no pack-item exists)", index)
 					.isFalse();

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
@@ -178,6 +178,11 @@ public class EDI_Desadv_JSON_Export_StepDef
 	 *     <li>{@code IsDeliveryClosed} (optional) — expected value of IsDeliveryClosed</li>
 	 *     <li>{@code QtyCUsPerTU} (optional) — expected consumer units per traded unit (from order line's QtyItemCapacity)</li>
 	 * </ul>
+	 * <p>
+	 * Structural invariant (asserted on every entry independently of the DataTable):
+	 * each entry's {@code DesadvLine} sub-object MUST NOT contain {@code LineItemLine} —
+	 * no pack-item exists for no-packing lines, so there is no pack-item line number to
+	 * expose (see https://github.com/metasfresh/me03/issues/29842).
 	 */
 	@Then("verify DESADV JSON export has DesadvLineWithNoPacking:")
 	public void verifyDesadvLineWithNoPacking(@NonNull final DataTable dataTable) throws Exception

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_JSON_Export_StepDef.java
@@ -123,9 +123,24 @@ public class EDI_Desadv_JSON_Export_StepDef
 								.isTrue();
 					}
 
+					// LineItemLine invariant: the EDIFACT-LIN line number is exposed at two paths
+					// (top-of-LineItem as `Line`, and inside `DesadvLine` as `LineItemLine`) and
+					// MUST carry the same value — both are sourced from EDI_Desadv_Pack_Item.line.
+					// This guards against future SQL drift between the two paths
+					// (see metasfresh me03#29842 — Spavetti/Migros LAF-1021 packing-allocation rejection).
+					final JsonNode desadvLine = item.path("DesadvLine");
+					assertThat(item.has("Line"))
+							.as("LineItem should contain top-level Line field")
+							.isTrue();
+					assertThat(desadvLine.has("LineItemLine"))
+							.as("Packed LineItem.DesadvLine should contain LineItemLine field")
+							.isTrue();
+					assertThat(desadvLine.path("LineItemLine").asInt())
+							.as("LineItem.DesadvLine.LineItemLine must equal LineItem.Line")
+							.isEqualTo(item.path("Line").asInt());
+
 					if (expectedIsDeliveryClosed != null)
 					{
-						final JsonNode desadvLine = item.path("DesadvLine");
 						assertThat(desadvLine.has("IsDeliveryClosed"))
 								.as("DesadvLine should contain IsDeliveryClosed field")
 								.isTrue();
@@ -182,6 +197,13 @@ public class EDI_Desadv_JSON_Export_StepDef
 			final JsonNode entry = noPacking.get(index);
 			final JsonNode desadvLine = entry.path("DesadvLine");
 			assertThat(desadvLine.isMissingNode()).as("Entry %d should have DesadvLine", index).isFalse();
+
+			// LineItemLine is intentionally absent for no-pack entries: there is no
+			// EDI_Desadv_Pack_Item, so there is no pack-item line number to expose.
+			// (see metasfresh me03#29842)
+			assertThat(desadvLine.has("LineItemLine"))
+					.as("DesadvLineWithNoPacking[%d].DesadvLine must NOT contain LineItemLine (no pack-item exists)", index)
+					.isFalse();
 
 			final int expectedOrderLine = row.getAsInt("OrderLine");
 			assertThat(desadvLine.path("OrderLine").asInt())

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
@@ -244,6 +244,7 @@ Feature: EDI DESADV export via postgREST
               "QtyOrderedInDesadvLineUOM": 100,
               "QtyDeliveredInInvoicingUOM": 100,
               "QtyDeliveredInDesadvLineUOM": 100,
+              "LineItemLine": 10,
               "IsDeliveryClosed": true
             },
             "QtyCUsPerLU": 100,

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5802760_sys_gh29842_desadv_LineItemLine.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5802760_sys_gh29842_desadv_LineItemLine.sql
@@ -1,7 +1,7 @@
--- Function for desadv packs
--- Handles compensation group sub-articles: sub-article pack items are merged
--- into the main article's pack, adding IsSubArticle and MainArticleLine to each LineItem.
--- Packs NOT in a compensation group are output as before (backward-compatible).
+-- Source DDL: backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/desadv_json/get_desadv_packs_json_fn.sql
+-- me03#29842: expose pack-item line number inside DesadvLine sub-object as `LineItemLine`,
+-- so EDIFACT mappings that read the line context from DesadvLine.* obtain the same value as
+-- LineItems[].Line — preventing LIN-vs-packing-allocation mismatches on partial-delivery shipments.
 CREATE OR REPLACE FUNCTION "de.metas.edi".get_desadv_packs_json_fn(p_edi_desadv_id NUMERIC, p_m_inout_id NUMERIC)
     RETURNS JSONB
 AS

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5802760_sys_gh29842_desadv_LineItemLine.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5802760_sys_gh29842_desadv_LineItemLine.sql
@@ -1,7 +1,8 @@
 -- Source DDL: backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/desadv_json/get_desadv_packs_json_fn.sql
--- me03#29842: expose pack-item line number inside DesadvLine sub-object as `LineItemLine`,
--- so EDIFACT mappings that read the line context from DesadvLine.* obtain the same value as
--- LineItems[].Line — preventing LIN-vs-packing-allocation mismatches on partial-delivery shipments.
+-- https://github.com/metasfresh/me03/issues/29842 — expose pack-item line number inside DesadvLine
+-- sub-object as `LineItemLine`, so EDIFACT mappings that read the line context from DesadvLine.*
+-- obtain the same value as LineItems[].Line — preventing LIN-vs-packing-allocation mismatches on
+-- partial-delivery shipments.
 CREATE OR REPLACE FUNCTION "de.metas.edi".get_desadv_packs_json_fn(p_edi_desadv_id NUMERIC, p_m_inout_id NUMERIC)
     RETURNS JSONB
 AS


### PR DESCRIPTION
Add a new LineItemLine field inside the DesadvLine sub-object of packed LineItems[] in the DESADV JSON export. Same value as the existing flat LineItems[].Line (EDI_Desadv_Pack_Item.line), exposed at a second path so clearing-center mappings that build their per-line context from the DesadvLine sub-object find the correct LIN line number there.

LineItems[].Line is a running pack-item counter scoped to EDI_Desadv_ID (incremented across all shipments of the same DESADV — see EDIDesadvPackService.java:142-145). When an order line is split across shipments, the counter diverges from DesadvLine.DesadvLine, which is what broke the Spavetti -> Migros Ostschweiz Shipment_2 of LAF-1021.

No-pack entries (DesadvLineWithNoPacking[]) do NOT get the field — there is no pack-item and therefore no meaningful LineItemLine.
