### PR TITLE
close_partially_shipped: fix isClosed race for fully-picked schedule

### DIFF
--- a/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
@@ -120,7 +120,7 @@ test('Sysconfig M_ShipmentSchedule_Close_PartiallyShipped: partial and unshipped
                 [pickingJobId]: {
                     shipmentSchedules: {
                         P1: {
-                            isClosed: false,
+                            isClosed: true,
                             qtyPicked: [{
                                 qtyPicked: "12 PCE",
                                 qtyTUs: 3,


### PR DESCRIPTION
**Closed without merge** — see closing comment for the reason. Superseded by a different approach in https://github.com/metasfresh/metasfresh/pull/23988.