### PR TITLE
me03#29557 — DepositType: German on AD_Reference/AD_Ref_List base column

### DIFF
--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/58028000_sys_me03_29557_DepositType_GermanBase.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/58028000_sys_me03_29557_DepositType_GermanBase.sql
@@ -1,0 +1,93 @@
+-- Run mode: SWING_CLIENT
+
+-- me03#29557 follow-up: move the German label to the BASE column of
+-- AD_Reference / AD_Ref_List (introduced by 58023600). Reason:
+-- the WebUI list-picker for List-typed columns renders option labels
+-- from AD_Ref_List.Name directly in several paths and does NOT always
+-- resolve through AD_Ref_List_Trl. The de_DE / de_CH _Trl rows are
+-- present with IsTranslated='Y' and the right German text, but a
+-- de_DE session still shows the base column 'Disposable Deposit' /
+-- 'Reusable Deposit'. Fix: put German on the base column and keep the
+-- English text as an en_US _Trl override.
+-- See mf15-ai-dev-support/claude/.claude/skills/metasfresh-db/SKILL.md
+-- §"AD_Message / AD_Element Base Language — German in the Base Column".
+
+-- No new ID-server entities are needed — this migration only updates
+-- existing rows (AD_Reference_ID=542089, AD_Ref_List_IDs 544229 / 544230,
+-- AD_Element_ID=584866) introduced by 58023600.
+
+-- ===========================================================================
+-- 1. AD_Reference: 'Deposit Type' -> 'Pfandart' on the base column
+-- ===========================================================================
+UPDATE AD_Reference
+SET    Name='Pfandart',
+       Updated=TO_TIMESTAMP('2026-05-16 09:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy=100
+WHERE  AD_Reference_ID=542089
+;
+
+-- AD_Reference_Trl(en_US) keeps the English label as an override
+UPDATE AD_Reference_Trl
+SET    Name='Deposit Type', IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-05-16 09:00:01','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy=100
+WHERE  AD_Reference_ID=542089 AND AD_Language='en_US'
+;
+
+-- AD_Reference_Trl(de_DE / de_CH) mirror the new base text (and are already
+-- IsTranslated='Y' from the original migration; we just re-affirm the text
+-- so the rows agree with the base column)
+UPDATE AD_Reference_Trl
+SET    Name='Pfandart', IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-05-16 09:00:02','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy=100
+WHERE  AD_Reference_ID=542089 AND AD_Language IN ('de_DE','de_CH')
+;
+
+-- ===========================================================================
+-- 2. AD_Ref_List: NRC -> 'Einwegpfand' on the base column
+-- ===========================================================================
+UPDATE AD_Ref_List
+SET    Name='Einwegpfand',
+       Updated=TO_TIMESTAMP('2026-05-16 09:00:03','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy=100
+WHERE  AD_Ref_List_ID=544229
+;
+
+UPDATE AD_Ref_List_Trl
+SET    Name='Disposable Deposit', IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-05-16 09:00:04','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy=100
+WHERE  AD_Ref_List_ID=544229 AND AD_Language='en_US'
+;
+
+UPDATE AD_Ref_List_Trl
+SET    Name='Einwegpfand', IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-05-16 09:00:05','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy=100
+WHERE  AD_Ref_List_ID=544229 AND AD_Language IN ('de_DE','de_CH')
+;
+
+-- ===========================================================================
+-- 3. AD_Ref_List: RC -> 'Mehrwegpfand' on the base column
+-- ===========================================================================
+UPDATE AD_Ref_List
+SET    Name='Mehrwegpfand',
+       Updated=TO_TIMESTAMP('2026-05-16 09:00:06','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy=100
+WHERE  AD_Ref_List_ID=544230
+;
+
+UPDATE AD_Ref_List_Trl
+SET    Name='Reusable Deposit', IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-05-16 09:00:07','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy=100
+WHERE  AD_Ref_List_ID=544230 AND AD_Language='en_US'
+;
+
+UPDATE AD_Ref_List_Trl
+SET    Name='Mehrwegpfand', IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-05-16 09:00:08','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy=100
+WHERE  AD_Ref_List_ID=544230 AND AD_Language IN ('de_DE','de_CH')
+;


### PR DESCRIPTION
## Summary

Follow-up to merged PR https://github.com/metasfresh/metasfresh/pull/23949 (issue https://github.com/metasfresh/me03/issues/29557).

The original migration ``58023600_sys_me03_29557_M_Product_DepositType.sql`` put the English labels (``Deposit Type`` / ``Disposable Deposit`` / ``Reusable Deposit``) on the **base column** of ``AD_Reference.Name`` and ``AD_Ref_List.Name``, with the German translations only as ``de_DE`` / ``de_CH`` rows in the ``_Trl`` tables (``IsTranslated='Y'``).

In a de_DE WebUI session the Pfandart dropdown nevertheless renders the English base values:

> Disposable Deposit  
> Reusable Deposit

i.e. the WebUI list-picker for List-typed columns does not always resolve through ``AD_Ref_List_Trl`` and surfaces ``AD_Ref_List.Name`` directly. This matches the ``metasfresh-db`` skill rule "AD_Message / AD_Element Base Language — German in the Base Column", which has been updated in mf15-ai-dev-support (commit ``151fc04``) to explicitly call out ``AD_Reference`` / ``AD_Ref_List``.

## What this PR does

New migration ``58028000_sys_me03_29557_DepositType_GermanBase.sql`` updates existing rows (no new IDs needed):

- ``AD_Reference.Name``: ``Deposit Type`` → ``Pfandart``
- ``AD_Ref_List.Name`` (NRC): ``Disposable Deposit`` → ``Einwegpfand``
- ``AD_Ref_List.Name`` (RC): ``Reusable Deposit`` → ``Mehrwegpfand``
- ``AD_Reference_Trl(en_US)``, ``AD_Ref_List_Trl(en_US)``: re-set the English text as an explicit override
- ``AD_Reference_Trl(de_DE/de_CH)``, ``AD_Ref_List_Trl(de_DE/de_CH)``: re-affirm the German text (was already correct, kept in sync)

## Test plan

- [x] Migration applied cleanly to swift_eagle test instance (seefruchtdev DB via SSH tunnel)
- [x] Pfandart dropdown verified by user in DE / CH / EN WebUI sessions — all three now show the correct localized labels (Einwegpfand/Mehrwegpfand, Einwegpfand/Mehrwegpfand, Disposable Deposit/Reusable Deposit)
- [x] Raw ``M_Product.DepositType`` stays the Value code (``NRC`` / ``RC``) — verified on ``M_Product_ID=1000157``
- [ ] CI green