### PR TITLE
picking: replace flaky expectErrorToast in 'Scan invalid HU' test

### DIFF
--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -11,6 +11,9 @@ import { expectErrorToast, VERY_SLOW_ACTION_TIMEOUT } from '../../utils/common';
 import { QTY_NOT_FOUND_REASON_NOT_FOUND } from '../../utils/screens/picking/GetQuantityDialog';
 import { SelectPickTargetLUScreen } from '../../utils/screens/picking/ReopenLUScreen';
 import { ConfirmActivityErrorPanel } from '../../utils/components/ConfirmActivityErrorPanel';
+import { BarcodeScannerComponent } from '../../utils/components/BarcodeScannerComponent';
+import { ErrorToast } from '../../utils/dialogs/ErrorToast';
+import { expect } from '@playwright/test';
 
 const createMasterdata = async ({
                                     language = 'en_US',
@@ -668,12 +671,28 @@ test('Scan invalid HU QR code and recover', async ({ page }, testInfo) => {
     await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
     await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
 
-    await expectErrorToast('Scanning non-existent HU QR code', async () => {
-        await PickingJobScreen.pickHU({
-            qrCode: 'HU#1#{"id":"00000000000000000000000000000000-99999","packingInfo":{"huUnitType":"LU","packingInstructionsId":1,"caption":"NonExistent"},"product":{"id":1,"code":"FAKE","name":"FAKE"}}',
-            isScanDirectly: true,
-        });
-    });
+    // Bypass expectErrorToast (see commit 8588b5c7152 — trolley.spec.js fix). Its Promise.race
+    // races React's toast render and is brittle under CI load — the historical failure mode here
+    // was a global-timeout exhaustion (extended to 180s in gh#23119, still flaky). Instead, wait
+    // for the POST round-trip explicitly, assert the backend contract (4xx) and the toast text
+    // directly via Playwright's auto-retrying expect. Cannot reuse pickHU here because it then
+    // tries to fill GetQuantityDialog which never opens for an invalid HU.
+    const fakeHuQrCode = 'HU#1#{"id":"00000000000000000000000000000000-99999","packingInfo":{"huUnitType":"LU","packingInstructionsId":1,"caption":"NonExistent"},"product":{"id":1,"code":"FAKE","name":"FAKE"}}';
+    const postPromise = page.waitForResponse(
+        (r) => r.url().endsWith('/picking/nextEligibleLineToPack') && r.request().method() === 'POST'
+    );
+    await BarcodeScannerComponent.type(fakeHuQrCode);
+    const postResponse = await postPromise;
+    expect(postResponse.status()).toBeGreaterThanOrEqual(400);
+    // Generic toast-presence check — the backend's AdempiereException is surfaced by the
+    // frontend's extractUserFriendlyErrorMessageFromAxiosError as the generic
+    // `error.PleaseTryAgain` fallback because Spring's error JSON doesn't match the
+    // expected `data.errors[0].message` shape. Asserting on the specific text would be brittle.
+    // Coverage parity with the original expectErrorToast (no validator) is preserved.
+    await expect(page.getByRole('alert')).toBeVisible({ timeout: 5000 });
+    // Dismiss the toast so the next step()'s automatic error-toast watchdog doesn't trip on it.
+    // The original `expectErrorToast` wrapper handled this implicitly via currentErrorWatcherId.
+    await ErrorToast.closePopup();
 
     await PickingJobScreen.waitForScreen();
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '0 TU', qtyPickedCatchWeight: '' });


### PR DESCRIPTION
## Scope

Replaces the flaky `expectErrorToast`-based assertion in `picking.spec.js` "Scan invalid HU QR code and recover" with the canonical `page.waitForResponse + DOM-assert` pattern previously applied to `tests/spec/distribution/trolley.spec.js` (commit https://github.com/metasfresh/metasfresh/commit/8588b5c7152).

This test has been a top recurring `mobile test` failure on multiple release branches in recent CI runs. Pre-existing 180 s `testInfo.setTimeout` (added in gh#23119) didn't help — the issue isn't slow tests, it's a `Promise.race` losing against React's toast render under load.

## Root cause

`expectErrorToast` races the caller's function against `ErrorToast.waitToPopup` via `Promise.race`. Under CI load the toast wait loses against a hanging `PickingJobScreen.pickHU` call (it tries to fill `GetQuantityDialog`, which never opens for an invalid HU), so the test burns the global timeout instead of failing cleanly. The bug class is documented in `e2e/mobile-webui/CLAUDE.md` § "`expectErrorToast` Is Coupled to the Toast DOM Element".

## What the fix does

1. **`page.waitForResponse` on the actual scan endpoint** — `/picking/nextEligibleLineToPack` (POST). The endpoint was verified from the trace network log; the picking-job-screen scan does NOT go through `/picking/hu/byScannedCode` (which is the line-screen path).
2. **Assert HTTP status `>= 400`** — backend contract check.
3. **Assert the alert role visible** — toast-presence parity with the original wrapper (no text validator). The actual toast text is the generic `error.PleaseTryAgain` because the backend's `AdempiereException` → JSON shape doesn't match the frontend's expected `data.errors[0].message`; asserting on specific text would be brittle.
4. **Explicit `ErrorToast.closePopup()`** — dismisses the toast so the next `step()`'s automatic error-toast watchdog doesn't trip on the residual alert.

The fix does NOT reuse `PickingJobScreen.pickHU` because that helper tries to fill `GetQuantityDialog` which never opens for an invalid HU.

## Verification

- **Local — green 5/5** against `mfstack` mobile profile (host-run via `compose-local.yml` overlay). Each run ~1.4 min. The validation also caught two earlier defects before push: (a) wrong URL match (`/picking/hu/byScannedCode` vs the actual `/picking/nextEligibleLineToPack`); (b) leftover toast tripping the next-step watchdog.
- **CI** — `cicd.yaml` is the ground truth from here. Acceptance: this PR stays green; subsequent base-branch runs do not list "Scan invalid HU QR code and recover" in `mobile test` failures.

## Out of scope

- The other top recurring offender (`by_ExternalBarcode_attribute.spec.js` "Wait for HU Info Panel"): root cause is a backend perf issue (slow `/byQRCode` under DB load — `isDisposalPending()` query + missing `M_HU.ExternalBarcode` index), not a Playwright fix. Addressed separately.
- `expectErrorToast` helper-level fix: the helper is used by ≥4 other tests; per-test workaround here doesn't address them. Addressed separately.