### PR TITLE
cicd: bump test-results artifact retention 1/7d → 30d

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1518,7 +1518,7 @@ jobs:
           name: cucumber-allure-results-${{ matrix.profile }}
           path: cucumber-allure-results/
           if-no-files-found: ignore
-          retention-days: 30
+          retention-days: 7
       - name: push-database-image metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postcucumber-${{ matrix.profile }}
         if: env.ACT != 'true'
         uses: nick-fields/retry@v3
@@ -1929,7 +1929,7 @@ jobs:
           name: allure-results-frontend-${{ matrix.shard_label }}
           path: docker-builds/e2e-tests/allure-results/
           if-no-files-found: ignore
-          retention-days: 30
+          retention-days: 1
 
       - name: push-image metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postfrontendtest-${{ matrix.shard_label }}
         if: env.ACT != 'true'

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -509,7 +509,7 @@ jobs:
         with:
           name: junit-results-jest
           path: jest/frontend/*.xml
-          retention-days: 1
+          retention-days: 30
           if-no-files-found: warn
       - name: Generate JUnit HTML for Jest
         if: always()
@@ -1283,7 +1283,7 @@ jobs:
           path: |
             junit/commons/**/*.xml
             junit/backend/**/*.xml
-          retention-days: 1
+          retention-days: 30
           if-no-files-found: warn
       - name: upload camel junit results
         uses: actions/upload-artifact@v4
@@ -1291,7 +1291,7 @@ jobs:
         with:
           name: junit-results-camel
           path: junit/camel/**/*.xml
-          retention-days: 1
+          retention-days: 30
           if-no-files-found: warn
       - name: Merge backend JUnit XML
         if: always()
@@ -1518,7 +1518,7 @@ jobs:
           name: cucumber-allure-results-${{ matrix.profile }}
           path: cucumber-allure-results/
           if-no-files-found: ignore
-          retention-days: 7
+          retention-days: 30
       - name: push-database-image metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postcucumber-${{ matrix.profile }}
         if: env.ACT != 'true'
         uses: nick-fields/retry@v3
@@ -1597,7 +1597,7 @@ jobs:
           name: junit-results-cucumber-${{ matrix.profile }}
           path: cucumber/cucumber-junit-${{ matrix.profile }}.xml
           if-no-files-found: ignore
-          retention-days: 1
+          retention-days: 30
       # Allure reports uploaded by publish-test-reports job
 
   cucumber-allure-report:
@@ -1866,7 +1866,7 @@ jobs:
           name: junit-results-playwright-mobile
           path: docker-builds/e2e-tests/playwright-report-mobile/junit/results.xml
           if-no-files-found: ignore
-          retention-days: 1
+          retention-days: 30
       # Allure reports uploaded by publish-test-reports job
 
   frontend_webui_test:
@@ -1929,7 +1929,7 @@ jobs:
           name: allure-results-frontend-${{ matrix.shard_label }}
           path: docker-builds/e2e-tests/allure-results/
           if-no-files-found: ignore
-          retention-days: 1
+          retention-days: 30
 
       - name: push-image metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postfrontendtest-${{ matrix.shard_label }}
         if: env.ACT != 'true'
@@ -1963,7 +1963,7 @@ jobs:
           name: junit-results-playwright-frontend-${{ matrix.shard_label }}
           path: docker-builds/e2e-tests/playwright-report-frontend/junit/results.xml
           if-no-files-found: ignore
-          retention-days: 1
+          retention-days: 30
 
   # =============================================================================
   # Merge Frontend Playwright Allure Results from Sharded Runners


### PR DESCRIPTION
## Why

The `test-reports.metasfresh.com` Allure server only retains the **last 3 builds** per branch, which blocks retroactive cross-run flake hunting. The GitHub Actions JUnit XML artifacts already have free retention up to 90 days, but their `retention-days:` was set to 1. 30 days gives ~4 weeks of cross-run data — sufficient for the typical 1–3 week flake-detection window. JUnit XML files are tiny (~10–100 KB each).

## What — only the small JUnit XML uploads

The full allure-results / playwright-report folders are intentionally **not** bumped: those can be MBs each and would multiply storage cost.

| Artifact | Old | New | Reason |
|---|---|---|---|
| `junit-results-jest` | 1d | **30d** | tiny XML |
| `junit-results-backend` | 1d | **30d** | tiny XML |
| `junit-results-camel` | 1d | **30d** | tiny XML |
| `junit-results-cucumber-{profile}` | 1d | **30d** | tiny XML |
| `junit-results-playwright-mobile` | 1d | **30d** | tiny XML — aligns with `playwright-mobile-report` which is already 30d |
| `junit-results-playwright-frontend-{shard}` | 1d | **30d** | tiny XML |
| `cucumber-allure-results-{profile}` | 7d | **7d** (unchanged) | large JSON + screenshots, multiplied by 7 profiles |
| `allure-results-frontend-{shard}` | 1d | **1d** (unchanged) | large JSON + screenshots |
| `migration-cli-jar` | 1d | **1d** (unchanged) | build artifact, no flake-analysis value |
| `metasfresh-client` | 5d | **5d** (unchanged) | build artifact |

JUnit XML is what cross-run flake analysis actually needs — test names, pass/fail status, failure messages. Allure reports add traces and screenshots which are nice-to-have but cost more to retain.

## Verification

- yaml-only change — `gh pr checks` is the integration gate. No tests altered, no migrations, no backend code.
- Acceptance: this PR's CI passes; subsequent base-branch builds expose the bumped retentions on JUnit XML artifact uploads.