### PR TITLE
cucumber: drain de.metas.material before alloc poll in S0265_40 + S0265_50

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/materialDispo_purchaseOrder_autoCreateFromProductPlanning.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/materialDispo_purchaseOrder_autoCreateFromProductPlanning.feature
@@ -355,6 +355,10 @@ Feature: PP_Product_Planning.IsCreatePlan / IsDocComplete automatically create/c
       | pc_1       | o_1                     | ol_1                        | p_1                     |
       | pc_2       | o_1                     | ol_2                        | p_2                     |
 
+    # Drain the material event queue so the debouncer handler runs before the alloc poll.
+    # Without this, CI-runner contention occasionally exhausts the 120 s poll budget below.
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     # The debouncer waits for the quiet period, then creates POs — both candidates get an alloc
     And after not more than 120s, C_PurchaseCandidate_Alloc are found
       | C_PurchaseCandidate_ID.Identifier | C_PurchaseCandidate_Alloc_ID.Identifier |
@@ -457,6 +461,10 @@ Feature: PP_Product_Planning.IsCreatePlan / IsDocComplete automatically create/c
       | Identifier | C_OrderSO_ID.Identifier | C_OrderLineSO_ID.Identifier | M_Product_ID.Identifier |
       | pc_1       | o_1                     | ol_1                        | p_1                     |
       | pc_2       | o_1                     | ol_2                        | p_2                     |
+
+    # Drain the material event queue so the debouncer handler runs before the alloc poll.
+    # Without this, CI-runner contention occasionally exhausts the 120 s poll budget below.
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     # The debouncer waits for the quiet period, then creates POs — one per vendor
     And after not more than 120s, C_PurchaseCandidate_Alloc are found


### PR DESCRIPTION
## What

Adds the canonical RabbitMQ-drain step between the candidates poll and the `C_PurchaseCandidate_Alloc` poll in scenarios **S0265_40** and **S0265_50** of `materialDispo_purchaseOrder_autoCreateFromProductPlanning.feature`. The drain text is verbatim from 28 other occurrences in the same file:

```
And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
```

(`RabbitMQ_StepDef.java:99` — the "5 minutes" is hard-coded, not a parameter.)

## Why

Sister scenarios S0265_10 / _20 / _30 all drain before checking async results; only _40 and _50 lacked it. The `test (cucumber) (profile6)` job has been failing repeatedly on recent CI runs with the symptom:

> the given supplier didn't succeed within the 120 seconds timeout (241 tries). The logging output of the last try is: item not found

Event chain (per `de.metas.purchasecandidate.base/CLAUDE.md`):
`SupplyRequiredEvent → PurchaseCandidateAdvisedEvent → PurchaseCandidateRequestedEvent → PurchaseCandidateRequestedHandler → workpackage C_PurchaseCandidates_GeneratePurchaseOrdersForSalesOrder`

The first three are material events on the `de.metas.material` queue. Under CI runner contention the 120 s alloc poll can start before the event chain has reached the handler → workpackage isn't enqueued in time → poll times out.
