### PR TITLE
db: partial index on M_HU_Attribute for ExternalBarcode lookups

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5802810_sys_gh29474_M_HU_Attribute_ExternalBarcode_Index.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5802810_sys_gh29474_M_HU_Attribute_ExternalBarcode_Index.sql
@@ -1,0 +1,4 @@
+
+CREATE INDEX IF NOT EXISTS m_hu_attribute_externalbarcode_lookup
+    ON m_hu_attribute (m_attribute_id, value)
+    WHERE m_attribute_id = 540174;


### PR DESCRIPTION
## What

Adds a partial index on `M_HU_Attribute(m_attribute_id, value)` for `m_attribute_id = 540174` — the ID of the `ExternalBarcode` HU attribute.

```sql
CREATE INDEX IF NOT EXISTS m_hu_attribute_externalbarcode_lookup
    ON m_hu_attribute (m_attribute_id, value)
    WHERE m_attribute_id = 540174;
```

## Why

`e2e/mobile-webui/tests/spec/humanager/by_ExternalBarcode_attribute.spec.js` (the "Wait for HU Info Panel" `getByTestId('huinfo-table')` 20 s wait) has been failing on multiple release branches in recent CI runs. The failing query path is:

`HandlingUnitsBL.getByExternalBarcode → addOnlyWithAttribute(ATTR_ExternalBarcode, scannedCode)` → SELECT from `M_HU_Attribute` filtered by `M_Attribute_ID=540174 AND Value=<scanned>`.

There is no covering index for this. Under CI runner DB contention, the seq scan on `M_HU_Attribute` exceeds the 20 s wait, surfacing as the timeout.

## Why this design

- **Partial form** (`WHERE m_attribute_id = 540174`): `M_HU_Attribute` has many rows per attribute; we only need fast lookup for ExternalBarcode-attribute rows. Keeps the index small and hot in cache.
- **`IF NOT EXISTS`**: idempotent for safe re-application.
- **Not `CONCURRENTLY`**: the workspace migration runner (`workspace_migrate.Main` / `rollout_migrate.Main`) wraps scripts in transactions; `CREATE INDEX CONCURRENTLY` cannot run inside a transaction.
- **Same pattern as the existing** `m_hu_attribute_lotnummer_lookup` index added in `5784690_sys_M_HU_Attribute_LotNo_Index.sql` for LotNo (`M_Attribute_ID=1000017`).
- **`M_Attribute_ID=540174` constant across all environments**: centrally allocated, originally inserted by `5772740_ExternalBarcode_attribute.sql`.

## Verification

- **Local apply** verified successfully against a local PostgreSQL inside the e2e Docker stack: SQL syntax accepted; `pg_indexes` shows the index `m_hu_attribute_externalbarcode_lookup` was created with the expected predicate.
- **EXPLAIN ANALYZE before/after** on real data deferred — the local DB doesn't have HUs with ExternalBarcode set, so the index isn't load-bearing locally; the perf signal will come from CI under real data volume.
- **Acceptance**: this PR's `db-apply-migrations` job passes; future `mobile test` runs do not list `by_ExternalBarcode_attribute.spec.js` in failures.

## Out of scope

- **Java-side lazy-load of `isDisposalPending(huId)`**: the other contributor to slow `/byQRCode`. Defer until index alone is observed in CI for 1–2 weeks; only revisit if the flake persists.
- Adjusting the screen-object wait timeout (`HUManagerScreen.waitForHUInfoPanel()` 20 s) — explicitly rejected as masking, not fixing.