### PR TITLE
tests/utils: grace-period in expectErrorToast to fix Promise.race loss

### DIFF
--- a/e2e/mobile-webui/tests/utils/common.js
+++ b/e2e/mobile-webui/tests/utils/common.js
@@ -69,6 +69,13 @@ export const expectErrorToast = async (title, func, toastValidator) => {
     return await test.step(`Expect error: ${title} (watcherId=${watcherId})`, async () => {
         const executeFuncFailOnSuccess = async () => {
             await func();
+            // Grace period: if func() returned cleanly but a toast is still pending, give
+            // React time to render before declaring "not detected". The original Promise.race
+            // could lose against a ~20ms-late toast render under CI load, producing false
+            // "not detected" failures (me03#29474). The hang-on-error semantic of Promise.race
+            // is preserved: if func() never returns (waiting for a screen that won't come),
+            // we never reach this sleep and the toast branch wins as before.
+            await new Promise(resolve => setTimeout(resolve, 2000));
             throw new Error(`Expected error toast not detected (watcherId=${watcherId})`);
         }
 


### PR DESCRIPTION
## What

5-line additive change to `e2e/mobile-webui/tests/utils/common.js` `expectErrorToast` helper: after `func()` returns, wait 2 s before throwing "Expected error toast not detected". The other `Promise.race` branches are unchanged.

## Why

`expectErrorToast` wraps the caller's `func()` in `Promise.race` against `ErrorToast.waitToPopup`. Under CI load and on slower local machines, the toast-DOM render lags a few hundred ms behind the backend response — also when `func()` typically returns. If `func()` resolves a few ms before React renders the toast, `executeFuncFailOnSuccess` wins the race and throws "Expected error toast not detected" — false-negative.

Documented gotcha in `e2e/mobile-webui/CLAUDE.md` § "`expectErrorToast` Is Coupled to the Toast DOM Element". Originating flake behind:

- https://github.com/metasfresh/metasfresh/pull/23988 (Scan invalid HU per-test workaround)
- https://github.com/metasfresh/metasfresh/commit/8588b5c7152 (trolley per-test workaround)

A previous attempt at a bigger refactor (sequential await-then-wait) broke 4 callers whose `func()` is supposed to hang (it relies on Promise.race short-circuiting). That approach was reverted. The grace period is the minimal preserving change.

## Verification

Local run on the e2e mobile stack:

- **BEFORE this fix** (original `Promise.race`-only code): `picking.spec.js` full → **15 passed, 1 failed** — and the 1 failure was exactly "Scan invalid HU QR code and recover", the race-loss test.
- **AFTER this fix** (with 2 s grace): "Scan invalid HU" isolated re-run → **1 passed (5.6 s)**, with the log line `[ OK ] Expected error toast detected (watcherId=105): Please try again` — toast detection won the race after the grace period.

Behavior on the 15 already-passing tests is preserved: their `func()` either hangs (waiting for a screen that won't appear — race wins on toast as before) or returns cleanly AND the toast appears immediately (race still wins on toast). The grace period only delays the FAILURE path; it never delays a passing test.

## Compatibility

All 9+ existing call sites in `tests/spec/picking/`, `tests/spec/distribution/`, `tests/spec/manufacturing/`, `tests/spec/picking/productBasedPicking/` work unchanged. No new arguments, no new contract.

## Out of scope (follow-up)

- Reverting the per-test `waitForResponse` workaround in `picking.spec.js` (https://github.com/metasfresh/metasfresh/pull/23988) and `distribution/trolley.spec.js` (https://github.com/metasfresh/metasfresh/commit/8588b5c7152). The helper grace-period subsumes them, but the workarounds are still correct and unify cleanly in a later PR.