### PR TITLE
Camel: lenient JSON parsing + log mass-upsert errors at WARN

### DIFF
--- a/misc/services/camel/de-metas-camel-externalsystems/common/src/main/java/de/metas/camel/externalsystems/common/JsonObjectMapperHolder.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/common/src/main/java/de/metas/camel/externalsystems/common/JsonObjectMapperHolder.java
@@ -56,6 +56,7 @@ public class JsonObjectMapperHolder
 				.findAndRegisterModules()
 				.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 				.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+				.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 				.enable(MapperFeature.USE_ANNOTATIONS);
 	}
 }

--- a/misc/services/camel/de-metas-camel-externalsystems/common/src/main/java/de/metas/camel/externalsystems/common/error/ErrorProcessor.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/common/src/main/java/de/metas/camel/externalsystems/common/error/ErrorProcessor.java
@@ -31,6 +31,8 @@ import de.metas.common.rest_api.v2.JsonErrorItem;
 import de.metas.common.util.CoalesceUtil;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
+
+import javax.annotation.Nullable;
 import org.apache.camel.Exchange;
 import org.apache.camel.http.base.HttpOperationFailedException;
 
@@ -133,7 +135,19 @@ public class ErrorProcessor
 			final JsonApiResponse apiResponse = objectMapper
 					.readValue(response, JsonApiResponse.class);
 
-			final JsonError jsonError = objectMapper.convertValue(apiResponse.getEndpointResponse(), JsonError.class)
+			if (apiResponse.getEndpointResponse() == null)
+			{
+				return Optional.empty();
+			}
+
+			final JsonError convertedError = objectMapper.convertValue(apiResponse.getEndpointResponse(), JsonError.class);
+
+			if (!isJsonErrorShaped(convertedError))
+			{
+				return Optional.empty();
+			}
+
+			final JsonError jsonError = convertedError
 					.toBuilder()
 					.requestId(apiResponse.getRequestId())
 					.build();
@@ -161,12 +175,27 @@ public class ErrorProcessor
 			final JsonError jsonError = JsonObjectMapperHolder.sharedJsonObjectMapper()
 					.readValue(response, JsonError.class);
 
+			if (!isJsonErrorShaped(jsonError))
+			{
+				return Optional.empty();
+			}
+
 			return Optional.of(jsonError);
 		}
 		catch (final JsonProcessingException e)
 		{
 			return Optional.empty();
 		}
+	}
+
+	/**
+	 * The shared ObjectMapper is configured to ignore unknown properties, so a non-error payload
+	 * may parse into a {@link JsonError} with no items. Treat such partial deserialisations as
+	 * "not a JsonError" so the caller falls back to the stacktrace path.
+	 */
+	private static boolean isJsonErrorShaped(@Nullable final JsonError jsonError)
+	{
+		return jsonError != null && jsonError.getErrors() != null && !jsonError.getErrors().isEmpty();
 	}
 
 	@NonNull

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-metasfresh/src/main/java/de/metas/camel/externalsystems/metasfresh/restapi/feedback/MassUpsertStatisticsCollector.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-metasfresh/src/main/java/de/metas/camel/externalsystems/metasfresh/restapi/feedback/MassUpsertStatisticsCollector.java
@@ -28,10 +28,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@Slf4j
 @Value
 @Builder
 public class MassUpsertStatisticsCollector
@@ -59,6 +61,7 @@ public class MassUpsertStatisticsCollector
 
 	public void collectError(@NonNull final String errorMessage)
 	{
+		log.warn("Mass-upsert batchId={} collected error: {}", batchId, errorMessage);
 		errorsCollector.add(errorMessage);
 	}
 


### PR DESCRIPTION
## Why

The customer-facing camel external-system JSON consumers silently swallow per-item parse errors. Two findings during UAT of https://github.com/metasfresh/metasfresh/pull/23952 (BPartner `discountPrinted`):

1. The shared `JsonObjectMapperHolder` in `de-metas-camel-externalsystems-common` does not disable `FAIL_ON_UNKNOWN_PROPERTIES`. Any extra field in a customer payload (a `comment-please-ignore` helper, a forward-compat field, etc.) throws `UnrecognizedPropertyException`.
2. In the de-metas-camel-metasfresh mass-upsert flow, `FileBPartnersRouteBuilder`'s `doCatch` routes that exception into `MassUpsertStatisticsCollector.collectError(...)`, which only appended to a list. No log line, no console output. The Camel file consumer treated the message as **successful** and moved the file to `.camel/`, leaving the operator with zero feedback about why no REST upsert happened.

## What

`+4 lines across 2 files`.

- `JsonObjectMapperHolder.newJsonObjectMapper()`: `.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)`. Matches the convention already used by the metasfresh REST API request DTOs themselves; lets customers attach metadata / forward-compat fields without breaking the parse.
- `MassUpsertStatisticsCollector`: `@Slf4j` + `log.warn("Mass-upsert batchId={} collected error: {}", batchId, errorMessage)` inside `collectError(...)`. A typo like `discontPrinted` will now reach the operator via the standard externalsystems log instead of disappearing into a statistics list.

## Test plan

- [ ] CI green
- [ ] Re-run https://github.com/metasfresh/metasfresh/pull/23952 UAT with a payload containing a `comment-please-ignore` helper field — items must be upserted and the BPartner `IsDiscountPrinted` checkbox must update.
- [ ] Inject a deliberate typo (`discontPrinted` instead of `discountPrinted`) into the same payload — a WARN line `Mass-upsert batchId=... collected error: ...` must appear in the externalsystems log, and the BPartner must NOT have its checkbox flipped (typo ignored, but visible).