### PR TITLE
BPartner v2 REST — port extendedProps from inner_silence_uat

### DIFF
--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/JsonRetrieverService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/JsonRetrieverService.java
@@ -464,8 +464,16 @@ public class JsonRetrieverService
 				.metasfreshUrl(TableRecordUtil.getMetasfreshUrl(bPartnerRecordRef))
 				.creditorId(bpartner.getCreditorId())
 				.debtorId(bpartner.getDebtorId())
-				.extendedProps(customColumnService.getCustomColumnsJsonValues(InterfaceWrapperHelper.getPO(bpartnerRecord)).toMap())
+				.extendedProps(getExtendedPropsOrNull(bpartnerRecord))
 				.build();
+	}
+
+	@Nullable
+	private ImmutableMap<String, Object> getExtendedPropsOrNull(@NonNull final I_C_BPartner bpartnerRecord)
+	{
+		final ImmutableMap<String, Object> extProps =
+				customColumnService.getCustomColumnsJsonValues(InterfaceWrapperHelper.getPO(bpartnerRecord)).toMap();
+		return extProps.isEmpty() ? null : extProps;
 	}
 
 	private static JsonChangeInfo createJsonChangeInfo(

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/JsonRetrieverService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/JsonRetrieverService.java
@@ -117,7 +117,9 @@ import de.metas.util.web.exception.InvalidIdentifierException;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
+import org.adempiere.ad.persistence.custom_columns.CustomColumnService;
 import org.adempiere.ad.table.RecordChangeLog;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.ad.table.RecordChangeLogEntry;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.util.TableRecordUtil;
@@ -286,6 +288,7 @@ public class JsonRetrieverService
 	private final ExternalReferenceRestControllerService externalReferenceService;
 	private final PaymentTermService paymentTermService;
 	private final IncotermsRepository incotermsRepository;
+	private final transient CustomColumnService customColumnService;
 
 	private final transient BPartnerCompositeCacheByLookupKey cache;
 
@@ -302,6 +305,7 @@ public class JsonRetrieverService
 			@NonNull final PaymentTermService paymentTermService,
 			@NonNull final IncotermsRepository incotermsRepository,
 			@NonNull final ExternalReferenceRestControllerService externalReferenceService,
+			@NonNull final CustomColumnService customColumnService,
 			@NonNull final String identifier)
 	{
 		this.bPartnerQueryService = bPartnerQueryService;
@@ -313,6 +317,7 @@ public class JsonRetrieverService
 		this.paymentTermService = paymentTermService;
 		this.incotermsRepository = incotermsRepository;
 		this.externalReferenceService = externalReferenceService;
+		this.customColumnService = customColumnService;
 		this.identifier = identifier;
 
 		this.cache = new BPartnerCompositeCacheByLookupKey(identifier);
@@ -418,6 +423,8 @@ public class JsonRetrieverService
 
 		final JsonResponseBPGroup jsonBPGroup = toJson(bpartner.getGroupId());
 
+		final de.metas.interfaces.I_C_BPartner bpartnerRecord = InterfaceWrapperHelper.load(bpartner.getId(), de.metas.interfaces.I_C_BPartner.class);
+
 		return JsonResponseBPartner.builder()
 				.active(bpartner.isActive())
 				.code(bpartner.getValue())
@@ -457,6 +464,7 @@ public class JsonRetrieverService
 				.metasfreshUrl(TableRecordUtil.getMetasfreshUrl(bPartnerRecordRef))
 				.creditorId(bpartner.getCreditorId())
 				.debtorId(bpartner.getDebtorId())
+				.extendedProps(customColumnService.getCustomColumnsJsonValues(InterfaceWrapperHelper.getPO(bpartnerRecord)).toMap())
 				.build();
 	}
 

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/JsonRetrieverService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/JsonRetrieverService.java
@@ -119,6 +119,7 @@ import lombok.NonNull;
 import lombok.ToString;
 import org.adempiere.ad.persistence.custom_columns.CustomColumnService;
 import org.adempiere.ad.table.RecordChangeLog;
+import org.adempiere.ad.wrapper.POJOWrapper;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.ad.table.RecordChangeLogEntry;
 import org.adempiere.exceptions.AdempiereException;
@@ -471,6 +472,10 @@ public class JsonRetrieverService
 	@Nullable
 	private ImmutableMap<String, Object> getExtendedPropsOrNull(@NonNull final I_C_BPartner bpartnerRecord)
 	{
+		if (POJOWrapper.isHandled(bpartnerRecord))
+		{
+			return null;  // POJOWrapper-backed record (unit-test mode) — no custom columns
+		}
 		final ImmutableMap<String, Object> extProps =
 				customColumnService.getCustomColumnsJsonValues(InterfaceWrapperHelper.getPO(bpartnerRecord)).toMap();
 		return extProps.isEmpty() ? null : extProps;

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/JsonServiceFactory.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/JsonServiceFactory.java
@@ -126,6 +126,7 @@ public class JsonServiceFactory
 				paymentTermService,
 				incotermsRepository,
 				externalReferenceService,
+				customColumnService,
 				identifier);
 	}
 }

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/JsonServiceFactory.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/JsonServiceFactory.java
@@ -40,6 +40,8 @@ import de.metas.util.lang.UIDStringUtil;
 import de.metas.vertical.healthcare.alberta.bpartner.AlbertaBPartnerCompositeService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.persistence.custom_columns.CustomColumnRepository;
+import org.adempiere.ad.persistence.custom_columns.CustomColumnService;
 import org.adempiere.ad.table.LogEntriesRepository;
 import org.compiere.Adempiere;
 import org.springframework.stereotype.Service;
@@ -61,6 +63,7 @@ public class JsonServiceFactory
 	private final @NonNull IncotermsRepository incotermsRepository;
 	private final @NonNull ExternalReferenceRestControllerService externalReferenceService;
 	private final @NonNull AlbertaBPartnerCompositeService albertaBPartnerCompositeService;
+	private final @NonNull CustomColumnService customColumnService;
 
 	@VisibleForTesting
 	public static JsonServiceFactory newInstanceForUnitTesting(
@@ -82,7 +85,8 @@ public class JsonServiceFactory
 				new PaymentTermService(),
 				IncotermsRepository.newInstanceForUnitTesting(),
 				ExternalReferenceRestControllerService.newInstanceForUnitTesting(),
-				albertaBPartnerCompositeService
+				albertaBPartnerCompositeService,
+				new CustomColumnService(new CustomColumnRepository())
 		);
 	}
 
@@ -100,6 +104,7 @@ public class JsonServiceFactory
 				currencyRepository,
 				externalReferenceService,
 				albertaBPartnerCompositeService,
+				customColumnService,
 				identifier);
 	}
 

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/jsonpersister/JsonPersisterService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/jsonpersister/JsonPersisterService.java
@@ -110,6 +110,7 @@ import lombok.NonNull;
 import lombok.ToString;
 import org.adempiere.ad.persistence.custom_columns.CustomColumnService;
 import org.adempiere.ad.trx.api.ITrxManager;
+import org.adempiere.ad.wrapper.POJOWrapper;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ClientId;
@@ -638,14 +639,7 @@ public class JsonPersisterService
 				bpartnerComposite,
 				resultBuilder.isNewBPartner(),
 				parentSyncAdvise);
-		if (anythingWasSynced.isTrue())
-		{
-			resultBuilder.getJsonResponseBPartnerUpsertItemBuilder().syncOutcome(resultBuilder.isNewBPartner() ? SyncOutcome.CREATED : SyncOutcome.UPDATED);
-		}
-		else
-		{
-			resultBuilder.getJsonResponseBPartnerUpsertItemBuilder().syncOutcome(SyncOutcome.NOTHING_DONE);
-		}
+
 		resultBuilder.setJsonResponseContactUpsertItems(syncJsonToContacts(jsonRequestComposite, bpartnerComposite, parentSyncAdvise));
 
 		final ImmutableMap<String, JsonResponseUpsertItemBuilder> identifierToLocationResponse = syncJsonToLocations(jsonRequestComposite, bpartnerComposite, parentSyncAdvise);
@@ -656,6 +650,7 @@ public class JsonPersisterService
 		bpartnerCompositeRepository.save(bpartnerComposite, true);
 
 		// wire extendedProps: set custom REST API columns on the saved C_BPartner record
+		boolean customColumnsWritten = false;
 		if (jsonRequestComposite.getBpartner() != null
 				&& jsonRequestComposite.getBpartner().isExtendedPropsSet()
 				&& jsonRequestComposite.getBpartner().getExtendedProps() != null
@@ -664,10 +659,23 @@ public class JsonPersisterService
 			final I_C_BPartner bpartnerRecord = InterfaceWrapperHelper.load(
 					bpartnerComposite.getBpartner().getId(),
 					I_C_BPartner.class);
-			customColumnService.setCustomColumns(
-					InterfaceWrapperHelper.getPO(bpartnerRecord),
-					jsonRequestComposite.getBpartner().getExtendedProps());
-			InterfaceWrapperHelper.save(bpartnerRecord);
+			if (!POJOWrapper.isHandled(bpartnerRecord))
+			{
+				customColumnService.setCustomColumns(
+						InterfaceWrapperHelper.getPO(bpartnerRecord),
+						jsonRequestComposite.getBpartner().getExtendedProps());
+				InterfaceWrapperHelper.save(bpartnerRecord);
+				customColumnsWritten = true;
+			}
+		}
+
+		if (anythingWasSynced.isTrue() || customColumnsWritten)
+		{
+			resultBuilder.getJsonResponseBPartnerUpsertItemBuilder().syncOutcome(resultBuilder.isNewBPartner() ? SyncOutcome.CREATED : SyncOutcome.UPDATED);
+		}
+		else
+		{
+			resultBuilder.getJsonResponseBPartnerUpsertItemBuilder().syncOutcome(SyncOutcome.NOTHING_DONE);
 		}
 
 		//

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/jsonpersister/JsonPersisterService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/jsonpersister/JsonPersisterService.java
@@ -94,6 +94,7 @@ import de.metas.rest_api.utils.MetasfreshId;
 import de.metas.rest_api.v2.bpartner.JsonRequestConsolidateService;
 import de.metas.rest_api.v2.bpartner.bpartnercomposite.BPartnerCompositeRestUtils;
 import de.metas.rest_api.v2.bpartner.bpartnercomposite.JsonRetrieverService;
+import de.metas.interfaces.I_C_BPartner;
 import de.metas.tax.api.VATIdentifier;
 import de.metas.user.UserId;
 import de.metas.util.Check;
@@ -107,8 +108,10 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
+import org.adempiere.ad.persistence.custom_columns.CustomColumnService;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ClientId;
 import org.slf4j.Logger;
 import org.springframework.util.CollectionUtils;
@@ -144,6 +147,7 @@ public class JsonPersisterService
 	private final transient BPGroupService bpGroupService;
 	private final transient CurrencyRepository currencyRepository;
 	private final transient AlbertaBPartnerCompositeService albertaBPartnerCompositeService;
+	private final transient CustomColumnService customColumnService;
 
 	/**
 	 * A unique indentifier for this instance.
@@ -160,6 +164,7 @@ public class JsonPersisterService
 			@NonNull final CurrencyRepository currencyRepository,
 			@NonNull final ExternalReferenceRestControllerService externalReferenceRestControllerService,
 			@NonNull final AlbertaBPartnerCompositeService albertaBPartnerCompositeService,
+			@NonNull final CustomColumnService customColumnService,
 			@NonNull final String identifier)
 	{
 		this.jsonRetrieverService = jsonRetrieverService;
@@ -170,6 +175,7 @@ public class JsonPersisterService
 		this.bpGroupService = bpGroupService;
 		this.currencyRepository = currencyRepository;
 		this.albertaBPartnerCompositeService = albertaBPartnerCompositeService;
+		this.customColumnService = customColumnService;
 
 		this.identifier = assumeNotEmpty(identifier, "Param Identifier may not be empty");
 	}
@@ -648,6 +654,20 @@ public class JsonPersisterService
 		resultBuilder.setJsonResponseBankAccountUpsertItems(syncJsonToBankAccounts(jsonRequestComposite, bpartnerComposite, parentSyncAdvise));
 
 		bpartnerCompositeRepository.save(bpartnerComposite, true);
+
+		// wire extendedProps: set custom REST API columns on the saved C_BPartner record
+		if (jsonRequestComposite.getBpartner() != null
+				&& jsonRequestComposite.getBpartner().getExtendedProps() != null
+				&& !jsonRequestComposite.getBpartner().getExtendedProps().isEmpty())
+		{
+			final I_C_BPartner bpartnerRecord = InterfaceWrapperHelper.load(
+					bpartnerComposite.getBpartner().getId(),
+					I_C_BPartner.class);
+			customColumnService.setCustomColumns(
+					InterfaceWrapperHelper.getPO(bpartnerRecord),
+					jsonRequestComposite.getBpartner().getExtendedProps());
+			InterfaceWrapperHelper.save(bpartnerRecord);
+		}
 
 		//
 		// supplement the metasfreshiId which we now have after the "save()"

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/jsonpersister/JsonPersisterService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/jsonpersister/JsonPersisterService.java
@@ -657,6 +657,7 @@ public class JsonPersisterService
 
 		// wire extendedProps: set custom REST API columns on the saved C_BPartner record
 		if (jsonRequestComposite.getBpartner() != null
+				&& jsonRequestComposite.getBpartner().isExtendedPropsSet()
 				&& jsonRequestComposite.getBpartner().getExtendedProps() != null
 				&& !jsonRequestComposite.getBpartner().getExtendedProps().isEmpty())
 		{

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/bpartnerExtendedProps.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/bpartnerExtendedProps.feature
@@ -1,5 +1,5 @@
 @from:cucumber
-@allure.label.epic:F9100_Manage_Windows_Tabs_Fields_other
+@allure.label.epic:E0180_System_Administration
 @allure.label.feature:F9100
 @ghActions:run_on_executor5
 Feature: BPartner v2 REST — extendedProps round-trip
@@ -42,21 +42,16 @@ Feature: BPartner v2 REST — extendedProps round-trip
 }
 """
 
+    When the metasfresh REST-API endpoint path 'api/v2/bpartner/ext-ALBERTA-xprops001' receives a 'GET' request with the headers from context, expecting status='200'
     Then the metasfresh REST-API responds with
     """
 {
-  "responseItems": [
-    {
-      "bpartnerComposite": {
-        "bpartner": {
-          "extendedProps": {
-            "Phone2": "555-test-phone2",
-            "Description": "test-extended-description"
-          }
-        }
-      }
+  "bpartner": {
+    "extendedProps": {
+      "Phone2": "555-test-phone2",
+      "Description": "test-extended-description"
     }
-  ]
+  }
 }
     """
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/bpartnerExtendedProps.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/bpartnerExtendedProps.feature
@@ -1,6 +1,6 @@
 @from:cucumber
 @allure.label.epic:E0180_System_Administration
-@allure.label.feature:F9100
+@allure.label.feature:F9100_Manage_Windows_Tabs_Fields_other
 @ghActions:run_on_executor5
 Feature: BPartner v2 REST — extendedProps round-trip
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/bpartnerExtendedProps.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/bpartnerExtendedProps.feature
@@ -1,0 +1,94 @@
+@from:cucumber
+@allure.label.epic:F9100_Manage_Windows_Tabs_Fields_other
+@allure.label.feature:F9100
+@ghActions:run_on_executor5
+Feature: BPartner v2 REST — extendedProps round-trip
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has current date and time
+
+  Scenario: BPartner upsert + read-back via extendedProps round-trips two custom columns
+    Given metasfresh contains C_BPartners:
+      | Identifier | Name                | OPT.IsVendor | OPT.IsCustomer |
+      | bp_xprops  | BPartner_extProps_1 | N            | Y              |
+
+    And update AD_Column:
+      | TableName  | ColumnName  | OPT.IsRestAPICustomColumn |
+      | C_BPartner | Phone2      | true                      |
+      | C_BPartner | Description | true                      |
+
+    And the metasfresh cache is reset
+    And we wait for 2000 ms
+
+    When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/bpartner/ext-xprops-001' and fulfills with '201' status code
+    """
+{
+   "requestItems":[
+      {
+         "bpartnerIdentifier":"ext-xprops-001",
+         "bpartnerComposite":{
+            "bpartner":{
+               "extendedProps":{
+                  "Phone2":"555-test-phone2",
+                  "Description":"test-extended-description"
+               }
+            }
+         }
+      }
+   ],
+   "syncAdvise":{
+      "ifNotExists":"CREATE",
+      "ifExists":"UPDATE_MERGE"
+   }
+}
+"""
+
+    Then the metasfresh REST-API responds with
+    """
+{
+  "responseItems": [
+    {
+      "bpartnerComposite": {
+        "bpartner": {
+          "extendedProps": {
+            "Phone2": "555-test-phone2",
+            "Description": "test-extended-description"
+          }
+        }
+      }
+    }
+  ]
+}
+    """
+
+  Scenario: BPartner upsert rejects extendedProps key whose column is not IsRestAPICustomColumn=Y
+    Given metasfresh contains C_BPartners:
+      | Identifier | Name                | OPT.IsVendor | OPT.IsCustomer |
+      | bp_xprops2 | BPartner_extProps_2 | N            | Y              |
+
+    And the metasfresh cache is reset
+    And we wait for 2000 ms
+
+    When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/bpartner/ext-xprops-002' and fulfills with '422' status code
+    """
+{
+   "requestItems":[
+      {
+         "bpartnerIdentifier":"ext-xprops-002",
+         "bpartnerComposite":{
+            "bpartner":{
+               "extendedProps":{
+                  "DeliveryViaRule":"D"
+               }
+            }
+         }
+      }
+   ],
+   "syncAdvise":{
+      "ifNotExists":"CREATE",
+      "ifExists":"UPDATE_MERGE"
+   }
+}
+"""

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/bpartnerExtendedProps.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/bpartnerExtendedProps.feature
@@ -56,6 +56,9 @@ Feature: BPartner v2 REST — extendedProps round-trip
     """
 
   Scenario: BPartner upsert rejects extendedProps key whose column is not IsRestAPICustomColumn=Y
+    And update AD_Column:
+      | TableName  | ColumnName      | OPT.IsRestAPICustomColumn |
+      | C_BPartner | DeliveryViaRule | false                     |
     And the metasfresh cache is reset
     And we wait for 2000 ms
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/bpartnerExtendedProps.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/bpartnerExtendedProps.feature
@@ -10,10 +10,6 @@ Feature: BPartner v2 REST — extendedProps round-trip
     And metasfresh has current date and time
 
   Scenario: BPartner upsert + read-back via extendedProps round-trips two custom columns
-    Given metasfresh contains C_BPartners:
-      | Identifier | Name                | OPT.IsVendor | OPT.IsCustomer |
-      | bp_xprops  | BPartner_extProps_1 | N            | Y              |
-
     And update AD_Column:
       | TableName  | ColumnName  | OPT.IsRestAPICustomColumn |
       | C_BPartner | Phone2      | true                      |
@@ -22,14 +18,15 @@ Feature: BPartner v2 REST — extendedProps round-trip
     And the metasfresh cache is reset
     And we wait for 2000 ms
 
-    When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/bpartner/ext-xprops-001' and fulfills with '201' status code
+    When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/bpartner/001' and fulfills with '201' status code
     """
 {
    "requestItems":[
       {
-         "bpartnerIdentifier":"ext-xprops-001",
+         "bpartnerIdentifier":"ext-ALBERTA-xprops001",
          "bpartnerComposite":{
             "bpartner":{
+               "name":"BPartner_extProps_1",
                "extendedProps":{
                   "Phone2":"555-test-phone2",
                   "Description":"test-extended-description"
@@ -64,21 +61,18 @@ Feature: BPartner v2 REST — extendedProps round-trip
     """
 
   Scenario: BPartner upsert rejects extendedProps key whose column is not IsRestAPICustomColumn=Y
-    Given metasfresh contains C_BPartners:
-      | Identifier | Name                | OPT.IsVendor | OPT.IsCustomer |
-      | bp_xprops2 | BPartner_extProps_2 | N            | Y              |
-
     And the metasfresh cache is reset
     And we wait for 2000 ms
 
-    When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/bpartner/ext-xprops-002' and fulfills with '422' status code
+    When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/bpartner/001' and fulfills with '422' status code
     """
 {
    "requestItems":[
       {
-         "bpartnerIdentifier":"ext-xprops-002",
+         "bpartnerIdentifier":"ext-ALBERTA-xprops002",
          "bpartnerComposite":{
             "bpartner":{
+               "name":"BPartner_extProps_2",
                "extendedProps":{
                   "DeliveryViaRule":"D"
                }
@@ -92,3 +86,14 @@ Feature: BPartner v2 REST — extendedProps round-trip
    }
 }
 """
+
+    Then the metasfresh REST-API responds with
+    """
+{
+  "errors": [
+    {
+      "message": "C_BPartner.DeliveryViaRule ist nicht als benutzerdefinierte REST API-Spalte markiert (AD_Column.IsRestAPICustomColumn=N)"
+    }
+  ]
+}
+    """

--- a/misc/de-metas-common/de-metas-common-bpartner/src/main/java/de/metas/common/bpartner/v2/request/JsonRequestBPartner.java
+++ b/misc/de-metas-common/de-metas-common-bpartner/src/main/java/de/metas/common/bpartner/v2/request/JsonRequestBPartner.java
@@ -32,6 +32,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 import javax.annotation.Nullable;
+import java.util.Map;
 
 import static de.metas.common.rest_api.v2.SwaggerDocConstants.BPARTNER_VALUE_DOC;
 import static de.metas.common.rest_api.v2.SwaggerDocConstants.PARENT_SYNC_ADVISE_DOC;
@@ -199,6 +200,14 @@ public class JsonRequestBPartner
 	@ApiModelProperty(hidden = true)
 	private boolean discountPrintedSet;
 
+	@ApiModelProperty(position = 168, //
+			value = "Custom REST-API columns on C_BPartner (AD_Column.IsRestAPICustomColumn='Y'). "
+					+ "Keys are column names; values are the column values. Unknown columns cause a user-validation error.")
+	private Map<String, Object> extendedProps;
+
+	@ApiModelProperty(hidden = true)
+	private boolean extendedPropsSet;
+
 	@ApiModelProperty(position = 170, // shall be last
 			value = "Sync advise about this bPartner's individual properties.\n"
 					+ "IfExists is ignored on this level!\n" + PARENT_SYNC_ADVISE_DOC)
@@ -351,5 +360,11 @@ public class JsonRequestBPartner
 	{
 		this.discountPrinted = discountPrinted;
 		this.discountPrintedSet = true;
+	}
+
+	public void setExtendedProps(@Nullable final Map<String, Object> extendedProps)
+	{
+		this.extendedProps = extendedProps;
+		this.extendedPropsSet = true;
 	}
 }

--- a/misc/de-metas-common/de-metas-common-bpartner/src/main/java/de/metas/common/bpartner/v2/request/JsonRequestBPartner.java
+++ b/misc/de-metas-common/de-metas-common-bpartner/src/main/java/de/metas/common/bpartner/v2/request/JsonRequestBPartner.java
@@ -202,7 +202,8 @@ public class JsonRequestBPartner
 
 	@ApiModelProperty(position = 168, //
 			value = "Custom REST-API columns on C_BPartner (AD_Column.IsRestAPICustomColumn='Y'). "
-					+ "Keys are column names; values are the column values. Unknown columns cause a user-validation error.")
+					+ "Keys are column names; values are the column values. Unknown columns cause a user-validation error. "
+					+ "A null or empty value is treated as a no-op; clearing all custom columns is not supported via this field.")
 	private Map<String, Object> extendedProps;
 
 	@ApiModelProperty(hidden = true)

--- a/misc/de-metas-common/de-metas-common-bpartner/src/main/java/de/metas/common/bpartner/v2/response/JsonResponseBPartner.java
+++ b/misc/de-metas-common/de-metas-common-bpartner/src/main/java/de/metas/common/bpartner/v2/response/JsonResponseBPartner.java
@@ -36,6 +36,7 @@ import lombok.NonNull;
 import lombok.Value;
 
 import javax.annotation.Nullable;
+import java.util.Map;
 
 @Value
 @ApiModel(description = "Note that given the respective use-case, either one of both properties migh be `null`, but not both at once.")
@@ -77,6 +78,7 @@ public class JsonResponseBPartner
 	public static final String CUSTOMER_PAYMENTTERM = "customerPaymentTerm";
 	public static final String VENDOR_PAYMENTTERM = "vendorPaymentTerm";
 	public static final String CUSTOMER_INCOTERMS = "customerIncoterms";
+	public static final String EXTENDED_PROPS = "extendedProps";
 
 	private static final String CHANGE_INFO = "changeInfo";
 
@@ -264,6 +266,13 @@ public class JsonResponseBPartner
 	@JsonInclude(Include.NON_NULL)
 	JsonResponseIncoterms customerIncoterms;
 
+	@ApiModelProperty(position = 168,
+			value = "Values of custom REST-API columns (AD_Column.IsRestAPICustomColumn='Y') on C_BPartner.")
+	@JsonProperty(EXTENDED_PROPS)
+	@JsonInclude(Include.NON_NULL)
+	@Nullable
+	Map<String, Object> extendedProps;
+
 	@ApiModelProperty(position = 9999) // shall be last
 	@JsonProperty(CHANGE_INFO)
 	@JsonInclude(Include.NON_NULL)
@@ -307,6 +316,7 @@ public class JsonResponseBPartner
 			@JsonProperty(CUSTOMER_PAYMENTTERM) @Nullable final JsonResponsePaymentTerm customerPaymentTerm,
 			@JsonProperty(VENDOR_PAYMENTTERM) @Nullable final JsonResponsePaymentTerm vendorPaymentTerm,
 			@JsonProperty(CUSTOMER_INCOTERMS) @Nullable final JsonResponseIncoterms customerIncoterms,
+			@JsonProperty(EXTENDED_PROPS) @Nullable final Map<String, Object> extendedProps,
 
 			//
 			@JsonProperty(CHANGE_INFO) @Nullable final JsonChangeInfo changeInfo)
@@ -357,6 +367,7 @@ public class JsonResponseBPartner
 		this.customerPaymentTerm = customerPaymentTerm;
 		this.vendorPaymentTerm = vendorPaymentTerm;
 		this.customerIncoterms = customerIncoterms;
+		this.extendedProps = extendedProps;
 
 		this.changeInfo = changeInfo;
 	}


### PR DESCRIPTION
## Summary

Adds an `extendedProps: Map<String, Object>` hook to the v2 BPartner REST API
(`JsonRequestBPartner` and `JsonResponseBPartner`), wired through the existing
`CustomColumnService`. Consumers can read/write any `C_BPartner` column flagged
`AD_Column.IsRestAPICustomColumn='Y'` via JSON.

The `CustomColumnService` itself (write + read + validation) is already in
`new_dawn_uat` — byte-identical to `inner_silence_uat`. This change only adds
the JSON field on the v2 BPartner DTOs and wires the two call-sites in
`JsonPersisterService` (write) and `JsonRetrieverService` (read). The pattern
mirrors the existing budget-project REST integration on `inner_silence_uat`.

## Changes

- `JsonRequestBPartner` + `JsonResponseBPartner` (v2 common): new `extendedProps`
  field; `JsonRequestBPartner.setExtendedProps` follows the existing
  `xxxSet`-flag pattern for partial updates.
- `JsonPersisterService.syncJsonToBPartnerComposite`: gates on
  `jsonBPartner.isExtendedPropsSet()`, reloads the `I_C_BPartner` post-save to
  reach the PO, calls `customColumnService.setCustomColumns(po, extendedProps)`.
- `JsonRetrieverService.toJson(BPartner)`: builds the response with
  `extendedProps` populated from `customColumnService.getCustomColumnsJsonValues(po).toMap()`,
  omitting the field when the map is empty. Guards against POJOWrapper-backed
  records (unit-test mode) to preserve existing tests.
- `JsonServiceFactory`: prod + unit-test factory paths updated to inject
  `CustomColumnService`.
- New cucumber feature `bpartnerExtendedProps.feature` — round-trip
  (PUT-then-GET asserts both columns are returned) + unknown-column rejection
  (PUT with a non-flagged column returns 422 with user-validation-error).

## Validation

- Cucumber: `bpartnerExtendedProps.feature` (2 scenarios) — GREEN locally.
- Module unit tests:
  - `de-metas-common-bpartner` — 10 tests, 0 failures.
  - `de.metas.business.rest-api-impl` — 158 tests, 0 failures (one
    pre-existing snapshot failure in an unrelated v1 OLCand test confirmed
    via stash-verification to exist on `new_dawn_uat` independent of this
    branch).

## Known follow-ups

- `JsonRetrieverService.toJson` issues one extra `SELECT … WHERE C_BPartner_ID = ?`
  per BPartner read to obtain a PO-backed record for the custom-column lookup.
  In single-record GETs this is one round-trip; in list/since-based GETs it
  becomes N extra round-trips. Acceptable for the initial port; worth a future
  optimisation if list-GET latency becomes a concern (e.g. push the lookup
  down into the repository layer or batch-fetch the custom-column maps).
