### PR TITLE
me03#29557 — Fix M_Product.DepositType: CHAR(3) -> VARCHAR(3)

### DIFF
--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5802960_sys_me03_29557_DepositType_varchar.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5802960_sys_me03_29557_DepositType_varchar.sql
@@ -1,0 +1,35 @@
+-- me03#29557: Change M_Product.DepositType from CHAR(3) to VARCHAR(3)
+--
+-- The original migration (58023600_sys_me03_29557_M_Product_DepositType.sql) created the
+-- column as CHAR(3). PostgreSQL space-pads CHAR(n) columns on read, so the 2-char value
+-- 'RC' was stored and emitted as 'RC ' (with a trailing space). Two symptoms:
+--   * Outgoing INVOIC-JSON carried "Product_DepositType": "RC "  — wrong wire format for
+--     downstream EDIFACT converters expecting a clean "RC".
+--   * WebUI save-after-switch (e.g. RC -> NRC) failed with the framework's optimistic-
+--     concurrency check:
+--       "Document's field was changed from when we last queried it ...
+--        Document field initial value: RC   PO value: RC "
+--     The document framework loaded the trimmed value 'RC' as the initial value but the
+--     PO save handler compared against the raw CHAR-padded 'RC ' — the inequality
+--     triggers a spurious "changed since query" failure on save.
+--
+-- Fix: switch to VARCHAR(3), then RTRIM any space-padded values that already exist in
+-- production data so subsequent reads/serialisations get the clean value.
+
+-- 1) Backup row(s) that carry the column today (defensive — usually <1k rows, but
+--    cheap insurance against the RTRIM accidentally clobbering a value we didn't expect)
+SELECT backup_table('m_product', '_pre_5802960_deposittype_varchar');
+
+-- 2) Switch the physical column type. t_alter_column handles view dependencies + the
+--    existing CHECK constraint stays attached (the constraint matches IN ('NRC','RC')
+--    by value, not by data type).
+INSERT INTO t_alter_column VALUES ('M_Product','DepositType','VARCHAR(3)',NULL,NULL);
+
+-- 3) Strip the trailing space the CHAR(3) padding left on 2-char values like 'RC'.
+--    'NRC' is unaffected (length 3 — no padding). NULL is unaffected.
+UPDATE m_product
+SET DepositType = RTRIM(DepositType),
+    Updated     = TO_TIMESTAMP('2026-05-18 17:00','YYYY-MM-DD HH24:MI'),
+    UpdatedBy   = 99 -- Support — flagged as a migration-script change, not business logic
+WHERE DepositType IS NOT NULL
+  AND DepositType <> RTRIM(DepositType);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediInvoicExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediInvoicExport.feature
@@ -251,6 +251,75 @@ Feature: EDI INVOIC export via postgREST
 }
     """
 
+  @Id:S0467_030
+  @from:cucumber
+@allure.label.epic:E0292_EDI
+@allure.label.feature:F00350_EDI
+@F00350
+  Scenario: INVOIC JSON export exposes Product_DepositType="RC" without space-padding (me03#29557 follow-up)
+    # Regression for the bug fixed by migration 5802960: M_Product.DepositType was originally CHAR(3),
+    # so the 2-char value 'RC' was stored and emitted as 'RC ' (space-padded). After the type change
+    # to VARCHAR(3) + RTRIM data fix the JSON must carry exactly "RC".
+    Given metasfresh contains C_BPartners without locations:
+      | Identifier | IsCustomer | REST.Context.Name | REST.Context.Value | IsVendor | M_PricingSystem_ID |
+      | customer1  | Y          | customerName      | customerValue      | N        | pricingSystem      |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier          | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | bpartner_location_1 | customer1     | Y               | Y               |
+    And metasfresh contains M_Products:
+      | Identifier        | Value                       | Name                       | Description                       | DepositType |
+      | product_S0467_030 | depositTypeRCProductValue   | depositTypeRCProductName   | depositTypeRCProductDescription   | RC          |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID      | PriceStd | C_UOM_ID |
+      | salesPLV               | product_S0467_030 | 5.00     | PCE      |
+    And metasfresh contains C_Invoice:
+      | Identifier            | REST.Context             | C_BPartner_ID | C_DocTypeTarget_ID.Name | DocumentNo | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | salesInvoiceS0467_030 | salesInvoiceS0467_030_ID | customer1     | Ausgangsrechnung        | S0467_030  | 2025-05-01   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID          | M_Product_ID      | QtyInvoiced |
+      | salesInvoiceS0467_030 | product_S0467_030 | 1 PCE       |
+    And the invoice identified by salesInvoiceS0467_030 is completed
+
+    And the following API_Audit_Config records are created:
+      | Identifier | SeqNo | OPT.Method | OPT.PathPrefix   | IsForceProcessedAsync | IsSynchronousAuditLoggingEnabled | IsWrapApiResponse |
+      | c_030      | 10    | GET        | api/v2/processes | N                     | Y                                | N                 |
+    And add HTTP headers
+      | Key          | Value                          |
+      | Content-Type | application/json;charset=UTF-8 |
+      | accept       | application/json;charset=UTF-8 |
+
+    When a 'POST' request with the below payload and headers from context is sent to the metasfresh REST-API 'api/v2/processes/C_Invoice_EDI_Export_JSON/invoke' and fulfills with '200' status code
+    """
+{
+  "processParameters": [
+    {
+      "name": "C_Invoice_ID",
+      "value": "@salesInvoiceS0467_030_ID@"
+    }
+  ]
+}
+    """
+
+    Then the metasfresh REST-API responds with
+    """
+{
+  "metasfresh_INVOIC": [
+    {
+      "Invoice_ID": @salesInvoiceS0467_030_ID@,
+      "Invoice_DocumentNo": "S0467_030",
+      "Lines": [
+        {
+          "Invoice_Line": 10,
+          "Product_Name": "depositTypeRCProductName",
+          "Product_Supplier_ProductNo": "depositTypeRCProductValue",
+          "Product_DepositType": "RC"
+        }
+      ]
+    }
+  ]
+}
+    """
+
   @from:cucumber
 @allure.label.epic:E0292_EDI
 @allure.label.feature:F00350_EDI


### PR DESCRIPTION
## Summary

Two symptoms reported during UAT on `seefruchtrelease`, both rooted in `M_Product.DepositType` being declared `CHAR(3)` by the original me03#29557 migration:

1. **INVOIC-JSON emitted `"Product_DepositType": "RC "`** (with a trailing space) for the 2-char value `RC`. PostgreSQL space-pads `CHAR(n)` reads; the view passes the value through unchanged. Downstream EDIFACT converters reading the JSON saw `"RC "` instead of `"RC"`.

2. **WebUI save-after-switch (e.g. RC → NRC) failed** with the framework's optimistic-concurrency guard:
   ```
   Document's field was changed from when we last queried it ...
   initialValue: RC   PO value: RC
   ... at DefaultSaveHandler.setPOValue:317
   ```
   The document framework loaded the **trimmed** value `RC` as `initialValue` but the PO save handler compared against the **raw CHAR-padded `RC `**. The bytewise inequality looked like an outside modification to the framework, blocking the save.

## Fix

- `t_alter_column` on `M_Product.DepositType`, switching it to `VARCHAR(3)`.
- `RTRIM` any value that's still space-padded from before the type change.

The `CHECK (DepositType IS NULL OR DepositType IN ('NRC','RC'))` constraint stays attached and keeps holding — `IN` compares by value after the trim. `AD_Column.FieldLength` is unchanged at 3.

## Files

- `backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5802960_sys_me03_29557_DepositType_varchar.sql` — migration (defensive `backup_table` + `t_alter_column` + RTRIM).
- `backend/de.metas.cucumber/.../ediInvoicExport.feature` — new scenario `S0467_030` covers the RC case end-to-end: configures a product with `DepositType='RC'`, completes an invoice, exports as JSON, asserts the JSON carries exactly `"RC"` (without trailing space). The existing `S0467_020` (NRC case) was unaffected — `NRC` is already 3 chars and therefore never padded.

## Test plan

- [x] Migration applies cleanly to the local swift_eagle_uat template DB.
- [x] `information_schema.columns` reports `character varying(3)` after the migration.
- [x] Existing data rows are clean (`'NRC'` length 3; padded `'RC '` would be trimmed to `'RC'`).
- [x] `S0467_030` passes locally.
- [ ] Full CI cucumber + Playwright suites green.

## Source issue

https://github.com/metasfresh/me03/issues/29557 (follow-up to the merged PR #23949 that introduced the column).