### PR TITLE
cucumber: drain de.metas.material before C_Invoice_Candidate poll in 2 invoice features

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/DeliveryDateAsInvoiceDate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/DeliveryDateAsInvoiceDate.feature
@@ -47,6 +47,14 @@ Feature: Invoice Date can be taken from DeliveryDate
     And after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
       | s_s_1                            | s_1                   |
+
+    # Drain the material event queue so invoice-candidate async creation completes before the poll.
+    # Background sets SKIP_WP_PROCESSOR_FOR_AUTOMATION=true, forcing async via RabbitMQ. Under CI load
+    # this poll occasionally exhausts its 60 s budget, cascading to the step-def's 120 s recompute
+    # fallback, which can in turn time out and abort the runner before any test completes
+    # ("Tests run: 0").
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     And after not more than 60s, C_Invoice_Candidate are found:
       | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
       | ic_1                              | sol_1                     | 10           |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceAggregationWithReversal.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceAggregationWithReversal.feature
@@ -48,6 +48,13 @@ Feature: Invoice aggregation of 2 IC2 when one IC was previously invoiced and re
       | s_s_2_1    | sol_2_1        | N             |
       | s_s_2_2    | sol_2_2        | N             |
 
+    # Drain the material event queue so invoice-candidate async creation completes before the poll.
+    # Background sets SKIP_WP_PROCESSOR_FOR_AUTOMATION=true, forcing async via RabbitMQ. Under CI load
+    # this poll occasionally exhausts its 60 s budget, cascading to the step-def's 120 s recompute
+    # fallback, which can in turn time out and abort the runner before any test completes
+    # ("Tests run: 0").
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
     And after not more than 60s, C_Invoice_Candidate are found:
       | C_Invoice_Candidate_ID | C_OrderLine_ID | QtyToInvoice |
       | ic_2_1                 | sol_2_1        | 0            |


### PR DESCRIPTION
## What

Same fix pattern as https://github.com/metasfresh/metasfresh/pull/23990 (materialDispo S0265_40/_50). Two more cucumber Backgrounds set `SKIP_WP_PROCESSOR_FOR_AUTOMATION=true` (forcing async via RabbitMQ) and poll `C_Invoice_Candidate` immediately after an async trigger, without first draining the material event queue. Adds the verbatim drain step:

```
And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
```

Affected files:
- `backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/DeliveryDateAsInvoiceDate.feature` — drain between the `M_InOut is found` step and the `C_Invoice_Candidate are found` poll
- `backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceAggregationWithReversal.feature` — drain between the `M_ShipmentSchedules are found` step and the `C_Invoice_Candidate are found` poll

## Why

Under CI runner contention (profile3 of 6 parallel cucumber profiles), the 60 s `C_Invoice_Candidate` poll occasionally exhausts its budget. The step-def's fallback `manuallyRecomputeInvoiceCandidate()` (`C_Invoice_Candidate_StepDef.java:1201`) invalidates and retries with 120 s. When the second poll also times out, the JUnit5 runner doesn't shut down cleanly — the cucumber engine reports `Tests run: 0, Failures: 0, Errors: 0` and the JUnit XML report is never written.

This `Tests run: 0` symptom was observed twice today on unrelated PRs that just happened to trigger profile3 within the contention window:

- https://github.com/metasfresh/metasfresh/actions/runs/26024661467 — `test (cucumber) (profile3)`
- https://github.com/metasfresh/metasfresh/actions/runs/26024776821 — `test (cucumber) (profile3)`

Both showed the identical log signature: a backend exception on an early scenario, followed by `C_Invoice_Candidate_StepDef — *** C_Invoice_Candidate was not found within 120 seconds (121 tries)`, followed by `Tests run: 0` and `JUnit XML report not found`.

## Risk

- Drain step is verbatim from 28+ existing occurrences across the cucumber feature tree (`RabbitMQ_StepDef.java:99` — "5 minutes" hard-coded, not a parameter).
- The fix is additive; it cannot break any currently-passing scenario.
- Sister scenarios in the same domain (`materialDispo` S0265_10/_20/_30/_40/_50) already use this exact pattern with `de.metas.material` as the queue.

## Verification

- **Local cucumber run** blocked by the same unrelated stale-jar issue as PR 23990 (`M_HU_Attribute_StepDef.java` references `HUAttributeUpdateRequest` that needs a `de.metas.handlingunits.base` jar rebuild).
- **CI is the integration gate.** Acceptance: `test (cucumber) (profile3)` stays green on this PR; subsequent base-branch runs do not show `Tests run: 0` on profile3.