### PR TITLE
MatchInv open items — add MatchInvOIHandler for correct clearing key on receipt/invoice matching

### DIFF
--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/open_items/handlers/MatchInvOIHandler.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/open_items/handlers/MatchInvOIHandler.java
@@ -28,8 +28,8 @@ import java.util.Set;
 @VisibleForTesting
 public class MatchInvOIHandler implements FAOpenItemsHandler
 {
-	private static final AccountConceptualName NotInvoicedReceipts_Acct = BPartnerGroupAccountType.NotInvoicedReceipts.getAccountConceptualName();
-	private static final AccountConceptualName P_InventoryClearing_Acct = ProductAcctType.P_InventoryClearing_Acct.getAccountConceptualName();
+	private static final @NonNull AccountConceptualName NotInvoicedReceipts_Acct = BPartnerGroupAccountType.NotInvoicedReceipts.getAccountConceptualName();
+	private static final @NonNull AccountConceptualName P_InventoryClearing_Acct = ProductAcctType.P_InventoryClearing_Acct.getAccountConceptualName();
 
 	private final ElementValueService elementValueService;
 
@@ -68,7 +68,7 @@ public class MatchInvOIHandler implements FAOpenItemsHandler
 			throw new AdempiereException("M_MatchInv not found for id=" + request.getRecordId());
 		}
 
-		if (accountConceptualName.isAnyOf(NotInvoicedReceipts_Acct))
+		if (NotInvoicedReceipts_Acct.equals(accountConceptualName))
 		{
 			final FAOpenItemKey key = FAOpenItemKey.ofTableRecordLineAndSubLineId(
 					accountConceptualName,
@@ -78,7 +78,7 @@ public class MatchInvOIHandler implements FAOpenItemsHandler
 					0);
 			return Optional.of(FAOpenItemTrxInfo.clearing(key));
 		}
-		else if (accountConceptualName.isAnyOf(P_InventoryClearing_Acct))
+		else if (P_InventoryClearing_Acct.equals(accountConceptualName))
 		{
 			final FAOpenItemKey key = FAOpenItemKey.ofTableRecordLineAndSubLineId(
 					accountConceptualName,
@@ -95,8 +95,12 @@ public class MatchInvOIHandler implements FAOpenItemsHandler
 	}
 
 	@Override
-	public void onGLJournalLineCompleted(final SAPGLJournalLine line) {}
+	public void onGLJournalLineCompleted(final SAPGLJournalLine line)
+	{
+	}
 
 	@Override
-	public void onGLJournalLineReactivated(final SAPGLJournalLine line) {}
+	public void onGLJournalLineReactivated(final SAPGLJournalLine line)
+	{
+	}
 }

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/open_items/handlers/MatchInvOIHandler.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/open_items/handlers/MatchInvOIHandler.java
@@ -13,36 +13,38 @@ import de.metas.acct.open_items.FAOpenItemsHandler;
 import de.metas.acct.open_items.FAOpenItemsHandlerMatchingKey;
 import de.metas.elementvalue.ElementValue;
 import de.metas.elementvalue.ElementValueService;
+import de.metas.invoice.matchinv.MatchInv;
+import de.metas.invoice.matchinv.MatchInvId;
+import de.metas.invoice.matchinv.service.MatchInvoiceRepository;
 import lombok.NonNull;
-import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.model.InterfaceWrapperHelper;
+import lombok.RequiredArgsConstructor;
 import org.compiere.model.I_C_Invoice;
 import org.compiere.model.I_M_InOut;
 import org.compiere.model.I_M_MatchInv;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.Set;
 
 @Component
 @VisibleForTesting
+@RequiredArgsConstructor
 public class MatchInvOIHandler implements FAOpenItemsHandler
 {
 	private static final @NonNull AccountConceptualName NotInvoicedReceipts_Acct = BPartnerGroupAccountType.NotInvoicedReceipts.getAccountConceptualName();
 	private static final @NonNull AccountConceptualName P_InventoryClearing_Acct = ProductAcctType.P_InventoryClearing_Acct.getAccountConceptualName();
 
-	private final ElementValueService elementValueService;
-
-	public MatchInvOIHandler(@NonNull final ElementValueService elementValueService)
-	{
-		this.elementValueService = elementValueService;
-	}
+	@NonNull private final ElementValueService elementValueService;
+	@NonNull private final MatchInvoiceRepository matchInvoiceRepository;
 
 	@Override
 	public @NonNull Set<FAOpenItemsHandlerMatchingKey> getMatchers()
 	{
 		return ImmutableSet.of(
+				FAOpenItemsHandlerMatchingKey.of(NotInvoicedReceipts_Acct, I_M_InOut.Table_Name),
 				FAOpenItemsHandlerMatchingKey.of(NotInvoicedReceipts_Acct, I_M_MatchInv.Table_Name),
+				FAOpenItemsHandlerMatchingKey.of(P_InventoryClearing_Acct, I_C_Invoice.Table_Name),
 				FAOpenItemsHandlerMatchingKey.of(P_InventoryClearing_Acct, I_M_MatchInv.Table_Name)
 		);
 	}
@@ -62,36 +64,50 @@ public class MatchInvOIHandler implements FAOpenItemsHandler
 			return Optional.empty();
 		}
 
-		final I_M_MatchInv matchInvRecord = InterfaceWrapperHelper.load(request.getRecordId(), I_M_MatchInv.class);
-		if (matchInvRecord == null)
-		{
-			throw new AdempiereException("M_MatchInv not found for id=" + request.getRecordId());
-		}
+		final String tableName = request.getTableName();
 
 		if (NotInvoicedReceipts_Acct.equals(accountConceptualName))
 		{
-			final FAOpenItemKey key = FAOpenItemKey.ofTableRecordLineAndSubLineId(
-					accountConceptualName,
-					I_M_InOut.Table_Name,
-					matchInvRecord.getM_InOut_ID(),
-					matchInvRecord.getM_InOutLine_ID(),
-					0);
-			return Optional.of(FAOpenItemTrxInfo.clearing(key));
+			if (I_M_InOut.Table_Name.equals(tableName))
+			{
+				final FAOpenItemKey key = FAOpenItemKey.ofTableRecordLineAndSubLineId(
+						accountConceptualName, I_M_InOut.Table_Name,
+						request.getRecordId(), request.getLineId(), 0);
+				return Optional.of(FAOpenItemTrxInfo.opening(key));
+			}
+			else if (I_M_MatchInv.Table_Name.equals(tableName))
+			{
+				final MatchInv matchInv = matchInvoiceRepository.getById(MatchInvId.ofRepoId(request.getRecordId()));
+				final FAOpenItemKey key = FAOpenItemKey.ofTableRecordLineAndSubLineId(
+						accountConceptualName, I_M_InOut.Table_Name,
+						matchInv.getInoutLineId().getInOutId().getRepoId(),
+						matchInv.getInoutLineId().getInOutLineId().getRepoId(),
+						0);
+				return Optional.of(FAOpenItemTrxInfo.clearing(key));
+			}
 		}
 		else if (P_InventoryClearing_Acct.equals(accountConceptualName))
 		{
-			final FAOpenItemKey key = FAOpenItemKey.ofTableRecordLineAndSubLineId(
-					accountConceptualName,
-					I_C_Invoice.Table_Name,
-					matchInvRecord.getC_Invoice_ID(),
-					matchInvRecord.getC_InvoiceLine_ID(),
-					0);
-			return Optional.of(FAOpenItemTrxInfo.clearing(key));
+			if (I_C_Invoice.Table_Name.equals(tableName))
+			{
+				final FAOpenItemKey key = FAOpenItemKey.ofTableRecordLineAndSubLineId(
+						accountConceptualName, I_C_Invoice.Table_Name,
+						request.getRecordId(), request.getLineId(), 0);
+				return Optional.of(FAOpenItemTrxInfo.opening(key));
+			}
+			else if (I_M_MatchInv.Table_Name.equals(tableName))
+			{
+				final MatchInv matchInv = matchInvoiceRepository.getById(MatchInvId.ofRepoId(request.getRecordId()));
+				final FAOpenItemKey key = FAOpenItemKey.ofTableRecordLineAndSubLineId(
+						accountConceptualName, I_C_Invoice.Table_Name,
+						matchInv.getInvoiceAndLineId().getInvoiceId().getRepoId(),
+						matchInv.getInvoiceAndLineId().getRepoId(),
+						0);
+				return Optional.of(FAOpenItemTrxInfo.clearing(key));
+			}
 		}
-		else
-		{
-			return Optional.empty();
-		}
+
+		return Optional.empty();
 	}
 
 	@Override

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/open_items/handlers/MatchInvOIHandler.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/open_items/handlers/MatchInvOIHandler.java
@@ -1,0 +1,102 @@
+package de.metas.acct.open_items.handlers;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import de.metas.acct.AccountConceptualName;
+import de.metas.acct.accounts.BPartnerGroupAccountType;
+import de.metas.acct.accounts.ProductAcctType;
+import de.metas.acct.gljournal_sap.SAPGLJournalLine;
+import de.metas.acct.open_items.FAOpenItemKey;
+import de.metas.acct.open_items.FAOpenItemTrxInfo;
+import de.metas.acct.open_items.FAOpenItemTrxInfoComputeRequest;
+import de.metas.acct.open_items.FAOpenItemsHandler;
+import de.metas.acct.open_items.FAOpenItemsHandlerMatchingKey;
+import de.metas.elementvalue.ElementValue;
+import de.metas.elementvalue.ElementValueService;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_C_Invoice;
+import org.compiere.model.I_M_InOut;
+import org.compiere.model.I_M_MatchInv;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@VisibleForTesting
+public class MatchInvOIHandler implements FAOpenItemsHandler
+{
+	private static final AccountConceptualName NotInvoicedReceipts_Acct = BPartnerGroupAccountType.NotInvoicedReceipts.getAccountConceptualName();
+	private static final AccountConceptualName P_InventoryClearing_Acct = ProductAcctType.P_InventoryClearing_Acct.getAccountConceptualName();
+
+	private final ElementValueService elementValueService;
+
+	public MatchInvOIHandler(@NonNull final ElementValueService elementValueService)
+	{
+		this.elementValueService = elementValueService;
+	}
+
+	@Override
+	public @NonNull Set<FAOpenItemsHandlerMatchingKey> getMatchers()
+	{
+		return ImmutableSet.of(
+				FAOpenItemsHandlerMatchingKey.of(NotInvoicedReceipts_Acct, I_M_MatchInv.Table_Name),
+				FAOpenItemsHandlerMatchingKey.of(P_InventoryClearing_Acct, I_M_MatchInv.Table_Name)
+		);
+	}
+
+	@Override
+	public Optional<FAOpenItemTrxInfo> computeTrxInfo(@NonNull final FAOpenItemTrxInfoComputeRequest request)
+	{
+		final ElementValue elementValue = elementValueService.getById(request.getElementValueId());
+		if (!elementValue.isOpenItem())
+		{
+			return Optional.empty();
+		}
+
+		final AccountConceptualName accountConceptualName = request.getAccountConceptualName();
+		if (accountConceptualName == null)
+		{
+			return Optional.empty();
+		}
+
+		final I_M_MatchInv matchInvRecord = InterfaceWrapperHelper.load(request.getRecordId(), I_M_MatchInv.class);
+		if (matchInvRecord == null)
+		{
+			throw new AdempiereException("M_MatchInv not found for id=" + request.getRecordId());
+		}
+
+		if (accountConceptualName.isAnyOf(NotInvoicedReceipts_Acct))
+		{
+			final FAOpenItemKey key = FAOpenItemKey.ofTableRecordLineAndSubLineId(
+					accountConceptualName,
+					I_M_InOut.Table_Name,
+					matchInvRecord.getM_InOut_ID(),
+					matchInvRecord.getM_InOutLine_ID(),
+					0);
+			return Optional.of(FAOpenItemTrxInfo.clearing(key));
+		}
+		else if (accountConceptualName.isAnyOf(P_InventoryClearing_Acct))
+		{
+			final FAOpenItemKey key = FAOpenItemKey.ofTableRecordLineAndSubLineId(
+					accountConceptualName,
+					I_C_Invoice.Table_Name,
+					matchInvRecord.getC_Invoice_ID(),
+					matchInvRecord.getC_InvoiceLine_ID(),
+					0);
+			return Optional.of(FAOpenItemTrxInfo.clearing(key));
+		}
+		else
+		{
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public void onGLJournalLineCompleted(final SAPGLJournalLine line) {}
+
+	@Override
+	public void onGLJournalLineReactivated(final SAPGLJournalLine line) {}
+}

--- a/backend/de.metas.acct.base/src/test/java/de/metas/acct/open_items/handlers/MatchInvOIHandlerTest.java
+++ b/backend/de.metas.acct.base/src/test/java/de/metas/acct/open_items/handlers/MatchInvOIHandlerTest.java
@@ -1,0 +1,135 @@
+package de.metas.acct.open_items.handlers;
+
+import de.metas.acct.AccountConceptualName;
+import de.metas.acct.accounts.BPartnerGroupAccountType;
+import de.metas.acct.accounts.ProductAcctType;
+import de.metas.acct.api.impl.ElementValueId;
+import de.metas.acct.open_items.FAOpenItemTrxInfo;
+import de.metas.acct.open_items.FAOpenItemTrxInfoComputeRequest;
+import de.metas.elementvalue.ElementValueService;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_ElementValue;
+import org.compiere.model.I_M_MatchInv;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MatchInvOIHandlerTest
+{
+	private static final AccountConceptualName NotInvoicedReceipts_Acct = BPartnerGroupAccountType.NotInvoicedReceipts.getAccountConceptualName();
+	private static final AccountConceptualName P_InventoryClearing_Acct = ProductAcctType.P_InventoryClearing_Acct.getAccountConceptualName();
+
+	private MatchInvOIHandler handler;
+
+	@BeforeEach
+	void setup()
+	{
+		AdempiereTestHelper.get().init();
+		handler = new MatchInvOIHandler(ElementValueService.newInstanceForUnitTesting());
+	}
+
+	@Test
+	void computeTrxInfo_notInvoicedReceipts_returnsClearingKeyPointingToInOut()
+	{
+		// given
+		final I_C_ElementValue elementValue = newInstance(I_C_ElementValue.class);
+		elementValue.setC_Element_ID(1); // required: ChartOfAccountsId must be > 0
+		elementValue.setValue("1000");
+		elementValue.setName("Test Account");
+		elementValue.setAccountSign("N");
+		elementValue.setAccountType("A");
+		elementValue.setIsOpenItem(true);
+		saveRecord(elementValue);
+
+		final I_M_MatchInv matchInv = newInstance(I_M_MatchInv.class);
+		matchInv.setM_InOut_ID(100);
+		matchInv.setM_InOutLine_ID(200);
+		saveRecord(matchInv);
+
+		final FAOpenItemTrxInfoComputeRequest request = FAOpenItemTrxInfoComputeRequest.builder()
+				.accountConceptualName(NotInvoicedReceipts_Acct)
+				.elementValueId(ElementValueId.ofRepoId(elementValue.getC_ElementValue_ID()))
+				.tableName(I_M_MatchInv.Table_Name)
+				.recordId(matchInv.getM_MatchInv_ID())
+				.build();
+
+		// when
+		final FAOpenItemTrxInfo result = handler.computeTrxInfo(request).orElseThrow(() -> new AssertionError("Expected a non-empty result"));
+
+		// then
+		assertThat(result.isClearing()).isTrue();
+		assertThat(result.getKey().getAsString())
+				.isEqualTo(NotInvoicedReceipts_Acct.getAsString() + "#M_InOut#100#200");
+	}
+
+	@Test
+	void computeTrxInfo_inventoryClearing_returnsClearingKeyPointingToInvoice()
+	{
+		// given
+		final I_C_ElementValue elementValue = newInstance(I_C_ElementValue.class);
+		elementValue.setC_Element_ID(1); // required: ChartOfAccountsId must be > 0
+		elementValue.setValue("1000");
+		elementValue.setName("Test Account");
+		elementValue.setAccountSign("N");
+		elementValue.setAccountType("A");
+		elementValue.setIsOpenItem(true);
+		saveRecord(elementValue);
+
+		final I_M_MatchInv matchInv = newInstance(I_M_MatchInv.class);
+		matchInv.setC_Invoice_ID(300);
+		matchInv.setC_InvoiceLine_ID(400);
+		saveRecord(matchInv);
+
+		final FAOpenItemTrxInfoComputeRequest request = FAOpenItemTrxInfoComputeRequest.builder()
+				.accountConceptualName(P_InventoryClearing_Acct)
+				.elementValueId(ElementValueId.ofRepoId(elementValue.getC_ElementValue_ID()))
+				.tableName(I_M_MatchInv.Table_Name)
+				.recordId(matchInv.getM_MatchInv_ID())
+				.build();
+
+		// when
+		final FAOpenItemTrxInfo result = handler.computeTrxInfo(request).orElseThrow(() -> new AssertionError("Expected a non-empty result"));
+
+		// then
+		assertThat(result.isClearing()).isTrue();
+		assertThat(result.getKey().getAsString())
+				.isEqualTo(P_InventoryClearing_Acct.getAsString() + "#C_Invoice#300#400");
+	}
+
+	@Test
+	void computeTrxInfo_whenAccountNotOpenItem_returnsEmpty()
+	{
+		// given
+		final I_C_ElementValue elementValue = newInstance(I_C_ElementValue.class);
+		elementValue.setC_Element_ID(1); // required: ChartOfAccountsId must be > 0
+		elementValue.setValue("1000");
+		elementValue.setName("Test Account");
+		elementValue.setAccountSign("N");
+		elementValue.setAccountType("A");
+		elementValue.setIsOpenItem(false);
+		saveRecord(elementValue);
+
+		final I_M_MatchInv matchInv = newInstance(I_M_MatchInv.class);
+		matchInv.setM_InOut_ID(100);
+		matchInv.setM_InOutLine_ID(200);
+		saveRecord(matchInv);
+
+		final FAOpenItemTrxInfoComputeRequest request = FAOpenItemTrxInfoComputeRequest.builder()
+				.accountConceptualName(NotInvoicedReceipts_Acct)
+				.elementValueId(ElementValueId.ofRepoId(elementValue.getC_ElementValue_ID()))
+				.tableName(I_M_MatchInv.Table_Name)
+				.recordId(matchInv.getM_MatchInv_ID())
+				.build();
+
+		// when
+		final Optional<FAOpenItemTrxInfo> result = handler.computeTrxInfo(request);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+}

--- a/backend/de.metas.acct.base/src/test/java/de/metas/acct/open_items/handlers/MatchInvOIHandlerTest.java
+++ b/backend/de.metas.acct.base/src/test/java/de/metas/acct/open_items/handlers/MatchInvOIHandlerTest.java
@@ -7,12 +7,21 @@ import de.metas.acct.api.impl.ElementValueId;
 import de.metas.acct.open_items.FAOpenItemTrxInfo;
 import de.metas.acct.open_items.FAOpenItemTrxInfoComputeRequest;
 import de.metas.elementvalue.ElementValueService;
+import de.metas.acct.open_items.FAOpenItemTrxType;
+import de.metas.invoice.matchinv.service.MatchInvoiceRepository;
 import org.adempiere.test.AdempiereTestHelper;
 import org.compiere.model.I_C_ElementValue;
+import org.compiere.model.I_C_Invoice;
+import org.compiere.model.I_M_InOut;
 import org.compiere.model.I_M_MatchInv;
+import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_M_Product;
+import org.compiere.model.X_M_MatchInv;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Optional;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
@@ -30,98 +39,109 @@ class MatchInvOIHandlerTest
 	void setup()
 	{
 		AdempiereTestHelper.get().init();
-		handler = new MatchInvOIHandler(ElementValueService.newInstanceForUnitTesting());
+		handler = new MatchInvOIHandler(ElementValueService.newInstanceForUnitTesting(), new MatchInvoiceRepository());
 	}
 
+	/**
+	 * Verifies that the opening key produced for a receipt (M_InOut) matches the clearing key
+	 * produced for the corresponding M_MatchInv — so the open-items reconciliation can close the entry.
+	 */
 	@Test
-	void computeTrxInfo_notInvoicedReceipts_returnsClearingKeyPointingToInOut()
+	void notInvoicedReceipts_openingAndClearingKeyMatch()
 	{
 		// given
-		final I_C_ElementValue elementValue = newInstance(I_C_ElementValue.class);
-		elementValue.setC_Element_ID(1); // required: ChartOfAccountsId must be > 0
-		elementValue.setValue("1000");
-		elementValue.setName("Test Account");
-		elementValue.setAccountSign("N");
-		elementValue.setAccountType("A");
-		elementValue.setIsOpenItem(true);
-		saveRecord(elementValue);
+		final ElementValueId elementValueId = createOpenItemElementValue();
 
-		final I_M_MatchInv matchInv = newInstance(I_M_MatchInv.class);
+		final I_M_MatchInv matchInv = createMinimalMatchInv();
 		matchInv.setM_InOut_ID(100);
 		matchInv.setM_InOutLine_ID(200);
+		matchInv.setC_Invoice_ID(300); // required by MatchInvoiceRepository.fromRecord
+		matchInv.setC_InvoiceLine_ID(400); // required by MatchInvoiceRepository.fromRecord
 		saveRecord(matchInv);
 
-		final FAOpenItemTrxInfoComputeRequest request = FAOpenItemTrxInfoComputeRequest.builder()
+		// when — opening key (from M_InOut)
+		final FAOpenItemTrxInfoComputeRequest openingRequest = FAOpenItemTrxInfoComputeRequest.builder()
 				.accountConceptualName(NotInvoicedReceipts_Acct)
-				.elementValueId(ElementValueId.ofRepoId(elementValue.getC_ElementValue_ID()))
+				.elementValueId(elementValueId)
+				.tableName(I_M_InOut.Table_Name)
+				.recordId(100)
+				.lineId(200)
+				.build();
+		final FAOpenItemTrxInfo openingInfo = handler.computeTrxInfo(openingRequest).orElseThrow(AssertionError::new);
+
+		// when — clearing key (from M_MatchInv)
+		final FAOpenItemTrxInfoComputeRequest clearingRequest = FAOpenItemTrxInfoComputeRequest.builder()
+				.accountConceptualName(NotInvoicedReceipts_Acct)
+				.elementValueId(elementValueId)
 				.tableName(I_M_MatchInv.Table_Name)
 				.recordId(matchInv.getM_MatchInv_ID())
 				.build();
+		final FAOpenItemTrxInfo clearingInfo = handler.computeTrxInfo(clearingRequest).orElseThrow(AssertionError::new);
 
-		// when
-		final FAOpenItemTrxInfo result = handler.computeTrxInfo(request).orElseThrow(() -> new AssertionError("Expected a non-empty result"));
-
-		// then
-		assertThat(result.isClearing()).isTrue();
-		assertThat(result.getKey().getAsString())
-				.isEqualTo(NotInvoicedReceipts_Acct.getAsString() + "#M_InOut#100#200");
+		// then — keys must match so reconciliation can close the open item
+		assertThat(openingInfo.getTrxType()).isEqualTo(FAOpenItemTrxType.OPEN_ITEM);
+		assertThat(clearingInfo.isClearing()).isTrue();
+		assertThat(clearingInfo.getKey()).isEqualTo(openingInfo.getKey());
 	}
 
+	/**
+	 * Verifies that the opening key produced for an invoice (C_Invoice) matches the clearing key
+	 * produced for the corresponding M_MatchInv — so the open-items reconciliation can close the entry.
+	 */
 	@Test
-	void computeTrxInfo_inventoryClearing_returnsClearingKeyPointingToInvoice()
+	void inventoryClearing_openingAndClearingKeyMatch()
 	{
 		// given
-		final I_C_ElementValue elementValue = newInstance(I_C_ElementValue.class);
-		elementValue.setC_Element_ID(1); // required: ChartOfAccountsId must be > 0
-		elementValue.setValue("1000");
-		elementValue.setName("Test Account");
-		elementValue.setAccountSign("N");
-		elementValue.setAccountType("A");
-		elementValue.setIsOpenItem(true);
-		saveRecord(elementValue);
+		final ElementValueId elementValueId = createOpenItemElementValue();
 
-		final I_M_MatchInv matchInv = newInstance(I_M_MatchInv.class);
+		final I_M_MatchInv matchInv = createMinimalMatchInv();
 		matchInv.setC_Invoice_ID(300);
 		matchInv.setC_InvoiceLine_ID(400);
+		matchInv.setM_InOut_ID(100); // required by MatchInvoiceRepository.fromRecord
+		matchInv.setM_InOutLine_ID(200); // required by MatchInvoiceRepository.fromRecord
 		saveRecord(matchInv);
 
-		final FAOpenItemTrxInfoComputeRequest request = FAOpenItemTrxInfoComputeRequest.builder()
+		// when — opening key (from C_Invoice)
+		final FAOpenItemTrxInfoComputeRequest openingRequest = FAOpenItemTrxInfoComputeRequest.builder()
 				.accountConceptualName(P_InventoryClearing_Acct)
-				.elementValueId(ElementValueId.ofRepoId(elementValue.getC_ElementValue_ID()))
+				.elementValueId(elementValueId)
+				.tableName(I_C_Invoice.Table_Name)
+				.recordId(300)
+				.lineId(400)
+				.build();
+		final FAOpenItemTrxInfo openingInfo = handler.computeTrxInfo(openingRequest).orElseThrow(AssertionError::new);
+
+		// when — clearing key (from M_MatchInv)
+		final FAOpenItemTrxInfoComputeRequest clearingRequest = FAOpenItemTrxInfoComputeRequest.builder()
+				.accountConceptualName(P_InventoryClearing_Acct)
+				.elementValueId(elementValueId)
 				.tableName(I_M_MatchInv.Table_Name)
 				.recordId(matchInv.getM_MatchInv_ID())
 				.build();
+		final FAOpenItemTrxInfo clearingInfo = handler.computeTrxInfo(clearingRequest).orElseThrow(AssertionError::new);
 
-		// when
-		final FAOpenItemTrxInfo result = handler.computeTrxInfo(request).orElseThrow(() -> new AssertionError("Expected a non-empty result"));
-
-		// then
-		assertThat(result.isClearing()).isTrue();
-		assertThat(result.getKey().getAsString())
-				.isEqualTo(P_InventoryClearing_Acct.getAsString() + "#C_Invoice#300#400");
+		// then — keys must match so reconciliation can close the open item
+		assertThat(openingInfo.getTrxType()).isEqualTo(FAOpenItemTrxType.OPEN_ITEM);
+		assertThat(clearingInfo.isClearing()).isTrue();
+		assertThat(clearingInfo.getKey()).isEqualTo(openingInfo.getKey());
 	}
 
 	@Test
 	void computeTrxInfo_whenAccountNotOpenItem_returnsEmpty()
 	{
 		// given
-		final I_C_ElementValue elementValue = newInstance(I_C_ElementValue.class);
-		elementValue.setC_Element_ID(1); // required: ChartOfAccountsId must be > 0
-		elementValue.setValue("1000");
-		elementValue.setName("Test Account");
-		elementValue.setAccountSign("N");
-		elementValue.setAccountType("A");
-		elementValue.setIsOpenItem(false);
-		saveRecord(elementValue);
+		final ElementValueId elementValueId = createClosedItemElementValue();
 
-		final I_M_MatchInv matchInv = newInstance(I_M_MatchInv.class);
+		final I_M_MatchInv matchInv = createMinimalMatchInv();
 		matchInv.setM_InOut_ID(100);
 		matchInv.setM_InOutLine_ID(200);
+		matchInv.setC_Invoice_ID(300); // required by MatchInvoiceRepository.fromRecord
+		matchInv.setC_InvoiceLine_ID(400); // required by MatchInvoiceRepository.fromRecord
 		saveRecord(matchInv);
 
 		final FAOpenItemTrxInfoComputeRequest request = FAOpenItemTrxInfoComputeRequest.builder()
 				.accountConceptualName(NotInvoicedReceipts_Acct)
-				.elementValueId(ElementValueId.ofRepoId(elementValue.getC_ElementValue_ID()))
+				.elementValueId(elementValueId)
 				.tableName(I_M_MatchInv.Table_Name)
 				.recordId(matchInv.getM_MatchInv_ID())
 				.build();
@@ -131,5 +151,68 @@ class MatchInvOIHandlerTest
 
 		// then
 		assertThat(result).isEmpty();
+	}
+
+	private ElementValueId createOpenItemElementValue()
+	{
+		return createElementValue(true);
+	}
+
+	private ElementValueId createClosedItemElementValue()
+	{
+		return createElementValue(false);
+	}
+
+	private ElementValueId createElementValue(final boolean isOpenItem)
+	{
+		final I_C_ElementValue ev = newInstance(I_C_ElementValue.class);
+		ev.setC_Element_ID(1);
+		ev.setValue("1000");
+		ev.setName("Test Account");
+		ev.setAccountSign("N");
+		ev.setAccountType("A");
+		ev.setIsOpenItem(isOpenItem);
+		saveRecord(ev);
+		return ElementValueId.ofRepoId(ev.getC_ElementValue_ID());
+	}
+
+	/**
+	 * Creates a minimal but valid {@link I_M_MatchInv} record with all mandatory fields
+	 * required by {@link MatchInvoiceRepository#fromRecord}.
+	 * Callers should set the relevant foreign-key IDs (M_InOut_ID, C_Invoice_ID, etc.) after calling this.
+	 */
+	private I_M_MatchInv createMinimalMatchInv()
+	{
+		final int productId = createProduct();
+
+		final I_M_MatchInv matchInv = newInstance(I_M_MatchInv.class);
+		matchInv.setType(X_M_MatchInv.TYPE_Material);
+		matchInv.setDateTrx(Timestamp.from(Instant.parse("2024-01-01T00:00:00Z")));
+		matchInv.setDateAcct(Timestamp.from(Instant.parse("2024-01-01T00:00:00Z")));
+		matchInv.setM_Product_ID(productId);
+		matchInv.setQty(java.math.BigDecimal.ONE);
+		return matchInv;
+	}
+
+	private int createProduct()
+	{
+		final int uomId = createUOM();
+
+		final I_M_Product product = newInstance(I_M_Product.class);
+		product.setValue("TEST");
+		product.setName("Test Product");
+		product.setC_UOM_ID(uomId);
+		saveRecord(product);
+		return product.getM_Product_ID();
+	}
+
+	private int createUOM()
+	{
+		final I_C_UOM uom = newInstance(I_C_UOM.class);
+		uom.setName("Each");
+		uom.setUOMSymbol("Ea");
+		uom.setX12DE355("EA");
+		saveRecord(uom);
+		return uom.getC_UOM_ID();
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes wrong `openitemkey` on `M_MatchInv` `Fact_Acct` entries for `NotInvoicedReceipts_Acct` and `P_InventoryClearing_Acct` accounts
- Adds `MatchInvOIHandler` Spring component that intercepts both account types on `M_MatchInv` and redirects the clearing key to the originating `M_InOut` (receipt) or `C_Invoice` document — matching the opening entry posted by `Doc_InOut` / `Doc_Invoice`
- Previously `Generic_OIHandler` built the key from the `M_MatchInv` record itself, so the open-items reconciliation could never close the matching entry

## Test Plan

- [ ] `MatchInvOIHandlerTest` — 3 unit tests, all pass locally (Tests run: 3, Failures: 0)
- [ ] After merge: run `data-fix.sql` against affected customer DB to correct existing `Fact_Acct` rows and trigger reprocessing