### PR TITLE
me03#29842 — Add LineItemLine to swift_eagle_release's DESADV packs function

### DIFF
--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5803090_sys_me03_29842_packs_fn_LineItemLine_align.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5803090_sys_me03_29842_packs_fn_LineItemLine_align.sql
@@ -1,7 +1,33 @@
--- Function for desadv packs
--- Handles compensation group sub-articles: sub-article pack items are merged
--- into the main article's pack, adding IsSubArticle and MainArticleLine to each LineItem.
--- Packs NOT in a compensation group are output as before (backward-compatible).
+-- Source DDL: backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/desadv_json/get_desadv_packs_json_fn.sql
+--
+-- Align swift_eagle_release with soft_panda_release's LineItemLine addition.
+--
+-- Background:
+--   * PR #23964 (soft_panda_release me03#29842) added a 'LineItemLine' key to
+--     LineItem.DesadvLine in the DESADV-JSON packs function. Migration
+--     5802760_sys_gh29842_desadv_LineItemLine.sql.
+--   * PR #23995 (swift_eagle_release me03#29063) added an 'asi_data.ean_cu'
+--     fallback to the GTIN_CU resolution chain in the same function, with a
+--     body that predated the LineItemLine addition on this branch. Migration
+--     5802910_sys_me03_29063_packs_fn_ean_cu_fallback.sql.
+--   * When swift_eagle_release is merged into new_dawn_uat (or any branch that
+--     already has 5802760), migrations run in prefix order: 5802760 first,
+--     5802910 second. The second CREATE OR REPLACE then wipes the LineItemLine
+--     key the first one added — cucumber profile5 fails (caught by PR #24005).
+--   * Fix in PR #24005 itself: an extra migration on the merge branch
+--     re-creates the function with the consolidated body. But that only fixes
+--     ONE merge; every subsequent swift_eagle_release -> new_dawn_uat merge
+--     would need the same patch.
+--
+-- This migration applies the same body permanently on swift_eagle_release so
+-- swift_eagle_release's own copy of get_desadv_packs_json_fn already emits
+-- LineItemLine. Future merges become no-ops on this front.
+--
+-- Effect on swift_eagle customers:
+--   The 'LineItemLine' JSON key is additive — recipients that don't read it
+--   are unaffected. swift_eagle's downstream EDIFACT converters can ignore the
+--   new key without any handling change.
+
 CREATE OR REPLACE FUNCTION "de.metas.edi".get_desadv_packs_json_fn(p_edi_desadv_id NUMERIC, p_m_inout_id NUMERIC)
     RETURNS JSONB
 AS


### PR DESCRIPTION
## Summary

Follow-up to PR #24005 (merge swift_eagle_release into new_dawn_uat). Aligns swift_eagle_release's own copy of `get_desadv_packs_json_fn` with soft_panda_release's, so future merges into new_dawn_uat do not silently regress on the `LineItemLine` key.

## Why

- PR #23964 (soft_panda_release me03#29842) added a `'LineItemLine'` JSON key to `LineItem.DesadvLine` in the DESADV-JSON packs function. Migration `5802760_sys_gh29842_desadv_LineItemLine.sql`.
- PR #23995 (me03#29063 EAN_CU fallback, on this branch) issued a `CREATE OR REPLACE FUNCTION` against a body that predated soft_panda's LineItemLine addition. Migration `5802910_sys_me03_29063_packs_fn_ean_cu_fallback.sql`.
- When swift_eagle_release is merged into new_dawn_uat, migrations run in numeric-prefix order: `5802760` adds LineItemLine, then `5802910` wipes it while adding ean_cu. Cucumber profile5 then fails on every DESADV scenario with `"Packed LineItem.DesadvLine should contain LineItemLine field"` — caught by PR #24005.
- PR #24005 carries a one-off merge-branch fix (`5803080`) that re-creates the function with both keys. But that fixes the **single** merge only; the next swift_eagle_release → new_dawn_uat merge would repeat the conflict unless swift_eagle_release's own definition is updated.

## Changes

- `backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/desadv_json/get_desadv_packs_json_fn.sql` — adds the line `'LineItemLine', ia.pi_line,` next to `'DesadvLine', dl.line,`. One-line change, mirroring soft_panda_release.
- `backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5803090_sys_me03_29842_packs_fn_LineItemLine_align.sql` — new migration with prefix > `5802910` that re-creates the function with the consolidated body (LineItemLine + ean_cu).

## Effect on swift_eagle customers

`LineItemLine` is an additive JSON key. Recipients that don't read it are unaffected; no downstream EDIFACT-converter change is required.

## Test plan

- [x] DDL file change matches soft_panda_release exactly (one line in the same position).
- [ ] Full CI cucumber + Playwright suites green.

## Related

- https://github.com/metasfresh/metasfresh/pull/23964 — the original LineItemLine PR on soft_panda_release
- https://github.com/metasfresh/metasfresh/pull/23995 — the EAN_CU PR on swift_eagle_release that caused the silent regression
- https://github.com/metasfresh/metasfresh/pull/24005 — the merge PR where the collision was caught