### PR TITLE
Material Dispo: clear MD_Candidate_RebookedFrom_ID before deleting referenced candidate

### DIFF
--- a/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/repository/CandidateRepositoryWriteService.java
+++ b/backend/de.metas.material/dispo-commons/src/main/java/de/metas/material/dispo/commons/repository/CandidateRepositoryWriteService.java
@@ -887,6 +887,18 @@ public class CandidateRepositoryWriteService
 
 	private void deleteTransactionDetailsRecords(@NonNull final CandidateId candidateId)
 	{
+		// Before deleting the rows owned by this candidate, clear any
+		// MD_Candidate_RebookedFrom_ID references that OTHER detail rows hold
+		// on it. The constraint MDCandidateRebookedFrom_MDCandidateTransactionDetail
+		// is DEFERRABLE INITIALLY DEFERRED, so the FK violation surfaces at
+		// commit time when the rebooked-from candidate gets removed.
+		queryBL.createQueryBuilder(I_MD_Candidate_Transaction_Detail.class)
+				.addEqualsFilter(I_MD_Candidate_Transaction_Detail.COLUMN_MD_Candidate_RebookedFrom_ID, candidateId.getRepoId())
+				.create()
+				.updateDirectly()
+				.addSetColumnValue(I_MD_Candidate_Transaction_Detail.COLUMNNAME_MD_Candidate_RebookedFrom_ID, null)
+				.execute();
+
 		queryBL.createQueryBuilder(I_MD_Candidate_Transaction_Detail.class)
 				.addEqualsFilter(I_MD_Candidate_Transaction_Detail.COLUMN_MD_Candidate_ID, candidateId.getRepoId())
 				.create()

--- a/backend/de.metas.material/dispo-commons/src/test/java/de/metas/material/dispo/commons/repository/CandidateRepositoryWriteServiceTests.java
+++ b/backend/de.metas.material/dispo-commons/src/test/java/de/metas/material/dispo/commons/repository/CandidateRepositoryWriteServiceTests.java
@@ -14,8 +14,10 @@ import de.metas.material.dispo.commons.candidate.TransactionDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.DemandDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.DistributionDetail;
 import de.metas.material.dispo.commons.candidate.businesscase.Flag;
+import de.metas.material.dispo.commons.candidate.CandidateId;
 import de.metas.material.dispo.commons.candidate.businesscase.ProductionDetail;
 import de.metas.material.dispo.commons.repository.query.CandidatesQuery;
+import de.metas.material.dispo.commons.repository.query.DeleteCandidatesQuery;
 import de.metas.material.dispo.commons.repository.repohelpers.StockChangeDetailRepo;
 import de.metas.material.dispo.model.I_MD_Candidate;
 import de.metas.material.dispo.model.I_MD_Candidate_Demand_Detail;
@@ -462,5 +464,50 @@ public class CandidateRepositoryWriteServiceTests
 		assertThat(transactionDetailRecord).isNotNull();
 		assertThat(transactionDetailRecord.getMovementQty()).isEqualByComparingTo("1");
 		assertThat(transactionDetailRecord.getM_Transaction_ID()).isEqualTo(33);
+	}
+
+	/**
+	 * Reproduces the FK violation
+	 * {@code MDCandidateRebookedFrom_MDCandidateTransactionDetail} that previously caused
+	 * the material event queue to back up when an MD_Candidate referenced via
+	 * {@code MD_Candidate_Transaction_Detail.MD_Candidate_RebookedFrom_ID} was deleted.
+	 * The delete must clear the rebooked-from references on OTHER transaction-detail rows
+	 * before removing the target candidate.
+	 */
+	@Test
+	public void deleteCandidatesAndDetailsByQuery_clears_RebookedFrom_reference_on_other_transactionDetails()
+	{
+		final java.sql.Timestamp now = de.metas.common.util.time.SystemTime.asTimestamp();
+
+		final I_MD_Candidate candidateA = newInstance(I_MD_Candidate.class);
+		candidateA.setMD_Candidate_Type(X_MD_Candidate.MD_CANDIDATE_TYPE_DEMAND);
+		candidateA.setDateProjected(now);
+		save(candidateA);
+		final CandidateId candidateAId = CandidateId.ofRepoId(candidateA.getMD_Candidate_ID());
+
+		final I_MD_Candidate candidateB = newInstance(I_MD_Candidate.class);
+		candidateB.setMD_Candidate_Type(X_MD_Candidate.MD_CANDIDATE_TYPE_DEMAND);
+		candidateB.setDateProjected(now);
+		save(candidateB);
+
+		final I_MD_Candidate_Transaction_Detail detailB = newInstance(I_MD_Candidate_Transaction_Detail.class);
+		detailB.setMD_Candidate_ID(candidateB.getMD_Candidate_ID());
+		detailB.setMD_Candidate_RebookedFrom_ID(candidateA.getMD_Candidate_ID());
+		save(detailB);
+		final int detailBId = detailB.getMD_Candidate_Transaction_Detail_ID();
+
+		candidateRepositoryWriteService.deleteCandidatesAndDetailsByQuery(
+				DeleteCandidatesQuery.builder().candidateId(candidateAId).build());
+
+		final int remainingA = Services.get(IQueryBL.class).createQueryBuilder(I_MD_Candidate.class)
+				.addEqualsFilter(I_MD_Candidate.COLUMNNAME_MD_Candidate_ID, candidateAId.getRepoId())
+				.create()
+				.count();
+		assertThat(remainingA).as("candidate A must be deleted").isZero();
+
+		final I_MD_Candidate_Transaction_Detail reloadedDetailB = load(detailBId, I_MD_Candidate_Transaction_Detail.class);
+		assertThat(reloadedDetailB).isNotNull();
+		assertThat(reloadedDetailB.getMD_Candidate_ID()).isEqualTo(candidateB.getMD_Candidate_ID());
+		assertThat(reloadedDetailB.getMD_Candidate_RebookedFrom_ID()).isZero();
 	}
 }


### PR DESCRIPTION
## Summary

`CandidateRepositoryWriteService.deleteTransactionDetailsRecords` removed `MD_Candidate_Transaction_Detail` rows **owned** by the candidate being deleted, but ignored rows from other candidates that **referenced** it via `MD_Candidate_Transaction_Detail.MD_Candidate_RebookedFrom_ID`.

The FK constraint `MDCandidateRebookedFrom_MDCandidateTransactionDetail` is `DEFERRABLE INITIALLY DEFERRED`, so the violation surfaced at commit time:

```
ERROR: update or delete on table "md_candidate" violates foreign key constraint
  "mdcandidaterebookedfrom_mdcandidatetransactiondetail" on table "md_candidate_transaction_detail"
DETAIL: Key (md_candidate_id)=(NNNN) is still referenced from "md_candidate_transaction_detail".
```

When the failure happened inside a `MaterialEvent` handler, the message was NACKed and requeued — the handler kept retrying forever, and the cucumber drain step `wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes` timed out. Two scenarios in `shipmentScheduleExport.feature` (`Export oxid shipment candidate`, `Export non-oxid shipment schedule from order candidate`) reproduced the failure on profile7.

## Fix

`deleteTransactionDetailsRecords` now NULLs every `MD_Candidate_RebookedFrom_ID` reference pointing to the candidate being deleted before deleting its owned rows — same shape as the existing parent-id cleanup at line 821.

`MD_Candidate_Transaction_Detail.MD_Candidate_RebookedFrom_ID` is a pure audit pointer ("rebooked from a now-deleted candidate") — verified that no Java code reads `getMD_Candidate_RebookedFrom_ID` / `getRebookedFromCandidateId` outside of writers. NULL on parent-delete is the correct semantic.

## Test plan

- [x] New unit test `CandidateRepositoryWriteServiceTests.deleteCandidatesAndDetailsByQuery_clears_RebookedFrom_reference_on_other_transactionDetails` — proved RED without the fix, GREEN with the fix.
- [x] `dispo-commons` unit suite: 87/87 GREEN.
- [x] `dispo-service` unit suite: 98/98 GREEN (1 preexisting skip).
- [ ] Full CI pipeline (in progress).