### PR TITLE
deep_tundra_uat: bump DB image to new_dawn_uat-preloaded

### DIFF
--- a/misc/dev-support/docker/infrastructure/env-files/deep_tundra_uat.env
+++ b/misc/dev-support/docker/infrastructure/env-files/deep_tundra_uat.env
@@ -15,7 +15,7 @@
 BRANCH_NAME=deep_tundra_uat
 
 DB_PORT=21432
-DB_DOCKER_IMG=metasfresh/metas-db:5.175-release-5.175
+DB_DOCKER_IMG=docker.io/metasfresh/metas-db:5.175-new-dawn-uat-preloaded
 
 RABBITMQ_PORT=21672
 RABBITMQ_MGMT_PORT=21673


### PR DESCRIPTION
## Summary
- One-line bump in `misc/dev-support/docker/infrastructure/env-files/deep_tundra_uat.env`: switch `DB_DOCKER_IMG` from `metasfresh/metas-db:5.175-release-5.175` (PG 9.5 bare release seed) to `docker.io/metasfresh/metas-db:5.175-new-dawn-uat-preloaded` (PG 11+, all `new_dawn_uat` migrations pre-applied).
- Aligns this env file with `new_dawn_uat.env`, `keen_hawk_uat.env`, `task_force_uat.env`, `soft_panda_uat.env` — all of which use a `-preloaded` variant.

## Why
The previous value (the bare 5.175 release seed) runs PostgreSQL 9.5.25. Many `new_dawn_uat` migration scripts now use `ADD COLUMN IF NOT EXISTS` which is PG 9.6+ syntax, so running `10_reset_db_to_seed_dump.sh deep_tundra_uat` followed by the migration tool fails with `syntax error at or near "NOT"` on the first such script. Switching to the preloaded image skips that whole class of problems and cuts the reset cycle from ~18 min (3,981 scripts) to ~3 min (image pull + the small delta of unapplied scripts).

## Test plan
- [ ] `bash misc/dev-support/docker/infrastructure/scripts/10_reset_db_to_seed_dump.sh deep_tundra_uat`
- [ ] Wait for `deep_tundra_uat_db` container healthy
- [ ] `psql -h localhost -p 21432 -U metasfresh -c "SELECT version();"` reports PG 11 or later
- [ ] `SELECT count(*) FROM ad_migrationscript;` is in the thousands (preloaded snapshot, not empty)