### PR TITLE
Trolley Release — release endpoint, conflict semantics, mobile UI button

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5802470_sys_me03_28959_AD_Message_TrolleyAlreadyAssigned.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5802470_sys_me03_28959_AD_Message_TrolleyAlreadyAssigned.sql
@@ -1,0 +1,37 @@
+-- AD_Message base text is in German (DE).
+-- Rationale: most users are German-speakers. If a translation is missing or broken, the
+-- fallback (AD_Message.MsgText) should show German to German users — better to show DE
+-- to EN users (mostly developers) than EN to DE users.
+-- en_US translation is provided via the AD_Message_Trl override below.
+
+-- 2026-05-15T10:01:00.000Z
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545686 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-15 10:01:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Dieser Wagen ist bereits {0} zugewiesen. Bitte den Nutzer um Freigabe.','E',TO_TIMESTAMP('2026-05-15 10:01:00','YYYY-MM-DD HH24:MI:SS'),100,'WFRestAPI_TrolleyAlreadyAssignedTo')
+;
+
+-- 2026-05-15T10:01:01.000Z
+UPDATE AD_Message SET ErrorCode='TrolleyAlreadyAssignedTo', Updated=TO_TIMESTAMP('2026-05-15 10:01:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545686 /*From ID Server*/
+;
+
+-- Seed AD_Message_Trl for every active system language using the base (DE) text.
+-- 2026-05-15T10:01:02.000Z
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Message_ID=545686 /*From ID Server*/
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- Override en_US with the English translation.
+-- 2026-05-15T10:01:03.000Z
+UPDATE AD_Message_Trl SET MsgText='This trolley is already assigned to {0}. Please ask them to release it first.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-15 10:01:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545686 /*From ID Server*/
+;
+
+-- Mark de_DE and de_CH as actively translated (same text as base; flips IsTranslated to Y).
+-- 2026-05-15T10:01:04.000Z
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-15 10:01:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545686 /*From ID Server*/
+;
+
+-- 2026-05-15T10:01:05.000Z
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-15 10:01:05','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545686 /*From ID Server*/
+;

--- a/backend/de.metas.workflow.rest-api/pom.xml
+++ b/backend/de.metas.workflow.rest-api/pom.xml
@@ -51,6 +51,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/controller/v2/WorkflowRestController.java
+++ b/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/controller/v2/WorkflowRestController.java
@@ -72,6 +72,7 @@ import org.compiere.util.Env;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -368,5 +369,12 @@ public class WorkflowRestController
 	{
 		final LocatorQRCode locatorQRCode = trolleyService.setCurrent(Env.getLoggedUserId(), request.getScannedCode());
 		return JsonGetCurrentTrolleyResponse.ofQRCode(locatorQRCode);
+	}
+
+	@DeleteMapping("/trolley")
+	public JsonGetCurrentTrolleyResponse clearCurrentTrolley()
+	{
+		trolleyService.clearCurrent(Env.getLoggedUserId());
+		return JsonGetCurrentTrolleyResponse.EMPTY;
 	}
 }

--- a/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/service/TrolleyAlreadyAssignedException.java
+++ b/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/service/TrolleyAlreadyAssignedException.java
@@ -1,0 +1,24 @@
+package de.metas.workflow.rest_api.service;
+
+import de.metas.i18n.AdMessageKey;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.warehouse.qrcode.LocatorQRCode;
+
+public class TrolleyAlreadyAssignedException extends AdempiereException
+{
+	private static final long serialVersionUID = 1L;
+
+	private static final AdMessageKey MSG_NAMED = AdMessageKey.of("WFRestAPI_TrolleyAlreadyAssignedTo");
+
+	public static TrolleyAlreadyAssignedException forNamedConflict(@NonNull final String holderDisplayName, @NonNull final LocatorQRCode locatorQRCode)
+	{
+		return new TrolleyAlreadyAssignedException(holderDisplayName, locatorQRCode);
+	}
+
+	private TrolleyAlreadyAssignedException(@NonNull final String holderDisplayName, @NonNull final LocatorQRCode locatorQRCode)
+	{
+		super(MSG_NAMED, holderDisplayName);
+		setParameter("locatorQRCode", locatorQRCode);
+	}
+}

--- a/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/service/TrolleyService.java
+++ b/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/service/TrolleyService.java
@@ -3,6 +3,7 @@ package de.metas.workflow.rest_api.service;
 import com.google.common.collect.HashBiMap;
 import de.metas.scannable_code.ScannedCode;
 import de.metas.user.UserId;
+import de.metas.user.api.IUserDAO;
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ import java.util.Optional;
 public class TrolleyService
 {
 	@NonNull private final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
+	@NonNull private final IUserDAO userDAO = Services.get(IUserDAO.class);
 	@NonNull private final LocatorScannedCodeResolverService locatorScannedCodeResolver;
 
 	private final HashBiMap<UserId, LocatorQRCode> userId2locator = HashBiMap.create();
@@ -37,10 +39,24 @@ public class TrolleyService
 
 		synchronized (userId2locator)
 		{
-			userId2locator.forcePut(userId, locatorQRCode);
+			final UserId currentHolderUserId = userId2locator.inverse().get(locatorQRCode);
+			if (currentHolderUserId != null && !currentHolderUserId.equals(userId))
+			{
+				final String holderName = userDAO.retrieveUserFullName(currentHolderUserId);
+				throw TrolleyAlreadyAssignedException.forNamedConflict(holderName, locatorQRCode);
+			}
+			userId2locator.put(userId, locatorQRCode);
 		}
 
 		return locatorQRCode;
+	}
+
+	public void clearCurrent(@NonNull final UserId userId)
+	{
+		synchronized (userId2locator)
+		{
+			userId2locator.remove(userId);
+		}
 	}
 
 	public Optional<LocatorQRCode> getCurrent(@NonNull final UserId userId)

--- a/backend/de.metas.workflow.rest-api/src/test/java/de/metas/workflow/rest_api/service/TrolleyServiceTest.java
+++ b/backend/de.metas.workflow.rest-api/src/test/java/de/metas/workflow/rest_api/service/TrolleyServiceTest.java
@@ -1,0 +1,104 @@
+package de.metas.workflow.rest_api.service;
+
+import de.metas.scannable_code.ScannedCode;
+import de.metas.user.UserId;
+import de.metas.user.api.IUserDAO;
+import de.metas.util.Services;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.LocatorId;
+import org.adempiere.warehouse.WarehouseId;
+import org.adempiere.warehouse.api.IWarehouseDAO;
+import org.adempiere.warehouse.qrcode.LocatorQRCode;
+import org.adempiere.warehouse.qrcode.resolver.LocatorScannedCodeResolverResult;
+import org.adempiere.warehouse.qrcode.resolver.LocatorScannedCodeResolverService;
+import org.compiere.model.I_M_Warehouse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TrolleyServiceTest
+{
+	private static final UserId USER_A = UserId.ofRepoId(1001);
+	private static final UserId USER_B = UserId.ofRepoId(1002);
+	private static final LocatorId LOCATOR_ID = LocatorId.ofRepoId(WarehouseId.ofRepoId(2001), 3001);
+
+	private LocatorScannedCodeResolverService resolver;
+	private IWarehouseDAO warehouseDAO;
+	private IUserDAO userDAO;
+	private TrolleyService service;
+
+	private ScannedCode scannedCode;
+	private LocatorQRCode locatorQRCode;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+
+		// Mock warehouse — getById returns an in-transit warehouse
+		warehouseDAO = mock(IWarehouseDAO.class);
+		final I_M_Warehouse warehouse = mock(I_M_Warehouse.class);
+		when(warehouse.isInTransit()).thenReturn(true);
+		when(warehouseDAO.getById(LOCATOR_ID.getWarehouseId())).thenReturn(warehouse);
+		Services.registerService(IWarehouseDAO.class, warehouseDAO);
+
+		// Mock user lookup — TrolleyService now always resolves the holder's name on conflict.
+		userDAO = mock(IUserDAO.class);
+		when(userDAO.retrieveUserFullName(USER_A)).thenReturn("Alice");
+		when(userDAO.retrieveUserFullName(USER_B)).thenReturn("Bob");
+		Services.registerService(IUserDAO.class, userDAO);
+
+		// Mock resolver — resolves a fixed ScannedCode to a fixed LocatorQRCode
+		resolver = mock(LocatorScannedCodeResolverService.class);
+		scannedCode = ScannedCode.ofString("CART-1");
+		locatorQRCode = LocatorQRCode.builder()
+				.locatorId(LOCATOR_ID)
+				.caption("CART-1")
+				.build();
+		final LocatorScannedCodeResolverResult resolved = LocatorScannedCodeResolverResult.found(locatorQRCode);
+		when(resolver.resolve(scannedCode)).thenReturn(resolved);
+
+		service = new TrolleyService(resolver);
+	}
+
+	@Test
+	void setCurrent_throwsTrolleyAlreadyAssignedException_whenAnotherUserAlreadyHoldsTheTrolley()
+	{
+		service.setCurrent(USER_A, scannedCode);
+		assertThatThrownBy(() -> service.setCurrent(USER_B, scannedCode))
+				.isInstanceOf(TrolleyAlreadyAssignedException.class);
+	}
+
+	@Test
+	void setCurrent_doesNotBumpOriginalHolder_whenSecondUserScansSameTrolley()
+	{
+		service.setCurrent(USER_A, scannedCode);
+		assertThatThrownBy(() -> service.setCurrent(USER_B, scannedCode))
+				.isInstanceOf(TrolleyAlreadyAssignedException.class);
+		assertThat(service.getCurrent(USER_A)).isPresent();
+		assertThat(service.getCurrent(USER_B)).isEmpty();
+	}
+
+	@Test
+	void clearCurrent_removesUserFromAssignmentMap()
+	{
+		service.setCurrent(USER_A, scannedCode);
+		service.clearCurrent(USER_A);
+		assertThat(service.getCurrent(USER_A)).isEmpty();
+		// The trolley must now be free — USER_B can claim it without conflict.
+		assertThatCode(() -> service.setCurrent(USER_B, scannedCode)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void clearCurrent_isIdempotent()
+	{
+		// user has no trolley — must not throw
+		service.clearCurrent(USER_A);
+		assertThat(service.getCurrent(USER_A)).isEmpty();
+	}
+}

--- a/e2e/mobile-webui/tests/spec/distribution/trolley.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/trolley.spec.js
@@ -4,8 +4,10 @@ import { LoginScreen } from "../../utils/screens/LoginScreen";
 import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
 import { DistributionJobsListScreen } from "../../utils/screens/distribution/DistributionJobsListScreen";
 import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
+import { BarcodeScannerComponent } from '../../utils/components/BarcodeScannerComponent';
 import { generateEAN13 } from '../../utils/ean13';
 import { allure } from 'allure-playwright';
+import { expect } from '@playwright/test';
 
 const createMasterdata = async ({ qtyToMove }) => {
     return await Backend.createMasterdata({
@@ -284,4 +286,85 @@ test('Pick multiple HUs (by HU code) to trolley and drop them all together in on
         });
     });
 
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Wagen freigeben: holder releases own trolley returns to scan screen', async ({ page }) => {
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
+    allure.tag('F5114');
+    allure.story('Trolley: holder can release their own Wagen');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({ qtyToMove: 100 });
+
+    await LoginScreen.login(masterdata.login.user1);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+
+    await DistributionJobsListScreen.scanTrolley({
+        scannedCode: masterdata.warehouses.whInTransit.locators.whInTransit_l1.qrCode,
+        expectHeader: masterdata.warehouses.whInTransit.locators.whInTransit_l1.code
+    });
+
+    await DistributionJobsListScreen.expectReleaseTrolleyButtonVisible({ visible: true });
+    await DistributionJobsListScreen.clickReleaseTrolleyButton();
+    await DistributionJobsListScreen.expectTrolleyScanScreen();
+
+    await DistributionJobsListScreen.goBack();
+    await ApplicationsListScreen.logout();
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Wagen freigeben: second user scanning held trolley sees conflict toast and original holder is not bumped', async ({ page }) => {
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
+    allure.tag('F5114');
+    allure.story('Trolley: conflict when second user scans held cart');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata({ qtyToMove: 100 });
+
+    // user1 takes whInTransit_l1
+    await LoginScreen.login(masterdata.login.user1);
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.scanTrolley({
+        scannedCode: masterdata.warehouses.whInTransit.locators.whInTransit_l1.qrCode,
+        expectHeader: masterdata.warehouses.whInTransit.locators.whInTransit_l1.code
+    });
+    await DistributionJobsListScreen.goBack();
+    await ApplicationsListScreen.logout();
+
+    // user2 tries to scan the same trolley — should see conflict toast
+    await LoginScreen.login(masterdata.login.user2);
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+
+    // Bypass expectErrorToast — its Promise.race rejects ~20ms before React renders the toast,
+    // so the toast wait loses the race even though the backend correctly throws 422 and the
+    // toast appears in the DOM. Assert the backend contract (422) and the toast text directly
+    // via Playwright's auto-retry; this avoids the helper's race-timing bug.
+    const postPromise = page.waitForResponse(
+        (r) => r.url().endsWith('/userWorkflows/trolley') && r.request().method() === 'POST'
+    );
+    await BarcodeScannerComponent.type({
+        scannedCode: masterdata.warehouses.whInTransit.locators.whInTransit_l1.qrCode
+    });
+    const postResponse = await postPromise;
+    expect(postResponse.status()).toBe(422);
+    await expect(page.getByRole('alert')).toContainText('already assigned', { timeout: 5000 });
+    await DistributionJobsListScreen.goBack();
+    await ApplicationsListScreen.logout();
+
+    // user1 still holds the trolley
+    await LoginScreen.login(masterdata.login.user1);
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.expectTrolley({
+        value: masterdata.warehouses.whInTransit.locators.whInTransit_l1.code
+    });
+    await DistributionJobsListScreen.goBack();
+    await ApplicationsListScreen.logout();
 });

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
@@ -1,5 +1,5 @@
 import { test } from "../../../../playwright.config";
-import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT, VERY_FAST_ACTION_TIMEOUT } from "../../common";
+import { ID_BACK_BUTTON, page, FAST_ACTION_TIMEOUT, SLOW_ACTION_TIMEOUT, VERY_FAST_ACTION_TIMEOUT } from "../../common";
 import { DistributionJobScreen } from "./DistributionJobScreen";
 import { DistributionJobsListFiltersScreen } from "./DistributionJobsListFiltersScreen";
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
@@ -109,6 +109,25 @@ export const DistributionJobsListScreen = {
         await dropAllButton.tap();
         await DistributionJobsDropAllScreen.waitForScreen();
         await DistributionJobsDropAllScreen.dropAll({ dropToQRCode })
+    }),
+
+    clickReleaseTrolleyButton: async () => await test.step(`${NAME} - Click 'Release trolley' footer button`, async () => {
+        await page.getByTestId('release-trolley-button').tap();
+    }),
+
+    expectReleaseTrolleyButtonVisible: async ({ visible }) => await test.step(`${NAME} - Expect release-trolley-button visible=${visible}`, async () => {
+        const btn = page.getByTestId('release-trolley-button');
+        if (visible) {
+            await expect(btn).toBeVisible({ timeout: FAST_ACTION_TIMEOUT });
+        } else {
+            await expect(btn).not.toBeVisible({ timeout: FAST_ACTION_TIMEOUT });
+        }
+    }),
+
+    expectTrolleyScanScreen: async () => await test.step(`${NAME} - Expect trolley scan screen (no trolley held)`, async () => {
+        // After release, the screen returns to the trolley-scan state.
+        // The barcode scanner input (#input-text) should be attached, waiting for a trolley scan.
+        await page.locator('#input-text').waitFor({ state: 'attached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/trolley.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/trolley.js
@@ -26,7 +26,7 @@ export const useCurrentTrolley = ({ applicationId }) => {
       return postCurrentTrolley({ scannedCode }).then((data) => setTrolley(data?.trolley ?? null));
     },
     clearTrolley: () => {
-      setTrolley(null);
+      return deleteCurrentTrolley().then(() => setTrolley(null));
     },
   };
 };
@@ -37,4 +37,8 @@ export const getCurrentTrolleyInfo = () => {
 
 export const postCurrentTrolley = ({ scannedCode }) => {
   return axios.post(`${trolleyAPIBase}`, { scannedCode }).then(unboxAxiosResponse);
+};
+
+export const deleteCurrentTrolley = () => {
+  return axios.delete(`${trolleyAPIBase}`).then(unboxAxiosResponse);
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/WFLaunchersScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/WFLaunchersScreen.jsx
@@ -19,6 +19,7 @@ import { useLaunchers } from './useLaunchers';
 import { APPLICATION_ID_Distribution } from '../../apps/distribution/constants';
 import DistributionJobsListActions from '../../apps/distribution/containers/DistributionJobsListActions';
 import { useCurrentTrolley } from '../../api/trolley';
+import { toastError } from '../../utils/toast';
 
 const WFLaunchersScreen = () => {
   const { history } = useScreenDefinition({ screenId: 'WFLaunchersScreen', back: '/' });
@@ -119,7 +120,9 @@ const WFLaunchersScreen = () => {
     return (
       <div className="container launchers-container">
         <BarcodeScannerComponent
-          onResolvedResult={({ scannedBarcode }) => setTrolleyByScannedCode(scannedBarcode)}
+          onResolvedResult={({ scannedBarcode }) =>
+            setTrolleyByScannedCode(scannedBarcode).catch((axiosError) => toastError({ axiosError }))
+          }
           inputPlaceholderText={trl('components.BarcodeScannerComponent.scanTrolleyPlaceholder')}
           continuousRunning={true}
         />
@@ -144,7 +147,7 @@ const WFLaunchersScreen = () => {
           additionalCssClass="action-button"
           typeFASIconName="fa-solid fa-cart-shopping"
           caption={trolley?.caption ?? trl('components.BarcodeScannerComponent.scanTrolleyPlaceholder')}
-          onClick={() => clearTrolley()}
+          onClick={() => clearTrolley().catch((axiosError) => toastError({ axiosError }))}
           testId="scanTrolley-button"
         />
       )}
@@ -179,6 +182,15 @@ const WFLaunchersScreen = () => {
           );
         })}
       {isLaunchersLoading && <Spinner />}
+      {isTrolleyRequired && trolley && (
+        <ButtonWithIndicator
+          captionKey="general.releaseTrolley.buttonCaption"
+          testId="release-trolley-button"
+          isDanger
+          onClick={() => clearTrolley().catch((axiosError) => toastError({ axiosError }))}
+          additionalCssClass="action-button"
+        />
+      )}
     </div>
   );
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -52,6 +52,9 @@ const translations = {
     workplace: 'Arbeitsplatz',
     workstation: 'Arbeitsstation',
     trolley: 'Wagen',
+    releaseTrolley: {
+      buttonCaption: 'Wagen freigeben',
+    },
   },
   login: {
     submitButton: 'Login',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -49,6 +49,9 @@ const translations = {
     workplace: 'Workplace',
     workstation: 'Workstation',
     trolley: 'Trolley',
+    releaseTrolley: {
+      buttonCaption: 'Release trolley',
+    },
   },
   login: {
     submitButton: 'Login',


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/v2/userWorkflows/trolley` to let the logged-in user release their currently-held trolley.
- Replaces silent `HashBiMap.forcePut` in `TrolleyService.setCurrent` with an explicit conflict check + translated exception, preserving the original holder's assignment when a second user scans the same trolley.
- Conflict error message always names the current holder, so the scanner can resolve the conflict directly with that user.
- Mobile UI: red "Release trolley" footer button on the launchers screen (visible only when a trolley is held), plus `toastError` on scan-path rejection (previously swallowed silently).

## Backend

- `TrolleyService.clearCurrent(UserId)` — idempotent, synchronised on the same monitor as `setCurrent`.
- `TrolleyService.setCurrent` — on conflict, resolves the current holder's display name via `IUserDAO.retrieveUserFullName` and throws `TrolleyAlreadyAssignedException.forNamedConflict(name, locator)`.
- `TrolleyAlreadyAssignedException extends AdempiereException` — single static factory `forNamedConflict(holderDisplayName, locatorQRCode)` wired to `AdMessageKey` so the message is translatable.
- `TrolleyServiceTest`: 4 unit tests — conflict-throws-exception, original-holder-not-bumped, idempotent clearCurrent, trolley-freed-after-clear.

## Frontend (mobile-webui)

- `api/trolley.js`: new exported `deleteCurrentTrolley`. `clearTrolley` rewritten to return a promise that clears local state only after the server confirms the release — so a server rejection leaves the UI consistent with backend state.
- New translation key `general.releaseTrolley.buttonCaption` (EN `Release trolley` / DE `Wagen freigeben`).
- `WFLaunchersScreen.jsx`: red `ButtonWithIndicator isDanger` footer button rendered when `isTrolleyRequired && trolley`; both the new button and the existing top trolley indicator wrap `clearTrolley()` with `.catch(toastError)`; the scan-path also gains a `.catch(toastError)` so conflict errors are no longer swallowed.

## Migrations

- `5802470_sys_me03_28959_AD_Message_TrolleyAlreadyAssigned.sql` — one AD_Message row `WFRestAPI_TrolleyAlreadyAssignedTo` with `{0}` placeholder for the holder name, EN/DE translations and `ErrorCode`.

## Test plan

- [ ] CI builds green (Java compile, db-apply-migrations, JUnit, frontend lint, mobile-webui Playwright baseline).
- [ ] UAT — user A holds a trolley, user B scans the same trolley: B sees a translated conflict toast naming user A; A still holds the trolley and can continue picking.
- [ ] UAT — user A taps "Release trolley" (red footer button): trolley is released server-side; UI returns to the trolley-scan screen.
- [ ] UAT — no trolley held: red "Release trolley" button is not rendered (`isTrolleyRequired && trolley` guard).