### PR TITLE
feat: PO date provisioning — PreparationDate = DatePromised − PO_TransportDays

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_BPartner.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_BPartner.java
@@ -2994,6 +2994,27 @@ public interface I_C_BPartner
 	String COLUMNNAME_PO_PricingSystem_ID = "PO_PricingSystem_ID";
 
 	/**
+	 * Set Purchase Transport Days.
+	 *
+	 * <br>Type: Integer
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setPO_TransportDays (int PO_TransportDays);
+
+	/**
+	 * Get Purchase Transport Days.
+	 *
+	 * <br>Type: Integer
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getPO_TransportDays();
+
+	ModelColumn<I_C_BPartner, Object> COLUMN_PO_TransportDays = new ModelColumn<>(I_C_BPartner.class, "PO_TransportDays", null);
+	String COLUMNNAME_PO_TransportDays = "PO_TransportDays";
+
+	/**
 	 * Set Order Reference.
 	 * Transaction Reference Number (Sales Order, Purchase Order) of your Business Partner
 	 *

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_BPartner.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_BPartner.java
@@ -2067,9 +2067,21 @@ public class X_C_BPartner extends org.compiere.model.PO implements I_C_BPartner,
 	}
 
 	@Override
-	public int getPO_PricingSystem_ID() 
+	public int getPO_PricingSystem_ID()
 	{
 		return get_ValueAsInt(COLUMNNAME_PO_PricingSystem_ID);
+	}
+
+	@Override
+	public void setPO_TransportDays (final int PO_TransportDays)
+	{
+		set_Value (COLUMNNAME_PO_TransportDays, PO_TransportDays);
+	}
+
+	@Override
+	public int getPO_TransportDays()
+	{
+		return get_ValueAsInt(COLUMNNAME_PO_TransportDays);
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/IBPartnerDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/IBPartnerDAO.java
@@ -84,6 +84,10 @@ public interface IBPartnerDAO extends ISingletonService
 
 	<T extends I_C_BPartner> T getById(BPartnerId bpartnerId, Class<T> modelClass);
 
+	Optional<Integer> getPurchaseTransportDays(BPartnerId bpartnerId);
+
+	Optional<Integer> getPurchaseTransportDays(I_C_BPartner bpartner);
+
 	List<I_C_BPartner> getByIds(@NonNull Collection<BPartnerId> bpartnerIds);
 
 	/**

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerDAO.java
@@ -195,6 +195,22 @@ public class BPartnerDAO implements IBPartnerDAO
 	}
 
 	@Override
+	public Optional<Integer> getPurchaseTransportDays(@NonNull final BPartnerId bpartnerId)
+	{
+		return getPurchaseTransportDays(getById(bpartnerId));
+	}
+
+	@Override
+	public Optional<Integer> getPurchaseTransportDays(@NonNull final I_C_BPartner bpartner)
+	{
+		if (InterfaceWrapperHelper.isNull(bpartner, I_C_BPartner.COLUMNNAME_PO_TransportDays))
+		{
+			return Optional.empty();
+		}
+		return Optional.of(bpartner.getPO_TransportDays());
+	}
+
+	@Override
 	public <T extends I_C_BPartner> T getById(@NonNull final BPartnerId bpartnerId, final Class<T> modelClass)
 	{
 		// NOTE: generally, don't load out of trx unless knowing the context that therefore knowing that it's OK.

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5803020_sys_gh28625_C_BPartner_PO_TransportDays.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5803020_sys_gh28625_C_BPartner_PO_TransportDays.sql
@@ -1,0 +1,170 @@
+-- PO Date Provisioning: add C_BPartner.PO_TransportDays (vendor-level default transport days)
+--
+-- AD_Element_ID : 584888  /*From ID Server*/
+-- AD_Column_ID  : 592551  /*From ID Server*/
+-- AD_Field_ID   : 780245  /*From ID Server*/
+-- AD_UI_Element_ID : 651686  /*From ID Server*/
+-- Vendor tab (Lieferant): AD_Tab_ID=224, AD_UI_ElementGroup_ID=1000033
+
+-- =============================================================================
+-- 1. AD_Element
+--    Timestamps: element at 14:00:00, column at 14:01:00, field/UI at 14:02:xx.
+--    Element_Trl UPDATEs below use 14:03:xx — deliberately later than all
+--    downstream skeleton-insert timestamps so update_TRL_Tables fires correctly.
+-- =============================================================================
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                        Created, CreatedBy, Updated, UpdatedBy,
+                        ColumnName, Name, PrintName, Description, Help)
+VALUES (584888 /*From ID Server*/, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-05-18 14:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        TO_TIMESTAMP('2026-05-18 14:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        'PO_TransportDays',
+        'Einkauf Transporttage',
+        'Einkauf Transporttage',
+        'Lieferzeit des Lieferanten in Tagen', NULL);
+
+-- Skeleton Trl rows for AD_Element
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID,
+                            Name, PrintName, Description, Help,
+                            IsTranslated, AD_Client_ID, AD_Org_ID,
+                            Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Element_ID,
+       t.Name, t.PrintName, t.Description, t.Help,
+       'N', t.AD_Client_ID, t.AD_Org_ID,
+       t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND t.AD_Element_ID = 584888
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID);
+
+-- English translation (en_US) — timestamp MUST be later than all downstream skeleton timestamps
+UPDATE AD_Element_Trl
+SET Name         = 'Purchase Transport Days',
+    PrintName    = 'Purchase Transport Days',
+    Description  = 'Vendor transport time in days',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-05-18 14:03:00', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 584888 AND AD_Language = 'en_US';
+
+-- German (de_DE — base language)
+UPDATE AD_Element_Trl
+SET Name         = 'Einkauf Transporttage',
+    PrintName    = 'Einkauf Transporttage',
+    Description  = 'Lieferzeit des Lieferanten in Tagen',
+    IsTranslated = 'N',
+    Updated      = TO_TIMESTAMP('2026-05-18 14:03:01', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 584888 AND AD_Language = 'de_DE';
+
+-- German (de_CH — same as de_DE)
+UPDATE AD_Element_Trl
+SET Name         = 'Einkauf Transporttage',
+    PrintName    = 'Einkauf Transporttage',
+    Description  = 'Lieferzeit des Lieferanten in Tagen',
+    IsTranslated = 'N',
+    Updated      = TO_TIMESTAMP('2026-05-18 14:03:02', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 584888 AND AD_Language = 'de_CH';
+
+-- =============================================================================
+-- 2. AD_Column on C_BPartner (AD_Table_ID=291)
+-- =============================================================================
+INSERT INTO AD_Column (AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                       Created, CreatedBy, Updated, UpdatedBy,
+                       Version, AD_Table_ID, AD_Element_ID, AD_Reference_ID,
+                       ColumnName, Name, Description, Help,
+                       FieldLength, IsMandatory, IsUpdateable, IsAlwaysUpdateable,
+                       DefaultValue, EntityType, IsKey, IsParent, IsSelectionColumn,
+                       IsTranslated, IsIdentifier, IsEncrypted, IsAllowLogging,
+                       PersonalDataCategory)
+VALUES (592551 /*From ID Server*/, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-05-18 14:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        TO_TIMESTAMP('2026-05-18 14:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        0, 291, 584888, 11,
+        'PO_TransportDays',
+        'Einkauf Transporttage',
+        NULL, NULL,
+        10, 'N', 'Y', 'N',
+        NULL, 'D', 'N', 'N', 'N',
+        'N', 'N', 'N', 'Y',
+        'NP');
+
+-- Skeleton Trl rows for AD_Column
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated,
+                           AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',
+       t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND t.AD_Column_ID = 592551
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+-- =============================================================================
+-- 3. Physical DDL — new column (t_alter_column only works on existing columns)
+-- =============================================================================
+ALTER TABLE C_BPartner ADD COLUMN IF NOT EXISTS PO_TransportDays INTEGER;
+
+-- =============================================================================
+-- 4. AD_Field on vendor tab (AD_Tab_ID=224, Geschäftspartner window 123)
+--    SeqNo=0: intentional — other PO fields on this tab (e.g. PO_InvoiceRule) also use SeqNo=0,
+--    meaning the Swing form-view does not render them; grid-view is controlled by SeqNoGrid=200.
+--    WebUI rendering is governed by AD_UI_Element below (step 5).
+-- =============================================================================
+INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive,
+                      Created, CreatedBy, Updated, UpdatedBy,
+                      AD_Tab_ID, AD_Column_ID, AD_Name_ID,
+                      Name, Description,
+                      IsDisplayed, IsDisplayedGrid, IsReadOnly, IsSameLine,
+                      SeqNo, SeqNoGrid, SortNo, EntityType)
+VALUES (780245 /*From ID Server*/, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-05-18 14:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        TO_TIMESTAMP('2026-05-18 14:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        224, 592551, NULL,
+        'Einkauf Transporttage', NULL,
+        'Y', 'Y', 'N', 'N',
+        0, 200, 0, 'D');
+
+-- Skeleton Trl rows for AD_Field
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Name, Description, Help,
+                          IsTranslated, AD_Client_ID, AD_Org_ID,
+                          Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Name, t.Description, t.Help,
+       'N', t.AD_Client_ID, t.AD_Org_ID,
+       t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND t.AD_Field_ID = 780245
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+
+-- Element link (enables zoom/reference navigation from this field)
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 780245;
+SELECT AD_Element_Link_Create_Missing_Field(780245);
+
+-- =============================================================================
+-- 5. AD_UI_Element (WebUI layout — AD_Field alone is not rendered in WebUI)
+--    Group: 1000033 (default PO group on vendor tab)
+--    SeqNo=150 (after PO_InvoiceRule at 148), SeqNoGrid=130 (after current max of 120)
+-- =============================================================================
+INSERT INTO AD_UI_Element (
+    AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+    AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+    Created, CreatedBy, IsActive, IsAdvancedField,
+    IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+    Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+    Updated, UpdatedBy
+) VALUES (
+    0, 780245, 0, 224,
+    1000033, 651686 /*From ID Server*/, 'F',
+    TO_TIMESTAMP('2026-05-18 14:02:01', 'YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'Y',
+    'Y', 'Y', 'N',
+    'Einkauf Transporttage', 150, 130, 0,
+    TO_TIMESTAMP('2026-05-18 14:02:01', 'YYYY-MM-DD HH24:MI:SS'), 100
+);
+
+-- =============================================================================
+-- 6. Propagate translations from AD_Element_Trl to AD_Column_Trl / AD_Field_Trl
+--    AD_Element_Trl UPDATEs above use timestamps 14:03:xx, which are later than
+--    all skeleton-insert timestamps (≤14:02:01), so the guard fires correctly.
+-- =============================================================================
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584888);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5803030_sys_gh28625_DeliveryTime_Promised_label_override.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5803030_sys_gh28625_DeliveryTime_Promised_label_override.sql
@@ -1,0 +1,45 @@
+-- PO Date Provisioning: override label of DeliveryTime_Promised to "Purchase Transport Days"
+-- in C_BPartner_Product context windows (BPartner window product tab + Product window BPartner tab).
+--
+-- The AD_Element for DeliveryTime_Promised (ID=1256) is NOT renamed globally — it keeps
+-- "Zugesicherte Lieferzeit" for PP_Product_Planning and M_Product_PO contexts.
+-- Instead, AD_Field.AD_Name_ID is set to the new PO_TransportDays element (584888)
+-- only on these two C_BPartner_Product-context fields.
+--
+-- Affected fields:
+--   AD_Field_ID=563649  Geschäftspartner window (123), tab "Produkt" (541077)
+--   AD_Field_ID=565318  Produkt window (140), tab "Geschäftspartner" (562)
+
+UPDATE AD_Field
+SET AD_Name_ID = 584888,
+    Name       = 'Einkauf Transporttage',
+    Updated    = TO_TIMESTAMP('2026-05-18 14:10:00', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy  = 100
+WHERE AD_Field_ID IN (563649, 565318);
+
+-- Propagate translations from element 584888 (Einkauf Transporttage / Purchase Transport Days)
+-- to all AD_Field_Trl rows where AD_Name_ID=584888 — covers the two fields above as well as
+-- the new PO_TransportDays field (780245) created in script 5803020.
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584888);
+
+-- =============================================================================
+-- AD_UI_Element for Produkt window (140), tab Geschäftspartner (AD_Tab_ID=562)
+--   Field 565318 = DeliveryTime_Promised relabelled to "Einkauf Transporttage".
+--   No UI element existed before; add as advanced field.
+--   Group: 1000021 (default), SeqNo=176 (after Wiederbeschaffung=175), SeqNoGrid=160
+-- =============================================================================
+INSERT INTO AD_UI_Element (
+    AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+    AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+    Created, CreatedBy, IsActive, IsAdvancedField,
+    IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+    Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+    Updated, UpdatedBy
+) VALUES (
+    0, 565318, 0, 562,
+    1000021, 651701 /*From ID Server*/, 'F',
+    TO_TIMESTAMP('2026-05-18 14:10:01', 'YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'Y',
+    'Y', 'Y', 'N',
+    'Einkauf Transporttage', 176, 160, 0,
+    TO_TIMESTAMP('2026-05-18 14:10:01', 'YYYY-MM-DD HH24:MI:SS'), 100
+);

--- a/backend/de.metas.business/src/main/java/de/metas/bpartner/effective/BPartnerEffective.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner/effective/BPartnerEffective.java
@@ -50,7 +50,7 @@ public class BPartnerEffective
 	@Nullable Incoterms incoterms;
 	@Nullable Incoterms poIncoterms;
 	boolean isAutoInvoice;
-	@Nullable @Getter Integer purchaseTransportDays;
+	@Getter int purchaseTransportDays;
 
 	@Nullable
 	public PaymentTermId getPaymentTermId(@NonNull final SOTrx soTrx)

--- a/backend/de.metas.business/src/main/java/de/metas/bpartner/effective/BPartnerEffective.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner/effective/BPartnerEffective.java
@@ -50,6 +50,7 @@ public class BPartnerEffective
 	@Nullable Incoterms incoterms;
 	@Nullable Incoterms poIncoterms;
 	boolean isAutoInvoice;
+	@Nullable @Getter Integer purchaseTransportDays;
 
 	@Nullable
 	public PaymentTermId getPaymentTermId(@NonNull final SOTrx soTrx)

--- a/backend/de.metas.business/src/main/java/de/metas/bpartner/effective/BPartnerEffectiveBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner/effective/BPartnerEffectiveBL.java
@@ -81,8 +81,7 @@ public class BPartnerEffectiveBL
 
 	public int getPurchaseTransportDays(@NonNull final BPartnerId bPartnerId)
 	{
-		final Integer days = getById(bPartnerId).getPurchaseTransportDays();
-		return days != null ? days : 0;
+		return getById(bPartnerId).getPurchaseTransportDays();
 	}
 
 	public BPartnerEffective getByRecord(@NonNull final I_C_BPartner bPartnerRecord)
@@ -184,7 +183,7 @@ public class BPartnerEffectiveBL
 				bPartnerBuilder::poIncoterms);
 
 		bPartnerBuilder.purchaseTransportDays(
-				bpartnerDAO.getPurchaseTransportDays(bPartnerRecord).orElse(null));
+				bpartnerDAO.getPurchaseTransportDays(bPartnerRecord).orElse(0));
 
 		return bPartnerBuilder.build();
 	}

--- a/backend/de.metas.business/src/main/java/de/metas/bpartner/effective/BPartnerEffectiveBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner/effective/BPartnerEffectiveBL.java
@@ -79,6 +79,12 @@ public class BPartnerEffectiveBL
 		return getByRecord(bpartnerDAO.getById(bPartnerId));
 	}
 
+	public int getPurchaseTransportDays(@NonNull final BPartnerId bPartnerId)
+	{
+		final Integer days = getById(bPartnerId).getPurchaseTransportDays();
+		return days != null ? days : 0;
+	}
+
 	public BPartnerEffective getByRecord(@NonNull final I_C_BPartner bPartnerRecord)
 	{
 		final I_C_BP_Group bpGroup = bpGroupDAO.getById(BPGroupId.ofRepoId(bPartnerRecord.getC_BP_Group_ID()));
@@ -176,6 +182,9 @@ public class BPartnerEffectiveBL
 				I_C_BPartner::getPO_IncotermLocation,
 				I_C_BP_Group::getPO_IncotermLocation,
 				bPartnerBuilder::poIncoterms);
+
+		bPartnerBuilder.purchaseTransportDays(
+				bpartnerDAO.getPurchaseTransportDays(bPartnerRecord).orElse(null));
 
 		return bPartnerBuilder.build();
 	}

--- a/backend/de.metas.business/src/main/java/de/metas/bpartner_product/BPartnerProductEffectiveBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner_product/BPartnerProductEffectiveBL.java
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.bpartner_product;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.effective.BPartnerEffectiveBL;
+import de.metas.organization.OrgId;
+import de.metas.product.ProductId;
+import de.metas.util.Services;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BPartnerProductEffectiveBL
+{
+	@NonNull private final IBPartnerProductDAO bpartnerProductDAO = Services.get(IBPartnerProductDAO.class);
+	@NonNull private final BPartnerEffectiveBL bpartnerEffectiveBL;
+
+	public int getPurchaseTransportDays(@NonNull final BPartnerId vendorId, @NonNull final ProductId productId, @NonNull final OrgId orgId)
+	{
+		return bpartnerProductDAO.getDeliveryTimePromised(vendorId, productId, orgId)
+				.orElseGet(() -> bpartnerEffectiveBL.getPurchaseTransportDays(vendorId));
+	}
+}

--- a/backend/de.metas.business/src/main/java/de/metas/bpartner_product/IBPartnerProductDAO.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner_product/IBPartnerProductDAO.java
@@ -89,6 +89,8 @@ public interface IBPartnerProductDAO extends ISingletonService
 
 	I_C_BPartner_Product retrieveByVendorId(BPartnerId vendorId, ProductId productId, OrgId orgId);
 
+	Optional<Integer> getDeliveryTimePromised(BPartnerId vendorId, ProductId productId, OrgId orgId);
+
 	List<I_C_BPartner_Product> retrieveAllBPartnerProductAssociations(Properties ctx, BPartnerId bpartnerId, ProductId productId, OrgId orgId, String trxName);
 
 	Optional<ProductId> getProductIdByCustomerProductNo(BPartnerId customerId, String customerProductNo);

--- a/backend/de.metas.business/src/main/java/de/metas/bpartner_product/impl/BPartnerProductDAO.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner_product/impl/BPartnerProductDAO.java
@@ -156,7 +156,15 @@ public class BPartnerProductDAO implements IBPartnerProductDAO
 			@NonNull final ProductId productId,
 			@NonNull final OrgId orgId)
 	{
-		final I_C_BPartner_Product record = retrieveByVendorId(vendorId, productId, orgId);
+		final I_C_BPartner_Product record = queryBL
+				.createQueryBuilderOutOfTrx(I_C_BPartner_Product.class)
+				.addOnlyActiveRecordsFilter()
+				.addInArrayFilter(I_C_BPartner_Product.COLUMNNAME_AD_Org_ID, orgId, OrgId.ANY)
+				.addEqualsFilter(I_C_BPartner_Product.COLUMNNAME_C_BPartner_ID, vendorId)
+				.addEqualsFilter(I_C_BPartner_Product.COLUMNNAME_M_Product_ID, productId)
+				.orderByDescending(I_C_BPartner_Product.COLUMNNAME_AD_Org_ID)
+				.create()
+				.first(I_C_BPartner_Product.class);
 		if (record == null || InterfaceWrapperHelper.isNull(record, I_C_BPartner_Product.COLUMNNAME_DeliveryTime_Promised))
 		{
 			return Optional.empty();

--- a/backend/de.metas.business/src/main/java/de/metas/bpartner_product/impl/BPartnerProductDAO.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner_product/impl/BPartnerProductDAO.java
@@ -151,6 +151,20 @@ public class BPartnerProductDAO implements IBPartnerProductDAO
 	}
 
 	@Override
+	public Optional<Integer> getDeliveryTimePromised(
+			@NonNull final BPartnerId vendorId,
+			@NonNull final ProductId productId,
+			@NonNull final OrgId orgId)
+	{
+		final I_C_BPartner_Product record = retrieveByVendorId(vendorId, productId, orgId);
+		if (record == null || InterfaceWrapperHelper.isNull(record, I_C_BPartner_Product.COLUMNNAME_DeliveryTime_Promised))
+		{
+			return Optional.empty();
+		}
+		return Optional.of(record.getDeliveryTime_Promised());
+	}
+
+	@Override
 	public Map<BPartnerId, I_C_BPartner_Product> retrieveByVendorIds(
 			@NonNull final Set<BPartnerId> vendorIds,
 			@NonNull final ProductId productId,

--- a/backend/de.metas.business/src/main/java/de/metas/order/IOrderBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/IOrderBL.java
@@ -68,6 +68,9 @@ public interface IOrderBL extends ISingletonService
 {
 	I_C_Order getById(OrderId orderId);
 
+	/** Returns max(PurchaseTransportDays across all order lines), or 0 if there are no lines or no transport days. */
+	int getMaxPurchaseTransportDays(I_C_Order order);
+
 	/**
 	 * Sets price list if there is a price list for the given order's location and pricing system.
 	 * <p>

--- a/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderBL.java
@@ -27,6 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import de.metas.bpartner.BPartnerContactId;
+import de.metas.bpartner_product.BPartnerProductEffectiveBL;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationAndCaptureId;
 import de.metas.bpartner.BPartnerLocationId;
@@ -140,6 +141,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -164,6 +166,7 @@ public class OrderBL implements IOrderBL
 	private final IPriceListDAO priceListDAO = Services.get(IPriceListDAO.class);
 	private final IOrderLineBL orderLineBL = Services.get(IOrderLineBL.class);
 	private final IUserDAO userDAO = Services.get(IUserDAO.class);
+	private final SpringContextHolder.Lazy<BPartnerProductEffectiveBL> bpartnerProductEffectiveBL = SpringContextHolder.lazyBean(BPartnerProductEffectiveBL.class);
 	private final IOrgDAO orgDAO = Services.get(IOrgDAO.class);
 	private final IProductBL productBL = Services.get(IProductBL.class);
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
@@ -1508,5 +1511,19 @@ public class OrderBL implements IOrderBL
 			orderLine.setM_AttributeSetInstance_ID(attributeSetInstanceId.getRepoId());
 		}
 
+	}
+
+	@Override
+	public int getMaxPurchaseTransportDays(@NonNull final I_C_Order order)
+	{
+		final BPartnerId vendorId = BPartnerId.ofRepoId(order.getC_BPartner_ID());
+		final OrgId orgId = OrgId.ofRepoId(order.getAD_Org_ID());
+		return orderDAO.retrieveOrderLines(order)
+				.stream()
+				.map(line -> ProductId.ofRepoIdOrNull(line.getM_Product_ID()))
+				.filter(Objects::nonNull)
+				.mapToInt(productId -> bpartnerProductEffectiveBL.get().getPurchaseTransportDays(vendorId, productId, orgId))
+				.max()
+				.orElse(0);
 	}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderBL.java
@@ -166,7 +166,6 @@ public class OrderBL implements IOrderBL
 	private final IPriceListDAO priceListDAO = Services.get(IPriceListDAO.class);
 	private final IOrderLineBL orderLineBL = Services.get(IOrderLineBL.class);
 	private final IUserDAO userDAO = Services.get(IUserDAO.class);
-	private final SpringContextHolder.Lazy<BPartnerProductEffectiveBL> bpartnerProductEffectiveBL = SpringContextHolder.lazyBean(BPartnerProductEffectiveBL.class);
 	private final IOrgDAO orgDAO = Services.get(IOrgDAO.class);
 	private final IProductBL productBL = Services.get(IProductBL.class);
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
@@ -175,8 +174,9 @@ public class OrderBL implements IOrderBL
 	private final ICurrencyBL currencyBL = Services.get(ICurrencyBL.class);
 	private final IAttributeSetInstanceBL attributeSetInstanceBL = Services.get(IAttributeSetInstanceBL.class);
 
-	private final SpringContextHolder.Lazy<BPartnerOrderParamsRepository> bpartnerOrderParamsRepository = SpringContextHolder.lazyBean(BPartnerOrderParamsRepository.class);
-	private final SpringContextHolder.Lazy<ProjectRepository> projectRepository = SpringContextHolder.lazyBean(ProjectRepository.class);
+	@NonNull private final SpringContextHolder.Lazy<BPartnerOrderParamsRepository> bpartnerOrderParamsRepository = SpringContextHolder.lazyBean(BPartnerOrderParamsRepository.class);
+	@NonNull private final SpringContextHolder.Lazy<ProjectRepository> projectRepository = SpringContextHolder.lazyBean(ProjectRepository.class);
+	@NonNull private final SpringContextHolder.Lazy<BPartnerProductEffectiveBL> bpartnerProductEffectiveBL = SpringContextHolder.lazyBean(BPartnerProductEffectiveBL.class);
 
 	@Override
 	public I_C_Order getById(@NonNull final OrderId orderId)
@@ -1516,6 +1516,11 @@ public class OrderBL implements IOrderBL
 	@Override
 	public int getMaxPurchaseTransportDays(@NonNull final I_C_Order order)
 	{
+		if(order.isSOTrx())
+		{
+			return 0;
+		}
+
 		final BPartnerId vendorId = BPartnerId.ofRepoId(order.getC_BPartner_ID());
 		final OrgId orgId = OrgId.ofRepoId(order.getAD_Org_ID());
 		return orderDAO.retrieveOrderLines(order)

--- a/backend/de.metas.business/src/test/java/de/metas/bpartner/effective/BPartnerEffectiveBLTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/bpartner/effective/BPartnerEffectiveBLTest.java
@@ -344,6 +344,25 @@ public class BPartnerEffectiveBLTest
 		assertEquals("TestPoIncotermsLocation3", poIncoterms.getLocationEffective());
 	}
 
+	@Test
+	public void getPurchaseTransportDays_noValueOnBPartner_returns0()
+	{
+		final I_C_BPartner partner = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		saveRecord(partner);
+
+		assertThat(bpartnerEffectiveBL.getPurchaseTransportDays(BPartnerId.ofRepoId(partner.getC_BPartner_ID()))).isEqualTo(0);
+	}
+
+	@Test
+	public void getPurchaseTransportDays_valueSetOnBPartner_returnsValue()
+	{
+		final I_C_BPartner partner = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		partner.setPO_TransportDays(5);
+		saveRecord(partner);
+
+		assertThat(bpartnerEffectiveBL.getPurchaseTransportDays(BPartnerId.ofRepoId(partner.getC_BPartner_ID()))).isEqualTo(5);
+	}
+
 	@Builder(builderMethodName = "setup", builderClassName = "$SetupBuilder")
 	private BPartnerId setupTest(
 			@Nullable final PricingSystemId bpartner_PricingSystemId,

--- a/backend/de.metas.business/src/test/java/de/metas/bpartner/effective/BPartnerEffectiveBLTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/bpartner/effective/BPartnerEffectiveBLTest.java
@@ -347,7 +347,11 @@ public class BPartnerEffectiveBLTest
 	@Test
 	public void getPurchaseTransportDays_noValueOnBPartner_returns0()
 	{
+		final I_C_BP_Group bpGroup = InterfaceWrapperHelper.newInstance(I_C_BP_Group.class);
+		saveRecord(bpGroup);
+
 		final I_C_BPartner partner = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		partner.setC_BP_Group_ID(bpGroup.getC_BP_Group_ID());
 		saveRecord(partner);
 
 		assertThat(bpartnerEffectiveBL.getPurchaseTransportDays(BPartnerId.ofRepoId(partner.getC_BPartner_ID()))).isEqualTo(0);
@@ -356,7 +360,11 @@ public class BPartnerEffectiveBLTest
 	@Test
 	public void getPurchaseTransportDays_valueSetOnBPartner_returnsValue()
 	{
+		final I_C_BP_Group bpGroup = InterfaceWrapperHelper.newInstance(I_C_BP_Group.class);
+		saveRecord(bpGroup);
+
 		final I_C_BPartner partner = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		partner.setC_BP_Group_ID(bpGroup.getC_BP_Group_ID());
 		partner.setPO_TransportDays(5);
 		saveRecord(partner);
 

--- a/backend/de.metas.business/src/test/java/de/metas/bpartner_product/BPartnerProductEffectiveBLTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/bpartner_product/BPartnerProductEffectiveBLTest.java
@@ -26,9 +26,9 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.effective.BPartnerEffectiveBL;
 import de.metas.organization.OrgId;
 import de.metas.product.ProductId;
-import de.metas.util.Services;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_BP_Group;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_BPartner_Product;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,10 +51,7 @@ public class BPartnerProductEffectiveBLTest
 	@Test
 	public void getPurchaseTransportDays_bpartnerProductHasValue_returnsBPartnerProductValue()
 	{
-		final I_C_BPartner vendor = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
-		vendor.setPO_TransportDays(3);
-		saveRecord(vendor);
-		final BPartnerId vendorId = BPartnerId.ofRepoId(vendor.getC_BPartner_ID());
+		final BPartnerId vendorId = createVendor(3);
 
 		final I_C_BPartner_Product bpartnerProduct = InterfaceWrapperHelper.newInstance(I_C_BPartner_Product.class);
 		bpartnerProduct.setC_BPartner_ID(vendorId.getRepoId());
@@ -68,10 +65,7 @@ public class BPartnerProductEffectiveBLTest
 	@Test
 	public void getPurchaseTransportDays_bpartnerProductHasNoValue_fallsBackToBPartner()
 	{
-		final I_C_BPartner vendor = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
-		vendor.setPO_TransportDays(3);
-		saveRecord(vendor);
-		final BPartnerId vendorId = BPartnerId.ofRepoId(vendor.getC_BPartner_ID());
+		final BPartnerId vendorId = createVendor(3);
 
 		final I_C_BPartner_Product bpartnerProduct = InterfaceWrapperHelper.newInstance(I_C_BPartner_Product.class);
 		bpartnerProduct.setC_BPartner_ID(vendorId.getRepoId());
@@ -85,10 +79,7 @@ public class BPartnerProductEffectiveBLTest
 	@Test
 	public void getPurchaseTransportDays_noBPartnerProduct_fallsBackToBPartner()
 	{
-		final I_C_BPartner vendor = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
-		vendor.setPO_TransportDays(5);
-		saveRecord(vendor);
-		final BPartnerId vendorId = BPartnerId.ofRepoId(vendor.getC_BPartner_ID());
+		final BPartnerId vendorId = createVendor(5);
 
 		// no C_BPartner_Product record at all
 		assertThat(bpartnerProductEffectiveBL.getPurchaseTransportDays(vendorId, ProductId.ofRepoId(42), OrgId.ANY)).isEqualTo(5);
@@ -97,11 +88,23 @@ public class BPartnerProductEffectiveBLTest
 	@Test
 	public void getPurchaseTransportDays_noBPartnerProductNoBPartnerValue_returns0()
 	{
-		final I_C_BPartner vendor = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
-		// PO_TransportDays not set → null in DB
-		saveRecord(vendor);
-		final BPartnerId vendorId = BPartnerId.ofRepoId(vendor.getC_BPartner_ID());
+		final BPartnerId vendorId = createVendor(null);
 
 		assertThat(bpartnerProductEffectiveBL.getPurchaseTransportDays(vendorId, ProductId.ofRepoId(42), OrgId.ANY)).isEqualTo(0);
+	}
+
+	private BPartnerId createVendor(final Integer poTransportDays)
+	{
+		final I_C_BP_Group bpGroup = InterfaceWrapperHelper.newInstance(I_C_BP_Group.class);
+		saveRecord(bpGroup);
+
+		final I_C_BPartner vendor = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		vendor.setC_BP_Group_ID(bpGroup.getC_BP_Group_ID());
+		if (poTransportDays != null)
+		{
+			vendor.setPO_TransportDays(poTransportDays);
+		}
+		saveRecord(vendor);
+		return BPartnerId.ofRepoId(vendor.getC_BPartner_ID());
 	}
 }

--- a/backend/de.metas.business/src/test/java/de/metas/bpartner_product/BPartnerProductEffectiveBLTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/bpartner_product/BPartnerProductEffectiveBLTest.java
@@ -1,0 +1,107 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.bpartner_product;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.effective.BPartnerEffectiveBL;
+import de.metas.organization.OrgId;
+import de.metas.product.ProductId;
+import de.metas.util.Services;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_C_BPartner_Product;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BPartnerProductEffectiveBLTest
+{
+	private BPartnerProductEffectiveBL bpartnerProductEffectiveBL;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+		bpartnerProductEffectiveBL = new BPartnerProductEffectiveBL(BPartnerEffectiveBL.newInstanceForUnitTesting());
+	}
+
+	@Test
+	public void getPurchaseTransportDays_bpartnerProductHasValue_returnsBPartnerProductValue()
+	{
+		final I_C_BPartner vendor = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		vendor.setPO_TransportDays(3);
+		saveRecord(vendor);
+		final BPartnerId vendorId = BPartnerId.ofRepoId(vendor.getC_BPartner_ID());
+
+		final I_C_BPartner_Product bpartnerProduct = InterfaceWrapperHelper.newInstance(I_C_BPartner_Product.class);
+		bpartnerProduct.setC_BPartner_ID(vendorId.getRepoId());
+		bpartnerProduct.setM_Product_ID(42);
+		bpartnerProduct.setDeliveryTime_Promised(7);
+		saveRecord(bpartnerProduct);
+
+		assertThat(bpartnerProductEffectiveBL.getPurchaseTransportDays(vendorId, ProductId.ofRepoId(42), OrgId.ANY)).isEqualTo(7);
+	}
+
+	@Test
+	public void getPurchaseTransportDays_bpartnerProductHasNoValue_fallsBackToBPartner()
+	{
+		final I_C_BPartner vendor = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		vendor.setPO_TransportDays(3);
+		saveRecord(vendor);
+		final BPartnerId vendorId = BPartnerId.ofRepoId(vendor.getC_BPartner_ID());
+
+		final I_C_BPartner_Product bpartnerProduct = InterfaceWrapperHelper.newInstance(I_C_BPartner_Product.class);
+		bpartnerProduct.setC_BPartner_ID(vendorId.getRepoId());
+		bpartnerProduct.setM_Product_ID(42);
+		// DeliveryTime_Promised not set → null in DB
+		saveRecord(bpartnerProduct);
+
+		assertThat(bpartnerProductEffectiveBL.getPurchaseTransportDays(vendorId, ProductId.ofRepoId(42), OrgId.ANY)).isEqualTo(3);
+	}
+
+	@Test
+	public void getPurchaseTransportDays_noBPartnerProduct_fallsBackToBPartner()
+	{
+		final I_C_BPartner vendor = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		vendor.setPO_TransportDays(5);
+		saveRecord(vendor);
+		final BPartnerId vendorId = BPartnerId.ofRepoId(vendor.getC_BPartner_ID());
+
+		// no C_BPartner_Product record at all
+		assertThat(bpartnerProductEffectiveBL.getPurchaseTransportDays(vendorId, ProductId.ofRepoId(42), OrgId.ANY)).isEqualTo(5);
+	}
+
+	@Test
+	public void getPurchaseTransportDays_noBPartnerProductNoBPartnerValue_returns0()
+	{
+		final I_C_BPartner vendor = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		// PO_TransportDays not set → null in DB
+		saveRecord(vendor);
+		final BPartnerId vendorId = BPartnerId.ofRepoId(vendor.getC_BPartner_ID());
+
+		assertThat(bpartnerProductEffectiveBL.getPurchaseTransportDays(vendorId, ProductId.ofRepoId(42), OrgId.ANY)).isEqualTo(0);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_Product_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_Product_StepDef.java
@@ -64,6 +64,7 @@ import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_IsExcludedFromS
 import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_M_Product_ID;
 import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_ProductNo;
 import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_SeqNo;
+import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_DeliveryTime_Promised;
 import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_UPC;
 import static org.compiere.model.I_C_BPartner_Product.COLUMNNAME_UsedForVendor;
 
@@ -203,6 +204,7 @@ public class C_BPartner_Product_StepDef
 		tableRow.getAsOptionalString(COLUMNNAME_GTIN).ifPresent(record::setGTIN);
 		tableRow.getAsOptionalString(COLUMNNAME_EAN_CU).ifPresent(record::setEAN_CU);
 		tableRow.getAsOptionalString(COLUMNNAME_UPC).ifPresent(record::setUPC);
+		tableRow.getAsOptionalInt(COLUMNNAME_DeliveryTime_Promised).ifPresent(record::setDeliveryTime_Promised);
 
 		saveRecord(record);
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
@@ -111,6 +111,7 @@ import static org.compiere.model.I_C_BPartner.COLUMNNAME_M_PricingSystem_ID;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PO_DiscountSchema_ID;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PO_InvoiceRule;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PO_PricingSystem_ID;
+import static org.compiere.model.I_C_BPartner.COLUMNNAME_PO_TransportDays;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PaymentRule;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PaymentRulePO;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_Value;
@@ -336,6 +337,7 @@ public class C_BPartner_StepDef
 		row.getAsOptionalString(COLUMNNAME_C_Incoterms_Customer_ID + ".Value")
 				.ifPresent(incotermValue -> bPartnerRecord.setC_Incoterms_Customer_ID(incotermsRepository.getByValue(incotermValue, OrgId.ofRepoId(orgId)).getId().getRepoId()));
 		row.getAsOptionalString(COLUMNNAME_IncotermLocation).ifPresent(bPartnerRecord::setIncotermLocation);
+		row.getAsOptionalInt(COLUMNNAME_PO_TransportDays).ifPresent(bPartnerRecord::setPO_TransportDays);
 
 		row.getAsOptionalIdentifier(COLUMNNAME_SO_Invoice_Aggregation_ID)
 				.map(aggregationTable::getId)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
@@ -351,10 +351,9 @@ public class C_Order_StepDef
 		final Instant preparationDate = tableRow.getAsOptionalInstant(I_C_Order.COLUMNNAME_PreparationDate).orElse(null);
 		final Instant datePromised = tableRow.getAsOptionalInstant(I_C_Order.COLUMNNAME_DatePromised).orElse(null);
 
-		final Instant preparationDateToBeSet = CoalesceUtil.coalesce(preparationDate, datePromised);
-		if (preparationDateToBeSet != null)
+		if (preparationDate != null)
 		{
-			order.setPreparationDate(Timestamp.from(preparationDateToBeSet));
+			order.setPreparationDate(Timestamp.from(preparationDate));
 		}
 
 		final Instant datePromisedToBeSet = CoalesceUtil.coalesce(datePromised, preparationDate);
@@ -953,6 +952,14 @@ public class C_Order_StepDef
 								.as("LC_Date for Identifier=%s", identifierStr)
 								.isEqualTo(expectedDate);
 					}
+				});
+
+		row.getAsOptionalLocalDate(COLUMNNAME_PreparationDate)
+				.ifPresent(preparationDate -> {
+					final ZoneId zoneId = orgDAO.getTimeZone(orgId);
+					softly.assertThat(TimeUtil.asLocalDate(order.getPreparationDate(), zoneId))
+							.as("PreparationDate for Identifier=%s", identifierStr)
+							.isEqualTo(preparationDate);
 				});
 
 		softly.assertAll();

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_DeliveryDay_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_DeliveryDay_StepDefData.java
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.tourplanning;
+
+import de.metas.cucumber.stepdefs.StepDefData;
+import de.metas.tourplanning.model.I_M_DeliveryDay;
+
+public class M_DeliveryDay_StepDefData extends StepDefData<I_M_DeliveryDay>
+{
+	public M_DeliveryDay_StepDefData()
+	{
+		super(I_M_DeliveryDay.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_TourVersionLine_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_TourVersionLine_StepDefData.java
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.tourplanning;
+
+import de.metas.cucumber.stepdefs.StepDefData;
+import de.metas.tourplanning.model.I_M_TourVersionLine;
+
+public class M_TourVersionLine_StepDefData extends StepDefData<I_M_TourVersionLine>
+{
+	public M_TourVersionLine_StepDefData()
+	{
+		super(I_M_TourVersionLine.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_TourVersion_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_TourVersion_StepDefData.java
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.tourplanning;
+
+import de.metas.cucumber.stepdefs.StepDefData;
+import de.metas.tourplanning.model.I_M_TourVersion;
+
+public class M_TourVersion_StepDefData extends StepDefData<I_M_TourVersion>
+{
+	public M_TourVersion_StepDefData()
+	{
+		super(I_M_TourVersion.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_Tour_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_Tour_StepDef.java
@@ -1,0 +1,138 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.tourplanning;
+
+import de.metas.cucumber.stepdefs.C_BPartner_Location_StepDefData;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.tourplanning.model.I_M_DeliveryDay;
+import de.metas.tourplanning.model.I_M_Tour;
+import de.metas.tourplanning.model.I_M_TourVersion;
+import de.metas.tourplanning.model.I_M_TourVersionLine;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_C_BPartner_Location;
+
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+
+/** Step definitions for M_Tour, M_TourVersion, M_TourVersionLine, and M_DeliveryDay tour planning entities. */
+@RequiredArgsConstructor
+public class M_Tour_StepDef
+{
+	private final M_Tour_StepDefData tourTable;
+	private final M_TourVersion_StepDefData tourVersionTable;
+	private final M_TourVersionLine_StepDefData tourVersionLineTable;
+	private final M_DeliveryDay_StepDefData deliveryDayTable;
+	private final C_BPartner_Location_StepDefData locationTable;
+
+	@Given("metasfresh contains M_Tours:")
+	public void metasfresh_contains_M_Tours(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::createTour);
+	}
+
+	@Given("metasfresh contains M_TourVersions:")
+	public void metasfresh_contains_M_TourVersions(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::createTourVersion);
+	}
+
+	@Given("metasfresh contains M_TourVersionLines:")
+	public void metasfresh_contains_M_TourVersionLines(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::createTourVersionLine);
+	}
+
+	@Given("metasfresh contains M_DeliveryDays:")
+	public void metasfresh_contains_M_DeliveryDays(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::createDeliveryDay);
+	}
+
+	private void createTour(@NonNull final DataTableRow row)
+	{
+		final String name = row.suggestValueAndName().getName();
+
+		final I_M_Tour tour = InterfaceWrapperHelper.newInstance(I_M_Tour.class);
+		tour.setName(name);
+		saveRecord(tour);
+
+		row.getAsOptionalIdentifier().ifPresent(id -> tourTable.putOrReplace(id, tour));
+	}
+
+	private void createTourVersion(@NonNull final DataTableRow row)
+	{
+		final I_M_Tour tour = row.getAsIdentifier(I_M_TourVersion.COLUMNNAME_M_Tour_ID).lookupNotNullIn(tourTable);
+		final String name = row.suggestValueAndName().getName();
+
+		final I_M_TourVersion tv = InterfaceWrapperHelper.newInstance(I_M_TourVersion.class);
+		tv.setM_Tour_ID(tour.getM_Tour_ID());
+		tv.setName(name);
+		row.getAsOptionalLocalDateTimestamp(I_M_TourVersion.COLUMNNAME_ValidFrom).ifPresent(tv::setValidFrom);
+		saveRecord(tv);
+
+		row.getAsOptionalIdentifier().ifPresent(id -> tourVersionTable.putOrReplace(id, tv));
+	}
+
+	private void createTourVersionLine(@NonNull final DataTableRow row)
+	{
+		final I_M_TourVersion tv = row.getAsIdentifier(I_M_TourVersionLine.COLUMNNAME_M_TourVersion_ID).lookupNotNullIn(tourVersionTable);
+		final I_C_BPartner_Location location = row.getAsIdentifier(I_M_TourVersionLine.COLUMNNAME_C_BPartner_Location_ID).lookupNotNullIn(locationTable);
+
+		final I_M_TourVersionLine tvl = InterfaceWrapperHelper.newInstance(I_M_TourVersionLine.class);
+		tvl.setM_TourVersion_ID(tv.getM_TourVersion_ID());
+		tvl.setC_BPartner_ID(location.getC_BPartner_ID());
+		tvl.setC_BPartner_Location_ID(location.getC_BPartner_Location_ID());
+		// IsToBeFetched=false → customer delivery; IsToBeFetched=true → vendor pickup
+		tvl.setIsToBeFetched(row.getAsBoolean(I_M_TourVersionLine.COLUMNNAME_IsToBeFetched));
+		tvl.setSeqNo(row.getAsInt(I_M_TourVersionLine.COLUMNNAME_SeqNo));
+		saveRecord(tvl);
+
+		row.getAsOptionalIdentifier().ifPresent(id -> tourVersionLineTable.putOrReplace(id, tvl));
+	}
+
+	private void createDeliveryDay(@NonNull final DataTableRow row)
+	{
+		final I_C_BPartner_Location location = row.getAsIdentifier(I_M_DeliveryDay.COLUMNNAME_C_BPartner_Location_ID).lookupNotNullIn(locationTable);
+		final I_M_Tour tour = row.getAsIdentifier(I_M_DeliveryDay.COLUMNNAME_M_Tour_ID).lookupNotNullIn(tourTable);
+		final I_M_TourVersion tv = row.getAsIdentifier(I_M_DeliveryDay.COLUMNNAME_M_TourVersion_ID).lookupNotNullIn(tourVersionTable);
+
+		final I_M_DeliveryDay dd = InterfaceWrapperHelper.newInstance(I_M_DeliveryDay.class);
+		dd.setC_BPartner_ID(location.getC_BPartner_ID());
+		dd.setC_BPartner_Location_ID(location.getC_BPartner_Location_ID());
+		dd.setDeliveryDate(row.getAsInstantTimestamp(I_M_DeliveryDay.COLUMNNAME_DeliveryDate));
+		dd.setDeliveryDateTimeMax(row.getAsInstantTimestamp(I_M_DeliveryDay.COLUMNNAME_DeliveryDateTimeMax));
+		// IsToBeFetched=false → SO delivery days; IsToBeFetched=true → PO (fetched-by-vendor) delivery days
+		dd.setIsToBeFetched(row.getAsBoolean(I_M_DeliveryDay.COLUMNNAME_IsToBeFetched));
+		dd.setIsManual(true);
+		dd.setProcessed(false);
+		dd.setM_Tour_ID(tour.getM_Tour_ID());
+		dd.setM_TourVersion_ID(tv.getM_TourVersion_ID());
+		saveRecord(dd);
+
+		row.getAsOptionalIdentifier().ifPresent(id -> deliveryDayTable.putOrReplace(id, dd));
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_Tour_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_Tour_StepDefData.java
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.tourplanning;
+
+import de.metas.cucumber.stepdefs.StepDefData;
+import de.metas.tourplanning.model.I_M_Tour;
+
+public class M_Tour_StepDefData extends StepDefData<I_M_Tour>
+{
+	public M_Tour_StepDefData()
+	{
+		super(I_M_Tour.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseCandidatePreparationDate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseCandidatePreparationDate.feature
@@ -33,6 +33,13 @@ Feature: Purchase candidate — PreparationDate propagated to generated PO
       | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
       | pp_so      | plv_so                 | product      | 10.00    | PCE               | Normal                        |
       | pp_po      | plv_po                 | product      | 10.00    | PCE               | Normal                        |
+    ## VendorProductInfoService.getVendorProductInfos only considers vendors with a PO_DiscountSchema_ID
+    And metasfresh contains M_DiscountSchemas:
+      | Identifier | Name              | DiscountType | ValidFrom  |
+      | ds         | po_transport_days | F            | 2022-01-01 |
+    And metasfresh contains M_DiscountSchemaBreaks:
+      | Identifier | M_DiscountSchema_ID | M_Product_ID | Base_PricingSystem_ID | SeqNo | IsBPartnerFlatDiscount | PriceBase | BreakValue | BreakDiscount |
+      | dsb        | ds                  | product      | ps                    | 10    | Y                      | P         | 0          | 0             |
     And metasfresh contains PP_Product_Plannings
       | Identifier | M_Product_ID | IsCreatePlan | IsPurchased | IsDocComplete |
       | ppln       | product      | true         | Y           | true          |
@@ -43,8 +50,8 @@ Feature: Purchase candidate — PreparationDate propagated to generated PO
       | Identifier       | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
       | customerLocation | customer      | Y               | Y               |
     And metasfresh contains C_BPartners without locations:
-      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID | PO_TransportDays |
-      | vendor     | Y        | N          | ps                 | 5                |
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID | PO_TransportDays | PO_DiscountSchema_ID |
+      | vendor     | Y        | N          | ps                 | 5                | ds                   |
     And metasfresh contains C_BPartner_Locations:
       | Identifier     | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
       | vendorLocation | vendor        | Y               | Y               |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseCandidatePreparationDate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseCandidatePreparationDate.feature
@@ -1,0 +1,83 @@
+@from:cucumber
+@allure.label.epic:E0140_Purchasing
+@allure.label.feature:F00600_Purchase_Order
+@ghActions:run_on_executor6
+Feature: Purchase candidate — PreparationDate propagated to generated PO
+  ## When a SO triggers auto-creation of a PO via purchase candidates,
+  ## the generated PO's PreparationDate = DatePromised − PO_TransportDays.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-06-01T13:30:13+02:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+
+  @from:cucumber
+  Scenario: PO auto-generated from purchase candidate has PreparationDate = DatePromised - PO_TransportDays
+    Given metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Currency.ISO_Code | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_so      | ps                 | EUR                 | true  | false         | 2              |
+      | pl_po      | ps                 | EUR                 | false | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_so     | pl_so          |
+      | plv_po     | pl_po          |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_so      | plv_so                 | product      | 10.00    | PCE               | Normal                        |
+      | pp_po      | plv_po                 | product      | 10.00    | PCE               | Normal                        |
+    And metasfresh contains PP_Product_Plannings
+      | Identifier | M_Product_ID | IsCreatePlan | IsPurchased | IsDocComplete |
+      | ppln       | product      | true         | Y           | true          |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID |
+      | customer   | N        | Y          | ps                 |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier       | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | customerLocation | customer      | Y               | Y               |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID | PO_TransportDays |
+      | vendor     | Y        | N          | ps                 | 5                |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier     | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | vendorLocation | vendor        | Y               | Y               |
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID |
+      | vendor        | product      |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | M_PricingSystem_ID | C_BPartner_Location_ID |
+      | so         | true    | customer      | 2022-06-01  | 2022-06-15Z  | ps                 | customerLocation       |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol        | so         | product      | 10         |
+    When the order identified by so is completed
+
+    And after not more than 60s, C_PurchaseCandidates are found
+      | Identifier | C_OrderSO_ID | C_OrderLineSO_ID | M_Product_ID |
+      | pc         | so           | sol              | product      |
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And after not more than 60s, C_PurchaseCandidate_Alloc are found
+      | C_PurchaseCandidate_ID | C_PurchaseCandidate_Alloc_ID |
+      | pc                     | pca                          |
+
+    And load C_OrderLines from C_PurchaseCandidate_Alloc
+      | C_OrderLinePO_ID | C_PurchaseCandidate_Alloc_ID |
+      | pol              | pca                          |
+
+    And load C_Order from C_OrderLine
+      | C_Order_ID | C_OrderLine_ID |
+      | po         | pol            |
+
+    Then validate the created orders
+      | C_Order_ID | DocBaseType | DocStatus | PreparationDate |
+      | po         | POO         | CO        | 2022-06-10      |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderPreparationDate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderPreparationDate.feature
@@ -1,0 +1,90 @@
+@from:cucumber
+@allure.label.epic:E0140_Purchasing
+@allure.label.feature:F00600_Purchase_Order
+@ghActions:run_on_executor7
+Feature: Purchase order — PreparationDate from transport days
+  ## PreparationDate = DatePromised − max(DeliveryTime_Promised or PO_TransportDays across all order lines).
+  ## Product-level DeliveryTime_Promised overrides vendor-level PO_TransportDays.
+  ## With multiple lines, the maximum transport days across all products wins.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-06-01T13:30:13+02:00[Europe/Berlin]
+
+    And metasfresh contains M_Products:
+      | Identifier |
+      | productA   |
+      | productB   |
+      | productC   |
+      | productD   |
+
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Currency.ISO_Code | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl         | ps                 | EUR                 | false | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv        | pl             |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_A       | plv                    | productA     | 10.00    | PCE               | Normal                        |
+      | pp_B       | plv                    | productB     | 10.00    | PCE               | Normal                        |
+      | pp_C       | plv                    | productC     | 10.00    | PCE               | Normal                        |
+      | pp_D       | plv                    | productD     | 10.00    | PCE               | Normal                        |
+
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsVendor | M_PricingSystem_ID | PO_TransportDays |
+      | vendor     | Y        | ps                 | 5                |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier     | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | vendorLocation | vendor        | Y               | Y               |
+
+  @from:cucumber
+  Scenario: PreparationDate uses vendor-level PO_TransportDays when no product-specific entry exists
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | M_PricingSystem_ID | C_BPartner_Location_ID |
+      | order_1    | N       | vendor        | 2022-06-01  | 2022-06-15Z  | ps                 | vendorLocation         |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered |
+      | orderLine_1 | order_1    | productA     | 10         |
+
+    Then validate the created orders
+      | Identifier | PreparationDate |
+      | order_1    | 2022-06-10      |
+
+  @from:cucumber
+  Scenario: Product-specific DeliveryTime_Promised overrides vendor-level PO_TransportDays
+    Given metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID | DeliveryTime_Promised |
+      | vendor        | productB     | 3                     |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | M_PricingSystem_ID | C_BPartner_Location_ID |
+      | order_2    | N       | vendor        | 2022-06-01  | 2022-06-15Z  | ps                 | vendorLocation         |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered |
+      | orderLine_2 | order_2    | productB     | 10         |
+
+    Then validate the created orders
+      | Identifier | PreparationDate |
+      | order_2    | 2022-06-12      |
+
+  @from:cucumber
+  Scenario: With multiple lines, PreparationDate uses the maximum transport days across all products
+    Given metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID | DeliveryTime_Promised |
+      | vendor        | productC     | 3                     |
+      | vendor        | productD     | 7                     |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | M_PricingSystem_ID | C_BPartner_Location_ID |
+      | order_3    | N       | vendor        | 2022-06-01  | 2022-06-15Z  | ps                 | vendorLocation         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | orderLineC | order_3    | productC     | 10         |
+      | orderLineD | order_3    | productD     | 10         |
+
+    Then validate the created orders
+      | Identifier | PreparationDate |
+      | order_3    | 2022-06-08      |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/tourPlanningPreparationDate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/tourPlanningPreparationDate.feature
@@ -1,0 +1,120 @@
+@from:cucumber
+@allure.label.epic:E0140_Purchasing
+@allure.label.feature:F00600_Purchase_Order
+@ghActions:run_on_executor7
+Feature: Tour planning — PreparationDate from delivery day or fallback
+  ## When a delivery day is configured for the bpartner location, PreparationDate = M_DeliveryDay.DeliveryDate.
+  ## When no delivery day matches, OrderDeliveryDayBL falls back to DatePromised (SO)
+  ## or DatePromised − PO_TransportDays (PO).
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-06-01T13:30:13+02:00[Europe/Berlin]
+
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Currency.ISO_Code | Name  | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_so      | ps                 | EUR                 | pl_so | true  | false         | 2              |
+      | pl_po      | ps                 | EUR                 | pl_po | false | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_so     | pl_so          |
+      | plv_po     | pl_po          |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_so      | plv_so                 | product      | 10.00    | PCE               | Normal                        |
+      | pp_po      | plv_po                 | product      | 10.00    | PCE               | Normal                        |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID |
+      | customer   | N        | Y          | ps                 |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier       | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | customerLocation | customer      | Y               | Y               |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID | PO_TransportDays |
+      | vendor     | Y        | N          | ps                 | 5                |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier     | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | vendorLocation | vendor        | Y               | Y               |
+
+  @from:cucumber
+  Scenario: SO PreparationDate equals DatePromised when no delivery day is configured
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | M_PricingSystem_ID | C_BPartner_Location_ID |
+      | so         | Y       | customer      | 2022-06-01  | 2022-06-15Z  | ps                 | customerLocation       |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol        | so         | product      | 10         |
+
+    Then validate the created orders
+      | Identifier | PreparationDate |
+      | so         | 2022-06-15      |
+
+  @from:cucumber
+  Scenario: PO PreparationDate equals DatePromised minus vendor PO_TransportDays when no delivery day is configured
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | M_PricingSystem_ID | C_BPartner_Location_ID |
+      | po         | N       | vendor        | 2022-06-01  | 2022-06-15Z  | ps                 | vendorLocation         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | pol        | po         | product      | 10         |
+
+    Then validate the created orders
+      | Identifier | PreparationDate |
+      | po         | 2022-06-10      |
+
+  @from:cucumber
+  Scenario: SO PreparationDate equals the matching delivery day DeliveryDate when a delivery day is configured
+    Given metasfresh contains M_Tours:
+      | Identifier |
+      | tour       |
+    And metasfresh contains M_TourVersions:
+      | Identifier  | M_Tour_ID | ValidFrom  |
+      | tourVersion | tour      | 2022-01-01 |
+    And metasfresh contains M_TourVersionLines:
+      | Identifier      | M_TourVersion_ID | C_BPartner_Location_ID | IsToBeFetched | SeqNo |
+      | tourVersionLine | tourVersion      | customerLocation       | false         | 10    |
+    And metasfresh contains M_DeliveryDays:
+      | Identifier  | C_BPartner_Location_ID | M_Tour_ID | M_TourVersion_ID | DeliveryDate         | DeliveryDateTimeMax  | IsToBeFetched |
+      | deliveryDay | customerLocation       | tour      | tourVersion      | 2022-06-13T06:00:00Z | 2022-06-14T12:00:00Z | false         |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | M_PricingSystem_ID | C_BPartner_Location_ID |
+      | so         | Y       | customer      | 2022-06-01  | 2022-06-15Z  | ps                 | customerLocation       |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol        | so         | product      | 10         |
+
+    Then validate the created orders
+      | Identifier | PreparationDate |
+      | so         | 2022-06-13      |
+
+  @from:cucumber
+  Scenario: PO PreparationDate equals the matching delivery day DeliveryDate when a delivery day is configured
+    Given metasfresh contains M_Tours:
+      | Identifier |
+      | tour       |
+    And metasfresh contains M_TourVersions:
+      | Identifier  | M_Tour_ID | ValidFrom  |
+      | tourVersion | tour      | 2022-01-01 |
+    And metasfresh contains M_TourVersionLines:
+      | Identifier      | M_TourVersion_ID | C_BPartner_Location_ID | IsToBeFetched | SeqNo |
+      | tourVersionLine | tourVersion      | vendorLocation         | true          | 10    |
+    And metasfresh contains M_DeliveryDays:
+      | Identifier  | C_BPartner_Location_ID | M_Tour_ID | M_TourVersion_ID | DeliveryDate         | DeliveryDateTimeMax  | IsToBeFetched |
+      | deliveryDay | vendorLocation         | tour      | tourVersion      | 2022-06-11T06:00:00Z | 2022-06-14T12:00:00Z | true          |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | M_PricingSystem_ID | C_BPartner_Location_ID |
+      | po         | N       | vendor        | 2022-06-01  | 2022-06-15Z  | ps                 | vendorLocation         |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | pol        | po         | product      | 10         |
+
+    Then validate the created orders
+      | Identifier | PreparationDate |
+      | po         | 2022-06-11      |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/callout/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/callout/C_OrderLine.java
@@ -13,7 +13,6 @@ import org.adempiere.ad.callout.api.ICalloutField;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.model.InterfaceWrapperHelper;
 
-@Interceptor(I_C_OrderLine.class)
 @Callout(I_C_OrderLine.class)
 public class C_OrderLine
 {

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/tourplanning/api/impl/OrderDeliveryDayBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/tourplanning/api/impl/OrderDeliveryDayBL.java
@@ -116,12 +116,22 @@ public class OrderDeliveryDayBL implements IOrderDeliveryDayBL
 		}
 		else if (isUseFallback)
 		{
-			int offset = getFallbackPreparationDateOffsetInHours();
-			order.setPreparationDate(TimeUtil.asTimestamp(computePreparationTime(datePromised, offset)));
+			final int offset = getFallbackPreparationDateOffsetInHours();
+			final ZonedDateTime fallbackBase;
+			if (soTrx.isPurchase())
+			{
+				final int maxTransportDays = Services.get(IOrderBL.class).getMaxPurchaseTransportDays(order);
+				fallbackBase = datePromised.minusDays(maxTransportDays);
+			}
+			else
+			{
+				fallbackBase = datePromised;
+			}
+			order.setPreparationDate(TimeUtil.asTimestamp(computePreparationTime(fallbackBase, offset)));
 			order.setM_Tour_ID(-1);
 			logger.debug(
-					"Setting PreparationDate={} for C_Order {} from order's DatePromised value, because the computed PreparationDate={} is null or has already passed (fallbackToDatePromised={}, systemTime={}).",
-					order.getDatePromised(), order, preparationDate, isUseFallback, systemTime);
+					"Setting PreparationDate={} for C_Order {} (soTrx={}, fallbackToDatePromised={}, systemTime={}).",
+					order.getPreparationDate(), order, soTrx, isUseFallback, systemTime);
 		}
 		else
 		{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/tourplanning/api/impl/OrderDeliveryDayBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/tourplanning/api/impl/OrderDeliveryDayBL.java
@@ -36,6 +36,7 @@ public class OrderDeliveryDayBL implements IOrderDeliveryDayBL
 	private static final Logger logger = LogManager.getLogger(OrderDeliveryDayBL.class);
 
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+	private final IOrderBL orderBL = Services.get(IOrderBL.class);
 
 	@Override
 	public boolean setPreparationDateAndTour(@NonNull final I_C_Order order, final boolean fallbackToDatePromised)
@@ -120,7 +121,7 @@ public class OrderDeliveryDayBL implements IOrderDeliveryDayBL
 			final ZonedDateTime fallbackBase;
 			if (soTrx.isPurchase())
 			{
-				final int maxTransportDays = Services.get(IOrderBL.class).getMaxPurchaseTransportDays(order);
+				final int maxTransportDays = orderBL.getMaxPurchaseTransportDays(order);
 				fallbackBase = datePromised.minusDays(maxTransportDays);
 			}
 			else

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/tourplanning/model/validator/C_OrderLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/tourplanning/model/validator/C_OrderLine.java
@@ -24,6 +24,10 @@ public class C_OrderLine
 	public void updatePreparationDate(@NonNull final I_C_OrderLine orderLine)
 	{
 		final I_C_Order order = orderBL.getById(OrderId.ofRepoId(orderLine.getC_Order_ID()));
+		if (order.isSOTrx())
+		{
+			return;
+		}
 		orderDeliveryDayBL.setPreparationDateAndTour(order, /* fallbackToDatePromised= */ true);
 		orderBL.save(order);
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/tourplanning/model/validator/C_OrderLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/tourplanning/model/validator/C_OrderLine.java
@@ -1,0 +1,30 @@
+package de.metas.tourplanning.model.validator;
+
+import de.metas.order.IOrderBL;
+import de.metas.order.OrderId;
+import de.metas.tourplanning.api.IOrderDeliveryDayBL;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.ad.modelvalidator.annotations.ModelChange;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_OrderLine;
+import org.compiere.model.ModelValidator;
+import org.springframework.stereotype.Component;
+
+@Interceptor(I_C_OrderLine.class)
+@Component
+public class C_OrderLine
+{
+	private final IOrderDeliveryDayBL orderDeliveryDayBL = Services.get(IOrderDeliveryDayBL.class);
+	private final IOrderBL orderBL = Services.get(IOrderBL.class);
+
+	@ModelChange(timings = { ModelValidator.TYPE_AFTER_NEW, ModelValidator.TYPE_AFTER_CHANGE, ModelValidator.TYPE_AFTER_DELETE },
+			ifColumnsChanged = { I_C_OrderLine.COLUMNNAME_M_Product_ID })
+	public void updatePreparationDate(@NonNull final I_C_OrderLine orderLine)
+	{
+		final I_C_Order order = orderBL.getById(OrderId.ofRepoId(orderLine.getC_Order_ID()));
+		orderDeliveryDayBL.setPreparationDateAndTour(order, /* fallbackToDatePromised= */ true);
+		orderBL.save(order);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `C_BPartner.PO_TransportDays` (vendor-level default transport days) with AD metadata, UI element on vendor tab, and relabelled field in C_BPartner_Product context windows
- `BPartnerProductEffectiveBL` resolves effective transport days (product-level override → BPartner default → 0)
- `OrderBL.getPOPreparationDate()` computes `DatePromised − maxTransportDays` for purchase orders
- New `C_OrderLine` interceptor (tourplanning) recalculates tour + preparation date when `M_Product_ID` changes on any order line
- Cucumber tests: tour planning preparation date, PO preparation date, purchase candidate preparation date

## Test plan

- [ ] Apply migration scripts `5803020` + `5803030` against local DB
- [ ] Verify `C_BPartner.PO_TransportDays` field visible on vendor tab (advanced) in BPartner window
- [ ] Verify "Einkauf Transporttage" label on BPartner product tab + Product BPartner tab (both advanced)
- [ ] Create purchase order with vendor having `PO_TransportDays=5`, set `DatePromised`, confirm `PreparationDate = DatePromised − 5d`
- [ ] Cucumber features `tourPlanningPreparationDate`, `purchaseOrderPreparationDate`, `purchaseCandidatePreparationDate` green on CI