### PR TITLE
cucumber: enable pretty plugin for scenario-level stdout tracing

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/RunCucumberTest.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/RunCucumberTest.java
@@ -43,7 +43,10 @@ import org.junit.platform.suite.api.Suite;
 // NOTE: cucumber.filter.tags moved to pom.xml <configurationParameters> (default: "not @ignore")
 // so it can be overridden via -Dcucumber.filter.tags="@ghActions:run_on_executor5 and not @ignore"
 // @ConfigurationParameter for FILTER_TAGS has highest JUnit5 priority and cannot be overridden!
-@ConfigurationParameter(key = Constants.PLUGIN_PROPERTY_NAME, value = "html:target/cucumber.html,json:target/cucumber.json,junit:target/cucumber-junit.xml,message:target/cucumber.message,io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm")
+// `pretty` plugin prints scenario / step boundaries to stdout — required so cucumber CI logs
+// identify which scenario was running when the runner crashes / times out (otherwise the only
+// signal is a generic "Tests run: 0" with no scenario context).
+@ConfigurationParameter(key = Constants.PLUGIN_PROPERTY_NAME, value = "pretty,html:target/cucumber.html,json:target/cucumber.json,junit:target/cucumber-junit.xml,message:target/cucumber.message,io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm")
 public class RunCucumberTest
 {
 }


### PR DESCRIPTION
## What

Adds the `pretty` plugin to the cucumber plugin chain in `RunCucumberTest.java`. Each scenario start and step is now logged to stdout during test execution.

```diff
-@ConfigurationParameter(key = Constants.PLUGIN_PROPERTY_NAME, value = "html:target/cucumber.html,json:target/cucumber.json,junit:target/cucumber-junit.xml,message:target/cucumber.message,io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm")
+@ConfigurationParameter(key = Constants.PLUGIN_PROPERTY_NAME, value = "pretty,html:target/cucumber.html,json:target/cucumber.json,junit:target/cucumber-junit.xml,message:target/cucumber.message,io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm")
```

## Why

The existing `html` / `json` / `junit` / `message` / `allure` plugins all write to disk only; nothing reports scenario boundaries on stdout. When the cucumber runner crashes mid-run (JVM hangs or times out without a clean exit), the JUnit XML is never written and the CI log ends with a generic `Tests run: 0, Failures: 0, Errors: 0` — with **zero information** about which scenario was actually running when things went sideways. This has happened multiple times across `profile3`, `profile5`, `profile7` on `new_dawn_uat` in the past week.

With `pretty` enabled, the last `Scenario:` line in the CI log identifies which scenario was alive at the moment of the cascade. That's the first concrete step toward fixing the underlying flake.

## Risk

- **No test-behaviour change.** Only CI log verbosity goes up.
- CI logs get bigger (~roughly proportional to scenario count × profile). For metasfresh's ~750 scenarios across 7 profiles, expect maybe a few hundred extra log lines per profile. Negligible vs the ~120 MB cucumber logs already produce.
- The pretty output may interleave oddly with Spring boot logs (cucumber/backend share the same stdout pipe in `cucumber-1` container). Acceptable for diagnostic purposes; grep-friendly.

## Verification

- Pure-diagnostic plugin addition. Acceptance is that the next failing cucumber CI run on this branch (or downstream merges) shows scenario names in the log.
- No test will start passing or failing differently because of this PR.