### PR TITLE
Picking step DTO — convert qtyPicked/qtyRejected to TU when pickingUnit.isTU

### DIFF
--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonPickingJobStep.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonPickingJobStep.java
@@ -34,7 +34,6 @@ import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
-import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.function.Function;
@@ -57,17 +56,9 @@ public class JsonPickingJobStep
 	@NonNull List<JsonPickingJobStepPickFrom> pickFromAlternatives;
 
 	public static JsonPickingJobStep of(
-			final PickingJobStep step,
-			final JsonOpts jsonOpts,
-			@NonNull final Function<UomId, ITranslatableString> getUOMSymbolById)
-	{
-		return of(step, null, jsonOpts, getUOMSymbolById);
-	}
-
-	public static JsonPickingJobStep of(
-			final PickingJobStep step,
-			@Nullable final PickingJobLine line,
-			final JsonOpts jsonOpts,
+			@NonNull final PickingJobStep step,
+			@NonNull final PickingJobLine line,
+			@NonNull final JsonOpts jsonOpts,
 			@NonNull final Function<UomId, ITranslatableString> getUOMSymbolById)
 	{
 		final String adLanguage = jsonOpts.getAdLanguage();
@@ -85,7 +76,7 @@ public class JsonPickingJobStep
 		// The step stores qtyToPick in CU (base UOM), but the frontend/user should see TU count.
 		final String uom;
 		final BigDecimal qtyToPick;
-		if (line != null && line.getPickingUnit().isTU())
+		if (line.getPickingUnit().isTU())
 		{
 			uom = "TU";
 			qtyToPick = line.getPackingInfo()

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonPickingJobStep.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonPickingJobStep.java
@@ -72,13 +72,13 @@ public class JsonPickingJobStep
 	{
 		final String adLanguage = jsonOpts.getAdLanguage();
 
-		final JsonPickingJobStepPickFrom mainPickFrom = JsonPickingJobStepPickFrom.of(step.getPickFrom(PickingJobStepPickFromKey.MAIN), jsonOpts, getUOMSymbolById);
+		final JsonPickingJobStepPickFrom mainPickFrom = JsonPickingJobStepPickFrom.of(step.getPickFrom(PickingJobStepPickFromKey.MAIN), line, jsonOpts, getUOMSymbolById);
 
 		final List<JsonPickingJobStepPickFrom> pickFromAlternatives = step.getPickFromKeys()
 				.stream()
 				.filter(PickingJobStepPickFromKey::isAlternative)
 				.map(step::getPickFrom)
-				.map(pickFrom -> JsonPickingJobStepPickFrom.of(pickFrom, jsonOpts, getUOMSymbolById))
+				.map(pickFrom -> JsonPickingJobStepPickFrom.of(pickFrom, line, jsonOpts, getUOMSymbolById))
 				.collect(ImmutableList.toImmutableList());
 
 		// When pickingUnit=TU, convert the step's CU qty to TU count for display.

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonPickingJobStepPickFrom.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonPickingJobStepPickFrom.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import de.metas.common.rest_api.v2.JsonQuantity;
 import de.metas.global_qrcodes.JsonDisplayableQRCode;
 import de.metas.handlingunits.picking.QtyRejectedWithReason;
+import de.metas.handlingunits.picking.job.model.PickingJobLine;
 import de.metas.handlingunits.picking.job.model.PickingJobStepPickFrom;
 import de.metas.handlingunits.picking.job.model.PickingJobStepPickedTo;
 import de.metas.i18n.ITranslatableString;
@@ -39,6 +40,7 @@ public class JsonPickingJobStepPickFrom
 
 	public static JsonPickingJobStepPickFrom of(
 			final PickingJobStepPickFrom pickFrom,
+			@Nullable final PickingJobLine line,
 			@NonNull final JsonOpts jsonOpts,
 			@NonNull final Function<UomId, ITranslatableString> getUOMSymbolById)
 	{
@@ -53,8 +55,13 @@ public class JsonPickingJobStepPickFrom
 		{
 			final QtyRejectedWithReason qtyRejected = pickedTo.getQtyRejected();
 
-			builder.qtyPicked(pickedTo.getQtyPicked().toBigDecimal())
-					.qtyRejected(qtyRejected != null ? qtyRejected.toBigDecimal() : null)
+			final BigDecimal qtyPickedToSerialize = convertToDisplayUnit(pickedTo.getQtyPicked(), line);
+			final BigDecimal qtyRejectedToSerialize = qtyRejected != null
+					? convertToDisplayUnit(qtyRejected.toQuantity(), line)
+					: null;
+
+			builder.qtyPicked(qtyPickedToSerialize)
+					.qtyRejected(qtyRejectedToSerialize)
 					.qtyRejectedReasonCode(qtyRejected != null ? qtyRejected.getReasonCode().getCode() : null)
 					.pickedCatchWeight(toJsonQuantity(pickedTo.getCatchWeight(), jsonOpts, getUOMSymbolById))
 					.actuallyPickedHUs(pickedTo.stream()
@@ -67,6 +74,20 @@ public class JsonPickingJobStepPickFrom
 		}
 
 		return builder.build();
+	}
+
+	@NonNull
+	private static BigDecimal convertToDisplayUnit(
+			@NonNull final Quantity qtyCUs,
+			@Nullable final PickingJobLine line)
+	{
+		if (line == null || !line.getPickingUnit().isTU())
+		{
+			return qtyCUs.toBigDecimal();
+		}
+		return line.getPackingInfo()
+				.computeQtyTUsOfTotalCUs(qtyCUs, line.getProductId())
+				.toBigDecimal();
 	}
 
 	@Nullable

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonPickingJobStepPickFrom.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonPickingJobStepPickFrom.java
@@ -39,8 +39,8 @@ public class JsonPickingJobStepPickFrom
 	@NonNull List<JsonPickingJobStepPickFromHU> actuallyPickedHUs;
 
 	public static JsonPickingJobStepPickFrom of(
-			final PickingJobStepPickFrom pickFrom,
-			@Nullable final PickingJobLine line,
+			@NonNull final PickingJobStepPickFrom pickFrom,
+			@NonNull final PickingJobLine line,
 			@NonNull final JsonOpts jsonOpts,
 			@NonNull final Function<UomId, ITranslatableString> getUOMSymbolById)
 	{
@@ -55,13 +55,13 @@ public class JsonPickingJobStepPickFrom
 		{
 			final QtyRejectedWithReason qtyRejected = pickedTo.getQtyRejected();
 
-			final BigDecimal qtyPickedToSerialize = convertToDisplayUnit(pickedTo.getQtyPicked(), line);
-			final BigDecimal qtyRejectedToSerialize = qtyRejected != null
+			final BigDecimal qtyPickedToSerializeBD = convertToDisplayUnit(pickedTo.getQtyPicked(), line);
+			final BigDecimal qtyRejectedToSerializeBD = qtyRejected != null
 					? convertToDisplayUnit(qtyRejected.toQuantity(), line)
 					: null;
 
-			builder.qtyPicked(qtyPickedToSerialize)
-					.qtyRejected(qtyRejectedToSerialize)
+			builder.qtyPicked(qtyPickedToSerializeBD)
+					.qtyRejected(qtyRejectedToSerializeBD)
 					.qtyRejectedReasonCode(qtyRejected != null ? qtyRejected.getReasonCode().getCode() : null)
 					.pickedCatchWeight(toJsonQuantity(pickedTo.getCatchWeight(), jsonOpts, getUOMSymbolById))
 					.actuallyPickedHUs(pickedTo.stream()
@@ -79,9 +79,9 @@ public class JsonPickingJobStepPickFrom
 	@NonNull
 	private static BigDecimal convertToDisplayUnit(
 			@NonNull final Quantity qtyCUs,
-			@Nullable final PickingJobLine line)
+			@NonNull final PickingJobLine line)
 	{
-		if (line == null || !line.getPickingUnit().isTU())
+		if (!line.getPickingUnit().isTU())
 		{
 			return qtyCUs.toBigDecimal();
 		}

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonPickingJobStepPickFrom.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonPickingJobStepPickFrom.java
@@ -55,9 +55,9 @@ public class JsonPickingJobStepPickFrom
 		{
 			final QtyRejectedWithReason qtyRejected = pickedTo.getQtyRejected();
 
-			final BigDecimal qtyPickedToSerializeBD = convertToDisplayUnit(pickedTo.getQtyPicked(), line);
+			final BigDecimal qtyPickedToSerializeBD = convertCuQtyForDisplay(pickedTo.getQtyPicked(), line);
 			final BigDecimal qtyRejectedToSerializeBD = qtyRejected != null
-					? convertToDisplayUnit(qtyRejected.toQuantity(), line)
+					? convertCuQtyForDisplay(qtyRejected.toQuantity(), line)
 					: null;
 
 			builder.qtyPicked(qtyPickedToSerializeBD)
@@ -77,7 +77,7 @@ public class JsonPickingJobStepPickFrom
 	}
 
 	@NonNull
-	private static BigDecimal convertToDisplayUnit(
+	private static BigDecimal convertCuQtyForDisplay(
 			@NonNull final Quantity qtyCUs,
 			@NonNull final PickingJobLine line)
 	{

--- a/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/rest_api/json/JsonPickingJobStepPickFromTest.java
+++ b/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/rest_api/json/JsonPickingJobStepPickFromTest.java
@@ -23,6 +23,7 @@
 package de.metas.picking.rest_api.json;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import de.metas.handlingunits.HUPIItemProduct;
 import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.handlingunits.HuId;
@@ -33,6 +34,10 @@ import de.metas.handlingunits.picking.QtyRejectedWithReason;
 import de.metas.handlingunits.picking.job.model.HUInfo;
 import de.metas.handlingunits.picking.job.model.LocatorInfo;
 import de.metas.handlingunits.picking.job.model.PickingJobLine;
+import de.metas.handlingunits.picking.job.model.PickingJobPickFromAlternativeId;
+import de.metas.handlingunits.picking.job.model.PickingJobProgress;
+import de.metas.handlingunits.picking.job.model.PickingJobStep;
+import de.metas.handlingunits.picking.job.model.PickingJobStepId;
 import de.metas.handlingunits.picking.job.model.PickingJobStepPickFrom;
 import de.metas.handlingunits.picking.job.model.PickingJobStepPickFromKey;
 import de.metas.handlingunits.picking.job.model.PickingJobStepPickedTo;
@@ -45,6 +50,7 @@ import de.metas.handlingunits.qrcodes.model.HUQRCodeUnitType;
 import de.metas.i18n.ITranslatableString;
 import de.metas.i18n.TranslatableStrings;
 import de.metas.product.ProductId;
+import de.metas.product.ProductValueAndName;
 import de.metas.quantity.Quantity;
 import de.metas.uom.UomId;
 import de.metas.workflow.rest_api.controller.v2.json.JsonOpts;
@@ -175,6 +181,126 @@ class JsonPickingJobStepPickFromTest
 
 		// Assert
 		assertThat(json.getQtyRejected()).isEqualByComparingTo("6");
+	}
+
+	// -----------------------------------------------------------------------
+	// Test (c): pickingUnit=CU → qtyPicked passes through unchanged
+	// -----------------------------------------------------------------------
+
+	@Test
+	void qtyPicked_isNotConverted_whenPickingUnit_isCU()
+	{
+		// Arrange
+		final I_C_UOM uomEach = buildUomEach();
+		final ProductId productId = ProductId.ofRepoId(1001);
+		final Quantity twelveCUs = Quantity.of(BigDecimal.valueOf(12), uomEach);
+
+		// line reports CU — no TU conversion expected
+		final PickingJobLine line = Mockito.mock(PickingJobLine.class);
+		Mockito.when(line.getPickingUnit()).thenReturn(PickingUnit.CU);
+
+		final PickingJobStepPickedToHU pickedHU = PickingJobStepPickedToHU.builder()
+				.pickFromHUId(HuId.ofRepoId(123))
+				.actualPickedHU(buildDummyHUInfo(uomEach))
+				.qtyPicked(twelveCUs)
+				.createdAt(Instant.now())
+				.build();
+
+		final PickingJobStepPickedTo pickedTo = PickingJobStepPickedTo.builder()
+				.actualPickedHUs(ImmutableList.of(pickedHU))
+				.build();
+
+		final PickingJobStepPickFrom pickFrom = buildPickFrom(pickedTo, uomEach);
+		final JsonOpts jsonOpts = JsonOpts.ofAdLanguage("en_US");
+		final Function<UomId, ITranslatableString> getUOMSymbolById = uomId -> TranslatableStrings.constant("EA");
+
+		// Act
+		final JsonPickingJobStepPickFrom json =
+				JsonPickingJobStepPickFrom.of(pickFrom, line, jsonOpts, getUOMSymbolById);
+
+		// Assert — raw CU value passes through; packingInfo must not have been consulted
+		assertThat(json.getQtyPicked()).isEqualByComparingTo("12");
+		Mockito.verify(line, Mockito.never()).getPackingInfo();
+	}
+
+	// -----------------------------------------------------------------------
+	// Test (d): JsonPickingJobStep.of end-to-end — alternative pickFrom with TU conversion
+	// -----------------------------------------------------------------------
+
+	@Test
+	void qtyPicked_inAlternativePickFrom_isMappedFromCuToTu()
+	{
+		// Arrange
+		final I_C_UOM uomEach = buildUomEach();
+		final ProductId productId = ProductId.ofRepoId(1001);
+		// 4 CU @ 2 CU/TU → expect 2 TU
+		final Quantity fourCUs = Quantity.of(BigDecimal.valueOf(4), uomEach);
+		final Quantity twoCUsPerTU = Quantity.of(BigDecimal.valueOf(2), uomEach);
+
+		final HUPIItemProduct packingInfo = HUPIItemProduct.builder()
+				.id(HUPIItemProductId.ofRepoId(999))
+				.name(TranslatableStrings.constant("2 per TU"))
+				.piItemId(HuPackingInstructionsItemId.ofRepoId(888))
+				.productId(productId)
+				.qtyCUsPerTU(twoCUsPerTU)
+				.build();
+
+		final PickingJobLine line = Mockito.mock(PickingJobLine.class);
+		Mockito.when(line.getPickingUnit()).thenReturn(PickingUnit.TU);
+		Mockito.when(line.getProductId()).thenReturn(productId);
+		Mockito.when(line.getPackingInfo()).thenReturn(packingInfo);
+
+		// Build main pickFrom with no pickedTo
+		final PickingJobStepPickFrom mainPickFrom = buildPickFrom(null, uomEach);
+
+		// Build alternative pickFrom with 4 CU picked
+		final PickingJobPickFromAlternativeId altId = PickingJobPickFromAlternativeId.ofRepoId(42);
+		final PickingJobStepPickFromKey altKey = PickingJobStepPickFromKey.alternative(altId);
+
+		final PickingJobStepPickedToHU altPickedHU = PickingJobStepPickedToHU.builder()
+				.pickFromHUId(HuId.ofRepoId(456))
+				.actualPickedHU(buildDummyHUInfo(uomEach))
+				.qtyPicked(fourCUs)
+				.createdAt(Instant.now())
+				.build();
+
+		final PickingJobStepPickedTo altPickedTo = PickingJobStepPickedTo.builder()
+				.actualPickedHUs(ImmutableList.of(altPickedHU))
+				.build();
+
+		final PickingJobStepPickFrom altPickFrom = PickingJobStepPickFrom.builder()
+				.pickFromKey(altKey)
+				.pickFromLocator(LocatorInfo.builder()
+						.id(LocatorId.ofRepoId(1, 100))
+						.caption("loc1")
+						.build())
+				.pickFromHU(buildDummyHUInfo(uomEach))
+				.pickedTo(altPickedTo)
+				.build();
+
+		// Mock PickingJobStep
+		final Quantity twoCUs = Quantity.of(BigDecimal.valueOf(2), uomEach);
+		final PickingJobStep step = Mockito.mock(PickingJobStep.class);
+		Mockito.when(step.getId()).thenReturn(PickingJobStepId.ofRepoId(1));
+		Mockito.when(step.getProgress()).thenReturn(PickingJobProgress.IN_PROGRESS);
+		Mockito.when(step.getProductId()).thenReturn(productId);
+		Mockito.when(step.getProductValueAndName()).thenReturn(
+				ProductValueAndName.of("VAL-001", TranslatableStrings.constant("Test product")));
+		Mockito.when(step.getQtyToPick()).thenReturn(twoCUs);
+		Mockito.when(step.getPickFromKeys()).thenReturn(
+				ImmutableSet.of(PickingJobStepPickFromKey.MAIN, altKey));
+		Mockito.when(step.getPickFrom(PickingJobStepPickFromKey.MAIN)).thenReturn(mainPickFrom);
+		Mockito.when(step.getPickFrom(altKey)).thenReturn(altPickFrom);
+
+		final JsonOpts jsonOpts = JsonOpts.ofAdLanguage("en_US");
+		final Function<UomId, ITranslatableString> getUOMSymbolById = uomId -> TranslatableStrings.constant("TU");
+
+		// Act
+		final JsonPickingJobStep json = JsonPickingJobStep.of(step, line, jsonOpts, getUOMSymbolById);
+
+		// Assert — one alternative; 4 CU @ 2 CU/TU = 2 TU
+		assertThat(json.getPickFromAlternatives()).hasSize(1);
+		assertThat(json.getPickFromAlternatives().get(0).getQtyPicked()).isEqualByComparingTo("2");
 	}
 
 	// -----------------------------------------------------------------------

--- a/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/rest_api/json/JsonPickingJobStepPickFromTest.java
+++ b/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/rest_api/json/JsonPickingJobStepPickFromTest.java
@@ -1,0 +1,212 @@
+/*
+ * #%L
+ * de.metas.picking.rest-api
+ * %%
+ * Copyright (C) 2023 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.picking.rest_api.json;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.handlingunits.HUPIItemProduct;
+import de.metas.handlingunits.HUPIItemProductId;
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.HuPackingInstructionsId;
+import de.metas.handlingunits.HuPackingInstructionsItemId;
+import de.metas.handlingunits.picking.QtyRejectedReasonCode;
+import de.metas.handlingunits.picking.QtyRejectedWithReason;
+import de.metas.handlingunits.picking.job.model.HUInfo;
+import de.metas.handlingunits.picking.job.model.LocatorInfo;
+import de.metas.handlingunits.picking.job.model.PickingJobLine;
+import de.metas.handlingunits.picking.job.model.PickingJobStepPickFrom;
+import de.metas.handlingunits.picking.job.model.PickingJobStepPickFromKey;
+import de.metas.handlingunits.picking.job.model.PickingJobStepPickedTo;
+import de.metas.handlingunits.picking.job.model.PickingJobStepPickedToHU;
+import de.metas.handlingunits.picking.job.model.PickingUnit;
+import de.metas.handlingunits.qrcodes.model.HUQRCode;
+import de.metas.handlingunits.qrcodes.model.HUQRCodePackingInfo;
+import de.metas.handlingunits.qrcodes.model.HUQRCodeUniqueId;
+import de.metas.handlingunits.qrcodes.model.HUQRCodeUnitType;
+import de.metas.i18n.ITranslatableString;
+import de.metas.i18n.TranslatableStrings;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.uom.UomId;
+import de.metas.workflow.rest_api.controller.v2.json.JsonOpts;
+import org.adempiere.warehouse.LocatorId;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RED test: verifies that {@link JsonPickingJobStepPickFrom#of(PickingJobStepPickFrom, PickingJobLine, JsonOpts, Function)}
+ * converts CU qty to TU qty when the parent line's picking unit is TU.
+ *
+ * <p>This test calls the post-fix 4-argument signature and therefore FAILS TO COMPILE
+ * against the current 3-argument production code — satisfying the RED phase.
+ * Task 2 adds the {@code PickingJobLine} parameter; after that the test must go GREEN.
+ *
+ * <p>Setup: 12 CU at 2 CU/TU → expected 6 TU.
+ */
+class JsonPickingJobStepPickFromTest
+{
+	/** A mocked {@link I_C_UOM} record with {@code C_UOM_ID=100}. */
+	private I_C_UOM buildUomEach()
+	{
+		final I_C_UOM uom = Mockito.mock(I_C_UOM.class);
+		Mockito.when(uom.getC_UOM_ID()).thenReturn(100);
+		Mockito.when(uom.getUOMType()).thenReturn("");
+		Mockito.when(uom.getX12DE355()).thenReturn("EA");
+		Mockito.when(uom.getStdPrecision()).thenReturn(2);
+		Mockito.when(uom.getCostingPrecision()).thenReturn(2);
+		return uom;
+	}
+
+	// -----------------------------------------------------------------------
+	// Test (a): qtyPicked 12 CU → 6 TU
+	// -----------------------------------------------------------------------
+
+	@Test
+	void qtyPicked_isMappedFromCuToTu()
+	{
+		// Arrange
+		final I_C_UOM uomEach = buildUomEach();
+		final ProductId productId = ProductId.ofRepoId(1001);
+		final Quantity twelveCUs = Quantity.of(BigDecimal.valueOf(12), uomEach);
+		// 2 CU/TU → 12 / 2 = 6 TU
+		final Quantity twoCUsPerTU = Quantity.of(BigDecimal.valueOf(2), uomEach);
+
+		final HUPIItemProduct packingInfo = HUPIItemProduct.builder()
+				.id(HUPIItemProductId.ofRepoId(999))
+				.name(TranslatableStrings.constant("2 per TU"))
+				.piItemId(HuPackingInstructionsItemId.ofRepoId(888))
+				.productId(productId)
+				.qtyCUsPerTU(twoCUsPerTU)
+				.build();
+
+		final PickingJobLine line = Mockito.mock(PickingJobLine.class);
+		Mockito.when(line.getPickingUnit()).thenReturn(PickingUnit.TU);
+		Mockito.when(line.getProductId()).thenReturn(productId);
+		Mockito.when(line.getPackingInfo()).thenReturn(packingInfo);
+
+		final PickingJobStepPickedToHU pickedHU = PickingJobStepPickedToHU.builder()
+				.pickFromHUId(HuId.ofRepoId(123))
+				.actualPickedHU(buildDummyHUInfo(uomEach))
+				.qtyPicked(twelveCUs)
+				.createdAt(Instant.now())
+				.build();
+
+		final PickingJobStepPickedTo pickedTo = PickingJobStepPickedTo.builder()
+				.actualPickedHUs(ImmutableList.of(pickedHU))
+				.build();
+
+		final PickingJobStepPickFrom pickFrom = buildPickFrom(pickedTo, uomEach);
+		final JsonOpts jsonOpts = JsonOpts.ofAdLanguage("en_US");
+		final Function<UomId, ITranslatableString> getUOMSymbolById = uomId -> TranslatableStrings.constant("TU");
+
+		// Act — calls the POST-FIX 4-arg signature; compile fails against current 3-arg code (RED)
+		final JsonPickingJobStepPickFrom json =
+				JsonPickingJobStepPickFrom.of(pickFrom, line, jsonOpts, getUOMSymbolById);
+
+		// Assert
+		assertThat(json.getQtyPicked()).isEqualByComparingTo("6");
+	}
+
+	// -----------------------------------------------------------------------
+	// Test (b): qtyRejected 12 CU → 6 TU
+	// -----------------------------------------------------------------------
+
+	@Test
+	void qtyRejected_isMappedFromCuToTu()
+	{
+		// Arrange
+		final I_C_UOM uomEach = buildUomEach();
+		final ProductId productId = ProductId.ofRepoId(1001);
+		final Quantity twelveCUs = Quantity.of(BigDecimal.valueOf(12), uomEach);
+		final Quantity twoCUsPerTU = Quantity.of(BigDecimal.valueOf(2), uomEach);
+
+		final HUPIItemProduct packingInfo = HUPIItemProduct.builder()
+				.id(HUPIItemProductId.ofRepoId(999))
+				.name(TranslatableStrings.constant("2 per TU"))
+				.piItemId(HuPackingInstructionsItemId.ofRepoId(888))
+				.productId(productId)
+				.qtyCUsPerTU(twoCUsPerTU)
+				.build();
+
+		final PickingJobLine line = Mockito.mock(PickingJobLine.class);
+		Mockito.when(line.getPickingUnit()).thenReturn(PickingUnit.TU);
+		Mockito.when(line.getProductId()).thenReturn(productId);
+		Mockito.when(line.getPackingInfo()).thenReturn(packingInfo);
+
+		// pickedTo with only qtyRejected; empty actualPickedHUs is allowed when qtyRejected != null
+		final PickingJobStepPickedTo pickedTo = PickingJobStepPickedTo.builder()
+				.actualPickedHUs(ImmutableList.of())
+				.qtyRejected(QtyRejectedWithReason.of(twelveCUs, QtyRejectedReasonCode.ofCode("DAMAGED")))
+				.build();
+
+		final PickingJobStepPickFrom pickFrom = buildPickFrom(pickedTo, uomEach);
+		final JsonOpts jsonOpts = JsonOpts.ofAdLanguage("en_US");
+		final Function<UomId, ITranslatableString> getUOMSymbolById = uomId -> TranslatableStrings.constant("TU");
+
+		// Act — calls the POST-FIX 4-arg signature; compile fails against current 3-arg code (RED)
+		final JsonPickingJobStepPickFrom json =
+				JsonPickingJobStepPickFrom.of(pickFrom, line, jsonOpts, getUOMSymbolById);
+
+		// Assert
+		assertThat(json.getQtyRejected()).isEqualByComparingTo("6");
+	}
+
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	private static PickingJobStepPickFrom buildPickFrom(
+			final PickingJobStepPickedTo pickedTo,
+			final I_C_UOM uomEach)
+	{
+		return PickingJobStepPickFrom.builder()
+				.pickFromKey(PickingJobStepPickFromKey.MAIN)
+				.pickFromLocator(LocatorInfo.builder()
+						.id(LocatorId.ofRepoId(1, 100))
+						.caption("loc1")
+						.build())
+				.pickFromHU(buildDummyHUInfo(uomEach))
+				.pickedTo(pickedTo)
+				.build();
+	}
+
+	private static HUInfo buildDummyHUInfo(@SuppressWarnings("unused") final I_C_UOM uomEach)
+	{
+		final HUQRCode qrCode = HUQRCode.builder()
+				.id(HUQRCodeUniqueId.random())
+				.packingInfo(HUQRCodePackingInfo.builder()
+						.huUnitType(HUQRCodeUnitType.TU)
+						.packingInstructionsId(HuPackingInstructionsId.ofRepoId(12340))
+						.caption("Test TU")
+						.build())
+				.attributes(ImmutableList.of())
+				.build();
+		return HUInfo.ofHuIdAndQRCode(HuId.ofRepoId(123), qrCode);
+	}
+}

--- a/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/rest_api/json/JsonPickingJobStepPickFromTest.java
+++ b/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/rest_api/json/JsonPickingJobStepPickFromTest.java
@@ -118,7 +118,7 @@ class JsonPickingJobStepPickFromTest
 
 		final PickingJobStepPickedToHU pickedHU = PickingJobStepPickedToHU.builder()
 				.pickFromHUId(HuId.ofRepoId(123))
-				.actualPickedHU(buildDummyHUInfo(uomEach))
+				.actualPickedHU(buildDummyHUInfo())
 				.qtyPicked(twelveCUs)
 				.createdAt(Instant.now())
 				.build();
@@ -127,7 +127,7 @@ class JsonPickingJobStepPickFromTest
 				.actualPickedHUs(ImmutableList.of(pickedHU))
 				.build();
 
-		final PickingJobStepPickFrom pickFrom = buildPickFrom(pickedTo, uomEach);
+		final PickingJobStepPickFrom pickFrom = buildPickFrom(pickedTo);
 		final JsonOpts jsonOpts = JsonOpts.ofAdLanguage("en_US");
 		final Function<UomId, ITranslatableString> getUOMSymbolById = uomId -> TranslatableStrings.constant("TU");
 
@@ -171,7 +171,7 @@ class JsonPickingJobStepPickFromTest
 				.qtyRejected(QtyRejectedWithReason.of(twelveCUs, QtyRejectedReasonCode.ofCode("DAMAGED")))
 				.build();
 
-		final PickingJobStepPickFrom pickFrom = buildPickFrom(pickedTo, uomEach);
+		final PickingJobStepPickFrom pickFrom = buildPickFrom(pickedTo);
 		final JsonOpts jsonOpts = JsonOpts.ofAdLanguage("en_US");
 		final Function<UomId, ITranslatableString> getUOMSymbolById = uomId -> TranslatableStrings.constant("TU");
 
@@ -201,7 +201,7 @@ class JsonPickingJobStepPickFromTest
 
 		final PickingJobStepPickedToHU pickedHU = PickingJobStepPickedToHU.builder()
 				.pickFromHUId(HuId.ofRepoId(123))
-				.actualPickedHU(buildDummyHUInfo(uomEach))
+				.actualPickedHU(buildDummyHUInfo())
 				.qtyPicked(twelveCUs)
 				.createdAt(Instant.now())
 				.build();
@@ -210,7 +210,7 @@ class JsonPickingJobStepPickFromTest
 				.actualPickedHUs(ImmutableList.of(pickedHU))
 				.build();
 
-		final PickingJobStepPickFrom pickFrom = buildPickFrom(pickedTo, uomEach);
+		final PickingJobStepPickFrom pickFrom = buildPickFrom(pickedTo);
 		final JsonOpts jsonOpts = JsonOpts.ofAdLanguage("en_US");
 		final Function<UomId, ITranslatableString> getUOMSymbolById = uomId -> TranslatableStrings.constant("EA");
 
@@ -251,7 +251,7 @@ class JsonPickingJobStepPickFromTest
 		Mockito.when(line.getPackingInfo()).thenReturn(packingInfo);
 
 		// Build main pickFrom with no pickedTo
-		final PickingJobStepPickFrom mainPickFrom = buildPickFrom(null, uomEach);
+		final PickingJobStepPickFrom mainPickFrom = buildPickFrom(null);
 
 		// Build alternative pickFrom with 4 CU picked
 		final PickingJobPickFromAlternativeId altId = PickingJobPickFromAlternativeId.ofRepoId(42);
@@ -259,7 +259,7 @@ class JsonPickingJobStepPickFromTest
 
 		final PickingJobStepPickedToHU altPickedHU = PickingJobStepPickedToHU.builder()
 				.pickFromHUId(HuId.ofRepoId(456))
-				.actualPickedHU(buildDummyHUInfo(uomEach))
+				.actualPickedHU(buildDummyHUInfo())
 				.qtyPicked(fourCUs)
 				.createdAt(Instant.now())
 				.build();
@@ -274,7 +274,7 @@ class JsonPickingJobStepPickFromTest
 						.id(LocatorId.ofRepoId(1, 100))
 						.caption("loc1")
 						.build())
-				.pickFromHU(buildDummyHUInfo(uomEach))
+				.pickFromHU(buildDummyHUInfo())
 				.pickedTo(altPickedTo)
 				.build();
 
@@ -308,8 +308,7 @@ class JsonPickingJobStepPickFromTest
 	// -----------------------------------------------------------------------
 
 	private static PickingJobStepPickFrom buildPickFrom(
-			final PickingJobStepPickedTo pickedTo,
-			final I_C_UOM uomEach)
+			final PickingJobStepPickedTo pickedTo)
 	{
 		return PickingJobStepPickFrom.builder()
 				.pickFromKey(PickingJobStepPickFromKey.MAIN)
@@ -317,12 +316,12 @@ class JsonPickingJobStepPickFromTest
 						.id(LocatorId.ofRepoId(1, 100))
 						.caption("loc1")
 						.build())
-				.pickFromHU(buildDummyHUInfo(uomEach))
+				.pickFromHU(buildDummyHUInfo())
 				.pickedTo(pickedTo)
 				.build();
 	}
 
-	private static HUInfo buildDummyHUInfo(@SuppressWarnings("unused") final I_C_UOM uomEach)
+	private static HUInfo buildDummyHUInfo()
 	{
 		final HUQRCode qrCode = HUQRCode.builder()
 				.id(HUQRCodeUniqueId.random())

--- a/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/rest_api/json/JsonPickingJobStepPickFromTest.java
+++ b/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/rest_api/json/JsonPickingJobStepPickFromTest.java
@@ -66,14 +66,11 @@ import java.util.function.Function;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * RED test: verifies that {@link JsonPickingJobStepPickFrom#of(PickingJobStepPickFrom, PickingJobLine, JsonOpts, Function)}
- * converts CU qty to TU qty when the parent line's picking unit is TU.
+ * Verifies that {@link JsonPickingJobStepPickFrom#of(PickingJobStepPickFrom, PickingJobLine, JsonOpts, Function)}
+ * converts CU qty to TU qty when the parent line's picking unit is TU, and passes raw CU
+ * through unchanged when the picking unit is CU.
  *
- * <p>This test calls the post-fix 4-argument signature and therefore FAILS TO COMPILE
- * against the current 3-argument production code — satisfying the RED phase.
- * Task 2 adds the {@code PickingJobLine} parameter; after that the test must go GREEN.
- *
- * <p>Setup: 12 CU at 2 CU/TU → expected 6 TU.
+ * <p>Setup for the TU cases: 12 CU at 2 CU/TU → expected 6 TU.
  */
 class JsonPickingJobStepPickFromTest
 {
@@ -131,7 +128,7 @@ class JsonPickingJobStepPickFromTest
 		final JsonOpts jsonOpts = JsonOpts.ofAdLanguage("en_US");
 		final Function<UomId, ITranslatableString> getUOMSymbolById = uomId -> TranslatableStrings.constant("TU");
 
-		// Act — calls the POST-FIX 4-arg signature; compile fails against current 3-arg code (RED)
+		// Act
 		final JsonPickingJobStepPickFrom json =
 				JsonPickingJobStepPickFrom.of(pickFrom, line, jsonOpts, getUOMSymbolById);
 
@@ -175,7 +172,7 @@ class JsonPickingJobStepPickFromTest
 		final JsonOpts jsonOpts = JsonOpts.ofAdLanguage("en_US");
 		final Function<UomId, ITranslatableString> getUOMSymbolById = uomId -> TranslatableStrings.constant("TU");
 
-		// Act — calls the POST-FIX 4-arg signature; compile fails against current 3-arg code (RED)
+		// Act
 		final JsonPickingJobStepPickFrom json =
 				JsonPickingJobStepPickFrom.of(pickFrom, line, jsonOpts, getUOMSymbolById);
 

--- a/backend/de.metas.picking.rest-api/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/backend/de.metas.picking.rest-api/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Summary
- Fixes the wrong `Ist` quantity shown on the mobile picking line ("Packzeile") step row when the line uses `pickingUnit=TU`.
- Backend-only — the JSON projection now converts `qtyPicked` and `qtyRejected` from CU to TU before serialising in `JsonPickingJobStepPickFrom`, mirroring the existing TU branch in `JsonPickingJobLine`.

## Root cause
`JsonPickingJobStepPickFrom.qtyPicked` was sent as a bare `BigDecimal` taken from `PickedTo.qtyPicked` (stored in CU), while the surrounding `JsonPickingJobStep.uom` is the step's UOM symbol (TU in TU-mode). Result: the mobile UI painted the CU number with the TU label — e.g. `Ist: 12 TU` for 12 CU at 2 CU/TU instead of the correct `6 TU`.

## Scope
- `JsonPickingJobStepPickFrom.of(...)` — converts `qtyPicked` + `qtyRejected` via `line.getPackingInfo().computeQtyTUsOfTotalCUs(...)` when `line.getPickingUnit().isTU()`.
- `JsonPickingJobStep.of(...)` — pre-existing 4-arg overload now receives a `@NonNull PickingJobLine`; dead 3-arg overload removed.
- `JsonPickingJobLine.builderFrom(...)` — unchanged on this branch (was already forwarding `line`).
- Includes `pickFromAlternatives` (same DTO).

## Test plan
- New unit test class `JsonPickingJobStepPickFromTest` — 4 test methods covering:
  - `qtyPicked` 12 CU → 6 TU (TU mode)
  - `qtyRejected` 12 CU → 6 TU (TU mode)
  - `qtyPicked` 12 CU passes through unchanged (CU mode)
  - alternative pickFrom: 4 CU → 2 TU via `JsonPickingJobStep.of(...)` end-to-end
- Full `de.metas.picking.rest-api` test suite: `Tests run: 10, Failures: 0, Errors: 0`.
- Reverse-dependency grep confirms no other backend module calls the changed `of(...)` signatures.

Refs me03 issue: https://github.com/metasfresh/me03/issues/29492
