### PR TITLE
Fact_Acct open items — accept NULL DocStatus so M_MatchInv / M_MatchPO clearing rows reconcile

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5803360_fact_acct_openItems_to_update_process_NullDocStatus.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5803360_fact_acct_openItems_to_update_process_NullDocStatus.sql
@@ -1,3 +1,27 @@
+-- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/fact_acct_openItems_to_update_process.sql
+--
+-- Fix: accept Fact_Acct rows with DocStatus IS NULL in the open-items aggregation.
+--
+-- Background:
+--   M_MatchInv and M_MatchPO have no DocStatus column at all; Doc.isDocStatusValidForPosting()
+--   explicitly accepts null DocStatus for these documents, and AcctDocRequiredServicesFacade
+--   writes NULL into Fact_Acct.DocStatus for their posting rows.
+--   The previous filter "WHERE fa.docstatus IN ('CO', 'CL')" therefore silently dropped every
+--   MatchInv/MatchPO clearing entry from the per-key aggregation. As a result, postings that
+--   should reconcile (e.g. NotInvoicedReceipts_Acct opening on M_InOut paired with the
+--   MatchInv clearing) stayed at IsOpenItemsReconciled='N' with OI_OpenAmount = the opening
+--   amount, even after the MatchInv-side OpenItemKey was correctly aligned with the opening's
+--   key (PR https://github.com/metasfresh/metasfresh/pull/24004).
+--
+--   Reversed/voided rows (DocStatus IN ('RE','VO')) are still excluded.
+--
+-- Data fix:
+--   After replacing the function, enqueue every OpenItemKey that has at least one Fact_Acct
+--   row with DocStatus IS NULL, so the background watcher reprocesses them with the corrected
+--   filter and the stuck IsOpenItemsReconciled / OI_OpenAmount / OI_OpenAmountSource values
+--   are recomputed.
+
+
 DROP FUNCTION IF EXISTS de_metas_acct.fact_acct_openItems_to_update_process(
     p_BatchSize integer
 )
@@ -85,4 +109,17 @@ BEGIN
     RETURN v_count; -- i.e. now many records were processed
 END;
 $BODY$
+;
+
+
+--
+-- Data fix: enqueue every OpenItemKey that has at least one Fact_Acct row with DocStatus IS NULL.
+-- The background watcher picks these up and reprocesses them with the corrected filter.
+INSERT INTO "de_metas_acct".fact_acct_openItems_to_update(openitemkey, c_acctschema_id, postingtype, account_id)
+SELECT DISTINCT fa.openitemkey, fa.c_acctschema_id, fa.postingtype, fa.account_id
+FROM fact_acct fa
+WHERE fa.openitemkey IS NOT NULL
+  AND fa.openitemkey IN (SELECT DISTINCT openitemkey
+                         FROM fact_acct
+                         WHERE openitemkey IS NOT NULL AND docstatus IS NULL)
 ;


### PR DESCRIPTION
## Summary

- Fix `de_metas_acct.fact_acct_openItems_to_update_process()` so it no longer silently drops Fact_Acct rows with `DocStatus IS NULL` from the open-items aggregation.
- Data fix in the migration script enqueues every affected OpenItemKey so the background watcher re-reconciles stuck rows.

## Background

`M_MatchInv` and `M_MatchPO` have no `DocStatus` column. `org.compiere.acct.Doc#isDocStatusValidForPosting()` explicitly accepts `docStatus == null` for these documents, and `AcctDocRequiredServicesFacade` writes `NULL` into `Fact_Acct.DocStatus` for their posting rows.

The processor's previous filter `WHERE fa.docstatus IN ('CO','CL')` therefore silently dropped every MatchInv/MatchPO clearing entry from the per-key aggregate. Even after https://github.com/metasfresh/metasfresh/pull/24004 aligned the MatchInv-side OpenItemKey with the opening's key, paired openings stayed at `IsOpenItemsReconciled='N'` with `OI_OpenAmount` equal to the opening's single-row balance, because the clearing row was invisible to the aggregate.

## Customer reproduction

Two groups with correct, matching OpenItemKeys still un-reconciled:

| AccountConceptualName | tablename | trxtype | amtdr | amtcr | oi_openamount | reconciled |
|---|---|---|---|---|---|---|
| NotInvoicedReceipts_Acct | M_InOut | O | 0 | 200 | -200 | N |
| NotInvoicedReceipts_Acct | M_MatchInv | C | 200 | 0 | NULL | N |
| P_InventoryClearing_Acct | C_Invoice | O | 200 | 0 | +200 | N |
| P_InventoryClearing_Acct | M_MatchInv | C | 0 | 200 | NULL | N |

Verification queries against the customer DB confirmed:
- M_MatchInv `Fact_Acct.DocStatus` = NULL while C_Invoice / M_InOut rows have `'CO'`.
- With the proposed filter, both keys aggregate to `balance_source = 0` (would set `IsOpenItemsReconciled='Y'`).

## Change

- `backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/fact_acct_openItems_to_update_process.sql` — relax the filter to `(fa.docstatus IN ('CO','CL') OR fa.docstatus IS NULL)`. Reversed/voided rows (`RE`/`VO`) remain excluded; NULL is treated as implicitly completed (matching `Doc.isDocStatusValidForPosting`).
- New migration script `5803360_fact_acct_openItems_to_update_process_NullDocStatus.sql` re-creates the function and enqueues every OpenItemKey that has at least one Fact_Acct row with `DocStatus IS NULL`, so the background watcher reprocesses them.

## Test plan

- [ ] CI green on `new_dawn_uat`.
- [ ] After rollout, re-query the two production OpenItemKeys above on the customer DB — expected: `IsOpenItemsReconciled='Y'`, `OI_OpenAmount=0` on the opening rows.
- [ ] Spot-check that previously-reconciled groups (no NULL-docstatus rows) are unchanged.
- [ ] Follow-up (out of scope here): add a Cucumber covering Doc_InOut + Doc_Invoice + Doc_MatchInv end-to-end reconciliation through the SQL processor — the current `MatchInvOIHandlerTest` only covers Java-side key generation.
