### PR TITLE
cucumber: regression guard for 1-order/2-shipments/2-invoices (me03#29921)

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceFromTwoShipmentsOfSameOrder.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceFromTwoShipmentsOfSameOrder.feature
@@ -1,0 +1,309 @@
+@from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00702.1_Header_Aggregation
+@ghActions:run_on_executor3
+Feature: One order, two shipments, two invoices — each invoice carries only its own shipment's qty
+  Regression guard for mf15#4139 / me03#29921. Three scenarios that ALL must produce two invoices,
+  where each invoice carries only the qty of its own shipment (never the qty of both shipments).
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-05-10T08:00:00+02:00[Europe/Berlin]
+    And all periods are open
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config de.metas.fresh.ordercheckup.FailIfOrderWarehouseHasNoPlant
+    And set sys config boolean value false for sys config de.metas.payment.esr.Enabled
+    # When true (soft_panda customer default), the IC auto-closes after a partial invoice and
+    # subsequent deliveries cannot reopen it. Force false so the scenarios below exercise the
+    # canonical partial-invoice flow.
+    And set sys config boolean value false for sys config C_Invoice_Candidate_Close_PartiallyInvoiced
+
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID |
+      | wh_1           |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | p_1        |
+      | p_2        |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_1       |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx |
+      | pl_1       | ps_1               | DE                    | EUR                 | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_1      | pl_1           |
+    And metasfresh contains C_TaxCategory
+      | Identifier  |
+      | taxCategory |
+    And metasfresh contains C_Tax
+      | Identifier | C_TaxCategory_ID | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
+      | tax19      | taxCategory      | 19   | DE                       | DE                        |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | plv_1                  | p_1          | 10.0     | PCE      | taxCategory      |
+      | plv_1                  | p_2          | 15.0     | PCE      | taxCategory      |
+
+    And metasfresh contains C_BPartners:
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID | OPT.InvoiceRule |
+      | customer_1 | N        | Y          | ps_1               | D               |
+
+  # ============================================================================
+  # SCENARIO A — single order line, two partial shipments via QtyToDeliver_Override
+  # Order line for 10 PCE; ship 4 then 6 by overriding QtyToDeliver before each
+  # generate-shipments call. Each shipment → one invoice with qty 4 / 6 — never 10.
+  # ============================================================================
+  @from:cucumber
+  @Id:MF4139_01
+  Scenario: A — 1 order line, 2 partial shipments via QtyToDeliver_Override, 2 invoices
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | M_Warehouse_ID | DeliveryRule | DateOrdered | PreparationDate      |
+      | so_1       | true    | customer_1    | wh_1           | F            | 2024-05-10  | 2024-05-09T21:00:00Z |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_1      | so_1       | p_1          | 10         |
+    And the order identified by so_1 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_1      | sol_1                     | N             |
+
+    # ---------- First partial shipment: 4 PCE of 10 ----------
+    And update shipment schedules
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver_Override |
+      | s_s_1                            | 4                         |
+    And after not more than 60s, shipment schedule is recomputed
+      | M_ShipmentSchedule_ID.Identifier |
+      | s_s_1                            |
+
+    And metasfresh has date and time 2024-05-15T08:00:00+02:00[Europe/Berlin]
+    And shipment is generated for the following shipment schedule
+      | M_InOut_ID.Identifier | M_ShipmentSchedule_ID.Identifier | quantityTypeToUse | isCompleteShipment |
+      | shipment_1            | s_s_1                            | D                 | Y                  |
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
+      | shipmentLine_1            | shipment_1            | p_1                     | 4           | true      |
+
+    And recompute shipment schedules
+      | M_ShipmentSchedule_ID.Identifier |
+      | s_s_1                            |
+    And after not more than 60s, shipment schedule is recomputed
+      | M_ShipmentSchedule_ID.Identifier |
+      | s_s_1                            |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_1                              | sol_1                     | 4            |
+    And validate invoice candidate
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | QtyOrdered | QtyDelivered | QtyInvoiced |
+      | ic_1                              | 4            | 10         | 4            | 0           |
+
+    When process invoice candidates
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_1                              |
+    Then after not more than 60s, C_Invoice are found:
+      | C_Invoice_Candidate_ID.Identifier | C_Invoice_ID.Identifier |
+      | ic_1                              | invoice_1               |
+    And validate created invoice lines
+      | C_InvoiceLine_ID.Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | Processed |
+      | invoiceLine_1               | invoice_1               | p_1                     | 4           | true      |
+    And validate invoice candidate
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | QtyOrdered | QtyDelivered | QtyInvoiced |
+      | ic_1                              | 0            | 10         | 4            | 4           |
+
+    # ---------- Second partial shipment: the remaining 6 PCE ----------
+    And update shipment schedules
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver_Override |
+      | s_s_1                            | 6                         |
+    And after not more than 60s, shipment schedule is recomputed
+      | M_ShipmentSchedule_ID.Identifier |
+      | s_s_1                            |
+
+    And metasfresh has date and time 2024-05-25T08:00:00+02:00[Europe/Berlin]
+    And shipment is generated for the following shipment schedule
+      | M_InOut_ID.Identifier  | M_ShipmentSchedule_ID.Identifier | quantityTypeToUse | isCompleteShipment |
+      | shipment_1, shipment_2 | s_s_1                            | D                 | Y                  |
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
+      | shipmentLine_2            | shipment_2            | p_1                     | 6           | true      |
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And validate invoice candidate
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | QtyOrdered | QtyDelivered | QtyInvoiced |
+      | ic_1                              | 6            | 10         | 10           | 4           |
+
+    # REGRESSION GUARD: 2nd invoice line MUST be qty 6 only (NOT 10).
+    When process invoice candidates
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_1                              |
+    Then after not more than 60s, C_Invoice are found:
+      | C_Invoice_Candidate_ID.Identifier | C_Invoice_ID.Identifier |
+      | ic_1                              | invoice_1, invoice_2    |
+    And validate created invoice lines
+      | C_InvoiceLine_ID.Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | Processed |
+      | invoiceLine_2               | invoice_2               | p_1                     | 6           | true      |
+    And validate invoice candidate
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | QtyOrdered | QtyDelivered | QtyInvoiced |
+      | ic_1                              | 0            | 10         | 10           | 10          |
+
+  # ============================================================================
+  # SCENARIO B — single order, two order lines, each shipped separately
+  # 1 order with 2 lines (p_1 / p_2). Ship line 1 → invoice it. Ship line 2 →
+  # invoice it. Each invoice MUST carry only its own line — never both lines.
+  # ============================================================================
+  @from:cucumber
+  @Id:MF4139_02
+  Scenario: B — 1 order with 2 order lines, each shipped + invoiced separately
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | M_Warehouse_ID | DeliveryRule | DateOrdered | PreparationDate      |
+      | so_1       | true    | customer_1    | wh_1           | F            | 2024-05-10  | 2024-05-09T21:00:00Z |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_1      | so_1       | p_1          | 10         |
+      | sol_2      | so_1       | p_2          | 6          |
+    And the order identified by so_1 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_1      | sol_1                     | N             |
+      | s_s_2      | sol_2                     | N             |
+
+    # ---------- Ship + invoice line 1 (p_1) ----------
+    And metasfresh has date and time 2024-05-15T08:00:00+02:00[Europe/Berlin]
+    And shipment is generated for the following shipment schedule
+      | M_InOut_ID.Identifier | M_ShipmentSchedule_ID.Identifier | quantityTypeToUse | isCompleteShipment |
+      | shipment_1            | s_s_1                            | D                 | Y                  |
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
+      | shipmentLine_1            | shipment_1            | p_1                     | 10          | true      |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_1                              | sol_1                     | 10           |
+    When process invoice candidates
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_1                              |
+    Then after not more than 60s, C_Invoice are found:
+      | C_Invoice_Candidate_ID.Identifier | C_Invoice_ID.Identifier |
+      | ic_1                              | invoice_1               |
+    And validate created invoice lines
+      | C_InvoiceLine_ID.Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | Processed |
+      | invoiceLine_1               | invoice_1               | p_1                     | 10          | true      |
+
+    # ---------- Ship + invoice line 2 (p_2) ----------
+    And metasfresh has date and time 2024-05-25T08:00:00+02:00[Europe/Berlin]
+    And shipment is generated for the following shipment schedule
+      | M_InOut_ID.Identifier | M_ShipmentSchedule_ID.Identifier | quantityTypeToUse | isCompleteShipment |
+      | shipment_2            | s_s_2                            | D                 | Y                  |
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
+      | shipmentLine_2            | shipment_2            | p_2                     | 6           | true      |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_2                              | sol_2                     | 6            |
+
+    # REGRESSION GUARD: 2nd invoice run is asked to invoice ic_2 only.
+    # It MUST NOT re-pick ic_1 (already fully invoiced) onto the new invoice.
+    When process invoice candidates
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_2                              |
+    Then after not more than 60s, C_Invoice are found:
+      | C_Invoice_Candidate_ID.Identifier | C_Invoice_ID.Identifier |
+      | ic_2                              | invoice_2               |
+    And validate created invoice lines
+      | C_InvoiceLine_ID.Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | Processed |
+      | invoiceLine_2               | invoice_2               | p_2                     | 6           | true      |
+
+  # ============================================================================
+  # SCENARIO C — single order line, two HUs each covering part of the qty
+  # Order line for 10 PCE. Two virtual HUs (4 PCE and 6 PCE). Pick + ship each
+  # HU independently → two shipments → two invoices, each carrying only its
+  # HU's qty.
+  # ============================================================================
+  @from:cucumber
+  @Id:MF4139_03
+  Scenario: C — 1 order line, 2 HUs (4 + 6) each in its own shipment, 2 invoices
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | M_Warehouse_ID | DeliveryRule | DateOrdered | PreparationDate      |
+      | so_1       | true    | customer_1    | wh_1           | F            | 2024-05-10  | 2024-05-09T21:00:00Z |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_1      | so_1       | p_1          | 10         |
+    And the order identified by so_1 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_1      | sol_1                     | N             |
+
+    # Two virtual HUs, each carrying part of the order qty.
+    # The step def only processes the first row of the table, so call it twice.
+    And the following virtual inventory is created
+      | M_HU_ID.Identifier | QtyToBeAdded | M_ShipmentSchedule_ID.Identifier | M_Product_ID.Identifier |
+      | hu_4               | 4            | s_s_1                            | p_1                     |
+    And the following virtual inventory is created
+      | M_HU_ID.Identifier | QtyToBeAdded | M_ShipmentSchedule_ID.Identifier | M_Product_ID.Identifier |
+      | hu_6               | 6            | s_s_1                            | p_1                     |
+
+    # ---------- Pick + ship HU hu_4 ----------
+    And the following qty is picked
+      | M_ShipmentSchedule_ID.Identifier | M_Product_ID.Identifier | QtyPicked | M_HU_ID.Identifier |
+      | s_s_1                            | p_1                     | 4         | hu_4               |
+    And metasfresh has date and time 2024-05-15T08:00:00+02:00[Europe/Berlin]
+    And shipment is generated for the following shipment schedule
+      | M_InOut_ID.Identifier | M_ShipmentSchedule_ID.Identifier | quantityTypeToUse | isCompleteShipment |
+      | shipment_1            | s_s_1                            | P                 | Y                  |
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
+      | shipmentLine_1            | shipment_1            | p_1                     | 4           | true      |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_1                              | sol_1                     | 4            |
+    When process invoice candidates
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_1                              |
+    Then after not more than 60s, C_Invoice are found:
+      | C_Invoice_Candidate_ID.Identifier | C_Invoice_ID.Identifier |
+      | ic_1                              | invoice_1               |
+    And validate created invoice lines
+      | C_InvoiceLine_ID.Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | Processed |
+      | invoiceLine_1               | invoice_1               | p_1                     | 4           | true      |
+
+    # ---------- Pick + ship HU hu_6 ----------
+    And the following qty is picked
+      | M_ShipmentSchedule_ID.Identifier | M_Product_ID.Identifier | QtyPicked | M_HU_ID.Identifier |
+      | s_s_1                            | p_1                     | 6         | hu_6               |
+    And metasfresh has date and time 2024-05-25T08:00:00+02:00[Europe/Berlin]
+    And shipment is generated for the following shipment schedule
+      | M_InOut_ID.Identifier  | M_ShipmentSchedule_ID.Identifier | quantityTypeToUse | isCompleteShipment |
+      | shipment_1, shipment_2 | s_s_1                            | P                 | Y                  |
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
+      | shipmentLine_2            | shipment_2            | p_1                     | 6           | true      |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And validate invoice candidate
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | QtyOrdered | QtyDelivered | QtyInvoiced |
+      | ic_1                              | 6            | 10         | 10           | 4           |
+
+    # REGRESSION GUARD: 2nd invoice line MUST be qty 6 only (NOT 10).
+    When process invoice candidates
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_1                              |
+    Then after not more than 60s, C_Invoice are found:
+      | C_Invoice_Candidate_ID.Identifier | C_Invoice_ID.Identifier |
+      | ic_1                              | invoice_1, invoice_2    |
+    And validate created invoice lines
+      | C_InvoiceLine_ID.Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | Processed |
+      | invoiceLine_2               | invoice_2               | p_1                     | 6           | true      |
+    And validate invoice candidate
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | QtyOrdered | QtyDelivered | QtyInvoiced |
+      | ic_1                              | 0            | 10         | 10           | 10          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceFromTwoShipmentsOfSameOrder.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceFromTwoShipmentsOfSameOrder.feature
@@ -1,10 +1,15 @@
 @from:cucumber
 @allure.label.epic:E0340_Invoicing
-@allure.label.feature:F00702.1_Header_Aggregation
+@allure.label.feature:F00702_Header_Aggregation
 @ghActions:run_on_executor3
-Feature: One order, two shipments, two invoices — each invoice carries only its own shipment's qty
-  Regression guard. Three scenarios that ALL must produce two invoices,
-  where each invoice carries only the qty of its own shipment (never the qty of both shipments).
+Feature: One order — multiple shipments — invoicing across the supported header-aggregation shapes
+  Regression guard for the supported invoicing shapes when one order is shipped in multiple steps.
+  Three "partial-invoice" scenarios (A–C) exercise C_Invoice_Candidate_Close_PartiallyInvoiced=N
+  and each must produce two invoices that each carry only their own shipment's qty.
+  Two "all-at-once" scenarios (D–E) exercise C_Invoice_Candidate_Close_PartiallyInvoiced=Y:
+  D produces one invoice with one line per shipment (default aggregation),
+  E produces one invoice per shipment via the "Per each shipment/receipt" attribute
+  (this is the shape that originally surfaced the bug fixed in this branch).
 
   Background:
     Given infrastructure and metasfresh are running

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceFromTwoShipmentsOfSameOrder.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceFromTwoShipmentsOfSameOrder.feature
@@ -56,7 +56,6 @@ Feature: One order, two shipments, two invoices — each invoice carries only it
   # generate-shipments call. Each shipment → one invoice with qty 4 / 6 — never 10.
   # ============================================================================
   @from:cucumber
-  @Id:MF4139_01
   Scenario: A — 1 order line, 2 partial shipments via QtyToDeliver_Override, 2 invoices
 
     And metasfresh contains C_Orders:
@@ -155,7 +154,6 @@ Feature: One order, two shipments, two invoices — each invoice carries only it
   # invoice it. Each invoice MUST carry only its own line — never both lines.
   # ============================================================================
   @from:cucumber
-  @Id:MF4139_02
   Scenario: B — 1 order with 2 order lines, each shipped + invoiced separately
 
     And metasfresh contains C_Orders:
@@ -228,7 +226,6 @@ Feature: One order, two shipments, two invoices — each invoice carries only it
   # HU's qty.
   # ============================================================================
   @from:cucumber
-  @Id:MF4139_03
   Scenario: C — 1 order line, 2 HUs (4 + 6) each in its own shipment, 2 invoices
 
     And metasfresh contains C_Orders:
@@ -319,7 +316,6 @@ Feature: One order, two shipments, two invoices — each invoice carries only it
   # because there's no partial invoice in this scenario.
   # ============================================================================
   @from:cucumber
-  @Id:MF4139_04
   Scenario: D — ship both, then one invoice with one line per shipment line
 
     # Override Background "off" → keep the customer's default on.
@@ -412,7 +408,6 @@ Feature: One order, two shipments, two invoices — each invoice carries only it
   # Runs with C_Invoice_Candidate_Close_PartiallyInvoiced=Y (customer config).
   # ============================================================================
   @from:cucumber
-  @Id:MF4139_05
   Scenario: E — ship both, then one invoice per shipment via aggregation config
 
     # Override Background "off" → keep the customer's default on.

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceFromTwoShipmentsOfSameOrder.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceFromTwoShipmentsOfSameOrder.feature
@@ -3,7 +3,7 @@
 @allure.label.feature:F00702.1_Header_Aggregation
 @ghActions:run_on_executor3
 Feature: One order, two shipments, two invoices — each invoice carries only its own shipment's qty
-  Regression guard for mf15#4139 / me03#29921. Three scenarios that ALL must produce two invoices,
+  Regression guard. Three scenarios that ALL must produce two invoices,
   where each invoice carries only the qty of its own shipment (never the qty of both shipments).
 
   Background:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceFromTwoShipmentsOfSameOrder.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceFromTwoShipmentsOfSameOrder.feature
@@ -307,3 +307,211 @@ Feature: One order, two shipments, two invoices — each invoice carries only it
     And validate invoice candidate
       | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | QtyOrdered | QtyDelivered | QtyInvoiced |
       | ic_1                              | 0            | 10         | 10           | 10          |
+
+  # ============================================================================
+  # SCENARIO D — supported header aggregation outcome: "one invoice with one
+  # line per InOutLine" (default behaviour). 1 order line, 2 partial shipments,
+  # invoice ONCE after both are shipped. Result: one C_Invoice with two
+  # C_InvoiceLine rows, one per shipment line (qty 4 and qty 6).
+  #
+  # Runs with the customer's IC-close sysconfig ON (C_Invoice_Candidate_Close_
+  # PartiallyInvoiced=Y) — the all-at-once invoice flow is unaffected by it
+  # because there's no partial invoice in this scenario.
+  # ============================================================================
+  @from:cucumber
+  @Id:MF4139_04
+  Scenario: D — ship both, then one invoice with one line per shipment line
+
+    # Override Background "off" → keep the customer's default on.
+    And set sys config boolean value true for sys config C_Invoice_Candidate_Close_PartiallyInvoiced
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | M_Warehouse_ID | DeliveryRule | DateOrdered | PreparationDate      |
+      | so_1       | true    | customer_1    | wh_1           | F            | 2024-05-10  | 2024-05-09T21:00:00Z |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_1      | so_1       | p_1          | 10         |
+    And the order identified by so_1 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_1      | sol_1                     | N             |
+
+    # ---------- First partial shipment: 4 PCE (no invoicing yet) ----------
+    And update shipment schedules
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver_Override |
+      | s_s_1                            | 4                         |
+    And after not more than 60s, shipment schedule is recomputed
+      | M_ShipmentSchedule_ID.Identifier |
+      | s_s_1                            |
+
+    And metasfresh has date and time 2024-05-15T08:00:00+02:00[Europe/Berlin]
+    And shipment is generated for the following shipment schedule
+      | M_InOut_ID.Identifier | M_ShipmentSchedule_ID.Identifier | quantityTypeToUse | isCompleteShipment |
+      | shipment_1            | s_s_1                            | D                 | Y                  |
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
+      | shipmentLine_1            | shipment_1            | p_1                     | 4           | true      |
+
+    And recompute shipment schedules
+      | M_ShipmentSchedule_ID.Identifier |
+      | s_s_1                            |
+    And after not more than 60s, shipment schedule is recomputed
+      | M_ShipmentSchedule_ID.Identifier |
+      | s_s_1                            |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # ---------- Second partial shipment: 6 PCE (still no invoicing) ----------
+    And update shipment schedules
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver_Override |
+      | s_s_1                            | 6                         |
+    And after not more than 60s, shipment schedule is recomputed
+      | M_ShipmentSchedule_ID.Identifier |
+      | s_s_1                            |
+
+    And metasfresh has date and time 2024-05-25T08:00:00+02:00[Europe/Berlin]
+    And shipment is generated for the following shipment schedule
+      | M_InOut_ID.Identifier  | M_ShipmentSchedule_ID.Identifier | quantityTypeToUse | isCompleteShipment |
+      | shipment_1, shipment_2 | s_s_1                            | D                 | Y                  |
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
+      | shipmentLine_2            | shipment_2            | p_1                     | 6           | true      |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # IC carries the cumulative delivery of both shipments.
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_1                              | sol_1                     | 10           |
+    And validate invoice candidate
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | QtyOrdered | QtyDelivered | QtyInvoiced |
+      | ic_1                              | 10           | 10         | 10           | 0           |
+
+    # With the default header + line aggregation, one C_Invoice is produced
+    # with TWO C_InvoiceLine rows — one per InOutLine, carrying that line's qty.
+    When process invoice candidates
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_1                              |
+    Then after not more than 60s, C_Invoice are found:
+      | C_Invoice_Candidate_ID.Identifier | C_Invoice_ID.Identifier |
+      | ic_1                              | invoice_1               |
+    And validate created invoice lines
+      | C_InvoiceLine_ID.Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | Processed |
+      | invoiceLine_1               | invoice_1               | p_1                     | 4           | true      |
+      | invoiceLine_2               | invoice_1               | p_1                     | 6           | true      |
+    And validate invoice candidate
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | QtyOrdered | QtyDelivered | QtyInvoiced |
+      | ic_1                              | 0            | 10         | 10           | 10          |
+
+  # ============================================================================
+  # SCENARIO E — supported header aggregation outcome: "one invoice per shipment"
+  # Same shape as D (1 order line, 2 partial shipments, invoice ONCE) but the
+  # BPartner is configured with a C_Aggregation that includes the "Per each
+  # shipment/receipt" attribute (C_Aggregation_Attribute_ID=540001, maps to
+  # M_InOut_ID). Result: ONE invoice PER shipment — two C_Invoice rows, one
+  # carrying qty 4 (shipment_1), the other qty 6 (shipment_2).
+  #
+  # Runs with C_Invoice_Candidate_Close_PartiallyInvoiced=Y (customer config).
+  # ============================================================================
+  @from:cucumber
+  @Id:MF4139_05
+  Scenario: E — ship both, then one invoice per shipment via aggregation config
+
+    # Override Background "off" → keep the customer's default on.
+    And set sys config boolean value true for sys config C_Invoice_Candidate_Close_PartiallyInvoiced
+
+    # Build a custom C_Aggregation that inherits the standard one (ID=1000000)
+    # and adds the "Per each shipment/receipt" attribute (ID=540001).
+    And metasfresh contains C_Aggregations:
+      | Identifier  | Name                        | TableName           | EntityType                | OPT.AggregationUsageLevel |
+      | aggPerShip  | perShipment_MF4139          | C_Invoice_Candidate | de.metas.invoicecandidate | H                         |
+    And load C_Aggregations:
+      | Identifier | C_Aggregation_ID |
+      | aggStd     | 1000000          |
+    And load C_Aggregation_Attributes:
+      | Identifier | C_Aggregation_Attribute_ID |
+      | attrInOut  | 540001                     |
+    And metasfresh contains C_AggregationItems:
+      | Identifier | C_Aggregation_ID.Identifier | EntityType                | Type | OPT.Included_Aggregation_ID.Identifier | OPT.C_Aggregation_Attribute_ID.Identifier |
+      | aggI_std   | aggPerShip                  | de.metas.invoicecandidate | INC  | aggStd                                 | null                                      |
+      | aggI_io    | aggPerShip                  | de.metas.invoicecandidate | ATR  | null                                   | attrInOut                                 |
+
+    # Assign the custom aggregation to our BPartner.
+    And update C_BPartner:
+      | Identifier | OPT.SO_Invoice_Aggregation_ID.Identifier |
+      | customer_1 | aggPerShip                               |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | M_Warehouse_ID | DeliveryRule | DateOrdered | PreparationDate      |
+      | so_1       | true    | customer_1    | wh_1           | F            | 2024-05-10  | 2024-05-09T21:00:00Z |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_1      | so_1       | p_1          | 10         |
+    And the order identified by so_1 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_1      | sol_1                     | N             |
+
+    # ---------- First partial shipment: 4 PCE (no invoicing yet) ----------
+    And update shipment schedules
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver_Override |
+      | s_s_1                            | 4                         |
+    And after not more than 60s, shipment schedule is recomputed
+      | M_ShipmentSchedule_ID.Identifier |
+      | s_s_1                            |
+
+    And metasfresh has date and time 2024-05-15T08:00:00+02:00[Europe/Berlin]
+    And shipment is generated for the following shipment schedule
+      | M_InOut_ID.Identifier | M_ShipmentSchedule_ID.Identifier | quantityTypeToUse | isCompleteShipment |
+      | shipment_1            | s_s_1                            | D                 | Y                  |
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
+      | shipmentLine_1            | shipment_1            | p_1                     | 4           | true      |
+
+    And recompute shipment schedules
+      | M_ShipmentSchedule_ID.Identifier |
+      | s_s_1                            |
+    And after not more than 60s, shipment schedule is recomputed
+      | M_ShipmentSchedule_ID.Identifier |
+      | s_s_1                            |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # ---------- Second partial shipment: 6 PCE (still no invoicing) ----------
+    And update shipment schedules
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver_Override |
+      | s_s_1                            | 6                         |
+    And after not more than 60s, shipment schedule is recomputed
+      | M_ShipmentSchedule_ID.Identifier |
+      | s_s_1                            |
+
+    And metasfresh has date and time 2024-05-25T08:00:00+02:00[Europe/Berlin]
+    And shipment is generated for the following shipment schedule
+      | M_InOut_ID.Identifier  | M_ShipmentSchedule_ID.Identifier | quantityTypeToUse | isCompleteShipment |
+      | shipment_1, shipment_2 | s_s_1                            | D                 | Y                  |
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
+      | shipmentLine_2            | shipment_2            | p_1                     | 6           | true      |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # IC carries the cumulative delivery of both shipments.
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_1                              | sol_1                     | 10           |
+    And validate invoice candidate
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | QtyOrdered | QtyDelivered | QtyInvoiced |
+      | ic_1                              | 10           | 10         | 10           | 0           |
+
+    # With "Per each shipment/receipt" in the aggregation key, a single
+    # invoice run produces TWO invoices — one per shipment. invoice_1 covers
+    # shipment_1 (qty 4); invoice_2 covers shipment_2 (qty 6).
+    When process invoice candidates
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_1                              |
+    Then after not more than 60s, C_Invoice are found:
+      | C_Invoice_Candidate_ID.Identifier | C_Invoice_ID.Identifier |
+      | ic_1                              | invoice_1, invoice_2    |
+    And validate created invoice lines
+      | C_InvoiceLine_ID.Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | Processed |
+      | invoiceLine_1               | invoice_1               | p_1                     | 4           | true      |
+      | invoiceLine_2               | invoice_2               | p_1                     | 6           | true      |
+    And validate invoice candidate
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | QtyOrdered | QtyDelivered | QtyInvoiced |
+      | ic_1                              | 0            | 10         | 10           | 10          |

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/invoicecandidate/spi/impl/FreshQuantityDiscountAggregator.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/invoicecandidate/spi/impl/FreshQuantityDiscountAggregator.java
@@ -34,6 +34,7 @@ import de.metas.invoicecandidate.api.IInvoiceLineAggregationRequest;
 import de.metas.invoicecandidate.api.IInvoiceLineRW;
 import de.metas.invoicecandidate.model.I_C_InvoiceCandidate_InOutLine;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
+import de.metas.invoicecandidate.InvoiceCandidateId;
 import de.metas.invoicecandidate.spi.IAggregator;
 import de.metas.invoicecandidate.spi.impl.aggregator.standard.DefaultAggregator;
 import de.metas.money.Money;
@@ -104,6 +105,14 @@ public class FreshQuantityDiscountAggregator implements IAggregator
 	public void setMatchInvoiceService(final MatchInvoiceService matchInvoiceService)
 	{
 		this.defaultAggregator.setMatchInvoiceService(matchInvoiceService);
+	}
+
+	@Override
+	public void setSharedIc2QtyInvoiceable(@javax.annotation.Nullable final java.util.Map<InvoiceCandidateId, StockQtyAndUOMQty> sharedMap)
+	{
+		// Forward the engine-supplied shared map to the wrapped DefaultAggregator so that allocations
+		// in this bucket reduce what subsequent buckets see.
+		this.defaultAggregator.setSharedIc2QtyInvoiceable(sharedMap);
 	}
 
 	/**

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/invoicecandidate/spi/impl/FreshQuantityDiscountAggregator.java
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/invoicecandidate/spi/impl/FreshQuantityDiscountAggregator.java
@@ -27,6 +27,7 @@ import de.metas.bpartner.service.IBPartnerDAO;
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.IMsgBL;
 import de.metas.invoice.matchinv.service.MatchInvoiceService;
+import de.metas.invoicecandidate.InvoiceCandidateId;
 import de.metas.invoicecandidate.api.IAggregationBL;
 import de.metas.invoicecandidate.api.IInvoiceCandAggregate;
 import de.metas.invoicecandidate.api.IInvoiceCandBL;
@@ -34,7 +35,6 @@ import de.metas.invoicecandidate.api.IInvoiceLineAggregationRequest;
 import de.metas.invoicecandidate.api.IInvoiceLineRW;
 import de.metas.invoicecandidate.model.I_C_InvoiceCandidate_InOutLine;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
-import de.metas.invoicecandidate.InvoiceCandidateId;
 import de.metas.invoicecandidate.spi.IAggregator;
 import de.metas.invoicecandidate.spi.impl.aggregator.standard.DefaultAggregator;
 import de.metas.money.Money;
@@ -52,6 +52,7 @@ import lombok.ToString;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_BPartner;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -107,11 +108,13 @@ public class FreshQuantityDiscountAggregator implements IAggregator
 		this.defaultAggregator.setMatchInvoiceService(matchInvoiceService);
 	}
 
+	/**
+	 * Forward the engine-supplied shared map to the wrapped DefaultAggregator so that allocations
+	 * in this bucket reduce what subsequent buckets see.
+	 */
 	@Override
-	public void setSharedIc2QtyInvoiceable(@javax.annotation.Nullable final java.util.Map<InvoiceCandidateId, StockQtyAndUOMQty> sharedMap)
+	public void setSharedIc2QtyInvoiceable(@Nullable final Map<InvoiceCandidateId, StockQtyAndUOMQty> sharedMap)
 	{
-		// Forward the engine-supplied shared map to the wrapped DefaultAggregator so that allocations
-		// in this bucket reduce what subsequent buckets see.
 		this.defaultAggregator.setSharedIc2QtyInvoiceable(sharedMap);
 	}
 
@@ -130,7 +133,7 @@ public class FreshQuantityDiscountAggregator implements IAggregator
 
 		// adding the list anyways, even if we won't ever add an icIol to it. That way we won't have to check for containsKey further down.
 		final List<I_C_InvoiceCandidate_InOutLine> list = ic2IndisputeIcIols.computeIfAbsent(
-				request.getC_Invoice_Candidate(), 
+				request.getC_Invoice_Candidate(),
 				k -> new ArrayList<>());
 
 		if (aggregationBL.isIolInDispute(request.getC_InvoiceCandidate_InOutLine()))

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationEngine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationEngine.java
@@ -55,6 +55,10 @@ import de.metas.order.impl.OrderEmailPropagationSysConfigRepository;
 import de.metas.organization.ClientAndOrgId;
 import de.metas.payment.paymentterm.PaymentTermId;
 import de.metas.payment.paymentterm.repository.IPaymentTermRepository;
+import de.metas.product.ProductId;
+import de.metas.quantity.StockQtyAndUOMQty;
+import de.metas.quantity.StockQtyAndUOMQtys;
+import de.metas.uom.UomId;
 import de.metas.pricing.PriceListId;
 import de.metas.pricing.PriceListVersionId;
 import de.metas.pricing.PricingSystemId;
@@ -83,6 +87,7 @@ import org.slf4j.Logger;
 import javax.annotation.Nullable;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -147,6 +152,15 @@ public final class AggregationEngine
 	 * Map: HeaderAggregationKey to {@link InvoiceHeaderAndLineAggregators}
 	 */
 	private final Map<AggregationKey, InvoiceHeaderAndLineAggregators> key2headerAndAggregators = new LinkedHashMap<>();
+
+	/**
+	 * Tracks every IC added to this engine, so we can build a single shared
+	 * {@code ic2QtyInvoiceable} map at {@link #aggregate()} time and thread it through every
+	 * bucket's line aggregator. Without sharing, ICIOLs of one IC split across multiple invoice
+	 * headers (e.g. via the "Per each shipment/receipt" header aggregation attribute) over-allocate
+	 * because each bucket starts fresh from {@code ic.getQtyToInvoice()}.
+	 */
+	private final HashMap<InvoiceCandidateId, I_C_Invoice_Candidate> seenIcs = new HashMap<>();
 
 	@Builder
 	private AggregationEngine(
@@ -294,6 +308,13 @@ public final class AggregationEngine
 			@Nullable final I_C_InvoiceCandidate_InOutLine iciol,
 			final boolean isLastIcIol)
 	{
+		// Remember every IC we see; aggregate() will build the shared ic2QtyInvoiceable
+		// map from these and pass it to every line aggregator. putIfAbsent: the first call
+		// for an IC carries the freshest pre-aggregation snapshot (the engine doesn't refresh
+		// the record before aggregate() runs), and any subsequent ICIOL calls for the same
+		// IC must not displace it.
+		seenIcs.putIfAbsent(InvoiceCandidateId.ofRepoId(icRecord.getC_Invoice_Candidate_ID()), icRecord);
+
 		final I_M_InOutLine icInOutLine = iciol == null ? null : iciol.getM_InOutLine();
 		final InOutId inoutId = icInOutLine != null ? InOutId.ofRepoIdOrNull(icInOutLine.getM_InOut_ID()) : null;
 
@@ -672,8 +693,22 @@ public final class AggregationEngine
 	{
 		final List<IInvoiceHeader> invoiceHeaders = new ArrayList<>();
 
+		// Build a shared "qty left to invoice per IC" map seeded with every IC's QtyToInvoice
+		// and thread it through every bucket's line aggregator before that bucket aggregates.
+		// Buckets are processed in insertion order (key2headerAndAggregators is a LinkedHashMap),
+		// and each bucket's aggregate() reduces the shared map via subtractQtyInvoiceable. So
+		// when ICIOLs of one IC are split across multiple invoice headers, each later bucket
+		// sees the residual left after earlier buckets consumed their share — instead of always
+		// seeing the IC's full QtyToInvoice and over-allocating.
+		final Map<InvoiceCandidateId, StockQtyAndUOMQty> sharedIc2QtyInvoiceable = buildSharedIc2QtyInvoiceable();
+
 		for (final InvoiceHeaderAndLineAggregators headerAndAggregators : key2headerAndAggregators.values())
 		{
+			for (final IAggregator lineAggregator : headerAndAggregators.getLineAggregators())
+			{
+				lineAggregator.setSharedIc2QtyInvoiceable(sharedIc2QtyInvoiceable);
+			}
+
 			final IInvoiceHeader invoiceHeader = aggregate(headerAndAggregators);
 
 			final ILoggable loggable = Loggables.get();
@@ -692,6 +727,30 @@ public final class AggregationEngine
 		}
 
 		return invoiceHeaders;
+	}
+
+	/**
+	 * Builds a single {@code ic2QtyInvoiceable} map covering every IC the engine has seen,
+	 * seeded with each IC's effective {@code QtyToInvoice}. Threaded into each bucket's
+	 * {@link de.metas.invoicecandidate.spi.impl.aggregator.standard.DefaultAggregator} so that
+	 * allocations in one bucket reduce what subsequent buckets see.
+	 */
+	private Map<InvoiceCandidateId, StockQtyAndUOMQty> buildSharedIc2QtyInvoiceable()
+	{
+		final HashMap<InvoiceCandidateId, StockQtyAndUOMQty> map = new HashMap<>();
+		for (final Map.Entry<InvoiceCandidateId, I_C_Invoice_Candidate> entry : seenIcs.entrySet())
+		{
+			final I_C_Invoice_Candidate ic = entry.getValue();
+			final ProductId productId = ProductId.ofRepoId(ic.getM_Product_ID());
+			final UomId icUomId = UomId.ofRepoId(ic.getC_UOM_ID());
+			// task 08507 (same rationale as DefaultAggregator.createInvoiceableQtysMap()):
+			// ic.getQtyToInvoice() is already the "effective" qty (override-aware).
+			final StockQtyAndUOMQty qtyToInvoice = StockQtyAndUOMQtys.create(
+					ic.getQtyToInvoice(), productId,
+					ic.getQtyToInvoiceInUOM(), icUomId);
+			map.put(entry.getKey(), qtyToInvoice);
+		}
+		return map;
 	}
 
 	/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationEngine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationEngine.java
@@ -99,7 +99,7 @@ import static de.metas.common.util.CoalesceUtil.coalesce;
 import static de.metas.common.util.CoalesceUtil.coalesceNotNull;
 
 /**
- * Aggregates multiple {@link I_C_Invoice_Candidate} records and returns a result that that is suitable to create invoices.
+ * Aggregates multiple {@link I_C_Invoice_Candidate} records and returns a result that is suitable to create invoices.
  *
  * @see IAggregator
  */
@@ -149,16 +149,29 @@ public final class AggregationEngine
 
 	private final AdTableId inoutLineTableId;
 	/**
-	 * Map: HeaderAggregationKey to {@link InvoiceHeaderAndLineAggregators}
+	 * Map: HeaderAggregationKey to {@link InvoiceHeaderAndLineAggregators}.
+	 * <p>
+	 * {@link LinkedHashMap} on purpose: {@link #aggregate()} iterates the buckets in insertion order, and the
+	 * shared {@code ic2QtyInvoiceable} map (see {@link #seenIcs}) is mutated bucket-by-bucket so each later
+	 * bucket sees the residual qty left after the earlier ones. Since ICIOLs are added in
+	 * {@code M_InOutLine_ID} order by {@link de.metas.invoicecandidate.api.IInvoiceCandDAO#retrieveICIOLAssociationsExclRE},
+	 * the buckets are processed in delivery order — which is what users expect when one IC is split across
+	 * multiple invoice headers (e.g. via the "Per each shipment/receipt" header aggregation attribute).
 	 */
 	private final Map<AggregationKey, InvoiceHeaderAndLineAggregators> key2headerAndAggregators = new LinkedHashMap<>();
 
 	/**
-	 * Tracks every IC added to this engine, so we can build a single shared
-	 * {@code ic2QtyInvoiceable} map at {@link #aggregate()} time and thread it through every
-	 * bucket's line aggregator. Without sharing, ICIOLs of one IC split across multiple invoice
-	 * headers (e.g. via the "Per each shipment/receipt" header aggregation attribute) over-allocate
-	 * because each bucket starts fresh from {@code ic.getQtyToInvoice()}.
+	 * Tracks every IC added to this engine, so we can build a single shared {@code ic2QtyInvoiceable} map
+	 * at {@link #aggregate()} time and thread it through every bucket's line aggregator. Without sharing,
+	 * ICIOLs of one IC split across multiple invoice headers (e.g. via the "Per each shipment/receipt"
+	 * header aggregation attribute) over-allocate because each bucket would start fresh from
+	 * {@code ic.getQtyToInvoice()}.
+	 * <p>
+	 * Stored as a live {@code I_C_Invoice_Candidate} reference (not a snapshot of its qty fields): the
+	 * engine is single-threaded per invoicing batch, callers do not mutate {@code QtyToInvoice} between
+	 * {@code addInvoiceCandidate*} and {@link #aggregate()}, and {@link de.metas.invoicecandidate.spi.impl.aggregator.standard.DefaultAggregator#addInvoiceCandidate}'s
+	 * own {@code InterfaceWrapperHelper.refresh(ic)} call is a DB re-read — it does not change the in-memory
+	 * qty within one aggregation pass.
 	 */
 	private final HashMap<InvoiceCandidateId, I_C_Invoice_Candidate> seenIcs = new HashMap<>();
 
@@ -741,7 +754,15 @@ public final class AggregationEngine
 		for (final Map.Entry<InvoiceCandidateId, I_C_Invoice_Candidate> entry : seenIcs.entrySet())
 		{
 			final I_C_Invoice_Candidate ic = entry.getValue();
-			final ProductId productId = ProductId.ofRepoId(ic.getM_Product_ID());
+			final ProductId productId = ProductId.ofRepoIdOrNull(ic.getM_Product_ID());
+			if (productId == null)
+			{
+				// charge-only IC (no M_Product_ID). It would have no M_InOutLine and therefore no ICIOL,
+				// so it shouldn't even be in seenIcs — guard defensively and skip; the bucket's
+				// fallback createInvoiceableQtysMap() handles charge-only ICs the same way (it only
+				// seeds entries for ICs that appear as InvoiceCandidateWithInOutLine).
+				continue;
+			}
 			final UomId icUomId = UomId.ofRepoId(ic.getC_UOM_ID());
 			// task 08507 (same rationale as DefaultAggregator.createInvoiceableQtysMap()):
 			// ic.getQtyToInvoice() is already the "effective" qty (override-aware).

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/IAggregator.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/IAggregator.java
@@ -23,13 +23,17 @@ package de.metas.invoicecandidate.spi;
  */
 
 import de.metas.invoice.matchinv.service.MatchInvoiceService;
+import de.metas.invoicecandidate.InvoiceCandidateId;
 import de.metas.invoicecandidate.api.IAggregationBL;
 import de.metas.invoicecandidate.api.IInvoiceCandAggregate;
 import de.metas.invoicecandidate.api.IInvoiceLineAggregationRequest;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.invoicecandidate.spi.impl.aggregator.standard.DefaultAggregator;
+import de.metas.quantity.StockQtyAndUOMQty;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -57,6 +61,15 @@ public interface IAggregator
 	void setContext(Properties ctx, String trxName);
 
 	default void setMatchInvoiceService(MatchInvoiceService matchInvoiceService){}
+
+	/**
+	 * Install an externally-supplied map of {@code C_Invoice_Candidate_ID → qty left to invoice}
+	 * that is shared across every header-aggregation bucket. When ICIOLs of one IC are split across multiple
+	 * invoice headers (e.g. via the "Per each shipment/receipt" header aggregation attribute), each bucket
+	 * mutates the same map, so the residual qty seen by subsequent buckets reflects what was already allocated.
+	 * The default implementation is a no-op for aggregators that don't track per-IC residual qty.
+	 */
+	default void setSharedIc2QtyInvoiceable(@Nullable Map<InvoiceCandidateId, StockQtyAndUOMQty> sharedMap){}
 
 
 	/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/IAggregator.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/IAggregator.java
@@ -67,7 +67,13 @@ public interface IAggregator
 	 * that is shared across every header-aggregation bucket. When ICIOLs of one IC are split across multiple
 	 * invoice headers (e.g. via the "Per each shipment/receipt" header aggregation attribute), each bucket
 	 * mutates the same map, so the residual qty seen by subsequent buckets reflects what was already allocated.
-	 * The default implementation is a no-op for aggregators that don't track per-IC residual qty.
+	 * <p>
+	 * The default implementation is a no-op — appropriate for aggregators that don't track per-IC residual qty
+	 * (because they aggregate at a coarser granularity than the IC).
+	 * <p>
+	 * <b>Implementors that DO track per-IC residual qty MUST override this method</b> and use the supplied map
+	 * instead of building their own, otherwise the same over-allocation bug fixed for {@link DefaultAggregator}
+	 * resurfaces. Wrapper aggregators must forward the call to the wrapped instance.
 	 */
 	default void setSharedIc2QtyInvoiceable(@Nullable Map<InvoiceCandidateId, StockQtyAndUOMQty> sharedMap){}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/DefaultAggregator.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/DefaultAggregator.java
@@ -44,6 +44,7 @@ import lombok.ToString;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_M_InOutLine;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -74,10 +75,27 @@ public class DefaultAggregator implements IAggregator
 	 */
 	private final Map<String, List<InvoiceCandidateWithInOutLine>> aggKey2iciol = new LinkedHashMap<>();
 
+	/**
+	 * When set, {@link #aggregate()} uses this externally-supplied map instead of building
+	 * its own via {@link #createInvoiceableQtysMap()}. The engine populates a single shared
+	 * map and threads it through every bucket's aggregator, so allocations in one bucket
+	 * reduce what subsequent buckets see — preventing over-allocation when ICIOLs of one IC
+	 * are split across multiple invoice headers (e.g. via the "Per each shipment/receipt"
+	 * header aggregation attribute).
+	 */
+	@Nullable
+	private Map<InvoiceCandidateId, StockQtyAndUOMQty> sharedIc2QtyInvoiceable;
+
 	@Override
 	public void setMatchInvoiceService(final MatchInvoiceService matchInvoiceService)
 	{
 		this.matchInvoiceService = matchInvoiceService;
+	}
+
+	@Override
+	public void setSharedIc2QtyInvoiceable(@Nullable final Map<InvoiceCandidateId, StockQtyAndUOMQty> sharedMap)
+	{
+		this.sharedIc2QtyInvoiceable = sharedMap;
 	}
 
 	@Override
@@ -182,8 +200,11 @@ public class DefaultAggregator implements IAggregator
 		final List<IInvoiceCandAggregate> invoiceCandAggregates = new ArrayList<>();
 
 		// ic2QtyInvoiceable keeps track of the qty that we have left to invoice,
-		// to make sure that we don't invoice more that the invoice candidate allows us to
-		final HashMap<InvoiceCandidateId, StockQtyAndUOMQty> ic2QtyInvoiceable = createInvoiceableQtysMap();
+		// to make sure that we don't invoice more that the invoice candidate allows us to.
+		// When the engine supplies a shared map, we use it so that allocations from earlier
+		// buckets are visible here; otherwise fall back to a local map for stand-alone callers.
+		final Map<InvoiceCandidateId, StockQtyAndUOMQty> ic2QtyInvoiceable =
+				sharedIc2QtyInvoiceable != null ? sharedIc2QtyInvoiceable : createInvoiceableQtysMap();
 
 		for (final String aggKey : new ArrayList<>(aggKey2iciol.keySet()))
 		{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/DefaultAggregator.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/DefaultAggregator.java
@@ -203,6 +203,9 @@ public class DefaultAggregator implements IAggregator
 		// to make sure that we don't invoice more that the invoice candidate allows us to.
 		// When the engine supplies a shared map, we use it so that allocations from earlier
 		// buckets are visible here; otherwise fall back to a local map for stand-alone callers.
+		// IMPORTANT: must be built BEFORE the bucket-removal loop below — the fallback
+		// createInvoiceableQtysMap() iterates aggKey2iciol.values() to seed every IC; later in
+		// the loop those entries are removed via aggKey2iciol.remove(aggKey).
 		final Map<InvoiceCandidateId, StockQtyAndUOMQty> ic2QtyInvoiceable =
 				sharedIc2QtyInvoiceable != null ? sharedIc2QtyInvoiceable : createInvoiceableQtysMap();
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/DefaultAggregator.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/DefaultAggregator.java
@@ -236,7 +236,9 @@ public class DefaultAggregator implements IAggregator
 		return invoiceCandAggregates;
 	}
 
-	/** @return a map of {@link I_C_Invoice_Candidate} to stockQty that could be invoiced */
+	/**
+	 * @return a map of {@link I_C_Invoice_Candidate} to stockQty that could be invoiced
+	 */
 	private HashMap<InvoiceCandidateId, StockQtyAndUOMQty> createInvoiceableQtysMap()
 	{
 		// ic2QtyInvoiceable keeps track of the stockQty that we have left to invoice, to make sure that we don't invoice more than the invoice candidate allows us to

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/InvoiceCandidateWithInOutLineAggregator.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/InvoiceCandidateWithInOutLineAggregator.java
@@ -59,7 +59,7 @@ import static de.metas.common.util.CoalesceUtil.firstGreaterThanZero;
 
 	// Parameters
 	@ToStringBuilder(skip = true)
-	private HashMap<InvoiceCandidateId, StockQtyAndUOMQty> _ic2QtyInvoiceable;
+	private Map<InvoiceCandidateId, StockQtyAndUOMQty> _ic2QtyInvoiceable;
 
 	/** This can be different from {@link #_ic2QtyInvoiceable} because it contains the final result from {@link #addInvoiceCandidateWithInOutLine(InvoiceCandidateWithInOutLine)} */
 	@ToStringBuilder(skip = true)
@@ -86,7 +86,7 @@ import static de.metas.common.util.CoalesceUtil.firstGreaterThanZero;
 	private final List<InvoiceCandidateWithInOutLine> _invoiceCandidateWithInOutLines = new ArrayList<>();
 	private final List<InvoiceCandidateInOutLineToUpdate> _iciolsToUpdate = new ArrayList<>();
 
-	public void setInvoiceableQtys(@NonNull final HashMap<InvoiceCandidateId, StockQtyAndUOMQty> ic2QtyInvoiceable)
+	public void setInvoiceableQtys(@NonNull final Map<InvoiceCandidateId, StockQtyAndUOMQty> ic2QtyInvoiceable)
 	{
 		this._ic2QtyInvoiceable = ic2QtyInvoiceable;
 	}


### PR DESCRIPTION
## Summary

Fixes https://github.com/metasfresh/me03/issues/29921 (parent https://github.com/metasfresh/mf15/issues/4139): when a per-orderline `C_Invoice_Candidate` is split across multiple invoice headers by header aggregation (e.g. `C_BPartner.SO_Invoice_Aggregation_ID` includes the built-in attribute `Per each shipment/receipt` → `M_InOut_ID`), the second invoice's line wrongly carried the qty of **both** shipments instead of just its own.

### Root cause

`DefaultAggregator.aggregate()` built its own `ic2QtyInvoiceable` map per header bucket, each seeded with the IC's full `QtyToInvoice`. The bucket containing the globally-last ICIOL was flagged `allocateRemainingQty=true` and skipped the per-ICIOL shipped-qty cap, returning the full IC qty (10) instead of just that shipment's qty (6). Bookkeeping ended up over-invoiced (`IC.QtyInvoiced` = 14 of `QtyDelivered` = 10).

### Fix

`AggregationEngine` now builds a single shared `ic2QtyInvoiceable` map covering every IC it has seen and threads it through every bucket's `IAggregator` via a new default method `setSharedIc2QtyInvoiceable(Map<…>)`. Buckets are processed in insertion order; each bucket's `aggregate()` decrements the shared map, so later buckets see the residual left after earlier buckets allocated. The existing `allocateRemainingQty` path keeps working for single-bucket residual cases (e.g. `QtyToInvoice_Override > shipped qty`).

`FreshQuantityDiscountAggregator` wraps `DefaultAggregator` and is the actual line aggregator for customers like soft_panda; its override forwards the shared map to the wrapped instance.

### Files

| File | Role |
|---|---|
| `backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/IAggregator.java` | new `setSharedIc2QtyInvoiceable(Map<…>)` default no-op |
| `backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/DefaultAggregator.java` | use shared map when supplied |
| `backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/spi/impl/aggregator/standard/InvoiceCandidateWithInOutLineAggregator.java` | relaxed `HashMap<…>` → `Map<…>` on field + setter |
| `backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/AggregationEngine.java` | track seen ICs, build + thread shared map at `aggregate()` time |
| `backend/de.metas.fresh/de.metas.fresh.base/src/main/java/de/metas/fresh/invoicecandidate/spi/impl/FreshQuantityDiscountAggregator.java` | forward shared map to wrapped `DefaultAggregator` |
| `backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceFromTwoShipmentsOfSameOrder.feature` | new feature with 5 scenarios (A-E) — regression guards for every supported invoicing shape |

### Cucumber scenarios

All five must continue to pass under any aggregation config (default or per-shipment) and under any `C_Invoice_Candidate_Close_PartiallyInvoiced` setting:

- **A** — 1 order line, 2 partial shipments via `QtyToDeliver_Override`, 2 invoices (sysconfig `C_Invoice_Candidate_Close_PartiallyInvoiced=N`)
- **B** — 1 order with 2 order lines, each shipped + invoiced separately (default config)
- **C** — 1 order line, 2 HUs (4 + 6) each in its own shipment, 2 invoices (default config)
- **D** — ship both, then one invoice with one line per shipment line (`C_Invoice_Candidate_Close_PartiallyInvoiced=Y`, default aggregation)
- **E** — ship both, then one invoice per shipment via aggregation config (`C_Invoice_Candidate_Close_PartiallyInvoiced=Y`, `Per each shipment/receipt` attribute active) — **this scenario reproduces the original bug; passes with the fix**

### Documentation

Feature documentation issue filed: https://github.com/metasfresh/mf15-documentation/issues/122 (F00702.1 — Header Aggregation).

## Test plan

- [x] Five cucumber scenarios all pass locally against `soft_panda_uat` Docker infra
- [x] Existing aggregation unit tests in `de.metas.swat.base` still pass
- [x] CI green on https://github.com/metasfresh/metasfresh/pull/24036
