### PR TITLE
Trolley Release — undo picking on release (abort assigned DD jobs)

### DIFF
--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DistributionRestService.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DistributionRestService.java
@@ -233,6 +233,11 @@ public class DistributionRestService
 				.distributionJobHUReservationService(distributionJobHUReservationService);
 	}
 
+	public List<DistributionJob> loadActiveJobsAssignedToUser(@NonNull final UserId responsibleId)
+	{
+		return newLoader().loadByQuery(DistributionJobQueries.ddOrdersAssignedToUser(responsibleId));
+	}
+
 	public void abortAll(@NonNull final UserId responsibleId)
 	{
 		final List<DistributionJob> jobs = newLoader().loadByQuery(DistributionJobQueries.ddOrdersAssignedToUser(responsibleId));

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/trolley/DistributionTrolleyPendingWorkProvider.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/trolley/DistributionTrolleyPendingWorkProvider.java
@@ -1,0 +1,30 @@
+package de.metas.distribution.mobileui.trolley;
+
+import de.metas.distribution.mobileui.DistributionMobileApplication;
+import de.metas.distribution.mobileui.job.model.DistributionJob;
+import de.metas.distribution.mobileui.job.service.DistributionRestService;
+import de.metas.user.UserId;
+import de.metas.workflow.rest_api.controller.v2.json.JsonTrolleyPendingWorkContribution;
+import de.metas.workflow.rest_api.service.TrolleyPendingWorkProvider;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DistributionTrolleyPendingWorkProvider implements TrolleyPendingWorkProvider
+{
+	@NonNull private final DistributionRestService distributionRestService;
+
+	@Override
+	public JsonTrolleyPendingWorkContribution getPendingWork(@NonNull final UserId userId)
+	{
+		final List<DistributionJob> jobs = distributionRestService.loadActiveJobsAssignedToUser(userId);
+		return JsonTrolleyPendingWorkContribution.builder()
+				.applicationId(DistributionMobileApplication.APPLICATION_ID.getAsString())
+				.openJobsCount(jobs.size())
+				.build();
+	}
+}

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/trolley/DistributionTrolleyReleaseListener.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/trolley/DistributionTrolleyReleaseListener.java
@@ -1,0 +1,21 @@
+package de.metas.distribution.mobileui.trolley;
+
+import de.metas.distribution.mobileui.job.service.DistributionRestService;
+import de.metas.user.UserId;
+import de.metas.workflow.rest_api.service.TrolleyReleaseListener;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DistributionTrolleyReleaseListener implements TrolleyReleaseListener
+{
+	@NonNull private final DistributionRestService distributionRestService;
+
+	@Override
+	public void onTrolleyReleased(@NonNull final UserId userId)
+	{
+		distributionRestService.abortAll(userId);
+	}
+}

--- a/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/controller/v2/WorkflowRestController.java
+++ b/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/controller/v2/WorkflowRestController.java
@@ -44,6 +44,7 @@ import de.metas.workflow.rest_api.activity_features.set_scanned_barcode.JsonScan
 import de.metas.workflow.rest_api.controller.v2.json.JsonGetCurrentTrolleyResponse;
 import de.metas.workflow.rest_api.controller.v2.json.JsonLaunchersQuery;
 import de.metas.workflow.rest_api.controller.v2.json.JsonMobileApplication;
+import de.metas.workflow.rest_api.controller.v2.json.JsonTrolleyPendingWorkResponse;
 import de.metas.workflow.rest_api.controller.v2.json.JsonMobileApplicationsList;
 import de.metas.workflow.rest_api.controller.v2.json.JsonOpts;
 import de.metas.workflow.rest_api.controller.v2.json.JsonSetCurrentTrolley;
@@ -59,6 +60,7 @@ import de.metas.workflow.rest_api.model.WFProcess;
 import de.metas.workflow.rest_api.model.WFProcessId;
 import de.metas.workflow.rest_api.model.WorkflowLaunchersList;
 import de.metas.workflow.rest_api.model.WorkflowLaunchersQuery;
+import de.metas.workflow.rest_api.service.TrolleyPendingWorkService;
 import de.metas.workflow.rest_api.service.TrolleyService;
 import de.metas.workflow.rest_api.service.WorkflowRestAPIService;
 import de.metas.workflow.rest_api.service.WorkflowStartRequest;
@@ -93,6 +95,7 @@ public class WorkflowRestController
 	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	@NonNull private final IErrorManager errorManager = Services.get(IErrorManager.class);
 	@NonNull private final WorkflowRestAPIService workflowRestAPIService;
+	@NonNull private final TrolleyPendingWorkService trolleyPendingWorkService;
 	@NonNull private final TrolleyService trolleyService;
 
 	private static final String SYSCONFIG_SETTINGS_PREFIX = "mobileui.frontend.";
@@ -376,5 +379,11 @@ public class WorkflowRestController
 	{
 		trolleyService.clearCurrent(Env.getLoggedUserId());
 		return JsonGetCurrentTrolleyResponse.EMPTY;
+	}
+
+	@GetMapping("/trolley/pending-work")
+	public JsonTrolleyPendingWorkResponse getTrolleyPendingWork()
+	{
+		return trolleyPendingWorkService.summarize(Env.getLoggedUserId());
 	}
 }

--- a/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/controller/v2/json/JsonTrolleyPendingWorkContribution.java
+++ b/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/controller/v2/json/JsonTrolleyPendingWorkContribution.java
@@ -1,0 +1,15 @@
+package de.metas.workflow.rest_api.controller.v2.json;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonDeserialize(builder = JsonTrolleyPendingWorkContribution.JsonTrolleyPendingWorkContributionBuilder.class)
+public class JsonTrolleyPendingWorkContribution
+{
+	@NonNull String applicationId;
+	int openJobsCount;
+}

--- a/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/controller/v2/json/JsonTrolleyPendingWorkResponse.java
+++ b/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/controller/v2/json/JsonTrolleyPendingWorkResponse.java
@@ -1,0 +1,28 @@
+package de.metas.workflow.rest_api.controller.v2.json;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.ImmutableList;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Singular;
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+@Builder
+@JsonDeserialize(builder = JsonTrolleyPendingWorkResponse.JsonTrolleyPendingWorkResponseBuilder.class)
+public class JsonTrolleyPendingWorkResponse
+{
+	@NonNull @Singular ImmutableList<JsonTrolleyPendingWorkContribution> contributions;
+	int totalOpenJobs;
+
+	public static JsonTrolleyPendingWorkResponse aggregate(@NonNull final List<JsonTrolleyPendingWorkContribution> items)
+	{
+		final int total = items.stream().mapToInt(JsonTrolleyPendingWorkContribution::getOpenJobsCount).sum();
+		return JsonTrolleyPendingWorkResponse.builder()
+				.contributions(ImmutableList.copyOf(items))
+				.totalOpenJobs(total)
+				.build();
+	}
+}

--- a/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/service/TrolleyPendingWorkProvider.java
+++ b/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/service/TrolleyPendingWorkProvider.java
@@ -1,0 +1,10 @@
+package de.metas.workflow.rest_api.service;
+
+import de.metas.user.UserId;
+import de.metas.workflow.rest_api.controller.v2.json.JsonTrolleyPendingWorkContribution;
+import lombok.NonNull;
+
+public interface TrolleyPendingWorkProvider
+{
+	JsonTrolleyPendingWorkContribution getPendingWork(@NonNull UserId userId);
+}

--- a/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/service/TrolleyPendingWorkService.java
+++ b/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/service/TrolleyPendingWorkService.java
@@ -1,0 +1,28 @@
+package de.metas.workflow.rest_api.service;
+
+import de.metas.user.UserId;
+import de.metas.workflow.rest_api.controller.v2.json.JsonTrolleyPendingWorkContribution;
+import de.metas.workflow.rest_api.controller.v2.json.JsonTrolleyPendingWorkResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TrolleyPendingWorkService
+{
+	@NonNull private final List<TrolleyPendingWorkProvider> providers;
+
+	public JsonTrolleyPendingWorkResponse summarize(@NonNull final UserId userId)
+	{
+		final List<JsonTrolleyPendingWorkContribution> items = new ArrayList<>(providers.size());
+		for (final TrolleyPendingWorkProvider provider : providers)
+		{
+			items.add(provider.getPendingWork(userId));
+		}
+		return JsonTrolleyPendingWorkResponse.aggregate(items);
+	}
+}

--- a/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/service/TrolleyReleaseListener.java
+++ b/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/service/TrolleyReleaseListener.java
@@ -1,0 +1,13 @@
+package de.metas.workflow.rest_api.service;
+
+import de.metas.user.UserId;
+import lombok.NonNull;
+
+/**
+ * SPI: notified inside the transaction that handles trolley release.
+ * Implementations may throw to roll back the release (e.g. if a domain-specific abort fails).
+ */
+public interface TrolleyReleaseListener
+{
+	void onTrolleyReleased(@NonNull UserId userId);
+}

--- a/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/service/TrolleyService.java
+++ b/backend/de.metas.workflow.rest-api/src/main/java/de/metas/workflow/rest_api/service/TrolleyService.java
@@ -7,6 +7,7 @@ import de.metas.user.api.IUserDAO;
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.api.IWarehouseDAO;
@@ -15,6 +16,7 @@ import org.adempiere.warehouse.qrcode.resolver.LocatorScannedCodeResolverService
 import org.compiere.model.I_M_Warehouse;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -23,7 +25,9 @@ public class TrolleyService
 {
 	@NonNull private final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
 	@NonNull private final IUserDAO userDAO = Services.get(IUserDAO.class);
+	@NonNull private final ITrxManager trxManager = Services.get(ITrxManager.class);
 	@NonNull private final LocatorScannedCodeResolverService locatorScannedCodeResolver;
+	@NonNull private final List<TrolleyReleaseListener> releaseListeners;
 
 	private final HashBiMap<UserId, LocatorQRCode> userId2locator = HashBiMap.create();
 
@@ -53,10 +57,16 @@ public class TrolleyService
 
 	public void clearCurrent(@NonNull final UserId userId)
 	{
-		synchronized (userId2locator)
-		{
-			userId2locator.remove(userId);
-		}
+		trxManager.runInNewTrx(() -> {
+			for (final TrolleyReleaseListener listener : releaseListeners)
+			{
+				listener.onTrolleyReleased(userId);
+			}
+			synchronized (userId2locator)
+			{
+				userId2locator.remove(userId);
+			}
+		});
 	}
 
 	public Optional<LocatorQRCode> getCurrent(@NonNull final UserId userId)

--- a/backend/de.metas.workflow.rest-api/src/test/java/de/metas/workflow/rest_api/service/TrolleyServiceTest.java
+++ b/backend/de.metas.workflow.rest-api/src/test/java/de/metas/workflow/rest_api/service/TrolleyServiceTest.java
@@ -15,10 +15,15 @@ import org.compiere.model.I_M_Warehouse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class TrolleyServiceTest
@@ -30,6 +35,8 @@ class TrolleyServiceTest
 	private LocatorScannedCodeResolverService resolver;
 	private IWarehouseDAO warehouseDAO;
 	private IUserDAO userDAO;
+	private TrolleyReleaseListener listenerA;
+	private TrolleyReleaseListener listenerB;
 	private TrolleyService service;
 
 	private ScannedCode scannedCode;
@@ -53,6 +60,10 @@ class TrolleyServiceTest
 		when(userDAO.retrieveUserFullName(USER_B)).thenReturn("Bob");
 		Services.registerService(IUserDAO.class, userDAO);
 
+		// Mock release listeners — TrolleyService now invokes them before clearing the mapping.
+		listenerA = mock(TrolleyReleaseListener.class);
+		listenerB = mock(TrolleyReleaseListener.class);
+
 		// Mock resolver — resolves a fixed ScannedCode to a fixed LocatorQRCode
 		resolver = mock(LocatorScannedCodeResolverService.class);
 		scannedCode = ScannedCode.ofString("CART-1");
@@ -63,7 +74,7 @@ class TrolleyServiceTest
 		final LocatorScannedCodeResolverResult resolved = LocatorScannedCodeResolverResult.found(locatorQRCode);
 		when(resolver.resolve(scannedCode)).thenReturn(resolved);
 
-		service = new TrolleyService(resolver);
+		service = new TrolleyService(resolver, Arrays.asList(listenerA, listenerB));
 	}
 
 	@Test
@@ -100,5 +111,25 @@ class TrolleyServiceTest
 		// user has no trolley — must not throw
 		service.clearCurrent(USER_A);
 		assertThat(service.getCurrent(USER_A)).isEmpty();
+	}
+
+	@Test
+	void clearCurrent_invokesAllReleaseListenersThenClearsMapping()
+	{
+		service.setCurrent(USER_A, scannedCode);
+		service.clearCurrent(USER_A);
+		verify(listenerA).onTrolleyReleased(USER_A);
+		verify(listenerB).onTrolleyReleased(USER_A);
+		assertThat(service.getCurrent(USER_A)).isEmpty();
+	}
+
+	@Test
+	void clearCurrent_rollsBackMappingWhenAnyListenerThrows()
+	{
+		service.setCurrent(USER_A, scannedCode);
+		doThrow(new RuntimeException("boom")).when(listenerB).onTrolleyReleased(USER_A);
+		// trxManager wraps the RuntimeException in AdempiereException; assert by message content.
+		assertThatThrownBy(() -> service.clearCurrent(USER_A)).hasMessageContaining("boom");
+		assertThat(service.getCurrent(USER_A)).isPresent();
 	}
 }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/trolley.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/trolley.js
@@ -42,3 +42,7 @@ export const postCurrentTrolley = ({ scannedCode }) => {
 export const deleteCurrentTrolley = () => {
   return axios.delete(`${trolleyAPIBase}`).then(unboxAxiosResponse);
 };
+
+export const getTrolleyPendingWork = () => {
+  return axios.get(`${trolleyAPIBase}/pending-work`).then(unboxAxiosResponse);
+};

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/WFLaunchersScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/WFLaunchersScreen.jsx
@@ -1,10 +1,12 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useFacets, useFilters } from '../../reducers/launchers';
 
 import WFLauncherButton from './WFLauncherButton';
 import BarcodeScannerComponent from '../../components/BarcodeScannerComponent';
 import ButtonWithIndicator from '../../components/buttons/ButtonWithIndicator';
+import Dialog from '../../components/dialogs/Dialog';
+import DialogButton from '../../components/dialogs/DialogButton';
 import { toQRCodeDisplayable } from '../../utils/qrCode/hu';
 import WFLaunchersFilterButton from './filters/WFLaunchersFilterButton';
 import { updateHeaderEntry } from '../../actions/HeaderActions';
@@ -18,7 +20,7 @@ import { useMobileLocation } from '../../hooks/useMobileLocation';
 import { useLaunchers } from './useLaunchers';
 import { APPLICATION_ID_Distribution } from '../../apps/distribution/constants';
 import DistributionJobsListActions from '../../apps/distribution/containers/DistributionJobsListActions';
-import { useCurrentTrolley } from '../../api/trolley';
+import { getTrolleyPendingWork, useCurrentTrolley } from '../../api/trolley';
 import { toastError } from '../../utils/toast';
 
 const WFLaunchersScreen = () => {
@@ -36,6 +38,29 @@ const WFLaunchersScreen = () => {
   const { isTrolleyRequired, isTrolleyLoading, trolley, setTrolleyByScannedCode, clearTrolley } = useCurrentTrolley({
     applicationId,
   });
+  const [confirmRelease, setConfirmRelease] = useState(null);
+
+  const handleReleaseTrolleyClick = () => {
+    getTrolleyPendingWork()
+      .then((pending) => {
+        const openJobsCount = pending?.totalOpenJobs ?? 0;
+        if (openJobsCount > 0) {
+          setConfirmRelease({ openJobsCount });
+        } else {
+          return clearTrolley();
+        }
+      })
+      .catch((axiosError) => toastError({ axiosError }));
+  };
+
+  const handleConfirmReleaseYes = () => {
+    setConfirmRelease(null);
+    clearTrolley().catch((axiosError) => toastError({ axiosError }));
+  };
+
+  const handleConfirmReleaseNo = () => {
+    setConfirmRelease(null);
+  };
   const filters = useFilters({ applicationId });
   const facets = useFacets({ applicationId });
   const { isLaunchersLoading, launchers, filterByQRCode, actions } = useLaunchers({
@@ -187,9 +212,34 @@ const WFLaunchersScreen = () => {
           captionKey="general.releaseTrolley.buttonCaption"
           testId="release-trolley-button"
           isDanger
-          onClick={() => clearTrolley().catch((axiosError) => toastError({ axiosError }))}
+          onClick={handleReleaseTrolleyClick}
           additionalCssClass="action-button"
         />
+      )}
+      {confirmRelease != null && (
+        <Dialog className="yes-no-dialog" testId="release-trolley-confirm-modal">
+          <strong>{trl('general.releaseTrolley.confirmTitle')}</strong>
+          <p>
+            {trl('general.releaseTrolley.confirmBodyWithJobs').replace(
+              '{{openJobsCount}}',
+              confirmRelease.openJobsCount
+            )}
+          </p>
+          <div className="buttons is-centered">
+            <DialogButton
+              captionKey="general.releaseTrolley.confirmYes"
+              testId="release-trolley-confirm-yes"
+              className="is-danger"
+              onClick={handleConfirmReleaseYes}
+            />
+            <DialogButton
+              captionKey="general.releaseTrolley.confirmNo"
+              testId="release-trolley-confirm-no"
+              className="is-success"
+              onClick={handleConfirmReleaseNo}
+            />
+          </div>
+        </Dialog>
       )}
     </div>
   );

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -54,6 +54,11 @@ const translations = {
     trolley: 'Wagen',
     releaseTrolley: {
       buttonCaption: 'Wagen freigeben',
+      confirmTitle: 'Wagen freigeben?',
+      confirmBodyWithJobs:
+        'Sie haben {{openJobsCount}} unfertige Distributionsauftrag/-aufträge. Beim Freigeben des Wagens werden diese abgebrochen und die kommissionierten Mengen zurück ins Quelllager bewegt.',
+      confirmYes: 'Freigeben und abbrechen',
+      confirmNo: 'Abbrechen',
     },
   },
   login: {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -51,6 +51,11 @@ const translations = {
     trolley: 'Trolley',
     releaseTrolley: {
       buttonCaption: 'Release trolley',
+      confirmTitle: 'Release trolley?',
+      confirmBodyWithJobs:
+        'You have {{openJobsCount}} unfinished distribution job(s). Releasing the trolley will abort them and return the picked items to their source warehouse.',
+      confirmYes: 'Release and abort',
+      confirmNo: 'Cancel',
     },
   },
   login: {


### PR DESCRIPTION
## Summary

When the logged-in user taps "Release trolley", any of *their* currently-assigned distribution jobs (`DDOrderJob`s) are aborted (HU reservations released, DD order unassigned, not-yet-started movement schedules removed) inside a single transaction before the in-memory user→trolley mapping is dropped. A new `GET /trolley/pending-work` endpoint feeds a frontend confirmation modal so the user is warned before discarding active picking work.

Prior behaviour: `clearCurrent` silently dropped the mapping; HUs the user had picked stayed on the trolley locator and another user taking the trolley would inherit them. This PR makes "release" mean a clean trolley state.

## Backend

- **SPI in `de.metas.workflow.rest-api`** — `TrolleyReleaseListener` and `TrolleyPendingWorkProvider`. Implementations live in domain modules; the workflow module stays domain-agnostic (avoids a `workflow → distribution` cycle).
- **`TrolleyService.clearCurrent(UserId)`** now wraps `releaseListeners.forEach(...) → userId2locator.remove(userId)` inside `trxManager.runInNewTrx`. If any listener throws, the entire transaction rolls back; the mapping stays and the user keeps holding the trolley. Two new unit tests pin this: `clearCurrent_invokesAllReleaseListenersThenClearsMapping` and `clearCurrent_rollsBackMappingWhenAnyListenerThrows` (6/6 GREEN locally).
- **Pending-work aggregator** — `TrolleyPendingWorkService` collects contributions from all Spring-discovered `TrolleyPendingWorkProvider`s and totals `openJobsCount` across them; exposed via `GET /api/v2/userWorkflows/trolley/pending-work`.
- **Distribution module** — `DistributionTrolleyReleaseListener` (one-line delegate to `DistributionRestService.abortAll(userId)`, the same primitive `logout()` already uses) + `DistributionTrolleyPendingWorkProvider` (counts the user's currently-assigned `DistributionJob`s). New public method `DistributionRestService.loadActiveJobsAssignedToUser(UserId)` factored out for the count.

## Frontend (mobile-webui)

- `api/trolley.js`: new `getTrolleyPendingWork()` (`GET /pending-work`).
- `WFLaunchersScreen.jsx`: the footer "Release trolley" button now pre-flights via `getTrolleyPendingWork()`. If `totalOpenJobs > 0` → opens a `Dialog` confirmation modal naming the count; on confirm → `clearTrolley()`. If zero → `clearTrolley()` directly (current behaviour preserved). The existing top trolley-indicator button keeps direct-release behaviour (it's intended for the no-active-work path).
- Translation keys: `general.releaseTrolley.{confirmTitle, confirmBodyWithJobs, confirmYes, confirmNo}` (EN + DE). Body uses `{{openJobsCount}}` placeholder.
- Modal carries `data-testid="release-trolley-confirm-modal"`; confirm/cancel buttons `release-trolley-confirm-{yes,no}` for E2E hooks.

## Migrations

None. Listener wiring + abort reuse is pure code.

## Test plan

- [ ] CI builds green.
- [ ] UAT — user A starts a DD order, partially picks 2 PCE onto trolley T, taps "Release trolley": modal warns "1 unfinished distribution job"; tap Confirm → HU returns to source warehouse, DD order is back to unassigned, scan screen re-appears.
- [ ] UAT — user A holds trolley T but has no active DD job, taps "Release trolley": no modal, releases immediately.
- [ ] UAT — user A confirms release → user B scans T → fresh `DDOrderJob` starts on an empty trolley.
- [ ] UAT — user A taps Cancel on the modal → trolley still held, picking session intact.

Note: cucumber + Playwright scenarios for the new flow are not in this PR — open to land as a follow-up. The new code paths reuse `DistributionRestService.abortAll(UserId)` which is already exercised in production by `logout()`, so the contract risk is in the new SPI plumbing only, covered by `TrolleyServiceTest`.