### PR TITLE
Customer Return: copy LU packing structure when full qty returned

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/customerReturn.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/customerReturn.feature
@@ -254,7 +254,6 @@ Feature: Customer Return from Shipment
     And the return inOut identified by customerReturn_CR4 is completed
 
     # Step 7: Verify return HU is LU-structured (copied from origin)
-    # RED: return currently does not copy the LU packing structure
     And load HUs assigned to M_InOut
       | M_InOut_ID         | M_HU_ID      |
       | customerReturn_CR4 | returnLU_CR4 |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/customerReturn.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/customerReturn.feature
@@ -190,3 +190,73 @@ Feature: Customer Return from Shipment
     And M_HU are validated:
       | M_HU_ID    | HUStatus | IsActive |
       | return_hu3 | D        | N        |
+
+
+  @from:cucumber
+  @allure.label.epic:E0110_Sales
+  @allure.label.feature:F00200_Sales_Order
+  Scenario: Complete customer return with LU packing structure copies origin HUs
+    # Step 1: LU/TU packing instructions
+    Given metasfresh contains M_HU_PI:
+      | M_HU_PI_ID.Identifier | Name     |
+      | huTU_CR4              | huTU_CR4 |
+      | huLU_CR4              | huLU_CR4 |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID.Identifier | M_HU_PI_ID.Identifier | Name            | HU_UnitType | IsCurrent |
+      | piVersionTU_CR4               | huTU_CR4              | piVersionTU_CR4 | TU          | Y         |
+      | piVersionLU_CR4               | huLU_CR4              | piVersionLU_CR4 | LU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType | OPT.Included_HU_PI_ID.Identifier |
+      | piItemMI_CR4               | piVersionTU_CR4               | 0   | MI       |                                  |
+      | piItemLU_CR4               | piVersionLU_CR4               | 1   | HU       | huTU_CR4                         |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | piItemProduct_CR4                  | piItemMI_CR4               | product_CR              | 10  | 2022-03-01 |
+
+    # Step 2: Order with TU packing instruction on line
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | OPT.POReference | OPT.M_PricingSystem_ID | OPT.C_BPartner_Location_ID | OPT.DeliveryRule | OPT.DeliveryViaRule |
+      | order_CR4  | Y       | customer_CR   | 2022-06-10  | so_ref_CR4      | ps_CR                  | customer_CR                | F                | S                   |
+    And metasfresh contains C_OrderLines:
+      | Identifier    | C_Order_ID | M_Product_ID | QtyEntered | OPT.M_HU_PI_Item_Product_ID |
+      | orderLine_CR4 | order_CR4  | product_CR   | 10         | piItemProduct_CR4           |
+
+    When the order identified by order_CR4 is completed
+
+    # Step 3: Shipment
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier   | C_OrderLine_ID | IsToRecompute |
+      | schedule_CR4 | orderLine_CR4  | N             |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | schedule_CR4          | D            | true                | false       |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID   |
+      | schedule_CR4          | shipment_CR4 |
+
+    # Step 4: Verify shipment HU is LU (precondition)
+    And load HUs assigned to M_InOut
+      | M_InOut_ID   | M_HU_ID        |
+      | shipment_CR4 | shipmentLU_CR4 |
+
+    And validate M_HUs:
+      | M_HU_ID        | M_HU_PI_ID |
+      | shipmentLU_CR4 | huLU_CR4   |
+
+    # Step 5: Full-qty customer return
+    And generate customer return from shipment
+      | M_InOut_ID   | CustomerReturn_ID  |
+      | shipment_CR4 | customerReturn_CR4 |
+
+    And the return inOut identified by customerReturn_CR4 is completed
+
+    # Step 6: Verify return HU is LU-structured (copied from origin)
+    And load HUs assigned to M_InOut
+      | M_InOut_ID         | M_HU_ID      |
+      | customerReturn_CR4 | returnLU_CR4 |
+
+    Then validate M_HUs:
+      | M_HU_ID      | HUStatus | IsActive | M_HU_PI_ID |
+      | returnLU_CR4 | A        | Y        | huLU_CR4   |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/customerReturn.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/customerReturn.feature
@@ -223,36 +223,38 @@ Feature: Customer Return from Shipment
 
     When the order identified by order_CR4 is completed
 
-    # Step 3: Shipment
+    # Step 3: Put stock into the warehouse with the LU structure so that on-the-fly pick can pick it
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_LU_HU_PI_ID | M_HU_ID        |
+      | inventory_CR4  | warehouseStd   | 2022-06-10   | product_CR   | 0 PCE   | 10 PCE   | piItemProduct_CR4       | huLU_CR4      | inventoryLU_CR4 |
+
+    # Step 4: Shipment — on-the-fly pick will grab the LU stock HU
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier   | C_OrderLine_ID | IsToRecompute |
       | schedule_CR4 | orderLine_CR4  | N             |
 
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
-      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
-      | schedule_CR4          | D            | true                | false       |
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | IsOnTheFlyPickToPackingInstructions |
+      | schedule_CR4          | D            | true                | false       | true                                |
 
     And after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID   |
       | schedule_CR4          | shipment_CR4 |
 
-    # Step 4: Verify shipment HU is LU (precondition)
+    # Step 5: Verify shipment has HUs assigned (precondition)
     And load HUs assigned to M_InOut
-      | M_InOut_ID   | M_HU_ID        |
-      | shipment_CR4 | shipmentLU_CR4 |
+      | M_InOut_ID   | M_HU_ID      |
+      | shipment_CR4 | shipmentHU_CR4 |
 
-    And validate M_HUs:
-      | M_HU_ID        | M_HU_PI_ID |
-      | shipmentLU_CR4 | huLU_CR4   |
-
-    # Step 5: Full-qty customer return
+    # Step 6: Full-qty customer return
     And generate customer return from shipment
       | M_InOut_ID   | CustomerReturn_ID  |
       | shipment_CR4 | customerReturn_CR4 |
 
     And the return inOut identified by customerReturn_CR4 is completed
 
-    # Step 6: Verify return HU is LU-structured (copied from origin)
+    # Step 7: Verify return HU is LU-structured (copied from origin)
+    # RED: return currently does not copy the LU packing structure
     And load HUs assigned to M_InOut
       | M_InOut_ID         | M_HU_ID      |
       | customerReturn_CR4 | returnLU_CR4 |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/CopyHUsCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/CopyHUsCommand.java
@@ -68,12 +68,17 @@ public class CopyHUsCommand
 	@Builder
 	private CopyHUsCommand(
 			@NonNull @Singular("huIdToCopy") final ImmutableSet<HuId> huIdsToCopy,
-			@Nullable final WarehouseId targetWarehouseId)
+			@Nullable final WarehouseId targetWarehouseId,
+			@Nullable final LocatorId targetLocatorId)
 	{
 		this.huIdsToCopy = huIdsToCopy;
 		this.huStatus = X_M_HU.HUSTATUS_Planning;
 
-		if (targetWarehouseId != null)
+		if (targetLocatorId != null)
+		{
+			this.targetLocatorId = targetLocatorId;
+		}
+		else if (targetWarehouseId != null)
 		{
 			final IWarehouseBL warehouseBL = Services.get(IWarehouseBL.class);
 			this.targetLocatorId = warehouseBL.getOrCreateDefaultLocatorId(targetWarehouseId);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/CopyHUsResponse.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/CopyHUsResponse.java
@@ -27,6 +27,7 @@ import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.util.collections.CollectionUtils;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.Singular;
 import lombok.Value;
@@ -34,9 +35,7 @@ import lombok.Value;
 @Builder
 public class CopyHUsResponse
 {
-	@NonNull @Singular ImmutableList<CopyHUsResponseItem> items;
-
-	public ImmutableList<CopyHUsResponseItem> getItems() {return items;}
+	@Getter @NonNull @Singular ImmutableList<CopyHUsResponseItem> items;
 
 	public I_M_HU getSingleNewHU() {return getSingleItem().getNewHU();}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/CopyHUsResponse.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/CopyHUsResponse.java
@@ -36,6 +36,8 @@ public class CopyHUsResponse
 {
 	@NonNull @Singular ImmutableList<CopyHUsResponseItem> items;
 
+	public ImmutableList<CopyHUsResponseItem> getItems() {return items;}
+
 	public I_M_HU getSingleNewHU() {return getSingleItem().getNewHU();}
 
 	public CopyHUsResponseItem getSingleItem() {return CollectionUtils.singleElement(items);}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/ReturnsServiceFacade.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/ReturnsServiceFacade.java
@@ -23,6 +23,8 @@
 package de.metas.handlingunits.inout.returns;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.inout.IHUInOutBL;
 import de.metas.handlingunits.inout.returns.customer.CreateCustomerReturnLineReq;
 import de.metas.handlingunits.inout.returns.customer.CustomerReturnHUsCreateCommand;
@@ -35,6 +37,7 @@ import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_InOut;
 import de.metas.handlingunits.model.I_M_InOutLine;
 import de.metas.inout.InOutId;
+import de.metas.inout.InOutLineId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.springframework.stereotype.Service;
@@ -42,6 +45,7 @@ import org.springframework.stereotype.Service;
 import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Main class for all material returns related services
@@ -50,6 +54,7 @@ import java.util.List;
 public class ReturnsServiceFacade
 {
 	private final IHUInOutBL huInOutBL = Services.get(IHUInOutBL.class);
+	private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
 	private final CustomerReturnsWithoutHUsProducer customerReturnsWithoutHUsProducer;
 
 	public ReturnsServiceFacade(
@@ -150,6 +155,37 @@ public class ReturnsServiceFacade
 					.build()
 					.execute();
 		}
+	}
+
+	private List<I_M_HU> getOriginNonVirtualHUs(@NonNull final I_M_InOutLine returnLine)
+	{
+		final int originInOutLineRepoId = returnLine.getReturn_Origin_InOutLine_ID();
+		if (originInOutLineRepoId <= 0)
+		{
+			return ImmutableList.of();
+		}
+
+		final InOutLineId originLineId = InOutLineId.ofRepoId(originInOutLineRepoId);
+		final Map<InOutLineId, List<I_M_HU>> husByLineId =
+				huInOutBL.retrieveShippedHUsByShipmentLineId(ImmutableSet.of(originLineId));
+		final List<I_M_HU> originHUs = husByLineId.getOrDefault(originLineId, ImmutableList.of());
+
+		return originHUs.stream()
+				.filter(hu -> !handlingUnitsBL.isVirtual(hu))
+				.collect(ImmutableList.toImmutableList());
+	}
+
+	private boolean isFullQtyReturn(@NonNull final I_M_InOutLine returnLine)
+	{
+		final int originInOutLineRepoId = returnLine.getReturn_Origin_InOutLine_ID();
+		if (originInOutLineRepoId <= 0)
+		{
+			return false;
+		}
+
+		final InOutLineId originLineId = InOutLineId.ofRepoId(originInOutLineRepoId);
+		final I_M_InOutLine originLine = huInOutBL.getLineById(originLineId);
+		return returnLine.getQtyEntered().compareTo(originLine.getQtyEntered()) == 0;
 	}
 
 	private boolean isSkipReturnLine(final I_M_InOutLine returnLine)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/ReturnsServiceFacade.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/ReturnsServiceFacade.java
@@ -149,9 +149,13 @@ public class ReturnsServiceFacade
 				continue;
 			}
 
+			final List<I_M_HU> originNonVirtualHUs = getOriginNonVirtualHUs(returnLine);
+			final boolean useCopyPath = !originNonVirtualHUs.isEmpty() && isFullQtyReturn(returnLine);
+
 			CustomerReturnHUsCreateCommand.builder()
 					.returnLine(returnLine)
-					.isOnlyCreateCUs(true)
+					.isOnlyCreateCUs(!useCopyPath)
+					.originHUsForCopy(useCopyPath ? originNonVirtualHUs : ImmutableList.of())
 					.build()
 					.execute();
 		}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/ReturnsServiceFacade.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/ReturnsServiceFacade.java
@@ -149,8 +149,9 @@ public class ReturnsServiceFacade
 				continue;
 			}
 
-			final List<I_M_HU> originNonVirtualHUs = getOriginNonVirtualHUs(returnLine);
-			final boolean useCopyPath = !originNonVirtualHUs.isEmpty() && isFullQtyReturn(returnLine);
+			final boolean isFullQty = isFullQtyReturn(returnLine);
+			final List<I_M_HU> originNonVirtualHUs = isFullQty ? getOriginNonVirtualHUs(returnLine) : ImmutableList.of();
+			final boolean useCopyPath = !originNonVirtualHUs.isEmpty();
 
 			CustomerReturnHUsCreateCommand.builder()
 					.returnLine(returnLine)
@@ -189,7 +190,7 @@ public class ReturnsServiceFacade
 
 		final InOutLineId originLineId = InOutLineId.ofRepoId(originInOutLineRepoId);
 		final I_M_InOutLine originLine = huInOutBL.getLineById(originLineId);
-		return returnLine.getQtyEntered().compareTo(originLine.getQtyEntered()) == 0;
+		return returnLine.getMovementQty().compareTo(originLine.getMovementQty()) == 0;
 	}
 
 	private boolean isSkipReturnLine(final I_M_InOutLine returnLine)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/ReturnsServiceFacade.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/ReturnsServiceFacade.java
@@ -36,10 +36,13 @@ import de.metas.handlingunits.inout.returns.vendor.MultiVendorHUReturnsInOutProd
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_InOut;
 import de.metas.handlingunits.model.I_M_InOutLine;
+import de.metas.handlingunits.trace.HUAccessService;
+import de.metas.handlingunits.trace.HUTraceEventsService;
 import de.metas.inout.InOutId;
 import de.metas.inout.InOutLineId;
 import de.metas.util.Services;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
@@ -51,17 +54,14 @@ import java.util.Map;
  * Main class for all material returns related services
  */
 @Service
+@RequiredArgsConstructor
 public class ReturnsServiceFacade
 {
 	private final IHUInOutBL huInOutBL = Services.get(IHUInOutBL.class);
 	private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
-	private final CustomerReturnsWithoutHUsProducer customerReturnsWithoutHUsProducer;
-
-	public ReturnsServiceFacade(
-			@NonNull final CustomerReturnsWithoutHUsProducer customerReturnsWithoutHUsProducer)
-	{
-		this.customerReturnsWithoutHUsProducer = customerReturnsWithoutHUsProducer;
-	}
+	@NonNull private final CustomerReturnsWithoutHUsProducer customerReturnsWithoutHUsProducer;
+	@NonNull private final HUTraceEventsService huTraceEventsService;
+	@NonNull private final HUAccessService huAccessService;
 
 	public boolean isCustomerReturn(@NonNull final org.compiere.model.I_M_InOut inout)
 	{
@@ -157,6 +157,8 @@ public class ReturnsServiceFacade
 					.returnLine(returnLine)
 					.isOnlyCreateCUs(!useCopyPath)
 					.originHUsForCopy(useCopyPath ? originNonVirtualHUs : ImmutableList.of())
+					.huTraceEventsService(huTraceEventsService)
+					.huAccessService(huAccessService)
 					.build()
 					.execute();
 		}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/customer/CustomerReturnHUsCreateCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/customer/CustomerReturnHUsCreateCommand.java
@@ -23,6 +23,7 @@
 package de.metas.handlingunits.inout.returns.customer;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import de.metas.common.util.time.SystemTime;
 import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.handlingunits.HuId;
@@ -44,9 +45,15 @@ import de.metas.handlingunits.hutransaction.IHUTrxBL;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_PI;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.handlingunits.model.I_M_InOut;
 import de.metas.handlingunits.model.I_M_InOutLine;
 import de.metas.handlingunits.model.X_M_HU;
 import de.metas.handlingunits.storage.impl.PlainProductStorage;
+import de.metas.handlingunits.trace.HUAccessService;
+import de.metas.handlingunits.trace.HUTraceEventsService;
+import de.metas.handlingunits.trace.HUTraceForReturnedQtyRequest;
+import de.metas.inout.InOutId;
+import de.metas.organization.OrgId;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
 import de.metas.uom.IUOMDAO;
@@ -58,9 +65,11 @@ import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.IContextAware;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.api.IWarehouseDAO;
+import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_UOM;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -125,7 +134,51 @@ public class CustomerReturnHUsCreateCommand
 		// after HUAssignments are copied in de.metas.handlingunits.model.validator.M_InOut.destroyHandlingUnitsForReversedInboundMovements
 		createdHUs.forEach(createdHU -> huAssignmentBL.assignHU(returnLine, createdHU, false, ITrx.TRXNAME_ThreadInherited));
 
+		if (!originHUsForCopy.isEmpty())
+		{
+			createTraceRecordsForCopiedHUs(createdHUs);
+		}
+
 		return createdHUs;
+	}
+
+	private void createTraceRecordsForCopiedHUs(@NonNull final List<I_M_HU> copiedTopLevelHUs)
+	{
+		final HUTraceEventsService huTraceEventsService = SpringContextHolder.instance.getBean(HUTraceEventsService.class);
+		final HUAccessService huAccessService = SpringContextHolder.instance.getBean(HUAccessService.class);
+
+		final InOutId customerReturnId = InOutId.ofRepoId(returnLine.getM_InOut_ID());
+		final I_M_InOut returnHeader = InterfaceWrapperHelper.load(returnLine.getM_InOut_ID(), I_M_InOut.class);
+		final OrgId orgId = OrgId.ofRepoId(returnLine.getAD_Org_ID());
+
+		for (final I_M_HU copiedTopLevelHU : copiedTopLevelHUs)
+		{
+			final HuId topLevelReturnedHUId = HuId.ofRepoId(copiedTopLevelHU.getM_HU_ID());
+
+			for (final I_M_HU copiedVHU : handlingUnitsBL.getVHUs(copiedTopLevelHU))
+			{
+				final HuId sourceVhuId = HuId.ofRepoId(copiedVHU.getClonedFrom_HU_ID());
+
+				huAccessService.retrieveProductAndQty(copiedVHU).ifPresent(productAndQty -> {
+					final ProductId productId = productAndQty.getLeft();
+					final Quantity qty = productAndQty.getRight();
+
+					final HUTraceForReturnedQtyRequest request = HUTraceForReturnedQtyRequest.builder()
+							.returnedVirtualHU(copiedVHU)
+							.topLevelReturnedHUId(topLevelReturnedHUId)
+							.sourceShippedVHUIds(ImmutableSet.of(sourceVhuId))
+							.customerReturnId(customerReturnId)
+							.docStatus(returnHeader.getDocStatus())
+							.eventTime(Instant.now())
+							.orgId(orgId)
+							.productId(productId)
+							.qty(qty)
+							.build();
+
+					huTraceEventsService.createAndAddFor(request);
+				});
+			}
+		}
 	}
 
 	private List<I_M_HU> createLUTUs()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/customer/CustomerReturnHUsCreateCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/customer/CustomerReturnHUsCreateCommand.java
@@ -60,6 +60,7 @@ import org.compiere.model.I_C_UOM;
 
 import java.math.BigDecimal;
 import java.util.List;
+import javax.annotation.Nullable;
 
 
 public class CustomerReturnHUsCreateCommand
@@ -75,15 +76,19 @@ public class CustomerReturnHUsCreateCommand
 
 	private final I_M_InOutLine returnLine;
 	private final boolean isOnlyCreateCUs;
+	@NonNull private final ImmutableList<I_M_HU> originHUsForCopy;
 
 	@Builder
 	private CustomerReturnHUsCreateCommand(
 			@NonNull final I_M_InOutLine returnLine,
-			final boolean isOnlyCreateCUs
-	)
+			final boolean isOnlyCreateCUs,
+			@Nullable final List<I_M_HU> originHUsForCopy)
 	{
 		this.returnLine = returnLine;
 		this.isOnlyCreateCUs = isOnlyCreateCUs;
+		this.originHUsForCopy = originHUsForCopy != null
+				? ImmutableList.copyOf(originHUsForCopy)
+				: ImmutableList.of();
 	}
 
 	public List<I_M_HU> execute()
@@ -95,15 +100,22 @@ public class CustomerReturnHUsCreateCommand
 	private List<I_M_HU> createHUsForReturnLine()
 	{
 		final List<I_M_HU> createdHUs;
-		final HUPIItemProductId hupiItemProductId = HUPIItemProductId.ofRepoIdOrNull(returnLine.getM_HU_PI_Item_Product_ID());
-		if (isOnlyCreateCUs || hupiItemProductId == null || hupiItemProductId.isVirtualHU())
+		if (!originHUsForCopy.isEmpty())
 		{
-			createdHUs = ImmutableList.of(createCUs());
-
-        }
+			createdHUs = copyOriginHUs(originHUsForCopy);
+		}
 		else
 		{
-			createdHUs = createLUTUs();
+			final HUPIItemProductId hupiItemProductId = HUPIItemProductId.ofRepoIdOrNull(returnLine.getM_HU_PI_Item_Product_ID());
+			if (isOnlyCreateCUs || hupiItemProductId == null || hupiItemProductId.isVirtualHU())
+			{
+				createdHUs = ImmutableList.of(createCUs());
+
+	        }
+			else
+			{
+				createdHUs = createLUTUs();
+			}
 		}
 
 		// huInOutBL.setAssignedHandlingUnits(returnLine, createdHUs) sets isTransferPackingMaterials true
@@ -177,5 +189,10 @@ public class CustomerReturnHUsCreateCommand
 		final PlainProductStorage productStorage = new PlainProductStorage(productId, uom, qty);
 
 		return new GenericAllocationSourceDestination(productStorage, returnLine);
+	}
+
+	private List<I_M_HU> copyOriginHUs(@NonNull final List<I_M_HU> originHUs)
+	{
+		throw new UnsupportedOperationException("not yet implemented");
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/customer/CustomerReturnHUsCreateCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/customer/CustomerReturnHUsCreateCommand.java
@@ -66,7 +66,6 @@ import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.IContextAware;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.api.IWarehouseDAO;
-import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_UOM;
 
 import java.math.BigDecimal;
@@ -86,24 +85,28 @@ public class CustomerReturnHUsCreateCommand
 	private final IHUTrxBL huTrxBL = Services.get(IHUTrxBL.class);
 	private final IHUAssignmentBL huAssignmentBL = Services.get(IHUAssignmentBL.class);
 	private final IHUInOutBL huInOutBL = Services.get(IHUInOutBL.class);
-	private final SpringContextHolder.Lazy<HUTraceEventsService> huTraceEventsServiceLazy = SpringContextHolder.lazyBean(HUTraceEventsService.class);
-	private final SpringContextHolder.Lazy<HUAccessService> huAccessServiceLazy = SpringContextHolder.lazyBean(HUAccessService.class);
 
 	private final I_M_InOutLine returnLine;
 	private final boolean isOnlyCreateCUs;
 	@NonNull private final ImmutableList<I_M_HU> originHUsForCopy;
+	@NonNull private final HUTraceEventsService huTraceEventsService;
+	@NonNull private final HUAccessService huAccessService;
 
 	@Builder
 	private CustomerReturnHUsCreateCommand(
 			@NonNull final I_M_InOutLine returnLine,
 			final boolean isOnlyCreateCUs,
-			@Nullable final List<I_M_HU> originHUsForCopy)
+			@Nullable final List<I_M_HU> originHUsForCopy,
+			@NonNull final HUTraceEventsService huTraceEventsService,
+			@NonNull final HUAccessService huAccessService)
 	{
 		this.returnLine = returnLine;
 		this.isOnlyCreateCUs = isOnlyCreateCUs;
 		this.originHUsForCopy = originHUsForCopy != null
 				? ImmutableList.copyOf(originHUsForCopy)
 				: ImmutableList.of();
+		this.huTraceEventsService = huTraceEventsService;
+		this.huAccessService = huAccessService;
 	}
 
 	public List<I_M_HU> execute()
@@ -160,7 +163,7 @@ public class CustomerReturnHUsCreateCommand
 			{
 				final HuId sourceVhuId = HuId.ofRepoId(copiedVHU.getClonedFrom_HU_ID());
 
-				huAccessServiceLazy.get().retrieveProductAndQty(copiedVHU).ifPresent(productAndQty -> {
+				huAccessService.retrieveProductAndQty(copiedVHU).ifPresent(productAndQty -> {
 					final HUTraceForReturnedQtyRequest request = HUTraceForReturnedQtyRequest.builder()
 							.returnedVirtualHU(copiedVHU)
 							.topLevelReturnedHUId(topLevelReturnedHUId)
@@ -173,7 +176,7 @@ public class CustomerReturnHUsCreateCommand
 							.qty(productAndQty.getRight())
 							.build();
 
-					huTraceEventsServiceLazy.get().createAndAddFor(request);
+					huTraceEventsService.createAndAddFor(request);
 				});
 			}
 		}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/customer/CustomerReturnHUsCreateCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/customer/CustomerReturnHUsCreateCommand.java
@@ -32,6 +32,7 @@ import de.metas.handlingunits.impl.CopyHUsResponse;
 import de.metas.handlingunits.IHUAssignmentBL;
 import de.metas.handlingunits.IHUPIItemProductDAO;
 import de.metas.handlingunits.IHandlingUnitsBL;
+import de.metas.handlingunits.inout.IHUInOutBL;
 import de.metas.handlingunits.IHandlingUnitsDAO;
 import de.metas.handlingunits.IMutableHUContext;
 import de.metas.handlingunits.allocation.IAllocationDestination;
@@ -84,6 +85,9 @@ public class CustomerReturnHUsCreateCommand
 	private final IWarehouseDAO warehousesRepo = Services.get(IWarehouseDAO.class);
 	private final IHUTrxBL huTrxBL = Services.get(IHUTrxBL.class);
 	private final IHUAssignmentBL huAssignmentBL = Services.get(IHUAssignmentBL.class);
+	private final IHUInOutBL huInOutBL = Services.get(IHUInOutBL.class);
+	private final SpringContextHolder.Lazy<HUTraceEventsService> huTraceEventsServiceLazy = SpringContextHolder.lazyBean(HUTraceEventsService.class);
+	private final SpringContextHolder.Lazy<HUAccessService> huAccessServiceLazy = SpringContextHolder.lazyBean(HUAccessService.class);
 
 	private final I_M_InOutLine returnLine;
 	private final boolean isOnlyCreateCUs;
@@ -121,8 +125,7 @@ public class CustomerReturnHUsCreateCommand
 			if (isOnlyCreateCUs || hupiItemProductId == null || hupiItemProductId.isVirtualHU())
 			{
 				createdHUs = ImmutableList.of(createCUs());
-
-	        }
+			}
 			else
 			{
 				createdHUs = createLUTUs();
@@ -144,12 +147,10 @@ public class CustomerReturnHUsCreateCommand
 
 	private void createTraceRecordsForCopiedHUs(@NonNull final List<I_M_HU> copiedTopLevelHUs)
 	{
-		final HUTraceEventsService huTraceEventsService = SpringContextHolder.instance.getBean(HUTraceEventsService.class);
-		final HUAccessService huAccessService = SpringContextHolder.instance.getBean(HUAccessService.class);
-
 		final InOutId customerReturnId = InOutId.ofRepoId(returnLine.getM_InOut_ID());
-		final I_M_InOut returnHeader = InterfaceWrapperHelper.load(returnLine.getM_InOut_ID(), I_M_InOut.class);
+		final I_M_InOut returnHeader = huInOutBL.getById(customerReturnId, I_M_InOut.class);
 		final OrgId orgId = OrgId.ofRepoId(returnLine.getAD_Org_ID());
+		final Instant movementDate = returnHeader.getMovementDate().toInstant();
 
 		for (final I_M_HU copiedTopLevelHU : copiedTopLevelHUs)
 		{
@@ -159,23 +160,20 @@ public class CustomerReturnHUsCreateCommand
 			{
 				final HuId sourceVhuId = HuId.ofRepoId(copiedVHU.getClonedFrom_HU_ID());
 
-				huAccessService.retrieveProductAndQty(copiedVHU).ifPresent(productAndQty -> {
-					final ProductId productId = productAndQty.getLeft();
-					final Quantity qty = productAndQty.getRight();
-
+				huAccessServiceLazy.get().retrieveProductAndQty(copiedVHU).ifPresent(productAndQty -> {
 					final HUTraceForReturnedQtyRequest request = HUTraceForReturnedQtyRequest.builder()
 							.returnedVirtualHU(copiedVHU)
 							.topLevelReturnedHUId(topLevelReturnedHUId)
 							.sourceShippedVHUIds(ImmutableSet.of(sourceVhuId))
 							.customerReturnId(customerReturnId)
 							.docStatus(returnHeader.getDocStatus())
-							.eventTime(Instant.now())
+							.eventTime(movementDate)
 							.orgId(orgId)
-							.productId(productId)
-							.qty(qty)
+							.productId(productAndQty.getLeft())
+							.qty(productAndQty.getRight())
 							.build();
 
-					huTraceEventsService.createAndAddFor(request);
+					huTraceEventsServiceLazy.get().createAndAddFor(request);
 				});
 			}
 		}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/customer/CustomerReturnHUsCreateCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/returns/customer/CustomerReturnHUsCreateCommand.java
@@ -25,7 +25,9 @@ package de.metas.handlingunits.inout.returns.customer;
 import com.google.common.collect.ImmutableList;
 import de.metas.common.util.time.SystemTime;
 import de.metas.handlingunits.HUPIItemProductId;
+import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.HuPackingInstructionsId;
+import de.metas.handlingunits.impl.CopyHUsResponse;
 import de.metas.handlingunits.IHUAssignmentBL;
 import de.metas.handlingunits.IHUPIItemProductDAO;
 import de.metas.handlingunits.IHandlingUnitsBL;
@@ -193,6 +195,20 @@ public class CustomerReturnHUsCreateCommand
 
 	private List<I_M_HU> copyOriginHUs(@NonNull final List<I_M_HU> originHUs)
 	{
-		throw new UnsupportedOperationException("not yet implemented");
+		final LocatorId returnLocatorId = warehousesRepo.getLocatorIdByRepoId(returnLine.getM_Locator_ID());
+
+		final ImmutableList<HuId> originHuIds = originHUs.stream()
+				.map(hu -> HuId.ofRepoId(hu.getM_HU_ID()))
+				.collect(ImmutableList.toImmutableList());
+
+		final CopyHUsResponse copyResponse = handlingUnitsBL.copyAsPlannedHUs()
+				.huIdsToCopy(originHuIds)
+				.targetLocatorId(returnLocatorId)
+				.build()
+				.execute();
+
+		return copyResponse.getItems().stream()
+				.map(CopyHUsResponse.CopyHUsResponseItem::getNewHU)
+				.collect(ImmutableList.toImmutableList());
 	}
 }

--- a/backend/de.metas.servicerepair.base/src/test/java/de/metas/servicerepair/customerreturns/RepairCustomerReturnsServiceTest.java
+++ b/backend/de.metas.servicerepair.base/src/test/java/de/metas/servicerepair/customerreturns/RepairCustomerReturnsServiceTest.java
@@ -25,8 +25,11 @@ package de.metas.servicerepair.customerreturns;
 import de.metas.handlingunits.inout.returns.ReturnsServiceFacade;
 import de.metas.handlingunits.inout.returns.customer.CustomerReturnInOutRecordFactory;
 import de.metas.handlingunits.inout.returns.customer.CustomerReturnsWithoutHUsProducer;
+import de.metas.handlingunits.trace.HUAccessService;
+import de.metas.handlingunits.trace.HUTraceEventsService;
 import de.metas.product.ProductId;
 import lombok.NonNull;
+import org.mockito.Mockito;
 import org.adempiere.mm.attributes.api.AttributeConstants;
 import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -53,7 +56,10 @@ class RepairCustomerReturnsServiceTest
 
 		final CustomerReturnInOutRecordFactory customerReturnRepository = new CustomerReturnInOutRecordFactory();
 		final CustomerReturnsWithoutHUsProducer customerReturnsWithoutHUsProducer = new CustomerReturnsWithoutHUsProducer(customerReturnRepository);
-		final ReturnsServiceFacade returnsServiceFacade = new ReturnsServiceFacade(customerReturnsWithoutHUsProducer);
+		final ReturnsServiceFacade returnsServiceFacade = new ReturnsServiceFacade(
+				customerReturnsWithoutHUsProducer,
+				Mockito.mock(HUTraceEventsService.class),
+				Mockito.mock(HUAccessService.class));
 		final AlreadyShippedHUsInPreviousSystemRepository alreadyShippedHUsInPreviousSystemRepository = new AlreadyShippedHUsInPreviousSystemRepository();
 		repairCustomerReturnsService = new RepairCustomerReturnsService(returnsServiceFacade, alreadyShippedHUsInPreviousSystemRepository);
 


### PR DESCRIPTION
## What

When generating a customer return from a shipment that had LU/TU packing structure, and the returned quantity equals the full shipped quantity, the return now copies the origin HUs (preserving pallet structure, locator, and attributes) instead of creating plain Virtual HUs.

## Why

Previously, completing a customer return always created a flat VHU regardless of the original shipment's packing structure. This lost the LU/TU hierarchy information for full-qty returns.

## Changes

**`CopyHUsCommand`** — added `targetLocatorId` parameter so the copy can land on the return locator directly.

**`CopyHUsResponse`** — added explicit `getItems()` getter (outer class uses `@Builder`, not `@Value`).

**`CustomerReturnHUsCreateCommand`** — new `originHUsForCopy` field; when non-empty, delegates to `copyOriginHUs()` (calls `IHandlingUnitsBL.copyAsPlannedHUs()`) and creates `M_HU_Trace` records for the copied VHUs.

**`ReturnsServiceFacade`** — added `getOriginNonVirtualHUs()` and `isFullQtyReturn()` helpers; the copy path activates when both return non-empty/true.

**cucumber** — added Scenario 4 in `customerReturn.feature` that verifies the returned LU carries the origin's `M_HU_PI_ID`.