### PR TITLE
patch-response.spec.js — bump Modal-edit-syncs-to-master PATCH timeout to 40s

### DIFF
--- a/e2e/frontend-webui/tests/spec/patch-response.spec.js
+++ b/e2e/frontend-webui/tests/spec/patch-response.spec.js
@@ -532,13 +532,20 @@ test.describe('PATCH Response Handling', () => {
         // field metadata
         const nameInput = getNameInput(page);
 
-        // Intercept the PATCH to verify it actually fires (not blocked)
+        // Intercept the PATCH to verify it actually fires (not blocked).
+        // Use a longer timeout (40s) than the shared SLOW_ACTION_TIMEOUT (20s):
+        // the post-modal-teardown PATCH path is genuinely slower than a typical
+        // master-field PATCH because the modal scope's document lock + render
+        // bookkeeping must settle before the master scope can re-acquire and
+        // PATCH. Under cold-container CI conditions this exceeds 20s.
+        // Bumping the shared SLOW_ACTION_TIMEOUT would mask real slow-down
+        // regressions in other tests — keep the override narrow to this step.
         const patchPromise = page.waitForResponse(
           (response) =>
             response.url().includes('/rest/api/window') &&
             response.request().method() === 'PATCH' &&
             response.status() === 200,
-          { timeout: SLOW_ACTION_TIMEOUT }
+          { timeout: 40000 }
         );
 
         await setTextField(page, nameInput, 'Edited On Master After Modal');

--- a/e2e/frontend-webui/tests/spec/patch-response.spec.js
+++ b/e2e/frontend-webui/tests/spec/patch-response.spec.js
@@ -21,6 +21,7 @@ import {
   FRONTEND_BASE_URL,
   SLOW_ACTION_TIMEOUT,
   FAST_ACTION_TIMEOUT,
+  VERY_SLOW_ACTION_TIMEOUT,
 } from '../utils/common';
 
 const TEST_WINDOW_ID = 127;
@@ -533,19 +534,19 @@ test.describe('PATCH Response Handling', () => {
         const nameInput = getNameInput(page);
 
         // Intercept the PATCH to verify it actually fires (not blocked).
-        // Use a longer timeout (40s) than the shared SLOW_ACTION_TIMEOUT (20s):
-        // the post-modal-teardown PATCH path is genuinely slower than a typical
-        // master-field PATCH because the modal scope's document lock + render
-        // bookkeeping must settle before the master scope can re-acquire and
-        // PATCH. Under cold-container CI conditions this exceeds 20s.
-        // Bumping the shared SLOW_ACTION_TIMEOUT would mask real slow-down
-        // regressions in other tests — keep the override narrow to this step.
+        // Use VERY_SLOW_ACTION_TIMEOUT (40s) rather than the shared
+        // SLOW_ACTION_TIMEOUT (20s): the post-modal-teardown PATCH path is
+        // genuinely slower than a typical master-field PATCH because the
+        // modal scope's document lock + render bookkeeping must settle before
+        // the master scope can re-acquire and PATCH. Under cold-container CI
+        // conditions this exceeds 20s. Bumping SLOW_ACTION_TIMEOUT globally
+        // would mask real slow-down regressions in other tests.
         const patchPromise = page.waitForResponse(
           (response) =>
             response.url().includes('/rest/api/window') &&
             response.request().method() === 'PATCH' &&
             response.status() === 200,
-          { timeout: 40000 }
+          { timeout: VERY_SLOW_ACTION_TIMEOUT }
         );
 
         await setTextField(page, nameInput, 'Edited On Master After Modal');


### PR DESCRIPTION
## Why

Targeted fix for a flake observed on the `Modal edit syncs to master, field remains editable after close` test in `e2e/frontend-webui/tests/spec/patch-response.spec.js` (line 456). The test failed 3× on a cold runner with `page.waitForResponse: Timeout 20000ms exceeded`, then passed cleanly in 9.0s on the same shard's automatic retry — classic cold-container slowness signature.

## Root cause

The post-modal-teardown PATCH path is genuinely slower than typical master-field PATCHes because the modal scope's document lock + render bookkeeping must settle before the master scope can re-acquire and PATCH. Under cold-VM / cold-container conditions this exceeds the shared `SLOW_ACTION_TIMEOUT` (20s). Other PATCH assertions in the same file complete well within 20s.

## Fix

Replace `{ timeout: SLOW_ACTION_TIMEOUT }` (20s) with `{ timeout: 40000 }` (40s) for this one `waitForResponse` only, with an inline comment explaining why this assertion needs more headroom than the shared constant.

## What this does NOT do

- **Does not weaken the test.** The PATCH-response assertion itself is unchanged.
- **Does not bump `SLOW_ACTION_TIMEOUT` globally.** The constant is used 30+ times across the spec; a global bump would mask real slow-down regressions in unrelated tests.
- **Does not add `page.waitForLoadState('networkidle')`** as a workaround — networkidle is fragile in Playwright when long-poll / WebSocket endpoints are open.

## Test plan

- [ ] CI green on this PR