### PR TITLE
pick_what_was_scheduled_to_workplace — filterByDocumentNo before startJob in workplace2

### DIFF
--- a/e2e/mobile-webui/tests/spec/picking/pick_what_was_scheduled_to_workplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/pick_what_was_scheduled_to_workplace.spec.js
@@ -170,6 +170,10 @@ test('Pick one sales order to different workplaces', async ({ page }) => {
 
         await ApplicationsListScreen.startPickingApplication();
         await PickingJobsListScreen.waitForScreen();
+        // Filter to SO1.documentNo before startJob — symmetric with workplace1 branch above (line 98).
+        // Without this, the workplace2 launcher list shows every accumulated job from earlier tests
+        // in the suite and the .tap() on the SO1 button races visibility under the 120s test budget.
+        await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
         const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
 
         await PickingJobScreen.waitForScreen();


### PR DESCRIPTION
## Why

`tests/spec/picking/pick_what_was_scheduled_to_workplace.spec.js:82 — "Pick one sales order to different workplaces"` flaked on a recent trunk run with `locator.tap: Test timeout of 120000ms exceeded` at line 173, where workplace2 calls `PickingJobsListScreen.startJob` directly without filtering the launcher list first.

## Root cause

The workplace1 branch above (line 98) does:
```js
await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: ... });
```

The workplace2 branch was missing the `filterByDocumentNo` call. Under mobile-test's sequential execution, by the time workplace2 logs in, the launcher list contains every job accumulated by earlier tests in the suite. `startJob`'s `.tap()` on the SO1 button then races visibility for 120s and times out.

## Fix

One-line symmetric addition — add `filterByDocumentNo` before `startJob` in workplace2 branch, matching workplace1.

## Test plan

- [ ] CI green
- [ ] No regression in workplace1 or workplace2 paths