### PR TITLE
Refactor HU QRCode process: lazy init & params

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/process/M_HU_Report_QRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/process/M_HU_Report_QRCode.java
@@ -1,29 +1,16 @@
 package de.metas.handlingunits.process;
 
-import com.google.common.collect.ImmutableSet;
 import de.metas.global_qrcodes.service.QRCodePDFResource;
-import de.metas.handlingunits.HuId;
-import de.metas.handlingunits.IHandlingUnitsDAO;
-import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
-import de.metas.handlingunits.report.HUToReport;
-import de.metas.handlingunits.report.HUToReportWrapper;
 import de.metas.printing.IMassPrintingService;
 import de.metas.process.AdProcessId;
-import de.metas.process.IProcessPrecondition;
-import de.metas.process.IProcessPreconditionsContext;
 import de.metas.process.JavaProcess;
 import de.metas.process.PInstanceId;
 import de.metas.process.Param;
-import de.metas.process.ProcessPreconditionsResolution;
+import de.metas.process.ProcessInfoParameter;
 import de.metas.process.RunOutOfTrx;
 import de.metas.report.PrintCopies;
-import de.metas.util.Services;
-import lombok.NonNull;
-import org.adempiere.ad.trx.api.ITrx;
-import org.adempiere.exceptions.AdempiereException;
 import org.compiere.SpringContextHolder;
-import org.compiere.util.DB;
 
 /*
  * #%L
@@ -52,33 +39,26 @@ import org.compiere.util.DB;
  * It takes M_HU_IDs from T_Selection, gets/generates QR-Codes for them
  * and then generate the PDF.
  */
-public class M_HU_Report_QRCode extends JavaProcess implements IProcessPrecondition
+public class M_HU_Report_QRCode extends JavaProcess
 {
-	@NonNull
-	private final HUQRCodesService huQRCodesService = SpringContextHolder.instance.getBean(HUQRCodesService.class);
-	@NonNull
-	private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
+	private HUQRCodesService huQRCodesService;
 
 	private static final String PARAM_AD_Process_ID = "AD_Process_ID";
 
 	@Param(parameterName = PARAM_AD_Process_ID)
-	private int p_ProcessId;
+	private int processId;
 
 	@Param(parameterName = "IsPrintPreview")
-	private boolean p_isPrintPreview;
+	private boolean isPrintPreview;
 
 	@Param(parameterName = IMassPrintingService.PARAM_PrintCopies)
 	private int p_PrintCopies;
 
 	@Override
-	public ProcessPreconditionsResolution checkPreconditionsApplicable(final @NonNull IProcessPreconditionsContext context)
+	protected void prepare()
 	{
-		if (context.isNoSelection())
-		{
-			return ProcessPreconditionsResolution.rejectBecauseNoSelection();
-		}
-
-		return ProcessPreconditionsResolution.accept();
+		// Deferred so plain-reflection instantiation during precondition checking does not throw
+		huQRCodesService = SpringContextHolder.instance.getBean(HUQRCodesService.class);
 	}
 
 	@Override
@@ -86,26 +66,24 @@ public class M_HU_Report_QRCode extends JavaProcess implements IProcessPrecondit
 	protected String doIt()
 	{
 		final PInstanceId selectionId = getPinstanceId();
-		final AdProcessId qrCodeProcessId = AdProcessId.ofRepoIdOrNull(p_ProcessId);
+		final AdProcessId qrCodeProcessId = AdProcessId.ofRepoIdOrNull(processId);
 
-		final ImmutableSet<HuId> huIdSet = handlingUnitsDAO.streamByQuery(
-						retrieveSelectedRecordsQueryBuilder(I_M_HU.class, false), HUToReportWrapper::of)
-				.map(HUToReport::getHUId)
-				.collect(ImmutableSet.toImmutableSet());
-
-		if (huIdSet.isEmpty())
-			throw new AdempiereException("No HUs");
-
-		DB.createT_Selection(selectionId, HuId.toRepoIds(huIdSet), ITrx.TRXNAME_None);
-
-		if (p_isPrintPreview)
+		if (getProcessInfo().isPrintPreview())
 		{
 			final QRCodePDFResource pdf = huQRCodesService.createPdfForSelectionOfHUIds(selectionId, qrCodeProcessId);
 			getResult().setReportData(pdf, pdf.getFilename(), pdf.getContentType());
 		}
 		else
 		{
-			huQRCodesService.printForSelectionOfHUIds(selectionId, qrCodeProcessId, PrintCopies.ofIntOrOne(p_PrintCopies));
+			final PrintCopies printCopies = getParameters().stream()
+					.filter(p -> IMassPrintingService.PARAM_PrintCopies.equals(p.getParameterName()))
+					.findFirst()
+					.map(ProcessInfoParameter::getParameterAsInt)
+					.filter(n -> n > 0)
+					.map(PrintCopies::ofInt)
+					.orElse(PrintCopies.ONE);
+
+			huQRCodesService.printForSelectionOfHUIds(selectionId, qrCodeProcessId, printCopies);
 		}
 
 		return MSG_OK;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/process/M_HU_Report_QRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/process/M_HU_Report_QRCode.java
@@ -62,17 +62,20 @@ public class M_HU_Report_QRCode extends JavaProcess
 		}
 		else
 		{
-			final PrintCopies printCopies = getParameters().stream()
-					.filter(processInfoParameter -> IMassPrintingService.PARAM_PrintCopies.equals(processInfoParameter.getParameterName()))
-					.findFirst()
-					.map(ProcessInfoParameter::getParameterAsInt)
-					.filter(nrOfCopies -> nrOfCopies > 0)
-					.map(PrintCopies::ofInt)
-					.orElse(PrintCopies.ONE);
-
-			huQRCodesService.printForSelectionOfHUIds(selectionId, qrCodeProcessId, printCopies);
+			huQRCodesService.printForSelectionOfHUIds(selectionId, qrCodeProcessId, getPrintCopies());
 		}
 
 		return MSG_OK;
+	}
+
+	private PrintCopies getPrintCopies()
+	{
+		return getParameters().stream()
+				.filter(p -> IMassPrintingService.PARAM_PrintCopies.equals(p.getParameterName()))
+				.findFirst()
+				.map(ProcessInfoParameter::getParameterAsInt)
+				.filter(nrOfCopies -> nrOfCopies > 0)
+				.map(PrintCopies::ofInt)
+				.orElse(PrintCopies.ONE);
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/process/M_HU_Report_QRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/process/M_HU_Report_QRCode.java
@@ -48,9 +48,6 @@ public class M_HU_Report_QRCode extends JavaProcess
 	@Param(parameterName = PARAM_AD_Process_ID)
 	private int processId;
 
-	@Param(parameterName = "IsPrintPreview")
-	private boolean isPrintPreview;
-
 	@Override
 	@RunOutOfTrx
 	protected String doIt()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/process/M_HU_Report_QRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/process/M_HU_Report_QRCode.java
@@ -68,6 +68,15 @@ public class M_HU_Report_QRCode extends JavaProcess
 		return MSG_OK;
 	}
 
+	/**
+	 * Reads the print-copies count from the runtime parameters.
+	 *
+	 * <p>Note: PrintCopies is intentionally NOT bound via {@code @Param} because it is NOT a formal
+	 * {@code AD_Process_Para} record in the database. Instead, it is a runtime parameter injected by
+	 * the HU report infrastructure ({@code HUReportProcessInstance.setCopies()}) before the process
+	 * executes. Adding a {@code @Param} binding without a matching {@code AD_Process_Para} would
+	 * cause a silent no-op at injection time and break the copy-count behaviour.
+	 */
 	private PrintCopies getPrintCopies()
 	{
 		return getParameters().stream()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/process/M_HU_Report_QRCode.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/process/M_HU_Report_QRCode.java
@@ -41,7 +41,7 @@ import org.compiere.SpringContextHolder;
  */
 public class M_HU_Report_QRCode extends JavaProcess
 {
-	private HUQRCodesService huQRCodesService;
+	private final HUQRCodesService huQRCodesService = SpringContextHolder.instance.getBean(HUQRCodesService.class);
 
 	private static final String PARAM_AD_Process_ID = "AD_Process_ID";
 
@@ -50,16 +50,6 @@ public class M_HU_Report_QRCode extends JavaProcess
 
 	@Param(parameterName = "IsPrintPreview")
 	private boolean isPrintPreview;
-
-	@Param(parameterName = IMassPrintingService.PARAM_PrintCopies)
-	private int p_PrintCopies;
-
-	@Override
-	protected void prepare()
-	{
-		// Deferred so plain-reflection instantiation during precondition checking does not throw
-		huQRCodesService = SpringContextHolder.instance.getBean(HUQRCodesService.class);
-	}
 
 	@Override
 	@RunOutOfTrx
@@ -76,10 +66,10 @@ public class M_HU_Report_QRCode extends JavaProcess
 		else
 		{
 			final PrintCopies printCopies = getParameters().stream()
-					.filter(p -> IMassPrintingService.PARAM_PrintCopies.equals(p.getParameterName()))
+					.filter(processInfoParameter -> IMassPrintingService.PARAM_PrintCopies.equals(processInfoParameter.getParameterName()))
 					.findFirst()
 					.map(ProcessInfoParameter::getParameterAsInt)
-					.filter(n -> n > 0)
+					.filter(nrOfCopies -> nrOfCopies > 0)
 					.map(PrintCopies::ofInt)
 					.orElse(PrintCopies.ONE);
 

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5804760_sys_M_HU_Report_QRCode_register_in_M_HU_Process.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5804760_sys_M_HU_Report_QRCode_register_in_M_HU_Process.sql
@@ -1,7 +1,8 @@
 -- Register M_HU_Report_QRCode (AD_Process_ID=584980) in M_HU_Process so that
 -- T_Selection is populated when the process runs and HU IDs can be retrieved.
 
-INSERT INTO M_HU_Process (ad_client_id, ad_org_id, ad_process_id, created, createdby, isactive, isapplytolus, isapplytotus, isapplytocus, m_hu_pi_id, m_hu_process_id, updated, updatedby, isprovideasuseraction, isapplytotoplevelhusonly) VALUES (0, 0, 584980/*From ID Server*/, '2022-02-10 17:33:55.000000 +01:00', 100, 'Y', 'Y', 'Y', 'Y', null, 540019/*From ID Server*/, '2022-02-10 18:53:24.000000 +01:00', 100, 'Y', 'N');
+INSERT INTO M_HU_Process (ad_client_id, ad_org_id, ad_process_id, created, createdby, isactive, isapplytolus, isapplytotus, isapplytocus, m_hu_pi_id, m_hu_process_id, updated, updatedby, isprovideasuseraction, isapplytotoplevelhusonly) VALUES (0, 0, 584980/*From ID Server*/, '2022-02-10 17:33:55.000000 +01:00', 100, 'Y', 'Y', 'Y', 'Y', null, 540019/*From ID Server*/, '2022-02-10 18:53:24.000000 +01:00', 100, 'Y', 'N')
+ON CONFLICT (m_hu_process_id) DO NOTHING;
 
 -- delete the process from AD_Table_Process because is registered in M_HU_Process
 delete from AD_Table_Process where ad_process_id = 584980/*From ID Server*/;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5804760_sys_M_HU_Report_QRCode_register_in_M_HU_Process.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5804760_sys_M_HU_Report_QRCode_register_in_M_HU_Process.sql
@@ -3,6 +3,8 @@
 
 INSERT INTO m_hu_process (ad_client_id, ad_org_id, ad_process_id, created, createdby, isactive, isapplytolus, isapplytotus, isapplytocus, m_hu_pi_id, m_hu_process_id, updated, updatedby, isprovideasuseraction, isapplytotoplevelhusonly) VALUES (0, 0, 584980, '2022-02-10 17:33:55.000000 +01:00', 100, 'Y', 'Y', 'Y', 'Y', null, 540019, '2022-02-10 18:53:24.000000 +01:00', 100, 'Y', 'N');
 
+-- delete the process from AD_Table_Process because is registered in M_HU_Process
 delete from AD_Table_Process  where ad_process_id = 584980;
 
+-- delete copy parameter from AD_Process_Para because is registered in M_HU_Process
 delete from ad_process_para where ad_process_para_id = 543183;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5804760_sys_M_HU_Report_QRCode_register_in_M_HU_Process.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5804760_sys_M_HU_Report_QRCode_register_in_M_HU_Process.sql
@@ -2,3 +2,7 @@
 -- T_Selection is populated when the process runs and HU IDs can be retrieved.
 
 INSERT INTO m_hu_process (ad_client_id, ad_org_id, ad_process_id, created, createdby, isactive, isapplytolus, isapplytotus, isapplytocus, m_hu_pi_id, m_hu_process_id, updated, updatedby, isprovideasuseraction, isapplytotoplevelhusonly) VALUES (0, 0, 584980, '2022-02-10 17:33:55.000000 +01:00', 100, 'Y', 'Y', 'Y', 'Y', null, 540019, '2022-02-10 18:53:24.000000 +01:00', 100, 'Y', 'N');
+
+delete from AD_Table_Process  where ad_process_id = 584980;
+
+delete from ad_process_para where ad_process_para_id = 543183;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5804760_sys_M_HU_Report_QRCode_register_in_M_HU_Process.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5804760_sys_M_HU_Report_QRCode_register_in_M_HU_Process.sql
@@ -1,0 +1,4 @@
+-- Register M_HU_Report_QRCode (AD_Process_ID=584980) in M_HU_Process so that
+-- T_Selection is populated when the process runs and HU IDs can be retrieved.
+
+INSERT INTO m_hu_process (ad_client_id, ad_org_id, ad_process_id, created, createdby, isactive, isapplytolus, isapplytotus, isapplytocus, m_hu_pi_id, m_hu_process_id, updated, updatedby, isprovideasuseraction, isapplytotoplevelhusonly) VALUES (0, 0, 584980, '2022-02-10 17:33:55.000000 +01:00', 100, 'Y', 'Y', 'Y', 'Y', null, 540019, '2022-02-10 18:53:24.000000 +01:00', 100, 'Y', 'N');

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5804760_sys_M_HU_Report_QRCode_register_in_M_HU_Process.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5804760_sys_M_HU_Report_QRCode_register_in_M_HU_Process.sql
@@ -1,10 +1,11 @@
 -- Register M_HU_Report_QRCode (AD_Process_ID=584980) in M_HU_Process so that
 -- T_Selection is populated when the process runs and HU IDs can be retrieved.
 
-INSERT INTO m_hu_process (ad_client_id, ad_org_id, ad_process_id, created, createdby, isactive, isapplytolus, isapplytotus, isapplytocus, m_hu_pi_id, m_hu_process_id, updated, updatedby, isprovideasuseraction, isapplytotoplevelhusonly) VALUES (0, 0, 584980, '2022-02-10 17:33:55.000000 +01:00', 100, 'Y', 'Y', 'Y', 'Y', null, 540019, '2022-02-10 18:53:24.000000 +01:00', 100, 'Y', 'N');
+INSERT INTO M_HU_Process (ad_client_id, ad_org_id, ad_process_id, created, createdby, isactive, isapplytolus, isapplytotus, isapplytocus, m_hu_pi_id, m_hu_process_id, updated, updatedby, isprovideasuseraction, isapplytotoplevelhusonly) VALUES (0, 0, 584980/*From ID Server*/, '2022-02-10 17:33:55.000000 +01:00', 100, 'Y', 'Y', 'Y', 'Y', null, 540019/*From ID Server*/, '2022-02-10 18:53:24.000000 +01:00', 100, 'Y', 'N');
 
 -- delete the process from AD_Table_Process because is registered in M_HU_Process
-delete from AD_Table_Process  where ad_process_id = 584980;
+delete from AD_Table_Process where ad_process_id = 584980/*From ID Server*/;
 
 -- delete copy parameter from AD_Process_Para because is registered in M_HU_Process
-delete from ad_process_para where ad_process_para_id = 543183;
+delete from AD_Process_Para where ad_process_para_id = 543183/*From ID Server*/;
+

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstance.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstance.java
@@ -2,13 +2,18 @@ package de.metas.ui.web.handlingunits.report;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.HuUnitType;
+import de.metas.handlingunits.IHandlingUnitsDAO;
+import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
 import de.metas.handlingunits.report.HUReportExecutor;
 import de.metas.handlingunits.report.HUReportExecutorResult;
 import de.metas.handlingunits.report.HUToReport;
+import de.metas.handlingunits.report.HUToReportWrapper;
 import de.metas.process.AdProcessId;
 import de.metas.report.PrintCopies;
+import de.metas.util.Services;
 import de.metas.ui.web.process.IProcessInstanceController;
 import de.metas.ui.web.process.IProcessInstanceParameter;
 import de.metas.ui.web.process.ProcessExecutionContext;
@@ -75,7 +80,10 @@ final class HUReportProcessInstance implements IProcessInstanceController
 	public static final String PARAM_IsPrintPreview = "IsPrintPreview";
 
 	private final DocumentId instanceId;
+	/** Non-null when launched from a grid/HU-editor view. Null when launched from a single-document (detail) view. */
 	private final ViewRowIdsSelection viewRowIdsSelection;
+	/** Non-null when launched from a single-document (detail) view. Null when launched from a grid view. */
+	private final HuId singleHuId;
 	private final AdProcessId reportAdProcessId;
 	private final Document parameters;
 	@Getter
@@ -88,12 +96,19 @@ final class HUReportProcessInstance implements IProcessInstanceController
 	@Builder
 	private HUReportProcessInstance(
 			@NonNull final DocumentId instanceId,
-			@NonNull final ViewRowIdsSelection viewRowIdsSelection,
+			final ViewRowIdsSelection viewRowIdsSelection,
+			final HuId singleHuId,
 			@NonNull final AdProcessId reportAdProcessId,
 			@NonNull final Document parameters)
 	{
+		if (viewRowIdsSelection == null && singleHuId == null)
+		{
+			throw new IllegalArgumentException("Either viewRowIdsSelection or singleHuId must be non-null");
+		}
+
 		this.instanceId = instanceId;
 		this.viewRowIdsSelection = viewRowIdsSelection;
+		this.singleHuId = singleHuId;
 		this.reportAdProcessId = reportAdProcessId;
 		this.parameters = parameters;
 		this.startProcessDirectly = parameters.getFieldNames().isEmpty();
@@ -110,6 +125,7 @@ final class HUReportProcessInstance implements IProcessInstanceController
 	{
 		instanceId = from.instanceId;
 		viewRowIdsSelection = from.viewRowIdsSelection;
+		singleHuId = from.singleHuId;
 		reportAdProcessId = from.reportAdProcessId;
 		parameters = from.parameters.copy(copyMode, changesCollector);
 		startProcessDirectly = from.startProcessDirectly;
@@ -161,13 +177,25 @@ final class HUReportProcessInstance implements IProcessInstanceController
 		final IViewsRepository viewsRepo = context.getViewsRepo();
 		final DocumentCollection documentsCollection = context.getDocumentsCollection();
 
-		final ViewId viewId = viewRowIdsSelection.getViewId();
-		final HUReportAwareView view = HUReportAwareViews.cast(viewsRepo.getView(viewId));
+		final ViewId viewId;
+		final List<HUToReport> husToReport;
+		if (viewRowIdsSelection != null)
+		{
+			viewId = viewRowIdsSelection.getViewId();
+			final HUReportAwareView view = HUReportAwareViews.cast(viewsRepo.getView(viewId));
+			husToReport = extractHUsToReportFromView(view);
+		}
+		else
+		{
+			viewId = null;
+			husToReport = extractHUsToReportForSingleHu(singleHuId);
+		}
+
 		final HUReportExecutorResult reportExecutorResult = HUReportExecutor.newInstance(context.getCtx())
 				.numberOfCopies(numberOfCopies)
 				.adJasperProcessId(getJasperProcess_ID())
 				.printPreview(isPrintPreview())
-				.executeNow(reportAdProcessId, extractHUsToReport(view));
+				.executeNow(reportAdProcessId, husToReport);
 
 		final ADProcessPostProcessService postProcessService = ADProcessPostProcessService.builder()
 				.viewsRepo(viewsRepo)
@@ -183,7 +211,7 @@ final class HUReportProcessInstance implements IProcessInstanceController
 		return lastExecutionResult = result;
 	}
 
-	private List<HUToReport> extractHUsToReport(final HUReportAwareView view)
+	private List<HUToReport> extractHUsToReportFromView(final HUReportAwareView view)
 	{
 		final Set<HUToReport> husToCheck = view.streamByIds(viewRowIdsSelection.getRowIds())
 				.map(HUReportAwareViewRowAsHUToReport::ofOrNull)
@@ -191,6 +219,13 @@ final class HUReportProcessInstance implements IProcessInstanceController
 				.collect(ImmutableSet.toImmutableSet());
 
 		return getHUsToProcess(husToCheck);
+	}
+
+	private static List<HUToReport> extractHUsToReportForSingleHu(@NonNull final HuId huId)
+	{
+		final I_M_HU hu = Services.get(IHandlingUnitsDAO.class).getById(huId);
+		final HUToReport huToReport = HUToReportWrapper.of(hu);
+		return getHUsToProcess(ImmutableSet.of(huToReport));
 	}
 
 	private static List<HUToReport> getHUsToProcess(@NonNull final Set<HUToReport> husToCheck)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstance.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstance.java
@@ -108,6 +108,10 @@ final class HUReportProcessInstance implements IProcessInstanceController
 		{
 			throw new AdempiereException("Either viewRowIdsSelection or singleHuId must be non-null");
 		}
+		if (viewRowIdsSelection != null && singleHuId != null)
+		{
+			throw new AdempiereException("viewRowIdsSelection and singleHuId are mutually exclusive; exactly one must be non-null");
+		}
 
 		this.instanceId = instanceId;
 		this.viewRowIdsSelection = viewRowIdsSelection;
@@ -191,7 +195,8 @@ final class HUReportProcessInstance implements IProcessInstanceController
 		else
 		{
 			viewId = null;
-			husToReport = extractHUsToReportForSingleHu(singleHuId);
+			// Constructor invariant: if viewRowIdsSelection == null then singleHuId != null
+			husToReport = extractHUsToReportForSingleHu(Objects.requireNonNull(singleHuId, "singleHuId"));
 		}
 
 		final HUReportExecutorResult reportExecutorResult = HUReportExecutor.newInstance(context.getCtx())

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstance.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstance.java
@@ -6,6 +6,7 @@ import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.HuUnitType;
 import de.metas.handlingunits.IHandlingUnitsDAO;
 import de.metas.handlingunits.model.I_M_HU;
+import javax.annotation.Nullable;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
 import de.metas.handlingunits.report.HUReportExecutor;
 import de.metas.handlingunits.report.HUReportExecutorResult;
@@ -79,11 +80,13 @@ final class HUReportProcessInstance implements IProcessInstanceController
 	public static final String PARAM_AD_Process_ID = "AD_Process_ID";
 	public static final String PARAM_IsPrintPreview = "IsPrintPreview";
 
+	@NonNull private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
+
 	private final DocumentId instanceId;
 	/** Non-null when launched from a grid/HU-editor view. Null when launched from a single-document (detail) view. */
-	private final ViewRowIdsSelection viewRowIdsSelection;
+	@Nullable private final ViewRowIdsSelection viewRowIdsSelection;
 	/** Non-null when launched from a single-document (detail) view. Null when launched from a grid view. */
-	private final HuId singleHuId;
+	@Nullable private final HuId singleHuId;
 	private final AdProcessId reportAdProcessId;
 	private final Document parameters;
 	@Getter
@@ -103,7 +106,7 @@ final class HUReportProcessInstance implements IProcessInstanceController
 	{
 		if (viewRowIdsSelection == null && singleHuId == null)
 		{
-			throw new IllegalArgumentException("Either viewRowIdsSelection or singleHuId must be non-null");
+			throw new AdempiereException("Either viewRowIdsSelection or singleHuId must be non-null");
 		}
 
 		this.instanceId = instanceId;
@@ -221,9 +224,9 @@ final class HUReportProcessInstance implements IProcessInstanceController
 		return getHUsToProcess(husToCheck);
 	}
 
-	private static List<HUToReport> extractHUsToReportForSingleHu(@NonNull final HuId huId)
+	private List<HUToReport> extractHUsToReportForSingleHu(@NonNull final HuId huId)
 	{
-		final I_M_HU hu = Services.get(IHandlingUnitsDAO.class).getById(huId);
+		final I_M_HU hu = handlingUnitsDAO.getById(huId);
 		final HUToReport huToReport = HUToReportWrapper.of(hu);
 		return getHUsToProcess(ImmutableSet.of(huToReport));
 	}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstancesRepository.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstancesRepository.java
@@ -99,6 +99,7 @@ public class HUReportProcessInstancesRepository implements IProcessInstancesRepo
 			.build();
 
 	private final ADProcessInstancesRepository processInstancesRepository;
+	@NonNull private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
 
 	public HUReportProcessInstancesRepository(@NonNull final ADProcessInstancesRepository processInstancesRepository)
 	{
@@ -214,6 +215,10 @@ public class HUReportProcessInstancesRepository implements IProcessInstancesRepo
 		if (preconditionsContext instanceof DocumentPreconditionsAsContext)
 		{
 			final DocumentPreconditionsAsContext documentContext = (DocumentPreconditionsAsContext) preconditionsContext;
+			if (!documentContext.isConsiderTableRelatedProcessDescriptors(PROCESS_HANDLER_TYPE))
+			{
+				return Stream.empty();
+			}
 			if (I_M_HU.Table_Name.equals(documentContext.getTableName()))
 			{
 				final I_M_HU hu = documentContext.getSelectedModel(I_M_HU.class);
@@ -238,9 +243,8 @@ public class HUReportProcessInstancesRepository implements IProcessInstancesRepo
 	 * Returns {@code null} for unknown/degenerate HU types (processes should not be shown for them).
 	 */
 	@Nullable
-	private static HuUnitType resolveHUUnitType(@NonNull final I_M_HU hu)
+	private HuUnitType resolveHUUnitType(@NonNull final I_M_HU hu)
 	{
-		final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
 		if (handlingUnitsBL.isLoadingUnit(hu))
 		{
 			return HuUnitType.LU;

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstancesRepository.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstancesRepository.java
@@ -17,8 +17,11 @@ import de.metas.process.AdProcessId;
 import de.metas.process.IADProcessDAO;
 import de.metas.ui.web.exceptions.EntityNotFoundException;
 import de.metas.handlingunits.HuId;
+import de.metas.util.Check;
+import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.ui.web.process.CreateProcessInstanceRequest;
+import de.metas.ui.web.window.datatypes.DocumentPath;
 import de.metas.ui.web.process.DocumentPreconditionsAsContext;
 import de.metas.ui.web.process.IProcessInstanceController;
 import de.metas.ui.web.process.IProcessInstancesRepository;
@@ -44,6 +47,7 @@ import de.metas.ui.web.window.model.Document;
 import de.metas.ui.web.window.model.IDocumentChangesCollector;
 import de.metas.util.Services;
 import lombok.NonNull;
+import javax.annotation.Nullable;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.IAutoCloseable;
 import org.compiere.model.I_AD_Process;
@@ -211,14 +215,47 @@ public class HUReportProcessInstancesRepository implements IProcessInstancesRepo
 			final DocumentPreconditionsAsContext documentContext = (DocumentPreconditionsAsContext) preconditionsContext;
 			if (I_M_HU.Table_Name.equals(documentContext.getTableName()))
 			{
+				final I_M_HU hu = documentContext.getSelectedModel(I_M_HU.class);
+				final HuUnitType huUnitType = resolveHUUnitType(hu);
+				if (huUnitType == null)
+				{
+					return Stream.empty();
+				}
 				return getIndexedWebuiHUProcessDescriptors()
 						.getAll()
 						.stream()
+						.filter(descriptor -> descriptor.appliesToHUUnitType(huUnitType))
 						.map(WebuiHUProcessDescriptor::toWebuiRelatedProcessDescriptorForSingleDocument);
 			}
 		}
 
 		return Stream.empty();
+	}
+
+	/**
+	 * Resolves the {@link HuUnitType} for the given HU.
+	 * Returns {@code null} for unknown/degenerate HU types (processes should not be shown for them).
+	 */
+	@Nullable
+	private static HuUnitType resolveHUUnitType(@NonNull final I_M_HU hu)
+	{
+		final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
+		if (handlingUnitsBL.isLoadingUnit(hu))
+		{
+			return HuUnitType.LU;
+		}
+		else if (handlingUnitsBL.isTransportUnitOrAggregate(hu))
+		{
+			return HuUnitType.TU;
+		}
+		else if (handlingUnitsBL.isVirtual(hu))
+		{
+			return HuUnitType.VHU;
+		}
+		else
+		{
+			return null; // unknown/degenerate HU type — show no processes
+		}
 	}
 
 	private boolean checkApplies(final WebuiHUProcessDescriptor descriptor, @NonNull final ViewAsPreconditionsContext viewContext)
@@ -278,9 +315,11 @@ public class HUReportProcessInstancesRepository implements IProcessInstancesRepo
 		if (viewRowIdsSelection == null)
 		{
 			// Launched from a single-document (detail) view — resolve the HU ID from the document path
-			singleHuId = request.getSingleDocumentPath() != null
-					? HuId.ofRepoId(request.getSingleDocumentPath().getDocumentId().toInt())
-					: null;
+			final DocumentPath singleDocumentPath = Check.assumeNotNull(
+					request.getSingleDocumentPath(),
+					"singleDocumentPath shall be set when viewRowIdsSelection is null; request={}",
+					request);
+			singleHuId = HuId.ofRepoId(singleDocumentPath.getDocumentId().toInt());
 		}
 		else
 		{

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstancesRepository.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstancesRepository.java
@@ -16,7 +16,9 @@ import de.metas.i18n.ITranslatableString;
 import de.metas.process.AdProcessId;
 import de.metas.process.IADProcessDAO;
 import de.metas.ui.web.exceptions.EntityNotFoundException;
+import de.metas.handlingunits.model.I_M_HU;
 import de.metas.ui.web.process.CreateProcessInstanceRequest;
+import de.metas.ui.web.process.DocumentPreconditionsAsContext;
 import de.metas.ui.web.process.IProcessInstanceController;
 import de.metas.ui.web.process.IProcessInstancesRepository;
 import de.metas.ui.web.process.ProcessHandlerType;
@@ -182,31 +184,40 @@ public class HUReportProcessInstancesRepository implements IProcessInstancesRepo
 	public Stream<WebuiRelatedProcessDescriptor> streamDocumentRelatedProcesses(final WebuiPreconditionsContext preconditionsContext)
 	{
 		final ViewAsPreconditionsContext viewContext = ViewAsPreconditionsContext.castOrNull(preconditionsContext);
-		if (viewContext == null)
+		if (viewContext != null)
 		{
-			return Stream.empty();
+			if (viewContext.isNoSelection())
+			{
+				return Stream.empty();
+			}
+			if (!HUReportAwareViews.isHUReportAwareView(viewContext.getView()))
+			{
+				return Stream.empty();
+			}
+			if (!viewContext.isConsiderTableRelatedProcessDescriptors(PROCESS_HANDLER_TYPE))
+			{
+				return Stream.empty();
+			}
+			return getIndexedWebuiHUProcessDescriptors()
+					.getAll()
+					.stream()
+					.filter(descriptor -> checkApplies(descriptor, viewContext))
+					.map(WebuiHUProcessDescriptor::toWebuiRelatedProcessDescriptor);
 		}
 
-		if (viewContext.isNoSelection())
+		if (preconditionsContext instanceof DocumentPreconditionsAsContext)
 		{
-			return Stream.empty();
+			final DocumentPreconditionsAsContext documentContext = (DocumentPreconditionsAsContext) preconditionsContext;
+			if (I_M_HU.Table_Name.equals(documentContext.getTableName()))
+			{
+				return getIndexedWebuiHUProcessDescriptors()
+						.getAll()
+						.stream()
+						.map(WebuiHUProcessDescriptor::toWebuiRelatedProcessDescriptorForSingleDocument);
+			}
 		}
 
-		if (!HUReportAwareViews.isHUReportAwareView(viewContext.getView()))
-		{
-			return Stream.empty();
-		}
-
-		if (!viewContext.isConsiderTableRelatedProcessDescriptors(PROCESS_HANDLER_TYPE))
-		{
-			return Stream.empty();
-		}
-
-		return getIndexedWebuiHUProcessDescriptors()
-				.getAll()
-				.stream()
-				.filter(descriptor -> checkApplies(descriptor, viewContext))
-				.map(WebuiHUProcessDescriptor::toWebuiRelatedProcessDescriptor);
+		return Stream.empty();
 	}
 
 	private boolean checkApplies(final WebuiHUProcessDescriptor descriptor, @NonNull final ViewAsPreconditionsContext viewContext)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstancesRepository.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstancesRepository.java
@@ -16,6 +16,7 @@ import de.metas.i18n.ITranslatableString;
 import de.metas.process.AdProcessId;
 import de.metas.process.IADProcessDAO;
 import de.metas.ui.web.exceptions.EntityNotFoundException;
+import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.ui.web.process.CreateProcessInstanceRequest;
 import de.metas.ui.web.process.DocumentPreconditionsAsContext;
@@ -272,9 +273,24 @@ public class HUReportProcessInstancesRepository implements IProcessInstancesRepo
 		final Document parameters = Document.builder(descriptor.getParametersDescriptor())
 				.initializeAsNewDocument(instanceId, /* version */"0");
 
+		final ViewRowIdsSelection viewRowIdsSelection = request.getViewRowIdsSelection();
+		final HuId singleHuId;
+		if (viewRowIdsSelection == null)
+		{
+			// Launched from a single-document (detail) view — resolve the HU ID from the document path
+			singleHuId = request.getSingleDocumentPath() != null
+					? HuId.ofRepoId(request.getSingleDocumentPath().getDocumentId().toInt())
+					: null;
+		}
+		else
+		{
+			singleHuId = null;
+		}
+
 		final HUReportProcessInstance instance = HUReportProcessInstance.builder()
 				.instanceId(instanceId)
-				.viewRowIdsSelection(request.getViewRowIdsSelection())
+				.viewRowIdsSelection(viewRowIdsSelection)
+				.singleHuId(singleHuId)
 				.reportAdProcessId(descriptor.getReportAdProcessId())
 				.parameters(parameters)
 				.build();

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstancesRepository.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstancesRepository.java
@@ -17,6 +17,7 @@ import de.metas.process.AdProcessId;
 import de.metas.process.IADProcessDAO;
 import de.metas.ui.web.exceptions.EntityNotFoundException;
 import de.metas.handlingunits.HuId;
+import de.metas.ui.web.view.ViewRowIdsSelection;
 import de.metas.util.Check;
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.model.I_M_HU;

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstancesRepository.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/HUReportProcessInstancesRepository.java
@@ -324,7 +324,7 @@ public class HUReportProcessInstancesRepository implements IProcessInstancesRepo
 					request.getSingleDocumentPath(),
 					"singleDocumentPath shall be set when viewRowIdsSelection is null; request={}",
 					request);
-			singleHuId = HuId.ofRepoId(singleDocumentPath.getDocumentId().toInt());
+			singleHuId = HuId.ofRepoId(singleDocumentPath.getDocumentId().toInt()); // M_HU always uses integer-based DocumentIds
 		}
 		else
 		{

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/WebuiHUProcessDescriptor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/report/WebuiHUProcessDescriptor.java
@@ -78,6 +78,18 @@ class WebuiHUProcessDescriptor
 				.build();
 	}
 
+	public WebuiRelatedProcessDescriptor toWebuiRelatedProcessDescriptorForSingleDocument()
+	{
+		return WebuiRelatedProcessDescriptor.builder()
+				.processId(processDescriptor.getProcessId())
+				.internalName(processDescriptor.getInternalName())
+				.processCaption(processDescriptor.getCaption())
+				.processDescription(processDescriptor.getDescription())
+				.displayPlace(DisplayPlace.SingleDocumentActionsMenu)
+				.preconditionsResolutionSupplier(ProcessPreconditionsResolution::accept)
+				.build();
+	}
+
 	public boolean appliesToHUUnitType(final HuUnitType huUnitType)
 	{
 		return huProcessDescriptor.appliesToHUUnitType(huUnitType);


### PR DESCRIPTION
Fix NPE when running M_HU_Report_QRCode from single-document view + minor cleanup


**Changes:**

- `HUReportProcessInstance`: add `singleHuId` field alongside `viewRowIdsSelection`; `startProcess()` now branches — grid path uses the view, single-document path loads the HU directly via `IHandlingUnitsDAO` + `HUToReportWrapper`
- `HUReportProcessInstancesRepository`: route `createNewProcessInstance()` to set `singleHuId` from `singleDocumentPath` when no view selection is present; `streamDocumentRelatedProcesses()` now filters by HU unit type for single-document context (mirrors the existing grid filtering)
- `WebuiHUProcessDescriptor`: add `toWebuiRelatedProcessDescriptorForSingleDocument()` for `DisplayPlace.SingleDocumentActionsMenu`
- `M_HU_Report_QRCode`: simplify `doIt()` — extract `getPrintCopies()` helper, remove dead field `p_isPrintPreview`, use `getProcessInfo().isPrintPreview()`
- SQL: register process in `M_HU_Process` so `T_Selection` is populated at execution time
