### PR TITLE
CostPrice: render single stable input — fix Tab-after-edit focus race in advanced edit

### DIFF
--- a/frontend/src/components/widget/CostPrice.js
+++ b/frontend/src/components/widget/CostPrice.js
@@ -8,21 +8,19 @@ export default class CostPrice extends PureComponent {
   constructor(props) {
     super(props);
     this.inputRef = React.createRef();
-    this.state = { editMode: false };
   }
 
   handleBlur = (e) => {
     const { onBlur } = this.props;
-    this.setState({ editMode: false });
     onBlur?.(e);
   };
 
   focus = () => {
     const { onFocus } = this.props;
-    this.setState({ editMode: true }, () => {
+    if (this.inputRef.current) {
       this.inputRef.current.focus();
-      onFocus?.();
-    });
+    }
+    onFocus?.();
   };
 
   render() {
@@ -37,43 +35,43 @@ export default class CostPrice extends PureComponent {
       value,
       precision,
     } = this.props;
-    const { onChange, onFocus, onKeyDown } = this.props;
-    const { editMode } = this.state;
+    const { onChange, onKeyDown } = this.props;
 
-    if (!editMode) {
-      return (
-        <input
-          className={cx(
-            className,
-            'input-field js-input-field',
-            rank ? `input-${rank}` : null
-          )}
-          type={'text'}
-          value={fieldValueToString({ fieldValue: value, precision })}
-          onChange={() => false}
-          onFocus={this.focus}
-        />
-      );
-    } else {
-      return (
-        <input
-          ref={this.inputRef}
-          type={'number'}
-          value={value}
-          autoComplete={autoComplete}
-          className={cx(className, rank ? `input-${rank}` : null)}
-          disabled={disabled}
-          placeholder={placeholder}
-          tabIndex={tabIndex}
-          title={title}
-          //
-          onChange={onChange}
-          onFocus={onFocus}
-          onBlur={this.handleBlur}
-          onKeyDown={onKeyDown}
-        />
-      );
-    }
+    // me03#27080 follow-up: previously this component swapped between a
+    // display <input type="text"> (formatted value, no real editing) and
+    // an edit <input type="number"> (real editing), toggled via an
+    // `editMode` state on focus/blur. The swap unmounted the focused
+    // input mid-Tab during PATCH-triggered re-renders, dropping focus
+    // to <body> and triggering the modal-wrapper safety net to grab
+    // focus into a tabindex=-1 scroll container (arrow-key scrolling
+    // instead of next-field navigation). We now render a single stable
+    // <input> at all times — never reconciled out from under the user.
+    // type="text" with inputMode="decimal" preserves the formatted value
+    // (so monetary trailing zeros render as "19.00", not "19" like a
+    // type="number" input would normalise), and on mobile still triggers
+    // the decimal numeric keyboard. ArrowUp / ArrowDown PATCH semantics
+    // continue to work because they are intercepted by
+    // RawWidget.handleKeyDown for the NumberWidgets list (CostPrice is
+    // in that list).
+    return (
+      <input
+        ref={this.inputRef}
+        type="text"
+        inputMode="decimal"
+        value={fieldValueToString({ fieldValue: value, precision })}
+        autoComplete={autoComplete}
+        className={cx(className, rank ? `input-${rank}` : null)}
+        disabled={disabled}
+        placeholder={placeholder}
+        tabIndex={tabIndex}
+        title={title}
+        //
+        onChange={onChange}
+        onFocus={this.focus}
+        onBlur={this.handleBlur}
+        onKeyDown={onKeyDown}
+      />
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/metasfresh/me03/issues/27080. In the advanced-edit modal, after changing a CostPrice/Number field's value and pressing Tab, focus would land on the modal's `panel-modal-content` scroll container (tabindex=-1) instead of the next form field. Pressing Up/Down arrows then scrolled the panel up/down instead of navigating fields. Reproduced reliably on Purchase Invoice line Price.

## Root cause

`frontend/src/components/widget/CostPrice.js` rendered two different `<input>` elements based on internal `editMode` state — a display `<input type="text">` (formatted value, no real editing) and an edit `<input type="number">` (real editing), toggled on focus/blur. When the user Tabbed off a changed price field, `handleBlur` set `editMode=false`; React reconciled the edit input out and replaced it with the display input while the browser was still mid-flight on its Tab default action. The focused element disappeared → focus dropped to `<body>`. The modal-wrapper safety-net ref callback in `Modal.js` (added in https://github.com/metasfresh/me03/issues/27080) then grabbed focus into the panel scroll container, producing the arrow-key-scrolls-panel symptom.

## Fix

Render a single stable `<input>` at all times — never reconciled out from under the user. `type="text"` with `inputMode="decimal"` preserves the formatted value (so monetary fields still render trailing zeros like `19.00`, which `type="number"` would normalise to `19`) and on mobile still triggers the decimal numeric keyboard. ArrowUp/ArrowDown PATCH semantics for number widgets are unaffected — they are intercepted by `RawWidget.handleKeyDown` for the NumberWidgets list (which includes CostPrice).

## Verification

Verified via playwright instrumentation against the deployed inner_silence hotfix instance at https://ipshotfix.modan.ch/window/541531/1079979 line 10:

- **Before fix**: focus after Tab on changed Price landed on `.panel-modal-content` (`tabindex=-1` scroll container). \`__focusCalls\` log captured the wrapper-ref grab at t≈548ms with \`activeBefore: { tag: BODY }\`.
- **After fix**: focus after Tab on changed Price lands on the **Activity** lookup dropdown — the next focusable field (Unit Price is read-only and naturally skipped by browser tab order). No wrapper grab fires.

Existing widget Jest test suites (20 files, 101 tests) still pass. Full frontend Jest suite (66 suites, 350 tests) passes. Lint clean.

## Test plan

- [ ] Open a draft (or cloned) Purchase Invoice.
- [ ] On a line, press \`ALT+E\` to open the advanced-edit modal.
- [ ] Tab through fields until focus is on **Price**.
- [ ] Change the price value.
- [ ] Press Tab → focus lands on **Activity** (next field), NOT on the panel.
- [ ] Pressing Up/Down does NOT scroll the panel.
- [ ] Repeat the price change a second time → still works (regression for the "subsequent attempts" path the user already had working).
- [ ] Test that monetary fields still render with trailing zeros (\`19.00\`, not \`19\`).
- [ ] Smoke test: ALT+E modal opens with focus on first field (no regression of #27080 initial-focus fix).
- [ ] Sanity check: other windows that use Number/CostPrice widgets (e.g., Sales Order line) still behave normally.