### PR TITLE
cucumber: combined rabbitMQ drain step — replace material-only with material+async chain

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java
@@ -109,6 +109,27 @@ public class RabbitMQ_StepDef
 		waitEmptyQueueByTopic(AsyncBatchQueueConfiguration.EVENTBUS_TOPIC.getName());
 	}
 
+	/**
+	 * Drains the material event queue first, then the async batch queue.
+	 *
+	 * <p>The ordering is intentional: a test action (e.g. order completion) publishes
+	 * {@link MaterialEventsQueueConfiguration} events first, whose listeners enqueue async
+	 * workpackages on {@link AsyncBatchQueueConfiguration}. Draining async alone would race
+	 * with material events still in flight — async could be empty simply because the
+	 * upstream material side hasn't been processed yet. Draining material then async
+	 * guarantees the chain has fully settled before the next assertion.
+	 *
+	 * <p>This is the preferred drain step for new scenarios. Prefer it over the individual
+	 * {@code wait until de.metas.material …} and {@code wait until de.metas.async …}
+	 * steps unless a scenario specifically needs to assert state between the two stages.
+	 */
+	@And("wait until all rabbitMQ queues are empty or throw exception after 5 minutes")
+	public void wait_empty_all_queues() throws InterruptedException
+	{
+		waitEmptyQueueByTopic(MaterialEventsQueueConfiguration.EVENTBUS_TOPIC.getName());
+		waitEmptyQueueByTopic(AsyncBatchQueueConfiguration.EVENTBUS_TOPIC.getName());
+	}
+
 	@Given("rabbitMQ queue is created")
 	public void create_queue(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/attributes/huWeightAttributesFromProductMaster.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/attributes/huWeightAttributesFromProductMaster.feature
@@ -149,7 +149,7 @@ Feature: HU weight attributes are derived from product master Net + Gross
     # transfer pairs. Both pairs of transfer trx_lines carry vhu_item_id on both sides, so the listener's
     # counterpart-VHU guard skips them. WeightTareDeltaTransferStrategy is also called by HULoader.transferAttributes
     # but skips via its source-tare guard because source tare is zero. Tare stays at 0.450.
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And create material receipt
       | M_HU_ID | M_ReceiptSchedule_ID | M_InOut_ID |
       | lu      | rs                   | receipt    |
@@ -256,7 +256,7 @@ Feature: HU weight attributes are derived from product master Net + Gross
       | lu      | WeightTare           | 0.450       |
       | lu      | WeightGross          | 18.450      |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And create material receipt
       | M_HU_ID | M_ReceiptSchedule_ID | M_InOut_ID |
       | lu      | rs                   | receipt    |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/average_po/reverseMaterialReceipt.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/average_po/reverseMaterialReceipt.feature
@@ -94,7 +94,7 @@ Feature: Average PO - Check costing when reversing a material receipt
       | M_HU_LUTU_Configuration_ID.Identifier | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier | OPT.M_LU_HU_PI_ID.Identifier |
       | huLuTuConfig                          | hu1                | rs1                             | N               | 1     | N               | 1     | N               | 10          | 101                                | 1000006                      |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And create material receipt
       | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
       | hu1                | rs1                             | receipt1              |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/createProductionOrder.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/createProductionOrder.feature
@@ -193,7 +193,7 @@ Feature: create production order
       | oc_1       | false     | p_1          | bom_1             | ppln_1                 | 540006        | 10 PCE     | 10 PCE       | 0 PCE        | 2021-04-16T21:00:00Z | 2021-04-16T21:00:00Z | false    | bomASI                    |
 
     # This avoids a potential race condition in which the PP_Order MD_Candidates are deleted, but not their associated STOCK records.
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, the MD_Candidate table has only the following records
       | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty  | ATP  | M_AttributeSetInstance_ID |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/delivery/deliveryRules.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/delivery/deliveryRules.feature
@@ -546,7 +546,7 @@ Feature: Delivery rules with and without quantity in stock
     And the inventory identified by inventory_FIFO2_1 is completed
     And the inventory identified by inventory_FIFO2_2 is completed
     And the inventory identified by inventory_FIFO2_3 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And after not more than 60 seconds metasfresh has MD_Stock data
       | M_Product_ID.Identifier | QtyOnHand |
       | product_FIFO_2          | 20        |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
@@ -91,7 +91,7 @@ Feature: EDI DESADV export via postgREST
       | C_Order_ID | Column     | REST.Context   |
       | o_1        | DocumentNo | o_1_DocumentNo |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And after not more than 180s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_1      | ol_1                      | N             |
@@ -391,7 +391,7 @@ Feature: EDI DESADV export via postgREST
       | C_Order_ID | Column     | REST.Context     |
       | o_cg       | DocumentNo | o_cg_DocumentNo  |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And after not more than 180s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID | IsToRecompute |
       | ss_main    | ol_main        | N             |
@@ -495,7 +495,7 @@ Feature: EDI DESADV export via postgREST
       | ol_ms_1    | o_ms_1     | prod_multiShip | 10         | huPiProd_ms             |
     And the order identified by o_ms_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And after not more than 180s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID | IsToRecompute |
       | ss_ms_1    | ol_ms_1        | N             |
@@ -521,7 +521,7 @@ Feature: EDI DESADV export via postgREST
       | ol_ms_2    | o_ms_2     | prod_multiShip | 10         | huPiProd_ms             |
     And the order identified by o_ms_2 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And after not more than 180s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID | IsToRecompute |
       | ss_ms_2    | ol_ms_2        | N             |
@@ -642,7 +642,7 @@ Feature: EDI DESADV export via postgREST
       | ol_notShipped | o_ns       | prod_notShipped | 50         |                             |
     And the order identified by o_ns is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And after not more than 180s, M_ShipmentSchedules are found:
       | Identifier    | C_OrderLine_ID | IsToRecompute |
       | ss_shipped    | ol_shipped     | N             |
@@ -751,7 +751,7 @@ Feature: EDI DESADV export via postgREST
       | C_Order_ID | Column     | REST.Context      |
       | o_050      | DocumentNo | o_050_DocumentNo  |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And after not more than 180s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_050    | ol_050                    | N             |
@@ -1003,7 +1003,7 @@ Feature: EDI DESADV export via postgREST
       | C_Order_ID | Column     | REST.Context      |
       | o_060      | DocumentNo | o_060_DocumentNo  |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And after not more than 180s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | s_s_060    | ol_060                    | N             |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/DeliveryDateAsInvoiceDate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/DeliveryDateAsInvoiceDate.feature
@@ -53,7 +53,7 @@ Feature: Invoice Date can be taken from DeliveryDate
     # this poll occasionally exhausts its 60 s budget, cascading to the step-def's 120 s recompute
     # fallback, which can in turn time out and abort the runner before any test completes
     # ("Tests run: 0").
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, C_Invoice_Candidate are found:
       | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceAggregationWithReversal.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceAggregationWithReversal.feature
@@ -53,7 +53,7 @@ Feature: Invoice aggregation of 2 IC2 when one IC was previously invoiced and re
     # this poll occasionally exhausts its 60 s budget, cascading to the step-def's 120 s recompute
     # fallback, which can in turn time out and abort the runner before any test completes
     # ("Tests run: 0").
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, C_Invoice_Candidate are found:
       | C_Invoice_Candidate_ID | C_OrderLine_ID | QtyToInvoice |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/packingmaterial/receipts.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/packingmaterial/receipts.feature
@@ -1011,7 +1011,7 @@ Feature: Packing material invoice candidates: receipts
       | receiptLine_1             | material_receipt_1    | packingProduct          | 1064        | true      | 1064           |
       | receiptLine_2             | material_receipt_1    | loadingProduct          | 14          | true      | 14             |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 120s, C_Invoice_Candidate are found:
       | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice | OPT.M_InOutLine_ID.Identifier |
@@ -1024,7 +1024,7 @@ Feature: Packing material invoice candidates: receipts
 
     When the material receipt identified by material_receipt_1 is reactivated
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then validate M_In_Out status
       | M_InOut_ID.Identifier | DocStatus |
@@ -1530,7 +1530,7 @@ Feature: Packing material invoice candidates: receipts
       | M_InOut_ID.Identifier | M_Product_ID.Identifier |
       | material_receipt_1    | loadingProduct          |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 120s, C_Invoice_Candidate are found:
       | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice | OPT.M_InOutLine_ID.Identifier |
@@ -1545,7 +1545,7 @@ Feature: Packing material invoice candidates: receipts
 
     When the material receipt identified by material_receipt_1 is reactivated
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then validate M_In_Out status
       | M_InOut_ID.Identifier | DocStatus |
@@ -1561,7 +1561,7 @@ Feature: Packing material invoice candidates: receipts
 
     When the material receipt identified by material_receipt_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then validate M_In_Out status
       | M_InOut_ID.Identifier | DocStatus |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
@@ -76,7 +76,7 @@ Feature: Maturing scenarios
       | M_HU_Storage_ID | M_HU_ID       | M_Product_ID | Qty |
       | maturing_hus_10 | rawgood_hu_10 | rawGood      | 10  |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
 
@@ -84,7 +84,7 @@ Feature: Maturing scenarios
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
       | oc_1       | false     | maturedGood  | bom_1             | prodPlanning           | 540006        | 10 PCE     | 10 PCE       | 0 PCE        | 2023-05-31T22:00:00Z | 2023-05-31T22:00:00Z | false    | true       | maturingConfig              | maturingConfigLine               | rawgood_hu_10 |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_AlreadyMaturedForOrdering' is ran once
 
@@ -149,7 +149,7 @@ Feature: Maturing scenarios
       | M_HU_Storage_ID.Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
       | rawgood_hus_20             | rawgood_hu_20      | rawGood                 | 20  |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
 
@@ -161,7 +161,7 @@ Feature: Maturing scenarios
       | M_HU_Storage_ID | Qty |
       | rawgood_hus_20  | 15  |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
 
@@ -204,7 +204,7 @@ Feature: Maturing scenarios
       | M_HU_Storage_ID | M_HU_ID       | M_Product_ID | Qty |
       | rawgood_hus_30  | rawgood_hu_30 | rawGood      | 30  |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
 
@@ -216,7 +216,7 @@ Feature: Maturing scenarios
       | M_HU_ID       | MovementDate         |
       | rawgood_hu_30 | 2024-01-01T21:00:00Z |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialCockpit/materialCockpit_SO_noProductPlanning.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialCockpit/materialCockpit_SO_noProductPlanning.feature
@@ -42,7 +42,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_1       | o_1                   | p_1                     | 10         |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -61,7 +61,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
       | s_s_1                            | s_1                   |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -72,7 +72,7 @@ Feature: sales order interaction with material cockpit - no product planning
 
     And the shipment identified by s_1 is reactivated
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -83,7 +83,7 @@ Feature: sales order interaction with material cockpit - no product planning
 
     And the shipment identified by s_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -125,7 +125,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_1       | o_1                   | p_1                     | 10         |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -136,7 +136,7 @@ Feature: sales order interaction with material cockpit - no product planning
 
     When the order identified by o_1 is reactivated
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -151,7 +151,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_1                      | 12             |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -191,7 +191,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
       | ol_1       | o_1                   | p_1                     | 10         |
     When the order identified by o_1 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -208,7 +208,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_2       | o_2                   | p_1                     | 10         |
     And the order identified by o_2 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -253,7 +253,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_1       | o_1                   | p_1                     | 10         |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -270,7 +270,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_2       | o_2                   | p_2                     | 10         |
     When the order identified by o_2 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -324,7 +324,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_1       | o_1                   | p_1                     | 10         | lineASI                                  |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -377,7 +377,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_1       | o_1                   | p_1                     | 10         | lineASI_1                                |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -404,7 +404,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_2       | o_2                   | p_1                     | 10         | lineASI_2                                |
     When the order identified by o_2 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -461,7 +461,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_2       | o_1                   | p_1                     | 10         |                                          |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -474,7 +474,7 @@ Feature: sales order interaction with material cockpit - no product planning
 
     When the order identified by o_1 is reactivated
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -491,7 +491,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_2                      | lineASI_1                                |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -545,7 +545,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_1       | o_1                   | p_1                     | 10         | lineASI_1                                |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -561,7 +561,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_2       | o_2                   | p_1                     | 10         | lineASI_1                                |
     When the order identified by o_2 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -615,7 +615,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_1       | o_1                   | p_1                     | 10         |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -629,7 +629,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_1                      | lineASI_1                                |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -644,7 +644,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_1                      | 12             |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -687,7 +687,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_1       | o_1                   | p_1                     | 10         |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -701,7 +701,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | o_1                   | 2021-04-17T00:00:00Z |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -755,7 +755,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_1       | o_1                   | p_1                     | 10         |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -769,7 +769,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_1                      | lineASI_1                                |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |
@@ -784,7 +784,7 @@ Feature: sales order interaction with material cockpit - no product planning
       | ol_1                      | 8              |
     When the order identified by o_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtyInventoryCount_AtDate | OPT.QtyOrdered_SalesOrder_AtDate |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/autoGeneratePurchaseOrderFromCandidate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/autoGeneratePurchaseOrderFromCandidate.feature
@@ -85,7 +85,7 @@ Feature: Auto-generate Purchase Order from Purchase Candidate when IsDocComplete
 
     # No manual enqueue step -- PO generation should be auto-triggered because IsDocComplete=Y
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, C_PurchaseCandidate_Alloc are found
       | C_PurchaseCandidate_ID | C_PurchaseCandidate_Alloc_ID |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/ddorder_manual_completion.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/ddorder_manual_completion.feature
@@ -45,7 +45,7 @@ Feature: Manual DD_Order completion creates MD_Candidates
     When the dd_order identified by ddOrder_man is completed
 
     # Wait for material dispo to process the event
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Verify SUPPLY + DEMAND candidates were created
     Then after not more than 60s, MD_Candidates are found

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/distribution.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/distribution.feature
@@ -360,7 +360,7 @@ Feature: create distribution to balance demand
       | c_2        | SUPPLY            | DISTRIBUTION              | p_1          | 2022-07-04T00:00:00Z | 0   | 0                      | targetWH       |
       | c_3        | DEMAND            | DISTRIBUTION              | p_1          | 2022-07-04T00:00:00Z | 0   | 0                      | sourceWH       |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And the order identified by SO is completed
 
@@ -431,7 +431,7 @@ Feature: create distribution to balance demand
       | 4          | SUPPLY            | DISTRIBUTION              | p_1          | 2022-07-04T00:00:00Z | 14  | 14                     | targetWH       |                       | ddOrderLine1    |
       | 5          | DEMAND            | DISTRIBUTION              | p_1          | 2022-07-04T00:00:00Z | -14 | -14                    | sourceWH       |                       | ddOrderLine1    |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And the order identified by SO is completed
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/distributionAgg.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/distributionAgg.feature
@@ -87,9 +87,9 @@ Feature: create distribution order based on aggregation sysconfig
       | ol_3       | SO2        | p_1          | 4          |
       | ol_4       | SO2        | p_1          | 5          |
     And the order identified by SO1 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And the order identified by SO2 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 30s, following DD_Order_Candidates are found
       | Identifier | M_Product_ID | M_Warehouse_From_ID | M_WarehouseTo_ID | Qty   | Processed |
@@ -140,9 +140,9 @@ Feature: create distribution order based on aggregation sysconfig
       | ol_3       | SO2        | p_1          | 4          |
       | ol_4       | SO2        | p_1          | 5          |
     And the order identified by SO1 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And the order identified by SO2 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 30s, following DD_Order_Candidates are found
       | Identifier | M_Product_ID | M_Warehouse_From_ID | M_WarehouseTo_ID | Qty   | Processed |
@@ -192,9 +192,9 @@ Feature: create distribution order based on aggregation sysconfig
       | ol_3       | SO2        | p_1          | 4          |
       | ol_4       | SO2        | p_1          | 5          |
     And the order identified by SO1 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And the order identified by SO2 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 30s, following DD_Order_Candidates are found
       | Identifier | M_Product_ID | M_Warehouse_From_ID | M_WarehouseTo_ID | Qty   | Processed |
@@ -243,9 +243,9 @@ Feature: create distribution order based on aggregation sysconfig
       | ol_3       | SO2        | p_1          | 4          |
       | ol_4       | SO2        | p_1          | 5          |
     And the order identified by SO1 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And the order identified by SO2 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 30s, following DD_Order_Candidates are found
       | Identifier | M_Product_ID | M_Warehouse_From_ID | M_WarehouseTo_ID | Qty   | Processed |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/materialDispo_purchaseOrder_autoCreateFromProductPlanning.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/materialDispo_purchaseOrder_autoCreateFromProductPlanning.feature
@@ -98,7 +98,7 @@ Feature: PP_Product_Planning.IsCreatePlan / IsDocComplete automatically create/c
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
       | pol_1                     | po_1                  | 2021-04-16      | p_1                     | 5          | 0            | 0           | 10    | 0        | EUR          | true      |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, MD_Candidates are found
       | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected        | Qty | Qty_AvailableToPromise |
@@ -191,7 +191,7 @@ Feature: PP_Product_Planning.IsCreatePlan / IsDocComplete automatically create/c
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
       | pol_1                     | po_1                  | 2021-04-16      | p_1                     | 5          | 0            | 0           | 10    | 0        | EUR          | false     |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, MD_Candidates are found
       | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected        | Qty | Qty_AvailableToPromise |
@@ -263,7 +263,7 @@ Feature: PP_Product_Planning.IsCreatePlan / IsDocComplete automatically create/c
       | Identifier | C_OrderSO_ID.Identifier | C_OrderLineSO_ID.Identifier | M_Product_ID.Identifier |
       | pc_1       | o_1                     | ol_1                        | p_1                     |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And no C_PurchaseCandidate_Alloc are found for:
       | C_PurchaseCandidate_ID.Identifier |
@@ -357,7 +357,7 @@ Feature: PP_Product_Planning.IsCreatePlan / IsDocComplete automatically create/c
 
     # Drain the material event queue so the debouncer handler runs before the alloc poll.
     # Without this, CI-runner contention occasionally exhausts the 120 s poll budget below.
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # The debouncer waits for the quiet period, then creates POs — both candidates get an alloc
     And after not more than 120s, C_PurchaseCandidate_Alloc are found
@@ -464,7 +464,7 @@ Feature: PP_Product_Planning.IsCreatePlan / IsDocComplete automatically create/c
 
     # Drain the material event queue so the debouncer handler runs before the alloc poll.
     # Without this, CI-runner contention occasionally exhausts the 120 s poll budget below.
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # The debouncer waits for the quiet period, then creates POs — one per vendor
     And after not more than 120s, C_PurchaseCandidate_Alloc are found

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/materialDispo_stockEstimateEvent.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/materialDispo_stockEstimateEvent.feature
@@ -29,7 +29,7 @@ Feature: material-dispo updates on StockEstimateEvent events
       | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected           | Qty | Qty_AvailableToPromise |
       | c_2        | INVENTORY_UP      | STOCK_CHANGE                  | p_1                     | 2021-06-23T00:00:00.00Z | 10  | 10                     |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyInventoryCount_AtDate | OPT.QtyStockChange | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
@@ -50,7 +50,7 @@ Feature: material-dispo updates on StockEstimateEvent events
       | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected           | Qty | Qty_AvailableToPromise |
       | INVENTORY_UP      |                               | p_1                     | 2020-12-12T00:00:00.00Z | 100 | 100                    |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyInventoryCount_AtDate | OPT.QtyStockChange | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
@@ -67,7 +67,7 @@ Feature: material-dispo updates on StockEstimateEvent events
       | MD_Candidate_ID.Identifier | Fresh_QtyOnHand_ID | Fresh_QtyOnHand_Line_ID | IsReverted |
       | c_2                        | 2                  | 22                      | N          |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyInventoryCount_AtDate | OPT.QtyStockChange | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/md_candidate_remove_from_atp.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/md_candidate_remove_from_atp.feature
@@ -136,7 +136,7 @@ Feature: MD_Candidate_Remove_From_ATP process
       | sol_atp_003 | so_atp_003 | product_atp  | 100        |
     And the order identified by so_atp_003 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And metasfresh has date and time 2024-09-20T10:00:00+01:00[Europe/Berlin]
     # Create purchase order (supply at T+3)
@@ -148,7 +148,7 @@ Feature: MD_Candidate_Remove_From_ATP process
       | pol_atp_003 | po_atp_003 | product_atp  | 150        |
     And the order identified by po_atp_003 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Verify all candidates
     And after not more than 10s, MD_Candidates are found
@@ -196,7 +196,7 @@ Feature: MD_Candidate_Remove_From_ATP process
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | sol_004_1  | so_004_1   | product_atp  | 30         |
     And the order identified by so_004_1 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Create purchase order 1 (supply_1_004 at T+2)
     And metasfresh contains C_Orders:
@@ -206,7 +206,7 @@ Feature: MD_Candidate_Remove_From_ATP process
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | pol_004_1  | po_004_1   | product_atp  | 50         |
     And the order identified by po_004_1 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Create sales order 2 (demand_2_004 at T+3) - this is the middle candidate we'll test
     And metasfresh contains C_Orders:
@@ -216,7 +216,7 @@ Feature: MD_Candidate_Remove_From_ATP process
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | sol_004_2  | so_004_2   | product_atp  | 40         |
     And the order identified by so_004_2 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Create purchase order 2 (supply_2_004 at T+4)
     And metasfresh contains C_Orders:
@@ -226,7 +226,7 @@ Feature: MD_Candidate_Remove_From_ATP process
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | pol_004_2  | po_004_2   | product_atp  | 60         |
     And the order identified by po_004_2 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Create sales order 3 (demand_3_004 at T+5)
     And metasfresh contains C_Orders:
@@ -236,7 +236,7 @@ Feature: MD_Candidate_Remove_From_ATP process
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | sol_004_3  | so_004_3   | product_atp  | 35         |
     And the order identified by so_004_3 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Verify all candidates are present with correct ATP chain
     And after not more than 10s, MD_Candidates are found

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/production.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/production.feature
@@ -371,7 +371,7 @@ Feature: Physical Inventory and disposal - Production dispo scenarios
       | c_l_1_1    | DEMAND            | PRODUCTION                | p_2          | 2021-04-16T21:00:00Z | -100 | -100                   |
 #      | c_l_1_2    | SUPPLY            |                           | p_2          | 2021-04-16T21:00:00Z | 100  | 0                      |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | M_Warehouse_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PP_Order_AtDate | OPT.QtyDemand_PP_Order_AtDate |
@@ -410,7 +410,7 @@ Feature: Physical Inventory and disposal - Production dispo scenarios
 
 
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PP_Order_AtDate | OPT.QtyDemand_PP_Order_AtDate |
@@ -498,7 +498,7 @@ Feature: Physical Inventory and disposal - Production dispo scenarios
       | 2/c_2      | SUPPLY            | PRODUCTION                | p_1          | 2021-04-16T21:00:00Z | 10   | 0                      |
       | 3/c_l_1    | DEMAND            | PRODUCTION                | p_2          | 2021-04-16T21:00:00Z | -100 | -100                   |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | M_Warehouse_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PP_Order_AtDate | OPT.QtyDemand_PP_Order_AtDate |
@@ -532,7 +532,7 @@ Feature: Physical Inventory and disposal - Production dispo scenarios
       | 4/c_3      | SUPPLY            | PRODUCTION                | p_1          | 2021-04-16T21:00:00Z | 10   | 0                      |
       | 5/c_l_3    | DEMAND            | PRODUCTION                | p_2          | 2021-04-16T21:00:00Z | -100 | -100                   |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PP_Order_AtDate | OPT.QtyDemand_PP_Order_AtDate |
@@ -563,7 +563,7 @@ Feature: Physical Inventory and disposal - Production dispo scenarios
       | 4/c_3      | SUPPLY            | PRODUCTION                | p_1          | 2021-04-16T21:00:00Z | 10  | 0                      |
       | 5/c_l_3    | DEMAND            | PRODUCTION                | p_2          | 2021-04-16T21:00:00Z | 100 | -100                   |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PP_Order_AtDate | OPT.QtyDemand_PP_Order_AtDate |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/production_and_distribution.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/production_and_distribution.feature
@@ -96,7 +96,7 @@ Feature: Production + Distribution material dispo scenarios
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | SO_L1      | SO         | bom_product  | 10         |
     When the order identified by SO is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed |
@@ -141,7 +141,7 @@ Feature: Production + Distribution material dispo scenarios
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | SO_L1      | SO         | bom_product  | 10         |
     When the order identified by SO is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed |
@@ -204,7 +204,7 @@ Feature: Production + Distribution material dispo scenarios
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | SO_L1      | SO         | bom_product  | 10         |
     When the order identified by SO is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed |
@@ -283,7 +283,7 @@ Feature: Production + Distribution material dispo scenarios
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | SO_L1      | SO         | bom_product  | 10         |
     When the order identified by SO is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed |
@@ -345,7 +345,7 @@ Feature: Production + Distribution material dispo scenarios
     #
     # Complete the Sales order and expect PP_Order_Candidate and DD_Order_Candidate to be generated
     When the order identified by SO is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed |
       | oc_1       | false     | bom_product  | bom_1             | bom_product_planning   | plant         | 10 PCE     | 10 PCE       | 0 PCE        | 2021-04-16T21:00:00Z | 2021-04-16T21:00:00Z | false    |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/salesOrder.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/salesOrder.feature
@@ -145,7 +145,7 @@ Feature: material dispo reacts to order docactions
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | ol_1       | o_1        | p_finished   | 10         |
     When the order identified by o_1 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     Then after not more than 60s, MD_Candidates are found
       | Identifier | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID | DateProjected        | Qty | ATP |
       | c_demand   | DEMAND            | SHIPMENT                  | p_finished   | 2024-09-22T21:00:00Z | 10  | -10 |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/supplyRequiredQtyViaProduction.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/supplyRequiredQtyViaProduction.feature
@@ -401,7 +401,7 @@ Feature: Disposal is correctly considered in Material Dispo. Stock shortage solv
       | c_2        | SUPPLY            | PRODUCTION                    | p_1                     | 2021-04-11T07:00:00Z | 10   | 0                      |
       | c_l_1      | DEMAND            | PRODUCTION                    | p_2                     | 2021-04-11T07:00:00Z | -100 | -100                   |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PP_Order_AtDate | OPT.QtyDemand_PP_Order_AtDate |
@@ -429,7 +429,7 @@ Feature: Disposal is correctly considered in Material Dispo. Stock shortage solv
 
     And the manufacturing order identified by ppo_1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 120s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PP_Order_AtDate | OPT.QtyDemand_PP_Order_AtDate |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/supplyRequiredQtyViaPurchase.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/supplyRequiredQtyViaPurchase.feature
@@ -83,7 +83,7 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
       | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
       | il_1                          | hu_1               |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyInventoryCount_AtDate | OPT.QtyStockChange | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
@@ -98,7 +98,7 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
       | c_1        | INVENTORY_UP      |                               | p_1                     |                      | 10  | 10                     | 2021-04-16T00:00:00             |
       | c_2        | INVENTORY_DOWN    |                               | p_1                     | 2021-04-16T21:00:00Z | -10 | 0                      |                                 |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyInventoryCount_AtDate | OPT.QtyStockChange | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
@@ -146,7 +146,7 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
       | pol_1                     | po_1                  | 2021-04-16      | p_1                     | 10         | 0            | 0           | 10    | 0        | EUR          | true      |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
@@ -218,7 +218,7 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
     And the inventory identified by i_1 is completed
     And the inventory identified by i_2 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyInventoryCount_AtDate | OPT.QtyStockChange | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
@@ -238,7 +238,7 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
       | c_2        | INVENTORY_UP      |                               | p_1                     |                      | 5   | 15                     | 2021-04-16T00:00:00             |
       | c_3        | INVENTORY_DOWN    |                               | p_1                     | 2021-04-16T21:00:00Z | -10 | 5                      |                                 |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyInventoryCount_AtDate | OPT.QtyStockChange | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
@@ -287,7 +287,7 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
       | pol_1                     | po_1                  | 2021-04-16      | p_1                     | 5          | 0            | 0           | 10    | 0        | EUR          | true      |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |
@@ -354,7 +354,7 @@ Feature: Disposal is correctly considered in Material Dispo; Stock shortage solv
       | Identifier | MD_Candidate_Type | OPT.MD_Candidate_BusinessCase | M_Product_ID.Identifier | DateProjected | Qty | Qty_AvailableToPromise | OPT.DateProjected_LocalTimeZone |
       | c_1        | INVENTORY_UP      |                               | p_1                     |               | 10  | 10                     | 2021-04-16T00:00:00             |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 90s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.AttributesKey.Identifier | OPT.QtyInventoryCount_AtDate | OPT.QtyStockChange | OPT.QtyDemand_SalesOrder_AtDate | OPT.QtyDemandSum_AtDate | OPT.QtySupplySum_AtDate | OPT.QtySupplyRequired_AtDate | OPT.QtyExpectedSurplus_AtDate | OPT.QtySupplyToSchedule_AtDate | OPT.MDCandidateQtyStock_AtDate | OPT.QtyStockCurrent_AtDate | OPT.QtySupply_PurchaseOrder_AtDate |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/dropship_warehouse.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/dropship_warehouse.feature
@@ -128,7 +128,7 @@ Feature: Dropship-warehouse SO auto-creates a PO and bypasses material dispositi
     When the order identified by so_dw2 is completed
 
     # Drain the event queue so any async processing that would create MD_Candidates has a chance to run
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Assert: no MD_Candidate demand rows created for the dropship-warehouse product
     Then no MD_Candidate exists for M_Product_ID product_dw
@@ -156,7 +156,7 @@ Feature: Dropship-warehouse SO auto-creates a PO and bypasses material dispositi
       | so_dw3                   | false   | POO         | CO            | true           |
 
     # Drain the event queue so any PO-completion async processing has a chance to run
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Assert: still zero non-STOCK MD_Candidate rows after PO completion + queue drain
     Then no MD_Candidate exists for M_Product_ID product_dw
@@ -190,7 +190,7 @@ Feature: Dropship-warehouse SO auto-creates a PO and bypasses material dispositi
       | po_dw4         | so_dw4                   | false   | POO         | CO            | true           |
 
     # Drain the material queue first so async work has a chance to complete.
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Register the PO's project as `proj1` (created by the PO's own BEFORE_COMPLETE).
     And validate the created orders
@@ -304,7 +304,7 @@ Feature: Dropship-warehouse SO auto-creates a PO and bypasses material dispositi
 
     # Drain the event queue so the full SupplyRequired → PurchaseCandidate → PO → ReceiptSchedule
     # → MD_Candidate chain has time to run
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Assert: at least one SUPPLY/PURCHASE MD_Candidate row exists for product_dw — confirming
     # that the bypass did NOT short-circuit the standard material-disposition flow on a regular warehouse
@@ -336,7 +336,7 @@ Feature: Dropship-warehouse SO auto-creates a PO and bypasses material dispositi
       | po_dw10_B      | so_dw10                  | vendor_dw_2       | false   | POO         | CO            | true           |
 
     # Drain the material queue first so async work has a chance to complete.
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Each PO has its OWN project — register them as projA and projB.
     And validate the created orders
@@ -397,7 +397,7 @@ Feature: Dropship-warehouse SO auto-creates a PO and bypasses material dispositi
       | po_dw11    | pol_dw11_1     | product_dw_2     |
 
     # Drain the material queue so any ReceiptScheduleCreatedEvent short-circuit has run.
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # The receipt schedule was created by PO completion; locate and register it.
     # Note: CreatePOFromSOsAggregator.java:324 uses AD_OrgInfo.DropShip_Warehouse_ID
@@ -422,7 +422,7 @@ Feature: Dropship-warehouse SO auto-creates a PO and bypasses material dispositi
       | hu_dw11            | rs_dw11                         | receipt_dw11          |
 
     # Drain the event queue so any TransactionCreatedEvent processing has a chance to run.
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # CORE assertion: even after the receipt fires m_transaction rows and TransactionCreatedEvent,
     # zero non-STOCK MD_Candidate rows must exist because isDropShipWarehouse=true triggers the

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/payment/paymentTerm.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/payment/paymentTerm.feature
@@ -80,7 +80,7 @@ Feature: Payment Term propagation
       | M_HU_ID | M_ReceiptSchedule_ID | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID | M_LU_HU_PI_ID |
       | hu1     | rs1                  | N               | 1     | N               | 1     | N               | 10          | product_TU_10CU         | LU            |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And create material receipt
       | M_HU_ID | M_ReceiptSchedule_ID | M_InOut_ID |
       | hu1     | rs1                  | receipt1   |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/multipleProductionCandidates.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/multipleProductionCandidates.feature
@@ -108,7 +108,7 @@ Feature: create multiple production candidates
     #
     # Complete the sales order and expected the PP_Order_Candidate to be generated.
     When the order identified by o_1 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed |
       | oc_1       | false     | p_1          | bom_1             | ppln_1                 | testResource  | 10 PCE     | 10 PCE       | 0 PCE        | 2021-04-16T21:00:00Z | 2021-04-16T21:00:00Z | false    |
@@ -126,12 +126,12 @@ Feature: create multiple production candidates
     # Expect a new PP_Order_Candidate to be generated for those 2 PCE.
     And the order identified by o_1 is reactivated
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And update C_OrderLine:
       | C_OrderLine_ID.Identifier | OPT.QtyEntered |
       | ol_1                      | 12             |
     And the order identified by o_1 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed |
       | oc_1       | false     | p_1          | bom_1             | ppln_1                 | testResource  | 0 PCE      | 0 PCE        | 0 PCE        | 2021-04-16T21:00:00Z | 2021-04-16T21:00:00Z | false    |
@@ -155,7 +155,7 @@ Feature: create multiple production candidates
       | PP_Order_Candidate_ID |
       | oc_1                  |
       | oc_2                  |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     Then after not more than 60s, PP_Orders are found
       | Identifier | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyOrdered | C_BPartner_ID | DatePromised         | DocStatus |
       | ppo_1      | p_1          | bom_1             | ppln_1                 | testResource  | 12 PCE     | 12         | endcustomer_2 | 2021-04-16T21:00:00Z | DR        |
@@ -290,15 +290,15 @@ Feature: create multiple production candidates
       | Identifier           | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | SeqNo |
       | ppOrderCandidate_3_1 | false     | p_1          | bom_1             | ppln_1                 | testResource  | 3 PCE      | 3 PCE        | 0 PCE        | 2022-11-07T21:00:00Z | 2022-11-07T21:00:00Z | false    | 10    |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And the order identified by o_3 is reactivated
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And update C_OrderLine:
       | C_OrderLine_ID.Identifier | OPT.QtyEntered |
       | ol_3                      | 12             |
     And the order identified by o_3 is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier           | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | SeqNo |
       | ppOrderCandidate_3_1 | false     | p_1          | bom_1             | ppln_1                 | testResource  | 0 PCE      | 0 PCE        | 0 PCE        | 2022-11-07T21:00:00Z | 2022-11-07T21:00:00Z | false    | 10    |
@@ -309,7 +309,7 @@ Feature: create multiple production candidates
       | PP_Order_Candidate_ID | QtyToProcess |
       | ppOrderCandidate_3_2  | 4            |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     When generate PP_Order process is invoked for selection, with completeDocument=true and autoProcessCandidateAfterProduction=true
       | PP_Order_Candidate_ID |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate.feature
@@ -188,7 +188,7 @@ Feature: Production dispo scenarios
 
     And the order identified by o_2 is reactivated
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 60s, PP_Order_Candidates are found
       | Identifier | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | OPT.IsClosed | OPT.Processed |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate_with_BOM_recursion.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate_with_BOM_recursion.feature
@@ -198,7 +198,7 @@ Feature: Production dispo scenarios with BOMs whose components have their own BO
 
     And the PP_Order ppo_1_S0460_20 is voided
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, PP_Orders are found
       | Identifier     | M_Product_ID         | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID  | QtyEntered | QtyOrdered | C_BPartner_ID     | DatePromised         | DocStatus |
@@ -474,7 +474,7 @@ Feature: Production dispo scenarios with BOMs whose components have their own BO
       | C_OrderLine_ID.Identifier | OPT.QtyEntered |
       | ol_1_S0460_40             | 1              |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     When the order identified by o_1_S0460_40 is completed
 
@@ -602,7 +602,7 @@ Feature: Production dispo scenarios with BOMs whose components have their own BO
       | C_OrderLine_ID.Identifier | OPT.QtyEntered |
       | ol_1_S0460_50             | 7              |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     When the order identified by o_1_S0460_50 is completed
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseCandidateDropShip.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseCandidateDropShip.feature
@@ -95,7 +95,7 @@ Feature: Dropship fields propagated from SO to Purchase Candidate and Purchase O
       | C_PurchaseCandidate_ID | QtyToPurchase | IsDropShip | DropShip_BPartner_ID | DropShip_Location_ID      |
       | pc_ds1                 | 10            | true       | dropship_dest_ds1    | dropship_dest_ds1_loc     |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Verify PO was auto-generated
     And after not more than 60s, C_PurchaseCandidate_Alloc are found
@@ -209,7 +209,7 @@ Feature: Dropship fields propagated from SO to Purchase Candidate and Purchase O
       | C_PurchaseCandidate_ID | QtyToPurchase | IsDropShip | DropShip_BPartner_ID | DropShip_Location_ID  |
       | pc_ds2b                | 5             | true       | dropship_dest_B      | dropship_dest_B_loc   |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Verify two separate POs were created (one per dropship destination)
     And after not more than 60s, C_PurchaseCandidate_Alloc are found

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseCandidatePackingAndAttributes.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseCandidatePackingAndAttributes.feature
@@ -125,7 +125,7 @@ Feature: Packing items, TU quantities, and attributes propagated from SO to Purc
       | C_PurchaseCandidate_ID | QtyToPurchase | M_HU_PI_Item_Product_ID | QtyEnteredTU |
       | pc_pk1                 | 30            | huPiItemProd_pk1        | 3            |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Verify PO was auto-generated
     And after not more than 60s, C_PurchaseCandidate_Alloc are found

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderProjectToSO.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderProjectToSO.feature
@@ -75,7 +75,7 @@ Feature: Purchase order project is automatically created when PO is completed
       | C_PurchaseCandidate_ID | QtyToPurchase |
       | pc_1                   | 10            |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, C_PurchaseCandidate_Alloc are found
       | C_PurchaseCandidate_ID | C_PurchaseCandidate_Alloc_ID |
@@ -89,7 +89,7 @@ Feature: Purchase order project is automatically created when PO is completed
       | C_Order_ID | C_OrderLine_ID |
       | po_1       | pol_1          |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
 ## PO header and lines
     Then validate the created orders

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation.feature
@@ -150,7 +150,7 @@ Feature: Qty Reservation delivery tracking
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID |
       | inventory_40   | warehouse_1    | 2026-03-01   | product_1    | 0 PCE   | 30 PCE   | huPIP_TU_10PCE          |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, metasfresh has this MD_Cockpit data
       | Identifier | M_Product_ID.Identifier | DateGeneral | OPT.QtyStockCurrent_AtDate |
@@ -198,7 +198,7 @@ Feature: Qty Reservation delivery tracking
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID |
       | inventory_50   | warehouse_1    | 2026-03-01   | product_1    | 0 PCE   | 10 PCE   | huPIP_TU_10PCE          |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised        | DeliveryRule | M_Warehouse_ID |
@@ -216,7 +216,7 @@ Feature: Qty Reservation delivery tracking
       | orderLine_5B | order_5B   | product_1    | 10         |
     And the order identified by order_5B is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier          | C_OrderLine_ID | IsToRecompute |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment.feature
@@ -62,7 +62,7 @@ Feature: Qty Reservation — shipment attribute and project propagation
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
       | inventory      | warehouse_1    | 2026-03-15   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE             | hu      |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And M_HU_Attribute is changed
       | M_HU_ID | M_Attribute_ID.Value | ValueStr |
       | hu      | ProjectValue         | P60      |
@@ -139,7 +139,7 @@ Feature: Qty Reservation — shipment attribute and project propagation
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID | M_HU_ID2 |
       | inventory      | warehouse_1    | 2026-03-15   | product      | 0 PCE   | 20 PCE   | huPIP_10PCE             | hu1     | hu2      |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And M_HU_Attribute is changed
       | M_HU_ID | M_Attribute_ID.Value | ValueStr |
       | hu1     | ProjectValue         | P70      |
@@ -224,7 +224,7 @@ Feature: Qty Reservation — shipment attribute and project propagation
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
       | inventory_B    | warehouse_1    | 2026-03-15   | product_B    | 0 PCE   | 10 PCE   | huPIP_B_10PCE           | hu_B    |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And M_HU_Attribute is changed
       | M_HU_ID | M_Attribute_ID.Value | ValueStr |
       | hu_A    | ProjectValue         | P80      |
@@ -328,7 +328,7 @@ Feature: Qty Reservation — shipment attribute and project propagation
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID |
       | inventory      | warehouse_1    | 2026-03-15   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE             | asi_DE                    | hu      |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     # Set Herkunft=DE and ProjectValue directly on the HU (inventory step creates the HU with the attribute but value=null)
     And M_HU_Attribute is changed
       | M_HU_ID | M_Attribute_ID.Value | ValueStr |
@@ -446,7 +446,7 @@ Feature: Qty Reservation — shipment attribute and project propagation
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID |
       | inventory_AT   | warehouse_1    | 2026-03-15   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE             | asi_AT                    | hu_AT   |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     # Set Herkunft and ProjectValue directly on each HU (inventory creates HU with attribute but value=null)
     And M_HU_Attribute is changed
       | M_HU_ID | M_Attribute_ID.Value | ValueStr |
@@ -600,7 +600,7 @@ Feature: Qty Reservation — shipment attribute and project propagation
     And metasfresh contains single line completed inventories
       | M_Inventory_ID  | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID  |
       | inventory_plain | warehouse_1    | 2026-03-15   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE             | hu_plain |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     # Set Herkunft and ProjectValue directly on each HU (inventory creates HU with attribute but value=null)
     And M_HU_Attribute is changed
       | M_HU_ID  | M_Attribute_ID.Value | ValueStr |
@@ -785,7 +785,7 @@ Feature: Qty Reservation — shipment attribute and project propagation
     And metasfresh contains single line completed inventories
       | M_Inventory_ID  | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID  | M_HU_ID2  | M_HU_ID3  |
       | inventory_plain | warehouse_1    | 2026-03-15   | product      | 0 PCE   | 30 PCE   | huPIP_10PCE             | hu_plain | hu_plain2 | hu_plain3 |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     # Set Herkunft and ProjectValue on each HU (inventory creates HU with attribute but value=null)
     And M_HU_Attribute is changed
       | M_HU_ID   | M_Attribute_ID.Value | ValueStr |
@@ -903,7 +903,7 @@ Feature: Qty Reservation — shipment attribute and project propagation
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
       | inventory      | warehouse_1    | 2026-03-15   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE             | hu      |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And M_HU_Attribute is changed
       | M_HU_ID | M_Attribute_ID.Value | ValueStr |
       | hu      | ProjectValue         | P180     |
@@ -979,7 +979,7 @@ Feature: Qty Reservation — shipment attribute and project propagation
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
       | inventory      | warehouse_1    | 2026-03-15   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE             | hu      |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment_multiSchedule.feature
@@ -92,7 +92,7 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID       |
       | inventory_AT   | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | asi_AT                    | hu_unreserved |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And M_HU_Attribute is changed
       | M_HU_ID       | M_Attribute_ID.Value | ValueStr |
       | hu_reserved   | 1000001              | DE       |
@@ -171,7 +171,7 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
       | inventory_2    | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | hu_2    |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Single order with 2 lines for the same product
     And metasfresh contains C_Orders:
@@ -264,7 +264,7 @@ Feature: Multi-schedule on-the-fly picking — no double-pick, respect reservati
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID |
       | inventory_CH   | warehouse      | 2026-04-16   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE              | asi_CH                    | hu_CH   |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And M_HU_Attribute is changed
       | M_HU_ID | M_Attribute_ID.Value | ValueStr |
       | hu_DE   | 1000001              | DE       |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/report/baseandcustom/report.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/report/baseandcustom/report.feature
@@ -94,7 +94,7 @@ Feature: Jasper Report Tests
       | M_HU_ID | M_ReceiptSchedule_ID | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID | M_LU_HU_PI_ID |
       | hu1     | rs1                  | N               | 1     | N               | 1     | N               | 10          | product_TU_10CU         | LU            |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
     And create material receipt
       | M_HU_ID | M_ReceiptSchedule_ID | M_InOut_ID |
       | hu1     | rs1                  | receipt1   |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/request/request.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/request/request.feature
@@ -52,7 +52,7 @@ Feature: R_Request upsert and retrieval via API
       | ol_1       | o1         | p1           | 3          |
     And the order identified by o1 is completed
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/request' and fulfills with '201' status code
 """

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/shipmentLineASIPropagation.feature
@@ -82,7 +82,7 @@ Feature: Shipment line ASI propagation
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_AttributeSetInstance_ID |
       | orderLine  | order      | product      | 10         | asi_order                 |
     And the order identified by order is completed
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Wait for shipment schedule
     And after not more than 60s, M_ShipmentSchedules are found:
@@ -145,7 +145,7 @@ Feature: Shipment line ASI propagation
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID |
       | inventory      | warehouse      | 2022-05-17   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE             | asi_HU                    | hu      |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     # Register the HU's Herkunft attribute
     And metasfresh contains M_HU_PI_Attribute:
@@ -225,7 +225,7 @@ Feature: Shipment line ASI propagation
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_AttributeSetInstance_ID | M_HU_ID |
       | inventory      | warehouse      | 2022-05-17   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE             | asi_HU                    | hu      |
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And metasfresh contains M_HU_PI_Attribute:
       | M_HU_PI_Version_ID | M_Attribute.Value |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentScheduleExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentScheduleExport.feature
@@ -122,7 +122,7 @@ Feature: Shipment schedule export rest-api
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
       | orderLine_1               | order_1               | 2022-02-02      | product_25_02           | 1          | 0            | 0           | 10.0  | 0        | EUR          | true      |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
@@ -218,7 +218,7 @@ Feature: Shipment schedule export rest-api
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
       | orderLine_1               | order_1               | 2022-02-02      | product_25_02           | 1          | 0            | 0           | 10.0  | 0        | EUR          | true      |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/simulation/purchaseSimulation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/simulation/purchaseSimulation.feature
@@ -134,7 +134,7 @@ Feature: create purchase simulation
       | C_OrderLine_ID.Identifier | OPT.QtyEntered |
       | ol_1                      | 30             |
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     And the order identified by o_1 is completed
 


### PR DESCRIPTION
## Why

`test (cucumber) (profile*)` failures dominate trunk flakes — **12 of 22 failed jobs (~55 %) on `new_dawn_uat` 2026-05-14..21** match the same `Tests run: 0` cascade signature. Root cause documented in `ai-work/29474/profile-flake-rootcause.md`.

The existing drain step `wait until de.metas.material rabbitMQ queue is empty` handles the upstream material event bus, but the actual async work (`M_ShipmentSchedule_Recompute`, invoice-candidate generation, purchase-order creation) is enqueued by material-event listeners onto `de.metas.async` — which the material drain does NOT wait for. The poll then races against in-flight async workpackages and times out.

## Why a new combined step instead of chaining two existing steps

A separate `wait until de.metas.async rabbitMQ queue is empty` step already exists but is used in only 5 feature files vs 38 for material. Asking test authors to remember to chain two drains in the right order invites mistakes:
- Forget async → flake
- Drain async first → still racy because material events haven't queued the async work yet
- Two-line drain blocks are noisy and easy to drift out of sync

## What this does

1. Adds a new step def at `backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java`:
   ```
   wait until all rabbitMQ queues are empty or throw exception after 5 minutes
   ```
   internally drains material first, then async (the producer-consumer order matters).

2. Converts **all 147 existing `de.metas.material` drains across 38 feature files** to use the new combined step.

3. Keeps the individual `de.metas.material` and `de.metas.async` step defs in place for the rare scenarios that need to assert state between the two stages.

## What this does NOT do

- Does not remove the existing single-queue step defs — they remain available.
- Does not touch the 5 feature files that already use async-only drains (they were intentionally async-only).
- Does not weaken any assertion.

## Test plan

- [ ] CI green on this PR — especially all 7 cucumber profile shards (the dominant flake source on trunk)
- [ ] If a profile shard fails, the cucumber pretty plugin (merged via #24031) will surface the failing scenario name so we can drill into the specific feature file