### PR TITLE
Port: CostPrice focus race fix to inner_silence_uat

### DIFF
--- a/frontend/src/components/widget/CostPrice.js
+++ b/frontend/src/components/widget/CostPrice.js
@@ -8,21 +8,19 @@ export default class CostPrice extends PureComponent {
   constructor(props) {
     super(props);
     this.inputRef = React.createRef();
-    this.state = { editMode: false };
   }
 
   handleBlur = (e) => {
     const { onBlur } = this.props;
-    this.setState({ editMode: false });
     onBlur?.(e);
   };
 
   focus = () => {
     const { onFocus } = this.props;
-    this.setState({ editMode: true }, () => {
+    if (this.inputRef.current) {
       this.inputRef.current.focus();
-      onFocus?.();
-    });
+    }
+    onFocus?.();
   };
 
   render() {
@@ -37,43 +35,43 @@ export default class CostPrice extends PureComponent {
       value,
       precision,
     } = this.props;
-    const { onChange, onFocus, onKeyDown } = this.props;
-    const { editMode } = this.state;
+    const { onChange, onKeyDown } = this.props;
 
-    if (!editMode) {
-      return (
-        <input
-          className={cx(
-            className,
-            'input-field js-input-field',
-            rank ? `input-${rank}` : null
-          )}
-          type={'text'}
-          value={fieldValueToString({ fieldValue: value, precision })}
-          onChange={() => false}
-          onFocus={this.focus}
-        />
-      );
-    } else {
-      return (
-        <input
-          ref={this.inputRef}
-          type={'number'}
-          value={value}
-          autoComplete={autoComplete}
-          className={cx(className, rank ? `input-${rank}` : null)}
-          disabled={disabled}
-          placeholder={placeholder}
-          tabIndex={tabIndex}
-          title={title}
-          //
-          onChange={onChange}
-          onFocus={onFocus}
-          onBlur={this.handleBlur}
-          onKeyDown={onKeyDown}
-        />
-      );
-    }
+    // me03#27080 follow-up: previously this component swapped between a
+    // display <input type="text"> (formatted value, no real editing) and
+    // an edit <input type="number"> (real editing), toggled via an
+    // `editMode` state on focus/blur. The swap unmounted the focused
+    // input mid-Tab during PATCH-triggered re-renders, dropping focus
+    // to <body> and triggering the modal-wrapper safety net to grab
+    // focus into a tabindex=-1 scroll container (arrow-key scrolling
+    // instead of next-field navigation). We now render a single stable
+    // <input> at all times — never reconciled out from under the user.
+    // type="text" with inputMode="decimal" preserves the formatted value
+    // (so monetary trailing zeros render as "19.00", not "19" like a
+    // type="number" input would normalise), and on mobile still triggers
+    // the decimal numeric keyboard. ArrowUp / ArrowDown PATCH semantics
+    // continue to work because they are intercepted by
+    // RawWidget.handleKeyDown for the NumberWidgets list (CostPrice is
+    // in that list).
+    return (
+      <input
+        ref={this.inputRef}
+        type="text"
+        inputMode="decimal"
+        value={fieldValueToString({ fieldValue: value, precision })}
+        autoComplete={autoComplete}
+        className={cx(className, rank ? `input-${rank}` : null)}
+        disabled={disabled}
+        placeholder={placeholder}
+        tabIndex={tabIndex}
+        title={title}
+        //
+        onChange={onChange}
+        onFocus={this.focus}
+        onBlur={this.handleBlur}
+        onKeyDown={onKeyDown}
+      />
+    );
   }
 }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/metasfresh/metasfresh/pull/24062 (squash commit https://github.com/metasfresh/metasfresh/commit/be231bfab96d63ceab905e8bad92cff8eec54f87) from \`inner_silence_hotfix\` to \`inner_silence_uat\`.

Follow-up to https://github.com/metasfresh/me03/issues/27080. Fixes the Tab-after-edit focus race in advanced-edit modal on CostPrice fields. See the primary PR for full analysis.

**Why cherry-pick, not merge-commit?** \`git merge-base origin/inner_silence_uat origin/inner_silence_hotfix\` returns empty — the two branches have unrelated histories on this clone, so a normal merge fails with \`refusing to merge unrelated histories\`. Per the \`metasfresh-patch-porter\` skill's "If NO merge-base" path, cherry-picking the squash-merge commit is the correct approach.

Diff is identical to the \`inner_silence_hotfix\` PR: \`frontend/src/components/widget/CostPrice.js\` only, +39/-41.

## Test plan

Same as https://github.com/metasfresh/metasfresh/pull/24062. Verification via playwright instrumentation already done against ipshotfix.modan.ch (deployed \`inner_silence_hotfix\`); same code path on \`inner_silence_uat\`.