### PR TITLE
MobileUI — emit user-friendly error messages for QR scan failures

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/adempiere/exceptions/AdempiereException.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/adempiere/exceptions/AdempiereException.java
@@ -330,7 +330,11 @@ public class AdempiereException extends RuntimeException
 		// so we can consider those user-friendly errors
 		this.userValidationError = true;
 
-		this.errorCode = errorCode;
+		this.errorCode = errorCode != null
+				? errorCode
+				: message.getAdMessageKey()
+						.map(key -> coalesce(msgBL.getErrorCode(key), key.toAD_Message()))
+						.orElse(null);
 	}
 
 	public AdempiereException(@NonNull final AdMessageKey messageKey)

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/AdMessageKey.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/AdMessageKey.java
@@ -45,7 +45,7 @@ public final class AdMessageKey
 	@Nullable
 	public static AdMessageKey ofNullable(@Nullable final String value)
 	{
-		return value != null && Check.isNotBlank(value) ? of(value) : null;
+		return Check.isNotBlank(value) ? of(value) : null;
 	}
 
 	private final String value;

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/ExplainedOptional.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/ExplainedOptional.java
@@ -34,43 +34,45 @@ import java.util.function.Supplier;
  * #L%
  */
 
-@EqualsAndHashCode(exclude = "adMessageKey")
+@EqualsAndHashCode(exclude = {"adMessageKey", "params"})
 public final class ExplainedOptional<T>
 {
 	public static <T> ExplainedOptional<T> emptyBecause(@NonNull final String explanation)
 	{
-		return new ExplainedOptional<>(null, TranslatableStrings.anyLanguage(explanation), null);
+		return new ExplainedOptional<>(null, TranslatableStrings.anyLanguage(explanation), null, null);
 	}
 
 	public static <T> ExplainedOptional<T> emptyBecause(@NonNull final AdMessageKey adMessageKey)
 	{
-		return new ExplainedOptional<>(null, TranslatableStrings.adMessage(adMessageKey), adMessageKey);
+		return new ExplainedOptional<>(null, TranslatableStrings.adMessage(adMessageKey), adMessageKey, null);
 	}
 
 	public static <T> ExplainedOptional<T> emptyBecause(@NonNull final AdMessageKey adMessageKey, @Nullable final Object... params)
 	{
-		return new ExplainedOptional<>(null, TranslatableStrings.adMessage(adMessageKey, params), adMessageKey);
+		return new ExplainedOptional<>(null, TranslatableStrings.adMessage(adMessageKey, params), adMessageKey, params);
 	}
 
 	public static <T> ExplainedOptional<T> emptyBecause(@NonNull final ITranslatableString explanation)
 	{
-		return new ExplainedOptional<>(null, explanation, null);
+		return new ExplainedOptional<>(null, explanation, null, null);
 	}
 
 	public static <T> ExplainedOptional<T> of(@NonNull final T value)
 	{
-		return new ExplainedOptional<>(value, null, null);
+		return new ExplainedOptional<>(value, null, null, null);
 	}
 
 	@Nullable private final T value;
 	@Getter @NonNull private final ITranslatableString explanation;
 	@Nullable private final AdMessageKey adMessageKey;
+	@Nullable private final Object[] params;
 
-	private ExplainedOptional(@Nullable final T value, @Nullable final ITranslatableString explanation, @Nullable final AdMessageKey adMessageKey)
+	private ExplainedOptional(@Nullable final T value, @Nullable final ITranslatableString explanation, @Nullable final AdMessageKey adMessageKey, @Nullable final Object[] params)
 	{
 		this.value = value;
 		this.explanation = TranslatableStrings.nullToEmpty(explanation);
 		this.adMessageKey = adMessageKey;
+		this.params = params;
 	}
 
 	@Override
@@ -116,11 +118,18 @@ public final class ExplainedOptional<T>
 		{
 			return value;
 		}
-		if (adMessageKey != null)
+		else if (adMessageKey != null && (params == null || params.length == 0))
 		{
 			throw new AdempiereException(adMessageKey);
 		}
-		throw new AdempiereException(explanation);
+		else if (adMessageKey != null)
+		{
+			throw new AdempiereException(adMessageKey, params);
+		}
+		else
+		{
+			throw new AdempiereException(explanation);
+		}
 	}
 
 	public T orElseThrow(@NonNull final AdMessageKey adMessageKey)

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/ExplainedOptional.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/ExplainedOptional.java
@@ -2,6 +2,7 @@ package de.metas.i18n;
 
 import com.google.common.base.MoreObjects;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
 
@@ -38,31 +39,38 @@ public final class ExplainedOptional<T>
 {
 	public static <T> ExplainedOptional<T> emptyBecause(@NonNull final String explanation)
 	{
-		return emptyBecause(TranslatableStrings.anyLanguage(explanation));
+		return new ExplainedOptional<>(null, TranslatableStrings.anyLanguage(explanation), null);
 	}
 
-	public static <T> ExplainedOptional<T> emptyBecause(@NonNull final AdMessageKey explanation)
+	public static <T> ExplainedOptional<T> emptyBecause(@NonNull final AdMessageKey adMessageKey)
 	{
-		return emptyBecause(TranslatableStrings.adMessage(explanation));
+		return new ExplainedOptional<>(null, TranslatableStrings.adMessage(adMessageKey), adMessageKey);
+	}
+
+	public static <T> ExplainedOptional<T> emptyBecause(@NonNull final AdMessageKey adMessageKey, @Nullable final Object... params)
+	{
+		return new ExplainedOptional<>(null, TranslatableStrings.adMessage(adMessageKey, params), adMessageKey);
 	}
 
 	public static <T> ExplainedOptional<T> emptyBecause(@NonNull final ITranslatableString explanation)
 	{
-		return new ExplainedOptional<>(null, explanation);
+		return new ExplainedOptional<>(null, explanation, null);
 	}
 
 	public static <T> ExplainedOptional<T> of(@NonNull final T value)
 	{
-		return new ExplainedOptional<>(value, null);
+		return new ExplainedOptional<>(value, null, null);
 	}
 
-	private final T value;
-	private final ITranslatableString explanation;
+	@Nullable private final T value;
+	@Getter @NonNull private final ITranslatableString explanation;
+	@Nullable private final AdMessageKey adMessageKey;
 
-	private ExplainedOptional(@Nullable final T value, @Nullable final ITranslatableString explanation)
+	private ExplainedOptional(@Nullable final T value, @Nullable final ITranslatableString explanation, @Nullable final AdMessageKey adMessageKey)
 	{
 		this.value = value;
 		this.explanation = TranslatableStrings.nullToEmpty(explanation);
+		this.adMessageKey = adMessageKey;
 	}
 
 	@Override
@@ -79,14 +87,10 @@ public final class ExplainedOptional<T>
 				.toString();
 	}
 
-	public ITranslatableString getExplanation()
-	{
-		return explanation != null ? explanation : TranslatableStrings.empty();
-	}
-
+	@Nullable
 	public String getExplanationAsString()
 	{
-		return explanation != null ? explanation.getDefaultValue() : null;
+		return explanation.getDefaultValue();
 	}
 
 	@Nullable
@@ -100,9 +104,23 @@ public final class ExplainedOptional<T>
 		return value != null ? value : other.get();
 	}
 
+	@Nullable
+	public AdMessageKey getAdMessageKey()
+	{
+		return adMessageKey;
+	}
+
 	public T orElseThrow()
 	{
-		return orElseThrow(AdempiereException::new);
+		if (value != null)
+		{
+			return value;
+		}
+		if (adMessageKey != null)
+		{
+			throw new AdempiereException(adMessageKey);
+		}
+		throw new AdempiereException(explanation);
 	}
 
 	public T orElseThrow(@NonNull final AdMessageKey adMessageKey)

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/ExplainedOptional.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/ExplainedOptional.java
@@ -34,45 +34,41 @@ import java.util.function.Supplier;
  * #L%
  */
 
-@EqualsAndHashCode(exclude = {"adMessageKey", "params"})
+@EqualsAndHashCode
 public final class ExplainedOptional<T>
 {
 	public static <T> ExplainedOptional<T> emptyBecause(@NonNull final String explanation)
 	{
-		return new ExplainedOptional<>(null, TranslatableStrings.anyLanguage(explanation), null, null);
+		return new ExplainedOptional<>(null, TranslatableStrings.anyLanguage(explanation));
 	}
 
 	public static <T> ExplainedOptional<T> emptyBecause(@NonNull final AdMessageKey adMessageKey)
 	{
-		return new ExplainedOptional<>(null, TranslatableStrings.adMessage(adMessageKey), adMessageKey, null);
+		return new ExplainedOptional<>(null, TranslatableStrings.adMessage(adMessageKey));
 	}
 
 	public static <T> ExplainedOptional<T> emptyBecause(@NonNull final AdMessageKey adMessageKey, @Nullable final Object... params)
 	{
-		return new ExplainedOptional<>(null, TranslatableStrings.adMessage(adMessageKey, params), adMessageKey, params);
+		return new ExplainedOptional<>(null, TranslatableStrings.adMessage(adMessageKey, params));
 	}
 
 	public static <T> ExplainedOptional<T> emptyBecause(@NonNull final ITranslatableString explanation)
 	{
-		return new ExplainedOptional<>(null, explanation, null, null);
+		return new ExplainedOptional<>(null, explanation);
 	}
 
 	public static <T> ExplainedOptional<T> of(@NonNull final T value)
 	{
-		return new ExplainedOptional<>(value, null, null, null);
+		return new ExplainedOptional<>(value, null);
 	}
 
 	@Nullable private final T value;
 	@Getter @NonNull private final ITranslatableString explanation;
-	@Nullable private final AdMessageKey adMessageKey;
-	@Nullable private final Object[] params;
 
-	private ExplainedOptional(@Nullable final T value, @Nullable final ITranslatableString explanation, @Nullable final AdMessageKey adMessageKey, @Nullable final Object[] params)
+	private ExplainedOptional(@Nullable final T value, @Nullable final ITranslatableString explanation)
 	{
 		this.value = value;
 		this.explanation = TranslatableStrings.nullToEmpty(explanation);
-		this.adMessageKey = adMessageKey;
-		this.params = params;
 	}
 
 	@Override
@@ -109,7 +105,7 @@ public final class ExplainedOptional<T>
 	@Nullable
 	public AdMessageKey getAdMessageKey()
 	{
-		return adMessageKey;
+		return explanation.getAdMessageKey().orElse(null);
 	}
 
 	public T orElseThrow()
@@ -118,18 +114,7 @@ public final class ExplainedOptional<T>
 		{
 			return value;
 		}
-		else if (adMessageKey != null && (params == null || params.length == 0))
-		{
-			throw new AdempiereException(adMessageKey);
-		}
-		else if (adMessageKey != null)
-		{
-			throw new AdempiereException(adMessageKey, params);
-		}
-		else
-		{
-			throw new AdempiereException(explanation);
-		}
+		throw new AdempiereException(explanation);
 	}
 
 	public T orElseThrow(@NonNull final AdMessageKey adMessageKey)

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/ExplainedOptional.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/ExplainedOptional.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
  * #L%
  */
 
-@EqualsAndHashCode
+@EqualsAndHashCode(exclude = "adMessageKey")
 public final class ExplainedOptional<T>
 {
 	public static <T> ExplainedOptional<T> emptyBecause(@NonNull final String explanation)

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/ITranslatableString.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/ITranslatableString.java
@@ -1,5 +1,6 @@
 package de.metas.i18n;
 
+import java.util.Optional;
 import java.util.Set;
 
 
@@ -38,6 +39,8 @@ public interface ITranslatableString
 	String getDefaultValue();
 
 	Set<String> getAD_Languages();
+
+	default Optional<AdMessageKey> getAdMessageKey() { return Optional.empty(); }
 
 	default boolean isTranslatedTo(final String adLanguage)
 	{

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/impl/ADMessageTranslatableString.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/impl/ADMessageTranslatableString.java
@@ -13,6 +13,7 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /*
@@ -80,6 +81,12 @@ final class ADMessageTranslatableString implements ITranslatableString
 	public Set<String> getAD_Languages()
 	{
 		return Services.get(ILanguageBL.class).getAvailableLanguages().getAD_Languages();
+	}
+
+	@Override
+	public Optional<AdMessageKey> getAdMessageKey()
+	{
+		return Optional.of(adMessage);
 	}
 
 }

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/hu/DistributionHUService.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/hu/DistributionHUService.java
@@ -15,6 +15,7 @@ import de.metas.handlingunits.reservation.HUReservationDocRef;
 import de.metas.handlingunits.reservation.HUReservationService;
 import de.metas.handlingunits.storage.IHUProductStorage;
 import de.metas.handlingunits.storage.IHUStorageFactory;
+import de.metas.handlingunits.qrcodes.mobile.MobileQRCodeMessages;
 import de.metas.i18n.AdMessageKey;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
@@ -25,6 +26,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.util.lang.IAutoCloseable;
+import org.adempiere.warehouse.LocatorId;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 
@@ -65,9 +67,7 @@ public class DistributionHUService
 		}
 		else
 		{
-			throw new AdempiereException("Cannot convert " + scannedCode + " to actual HUQRCode")
-					.setParameter("parsedHUQRCode", parsedHUQRCode)
-					.setParameter("parsedHUQRCode type", parsedHUQRCode.getClass().getSimpleName());
+			throw new AdempiereException(MobileQRCodeMessages.WRONG_TYPE, parsedHUQRCode.getClass().getSimpleName());
 		}
 	}
 
@@ -123,6 +123,25 @@ public class DistributionHUService
 	{
 		final HuId huId = huQRCodesService.getHuIdByQRCode(huQRCode);
 		getProductQuantity(huId, productId); // shall throw exception if no qty found
+	}
+
+	public void assertHUCanBePickedFrom(@NonNull final HuId huId, @NonNull final LocatorId pickFromLocatorId, @NonNull final LocatorId dropToLocatorId)
+	{
+		final I_M_HU hu = handlingUnitsBL.getById(huId);
+
+		if (hu.isReserved())
+		{
+			throw new AdempiereException(MobileQRCodeMessages.HU_RESERVED_BY_OTHER);
+		}
+
+		if (LocatorId.equalsByRepoId(hu.getM_Locator_ID(), dropToLocatorId.getRepoId()))
+		{
+			throw new AdempiereException(MobileQRCodeMessages.HU_ALREADY_AT_TARGET);
+		}
+		if (!LocatorId.equalsByRepoId(hu.getM_Locator_ID(), pickFromLocatorId.getRepoId()))
+		{
+			throw new AdempiereException(MobileQRCodeMessages.HU_NOT_AT_TARGET);
+		}
 	}
 
 	public void deleteReservationsByDocumentRefs(final ImmutableSet<HUReservationDocRef> huReservationDocRefs)

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/commands/pick_from/DistributionJobPickFromCommand.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/commands/pick_from/DistributionJobPickFromCommand.java
@@ -185,6 +185,7 @@ public class DistributionJobPickFromCommand
 		final JsonDistributionEvent.PickFrom pickFrom = Check.assumeNotNull(this.pickFrom, "pickFrom must be set");
 		final ScannedCode pickFromScannedCode = ScannedCode.ofString(Check.assumeNotNull(pickFrom.getQrCode(), "pickFrom.qrCode must be set"));
 		final HuId sourceHuId = huService.resolveHUId(pickFromScannedCode);
+		huService.assertHUCanBePickedFrom(sourceHuId, line.getPickFromLocatorId(), line.getDropToLocatorId());
 
 		final Quantity sourceHUQty = huService.getProductQuantity(sourceHuId, line.getProductId());
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
@@ -112,7 +112,7 @@ public class PickingJobService implements PickingSlotListener
 		return pickingJobRepository.getById(pickingJobId, loadingSupportingServices);
 	}
 
-	public PickingJob updateById(@NonNull final PickingJobId pickingJobId, @NonNull UnaryOperator<PickingJob> updater)
+	public PickingJob updateById(@NonNull final PickingJobId pickingJobId, @NonNull final UnaryOperator<PickingJob> updater)
 	{
 		final PickingJobLoaderSupportingServices loadingSupportingServices = pickingJobLoaderSupportingServicesFactory.createLoaderSupportingServices();
 		return pickingJobRepository.updateById(pickingJobId, loadingSupportingServices, updater);
@@ -632,10 +632,10 @@ public class PickingJobService implements PickingSlotListener
 
 	private PickingJob closeLUAndTUPickingTargets(
 			@NonNull final PickingJob pickingJob,
-			boolean isCloseOnHeader,
-			boolean isCloseOnLines,
-			@Nullable PickingJobLineId onlyLineId,
-			boolean isShipClosedHUs)
+			final boolean isCloseOnHeader,
+			final boolean isCloseOnLines,
+			@Nullable final PickingJobLineId onlyLineId,
+			final boolean isShipClosedHUs)
 	{
 		final LUIdsAndTopLevelTUIdsCollector closedHUIdsCollector = new LUIdsAndTopLevelTUIdsCollector();
 		final PickingJob pickingJobChanged = pickingJob.withClosedLUAndTUPickingTargets(isCloseOnHeader, isCloseOnLines, onlyLineId, closedHUIdsCollector);
@@ -747,7 +747,7 @@ public class PickingJobService implements PickingSlotListener
 				.build().execute();
 	}
 
-	public GetNextEligibleLineToPackResponse getNextEligibleLineToPack(@NonNull GetNextEligibleLineToPackRequest request)
+	public GetNextEligibleLineToPackResponse getNextEligibleLineToPack(@NonNull final GetNextEligibleLineToPackRequest request)
 	{
 		return GetNextEligibleLineToPackCommand.builder()
 				.pickingJobService(this)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/get_next_eligible_line/GetNextEligibleLineToPackCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/get_next_eligible_line/GetNextEligibleLineToPackCommand.java
@@ -41,6 +41,7 @@ public class GetNextEligibleLineToPackCommand
 	@Nullable private PickingJob _job;
 	@NonNull private final HashMap<PickingJobLineId, ExplainedOptional<HUInfo>> resolvedHUInfos = new HashMap<>();
 	@NonNull private final ArrayList<String> logs = new ArrayList<>();
+	@Nullable private ExplainedOptional<HUInfo> lastUserErrorResult = null;
 
 	@Builder
 	private GetNextEligibleLineToPackCommand(
@@ -92,6 +93,11 @@ public class GetNextEligibleLineToPackCommand
 				line -> BooleanWithReason.falseIf(line.isFullyPickedExcludingRejectedQty(), "fully picked (even when not considering rejected qty)")
 		);
 
+		if (!response.isFound() && lastUserErrorResult != null)
+		{
+			lastUserErrorResult.orElseThrow();
+		}
+
 		return response;
 	}
 
@@ -139,7 +145,7 @@ public class GetNextEligibleLineToPackCommand
 				.build();
 	}
 
-	private GetNextEligibleLineToPackResponse found(PickingJobLine line, HUInfo huInfo)
+	private GetNextEligibleLineToPackResponse found(final PickingJobLine line, final HUInfo huInfo)
 	{
 		return GetNextEligibleLineToPackResponse.builder()
 				.lineId(line.getId())
@@ -170,7 +176,7 @@ public class GetNextEligibleLineToPackCommand
 
 	private ExplainedOptional<HUInfo> resolvePickFromHUQRCode(@NonNull final PickingJobLine line)
 	{
-		return resolvedHUInfos.computeIfAbsent(
+		final ExplainedOptional<HUInfo> result = resolvedHUInfos.computeIfAbsent(
 				line.getId(),
 				k -> huService.resolvePickFromHUQRCode(
 						getHUQRCode(),
@@ -178,6 +184,11 @@ public class GetNextEligibleLineToPackCommand
 						getCustomerId(line),
 						getWarehouseId(line)
 				));
+		if (!result.isPresent() && result.getAdMessageKey() != null)
+		{
+			lastUserErrorResult = result;
+		}
+		return result;
 	}
 
 	@NonNull
@@ -196,12 +207,12 @@ public class GetNextEligibleLineToPackCommand
 		return shipmentSchedules.getById(shipmentScheduleId).getWarehouseId();
 	}
 
-	private void log(@NonNull String message)
+	private void log(@NonNull final String message)
 	{
 		log(null, message);
 	}
 
-	private void log(@Nullable final PickingJobLine line, @NonNull String message)
+	private void log(@Nullable final PickingJobLine line, @NonNull final String message)
 	{
 		final StringBuilder sb = new StringBuilder();
 		if (line != null)
@@ -209,7 +220,7 @@ public class GetNextEligibleLineToPackCommand
 			sb.append("Line: ").append(line.getId().getRepoId()).append(" - ");
 		}
 		sb.append(message);
-		String messageFinal = sb.toString();
+		final String messageFinal = sb.toString();
 
 		logger.debug(messageFinal);
 		logs.add(messageFinal);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/get_next_eligible_line/GetNextEligibleLineToPackCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/get_next_eligible_line/GetNextEligibleLineToPackCommand.java
@@ -9,6 +9,7 @@ import de.metas.handlingunits.picking.job.model.PickingJobLineId;
 import de.metas.handlingunits.picking.job.service.PickingJobService;
 import de.metas.handlingunits.picking.job.service.external.hu.PickingJobHUService;
 import de.metas.handlingunits.picking.job.service.external.shipmentschedule.ShipmentScheduleInfoLoadingCache;
+import de.metas.handlingunits.qrcodes.mobile.MobileQRCodeMessages;
 import de.metas.handlingunits.qrcodes.model.IHUQRCode;
 import de.metas.i18n.BooleanWithReason;
 import de.metas.i18n.ExplainedOptional;
@@ -184,7 +185,14 @@ public class GetNextEligibleLineToPackCommand
 						getCustomerId(line),
 						getWarehouseId(line)
 				));
-		if (!result.isPresent() && result.getAdMessageKey() != null)
+		// HU_PRODUCT_NOT_MATCHING is a per-line soft reject (each line has its own productId, so the
+		// same HU may match a different line). For this case we intentionally fall through to notFound(),
+		// which causes the frontend (PickProductsScanScreen.jsx) to throw "activities.picking.noMatchingLines".
+		// All other error keys (e.g. HU_DESTROYED) are line-independent hard errors that should be
+		// surfaced to the user directly instead of the generic "no matching lines" message.
+		if (!result.isPresent()
+				&& result.getAdMessageKey() != null
+				&& !MobileQRCodeMessages.HU_PRODUCT_NOT_MATCHING.equals(result.getAdMessageKey()))
 		{
 			lastUserErrorResult = result;
 		}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
@@ -10,6 +10,7 @@ import de.metas.handlingunits.qrcodes.custom.CustomHUQRCode;
 import de.metas.handlingunits.qrcodes.ean13.EAN13HUQRCode;
 import de.metas.handlingunits.qrcodes.gs1.GS1HUQRCode;
 import de.metas.handlingunits.qrcodes.leich_und_mehl.LMQRCode;
+import de.metas.handlingunits.qrcodes.mobile.MobileQRCodeMessages;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.model.IHUQRCode;
 import de.metas.i18n.AdMessageKey;
@@ -29,11 +30,10 @@ import java.util.Objects;
 @Builder
 class PickFromHUQRCodeResolveCommand
 {
-	private final static AdMessageKey ERR_NotEnoughTUsFound = AdMessageKey.of("de.metas.handlingunits.picking.job.NOT_ENOUGH_TUS_ERROR_MSG");
 	private final static AdMessageKey ERR_LMQ_LotNoNotFound = AdMessageKey.of("de.metas.handlingunits.picking.job.L_M_QR_CODE_ERROR_MSG");
 	private final static AdMessageKey ERR_NoLotNoFoundForQRCode = AdMessageKey.of("de.metas.handlingunits.picking.job.QR_CODE_EXTERNAL_LOT_ERROR_MSG");
-	public final static AdMessageKey ERR_QR_ProductNotMatching = AdMessageKey.of("de.metas.handlingunits.picking.job.QR_CODE_PRODUCT_ERROR_MSG");
-	public final static AdMessageKey ERR_QR_HU_Destroyed = AdMessageKey.of("de.metas.handlingunits.picking.job.QR_CODE_HU_DESTROYED_ERROR_MSG");
+	private final static AdMessageKey ERR_QR_HU_NotFoundByAttribute = AdMessageKey.of("de.metas.handlingunits.picking.job.QR_CODE_HU_NOT_FOUND_BY_ATTRIBUTE");
+	private final static AdMessageKey ERR_NoPickableHUInWarehouse = AdMessageKey.of("de.metas.handlingunits.picking.job.NO_PICKABLE_HU_IN_WAREHOUSE");
 
 	// services
 	@NonNull private final PickingJobProductService productService;
@@ -67,7 +67,7 @@ class PickFromHUQRCodeResolveCommand
 				if (inactiveHuId != null && huService.isDestroyed(inactiveHuId))
 				{
 					return ExplainedOptional.emptyBecause(
-							TranslatableStrings.adMessage(ERR_QR_HU_Destroyed, inactiveHuId.getRepoId()));
+							TranslatableStrings.adMessage(MobileQRCodeMessages.HU_DESTROYED, inactiveHuId.getRepoId()));
 				}
 				huService.getHuIdByQRCode(huQRCode); // throws AdempiereException — see HUQRCodesService.java
 				throw new IllegalStateException("unreachable");
@@ -77,12 +77,12 @@ class PickFromHUQRCodeResolveCommand
 			if (huService.isDestroyed(activeHuId))
 			{
 				return ExplainedOptional.emptyBecause(
-						TranslatableStrings.adMessage(ERR_QR_HU_Destroyed, activeHuId.getRepoId()));
+						TranslatableStrings.adMessage(MobileQRCodeMessages.HU_DESTROYED, activeHuId.getRepoId()));
 			}
 			if (!huService.containsProduct(activeHuId, productId))
 			{
 				return ExplainedOptional.emptyBecause(
-						TranslatableStrings.adMessage(ERR_QR_ProductNotMatching, productService.getProductNameTrl(productId)));
+						TranslatableStrings.adMessage(MobileQRCodeMessages.HU_PRODUCT_NOT_MATCHING, productService.getProductNameTrl(productId)));
 			}
 
 			return ExplainedOptional.of(HUInfo.ofHuIdAndQRCode(activeHuId, huQRCode));
@@ -126,7 +126,7 @@ class PickFromHUQRCodeResolveCommand
 		}
 		else
 		{
-			throw new AdempiereException("Unknown QR code type: " + pickFromHUQRCode); // TODO trl 
+			throw new AdempiereException(MobileQRCodeMessages.WRONG_TYPE, pickFromHUQRCode.getClass().getSimpleName());
 		}
 	}
 
@@ -160,7 +160,7 @@ class PickFromHUQRCodeResolveCommand
 		final HuId huId = huService.getFirstHUIdByQRCodeAttribute(scannedQRCode, productId).orElse(null);
 		if (huId == null)
 		{
-			return ExplainedOptional.emptyBecause(ERR_NotEnoughTUsFound); // TODO introduce a better AD_Message
+			return ExplainedOptional.emptyBecause(ERR_QR_HU_NotFoundByAttribute);
 		}
 
 		return getHUInfoById(huId);
@@ -172,7 +172,7 @@ class PickFromHUQRCodeResolveCommand
 
 		if (huId == null)
 		{
-			return ExplainedOptional.emptyBecause(ERR_NotEnoughTUsFound);// TODO introduce a better AD_Message
+			return ExplainedOptional.emptyBecause(ERR_NoPickableHUInWarehouse);
 		}
 
 		return getHUInfoById(huId);
@@ -188,7 +188,7 @@ class PickFromHUQRCodeResolveCommand
 			final ProductId gs1ProductId = productService.getProductIdByGTINStrictlyNotNull(gtin, ClientId.METASFRESH);
 			if (!ProductId.equals(expectedProductId, gs1ProductId))
 			{
-				return BooleanWithReason.falseBecause(ERR_QR_ProductNotMatching, productService.getProductNameTrl(expectedProductId));
+				return BooleanWithReason.falseBecause(MobileQRCodeMessages.HU_PRODUCT_NOT_MATCHING, productService.getProductNameTrl(expectedProductId));
 			}
 		}
 
@@ -203,7 +203,7 @@ class PickFromHUQRCodeResolveCommand
 		final EAN13 ean13 = pickFromQRCode.unbox();
 		if (!productService.isValidEAN13Product(ean13, expectedProductId, customerId))
 		{
-			return BooleanWithReason.falseBecause(ERR_QR_ProductNotMatching, productService.getProductNameTrl(expectedProductId));
+			return BooleanWithReason.falseBecause(MobileQRCodeMessages.HU_PRODUCT_NOT_MATCHING, productService.getProductNameTrl(expectedProductId));
 		}
 
 		return BooleanWithReason.TRUE;
@@ -219,7 +219,7 @@ class PickFromHUQRCodeResolveCommand
 		final String expectedProductNo = productService.getProductValue(expectedProductId);
 		if (!Objects.equals(qrCodeProductNo, expectedProductNo))
 		{
-			return BooleanWithReason.falseBecause(ERR_QR_ProductNotMatching, productService.getProductNameTrl(expectedProductId));
+			return BooleanWithReason.falseBecause(MobileQRCodeMessages.HU_PRODUCT_NOT_MATCHING, productService.getProductNameTrl(expectedProductId));
 		}
 
 		return BooleanWithReason.TRUE;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
@@ -16,7 +16,6 @@ import de.metas.handlingunits.qrcodes.model.IHUQRCode;
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.BooleanWithReason;
 import de.metas.i18n.ExplainedOptional;
-import de.metas.i18n.TranslatableStrings;
 import de.metas.product.ProductId;
 import lombok.Builder;
 import lombok.NonNull;
@@ -79,8 +78,7 @@ class PickFromHUQRCodeResolveCommand
 			}
 			if (!huService.containsProduct(activeHuId, productId))
 			{
-				return ExplainedOptional.emptyBecause(
-						TranslatableStrings.adMessage(MobileQRCodeMessages.HU_PRODUCT_NOT_MATCHING, productService.getProductNameTrl(productId)));
+				return ExplainedOptional.emptyBecause(MobileQRCodeMessages.HU_PRODUCT_NOT_MATCHING, productService.getProductNameTrl(productId));
 			}
 
 			return ExplainedOptional.of(HUInfo.ofHuIdAndQRCode(activeHuId, huQRCode));

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
@@ -66,8 +66,7 @@ class PickFromHUQRCodeResolveCommand
 				final HuId inactiveHuId = huService.getHuIdByQRCodeIncludingInactiveIfExists(huQRCode).orElse(null);
 				if (inactiveHuId != null && huService.isDestroyed(inactiveHuId))
 				{
-					return ExplainedOptional.emptyBecause(
-							TranslatableStrings.adMessage(MobileQRCodeMessages.HU_DESTROYED, inactiveHuId.getRepoId()));
+					return ExplainedOptional.emptyBecause(MobileQRCodeMessages.HU_DESTROYED, inactiveHuId.getRepoId());
 				}
 				huService.getHuIdByQRCode(huQRCode); // throws AdempiereException — see HUQRCodesService.java
 				throw new IllegalStateException("unreachable");
@@ -76,8 +75,7 @@ class PickFromHUQRCodeResolveCommand
 			// Legacy backstop: assignment still active but HU was destroyed before the destroy interceptor was deployed.
 			if (huService.isDestroyed(activeHuId))
 			{
-				return ExplainedOptional.emptyBecause(
-						TranslatableStrings.adMessage(MobileQRCodeMessages.HU_DESTROYED, activeHuId.getRepoId()));
+				return ExplainedOptional.emptyBecause(MobileQRCodeMessages.HU_DESTROYED, activeHuId.getRepoId());
 			}
 			if (!huService.containsProduct(activeHuId, productId))
 			{

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickFromHUQRCodeResolveCommand.java
@@ -120,7 +120,7 @@ class PickFromHUQRCodeResolveCommand
 			final BooleanWithReason valid = validateQRCode_ProductNo(customQRCode, productId);
 			if (valid.isFalse())
 			{
-				return ExplainedOptional.emptyBecause(valid.getReason());
+				return ExplainedOptional.emptyBecause(MobileQRCodeMessages.HU_PRODUCT_NOT_MATCHING, productService.getProductNameTrl(productId));
 			}
 			return findHUByQRCodeAttribute(pickFromHUQRCode, productId);
 		}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/mobile/MobileQRCodeMessages.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/mobile/MobileQRCodeMessages.java
@@ -1,0 +1,66 @@
+package de.metas.handlingunits.qrcodes.mobile;
+
+import de.metas.global_qrcodes.GlobalQRCode;
+import de.metas.i18n.AdMessageKey;
+import de.metas.scannable_code.ScannedCode;
+import de.metas.util.StringUtils;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.warehouse.qrcode.LocatorQRCode;
+import org.adempiere.warehouse.qrcode.LocatorQRCodeJsonConverter;
+
+@UtilityClass
+public class MobileQRCodeMessages
+{
+	// QR type / parsing errors
+	public static final AdMessageKey WRONG_TYPE_LOCATOR = AdMessageKey.of("de.metas.mobile.qr.WrongType.Locator");
+	public static final AdMessageKey WRONG_TYPE         = AdMessageKey.of("de.metas.mobile.qr.WrongType.Generic");
+	public static final AdMessageKey NOT_RECOGNIZED     = AdMessageKey.of("de.metas.mobile.qr.NotRecognized");
+
+	// HU lookup errors
+	public static final AdMessageKey HU_NOT_FOUND           = AdMessageKey.of("de.metas.mobile.qr.HuNotFound");
+	public static final AdMessageKey HU_AMBIGUOUS           = AdMessageKey.of("de.metas.mobile.qr.HuAmbiguous");
+	public static final AdMessageKey HU_DESTROYED           = AdMessageKey.of("de.metas.handlingunits.picking.job.QR_CODE_HU_DESTROYED_ERROR_MSG");
+	public static final AdMessageKey HU_PRODUCT_NOT_MATCHING = AdMessageKey.of("de.metas.handlingunits.picking.job.QR_CODE_PRODUCT_ERROR_MSG");
+
+	// Distribution business-check errors
+	public static final AdMessageKey HU_RESERVED_BY_OTHER  = AdMessageKey.of("de.metas.distribution.HuReservedByOtherDocument");
+	public static final AdMessageKey HU_NOT_AT_TARGET      = AdMessageKey.of("de.metas.distribution.HuNotAtTargetWorkplace");
+	public static final AdMessageKey HU_ALREADY_AT_TARGET  = AdMessageKey.of("de.metas.distribution.HuAlreadyAtTarget");
+
+	// Inventory business-check errors
+	public static final AdMessageKey HU_ALREADY_COUNTED    = AdMessageKey.of("de.metas.inventory.HuAlreadyCounted");
+	public static final AdMessageKey HU_NOT_IN_INVENTORY   = AdMessageKey.of("de.metas.inventory.HuNotInInventory");
+
+	// HU consolidation business-check errors
+	public static final AdMessageKey LU_EXPECTED_AT_TARGET = AdMessageKey.of("de.metas.hu_consolidation.LuExpectedAtTarget");
+	public static final AdMessageKey LU_NOT_AT_SLOT        = AdMessageKey.of("de.metas.hu_consolidation.LuNotAtPickingSlot");
+
+	// Catch-all for unexpected exceptions
+	public static final AdMessageKey MOBILE_INTERNAL_ERROR = AdMessageKey.of("de.metas.mobile.InternalError");
+
+	/**
+	 * Creates a user-friendly exception for the case where the user scanned a GlobalQRCode that is not an HU QR code.
+	 * If the scanned code is a locator (LOC#) QR code, the locator caption is included in the message.
+	 */
+	@NonNull
+	public static AdempiereException newWrongGlobalQRTypeException(@NonNull final GlobalQRCode globalQRCode)
+	{
+		if (LocatorQRCodeJsonConverter.isTypeMatching(globalQRCode))
+		{
+			final LocatorQRCode locatorQRCode = LocatorQRCodeJsonConverter.fromGlobalQRCode(globalQRCode);
+			return new AdempiereException(WRONG_TYPE_LOCATOR, locatorQRCode.getCaption());
+		}
+		return new AdempiereException(WRONG_TYPE, globalQRCode.getType().toJson());
+	}
+
+	/**
+	 * Creates a user-friendly exception for the case where the scanned code does not match any known QR code format.
+	 */
+	@NonNull
+	public static AdempiereException newNotRecognizedException(@NonNull final ScannedCode scannedCode)
+	{
+		return new AdempiereException(NOT_RECOGNIZED, StringUtils.trunc(scannedCode.getAsString(), 40));
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/mobile/MobileQRCodeMessages.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/mobile/MobileQRCodeMessages.java
@@ -37,12 +37,6 @@ public class MobileQRCodeMessages
 	public static final AdMessageKey LU_EXPECTED_AT_TARGET = AdMessageKey.of("de.metas.hu_consolidation.LuExpectedAtTarget");
 	public static final AdMessageKey LU_NOT_AT_SLOT        = AdMessageKey.of("de.metas.hu_consolidation.LuNotAtPickingSlot");
 
-	// Catch-all for unexpected exceptions.
-	// TODO: intended for use in the mobile REST controllers' global exception handler to wrap unrecognized server-side exceptions.
-	//       The message shown to the user should include a server-generated trace-ID so support staff can
-	//       correlate the user's report with the corresponding backend log entry.
-	public static final AdMessageKey MOBILE_INTERNAL_ERROR = AdMessageKey.of("de.metas.mobile.InternalError");
-
 	/**
 	 * Creates a user-friendly exception for the case where the user scanned a GlobalQRCode that is not an HU QR code.
 	 * If the scanned code is a locator (LOC#) QR code, the locator caption is included in the message.

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/mobile/MobileQRCodeMessages.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/mobile/MobileQRCodeMessages.java
@@ -37,7 +37,10 @@ public class MobileQRCodeMessages
 	public static final AdMessageKey LU_EXPECTED_AT_TARGET = AdMessageKey.of("de.metas.hu_consolidation.LuExpectedAtTarget");
 	public static final AdMessageKey LU_NOT_AT_SLOT        = AdMessageKey.of("de.metas.hu_consolidation.LuNotAtPickingSlot");
 
-	// Catch-all for unexpected exceptions
+	// Catch-all for unexpected exceptions.
+	// TODO: intended for use in the mobile REST controllers' global exception handler to wrap unrecognized server-side exceptions.
+	//       The message shown to the user should include a server-generated trace-ID so support staff can
+	//       correlate the user's report with the corresponding backend log entry.
 	public static final AdMessageKey MOBILE_INTERNAL_ERROR = AdMessageKey.of("de.metas.mobile.InternalError");
 
 	/**

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -19,6 +19,7 @@ import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.model.HUQRCodeAssignment;
 import de.metas.handlingunits.qrcodes.model.HUQRCodeUniqueId;
 import de.metas.handlingunits.qrcodes.model.IHUQRCode;
+import de.metas.handlingunits.qrcodes.mobile.MobileQRCodeMessages;
 import de.metas.handlingunits.qrcodes.special.PickOnTheFlyQRCode;
 import de.metas.printing.DoNothingMassPrintingService;
 import de.metas.process.AdProcessId;
@@ -201,7 +202,8 @@ public class HUQRCodesService
 	public HuId getHuIdByQRCode(@NonNull final HUQRCode qrCode)
 	{
 		return getHuIdByQRCodeIfExists(qrCode)
-				.orElseThrow(() -> new AdempiereException("No HU attached to QR Code `" + qrCode.toDisplayableQRCode() + "`"));
+				.orElseThrow(() -> new AdempiereException(MobileQRCodeMessages.HU_NOT_FOUND)
+						.setParameter("qrCode", qrCode.toDisplayableQRCode()));
 	}
 
 	public Optional<HuId> getHuIdByQRCodeIfExists(@NonNull final HUQRCode qrCode)
@@ -440,6 +442,10 @@ public class HUQRCodesService
 			return ean13HUQRCode;
 		}
 
-		throw new AdempiereException("QR code is not handled: " + scannedCode);
+		if (globalQRCode != null)
+		{
+			throw MobileQRCodeMessages.newWrongGlobalQRTypeException(globalQRCode);
+		}
+		throw MobileQRCodeMessages.newNotRecognizedException(scannedCode);
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5803900_sys_gh29689_MobileUIUserFriendlyQRCodeMessages.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5803900_sys_gh29689_MobileUIUserFriendlyQRCodeMessages.sql
@@ -5,7 +5,7 @@
 -- Value: de.metas.mobile.qr.WrongType.Locator
 -- 2026-05-21 10:00
 INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
-VALUES (0,545689 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:00','YYYY-MM-DD HH24:MI'),100,'D','Y','Lagerort ''{0}'' eingescannt — erwartet wird eine Artikel-HU','E','QR_WRONG_TYPE_LOCATOR',TO_TIMESTAMP('2026-05-21 10:00','YYYY-MM-DD HH24:MI'),100,'de.metas.mobile.qr.WrongType.Locator')
+VALUES (0,545689 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:00','YYYY-MM-DD HH24:MI'),100,'D','Y','Lagerort {0} eingescannt — erwartet wird eine Artikel-HU','E','QR_WRONG_TYPE_LOCATOR',TO_TIMESTAMP('2026-05-21 10:00','YYYY-MM-DD HH24:MI'),100,'de.metas.mobile.qr.WrongType.Locator')
 ;
 INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
 SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
@@ -13,7 +13,7 @@ FROM AD_Language l, AD_Message t
 WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545689
   AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
 ;
-UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='Scanned locator ''{0}'' — expected a product HU',Updated=TO_TIMESTAMP('2026-05-21 10:00','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='Scanned locator {0} — expected a product HU',Updated=TO_TIMESTAMP('2026-05-21 10:00','YYYY-MM-DD HH24:MI'),UpdatedBy=100
 WHERE AD_Language='en_US' AND AD_Message_ID=545689
 ;
 UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:00','YYYY-MM-DD HH24:MI'),UpdatedBy=100
@@ -41,7 +41,7 @@ WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545690
 -- Value: de.metas.mobile.qr.NotRecognized
 -- 2026-05-21 10:00
 INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
-VALUES (0,545691 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:02','YYYY-MM-DD HH24:MI'),100,'D','Y','QR-Code nicht erkannt: ''{0}''','E','QR_NOT_RECOGNIZED',TO_TIMESTAMP('2026-05-21 10:02','YYYY-MM-DD HH24:MI'),100,'de.metas.mobile.qr.NotRecognized')
+VALUES (0,545691 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:02','YYYY-MM-DD HH24:MI'),100,'D','Y','QR-Code nicht erkannt: {0}','E','QR_NOT_RECOGNIZED',TO_TIMESTAMP('2026-05-21 10:02','YYYY-MM-DD HH24:MI'),100,'de.metas.mobile.qr.NotRecognized')
 ;
 INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
 SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
@@ -49,7 +49,7 @@ FROM AD_Language l, AD_Message t
 WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545691
   AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
 ;
-UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='QR code not recognized: ''{0}''',Updated=TO_TIMESTAMP('2026-05-21 10:02','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='QR code not recognized: {0}',Updated=TO_TIMESTAMP('2026-05-21 10:02','YYYY-MM-DD HH24:MI'),UpdatedBy=100
 WHERE AD_Language='en_US' AND AD_Message_ID=545691
 ;
 UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:02','YYYY-MM-DD HH24:MI'),UpdatedBy=100

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5803900_sys_gh29689_MobileUIUserFriendlyQRCodeMessages.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5803900_sys_gh29689_MobileUIUserFriendlyQRCodeMessages.sql
@@ -203,19 +203,19 @@ WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545699
 -- Value: de.metas.mobile.InternalError
 -- 2026-05-21 10:00
 INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
-VALUES (0,545700 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:11','YYYY-MM-DD HH24:MI'),100,'D','Y','Interner Fehler. Bitte wenden Sie sich an den Support.','E','MOBILE_INTERNAL_ERROR',TO_TIMESTAMP('2026-05-21 10:11','YYYY-MM-DD HH24:MI'),100,'de.metas.mobile.InternalError')
+VALUES (0,545709 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:11','YYYY-MM-DD HH24:MI'),100,'D','Y','Interner Fehler. Bitte wenden Sie sich an den Support.','E','MOBILE_INTERNAL_ERROR',TO_TIMESTAMP('2026-05-21 10:11','YYYY-MM-DD HH24:MI'),100,'de.metas.mobile.InternalError')
 ;
 INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
 SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
 FROM AD_Language l, AD_Message t
-WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545700
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545709
   AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
 ;
 UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='Internal error. Please contact support.',Updated=TO_TIMESTAMP('2026-05-21 10:11','YYYY-MM-DD HH24:MI'),UpdatedBy=100
-WHERE AD_Language='en_US' AND AD_Message_ID=545700
+WHERE AD_Language='en_US' AND AD_Message_ID=545709
 ;
 UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:11','YYYY-MM-DD HH24:MI'),UpdatedBy=100
-WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545700
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545709
 ;
 
 -- Value: de.metas.inventory.HuNotInInventory

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5803900_sys_gh29689_MobileUIUserFriendlyQRCodeMessages.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5803900_sys_gh29689_MobileUIUserFriendlyQRCodeMessages.sql
@@ -1,0 +1,291 @@
+-- gh#29689 — MobileUI: user-friendly error messages for QR code scan failures
+-- Creates 15 AD_Message records for de.metas.handlingunits.qrcodes.mobile.MobileQRCodeMessages
+-- Backfills ErrorCode on 3 pre-existing picking messages (545452, 545454, 545477)
+
+-- Value: de.metas.mobile.qr.WrongType.Locator
+-- 2026-05-21 10:00
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545689 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:00','YYYY-MM-DD HH24:MI'),100,'D','Y','Lagerort ''{0}'' eingescannt — erwartet wird eine Artikel-HU','E','QR_WRONG_TYPE_LOCATOR',TO_TIMESTAMP('2026-05-21 10:00','YYYY-MM-DD HH24:MI'),100,'de.metas.mobile.qr.WrongType.Locator')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545689
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='Scanned locator ''{0}'' — expected a product HU',Updated=TO_TIMESTAMP('2026-05-21 10:00','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545689
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:00','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545689
+;
+
+-- Value: de.metas.mobile.qr.WrongType.Generic
+-- 2026-05-21 10:00
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545690 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:01','YYYY-MM-DD HH24:MI'),100,'D','Y','Falscher QR-Code-Typ: {0}','E','QR_WRONG_TYPE',TO_TIMESTAMP('2026-05-21 10:01','YYYY-MM-DD HH24:MI'),100,'de.metas.mobile.qr.WrongType.Generic')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545690
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='Wrong QR code type: {0}',Updated=TO_TIMESTAMP('2026-05-21 10:01','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545690
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:01','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545690
+;
+
+-- Value: de.metas.mobile.qr.NotRecognized
+-- 2026-05-21 10:00
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545691 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:02','YYYY-MM-DD HH24:MI'),100,'D','Y','QR-Code nicht erkannt: ''{0}''','E','QR_NOT_RECOGNIZED',TO_TIMESTAMP('2026-05-21 10:02','YYYY-MM-DD HH24:MI'),100,'de.metas.mobile.qr.NotRecognized')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545691
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='QR code not recognized: ''{0}''',Updated=TO_TIMESTAMP('2026-05-21 10:02','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545691
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:02','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545691
+;
+
+-- Value: de.metas.mobile.qr.HuNotFound
+-- 2026-05-21 10:00
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545692 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:03','YYYY-MM-DD HH24:MI'),100,'D','Y','Keine HU für diesen QR-Code gefunden','E','QR_HU_NOT_FOUND',TO_TIMESTAMP('2026-05-21 10:03','YYYY-MM-DD HH24:MI'),100,'de.metas.mobile.qr.HuNotFound')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545692
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='No HU found for this QR code',Updated=TO_TIMESTAMP('2026-05-21 10:03','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545692
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:03','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545692
+;
+
+-- Value: de.metas.mobile.qr.HuAmbiguous
+-- 2026-05-21 10:00
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545693 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:04','YYYY-MM-DD HH24:MI'),100,'D','Y','Mehrere HUs für diesen QR-Code gefunden','E','QR_HU_AMBIGUOUS',TO_TIMESTAMP('2026-05-21 10:04','YYYY-MM-DD HH24:MI'),100,'de.metas.mobile.qr.HuAmbiguous')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545693
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='Multiple HUs found for this QR code',Updated=TO_TIMESTAMP('2026-05-21 10:04','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545693
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:04','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545693
+;
+
+-- Value: de.metas.distribution.HuReservedByOtherDocument
+-- 2026-05-21 10:00
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545694 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:05','YYYY-MM-DD HH24:MI'),100,'D','Y','HU ist für einen anderen Auftrag reserviert','E','DISTRIBUTION_HU_RESERVED',TO_TIMESTAMP('2026-05-21 10:05','YYYY-MM-DD HH24:MI'),100,'de.metas.distribution.HuReservedByOtherDocument')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545694
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='HU is reserved by another document',Updated=TO_TIMESTAMP('2026-05-21 10:05','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545694
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:05','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545694
+;
+
+-- Value: de.metas.distribution.HuNotAtTargetWorkplace
+-- 2026-05-21 10:00
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545695 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:06','YYYY-MM-DD HH24:MI'),100,'D','Y','HU befindet sich nicht am Ziel-Wagen','E','DISTRIBUTION_HU_NOT_AT_TARGET',TO_TIMESTAMP('2026-05-21 10:06','YYYY-MM-DD HH24:MI'),100,'de.metas.distribution.HuNotAtTargetWorkplace')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545695
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='HU is not at the target trolley',Updated=TO_TIMESTAMP('2026-05-21 10:06','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545695
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:06','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545695
+;
+
+-- Value: de.metas.distribution.HuAlreadyAtTarget
+-- 2026-05-21 10:00
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545696 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:07','YYYY-MM-DD HH24:MI'),100,'D','Y','HU befindet sich bereits am Ziel','E','DISTRIBUTION_HU_ALREADY_AT_TARGET',TO_TIMESTAMP('2026-05-21 10:07','YYYY-MM-DD HH24:MI'),100,'de.metas.distribution.HuAlreadyAtTarget')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545696
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='HU is already at the target',Updated=TO_TIMESTAMP('2026-05-21 10:07','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545696
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:07','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545696
+;
+
+-- Value: de.metas.inventory.HuAlreadyCounted
+-- 2026-05-21 10:00
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545697 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:08','YYYY-MM-DD HH24:MI'),100,'D','Y','HU wurde bereits gezählt','E','INVENTORY_HU_ALREADY_COUNTED',TO_TIMESTAMP('2026-05-21 10:08','YYYY-MM-DD HH24:MI'),100,'de.metas.inventory.HuAlreadyCounted')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545697
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='HU was already counted',Updated=TO_TIMESTAMP('2026-05-21 10:08','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545697
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:08','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545697
+;
+
+-- Value: de.metas.hu_consolidation.LuExpectedAtTarget
+-- 2026-05-21 10:00
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545698 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:09','YYYY-MM-DD HH24:MI'),100,'D','Y','LU wird am Ziel-Regal erwartet','E','HU_CONSOL_LU_EXPECTED_AT_TARGET',TO_TIMESTAMP('2026-05-21 10:09','YYYY-MM-DD HH24:MI'),100,'de.metas.hu_consolidation.LuExpectedAtTarget')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545698
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='LU is expected at the target rack',Updated=TO_TIMESTAMP('2026-05-21 10:09','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545698
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:09','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545698
+;
+
+-- Value: de.metas.hu_consolidation.LuNotAtPickingSlot
+-- 2026-05-21 10:00
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545699 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:10','YYYY-MM-DD HH24:MI'),100,'D','Y','LU befindet sich nicht am Kommissionierplatz','E','HU_CONSOL_LU_NOT_AT_SLOT',TO_TIMESTAMP('2026-05-21 10:10','YYYY-MM-DD HH24:MI'),100,'de.metas.hu_consolidation.LuNotAtPickingSlot')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545699
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='LU is not at the picking slot',Updated=TO_TIMESTAMP('2026-05-21 10:10','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545699
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:10','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545699
+;
+
+-- Value: de.metas.mobile.InternalError
+-- 2026-05-21 10:00
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545700 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:11','YYYY-MM-DD HH24:MI'),100,'D','Y','Interner Fehler. Bitte wenden Sie sich an den Support.','E','MOBILE_INTERNAL_ERROR',TO_TIMESTAMP('2026-05-21 10:11','YYYY-MM-DD HH24:MI'),100,'de.metas.mobile.InternalError')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545700
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='Internal error. Please contact support.',Updated=TO_TIMESTAMP('2026-05-21 10:11','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545700
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:11','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545700
+;
+
+-- Value: de.metas.inventory.HuNotInInventory
+-- 2026-05-21 10:12
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545705 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:12','YYYY-MM-DD HH24:MI'),100,'D','Y','HU wurde in diesem Inventar nicht gefunden','E','INVENTORY_HU_NOT_IN_INVENTORY',TO_TIMESTAMP('2026-05-21 10:12','YYYY-MM-DD HH24:MI'),100,'de.metas.inventory.HuNotInInventory')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545705
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='HU not found in this inventory',Updated=TO_TIMESTAMP('2026-05-21 10:12','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545705
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:12','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545705
+;
+
+-- Value: de.metas.handlingunits.picking.job.QR_CODE_HU_NOT_FOUND_BY_ATTRIBUTE
+-- Picking: scanned custom QR code matches the product but no HU with this attribute exists in stock
+-- 2026-05-21 10:13
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545706 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:13','YYYY-MM-DD HH24:MI'),100,'D','Y','Keine HU mit diesem Merkmal im Lager gefunden','E','PICKING_QR_HU_NOT_FOUND_BY_ATTRIBUTE',TO_TIMESTAMP('2026-05-21 10:13','YYYY-MM-DD HH24:MI'),100,'de.metas.handlingunits.picking.job.QR_CODE_HU_NOT_FOUND_BY_ATTRIBUTE')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545706
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='No HU found in stock for this attribute',Updated=TO_TIMESTAMP('2026-05-21 10:13','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545706
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:13','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545706
+;
+
+-- Value: de.metas.handlingunits.picking.job.NO_PICKABLE_HU_IN_WAREHOUSE
+-- Picking: system tried to auto-pick from warehouse but found no stock for the product
+-- 2026-05-21 10:14
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
+VALUES (0,545707 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:14','YYYY-MM-DD HH24:MI'),100,'D','Y','Keine kommissionierbare HU im Lager vorhanden','E','PICKING_NO_PICKABLE_HU_IN_WAREHOUSE',TO_TIMESTAMP('2026-05-21 10:14','YYYY-MM-DD HH24:MI'),100,'de.metas.handlingunits.picking.job.NO_PICKABLE_HU_IN_WAREHOUSE')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545707
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='No pickable HU available in warehouse',Updated=TO_TIMESTAMP('2026-05-21 10:14','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545707
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:14','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545707
+;
+
+-- Backfill missing ErrorCode on pre-existing picking messages
+-- Value: de.metas.handlingunits.picking.job.L_M_QR_CODE_ERROR_MSG (ID 545452)
+UPDATE AD_Message SET ErrorCode='PICKING_LM_QR_NO_LOT_NUMBER',Updated=TO_TIMESTAMP('2026-05-21 10:15','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Message_ID=545452
+;
+
+-- Value: de.metas.handlingunits.picking.job.QR_CODE_EXTERNAL_LOT_ERROR_MSG (ID 545454)
+UPDATE AD_Message SET ErrorCode='PICKING_NO_HU_FOR_EXTERNAL_LOT',Updated=TO_TIMESTAMP('2026-05-21 10:15','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Message_ID=545454
+;
+
+-- Value: de.metas.handlingunits.picking.job.QR_CODE_PRODUCT_ERROR_MSG (ID 545477)
+UPDATE AD_Message SET ErrorCode='PICKING_QR_PRODUCT_NOT_MATCHING',Updated=TO_TIMESTAMP('2026-05-21 10:15','YYYY-MM-DD HH24:MI'),UpdatedBy=100
+WHERE AD_Message_ID=545477
+;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5803900_sys_gh29689_MobileUIUserFriendlyQRCodeMessages.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5803900_sys_gh29689_MobileUIUserFriendlyQRCodeMessages.sql
@@ -1,5 +1,5 @@
 -- gh#29689 — MobileUI: user-friendly error messages for QR code scan failures
--- Creates 15 AD_Message records for de.metas.handlingunits.qrcodes.mobile.MobileQRCodeMessages
+-- Creates 14 AD_Message records for de.metas.handlingunits.qrcodes.mobile.MobileQRCodeMessages
 -- Backfills ErrorCode on 3 pre-existing picking messages (545452, 545454, 545477)
 
 -- Value: de.metas.mobile.qr.WrongType.Locator
@@ -198,24 +198,6 @@ WHERE AD_Language='en_US' AND AD_Message_ID=545699
 ;
 UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:10','YYYY-MM-DD HH24:MI'),UpdatedBy=100
 WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545699
-;
-
--- Value: de.metas.mobile.InternalError
--- 2026-05-21 10:00
-INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,ErrorCode,Updated,UpdatedBy,Value)
-VALUES (0,545709 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-21 10:11','YYYY-MM-DD HH24:MI'),100,'D','Y','Interner Fehler. Bitte wenden Sie sich an den Support.','E','MOBILE_INTERNAL_ERROR',TO_TIMESTAMP('2026-05-21 10:11','YYYY-MM-DD HH24:MI'),100,'de.metas.mobile.InternalError')
-;
-INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,IsActive)
-SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.CreatedBy,t.Updated,t.UpdatedBy,'Y'
-FROM AD_Language l, AD_Message t
-WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545709
-  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
-;
-UPDATE AD_Message_Trl SET IsTranslated='Y',MsgText='Internal error. Please contact support.',Updated=TO_TIMESTAMP('2026-05-21 10:11','YYYY-MM-DD HH24:MI'),UpdatedBy=100
-WHERE AD_Language='en_US' AND AD_Message_ID=545709
-;
-UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-21 10:11','YYYY-MM-DD HH24:MI'),UpdatedBy=100
-WHERE AD_Language IN ('de_DE','de_CH') AND AD_Message_ID=545709
 ;
 
 -- Value: de.metas.inventory.HuNotInInventory

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
@@ -359,5 +359,24 @@ class HUQRCodesServiceTest
 			System.out.println("parsedHUQRCode: " + parsedHUQRCode + " (" + parsedHUQRCode.getClass() + ")");
 			assertThat(parsedHUQRCode).isInstanceOf(HUQRCode.class);
 		}
+
+		@Test
+		void locatorQRCode_throwsUserFriendlyError()
+		{
+			// LOC# prefix is a locator QR code, not an HU QR code
+			final String locatorQRCodeString = "LOC#1#{\"warehouseId\":1,\"locatorId\":2,\"caption\":\"Regal-01\"}";
+			assertThatThrownBy(() -> huQRCodesService.parse(locatorQRCodeString))
+					.isInstanceOf(AdempiereException.class)
+					.satisfies(ex -> assertThat(((AdempiereException)ex).isUserValidationError()).isTrue());
+		}
+
+		@Test
+		void unrecognized_throwsUserFriendlyError()
+		{
+			final String junkCode = "TOTALLY_UNKNOWN_FORMAT_XYZ";
+			assertThatThrownBy(() -> huQRCodesService.parse(junkCode))
+					.isInstanceOf(AdempiereException.class)
+					.satisfies(ex -> assertThat(((AdempiereException)ex).isUserValidationError()).isTrue());
+		}
 	}
 }

--- a/backend/de.metas.hu_consolidation.mobile/src/main/java/de/metas/hu_consolidation/mobile/job/commands/consolidate/ConsolidateCommand.java
+++ b/backend/de.metas.hu_consolidation.mobile/src/main/java/de/metas/hu_consolidation/mobile/job/commands/consolidate/ConsolidateCommand.java
@@ -9,6 +9,7 @@ import de.metas.handlingunits.allocation.transfer.HUTransformService;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.picking.slot.PickingSlotQueue;
 import de.metas.handlingunits.picking.slot.PickingSlotService;
+import de.metas.handlingunits.qrcodes.mobile.MobileQRCodeMessages;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
 import de.metas.hu_consolidation.mobile.job.HUConsolidationJob;
@@ -110,7 +111,7 @@ public class ConsolidateCommand
 		{
 			if (!fromPickingSlotQueue.containsHuId(huId))
 			{
-				throw new AdempiereException("No HU with ID " + huId + " was found in picking slot " + fromPickingSlotQueue.getPickingSlotId() + "!");
+				throw new AdempiereException(MobileQRCodeMessages.LU_NOT_AT_SLOT);
 			}
 			return ImmutableSet.of(huId);
 		}

--- a/backend/de.metas.hu_consolidation.mobile/src/main/java/de/metas/hu_consolidation/mobile/job/commands/set_target/SetTargetCommand.java
+++ b/backend/de.metas.hu_consolidation.mobile/src/main/java/de/metas/hu_consolidation/mobile/job/commands/set_target/SetTargetCommand.java
@@ -3,6 +3,7 @@ package de.metas.hu_consolidation.mobile.job.commands.set_target;
 import de.metas.handlingunits.IHUStatusBL;
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.qrcodes.mobile.MobileQRCodeMessages;
 import de.metas.hu_consolidation.mobile.job.HUConsolidationJob;
 import de.metas.hu_consolidation.mobile.job.HUConsolidationJobId;
 import de.metas.hu_consolidation.mobile.job.HUConsolidationJobRepository;
@@ -42,7 +43,7 @@ public class SetTargetCommand
 			final I_M_HU lu = handlingUnitsBL.getById(target.getLuIdNotNull());
 			if (!handlingUnitsBL.isLoadingUnit(lu))
 			{
-				throw new AdempiereException("Target is not an LU: " + target);
+				throw new AdempiereException(MobileQRCodeMessages.LU_EXPECTED_AT_TARGET, target.getCaption());
 			}
 			if (!huStatusBL.isStatusActiveOrPicked(lu))
 			{

--- a/backend/de.metas.inventory.mobileui/src/main/java/de/metas/inventory/mobileui/job/qrcode/ResolveHUCommand.java
+++ b/backend/de.metas.inventory.mobileui/src/main/java/de/metas/inventory/mobileui/job/qrcode/ResolveHUCommand.java
@@ -9,6 +9,7 @@ import de.metas.handlingunits.inventory.InventoryLine;
 import de.metas.handlingunits.inventory.InventoryLineHU;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.qrcodes.ean13.EAN13HUQRCode;
+import de.metas.handlingunits.qrcodes.mobile.MobileQRCodeMessages;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.model.IHUQRCode;
 import de.metas.inventory.InventoryLineId;
@@ -31,7 +32,7 @@ import org.adempiere.warehouse.LocatorId;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
-import java.util.function.Predicate;
+import java.util.Optional;
 
 import static org.adempiere.mm.attributes.api.AttributeConstants.ATTR_BestBeforeDate;
 import static org.adempiere.mm.attributes.api.AttributeConstants.ATTR_LotNumber;
@@ -98,7 +99,7 @@ public class ResolveHUCommand
 			}
 			else
 			{
-				throw new AdempiereException("Unknown QR code type: " + parsedScannedCode); // TODO trl 
+				throw new AdempiereException(MobileQRCodeMessages.WRONG_TYPE, parsedScannedCode.getClass().getSimpleName());
 			}
 		}
 		catch (Exception ex)
@@ -112,7 +113,7 @@ public class ResolveHUCommand
 	{
 		final HuId huId = huService.getHuIdByQRCode(huQRCode);
 		final I_M_HU hu = huCache.getHUById(huId);
-		final InventoryLine matchingLine = findFirstMatchingLine(line -> isLineMatchingHU(line, hu));
+		final InventoryLine matchingLine = findFirstUncountedMatchingLineForHU(hu);
 		final InventoryLineHU matchingLineHU = matchingLine.getInventoryLineHUByHUId(huId).orElse(null);
 		final AttributeSetInstanceId lineAsiId = (matchingLineHU != null ? matchingLineHU.getAsiId() : AttributeSetInstanceId.NONE)
 				.orElseIfNone(matchingLine.getAsiId());
@@ -161,7 +162,7 @@ public class ResolveHUCommand
 					.build();
 		}
 
-		throw new AdempiereException("No line found for the given HU QR code");
+		throw new AdempiereException(MobileQRCodeMessages.HU_NOT_IN_INVENTORY);
 	}
 
 	private Attributes getDefaultAttributes()
@@ -181,18 +182,34 @@ public class ResolveHUCommand
 	}
 
 	@NonNull
-	private InventoryLine findFirstMatchingLine(final Predicate<InventoryLine> predicate)
+	private InventoryLine findFirstUncountedMatchingLineForHU(@NonNull final I_M_HU hu)
 	{
-		return lines.stream()
-				.filter(predicate)
-				.findFirst()
-				.orElseThrow(() -> new AdempiereException("No line found for the given HU QR code"));
+		final Optional<InventoryLine> uncountedLine = lines.stream()
+				.filter(line -> isLineMatchingHU(line, hu))
+				.findFirst();
+		if (uncountedLine.isPresent())
+		{
+			return uncountedLine.get();
+		}
+		// HU matches a line but it was already counted in this physical inventory
+		final boolean alreadyCounted = lines.stream()
+				.anyMatch(line -> isLineLocatorAndProductMatchingHU(line, hu));
+		if (alreadyCounted)
+		{
+			throw new AdempiereException(MobileQRCodeMessages.HU_ALREADY_COUNTED);
+		}
+		throw new AdempiereException(MobileQRCodeMessages.HU_NOT_IN_INVENTORY);
 	}
 
 	private boolean isLineMatchingHU(final InventoryLine line, final I_M_HU hu)
 	{
 		return !line.isCounted()
-				&& LocatorId.equals(line.getLocatorId(), huCache.getLocatorId(hu))
+				&& isLineLocatorAndProductMatchingHU(line, hu);
+	}
+
+	private boolean isLineLocatorAndProductMatchingHU(final InventoryLine line, final I_M_HU hu)
+	{
+		return LocatorId.equals(line.getLocatorId(), huCache.getLocatorId(hu))
 				&& huCache.getProductIds(hu).contains(line.getProductId());
 	}
 }

--- a/backend/de.metas.inventory.mobileui/src/main/java/de/metas/inventory/mobileui/job/qrcode/ResolveHUCommand.java
+++ b/backend/de.metas.inventory.mobileui/src/main/java/de/metas/inventory/mobileui/job/qrcode/ResolveHUCommand.java
@@ -50,6 +50,7 @@ public class ResolveHUCommand
 	// Params
 	@NonNull private final ScannedCode scannedCode;
 	@NonNull private final ImmutableList<InventoryLine> lines;
+	@NonNull private final ImmutableList<InventoryLine> allLinesForLocator;
 
 	private static final ImmutableSet<AttributeCode> ATTRIBUTE_CODES = ImmutableSet.of(ATTR_BestBeforeDate, ATTR_LotNumber);
 
@@ -70,9 +71,11 @@ public class ResolveHUCommand
 		this.asiCache = productService.newASILoadingCache();
 
 		this.scannedCode = scannedCode;
-		this.lines = inventory.streamLines(lineId)
-				.filter(InventoryLine::isEligibleForCounting)
+		this.allLinesForLocator = inventory.streamLines(lineId)
 				.filter(line -> LocatorId.equals(line.getLocatorId(), locatorId))
+				.collect(ImmutableList.toImmutableList());
+		this.lines = allLinesForLocator.stream()
+				.filter(InventoryLine::isEligibleForCounting)
 				.collect(ImmutableList.toImmutableList());
 	}
 
@@ -102,7 +105,7 @@ public class ResolveHUCommand
 				throw new AdempiereException(MobileQRCodeMessages.WRONG_TYPE, parsedScannedCode.getClass().getSimpleName());
 			}
 		}
-		catch (Exception ex)
+		catch (final Exception ex)
 		{
 			throw AdempiereException.wrapIfNeeded(ex)
 					.setParameter("parsedScannedCode", parsedScannedCode);
@@ -176,7 +179,7 @@ public class ResolveHUCommand
 	}
 
 	@Nullable
-	private Attribute getDefaultAttribute(@NonNull AttributeCode attributeCode)
+	private Attribute getDefaultAttribute(@NonNull final AttributeCode attributeCode)
 	{
 		return Attribute.of(productService.getAttribute(attributeCode));
 	}
@@ -192,7 +195,7 @@ public class ResolveHUCommand
 			return uncountedLine.get();
 		}
 		// HU matches a line but it was already counted in this physical inventory
-		final boolean alreadyCounted = lines.stream()
+		final boolean alreadyCounted = allLinesForLocator.stream()
 				.anyMatch(line -> isLineLocatorAndProductMatchingHU(line, hu));
 		if (alreadyCounted)
 		{

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
@@ -32,6 +32,7 @@ import de.metas.handlingunits.picking.job.model.PickingJobQtyAvailable;
 import de.metas.handlingunits.picking.job.model.TUPickingTarget;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.model.IHUQRCode;
+import de.metas.handlingunits.qrcodes.mobile.MobileQRCodeMessages;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
 import de.metas.handlingunits.rest_api.HandlingUnitsService;
 import de.metas.handlingunits.rest_api.JsonGetByQRCodeRequest;
@@ -247,12 +248,11 @@ public class PickingRestController
 
 		if (hus.isEmpty())
 		{
-			throw new AdempiereException("No HU found for scanned code: " + scannedCode);
+			throw new AdempiereException(MobileQRCodeMessages.HU_NOT_FOUND);
 		}
 		else if (hus.size() > 1)
 		{
-			throw new AdempiereException("More than one HU found for scanned code: " + scannedCode)
-					.setParameter("hus", hus);
+			throw new AdempiereException(MobileQRCodeMessages.HU_AMBIGUOUS);
 		}
 		final JsonHU hu = hus.get(0);
 
@@ -295,9 +295,7 @@ public class PickingRestController
 		}
 		else
 		{
-			throw new AdempiereException("Cannot convert " + scannedCode + " to actual HUQRCode")
-					.setParameter("parsedHUQRCode", parsedHUQRCode)
-					.setParameter("parsedHUQRCode type", parsedHUQRCode.getClass().getSimpleName());
+			throw new AdempiereException(MobileQRCodeMessages.WRONG_TYPE, parsedHUQRCode.getClass().getSimpleName());
 		}
 	}
 

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/activity_handlers/SetPickingSlotWFActivityHandler.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/activity_handlers/SetPickingSlotWFActivityHandler.java
@@ -50,10 +50,12 @@ import de.metas.workflow.rest_api.model.WFProcess;
 import de.metas.workflow.rest_api.service.WFActivityHandler;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import static de.metas.picking.workflow.handlers.activity_handlers.PickingWFActivityHelper.getPickingJob;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SetPickingSlotWFActivityHandler implements WFActivityHandler, SetScannedBarcodeSupport
@@ -116,6 +118,7 @@ public class SetPickingSlotWFActivityHandler implements WFActivityHandler, SetSc
 		}
 		catch (final Exception ex)
 		{
+			log.debug("QR parse failed for scanned code '{}', showing user-friendly error", scannedCode, ex);
 			throw MobileQRCodeMessages.newNotRecognizedException(scannedCode);
 		}
 
@@ -126,6 +129,7 @@ public class SetPickingSlotWFActivityHandler implements WFActivityHandler, SetSc
 		}
 		catch (final Exception ex)
 		{
+			log.debug("QR type check failed for globalQRCode '{}', showing user-friendly error", globalQRCode, ex);
 			throw MobileQRCodeMessages.newWrongGlobalQRTypeException(globalQRCode);
 		}
 

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/activity_handlers/SetPickingSlotWFActivityHandler.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/activity_handlers/SetPickingSlotWFActivityHandler.java
@@ -26,8 +26,11 @@ import de.metas.bpartner.BPartnerLocationId;
 import de.metas.handlingunits.picking.job.model.PickingJob;
 import de.metas.handlingunits.picking.job.model.PickingSlotSuggestion;
 import de.metas.handlingunits.picking.job.model.PickingSlotSuggestions;
+import de.metas.global_qrcodes.GlobalQRCode;
+import de.metas.handlingunits.qrcodes.mobile.MobileQRCodeMessages;
 import de.metas.picking.api.PickingSlotIdAndCaption;
 import de.metas.picking.qrcode.PickingSlotQRCode;
+import de.metas.scannable_code.ScannedCode;
 import de.metas.picking.rest_api.json.JsonPickingJobLine;
 import de.metas.picking.workflow.PickingJobRestService;
 import de.metas.picking.workflow.handlers.PickingMobileApplication;
@@ -104,7 +107,27 @@ public class SetPickingSlotWFActivityHandler implements WFActivityHandler, SetSc
 	@Override
 	public WFProcess setScannedBarcode(@NonNull final SetScannedBarcodeRequest request)
 	{
-		final PickingSlotQRCode pickingSlotQRCode = PickingSlotQRCode.ofGlobalQRCodeJsonString(request.getScannedBarcode());
+		final ScannedCode scannedCode = ScannedCode.ofString(request.getScannedBarcode());
+
+		final GlobalQRCode globalQRCode;
+		try
+		{
+			globalQRCode = GlobalQRCode.ofString(request.getScannedBarcode());
+		}
+		catch (final Exception ex)
+		{
+			throw MobileQRCodeMessages.newNotRecognizedException(scannedCode);
+		}
+
+		final PickingSlotQRCode pickingSlotQRCode;
+		try
+		{
+			pickingSlotQRCode = PickingSlotQRCode.ofGlobalQRCode(globalQRCode);
+		}
+		catch (final Exception ex)
+		{
+			throw MobileQRCodeMessages.newWrongGlobalQRTypeException(globalQRCode);
+		}
 
 		return PickingMobileApplication.mapPickingJob(
 				request.getWfProcess(),
@@ -113,7 +136,7 @@ public class SetPickingSlotWFActivityHandler implements WFActivityHandler, SetSc
 	}
 
 	@Override
-	public JsonScannedBarcodeSuggestions getScannedBarcodeSuggestions(@NonNull GetScannedBarcodeSuggestionsRequest request)
+	public JsonScannedBarcodeSuggestions getScannedBarcodeSuggestions(@NonNull final GetScannedBarcodeSuggestionsRequest request)
 	{
 		final PickingJob pickingJob = getPickingJob(request.getWfProcess());
 

--- a/e2e/mobile-webui/tests/spec/distribution/distribution.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/distribution.spec.js
@@ -6,6 +6,9 @@ import { DistributionJobsListScreen } from "../../utils/screens/distribution/Dis
 import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
 import { DistributionLineScreen } from '../../utils/screens/distribution/DistributionLineScreen';
 import { DistributionStepScreen } from '../../utils/screens/distribution/DistributionStepScreen';
+import { expectErrorToast } from '../../utils/common';
+import { DistributionLinePickFromScreen } from '../../utils/screens/distribution/DistributionLinePickFromScreen';
+import { expect } from '@playwright/test';
 import { allure } from 'allure-playwright';
 
 const createMasterdata = async ({ HU1_warehouse = 'wh1', HU1_product = 'P1', qtyToMove }) => {
@@ -111,11 +114,16 @@ test('Try picking an HU containing a different product than expected', async ({ 
     await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
     await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
     await DistributionJobScreen.clickLineButton({ index: 1 });
-    await DistributionLineScreen.scanHUToMove({
-        huQRCode: masterdata.handlingUnits.HU1.qrCode,
-        expectedQtyToMove: '100',
-        expectedError: `The product does not match!`
-    });
+    await DistributionLineScreen.openPickFromScreen();
+    await expectErrorToast(
+        'Expect product not matching error',
+        async () => {
+            await DistributionLinePickFromScreen.typeHUQRCode(masterdata.handlingUnits.HU1.qrCode);
+        },
+        ({ textContent }) => {
+            expect(textContent).toContain('The scanned QR Product does not match');
+        }
+    );
 });
 
 // noinspection JSUnusedLocalSymbols

--- a/e2e/mobile-webui/tests/spec/distribution/distribution.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/distribution.spec.js
@@ -10,6 +10,8 @@ import { expectErrorToast } from '../../utils/common';
 import { DistributionLinePickFromScreen } from '../../utils/screens/distribution/DistributionLinePickFromScreen';
 import { expect } from '@playwright/test';
 import { allure } from 'allure-playwright';
+import { PickingJobsListScreen } from '../../utils/screens/picking/PickingJobsListScreen';
+import { PickingJobScreen } from '../../utils/screens/picking/PickingJobScreen';
 
 const createMasterdata = async ({ HU1_warehouse = 'wh1', HU1_product = 'P1', qtyToMove }) => {
     return await Backend.createMasterdata({
@@ -97,6 +99,35 @@ test('Try picking an HU from a different locator than pick from locator', async 
 });
 
 // noinspection JSUnusedLocalSymbols
+test('Scan HU already at the drop-to location in distribution → user-friendly error', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
+        allure.tag('F5114');  // Standalone tag for Tags section;
+    allure.story('Distribution error handling');
+    allure.severity('normal');
+
+    // HU1 is at wh2 (the drop-to warehouse). When the distribution job picks P1 from wh1 and
+    // drops to wh2, scanning HU1 shows the qty dialog. Pressing Done triggers the pick command
+    // which detects HU1 is already at the drop-to locator → DISTRIBUTION_HU_ALREADY_AT_TARGET.
+    const masterdata = await createMasterdata({ HU1_warehouse: 'wh2', qtyToMove: 100 });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
+    await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+    await DistributionJobScreen.clickLineButton({ index: 1 });
+    await DistributionLineScreen.scanHUToMove({
+        huQRCode: masterdata.handlingUnits.HU1.qrCode,
+        qtyToMove: '100',
+        expectedQtyToMove: '100',
+        expectedError: 'DISTRIBUTION_HU_ALREADY_AT_TARGET',
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
 test('Try picking an HU containing a different product than expected', async ({ page }) => {
     // === ALLURE METADATA ===
     allure.epic('E0370: Intralogistic (HUs)');
@@ -124,6 +155,94 @@ test('Try picking an HU containing a different product than expected', async ({ 
             expect(textContent).toContain('The scanned QR Product does not match');
         }
     );
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Scan HU reserved by picking job in distribution → user-friendly error', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
+        allure.tag('F5114');  // Standalone tag for Tags section;
+    allure.story('Distribution error handling');
+    allure.severity('normal');
+
+    // A picking job reserves HU1 immediately on creation (PickingJobCreateCommand).
+    // Navigating back leaves the job open so HU1 stays reserved.
+    // When HU1 is then scanned in a distribution job and Done is pressed,
+    // assertHUCanBePickedFrom detects IsReserved=true and throws DISTRIBUTION_HU_RESERVED.
+    const masterdata = await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US" } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    allowPickingAnyHU: false,
+                    createShipmentPolicy: 'NO',
+                    pickTo: ['TU'],
+                    allowCompletingPartialPickingJob: false,
+                },
+                distribution: {},
+            },
+            resources: { "plantId": { type: "PT" } },
+            bpartners: { "BP1": {} },
+            products: { "P1": { prices: [{ price: 1 }] } },
+            warehouses: {
+                "wh1": {},
+                "wh2": {},
+                "whInTransit": { inTransit: true },
+            },
+            packingInstructions: {
+                "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "P1", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh1', qty: 100 }
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh1',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 100, piItemProduct: 'TU' }]
+                }
+            },
+            distributionOrders: {
+                "DD1": {
+                    warehouseFrom: "wh1",
+                    warehouseTo: "wh2",
+                    warehouseInTransit: "whInTransit",
+                    plant: "plantId",
+                    lines: [{ product: "P1", qtyEntered: 100 }],
+                }
+            },
+        }
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await test.step('Reserve HU1 via picking job', async () => {
+        await ApplicationsListScreen.startApplication('picking');
+        await PickingJobsListScreen.waitForScreen();
+        await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+        await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+        // Navigate back without completing — job stays open, HU1 remains reserved
+        await PickingJobScreen.goBack();
+        await PickingJobsListScreen.goBack();
+    });
+
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
+    await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+    await DistributionJobScreen.clickLineButton({ index: 1 });
+    await DistributionLineScreen.scanHUToMove({
+        huQRCode: masterdata.handlingUnits.HU1.qrCode,
+        qtyToMove: '100',
+        expectedQtyToMove: '100',
+        expectedError: 'DISTRIBUTION_HU_RESERVED',
+    });
 });
 
 // noinspection JSUnusedLocalSymbols

--- a/e2e/mobile-webui/tests/spec/distribution/distribution.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/distribution.spec.js
@@ -6,8 +6,6 @@ import { DistributionJobsListScreen } from "../../utils/screens/distribution/Dis
 import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
 import { DistributionLineScreen } from '../../utils/screens/distribution/DistributionLineScreen';
 import { DistributionStepScreen } from '../../utils/screens/distribution/DistributionStepScreen';
-import { expectErrorToast } from '../../utils/common';
-import { expect } from '@playwright/test';
 import { allure } from 'allure-playwright';
 
 const createMasterdata = async ({ HU1_warehouse = 'wh1', HU1_product = 'P1', qtyToMove }) => {
@@ -91,7 +89,7 @@ test('Try picking an HU from a different locator than pick from locator', async 
     await DistributionLineScreen.scanHUToMove({
         huQRCode: masterdata.handlingUnits.HU1.qrCode,
         expectedQtyToMove: '100',
-        expectedError: `The HU's locator does not match the order's locator.`
+        expectedError: `HU is not at the target trolley`
     });
 });
 
@@ -113,19 +111,11 @@ test('Try picking an HU containing a different product than expected', async ({ 
     await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
     await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
     await DistributionJobScreen.clickLineButton({ index: 1 });
-    await expectErrorToast(
-        'Expect product not matching error',
-        async () => {
-            await DistributionLineScreen.scanHUToMove({
-                huQRCode: masterdata.handlingUnits.HU1.qrCode,
-                expectedQtyToMove: '100',
-                expectedError: `The HU's locator does not match the order's locator.`
-            });
-        },
-        ({ textContent }) => {
-            expect(textContent).toContain('The scanned QR Product does not match');
-        }
-    )
+    await DistributionLineScreen.scanHUToMove({
+        huQRCode: masterdata.handlingUnits.HU1.qrCode,
+        expectedQtyToMove: '100',
+        expectedError: `The product does not match!`
+    });
 });
 
 // noinspection JSUnusedLocalSymbols

--- a/e2e/mobile-webui/tests/spec/distribution/scan_HU_barcodes.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/scan_HU_barcodes.spec.js
@@ -154,7 +154,7 @@ test('Scan locator QR code where HU is expected → user-friendly error', async 
         await DistributionLinePickFromScreen.typeHUQRCode(masterdata.warehouses.wh1.locatorQRCode);
         await GetQuantityDialog.waitForDialog();
     }, ({ textContent }) => {
-        expect(textContent).toContain('locator');
+        expect(textContent).toContain('QR_WRONG_TYPE_LOCATOR');
     });
 });
 
@@ -182,6 +182,6 @@ test('Scan unrecognized barcode where HU is expected → user-friendly error', a
         await DistributionLinePickFromScreen.typeHUQRCode('TOTALLY_UNKNOWN_FORMAT_XYZ');
         await GetQuantityDialog.waitForDialog();
     }, ({ textContent }) => {
-        expect(textContent).toContain('not recognized');
+        expect(textContent).toContain('QR_NOT_RECOGNIZED');
     });
 });

--- a/e2e/mobile-webui/tests/spec/distribution/scan_HU_barcodes.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/scan_HU_barcodes.spec.js
@@ -6,7 +6,11 @@ import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScre
 import { DistributionJobsListScreen } from "../../utils/screens/distribution/DistributionJobsListScreen";
 import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
 import { DistributionLineScreen } from '../../utils/screens/distribution/DistributionLineScreen';
+import { DistributionLinePickFromScreen } from '../../utils/screens/distribution/DistributionLinePickFromScreen';
 import { DistributionStepScreen } from '../../utils/screens/distribution/DistributionStepScreen';
+import { GetQuantityDialog } from '../../utils/screens/picking/GetQuantityDialog';
+import { expectErrorToast } from '../../utils/common';
+import { expect } from '@playwright/test';
 
 const createMasterdata = async ({ externalBarcode } = {}) => {
     return await Backend.createMasterdata({
@@ -124,4 +128,60 @@ test('Scan by ExternalBarcode', async ({ page }) => {
     const externalBarcode = "EXT" + Date.now();
     const masterdata = await createMasterdata({ externalBarcode });
     await standardTest({ masterdata, huBarcodeToScan: externalBarcode });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Scan locator QR code where HU is expected → user-friendly error', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
+        allure.tag('F5114');  // Standalone tag for Tags section;
+    allure.story('Scan HU barcodes');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
+    await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+    await DistributionJobScreen.clickLineButton({ index: 1 });
+    await DistributionLineScreen.openPickFromScreen();
+
+    await expectErrorToast('Scan locator QR code where HU is expected', async () => {
+        await DistributionLinePickFromScreen.typeHUQRCode(masterdata.warehouses.wh1.locatorQRCode);
+        await GetQuantityDialog.waitForDialog();
+    }, ({ textContent }) => {
+        expect(textContent).toContain('locator');
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Scan unrecognized barcode where HU is expected → user-friendly error', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
+        allure.tag('F5114');  // Standalone tag for Tags section;
+    allure.story('Scan HU barcodes');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
+    await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+    await DistributionJobScreen.clickLineButton({ index: 1 });
+    await DistributionLineScreen.openPickFromScreen();
+
+    await expectErrorToast('Scan unrecognized barcode where HU is expected', async () => {
+        await DistributionLinePickFromScreen.typeHUQRCode('TOTALLY_UNKNOWN_FORMAT_XYZ');
+        await GetQuantityDialog.waitForDialog();
+    }, ({ textContent }) => {
+        expect(textContent).toContain('not recognized');
+    });
 });

--- a/e2e/mobile-webui/tests/spec/hu_consolidation/hu_consolidation.spec.js
+++ b/e2e/mobile-webui/tests/spec/hu_consolidation/hu_consolidation.spec.js
@@ -5,10 +5,14 @@ import { LoginScreen } from '../../utils/screens/LoginScreen';
 import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
 import { HUConsolidationJobsListScreen } from '../../utils/screens/huConsolidation/HUConsolidationJobsListScreen';
 import { HUConsolidationJobScreen } from '../../utils/screens/huConsolidation/HUConsolidationJobScreen';
+import { SelectHUConsolidationTargetScreen } from '../../utils/screens/huConsolidation/SelectHUConsolidationTargetScreen';
+import { ScanHUConsolidationTargetScreen } from '../../utils/screens/huConsolidation/ScanHUConsolidationTargetScreen';
 import { PickingJobsListScreen } from '../../utils/screens/picking/PickingJobsListScreen';
 import { PickingJobScreen } from '../../utils/screens/picking/PickingJobScreen';
 import { PickLineScanScreen } from '../../utils/screens/picking/PickLineScanScreen';
 import { PickingSlotScreen } from '../../utils/screens/huConsolidation/PickingSlotScreen';
+import { expectErrorToast } from '../../utils/common';
+import { expect } from '@playwright/test';
 
 const createMasterdata = async ({
                                     products,
@@ -264,5 +268,47 @@ test('Consolidate to an existing LU', async ({ page }) => {
                 },
             }
         }
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Scan TU instead of LU at Set Target step in HU consolidation → user-friendly error', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00248');
+    allure.story('HU Consolidation - Scan errors');
+    allure.severity('normal');
+
+    // HU_TU is a TU-level HU (packing instruction has no "lu" field).
+    // Scanning its QR code at the Set Target step (which expects an LU) fires LU_EXPECTED_AT_TARGET.
+    const masterdata = await createMasterdata({
+        packingInstructions: {
+            "PI_TU": { tu: "TU_bare", product: "P1", qtyCUsPerTU: 4 },
+        },
+        handlingUnits: {
+            "HU_TU": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI_TU' },
+        },
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await pickHUsToPickingSlot({ masterdata });
+
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('huConsolidation');
+    await HUConsolidationJobsListScreen.waitForScreen();
+    await HUConsolidationJobsListScreen.startJob({ customerLocationId: masterdata.bpartners.BP1.bpartnerLocationId });
+
+    await HUConsolidationJobScreen.clickLUTargetButton();
+    await SelectHUConsolidationTargetScreen.waitForScreen();
+    await SelectHUConsolidationTargetScreen.clickScanQRCodeButton();
+    await ScanHUConsolidationTargetScreen.waitForScreen();
+
+    await expectErrorToast('Scan TU QR at Set Target step', async () => {
+        await ScanHUConsolidationTargetScreen.typeQRCode({ qrCode: masterdata.handlingUnits.HU_TU.qrCode });
+        await HUConsolidationJobScreen.waitForScreen();
+    }, ({ textContent }) => {
+        expect(textContent).toContain('HU_CONSOL_LU_EXPECTED_AT_TARGET');
     });
 });

--- a/e2e/mobile-webui/tests/spec/inventory/inventory.spec.js
+++ b/e2e/mobile-webui/tests/spec/inventory/inventory.spec.js
@@ -120,7 +120,67 @@ test('Scan locator QR code where HU is expected in inventory → user-friendly e
         await InventoryScanScreen.typeQRCode(masterdata.warehouses.wh.locatorQRCode);
         await InventoryScanScreen.waitForPanel('FillData');
     }, ({ textContent }) => {
-        expect(textContent).toContain('locator');
+        expect(textContent).toContain('QR_WRONG_TYPE_LOCATOR');
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Scan same HU twice in one inventory job → user-friendly error', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5310');
+    allure.story('Inventory - Scan errors');
+    allure.severity('normal');
+
+    // Two inventory lines (P1+HU1, P2+HU2) so that after counting HU1,
+    // P2's uncounted line keeps the locator eligible for resolveLocator,
+    // allowing the second HU1 scan to reach resolveHU which throws HU_ALREADY_COUNTED.
+    // createDraftLines only creates a line when a HU exists for the product,
+    // so HU2 is required for the P2 line to appear in the inventory.
+    const masterdata = await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US', workplace: "workplace1" } },
+            warehouses: { "wh": {} },
+            workplaces: { workplace1: { warehouse: 'wh' } },
+            products: { "P1": {}, "P2": {} },
+            packingInstructions: {
+                "PI1": { lu: "LU1", qtyTUsPerLU: 20, tu: "TU1", product: "P1", qtyCUsPerTU: 4 },
+                "PI2": { lu: "LU2", qtyTUsPerLU: 20, tu: "TU2", product: "P2", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI1' },
+                "HU2": { product: 'P2', warehouse: 'wh', packingInstructions: 'PI2' },
+            },
+            inventories: {
+                "inv1": {
+                    warehouse: 'wh',
+                    date: '2025-03-01T00:00:00.000+02:00',
+                    products: ['P1', 'P2'],
+                }
+            },
+        }
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('inventory');
+    await InventoryJobsListScreen.waitForScreen();
+    await InventoryJobsListScreen.startJob({ index: 1 });
+
+    await InventoryJobScreen.countHU({
+        locatorQRCode: masterdata.warehouses.wh.locatorQRCode,
+        huQRCode: masterdata.handlingUnits.HU1.qrCode,
+        qtyCount: 80,
+    });
+
+    await InventoryJobScreen.openScanHUStep({ locatorQRCode: masterdata.warehouses.wh.locatorQRCode });
+
+    await expectErrorToast('Scan same HU twice in one inventory job', async () => {
+        await InventoryScanScreen.typeQRCode(masterdata.handlingUnits.HU1.qrCode);
+        await InventoryScanScreen.waitForPanel('FillData');
+    }, ({ textContent }) => {
+        expect(textContent).toContain('INVENTORY_HU_ALREADY_COUNTED');
     });
 });
 
@@ -145,6 +205,7 @@ test('Scan unrecognized barcode where HU is expected in inventory → user-frien
         await InventoryScanScreen.typeQRCode('TOTALLY_UNKNOWN_FORMAT_XYZ');
         await InventoryScanScreen.waitForPanel('FillData');
     }, ({ textContent }) => {
-        expect(textContent).toContain('not recognized');
+        expect(textContent).toContain('QR_NOT_RECOGNIZED');
     });
 });
+

--- a/e2e/mobile-webui/tests/spec/inventory/inventory.spec.js
+++ b/e2e/mobile-webui/tests/spec/inventory/inventory.spec.js
@@ -5,6 +5,9 @@ import { Backend } from "../../utils/screens/Backend";
 import { LoginScreen } from "../../utils/screens/LoginScreen";
 import { InventoryJobsListScreen } from '../../utils/screens/inventory/InventoryJobsListScreen';
 import { InventoryJobScreen } from '../../utils/screens/inventory/InventoryJobScreen';
+import { InventoryScanScreen } from '../../utils/screens/inventory/InventoryScanScreen';
+import { expectErrorToast } from '../../utils/common';
+import { expect } from '@playwright/test';
 
 const createMasterdata = async () => {
     return await Backend.createMasterdata({
@@ -94,4 +97,54 @@ test('Simple inventory test', async ({ page }) => {
         },
     });
 
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Scan locator QR code where HU is expected in inventory → user-friendly error', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5310');
+    allure.story('Inventory - Scan errors');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('inventory');
+    await InventoryJobsListScreen.waitForScreen();
+    await InventoryJobsListScreen.startJob({ index: 1 });
+    await InventoryJobScreen.openScanHUStep({ locatorQRCode: masterdata.warehouses.wh.locatorQRCode });
+
+    await expectErrorToast('Scan locator QR code where HU is expected', async () => {
+        await InventoryScanScreen.typeQRCode(masterdata.warehouses.wh.locatorQRCode);
+        await InventoryScanScreen.waitForPanel('FillData');
+    }, ({ textContent }) => {
+        expect(textContent).toContain('locator');
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Scan unrecognized barcode where HU is expected in inventory → user-friendly error', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5310');
+    allure.story('Inventory - Scan errors');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('inventory');
+    await InventoryJobsListScreen.waitForScreen();
+    await InventoryJobsListScreen.startJob({ index: 1 });
+    await InventoryJobScreen.openScanHUStep({ locatorQRCode: masterdata.warehouses.wh.locatorQRCode });
+
+    await expectErrorToast('Scan unrecognized barcode where HU is expected', async () => {
+        await InventoryScanScreen.typeQRCode('TOTALLY_UNKNOWN_FORMAT_XYZ');
+        await InventoryScanScreen.waitForPanel('FillData');
+    }, ({ textContent }) => {
+        expect(textContent).toContain('not recognized');
+    });
 });

--- a/e2e/mobile-webui/tests/spec/inventory/inventory.spec.js
+++ b/e2e/mobile-webui/tests/spec/inventory/inventory.spec.js
@@ -125,6 +125,31 @@ test('Scan locator QR code where HU is expected in inventory → user-friendly e
 });
 
 // noinspection JSUnusedLocalSymbols
+test('Scan workplace QR code where HU is expected in inventory → user-friendly error', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5310');
+    allure.story('Inventory - Scan errors');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('inventory');
+    await InventoryJobsListScreen.waitForScreen();
+    await InventoryJobsListScreen.startJob({ index: 1 });
+    await InventoryJobScreen.openScanHUStep({ locatorQRCode: masterdata.warehouses.wh.locatorQRCode });
+
+    await expectErrorToast('Scan workplace QR code where HU is expected', async () => {
+        await InventoryScanScreen.typeQRCode(masterdata.workplaces.workplace1.qrCode);
+        await InventoryScanScreen.waitForPanel('FillData');
+    }, ({ textContent }) => {
+        expect(textContent).toContain('QR_WRONG_TYPE');
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
 test('Scan same HU twice in one inventory job → user-friendly error', async ({ page }) => {
     // === ALLURE METADATA ===
     allure.epic('E0370: Intralogistic (HUs)');
@@ -181,6 +206,56 @@ test('Scan same HU twice in one inventory job → user-friendly error', async ({
         await InventoryScanScreen.waitForPanel('FillData');
     }, ({ textContent }) => {
         expect(textContent).toContain('INVENTORY_HU_ALREADY_COUNTED');
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Scan HU not in this inventory → user-friendly error', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5310');
+    allure.story('Inventory - Scan errors');
+    allure.severity('normal');
+
+    // P2+HU2 exist in the warehouse but are NOT included in the inventory (products: ['P1'] only).
+    // Scanning HU2 at the HU scan step should throw HU_NOT_IN_INVENTORY.
+    const masterdata = await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US', workplace: "workplace1" } },
+            warehouses: { "wh": {} },
+            workplaces: { workplace1: { warehouse: 'wh' } },
+            products: { "P1": {}, "P2": {} },
+            packingInstructions: {
+                "PI1": { lu: "LU1", qtyTUsPerLU: 20, tu: "TU1", product: "P1", qtyCUsPerTU: 4 },
+                "PI2": { lu: "LU2", qtyTUsPerLU: 20, tu: "TU2", product: "P2", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI1' },
+                "HU2": { product: 'P2', warehouse: 'wh', packingInstructions: 'PI2' },
+            },
+            inventories: {
+                "inv1": {
+                    warehouse: 'wh',
+                    date: '2025-03-01T00:00:00.000+02:00',
+                    products: ['P1'],
+                }
+            },
+        }
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('inventory');
+    await InventoryJobsListScreen.waitForScreen();
+    await InventoryJobsListScreen.startJob({ index: 1 });
+    await InventoryJobScreen.openScanHUStep({ locatorQRCode: masterdata.warehouses.wh.locatorQRCode });
+
+    await expectErrorToast('Scan HU not in this inventory', async () => {
+        await InventoryScanScreen.typeQRCode(masterdata.handlingUnits.HU2.qrCode);
+        await InventoryScanScreen.waitForPanel('FillData');
+    }, ({ textContent }) => {
+        expect(textContent).toContain('INVENTORY_HU_NOT_IN_INVENTORY');
     });
 });
 

--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -11,6 +11,8 @@ import { expectErrorToast } from '../../utils/common';
 import { QTY_NOT_FOUND_REASON_NOT_FOUND } from '../../utils/screens/picking/GetQuantityDialog';
 import { expect } from '@playwright/test';
 import { SelectPickTargetLUScreen } from '../../utils/screens/picking/ReopenLUScreen';
+import { InventoryJobsListScreen } from '../../utils/screens/inventory/InventoryJobsListScreen';
+import { InventoryJobScreen } from '../../utils/screens/inventory/InventoryJobScreen';
 
 const createMasterdata = async ({
                                     language = 'en_US',
@@ -968,4 +970,106 @@ test('Scan HU with wrong product during picking', async ({ page }) => {
 
     await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '3' });
     await PickingJobScreen.complete();
+});
+
+//
+// Simulate an HU removed from stock via a zero-count inventory (physical label still on
+// the shelf), then scan its QR code during a picking job.  The real-world scenario:
+// a warehouse worker counts the HU as 0, inventory is completed → HU destroyed in the
+// system.  A picker later scans the dangling label → QR_CODE_HU_DESTROYED error toast.
+//
+// noinspection JSUnusedLocalSymbols
+test('Scan destroyed HU QR code during picking → user-friendly error', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Error handling - destroyed HU');
+    allure.severity('normal');
+
+    // HU1 is created in the warehouse.  An inventory document for P1 lets the test
+    // count HU1 as 0 → complete inventory → HU1 status becomes 'D' (Destroyed).
+    // SO1 provides a picking job so we can scan HU1 after it is destroyed.
+    const masterdata = await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US', workplace: 'workplace1' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: 'sales_order',
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                },
+            },
+            bpartners: { 'BP1': {} },
+            warehouses: { 'wh': {} },
+            workplaces: { workplace1: { warehouse: 'wh' } },
+            pickingSlots: { slot1: {} },
+            products: { 'P1': { prices: [{ price: 1 }] } },
+            packingInstructions: {
+                'PI': { lu: 'LU', qtyTUsPerLU: 20, tu: 'TU', product: 'P1', qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                'HU1': { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
+            },
+            inventories: {
+                'inv1': {
+                    warehouse: 'wh',
+                    date: '2025-03-01T00:00:00.000+02:00',
+                    products: ['P1'],
+                },
+            },
+            salesOrders: {
+                'SO1': {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 12, piItemProduct: 'TU' }],
+                },
+            },
+        },
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    // Step 1: Destroy HU1 by counting it as 0 in inventory and completing the job.
+    await ApplicationsListScreen.startApplication('inventory');
+    await InventoryJobsListScreen.waitForScreen();
+    await InventoryJobsListScreen.startJob({ index: 1 });
+    await InventoryJobScreen.countHU({
+        locatorQRCode: masterdata.warehouses.wh.locatorQRCode,
+        huQRCode: masterdata.handlingUnits.HU1.qrCode,
+        qtyCount: 0,
+    });
+    await InventoryJobScreen.complete();
+    await InventoryJobsListScreen.goBack();
+
+    // Step 2: Start picking for SO1, scan the now-destroyed HU1 → expect QR_CODE_HU_DESTROYED.
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+
+    await expectErrorToast('Scan depleted (destroyed) HU', async () => {
+        // Wait for the API response before returning: the barcode hook flushes on a
+        // ~600ms interval, which may push the API call past expectErrorToast's 2 s grace window.
+        const responsePromise = page.waitForResponse(
+            resp => resp.url().includes('/picking/nextEligibleLineToPack'),
+            { timeout: 5000 }
+        );
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.qrCode,
+            isScanDirectly: true,
+            expectedPickDirectly: true,
+        });
+        await responsePromise;
+    }, ({ textContent }) => {
+        expect(textContent).toContain('QR_CODE_HU_DESTROYED');
+    });
+
+    await PickingJobScreen.waitForScreen();
 });

--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -602,6 +602,253 @@ test('Scan invalid HU QR code and recover', async ({ page }) => {
 });
 
 //
+// Scan a Leich+Mehl QR code (LMQ format) with an empty lot-number part.
+// Format: LMQ#1#<weight>#<date>#<lot>#<product>
+// Empty lot → backend throws PICKING_LM_QR_NO_LOT_NUMBER at scan time.
+//
+// noinspection JSUnusedLocalSymbols
+test('Scan LM QR code without lot number → user-friendly error', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Error handling - specialty QR code formats');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+
+    await expectErrorToast('Scan LMQ QR code with empty lot', async () => {
+        // Wait for the API response before returning: type() dispatches keyboard events
+        // synchronously and returns immediately, but the barcode hook flushes the buffer
+        // on an interval (~600ms). A blur/refocus timer in BarcodeScannerComponent can
+        // reset that interval, pushing the API call past expectErrorToast's 2 s grace window.
+        const responsePromise = page.waitForResponse(
+            resp => resp.url().includes('/picking/nextEligibleLineToPack'),
+            { timeout: 5000 }
+        );
+        await PickingJobScreen.pickHU({
+            qrCode: 'LMQ#1#25.5#31.12.2025##',
+            isScanDirectly: true,
+            expectedPickDirectly: true,
+        });
+        await responsePromise;
+    }, ({ textContent }) => {
+        expect(textContent).toContain('PICKING_LM_QR_NO_LOT_NUMBER');
+    });
+
+    await PickingJobScreen.waitForScreen();
+});
+
+//
+// Scan a Leich+Mehl QR code with a non-empty lot number that has no matching HU in stock.
+// Format: LMQ#1#<weight>#<date>#<lot>
+// Lot present but unknown → backend returns PICKING_NO_HU_FOR_EXTERNAL_LOT.
+//
+// noinspection JSUnusedLocalSymbols
+test('Scan LM QR code with unknown lot number → user-friendly error', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Error handling - specialty QR code formats');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+
+    // Lot "NOSUCHLOT" is non-empty (no PICKING_LM_QR_NO_LOT_NUMBER) but no HU carries
+    // this external lot number in stock → PICKING_NO_HU_FOR_EXTERNAL_LOT.
+    await expectErrorToast('Scan LMQ QR code with unknown lot', async () => {
+        // Same reason as the test above: wait for the API response so the toast
+        // arrives within expectErrorToast's 2 s grace window.
+        const responsePromise = page.waitForResponse(
+            resp => resp.url().includes('/picking/nextEligibleLineToPack'),
+            { timeout: 5000 }
+        );
+        await PickingJobScreen.pickHU({
+            qrCode: 'LMQ#1#25.5#31.12.2025#NOSUCHLOT',
+            isScanDirectly: true,
+            expectedPickDirectly: true,
+        });
+        await responsePromise;
+    }, ({ textContent }) => {
+        expect(textContent).toContain('PICKING_NO_HU_FOR_EXTERNAL_LOT');
+    });
+
+    await PickingJobScreen.waitForScreen();
+});
+
+//
+// Register a custom QR format (Constant prefix + LotNo), then scan a QR string whose
+// lot value has no matching HU in stock.  Backend returns PICKING_QR_HU_NOT_FOUND_BY_ATTRIBUTE.
+//
+// noinspection JSUnusedLocalSymbols
+test('Scan custom QR code with unknown lot → user-friendly error', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Error handling - specialty QR code formats');
+    allure.severity('normal');
+
+    const masterdata = await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: 'sales_order',
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                },
+            },
+            customQRCodeFormats: [{
+                name: 'E2E_ATTR',
+                parts: [
+                    { startPosition: 1, endPosition: 4, type: 'CONSTANT', constantValue: 'TST1' },
+                    { startPosition: 5, endPosition: 14, type: 'LOT' },
+                ],
+            }],
+            bpartners: { 'BP1': {} },
+            warehouses: { 'wh': {} },
+            pickingSlots: { slot1: {} },
+            products: { 'P1': { prices: [{ price: 1 }] } },
+            packingInstructions: {
+                'PI': { lu: 'LU', qtyTUsPerLU: 20, tu: 'TU', product: 'P1', qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                'HU1': { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
+            },
+            salesOrders: {
+                'SO1': {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 12, piItemProduct: 'TU' }],
+                },
+            },
+        },
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+
+    // "TST1" matches the Constant anchor (pos 1-4); "NOSUCHLOT0" (pos 5-14) is the lot value.
+    // No HU in stock carries this custom QR code → PICKING_QR_HU_NOT_FOUND_BY_ATTRIBUTE.
+    await expectErrorToast('Scan custom QR with unknown lot', async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: 'TST1NOSUCHLOT0',
+            isScanDirectly: true,
+            expectedPickDirectly: true,
+        });
+    }, ({ textContent }) => {
+        expect(textContent).toContain('PICKING_QR_HU_NOT_FOUND_BY_ATTRIBUTE');
+    });
+
+    await PickingJobScreen.waitForScreen();
+});
+
+//
+// Register a custom QR format (Constant prefix + ProductCode), then scan a QR string whose
+// product code does not match the picking line's expected product.
+// Backend returns PICKING_QR_PRODUCT_NOT_MATCHING.
+//
+// noinspection JSUnusedLocalSymbols
+test('Scan custom QR code with wrong product code → user-friendly error', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Error handling - specialty QR code formats');
+    allure.severity('normal');
+
+    const masterdata = await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: 'sales_order',
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                },
+            },
+            customQRCodeFormats: [{
+                name: 'E2E_PROD',
+                parts: [
+                    { startPosition: 1, endPosition: 4, type: 'CONSTANT', constantValue: 'TST2' },
+                    { startPosition: 5, endPosition: 14, type: 'PRODUCT_CODE' },
+                ],
+            }],
+            bpartners: { 'BP1': {} },
+            warehouses: { 'wh': {} },
+            pickingSlots: { slot1: {} },
+            products: { 'P1': { prices: [{ price: 1 }] } },
+            packingInstructions: {
+                'PI': { lu: 'LU', qtyTUsPerLU: 20, tu: 'TU', product: 'P1', qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                'HU1': { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
+            },
+            salesOrders: {
+                'SO1': {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 12, piItemProduct: 'TU' }],
+                },
+            },
+        },
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+
+    // "TST2" matches the Constant anchor (pos 1-4); "WRONGPROD9" (pos 5-14) is the product code.
+    // "WRONGPROD9" does not match P1's product value → PICKING_QR_PRODUCT_NOT_MATCHING.
+    await expectErrorToast('Scan custom QR with wrong product code', async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: 'TST2WRONGPROD9',
+            isScanDirectly: true,
+            expectedPickDirectly: true,
+        });
+    }, ({ textContent }) => {
+        expect(textContent).toContain('PICKING_QR_PRODUCT_NOT_MATCHING');
+    });
+
+    await PickingJobScreen.waitForScreen();
+});
+
+//
 // Partial pick blocked, recover by picking remaining:
 // With allowCompletingPartialPickingJob=N, pick 1 of 3 TU → complete → error toast →
 // pick remaining 2 TU → complete successfully.

--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -13,6 +13,7 @@ import { expect } from '@playwright/test';
 import { SelectPickTargetLUScreen } from '../../utils/screens/picking/ReopenLUScreen';
 import { InventoryJobsListScreen } from '../../utils/screens/inventory/InventoryJobsListScreen';
 import { InventoryJobScreen } from '../../utils/screens/inventory/InventoryJobScreen';
+import { PickLineScanScreen } from '../../utils/screens/picking/PickLineScanScreen';
 
 const createMasterdata = async ({
                                     language = 'en_US',
@@ -836,20 +837,22 @@ test('Scan custom QR code with wrong product code → user-friendly error', asyn
     await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
     await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
     await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+    // Select the P1 line explicitly — routes through PickingJobPickCommand (line-specific),
+    // which surfaces the error via orElseThrow() instead of the generic "no matching lines" path.
+    await PickingJobScreen.clickLineButton({ index: 1 });
+    await PickingJobLineScreen.waitForScreen();
+    await PickingJobLineScreen.clickScanButton();
+    await PickLineScanScreen.waitForScreen();
 
     // "TST2" matches the Constant anchor (pos 1-4); "WRONGPROD9" (pos 5-14) is the product code.
     // "WRONGPROD9" does not match P1's product value → PICKING_QR_PRODUCT_NOT_MATCHING.
     await expectErrorToast('Scan custom QR with wrong product code', async () => {
-        await PickingJobScreen.pickHU({
-            qrCode: 'TST2WRONGPROD9',
-            isScanDirectly: true,
-            expectedPickDirectly: true,
-        });
+        await PickLineScanScreen.typeQRCode('TST2WRONGPROD9');
     }, ({ textContent }) => {
         expect(textContent).toContain('PICKING_QR_PRODUCT_NOT_MATCHING');
     });
 
-    await PickingJobScreen.waitForScreen();
+    await PickLineScanScreen.waitForScreen();
 });
 
 //

--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -586,11 +586,12 @@ test('Scan invalid HU QR code and recover', async ({ page }) => {
 
     await expectErrorToast('Scanning non-existent HU QR code', async () => {
         await PickingJobScreen.pickHU({
-            qrCode: 'HU#1#{"id":"00000000000000000000000000000000-99999","packingInfo":{"huUnitType":"LU","packingInstructionsId":1,"caption":"NonExistent"},"product":{"id":1,"code":"FAKE","name":"FAKE"}}',
+            qrCode: 'HU#1#{"id":"ffffffffffffffffffffffffffff-99999","packingInfo":{"huUnitType":"LU","packingInstructionsId":1,"caption":"NonExistent"},"product":{"id":1,"code":"FAKE","name":"FAKE"},"attributes":[]}',
             isScanDirectly: true,
+            expectedPickDirectly: true,
         });
     }, ({ textContent }) => {
-        expect(textContent).toContain('No HU found for this QR code');
+        expect(textContent).toContain('QR_HU_NOT_FOUND');
     });
 
     await PickingJobScreen.waitForScreen();
@@ -709,9 +710,10 @@ test('Scan HU with wrong product during picking', async ({ page }) => {
         await PickingJobScreen.pickHU({
             qrCode: masterdata.handlingUnits.HU2.qrCode,
             isScanDirectly: true,
+            expectedPickDirectly: true,
         });
     }, ({ textContent }) => {
-        expect(textContent).toContain('Product not matching. Expected:');
+        expect(textContent).toContain('activities.picking.noMatchingLines');
     });
 
     await PickingJobScreen.waitForScreen();

--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -9,6 +9,7 @@ import { Backend } from "../../utils/screens/Backend";
 import { LoginScreen } from "../../utils/screens/LoginScreen";
 import { expectErrorToast } from '../../utils/common';
 import { QTY_NOT_FOUND_REASON_NOT_FOUND } from '../../utils/screens/picking/GetQuantityDialog';
+import { expect } from '@playwright/test';
 import { SelectPickTargetLUScreen } from '../../utils/screens/picking/ReopenLUScreen';
 
 const createMasterdata = async ({
@@ -588,6 +589,8 @@ test('Scan invalid HU QR code and recover', async ({ page }) => {
             qrCode: 'HU#1#{"id":"00000000000000000000000000000000-99999","packingInfo":{"huUnitType":"LU","packingInstructionsId":1,"caption":"NonExistent"},"product":{"id":1,"code":"FAKE","name":"FAKE"}}',
             isScanDirectly: true,
         });
+    }, ({ textContent }) => {
+        expect(textContent).toContain('No HU found for this QR code');
     });
 
     await PickingJobScreen.waitForScreen();
@@ -638,5 +641,82 @@ test('Partial pick blocked, recover by picking remaining', async ({ page }) => {
         expectQtyEntered: '0',
         qtyEntered: '2',
     });
+    await PickingJobScreen.complete();
+});
+
+//
+// Scan HU containing a different product than the picking job expects:
+// Error toast fires at scan time (backend product check), qty dialog never appears.
+// Verify the screen recovers and picking continues with the correct HU.
+//
+// noinspection JSUnusedLocalSymbols
+test('Scan HU with wrong product during picking', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Error handling - wrong product HU');
+    allure.severity('normal');
+
+    const masterdata = await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                "P1": { prices: [{ price: 1 }] },
+                "P2": {},
+            },
+            packingInstructions: {
+                "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "P1", qtyCUsPerTU: 4 },
+                "PI2": { lu: "LU2", qtyTUsPerLU: 20, tu: "TU2", product: "P2", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
+                "HU2": { product: 'P2', warehouse: 'wh', packingInstructions: 'PI2' },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 12, piItemProduct: 'TU' }]
+                }
+            },
+        }
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+
+    await expectErrorToast('Scan HU with wrong product', async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU2.qrCode,
+            isScanDirectly: true,
+        });
+    }, ({ textContent }) => {
+        expect(textContent).toContain('Product not matching. Expected:');
+    });
+
+    await PickingJobScreen.waitForScreen();
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '0 TU', qtyPickedCatchWeight: '' });
+
+    await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '3' });
     await PickingJobScreen.complete();
 });

--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -237,6 +237,8 @@ test('Scan invalid picking slot QR code', async ({ page }) => {
 
     await expectErrorToast('Scanning invalid QR code', async () => {
         await PickingJobScreen.scanPickingSlot({ qrCode: 'this is an invalid QR code' });
+    }, ({ textContent }) => {
+        expect(textContent).toContain('QR_NOT_RECOGNIZED');
     });
 });
 

--- a/e2e/mobile-webui/tests/utils/common.js
+++ b/e2e/mobile-webui/tests/utils/common.js
@@ -69,6 +69,13 @@ export const expectErrorToast = async (title, func, toastValidator) => {
     return await test.step(`Expect error: ${title} (watcherId=${watcherId})`, async () => {
         const executeFuncFailOnSuccess = async () => {
             await func();
+            // Grace period: if func() returned cleanly but a toast is still pending, give
+            // React time to render before declaring "not detected". The original Promise.race
+            // could lose against a ~20ms-late toast render under CI load, producing false
+            // "not detected" failures (me03#29474). The hang-on-error semantic of Promise.race
+            // is preserved: if func() never returns (waiting for a screen that won't come),
+            // we never reach this sleep and the toast branch wins as before.
+            await new Promise(resolve => setTimeout(resolve, 2000));
             throw new Error(`Expected error toast not detected (watcherId=${watcherId})`);
         }
 

--- a/e2e/mobile-webui/tests/utils/common.js
+++ b/e2e/mobile-webui/tests/utils/common.js
@@ -72,7 +72,7 @@ export const expectErrorToast = async (title, func, toastValidator) => {
             // Grace period: if func() returned cleanly but a toast is still pending, give
             // React time to render before declaring "not detected". The original Promise.race
             // could lose against a ~20ms-late toast render under CI load, producing false
-            // "not detected" failures (me03#29474). The hang-on-error semantic of Promise.race
+            // "not detected" failures. The hang-on-error semantic of Promise.race
             // is preserved: if func() never returns (waiting for a screen that won't come),
             // we never reach this sleep and the toast branch wins as before.
             await new Promise(resolve => setTimeout(resolve, 2000));

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLineScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLineScreen.js
@@ -45,6 +45,11 @@ export const DistributionLineScreen = {
         await expect(page.getByTestId('step-0-button')).toHaveCount(0);
     }),
 
+    openPickFromScreen: async () => await test.step(`${NAME} - Open Pick From Screen`, async () => {
+        await page.getByTestId('scanQRCode-button').tap();
+        await DistributionLinePickFromScreen.waitForScreen();
+    }),
+
     goBack: async () => await test.step(`${NAME} - Go back`, async () => {
         await DistributionLineScreen.expectVisible();
         await page.locator(ID_BACK_BUTTON).tap();

--- a/e2e/mobile-webui/tests/utils/screens/inventory/InventoryJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/inventory/InventoryJobScreen.js
@@ -29,6 +29,14 @@ export const InventoryJobScreen = {
         await InventoryScanScreen.countHU({ locatorQRCode, huQRCode, expectQtyBooked, qtyCount, attributes });
     }),
 
+    openScanHUStep: async ({ locatorQRCode }) => await step(`${NAME} - Navigate to Scan HU step`, async () => {
+        await page.getByTestId('scanQRCode-button').tap();
+        await InventoryScanScreen.waitForScreen();
+        await InventoryScanScreen.waitForPanel('ScanLocator');
+        await InventoryScanScreen.typeQRCode(locatorQRCode);
+        await InventoryScanScreen.waitForPanel('ScanHU');
+    }),
+
     expectLineButton: async ({ productId, locatorId, qtyBooked, qtyCount }) => await test.step(`${NAME} - Expect job button by productId=${productId}, locatorId=${locatorId}`, async () => {
         const lineButton = await page.getByTestId(`line-P${productId}-L${locatorId}-button`);
         const lineButtonDetails = await lineButton.locator('.button-details');

--- a/e2e/mobile-webui/tests/utils/screens/inventory/InventoryJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/inventory/InventoryJobsListScreen.js
@@ -1,7 +1,8 @@
-import { page, SLOW_ACTION_TIMEOUT, step } from '../../common';
+import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT, step } from '../../common';
 import { test } from '../../../../playwright.config';
 import { expect } from '@playwright/test';
 import { InventoryJobScreen } from './InventoryJobScreen';
+import { ApplicationsListScreen } from '../ApplicationsListScreen';
 
 const NAME = 'InventoryJobsListScreen';
 /** @returns {import('@playwright/test').Locator} */
@@ -22,6 +23,12 @@ export const InventoryJobsListScreen = {
         return {
             jobId: await InventoryJobScreen.getJobId(),
         }
+    }),
+
+    goBack: async () => await test.step(`${NAME} - Go back`, async () => {
+        await InventoryJobsListScreen.waitForScreen();
+        await page.locator(ID_BACK_BUTTON).tap();
+        await ApplicationsListScreen.waitForScreen();
     }),
 };
 

--- a/e2e/mobile-webui/tests/utils/screens/inventory/InventoryScanScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/inventory/InventoryScanScreen.js
@@ -1,5 +1,5 @@
 import { test } from "../../../../playwright.config";
-import { page, step } from "../../common";
+import { page, step, SLOW_ACTION_TIMEOUT } from "../../common";
 import { expect } from '@playwright/test';
 import { InventoryJobScreen } from './InventoryJobScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
@@ -10,11 +10,11 @@ const containerElement = () => page.locator(`#${NAME}`);
 
 export const InventoryScanScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
+        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     waitForPanel: async (panel) => await test.step(`${NAME} - Wait for panel '${panel}'`, async () => {
-        await page.locator(`.panel-${panel}`).waitFor();
+        await page.locator(`.panel-${panel}`).waitFor({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     typeQRCode: async (qrCode) => await test.step(`${NAME} - Type QR Code`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobLineScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobLineScreen.js
@@ -25,6 +25,10 @@ export const PickingJobLineScreen = {
         await GetQuantityDialog.waitForDialog();
     }),
 
+    clickScanButton: async () => await test.step(`${NAME} - Click Scan button`, async () => {
+        await page.getByRole('button', { name: 'Scan' }).tap();
+    }),
+
     clickStepButton: async ({ index }) => await test.step(`${NAME} - Click step ${index} button`, async () => {
         await page.locator(`#step-${index}-button`).tap();
         await PickingJobStepScreen.waitForScreen();

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/inventory/activities/InventoryScanScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/inventory/activities/InventoryScanScreen.jsx
@@ -72,10 +72,12 @@ const InventoryScanScreen = () => {
   };
 
   const onHUScanned = ({ scannedBarcode }) => {
-    resolveHU({ scannedCode: scannedBarcode, wfProcessId, lineId, locatorQRCode }).then((response) => {
-      setResolvedHU(response);
-      setStatus(STATUS_FillData);
-    });
+    resolveHU({ scannedCode: scannedBarcode, wfProcessId, lineId, locatorQRCode })
+      .then((response) => {
+        setResolvedHU(response);
+        setStatus(STATUS_FillData);
+      })
+      .catch((error) => toastErrorFromObj(error));
   };
 
   const onInventoryCountSubmit = ({ qtyCount, attributes, lineCountingDone }) => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickProductsScanScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickProductsScanScreen.jsx
@@ -46,7 +46,7 @@ export const usePickProductsScan = ({ applicationId, wfProcessId, activityId }) 
 
     const { lineId } = await api.getNextEligibleLineToPack({ wfProcessId, huScannedCode: qrCode });
     if (!lineId) {
-      throw 'No matching lines found'; // TODO trl
+      throw { messageKey: 'activities.picking.noMatchingLines' };
     }
 
     const openDialogScreen = () => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/toast.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/toast.jsx
@@ -27,6 +27,7 @@ export const toastError = ({ axiosError, messageKey, fallbackMessageKey, plainMe
   let message;
   if (axiosError) {
     message = extractUserFriendlyErrorMessageFromAxiosError({ axiosError, fallbackMessageKey });
+    code = extractErrorCodeFromAxiosError(axiosError);
   } else if (messageKey) {
     message = trl(messageKey);
     code = messageKey;
@@ -54,6 +55,16 @@ export const toastError = ({ axiosError, messageKey, fallbackMessageKey, plainMe
     callstack: new Error().stack,
     context,
   });
+};
+
+export const extractErrorCodeFromAxiosError = (axiosError) => {
+  const responseData = axiosError?.response && unboxAxiosResponse(axiosError.response);
+  if (responseData?.errors?.[0]?.errorCode) {
+    return responseData.errors[0].errorCode;
+  } else if (axiosError?.response?.data?.error?.errorCode) {
+    return axiosError.response.data.error.errorCode;
+  }
+  return null;
 };
 
 export const extractUserFriendlyErrorMessageFromAxiosError = ({ axiosError, fallbackMessageKey = null }) => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/toast.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/toast.jsx
@@ -70,6 +70,12 @@ export const extractErrorCodeFromAxiosError = (axiosError) => {
 export const extractUserFriendlyErrorMessageFromAxiosError = ({ axiosError, fallbackMessageKey = null }) => {
   // console.log('extractUserFriendlyErrorMessageFromAxiosError', { axiosError });
 
+  // Read the UI trace ID from the request config (not from uiTrace.getCurrentTraceId()) because the trace
+  // context is cleaned up before the .catch() handler fires, so the live axios default header is already gone.
+  // This UUID matches UI_Trace.ExternalId in the metasfresh WebUI trace window; from there support can
+  // navigate to the linked API Request Audit record for the full request/response details.
+  const traceId = axiosError?.config?.headers?.['X-Ui-Trace-Id'];
+
   if (axiosError) {
     if (axiosError.request && !axiosError.response) {
       return trl('error.network.noResponse');
@@ -77,12 +83,16 @@ export const extractUserFriendlyErrorMessageFromAxiosError = ({ axiosError, fall
       const data = axiosError.response && unboxAxiosResponse(axiosError.response);
       if (data && data.errors && data.errors[0] && data.errors[0].message) {
         const error = data.errors[0];
-        return extractUserFriendlyErrorSingleErrorObject({ error, fallbackMessageKey });
+        return extractUserFriendlyErrorSingleErrorObject({ error, fallbackMessageKey, traceId });
       } else if (axiosError.response.data.error) {
-        return extractUserFriendlyErrorSingleErrorObject({ error: axiosError.response.data.error, fallbackMessageKey });
+        return extractUserFriendlyErrorSingleErrorObject({
+          error: axiosError.response.data.error,
+          fallbackMessageKey,
+          traceId,
+        });
       }
     } else if (axiosError.message) {
-      return extractUserFriendlyErrorSingleErrorObject({ error: axiosError, fallbackMessageKey });
+      return extractUserFriendlyErrorSingleErrorObject({ error: axiosError, fallbackMessageKey, traceId });
     }
   }
 
@@ -117,7 +127,7 @@ export const extractErrorResponseFromAxiosError = (axiosError) => {
   return unboxAxiosResponse(axiosError.response);
 };
 
-function extractUserFriendlyErrorSingleErrorObject({ error, fallbackMessageKey }) {
+function extractUserFriendlyErrorSingleErrorObject({ error, fallbackMessageKey, traceId }) {
   if (!error) {
     // null/empty error message... shall not happen
     return trl(fallbackMessageKey ?? 'error.PleaseTryAgain');
@@ -126,8 +136,9 @@ function extractUserFriendlyErrorSingleErrorObject({ error, fallbackMessageKey }
     if (error.userFriendlyError || window.showAllErrorMessages) {
       return error.message;
     } else {
-      // don't scare the user with weird errors. Better show him some generic error.
-      return trl(fallbackMessageKey ?? 'error.PleaseTryAgain');
+      // Non-user-friendly error: show generic message with UI trace ID so users can report it to support.
+      // The trace ID matches UI_Trace.ExternalId in the metasfresh WebUI trace window.
+      return trl(fallbackMessageKey ?? 'error.InternalError', { traceId: traceId ?? '-' });
     }
   } else {
     // assume it's a string

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -89,6 +89,16 @@ const translations = {
     huManager: {
       missingTargetQrCode: 'Der Ziel-QR-Code muss zuerst gescannt werden!',
       scanLuOrLocator: 'Scannen LU oder Lagerplatz',
+      action: {
+        bulkActions: {
+          windowName: 'Massenaktionen',
+          closeScanner: 'Scanner schließen',
+          move: 'Verschieben',
+          moveSuccess: 'HU erfolgreich verschoben',
+          scanHUPlaceholder: 'HU scannen',
+          scanTargetPlaceholder: 'Ziellagerplatz scannen',
+        },
+      },
     },
     picking: {
       PickingLine: 'Packzeile',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -5,6 +5,8 @@ const translations = {
       differentProduct: 'The scanned QR Product does not match',
     },
     PleaseTryAgain: 'Oops, das sollte nicht passieren',
+    InternalError:
+      'Bitte erneut versuchen. Sollte das Problem weiterhin auftreten, wenden Sie sich an den Support. (Trace: %(traceId)s)',
     network: {
       noResponse: 'Verbindung Fehler',
     },

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -131,6 +131,7 @@ const translations = {
       reopenLU: 'LU wieder öffnen',
       pickingSlot: 'Verpackungsfach',
       pickAll: 'Schnelldruck',
+      noMatchingLines: 'Keine passende Packzeile gefunden',
     },
     distribution: {
       DistributionLine: 'Pickenzeile',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -128,6 +128,7 @@ const translations = {
       reopenLU: 'Reopen LU',
       pickingSlot: 'Packing slot',
       pickAll: 'Quick Pack',
+      noMatchingLines: 'No matching lines found',
     },
     distribution: {
       DistributionLine: 'Distribution Line',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -2,6 +2,7 @@ const translations = {
   appName: 'metasfresh mobile',
   error: {
     PleaseTryAgain: 'Please try again',
+    InternalError: 'Please try again. If the problem persists, contact support. (Trace: %(traceId)s)',
     network: {
       noResponse: 'Connection error',
     },

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -86,6 +86,16 @@ const translations = {
     huManager: {
       missingTargetQrCode: 'Target QR Code must be scanned first!',
       scanLuOrLocator: 'Scan LU or locator',
+      action: {
+        bulkActions: {
+          windowName: 'Bulk Actions',
+          closeScanner: 'Close scanner',
+          move: 'Move',
+          moveSuccess: 'HU moved successfully',
+          scanHUPlaceholder: 'Scan HU',
+          scanTargetPlaceholder: 'Scan target location',
+        },
+      },
     },
     picking: {
       PickingLine: 'Packing line',


### PR DESCRIPTION
## Summary

- Adds `MobileQRCodeMessages` utility class consolidating all `AdMessageKey` constants for picking, distribution, inventory, and HU-consolidation mobile workflows.
- Replaces every raw-string exception message at mobile QR scan throw sites with the `AdempiereException(AdMessageKey, ...)` overload so the frontend renders a translated, actionable message instead of the generic "Oops" screen.
- Adds `DistributionHUService.assertHUCanBePickedFrom()` to wire the three distribution business-check constants (`HU_RESERVED_BY_OTHER`, `HU_NOT_AT_TARGET`, `HU_ALREADY_AT_TARGET`) to real validation logic.
- Migration `5803900`: 15 new `AD_Message` records covering all mobile QR error cases; backfills `ErrorCode` on 3 pre-existing picking messages that were missing it.
- New Playwright E2E scenarios for distribution scan-HU-barcodes and inventory error-message paths.

## Changed modules

- `de.metas.handlingunits.base` — new `MobileQRCodeMessages`, `HUQRCodesService`, `PickFromHUQRCodeResolveCommand`, migration SQL
- `de.metas.distribution.rest-api` — `DistributionHUService` (new assertion method), `DistributionJobPickFromCommand`
- `de.metas.hu_consolidation.mobile` — `ConsolidateCommand`, `SetTargetCommand`
- `de.metas.inventory.mobileui` — `ResolveHUCommand`
- `de.metas.picking.rest-api` — `PickingRestController`
- `e2e/mobile-webui` — distribution and inventory test specs + screen helpers