### PR TITLE
cucumber CI: replace external SMTP relay with local MailPit container

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1448,12 +1448,14 @@ jobs:
         env:
           mfversion: ${{ needs.init.outputs.tag-fixed }}
           cucumberparams: ${{ matrix.params }}
-          TEST_SMTP_HOST: ${{ secrets.TEST_SMTP_HOST }}
-          TEST_SMTP_PORT: "587"
-          TEST_SMTP_STARTTLS: "true"
-          TEST_SMTP_FROM: ${{ secrets.TEST_SMTP_FROM }}
-          TEST_SMTP_USER: ${{ secrets.TEST_SMTP_USER }}
-          TEST_SMTP_PASSWORD: ${{ secrets.TEST_SMTP_PASSWORD }}
+          # TEST_SMTP_* env vars are no longer set here: the cucumber compose
+          # now starts a local MailPit container and the SMTP defaults in
+          # docker-builds/cucumber/compose.yml point at it. The previous
+          # external SMTP relay was rejecting the secrets-stored credentials
+          # since 2026-05-21 (provider-side lockout), keeping profile4 red
+          # across every branch. Removing the secrets reference also lets
+          # forks and PR-from-fork builds run the SMTP scenario without
+          # needing the org secrets.
         timeout-minutes: 120
         run: |
           mkdir -p cucumber

--- a/docker-builds/cucumber/compose.yml
+++ b/docker-builds/cucumber/compose.yml
@@ -55,15 +55,40 @@ services:
       mode: replicated
       replicas: 1
 
+  # Local SMTP relay for cucumber's `Test sending an outbound mail` scenario.
+  # Replaces the previous external-secrets-based SMTP relay: the external
+  # provider rejected our credentials on 2026-05-21 (locked out the test
+  # account) and the cucumber profile4 job has been red since. MailPit with
+  # --smtp-auth-accept-any removes the external dependency entirely.
+  # Image pinned (no :latest) so a future upstream change can't silently
+  # re-break the test.
+  mailpit:
+    image: axllent/mailpit:v1.20.5
+    command: ["--smtp-auth-accept-any", "--smtp-auth-allow-insecure", "--smtp=0.0.0.0:587"]
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:8025 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      start_period: 10s
+      retries: 10
+    deploy:
+      mode: replicated
+      replicas: 1
+
   cucumber:
     image: ${mfregistry:-metasfresh}/metas-cucumber:$mfversion
     environment:
-      - TEST_SMTP_HOST=$TEST_SMTP_HOST
+      # SMTP defaults point at the local mailpit container above.
+      # The env vars are still parametrised so a future scenario that
+      # needs a real external SMTP relay can override them at the
+      # compose `up` invocation, but the default cucumber run is now
+      # self-contained.
+      - TEST_SMTP_HOST=${TEST_SMTP_HOST:-mailpit}
       - TEST_SMTP_PORT=${TEST_SMTP_PORT:-587}
-      - TEST_SMTP_STARTTLS=${TEST_SMTP_STARTTLS:-true}
-      - TEST_SMTP_FROM=$TEST_SMTP_FROM
-      - TEST_SMTP_USER=$TEST_SMTP_USER
-      - TEST_SMTP_PASSWORD=$TEST_SMTP_PASSWORD
+      - TEST_SMTP_STARTTLS=${TEST_SMTP_STARTTLS:-false}
+      - TEST_SMTP_FROM=${TEST_SMTP_FROM:-noreply@cucumber.metasfresh.test}
+      - TEST_SMTP_USER=${TEST_SMTP_USER:-cucumber}
+      - TEST_SMTP_PASSWORD=${TEST_SMTP_PASSWORD:-cucumber}
       - CUCUMBER_IS_USING_PROVIDED_INFRASTRUCTURE=true
       - CUCUMBER_EXTERNALLY_RUNNING_RABBITMQ_HOST=rabbitmq
       - CUCUMBER_EXTERNALLY_RUNNING_RABBITMQ_PORT=5672
@@ -80,6 +105,8 @@ services:
         condition: service_healthy
       postgrest:
         condition: service_started
+      mailpit:
+        condition: service_healthy
     volumes:
       - ./cucumber:/reports
     deploy:


### PR DESCRIPTION
## Why

The cucumber `Test sending an outbound mail / SMTP` scenario (profile4) has been failing on every trunk and PR run since 2026-05-21 ~14:38Z with:

```
de.metas.email.impl.EMailSendException:
(ME) - Invalid Username/Password: 535 5.7.8 Error: authentication failed
```

### Evidence the failure is provider-side

`gh secret list --repo metasfresh/metasfresh` shows the `TEST_SMTP_HOST/USER/PASSWORD/FROM` secrets were last updated on 2024-11-11 — identical between yesterday's pass and today's deterministic fails. So the credentials in the workflow haven't changed.

Confirmed across 5+ consecutive trunk + PR runs today (4 commit SHAs, 3 branches) — same exception, same message, same scenario. All other cucumber profiles + mobile-test + frontend webui shards have stayed green throughout, so the regression is isolated to the SMTP path.

This is an **external SMTP provider lockout**: account block / IP-allowlist change / sending limit / forced 2FA. Not something a code change in this repo can fix.

## What this PR does

The `Test sending an outbound mail / SMTP` scenario asserts `email successfully sent` only — no recipient-inbox verification, no content check. It verifies the send code path, not the production relay. So we can swap the external relay for a local MailPit container without weakening the assertion.

### `docker-builds/cucumber/compose.yml`
- Adds a `mailpit` service (`axllent/mailpit:v1.20.5`, **PINNED** — no `:latest` so a future upstream change can't silently re-break the test).
- Configures `--smtp-auth-accept-any --smtp-auth-allow-insecure --smtp=0.0.0.0:587`, matching the dev-infrastructure compose at `misc/dev-support/docker/infrastructure/docker-compose.yml:103-109`.
- The cucumber service now `depends_on` mailpit and reads `TEST_SMTP_HOST=mailpit` / `PORT=587` / `STARTTLS=false` / `USER=cucumber` / `PASSWORD=cucumber` by default. The env vars are still parametrised so a future scenario can override them.

### `.github/workflows/cicd.yaml`
- Drops the `secrets.TEST_SMTP_*` env vars in the cucumber-run step. Compose defaults take over.
- Side benefit: PR-from-fork builds can now run the SMTP scenario without needing the org secrets.

## Trade-offs

- The test no longer covers real STARTTLS (MailPit has no TLS in this config).
- The test no longer covers real-credential auth (`--smtp-auth-accept-any` accepts anything).

Both acceptable for a CI smoke test. End-to-end SMTP relay validation belongs in a production smoke test, not in the per-PR cucumber pipeline.

## Test plan

- [ ] CI green on this PR — specifically `test (cucumber) (profile4)`
- [ ] After merge: `secrets.TEST_SMTP_*` can eventually be deleted from the repo settings (out of scope here; the workflow no longer references them)