### PR TITLE
5796400 CannotTransformReservedHU AD_Message — use AD_Message_ID 545710 from ID server (was hardcoded 545700)

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5796400_sys_add_CannotTransformReservedHU_AD_Message.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5796400_sys_add_CannotTransformReservedHU_AD_Message.sql
@@ -1,11 +1,11 @@
 -- 2026-04-15
 -- Add AD_Message for HUTransformService reservation guard
-INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,545700,0,TO_TIMESTAMP('2026-04-15 00:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','Die Handling Unit kann nicht transformiert oder verschoben werden, da sie fuer einen anderen Vorgang reserviert ist.','E',TO_TIMESTAMP('2026-04-15 00:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits.CannotTransformReservedHU')
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,545710 /*From ID Server*/,0,TO_TIMESTAMP('2026-04-15 00:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','Die Handling Unit kann nicht transformiert oder verschoben werden, da sie fuer einen anderen Vorgang reserviert ist.','E',TO_TIMESTAMP('2026-04-15 00:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits.CannotTransformReservedHU')
 ;
 
-INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Message t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=545700 AND NOT EXISTS (SELECT * FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Message t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=545710 AND NOT EXISTS (SELECT * FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
 ;
 
 -- en_US translation
-UPDATE AD_Message_Trl SET MsgText='Cannot transform or move this handling unit because it is reserved for another process.', IsTranslated='Y' WHERE AD_Message_ID=545700 AND AD_Language='en_US'
+UPDATE AD_Message_Trl SET MsgText='Cannot transform or move this handling unit because it is reserved for another process.', IsTranslated='Y' WHERE AD_Message_ID=545710 AND AD_Language='en_US'
 ;


### PR DESCRIPTION
## Why

`backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5796400_sys_add_CannotTransformReservedHU_AD_Message.sql` used a hardcoded `AD_Message_ID=545700`. Per project convention, AD_*_ID values in migration scripts must be allocated from the central ID server (`http://idserver.metas.de` with `TABLE=AD_Message`) and annotated with `/*From ID Server*/` at the allocation point.

The fresh server response (today) is `545710` — only 10 above the previously hardcoded `545700`, which makes it likely the original was invented rather than allocated.

## Change

- Replace `545700` with `545710 /*From ID Server*/` in the `INSERT INTO AD_Message` line.
- Update the two follow-on references (`AD_Message_Trl INSERT` and the `en_US UPDATE`) to use `545710` (no annotation — they're filters, not allocations).

## ⚠ Caveat — migration immutability

This script is already integrated into `new_dawn_uat` (introduced by the merge from PR 23412 on `soft_panda_release`). The metasfresh migration tool tracks applied scripts and **will not re-apply** this one on databases where it has already run. As a result:
- Databases that have already applied the script carry `AD_Message_ID=545700`.
- Future-applied (fresh) databases will carry `545710`.

The application looks the message up by `Value` (`de.metas.handlingunits.CannotTransformReservedHU`), not by ID, so functional behaviour is preserved either way. The inconsistency is on the PK only and does not affect user-facing behaviour. A separate normalisation script could be added later if PK consistency across the fleet matters for any downstream tooling — out of scope here.

## Test plan

- [ ] CI green