### PR TITLE
5796400 CannotTransformReservedHU AD_Message — revert to 545700 (was confirmed from ID server)

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5796400_sys_add_CannotTransformReservedHU_AD_Message.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5796400_sys_add_CannotTransformReservedHU_AD_Message.sql
@@ -1,11 +1,11 @@
 -- 2026-04-15
 -- Add AD_Message for HUTransformService reservation guard
-INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,545710 /*From ID Server*/,0,TO_TIMESTAMP('2026-04-15 00:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','Die Handling Unit kann nicht transformiert oder verschoben werden, da sie fuer einen anderen Vorgang reserviert ist.','E',TO_TIMESTAMP('2026-04-15 00:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits.CannotTransformReservedHU')
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,545700 /*From ID Server*/,0,TO_TIMESTAMP('2026-04-15 00:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','Die Handling Unit kann nicht transformiert oder verschoben werden, da sie fuer einen anderen Vorgang reserviert ist.','E',TO_TIMESTAMP('2026-04-15 00:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits.CannotTransformReservedHU')
 ;
 
-INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Message t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=545710 AND NOT EXISTS (SELECT * FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Message t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=545700 AND NOT EXISTS (SELECT * FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
 ;
 
 -- en_US translation
-UPDATE AD_Message_Trl SET MsgText='Cannot transform or move this handling unit because it is reserved for another process.', IsTranslated='Y' WHERE AD_Message_ID=545710 AND AD_Language='en_US'
+UPDATE AD_Message_Trl SET MsgText='Cannot transform or move this handling unit because it is reserved for another process.', IsTranslated='Y' WHERE AD_Message_ID=545700 AND AD_Language='en_US'
 ;


### PR DESCRIPTION
## Why

Reverts the ID change from https://github.com/metasfresh/metasfresh/pull/24073. The original `545700` was confirmed to have been allocated from the central ID server when the script was first authored — only the inline `/*From ID Server*/` annotation was missing.

Restoring `545700` + keeping the annotation in place documents the provenance without changing the value that has already been applied across all environments (which avoids the migration-immutability inconsistency PR #24073 introduced).

## Change

- `545710` → `545700` in the INSERT (annotation `/*From ID Server*/` retained).
- `545710` → `545700` in the two follow-on filter references.

## Test plan

- [ ] CI green (will be admin-merged immediately per the same user direction that admin-merged #24073)