### PR TITLE
device.scales: harden TcpConnectionEndPoint connect path (me03#29754)

### DIFF
--- a/backend/de.metas.device.scales/src/main/java/de/metas/device/scales/endpoint/TcpConnectionEndPoint.java
+++ b/backend/de.metas.device.scales/src/main/java/de/metas/device/scales/endpoint/TcpConnectionEndPoint.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
@@ -39,6 +40,15 @@ import java.net.UnknownHostException;
 public class TcpConnectionEndPoint implements ITcpConnectionEndPoint
 {
 	private static final Logger logger = LogManager.getLogger(TcpConnectionEndPoint.class);
+
+	/**
+	 * Default connect timeout. Industrial scales (Bizerba IT3, etc.) often run minimal TCP stacks
+	 * with a single listener slot; if a previous probe (e.g. an nmap SYN scan) wedges that slot,
+	 * a plain {@code new Socket(host, port)} can block on the OS default (~21s Windows / ~75s Linux).
+	 * 2s is long enough for a LAN scale to accept the connection and short enough to surface
+	 * "scale offline" to the operator quickly.
+	 */
+	private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 2000;
 
 	private String hostName;
 	private int port;
@@ -48,6 +58,8 @@ public class TcpConnectionEndPoint implements ITcpConnectionEndPoint
 	 */
 	private int readTimeoutMillis = 500;
 
+	private int connectTimeoutMillis = DEFAULT_CONNECT_TIMEOUT_MILLIS;
+
 	/**
 	 * Opens a socked, sends the command, reads the response and closes the socked again afterwards.
 	 * Note: discards everything besides the last line.
@@ -56,7 +68,7 @@ public class TcpConnectionEndPoint implements ITcpConnectionEndPoint
 	@Nullable
 	public String sendCmd(@NonNull final String cmd)
 	{
-		try (final Socket clientSocket = new Socket(hostName, port);
+		try (final Socket clientSocket = openSocket();
 				final OutputStream out = clientSocket.getOutputStream();)
 		{
 			clientSocket.setSoTimeout(readTimeoutMillis);
@@ -74,6 +86,38 @@ public class TcpConnectionEndPoint implements ITcpConnectionEndPoint
 		catch (final IOException e)
 		{
 			throw new EndPointException("Caught IOException: " + e.getLocalizedMessage(), e);
+		}
+	}
+
+	/**
+	 * Constructs a {@link Socket}, connects with an explicit {@link #connectTimeoutMillis} and enables TCP keep-alive.
+	 * If anything fails, the partially-constructed socket is closed before the exception propagates.
+	 *
+	 * Rationale: see {@link #DEFAULT_CONNECT_TIMEOUT_MILLIS}. TCP keep-alive is enabled so that a half-dead
+	 * scale (peer never sends FIN/RST) is eventually surfaced as a read failure on our side instead of
+	 * hanging the calling thread.
+	 */
+	@NonNull
+	private Socket openSocket() throws IOException
+	{
+		final Socket socket = new Socket();
+		try
+		{
+			socket.connect(new InetSocketAddress(hostName, port), connectTimeoutMillis);
+			socket.setKeepAlive(true);
+			return socket;
+		}
+		catch (final IOException e)
+		{
+			try
+			{
+				socket.close();
+			}
+			catch (final IOException closeEx)
+			{
+				e.addSuppressed(closeEx);
+			}
+			throw e;
 		}
 	}
 
@@ -116,6 +160,15 @@ public class TcpConnectionEndPoint implements ITcpConnectionEndPoint
 	public TcpConnectionEndPoint setReadTimeoutMillis(final int readTimeoutMillis)
 	{
 		this.readTimeoutMillis = readTimeoutMillis;
+		return this;
+	}
+
+	/**
+	 * TCP connect timeout. See {@link #DEFAULT_CONNECT_TIMEOUT_MILLIS} for rationale.
+	 */
+	public TcpConnectionEndPoint setConnectTimeoutMillis(final int connectTimeoutMillis)
+	{
+		this.connectTimeoutMillis = connectTimeoutMillis;
 		return this;
 	}
 


### PR DESCRIPTION
## Summary

Defensive hardening of `TcpConnectionEndPoint.sendCmd()` against wedged scale TCP stacks.

Context: https://github.com/metasfresh/me03/issues/29754 — Bizerba IT3 scales going offline. The root cause is the scale's tiny embedded TCP stack getting wedged by `nmap -sS` SYN scans run by IT monitoring (single listener slot stuck in `SYN_RCVD`). Fix on that side is to use `nmap -sT` / `curl` instead.

This PR doesn't fix the underlying scale-side problem (we can't — the scale firmware has no relevant TCP knob). It hardens metasfresh so a wedged scale doesn't *also* block our threads.

### Changes

- Replace `new Socket(host, port)` with `new Socket()` + explicit `connect(addr, connectTimeoutMillis)` — default **2s** (vs OS default ~21s Windows / ~75s Linux). Wedged scale → fast "offline" error instead of long hang.
- Enable `setKeepAlive(true)` so a half-dead peer eventually surfaces as a read failure.
- Close the socket if `connect`/`setKeepAlive` fail before try-with-resources takes ownership (no leaks on connect timeout).
- New `setConnectTimeoutMillis(int)` setter (not yet wired through `ConfigureDeviceHandler` — default 2s is fine for LAN scales; can be made AD_Device-configurable later if needed).

We continue to **never send RST** (no `setSoLinger(true,0)` anywhere) — try-with-resources gives a graceful FIN, which matters for fragile scale stacks.

More related specs to follow in this same PR.

## Test plan

- [x] `compile-module.sh backend/de.metas.device.scales` — green
- [x] `run-unit-test.sh backend/de.metas.device.scales` — 4 tests, 0 failures (2 pre-existing `@Ignore`d socket tests skipped)
- [ ] CI pipeline green
- [ ] Manual verification by IT team after deployment: confirm `nmap -sT` (TCP connect) doesn't wedge the scale and metasfresh still talks to the scale; verify that an unreachable scale IP fails fast in WebUI (≤3s) rather than hanging