### PR TITLE
AD_Element: rename shared VAT Code elements to DATEV/ERP-style German base names

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5804190_VATCode_AD_Element_DE_rename.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5804190_VATCode_AD_Element_DE_rename.sql
@@ -1,0 +1,62 @@
+-- Rename shared VAT Code AD_Elements to DATEV/ERP-style German base names
+-- The German base Name column was holding English. metasfresh convention: DE base, EN via _Trl.
+-- 3 elements affected (used across 50+ windows/columns):
+--   542958 C_VAT_Code_ID      -> USt.-Code
+--   542959 VATCode            -> USt.-Code
+--   584891 VATCodeAmountType  -> USt.-Code Betragsart
+-- Cascade via update_TRL_Tables_On_AD_Element_TRL_Update(<id>, NULL) propagates to
+-- AD_Column, AD_Field, AD_Process_Para, AD_PrintFormatItem, AD_Tab, AD_Window, AD_Menu.
+
+-- AD_Element 542958 — C_VAT_Code_ID
+UPDATE AD_Element
+SET Name = 'USt.-Code',
+    PrintName = 'USt.-Code',
+    Updated = TIMESTAMP '2026-05-22 13:00:01',
+    UpdatedBy = 100
+WHERE AD_Element_ID = 542958;
+
+UPDATE AD_Element_Trl
+SET Name = 'VAT Code',
+    PrintName = 'VAT Code',
+    IsTranslated = 'Y',
+    Updated = TIMESTAMP '2026-05-22 13:00:02',
+    UpdatedBy = 100
+WHERE AD_Element_ID = 542958 AND AD_Language = 'en_US';
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(542958, NULL);
+
+-- AD_Element 542959 — VATCode
+UPDATE AD_Element
+SET Name = 'USt.-Code',
+    PrintName = 'USt.-Code',
+    Updated = TIMESTAMP '2026-05-22 13:00:03',
+    UpdatedBy = 100
+WHERE AD_Element_ID = 542959;
+
+UPDATE AD_Element_Trl
+SET Name = 'VAT Code',
+    PrintName = 'VAT Code',
+    IsTranslated = 'Y',
+    Updated = TIMESTAMP '2026-05-22 13:00:04',
+    UpdatedBy = 100
+WHERE AD_Element_ID = 542959 AND AD_Language = 'en_US';
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(542959, NULL);
+
+-- AD_Element 584891 — VATCodeAmountType
+UPDATE AD_Element
+SET Name = 'USt.-Code Betragsart',
+    PrintName = 'USt.-Code Betragsart',
+    Updated = TIMESTAMP '2026-05-22 13:00:05',
+    UpdatedBy = 100
+WHERE AD_Element_ID = 584891;
+
+UPDATE AD_Element_Trl
+SET Name = 'VAT Code Amount Type',
+    PrintName = 'VAT Code Amount Type',
+    IsTranslated = 'Y',
+    Updated = TIMESTAMP '2026-05-22 13:00:06',
+    UpdatedBy = 100
+WHERE AD_Element_ID = 584891 AND AD_Language = 'en_US';
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584891, NULL);


### PR DESCRIPTION
## Summary

Renames 3 shared AD_Elements that have English values in the German base `Name` column. metasfresh convention: German base, English via `_Trl[en_US]` override.

| AD_Element_ID | ColumnName | Current DE base | New DE base | EN |
|---|---|---|---|---|
| 542958 | C_VAT_Code_ID | VAT Code | **USt.-Code** | VAT Code |
| 542959 | VATCode | VAT Code | **USt.-Code** | VAT Code |
| 584891 | VATCodeAmountType | VAT Code Amount Type | **USt.-Code Betragsart** | VAT Code Amount Type |

DATEV-style abbreviation (`USt.` = Umsatzsteuer) per common German accounting convention; matches sibling elements already in the codebase.

## Cascade

For each element, the rename uses `update_TRL_Tables_On_AD_Element_TRL_Update(<id>, NULL)`, which chains through `update_ad_element_on_ad_element_trl_update` → column/field/process-para/print-format/tab/window/menu translation updates — so every downstream display (column headers, field labels, process parameters, print format items, tab names, window names, menu entries) follows the rename consistently.

## Split rationale

Originally surfaced on review of https://github.com/metasfresh/metasfresh/pull/24064 (Tax Declaration Iter 5). Because the impact is across ~50+ unrelated windows, kept it out of that PR so its diff stays scoped to Tax Declaration.

## Test plan

- [ ] `db-apply-migrations` job green (validates script applies + cascade functions exist).
- [ ] Spot-check after merge: open the Tax Declaration line tab — VATCode column header reads `USt.-Code` in DE / `VAT Code` in EN.
- [ ] Spot-check after merge: open the C_Tax window — C_VAT_Code_ID-related fields read `USt.-Code` in DE / `VAT Code` in EN.