### PR TITLE
PurchaseCandidates debouncer — first() → firstOnly() on C_Queue_WorkPackage lookup

### DIFF
--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/async/C_PurchaseCandidates_GeneratePurchaseOrdersForSalesOrder.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/async/C_PurchaseCandidates_GeneratePurchaseOrdersForSalesOrder.java
@@ -115,7 +115,13 @@ public class C_PurchaseCandidates_GeneratePurchaseOrdersForSalesOrder extends Wo
 						C_PurchaseCandidates_GeneratePurchaseOrdersForSalesOrder.class.getName())
 				.create();
 
-		// Main query: find unprocessed WP with matching parameter and our processor
+		// Main query: find unprocessed WP with matching parameter and our processor.
+		// firstOnly (not first): the debouncer invariant in enqueueOrUpdateExisting above
+		// guarantees at most one unprocessed WP per (salesOrderId, processor) — a second WP
+		// is never created while one is still unprocessed. firstOnly throws if the invariant
+		// ever leaks (which we'd want to surface), and never trips the IQueryBuilder.first()
+		// "ORDER BY clause can be a developer error" warning/exception that was previously
+		// caught upstream by EventLogUserService.invokeHandlerAndLog as silent log noise.
 		return queryBL
 				.createQueryBuilder(I_C_Queue_WorkPackage.class)
 				.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_Processed, false)
@@ -128,7 +134,7 @@ public class C_PurchaseCandidates_GeneratePurchaseOrdersForSalesOrder extends Wo
 						I_C_Queue_WorkPackage_Param.COLUMNNAME_C_Queue_WorkPackage_ID,
 						paramQuery)
 				.create()
-				.first(I_C_Queue_WorkPackage.class);
+				.firstOnly(I_C_Queue_WorkPackage.class);
 	}
 
 	@Override


### PR DESCRIPTION
## Why

`backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/async/C_PurchaseCandidates_GeneratePurchaseOrdersForSalesOrder.java:131` calls `.first(I_C_Queue_WorkPackage.class)` without an `.orderBy(...)`. Under the dev-mode strict check in `TypedSqlQuery`, this:

- logs a `WARN` per invocation;
- throws `AdempiereException: Using first() without an ORDER BY clause can be a developer error` — caught upstream by `EventLogUserService.invokeHandlerAndLog`, so it doesn't directly fail tests, but it **floods cucumber CI logs** with tens of thousands of WARN lines per run and **silently short-circuits** the would-be enqueue path that follows.

The intermittent `profile1` `purchaseSimulation.feature:75` failures we've been tracking are caused by this — see `ai-work/29474/trunk-flake-audit-2026-05-22.md`.

## Fix

`.first(...)` → `.firstOnly(...)`. The debouncer invariant in `enqueueOrUpdateExisting` (lines 68-92, same file) guarantees at most ONE unprocessed WP per `(salesOrderId, processor)` — a new WP is only created when no existing unprocessed one is found. `firstOnly` is therefore the correct semantic: returns the single match or null, throws only if the invariant ever leaks (which would be a debouncer-leakage bug we'd want to surface, not hide).

Inline comment added to document the invariant for future readers.

## Test plan

- [ ] CI green
- [ ] Cucumber logs no longer contain `WARN TypedSqlQuery - Using first() without an ORDER BY` for `C_Queue_WorkPackage`
- [ ] No regression of the SO-driven purchase candidate flow (covered by `purchaseSimulation.feature` already)