### PR TITLE
me03 #29369: fix OPS-tab translations + default sort

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804210_sys_me03_29369_fix_ops_tab_translations_and_sortno.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804210_sys_me03_29369_fix_ops_tab_translations_and_sortno.sql
@@ -1,0 +1,96 @@
+-- me03 #29369 — fix translations + default sort on Order Payment Schedule tab (window 541889 / tab 548450)
+--
+-- Three small polish items surfaced during the iter-3 UAT on customer instance:
+--
+-- (1) AD_Element 584784 `DueAmt_Actual` (UI label "Tatsächlich fälliger Betrag") — en_GB trl row
+--     still carries the German fallback (`Tatsächlich fälliger Betrag`, IsTranslated='N'). English-
+--     locale users in en_GB profiles see the German string. The en_US row already has the correct
+--     "Actual due amount" — copy it into en_GB.
+--
+-- (2) AD_Element 577683 `OffsetDays` (UI label "Offset days") — the AD_Element.Name BASE language
+--     value is the English string "Offset days" (German base column carrying English text!), and
+--     every AD_Element_Trl row (including en_US) is the same English string with IsTranslated='N'.
+--     Fix:
+--       - Update AD_Element.Name (German base) to "Versatztage"
+--       - Set en_US + en_GB AD_Element_Trl rows to "Offset days" with IsTranslated='Y'
+--     Other languages are intentionally left to fall back to the German base (consistent with the
+--     rest of the AD trl coverage on this customer).
+--
+-- (3) AD_Field 754537 `SeqNo` on the OPS tab — currently AD_Field.SortNo IS NULL, so the grid
+--     renders rows in undefined order (LC + 3 BL rows appear shuffled). Setting SortNo=1 makes
+--     SeqNo the default sort column ascending, so the rows render as 10/20/30/40.
+--
+-- All Element-level updates are followed by update_TRL_Tables_On_AD_Element_TRL_Update(elem, NULL)
+-- so AD_Field_Trl / AD_Column_Trl / AD_Tab_Trl / AD_Menu_Trl rows propagate consistently. This is
+-- the idiomatic cascade per the metasfresh-application-dictionary skill — direct AD_Field_Trl
+-- UPDATEs on Name would be silently overwritten on the next element sync.
+--
+-- UpdatedBy = 100 (metasfresh user) per the AD-dictionary CreatedBy convention.
+
+-- ============================================================================
+-- (1) DueAmt_Actual — fix en_GB to match en_US
+-- ============================================================================
+UPDATE AD_Element_Trl trl
+   SET Name         = en.Name,
+       PrintName    = en.PrintName,
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-05-22 14:30:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+  FROM AD_Element_Trl en
+ WHERE trl.AD_Element_ID = 584784
+   AND trl.AD_Language   = 'en_GB'
+   AND en.AD_Element_ID  = 584784
+   AND en.AD_Language    = 'en_US'
+   AND en.IsTranslated   = 'Y'
+;
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584784, NULL);
+
+-- ============================================================================
+-- (2) OffsetDays — fix the German base + set proper English trl for en_US + en_GB
+-- ============================================================================
+
+-- (2a) Update AD_Element.Name (German base column) — currently carries the English string
+UPDATE AD_Element
+   SET Name      = 'Versatztage',
+       PrintName = 'Versatztage',
+       Updated   = TO_TIMESTAMP('2026-05-22 14:30:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+ WHERE AD_Element_ID = 577683
+   AND Name          = 'Offset days'
+;
+
+-- (2b) Set en_US trl to "Offset days" (the English text the en_US AD_Element_Trl row should hold)
+UPDATE AD_Element_Trl
+   SET Name         = 'Offset days',
+       PrintName    = 'Offset days',
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-05-22 14:30:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 577683
+   AND AD_Language   = 'en_US'
+;
+
+-- (2c) Set en_GB trl to match en_US
+UPDATE AD_Element_Trl
+   SET Name         = 'Offset days',
+       PrintName    = 'Offset days',
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-05-22 14:30:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 577683
+   AND AD_Language   = 'en_GB'
+;
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(577683, NULL);
+
+-- ============================================================================
+-- (3) AD_Field.SortNo — set default sort on the SeqNo field of OPS tab
+--    (window 541889 → tab 548450 "Zahlungsplan" → field 754537 SeqNo)
+-- ============================================================================
+UPDATE AD_Field
+   SET SortNo    = 1,
+       Updated   = TO_TIMESTAMP('2026-05-22 14:30:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+ WHERE AD_Field_ID = 754537
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804230_sys_me03_29369_fix_ops_tab_translations_followup.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804230_sys_me03_29369_fix_ops_tab_translations_followup.sql
@@ -1,0 +1,53 @@
+-- me03 #29369 — corrective follow-up to 5804210
+--
+-- After 5804210 applied, two issues remained on the live AD trl state:
+--
+-- (a) AD_Field_Trl(777250 / DueAmt_Actual, en_US) still showed the German fallback
+--     "Tatsächlich fälliger Betrag" with IsTranslated='N'. Root cause: the cascade
+--     (update_trl_tables_on_ad_element_trl_update) skips rows where
+--     AD_Field_Trl.Updated = AD_Element_Trl.Updated — and en_US's element trl row
+--     was untouched by 5804210, so its timestamp matched the field trl's. The
+--     en_US AD_Element_Trl row had carried the correct "Actual due amount" value
+--     since 2026-04-24 but the propagation to AD_Field_Trl never ran (timestamps
+--     identical at that moment). Fix: bump AD_Element_Trl(en_US).Updated so the
+--     cascade's `f.updated < e_trl.updated` check passes, then re-run the cascade.
+--
+-- (b) AD_Element 577683 / OffsetDays — 5804210 directly UPDATEd AD_Element.Name
+--     to 'Versatztage', which was promptly overwritten back to 'Offset days' by
+--     the base-language back-sync inside update_trl_tables_on_ad_element_trl_update
+--     (it reads AD_Element_Trl(de_DE).Name — which 5804210 did NOT touch — and
+--     writes it back into AD_Element.Name). Fix: update AD_Element_Trl(de_DE) +
+--     (de_CH for consistency) to 'Versatztage' and let the cascade write
+--     AD_Element.Name + AD_Field_Trl(de_DE) for us.
+
+-- ============================================================================
+-- (a) DueAmt_Actual — bump AD_Element_Trl(en_US).Updated to retrigger cascade
+-- ============================================================================
+-- Name already correct ("Actual due amount" since 2026-04-24); only the
+-- timestamp needs to advance so the cascade no longer no-ops the en_US row.
+UPDATE AD_Element_Trl
+   SET Updated   = TO_TIMESTAMP('2026-05-22 16:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+ WHERE AD_Element_ID = 584784
+   AND AD_Language   = 'en_US'
+;
+
+-- ============================================================================
+-- (b) OffsetDays — fix the German trl rows; let the cascade sync everything
+-- ============================================================================
+UPDATE AD_Element_Trl
+   SET Name         = 'Versatztage',
+       PrintName    = 'Versatztage',
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-05-22 16:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+ WHERE AD_Element_ID = 577683
+   AND AD_Language   IN ('de_DE', 'de_CH')
+;
+
+-- ============================================================================
+-- (c) Cascade — propagates to AD_Field_Trl, AD_Column_Trl, AD_Tab_Trl,
+--     AD_Menu_Trl AND writes back to AD_Element.Name from the de_DE base trl row.
+-- ============================================================================
+SELECT update_trl_tables_on_ad_element_trl_update(584784, NULL);
+SELECT update_trl_tables_on_ad_element_trl_update(577683, NULL);


### PR DESCRIPTION
## Summary

Three minor AD polish items on the **Order Payment Schedule** tab (Bestellung window 541889 / tab 548450), surfaced during the iter-3 UAT on the customer instance:

1. **`DueAmt_Actual` (element 584784)** — en_GB trl row still carried the German fallback (IsTranslated='N'); English-locale users in en_GB profiles saw the German label. Copy the existing en_US "Actual due amount" into en_GB.
2. **`OffsetDays` (element 577683)** — AD_Element.Name (German base column) carried the English string "Offset days" and every trl row was the same English text with IsTranslated='N'. Set the German base to **`Versatztage`** and the en_US + en_GB trl rows to "Offset days" with IsTranslated='Y'.
3. **`SeqNo` field on the OPS tab (AD_Field 754537)** — AD_Field.SortNo was NULL, so the LC + BL sub-rows rendered in undefined order on the WebUI grid. Set SortNo=1 so SeqNo is the default sort ascending (10/20/30/40).

Element-level updates are followed by `update_TRL_Tables_On_AD_Element_TRL_Update(elem, NULL)` so AD_Field_Trl / AD_Column_Trl / AD_Tab_Trl / AD_Menu_Trl propagate consistently.

## Test plan

- [ ] Migration applies cleanly on CI's preloaded-DB stage.
- [ ] After deploy, switch user profile to en_GB and open a PO with a complex payment term -> Zahlungsplan tab -> column header reads "Actual due amount" (not the German fallback).
- [ ] On a de_DE profile open the same tab -> "Offset days" column now reads "Versatztage".
- [ ] On any profile open a completed PO with multiple OPS rows -> rows render sorted by SeqNo ascending (LC first, BL sub-rows in receipt order, remainder last if present).

Related me03: https://github.com/metasfresh/me03/issues/29369