### PR TITLE
cucumber CI: replace external SMTP relay with local MailPit container (port #24068 → taloned_owl_hotfix) [me03#29983]

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1448,12 +1448,14 @@ jobs:
         env:
           mfversion: ${{ needs.init.outputs.tag-fixed }}
           cucumberparams: ${{ matrix.params }}
-          TEST_SMTP_HOST: ${{ secrets.TEST_SMTP_HOST }}
-          TEST_SMTP_PORT: "587"
-          TEST_SMTP_STARTTLS: "true"
-          TEST_SMTP_FROM: ${{ secrets.TEST_SMTP_FROM }}
-          TEST_SMTP_USER: ${{ secrets.TEST_SMTP_USER }}
-          TEST_SMTP_PASSWORD: ${{ secrets.TEST_SMTP_PASSWORD }}
+          # TEST_SMTP_* env vars are no longer set here: the cucumber compose
+          # now starts a local MailPit container and the SMTP defaults in
+          # docker-builds/cucumber/compose.yml point at it. The previous
+          # external SMTP relay was rejecting the secrets-stored credentials
+          # since 2026-05-21 (provider-side lockout), keeping profile4 red
+          # across every branch. Removing the secrets reference also lets
+          # forks and PR-from-fork builds run the SMTP scenario without
+          # needing the org secrets.
         timeout-minutes: 120
         run: |
           mkdir -p cucumber

--- a/docker-builds/cucumber/compose.yml
+++ b/docker-builds/cucumber/compose.yml
@@ -55,13 +55,40 @@ services:
       mode: replicated
       replicas: 1
 
+  # Local SMTP relay for cucumber's `Test sending an outbound mail` scenario.
+  # Replaces the previous external-secrets-based SMTP relay: the external
+  # provider rejected our credentials on 2026-05-21 (locked out the test
+  # account) and the cucumber profile4 job has been red since. MailPit with
+  # --smtp-auth-accept-any removes the external dependency entirely.
+  # Image pinned (no :latest) so a future upstream change can't silently
+  # re-break the test.
+  mailpit:
+    image: axllent/mailpit:v1.20.5
+    command: ["--smtp-auth-accept-any", "--smtp-auth-allow-insecure", "--smtp=0.0.0.0:587"]
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:8025 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      start_period: 10s
+      retries: 10
+    deploy:
+      mode: replicated
+      replicas: 1
+
   cucumber:
     image: ${mfregistry:-metasfresh}/metas-cucumber:$mfversion
     environment:
-      - TEST_SMTP_HOST=$TEST_SMTP_HOST
-      - TEST_SMTP_FROM=$TEST_SMTP_FROM
-      - TEST_SMTP_USER=$TEST_SMTP_USER
-      - TEST_SMTP_PASSWORD=$TEST_SMTP_PASSWORD
+      # SMTP defaults point at the local mailpit container above.
+      # The env vars are still parametrised so a future scenario that
+      # needs a real external SMTP relay can override them at the
+      # compose `up` invocation, but the default cucumber run is now
+      # self-contained.
+      - TEST_SMTP_HOST=${TEST_SMTP_HOST:-mailpit}
+      - TEST_SMTP_PORT=${TEST_SMTP_PORT:-587}
+      - TEST_SMTP_STARTTLS=${TEST_SMTP_STARTTLS:-false}
+      - TEST_SMTP_FROM=${TEST_SMTP_FROM:-noreply@cucumber.metasfresh.test}
+      - TEST_SMTP_USER=${TEST_SMTP_USER:-cucumber}
+      - TEST_SMTP_PASSWORD=${TEST_SMTP_PASSWORD:-cucumber}
       - CUCUMBER_IS_USING_PROVIDED_INFRASTRUCTURE=true
       - CUCUMBER_EXTERNALLY_RUNNING_RABBITMQ_HOST=rabbitmq
       - CUCUMBER_EXTERNALLY_RUNNING_RABBITMQ_PORT=5672
@@ -78,6 +105,8 @@ services:
         condition: service_healthy
       postgrest:
         condition: service_started
+      mailpit:
+        condition: service_healthy
     volumes:
       - ./cucumber:/reports
     deploy:


### PR DESCRIPTION
## Why

Port of https://github.com/metasfresh/metasfresh/pull/24068 (commit `034e9e6`, merged to `new_dawn_uat` 2026-05-22) to `taloned_owl_hotfix`.

cucumber `Test sending an outbound mail / SMTP` scenario (profile4) was failing deterministically against the external SMTP relay since 2026-05-21 (provider-side lockout). The fix swaps the external relay for a local MailPit container (`axllent/mailpit:v1.20.5`, pinned) and removes the `secrets.TEST_SMTP_*` env from the cucumber-run step.

Tracking: https://github.com/metasfresh/me03/issues/29983

## Conflict resolution

Cherry-picked with `git cherry-pick -X theirs 034e9e6bcc6` — strategy option resolves the env-block conflict on the source side without touching unrelated divergences in either file.

## Validation

- `docker compose -f docker-builds/cucumber/compose.yml config -q` → exit 0
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cicd.yaml'))"` → exit 0
- Real validation = this PR's own cucumber profile4 run on CI.

## Labels requested

- `ops:auto_squash_merge` (queue: squash-queue, merge_method: squash)
- `ops:without_review_approval` (already-reviewed in #24068)