### PR TITLE
gh#28631 follow-up: drop the broken @#AD_Role_Group ReadOnlyLogic from BPartner Delivery-Stop fields

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804280_sys_gh28631_drop_broken_DeliveryStop_ReadOnlyLogic.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804280_sys_gh28631_drop_broken_DeliveryStop_ReadOnlyLogic.sql
@@ -1,0 +1,26 @@
+-- gh#28631: Delivery / Order Stop — drop the broken @#AD_Role_Group ReadOnlyLogic from the two
+-- new BPartner-window AD_Field rows.
+--
+-- Background: PR https://github.com/metasfresh/metasfresh/pull/22796 shipped with
+-- ReadOnlyLogic='@#AD_Role_Group/''''@!Accounting' on AD_Field 774882 (IsDeliveryStop) and
+-- 774883 (DeliveryStopReason) — intent: "editable only for the Accounting role group".
+-- The @#AD_Role_Group context variable resolves via UserRolePermissions.getRoleGroup(),
+-- which reads Role.roleGroup. But that field is never populated:
+--   * the only path that would populate it (RoleDAO.toRole() line 87) is commented out
+--   * the generated I_AD_Role has no getRole_Group() — no DB column to read from
+--   * no migration in metasfresh / mf15-private-extensions / any customer repo adds the column
+-- → @#AD_Role_Group is always null → '' != 'Accounting' is always TRUE → the field is
+--   read-only for every user on every deployment, including the intended Accounting users.
+--
+-- Fix: drop the gate from core. Customer repos that want a per-role gate add their own
+-- ReadOnlyLogic (using @#AD_Role_ID@ — which DOES work) in a customer-side migration.
+-- See dt204 PR (companion) for the per-customer override on these same field IDs plus the
+-- dt204 custom-window field IDs.
+
+UPDATE AD_Field
+SET ReadOnlyLogic = NULL,
+    Updated = TO_TIMESTAMP('2026-05-23 14:00', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_Field_ID IN (
+    774882, -- IsDeliveryStop on AD_Window 123 (base Geschäftspartner)
+    774883  -- DeliveryStopReason on AD_Window 123 (base Geschäftspartner)
+);


### PR DESCRIPTION
## Summary

PR https://github.com/metasfresh/metasfresh/pull/22796 shipped `ReadOnlyLogic='@#AD_Role_Group/''''@!Accounting'` on the two new BPartner-window AD_Field rows (`774882` IsDeliveryStop, `774883` DeliveryStopReason). Intent: editable only by the Accounting role group.

The expression resolves via `userRolePermissions.getRoleGroup()`, which reads `Role.roleGroup`. But that field is **never populated** anywhere:

- The only line that would populate it (`RoleDAO.toRole()` line 87) is **commented out** since https://github.com/metasfresh/metasfresh/pull/19965 (2025-01-31, "Port webui changes from master").
- The generated `I_AD_Role` has no `getRole_Group()` — there is no DB column to read from.
- No migration in metasfresh, mf15-private-extensions, or any customer repo adds the column.

Effect on every deployment: `@#AD_Role_Group` is always null → the expression `''!Accounting` is always TRUE → the field is **read-only for every user**, including the intended privileged users.

## What this PR does

Drops the gate from core via UPDATE on the two AD_Field rows (`ReadOnlyLogic = NULL`). The field becomes editable for anyone with C_BPartner edit rights — the original spec intent (per-role gating for `Finance` on dt204) is delivered separately in the dt204 companion PR.

## Companion

- **dt204**: a customer-side migration sets `ReadOnlyLogic='@#AD_Role_ID@!540174'` (Finance role) on both the metasfresh base-window rows (`774882`, `774883`) and the dt204 custom-window rows (`774888`, `774889`). Prefix `5804290` runs after this PR's `5804280`, so the dt204 gate wins.

## Test plan

- [x] Migration `5804280` applied locally against the `deep_tundra_uat` GDPR-scrambled DB. `AD_Field.ReadOnlyLogic` verified NULL on `774882` and `774883` after apply.
- [ ] CI: db-apply-migrations green.