### PR TITLE
gh#28631 follow-up: fix SeqNo collision of new BPartner-window UI elements

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804300_sys_gh28631_FixDeliveryStop_UIElement_SeqNo.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804300_sys_gh28631_FixDeliveryStop_UIElement_SeqNo.sql
@@ -1,0 +1,23 @@
+-- gh#28631: Fix the SeqNo of the two new BPartner-window AD_UI_Element rows created by 5793400.
+--
+-- The original 5793400 placed Liefer-/Auftragssperre (648530) at SeqNo=100 and
+-- Lieferstopp Grund (648531) at SeqNo=110 inside AD_UI_ElementGroup 540671
+-- ("advanced edit") on AD_Tab 220 of AD_Window 123. Pre-existing UI elements
+-- `freight cost id` (560118) and `shipper` (560119) already occupy those same
+-- SeqNos. Render order with ties is undefined, so the rendered "Erweiterte Erfassung"
+-- panel interleaves the new fields with unrelated freight/shipper fields
+-- (Frachtkostenpauschale → Liefer-/Auftragssperre → Lieferweg → Lieferstopp Grund).
+--
+-- Fix: move both new fields just BEFORE `Frachtkostenpauschale` (SeqNo=100), into
+-- the gap above it. Final order in the group: Sonstiges (90) → Liefer-/Auftragssperre
+-- (95) → Lieferstopp Grund (96) → Frachtkostenpauschale (100) → Lieferweg (110) → …
+
+UPDATE AD_UI_Element
+SET SeqNo = 95,
+    Updated = TO_TIMESTAMP('2026-05-24 11:00', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_UI_Element_ID = 648530;
+
+UPDATE AD_UI_Element
+SET SeqNo = 96,
+    Updated = TO_TIMESTAMP('2026-05-24 11:00', 'YYYY-MM-DD HH24:MI'), UpdatedBy = 0
+WHERE AD_UI_Element_ID = 648531;


### PR DESCRIPTION
## Summary

PR #22796 shipped two new AD_UI_Element rows on the base Geschäftspartner window (AD_Window 123, AD_Tab 220, AD_UI_ElementGroup 540671 "advanced edit"):

| AD_UI_Element_ID | AD_Field_ID | Name | SeqNo |
|---|---|---|---|
| 648530 | 774882 | Liefer-/Auftragssperre | 100 |
| 648531 | 774883 | Lieferstopp Grund | 110 |

But that group already had `freight cost id` (560118) at SeqNo=100 and `shipper` (560119) at SeqNo=110. With ties, render order is undefined, so the customer's "Erweiterte Erfassung" panel renders:

```
Frachtkostenpauschale (existing, SeqNo=100)
Liefer-/Auftragssperre (new, SeqNo=100)
Lieferweg (existing, SeqNo=110)
Lieferstopp Grund (new, SeqNo=110)
```

— the two new fields are split by the unrelated shipping fields.

## Fix

Move both new UI elements to SeqNos 95 and 96 — the gap between `Sonstiges` (90) and `Frachtkostenpauschale` (100). Final group order:

```
Sonstiges               (90)
Liefer-/Auftragssperre  (95)
Lieferstopp Grund       (96)
Frachtkostenpauschale  (100)
Lieferweg              (110)
Zuordnung Mindesthaltbarkeit (120)
```

## Test plan

- [x] Migration `5804300` applied locally against the `deep_tundra_uat` scrambled DB; verified the two SeqNos updated to 95/96 and registry status `CO`.
- [ ] CI: `db-apply-migrations` green.