### PR TITLE
mf15#4157: ad_field_v honour AD_Field-level ReadOnlyLogic override

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/views/ad_field_v.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/views/ad_field_v.sql
@@ -45,7 +45,9 @@ SELECT t.ad_window_id
      , COALESCE(f.ad_val_rule_id, c.ad_val_rule_id)                                                                                               AS ad_val_rule_id
      , c.ad_process_id
      , c.isalwaysupdateable
-     , c.readonlylogic
+     -- mf15#4157: honour AD_Field-level ReadOnlyLogic override; fall back to AD_Column when the field has no override.
+     -- NULLIF treats empty-string as "not overridden" (legacy AD_Field rows often carry ''-default instead of NULL).
+     , COALESCE(NULLIF(f.readonlylogic, ''), c.readonlylogic)                                                                                    AS readonlylogic
      , c.mandatorylogic
      , c.isupdateable
      , c.isencrypted                                                                                                                              AS isencryptedcolumn

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804310_sys_mf15_4157_ad_field_v_honour_field_readonlylogic.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804310_sys_mf15_4157_ad_field_v_honour_field_readonlylogic.sql
@@ -1,22 +1,27 @@
--- NOTE: keep in sync with ad_field_v
+-- Source DDL: backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/views/ad_field_v.sql
+-- mf15#4157: ad_field_v silently ignored AD_Field-level ReadOnlyLogic overrides because the view sourced
+-- readonlylogic exclusively from c.readonlylogic. Every per-field role/column gate set in migrations
+-- against AD_Field.ReadOnlyLogic was a no-op since the WebUI / Swing client loads GridFieldVO from this
+-- view. Fix: honour the AD_Field override when set (non-empty), fall back to AD_Column.ReadOnlyLogic
+-- when not. NULLIF treats empty-string as "not overridden" — legacy AD_Field rows commonly default
+-- ReadOnlyLogic to '' rather than NULL.
+--
+-- Triggered by me03#30014 (Delivery / Order Stop) where ReadOnlyLogic placed on the new
+-- BPartner-window AD_Field rows by https://github.com/metasfresh/metasfresh/pull/22796 never
+-- evaluated; the customer workaround was to move the expression to AD_Column.ReadOnlyLogic.
 
-DROP VIEW IF EXISTS ad_field_vt
-;
+DROP VIEW IF EXISTS ad_field_v$new;
 
-CREATE OR REPLACE VIEW ad_field_vt AS
-SELECT c_trl.ad_language
-     , t.ad_window_id
+CREATE OR REPLACE VIEW ad_field_v$new AS
+SELECT t.ad_window_id
      , f.colorlogic
      , t.ad_tab_id
      , f.ad_field_id
      , tbl.ad_table_id
      , c.ad_column_id
-     , COALESCE(f.name, c.name)                                                                                                                   AS name_BaseLang
-     , COALESCE(f_trl.name, f.name, c_trl.name, c.name)                                                                                           AS name
-     , COALESCE(f.description, c.description)                                                                                                     AS description_BaseLang
-     , COALESCE(f.help, t.help)                                                                                                                   AS help_BaseLang
-     , COALESCE(f_trl.description, f.description, c.description)                                                                                  AS description
-     , COALESCE(f_trl.help, f.help, t.help)                                                                                                       AS help
+     , COALESCE(f.name, c.name)                                                                                                                   AS name
+     , COALESCE(f.description, c.description)                                                                                                     AS description
+     , COALESCE(f.help, t.help)                                                                                                                   AS help
      , f.isdisplayed
      , f.isdisplayedgrid
      , f.IsHideGridColumnIfEmpty
@@ -49,17 +54,14 @@ SELECT c_trl.ad_language
      , COALESCE(f.ad_val_rule_id, c.ad_val_rule_id)                                                                                               AS ad_val_rule_id
      , c.ad_process_id
      , c.isalwaysupdateable
-     -- mf15#4157: honour AD_Field-level ReadOnlyLogic override; fall back to AD_Column when the field has no override.
-     -- NULLIF treats empty-string as "not overridden" (legacy AD_Field rows often carry ''-default instead of NULL).
-     , COALESCE(NULLIF(f.readonlylogic, ''), c.readonlylogic)                                                                                    AS readonlylogic
+     , COALESCE(NULLIF(f.readonlylogic, ''), c.readonlylogic)                                                                                     AS readonlylogic
      , c.mandatorylogic
      , c.isupdateable
      , c.isencrypted                                                                                                                              AS isencryptedcolumn
      , tbl.tablename
      , c.valuemin
      , c.valuemax
-     , fg.name                                                                                                                                    AS fieldgroup_BaseLang
-     , COALESCE(fg_trl.name, fg.name)                                                                                                             AS fieldgroup
+     , fg.name                                                                                                                                    AS fieldgroup
      , vr.code                                                                                                                                    AS validationcode
      , f.included_tab_id
      , fg.fieldgrouptype
@@ -90,12 +92,18 @@ SELECT c_trl.ad_language
 FROM ad_tab t
          JOIN ad_table tbl ON tbl.ad_table_id = t.ad_table_id
          JOIN ad_column c ON c.ad_table_id = t.ad_table_id
-         JOIN ad_column_trl c_trl ON c_trl.ad_column_id = c.ad_column_id
          LEFT JOIN ad_field f ON f.ad_tab_id = t.ad_tab_id AND f.ad_column_id = c.ad_column_id
-         LEFT JOIN ad_field_trl f_trl ON f_trl.ad_field_id = f.ad_field_id AND f_trl.ad_language::text = c_trl.ad_language::text
          LEFT JOIN ad_fieldgroup fg ON fg.ad_fieldgroup_id = f.ad_fieldgroup_id
-         LEFT JOIN ad_fieldgroup_trl fg_trl ON fg_trl.ad_fieldgroup_id = f.ad_fieldgroup_id AND fg_trl.ad_language::text = c_trl.ad_language::text
          LEFT JOIN ad_val_rule vr ON vr.ad_val_rule_id = COALESCE(f.ad_val_rule_id, c.ad_val_rule_id)
 WHERE (f.isactive = 'Y' OR f.AD_Field_ID IS NULL)
   AND c.isactive = 'Y'
 ;
+
+SELECT db_alter_view(
+    'ad_field_v',
+    (SELECT view_definition
+     FROM information_schema.views
+     WHERE lower(views.table_name) = lower('ad_field_v$new'))
+);
+
+DROP VIEW IF EXISTS ad_field_v$new;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804320_sys_mf15_4157_ad_field_vt_honour_field_readonlylogic.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804320_sys_mf15_4157_ad_field_vt_honour_field_readonlylogic.sql
@@ -1,9 +1,9 @@
--- NOTE: keep in sync with ad_field_v
+-- Source DDL: backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/views/ad_field_vt.sql
+-- mf15#4157 — translated-language sibling of ad_field_v. Same readonlylogic fix.
 
-DROP VIEW IF EXISTS ad_field_vt
-;
+DROP VIEW IF EXISTS ad_field_vt$new;
 
-CREATE OR REPLACE VIEW ad_field_vt AS
+CREATE OR REPLACE VIEW ad_field_vt$new AS
 SELECT c_trl.ad_language
      , t.ad_window_id
      , f.colorlogic
@@ -49,9 +49,7 @@ SELECT c_trl.ad_language
      , COALESCE(f.ad_val_rule_id, c.ad_val_rule_id)                                                                                               AS ad_val_rule_id
      , c.ad_process_id
      , c.isalwaysupdateable
-     -- mf15#4157: honour AD_Field-level ReadOnlyLogic override; fall back to AD_Column when the field has no override.
-     -- NULLIF treats empty-string as "not overridden" (legacy AD_Field rows often carry ''-default instead of NULL).
-     , COALESCE(NULLIF(f.readonlylogic, ''), c.readonlylogic)                                                                                    AS readonlylogic
+     , COALESCE(NULLIF(f.readonlylogic, ''), c.readonlylogic)                                                                                     AS readonlylogic
      , c.mandatorylogic
      , c.isupdateable
      , c.isencrypted                                                                                                                              AS isencryptedcolumn
@@ -99,3 +97,12 @@ FROM ad_tab t
 WHERE (f.isactive = 'Y' OR f.AD_Field_ID IS NULL)
   AND c.isactive = 'Y'
 ;
+
+SELECT db_alter_view(
+    'ad_field_vt',
+    (SELECT view_definition
+     FROM information_schema.views
+     WHERE lower(views.table_name) = lower('ad_field_vt$new'))
+);
+
+DROP VIEW IF EXISTS ad_field_vt$new;


### PR DESCRIPTION
## Summary

The views `ad_field_v` and `ad_field_vt` (which `GridFieldVO.getSQL` loads from — see `org/compiere/model/GridFieldVO.java:76`) sourced `readonlylogic` exclusively from `c.readonlylogic` (AD_Column). Every migration / customisation that set `AD_Field.ReadOnlyLogic` was a silent no-op — the column never made it through the view into the runtime.

### How it bit us

While gating the gh#28631 Delivery / Order Stop fields to the dt204 `Finance` role, the AD_Field-level expression (`@#AD_Role_ID/0@!540174`) never fired:
- Sales user → still editable
- Finance user → still editable

Several iterations of syntax permutations later (`@#AD_Role_Group/''@!Accounting` → `@#AD_Role_ID@!540174` → `@#AD_Role_ID/0@!540174` → various AD_Field hotfixes; commits #22796, #24158, #24228, dt204 #1253, #1346, #1348) finally led to diffing `pg_get_viewdef('ad_field_v')`. The customer-side workaround that actually works today is to move the expression to `AD_Column.ReadOnlyLogic`.

### Fix

In both `ad_field_v` and `ad_field_vt`, replace:

```sql
, c.readonlylogic
```

with:

```sql
, COALESCE(NULLIF(f.readonlylogic, ''), c.readonlylogic) AS readonlylogic
```

`NULLIF(…, '')` is to handle legacy rows where `AD_Field.ReadOnlyLogic` carries `''` rather than `NULL` (the column default is `NULL` but UI tooling and older migrations have set `''`).

### Files

| Path | Change |
|---|---|
| `migration/src/main/sql/postgresql/ddl/public/views/ad_field_v.sql` | View DDL inventory file updated. |
| `migration/src/main/sql/postgresql/ddl/public/views/ad_field_vt.sql` | Same, translated-language sibling. |
| `migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804310_sys_mf15_4157_…ad_field_v…sql` | `db_alter_view('ad_field_v', …)` |
| `migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804320_sys_mf15_4157_…ad_field_vt…sql` | `db_alter_view('ad_field_vt', …)` |

One migration per DDL entity per the `metasfresh-db` skill convention.

### Scope deliberately *not* in this PR

- **`isalwaysupdateable`**: also c.-only sourced in the view, but `AD_Field.isalwaysupdateable` has a default of `'N'` so a naive `COALESCE` flips semantics (the field default would silently mask any AD_Column `'Y'`). Needs a design call before fixing — flagged in mf15#4157.
- **`displaylogic`** (the inverse case — view uses `f.displaylogic` only, ignoring `c.displaylogic`): lower severity, also flagged for follow-up.
- **`mandatorylogic`**: not a bug. `AD_Field` doesn't have that column; only `AD_Column` does. View's c.-only sourcing is correct.

### Test plan

- [x] Both migrations applied locally against the `deep_tundra_uat` scrambled DB. `pg_get_viewdef` confirms the COALESCE is now in place. Migration registry entries `5804310` and `5804320` show status `CO`.
- [ ] CI: `db-apply-migrations` green.
- [ ] Customer-side verification on dantherm (https://danthermuat.metasfresh.com/) after this image rolls out:
  - dt204 can revert from the `AD_Column`-level workaround back to the `AD_Field`-level gate (one window at a time, finer-grained control).
  - Or keep the column-level patch — the new behaviour is purely additive when `AD_Field.ReadOnlyLogic` is empty.