### PR TITLE
Re-Substitute per-user context vars in the layout-expression revaluator

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentFieldLogicExpressionResultRevaluator.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentFieldLogicExpressionResultRevaluator.java
@@ -33,6 +33,7 @@ public class DocumentFieldLogicExpressionResultRevaluator
 	private static final Logger logger = LogManager.getLogger(DocumentFieldLogicExpressionResultRevaluator.class);
 
 	private static final CtxName CTXNAME_AD_Role_Group = CtxNames.parse("#AD_Role_Group");
+	private static final CtxName CTXNAME_AD_Role_ID = CtxNames.parse("#AD_Role_ID");
 
 	private final LogicExpressionResultWithReason alwaysReturnResult;
 	@Nullable private final IUserRolePermissions userRolePermissions;
@@ -93,6 +94,20 @@ public class DocumentFieldLogicExpressionResultRevaluator
 				{
 					newParameters = newParameters == null ? copyToNewParameters(usedParameters) : newParameters;
 					newParameters.put(CTXNAME_AD_Role_Group.getName(), newValue);
+				}
+			}
+			else if (CTXNAME_AD_Role_ID.equalsByName(usedParameterName))
+			{
+				// mf15#4157: the result of a layout expression that depends on @#AD_Role_ID@ is cached at
+				// descriptor-build time with the FIRST loading user's role ID baked in. Without re-substituting
+				// per request, every subsequent user with a different role sees the cached evaluation — turning
+				// role-specific ReadOnlyLogic into a coin flip that depends on who logged in first.
+				final String usedValue = StringUtils.trimBlankToNull(usedParameterEntry.getValue());
+				final String newValue = String.valueOf(userRolePermissions.getRoleId().getRepoId());
+				if (!Objects.equals(usedValue, newValue))
+				{
+					newParameters = newParameters == null ? copyToNewParameters(usedParameters) : newParameters;
+					newParameters.put(CTXNAME_AD_Role_ID.getName(), newValue);
 				}
 			}
 		}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentFieldLogicExpressionResultRevaluator.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentFieldLogicExpressionResultRevaluator.java
@@ -13,6 +13,7 @@ import org.adempiere.ad.expression.api.LogicExpressionResultWithReason;
 import org.adempiere.ad.expression.api.impl.LogicExpressionEvaluator;
 import org.compiere.util.CtxName;
 import org.compiere.util.CtxNames;
+import org.compiere.util.Env;
 import org.compiere.util.Evaluatees;
 import org.slf4j.Logger;
 
@@ -34,10 +35,12 @@ public class DocumentFieldLogicExpressionResultRevaluator
 
 	private static final Logger logger = LogManager.getLogger(DocumentFieldLogicExpressionResultRevaluator.class);
 
+	// `#AD_Role_Group` is not declared in Env.java — kept local. The other three reuse the Env constants
+	// as the single source of truth for the context-variable name strings (review note on #24231).
 	private static final CtxName CTXNAME_AD_Role_Group = CtxNames.parse("#AD_Role_Group");
-	private static final CtxName CTXNAME_AD_Role_ID = CtxNames.parse("#AD_Role_ID");
-	private static final CtxName CTXNAME_AD_User_ID = CtxNames.parse("#AD_User_ID");
-	private static final CtxName CTXNAME_AD_Client_ID = CtxNames.parse("#AD_Client_ID");
+	private static final CtxName CTXNAME_AD_Role_ID = CtxNames.parse(Env.CTXNAME_AD_Role_ID);
+	private static final CtxName CTXNAME_AD_User_ID = CtxNames.parse(Env.CTXNAME_AD_User_ID);
+	private static final CtxName CTXNAME_AD_Client_ID = CtxNames.parse(Env.CTXNAME_AD_Client_ID);
 
 	private final LogicExpressionResultWithReason alwaysReturnResult;
 	@Nullable private final IUserRolePermissions userRolePermissions;

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentFieldLogicExpressionResultRevaluator.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentFieldLogicExpressionResultRevaluator.java
@@ -3,7 +3,9 @@ package de.metas.ui.web.window.model;
 import de.metas.i18n.TranslatableStrings;
 import de.metas.logging.LogManager;
 import de.metas.security.IUserRolePermissions;
+import de.metas.user.UserId;
 import de.metas.util.StringUtils;
+import org.adempiere.service.ClientId;
 import lombok.NonNull;
 import org.adempiere.ad.expression.api.IExpressionEvaluator;
 import org.adempiere.ad.expression.api.LogicExpressionResult;
@@ -34,6 +36,8 @@ public class DocumentFieldLogicExpressionResultRevaluator
 
 	private static final CtxName CTXNAME_AD_Role_Group = CtxNames.parse("#AD_Role_Group");
 	private static final CtxName CTXNAME_AD_Role_ID = CtxNames.parse("#AD_Role_ID");
+	private static final CtxName CTXNAME_AD_User_ID = CtxNames.parse("#AD_User_ID");
+	private static final CtxName CTXNAME_AD_Client_ID = CtxNames.parse("#AD_Client_ID");
 
 	private final LogicExpressionResultWithReason alwaysReturnResult;
 	@Nullable private final IUserRolePermissions userRolePermissions;
@@ -108,6 +112,28 @@ public class DocumentFieldLogicExpressionResultRevaluator
 				{
 					newParameters = newParameters == null ? copyToNewParameters(usedParameters) : newParameters;
 					newParameters.put(CTXNAME_AD_Role_ID.getName(), newValue);
+				}
+			}
+			else if (CTXNAME_AD_User_ID.equalsByName(usedParameterName))
+			{
+				// mirrors the #AD_Role_ID handling for #AD_User_ID
+				final String usedValue = StringUtils.trimBlankToNull(usedParameterEntry.getValue());
+				final String newValue = String.valueOf(userRolePermissions.getUserId().getRepoId());
+				if (!Objects.equals(usedValue, newValue))
+				{
+					newParameters = newParameters == null ? copyToNewParameters(usedParameters) : newParameters;
+					newParameters.put(CTXNAME_AD_User_ID.getName(), newValue);
+				}
+			}
+			else if (CTXNAME_AD_Client_ID.equalsByName(usedParameterName))
+			{
+				// mirrors the #AD_Role_ID handling for #AD_Client_ID
+				final String usedValue = StringUtils.trimBlankToNull(usedParameterEntry.getValue());
+				final String newValue = String.valueOf(userRolePermissions.getClientId().getRepoId());
+				if (!Objects.equals(usedValue, newValue))
+				{
+					newParameters = newParameters == null ? copyToNewParameters(usedParameters) : newParameters;
+					newParameters.put(CTXNAME_AD_Client_ID.getName(), newValue);
 				}
 			}
 		}

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/window/model/DocumentFieldLogicExpressionResultRevaluatorTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/window/model/DocumentFieldLogicExpressionResultRevaluatorTest.java
@@ -3,6 +3,8 @@ package de.metas.ui.web.window.model;
 import de.metas.security.IUserRolePermissions;
 import de.metas.security.RoleGroup;
 import de.metas.security.RoleId;
+import de.metas.user.UserId;
+import org.adempiere.service.ClientId;
 import org.adempiere.ad.expression.api.IExpressionEvaluator;
 import org.adempiere.ad.expression.api.LogicExpressionResult;
 import org.adempiere.ad.expression.api.impl.LogicExpressionCompiler;
@@ -10,6 +12,8 @@ import org.compiere.util.Evaluatees;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import javax.annotation.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,9 +30,16 @@ class DocumentFieldLogicExpressionResultRevaluatorTest
 
 	private static IUserRolePermissions roleWithId(final int adRoleId)
 	{
-		final IUserRolePermissions userRolePermissions = Mockito.mock(IUserRolePermissions.class);
-		Mockito.doReturn(RoleId.ofRepoId(adRoleId)).when(userRolePermissions).getRoleId();
-		return userRolePermissions;
+		return perms(adRoleId, null, null);
+	}
+
+	private static IUserRolePermissions perms(@Nullable final Integer roleId, @Nullable final Integer userId, @Nullable final Integer clientId)
+	{
+		final IUserRolePermissions p = Mockito.mock(IUserRolePermissions.class);
+		if (roleId != null)   { Mockito.doReturn(RoleId.ofRepoId(roleId)).when(p).getRoleId(); }
+		if (userId != null)   { Mockito.doReturn(UserId.ofRepoId(userId)).when(p).getUserId(); }
+		if (clientId != null) { Mockito.doReturn(ClientId.ofRepoId(clientId)).when(p).getClientId(); }
+		return p;
 	}
 
 	@SuppressWarnings("SameParameterValue")
@@ -178,6 +189,100 @@ class DocumentFieldLogicExpressionResultRevaluatorTest
 				// If the revaluator were to forget #AD_Role_ID, the second caller would still see TRUE.
 				final DocumentFieldLogicExpressionResultRevaluator second =
 						DocumentFieldLogicExpressionResultRevaluator.using(roleWithId(540173));
+				assertThat(second.revaluate(expression).booleanValue()).isFalse();
+			}
+		}
+
+		/**
+		 * Regression coverage for the per-request {@code #AD_User_ID} substitution path.
+		 * Mirrors {@code expression_AD_Role_ID_equals_540174} — same latent-bug shape.
+		 */
+		@Nested
+		class expression_AD_User_ID_equals_12345
+		{
+			// Compiled at descriptor build time with @#AD_User_ID/0@ defaulting to 0 (i.e. unknown).
+			final LogicExpressionResult expression = expr("@#AD_User_ID/0@=12345");
+
+			@Test
+			void compile_time_default_value_resolves_to_false()
+			{
+				assertThat(expression.booleanValue()).isFalse();
+			}
+
+			@Test
+			void caller_with_matching_id_sees_TRUE()
+			{
+				final DocumentFieldLogicExpressionResultRevaluator revaluator =
+						DocumentFieldLogicExpressionResultRevaluator.using(perms(null, 12345, null));
+				assertThat(revaluator.revaluate(expression).booleanValue()).isTrue();
+			}
+
+			@Test
+			void caller_with_different_id_sees_FALSE()
+			{
+				final DocumentFieldLogicExpressionResultRevaluator revaluator =
+						DocumentFieldLogicExpressionResultRevaluator.using(perms(null, 99999, null));
+				assertThat(revaluator.revaluate(expression).booleanValue()).isFalse();
+			}
+
+			@Test
+			void substitution_is_independent_of_first_loaded_value()
+			{
+				// First request: user 12345 → substitution flips the cached '0' to '12345' → result TRUE
+				final DocumentFieldLogicExpressionResultRevaluator first =
+						DocumentFieldLogicExpressionResultRevaluator.using(perms(null, 12345, null));
+				assertThat(first.revaluate(expression).booleanValue()).isTrue();
+
+				// Second request, same cached `expression` instance: user 99999 → substitution flips to '99999' → result FALSE.
+				final DocumentFieldLogicExpressionResultRevaluator second =
+						DocumentFieldLogicExpressionResultRevaluator.using(perms(null, 99999, null));
+				assertThat(second.revaluate(expression).booleanValue()).isFalse();
+			}
+		}
+
+		/**
+		 * Regression coverage for the per-request {@code #AD_Client_ID} substitution path.
+		 * Mirrors {@code expression_AD_Role_ID_equals_540174} — same latent-bug shape.
+		 */
+		@Nested
+		class expression_AD_Client_ID_equals_1000000
+		{
+			// Compiled at descriptor build time with @#AD_Client_ID/0@ defaulting to 0 (i.e. unknown).
+			final LogicExpressionResult expression = expr("@#AD_Client_ID/0@=1000000");
+
+			@Test
+			void compile_time_default_value_resolves_to_false()
+			{
+				assertThat(expression.booleanValue()).isFalse();
+			}
+
+			@Test
+			void caller_with_matching_id_sees_TRUE()
+			{
+				final DocumentFieldLogicExpressionResultRevaluator revaluator =
+						DocumentFieldLogicExpressionResultRevaluator.using(perms(null, null, 1000000));
+				assertThat(revaluator.revaluate(expression).booleanValue()).isTrue();
+			}
+
+			@Test
+			void caller_with_different_id_sees_FALSE()
+			{
+				final DocumentFieldLogicExpressionResultRevaluator revaluator =
+						DocumentFieldLogicExpressionResultRevaluator.using(perms(null, null, 1000001));
+				assertThat(revaluator.revaluate(expression).booleanValue()).isFalse();
+			}
+
+			@Test
+			void substitution_is_independent_of_first_loaded_value()
+			{
+				// First request: client 1000000 → substitution flips the cached '0' to '1000000' → result TRUE
+				final DocumentFieldLogicExpressionResultRevaluator first =
+						DocumentFieldLogicExpressionResultRevaluator.using(perms(null, null, 1000000));
+				assertThat(first.revaluate(expression).booleanValue()).isTrue();
+
+				// Second request, same cached `expression` instance: client 1000001 → substitution flips to '1000001' → result FALSE.
+				final DocumentFieldLogicExpressionResultRevaluator second =
+						DocumentFieldLogicExpressionResultRevaluator.using(perms(null, null, 1000001));
 				assertThat(second.revaluate(expression).booleanValue()).isFalse();
 			}
 		}

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/window/model/DocumentFieldLogicExpressionResultRevaluatorTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/window/model/DocumentFieldLogicExpressionResultRevaluatorTest.java
@@ -2,6 +2,7 @@ package de.metas.ui.web.window.model;
 
 import de.metas.security.IUserRolePermissions;
 import de.metas.security.RoleGroup;
+import de.metas.security.RoleId;
 import org.adempiere.ad.expression.api.IExpressionEvaluator;
 import org.adempiere.ad.expression.api.LogicExpressionResult;
 import org.adempiere.ad.expression.api.impl.LogicExpressionCompiler;
@@ -20,6 +21,13 @@ class DocumentFieldLogicExpressionResultRevaluatorTest
 
 		final IUserRolePermissions userRolePermissions = Mockito.mock(IUserRolePermissions.class);
 		Mockito.doReturn(roleGroup).when(userRolePermissions).getRoleGroup();
+		return userRolePermissions;
+	}
+
+	private static IUserRolePermissions roleWithId(final int adRoleId)
+	{
+		final IUserRolePermissions userRolePermissions = Mockito.mock(IUserRolePermissions.class);
+		Mockito.doReturn(RoleId.ofRepoId(adRoleId)).when(userRolePermissions).getRoleId();
 		return userRolePermissions;
 	}
 
@@ -121,6 +129,57 @@ class DocumentFieldLogicExpressionResultRevaluatorTest
 				assertThat(revaluator.revaluate(expression)).isSameAs(expression);
 			}
 
+		}
+
+		/**
+		 * Regression coverage for the per-request {@code #AD_Role_ID} substitution path
+		 * (mf15#4157). A ReadOnlyLogic / DisplayLogic expression referencing {@code @#AD_Role_ID/0@}
+		 * must NOT be evaluated against the role-id of the user who happened to load the descriptor
+		 * first — every subsequent caller has to see the substitution under their own role.
+		 */
+		@Nested
+		class expression_AD_Role_ID_equals_540174
+		{
+			// Compiled at descriptor build time with @#AD_Role_ID/0@ defaulting to 0 (i.e. unknown).
+			// Without the revaluator's per-request substitution, every later caller would inherit '0=540174 -> false'.
+			final LogicExpressionResult expression = expr("@#AD_Role_ID/0@=540174");
+
+			@Test
+			void compile_time_default_value_resolves_to_false()
+			{
+				assertThat(expression.booleanValue()).isFalse();
+			}
+
+			@Test
+			void caller_with_role_id_540174_sees_TRUE()
+			{
+				final DocumentFieldLogicExpressionResultRevaluator revaluator =
+						DocumentFieldLogicExpressionResultRevaluator.using(roleWithId(540174));
+				assertThat(revaluator.revaluate(expression).booleanValue()).isTrue();
+			}
+
+			@Test
+			void caller_with_different_role_id_sees_FALSE()
+			{
+				final DocumentFieldLogicExpressionResultRevaluator revaluator =
+						DocumentFieldLogicExpressionResultRevaluator.using(roleWithId(540173));
+				assertThat(revaluator.revaluate(expression).booleanValue()).isFalse();
+			}
+
+			@Test
+			void substitution_is_independent_of_first_loaded_value()
+			{
+				// First request: role 540174 → substitution flips the cached '0' to '540174' → result TRUE
+				final DocumentFieldLogicExpressionResultRevaluator first =
+						DocumentFieldLogicExpressionResultRevaluator.using(roleWithId(540174));
+				assertThat(first.revaluate(expression).booleanValue()).isTrue();
+
+				// Second request, same cached `expression` instance: role 540173 → substitution flips to '540173' → result FALSE.
+				// If the revaluator were to forget #AD_Role_ID, the second caller would still see TRUE.
+				final DocumentFieldLogicExpressionResultRevaluator second =
+						DocumentFieldLogicExpressionResultRevaluator.using(roleWithId(540173));
+				assertThat(second.revaluate(expression).booleanValue()).isFalse();
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Companion to https://github.com/metasfresh/metasfresh/pull/24230 (view fix). Together they restore the spec-correct behaviour of per-role / per-user `AD_Field.ReadOnlyLogic` (and `DisplayLogic`) gating.

The `DocumentFieldLogicExpressionResultRevaluator` runs after each layout-expression evaluation to **re-substitute** context variables that vary between requests on the same cached `LogicExpressionResult`. Before this PR it handled exactly one variable — `#AD_Role_Group`. Every other per-user / per-session context variable inherited the value baked in at descriptor-build time — i.e. the role / user / client of whichever caller happened to load the descriptor first after a server restart.

This PR extends the per-request substitution to three more variables:

| Variable | Source | Before | After |
|---|---|---|---|
| `#AD_Role_Group` | `userRolePermissions.getRoleGroup().getName()` | ✅ already handled | unchanged |
| `#AD_Role_ID` | `userRolePermissions.getRoleId().getRepoId()` | ❌ inherits first loader's role | ✅ per-request |
| `#AD_User_ID` | `userRolePermissions.getUserId().getRepoId()` | ❌ latent (no current usage but same bug shape) | ✅ per-request |
| `#AD_Client_ID` | `userRolePermissions.getClientId().getRepoId()` | ❌ latent | ✅ per-request |

`#AD_Org_ID` is intentionally out of scope — `IUserRolePermissions` exposes `getAD_Org_IDs_AsSet()` (the role's permitted orgs) but not the currently-active org, which lives in session context. That's a separate design call.

## How the bug manifests for `#AD_Role_ID` — reproduction on dantherm (mf15#4157)

| Step | What happens |
|---|---|
| 1. restart instance | descriptor cache empty |
| 2. log in as **Finance** (`AD_Role_ID=540174`) → open BPartner | descriptor built with `usedParameters[#AD_Role_ID]='540174'` → `@#AD_Role_ID/0@!540174` resolves to `540174 != 540174` = FALSE → field editable ✅ |
| 3. open incognito → log in as **Sales** (`AD_Role_ID=540173`) → same BPartner | same cached `LogicExpressionResult` → still reports FALSE → field editable ❌ (should be read-only for Sales) |

The same shape applies for any expression referencing `#AD_User_ID` or `#AD_Client_ID` — latent today because no AD_Field uses them yet, but the same bug would activate as soon as one does.

## Fix shape

Extend `computeNewParametersIfChanged` with three additional `else if` branches that mirror the existing `#AD_Role_Group` handling exactly — same "only-if-changed" check via `Objects.equals`, same lazy-init of `newParameters`, same `usedParameters` substitution. Differences are just the `CtxName` constant and the `IUserRolePermissions` getter.

```java
else if (CTXNAME_AD_Role_ID.equalsByName(usedParameterName))
{
    // mf15#4157: see this PR description for the cached-first-loader bug
    final String usedValue = StringUtils.trimBlankToNull(usedParameterEntry.getValue());
    final String newValue = String.valueOf(userRolePermissions.getRoleId().getRepoId());
    if (!Objects.equals(usedValue, newValue))
    {
        newParameters = newParameters == null ? copyToNewParameters(usedParameters) : newParameters;
        newParameters.put(CTXNAME_AD_Role_ID.getName(), newValue);
    }
}
// + identical branches for #AD_User_ID and #AD_Client_ID
```

Total production diff: ~30 LOC across the three new branches plus two new `CtxName` constants and two import lines.

## Test coverage

`DocumentFieldLogicExpressionResultRevaluatorTest` gets three new nested classes — `expression_AD_Role_ID_equals_540174`, `expression_AD_User_ID_equals_12345`, `expression_AD_Client_ID_equals_1000000` — each with four `@Test` methods:

| Method | What it asserts |
|---|---|
| `compile_time_default_value_resolves_to_false` | `/0` default keeps the unsubstituted expression evaluating to FALSE — precondition for the substitution mattering |
| `caller_with_matching_id_sees_TRUE` | substitution to the expected id flips the cached value |
| `caller_with_different_id_sees_FALSE` | substitution to a non-matching id gives the opposite result |
| `substitution_is_independent_of_first_loaded_value` | **directly mirrors the production failure mode** — same compiled `LogicExpressionResult` instance re-evaluated by two different revaluators with different ids, asserts each gets the correct boolean. Without the fix the second assertion fails. |

The test helper was generalised to `perms(@Nullable roleId, @Nullable userId, @Nullable clientId)` so a single mock can stub any combination. `roleWithId(int)` is preserved as a thin delegate for the pre-existing tests.

12 new test methods. Total: 13 → 21 tests in the class, all green locally (JDK 8, 2.6 s).

## Why two PRs

| | Without this PR | Without #24230 (view fix) | Both merged |
|---|---|---|---|
| `AD_Field.ReadOnlyLogic` reaches `GridFieldVO` | ❌ (view drops it) | ✅ | ✅ |
| Per-user context vars re-substituted in cached expression | ❌ | ❌ | ✅ |
| Per-role / per-user gate actually works | NO | NO | YES |

The customer workaround landed during UAT (set `ReadOnlyLogic` on `AD_Column.ReadOnlyLogic` instead of `AD_Field.ReadOnlyLogic`) sidesteps the view bug — but still requires this PR for the per-user substitution to work correctly. Otherwise the first-loader-after-restart determines the gate for every subsequent caller.

## Test plan

- [x] `mvn surefire:test -Dtest=DocumentFieldLogicExpressionResultRevaluatorTest` — 21 tests, 0 failures locally (JDK 8, against pre-cached `.m2-local`).
- [ ] CI: `java` + `test (java)` green.
- [ ] Customer-side verification on dantherm after merge: log in as Finance → field editable; log in as Sales → field read-only; restart the server and reverse the login order — both roles still see the correct state.
