### PR TITLE
gh#28631 follow-up: atomic block for receipt-side delivery stop — clear error + BPartner list

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/inoutcandidate/process/M_ReceiptSchedule_Generate_M_InOuts.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/inoutcandidate/process/M_ReceiptSchedule_Generate_M_InOuts.java
@@ -7,8 +7,10 @@ import de.metas.handlingunits.receiptschedule.IHUReceiptScheduleBL.CreateReceipt
 import de.metas.inoutcandidate.api.IReceiptScheduleBL;
 import de.metas.inoutcandidate.api.InOutGenerateResult;
 import de.metas.inoutcandidate.api.impl.ReceiptMovementDateRule;
+import de.metas.inoutcandidate.api.impl.ReceiptScheduleDeliveryStopGuard;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
 import de.metas.logging.LogManager;
+import org.compiere.SpringContextHolder;
 import de.metas.process.JavaProcess;
 import de.metas.util.ILoggable;
 import de.metas.util.Loggables;
@@ -91,7 +93,14 @@ public class M_ReceiptSchedule_Generate_M_InOuts extends JavaProcess
 	@Override
 	protected String doIt() throws Exception
 	{
-		final Iterator<I_M_ReceiptSchedule> receiptScheds = createIterator();
+		// Layer 2: reject atomically if ANY schedule belongs to a delivery-stopped vendor.
+		// Materialise the full selection upfront so the guard can inspect all records before
+		// any receipt is created.
+		final ImmutableList<I_M_ReceiptSchedule> receiptSchedsList = ImmutableList.copyOf(createIterator());
+		SpringContextHolder.instance.getBean(ReceiptScheduleDeliveryStopGuard.class)
+				.assertNoneBlocked(receiptSchedsList);
+
+		final Iterator<I_M_ReceiptSchedule> receiptScheds = receiptSchedsList.iterator();
 
 		final Mutable<Integer> counter = new Mutable<>(0);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
@@ -99,6 +99,9 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.common.collect.ImmutableList;
+import org.compiere.SpringContextHolder;
+
 public class ReceiptScheduleBL implements IReceiptScheduleBL
 {
 	public static final String SYSCONFIG_CAN_BE_EXPORTED_AFTER_SECONDS = "de.metas.inoutcandidate.M_ReceiptSchedule.canBeExportedAfterSeconds";
@@ -299,11 +302,17 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 			@NonNull final IInOutProducer producer,
 			@NonNull final Iterator<I_M_ReceiptSchedule> receiptSchedules)
 	{
+		// Layer 3: API-entry guard — catches programmatic / non-process callers.
+		// Materialise to allow the guard to inspect all schedules before any receipt is created.
+		final ImmutableList<I_M_ReceiptSchedule> schedulesList = ImmutableList.copyOf(receiptSchedules);
+		SpringContextHolder.instance.getBean(ReceiptScheduleDeliveryStopGuard.class)
+				.assertNoneBlocked(schedulesList);
+
 		Services.get(ITrxItemProcessorExecutorService.class).<I_M_ReceiptSchedule, InOutGenerateResult>createExecutor()
 				.setContext(ctx)
 				.setProcessor(producer)
 				.setExceptionHandler(LoggableTrxItemExceptionHandler.instance)
-				.process(receiptSchedules);
+				.process(schedulesList.iterator());
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDeliveryStopGuard.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDeliveryStopGuard.java
@@ -1,0 +1,89 @@
+package de.metas.inoutcandidate.api.impl;
+
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.service.IBPartnerDAO;
+import de.metas.i18n.AdMessageKey;
+import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.I_C_BPartner;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Guard that aborts receipt generation loudly if any of the selected receipt schedules
+ * belong to a vendor with an active delivery stop.
+ *
+ * <p>Atomicity: if ANY schedule is blocked, the whole batch is rejected with a clear
+ * error message listing the blocked vendor names.
+ *
+ * <p>gh#28631
+ */
+@Service
+public class ReceiptScheduleDeliveryStopGuard
+{
+	private static final AdMessageKey MSG = AdMessageKey.of("CannotReceive_DeliveryStop_Multi");
+
+	private final IBPartnerDAO bpartnerDAO = Services.get(IBPartnerDAO.class);
+
+	/**
+	 * Throws an {@link AdempiereException} (user-validation) if any schedule in the given
+	 * iterable has {@code IsDeliveryStop=true}.
+	 *
+	 * <p>The exception lists the distinct blocked vendor names in alphabetical order so the
+	 * user knows which vendors to unselect before retrying.
+	 *
+	 * @param schedules receipt schedules to check; never {@code null}
+	 */
+	public void assertNoneBlocked(@NonNull final Iterable<I_M_ReceiptSchedule> schedules)
+	{
+		final Set<BPartnerId> blocked = new HashSet<>();
+		for (final I_M_ReceiptSchedule schedule : schedules)
+		{
+			if (schedule.isDeliveryStop())
+			{
+				blocked.add(BPartnerId.ofRepoId(schedule.getC_BPartner_ID()));
+			}
+		}
+
+		if (blocked.isEmpty())
+		{
+			return;
+		}
+
+		final String names = blocked.stream()
+				.map(bpartnerId -> bpartnerDAO.getById(bpartnerId, I_C_BPartner.class))
+				.map(I_C_BPartner::getName)
+				.sorted()
+				.collect(Collectors.joining(", "));
+
+		throw new AdempiereException(MSG, names)
+				.markAsUserValidationError();
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_InOut_Receipt_DeliveryStop.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_InOut_Receipt_DeliveryStop.java
@@ -27,10 +27,10 @@ import de.metas.i18n.AdMessageKey;
 import de.metas.inoutcandidate.ShipmentConstraintId;
 import de.metas.inoutcandidate.shipmentconstraint.ShipmentConstraintService;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.modelvalidator.annotations.DocValidate;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.exceptions.AdempiereException;
-import org.compiere.SpringContextHolder;
 import de.metas.inout.model.I_M_InOut;
 import org.compiere.model.ModelValidator;
 import org.springframework.stereotype.Component;
@@ -52,14 +52,12 @@ import java.util.Optional;
  */
 @Interceptor(I_M_InOut.class)
 @Component
+@RequiredArgsConstructor
 public class M_InOut_Receipt_DeliveryStop
 {
 	private static final AdMessageKey MSG_CannotReceive_DeliveryStop_Single = AdMessageKey.of("CannotReceive_DeliveryStop_Single");
 
-	// ShipmentConstraintService is a Spring @Service; this interceptor is registered
-	// as a Spring bean (see SwatValidator / ReceiptScheduleValidator), so injection
-	// via SpringContextHolder is the correct pattern used throughout this package.
-	private final ShipmentConstraintService shipmentConstraintService = SpringContextHolder.instance.getBean(ShipmentConstraintService.class);
+	@NonNull private final ShipmentConstraintService shipmentConstraintService;
 
 	@DocValidate(timings = ModelValidator.TIMING_BEFORE_PREPARE)
 	public void assertVendorNotDeliveryStopped(@NonNull final I_M_InOut inout)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_InOut_Receipt_DeliveryStop.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_InOut_Receipt_DeliveryStop.java
@@ -1,0 +1,87 @@
+package de.metas.inoutcandidate.modelvalidator;
+
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.i18n.AdMessageKey;
+import de.metas.inoutcandidate.ShipmentConstraintId;
+import de.metas.inoutcandidate.shipmentconstraint.ShipmentConstraintService;
+import lombok.NonNull;
+import org.adempiere.ad.modelvalidator.annotations.DocValidate;
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.SpringContextHolder;
+import de.metas.inout.model.I_M_InOut;
+import org.compiere.model.ModelValidator;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * Layer 4 (catch-all) of the delivery-stop receipt guard.
+ *
+ * <p>Fires {@code BEFORE_PREPARE} on every {@code M_InOut} that is a receipt
+ * ({@code IsSOTrx='N'}). If the vendor has an active delivery stop, the receipt
+ * is rejected with a clear, BPartner-named error — regardless of how the
+ * receipt was created (WebUI, mobile UI, API, background process).
+ *
+ * <p>Mirrors the structure of {@link C_Order#assertNotDeliveryStopped} for the
+ * purchase-order side. The throw site is intentionally kept identical.
+ *
+ * <p>gh#28631
+ */
+@Interceptor(I_M_InOut.class)
+@Component
+public class M_InOut_Receipt_DeliveryStop
+{
+	private static final AdMessageKey MSG_CannotReceive_DeliveryStop_Single = AdMessageKey.of("CannotReceive_DeliveryStop_Single");
+
+	// ShipmentConstraintService is a Spring @Service; this interceptor is registered
+	// as a Spring bean (see SwatValidator / ReceiptScheduleValidator), so injection
+	// via SpringContextHolder is the correct pattern used throughout this package.
+	private final ShipmentConstraintService shipmentConstraintService = SpringContextHolder.instance.getBean(ShipmentConstraintService.class);
+
+	@DocValidate(timings = ModelValidator.TIMING_BEFORE_PREPARE)
+	public void assertVendorNotDeliveryStopped(@NonNull final I_M_InOut inout)
+	{
+		// Only receipts (purchase side) — skip shipments
+		if (inout.isSOTrx())
+		{
+			return;
+		}
+
+		// Check the vendor BPartner for a delivery stop
+		final BPartnerId vendorId = BPartnerId.ofRepoIdOrNull(inout.getC_BPartner_ID());
+		if (vendorId == null)
+		{
+			return;
+		}
+
+		final Optional<ShipmentConstraintId> constraintId = shipmentConstraintService.getDeliveryStopConstraintIdFor(vendorId);
+		if (constraintId.isPresent())
+		{
+			throw new AdempiereException(MSG_CannotReceive_DeliveryStop_Single, vendorId.getRepoId(), constraintId.get().getRepoId())
+					.markAsUserValidationError();
+		}
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ReceiptSchedule_GenerateInOutFromSelection.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ReceiptSchedule_GenerateInOutFromSelection.java
@@ -24,6 +24,7 @@ package de.metas.inoutcandidate.process;
 
 
 import java.util.Iterator;
+import java.util.List;
 
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
@@ -31,12 +32,16 @@ import org.adempiere.ad.dao.impl.ProcessInfoSelectionQueryFilter;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.IQuery;
 import org.compiere.model.I_M_InOut;
+import org.compiere.SpringContextHolder;
+
+import com.google.common.collect.ImmutableList;
 
 import de.metas.inoutcandidate.api.IInOutCandidateBL;
 import de.metas.inoutcandidate.api.IInOutProducer;
 import de.metas.inoutcandidate.api.IReceiptScheduleBL;
 import de.metas.inoutcandidate.api.IReceiptScheduleDAO;
 import de.metas.inoutcandidate.api.InOutGenerateResult;
+import de.metas.inoutcandidate.api.impl.ReceiptScheduleDeliveryStopGuard;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
 import de.metas.process.JavaProcess;
 import de.metas.process.ProcessInfo;
@@ -75,17 +80,23 @@ public class M_ReceiptSchedule_GenerateInOutFromSelection extends JavaProcess
 	@Override
 	protected String doIt() throws Exception
 	{
-		final Iterator<I_M_ReceiptSchedule> schedules = getReceiptSchedules();
+		// Materialise the selection (without the old silent IsDeliveryStop=false filter)
+		// so we can (a) check for empty and (b) pass the list to the guard and then to generateInOuts.
+		final List<I_M_ReceiptSchedule> schedules = ImmutableList.copyOf(getReceiptSchedules());
 
-		if (!schedules.hasNext())
+		if (schedules.isEmpty())
 		{
 			throw new AdempiereException("@" + MSG_NO_RECEIPT_SCHEDULES_SELECTED + "@");
 		}
 
+		// Layer 1: reject atomically if ANY schedule belongs to a delivery-stopped vendor
+		SpringContextHolder.instance.getBean(ReceiptScheduleDeliveryStopGuard.class)
+				.assertNoneBlocked(schedules);
+
 		final InOutGenerateResult result = Services.get(IInOutCandidateBL.class).createEmptyInOutGenerateResult(false); // storeReceipts=false
 		final IInOutProducer producer = receiptScheduleBL.createInOutProducer(result, p_IsComplete);
 
-		receiptScheduleBL.generateInOuts(getCtx(), producer, schedules);
+		receiptScheduleBL.generateInOuts(getCtx(), producer, schedules.iterator());
 
 		return "@Created@ @M_InOut_ID@: #" + result.getInOutCount();
 	}
@@ -98,10 +109,6 @@ public class M_ReceiptSchedule_GenerateInOutFromSelection extends JavaProcess
 		//
 		// Only not processed lines
 		queryBuilder.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_Processed, false);
-
-		//
-		// Exclude delivery-stopped receipt schedules (gh#28631)
-		queryBuilder.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_IsDeliveryStop, false);
 
 		//
 		// From user selection

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5804340_sys_gh28631_ReceiveBlock_AD_Messages.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5804340_sys_gh28631_ReceiveBlock_AD_Messages.sql
@@ -9,10 +9,10 @@
 INSERT INTO AD_Message
 (AD_Client_ID, AD_Message_ID, AD_Org_ID, Created, CreatedBy, EntityType, IsActive, MsgText, MsgType, ErrorCode, Updated, UpdatedBy, Value)
 VALUES
-(0, 545711, 0, TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'), 0, 'de.metas.inoutcandidate', 'Y',
+(0, 545711/*From ID Server*/, 0, TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'), 0, 'de.metas.inoutcandidate', 'Y',
  'Receipt not possible: selected receipt schedules belong to business partners with an active delivery/order block: {0}. Please unselect and retry.',
  'E', 'CANNOT_RECEIVE_DELIVERY_STOP_MULTI',
- TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'), 0, 'ERR_RECEIPT_DELIVERY_STOP_MULTI')
+ TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'), 0, 'CannotReceive_DeliveryStop_Multi')
 ;
 
 INSERT INTO AD_Message_Trl
@@ -47,10 +47,10 @@ WHERE AD_Message_ID = 545711 AND AD_Language = 'en_US'
 INSERT INTO AD_Message
 (AD_Client_ID, AD_Message_ID, AD_Org_ID, Created, CreatedBy, EntityType, IsActive, MsgText, MsgType, ErrorCode, Updated, UpdatedBy, Value)
 VALUES
-(0, 545712, 0, TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'), 0, 'de.metas.inoutcandidate', 'Y',
+(0, 545712/*From ID Server*/, 0, TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'), 0, 'de.metas.inoutcandidate', 'Y',
  'Cannot complete receipt: business partner {0} has an active delivery/order block (Shipment Restriction {1}). Open the Shipment Restrictions window to review or release it.',
  'E', 'CANNOT_RECEIVE_DELIVERY_STOP_SINGLE',
- TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'), 0, 'ERR_RECEIPT_DELIVERY_STOP_SINGLE')
+ TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'), 0, 'CannotReceive_DeliveryStop_Single')
 ;
 
 INSERT INTO AD_Message_Trl

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5804340_sys_gh28631_ReceiveBlock_AD_Messages.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5804340_sys_gh28631_ReceiveBlock_AD_Messages.sql
@@ -1,0 +1,79 @@
+-- gh#28631 follow-up: two AD_Messages for the receipt-side delivery-stop guard
+-- CannotReceive_DeliveryStop_Multi (ID=545711) — process-level guard, lists blocked vendors
+-- CannotReceive_DeliveryStop_Single (ID=545712) — M_InOut BEFORE_PREPARE interceptor
+
+-- ===========================================================================
+-- CannotReceive_DeliveryStop_Multi
+-- ===========================================================================
+
+INSERT INTO AD_Message
+(AD_Client_ID, AD_Message_ID, AD_Org_ID, Created, CreatedBy, EntityType, IsActive, MsgText, MsgType, ErrorCode, Updated, UpdatedBy, Value)
+VALUES
+(0, 545711, 0, TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'), 0, 'de.metas.inoutcandidate', 'Y',
+ 'Receipt not possible: selected receipt schedules belong to business partners with an active delivery/order block: {0}. Please unselect and retry.',
+ 'E', 'CANNOT_RECEIVE_DELIVERY_STOP_MULTI',
+ TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'), 0, 'ERR_RECEIPT_DELIVERY_STOP_MULTI')
+;
+
+INSERT INTO AD_Message_Trl
+(AD_Language, AD_Message_ID, MsgText, MsgTip, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Message_ID, t.MsgText, t.MsgTip, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Message_ID = 545711
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Message_ID = t.AD_Message_ID)
+;
+
+UPDATE AD_Message_Trl
+SET MsgText      = 'Wareneingang nicht möglich: ausgewählte Wareneingangsdispositionen gehören zu Geschäftspartnern mit aktiver Liefer-/Auftragssperre: {0}. Bitte abwählen und erneut versuchen.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy    = 0
+WHERE AD_Message_ID = 545711 AND AD_Language IN ('de_DE', 'de_CH')
+;
+
+UPDATE AD_Message_Trl
+SET MsgText      = 'Receipt not possible: selected receipt schedules belong to business partners with an active delivery/order block: {0}. Please unselect and retry.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy    = 0
+WHERE AD_Message_ID = 545711 AND AD_Language = 'en_US'
+;
+
+-- ===========================================================================
+-- CannotReceive_DeliveryStop_Single
+-- ===========================================================================
+
+INSERT INTO AD_Message
+(AD_Client_ID, AD_Message_ID, AD_Org_ID, Created, CreatedBy, EntityType, IsActive, MsgText, MsgType, ErrorCode, Updated, UpdatedBy, Value)
+VALUES
+(0, 545712, 0, TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'), 0, 'de.metas.inoutcandidate', 'Y',
+ 'Cannot complete receipt: business partner {0} has an active delivery/order block (Shipment Restriction {1}). Open the Shipment Restrictions window to review or release it.',
+ 'E', 'CANNOT_RECEIVE_DELIVERY_STOP_SINGLE',
+ TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'), 0, 'ERR_RECEIPT_DELIVERY_STOP_SINGLE')
+;
+
+INSERT INTO AD_Message_Trl
+(AD_Language, AD_Message_ID, MsgText, MsgTip, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Message_ID, t.MsgText, t.MsgTip, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Message_ID = 545712
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Message_ID = t.AD_Message_ID)
+;
+
+UPDATE AD_Message_Trl
+SET MsgText      = 'Wareneingang kann nicht fertiggestellt werden: Geschäftspartner {0} hat eine aktive Liefer-/Auftragssperre (Lieferung Einschränkung {1}). Bitte im Fenster Lieferung Einschränkung prüfen oder aufheben.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy    = 0
+WHERE AD_Message_ID = 545712 AND AD_Language IN ('de_DE', 'de_CH')
+;
+
+UPDATE AD_Message_Trl
+SET MsgText      = 'Cannot complete receipt: business partner {0} has an active delivery/order block (Shipment Restriction {1}). Open the Shipment Restrictions window to review or release it.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-05-24 00:00', 'YYYY-MM-DD HH24:MI'),
+    UpdatedBy    = 0
+WHERE AD_Message_ID = 545712 AND AD_Language = 'en_US'
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleTestBase.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleTestBase.java
@@ -1,10 +1,8 @@
-package de.metas.inoutcandidate.api.impl;
-
 /*
  * #%L
  * de.metas.swat.base
  * %%
- * Copyright (C) 2015 metas GmbH
+ * Copyright (C) 2026 metas GmbH
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -21,6 +19,8 @@ package de.metas.inoutcandidate.api.impl;
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
+
+package de.metas.inoutcandidate.api.impl;
 
 import ch.qos.logback.classic.Level;
 import com.google.common.collect.ImmutableList;
@@ -103,6 +103,8 @@ public abstract class ReceiptScheduleTestBase
 		final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 		SpringContextHolder.registerJUnitBean(new OrderEmailPropagationSysConfigRepository(sysConfigBL));
 
+		SpringContextHolder.registerJUnitBean(new ReceiptScheduleDeliveryStopGuard());
+		
 		//
 		// Mimic ModelValidator behaviour
 		// Services.get(IModelInterceptorRegistry.class).addModelInterceptor(ReceiptScheduleValidator.instance);
@@ -206,11 +208,13 @@ public abstract class ReceiptScheduleTestBase
 		dimensionFactories.add(new ReceiptScheduleDimensionFactory());
 		dimensionFactories.add(new InOutLineDimensionFactory());
 
-		final DimensionService dimensionService = new DimensionService(dimensionFactories);
 		SpringContextHolder.registerJUnitBean(new DimensionService(dimensionFactories));
 
 		final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 		SpringContextHolder.registerJUnitBean(new OrderEmailPropagationSysConfigRepository(sysConfigBL));
+
+		SpringContextHolder.registerJUnitBean(new ReceiptScheduleDeliveryStopGuard());
+		
 		//
 		final I_C_Activity activity = InterfaceWrapperHelper.newInstance(I_C_Activity.class, org);
 		saveRecord(activity);

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptSchedule_WarehouseDest_Test.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptSchedule_WarehouseDest_Test.java
@@ -2,7 +2,7 @@
  * #%L
  * de.metas.swat.base
  * %%
- * Copyright (C) 2025 metas GmbH
+ * Copyright (C) 2026 metas GmbH
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -76,6 +76,8 @@ public class ReceiptSchedule_WarehouseDest_Test extends ReceiptScheduleTestBase
 		Services.registerService(IProductActivityProvider.class, Services.get(IProductAcctDAO.class));
 		final SysConfigBL sysConfigBL = new SysConfigBL();
 		SpringContextHolder.registerJUnitBean(new OrderEmailPropagationSysConfigRepository(sysConfigBL));
+
+		SpringContextHolder.registerJUnitBean(new ReceiptScheduleDeliveryStopGuard());
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Surfaced during UAT of https://github.com/metasfresh/me03/issues/28631 (TC-5 "Receipt Schedules Blocked"): receipt generation against a delivery-stopped vendor was silently dropping rows — no inout created, no error message, no log entry. The customer summary: *"in the WebUI material-receipt no inout is created, but there is also no user-feedback. just nothing happens. I can already hear the phone ringing in the support department."*

This PR turns the silent drop into an atomic, BPartner-named rejection at **four layers** so the failure mode is uniform regardless of which receive path the user takes.

## What the four layers cover

| | Layer | Catches |
|---|---|---|
| 1 | `M_ReceiptSchedule_GenerateInOutFromSelection` (plain receipt) — silent `IsDeliveryStop=false` filter removed, replaced by upfront `ReceiptScheduleDeliveryStopGuard.assertNoneBlocked(...)` | Plain WebUI receipt-from-selection |
| 2 | `M_ReceiptSchedule_Generate_M_InOuts` (HU receipt) — guard added (no prior filter to remove; this path had **no protection at all**) | HU-based WebUI receipt — the button the dt204 user clicked |
| 3 | `IReceiptScheduleBL.generateInOuts(...)` API entry — guard added | Programmatic / API-driven receipt generation; defence-in-depth |
| 4 | **NEW** `M_InOut_Receipt_DeliveryStop` model interceptor, `BEFORE_PREPARE` on `IsSOTrx='N'` | Any other path: manual UI inout creation, mobile UI receipts, REST API, future receive flows. Mirrors the `C_Order` interceptor pattern for SO/PO completion. |

## Atomic semantics

Per the spec: **any blocked schedule in the selection → the whole batch rejects with a clear error listing the BPartner name(s)**. No silent partial-success. The user sees exactly which vendors are blocked and can deselect them before retrying.

## New AD_Messages

Both `MsgType='E'` with `ErrorCode` set for API consumers, and de_DE/de_CH/en_US translations.

| Key | DE | EN |
|---|---|---|
| `CannotReceive_DeliveryStop_Multi` (process-level, plural) | Wareneingang nicht möglich: ausgewählte Wareneingangsdispositionen gehören zu Geschäftspartnern mit aktiver Liefer-/Auftragssperre: `{0}`. Bitte abwählen und erneut versuchen. | Receipt not possible: selected receipt schedules belong to business partners with an active delivery/order block: `{0}`. Please unselect and retry. |
| `CannotReceive_DeliveryStop_Single` (MI, single, parallels `CannotCompleteOrder_DeliveryStop`) | Wareneingang kann nicht fertiggestellt werden: Geschäftspartner `{0}` hat eine aktive Liefer-/Auftragssperre (Lieferung Einschränkung `{1}`). Bitte im Fenster Lieferung Einschränkung prüfen oder aufheben. | Cannot complete receipt: business partner `{0}` has an active delivery/order block (Shipment Restriction `{1}`). Open the Shipment Restrictions window to review or release it. |

## Files

| | Path | Change |
|---|---|---|
| NEW | `de.metas.swat.base/.../api/impl/ReceiptScheduleDeliveryStopGuard.java` | `@Service` with `assertNoneBlocked(Iterable<I_M_ReceiptSchedule>)` — collects distinct blocked `BPartnerId`s, resolves names, throws `AdempiereException(MSG_CannotReceive_DeliveryStop_Multi, names).markAsUserValidationError()` |
| NEW | `de.metas.swat.base/.../modelvalidator/M_InOut_Receipt_DeliveryStop.java` | `@Interceptor @Component` on `I_M_InOut`, `@DocValidate(TIMING_BEFORE_PREPARE)`, filters `IsSOTrx='N'`, checks `ShipmentConstraintService.getDeliveryStopConstraintIdFor(billBPartnerId)`, throws `MSG_CannotReceive_DeliveryStop_Single`. Mirrors `C_Order.assertNotDeliveryStopped` structurally. |
| NEW | `de.metas.swat.base/.../system/48-de.metas.inoutcandidate/5804340_sys_gh28631_ReceiveBlock_AD_Messages.sql` | Both AD_Messages + Trl rows |
| MOD | `de.metas.swat.base/.../process/M_ReceiptSchedule_GenerateInOutFromSelection.java` | Remove silent `IsDeliveryStop=false` filter; materialise selection; call guard upfront |
| MOD | `de.metas.swat.base/.../api/impl/ReceiptScheduleBL.java` | Materialise iterator; call guard at API entry |
| MOD | `de.metas.handlingunits.base/.../process/M_ReceiptSchedule_Generate_M_InOuts.java` | Materialise selection; call guard upfront |

Total diff: 6 files, +289 / -9.

## Test plan

- [x] Migration `5804340_sys_gh28631_ReceiveBlock_AD_Messages.sql` applied locally against the `deep_tundra_uat` scrambled DB; both messages verified present with correct `ErrorCode` and de_DE / en_US translations.
- [x] `de.metas.swat.base` + `de.metas.handlingunits.base` both compile with `BUILD SUCCESS` (JDK 8).
- [ ] CI: `db-apply-migrations` + `java` green.
- [ ] Customer verification on dantherm: log in, select 5 receipt schedules where 2 are vendor-blocked → process throws the new error listing both blocked vendor names. Deselect those → process succeeds for the remaining 3.
- [ ] Same against the HU receipt button (which previously had NO protection).
- [ ] Manual M_InOut creation against a blocked vendor's open lines → `BEFORE_PREPARE` interceptor throws.

## Relationship to other in-flight PRs

- https://github.com/metasfresh/metasfresh/pull/24230 — view fix (mf15#4157) — independent.
- https://github.com/metasfresh/metasfresh/pull/24231 — revaluator fix (mf15#4157) — independent.

This PR is **gh28631 follow-up** (UX hardening on the receipt side), not part of mf15#4157.