### PR TITLE
cucumber: drain async queues before m_cost-touching reversal steps (mf15#4160)

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/packingmaterial/receipts.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/packingmaterial/receipts.feature
@@ -329,6 +329,15 @@ Feature: Packing material invoice candidates: receipts
     And create M_HU_LUTU_Configuration for M_ReceiptSchedule and generate M_HUs
       | M_HU_LUTU_Configuration_ID.Identifier | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier | OPT.M_LU_HU_PI_ID.Identifier |
       | huLuTuConfig                          | processedTopHU     | receiptSchedule_PO              | N               | 1     | N               | 10    | N               | 10          | 101                                | huPackingLU_140              |
+
+    # Drain async queues before the receipt-creation step — the order-completion above schedules
+    # async events that UPDATE M_Cost on the same product. Without this drain, the receipt's
+    # MatchInv listener chain (deleteByInOutId → AcctMatchInvListener.onAfterDeleted → voidCosts)
+    # races on M_Cost and deadlocks (`org.adempiere.exceptions.DBDeadLockDetectedException`).
+    # Drain is a test-side band-aid; underlying concurrency bug tracked in
+    # https://github.com/metasfresh/mf15/issues/4160 — remove this drain once that issue is fixed.
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
+
     And create material receipt
       | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
       | processedTopHU     | receiptSchedule_PO              | material_receipt_1    |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPaymentReversalCascade.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPaymentReversalCascade.feature
@@ -236,6 +236,14 @@ Feature: Split-payment — reversal cascade (AC #16/#17/#18/#25)
       | C_Payment_ID.Identifier | OpenAmt  |
       | lcPayment               | 12000.00 |
 
+    # Drain async queues before the second reversal — the invoice-reversal step (above) schedules
+    # async accounting reposting that UPDATEs M_Cost on the same product. Without this drain, the
+    # subsequent material-receipt reversal's voidCosts path races on the same M_Cost row and
+    # deadlocks (`org.adempiere.exceptions.DBDeadLockDetectedException` on table m_cost).
+    # Drain is a test-side band-aid; underlying concurrency bug tracked in
+    # https://github.com/metasfresh/mf15/issues/4160 — remove this drain once that issue is fixed.
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
+
     # ── Step 2: reverse R1 ──
     And the material receipt identified by r1 is reversed
 


### PR DESCRIPTION
## Summary

Test-side band-aid for the dominant trunk-flake bucket in the 2026-05-22..25 audit window: **m_cost deadlock on `voidAndDelete` path when two transactions touch the same M_Cost row** (https://github.com/metasfresh/mf15/issues/4160).

4 of 6 trunk failures (67 %) in the audit window were this exact bug — 3 hits on `splitPaymentReversalCascade.feature:225` TC5b and 1 hit on `receipts.feature:297`. The TC5b case reproduces deterministically (`workflow_dispatch` rerun on a known-good commit still deadlocks — see https://github.com/metasfresh/metasfresh/actions/runs/26357686433).

Both scenarios fire two M_Cost-touching operations back-to-back without waiting for the prior step's async accounting repost to drain. Inserting `wait until all rabbitMQ queues are empty or throw exception after 5 minutes` (the existing combined-drain step from https://github.com/metasfresh/metasfresh/pull/24063) between the operations forces serialisation at the test level and unblocks CI.

## Scope of this PR

- `splitPaymentReversalCascade.feature:225` (TC5b) — drain between `inv1 is reversed` (Step 1) and `r1 is reversed` (Step 2)
- `receipts.feature:297` — drain between order completion / HU setup and `create material receipt`

## What this PR does NOT do

This is **explicitly NOT** a fix for the underlying customer-load concurrency bug. Under production load, the same race can fire anywhere two concurrent transactions touch the same M_Cost row via the `MatchInvoiceService.deleteByInOutId → AcctMatchInvListener.onAfterDeleted → voidCosts` chain — not just in these two cucumber scenarios. The real fix (pessimistic row lock at `voidCosts` entry) is tracked in https://github.com/metasfresh/mf15/issues/4160.

The inserted drain comments explicitly state "remove this drain once mf15#4160 is fixed" so future maintainers know not to leave it forever.

## Risk

- Inserted step is a verbatim copy of the existing `@And("wait until all rabbitMQ queues are empty or throw exception after 5 minutes")` step from PR https://github.com/metasfresh/metasfresh/pull/24063, which is already used by 38 other feature files. Stepdef-resolution risk: zero.
- Drain is idempotent and additive — cannot make any other scenario fail.
- Estimated CI cost: +1-2 s per affected scenario.

## Test plan

- [ ] CI cucumber profile1 passes on TC5b
- [ ] CI cucumber profile1 passes on `receipts.feature:297`
- [ ] No new failures introduced

## Related

- mf15#4160 — real concurrency-bug fix (must be done by the costing team)
- me03#29474 — flake-audit sprint issue (closed prematurely 2026-05-22T15:04; closure was based on a 3-run window before the bug became visible — see the trunk-flake-audit through 2026-05-25 in `ai-work/flaky/`)
