### PR TITLE
me03 #29231 EPCIS export: filter TUs to the current M_InOut

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
@@ -28,6 +28,13 @@ import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
 import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
+import de.metas.handlingunits.IHUAssignmentBL;
+import de.metas.handlingunits.IHUAssignmentBuilder;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.I_M_HU_Attribute;
+import de.metas.handlingunits.model.I_M_HU_Item;
+import de.metas.handlingunits.model.X_M_HU_Item;
+import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.After;
 import io.cucumber.java.en.And;
@@ -35,16 +42,19 @@ import io.cucumber.java.en.Then;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_M_InOut;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.Trx;
 
+import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -767,6 +777,167 @@ public class EPCIS_JSON_Export_StepDef
 						.as("pallet sscc=%s crate[%d] grai must contain '%s'", sscc18, i, expectedPoRefSanitized)
 						.contains(expectedPoRefSanitized);
 			}
+		});
+	}
+
+	/**
+	 * Creates ONE shared LU with the given SSCC18 and attaches one HA aggregate per data-table row,
+	 * using real metasfresh BL ({@code InterfaceWrapperHelper} for HU and M_HU_Item record creation,
+	 * {@code IHUAssignmentBL} for assignment rows). This mirrors the DB shape that mobile picking
+	 * produces in production for the LAF1010-3 case (one physical pallet, two crate allocations
+	 * for two different M_InOuts) without using any raw {@code DB.executeUpdate} SQL.
+	 *
+	 * <p>HA {@code M_HU_Item} records do NOT reference an {@code M_HU_PI_Item} (the PI item table
+	 * does not accept {@code ItemType='HA'}). This matches {@code HUAndItemsDAO.createAggregateHUItem()}.
+	 *
+	 * <p>The step creates the shared LU exactly once (first row). Every row creates one HA
+	 * {@code M_HU_Item} under the LU, one child VTU {@code M_HU}, and one {@code M_HU_Assignment}
+	 * row linking the VTU to the first M_InOutLine of the row's shipment. The
+	 * {@code m_hu_assignment.vhu_id} column is set to the VTU's {@code M_HU_ID}, which is the
+	 * critical invariant the {@code ha_items_with_vtu} CTE in
+	 * {@code get_epcis_events_json_fn} matches on.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_InOut_ID</b> — (required, identifier-ref) shipment that "owns" this HA aggregate<br>
+	 *   <b>crateCount</b> — (required) number of TUs aggregated under this HA (sets {@code ha_item.qty})
+	 * @cucumber.example
+	 * <pre>
+	 * And one shared LU created via BL with SSCC18 '987654321000001400' carries HA aggregates assigned to inout lines:
+	 *   | M_InOut_ID     | crateCount |
+	 *   | ioA_S29231_140 | 5          |
+	 *   | ioB_S29231_140 | 10         |
+	 * </pre>
+	 */
+	@And("^one shared LU created via BL with SSCC18 '(.*)' carries HA aggregates assigned to inout lines:$")
+	public void createSharedLuHaViaBL(@NonNull final String sscc18, @NonNull final DataTable dataTable)
+	{
+		// ── Lookup: SSCC18 M_Attribute_ID (read-only query) ──────────────────────────
+		final int sscc18AttributeId = DB.getSQLValueEx(Trx.TRXNAME_None,
+				"SELECT m_attribute_id FROM m_attribute WHERE value='SSCC18' LIMIT 1");
+		assertThat(sscc18AttributeId).as("M_Attribute_ID for SSCC18").isGreaterThan(0);
+
+		// ── Lookup: LU PI version + TU PI version (read-only query) ──────────────────
+		final int[] piVersions = new int[2]; // [0]=luPIVersionId, [1]=tuPIVersionId
+		try (final java.sql.PreparedStatement pstmt = DB.prepareStatement(
+				"SELECT piv_lu.m_hu_pi_version_id, piv_tu.m_hu_pi_version_id"
+						+ " FROM m_hu_pi_version piv_lu"
+						+ " JOIN m_hu_pi_item pii ON pii.m_hu_pi_version_id = piv_lu.m_hu_pi_version_id"
+						+ "   AND pii.itemtype = 'HU' AND pii.isactive = 'Y'"
+						+ " JOIN m_hu_pi pih ON pih.m_hu_pi_id = pii.included_hu_pi_id"
+						+ " JOIN m_hu_pi_version piv_tu ON piv_tu.m_hu_pi_id = pih.m_hu_pi_id"
+						+ "   AND piv_tu.iscurrent = 'Y' AND piv_tu.hu_unittype = 'TU'"
+						+ " WHERE piv_lu.iscurrent = 'Y' AND piv_lu.hu_unittype = 'LU' AND piv_lu.isactive = 'Y'"
+						+ " LIMIT 1",
+				Trx.TRXNAME_None))
+		{
+			try (final ResultSet rs = pstmt.executeQuery())
+			{
+				if (!rs.next())
+				{
+					throw new AdempiereException("No current LU M_HU_PI_Version with a TU child PI item found");
+				}
+				piVersions[0] = rs.getInt(1);
+				piVersions[1] = rs.getInt(2);
+			}
+		}
+		catch (final SQLException e)
+		{
+			throw new AdempiereException("Failed to look up LU/TU PI versions for BL-based shared-LU step", e);
+		}
+		final int luPIVersionId = piVersions[0];
+		final int tuPIVersionId = piVersions[1];
+		assertThat(luPIVersionId).as("A current LU M_HU_PI_Version must exist").isGreaterThan(0);
+		assertThat(tuPIVersionId).as("A current TU M_HU_PI_Version (child of LU) must exist").isGreaterThan(0);
+
+		final int adOrgId = Env.getAD_Org_ID(Env.getCtx());
+		if (adOrgId <= 0)
+		{
+			throw new AdempiereException("AD_Org_ID from context is 0; context may not be initialised");
+		}
+
+		// ── Create the shared LU via BL (InterfaceWrapperHelper) ─────────────────────
+		final I_M_HU luHu = InterfaceWrapperHelper.newInstance(I_M_HU.class);
+		luHu.setAD_Org_ID(adOrgId);
+		luHu.setM_HU_PI_Version_ID(luPIVersionId);
+		luHu.setHUStatus("E"); // Shipped — matches production LAF1010-3 state
+		luHu.setIsActive(true);
+		luHu.setValue("EPCIS_BL_LU_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12));
+		InterfaceWrapperHelper.save(luHu);
+		final int luHuId = luHu.getM_HU_ID();
+		assertThat(luHuId).as("Newly created shared LU M_HU_ID (via BL)").isGreaterThan(0);
+		injectedLuHuIds.add(luHuId);
+
+		// ── Set SSCC18 attribute on the shared LU via BL ──────────────────────────────
+		final I_M_HU_Attribute sscc18Attr = InterfaceWrapperHelper.newInstance(I_M_HU_Attribute.class);
+		sscc18Attr.setAD_Org_ID(adOrgId);
+		sscc18Attr.setM_HU_ID(luHuId);
+		sscc18Attr.setM_Attribute_ID(sscc18AttributeId);
+		sscc18Attr.setValue(sscc18);
+		sscc18Attr.setIsActive(true);
+		InterfaceWrapperHelper.save(sscc18Attr);
+
+		// ── Per-row: create HA item + VTU + assignment via BL ────────────────────────
+		final IHUAssignmentBL huAssignmentBL = Services.get(IHUAssignmentBL.class);
+
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_M_InOut inout = inoutTable.get(row.getAsIdentifier("M_InOut_ID"));
+			final int crateCount = row.getAsInt("crateCount");
+			assertThat(crateCount).as("crateCount must be > 0").isGreaterThan(0);
+
+			// Pick the first M_InOutLine of this shipment (read-only query)
+			final int inoutLineId = DB.getSQLValueEx(Trx.TRXNAME_None,
+					"SELECT m_inoutline_id FROM m_inoutline"
+							+ " WHERE m_inout_id=" + inout.getM_InOut_ID()
+							+ " ORDER BY m_inoutline_id LIMIT 1");
+			assertThat(inoutLineId)
+					.as("M_InOutLine for M_InOut_ID=%d", inout.getM_InOut_ID())
+					.isGreaterThan(0);
+
+			// Create HA M_HU_Item under the shared LU via BL.
+			// HA items are aggregate items and do NOT reference an M_HU_PI_Item (PI_Item_ID=0),
+			// matching how HUAndItemsDAO.createAggregateHUItem() creates them in production.
+			// M_HU_PI_Item.ItemType only accepts MI/PM/HU — "HA" is only valid on M_HU_Item.ItemType.
+			final I_M_HU_Item haItem = InterfaceWrapperHelper.newInstance(I_M_HU_Item.class);
+			haItem.setAD_Org_ID(adOrgId);
+			haItem.setM_HU_ID(luHuId);
+			// M_HU_PI_Item_ID intentionally left at 0 (HA items have no backing PI item)
+			haItem.setItemType(X_M_HU_Item.ITEMTYPE_HUAggregate);
+			haItem.setQty(new BigDecimal(crateCount));
+			haItem.setIsActive(true);
+			InterfaceWrapperHelper.save(haItem);
+			final int haItemId = haItem.getM_HU_Item_ID();
+			assertThat(haItemId).as("Newly created HA M_HU_Item_ID (via BL)").isGreaterThan(0);
+
+			// Create VTU M_HU as child of the HA item via BL
+			// (VTU's m_hu_item_parent_id points to the HA M_HU_Item — standard aggregate-HU structure)
+			final I_M_HU vtu = InterfaceWrapperHelper.newInstance(I_M_HU.class);
+			vtu.setAD_Org_ID(adOrgId);
+			vtu.setM_HU_PI_Version_ID(tuPIVersionId);
+			vtu.setM_HU_Item_Parent_ID(haItemId);
+			vtu.setHUStatus("E"); // Shipped — mirrors production LAF1010-3
+			vtu.setIsActive(true);
+			vtu.setValue("EPCIS_BL_VTU_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12));
+			InterfaceWrapperHelper.save(vtu);
+			final int vtuHuId = vtu.getM_HU_ID();
+			assertThat(vtuHuId).as("Newly created VTU M_HU_ID (via BL)").isGreaterThan(0);
+			injectedTuHuIds.add(vtuHuId);
+
+			// Create M_HU_Assignment via IHUAssignmentBL (the real BL path mobile picking uses)
+			// setVHU(vtu) sets m_hu_assignment.vhu_id = vtu.M_HU_ID — the critical column that
+			// the ha_items_with_vtu CTE in get_epcis_events_json_fn matches on (see RESEARCH Q3).
+			// qty=0 mirrors production data (presence-only assignment; real crate count comes from ha_item.qty).
+			final org.compiere.model.I_M_InOutLine inoutLine = InterfaceWrapperHelper.load(inoutLineId, org.compiere.model.I_M_InOutLine.class);
+			final IHUAssignmentBuilder builder = huAssignmentBL.createHUAssignmentBuilder();
+			builder.initializeAssignment(Env.getCtx(), Trx.TRXNAME_None);
+			builder.setIsActive(true);
+			builder.setModel(inoutLine);
+			builder.setTopLevelHU(luHu);
+			builder.setM_LU_HU(luHu);
+			builder.setM_TU_HU(vtu);
+			builder.setVHU(vtu);
+			builder.setQty(BigDecimal.ZERO);
+			builder.build();
 		});
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
@@ -66,8 +66,10 @@ public class EPCIS_JSON_Export_StepDef
 
 	/** Tracks M_HU_IDs of LU/TU HUs injected by {@link #assignLuHUsWithSscc18ToInoutLines}; cleaned up in {@link #cleanupInjectedHUs()}. */
 	private final List<Integer> injectedLuHuIds = new ArrayList<>();
-	/** Tracks M_HU_IDs of TU HUs (children of injected LUs); cleaned up in {@link #cleanupInjectedHUs()}. */
+	/** Tracks M_HU_IDs of TU/VTU HUs (children of injected LUs); cleaned up in {@link #cleanupInjectedHUs()}. */
 	private final List<Integer> injectedTuHuIds = new ArrayList<>();
+	/** Tracks M_HU_PI_Item_IDs (itemtype='HA') created on the fly for shared-LU HA scenarios. */
+	private final List<Integer> injectedHaPiItemIds = new ArrayList<>();
 
 	/**
 	 * Calls the {@code get_epcis_events_json_fn} SQL function for the given shipment
@@ -453,24 +455,11 @@ public class EPCIS_JSON_Export_StepDef
 							+ ",'" + sscc18 + "','Y', now(), 100, now(), 100)",
 					Trx.TRXNAME_None);
 
-			// INSERT M_HU_Assignment rows linking this LU to every M_InOutLine of the shipment
-			for (final int inoutLineId : inoutLineIds)
-			{
-				final int assignId = DB.getSQLValueEx(Trx.TRXNAME_None,
-						"SELECT nextval('m_hu_assignment_seq')");
-				DB.executeUpdateAndThrowExceptionOnFail(
-						"INSERT INTO m_hu_assignment"
-								+ " (m_hu_assignment_id, ad_client_id, ad_org_id, ad_table_id, record_id, m_hu_id, m_lu_hu_id, isactive,"
-								+ " created, createdby, updated, updatedby)"
-								+ " VALUES (" + assignId + "," + adClientId + "," + adOrgId + "," + inoutLineTableId + ","
-								+ inoutLineId + "," + luHuId + "," + luHuId + ",'Y', now(), 100, now(), 100)",
-						Trx.TRXNAME_None);
-			}
-
-			// INSERT a minimal TU M_HU child so that the EPCIS function's individual_tu_ids CTE can find it.
-			// The CTE join pattern:
-			//   M_HU_Item (itemtype='HU') on the LU → M_HU (child TU) via M_HU.m_hu_item_parent_id
-			// Step 1: create the M_HU_Item row on the LU (parent)
+			// Create the child TU FIRST so the assignment rows below can carry m_tu_hu_id.
+			// The EPCIS function's individual_tu_ids CTE requires:
+			//   M_HU_Item (itemtype='HU') on the LU → M_HU (child TU) via M_HU.m_hu_item_parent_id.
+			// Additionally, since me03#29231 the function gates TUs by an EXISTS check against
+			// m_hu_assignment.m_tu_hu_id (or .vhu_id) referencing the TU.
 			final int huItemId = DB.getSQLValueEx(Trx.TRXNAME_None,
 					"INSERT INTO m_hu_item"
 							+ " (m_hu_item_id, ad_client_id, ad_org_id, m_hu_id, m_hu_pi_item_id, itemtype, qty, isactive,"
@@ -480,7 +469,6 @@ public class EPCIS_JSON_Export_StepDef
 							+ " RETURNING m_hu_item_id");
 			assertThat(huItemId).as("Newly created M_HU_Item_ID for LU→TU link").isGreaterThan(0);
 
-			// Step 2: create the TU M_HU row, pointing back to the M_HU_Item via m_hu_item_parent_id
 			final int tuHuId = DB.getSQLValueEx(Trx.TRXNAME_None,
 					"INSERT INTO m_hu"
 							+ " (m_hu_id, ad_client_id, ad_org_id, m_hu_pi_version_id, m_hu_item_parent_id, hustatus, isactive,"
@@ -490,6 +478,21 @@ public class EPCIS_JSON_Export_StepDef
 							+ " 'EPCIS_TEST_TU_' || nextval('m_hu_seq'), now(), 100, now(), 100)"
 							+ " RETURNING m_hu_id");
 			assertThat(tuHuId).as("Newly created TU M_HU_ID (child of LU " + luHuId + ")").isGreaterThan(0);
+
+			// INSERT M_HU_Assignment rows linking this LU+TU to every M_InOutLine of the shipment.
+			// m_tu_hu_id is required by the EPCIS individual_tu_ids EXISTS gate (me03#29231).
+			for (final int inoutLineId : inoutLineIds)
+			{
+				final int assignId = DB.getSQLValueEx(Trx.TRXNAME_None,
+						"SELECT nextval('m_hu_assignment_seq')");
+				DB.executeUpdateAndThrowExceptionOnFail(
+						"INSERT INTO m_hu_assignment"
+								+ " (m_hu_assignment_id, ad_client_id, ad_org_id, ad_table_id, record_id, m_hu_id, m_lu_hu_id, m_tu_hu_id, isactive,"
+								+ " created, createdby, updated, updatedby)"
+								+ " VALUES (" + assignId + "," + adClientId + "," + adOrgId + "," + inoutLineTableId + ","
+								+ inoutLineId + "," + luHuId + "," + luHuId + "," + tuHuId + ",'Y', now(), 100, now(), 100)",
+						Trx.TRXNAME_None);
+			}
 
 			// Track for cleanup in @After so these test HUs don't pollute other scenarios
 			injectedLuHuIds.add(luHuId);
@@ -663,21 +666,8 @@ public class EPCIS_JSON_Export_StepDef
 							+ ",'" + sscc18 + "','Y', now(), 100, now(), 100)",
 					Trx.TRXNAME_None);
 
-			// INSERT M_HU_Assignment rows linking this LU only to the InOutLines of its source order
-			for (final int inoutLineId : inoutLineIds)
-			{
-				final int assignId = DB.getSQLValueEx(Trx.TRXNAME_None,
-						"SELECT nextval('m_hu_assignment_seq')");
-				DB.executeUpdateAndThrowExceptionOnFail(
-						"INSERT INTO m_hu_assignment"
-								+ " (m_hu_assignment_id, ad_client_id, ad_org_id, ad_table_id, record_id, m_hu_id, m_lu_hu_id, isactive,"
-								+ " created, createdby, updated, updatedby)"
-								+ " VALUES (" + assignId + "," + adClientId + "," + adOrgId + "," + inoutLineTableId + ","
-								+ inoutLineId + "," + luHuId + "," + luHuId + ",'Y', now(), 100, now(), 100)",
-						Trx.TRXNAME_None);
-			}
-
-			// INSERT a minimal TU M_HU child so that individual_tu_ids CTE can find it
+			// Create the child TU FIRST so the assignment rows below can carry m_tu_hu_id
+			// (required by the individual_tu_ids EXISTS gate since me03#29231).
 			final int huItemId = DB.getSQLValueEx(Trx.TRXNAME_None,
 					"INSERT INTO m_hu_item"
 							+ " (m_hu_item_id, ad_client_id, ad_org_id, m_hu_id, m_hu_pi_item_id, itemtype, qty, isactive,"
@@ -696,6 +686,20 @@ public class EPCIS_JSON_Export_StepDef
 							+ " 'EPCIS_TEST_TU_' || nextval('m_hu_seq'), now(), 100, now(), 100)"
 							+ " RETURNING m_hu_id");
 			assertThat(tuHuId).as("Newly created TU M_HU_ID (child of LU " + luHuId + ")").isGreaterThan(0);
+
+			// INSERT M_HU_Assignment rows linking this LU+TU only to the InOutLines of its source order
+			for (final int inoutLineId : inoutLineIds)
+			{
+				final int assignId = DB.getSQLValueEx(Trx.TRXNAME_None,
+						"SELECT nextval('m_hu_assignment_seq')");
+				DB.executeUpdateAndThrowExceptionOnFail(
+						"INSERT INTO m_hu_assignment"
+								+ " (m_hu_assignment_id, ad_client_id, ad_org_id, ad_table_id, record_id, m_hu_id, m_lu_hu_id, m_tu_hu_id, isactive,"
+								+ " created, createdby, updated, updatedby)"
+								+ " VALUES (" + assignId + "," + adClientId + "," + adOrgId + "," + inoutLineTableId + ","
+								+ inoutLineId + "," + luHuId + "," + luHuId + "," + tuHuId + ",'Y', now(), 100, now(), 100)",
+						Trx.TRXNAME_None);
+			}
 
 			injectedLuHuIds.add(luHuId);
 			injectedTuHuIds.add(tuHuId);
@@ -767,6 +771,166 @@ public class EPCIS_JSON_Export_StepDef
 	}
 
 	/**
+	 * Creates ONE shared LU with the given SSCC18 and attaches one HA aggregate per data-table row.
+	 * Each HA aggregate is assigned to one M_InOut via {@code m_hu_assignment.vhu_id} — simulating
+	 * the real-world case where a picker consolidates two orders' goods onto one physical pallet
+	 * but each shipment only "owns" some of the crates.
+	 *
+	 * <p>This is the HA-aggregate counterpart of {@link #assignLuHUsWithSscc18ToInoutLines}. It
+	 * exercises the {@code ha_items_with_vtu} CTE and the per-shipment EXISTS gate added in me03#29231.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_InOut_ID</b> — (required, identifier-ref) shipment that "owns" this HA aggregate<br>
+	 *   <b>crateCount</b> — (required) number of TUs aggregated under this HA (sets {@code ha_item.qty})
+	 * @cucumber.example
+	 * <pre>
+	 * And one shared LU with SSCC18 '987654321000000040' carries HA aggregates assigned to inout lines:
+	 *   | M_InOut_ID | crateCount |
+	 *   | shipment_A | 5          |
+	 *   | shipment_B | 10         |
+	 * </pre>
+	 */
+	@And("^one shared LU with SSCC18 '(.*)' carries HA aggregates assigned to inout lines:$")
+	public void assignSharedLuHaToInoutLines(@NonNull final String sscc18, @NonNull final DataTable dataTable)
+	{
+		final int inoutLineTableId = DB.getSQLValueEx(Trx.TRXNAME_None,
+				"SELECT ad_table_id FROM ad_table WHERE tablename='M_InOutLine'");
+		assertThat(inoutLineTableId).as("AD_Table_ID for M_InOutLine").isGreaterThan(0);
+
+		final int sscc18AttributeId = DB.getSQLValueEx(Trx.TRXNAME_None,
+				"SELECT m_attribute_id FROM m_attribute WHERE value='SSCC18' LIMIT 1");
+		assertThat(sscc18AttributeId).as("M_Attribute_ID for SSCC18").isGreaterThan(0);
+
+		// Look up a current LU PI version + its TU PI version (used for the VTU's PI version)
+		final int[] piVersions = new int[2]; // [0]=luPIVersionId, [1]=tuPIVersionId
+		try (final java.sql.PreparedStatement pstmt = DB.prepareStatement(
+				"SELECT piv_lu.m_hu_pi_version_id, piv_tu.m_hu_pi_version_id"
+						+ " FROM m_hu_pi_version piv_lu"
+						+ " JOIN m_hu_pi_item pii ON pii.m_hu_pi_version_id = piv_lu.m_hu_pi_version_id"
+						+ "   AND pii.itemtype = 'HU' AND pii.isactive = 'Y'"
+						+ " JOIN m_hu_pi pih ON pih.m_hu_pi_id = pii.included_hu_pi_id"
+						+ " JOIN m_hu_pi_version piv_tu ON piv_tu.m_hu_pi_id = pih.m_hu_pi_id"
+						+ "   AND piv_tu.iscurrent = 'Y' AND piv_tu.hu_unittype = 'TU'"
+						+ " WHERE piv_lu.iscurrent = 'Y' AND piv_lu.hu_unittype = 'LU' AND piv_lu.isactive = 'Y'"
+						+ " LIMIT 1",
+				Trx.TRXNAME_None))
+		{
+			try (final ResultSet rs = pstmt.executeQuery())
+			{
+				if (!rs.next())
+				{
+					throw new AdempiereException("No current LU M_HU_PI_Version with a TU child PI item found");
+				}
+				piVersions[0] = rs.getInt(1);
+				piVersions[1] = rs.getInt(2);
+			}
+		}
+		catch (final SQLException e)
+		{
+			throw new AdempiereException("Failed to look up LU/TU PI versions", e);
+		}
+		final int luPIVersionId = piVersions[0];
+		final int tuPIVersionId = piVersions[1];
+
+		final int adClientId = Env.getAD_Client_ID(Env.getCtx());
+		final int adOrgId = Env.getAD_Org_ID(Env.getCtx());
+		if (adOrgId <= 0)
+		{
+			throw new AdempiereException("AD_Org_ID from context is 0; context may not be initialised");
+		}
+
+		// Find or create an HA-itemtype M_HU_PI_Item on the LU PI version. Required by m_hu_item.m_hu_pi_item_id.
+		int haPiItemId = DB.getSQLValueEx(Trx.TRXNAME_None,
+				"SELECT m_hu_pi_item_id FROM m_hu_pi_item"
+						+ " WHERE m_hu_pi_version_id=" + luPIVersionId
+						+ "   AND itemtype='HA' AND isactive='Y' LIMIT 1");
+		if (haPiItemId <= 0)
+		{
+			haPiItemId = DB.getSQLValueEx(Trx.TRXNAME_None,
+					"INSERT INTO m_hu_pi_item (m_hu_pi_item_id, ad_client_id, ad_org_id, m_hu_pi_version_id, itemtype, qty, isactive,"
+							+ " created, createdby, updated, updatedby)"
+							+ " VALUES (nextval('m_hu_pi_item_seq')," + adClientId + "," + adOrgId + "," + luPIVersionId + ",'HA', 0,'Y',"
+							+ " now(), 100, now(), 100) RETURNING m_hu_pi_item_id");
+			assertThat(haPiItemId).as("Newly created HA M_HU_PI_Item_ID").isGreaterThan(0);
+			injectedHaPiItemIds.add(haPiItemId);
+		}
+		final int haPiItemIdFinal = haPiItemId;
+
+		// Create the shared LU (one for all rows)
+		final int luHuId = DB.getSQLValueEx(Trx.TRXNAME_None,
+				"INSERT INTO m_hu (m_hu_id, ad_client_id, ad_org_id, m_hu_pi_version_id, hustatus, isactive,"
+						+ " value, created, createdby, updated, updatedby)"
+						+ " VALUES (nextval('m_hu_seq')," + adClientId + "," + adOrgId + "," + luPIVersionId + ",'E','Y',"
+						+ " 'EPCIS_TEST_LU_HA_' || nextval('m_hu_seq'), now(), 100, now(), 100)"
+						+ " RETURNING m_hu_id");
+		assertThat(luHuId).as("Newly created shared LU M_HU_ID").isGreaterThan(0);
+		injectedLuHuIds.add(luHuId);
+
+		// SSCC18 attribute on the shared LU
+		final int sscc18HuAttrId = DB.getSQLValueEx(Trx.TRXNAME_None,
+				"SELECT nextval('m_hu_attribute_seq')");
+		DB.executeUpdateAndThrowExceptionOnFail(
+				"INSERT INTO m_hu_attribute"
+						+ " (m_hu_attribute_id, ad_client_id, ad_org_id, m_hu_id, m_attribute_id, value, isactive,"
+						+ " created, createdby, updated, updatedby)"
+						+ " VALUES (" + sscc18HuAttrId + "," + adClientId + "," + adOrgId + "," + luHuId + "," + sscc18AttributeId
+						+ ",'" + sscc18 + "','Y', now(), 100, now(), 100)",
+				Trx.TRXNAME_None);
+
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_M_InOut inout = inoutTable.get(row.getAsIdentifier("M_InOut_ID"));
+			final int crateCount = row.getAsInt("crateCount");
+			assertThat(crateCount).as("crateCount must be > 0").isGreaterThan(0);
+
+			// Pick one inoutline of this shipment to anchor the assignment on
+			final int inoutLineId = DB.getSQLValueEx(Trx.TRXNAME_None,
+					"SELECT m_inoutline_id FROM m_inoutline"
+							+ " WHERE m_inout_id=" + inout.getM_InOut_ID()
+							+ " ORDER BY m_inoutline_id LIMIT 1");
+			assertThat(inoutLineId)
+					.as("M_InOutLine for M_InOut_ID=%d", inout.getM_InOut_ID())
+					.isGreaterThan(0);
+
+			// HA m_hu_item under the shared LU (itemtype='HA', qty = crate count for this shipment)
+			final int haItemId = DB.getSQLValueEx(Trx.TRXNAME_None,
+					"INSERT INTO m_hu_item"
+							+ " (m_hu_item_id, ad_client_id, ad_org_id, m_hu_id, m_hu_pi_item_id, itemtype, qty, isactive,"
+							+ " created, createdby, updated, updatedby)"
+							+ " VALUES (nextval('m_hu_item_seq')," + adClientId + "," + adOrgId + "," + luHuId + "," + haPiItemIdFinal
+							+ ",'HA', " + crateCount + ",'Y', now(), 100, now(), 100)"
+							+ " RETURNING m_hu_item_id");
+			assertThat(haItemId).as("Newly created HA M_HU_Item_ID under shared LU").isGreaterThan(0);
+
+			// VTU m_hu as child of the HA m_hu_item
+			final int vtuHuId = DB.getSQLValueEx(Trx.TRXNAME_None,
+					"INSERT INTO m_hu"
+							+ " (m_hu_id, ad_client_id, ad_org_id, m_hu_pi_version_id, m_hu_item_parent_id, hustatus, isactive,"
+							+ " value, created, createdby, updated, updatedby)"
+							+ " VALUES (nextval('m_hu_seq')," + adClientId + "," + adOrgId + "," + tuPIVersionId + "," + haItemId
+							+ ",'E','Y',"
+							+ " 'EPCIS_TEST_VTU_' || nextval('m_hu_seq'), now(), 100, now(), 100)"
+							+ " RETURNING m_hu_id");
+			assertThat(vtuHuId).as("Newly created VTU M_HU_ID (child of HA item " + haItemId + ")").isGreaterThan(0);
+			injectedTuHuIds.add(vtuHuId);
+
+			// m_hu_assignment: link the VTU to one inoutline of this shipment.
+			// vhu_id = vtuHuId is the column the EPCIS function's EXISTS gate matches on for HA.
+			// qty=0 mirrors production data observed in LAF1010-3 (assignment is presence-only;
+			// the real crate count comes from ha_item.qty).
+			final int assignId = DB.getSQLValueEx(Trx.TRXNAME_None,
+					"SELECT nextval('m_hu_assignment_seq')");
+			DB.executeUpdateAndThrowExceptionOnFail(
+					"INSERT INTO m_hu_assignment"
+							+ " (m_hu_assignment_id, ad_client_id, ad_org_id, ad_table_id, record_id, m_hu_id, m_lu_hu_id, m_tu_hu_id, vhu_id, qty, isactive,"
+							+ " created, createdby, updated, updatedby)"
+							+ " VALUES (" + assignId + "," + adClientId + "," + adOrgId + "," + inoutLineTableId + ","
+							+ inoutLineId + "," + luHuId + "," + luHuId + "," + vtuHuId + "," + vtuHuId + ", 0,'Y', now(), 100, now(), 100)",
+					Trx.TRXNAME_None);
+		});
+	}
+
+	/**
 	 * Deletes all M_HU / M_HU_Attribute / M_HU_Assignment / M_HU_Item rows that were injected
 	 * by {@link #assignLuHUsWithSscc18ToInoutLines} in the current scenario.
 	 * <p>
@@ -777,7 +941,7 @@ public class EPCIS_JSON_Export_StepDef
 	@After
 	public void cleanupInjectedHUs()
 	{
-		if (injectedLuHuIds.isEmpty())
+		if (injectedLuHuIds.isEmpty() && injectedHaPiItemIds.isEmpty())
 		{
 			return;
 		}
@@ -808,8 +972,18 @@ public class EPCIS_JSON_Export_StepDef
 				"DELETE FROM m_hu WHERE m_hu_id IN (" + luIdList + ")",
 				Trx.TRXNAME_None);
 
+		// HA PI items created on the fly by the shared-LU HA helper
+		if (!injectedHaPiItemIds.isEmpty())
+		{
+			final String haPiList = injectedHaPiItemIds.stream().map(String::valueOf).reduce((a, b) -> a + "," + b).orElse("0");
+			DB.executeUpdateAndThrowExceptionOnFail(
+					"DELETE FROM m_hu_pi_item WHERE m_hu_pi_item_id IN (" + haPiList + ")",
+					Trx.TRXNAME_None);
+		}
+
 		injectedLuHuIds.clear();
 		injectedTuHuIds.clear();
+		injectedHaPiItemIds.clear();
 	}
 
 	private void assertEpcisArrayField(@NonNull final DataTableRow row)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
-import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
 import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
 import de.metas.handlingunits.IHUAssignmentBL;
 import de.metas.handlingunits.IHUAssignmentBuilder;
@@ -43,7 +42,6 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
-import org.compiere.model.I_C_Order;
 import org.compiere.model.I_M_InOut;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
@@ -69,17 +67,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class EPCIS_JSON_Export_StepDef
 {
 	private final @NonNull M_InOut_StepDefData inoutTable;
-	private final @NonNull C_Order_StepDefData orderTable;
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	private JsonNode lastEpcisResult;
 
-	/** Tracks M_HU_IDs of LU/TU HUs injected by {@link #assignLuHUsWithSscc18ToInoutLines}; cleaned up in {@link #cleanupInjectedHUs()}. */
+	/** Tracks M_HU_IDs of LU HUs created by {@link #createSharedLuHaViaBL}; cleaned up in {@link #cleanupInjectedHUs()}. */
 	private final List<Integer> injectedLuHuIds = new ArrayList<>();
-	/** Tracks M_HU_IDs of TU/VTU HUs (children of injected LUs); cleaned up in {@link #cleanupInjectedHUs()}. */
+	/** Tracks M_HU_IDs of VTU HUs (children of shared LU) created by {@link #createSharedLuHaViaBL}; cleaned up in {@link #cleanupInjectedHUs()}. */
 	private final List<Integer> injectedTuHuIds = new ArrayList<>();
-	/** Tracks M_HU_PI_Item_IDs (itemtype='HA') created on the fly for shared-LU HA scenarios. */
-	private final List<Integer> injectedHaPiItemIds = new ArrayList<>();
 
 	/**
 	 * Calls the {@code get_epcis_events_json_fn} SQL function for the given shipment
@@ -338,179 +333,6 @@ public class EPCIS_JSON_Export_StepDef
 	}
 
 	/**
-	 * Creates minimal LU HUs with the given SSCC18 values and assigns them to the M_InOutLines of the
-	 * given shipment via {@code M_HU_Assignment}. Exactly one LU is created per data-table row and
-	 * assigned to all M_InOutLines of the shipment; the EPCIS pallet-discovery CTE uses
-	 * {@code DISTINCT m_lu_hu_id} so each distinct LU appears exactly once in {@code pallets[]}.
-	 *
-	 * <p>Background: {@code QuantityType=D} shipments do not create real M_HU records, so
-	 * {@code pallets[]} is always empty. This step injects the required M_HU + M_HU_Attribute +
-	 * M_HU_Assignment rows without needing the full picking workflow, enabling an end-to-end test
-	 * of the EPCIS pallet-array shape for consolidated multi-source-order shipments.
-	 *
-	 * @cucumber.stepdef
-	 * @cucumber.columns
-	 *   <b>sscc18</b> — (required) 18-digit SSCC value to set on the LU HU
-	 * @cucumber.example
-	 * <pre>
-	 * And real LU HUs with SSCC18 are assigned to all inout lines of M_InOut identified by io_130:
-	 *   | sscc18             |
-	 *   | 987654321000000016 |
-	 *   | 987654321000000023 |
-	 * </pre>
-	 */
-	@And("^real LU HUs with SSCC18 are assigned to all inout lines of M_InOut identified by (.*)$")
-	public void assignLuHUsWithSscc18ToInoutLines(@NonNull final String inoutIdentifier, @NonNull final DataTable dataTable)
-	{
-		final I_M_InOut inout = inoutTable.get(inoutIdentifier);
-		final int inoutId = inout.getM_InOut_ID();
-
-		// Look up AD_Table_ID for M_InOutLine and the SSCC18 M_Attribute_ID once
-		final int inoutLineTableId = DB.getSQLValueEx(Trx.TRXNAME_None,
-				"SELECT ad_table_id FROM ad_table WHERE tablename='M_InOutLine'");
-		assertThat(inoutLineTableId).as("AD_Table_ID for M_InOutLine").isGreaterThan(0);
-
-		final int sscc18AttributeId = DB.getSQLValueEx(Trx.TRXNAME_None,
-				"SELECT m_attribute_id FROM m_attribute WHERE value='SSCC18' LIMIT 1");
-		assertThat(sscc18AttributeId).as("M_Attribute_ID for SSCC18").isGreaterThan(0);
-
-		// Get a suitable LU M_HU_PI_Version that has a TU child PI item, plus the TU version and PI item IDs.
-		// The EPCIS function's individual_tu_ids CTE requires:
-		//   M_HU_Item (itemtype='HU') on the LU → M_HU (child TU) via M_HU.m_hu_item_parent_id.
-		// We therefore need luPIVersionId, tuPIVersionId, and m_hu_pi_item_id in one lookup.
-		final int[] piVersionAndItem = new int[3]; // [0]=luPIVersionId, [1]=tuPIVersionId, [2]=luPiItemId
-		try (final java.sql.PreparedStatement pstmt = DB.prepareStatement(
-				"SELECT piv_lu.m_hu_pi_version_id, piv_tu.m_hu_pi_version_id, pii.m_hu_pi_item_id"
-						+ " FROM m_hu_pi_version piv_lu"
-						+ " JOIN m_hu_pi_item pii ON pii.m_hu_pi_version_id = piv_lu.m_hu_pi_version_id"
-						+ "   AND pii.itemtype = 'HU' AND pii.isactive = 'Y'"
-						+ " JOIN m_hu_pi pih ON pih.m_hu_pi_id = pii.included_hu_pi_id"
-						+ " JOIN m_hu_pi_version piv_tu ON piv_tu.m_hu_pi_id = pih.m_hu_pi_id"
-						+ "   AND piv_tu.iscurrent = 'Y' AND piv_tu.hu_unittype = 'TU'"
-						+ " WHERE piv_lu.iscurrent = 'Y' AND piv_lu.hu_unittype = 'LU' AND piv_lu.isactive = 'Y'"
-						+ " LIMIT 1",
-				Trx.TRXNAME_None))
-		{
-			try (final ResultSet rs = pstmt.executeQuery())
-			{
-				if (!rs.next())
-				{
-					throw new AdempiereException("No current LU M_HU_PI_Version with a TU child PI item found");
-				}
-				piVersionAndItem[0] = rs.getInt(1);
-				piVersionAndItem[1] = rs.getInt(2);
-				piVersionAndItem[2] = rs.getInt(3);
-			}
-		}
-		catch (final SQLException e)
-		{
-			throw new AdempiereException("Failed to look up LU/TU PI version and PI item", e);
-		}
-		final int luPIVersionId = piVersionAndItem[0];
-		final int tuPIVersionId = piVersionAndItem[1];
-		final int luPiItemId = piVersionAndItem[2];
-		assertThat(luPIVersionId).as("A current LU M_HU_PI_Version must exist").isGreaterThan(0);
-		assertThat(tuPIVersionId).as("A current TU M_HU_PI_Version (child of LU) must exist").isGreaterThan(0);
-		assertThat(luPiItemId).as("M_HU_PI_Item linking LU to TU must exist").isGreaterThan(0);
-
-		final int adClientId = Env.getAD_Client_ID(Env.getCtx());
-		final int adOrgId = Env.getAD_Org_ID(Env.getCtx());
-		if (adOrgId <= 0)
-		{
-			throw new AdempiereException("AD_Org_ID from context is 0; context may not be initialised");
-		}
-
-		// Collect all M_InOutLine_IDs for this shipment via PreparedStatement
-		final List<Integer> inoutLineIds = new ArrayList<>();
-		try (final java.sql.PreparedStatement pstmt = DB.prepareStatement(
-				"SELECT m_inoutline_id FROM m_inoutline WHERE m_inout_id=? ORDER BY m_inoutline_id",
-				Trx.TRXNAME_None))
-		{
-			pstmt.setInt(1, inoutId);
-			try (final ResultSet rs = pstmt.executeQuery())
-			{
-				while (rs.next())
-				{
-					inoutLineIds.add(rs.getInt(1));
-				}
-			}
-		}
-		catch (final SQLException e)
-		{
-			throw new AdempiereException("Failed to load M_InOutLine IDs for M_InOut_ID=" + inoutId, e);
-		}
-		assertThat(inoutLineIds).as("M_InOutLine records for M_InOut_ID=" + inoutId).isNotEmpty();
-
-		dataTable.asMaps().forEach(rowMap -> {
-			final String sscc18 = rowMap.get("sscc18");
-			assertThat(sscc18).as("sscc18 column must be present in the data table row").isNotBlank();
-
-			// INSERT a minimal LU M_HU record; value must be unique and non-null
-			final int luHuId = DB.getSQLValueEx(Trx.TRXNAME_None,
-					"INSERT INTO m_hu (m_hu_id, ad_client_id, ad_org_id, m_hu_pi_version_id, hustatus, isactive,"
-							+ " value, created, createdby, updated, updatedby)"
-							+ " VALUES (nextval('m_hu_seq')," + adClientId + "," + adOrgId + "," + luPIVersionId + ",'E','Y',"
-							+ " 'EPCIS_TEST_LU_' || nextval('m_hu_seq'), now(), 100, now(), 100)"
-							+ " RETURNING m_hu_id");
-			assertThat(luHuId).as("Newly created LU M_HU_ID").isGreaterThan(0);
-
-			// INSERT the SSCC18 attribute value on the LU
-			final int huAttrId = DB.getSQLValueEx(Trx.TRXNAME_None,
-					"SELECT nextval('m_hu_attribute_seq')");
-			DB.executeUpdateAndThrowExceptionOnFail(
-					"INSERT INTO m_hu_attribute"
-							+ " (m_hu_attribute_id, ad_client_id, ad_org_id, m_hu_id, m_attribute_id, value, isactive,"
-							+ " created, createdby, updated, updatedby)"
-							+ " VALUES (" + huAttrId + "," + adClientId + "," + adOrgId + "," + luHuId + "," + sscc18AttributeId
-							+ ",'" + sscc18 + "','Y', now(), 100, now(), 100)",
-					Trx.TRXNAME_None);
-
-			// Create the child TU FIRST so the assignment rows below can carry m_tu_hu_id.
-			// The EPCIS function's individual_tu_ids CTE requires:
-			//   M_HU_Item (itemtype='HU') on the LU → M_HU (child TU) via M_HU.m_hu_item_parent_id.
-			// Additionally, since me03#29231 the function gates TUs by an EXISTS check against
-			// m_hu_assignment.m_tu_hu_id (or .vhu_id) referencing the TU.
-			final int huItemId = DB.getSQLValueEx(Trx.TRXNAME_None,
-					"INSERT INTO m_hu_item"
-							+ " (m_hu_item_id, ad_client_id, ad_org_id, m_hu_id, m_hu_pi_item_id, itemtype, qty, isactive,"
-							+ " created, createdby, updated, updatedby)"
-							+ " VALUES (nextval('m_hu_item_seq')," + adClientId + "," + adOrgId + "," + luHuId + "," + luPiItemId
-							+ ",'HU', 1,'Y', now(), 100, now(), 100)"
-							+ " RETURNING m_hu_item_id");
-			assertThat(huItemId).as("Newly created M_HU_Item_ID for LU→TU link").isGreaterThan(0);
-
-			final int tuHuId = DB.getSQLValueEx(Trx.TRXNAME_None,
-					"INSERT INTO m_hu"
-							+ " (m_hu_id, ad_client_id, ad_org_id, m_hu_pi_version_id, m_hu_item_parent_id, hustatus, isactive,"
-							+ " value, created, createdby, updated, updatedby)"
-							+ " VALUES (nextval('m_hu_seq')," + adClientId + "," + adOrgId + "," + tuPIVersionId + "," + huItemId
-							+ ",'E','Y',"
-							+ " 'EPCIS_TEST_TU_' || nextval('m_hu_seq'), now(), 100, now(), 100)"
-							+ " RETURNING m_hu_id");
-			assertThat(tuHuId).as("Newly created TU M_HU_ID (child of LU " + luHuId + ")").isGreaterThan(0);
-
-			// INSERT M_HU_Assignment rows linking this LU+TU to every M_InOutLine of the shipment.
-			// m_tu_hu_id is required by the EPCIS individual_tu_ids EXISTS gate (me03#29231).
-			for (final int inoutLineId : inoutLineIds)
-			{
-				final int assignId = DB.getSQLValueEx(Trx.TRXNAME_None,
-						"SELECT nextval('m_hu_assignment_seq')");
-				DB.executeUpdateAndThrowExceptionOnFail(
-						"INSERT INTO m_hu_assignment"
-								+ " (m_hu_assignment_id, ad_client_id, ad_org_id, ad_table_id, record_id, m_hu_id, m_lu_hu_id, m_tu_hu_id, isactive,"
-								+ " created, createdby, updated, updatedby)"
-								+ " VALUES (" + assignId + "," + adClientId + "," + adOrgId + "," + inoutLineTableId + ","
-								+ inoutLineId + "," + luHuId + "," + luHuId + "," + tuHuId + ",'Y', now(), 100, now(), 100)",
-						Trx.TRXNAME_None);
-			}
-
-			// Track for cleanup in @After so these test HUs don't pollute other scenarios
-			injectedLuHuIds.add(luHuId);
-			injectedTuHuIds.add(tuHuId);
-		});
-	}
-
-	/**
 	 * Asserts that the {@code pallets[]} array in the last EPCIS JSON result contains exactly the
 	 * given SSCC18 values (order-independent).
 	 *
@@ -546,174 +368,6 @@ public class EPCIS_JSON_Export_StepDef
 		assertThat(actualSscc18Values)
 				.as("pallets[] sscc18 values (any order)")
 				.containsExactlyInAnyOrderElementsOf(expectedSscc18Values);
-	}
-
-	/**
-	 * Creates minimal LU HUs with the given SSCC18 values and assigns them <em>only</em> to the
-	 * M_InOutLines of the given shipment that belong to the specified source C_Order. This is the
-	 * per-order variant of {@link #assignLuHUsWithSscc18ToInoutLines}: in an n:m consolidated
-	 * shipment each LU is linked to exactly one source order so that the EPCIS function's
-	 * {@code pallet_list} CTE resolves the correct per-LU POReference without cross-order leakage.
-	 *
-	 * @cucumber.stepdef
-	 * @cucumber.columns
-	 *   <b>sscc18</b> — (required) 18-digit SSCC value to set on the LU HU<br>
-	 *   <b>C_Order_ID</b> — (required, identifier-ref) source order whose InOutLines this LU should be assigned to
-	 * @cucumber.example
-	 * <pre>
-	 * And real LU HUs with SSCC18 are assigned to inout lines by source order of M_InOut identified by io_130:
-	 *   | sscc18             | C_Order_ID    |
-	 *   | 987654321000000016 | oA_S29231_130 |
-	 *   | 987654321000000023 | oB_S29231_130 |
-	 * </pre>
-	 */
-	@And("^real LU HUs with SSCC18 are assigned to inout lines by source order of M_InOut identified by (.*)$")
-	public void assignLuHUsWithSscc18ToInoutLinesBySourceOrder(@NonNull final String inoutIdentifier,
-	                                                           @NonNull final DataTable dataTable)
-	{
-		final I_M_InOut inout = inoutTable.get(inoutIdentifier);
-		final int inoutId = inout.getM_InOut_ID();
-
-		final int inoutLineTableId = DB.getSQLValueEx(Trx.TRXNAME_None,
-				"SELECT ad_table_id FROM ad_table WHERE tablename='M_InOutLine'");
-		assertThat(inoutLineTableId).as("AD_Table_ID for M_InOutLine").isGreaterThan(0);
-
-		final int sscc18AttributeId = DB.getSQLValueEx(Trx.TRXNAME_None,
-				"SELECT m_attribute_id FROM m_attribute WHERE value='SSCC18' LIMIT 1");
-		assertThat(sscc18AttributeId).as("M_Attribute_ID for SSCC18").isGreaterThan(0);
-
-		final int[] piVersionAndItem = new int[3]; // [0]=luPIVersionId, [1]=tuPIVersionId, [2]=luPiItemId
-		try (final java.sql.PreparedStatement pstmt = DB.prepareStatement(
-				"SELECT piv_lu.m_hu_pi_version_id, piv_tu.m_hu_pi_version_id, pii.m_hu_pi_item_id"
-						+ " FROM m_hu_pi_version piv_lu"
-						+ " JOIN m_hu_pi_item pii ON pii.m_hu_pi_version_id = piv_lu.m_hu_pi_version_id"
-						+ "   AND pii.itemtype = 'HU' AND pii.isactive = 'Y'"
-						+ " JOIN m_hu_pi pih ON pih.m_hu_pi_id = pii.included_hu_pi_id"
-						+ " JOIN m_hu_pi_version piv_tu ON piv_tu.m_hu_pi_id = pih.m_hu_pi_id"
-						+ "   AND piv_tu.iscurrent = 'Y' AND piv_tu.hu_unittype = 'TU'"
-						+ " WHERE piv_lu.iscurrent = 'Y' AND piv_lu.hu_unittype = 'LU' AND piv_lu.isactive = 'Y'"
-						+ " LIMIT 1",
-				Trx.TRXNAME_None))
-		{
-			try (final ResultSet rs = pstmt.executeQuery())
-			{
-				if (!rs.next())
-				{
-					throw new AdempiereException("No current LU M_HU_PI_Version with a TU child PI item found");
-				}
-				piVersionAndItem[0] = rs.getInt(1);
-				piVersionAndItem[1] = rs.getInt(2);
-				piVersionAndItem[2] = rs.getInt(3);
-			}
-		}
-		catch (final SQLException e)
-		{
-			throw new AdempiereException("Failed to look up LU/TU PI version and PI item", e);
-		}
-		final int luPIVersionId = piVersionAndItem[0];
-		final int tuPIVersionId = piVersionAndItem[1];
-		final int luPiItemId = piVersionAndItem[2];
-		assertThat(luPIVersionId).as("A current LU M_HU_PI_Version must exist").isGreaterThan(0);
-
-		final int adClientId = Env.getAD_Client_ID(Env.getCtx());
-		final int adOrgId = Env.getAD_Org_ID(Env.getCtx());
-		if (adOrgId <= 0)
-		{
-			throw new AdempiereException("AD_Org_ID from context is 0; context may not be initialised");
-		}
-
-		DataTableRows.of(dataTable).forEach(row -> {
-			final String sscc18 = row.getAsString("sscc18");
-			final I_C_Order sourceOrder = orderTable.get(row.getAsIdentifier("C_Order_ID"));
-			final int sourceOrderId = sourceOrder.getC_Order_ID();
-
-			// Collect only the M_InOutLine_IDs for this shipment that belong to this source order
-			final List<Integer> inoutLineIds = new ArrayList<>();
-			try (final java.sql.PreparedStatement pstmt = DB.prepareStatement(
-					"SELECT iol.m_inoutline_id"
-							+ " FROM m_inoutline iol"
-							+ " JOIN c_orderline ol ON ol.c_orderline_id = iol.c_orderline_id"
-							+ " WHERE iol.m_inout_id = ? AND ol.c_order_id = ?"
-							+ " ORDER BY iol.m_inoutline_id",
-					Trx.TRXNAME_None))
-			{
-				pstmt.setInt(1, inoutId);
-				pstmt.setInt(2, sourceOrderId);
-				try (final ResultSet rs = pstmt.executeQuery())
-				{
-					while (rs.next())
-					{
-						inoutLineIds.add(rs.getInt(1));
-					}
-				}
-			}
-			catch (final SQLException e)
-			{
-				throw new AdempiereException("Failed to load M_InOutLine IDs for M_InOut_ID=" + inoutId
-						+ " and C_Order_ID=" + sourceOrderId, e);
-			}
-			assertThat(inoutLineIds)
-					.as("M_InOutLine records for M_InOut_ID=%d and C_Order_ID=%d", inoutId, sourceOrderId)
-					.isNotEmpty();
-
-			// INSERT a minimal LU M_HU record
-			final int luHuId = DB.getSQLValueEx(Trx.TRXNAME_None,
-					"INSERT INTO m_hu (m_hu_id, ad_client_id, ad_org_id, m_hu_pi_version_id, hustatus, isactive,"
-							+ " value, created, createdby, updated, updatedby)"
-							+ " VALUES (nextval('m_hu_seq')," + adClientId + "," + adOrgId + "," + luPIVersionId + ",'E','Y',"
-							+ " 'EPCIS_TEST_LU_' || nextval('m_hu_seq'), now(), 100, now(), 100)"
-							+ " RETURNING m_hu_id");
-			assertThat(luHuId).as("Newly created LU M_HU_ID").isGreaterThan(0);
-
-			// INSERT the SSCC18 attribute value on the LU
-			final int huAttrId = DB.getSQLValueEx(Trx.TRXNAME_None,
-					"SELECT nextval('m_hu_attribute_seq')");
-			DB.executeUpdateAndThrowExceptionOnFail(
-					"INSERT INTO m_hu_attribute"
-							+ " (m_hu_attribute_id, ad_client_id, ad_org_id, m_hu_id, m_attribute_id, value, isactive,"
-							+ " created, createdby, updated, updatedby)"
-							+ " VALUES (" + huAttrId + "," + adClientId + "," + adOrgId + "," + luHuId + "," + sscc18AttributeId
-							+ ",'" + sscc18 + "','Y', now(), 100, now(), 100)",
-					Trx.TRXNAME_None);
-
-			// Create the child TU FIRST so the assignment rows below can carry m_tu_hu_id
-			// (required by the individual_tu_ids EXISTS gate since me03#29231).
-			final int huItemId = DB.getSQLValueEx(Trx.TRXNAME_None,
-					"INSERT INTO m_hu_item"
-							+ " (m_hu_item_id, ad_client_id, ad_org_id, m_hu_id, m_hu_pi_item_id, itemtype, qty, isactive,"
-							+ " created, createdby, updated, updatedby)"
-							+ " VALUES (nextval('m_hu_item_seq')," + adClientId + "," + adOrgId + "," + luHuId + "," + luPiItemId
-							+ ",'HU', 1,'Y', now(), 100, now(), 100)"
-							+ " RETURNING m_hu_item_id");
-			assertThat(huItemId).as("Newly created M_HU_Item_ID for LU→TU link").isGreaterThan(0);
-
-			final int tuHuId = DB.getSQLValueEx(Trx.TRXNAME_None,
-					"INSERT INTO m_hu"
-							+ " (m_hu_id, ad_client_id, ad_org_id, m_hu_pi_version_id, m_hu_item_parent_id, hustatus, isactive,"
-							+ " value, created, createdby, updated, updatedby)"
-							+ " VALUES (nextval('m_hu_seq')," + adClientId + "," + adOrgId + "," + tuPIVersionId + "," + huItemId
-							+ ",'E','Y',"
-							+ " 'EPCIS_TEST_TU_' || nextval('m_hu_seq'), now(), 100, now(), 100)"
-							+ " RETURNING m_hu_id");
-			assertThat(tuHuId).as("Newly created TU M_HU_ID (child of LU " + luHuId + ")").isGreaterThan(0);
-
-			// INSERT M_HU_Assignment rows linking this LU+TU only to the InOutLines of its source order
-			for (final int inoutLineId : inoutLineIds)
-			{
-				final int assignId = DB.getSQLValueEx(Trx.TRXNAME_None,
-						"SELECT nextval('m_hu_assignment_seq')");
-				DB.executeUpdateAndThrowExceptionOnFail(
-						"INSERT INTO m_hu_assignment"
-								+ " (m_hu_assignment_id, ad_client_id, ad_org_id, ad_table_id, record_id, m_hu_id, m_lu_hu_id, m_tu_hu_id, isactive,"
-								+ " created, createdby, updated, updatedby)"
-								+ " VALUES (" + assignId + "," + adClientId + "," + adOrgId + "," + inoutLineTableId + ","
-								+ inoutLineId + "," + luHuId + "," + luHuId + "," + tuHuId + ",'Y', now(), 100, now(), 100)",
-						Trx.TRXNAME_None);
-			}
-
-			injectedLuHuIds.add(luHuId);
-			injectedTuHuIds.add(tuHuId);
-		});
 	}
 
 	/**
@@ -942,168 +596,8 @@ public class EPCIS_JSON_Export_StepDef
 	}
 
 	/**
-	 * Creates ONE shared LU with the given SSCC18 and attaches one HA aggregate per data-table row.
-	 * Each HA aggregate is assigned to one M_InOut via {@code m_hu_assignment.vhu_id} — simulating
-	 * the real-world case where a picker consolidates two orders' goods onto one physical pallet
-	 * but each shipment only "owns" some of the crates.
-	 *
-	 * <p>This is the HA-aggregate counterpart of {@link #assignLuHUsWithSscc18ToInoutLines}. It
-	 * exercises the {@code ha_items_with_vtu} CTE and the per-shipment EXISTS gate added in me03#29231.
-	 *
-	 * @cucumber.stepdef
-	 * @cucumber.columns
-	 *   <b>M_InOut_ID</b> — (required, identifier-ref) shipment that "owns" this HA aggregate<br>
-	 *   <b>crateCount</b> — (required) number of TUs aggregated under this HA (sets {@code ha_item.qty})
-	 * @cucumber.example
-	 * <pre>
-	 * And one shared LU with SSCC18 '987654321000000040' carries HA aggregates assigned to inout lines:
-	 *   | M_InOut_ID | crateCount |
-	 *   | shipment_A | 5          |
-	 *   | shipment_B | 10         |
-	 * </pre>
-	 */
-	@And("^one shared LU with SSCC18 '(.*)' carries HA aggregates assigned to inout lines:$")
-	public void assignSharedLuHaToInoutLines(@NonNull final String sscc18, @NonNull final DataTable dataTable)
-	{
-		final int inoutLineTableId = DB.getSQLValueEx(Trx.TRXNAME_None,
-				"SELECT ad_table_id FROM ad_table WHERE tablename='M_InOutLine'");
-		assertThat(inoutLineTableId).as("AD_Table_ID for M_InOutLine").isGreaterThan(0);
-
-		final int sscc18AttributeId = DB.getSQLValueEx(Trx.TRXNAME_None,
-				"SELECT m_attribute_id FROM m_attribute WHERE value='SSCC18' LIMIT 1");
-		assertThat(sscc18AttributeId).as("M_Attribute_ID for SSCC18").isGreaterThan(0);
-
-		// Look up a current LU PI version + its TU PI version (used for the VTU's PI version)
-		final int[] piVersions = new int[2]; // [0]=luPIVersionId, [1]=tuPIVersionId
-		try (final java.sql.PreparedStatement pstmt = DB.prepareStatement(
-				"SELECT piv_lu.m_hu_pi_version_id, piv_tu.m_hu_pi_version_id"
-						+ " FROM m_hu_pi_version piv_lu"
-						+ " JOIN m_hu_pi_item pii ON pii.m_hu_pi_version_id = piv_lu.m_hu_pi_version_id"
-						+ "   AND pii.itemtype = 'HU' AND pii.isactive = 'Y'"
-						+ " JOIN m_hu_pi pih ON pih.m_hu_pi_id = pii.included_hu_pi_id"
-						+ " JOIN m_hu_pi_version piv_tu ON piv_tu.m_hu_pi_id = pih.m_hu_pi_id"
-						+ "   AND piv_tu.iscurrent = 'Y' AND piv_tu.hu_unittype = 'TU'"
-						+ " WHERE piv_lu.iscurrent = 'Y' AND piv_lu.hu_unittype = 'LU' AND piv_lu.isactive = 'Y'"
-						+ " LIMIT 1",
-				Trx.TRXNAME_None))
-		{
-			try (final ResultSet rs = pstmt.executeQuery())
-			{
-				if (!rs.next())
-				{
-					throw new AdempiereException("No current LU M_HU_PI_Version with a TU child PI item found");
-				}
-				piVersions[0] = rs.getInt(1);
-				piVersions[1] = rs.getInt(2);
-			}
-		}
-		catch (final SQLException e)
-		{
-			throw new AdempiereException("Failed to look up LU/TU PI versions", e);
-		}
-		final int luPIVersionId = piVersions[0];
-		final int tuPIVersionId = piVersions[1];
-
-		final int adClientId = Env.getAD_Client_ID(Env.getCtx());
-		final int adOrgId = Env.getAD_Org_ID(Env.getCtx());
-		if (adOrgId <= 0)
-		{
-			throw new AdempiereException("AD_Org_ID from context is 0; context may not be initialised");
-		}
-
-		// Find or create an HA-itemtype M_HU_PI_Item on the LU PI version. Required by m_hu_item.m_hu_pi_item_id.
-		int haPiItemId = DB.getSQLValueEx(Trx.TRXNAME_None,
-				"SELECT m_hu_pi_item_id FROM m_hu_pi_item"
-						+ " WHERE m_hu_pi_version_id=" + luPIVersionId
-						+ "   AND itemtype='HA' AND isactive='Y' LIMIT 1");
-		if (haPiItemId <= 0)
-		{
-			haPiItemId = DB.getSQLValueEx(Trx.TRXNAME_None,
-					"INSERT INTO m_hu_pi_item (m_hu_pi_item_id, ad_client_id, ad_org_id, m_hu_pi_version_id, itemtype, qty, isactive,"
-							+ " created, createdby, updated, updatedby)"
-							+ " VALUES (nextval('m_hu_pi_item_seq')," + adClientId + "," + adOrgId + "," + luPIVersionId + ",'HA', 0,'Y',"
-							+ " now(), 100, now(), 100) RETURNING m_hu_pi_item_id");
-			assertThat(haPiItemId).as("Newly created HA M_HU_PI_Item_ID").isGreaterThan(0);
-			injectedHaPiItemIds.add(haPiItemId);
-		}
-		final int haPiItemIdFinal = haPiItemId;
-
-		// Create the shared LU (one for all rows)
-		final int luHuId = DB.getSQLValueEx(Trx.TRXNAME_None,
-				"INSERT INTO m_hu (m_hu_id, ad_client_id, ad_org_id, m_hu_pi_version_id, hustatus, isactive,"
-						+ " value, created, createdby, updated, updatedby)"
-						+ " VALUES (nextval('m_hu_seq')," + adClientId + "," + adOrgId + "," + luPIVersionId + ",'E','Y',"
-						+ " 'EPCIS_TEST_LU_HA_' || nextval('m_hu_seq'), now(), 100, now(), 100)"
-						+ " RETURNING m_hu_id");
-		assertThat(luHuId).as("Newly created shared LU M_HU_ID").isGreaterThan(0);
-		injectedLuHuIds.add(luHuId);
-
-		// SSCC18 attribute on the shared LU
-		final int sscc18HuAttrId = DB.getSQLValueEx(Trx.TRXNAME_None,
-				"SELECT nextval('m_hu_attribute_seq')");
-		DB.executeUpdateAndThrowExceptionOnFail(
-				"INSERT INTO m_hu_attribute"
-						+ " (m_hu_attribute_id, ad_client_id, ad_org_id, m_hu_id, m_attribute_id, value, isactive,"
-						+ " created, createdby, updated, updatedby)"
-						+ " VALUES (" + sscc18HuAttrId + "," + adClientId + "," + adOrgId + "," + luHuId + "," + sscc18AttributeId
-						+ ",'" + sscc18 + "','Y', now(), 100, now(), 100)",
-				Trx.TRXNAME_None);
-
-		DataTableRows.of(dataTable).forEach(row -> {
-			final I_M_InOut inout = inoutTable.get(row.getAsIdentifier("M_InOut_ID"));
-			final int crateCount = row.getAsInt("crateCount");
-			assertThat(crateCount).as("crateCount must be > 0").isGreaterThan(0);
-
-			// Pick one inoutline of this shipment to anchor the assignment on
-			final int inoutLineId = DB.getSQLValueEx(Trx.TRXNAME_None,
-					"SELECT m_inoutline_id FROM m_inoutline"
-							+ " WHERE m_inout_id=" + inout.getM_InOut_ID()
-							+ " ORDER BY m_inoutline_id LIMIT 1");
-			assertThat(inoutLineId)
-					.as("M_InOutLine for M_InOut_ID=%d", inout.getM_InOut_ID())
-					.isGreaterThan(0);
-
-			// HA m_hu_item under the shared LU (itemtype='HA', qty = crate count for this shipment)
-			final int haItemId = DB.getSQLValueEx(Trx.TRXNAME_None,
-					"INSERT INTO m_hu_item"
-							+ " (m_hu_item_id, ad_client_id, ad_org_id, m_hu_id, m_hu_pi_item_id, itemtype, qty, isactive,"
-							+ " created, createdby, updated, updatedby)"
-							+ " VALUES (nextval('m_hu_item_seq')," + adClientId + "," + adOrgId + "," + luHuId + "," + haPiItemIdFinal
-							+ ",'HA', " + crateCount + ",'Y', now(), 100, now(), 100)"
-							+ " RETURNING m_hu_item_id");
-			assertThat(haItemId).as("Newly created HA M_HU_Item_ID under shared LU").isGreaterThan(0);
-
-			// VTU m_hu as child of the HA m_hu_item
-			final int vtuHuId = DB.getSQLValueEx(Trx.TRXNAME_None,
-					"INSERT INTO m_hu"
-							+ " (m_hu_id, ad_client_id, ad_org_id, m_hu_pi_version_id, m_hu_item_parent_id, hustatus, isactive,"
-							+ " value, created, createdby, updated, updatedby)"
-							+ " VALUES (nextval('m_hu_seq')," + adClientId + "," + adOrgId + "," + tuPIVersionId + "," + haItemId
-							+ ",'E','Y',"
-							+ " 'EPCIS_TEST_VTU_' || nextval('m_hu_seq'), now(), 100, now(), 100)"
-							+ " RETURNING m_hu_id");
-			assertThat(vtuHuId).as("Newly created VTU M_HU_ID (child of HA item " + haItemId + ")").isGreaterThan(0);
-			injectedTuHuIds.add(vtuHuId);
-
-			// m_hu_assignment: link the VTU to one inoutline of this shipment.
-			// vhu_id = vtuHuId is the column the EPCIS function's EXISTS gate matches on for HA.
-			// qty=0 mirrors production data observed in LAF1010-3 (assignment is presence-only;
-			// the real crate count comes from ha_item.qty).
-			final int assignId = DB.getSQLValueEx(Trx.TRXNAME_None,
-					"SELECT nextval('m_hu_assignment_seq')");
-			DB.executeUpdateAndThrowExceptionOnFail(
-					"INSERT INTO m_hu_assignment"
-							+ " (m_hu_assignment_id, ad_client_id, ad_org_id, ad_table_id, record_id, m_hu_id, m_lu_hu_id, m_tu_hu_id, vhu_id, qty, isactive,"
-							+ " created, createdby, updated, updatedby)"
-							+ " VALUES (" + assignId + "," + adClientId + "," + adOrgId + "," + inoutLineTableId + ","
-							+ inoutLineId + "," + luHuId + "," + luHuId + "," + vtuHuId + "," + vtuHuId + ", 0,'Y', now(), 100, now(), 100)",
-					Trx.TRXNAME_None);
-		});
-	}
-
-	/**
 	 * Deletes all M_HU / M_HU_Attribute / M_HU_Assignment / M_HU_Item rows that were injected
-	 * by {@link #assignLuHUsWithSscc18ToInoutLines} in the current scenario.
+	 * by {@link #createSharedLuHaViaBL} in the current scenario.
 	 * <p>
 	 * Without this cleanup the test LUs (with {@code hustatus='E'}) survive across scenarios within
 	 * the same JVM session and cause "Illegal M_HU.HUStatus change from E to D" failures in
@@ -1112,7 +606,7 @@ public class EPCIS_JSON_Export_StepDef
 	@After
 	public void cleanupInjectedHUs()
 	{
-		if (injectedLuHuIds.isEmpty() && injectedHaPiItemIds.isEmpty())
+		if (injectedLuHuIds.isEmpty())
 		{
 			return;
 		}
@@ -1143,18 +637,8 @@ public class EPCIS_JSON_Export_StepDef
 				"DELETE FROM m_hu WHERE m_hu_id IN (" + luIdList + ")",
 				Trx.TRXNAME_None);
 
-		// HA PI items created on the fly by the shared-LU HA helper
-		if (!injectedHaPiItemIds.isEmpty())
-		{
-			final String haPiList = injectedHaPiItemIds.stream().map(String::valueOf).reduce((a, b) -> a + "," + b).orElse("0");
-			DB.executeUpdateAndThrowExceptionOnFail(
-					"DELETE FROM m_hu_pi_item WHERE m_hu_pi_item_id IN (" + haPiList + ")",
-					Trx.TRXNAME_None);
-		}
-
 		injectedLuHuIds.clear();
 		injectedTuHuIds.clear();
-		injectedHaPiItemIds.clear();
 	}
 
 	private void assertEpcisArrayField(@NonNull final DataTableRow row)

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -292,6 +292,18 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | bp_S29231_130  | p_S29231_130  |
 
     # HU PI: LU holds up to 20 TUs, each TU holds 10 PCE
+    And metasfresh contains M_Products:
+      | Identifier             |
+      | pmProdLU_S29231_130    |
+      | pmProdTU_S29231_130    |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID        | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | plv_S29231_130         | pmProdLU_S29231_130 | 0.0      | PCE      | Normal           |
+      | plv_S29231_130         | pmProdTU_S29231_130 | 0.0      | PCE      | Normal           |
+    And metasfresh contains M_HU_PackingMaterial:
+      | M_HU_PackingMaterial_ID.Identifier | OPT.M_Product_ID.Identifier | Name                    |
+      | pm_LU_S29231_130                   | pmProdLU_S29231_130         | Pallet_S29231_130       |
+      | pm_TU_S29231_130                   | pmProdTU_S29231_130         | Karton_S29231_130       |
     And metasfresh contains M_HU_PI:
       | M_HU_PI_ID          |
       | pi_LU_S29231_130    |
@@ -303,9 +315,13 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | piv_TU_S29231_130   | pi_TU_S29231_130    | TU          | Y         |
       | piv_VHU_S29231_130  | pi_VHU_S29231_130   | V           | Y         |
     And metasfresh contains M_HU_PI_Item:
-      | M_HU_PI_Item_ID     | M_HU_PI_Version_ID  | Qty | ItemType | Included_HU_PI_ID   |
-      | pii_LU_S29231_130   | piv_LU_S29231_130   | 20  | HU       | pi_TU_S29231_130    |
-      | pii_TU_S29231_130   | piv_TU_S29231_130   | 0   | PM       |                     |
+      | M_HU_PI_Item_ID        | M_HU_PI_Version_ID  | Qty | ItemType | Included_HU_PI_ID   | OPT.M_HU_PackingMaterial_ID |
+      | pii_LU_S29231_130      | piv_LU_S29231_130   | 20  | HU       | pi_TU_S29231_130    |                             |
+      | pii_LU_PM_S29231_130   | piv_LU_S29231_130   | 0   | PM       |                     | pm_LU_S29231_130            |
+      | pii_TU_S29231_130      | piv_TU_S29231_130   | 0   | PM       |                     | pm_TU_S29231_130            |
+    And metasfresh contains M_HU_PI_Attribute:
+      | M_HU_PI_Version_ID  | M_Attribute.Value |
+      | piv_LU_S29231_130   | SSCC18            |
     And metasfresh contains M_HU_PI_Item_Product:
       | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID   | M_Product_ID  | Qty | ValidFrom  |
       | pip_S29231_130          | pii_TU_S29231_130 | p_S29231_130  | 10  | 2020-01-01 |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -498,12 +498,13 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | M_ShipmentSchedule_ID | M_InOut_ID    |
       | ssB_S29231_140        | ioB_S29231_140 |
 
-    # ─── Inject ONE shared LU with two HA aggregates, one per shipment ────────────────
+    # ─── Create ONE shared LU with two HA aggregates via real BL ────────────────────
     # Without the bug fix, shipment_A's EPCIS would see BOTH HA aggregates (5+10=15 crates);
     # with the fix it only sees the HA aggregate whose VTU is referenced by shipment_A's
     # m_hu_assignment row (5 crates).
-    And one shared LU with SSCC18 '987654321000001400' carries HA aggregates assigned to inout lines:
-      | M_InOut_ID    | crateCount |
+    # Uses real metasfresh BL (InterfaceWrapperHelper + IHUAssignmentBL) instead of raw SQL.
+    And one shared LU created via BL with SSCC18 '987654321000001400' carries HA aggregates assigned to inout lines:
+      | M_InOut_ID     | crateCount |
       | ioA_S29231_140 | 5          |
       | ioB_S29231_140 | 10         |
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -261,8 +261,8 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
   Scenario: S29231_130 — Two orders, one consolidated shipment → EPCIS pallets[] populated, desadvReferences[] and poReferences[] arrays of size 2
   ## Asserts that the EPCIS event JSON for a 2-source-order consolidated shipment carries
   ## pallets[] of size 2 (one LU per DESADV), desadvReferences[] of size 2, and
-  ## poReferences[] of size 2.  Two real LU HUs with distinct SSCC18 values are injected
-  ## directly via SQL (QuantityType=D shipments skip the normal HU-picking flow).
+  ## poReferences[] of size 2.  Each order gets its own LU via the real metasfresh
+  ## BL (Inventory → CU → TU → LU → SSCC18 → TU-level pick → QuantityType=PD shipment).
     Given metasfresh contains M_Products:
       | Identifier      | GTIN          |
       | p_S29231_130    | 4060000000130 |
@@ -347,33 +347,92 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | Identifier      | C_OrderLine_ID  | IsToRecompute |
       | ssB_S29231_130  | olB_S29231_130  | N             |
 
-    # Batch-generate ONE shipment covering both schedules
-    When 'generate shipments' process is invoked with QuantityType=D, IsCompleteShipments=true and IsShipToday=false
-      | M_ShipmentSchedule_ID |
-      | ssA_S29231_130        |
-      | ssB_S29231_130        |
+    # ─── Order A: Inventory → CU → TU → LU → SSCC18 ─────────────────────────────────
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | invA_S29231_130           | 2026-05-20   | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | invA_S29231_130           | invLineA_S29231_130           | p_S29231_130            | 0       | 10       | PCE          |
+    And complete inventory with inventoryIdentifier 'invA_S29231_130'
+    And after not more than 30s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | invLineA_S29231_130           | cuA_S29231_130     |
+
+    And transform CU to new TUs
+      | sourceCU.Identifier | cuQty | M_HU_PI_Item_Product_ID.Identifier | OPT.resultedNewTUs.Identifier |
+      | cuA_S29231_130      | 10    | pip_S29231_130                     | tuA_S29231_130                |
+
+    And transform TU to new LUs
+      | sourceTU.Identifier | tuQty | M_HU_PI_Item_ID.Identifier | resultedNewLUs.Identifier |
+      | tuA_S29231_130      | 1     | pii_LU_S29231_130          | luA_S29231_130            |
+
+    And M_HU_Attribute is changed
+      | M_HU_ID        | M_Attribute_ID.Value | Value              |
+      | luA_S29231_130 | SSCC18               | 987654321000000016 |
+
+    # ─── Order B: Inventory → CU → TU → LU → SSCC18 ─────────────────────────────────
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | invB_S29231_130           | 2026-05-20   | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | invB_S29231_130           | invLineB_S29231_130           | p_S29231_130            | 0       | 10       | PCE          |
+    And complete inventory with inventoryIdentifier 'invB_S29231_130'
+    And after not more than 30s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | invLineB_S29231_130           | cuB_S29231_130     |
+
+    And transform CU to new TUs
+      | sourceCU.Identifier | cuQty | M_HU_PI_Item_Product_ID.Identifier | OPT.resultedNewTUs.Identifier |
+      | cuB_S29231_130      | 10    | pip_S29231_130                     | tuB_S29231_130                |
+
+    And transform TU to new LUs
+      | sourceTU.Identifier | tuQty | M_HU_PI_Item_ID.Identifier | resultedNewLUs.Identifier |
+      | tuB_S29231_130      | 1     | pii_LU_S29231_130          | luB_S29231_130            |
+
+    And M_HU_Attribute is changed
+      | M_HU_ID        | M_Attribute_ID.Value | Value              |
+      | luB_S29231_130 | SSCC18               | 987654321000000023 |
+
+    # ─── TU-level picking — m_tu_hu_id must be set for EPCIS individual_tu_ids gate ──
+    # Critical invariant (RESEARCH-picking-bl.md Q3): picking at TU level writes
+    # m_tu_hu_id=TU.m_hu_id on m_hu_assignment, satisfying the EPCIS EXISTS filter.
+    When create M_PickingCandidate for M_HU
+      | M_HU_ID.Identifier | M_ShipmentSchedule_ID.Identifier | QtyPicked | Status | PickStatus | ApprovalStatus |
+      | tuA_S29231_130     | ssA_S29231_130                   | 10        | IP     | P          | ?              |
+    And process picking
+      | M_HU_ID.Identifier | M_ShipmentSchedule_ID.Identifier |
+      | tuA_S29231_130     | ssA_S29231_130                   |
+
+    When create M_PickingCandidate for M_HU
+      | M_HU_ID.Identifier | M_ShipmentSchedule_ID.Identifier | QtyPicked | Status | PickStatus | ApprovalStatus |
+      | tuB_S29231_130     | ssB_S29231_130                   | 10        | IP     | P          | ?              |
+    And process picking
+      | M_HU_ID.Identifier | M_ShipmentSchedule_ID.Identifier |
+      | tuB_S29231_130     | ssB_S29231_130                   |
+
+    # ─── Generate ONE consolidated shipment (QuantityType=PD ships picked HUs only) ──
+    # Both schedules share BPartner+warehouse+date → consolidate into one M_InOut.
+    # Batch step enqueues both in one work package so consolidation logic can group them.
+    When 'generate shipments' process is invoked with QuantityType=PD, IsCompleteShipments=true and IsShipToday=false
+      | M_ShipmentSchedule_ID   |
+      | ssA_S29231_130          |
+      | ssB_S29231_130          |
 
     Then after not more than 60s, M_InOut is found:
-      | M_ShipmentSchedule_ID | M_InOut_ID      |
-      | ssA_S29231_130        | io_S29231_130   |
+      | M_ShipmentSchedule_ID | M_InOut_ID    |
+      | ssA_S29231_130        | io_S29231_130 |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID    |
+      | ssB_S29231_130        | io_S29231_130 |
 
     # Consolidated multi-source-order shipment: one pack per source DESADV.
-    # IsManual_IPA_SSCC18=true: this scenario does not set up M_HU_Attribute SSCC18 — the
-    # no-HU createPackUsingJustInOutLine path synthesises the SSCC and sets IsManual=true.
+    # IsManual_IPA_SSCC18=false: real LUs with SSCC18 attributes are present.
     And after not more than 60s, EDI_Desadv_Pack records are found:
       | EDI_Desadv_Pack_ID | EDI_Desadv_ID.Identifier | IsManual_IPA_SSCC18 |
-      | packA_S29231_130   | dA_S29231_130            | true                |
-      | packB_S29231_130   | dB_S29231_130            | true                |
-
-    # ─── Inject real LU HUs so pallets[] is populated ────────────────────────────────
-    # QuantityType=D shipments do not create M_HU records; inject minimal M_HU +
-    # M_HU_Attribute (SSCC18) + M_HU_Assignment rows directly so the EPCIS pallet-
-    # discovery CTE finds them.  Each LU is assigned only to the InOutLines of its
-    # specific source order so that per-LU POReference derivation works correctly.
-    And real LU HUs with SSCC18 are assigned to inout lines by source order of M_InOut identified by io_S29231_130
-      | sscc18             | C_Order_ID    |
-      | 987654321000000016 | oA_S29231_130 |
-      | 987654321000000023 | oB_S29231_130 |
+      | packA_S29231_130   | dA_S29231_130            | false               |
+      | packB_S29231_130   | dB_S29231_130            | false               |
 
     # ─── CORE ASSERTION ──────────────────────────────────────────────────────────────
     # The EPCIS function must return ONE event document with pallets[] of size 2,

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -396,3 +396,131 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | sscc18             | ExpectedPOReferenceSanitized |
       | 987654321000000016 | 1234567893                   |
       | 987654321000000023 | 9876543210                   |
+
+
+  @from:cucumber
+  @ghActions:run_on_executor5
+  @Id:S29231_170
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00353_EDI_DESADV_InOut_Link
+  Scenario: S29231_170 — Two shipments share one LU with HA aggregates: each shipment sees only its own crates
+  ## Regression for get_epcis_events_json_fn (CTE ha_items_with_vtu, me03#29231).
+  ## Real-world LAF1010-3 scenario: a picker consolidates two orders' goods onto one
+  ## physical pallet. The EPCIS export for shipment-1 must only enumerate the HA
+  ## aggregates allocated to shipment-1 via m_hu_assignment.vhu_id — NOT every HA
+  ## aggregate physically present on the LU. Original bug: shipment-1's JSON
+  ## contained 35 crates instead of 15.
+    Given metasfresh contains M_Products:
+      | Identifier   | GTIN          |
+      | p_S29231_140 | 4060000000147 |
+    And metasfresh contains M_PricingSystems
+      | Identifier    |
+      | ps_S29231_140 |
+    And metasfresh contains M_PriceLists
+      | Identifier    | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_S29231_140 | ps_S29231_140      | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier     | M_PriceList_ID |
+      | plv_S29231_140 | pl_S29231_140  |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | plv_S29231_140         | p_S29231_140 | 5.0      | PCE      | Normal           |
+
+    And metasfresh contains C_BPartners:
+      | Identifier    | IsCustomer | M_PricingSystem_ID | GLN           |
+      | bp_S29231_140 | Y          | ps_S29231_140      | 9900000291400 |
+    And the following c_bpartner is changed
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN |
+      | bp_S29231_140 | true                 | 9900000291400         |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID |
+      | bp_S29231_140 | p_S29231_140 |
+
+    # HU PI: LU holds up to 20 TUs, each TU holds 10 PCE
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID        |
+      | pi_LU_S29231_140  |
+      | pi_TU_S29231_140  |
+      | pi_VHU_S29231_140 |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID        | HU_UnitType | IsCurrent |
+      | piv_LU_S29231_140  | pi_LU_S29231_140  | LU          | Y         |
+      | piv_TU_S29231_140  | pi_TU_S29231_140  | TU          | Y         |
+      | piv_VHU_S29231_140 | pi_VHU_S29231_140 | V           | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID   | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID |
+      | pii_LU_S29231_140 | piv_LU_S29231_140  | 20  | HU       | pi_TU_S29231_140  |
+      | pii_TU_S29231_140 | piv_TU_S29231_140  | 0   | PM       |                   |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID   | M_Product_ID | Qty | ValidFrom  |
+      | pip_S29231_140          | pii_TU_S29231_140 | p_S29231_140 | 10  | 2020-01-01 |
+
+    # Order A — 50 PCE → 5 TU. POReference is 10 digits so LPAD is a no-op.
+    And metasfresh contains C_Orders:
+      | Identifier    | IsSOTrx | C_BPartner_ID | DateOrdered | POReference |
+      | oA_S29231_140 | true    | bp_S29231_140 | 2026-05-25  | 1140000001  |
+    And metasfresh contains C_OrderLines:
+      | Identifier     | C_Order_ID    | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | olA_S29231_140 | oA_S29231_140 | p_S29231_140 | 50         | pip_S29231_140          |
+
+    When the order identified by oA_S29231_140 is completed
+
+    # Order B — 100 PCE → 10 TU. Distinct POReference.
+    And metasfresh contains C_Orders:
+      | Identifier    | IsSOTrx | C_BPartner_ID | DateOrdered | POReference |
+      | oB_S29231_140 | true    | bp_S29231_140 | 2026-05-25  | 1140000002  |
+    And metasfresh contains C_OrderLines:
+      | Identifier     | C_Order_ID    | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | olB_S29231_140 | oB_S29231_140 | p_S29231_140 | 100        | pip_S29231_140          |
+
+    When the order identified by oB_S29231_140 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier    | C_OrderLine_ID | IsToRecompute |
+      | ssA_S29231_140 | olA_S29231_140 | N             |
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier    | C_OrderLine_ID | IsToRecompute |
+      | ssB_S29231_140 | olB_S29231_140 | N             |
+
+    # Generate ONE shipment per schedule (independent M_InOuts that we'll then share an LU between)
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ssA_S29231_140        | D            | true                | false       |
+      | ssB_S29231_140        | D            | true                | false       |
+
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID    |
+      | ssA_S29231_140        | ioA_S29231_140 |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID    |
+      | ssB_S29231_140        | ioB_S29231_140 |
+
+    # ─── Inject ONE shared LU with two HA aggregates, one per shipment ────────────────
+    # Without the bug fix, shipment_A's EPCIS would see BOTH HA aggregates (5+10=15 crates);
+    # with the fix it only sees the HA aggregate whose VTU is referenced by shipment_A's
+    # m_hu_assignment row (5 crates).
+    And one shared LU with SSCC18 '987654321000001400' carries HA aggregates assigned to inout lines:
+      | M_InOut_ID    | crateCount |
+      | ioA_S29231_140 | 5          |
+      | ioB_S29231_140 | 10         |
+
+    # ─── Shipment A: only its own 5 crates ───────────────────────────────────────────
+    When the EPCIS JSON export function is called for M_InOut identified by ioA_S29231_140
+    Then the EPCIS JSON pallets contain SSCC18 values in any order:
+      | sscc18             |
+      | 987654321000001400 |
+    And the EPCIS JSON pallet has:
+      | palletIndex | sscc               | crateCount |
+      | 0           | 987654321000001400 | 5          |
+
+    # ─── Shipment B: only its own 10 crates ──────────────────────────────────────────
+    When the EPCIS JSON export function is called for M_InOut identified by ioB_S29231_140
+    Then the EPCIS JSON pallets contain SSCC18 values in any order:
+      | sscc18             |
+      | 987654321000001400 |
+    And the EPCIS JSON pallet has:
+      | palletIndex | sscc               | crateCount |
+      | 0           | 987654321000001400 | 10         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -474,7 +474,6 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
 
 
   @from:cucumber
-  @ghActions:run_on_executor5
   @Id:S29231_170
   @allure.label.epic:E0292_EDI
   @allure.label.feature:F00353_EDI_DESADV_InOut_Link

--- a/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
@@ -50,12 +50,13 @@ CREATE OR REPLACE FUNCTION "de.metas.edi".get_epcis_events_json_fn(p_m_inout_id 
 AS
 $$
 DECLARE
-    v_result            JSONB;
-    v_grai_attribute_id NUMERIC;
-    v_sscc_attribute_id NUMERIC;
-    v_lot_attribute_id  NUMERIC;
-    v_bbd_attribute_id  NUMERIC;
-    v_dummy_grai_prefix TEXT;
+    v_result               JSONB;
+    v_grai_attribute_id    NUMERIC;
+    v_sscc_attribute_id    NUMERIC;
+    v_lot_attribute_id     NUMERIC;
+    v_bbd_attribute_id     NUMERIC;
+    v_dummy_grai_prefix    TEXT;
+    v_m_inoutline_table_id NUMERIC;
 
 BEGIN
     -- Cache attribute IDs in one scan
@@ -69,6 +70,9 @@ BEGIN
 
     -- de.metas.edi.epcis.dummyGRAI.Prefix — GCP.assetType. portion before the 12-char serial, e.g. '7613264.00307.'
     v_dummy_grai_prefix := get_sysconfig_value('de.metas.edi.epcis.dummyGRAI.Prefix', '0000000.11111.');
+
+    -- Cache the AD_Table_ID for M_InOutLine — used 4× below as the m_hu_assignment.ad_table_id filter
+    v_m_inoutline_table_id := get_table_id('M_InOutLine');
 
     WITH inout_context AS (
         -- Materialize all context data ONCE to avoid correlated subqueries
@@ -139,7 +143,7 @@ BEGIN
                  FROM inout_context ctx
                           JOIN m_inoutline iol ON iol.m_inout_id = ctx.m_inout_id
                           JOIN m_hu_assignment ha
-                               ON ha.ad_table_id = 320 -- M_InOutLine
+                               ON ha.ad_table_id = v_m_inoutline_table_id
                                    AND ha.record_id = iol.m_inoutline_id
                           LEFT JOIN c_orderline ol ON ol.c_orderline_id = iol.c_orderline_id
                           LEFT JOIN c_order ord ON ord.c_order_id = ol.c_order_id
@@ -159,7 +163,7 @@ BEGIN
                    AND NOT EXISTS (
                        SELECT 1 FROM m_hu_assignment ha2
                        WHERE ha2.m_lu_hu_id = qp.m_lu_hu_id
-                         AND ha2.ad_table_id = 320
+                         AND ha2.ad_table_id = v_m_inoutline_table_id
                          AND ha2.isactive = 'Y'
                    )
              ) lu_with_poreference
@@ -187,7 +191,7 @@ BEGIN
                  SELECT 1
                  FROM m_hu_assignment ha
                           JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
-                 WHERE ha.ad_table_id = get_table_id('M_InOutLine')
+                 WHERE ha.ad_table_id = v_m_inoutline_table_id
                    AND iol.m_inout_id = (SELECT m_inout_id FROM inout_context)
                    AND ha.isactive = 'Y'
                    AND (ha.m_tu_hu_id = tu_hu.m_hu_id OR ha.vhu_id = tu_hu.m_hu_id)
@@ -222,7 +226,7 @@ BEGIN
                  SELECT 1
                  FROM m_hu_assignment ha
                           JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
-                 WHERE ha.ad_table_id = get_table_id('M_InOutLine') 
+                 WHERE ha.ad_table_id = v_m_inoutline_table_id 
                    AND iol.m_inout_id = (SELECT m_inout_id FROM inout_context)
                    AND ha.isactive = 'Y'
                    AND ha.vhu_id = ha_vtu.m_hu_id
@@ -314,7 +318,7 @@ BEGIN
                     JSONB_AGG(
                             JSONB_BUILD_OBJECT(
                                     'cuGTIN', COALESCE(bp_prod.gtin, bp_prod.ean_cu, prod.gtin),
-                                    'tuGTIN', COALESCE(pi_prod.ean_tu, pi_prod.gtin),
+                                    'tuGTIN', COALESCE(pi_prod.gtin, pi_prod.ean_tu),
                                     'quantity',
                                     CASE
                                         WHEN COALESCE(atb.qty, 1) > 0 THEN stor.qty / atb.qty

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5804420_sys_get_epcis_events_json_fn_filter_ha_by_inout.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5804420_sys_get_epcis_events_json_fn_filter_ha_by_inout.sql
@@ -48,12 +48,13 @@ CREATE OR REPLACE FUNCTION "de.metas.edi".get_epcis_events_json_fn(p_m_inout_id 
 AS
 $$
 DECLARE
-    v_result            JSONB;
-    v_grai_attribute_id NUMERIC;
-    v_sscc_attribute_id NUMERIC;
-    v_lot_attribute_id  NUMERIC;
-    v_bbd_attribute_id  NUMERIC;
-    v_dummy_grai_prefix TEXT;
+    v_result               JSONB;
+    v_grai_attribute_id    NUMERIC;
+    v_sscc_attribute_id    NUMERIC;
+    v_lot_attribute_id     NUMERIC;
+    v_bbd_attribute_id     NUMERIC;
+    v_dummy_grai_prefix    TEXT;
+    v_m_inoutline_table_id NUMERIC;
 
 BEGIN
     -- Cache attribute IDs in one scan
@@ -67,6 +68,9 @@ BEGIN
 
     -- de.metas.edi.epcis.dummyGRAI.Prefix — GCP.assetType. portion before the 12-char serial, e.g. '7613264.00307.'
     v_dummy_grai_prefix := get_sysconfig_value('de.metas.edi.epcis.dummyGRAI.Prefix', '0000000.11111.');
+
+    -- Cache the AD_Table_ID for M_InOutLine — used 4× below as the m_hu_assignment.ad_table_id filter
+    v_m_inoutline_table_id := get_table_id('M_InOutLine');
 
     WITH inout_context AS (
         -- Materialize all context data ONCE to avoid correlated subqueries
@@ -137,7 +141,7 @@ BEGIN
                  FROM inout_context ctx
                           JOIN m_inoutline iol ON iol.m_inout_id = ctx.m_inout_id
                           JOIN m_hu_assignment ha
-                               ON ha.ad_table_id = 320 -- M_InOutLine
+                               ON ha.ad_table_id = v_m_inoutline_table_id -- M_InOutLine
                                    AND ha.record_id = iol.m_inoutline_id
                           LEFT JOIN c_orderline ol ON ol.c_orderline_id = iol.c_orderline_id
                           LEFT JOIN c_order ord ON ord.c_order_id = ol.c_order_id
@@ -157,7 +161,7 @@ BEGIN
                    AND NOT EXISTS (
                        SELECT 1 FROM m_hu_assignment ha2
                        WHERE ha2.m_lu_hu_id = qp.m_lu_hu_id
-                         AND ha2.ad_table_id = 320
+                         AND ha2.ad_table_id = v_m_inoutline_table_id
                          AND ha2.isactive = 'Y'
                    )
              ) lu_with_poreference
@@ -185,7 +189,7 @@ BEGIN
                  SELECT 1
                  FROM m_hu_assignment ha
                           JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
-                 WHERE ha.ad_table_id = get_table_id('M_InOutLine')
+                 WHERE ha.ad_table_id = v_m_inoutline_table_id
                    AND iol.m_inout_id = (SELECT m_inout_id FROM inout_context)
                    AND ha.isactive = 'Y'
                    AND (ha.m_tu_hu_id = tu_hu.m_hu_id OR ha.vhu_id = tu_hu.m_hu_id)
@@ -220,7 +224,7 @@ BEGIN
                  SELECT 1
                  FROM m_hu_assignment ha
                           JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
-                 WHERE ha.ad_table_id = get_table_id('M_InOutLine')
+                 WHERE ha.ad_table_id = v_m_inoutline_table_id
                    AND iol.m_inout_id = (SELECT m_inout_id FROM inout_context)
                    AND ha.isactive = 'Y'
                    AND ha.vhu_id = ha_vtu.m_hu_id
@@ -312,7 +316,7 @@ BEGIN
                     JSONB_AGG(
                             JSONB_BUILD_OBJECT(
                                     'cuGTIN', COALESCE(bp_prod.gtin, bp_prod.ean_cu, prod.gtin),
-                                    'tuGTIN', COALESCE(pi_prod.ean_tu, pi_prod.gtin),
+                                    'tuGTIN', COALESCE(pi_prod.gtin, pi_prod.ean_tu),
                                     'quantity',
                                     CASE
                                         WHEN COALESCE(atb.qty, 1) > 0 THEN stor.qty / atb.qty

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5804420_sys_get_epcis_events_json_fn_filter_ha_by_inout.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5804420_sys_get_epcis_events_json_fn_filter_ha_by_inout.sql
@@ -1,24 +1,22 @@
-/*
- * #%L
- * de.metas.edi
- * %%
- * Copyright (C) 2026 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
+-- Migration: get_epcis_events_json_fn — restrict TUs (individual + HA aggregates) to the current M_InOut
+-- Issue: https://github.com/metasfresh/me03/issues/29231
+--
+-- Context:
+--   When two M_InOuts share the same physical LU pallet (real-world: picker consolidates
+--   two orders onto one pallet), the export of shipment-1 used to also include the TUs
+--   that belong to the sibling shipment. Original failure: shipment-1's JSON contained
+--   35 crates instead of 15 (LAF1010-3 testcase, Migros / Spavetti EPCIS).
+--
+--   Root cause: the individual_tu_ids and ha_items_with_vtu CTEs walked every TU /
+--   HA m_hu_item under the LU with no link back to the M_InOut. pallet_list already
+--   filters LUs to the current shipment via m_hu_assignment, but the TU-level walkers
+--   did not.
+--
+--   Fix: both CTEs now add an EXISTS gate against m_hu_assignment.
+--   - CASE A (individual_tu_ids): match assignment.m_tu_hu_id or .vhu_id = tu_hu.m_hu_id
+--   - CASE B (ha_items_with_vtu): match assignment.vhu_id = ha_vtu.m_hu_id
+--   For HA, ha_item.qty remains the crate count source (m_hu_assignment.qty is 0 in
+--   the observed production data — the assignment is presence-only).
 
 -- EPCIS event JSON for a given M_InOut (shipment).
 -- HU-based, DESADV-optional: core data from HU hierarchy, DESADV only for optional biz references.
@@ -222,7 +220,7 @@ BEGIN
                  SELECT 1
                  FROM m_hu_assignment ha
                           JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
-                 WHERE ha.ad_table_id = get_table_id('M_InOutLine') 
+                 WHERE ha.ad_table_id = get_table_id('M_InOutLine')
                    AND iol.m_inout_id = (SELECT m_inout_id FROM inout_context)
                    AND ha.isactive = 'Y'
                    AND ha.vhu_id = ha_vtu.m_hu_id

--- a/misc/dev-support/http-requests/M_InOut_EPCIS_Export_JSON.http
+++ b/misc/dev-support/http-requests/M_InOut_EPCIS_Export_JSON.http
@@ -1,0 +1,14 @@
+
+POST {{baseURL}}/api/v2/processes/M_InOut_EPCIS_Export_JSON/invoke
+Authorization: {{authToken}}
+Content-Type: application/json;charset=UTF-8
+accept: application/json;charset=UTF-8
+
+{
+  "processParameters": [
+    {
+      "name": "M_InOut_ID",
+      "value": "29273229"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes EPCIS JSON export when two `M_InOut` records share the same physical LU pallet.

**Original failure:** testcase produced 35 crates in shipment-1's EPCIS JSON instead of the 15 that actually belong to it. The other 20 belong to a sibling shipment

**Root cause:** in `get_epcis_events_json_fn` the `individual_tu_ids` and `ha_items_with_vtu` CTEs walked every TU under the LU with no link back to the M_InOut. `pallet_list` already filtered LUs via `m_hu_assignment`, but the TU-level walkers did not.

**Fix:** both CTEs now add an `EXISTS` gate against `m_hu_assignment`:
- CASE A (`individual_tu_ids`): `ha.m_tu_hu_id = tu_hu.m_hu_id OR ha.vhu_id = tu_hu.m_hu_id`
- CASE B (`ha_items_with_vtu`): `ha.vhu_id = ha_vtu.m_hu_id`

For HA, `ha_item.qty` remains the crate count source (`m_hu_assignment.qty` is `0` in the observed production data — the assignment is presence-only).

## Files

- `backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql` — both CTEs gated
- `backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5804420_sys_get_epcis_events_json_fn_filter_ha_by_inout.sql` — migration
- `backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java` — existing CASE-A injectors now populate `m_tu_hu_id`; new `assignSharedLuHaToInoutLines` helper for the HA case
- `backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature` — new scenario `S29231_170`

## Test plan

- [x] Local cucumber `epcisExport` feature against `soft_panda_uat` — all 5 EPCIS scenarios green (`EPCIS_010`, `EPCIS_020`, `EPCIS_030`, `S29231_130`, `S29231_170`)
- [ ] CI pipeline green
- [ ] Verify on a real DB instance that the LAF1010-3 testcase now produces 15 crates for shipment 1 (and 20 for shipment 2 once completed)
