### PR TITLE
Tax Declaration — add missing AD_Field + AD_UI_Element for C_DocType_ID

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5804540_TaxDeclaration_AD_Field_C_DocType_ID.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5804540_TaxDeclaration_AD_Field_C_DocType_ID.sql
@@ -45,3 +45,4 @@ VALUES (0, 780485 /*From ID Server*/, 0, 549256,
     'Y', 'Y', 'N',
     'Document Type', 15, 15, 0,
     TIMESTAMP '2026-05-26 00:00:00', 100);
+-- (CI re-trigger 2026-05-26: empty commit didn't fire workflow because paths-ignore + zero-file-change skips Actions; comment-only line forces a real diff)

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5804540_TaxDeclaration_AD_Field_C_DocType_ID.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5804540_TaxDeclaration_AD_Field_C_DocType_ID.sql
@@ -1,0 +1,47 @@
+-- Tax Declaration — add AD_Field + AD_UI_Element for C_DocType_ID on header tab 549256 (column 592580 was added by integrated 5803920 without the UI rows)
+-- WebUI silently ignores AD_Columns without paired AD_Field + AD_UI_Element rows.
+-- Mirror pattern of existing sibling field 779186 (C_AcctSchema_ID) created in 5802040.
+-- Tab: 549256 (header tab of Tax Declaration window 542146)
+-- ElementGroup: 555313 (default identity-class group: AD_Org_ID, DocumentNo, C_AcctSchema_ID, ...)
+-- Column: 592580 (C_TaxDeclaration.C_DocType_ID, AD_Element_ID=196 reuse)
+
+-- AD_Field row for C_DocType_ID
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+    Created, CreatedBy, DisplayLength, EntityType,
+    IsActive, IsDisplayed, IsDisplayedGrid,
+    IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly, IsSameLine,
+    Name, Updated, UpdatedBy)
+VALUES (0, 592580, 780485 /*From ID Server*/, 0, 549256,
+    TIMESTAMP '2026-05-26 00:00:00', 100, 1, 'de.metas.acct',
+    'Y', 'Y', 'Y',
+    'N', 'N', 'N', 'N', 'N',
+    'Document Type', TIMESTAMP '2026-05-26 00:00:00', 100);
+
+-- AD_Field_Trl rows for system languages (matches pattern from 5802040)
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name,
+    IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name,
+    'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Field_ID = 780485
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt
+    WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+
+-- Pull element translations onto the new field (Belegart / Document Type / Type de document, etc.)
+SELECT update_FieldTranslation_From_AD_Name_Element(196);
+
+-- AD_UI_Element row pairing the field into the "default" group (555313).
+-- SeqNo=15 places it between DocumentNo (SeqNo=10) and Buchführungs-Schema (SeqNo=20) — identity columns first.
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+    AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+    Created, CreatedBy, IsActive, IsAdvancedField,
+    IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+    Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+    Updated, UpdatedBy)
+VALUES (0, 780485 /*From ID Server*/, 0, 549256,
+    555313, 651840 /*From ID Server*/, 'F',
+    TIMESTAMP '2026-05-26 00:00:00', 100, 'Y', 'N',
+    'Y', 'Y', 'N',
+    'Document Type', 15, 15, 0,
+    TIMESTAMP '2026-05-26 00:00:00', 100);


### PR DESCRIPTION
## Summary

Adds the missing `AD_Field` + `AD_UI_Element` rows for `C_DocType_ID` on the Tax Declaration header tab (`AD_Tab_ID=549256`, window 542146).

## Background

PR https://github.com/metasfresh/metasfresh/pull/24064 (Tax Declaration Iter 5/14) added `AD_Column.C_DocType_ID` (`AD_Column_ID=592580`) via integrated migration `5803920_C_TaxDeclaration_AddColumn_C_DocType_ID.sql` but did not add the `AD_Field` + `AD_UI_Element` rows. WebUI silently ignores `AD_Column`s without paired `AD_Field` / `AD_UI_Element` — so the **Belegart** / **Document Type** field was invisible on the header tab. Caught during UAT walkthrough on https://danthermuat.metasfresh.com.

## Layout placement

The field is placed in `AD_UI_ElementGroup=555313` ("default") on section `main` / column `549485` of `AD_Tab=549256`, alongside the other identity-class columns (`AD_Org_ID`, `C_AcctSchema_ID`, `DocumentNo`, `C_Period_ID`). `SeqNo=15` puts it between `DocumentNo` (10) and `C_AcctSchema_ID` (20).

## Verification

Applied locally via `workspace_migrate.Main` on the `deep_tundra_uat` DB - 1 new `AD_Field` (`780485`), 11 `AD_Field_Trl` rows (DE/CH `Belegart`, EN `Document Type`, FR/CH `Type de document`), 1 `AD_UI_Element` (`651840`). The `update_FieldTranslation_From_AD_Name_Element(196)` cascade pulled the existing `AD_Element.C_DocType_ID` translations onto the new field, so all system languages get the right label automatically.

## Test plan

- [ ] After merge + dt204 cascade rebuild, open Tax Declaration window on the UAT instance - `Belegart` / `Document Type` field is visible on the header tab in the default group, populated with the TXD doctype on new records (per existing tab callout from PR #24064).
