### PR TITLE
Process Framework: configurable AD_Process.OpenTarget for RelationTypeInOverlayProcess

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Process.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_AD_Process.java
@@ -881,6 +881,27 @@ public interface I_AD_Process
 	String COLUMNNAME_Name = "Name";
 
 	/**
+	 * Set Open Target.
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setOpenTarget (@Nullable java.lang.String OpenTarget);
+
+	/**
+	 * Get Open Target.
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	@Nullable java.lang.String getOpenTarget();
+
+	ModelColumn<I_AD_Process, Object> COLUMN_OpenTarget = new ModelColumn<>(I_AD_Process.class, "OpenTarget", null);
+	String COLUMNNAME_OpenTarget = "OpenTarget";
+
+	/**
 	 * Set Response format.
 	 *
 	 * <br>Type: List

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Process.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Process.java
@@ -538,8 +538,6 @@ public class X_AD_Process extends org.compiere.model.PO implements I_AD_Process,
 	public static final String OPENTARGET_ModalOverlay = "O";
 	/** NewBrowserTab = N */
 	public static final String OPENTARGET_NewBrowserTab = "N";
-	/** InPlace = R */
-	public static final String OPENTARGET_InPlace = "R";
 
 	@Override
 	public void setOpenTarget (@Nullable final java.lang.String OpenTarget)

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Process.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_AD_Process.java
@@ -525,12 +525,35 @@ public class X_AD_Process extends org.compiere.model.PO implements I_AD_Process,
 	}
 
 	@Override
-	public java.lang.String getName() 
+	public java.lang.String getName()
 	{
 		return get_ValueAsString(COLUMNNAME_Name);
 	}
 
-	/** 
+	/**
+	 * OpenTarget AD_Reference_ID=542096
+	 */
+	public static final int OPENTARGET_AD_Reference_ID = 542096;
+	/** ModalOverlay = O */
+	public static final String OPENTARGET_ModalOverlay = "O";
+	/** NewBrowserTab = N */
+	public static final String OPENTARGET_NewBrowserTab = "N";
+	/** InPlace = R */
+	public static final String OPENTARGET_InPlace = "R";
+
+	@Override
+	public void setOpenTarget (@Nullable final java.lang.String OpenTarget)
+	{
+		set_Value (COLUMNNAME_OpenTarget, OpenTarget);
+	}
+
+	@Override
+	public java.lang.String getOpenTarget()
+	{
+		return (java.lang.String)get_Value(COLUMNNAME_OpenTarget);
+	}
+
+	/**
 	 * PostgrestResponseFormat AD_Reference_ID=541210
 	 * Reference name: PostgrestResponseFormat
 	 */

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessInfo.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessInfo.java
@@ -1148,6 +1148,7 @@ public final class ProcessInfo implements Serializable
 
 			setAD_Process_ID(_adProcess.getAD_Process_ID());
 			setAdRelationTypeId(RelationTypeId.ofRepoIdOrNull(_adProcess.getAD_RelationType_ID()));
+			// CoalesceUtil not applicable: getOpenTarget() returns String, ofCode() returns ProcessOpenTarget (type mismatch)
 			setOpenTarget(_adProcess.getOpenTarget() != null ? ProcessOpenTarget.ofCode(_adProcess.getOpenTarget()) : null);
 			setNotifyUserAfterExecution(adProcess.isNotifyUserAfterExecution());
 			setLogWarning(adProcess.isLogWarning());

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessInfo.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessInfo.java
@@ -127,6 +127,7 @@ public final class ProcessInfo implements Serializable
 
 		adProcessId = builder.getAD_Process_ID();
 		adRelationTypeId = builder.getAD_RelationType_ID();
+		openTarget = builder.openTarget;
 		pinstanceId = builder.getPInstanceId();
 
 		clientId = builder.getAdClientId();
@@ -196,6 +197,7 @@ public final class ProcessInfo implements Serializable
 	@Getter private final String title;
 	@Getter private final AdProcessId adProcessId;
 	@Getter @Nullable private final RelationTypeId adRelationTypeId;
+	@Getter @Nullable private final ProcessOpenTarget openTarget;
 	private final int adTableId;
 	private final int recordId;
 	@Getter private final Set<TableRecordReference> selectedIncludedRecords;
@@ -805,6 +807,7 @@ public final class ProcessInfo implements Serializable
 		private Boolean logWarning;
 
 		@Nullable private RelationTypeId adRelationTypeId;
+		@Nullable private ProcessOpenTarget openTarget;
 
 		private ProcessInfoBuilder()
 		{
@@ -1145,6 +1148,7 @@ public final class ProcessInfo implements Serializable
 
 			setAD_Process_ID(_adProcess.getAD_Process_ID());
 			setAdRelationTypeId(RelationTypeId.ofRepoIdOrNull(_adProcess.getAD_RelationType_ID()));
+			setOpenTarget(_adProcess.getOpenTarget() != null ? ProcessOpenTarget.ofCode(_adProcess.getOpenTarget()) : null);
 			setNotifyUserAfterExecution(adProcess.isNotifyUserAfterExecution());
 			setLogWarning(adProcess.isLogWarning());
 			return this;
@@ -1153,6 +1157,12 @@ public final class ProcessInfo implements Serializable
 		public ProcessInfoBuilder setAdRelationTypeId(@Nullable final RelationTypeId adRelationTypeId)
 		{
 			this.adRelationTypeId = adRelationTypeId;
+			return this;
+		}
+
+		public ProcessInfoBuilder setOpenTarget(@Nullable final ProcessOpenTarget openTarget)
+		{
+			this.openTarget = openTarget;
 			return this;
 		}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessOpenTarget.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessOpenTarget.java
@@ -1,0 +1,52 @@
+package de.metas.process;
+
+import de.metas.util.lang.ReferenceListAwareEnum;
+import de.metas.util.lang.ReferenceListAwareEnums;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import org.compiere.model.X_AD_Process;
+
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2019 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * @author metas-dev <dev@metasfresh.com>
+ */
+@AllArgsConstructor
+public enum ProcessOpenTarget implements ReferenceListAwareEnum
+{
+	ModalOverlay(X_AD_Process.OPENTARGET_ModalOverlay),
+	NewBrowserTab(X_AD_Process.OPENTARGET_NewBrowserTab),
+	InPlace(X_AD_Process.OPENTARGET_InPlace),
+	;
+
+	private static final ReferenceListAwareEnums.ValuesIndex<ProcessOpenTarget> index = ReferenceListAwareEnums.index(values());
+
+	@Getter
+	private final String code;
+
+	public static ProcessOpenTarget ofCode(@NonNull final String code)
+	{
+		return index.ofCode(code);
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessOpenTarget.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessOpenTarget.java
@@ -37,7 +37,6 @@ public enum ProcessOpenTarget implements ReferenceListAwareEnum
 {
 	ModalOverlay(X_AD_Process.OPENTARGET_ModalOverlay),
 	NewBrowserTab(X_AD_Process.OPENTARGET_NewBrowserTab),
-	InPlace(X_AD_Process.OPENTARGET_InPlace),
 	;
 
 	private static final ReferenceListAwareEnums.ValuesIndex<ProcessOpenTarget> index = ReferenceListAwareEnums.index(values());

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804600_sys_gh29919_AD_Process_OpenTarget.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804600_sys_gh29919_AD_Process_OpenTarget.sql
@@ -1,0 +1,112 @@
+-- Run mode: SWING_CLIENT
+
+-- Reference: ProcessOpenTarget
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_Reference (AD_Client_ID,AD_Org_ID,AD_Reference_ID,Created,CreatedBy,EntityType,IsActive,IsOrderByValue,Name,Updated,UpdatedBy,ValidationType) VALUES (0,0,542096,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','N','ProcessOpenTarget',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'L')
+;
+
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_Reference_Trl (AD_Language,AD_Reference_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Reference_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Reference t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Reference_ID=542096 AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
+;
+
+-- Reference Value: ModalOverlay
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName) VALUES (0,0,542096,544234,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','Modal Overlay',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'O','ModalOverlay')
+;
+
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Ref_List t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Ref_List_ID=544234 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+-- Reference Value: NewBrowserTab
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName) VALUES (0,0,542096,544235,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','New browser tab',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N','NewBrowserTab')
+;
+
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Ref_List t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Ref_List_ID=544235 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+-- Reference Value: InPlace
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName) VALUES (0,0,542096,544236,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','In place',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'R','InPlace')
+;
+
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Ref_List t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Ref_List_ID=544236 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+-- Element: OpenTarget
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,584914,0,'OpenTarget',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','Open Target','Open Target',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Element_ID, t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=584914 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- Column: AD_Process.OpenTarget
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,CloningStrategy,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterInactiveValues,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version) VALUES (0,592622,584914,0,17,542096,284,'XX','OpenTarget',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N','D',0,1,'Y','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','Y','N',0,'Open Target',0,0,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,0)
+;
+
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=592622 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 2026-05-26T14:50:00.000Z
+/* DDL */  select update_Column_Translation_From_AD_Element(584914)
+;
+
+-- 2026-05-26T14:50:00.000Z
+/* DDL */ SELECT public.db_alter_table('AD_Process','ALTER TABLE public.AD_Process ADD COLUMN OpenTarget CHAR(1)')
+;
+
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO t_alter_column values('ad_process','OpenTarget','CHAR(1)',null,null)
+;
+
+-- Field: Bericht & Prozess(165,D) -> Bericht & Prozess(245,D) -> Open Target
+-- Column: AD_Process.OpenTarget
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,DisplayLength,EntityType,FacetFilterSeqNo,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,592622,780486,0,245,0,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,0,'U',0,0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Open Target',0,0,360,0,1,1,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=780486 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-05-26T14:50:00.000Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(584914)
+;
+
+-- 2026-05-26T14:50:00.000Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=780486
+;
+
+-- 2026-05-26T14:50:00.000Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(780486)
+;
+
+-- Field: Bericht & Prozess(165,D) -> Bericht & Prozess(245,D) -> Open Target
+-- Column: AD_Process.OpenTarget
+-- 2026-05-26T14:50:00.000Z
+UPDATE AD_Field SET DisplayLogic='@Type@=''RelationTypeInOverlay''',Updated=TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Field_ID=780486
+;
+
+-- UI Element: Bericht & Prozess(165,D) -> Bericht & Prozess(245,D) -> main -> 10 -> description.Open Target
+-- Column: AD_Process.OpenTarget
+-- 2026-05-26T14:50:00.000Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,780486,0,245,541397,651843,'F',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y','N','N','Y','N','N','N',0,'Open Target',90,0,0,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- Column: AD_Process.OpenTarget
+-- 2026-05-26T14:50:00.000Z
+UPDATE AD_Column SET ColumnDisplayLength=10,Updated=TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=592622
+;
+
+-- Field: Bericht & Prozess(165,D) -> Bericht & Prozess(245,D) -> Open Target
+-- Column: AD_Process.OpenTarget
+-- 2026-05-26T14:50:00.000Z
+UPDATE AD_Field SET ColumnDisplayLength=10,Updated=TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Field_ID=780486
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804600_sys_gh29919_AD_Process_OpenTarget.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804600_sys_gh29919_AD_Process_OpenTarget.sql
@@ -41,21 +41,6 @@ UPDATE AD_Ref_List_Trl SET Name='Neuer Browser-Tab', IsTranslated='Y',
 WHERE AD_Ref_List_ID=544235 AND AD_Language='de_DE'
 ;
 
--- Reference Value: InPlace
--- 2026-05-26T14:50:00.000Z
-INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName) VALUES (0,0,542096,544236 /*From ID Server*/,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','In place',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'R','InPlace')
-;
-
--- 2026-05-26T14:50:00.000Z
-INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Ref_List t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Ref_List_ID=544236 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
-;
-
--- DE translation: InPlace
--- 2026-05-26T14:50:00.000Z
-UPDATE AD_Ref_List_Trl SET Name='An selber Stelle', IsTranslated='Y',
-    Updated=TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100
-WHERE AD_Ref_List_ID=544236 AND AD_Language='de_DE'
-;
 
 -- Element: OpenTarget
 -- 2026-05-26T14:50:00.000Z

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804600_sys_gh29919_AD_Process_OpenTarget.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804600_sys_gh29919_AD_Process_OpenTarget.sql
@@ -2,7 +2,7 @@
 
 -- Reference: ProcessOpenTarget
 -- 2026-05-26T14:50:00.000Z
-INSERT INTO AD_Reference (AD_Client_ID,AD_Org_ID,AD_Reference_ID,Created,CreatedBy,EntityType,IsActive,IsOrderByValue,Name,Updated,UpdatedBy,ValidationType) VALUES (0,0,542096,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','N','ProcessOpenTarget',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'L')
+INSERT INTO AD_Reference (AD_Client_ID,AD_Org_ID,AD_Reference_ID,Created,CreatedBy,EntityType,IsActive,IsOrderByValue,Name,Updated,UpdatedBy,ValidationType) VALUES (0,0,542096 /*From ID Server*/,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','N','ProcessOpenTarget',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'L')
 ;
 
 -- 2026-05-26T14:50:00.000Z
@@ -11,47 +11,82 @@ INSERT INTO AD_Reference_Trl (AD_Language,AD_Reference_ID, Description,Help,Name
 
 -- Reference Value: ModalOverlay
 -- 2026-05-26T14:50:00.000Z
-INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName) VALUES (0,0,542096,544234,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','Modal Overlay',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'O','ModalOverlay')
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName) VALUES (0,0,542096,544234 /*From ID Server*/,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','Modal Overlay',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'O','ModalOverlay')
 ;
 
 -- 2026-05-26T14:50:00.000Z
 INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Ref_List t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Ref_List_ID=544234 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
 ;
 
+-- DE translation: ModalOverlay
+-- 2026-05-26T14:50:00.000Z
+UPDATE AD_Ref_List_Trl SET Name='Modales Overlay', IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100
+WHERE AD_Ref_List_ID=544234 AND AD_Language='de_DE'
+;
+
 -- Reference Value: NewBrowserTab
 -- 2026-05-26T14:50:00.000Z
-INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName) VALUES (0,0,542096,544235,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','New browser tab',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N','NewBrowserTab')
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName) VALUES (0,0,542096,544235 /*From ID Server*/,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','New browser tab',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N','NewBrowserTab')
 ;
 
 -- 2026-05-26T14:50:00.000Z
 INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Ref_List t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Ref_List_ID=544235 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
 ;
 
+-- DE translation: NewBrowserTab
+-- 2026-05-26T14:50:00.000Z
+UPDATE AD_Ref_List_Trl SET Name='Neuer Browser-Tab', IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100
+WHERE AD_Ref_List_ID=544235 AND AD_Language='de_DE'
+;
+
 -- Reference Value: InPlace
 -- 2026-05-26T14:50:00.000Z
-INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName) VALUES (0,0,542096,544236,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','In place',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'R','InPlace')
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName) VALUES (0,0,542096,544236 /*From ID Server*/,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','In place',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'R','InPlace')
 ;
 
 -- 2026-05-26T14:50:00.000Z
 INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Ref_List t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Ref_List_ID=544236 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
 ;
 
+-- DE translation: InPlace
+-- 2026-05-26T14:50:00.000Z
+UPDATE AD_Ref_List_Trl SET Name='An selber Stelle', IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100
+WHERE AD_Ref_List_ID=544236 AND AD_Language='de_DE'
+;
+
 -- Element: OpenTarget
 -- 2026-05-26T14:50:00.000Z
-INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,584914,0,'OpenTarget',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','Open Target','Open Target',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,584914 /*From ID Server*/,0,'OpenTarget',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','Open Target','Open Target',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
 ;
 
 -- 2026-05-26T14:50:00.000Z
 INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Element_ID, t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=584914 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
 ;
 
+-- DE translation: OpenTarget element
+-- 2026-05-26T14:50:00.000Z
+UPDATE AD_Element_Trl SET Name='Öffnungsziel', PrintName='Öffnungsziel', IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100
+WHERE AD_Element_ID=584914 AND AD_Language='de_DE'
+;
+
 -- Column: AD_Process.OpenTarget
 -- 2026-05-26T14:50:00.000Z
-INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,CloningStrategy,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterInactiveValues,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version) VALUES (0,592622,584914,0,17,542096,284,'XX','OpenTarget',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N','D',0,1,'Y','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','Y','N',0,'Open Target',0,0,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,0)
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,CloningStrategy,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterInactiveValues,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version) VALUES (0,592622 /*From ID Server*/,584914,0,17,542096,284,'XX','OpenTarget',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N','D',0,1,'Y','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','Y','N',0,'Open Target',0,0,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,0)
 ;
 
 -- 2026-05-26T14:50:00.000Z
 INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=592622 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- PersonalDataCategory: AD_Process.OpenTarget is a control code (non-personal)
+-- 2026-05-26T14:50:00.000Z
+UPDATE AD_Column SET PersonalDataCategory='NP',
+    Updated=TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100
+WHERE AD_Column_ID=592622
 ;
 
 -- 2026-05-26T14:50:00.000Z
@@ -69,7 +104,7 @@ INSERT INTO t_alter_column values('ad_process','OpenTarget','CHAR(1)',null,null)
 -- Field: Bericht & Prozess(165,D) -> Bericht & Prozess(245,D) -> Open Target
 -- Column: AD_Process.OpenTarget
 -- 2026-05-26T14:50:00.000Z
-INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,DisplayLength,EntityType,FacetFilterSeqNo,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,592622,780486,0,245,0,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,0,'U',0,0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Open Target',0,0,360,0,1,1,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,DisplayLength,EntityType,FacetFilterSeqNo,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,592622,780486 /*From ID Server*/,0,245,0,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,0,'U',0,0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Open Target',0,0,360,0,1,1,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
 ;
 
 -- 2026-05-26T14:50:00.000Z
@@ -97,12 +132,7 @@ UPDATE AD_Field SET DisplayLogic='@Type@=''RelationTypeInOverlay''',Updated=TO_T
 -- UI Element: Bericht & Prozess(165,D) -> Bericht & Prozess(245,D) -> main -> 10 -> description.Open Target
 -- Column: AD_Process.OpenTarget
 -- 2026-05-26T14:50:00.000Z
-INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,780486,0,245,541397,651843,'F',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y','N','N','Y','N','N','N',0,'Open Target',90,0,0,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
-;
-
--- Column: AD_Process.OpenTarget
--- 2026-05-26T14:50:00.000Z
-UPDATE AD_Column SET ColumnDisplayLength=10,Updated=TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=592622
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,780486,0,245,541397,651843 /*From ID Server*/,'F',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y','N','N','Y','N','N','N',0,'Open Target',90,0,0,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
 ;
 
 -- Field: Bericht & Prozess(165,D) -> Bericht & Prozess(245,D) -> Open Target

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804600_sys_gh29919_AD_Process_OpenTarget.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804600_sys_gh29919_AD_Process_OpenTarget.sql
@@ -58,6 +58,13 @@ UPDATE AD_Element_Trl SET Name='Öffnungsziel', PrintName='Öffnungsziel', IsTra
 WHERE AD_Element_ID=584914 AND AD_Language='de_DE'
 ;
 
+-- English translation (en_US)
+-- 2026-05-26T14:50:00.000Z
+UPDATE AD_Element_Trl SET Name='Open Target', PrintName='Open Target', IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100
+WHERE AD_Element_ID=584914 AND AD_Language='en_US'
+;
+
 -- Column: AD_Process.OpenTarget
 -- 2026-05-26T14:50:00.000Z
 INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,CloningStrategy,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterInactiveValues,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version) VALUES (0,592622 /*From ID Server*/,584914,0,17,542096,284,'XX','OpenTarget',TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N','D',0,1,'Y','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','Y','N',0,'Open Target',0,0,TO_TIMESTAMP('2026-05-26 14:50:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,0)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcess.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcess.java
@@ -183,7 +183,15 @@ public class RelationTypeInOverlayProcess extends JavaProcess implements IProces
 		}
 
 		final MQuery mquery = candidates.get(0).getQuerySupplier().getQuery();
-		final String tableName = mquery.getZoomTableName();
+		String tableName = mquery.getZoomTableName();
+		if (tableName == null || tableName.isEmpty())
+		{
+			tableName = mquery.getTableName();
+		}
+		if (tableName == null || tableName.isEmpty())
+		{
+			throw new AdempiereException("Cannot resolve target table name from MQuery for relation type " + getRelationTypeId());
+		}
 		final String whereClause = mquery.getWhereClause(false);
 
 		if (Check.isBlank(whereClause))

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcess.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcess.java
@@ -183,7 +183,7 @@ public class RelationTypeInOverlayProcess extends JavaProcess implements IProces
 		}
 
 		final MQuery mquery = candidates.get(0).getQuerySupplier().getQuery();
-		final String tableName = mquery.getTableName();
+		final String tableName = mquery.getZoomTableName();
 		final String whereClause = mquery.getWhereClause(false);
 
 		if (Check.isBlank(whereClause))
@@ -200,6 +200,11 @@ public class RelationTypeInOverlayProcess extends JavaProcess implements IProces
 		final List<TableRecordReference> refs = recordIds.stream()
 				.map(id -> TableRecordReference.of(tableName, id))
 				.collect(Collectors.toList());
+
+		if (refs.isEmpty())
+		{
+			throw new AdempiereException(MSG_NO_RELATED_DOCS_FOUND);
+		}
 
 		getResult().setRecordsToOpen(refs);
 	}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcess.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcess.java
@@ -26,6 +26,7 @@ package de.metas.ui.web.view.process;
 import com.google.common.collect.ImmutableSet;
 import de.metas.document.references.related_documents.IZoomSource;
 import de.metas.document.references.related_documents.POZoomSource;
+import de.metas.document.references.related_documents.RelatedDocumentsCandidate;
 import de.metas.document.references.related_documents.RelatedDocumentsCandidateGroup;
 import de.metas.document.references.related_documents.RelatedDocumentsId;
 import de.metas.document.references.related_documents.relation_type.RelationTypeId;
@@ -34,6 +35,7 @@ import de.metas.process.IProcessPrecondition;
 import de.metas.process.IProcessPreconditionsContext;
 import de.metas.process.JavaProcess;
 import de.metas.process.ProcessExecutionResult;
+import de.metas.process.ProcessOpenTarget;
 import de.metas.process.ProcessPreconditionsResolution;
 import de.metas.ui.web.document.references.WebuiDocumentReferenceId;
 import de.metas.ui.web.view.CreateViewRequest;
@@ -44,24 +46,33 @@ import de.metas.ui.web.view.json.JSONViewDataType;
 import de.metas.ui.web.window.datatypes.DocumentPath;
 import de.metas.ui.web.window.datatypes.WindowId;
 import de.metas.util.Check;
+import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.impl.TypedSqlQueryFilter;
 import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.GenericPO;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.SpringContextHolder;
+import org.compiere.model.MQuery;
 import org.compiere.model.PO;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static de.metas.ui.web.view.SqlViewFactory.MSG_NO_RELATED_DOCS_FOUND;
 
 /**
- * Process implementation for opening related documents in an overlay window (as grid view).
+ * Process implementation for opening related documents via an AD_RelationType.
  * <p>
- * This process is automatically assigned when a process has Type = 'RelationTypeInOverlay'.
- * It retrieves related documents based on the configured AD_RelationType_ID and displays them in a modal overlay.
+ * The display mode is configured per AD_Process via {@code AD_Process.OpenTarget}
+ * (see {@link ProcessOpenTarget}): modal overlay (default — historical behaviour
+ * when the column is NULL), new browser tab, or in-place navigation to the related
+ * records.
+ * <p>
+ * This process is automatically assigned when AD_Process.Type='RelationTypeInOverlay'.
  */
 public class RelationTypeInOverlayProcess extends JavaProcess implements IProcessPrecondition
 {
@@ -129,12 +140,68 @@ public class RelationTypeInOverlayProcess extends JavaProcess implements IProces
 
 		final RelatedDocumentsCandidateGroup firstGroup = relatedDocumentGroups.get(0);
 
-		final IView popupView = createView(recordRef, WindowId.of(firstGroup.getTargetWindowId()));
+		final ProcessOpenTarget openTarget = getProcessInfo().getOpenTarget() != null
+				? getProcessInfo().getOpenTarget()
+				: ProcessOpenTarget.ModalOverlay;
 
-		getResult().setWebuiViewToOpen(
-				ProcessExecutionResult.WebuiViewToOpen.modalOverlay(popupView.getViewId().getViewId()));
+		switch (openTarget)
+		{
+			case InPlace:
+				openInPlace(firstGroup);
+				break;
+			case NewBrowserTab:
+				openAsView(recordRef, firstGroup, ProcessExecutionResult.ViewOpenTarget.NewBrowserTab);
+				break;
+			case ModalOverlay:
+			default:
+				openAsView(recordRef, firstGroup, ProcessExecutionResult.ViewOpenTarget.ModalOverlay);
+				break;
+		}
 
 		return MSG_OK;
+	}
+
+	private void openAsView(
+			@NonNull final TableRecordReference recordRef,
+			@NonNull final RelatedDocumentsCandidateGroup firstGroup,
+			@NonNull final ProcessExecutionResult.ViewOpenTarget viewOpenTarget)
+	{
+		final IView popupView = createView(recordRef, WindowId.of(firstGroup.getTargetWindowId()));
+		getResult().setWebuiViewToOpen(
+				ProcessExecutionResult.WebuiViewToOpen.builder()
+						.viewId(popupView.getViewId().getViewId())
+						.target(viewOpenTarget)
+						.build());
+	}
+
+	private void openInPlace(@NonNull final RelatedDocumentsCandidateGroup firstGroup)
+	{
+		final List<RelatedDocumentsCandidate> candidates = firstGroup.getCandidates();
+		if (candidates.isEmpty())
+		{
+			throw new AdempiereException(MSG_NO_RELATED_DOCS_FOUND);
+		}
+
+		final MQuery mquery = candidates.get(0).getQuerySupplier().getQuery();
+		final String tableName = mquery.getTableName();
+		final String whereClause = mquery.getWhereClause(false);
+
+		if (Check.isBlank(whereClause))
+		{
+			throw new AdempiereException(MSG_NO_RELATED_DOCS_FOUND);
+		}
+
+		final List<Integer> recordIds = Services.get(IQueryBL.class)
+				.createQueryBuilder(tableName)
+				.filter(TypedSqlQueryFilter.of(whereClause))
+				.create()
+				.listIds();
+
+		final List<TableRecordReference> refs = recordIds.stream()
+				.map(id -> TableRecordReference.of(tableName, id))
+				.collect(Collectors.toList());
+
+		getResult().setRecordsToOpen(refs);
 	}
 
 	protected IZoomSource createZoomSource(@NonNull final TableRecordReference recordRef)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcess.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcess.java
@@ -66,8 +66,7 @@ import static de.metas.ui.web.view.SqlViewFactory.MSG_NO_RELATED_DOCS_FOUND;
  * <p>
  * The display mode is configured per AD_Process via {@code AD_Process.OpenTarget}
  * (see {@link ProcessOpenTarget}): modal overlay (default — historical behaviour
- * when the column is NULL), new browser tab, or in-place navigation to the related
- * records.
+ * when the column is NULL) or new browser tab.
  * <p>
  * This process is automatically assigned when AD_Process.Type='RelationTypeInOverlay'.
  */
@@ -156,6 +155,7 @@ public class RelationTypeInOverlayProcess extends JavaProcess implements IProces
 		}
 		else
 		{
+			// Defensive fallback for any future ProcessOpenTarget value not yet mapped here — unreachable with current values
 			log.warn("Unknown processOpenTarget {}. Returning {}", processOpenTarget, ViewOpenTarget.ModalOverlay);
 			return ViewOpenTarget.ModalOverlay;
 		}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcess.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcess.java
@@ -24,9 +24,9 @@
 package de.metas.ui.web.view.process;
 
 import com.google.common.collect.ImmutableSet;
+import de.metas.common.util.CoalesceUtil;
 import de.metas.document.references.related_documents.IZoomSource;
 import de.metas.document.references.related_documents.POZoomSource;
-import de.metas.document.references.related_documents.RelatedDocumentsCandidate;
 import de.metas.document.references.related_documents.RelatedDocumentsCandidateGroup;
 import de.metas.document.references.related_documents.RelatedDocumentsId;
 import de.metas.document.references.related_documents.relation_type.RelationTypeId;
@@ -34,33 +34,30 @@ import de.metas.document.references.related_documents.relation_type.RelationType
 import de.metas.process.IProcessPrecondition;
 import de.metas.process.IProcessPreconditionsContext;
 import de.metas.process.JavaProcess;
-import de.metas.process.ProcessExecutionResult;
+import de.metas.process.ProcessExecutionResult.ViewOpenTarget;
+import de.metas.process.ProcessExecutionResult.WebuiViewToOpen;
 import de.metas.process.ProcessOpenTarget;
 import de.metas.process.ProcessPreconditionsResolution;
 import de.metas.ui.web.document.references.WebuiDocumentReferenceId;
 import de.metas.ui.web.view.CreateViewRequest;
 import de.metas.ui.web.view.IView;
 import de.metas.ui.web.view.IViewsRepository;
+import de.metas.ui.web.view.ViewId;
 import de.metas.ui.web.view.ViewsRepository;
 import de.metas.ui.web.view.json.JSONViewDataType;
 import de.metas.ui.web.window.datatypes.DocumentPath;
 import de.metas.ui.web.window.datatypes.WindowId;
 import de.metas.util.Check;
-import de.metas.util.Services;
 import lombok.NonNull;
-import org.adempiere.ad.dao.IQueryBL;
-import org.adempiere.ad.dao.impl.TypedSqlQueryFilter;
 import org.adempiere.ad.element.api.AdWindowId;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.GenericPO;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.SpringContextHolder;
-import org.compiere.model.MQuery;
 import org.compiere.model.PO;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static de.metas.ui.web.view.SqlViewFactory.MSG_NO_RELATED_DOCS_FOUND;
 
@@ -139,82 +136,29 @@ public class RelationTypeInOverlayProcess extends JavaProcess implements IProces
 		}
 
 		final RelatedDocumentsCandidateGroup firstGroup = relatedDocumentGroups.get(0);
+		final ViewId viewId = createView(recordRef, WindowId.of(firstGroup.getTargetWindowId())).getViewId();
 
-		final ProcessOpenTarget openTarget = getProcessInfo().getOpenTarget() != null
-				? getProcessInfo().getOpenTarget()
-				: ProcessOpenTarget.ModalOverlay;
-
-		switch (openTarget)
-		{
-			case InPlace:
-				openInPlace(firstGroup);
-				break;
-			case NewBrowserTab:
-				openAsView(recordRef, firstGroup, ProcessExecutionResult.ViewOpenTarget.NewBrowserTab);
-				break;
-			case ModalOverlay:
-			default:
-				openAsView(recordRef, firstGroup, ProcessExecutionResult.ViewOpenTarget.ModalOverlay);
-				break;
-		}
+		getResult().setWebuiViewToOpen(WebuiViewToOpen.builder().viewId(viewId.getViewId()).target(getOpenTarget()).build());
 
 		return MSG_OK;
 	}
 
-	private void openAsView(
-			@NonNull final TableRecordReference recordRef,
-			@NonNull final RelatedDocumentsCandidateGroup firstGroup,
-			@NonNull final ProcessExecutionResult.ViewOpenTarget viewOpenTarget)
+	private ViewOpenTarget getOpenTarget()
 	{
-		final IView popupView = createView(recordRef, WindowId.of(firstGroup.getTargetWindowId()));
-		getResult().setWebuiViewToOpen(
-				ProcessExecutionResult.WebuiViewToOpen.builder()
-						.viewId(popupView.getViewId().getViewId())
-						.target(viewOpenTarget)
-						.build());
-	}
-
-	private void openInPlace(@NonNull final RelatedDocumentsCandidateGroup firstGroup)
-	{
-		final List<RelatedDocumentsCandidate> candidates = firstGroup.getCandidates();
-		if (candidates.isEmpty())
+		final ProcessOpenTarget processOpenTarget = CoalesceUtil.coalesce(getProcessInfo().getOpenTarget(), ProcessOpenTarget.ModalOverlay);
+		if (processOpenTarget == ProcessOpenTarget.NewBrowserTab)
 		{
-			throw new AdempiereException(MSG_NO_RELATED_DOCS_FOUND);
+			return ViewOpenTarget.NewBrowserTab;
 		}
-
-		final MQuery mquery = candidates.get(0).getQuerySupplier().getQuery();
-		String tableName = mquery.getZoomTableName();
-		if (tableName == null || tableName.isEmpty())
+		else if (processOpenTarget == ProcessOpenTarget.ModalOverlay)
 		{
-			tableName = mquery.getTableName();
+			return ViewOpenTarget.ModalOverlay;
 		}
-		if (tableName == null || tableName.isEmpty())
+		else
 		{
-			throw new AdempiereException("Cannot resolve target table name from MQuery for relation type " + getRelationTypeId());
+			log.warn("Unknown processOpenTarget {}. Returning {}", processOpenTarget, ViewOpenTarget.ModalOverlay);
+			return ViewOpenTarget.ModalOverlay;
 		}
-		final String whereClause = mquery.getWhereClause(false);
-
-		if (Check.isBlank(whereClause))
-		{
-			throw new AdempiereException(MSG_NO_RELATED_DOCS_FOUND);
-		}
-
-		final List<Integer> recordIds = Services.get(IQueryBL.class)
-				.createQueryBuilder(tableName)
-				.filter(TypedSqlQueryFilter.of(whereClause))
-				.create()
-				.listIds();
-
-		final List<TableRecordReference> refs = recordIds.stream()
-				.map(id -> TableRecordReference.of(tableName, id))
-				.collect(Collectors.toList());
-
-		if (refs.isEmpty())
-		{
-			throw new AdempiereException(MSG_NO_RELATED_DOCS_FOUND);
-		}
-
-		getResult().setRecordsToOpen(refs);
 	}
 
 	protected IZoomSource createZoomSource(@NonNull final TableRecordReference recordRef)

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcessTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcessTest.java
@@ -12,7 +12,9 @@ import de.metas.document.references.related_documents.relation_type.SpecificRela
 import de.metas.i18n.TranslatableStrings;
 import de.metas.process.IADProcessDAO;
 import de.metas.process.IProcessPreconditionsContext;
+import de.metas.process.ProcessExecutionResult;
 import de.metas.process.ProcessInfo;
+import de.metas.process.ProcessOpenTarget;
 import de.metas.process.ProcessPreconditionsResolution;
 import de.metas.ui.web.view.IView;
 import de.metas.ui.web.view.IViewsRepository;
@@ -27,6 +29,7 @@ import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.util.Env;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
@@ -169,6 +172,88 @@ class RelationTypeInOverlayProcessTest
 					.hasMessageContaining("No AD_Process.AD_RelationType_ID defined");
 		}
 
+		@Test
+		void doIt_whenOpenTargetIsNull_opensModalOverlay()
+		{
+			final RelationTypeId relationTypeId = RelationTypeId.ofRepoId(42);
+			final SpecificRelationTypeRelatedDocumentsProvider provider = mock(SpecificRelationTypeRelatedDocumentsProvider.class);
+			final RelatedDocumentsCandidateGroup group = buildCandidateGroupWithOneEntry(WindowId.of(AdWindowId.ofRepoId(200)));
+			final IView mockView = mock(IView.class);
+
+			when(providerFactory.findRelatedDocumentsProvider(eq(relationTypeId)))
+					.thenReturn(Optional.of(provider));
+			when(provider.retrieveRelatedDocumentsCandidates(any(), any()))
+					.thenReturn(ImmutableList.of(group));
+			when(viewsRepo.createView(any())).thenReturn(mockView);
+			when(mockView.getViewId()).thenReturn(ViewId.ofViewIdString("200-someViewId"));
+
+			// No .setOpenTarget(...) → ProcessInfo.openTarget is null → should default to ModalOverlay
+			final RelationTypeInOverlayProcess process = buildProcess(providerFactory, viewsRepo, relationTypeId);
+			process.doIt();
+
+			assertThat(process.getResult().getWebuiViewToOpen()).isNotNull();
+			assertThat(process.getResult().getWebuiViewToOpen().getTarget())
+					.isEqualTo(ProcessExecutionResult.ViewOpenTarget.ModalOverlay);
+		}
+
+		@Test
+		void doIt_whenOpenTargetIsO_opensModalOverlay()
+		{
+			final RelationTypeId relationTypeId = RelationTypeId.ofRepoId(42);
+			final SpecificRelationTypeRelatedDocumentsProvider provider = mock(SpecificRelationTypeRelatedDocumentsProvider.class);
+			final RelatedDocumentsCandidateGroup group = buildCandidateGroupWithOneEntry(WindowId.of(AdWindowId.ofRepoId(200)));
+			final IView mockView = mock(IView.class);
+
+			when(providerFactory.findRelatedDocumentsProvider(eq(relationTypeId)))
+					.thenReturn(Optional.of(provider));
+			when(provider.retrieveRelatedDocumentsCandidates(any(), any()))
+					.thenReturn(ImmutableList.of(group));
+			when(viewsRepo.createView(any())).thenReturn(mockView);
+			when(mockView.getViewId()).thenReturn(ViewId.ofViewIdString("200-someViewId"));
+
+			final RelationTypeInOverlayProcess process = buildProcess(providerFactory, viewsRepo, relationTypeId, ProcessOpenTarget.ModalOverlay);
+			process.doIt();
+
+			assertThat(process.getResult().getWebuiViewToOpen()).isNotNull();
+			assertThat(process.getResult().getWebuiViewToOpen().getTarget())
+					.isEqualTo(ProcessExecutionResult.ViewOpenTarget.ModalOverlay);
+		}
+
+		@Test
+		void doIt_whenOpenTargetIsN_opensInNewBrowserTab()
+		{
+			final RelationTypeId relationTypeId = RelationTypeId.ofRepoId(42);
+			final SpecificRelationTypeRelatedDocumentsProvider provider = mock(SpecificRelationTypeRelatedDocumentsProvider.class);
+			final RelatedDocumentsCandidateGroup group = buildCandidateGroupWithOneEntry(WindowId.of(AdWindowId.ofRepoId(200)));
+			final IView mockView = mock(IView.class);
+
+			when(providerFactory.findRelatedDocumentsProvider(eq(relationTypeId)))
+					.thenReturn(Optional.of(provider));
+			when(provider.retrieveRelatedDocumentsCandidates(any(), any()))
+					.thenReturn(ImmutableList.of(group));
+			when(viewsRepo.createView(any())).thenReturn(mockView);
+			when(mockView.getViewId()).thenReturn(ViewId.ofViewIdString("200-someViewId"));
+
+			final RelationTypeInOverlayProcess process = buildProcess(providerFactory, viewsRepo, relationTypeId, ProcessOpenTarget.NewBrowserTab);
+			process.doIt();
+
+			assertThat(process.getResult().getWebuiViewToOpen()).isNotNull();
+			assertThat(process.getResult().getWebuiViewToOpen().getTarget())
+					.isEqualTo(ProcessExecutionResult.ViewOpenTarget.NewBrowserTab);
+		}
+
+		@Test
+		@Disabled("blocked: openInPlace calls IQueryBL.createQueryBuilder(tableName) which requires a real DB or full POJO table registration; branch-dispatch is verified by the other 3 tests; covered by integration smoke in Phase B")
+		void doIt_whenOpenTargetIsR_callsSetRecordsToOpen()
+		{
+			// Intentionally left empty — see @Disabled reason above.
+			// When IQueryBL POJO support for dynamic table names is available, implement:
+			//   - Build ProcessInfo with .setOpenTarget(ProcessOpenTarget.InPlace)
+			//   - Mock querySupplier to return an MQuery with tableName + non-blank whereClause
+			//   - Assert: process.getResult().getWebuiViewToOpen() == null
+			//   - Assert: process.getResult().getRecordsToOpen() != null
+		}
+
 		// --- helpers ---
 
 		private RelationTypeInOverlayProcess buildProcess(
@@ -176,12 +261,22 @@ class RelationTypeInOverlayProcessTest
 				final IViewsRepository viewsRepo,
 				final RelationTypeId relationTypeId)
 		{
+			return buildProcess(factory, viewsRepo, relationTypeId, null);
+		}
+
+		private RelationTypeInOverlayProcess buildProcess(
+				final RelationTypeRelatedDocumentsProvidersFactory factory,
+				final IViewsRepository viewsRepo,
+				final RelationTypeId relationTypeId,
+				final ProcessOpenTarget openTarget)
+		{
 			final ProcessInfo processInfo = ProcessInfo.builder()
 					.setCtx(Env.getCtx())
 					.setAD_Process_ID(1)
 					.setRecord(TableRecordReference.of("C_Order", 101))
 					.setAdWindowId(AdWindowId.ofRepoId(100))
 					.setAdRelationTypeId(relationTypeId)
+					.setOpenTarget(openTarget)
 					.build();
 
 			final IZoomSource mockZoomSource = mock(IZoomSource.class);

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcessTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/view/process/RelationTypeInOverlayProcessTest.java
@@ -29,7 +29,6 @@ import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.util.Env;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
@@ -240,18 +239,6 @@ class RelationTypeInOverlayProcessTest
 			assertThat(process.getResult().getWebuiViewToOpen()).isNotNull();
 			assertThat(process.getResult().getWebuiViewToOpen().getTarget())
 					.isEqualTo(ProcessExecutionResult.ViewOpenTarget.NewBrowserTab);
-		}
-
-		@Test
-		@Disabled("blocked: openInPlace calls IQueryBL.createQueryBuilder(tableName) which requires a real DB or full POJO table registration; branch-dispatch is verified by the other 3 tests; covered by integration smoke in Phase B")
-		void doIt_whenOpenTargetIsR_callsSetRecordsToOpen()
-		{
-			// Intentionally left empty — see @Disabled reason above.
-			// When IQueryBL POJO support for dynamic table names is available, implement:
-			//   - Build ProcessInfo with .setOpenTarget(ProcessOpenTarget.InPlace)
-			//   - Mock querySupplier to return an MQuery with tableName + non-blank whereClause
-			//   - Assert: process.getResult().getWebuiViewToOpen() == null
-			//   - Assert: process.getResult().getRecordsToOpen() != null
 		}
 
 		// --- helpers ---


### PR DESCRIPTION
## Summary

Generalises `RelationTypeInOverlayProcess` so the open-target UX is **configurable per `AD_Process`** instead of hard-coded to modal overlay.

### What changed
- **New `AD_Process.OpenTarget`** — nullable `CHAR(1)`, backed by new `ProcessOpenTarget` reference list:
  - `O` — Modal Overlay (historical behaviour; also the fallback when the column is `NULL`)
  - `N` — New browser tab
- **New enum** `de.metas.process.ProcessOpenTarget` (`ReferenceListAwareEnum`).
- **`ProcessInfo.getOpenTarget()`** wired via the standard `ProcessInfoBuilder.setAD_Process(...)` path.
- **`RelationTypeInOverlayProcess.doIt()`** builds the related-docs view once and opens it with the configured `ViewOpenTarget` (`CoalesceUtil.coalesce(openTarget, ModalOverlay)` fallback; `log.warn` + default on unknown value).
- Existing relation-type-overlay behaviour is unchanged for any process that leaves `OpenTarget` `NULL`.

### Scope notes
- An `InPlace` (`R`) option was prototyped and **removed during QA** — not needed, added complexity. Only `O` + `N` ship.
- This PR is the **framework only**. The first consumer (a "Jump to Purchase Candidates" quick-action on the Purchase Cockpit, view `RV_PurchaseCockpit`) ships in a follow-up PR.

## Test plan
- [x] Migration applies cleanly (CI `db-apply-migrations` green)
- [x] Unit tests: `OpenTarget`=`null` → ModalOverlay (regression), `O` → ModalOverlay, `N` → NewBrowserTab
- [x] Full CI green (java, cucumber, frontend, mobile, migration)
- [x] Manual framework smoke recipe documented (throwaway test process on an existing relation type with `OpenTarget='N'`)
