### PR TITLE
Tax Declaration — filter C_DocType_ID dropdown to DocBaseType='TXD'

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5804690_TaxDeclaration_C_DocType_ID_ValRule.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5804690_TaxDeclaration_C_DocType_ID_ValRule.sql
@@ -1,0 +1,18 @@
+-- Tax Declaration — filter C_DocType_ID dropdown to DocBaseType='TXD'
+-- Caught during UAT walkthrough on https://danthermuat.metasfresh.com: the
+-- "Belegart" / "Document Type" field on the Tax Declaration header tab
+-- (AD_Field=780485 / AD_Column=592580 on AD_Table=C_TaxDeclaration) was rendering
+-- every C_DocType row instead of only Tax Declaration doctypes. Same pattern
+-- as existing AD_Val_Rule rows 102 (GL Journals), 121 (GL Documents),
+-- 125 (Shipments/Receipts), 126 (AR Pro Forma): one rule per DocBaseType.
+
+INSERT INTO AD_Val_Rule (AD_Val_Rule_ID, AD_Client_ID, AD_Org_ID, IsActive,
+    Created, CreatedBy, Updated, UpdatedBy,
+    Name, Type, Code, EntityType)
+VALUES (540789 /*From ID Server*/, 0, 0, 'Y',
+    TIMESTAMP '2026-05-26 00:00:00', 100, TIMESTAMP '2026-05-26 00:00:00', 100,
+    'C_DocType Tax Declaration', 'S', 'C_DocType.DocBaseType=''TXD''', 'de.metas.acct');
+
+UPDATE AD_Column SET AD_Val_Rule_ID = 540789,
+    Updated = TIMESTAMP '2026-05-26 00:00:01', UpdatedBy = 100
+WHERE AD_Column_ID = 592580;


### PR DESCRIPTION
## Summary

Filters the `C_DocType_ID` dropdown on the Tax Declaration header tab so it shows ONLY doctypes with `DocBaseType='TXD'` (Tax Declaration), not every doctype in the system.

## Background

Caught during UAT walkthrough on https://danthermuat.metasfresh.com — the **Belegart** / **Document Type** field added by PR https://github.com/metasfresh/metasfresh/pull/24256 was working but unfiltered, listing every `C_DocType` row. The standard pattern in metasfresh is one `AD_Val_Rule` per `DocBaseType`, attached via `AD_Column.AD_Val_Rule_ID`. Existing precedents I mirrored: `AD_Val_Rule_ID=102` (GLJ), `121` (GLD), `125` (MMR/MMS), `126` (ARF).

## Changes

1. New `AD_Val_Rule` (`540789`, name `C_DocType Tax Declaration`, `Type='S'`, `Code=C_DocType.DocBaseType='TXD'`, `EntityType=de.metas.acct`).
2. `UPDATE AD_Column SET AD_Val_Rule_ID = 540789 WHERE AD_Column_ID = 592580` (the `C_TaxDeclaration.C_DocType_ID` column).

## Verification

Applied locally on `deep_tundra_uat`. `AD_Column 592580` now references `AD_Val_Rule 540789`. After deploy, the dropdown on the Tax Declaration header tab should only show the single TXD doctype (created by integrated migration `5803910` from PR https://github.com/metasfresh/metasfresh/pull/24064).

## Test plan

- [ ] After merge + dt204 cascade, open Tax Declaration window on UAT — `Belegart` dropdown now shows only doctypes with `DocBaseType='TXD'`.
