### PR TITLE
Tax Declaration — fix C_DocType + AD_Ref_List TXD translations

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5804770_TaxDeclaration_C_DocType_AD_Ref_List_TXD_translations.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5804770_TaxDeclaration_C_DocType_AD_Ref_List_TXD_translations.sql
@@ -1,0 +1,55 @@
+-- Tax Declaration translations:
+--   * C_DocType row with DocBaseType='TXD' (C_DocType_ID=541176) — Name/PrintName: base = de_DE = 'Steuererklärung', en_*/en_US = 'Tax Declaration'.
+--   * AD_Ref_List entry for DocBaseType (AD_Reference_ID=183) with Value='TXD' (AD_Ref_List_ID=544233) — same convention.
+-- Base language is de_DE. Per-language trl rows are explicit overrides.
+
+-- ===== C_DocType (TXD) =====
+
+UPDATE C_DocType
+SET Name='Steuererklärung',
+    PrintName='Steuererklärung',
+    Updated=TIMESTAMP '2026-05-26 00:00:00',
+    UpdatedBy=99
+WHERE DocBaseType='TXD';
+
+UPDATE C_DocType_Trl
+SET Name='Steuererklärung',
+    PrintName='Steuererklärung',
+    IsTranslated='Y',
+    Updated=TIMESTAMP '2026-05-26 00:00:00',
+    UpdatedBy=99
+WHERE C_DocType_ID=(SELECT C_DocType_ID FROM C_DocType WHERE DocBaseType='TXD')
+  AND AD_Language IN ('de_DE','de_CH');
+
+UPDATE C_DocType_Trl
+SET Name='Tax Declaration',
+    PrintName='Tax Declaration',
+    IsTranslated='Y',
+    Updated=TIMESTAMP '2026-05-26 00:00:00',
+    UpdatedBy=99
+WHERE C_DocType_ID=(SELECT C_DocType_ID FROM C_DocType WHERE DocBaseType='TXD')
+  AND AD_Language IN ('en_US','en_GB');
+
+-- ===== AD_Ref_List DocBaseType=TXD (AD_Reference_ID=183, Value='TXD') =====
+
+UPDATE AD_Ref_List
+SET Name='Steuererklärung',
+    Updated=TIMESTAMP '2026-05-26 00:00:00',
+    UpdatedBy=99
+WHERE AD_Reference_ID=183 AND Value='TXD';
+
+UPDATE AD_Ref_List_Trl
+SET Name='Steuererklärung',
+    IsTranslated='Y',
+    Updated=TIMESTAMP '2026-05-26 00:00:00',
+    UpdatedBy=99
+WHERE AD_Ref_List_ID=(SELECT AD_Ref_List_ID FROM AD_Ref_List WHERE AD_Reference_ID=183 AND Value='TXD')
+  AND AD_Language IN ('de_DE','de_CH');
+
+UPDATE AD_Ref_List_Trl
+SET Name='Tax Declaration',
+    IsTranslated='Y',
+    Updated=TIMESTAMP '2026-05-26 00:00:00',
+    UpdatedBy=99
+WHERE AD_Ref_List_ID=(SELECT AD_Ref_List_ID FROM AD_Ref_List WHERE AD_Reference_ID=183 AND Value='TXD')
+  AND AD_Language IN ('en_US','en_GB');


### PR DESCRIPTION
Fixes translation rows for the Tax Declaration document type so they follow the metasfresh convention (de_DE = base language, en_US/de_CH/en_GB as explicit Trl overrides).

Before: both `C_DocType` and `AD_Ref_List` (AD_Reference_ID=183, Value=`TXD`) had `Name='Tax Declaration'` in **all** languages including de_DE, with `IsTranslated='N'` everywhere.

After:
- `C_DocType.Name` / `PrintName` = `Steuererklärung` (base = de_DE)
- `C_DocType_Trl[de_DE,de_CH]` = `Steuererklärung`, `IsTranslated='Y'`
- `C_DocType_Trl[en_US,en_GB]` = `Tax Declaration`, `IsTranslated='Y'`
- `AD_Ref_List.Name` = `Steuererklärung`
- `AD_Ref_List_Trl` set the same way

Discovered during UAT walkthrough of https://danthermuat.metasfresh.com.