### PR TITLE
DD_Order mobileUI — add 'Lagerort leer' button to switch pick-from locator to next active

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804780_sys_AD_Message_DDOrder_SwitchPickFromLocator.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804780_sys_AD_Message_DDOrder_SwitchPickFromLocator.sql
@@ -18,8 +18,9 @@ INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,E
 VALUES (0,545723 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-26 18:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Lagerort leer kann nicht mehr genutzt werden, sobald die Kommissionierung begonnen hat.','E',TO_TIMESTAMP('2026-05-26 18:00:00','YYYY-MM-DD HH24:MI:SS'),100,'MobileUI_DDOrder_SwitchPickFromLocator_NotAvailable')
 ;
 
+-- AD_Message.ErrorCode is varchar(40); use a shorter form (the full key lives in AD_Message.Value).
 -- 2026-05-26T18:00:01.000Z
-UPDATE AD_Message SET ErrorCode='MobileUI_DDOrder_SwitchPickFromLocator_NotAvailable', Updated=TO_TIMESTAMP('2026-05-26 18:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545723 /*From ID Server*/
+UPDATE AD_Message SET ErrorCode='SwitchPickFromLocator_NotAvailable', Updated=TO_TIMESTAMP('2026-05-26 18:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545723 /*From ID Server*/
 ;
 
 -- Seed AD_Message_Trl for every active system language using the base (DE) text.
@@ -55,7 +56,7 @@ VALUES (0,545724 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-26 18:00:06','YYYY-M
 ;
 
 -- 2026-05-26T18:00:07.000Z
-UPDATE AD_Message SET ErrorCode='MobileUI_DDOrder_SwitchPickFromLocator_NoAlternative', Updated=TO_TIMESTAMP('2026-05-26 18:00:07','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545724 /*From ID Server*/
+UPDATE AD_Message SET ErrorCode='SwitchPickFromLocator_NoAlternative', Updated=TO_TIMESTAMP('2026-05-26 18:00:07','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545724 /*From ID Server*/
 ;
 
 -- Seed AD_Message_Trl for every active system language using the base (DE) text.

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804780_sys_AD_Message_DDOrder_SwitchPickFromLocator.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804780_sys_AD_Message_DDOrder_SwitchPickFromLocator.sql
@@ -1,0 +1,82 @@
+-- AD_Message keys for the DD_Order mobileUI "Lagerort leer" (switch pick-from locator) button.
+-- Two error keys are added: one for "not available" (button pressed when picking already started or
+-- when lines have diverging locators — defensive, normally hidden by canSwitchPickFromLocator)
+-- and one for "no alternative locator available" (warehouse has zero or only one active locator).
+
+-- AD_Message base text is in German (DE).
+-- Rationale: most users are German-speakers. If a translation is missing or broken, the
+-- fallback (AD_Message.MsgText) should show German to German users — better to show DE
+-- to EN users (mostly developers) than EN to DE users.
+-- en_US translation is provided via the AD_Message_Trl override below.
+
+-- =============================================================================
+-- Message #1: MobileUI_DDOrder_SwitchPickFromLocator_NotAvailable
+-- =============================================================================
+
+-- 2026-05-26T18:00:00.000Z
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545723 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-26 18:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Lagerort leer kann nicht mehr genutzt werden, sobald die Kommissionierung begonnen hat.','E',TO_TIMESTAMP('2026-05-26 18:00:00','YYYY-MM-DD HH24:MI:SS'),100,'MobileUI_DDOrder_SwitchPickFromLocator_NotAvailable')
+;
+
+-- 2026-05-26T18:00:01.000Z
+UPDATE AD_Message SET ErrorCode='MobileUI_DDOrder_SwitchPickFromLocator_NotAvailable', Updated=TO_TIMESTAMP('2026-05-26 18:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545723 /*From ID Server*/
+;
+
+-- Seed AD_Message_Trl for every active system language using the base (DE) text.
+-- 2026-05-26T18:00:02.000Z
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Message_ID=545723 /*From ID Server*/
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- Override en_US with the English translation.
+-- 2026-05-26T18:00:03.000Z
+UPDATE AD_Message_Trl SET MsgText='The ''Locator empty'' action is not available once picking has started.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-26 18:00:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545723 /*From ID Server*/
+;
+
+-- Mark de_DE and de_CH as actively translated (same text as base; flips IsTranslated to Y).
+-- 2026-05-26T18:00:04.000Z
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-26 18:00:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545723 /*From ID Server*/
+;
+
+-- 2026-05-26T18:00:05.000Z
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-26 18:00:05','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545723 /*From ID Server*/
+;
+
+-- =============================================================================
+-- Message #2: MobileUI_DDOrder_SwitchPickFromLocator_NoAlternative
+-- =============================================================================
+
+-- 2026-05-26T18:00:06.000Z
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545724 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-26 18:00:06','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Kein weiterer Lagerort verfügbar.','E',TO_TIMESTAMP('2026-05-26 18:00:06','YYYY-MM-DD HH24:MI:SS'),100,'MobileUI_DDOrder_SwitchPickFromLocator_NoAlternative')
+;
+
+-- 2026-05-26T18:00:07.000Z
+UPDATE AD_Message SET ErrorCode='MobileUI_DDOrder_SwitchPickFromLocator_NoAlternative', Updated=TO_TIMESTAMP('2026-05-26 18:00:07','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545724 /*From ID Server*/
+;
+
+-- Seed AD_Message_Trl for every active system language using the base (DE) text.
+-- 2026-05-26T18:00:08.000Z
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Message_ID=545724 /*From ID Server*/
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- Override en_US with the English translation.
+-- 2026-05-26T18:00:09.000Z
+UPDATE AD_Message_Trl SET MsgText='No alternative locator available.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-26 18:00:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545724 /*From ID Server*/
+;
+
+-- Mark de_DE and de_CH as actively translated (same text as base; flips IsTranslated to Y).
+-- 2026-05-26T18:00:10.000Z
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-26 18:00:10','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545724 /*From ID Server*/
+;
+
+-- 2026-05-26T18:00:11.000Z
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-26 18:00:11','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545724 /*From ID Server*/
+;

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/DistributionMobileApplication.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/DistributionMobileApplication.java
@@ -261,6 +261,12 @@ public class DistributionMobileApplication implements WorkflowBasedMobileApplica
 		return toWFProcess(job);
 	}
 
+	public WFProcess switchPickFromLocatorToNext(@NonNull final WFProcessId wfProcessId, @NonNull final UserId callerId)
+	{
+		final DistributionJob job = distributionRestService.switchPickFromLocatorToNext(DistributionJobId.ofWFProcessId(wfProcessId), callerId);
+		return toWFProcess(job);
+	}
+
 	public void printMaterialInTransitReport(@NonNull final UserId userId, @NonNull final String adLanguage)
 	{
 		distributionRestService.printMaterialInTransitReport(userId, adLanguage);

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/LocatorValueRoundRobinResolver.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/LocatorValueRoundRobinResolver.java
@@ -1,0 +1,76 @@
+package de.metas.distribution.mobileui.external_services.warehouse;
+
+import de.metas.i18n.AdMessageKey;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.warehouse.LocatorId;
+import org.adempiere.warehouse.WarehouseId;
+import org.adempiere.warehouse.api.IWarehouseDAO;
+import org.compiere.model.I_M_Locator;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class LocatorValueRoundRobinResolver implements NextPickFromLocatorResolver
+{
+	public static final AdMessageKey MSG_NO_ALTERNATIVE =
+			AdMessageKey.of("MobileUI_DDOrder_SwitchPickFromLocator_NoAlternative");
+
+	@Override
+	public @NonNull LocatorId resolveNext(@NonNull final WarehouseId warehouseId, @NonNull final LocatorId currentLocatorId)
+	{
+		final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
+
+		final List<I_M_Locator> allLocators = warehouseDAO.getLocators(warehouseId);
+
+		// Filter active only, sort by Value ascending (nulls last for safety)
+		final List<I_M_Locator> candidates = allLocators.stream()
+				.filter(I_M_Locator::isActive)
+				.sorted(Comparator.comparing(
+						l -> l.getValue() != null ? l.getValue() : "￿",
+						String::compareTo))
+				.collect(Collectors.toList());
+
+		if (candidates.isEmpty())
+		{
+			throw new AdempiereException(MSG_NO_ALTERNATIVE);
+		}
+
+		// Find index of currentLocatorId in the sorted candidates
+		int currentIdx = -1;
+		for (int i = 0; i < candidates.size(); i++)
+		{
+			final I_M_Locator candidate = candidates.get(i);
+			final LocatorId candidateId = LocatorId.ofRepoId(candidate.getM_Warehouse_ID(), candidate.getM_Locator_ID());
+			if (candidateId.equals(currentLocatorId))
+			{
+				currentIdx = i;
+				break;
+			}
+		}
+
+		// If currentLocatorId is NOT in the set → return the first candidate
+		if (currentIdx < 0)
+		{
+			return locatorId(candidates.get(0));
+		}
+
+		// If currentLocatorId IS the only candidate → throw
+		if (candidates.size() == 1)
+		{
+			throw new AdempiereException(MSG_NO_ALTERNATIVE);
+		}
+
+		// Otherwise return candidates[(idx+1) % size]
+		return locatorId(candidates.get((currentIdx + 1) % candidates.size()));
+	}
+
+	private static LocatorId locatorId(final I_M_Locator locator)
+	{
+		return LocatorId.ofRepoId(locator.getM_Warehouse_ID(), locator.getM_Locator_ID());
+	}
+}

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/LocatorValueRoundRobinResolver.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/LocatorValueRoundRobinResolver.java
@@ -1,11 +1,9 @@
 package de.metas.distribution.mobileui.external_services.warehouse;
 
-import de.metas.i18n.AdMessageKey;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.warehouse.LocatorId;
-import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.IWarehouseDAO;
 import org.compiere.model.I_M_Locator;
 import org.springframework.stereotype.Component;
@@ -17,17 +15,12 @@ import java.util.stream.Collectors;
 @Component
 public class LocatorValueRoundRobinResolver implements NextPickFromLocatorResolver
 {
-	static final AdMessageKey MSG_NO_ALTERNATIVE = AdMessageKey.of("MobileUI_DDOrder_SwitchPickFromLocator_NoAlternative");
-
 	@NonNull private final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
 
 	@Override
-	public @NonNull LocatorId resolveNext(@NonNull final WarehouseId warehouseId, @NonNull final LocatorId currentLocatorId)
+	public @NonNull LocatorId resolveNext(@NonNull final LocatorId currentLocatorId)
 	{
-		final List<I_M_Locator> allLocators = warehouseDAO.getLocators(warehouseId);
-
-		// Filter active only, sort by Value ascending (nulls last for safety)
-		final List<I_M_Locator> candidates = allLocators.stream()
+		final List<I_M_Locator> candidates = warehouseDAO.getLocators(currentLocatorId.getWarehouseId()).stream()
 				.filter(I_M_Locator::isActive)
 				.sorted(Comparator.comparing(I_M_Locator::getValue, Comparator.nullsLast(String::compareTo)))
 				.collect(Collectors.toList());
@@ -37,36 +30,28 @@ public class LocatorValueRoundRobinResolver implements NextPickFromLocatorResolv
 			throw new AdempiereException(MSG_NO_ALTERNATIVE);
 		}
 
-		// Find index of currentLocatorId in the sorted candidates
 		int currentIdx = -1;
 		for (int i = 0; i < candidates.size(); i++)
 		{
-			final I_M_Locator candidate = candidates.get(i);
-			final LocatorId candidateId = LocatorId.ofRepoId(candidate.getM_Warehouse_ID(), candidate.getM_Locator_ID());
-			if (candidateId.equals(currentLocatorId))
+			if (LocatorId.equals(locatorId(candidates.get(i)), currentLocatorId))
 			{
 				currentIdx = i;
 				break;
 			}
 		}
 
-		// If currentLocatorId is NOT in the set → return the first candidate
 		if (currentIdx < 0)
 		{
 			return locatorId(candidates.get(0));
 		}
-
-		// If currentLocatorId IS the only candidate → throw
 		if (candidates.size() == 1)
 		{
 			throw new AdempiereException(MSG_NO_ALTERNATIVE);
 		}
-
-		// Otherwise return candidates[(idx+1) % size]
 		return locatorId(candidates.get((currentIdx + 1) % candidates.size()));
 	}
 
-	private static LocatorId locatorId(final I_M_Locator locator)
+	private static LocatorId locatorId(@NonNull final I_M_Locator locator)
 	{
 		return LocatorId.ofRepoId(locator.getM_Warehouse_ID(), locator.getM_Locator_ID());
 	}

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/LocatorValueRoundRobinResolver.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/LocatorValueRoundRobinResolver.java
@@ -17,22 +17,19 @@ import java.util.stream.Collectors;
 @Component
 public class LocatorValueRoundRobinResolver implements NextPickFromLocatorResolver
 {
-	public static final AdMessageKey MSG_NO_ALTERNATIVE =
-			AdMessageKey.of("MobileUI_DDOrder_SwitchPickFromLocator_NoAlternative");
+	static final AdMessageKey MSG_NO_ALTERNATIVE = AdMessageKey.of("MobileUI_DDOrder_SwitchPickFromLocator_NoAlternative");
+
+	@NonNull private final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
 
 	@Override
 	public @NonNull LocatorId resolveNext(@NonNull final WarehouseId warehouseId, @NonNull final LocatorId currentLocatorId)
 	{
-		final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
-
 		final List<I_M_Locator> allLocators = warehouseDAO.getLocators(warehouseId);
 
 		// Filter active only, sort by Value ascending (nulls last for safety)
 		final List<I_M_Locator> candidates = allLocators.stream()
 				.filter(I_M_Locator::isActive)
-				.sorted(Comparator.comparing(
-						l -> l.getValue() != null ? l.getValue() : "￿",
-						String::compareTo))
+				.sorted(Comparator.comparing(I_M_Locator::getValue, Comparator.nullsLast(String::compareTo)))
 				.collect(Collectors.toList());
 
 		if (candidates.isEmpty())

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/NextPickFromLocatorResolver.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/NextPickFromLocatorResolver.java
@@ -1,0 +1,10 @@
+package de.metas.distribution.mobileui.external_services.warehouse;
+
+import org.adempiere.warehouse.LocatorId;
+import org.adempiere.warehouse.WarehouseId;
+import org.springframework.lang.NonNull;
+
+public interface NextPickFromLocatorResolver
+{
+	@NonNull LocatorId resolveNext(@NonNull WarehouseId warehouseId, @NonNull LocatorId currentLocatorId);
+}

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/NextPickFromLocatorResolver.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/NextPickFromLocatorResolver.java
@@ -1,8 +1,8 @@
 package de.metas.distribution.mobileui.external_services.warehouse;
 
+import lombok.NonNull;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
-import org.springframework.lang.NonNull;
 
 public interface NextPickFromLocatorResolver
 {

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/NextPickFromLocatorResolver.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/NextPickFromLocatorResolver.java
@@ -1,10 +1,12 @@
 package de.metas.distribution.mobileui.external_services.warehouse;
 
+import de.metas.i18n.AdMessageKey;
 import lombok.NonNull;
 import org.adempiere.warehouse.LocatorId;
-import org.adempiere.warehouse.WarehouseId;
 
 public interface NextPickFromLocatorResolver
 {
-	@NonNull LocatorId resolveNext(@NonNull WarehouseId warehouseId, @NonNull LocatorId currentLocatorId);
+	AdMessageKey MSG_NO_ALTERNATIVE = AdMessageKey.of("MobileUI_DDOrder_SwitchPickFromLocator_NoAlternative");
+
+	@NonNull LocatorId resolveNext(@NonNull LocatorId currentLocatorId);
 }

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/model/DistributionJob.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/model/DistributionJob.java
@@ -195,6 +195,17 @@ public class DistributionJob
 				.collect(GuavaCollectors.singleElementOrNull());
 	}
 
+	@NonNull
+	public LocatorId getSinglePickFromLocatorId()
+	{
+		final LocatorId locatorId = getSinglePickFromLocatorIdOrNull();
+		if (locatorId == null)
+		{
+			throw new AdempiereException("No single pick-from locator for " + this);
+		}
+		return locatorId;
+	}
+
 	public Optional<LocatorInfo> getSinglePickFromLocator()
 	{
 		return lines.stream()

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/model/DistributionJob.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/model/DistributionJob.java
@@ -203,6 +203,12 @@ public class DistributionJob
 				.collect(GuavaCollectors.singleElementOrEmpty());
 	}
 
+	public boolean canSwitchPickFromLocator()
+	{
+		return getSinglePickFromLocatorIdOrNull() != null
+				&& streamSteps().noneMatch(DistributionJobStep::isPickedFromLocator);
+	}
+
 	@Nullable
 	public LocatorId getSingleDropToLocatorIdOrNull()
 	{

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DistributionJobLoaderSupportingServices.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DistributionJobLoaderSupportingServices.java
@@ -94,6 +94,16 @@ public class DistributionJobLoaderSupportingServices
 				.collect(Collectors.groupingBy(ddOrderLine -> DDOrderId.ofRepoId(ddOrderLine.getDD_Order_ID()), Collectors.toList()));
 	}
 
+	public List<I_DD_OrderLine> retrieveLines(@NonNull final I_DD_Order ddOrder)
+	{
+		return ddOrderService.retrieveLines(ddOrder);
+	}
+
+	public void saveLine(@NonNull final I_DD_OrderLine ddOrderLine)
+	{
+		ddOrderService.saveLine(ddOrderLine);
+	}
+
 	public Map<DDOrderLineId, List<DDOrderMoveSchedule>> getSchedulesByDDOrderLineIds(final Set<DDOrderLineId> ddOrderLineIds)
 	{
 		if (ddOrderLineIds.isEmpty()) {return ImmutableMap.of();}

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DistributionRestService.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DistributionRestService.java
@@ -138,7 +138,6 @@ public class DistributionRestService
 				.trxManager(trxManager)
 				.loadingSupportServices(loadingSupportServices)
 				.nextLocatorResolver(nextPickFromLocatorResolver)
-				.ddOrderService(ddOrderService)
 				.jobId(jobId)
 				.build()
 				.execute();

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DistributionRestService.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DistributionRestService.java
@@ -10,6 +10,8 @@ import de.metas.distribution.mobileui.config.MobileUIDistributionConfigRepositor
 import de.metas.distribution.mobileui.external_services.hu.DistributionHUService;
 import de.metas.distribution.mobileui.external_services.product.DistributionProductService;
 import de.metas.distribution.mobileui.external_services.warehouse.DistributionWarehouseService;
+import de.metas.distribution.mobileui.external_services.warehouse.NextPickFromLocatorResolver;
+import de.metas.distribution.mobileui.job.service.commands.switch_pick_from_locator.DistributionJobSwitchPickFromLocatorCommand;
 import de.metas.distribution.mobileui.job.model.DistributionJob;
 import de.metas.distribution.mobileui.job.model.DistributionJobId;
 import de.metas.distribution.mobileui.job.model.DistributionJobLine;
@@ -53,6 +55,7 @@ public class DistributionRestService
 	@NonNull private final DistributionHUService huService;
 	@NonNull private final DistributionWarehouseService warehouseService;
 	@NonNull private final DistributionProductService productService;
+	@NonNull private final NextPickFromLocatorResolver nextPickFromLocatorResolver;
 
 	public MobileUIDistributionConfig getConfig() {return configRepository.getConfig();}
 
@@ -122,6 +125,23 @@ public class DistributionRestService
 	private DistributionJobLoader newLoader()
 	{
 		return new DistributionJobLoader(loadingSupportServices);
+	}
+
+	public DistributionJob switchPickFromLocatorToNext(
+			@NonNull final DistributionJobId jobId,
+			@NonNull final UserId callerId)
+	{
+		final DistributionJob job = getJobById(jobId);
+		job.assertCanEdit(callerId);
+
+		return DistributionJobSwitchPickFromLocatorCommand.builder()
+				.trxManager(trxManager)
+				.loadingSupportServices(loadingSupportServices)
+				.nextLocatorResolver(nextPickFromLocatorResolver)
+				.ddOrderService(ddOrderService)
+				.jobId(jobId)
+				.build()
+				.execute();
 	}
 
 	public DistributionJob processEvent(@NonNull final JsonDistributionEvent event, @NonNull final UserId callerId)

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/commands/switch_pick_from_locator/DistributionJobSwitchPickFromLocatorCommand.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/commands/switch_pick_from_locator/DistributionJobSwitchPickFromLocatorCommand.java
@@ -8,13 +8,11 @@ import de.metas.distribution.mobileui.job.model.DistributionJobId;
 import de.metas.distribution.mobileui.job.service.DistributionJobLoader;
 import de.metas.distribution.mobileui.job.service.DistributionJobLoaderSupportingServices;
 import de.metas.i18n.AdMessageKey;
-import de.metas.util.Check;
 import lombok.Builder;
 import lombok.NonNull;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.warehouse.LocatorId;
-import org.adempiere.warehouse.WarehouseId;
 import org.eevolution.model.I_DD_Order;
 import org.eevolution.model.I_DD_OrderLine;
 
@@ -61,18 +59,19 @@ public class DistributionJobSwitchPickFromLocatorCommand
 			throw new AdempiereException(MSG_NOT_AVAILABLE);
 		}
 
-		final LocatorId currentLocatorId = Check.assumeNotNull(
-				job.getSinglePickFromLocatorIdOrNull(),
-				"job.getSinglePickFromLocatorIdOrNull() is non-null because canSwitchPickFromLocator() was true");
-		final WarehouseId warehouseId = job.getPickFromWarehouse().getWarehouseId();
-		final LocatorId nextLocatorId = nextLocatorResolver.resolveNext(warehouseId, currentLocatorId);
+		final LocatorId currentLocatorId = job.getSinglePickFromLocatorId();
+		final LocatorId nextLocatorId = nextLocatorResolver.resolveNext(currentLocatorId);
 
 		final DDOrderId ddOrderId = jobId.toDDOrderId();
 		final I_DD_Order ddOrder = loadingSupportServices.getDDOrderById(ddOrderId);
 		final List<I_DD_OrderLine> lines = ddOrderService.retrieveLines(ddOrder);
 		for (final I_DD_OrderLine line : lines)
 		{
-			switchLinePickFromLocator(line, nextLocatorId);
+			// Resilience: only move lines that still sit on the locator we resolved the next one from.
+			if (LocatorId.equalsByRepoId(line.getM_Locator_ID(), currentLocatorId.getRepoId()))
+			{
+				switchLinePickFromLocator(line, nextLocatorId);
+			}
 		}
 
 		// Reload with a FRESH loader: the `loader` above cached the pre-switch lines in its instance-level

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/commands/switch_pick_from_locator/DistributionJobSwitchPickFromLocatorCommand.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/commands/switch_pick_from_locator/DistributionJobSwitchPickFromLocatorCommand.java
@@ -18,6 +18,7 @@ import org.adempiere.warehouse.WarehouseId;
 import org.eevolution.model.I_DD_Order;
 import org.eevolution.model.I_DD_OrderLine;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 public class DistributionJobSwitchPickFromLocatorCommand
@@ -71,10 +72,37 @@ public class DistributionJobSwitchPickFromLocatorCommand
 		final List<I_DD_OrderLine> lines = ddOrderService.retrieveLines(ddOrder);
 		for (final I_DD_OrderLine line : lines)
 		{
-			line.setM_Locator_ID(nextLocatorId.getRepoId());
-			ddOrderService.saveLine(line);
+			switchLinePickFromLocator(line, nextLocatorId);
 		}
 
-		return loader.loadByJobId(jobId);
+		// Reload with a FRESH loader: the `loader` above cached the pre-switch lines in its instance-level
+		// ddOrderLinesCache, so reusing it would return the old M_Locator_ID and the mobile UI would not reflect
+		// the switch (even though the DB is correctly updated).
+		return new DistributionJobLoader(loadingSupportServices).loadByJobId(jobId);
+	}
+
+	/**
+	 * Move the line's pick-from locator to {@code nextLocatorId}, carrying the (legacy, locator-level) reservation along.
+	 * <p>
+	 * {@code MDDOrderLine.beforeSave} forbids changing {@code M_Locator_ID} while {@code QtyReserved != 0}
+	 * ({@code canChangeWarehouse} throws {@code @QtyReserved}). So un-reserve on the old locator (set qty to 0,
+	 * which lets the locator change pass), then re-reserve the same qty on the new locator.
+	 */
+	private void switchLinePickFromLocator(@NonNull final I_DD_OrderLine line, @NonNull final LocatorId nextLocatorId)
+	{
+		final BigDecimal qtyReserved = line.getQtyReserved();
+
+		if (qtyReserved.signum() != 0)
+		{
+			line.setQtyReserved(BigDecimal.ZERO);
+		}
+		line.setM_Locator_ID(nextLocatorId.getRepoId());
+		ddOrderService.saveLine(line);
+
+		if (qtyReserved.signum() != 0)
+		{
+			line.setQtyReserved(qtyReserved);
+			ddOrderService.saveLine(line);
+		}
 	}
 }

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/commands/switch_pick_from_locator/DistributionJobSwitchPickFromLocatorCommand.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/commands/switch_pick_from_locator/DistributionJobSwitchPickFromLocatorCommand.java
@@ -1,7 +1,6 @@
 package de.metas.distribution.mobileui.job.service.commands.switch_pick_from_locator;
 
 import de.metas.distribution.ddorder.DDOrderId;
-import de.metas.distribution.ddorder.DDOrderService;
 import de.metas.distribution.mobileui.external_services.warehouse.NextPickFromLocatorResolver;
 import de.metas.distribution.mobileui.job.model.DistributionJob;
 import de.metas.distribution.mobileui.job.model.DistributionJobId;
@@ -26,7 +25,6 @@ public class DistributionJobSwitchPickFromLocatorCommand
 	@NonNull private final ITrxManager trxManager;
 	@NonNull private final DistributionJobLoaderSupportingServices loadingSupportServices;
 	@NonNull private final NextPickFromLocatorResolver nextLocatorResolver;
-	@NonNull private final DDOrderService ddOrderService;
 	@NonNull private final DistributionJobId jobId;
 
 	@Builder
@@ -34,13 +32,11 @@ public class DistributionJobSwitchPickFromLocatorCommand
 			@NonNull final ITrxManager trxManager,
 			@NonNull final DistributionJobLoaderSupportingServices loadingSupportServices,
 			@NonNull final NextPickFromLocatorResolver nextLocatorResolver,
-			@NonNull final DDOrderService ddOrderService,
 			@NonNull final DistributionJobId jobId)
 	{
 		this.trxManager = trxManager;
 		this.loadingSupportServices = loadingSupportServices;
 		this.nextLocatorResolver = nextLocatorResolver;
-		this.ddOrderService = ddOrderService;
 		this.jobId = jobId;
 	}
 
@@ -64,7 +60,7 @@ public class DistributionJobSwitchPickFromLocatorCommand
 
 		final DDOrderId ddOrderId = jobId.toDDOrderId();
 		final I_DD_Order ddOrder = loadingSupportServices.getDDOrderById(ddOrderId);
-		final List<I_DD_OrderLine> lines = ddOrderService.retrieveLines(ddOrder);
+		final List<I_DD_OrderLine> lines = loadingSupportServices.retrieveLines(ddOrder);
 		for (final I_DD_OrderLine line : lines)
 		{
 			// Resilience: only move lines that still sit on the locator we resolved the next one from.
@@ -96,12 +92,12 @@ public class DistributionJobSwitchPickFromLocatorCommand
 			line.setQtyReserved(BigDecimal.ZERO);
 		}
 		line.setM_Locator_ID(nextLocatorId.getRepoId());
-		ddOrderService.saveLine(line);
+		loadingSupportServices.saveLine(line);
 
 		if (qtyReserved.signum() != 0)
 		{
 			line.setQtyReserved(qtyReserved);
-			ddOrderService.saveLine(line);
+			loadingSupportServices.saveLine(line);
 		}
 	}
 }

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/commands/switch_pick_from_locator/DistributionJobSwitchPickFromLocatorCommand.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/commands/switch_pick_from_locator/DistributionJobSwitchPickFromLocatorCommand.java
@@ -8,11 +8,11 @@ import de.metas.distribution.mobileui.job.model.DistributionJobId;
 import de.metas.distribution.mobileui.job.service.DistributionJobLoader;
 import de.metas.distribution.mobileui.job.service.DistributionJobLoaderSupportingServices;
 import de.metas.i18n.AdMessageKey;
+import de.metas.util.Check;
 import lombok.Builder;
 import lombok.NonNull;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.eevolution.model.I_DD_Order;
@@ -60,8 +60,9 @@ public class DistributionJobSwitchPickFromLocatorCommand
 			throw new AdempiereException(MSG_NOT_AVAILABLE);
 		}
 
-		final LocatorId currentLocatorId = job.getSinglePickFromLocatorIdOrNull();
-		// canSwitchPickFromLocator guarantees currentLocatorId is non-null
+		final LocatorId currentLocatorId = Check.assumeNotNull(
+				job.getSinglePickFromLocatorIdOrNull(),
+				"job.getSinglePickFromLocatorIdOrNull() is non-null because canSwitchPickFromLocator() was true");
 		final WarehouseId warehouseId = job.getPickFromWarehouse().getWarehouseId();
 		final LocatorId nextLocatorId = nextLocatorResolver.resolveNext(warehouseId, currentLocatorId);
 
@@ -71,7 +72,7 @@ public class DistributionJobSwitchPickFromLocatorCommand
 		for (final I_DD_OrderLine line : lines)
 		{
 			line.setM_Locator_ID(nextLocatorId.getRepoId());
-			InterfaceWrapperHelper.save(line);
+			ddOrderService.saveLine(line);
 		}
 
 		return loader.loadByJobId(jobId);

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/commands/switch_pick_from_locator/DistributionJobSwitchPickFromLocatorCommand.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/commands/switch_pick_from_locator/DistributionJobSwitchPickFromLocatorCommand.java
@@ -1,0 +1,79 @@
+package de.metas.distribution.mobileui.job.service.commands.switch_pick_from_locator;
+
+import de.metas.distribution.ddorder.DDOrderId;
+import de.metas.distribution.ddorder.DDOrderService;
+import de.metas.distribution.mobileui.external_services.warehouse.NextPickFromLocatorResolver;
+import de.metas.distribution.mobileui.job.model.DistributionJob;
+import de.metas.distribution.mobileui.job.model.DistributionJobId;
+import de.metas.distribution.mobileui.job.service.DistributionJobLoader;
+import de.metas.distribution.mobileui.job.service.DistributionJobLoaderSupportingServices;
+import de.metas.i18n.AdMessageKey;
+import lombok.Builder;
+import lombok.NonNull;
+import org.adempiere.ad.trx.api.ITrxManager;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.warehouse.LocatorId;
+import org.adempiere.warehouse.WarehouseId;
+import org.eevolution.model.I_DD_Order;
+import org.eevolution.model.I_DD_OrderLine;
+
+import java.util.List;
+
+public class DistributionJobSwitchPickFromLocatorCommand
+{
+	static final AdMessageKey MSG_NOT_AVAILABLE = AdMessageKey.of("MobileUI_DDOrder_SwitchPickFromLocator_NotAvailable");
+
+	@NonNull private final ITrxManager trxManager;
+	@NonNull private final DistributionJobLoaderSupportingServices loadingSupportServices;
+	@NonNull private final NextPickFromLocatorResolver nextLocatorResolver;
+	@NonNull private final DDOrderService ddOrderService;
+	@NonNull private final DistributionJobId jobId;
+
+	@Builder
+	private DistributionJobSwitchPickFromLocatorCommand(
+			@NonNull final ITrxManager trxManager,
+			@NonNull final DistributionJobLoaderSupportingServices loadingSupportServices,
+			@NonNull final NextPickFromLocatorResolver nextLocatorResolver,
+			@NonNull final DDOrderService ddOrderService,
+			@NonNull final DistributionJobId jobId)
+	{
+		this.trxManager = trxManager;
+		this.loadingSupportServices = loadingSupportServices;
+		this.nextLocatorResolver = nextLocatorResolver;
+		this.ddOrderService = ddOrderService;
+		this.jobId = jobId;
+	}
+
+	public DistributionJob execute()
+	{
+		return trxManager.callInThreadInheritedTrx(this::executeInTrx);
+	}
+
+	private DistributionJob executeInTrx()
+	{
+		final DistributionJobLoader loader = new DistributionJobLoader(loadingSupportServices);
+		final DistributionJob job = loader.loadByJobId(jobId);
+
+		if (!job.canSwitchPickFromLocator())
+		{
+			throw new AdempiereException(MSG_NOT_AVAILABLE);
+		}
+
+		final LocatorId currentLocatorId = job.getSinglePickFromLocatorIdOrNull();
+		// canSwitchPickFromLocator guarantees currentLocatorId is non-null
+		final WarehouseId warehouseId = job.getPickFromWarehouse().getWarehouseId();
+		final LocatorId nextLocatorId = nextLocatorResolver.resolveNext(warehouseId, currentLocatorId);
+
+		final DDOrderId ddOrderId = jobId.toDDOrderId();
+		final I_DD_Order ddOrder = loadingSupportServices.getDDOrderById(ddOrderId);
+		final List<I_DD_OrderLine> lines = ddOrderService.retrieveLines(ddOrder);
+		for (final I_DD_OrderLine line : lines)
+		{
+			line.setM_Locator_ID(nextLocatorId.getRepoId());
+			InterfaceWrapperHelper.save(line);
+		}
+
+		return loader.loadByJobId(jobId);
+	}
+}

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/rest_api/DistributionRestController.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/rest_api/DistributionRestController.java
@@ -85,6 +85,13 @@ public class DistributionRestController
 		return distributionMobileApplication.complete(WFProcessId.ofString(wfProcessIdStr), getLoggedUserId());
 	}
 
+	@PostMapping("/job/{wfProcessId}/switchPickFromLocatorToNext")
+	public WFProcess switchPickFromLocatorToNext(@PathVariable("wfProcessId") final String wfProcessIdStr)
+	{
+		assertApplicationAccess();
+		return distributionMobileApplication.switchPickFromLocatorToNext(WFProcessId.ofString(wfProcessIdStr), getLoggedUserId());
+	}
+
 	@PostMapping("/print/materialInTransitReport")
 	public void printMaterialInTransitReport()
 	{

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/rest_api/DistributionRestController.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/rest_api/DistributionRestController.java
@@ -90,9 +90,7 @@ public class DistributionRestController
 	{
 		assertApplicationAccess();
 		final WFProcess wfProcess = distributionMobileApplication.switchPickFromLocatorToNext(WFProcessId.ofString(wfProcessIdStr), getLoggedUserId());
-		// Serialize the full job (incl. activity detail: lines, pickFromLocator, canSwitchPickFromLocator)
-		// like /event does. Returning the raw WFProcess yields a summary-only payload, so the mobile UI
-		// would keep showing the old locator after the switch.
+		// toJson carries the activity detail with the switched locator; a raw WFProcess serializes summary-only.
 		return workflowRestController.toJson(wfProcess);
 	}
 

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/rest_api/DistributionRestController.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/rest_api/DistributionRestController.java
@@ -86,10 +86,14 @@ public class DistributionRestController
 	}
 
 	@PostMapping("/job/{wfProcessId}/switchPickFromLocatorToNext")
-	public WFProcess switchPickFromLocatorToNext(@PathVariable("wfProcessId") final String wfProcessIdStr)
+	public JsonWFProcess switchPickFromLocatorToNext(@PathVariable("wfProcessId") final String wfProcessIdStr)
 	{
 		assertApplicationAccess();
-		return distributionMobileApplication.switchPickFromLocatorToNext(WFProcessId.ofString(wfProcessIdStr), getLoggedUserId());
+		final WFProcess wfProcess = distributionMobileApplication.switchPickFromLocatorToNext(WFProcessId.ofString(wfProcessIdStr), getLoggedUserId());
+		// Serialize the full job (incl. activity detail: lines, pickFromLocator, canSwitchPickFromLocator)
+		// like /event does. Returning the raw WFProcess yields a summary-only payload, so the mobile UI
+		// would keep showing the old locator after the switch.
+		return workflowRestController.toJson(wfProcess);
 	}
 
 	@PostMapping("/print/materialInTransitReport")

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/rest_api/json/JsonDistributionJob.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/rest_api/json/JsonDistributionJob.java
@@ -21,6 +21,7 @@ public class JsonDistributionJob
 	boolean requireScanningProductCode;
 	boolean completeJobAutomatically;
 	boolean navigateToJobsListAfterPickFromComplete;
+	boolean canSwitchPickFromLocator;
 	@NonNull JsonRejectReasonsList qtyRejectedReasons;
 
 	public static JsonDistributionJob.JsonDistributionJobBuilder builderFrom(
@@ -29,6 +30,7 @@ public class JsonDistributionJob
 	{
 		return builder()
 				.pickingInstruction(job.getPickingInstruction().translate(jsonOpts.getAdLanguage()))
+				.canSwitchPickFromLocator(job.canSwitchPickFromLocator())
 				.lines(job.getLines()
 						.stream()
 						.map(line -> JsonDistributionJobLine.of(line, job, jsonOpts))

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/rest_api/json/JsonLocatorInfo.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/rest_api/json/JsonLocatorInfo.java
@@ -11,12 +11,14 @@ import lombok.extern.jackson.Jacksonized;
 @Jacksonized
 public class JsonLocatorInfo
 {
+	int id;
 	@NonNull String caption;
 	@NonNull String qrCode;
 
 	public static JsonLocatorInfo of(@NonNull final LocatorInfo locatorInfo)
 	{
 		return builder()
+				.id(locatorInfo.getLocatorId().getRepoId())
 				.caption(locatorInfo.getCaption())
 				.qrCode(locatorInfo.getQrCode().toGlobalQRCodeJsonString())
 				.build();

--- a/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/external_services/warehouse/LocatorValueRoundRobinResolverTest.java
+++ b/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/external_services/warehouse/LocatorValueRoundRobinResolverTest.java
@@ -91,12 +91,11 @@ class LocatorValueRoundRobinResolverTest
 	@Test
 	void returns_first_when_current_not_in_set()
 	{
-		// Create A, B; pass a synthetic LocatorId that doesn't exist
 		final LocatorId a = locator("A", true);
 		locator("B", true);
 
-		final LocatorId syntheticId = LocatorId.ofRepoId(warehouseId.getRepoId(), 99_999_999);
-		assertThat(resolver.resolveNext(warehouseId, syntheticId)).isEqualTo(a);
+		final LocatorId nonexistent = LocatorId.ofRepoId(warehouseId.getRepoId(), 99_999_999);
+		assertThat(resolver.resolveNext(warehouseId, nonexistent)).isEqualTo(a);
 	}
 
 	@Test

--- a/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/external_services/warehouse/LocatorValueRoundRobinResolverTest.java
+++ b/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/external_services/warehouse/LocatorValueRoundRobinResolverTest.java
@@ -1,0 +1,126 @@
+package de.metas.distribution.mobileui.external_services.warehouse;
+
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.LocatorId;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_M_Locator;
+import org.compiere.model.I_M_Warehouse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.save;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LocatorValueRoundRobinResolverTest
+{
+	private LocatorValueRoundRobinResolver resolver;
+	private WarehouseId warehouseId;
+
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+		resolver = new LocatorValueRoundRobinResolver();
+
+		final I_M_Warehouse warehouse = newInstance(I_M_Warehouse.class);
+		warehouse.setName("WH");
+		save(warehouse);
+		warehouseId = WarehouseId.ofRepoId(warehouse.getM_Warehouse_ID());
+	}
+
+	private LocatorId locator(final String value, final boolean active)
+	{
+		final I_M_Locator locator = newInstance(I_M_Locator.class);
+		locator.setM_Warehouse_ID(warehouseId.getRepoId());
+		locator.setValue(value);
+		locator.setIsActive(active);
+		save(locator);
+		return LocatorId.ofRepoId(locator.getM_Warehouse_ID(), locator.getM_Locator_ID());
+	}
+
+	@Test
+	void advances_mid_list()
+	{
+		final LocatorId a = locator("A", true);
+		final LocatorId b = locator("B", true);
+		locator("C", true);
+
+		assertThat(resolver.resolveNext(warehouseId, a)).isEqualTo(b);
+	}
+
+	@Test
+	void wraps_from_last_to_first()
+	{
+		final LocatorId a = locator("A", true);
+		locator("B", true);
+		final LocatorId c = locator("C", true);
+
+		assertThat(resolver.resolveNext(warehouseId, c)).isEqualTo(a);
+	}
+
+	@Test
+	void orders_by_value_not_by_id()
+	{
+		// Create Z first (lower ID), then A (higher ID), then M
+		// Sorted by Value: A, M, Z
+		final LocatorId z = locator("Z", true);
+		final LocatorId a = locator("A", true);
+		final LocatorId m = locator("M", true);
+
+		// Value ordering: A -> M -> Z -> A
+		assertThat(resolver.resolveNext(warehouseId, a)).isEqualTo(m);
+		assertThat(resolver.resolveNext(warehouseId, m)).isEqualTo(z);
+		assertThat(resolver.resolveNext(warehouseId, z)).isEqualTo(a);
+	}
+
+	@Test
+	void skips_inactive_locators()
+	{
+		// A (active), B (INACTIVE), C (active)
+		// Expect resolveNext(A) == C (skips B)
+		final LocatorId a = locator("A", true);
+		locator("B", false);
+		final LocatorId c = locator("C", true);
+
+		assertThat(resolver.resolveNext(warehouseId, a)).isEqualTo(c);
+	}
+
+	@Test
+	void returns_first_when_current_not_in_set()
+	{
+		// Create A, B; pass a synthetic LocatorId that doesn't exist
+		final LocatorId a = locator("A", true);
+		locator("B", true);
+
+		final LocatorId syntheticId = LocatorId.ofRepoId(warehouseId.getRepoId(), 99_999_999);
+		assertThat(resolver.resolveNext(warehouseId, syntheticId)).isEqualTo(a);
+	}
+
+	@Test
+	void throws_when_only_current_active_locator_exists()
+	{
+		// A active, B inactive — only A is in the set
+		final LocatorId a = locator("A", true);
+		locator("B", false);
+
+		assertThatThrownBy(() -> resolver.resolveNext(warehouseId, a))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining(LocatorValueRoundRobinResolver.MSG_NO_ALTERNATIVE.toAD_Message());
+	}
+
+	@Test
+	void throws_when_zero_active_locators()
+	{
+		// Create only inactive locators
+		locator("A", false);
+		locator("B", false);
+
+		final LocatorId syntheticId = LocatorId.ofRepoId(warehouseId.getRepoId(), 99_999_999);
+		assertThatThrownBy(() -> resolver.resolveNext(warehouseId, syntheticId))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining(LocatorValueRoundRobinResolver.MSG_NO_ALTERNATIVE.toAD_Message());
+	}
+}

--- a/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/external_services/warehouse/LocatorValueRoundRobinResolverTest.java
+++ b/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/external_services/warehouse/LocatorValueRoundRobinResolverTest.java
@@ -48,7 +48,7 @@ class LocatorValueRoundRobinResolverTest
 		final LocatorId b = locator("B", true);
 		locator("C", true);
 
-		assertThat(resolver.resolveNext(warehouseId, a)).isEqualTo(b);
+		assertThat(resolver.resolveNext(a)).isEqualTo(b);
 	}
 
 	@Test
@@ -58,7 +58,7 @@ class LocatorValueRoundRobinResolverTest
 		locator("B", true);
 		final LocatorId c = locator("C", true);
 
-		assertThat(resolver.resolveNext(warehouseId, c)).isEqualTo(a);
+		assertThat(resolver.resolveNext(c)).isEqualTo(a);
 	}
 
 	@Test
@@ -71,9 +71,9 @@ class LocatorValueRoundRobinResolverTest
 		final LocatorId m = locator("M", true);
 
 		// Value ordering: A -> M -> Z -> A
-		assertThat(resolver.resolveNext(warehouseId, a)).isEqualTo(m);
-		assertThat(resolver.resolveNext(warehouseId, m)).isEqualTo(z);
-		assertThat(resolver.resolveNext(warehouseId, z)).isEqualTo(a);
+		assertThat(resolver.resolveNext(a)).isEqualTo(m);
+		assertThat(resolver.resolveNext(m)).isEqualTo(z);
+		assertThat(resolver.resolveNext(z)).isEqualTo(a);
 	}
 
 	@Test
@@ -85,7 +85,7 @@ class LocatorValueRoundRobinResolverTest
 		locator("B", false);
 		final LocatorId c = locator("C", true);
 
-		assertThat(resolver.resolveNext(warehouseId, a)).isEqualTo(c);
+		assertThat(resolver.resolveNext(a)).isEqualTo(c);
 	}
 
 	@Test
@@ -95,7 +95,7 @@ class LocatorValueRoundRobinResolverTest
 		locator("B", true);
 
 		final LocatorId nonexistent = LocatorId.ofRepoId(warehouseId.getRepoId(), 99_999_999);
-		assertThat(resolver.resolveNext(warehouseId, nonexistent)).isEqualTo(a);
+		assertThat(resolver.resolveNext(nonexistent)).isEqualTo(a);
 	}
 
 	@Test
@@ -105,9 +105,9 @@ class LocatorValueRoundRobinResolverTest
 		final LocatorId a = locator("A", true);
 		locator("B", false);
 
-		assertThatThrownBy(() -> resolver.resolveNext(warehouseId, a))
+		assertThatThrownBy(() -> resolver.resolveNext(a))
 				.isInstanceOf(AdempiereException.class)
-				.hasMessageContaining(LocatorValueRoundRobinResolver.MSG_NO_ALTERNATIVE.toAD_Message());
+				.hasMessageContaining(NextPickFromLocatorResolver.MSG_NO_ALTERNATIVE.toAD_Message());
 	}
 
 	@Test
@@ -118,8 +118,8 @@ class LocatorValueRoundRobinResolverTest
 		locator("B", false);
 
 		final LocatorId syntheticId = LocatorId.ofRepoId(warehouseId.getRepoId(), 99_999_999);
-		assertThatThrownBy(() -> resolver.resolveNext(warehouseId, syntheticId))
+		assertThatThrownBy(() -> resolver.resolveNext(syntheticId))
 				.isInstanceOf(AdempiereException.class)
-				.hasMessageContaining(LocatorValueRoundRobinResolver.MSG_NO_ALTERNATIVE.toAD_Message());
+				.hasMessageContaining(NextPickFromLocatorResolver.MSG_NO_ALTERNATIVE.toAD_Message());
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/DDOrderService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/DDOrderService.java
@@ -104,7 +104,7 @@ public class DDOrderService
 		ddOrderLowLevelDAO.save(ddOrder);
 	}
 
-	public void saveLine(final I_DD_OrderLine ddOrderLine)
+	public void saveLine(@NonNull final I_DD_OrderLine ddOrderLine)
 	{
 		ddOrderLowLevelDAO.save(ddOrderLine);
 	}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/DDOrderService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/DDOrderService.java
@@ -104,6 +104,11 @@ public class DDOrderService
 		ddOrderLowLevelDAO.save(ddOrder);
 	}
 
+	public void saveLine(final I_DD_OrderLine ddOrderLine)
+	{
+		ddOrderLowLevelDAO.save(ddOrderLine);
+	}
+
 	public List<I_DD_OrderLine> retrieveLines(final I_DD_Order order)
 	{
 		return ddOrderLowLevelDAO.retrieveLines(order);

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 10 | 80% |
 | Picking | 44 | 47 | 94% |
-| Distribution | 27 | 30 | 90% |
+| Distribution | 30 | 33 | 91% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
 | HU Consolidation | 4 | 5 | 80% |
@@ -193,8 +193,11 @@
 | Pick multiple HUs by M_HU_ID; Drop All via locator code | `distribution/job_dropAllButton.spec.js` |
 | Pick from multiple jobs in launchers list; Drop All from jobs-list screen | `distribution/launchers_dropAllButton.spec.js` |
 | navigateToJobsListAfterPickFromComplete=true → last line pick navigates to next job | `distribution/navigateToJobsListAfterPickFromComplete.spec.js` |
+| "Lagerort leer" button advances the job's pick-from locator to the next active locator | `distribution/switchPickFromLocator.spec.js` |
+| "Lagerort leer" successive presses cycle round-robin through all active locators | `distribution/switchPickFromLocator.spec.js` |
+| "Lagerort leer" button is hidden once picking has started | `distribution/switchPickFromLocator.spec.js` |
 
-**5/5 — 100%**
+**8/8 — 100%**
 
 ### Distribution — HU scanning
 

--- a/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
@@ -1,0 +1,121 @@
+import { test } from "../../../playwright.config";
+import { Backend } from "../../utils/screens/Backend";
+import { allure } from 'allure-playwright';
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { DistributionJobsListScreen } from "../../utils/screens/distribution/DistributionJobsListScreen";
+import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
+import { DistributionLineScreen } from '../../utils/screens/distribution/DistributionLineScreen';
+
+const createMasterdata = async ({ qtyToMove }) => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US" } },
+            mobileConfig: { distribution: {} },
+            resources: { "plantId": { type: "PT" } },
+            products: { "P1": {} },
+            warehouses: {
+                // Source warehouse with 3 active locators — ordering by M_Locator.Value should give wh1_l1 < wh1_l2 < wh1_l3.
+                "wh1": { locators: { wh1_l1: {}, wh1_l2: {}, wh1_l3: {} } },
+                "wh2": { locators: { wh2_l1: {} } },
+                "whInTransit": { inTransit: true },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh1', qty: qtyToMove },
+            },
+            distributionOrders: {
+                "DD1": {
+                    warehouseFrom: "wh1",
+                    warehouseTo: "wh2",
+                    warehouseInTransit: "whInTransit",
+                    plant: "plantId",
+                    lines: [
+                        { product: "P1", qtyEntered: qtyToMove },
+                    ],
+                },
+            },
+        },
+    });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('Switch pick-from locator — button advances to next active locator', async ({ page }) => {
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114');
+    allure.story('mobileUI DD_Order picker can switch from-locator when current locator is empty');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({ qtyToMove: 100 });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+
+    await test.step('Fresh job: button is visible', async () => {
+        await DistributionJobScreen.expectSwitchPickFromLocatorButton({ visible: true });
+    });
+
+    await test.step('Press "Lagerort leer" — locator advances, button remains visible (still has alternatives)', async () => {
+        await DistributionJobScreen.switchPickFromLocator();
+        await DistributionJobScreen.expectSwitchPickFromLocatorButton({ visible: true });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Switch pick-from locator — successive presses cycle round-robin', async ({ page }) => {
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114');
+    allure.story('mobileUI DD_Order switch from-locator wraps round-robin through all active locators');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({ qtyToMove: 100 });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+
+    // The warehouse has 3 active locators. Three presses cycle wh1_l1 -> wh1_l2 -> wh1_l3 -> wh1_l1.
+    // Each press succeeds without error and the button stays available (no "no-alternative" rejection
+    // until picking starts or the warehouse has <=1 active locators).
+    await test.step('Press 3 times — round-robin cycles through all locators', async () => {
+        await DistributionJobScreen.switchPickFromLocator();
+        await DistributionJobScreen.switchPickFromLocator();
+        await DistributionJobScreen.switchPickFromLocator();
+        await DistributionJobScreen.expectSwitchPickFromLocatorButton({ visible: true });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Switch pick-from locator — button hidden once picking has started', async ({ page }) => {
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114');
+    allure.story('mobileUI DD_Order switch from-locator is unavailable after the first pick');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({ qtyToMove: 100 });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+
+    await test.step('Pick the line', async () => {
+        await DistributionJobScreen.clickLineButton({ index: 1 });
+        await DistributionLineScreen.scanHUToMove({
+            huQRCode: masterdata.handlingUnits.HU1.qrCode,
+            qtyToMove: '100',
+            expectedQtyToMove: '100',
+        });
+        await DistributionLineScreen.goBack();
+    });
+
+    await test.step('After pick: switch button is hidden', async () => {
+        await DistributionJobScreen.expectSwitchPickFromLocatorButton({ visible: false });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
@@ -8,6 +8,13 @@ import { DistributionJobsListScreen } from "../../utils/screens/distribution/Dis
 import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
 import { DistributionLineScreen } from '../../utils/screens/distribution/DistributionLineScreen';
 
+// The 3 source locators sorted by M_Locator.Value — the resolver's ordering key. The masterdata
+// `code` is the locator Value, so this is the exact sequence the round-robin advances through.
+const locatorIdsOrderedByValue = (masterdata) =>
+    Object.values(masterdata.warehouses.wh1.locators)
+        .sort((a, b) => a.code.localeCompare(b.code))
+        .map((locator) => locator.id);
+
 const createMasterdata = async ({ qtyToMove }) => {
     return await Backend.createMasterdata({
         language: "en_US",
@@ -61,13 +68,14 @@ test('Switch pick-from locator — button advances to next active locator', asyn
         await DistributionJobScreen.expectSwitchPickFromLocatorButton({ visible: true });
     });
 
-    await test.step('Press "Lagerort leer" — locator advances, button remains visible (still has alternatives)', async () => {
-        const locatorBefore = await DistributionJobScreen.getPickFromLocator();
-        expect(locatorBefore).toBeTruthy();
-        await DistributionJobScreen.switchPickFromLocator();
-        // The thunk dispatches the redux update after the POST resolves, so the rendered
-        // attribute settles a render-tick later — poll until it reflects the new locator.
-        await expect.poll(async () => await DistributionJobScreen.getPickFromLocator()).not.toEqual(locatorBefore);
+    await test.step('Press "Lagerort leer" — locator advances to the exact next active locator (by Value)', async () => {
+        const orderedLocatorIds = locatorIdsOrderedByValue(masterdata);
+        const currentLocatorId = Number(await DistributionJobScreen.getPickFromLocator());
+        const currentIdx = orderedLocatorIds.indexOf(currentLocatorId);
+        expect(currentIdx).toBeGreaterThanOrEqual(0);
+        const expectNextLocatorId = orderedLocatorIds[(currentIdx + 1) % orderedLocatorIds.length];
+
+        await DistributionJobScreen.switchPickFromLocator({ expectNextLocatorId });
         await DistributionJobScreen.expectSwitchPickFromLocatorButton({ visible: true });
     });
 });
@@ -89,30 +97,27 @@ test('Switch pick-from locator — successive presses cycle round-robin', async 
     await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
     await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
 
-    // The warehouse has 3 active locators. Three presses cycle wh1_l1 -> wh1_l2 -> wh1_l3 -> wh1_l1.
-    // Each press succeeds without error and the button stays available (no "no-alternative" rejection
-    // until picking starts or the warehouse has <=1 active locators).
-    await test.step('Press 3 times — round-robin cycles through all 3 locators and wraps back to the start', async () => {
-        // After each switch the rendered attribute settles a render-tick after the POST resolves,
-        // so poll until it changes from the previous value before capturing the settled locator.
-        const locator0 = await DistributionJobScreen.getPickFromLocator();
+    // The warehouse has 3 active locators. Three presses cycle through all of them by Value and wrap
+    // back to the start. Each press lands on the exact locator the resolver dictates (not just "a
+    // different one"), and the button stays available until picking starts.
+    await test.step('Press 3 times — round-robin advances through the exact Value-ordered sequence and wraps back', async () => {
+        const orderedLocatorIds = locatorIdsOrderedByValue(masterdata);
+        const startLocatorId = Number(await DistributionJobScreen.getPickFromLocator());
+        let idx = orderedLocatorIds.indexOf(startLocatorId);
+        expect(idx).toBeGreaterThanOrEqual(0);
 
-        await DistributionJobScreen.switchPickFromLocator();
-        await expect.poll(async () => await DistributionJobScreen.getPickFromLocator()).not.toEqual(locator0);
-        const locator1 = await DistributionJobScreen.getPickFromLocator();
+        const visited = [startLocatorId];
+        for (let press = 0; press < 3; press++) {
+            const expectNextLocatorId = orderedLocatorIds[(idx + 1) % orderedLocatorIds.length];
+            await DistributionJobScreen.switchPickFromLocator({ expectNextLocatorId });
+            idx = (idx + 1) % orderedLocatorIds.length;
+            visited.push(expectNextLocatorId);
+        }
 
-        await DistributionJobScreen.switchPickFromLocator();
-        await expect.poll(async () => await DistributionJobScreen.getPickFromLocator()).not.toEqual(locator1);
-        const locator2 = await DistributionJobScreen.getPickFromLocator();
-
-        await DistributionJobScreen.switchPickFromLocator();
-        await expect.poll(async () => await DistributionJobScreen.getPickFromLocator()).not.toEqual(locator2);
-        const locator3 = await DistributionJobScreen.getPickFromLocator();
-
-        // Each of the first three reads is a distinct active locator...
-        expect(new Set([locator0, locator1, locator2]).size).toEqual(3);
-        // ...and the fourth read wraps back to the first (round-robin).
-        expect(locator3).toEqual(locator0);
+        // The first three presses visit each of the 3 active locators exactly once...
+        expect(new Set([visited[0], visited[1], visited[2]]).size).toEqual(3);
+        // ...and the third press wraps back to the starting locator (round-robin).
+        expect(visited[3]).toEqual(startLocatorId);
 
         await DistributionJobScreen.expectSwitchPickFromLocatorButton({ visible: true });
     });

--- a/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
@@ -1,4 +1,5 @@
 import { test } from "../../../playwright.config";
+import { expect } from '@playwright/test';
 import { Backend } from "../../utils/screens/Backend";
 import { allure } from 'allure-playwright';
 import { LoginScreen } from "../../utils/screens/LoginScreen";
@@ -60,7 +61,12 @@ test('Switch pick-from locator — button advances to next active locator', asyn
     });
 
     await test.step('Press "Lagerort leer" — locator advances, button remains visible (still has alternatives)', async () => {
+        const locatorBefore = await DistributionJobScreen.getPickFromLocator();
+        expect(locatorBefore).toBeTruthy();
         await DistributionJobScreen.switchPickFromLocator();
+        // The thunk dispatches the redux update after the POST resolves, so the rendered
+        // attribute settles a render-tick later — poll until it reflects the new locator.
+        await expect.poll(async () => await DistributionJobScreen.getPickFromLocator()).not.toEqual(locatorBefore);
         await DistributionJobScreen.expectSwitchPickFromLocatorButton({ visible: true });
     });
 });
@@ -84,10 +90,28 @@ test('Switch pick-from locator — successive presses cycle round-robin', async 
     // The warehouse has 3 active locators. Three presses cycle wh1_l1 -> wh1_l2 -> wh1_l3 -> wh1_l1.
     // Each press succeeds without error and the button stays available (no "no-alternative" rejection
     // until picking starts or the warehouse has <=1 active locators).
-    await test.step('Press 3 times — round-robin cycles through all locators', async () => {
+    await test.step('Press 3 times — round-robin cycles through all 3 locators and wraps back to the start', async () => {
+        // After each switch the rendered attribute settles a render-tick after the POST resolves,
+        // so poll until it changes from the previous value before capturing the settled locator.
+        const locator0 = await DistributionJobScreen.getPickFromLocator();
+
         await DistributionJobScreen.switchPickFromLocator();
+        await expect.poll(async () => await DistributionJobScreen.getPickFromLocator()).not.toEqual(locator0);
+        const locator1 = await DistributionJobScreen.getPickFromLocator();
+
         await DistributionJobScreen.switchPickFromLocator();
+        await expect.poll(async () => await DistributionJobScreen.getPickFromLocator()).not.toEqual(locator1);
+        const locator2 = await DistributionJobScreen.getPickFromLocator();
+
         await DistributionJobScreen.switchPickFromLocator();
+        await expect.poll(async () => await DistributionJobScreen.getPickFromLocator()).not.toEqual(locator2);
+        const locator3 = await DistributionJobScreen.getPickFromLocator();
+
+        // Each of the first three reads is a distinct active locator...
+        expect(new Set([locator0, locator1, locator2]).size).toEqual(3);
+        // ...and the fourth read wraps back to the first (round-robin).
+        expect(locator3).toEqual(locator0);
+
         await DistributionJobScreen.expectSwitchPickFromLocatorButton({ visible: true });
     });
 });

--- a/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
@@ -43,6 +43,7 @@ const createMasterdata = async ({ qtyToMove }) => {
 // noinspection JSUnusedLocalSymbols
 test('Switch pick-from locator — button advances to next active locator', async ({ page }) => {
     allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
     allure.tag('F5114');
     allure.story('mobileUI DD_Order picker can switch from-locator when current locator is empty');
     allure.severity('normal');
@@ -74,6 +75,7 @@ test('Switch pick-from locator — button advances to next active locator', asyn
 // noinspection JSUnusedLocalSymbols
 test('Switch pick-from locator — successive presses cycle round-robin', async ({ page }) => {
     allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
     allure.tag('F5114');
     allure.story('mobileUI DD_Order switch from-locator wraps round-robin through all active locators');
     allure.severity('normal');
@@ -119,6 +121,7 @@ test('Switch pick-from locator — successive presses cycle round-robin', async 
 // noinspection JSUnusedLocalSymbols
 test('Switch pick-from locator — button hidden once picking has started', async ({ page }) => {
     allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
     allure.tag('F5114');
     allure.story('mobileUI DD_Order switch from-locator is unavailable after the first pick');
     allure.severity('normal');

--- a/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
@@ -52,6 +52,7 @@ test('Switch pick-from locator — button advances to next active locator', asyn
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('distribution');
     await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
     await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
 
     await test.step('Fresh job: button is visible', async () => {
@@ -77,6 +78,7 @@ test('Switch pick-from locator — successive presses cycle round-robin', async 
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('distribution');
     await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
     await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
 
     // The warehouse has 3 active locators. Three presses cycle wh1_l1 -> wh1_l2 -> wh1_l3 -> wh1_l1.
@@ -103,6 +105,7 @@ test('Switch pick-from locator — button hidden once picking has started', asyn
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('distribution');
     await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
     await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
 
     await test.step('Pick the line', async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobScreen.js
@@ -93,10 +93,23 @@ export const DistributionJobScreen = {
         }
     }),
 
+    getPickFromLocator: async () => await test.step(`${NAME} - Get current pick-from locator`, async () => {
+        const button = switchPickFromLocatorButtonLocator();
+        await expect(button).toBeVisible({ timeout: FAST_ACTION_TIMEOUT });
+        return await button.getAttribute('data-pickfromlocator');
+    }),
+
     switchPickFromLocator: async () => await test.step(`${NAME} - Switch pick-from locator to next`, async () => {
         const button = switchPickFromLocatorButtonLocator();
         await expect(button).toBeEnabled({ timeout: FAST_ACTION_TIMEOUT });
+        // Set up the response listener immediately before the tap so we don't return
+        // while the (spinner-less) switch POST is still in flight.
+        const responsePromise = page.waitForResponse(
+            (response) => response.url().includes('/switchPickFromLocatorToNext') && response.request().method() === 'POST',
+            { timeout: SLOW_ACTION_TIMEOUT }
+        );
         await button.tap();
+        await responsePromise;
         await DistributionJobScreen.waitForScreen();
     }),
 

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobScreen.js
@@ -84,6 +84,22 @@ export const DistributionJobScreen = {
         }
     }),
 
+    expectSwitchPickFromLocatorButton: async ({ visible }) => await test.step(`${NAME} - Expect Switch Pick-From Locator button visible=${visible}`, async () => {
+        const button = switchPickFromLocatorButtonLocator();
+        if (visible) {
+            await expect(button).toBeVisible({ timeout: FAST_ACTION_TIMEOUT });
+        } else {
+            await expect(button).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
+        }
+    }),
+
+    switchPickFromLocator: async () => await test.step(`${NAME} - Switch pick-from locator to next`, async () => {
+        const button = switchPickFromLocatorButtonLocator();
+        await expect(button).toBeEnabled({ timeout: FAST_ACTION_TIMEOUT });
+        await button.tap();
+        await DistributionJobScreen.waitForScreen();
+    }),
+
     dropAllTo: async ({ dropToLocatorQRCode, expectNextScreen }) => await test.step(`${NAME} - Drop All To ${dropToLocatorQRCode}`, async () => {
         const dropAllButton = dropAllButtonLocator();
         await expect(dropAllButton).toBeEnabled({ timeout: VERY_FAST_ACTION_TIMEOUT });
@@ -125,6 +141,10 @@ const expectLineButtonAttribute = async ({ lineButton, attribute, value }) => aw
 
 const dropAllButtonLocator = () => {
     return page.getByTestId('scanDropToLocator-button');
+};
+
+const switchPickFromLocatorButtonLocator = () => {
+    return page.getByTestId('switchPickFromLocator-button');
 };
 
 const clickCompleteButton = async () => await test.step(`${NAME} - Click Complete button`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobScreen.js
@@ -99,7 +99,7 @@ export const DistributionJobScreen = {
         return await button.getAttribute('data-pickfromlocator');
     }),
 
-    switchPickFromLocator: async () => await test.step(`${NAME} - Switch pick-from locator to next`, async () => {
+    switchPickFromLocator: async ({ expectNextLocatorId } = {}) => await test.step(`${NAME} - Switch pick-from locator to next`, async () => {
         const button = switchPickFromLocatorButtonLocator();
         await expect(button).toBeEnabled({ timeout: FAST_ACTION_TIMEOUT });
         // Set up the response listener immediately before the tap so we don't return
@@ -111,6 +111,14 @@ export const DistributionJobScreen = {
         await button.tap();
         await responsePromise;
         await DistributionJobScreen.waitForScreen();
+
+        if (expectNextLocatorId !== undefined) {
+            // The thunk dispatches the redux update after the POST resolves, so the rendered attribute
+            // settles a render-tick later — poll until it reflects the expected locator id.
+            await expect
+                .poll(async () => await DistributionJobScreen.getPickFromLocator(), { timeout: FAST_ACTION_TIMEOUT })
+                .toEqual(String(expectNextLocatorId));
+        }
     }),
 
     dropAllTo: async ({ dropToLocatorQRCode, expectNextScreen }) => await test.step(`${NAME} - Drop All To ${dropToLocatorQRCode}`, async () => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/distribution.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/distribution.js
@@ -59,6 +59,12 @@ export const completeDistributionJob = ({ wfProcessId }) => {
     .then((response) => unboxAxiosResponse(response));
 };
 
+export const switchDistributionPickFromLocatorToNext = ({ wfProcessId }) => {
+  return axios
+    .post(`${apiBasePath}/distribution/job/${wfProcessId}/switchPickFromLocatorToNext`)
+    .then((response) => unboxAxiosResponse(response));
+};
+
 export const getNextEligiblePickFromLine = ({ wfProcessId, lineId, huQRCode, productScannedCode }) => {
   return axios
     .post(`${apiBasePath}/distribution/nextEligiblePickFromLine`, {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/distribution/redux/postDistributionSwitchPickFromLocatorThunk.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/distribution/redux/postDistributionSwitchPickFromLocatorThunk.js
@@ -1,0 +1,9 @@
+import { switchDistributionPickFromLocatorToNext } from '../../../api/distribution';
+import { updateWFProcess } from '../../../actions/WorkflowActions';
+
+export const postDistributionSwitchPickFromLocatorThunk =
+  ({ wfProcessId }) =>
+  async (dispatch) => {
+    const wfProcess = await switchDistributionPickFromLocatorToNext({ wfProcessId });
+    dispatch(updateWFProcess({ wfProcess }));
+  };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionMoveActivity.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionMoveActivity.jsx
@@ -67,6 +67,7 @@ const DistributionMoveActivity = ({ applicationId, wfProcessId, activityId, acti
       {canSwitchPickFromLocator && (
         <ButtonWithIndicator
           testId="switchPickFromLocator-button"
+          data-pickfromlocator={lines[0]?.pickFromLocator?.caption}
           caption={trl('activities.distribution.switchPickFromLocator')}
           disabled={!isUserEditable}
           onClick={onSwitchPickFromLocator}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionMoveActivity.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionMoveActivity.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
 
 import * as CompleteStatus from '../../../constants/CompleteStatus';
 
@@ -10,12 +11,15 @@ import { trl } from '../../../utils/translations';
 import { distributionDropAllToScreenLocation, distributionPickFromScreenLocation } from '../../../routes/distribution';
 import { useMobileNavigation } from '../../../hooks/useMobileNavigation';
 import BarcodeScannerComponent from '../../../components/BarcodeScannerComponent';
+import { postDistributionSwitchPickFromLocatorThunk } from '../../../apps/distribution/redux/postDistributionSwitchPickFromLocatorThunk';
+import { toastError } from '../../../utils/toast';
 
 const DistributionMoveActivity = ({ applicationId, wfProcessId, activityId, activityState }) => {
   const history = useMobileNavigation();
+  const dispatch = useDispatch();
   const lines = getLinesArrayFromActivity(activityState);
   const {
-    dataStored: { isUserEditable, hasLinesInTransit },
+    dataStored: { isUserEditable, hasLinesInTransit, canSwitchPickFromLocator },
   } = activityState;
 
   const onScannedCode = ({ scannedBarcode: huQRCode }) => {
@@ -30,6 +34,12 @@ const DistributionMoveActivity = ({ applicationId, wfProcessId, activityId, acti
         activityId,
       })
     );
+  };
+
+  const onSwitchPickFromLocator = () => {
+    dispatch(postDistributionSwitchPickFromLocatorThunk({ wfProcessId })).catch((axiosError) => {
+      toastError({ axiosError });
+    });
   };
 
   return (
@@ -54,6 +64,14 @@ const DistributionMoveActivity = ({ applicationId, wfProcessId, activityId, acti
           />
         );
       })}
+      {canSwitchPickFromLocator && (
+        <ButtonWithIndicator
+          testId="switchPickFromLocator-button"
+          caption={trl('activities.distribution.switchPickFromLocator')}
+          disabled={!isUserEditable}
+          onClick={onSwitchPickFromLocator}
+        />
+      )}
       <ButtonWithIndicator
         testId="scanDropToLocator-button"
         caption={trl('activities.distribution.scanDropToLocator')}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionMoveActivity.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionMoveActivity.jsx
@@ -67,7 +67,7 @@ const DistributionMoveActivity = ({ applicationId, wfProcessId, activityId, acti
       {canSwitchPickFromLocator && (
         <ButtonWithIndicator
           testId="switchPickFromLocator-button"
-          data-pickfromlocator={lines[0]?.pickFromLocator?.caption}
+          data-pickfromlocator={lines[0]?.pickFromLocator?.id}
           caption={trl('activities.distribution.switchPickFromLocator')}
           disabled={!isUserEditable}
           onClick={onSwitchPickFromLocator}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/wfProcesses/distribution.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/wfProcesses/distribution.js
@@ -129,6 +129,7 @@ const mergeActivityDataStored = ({ draftActivityDataStored, fromActivity }) => {
   draftActivityDataStored.requireScanningProductCode = job.requireScanningProductCode;
   draftActivityDataStored.isCompleteJobAutomatically = job.completeJobAutomatically;
   draftActivityDataStored.isNavigateToJobsListAfterPickFromComplete = job.navigateToJobsListAfterPickFromComplete;
+  draftActivityDataStored.canSwitchPickFromLocator = !!job.canSwitchPickFromLocator;
   draftActivityDataStored.qtyRejectedReasons = job.qtyRejectedReasons;
 
   //

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -142,6 +142,7 @@ const translations = {
       scanHU: 'Scan HU',
       scanProduct: 'Artikel scannen',
       scanDropToLocator: 'Ziel-Lagerplatz scannen',
+      switchPickFromLocator: 'Lagerort leer',
       invalidLocatorQRCode: 'Lagerplatz QR ungültig',
       invalidQtyToMove: 'Bewegungsmenge ungültig',
       qrcode: {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -139,6 +139,7 @@ const translations = {
       scanHU: 'Scan pick from HU',
       scanProduct: 'Scan Product',
       scanDropToLocator: 'Scan drop to Locator',
+      switchPickFromLocator: 'Locator empty',
       invalidLocatorQRCode: 'Invalid locator QR code',
       invalidQtyToMove: 'Invalid qty to move',
       qrcode: {


### PR DESCRIPTION
## Summary

Adds a **"Lagerort leer"** ("Locator empty") button to the DD_Order mobile app's job-detail screen. When the picker arrives at a locator and finds no material, pressing the button switches the underlying DD_Order's pick-from locator to the **next active locator of the same warehouse** (ordered by `M_Locator.Value`, round-robin). No inventory side-effects.

## Backend

- New SPI `NextPickFromLocatorResolver` + default `LocatorValueRoundRobinResolver` (warehouse → active locators by `M_Locator.Value` ASC → round-robin advance).
- New `DistributionJobSwitchPickFromLocatorCommand` (transactional; loads job → guards → resolves next → updates `DD_OrderLine.M_Locator_ID` on every line → reloads).
- New REST endpoint `POST /api/v2/distribution/job/{wfProcessId}/switchPickFromLocatorToNext` returning the refreshed workflow.
- New `DistributionJob.canSwitchPickFromLocator()` (`true` iff no step is picked AND all lines share one locator).
- New JSON field `JsonDistributionJob.canSwitchPickFromLocator` for server-driven button visibility.
- Two new `AD_Message` keys (DE base + EN/de_DE/de_CH translations): `MobileUI_DDOrder_SwitchPickFromLocator_NotAvailable`, `MobileUI_DDOrder_SwitchPickFromLocator_NoAlternative`.

## Frontend (mobileUI)

- New API + thunk `postDistributionSwitchPickFromLocatorThunk`.
- Reducer wiring (`canSwitchPickFromLocator` flag on activity dataStored).
- New button on `DistributionMoveActivity`: visible only when server says `canSwitchPickFromLocator=true`; on press, dispatches the thunk and updates the workflow.
- i18n DE: `Lagerort leer` / EN: `Locator empty`.

## Tests

- **Unit (JUnit)**: `LocatorValueRoundRobinResolverTest` — 7 cases (advance, wrap, ordering by `Value` not by ID, skip inactive, current-not-in-set returns first, only-current throws `NoAlternative`, zero-active throws `NoAlternative`).
- **Playwright (mobileUI E2E)**: 3 scenarios in `distribution/switchPickFromLocator.spec.js` — advance to next; round-robin cycling; button hidden after picking starts.

## Issue

https://github.com/metasfresh/me03/issues/29964

## Test plan

- [x] Unit tests passing (7/7 in `LocatorValueRoundRobinResolverTest`)
- [ ] CI green (this run)
- [ ] Playwright scenarios green
- [ ] Migration applies cleanly on CI

## Out of scope (parked for follow-ups)

- Custom dt204 preconfigured locator ordering — see `pending-questions.md`; v1 ships the `M_Locator.Value` default behind `NextPickFromLocatorResolver` SPI so a future impl can replace it without ripple.
- Mid-job switching (when at least one line is already picked) — needs effort estimate.