### PR TITLE
me03#30002 fix NPE adding order line: null-guard ASI in AttributeSetInstanceBL

### DIFF
--- a/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/AttributeSetInstanceBL.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/AttributeSetInstanceBL.java
@@ -612,8 +612,12 @@ public class AttributeSetInstanceBL implements IAttributeSetInstanceBL
 	}
 
 	@Override
-	public List<I_M_AttributeInstance> getAttributeInstances(final I_M_AttributeSetInstance attributeSetInstance)
+	public List<I_M_AttributeInstance> getAttributeInstances(@Nullable final I_M_AttributeSetInstance attributeSetInstance)
 	{
+		if (attributeSetInstance == null)
+		{
+			return ImmutableList.of();
+		}
 		//
 		// Ordering by M_AttributeUse.SeqNo
 		final AttributeSetId attributeSetId = AttributeSetId.ofRepoIdOrNone(attributeSetInstance.getM_AttributeSet_ID());

--- a/backend/de.metas.procurement.base/src/main/java/de/metas/procurement/base/impl/PMMProductBL.java
+++ b/backend/de.metas.procurement.base/src/main/java/de/metas/procurement/base/impl/PMMProductBL.java
@@ -129,7 +129,7 @@ public class PMMProductBL implements IPMMProductBL
 														   @NonNull final ProductId productId,
 														   @Nullable final BPartnerId partnerId,
 														   final int huPIPId,
-														   final I_M_AttributeSetInstance asi)
+														   @Nullable final I_M_AttributeSetInstance asi)
 	{
 		final IAttributeSetInstanceBL asiBL = Services.get(IAttributeSetInstanceBL.class);
 		final IPMMProductDAO productDAO = Services.get(IPMMProductDAO.class);

--- a/backend/de.metas.procurement.base/src/main/java/de/metas/procurement/base/order/impl/PMMPricingAware_C_OrderLine.java
+++ b/backend/de.metas.procurement.base/src/main/java/de/metas/procurement/base/order/impl/PMMPricingAware_C_OrderLine.java
@@ -228,6 +228,7 @@ public class PMMPricingAware_C_OrderLine implements IPMMPricingAware
 		return price;
 	}
 
+	@Nullable
 	public I_M_AttributeSetInstance getM_AttributeSetInstance()
 	{
 		return orderLine.getM_AttributeSetInstance();


### PR DESCRIPTION
## Issue
https://github.com/metasfresh/me03/issues/30002 — *Bestellzeile kann nicht hinzugefügt werden*

## Root cause
`AttributeSetInstanceBL.getAttributeInstances(I_M_AttributeSetInstance)` dereferenced its parameter before checking for null. When the order line had no ASI (`C_OrderLine.M_AttributeSetInstance_ID` not set), the procurement flatrate pricing rule pulled a null ASI from `PMMPricingAware_C_OrderLine.getM_AttributeSetInstance()` and the call chain blew up with a 500 NPE on the quickInput `complete` endpoint:

```
AttributeSetInstanceBL.getAttributeInstances:619
 <- PMMProductBL.getPMMProductForDateProductAndASI:145
 <- PMMPricingAware_C_OrderLine.getC_Flatrate_Term:141
 <- ProcurementFlatrateRule.applies:85
 <- AggregatedPricingRule.calculate:89
 <- PricingBL.calculatePrice0:208
 <- OrderLineQuickInputProcessor.process:117
```

## Fix
- `AttributeSetInstanceBL.getAttributeInstances(I_M_AttributeSetInstance)` — accept `@Nullable` and return `ImmutableList.of()` when null.
- `PMMPricingAware_C_OrderLine.getM_AttributeSetInstance()` — annotate `@Nullable` (documents that the return can be null).
- `PMMProductBL.getPMMProductForDateProductAndASI(...)` — annotate `asi` param `@Nullable`.

## Local validation
- Compiled `de.metas.business` (BUILD SUCCESS)
- Compiled `de.metas.procurement.base` (BUILD SUCCESS)
- Ran `de.metas.procurement.base` unit tests — all pass.
- Ran ASI-relevant `de.metas.business` tests (`AttributesKeysTest`, `ImmutableAttributeSetTest`) — all pass.
- Full `de.metas.business` unit suite shows 3 pre-existing failures (`FreightCostTest`, `CustomsInvoiceServiceTest`, `MPaymentTest\$computeAllocationAmt`) — all due to `NotFound C_ConversionType_ID` in test setup, unrelated to this change.