### PR TITLE
Purchase Cockpit: jump to Purchase Candidates

### DIFF
--- a/backend/de.metas.purchasecandidate.base/src/main/sql/postgresql/system/45-de.metas.purchasecandidate/5804880_sys_gh29919_PurchaseCockpit_jump_to_PurchaseCandidate.sql
+++ b/backend/de.metas.purchasecandidate.base/src/main/sql/postgresql/system/45-de.metas.purchasecandidate/5804880_sys_gh29919_PurchaseCockpit_jump_to_PurchaseCandidate.sql
@@ -1,0 +1,128 @@
+-- Migration: 5804880
+-- Issue: https://github.com/metasfresh/me03/issues/29919
+-- Purpose: Add AD_RelationType + AD_Process for "Jump to Purchase Candidates" quick-action on the Purchase Cockpit
+--          Consuming the OpenTarget framework from PR-A
+
+-- ============================================================================
+-- BLOCK A: Source AD_Reference + AD_Ref_Table (RV_PurchaseCockpit)
+-- ============================================================================
+
+INSERT INTO AD_Reference
+  (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+   Name, Description, Help, ValidationType, VFormat, EntityType, IsOrderByValue)
+VALUES
+  (542097, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+   'RV_PurchaseCockpit (Purchase Cockpit jump source)', 'Einkaufsdisposition', NULL, 'T', NULL, 'D', 'N')
+ON CONFLICT (AD_Reference_ID) DO NOTHING;
+
+INSERT INTO AD_Ref_Table
+  (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+   AD_Table_ID, AD_Key, AD_Display, IsValueDisplayed, WhereClause, OrderByClause, EntityType, AD_Window_ID, ShowInactiveValues)
+VALUES
+  (542097, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+   542581, 592051, 592051, 'N', NULL, NULL, 'D', NULL, 'N')
+ON CONFLICT (AD_Reference_ID) DO NOTHING;
+
+-- ============================================================================
+-- BLOCK B: Target AD_Reference + AD_Ref_Table (C_PurchaseCandidate) WITH EXISTS WhereClause
+-- ============================================================================
+
+INSERT INTO AD_Reference
+  (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+   Name, Description, Help, ValidationType, VFormat, EntityType, IsOrderByValue)
+VALUES
+  (542098, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+   'C_PurchaseCandidate (Purchase Cockpit jump target)', 'Bestelldisposition', NULL, 'T', NULL, 'D', 'N')
+ON CONFLICT (AD_Reference_ID) DO NOTHING;
+
+INSERT INTO AD_Ref_Table
+  (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+   AD_Table_ID, AD_Key, AD_Display, IsValueDisplayed, WhereClause, OrderByClause, EntityType, AD_Window_ID, ShowInactiveValues)
+VALUES
+  (542098, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+   540861, 557857, 557857, 'N',
+   $WC$EXISTS (
+     SELECT 1 FROM RV_PurchaseCockpit rv
+     WHERE rv.RV_PurchaseCockpit_ID = @RV_PurchaseCockpit_ID/-1@
+       AND rv.AD_Org_ID      = C_PurchaseCandidate.AD_Org_ID
+       AND rv.M_Product_ID   = C_PurchaseCandidate.M_Product_ID
+       AND rv.M_Warehouse_ID = C_PurchaseCandidate.M_WarehousePO_ID
+       AND COALESCE(rv.AttributesKey, '') = COALESCE(generateasistorageattributeskey(C_PurchaseCandidate.M_AttributeSetInstance_ID), '')
+       AND C_PurchaseCandidate.QtyToPurchase > 0
+   )$WC$,
+   NULL, 'D', NULL, 'N')
+ON CONFLICT (AD_Reference_ID) DO NOTHING;
+
+-- ============================================================================
+-- BLOCK C: AD_RelationType
+-- ============================================================================
+
+INSERT INTO AD_RelationType
+  (AD_RelationType_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+   Name, Description, IsDirected, IsExplicit, Type, InternalName, Role_Source, Role_Target,
+   AD_Reference_Source_ID, AD_Reference_Target_ID, EntityType, IsTableRecordIDTarget)
+VALUES
+  (540498, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+   'RV_PurchaseCockpit → C_PurchaseCandidate', NULL, 'Y', 'N', 'I', 'RV_PurchaseCockpit_C_PurchaseCandidate', NULL, NULL,
+   542097, 542098, 'D', 'N')
+ON CONFLICT (AD_RelationType_ID) DO NOTHING;
+
+-- ============================================================================
+-- BLOCK D: AD_Process + AD_Process_Trl
+-- ============================================================================
+
+INSERT INTO AD_Process
+  (AD_Process_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+   Value, Name, Description, Help, AccessLevel, EntityType, ProcedureName, IsReport, IsDirectPrint,
+   ClassNAME, AD_ReportView_ID, AD_PrintFormat_ID, WorkflowValue, AD_Workflow_ID, IsBetaFunctionality,
+   IsServerProcess, ShowHelp, JasperReport, AD_Form_ID, CopyFromProcess, LockWaitTimeout, RefreshAllAfterExecution,
+   JasperReport_Tabular, AllowProcessRerun, IsUseBPartnerLanguage, IsApplySecuritySettings, TechnicalNote,
+   IsTranslateExcelHeaders, JSONPath, IsNotifyUserAfterExecution, PostgRESTResponseFormat, IsFormatExcelFile,
+   SpreadsheetFormat, CSVFieldDelimiter, IsUpdateExportDate, IsLogWarning, CSVFieldQuote,
+   AD_RelationType_ID, IsIncludeCSVHeaderRow, FileNamePattern, OpenTarget, Type)
+VALUES
+  (585624, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+   'gh29919_JumpToPurchaseCandidate', 'Sprung zu Bestellvorschlägen', NULL, NULL, '3', 'D', NULL, 'N', 'N',
+   'de.metas.ui.web.view.process.RelationTypeInOverlayProcess', NULL, NULL, NULL, NULL, 'N',
+   'N', 'N', NULL, NULL, 'N', 0, 'N',
+   NULL, 'Y', 'Y', 'N', NULL,
+   'Y', NULL, 'N', 'json', 'Y',
+   'xls', NULL, 'N', 'N', '"',
+   540498, 'Y', NULL, 'N', 'RelationTypeInOverlay')
+ON CONFLICT (AD_Process_ID) DO NOTHING;
+
+-- Copy translations from base language
+INSERT INTO AD_Process_Trl
+  (AD_Process_ID, AD_Client_ID, AD_Org_ID, AD_Language, IsActive, Created, CreatedBy, Updated, UpdatedBy, IsTranslated, Name, Description, Help)
+SELECT p.AD_Process_ID, p.AD_Client_ID, p.AD_Org_ID, l.AD_Language, p.IsActive, NOW(), 100, NOW(), 100,
+       CASE WHEN l.AD_Language IN ('de_DE', 'en_US') THEN 'Y' ELSE 'N' END,
+       CASE WHEN l.AD_Language = 'de_DE' THEN 'Sprung zu Bestellvorschlägen'
+            WHEN l.AD_Language = 'en_US' THEN 'Jump to Purchase Candidates'
+            ELSE p.Name
+       END,
+       NULL, NULL
+FROM AD_Process p
+CROSS JOIN AD_Language l
+WHERE p.AD_Process_ID = 585624
+  AND l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND NOT EXISTS (
+    SELECT 1 FROM AD_Process_Trl pt
+    WHERE pt.AD_Process_ID = p.AD_Process_ID
+      AND pt.AD_Language = l.AD_Language
+  )
+ON CONFLICT (AD_Process_ID, AD_Language) DO NOTHING;
+
+-- ============================================================================
+-- BLOCK E: AD_Table_Process
+-- ============================================================================
+
+INSERT INTO AD_Table_Process
+  (AD_Table_Process_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+   AD_Table_ID, AD_Process_ID, WEBUI_ViewQuickAction, WEBUI_ViewQuickAction_Default, WEBUI_ViewAction,
+   WEBUI_IncludedTabTopAction, EntityType)
+VALUES
+  (541644, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+   542581, 585624, 'Y', 'N', 'Y',
+   'N', 'D')
+ON CONFLICT (AD_Table_Process_ID) DO NOTHING;

--- a/backend/de.metas.purchasecandidate.base/src/main/sql/postgresql/system/45-de.metas.purchasecandidate/5804880_sys_gh29919_PurchaseCockpit_jump_to_PurchaseCandidate.sql
+++ b/backend/de.metas.purchasecandidate.base/src/main/sql/postgresql/system/45-de.metas.purchasecandidate/5804880_sys_gh29919_PurchaseCockpit_jump_to_PurchaseCandidate.sql
@@ -11,7 +11,7 @@ INSERT INTO AD_Reference
   (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
    Name, Description, Help, ValidationType, VFormat, EntityType, IsOrderByValue)
 VALUES
-  (542097, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+  (542097 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100,
    'RV_PurchaseCockpit (Purchase Cockpit jump source)', 'Einkaufsdisposition', NULL, 'T', NULL, 'D', 'N')
 ON CONFLICT (AD_Reference_ID) DO NOTHING;
 
@@ -19,7 +19,7 @@ INSERT INTO AD_Ref_Table
   (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
    AD_Table_ID, AD_Key, AD_Display, IsValueDisplayed, WhereClause, OrderByClause, EntityType, AD_Window_ID, ShowInactiveValues)
 VALUES
-  (542097, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+  (542097 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100,
    542581, 592051, 592051, 'N', NULL, NULL, 'D', NULL, 'N')
 ON CONFLICT (AD_Reference_ID) DO NOTHING;
 
@@ -31,7 +31,7 @@ INSERT INTO AD_Reference
   (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
    Name, Description, Help, ValidationType, VFormat, EntityType, IsOrderByValue)
 VALUES
-  (542098, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+  (542098 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100,
    'C_PurchaseCandidate (Purchase Cockpit jump target)', 'Bestelldisposition', NULL, 'T', NULL, 'D', 'N')
 ON CONFLICT (AD_Reference_ID) DO NOTHING;
 
@@ -39,7 +39,7 @@ INSERT INTO AD_Ref_Table
   (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
    AD_Table_ID, AD_Key, AD_Display, IsValueDisplayed, WhereClause, OrderByClause, EntityType, AD_Window_ID, ShowInactiveValues)
 VALUES
-  (542098, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+  (542098 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100,
    540861, 557857, 557857, 'N',
    $WC$EXISTS (
      SELECT 1 FROM RV_PurchaseCockpit rv
@@ -62,7 +62,7 @@ INSERT INTO AD_RelationType
    Name, Description, IsDirected, IsExplicit, Type, InternalName, Role_Source, Role_Target,
    AD_Reference_Source_ID, AD_Reference_Target_ID, EntityType, IsTableRecordIDTarget)
 VALUES
-  (540498, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+  (540498 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100,
    'RV_PurchaseCockpit → C_PurchaseCandidate', NULL, 'Y', 'N', 'I', 'RV_PurchaseCockpit_C_PurchaseCandidate', NULL, NULL,
    542097, 542098, 'D', 'N')
 ON CONFLICT (AD_RelationType_ID) DO NOTHING;
@@ -81,10 +81,10 @@ INSERT INTO AD_Process
    SpreadsheetFormat, CSVFieldDelimiter, IsUpdateExportDate, IsLogWarning, CSVFieldQuote,
    AD_RelationType_ID, IsIncludeCSVHeaderRow, FileNamePattern, OpenTarget, Type)
 VALUES
-  (585624, 0, 0, 'Y', NOW(), 100, NOW(), 100,
-   'gh29919_JumpToPurchaseCandidate', 'Sprung zu Bestellvorschlägen', NULL, NULL, '3', 'D', NULL, 'N', 'N',
+  (585624 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100,
+   'RV_PurchaseCockpit_JumpToPurchaseCandidate', 'Sprung zu Bestellvorschlägen', NULL, NULL, '3', 'D', NULL, 'N', 'N',
    'de.metas.ui.web.view.process.RelationTypeInOverlayProcess', NULL, NULL, NULL, NULL, 'N',
-   'N', 'N', NULL, NULL, 'N', 0, 'N',
+   'N', 'S', NULL, NULL, 'N', 0, 'N',
    NULL, 'Y', 'Y', 'N', NULL,
    'Y', NULL, 'N', 'json', 'Y',
    'xls', NULL, 'N', 'N', '"',
@@ -94,7 +94,7 @@ ON CONFLICT (AD_Process_ID) DO NOTHING;
 -- Copy translations from base language
 INSERT INTO AD_Process_Trl
   (AD_Process_ID, AD_Client_ID, AD_Org_ID, AD_Language, IsActive, Created, CreatedBy, Updated, UpdatedBy, IsTranslated, Name, Description, Help)
-SELECT p.AD_Process_ID, p.AD_Client_ID, p.AD_Org_ID, l.AD_Language, p.IsActive, NOW(), 100, NOW(), 100,
+SELECT p.AD_Process_ID, p.AD_Client_ID, p.AD_Org_ID, l.AD_Language, p.IsActive, TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100,
        CASE WHEN l.AD_Language IN ('de_DE', 'en_US') THEN 'Y' ELSE 'N' END,
        CASE WHEN l.AD_Language = 'de_DE' THEN 'Sprung zu Bestellvorschlägen'
             WHEN l.AD_Language = 'en_US' THEN 'Jump to Purchase Candidates'
@@ -122,7 +122,7 @@ INSERT INTO AD_Table_Process
    AD_Table_ID, AD_Process_ID, WEBUI_ViewQuickAction, WEBUI_ViewQuickAction_Default, WEBUI_ViewAction,
    WEBUI_IncludedTabTopAction, EntityType)
 VALUES
-  (541644, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+  (541644 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100, TO_TIMESTAMP('2026-05-27 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC', 100,
    542581, 585624, 'Y', 'N', 'Y',
    'N', 'D')
 ON CONFLICT (AD_Table_Process_ID) DO NOTHING;


### PR DESCRIPTION
## What

Adds a **"Sprung zu Bestellvorschläge" / "Jump to Purchase Candidates"** quick-action button to the **Purchase Cockpit** (window 542101 "Einkaufs-Cockpit", view `RV_PurchaseCockpit`, AD_Table_ID 542581).

Clicking it opens the matching `C_PurchaseCandidate` rows **in a new browser tab**, filtered by the cockpit row's demand identity `(org, product, warehouse, attributesKey)` with `QtyToPurchase > 0`. No vendor filter — the cockpit's vendor is derived master-data, not a demand dimension.

## How

This is a **metadata-only consumer** (zero Java) of the framework added in https://github.com/metasfresh/metasfresh/pull/24259 (`AD_Process.OpenTarget`). A single migration script adds:

- A new `AD_RelationType` `RV_PurchaseCockpit → C_PurchaseCandidate` (source + target `AD_Reference` / `AD_Ref_Table`, with the demand-identity `WhereClause` on the target side).
- A new `AD_Process` (`Type='RelationTypeInOverlay'`, `OpenTarget='N'` = new browser tab, `ShowHelp='S'`).
- A new `AD_Table_Process` wiring the process as a quick action on `RV_PurchaseCockpit`.

## Testing

- Migration applied cleanly against local infra; target-side `WhereClause` verified to parse (COUNT query, no syntax error).
- No automated frontend test in this PR — matches the sibling relation-type jumps (none have one). The button gets exercised at the peer-review demo on customer UAT data.

Closes the framework-consumer half of the feature; framework half = https://github.com/metasfresh/metasfresh/pull/24259 (merged).
