### PR TITLE
Port: Camel lenient JSON parsing + ErrorProcessor non-error guard (new_dawn_uat)

### DIFF
--- a/misc/services/camel/de-metas-camel-externalsystems/common/src/main/java/de/metas/camel/externalsystems/common/JsonObjectMapperHolder.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/common/src/main/java/de/metas/camel/externalsystems/common/JsonObjectMapperHolder.java
@@ -53,6 +53,7 @@ public class JsonObjectMapperHolder
 				.findAndRegisterModules()
 				.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 				.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+				.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 				.enable(MapperFeature.USE_ANNOTATIONS);
 	}
 }

--- a/misc/services/camel/de-metas-camel-externalsystems/common/src/main/java/de/metas/camel/externalsystems/common/error/ErrorProcessor.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/common/src/main/java/de/metas/camel/externalsystems/common/error/ErrorProcessor.java
@@ -31,6 +31,8 @@ import de.metas.common.rest_api.v2.JsonErrorItem;
 import de.metas.common.util.CoalesceUtil;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
+
+import javax.annotation.Nullable;
 import org.apache.camel.Exchange;
 import org.apache.camel.http.base.HttpOperationFailedException;
 
@@ -139,7 +141,19 @@ public class ErrorProcessor
 			final JsonApiResponse apiResponse = objectMapper
 					.readValue(response, JsonApiResponse.class);
 
-			final JsonError jsonError = objectMapper.convertValue(apiResponse.getEndpointResponse(), JsonError.class)
+			if (apiResponse.getEndpointResponse() == null)
+			{
+				return Optional.empty();
+			}
+
+			final JsonError convertedError = objectMapper.convertValue(apiResponse.getEndpointResponse(), JsonError.class);
+
+			if (!isJsonErrorShaped(convertedError))
+			{
+				return Optional.empty();
+			}
+
+			final JsonError jsonError = convertedError
 					.toBuilder()
 					.requestId(apiResponse.getRequestId())
 					.build();
@@ -167,11 +181,26 @@ public class ErrorProcessor
 			final JsonError jsonError = JsonObjectMapperHolder.sharedJsonObjectMapper()
 					.readValue(response, JsonError.class);
 
+			if (!isJsonErrorShaped(jsonError))
+			{
+				return Optional.empty();
+			}
+
 			return Optional.of(jsonError);
 		}
 		catch (final JsonProcessingException e)
 		{
 			return Optional.empty();
 		}
+	}
+
+	/**
+	 * The shared ObjectMapper is configured to ignore unknown properties, so a non-error payload
+	 * may parse into a {@link JsonError} with no items. Treat such partial deserialisations as
+	 * "not a JsonError" so the caller falls back to the stacktrace path.
+	 */
+	private static boolean isJsonErrorShaped(@Nullable final JsonError jsonError)
+	{
+		return jsonError != null && jsonError.getErrors() != null && !jsonError.getErrors().isEmpty();
 	}
 }


### PR DESCRIPTION
Port of https://github.com/metasfresh/metasfresh/pull/23993 (merged into `inner_silence_uat` as commit `ec2c446ef7f`) to `new_dawn_uat`.

## Summary
- `JsonObjectMapperHolder` (shared by all camel external-system modules): disable `FAIL_ON_UNKNOWN_PROPERTIES`. Customers can now attach metadata / forward-compat fields without breaking the parse.
- `ErrorProcessor`: explicit `isJsonErrorShaped(...)` guard replaces the implicit "Jackson throws → wrong shape" detection that lenient mode breaks. Restores the V2 → V1 → stacktrace fallback chain and removes the NPE on V1-shaped bodies.

## Divergence note
The original commit also added WARN-logging in `MassUpsertStatisticsCollector` (module `de-metas-camel-metasfresh`). That module does not exist on `new_dawn_uat`, so the file is dropped from the port. The shared-mapper + ErrorProcessor changes still benefit every camel external-system integration on `new_dawn_uat`.

Diff: `+31 / -1` across 2 files.

## Test plan
- [ ] CI green
- [ ] `de-metas-camel-externalsystems-common` JUnit suite passes (4 ErrorProcessorTest cases, 2 auth tests)