### PR TITLE
Split Sales Order — continuation order for unshipped quantity

### DIFF
--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5804900_sys_me03_29261_AD_Message_C_Order_Split_validation.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5804900_sys_me03_29261_AD_Message_C_Order_Split_validation.sql
@@ -5,11 +5,11 @@ INSERT INTO AD_Message (
     AD_Message_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
     Value, MsgText, MsgType, EntityType
 ) VALUES
-    (545728, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+    (545728 /*From ID Server*/, 0, 0, 'Y', NOW(), 100, NOW(), 100,
      'C_Order_Split_NoShipments',
      'Der Auftrag hat keine fertig gestellten Lieferscheine — eine Aufteilung ist nur nach mindestens einer Lieferung sinnvoll.',
      'E', 'de.metas.order'),
-    (545729, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+    (545729 /*From ID Server*/, 0, 0, 'Y', NOW(), 100, NOW(), 100,
      'C_Order_Split_NothingToSplit',
      'Der Auftrag hat keine offene Liefermenge — es gibt nichts aufzuteilen.',
      'E', 'de.metas.order');
@@ -19,9 +19,9 @@ INSERT INTO AD_Message_Trl (
     AD_Message_ID, AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
     MsgText, IsTranslated
 ) VALUES
-    (545728, 'en_US', 0, 0, 'Y', NOW(), 100, NOW(), 100,
+    (545728 /*From ID Server*/, 'en_US', 0, 0, 'Y', NOW(), 100, NOW(), 100,
      'Order has no completed shipments — splitting is only meaningful after at least one shipment.',
      'Y'),
-    (545729, 'en_US', 0, 0, 'Y', NOW(), 100, NOW(), 100,
+    (545729 /*From ID Server*/, 'en_US', 0, 0, 'Y', NOW(), 100, NOW(), 100,
      'Order has no unshipped quantity — nothing to split off.',
      'Y');

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5804900_sys_me03_29261_AD_Message_C_Order_Split_validation.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5804900_sys_me03_29261_AD_Message_C_Order_Split_validation.sql
@@ -1,0 +1,27 @@
+-- AD_Messages for OrderSplit validation errors
+-- Base language is German per metasfresh convention (DE-base + en_US translation).
+
+INSERT INTO AD_Message (
+    AD_Message_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+    Value, MsgText, MsgType, EntityType
+) VALUES
+    (545728, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+     'C_Order_Split_NoShipments',
+     'Der Auftrag hat keine fertig gestellten Lieferscheine — eine Aufteilung ist nur nach mindestens einer Lieferung sinnvoll.',
+     'E', 'de.metas.order'),
+    (545729, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+     'C_Order_Split_NothingToSplit',
+     'Der Auftrag hat keine offene Liefermenge — es gibt nichts aufzuteilen.',
+     'E', 'de.metas.order');
+
+-- English translation (en_US)
+INSERT INTO AD_Message_Trl (
+    AD_Message_ID, AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+    MsgText, IsTranslated
+) VALUES
+    (545728, 'en_US', 0, 0, 'Y', NOW(), 100, NOW(), 100,
+     'Order has no completed shipments — splitting is only meaningful after at least one shipment.',
+     'Y'),
+    (545729, 'en_US', 0, 0, 'Y', NOW(), 100, NOW(), 100,
+     'Order has no unshipped quantity — nothing to split off.',
+     'Y');

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5804910_sys_me03_29261_AD_Process_C_Order_Split.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5804910_sys_me03_29261_AD_Process_C_Order_Split.sql
@@ -1,0 +1,33 @@
+-- AD_Process: C_Order_Split
+-- Base language is German per metasfresh convention; en_US translation in AD_Process_Trl.
+-- Note: AD_Process does NOT have an AD_Table_ID column in this codebase.
+-- Process-to-table binding is handled in the AD_Table_Process migration (5804940_*.sql).
+
+INSERT INTO AD_Process (
+    AD_Process_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+    Value, Name, Description, Help, EntityType, Classname, AccessLevel, IsReport,
+    ShowHelp
+) VALUES (
+    585625 /*From ID Server*/, 0, 0, 'Y', NOW(), 100, NOW(), 100,
+    'C_Order_Split',
+    'Auftrag aufteilen (Folgeauftrag für offene Menge)',
+    'Erstellt einen Folgeauftrag mit allen Positionen, deren Liefermenge noch offen ist. Anschließend werden die Lieferdispositionen und aktiven Reservierungen des ursprünglichen Auftrags geschlossen.',
+    'Wird nach Teil-Lieferung verwendet, wenn die Restmenge in einem anderen Projektkontext reserviert / beschafft werden soll. Die Fakturierungs-Kandidaten des ursprünglichen Auftrags bleiben unverändert und können später mit jenen des Folgeauftrags zusammen fakturiert werden.',
+    'de.metas.order',
+    'de.metas.order.split.C_Order_Split',
+    '7',
+    'N',
+    'Y'
+);
+
+-- English translation (en_US)
+INSERT INTO AD_Process_Trl (
+    AD_Process_ID, AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+    Name, Description, Help, IsTranslated
+) VALUES (
+    585625 /*From ID Server*/, 'en_US', 0, 0, 'Y', NOW(), 100, NOW(), 100,
+    'Split order (continuation order for unshipped qty)',
+    'Creates a continuation sales order containing all lines that still have unshipped quantity, then closes the shipment schedules and active reservations of the original order.',
+    'Use after the original order has been partially shipped and the remaining quantity needs to be re-reserved / re-sourced in a different project context. Invoice candidates on the original order are left untouched and can be invoiced together with the continuation order''s invoice candidates.',
+    'Y'
+);

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5804920_sys_me03_29261_AD_Process_Access_C_Order_Split.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5804920_sys_me03_29261_AD_Process_Access_C_Order_Split.sql
@@ -1,0 +1,17 @@
+-- Grant process access to standard test/admin roles.
+-- The System role is auto-granted on AD_Process insert by the model interceptor;
+-- explicitly seeding GardenAdmin + metasfresh Admin so test users see the action.
+
+INSERT INTO AD_Process_Access (
+    AD_Role_ID, AD_Process_ID, AD_Client_ID, AD_Org_ID, IsActive,
+    Created, CreatedBy, Updated, UpdatedBy, IsReadWrite
+)
+SELECT r.AD_Role_ID, 585625 /*From ID Server*/, 0, 0, 'Y',
+       NOW(), 100, NOW(), 100, 'Y'
+FROM AD_Role r
+WHERE r.Name IN ('System', 'GardenAdmin', 'metasfresh Admin')
+  AND NOT EXISTS (
+      SELECT 1 FROM AD_Process_Access pa
+      WHERE pa.AD_Role_ID = r.AD_Role_ID
+        AND pa.AD_Process_ID = 585625 /*From ID Server*/
+  );

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5804940_sys_me03_29261_AD_Table_Process_C_Order_Split.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5804940_sys_me03_29261_AD_Table_Process_C_Order_Split.sql
@@ -1,0 +1,20 @@
+-- Bind AD_Process C_Order_Split to AD_Table C_Order so the process appears
+-- on the sales-order window (as a document action) and on the orders list
+-- view (as a view action). Process-to-table binding lives in AD_Table_Process
+-- in this codebase (AD_Process itself has no AD_Table_ID column).
+
+INSERT INTO AD_Table_Process (
+    AD_Table_Process_ID, AD_Client_ID, AD_Org_ID, IsActive,
+    Created, CreatedBy, Updated, UpdatedBy,
+    AD_Table_ID, AD_Process_ID, EntityType,
+    WEBUI_DocumentAction, WEBUI_ViewAction,
+    WEBUI_ViewQuickAction, WEBUI_ViewQuickAction_Default,
+    WEBUI_IncludedTabTopAction
+) VALUES (
+    541645 /*From ID Server*/, 0, 0, 'Y',
+    NOW(), 100, NOW(), 100,
+    259, 585625 /*From ID Server*/, 'de.metas.order',
+    'Y', 'Y',
+    'N', 'N',
+    'N'
+);

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5804950_sys_me03_29261_AD_Process_C_Order_Split_fixups.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5804950_sys_me03_29261_AD_Process_C_Order_Split_fixups.sql
@@ -1,0 +1,20 @@
+-- Fix-ups for AD_Process C_Order_Split (registered in 5804910 + 5804940).
+-- Two corrections raised in code review of commit 0e781f9:
+--   1. AD_Process.AccessLevel '7' (System+Org+Client) is wider than needed for a
+--      user-facing transactional process; '3' (Org+Client) is the standard.
+--   2. AD_Table_Process.AD_Window_ID was NULL → the action appeared on every C_Order
+--      window including the purchase-order window (AD_Window_ID 181 "Bestellung").
+--      Bind it explicitly to the sales-order window (AD_Window_ID 143 "Auftrag")
+--      so it only shows up on sales orders.
+
+UPDATE AD_Process
+   SET AccessLevel = '3',
+       Updated = NOW(),
+       UpdatedBy = 100
+ WHERE Value = 'C_Order_Split';
+
+UPDATE AD_Table_Process
+   SET AD_Window_ID = 143 /*From ID Server*/,
+       Updated = NOW(),
+       UpdatedBy = 100
+ WHERE AD_Process_ID = 585625 /*From ID Server*/;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5805150_sys_OrderSplit_AD_Message_ErrorCode_and_Trl.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5805150_sys_OrderSplit_AD_Message_ErrorCode_and_Trl.sql
@@ -9,7 +9,6 @@
 
 -- Set ErrorCode on both error messages
 UPDATE AD_Message
-UPDATE AD_Message
    SET ErrorCode = 'ORDER_SPLIT_NO_SHIPMENTS',
        Updated = TO_TIMESTAMP('2026-05-28 06:30:00', 'YYYY-MM-DD HH24:MI:SS'),
        UpdatedBy = 100

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5805150_sys_OrderSplit_AD_Message_ErrorCode_and_Trl.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5805150_sys_OrderSplit_AD_Message_ErrorCode_and_Trl.sql
@@ -1,0 +1,43 @@
+-- Follow-up for the OrderSplit validation AD_Messages (registered earlier in 5804900):
+--   * Set ErrorCode on both MsgType='E' rows so API consumers can handle them
+--     programmatically.
+--   * Seed AD_Message_Trl for de_DE and de_CH (base text is already German, just
+--     copy the MsgText and mark IsTranslated='Y'). The earlier script only seeded
+--     en_US.
+-- Timestamps are hardcoded (TO_TIMESTAMP) per metasfresh-db convention so the script
+-- is deterministic across DB replays.
+
+-- Set ErrorCode on both error messages
+UPDATE AD_Message
+UPDATE AD_Message
+   SET ErrorCode = 'ORDER_SPLIT_NO_SHIPMENTS',
+       Updated = TO_TIMESTAMP('2026-05-28 06:30:00', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+ WHERE Value = 'C_Order_Split_NoShipments';
+
+UPDATE AD_Message
+   SET ErrorCode = 'ORDER_SPLIT_NOTHING_TO_SPLIT',
+       Updated = TO_TIMESTAMP('2026-05-28 06:30:00', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+ WHERE Value = 'C_Order_Split_NothingToSplit';
+
+-- Seed AD_Message_Trl for de_DE and de_CH (base text is German, IsTranslated='Y').
+-- en_US is already inserted by 5804900. The SELECT … WHERE NOT EXISTS guard keeps this
+-- script idempotent.
+INSERT INTO AD_Message_Trl (
+    AD_Message_ID, AD_Language, AD_Client_ID, AD_Org_ID, IsActive,
+    Created, CreatedBy, Updated, UpdatedBy,
+    MsgText, IsTranslated
+)
+SELECT m.AD_Message_ID, lang.AD_Language, 0, 0, 'Y',
+       TO_TIMESTAMP('2026-05-28 06:30:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       TO_TIMESTAMP('2026-05-28 06:30:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       m.MsgText, 'Y'
+FROM AD_Message m
+CROSS JOIN (VALUES ('de_DE'), ('de_CH')) AS lang(AD_Language)
+WHERE m.Value IN ('C_Order_Split_NoShipments', 'C_Order_Split_NothingToSplit')
+  AND NOT EXISTS (
+      SELECT 1 FROM AD_Message_Trl t
+      WHERE t.AD_Message_ID = m.AD_Message_ID
+        AND t.AD_Language = lang.AD_Language
+  );

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_Split_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_Split_StepDef.java
@@ -336,6 +336,7 @@ public class C_Order_Split_StepDef
 				.setAD_Process_ID(processId.getRepoId())
 				.setRecord(I_C_Order.Table_Name, order.getC_Order_ID())
 				.buildAndPrepareExecution()
-				.executeSync();
+				.executeSync()
+				.getResult();
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_Split_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_Split_StepDef.java
@@ -1,0 +1,341 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.order;
+
+import de.metas.cucumber.stepdefs.M_Product_StepDefData;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.cucumber.stepdefs.StepDefUtil;
+import de.metas.process.AdProcessId;
+import de.metas.process.IADProcessDAO;
+import de.metas.process.ProcessExecutionResult;
+import de.metas.process.ProcessInfo;
+import de.metas.util.Services;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_OrderLine;
+import org.compiere.model.I_M_Product;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Step definitions for invoking the {@code C_Order_Split} AD_Process and asserting its outcome.
+ *
+ * <h3>Steps provided:</h3>
+ * <ul>
+ *   <li>{@code the C_Order_Split process is invoked on "<identifier>"} — runs the process; fails if the process result is an error</li>
+ *   <li>{@code the C_Order_Split process is invoked on "<identifier>" expecting validation failure} — runs the process, captures the error message; asserts an error WAS raised</li>
+ *   <li>{@code the validation error message includes "<substring>"} — asserts the captured error message contains the expected substring</li>
+ *   <li>{@code the continuation order for "<identifier>" is found and stored as "<newIdentifier>"} — looks up the NEW SO by POReference=oldSO.DocumentNo and registers it</li>
+ *   <li>{@code no continuation order exists for "<identifier>"} — asserts that no C_Order with POReference=oldSO.DocumentNo was created</li>
+ *   <li>{@code the continuation order "<identifier>" has exactly <N> line(s)} — asserts line count on the continuation order</li>
+ *   <li>{@code the continuation order "<identifier>" has exactly 1 line with QtyEntered=<qty> for product "<productIdentifier>"} — asserts a specific line's qty</li>
+ *   <li>{@code the continuation order "<identifier>" has no line for product "<productIdentifier>"} — asserts a product does NOT appear in the continuation order</li>
+ * </ul>
+ */
+@RequiredArgsConstructor
+public class C_Order_Split_StepDef
+{
+	@NonNull private final IADProcessDAO adProcessDAO = Services.get(IADProcessDAO.class);
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@NonNull private final C_Order_StepDefData orderTable;
+	@NonNull private final M_Product_StepDefData productTable;
+
+	/** Stores the last validation-failure message from the process, available for assertion by the next Then step. */
+	@Nullable
+	private String lastValidationErrorMessage;
+
+	// ---- process invocation ----
+
+	/**
+	 * Invokes the {@code C_Order_Split} process on the order identified by {@code orderIdentifier}.
+	 * Fails immediately if the process returns an error result.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * When the C_Order_Split process is invoked on "so_os10"
+	 * </pre>
+	 */
+	@When("the C_Order_Split process is invoked on {string}")
+	public void invokeOrderSplit(@NonNull final String orderIdentifier)
+	{
+		lastValidationErrorMessage = null;
+
+		final I_C_Order order = orderTable.get(StepDefDataIdentifier.ofString(orderIdentifier));
+		final ProcessExecutionResult result = buildAndExecuteProcess(order);
+
+		if (result.isError())
+		{
+			throw new AssertionError("C_Order_Split process returned an error (expected success): " + result.getSummary());
+		}
+	}
+
+	/**
+	 * Invokes the {@code C_Order_Split} process on the order identified by {@code orderIdentifier},
+	 * expecting it to throw an {@link AdempiereException} due to a validation guard.
+	 * Captures the exception message for assertion by {@code the validation error message includes ...}.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * When the C_Order_Split process is invoked on "so_os60" expecting validation failure
+	 * </pre>
+	 */
+	@When("the C_Order_Split process is invoked on {string} expecting validation failure")
+	public void invokeOrderSplitExpectingValidationFailure(@NonNull final String orderIdentifier)
+	{
+		lastValidationErrorMessage = null;
+
+		final I_C_Order order = orderTable.get(StepDefDataIdentifier.ofString(orderIdentifier));
+		try
+		{
+			final ProcessExecutionResult result = buildAndExecuteProcess(order);
+			if (result.isError())
+			{
+				// Process returned an error result (not an exception) — treat as validation failure
+				lastValidationErrorMessage = result.getSummary();
+			}
+			else
+			{
+				throw new AssertionError("C_Order_Split process was expected to fail with a validation error, but it succeeded.");
+			}
+		}
+		catch (final AdempiereException ex)
+		{
+			lastValidationErrorMessage = ex.getMessage();
+		}
+		catch (final Exception ex)
+		{
+			// Any other runtime exception from the process is also treated as a validation failure
+			lastValidationErrorMessage = ex.getMessage();
+		}
+
+		assertThat(lastValidationErrorMessage)
+				.as("Expected a non-null validation error message but got null")
+				.isNotNull();
+	}
+
+	/**
+	 * Asserts that the most recently captured validation error message contains the given {@code expectedSubstring}.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then the validation error message includes "C_Order_Split_NoShipments"
+	 * </pre>
+	 */
+	@Then("the validation error message includes {string}")
+	public void validationErrorMessageIncludes(@NonNull final String expectedSubstring)
+	{
+		assertThat(lastValidationErrorMessage)
+				.as("Validation error message should contain '" + expectedSubstring + "'")
+				.contains(expectedSubstring);
+	}
+
+	// ---- continuation order assertions ----
+
+	/**
+	 * Looks up the NEW (continuation) SO whose {@code POReference} equals the DocumentNo of the OLD SO,
+	 * and registers it in {@link C_Order_StepDefData} under {@code newOrderIdentifier} so that
+	 * subsequent {@code validate the created orders} steps can reference it.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then the continuation order for "so_os10" is found and stored as "new_so_os10"
+	 * </pre>
+	 */
+	@Then("the continuation order for {string} is found and stored as {string}")
+	public void continuationOrderIsFoundAndStoredAs(
+			@NonNull final String oldOrderIdentifier,
+			@NonNull final String newOrderIdentifier)
+	{
+		final I_C_Order oldOrder = orderTable.get(StepDefDataIdentifier.ofString(oldOrderIdentifier));
+		final String oldDocumentNo = oldOrder.getDocumentNo();
+
+		final I_C_Order newOrder = queryBL.createQueryBuilder(I_C_Order.class)
+				.addEqualsFilter(I_C_Order.COLUMNNAME_POReference, oldDocumentNo)
+				.addEqualsFilter(I_C_Order.COLUMNNAME_IsSOTrx, true)
+				.create()
+				.firstOnlyOrNull(I_C_Order.class);
+
+		assertThat(newOrder)
+				.as("Expected a continuation SO with POReference='%s' but found none", oldDocumentNo)
+				.isNotNull();
+
+		orderTable.putOrReplace(StepDefDataIdentifier.ofString(newOrderIdentifier), newOrder);
+	}
+
+	/**
+	 * Asserts that NO continuation SO was created for the given old order
+	 * (i.e. no C_Order with POReference=oldSO.DocumentNo exists).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * And no continuation order exists for "so_os60"
+	 * </pre>
+	 */
+	@And("no continuation order exists for {string}")
+	public void noContinuationOrderExistsFor(@NonNull final String oldOrderIdentifier)
+	{
+		final I_C_Order oldOrder = orderTable.get(StepDefDataIdentifier.ofString(oldOrderIdentifier));
+		final String oldDocumentNo = oldOrder.getDocumentNo();
+
+		final int count = queryBL.createQueryBuilder(I_C_Order.class)
+				.addEqualsFilter(I_C_Order.COLUMNNAME_POReference, oldDocumentNo)
+				.addEqualsFilter(I_C_Order.COLUMNNAME_IsSOTrx, true)
+				.create()
+				.count();
+
+		assertThat(count)
+				.as("Expected no continuation SO with POReference='%s', but found %d", oldDocumentNo, count)
+				.isZero();
+	}
+
+	/**
+	 * Asserts that the continuation order (already registered under {@code continuationOrderIdentifier})
+	 * has exactly {@code expectedLineCount} active C_OrderLine rows.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * And the continuation order "new_so_os20" has exactly 2 lines
+	 * </pre>
+	 */
+	@And("the continuation order {string} has exactly {int} lines")
+	public void continuationOrderHasExactlyNLines(
+			@NonNull final String continuationOrderIdentifier,
+			final int expectedLineCount)
+	{
+		final I_C_Order continuationOrder = orderTable.get(StepDefDataIdentifier.ofString(continuationOrderIdentifier));
+		InterfaceWrapperHelper.refresh(continuationOrder);
+
+		final int actualCount = queryBL.createQueryBuilder(I_C_OrderLine.class)
+				.addEqualsFilter(I_C_OrderLine.COLUMNNAME_C_Order_ID, continuationOrder.getC_Order_ID())
+				.addOnlyActiveRecordsFilter()
+				.create()
+				.count();
+
+		assertThat(actualCount)
+				.as("Continuation order '%s' should have exactly %d lines but has %d", continuationOrderIdentifier, expectedLineCount, actualCount)
+				.isEqualTo(expectedLineCount);
+	}
+
+	/**
+	 * Asserts that the continuation order has exactly 1 active C_OrderLine for the given product
+	 * with the specified QtyEntered.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * And the continuation order "new_so_os10" has exactly 1 line with QtyEntered=2 for product "product_os"
+	 * </pre>
+	 */
+	@And("the continuation order {string} has exactly 1 line with QtyEntered={int} for product {string}")
+	public void continuationOrderHasLineWithQtyForProduct(
+			@NonNull final String continuationOrderIdentifier,
+			final int expectedQtyEntered,
+			@NonNull final String productIdentifier)
+	{
+		final I_C_Order continuationOrder = orderTable.get(StepDefDataIdentifier.ofString(continuationOrderIdentifier));
+		InterfaceWrapperHelper.refresh(continuationOrder);
+
+		final I_M_Product product = productTable.get(StepDefDataIdentifier.ofString(productIdentifier));
+
+		final List<I_C_OrderLine> matchingLines = queryBL.createQueryBuilder(I_C_OrderLine.class)
+				.addEqualsFilter(I_C_OrderLine.COLUMNNAME_C_Order_ID, continuationOrder.getC_Order_ID())
+				.addEqualsFilter(I_C_OrderLine.COLUMNNAME_M_Product_ID, product.getM_Product_ID())
+				.addOnlyActiveRecordsFilter()
+				.create()
+				.list(I_C_OrderLine.class);
+
+		assertThat(matchingLines)
+				.as("Expected exactly 1 line for product '%s' in continuation order '%s'", productIdentifier, continuationOrderIdentifier)
+				.hasSize(1);
+
+		final I_C_OrderLine line = matchingLines.get(0);
+		assertThat(line.getQtyEntered())
+				.as("QtyEntered for product '%s' in continuation order '%s'", productIdentifier, continuationOrderIdentifier)
+				.isEqualByComparingTo(BigDecimal.valueOf(expectedQtyEntered));
+	}
+
+	/**
+	 * Asserts that the continuation order has NO active C_OrderLine for the given product.
+	 * Used to verify that fully-delivered or over-delivered lines from the OLD SO
+	 * were NOT copied to the NEW SO.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * And the continuation order "new_so_os20" has no line for product "product_os"
+	 * </pre>
+	 */
+	@And("the continuation order {string} has no line for product {string}")
+	public void continuationOrderHasNoLineForProduct(
+			@NonNull final String continuationOrderIdentifier,
+			@NonNull final String productIdentifier)
+	{
+		final I_C_Order continuationOrder = orderTable.get(StepDefDataIdentifier.ofString(continuationOrderIdentifier));
+		InterfaceWrapperHelper.refresh(continuationOrder);
+
+		final I_M_Product product = productTable.get(StepDefDataIdentifier.ofString(productIdentifier));
+
+		final int count = queryBL.createQueryBuilder(I_C_OrderLine.class)
+				.addEqualsFilter(I_C_OrderLine.COLUMNNAME_C_Order_ID, continuationOrder.getC_Order_ID())
+				.addEqualsFilter(I_C_OrderLine.COLUMNNAME_M_Product_ID, product.getM_Product_ID())
+				.addOnlyActiveRecordsFilter()
+				.create()
+				.count();
+
+		assertThat(count)
+				.as("Continuation order '%s' should NOT have a line for product '%s', but found %d", continuationOrderIdentifier, productIdentifier, count)
+				.isZero();
+	}
+
+	// ---- private helpers ----
+
+	private ProcessExecutionResult buildAndExecuteProcess(@NonNull final I_C_Order order)
+	{
+		final AdProcessId processId = adProcessDAO.retrieveProcessIdByValue("C_Order_Split");
+		assertThat(processId).as("AD_Process 'C_Order_Split' must exist in the database").isNotNull();
+
+		return ProcessInfo.builder()
+				.setAD_Process_ID(processId.getRepoId())
+				.setRecord(I_C_Order.Table_Name, order.getC_Order_ID())
+				.buildAndPrepareExecution()
+				.executeSync();
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderSplit.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderSplit.feature
@@ -324,7 +324,7 @@ Feature: Split sales order — create a continuation order for unshipped quantit
 
     When the C_Order_Split process is invoked on "so_os60" expecting validation failure
 
-    Then the validation error message includes "C_Order_Split_NoShipments"
+    Then the validation error message includes "keine fertig gestellten Lieferscheine"
 
     # No continuation order created
     And no continuation order exists for "so_os60"
@@ -364,7 +364,7 @@ Feature: Split sales order — create a continuation order for unshipped quantit
 
     When the C_Order_Split process is invoked on "so_os70" expecting validation failure
 
-    Then the validation error message includes "C_Order_Split_NothingToSplit"
+    Then the validation error message includes "keine offene Liefermenge"
 
     # No continuation order created
     And no continuation order exists for "so_os70"

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderSplit.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderSplit.feature
@@ -65,8 +65,8 @@ Feature: Split sales order — create a continuation order for unshipped quantit
 
     # Deliver 8 of 10 (partial shipment)
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
-      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override |
-      | sched_os10_1          | D            | true                | false       | 8                     |
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
+      | sched_os10_1          | D            | false               | false       | 8                                               |
 
     # Wait for the async shipment workpackage to complete and create the M_InOut
     And after not more than 60s, M_InOut is found:
@@ -135,8 +135,8 @@ Feature: Split sales order — create a continuation order for unshipped quantit
       | M_ShipmentSchedule_ID | M_InOut_ID    |
       | sched_os20_A          | inout_os20_A  |
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
-      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override |
-      | sched_os20_B          | D            | true                | false       | 4                     |
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
+      | sched_os20_B          | D            | false               | false       | 4                                               |
     And after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID    |
       | sched_os20_B          | inout_os20_B  |
@@ -197,8 +197,8 @@ Feature: Split sales order — create a continuation order for unshipped quantit
       | M_ShipmentSchedule_ID | M_InOut_ID    |
       | sched_os30_A          | inout_os30_A  |
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
-      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override |
-      | sched_os30_B          | D            | true                | false       | 6                     |
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
+      | sched_os30_B          | D            | false               | false       | 6                                               |
     And after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID    |
       | sched_os30_B          | inout_os30_B  |
@@ -244,8 +244,8 @@ Feature: Split sales order — create a continuation order for unshipped quantit
       | sched_os40_1 | sol_os40_1     | N             |
 
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
-      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override |
-      | sched_os40_1          | D            | true                | false       | 4                     |
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
+      | sched_os40_1          | D            | false               | false       | 4                                               |
     And after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID  |
       | sched_os40_1          | inout_os40  |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderSplit.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderSplit.feature
@@ -29,10 +29,10 @@ Feature: Split sales order — create a continuation order for unshipped quantit
       | Identifier | IsStocked |
       | product_os | false     |
     And metasfresh contains M_ProductPrices
-      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | plv_os                 | product_os   | 10.00    | PCE               | Normal                        |
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_os      | plv_os                 | product_os   | 10.00    | PCE               | Normal                        |
 
-    And metasfresh contains C_BPartners:
+    And metasfresh contains C_BPartners without locations:
       | Identifier | IsCustomer | M_PricingSystem_ID |
       | bp_os      | true       | ps_os              |
     And metasfresh contains C_BPartner_Locations:
@@ -40,7 +40,7 @@ Feature: Split sales order — create a continuation order for unshipped quantit
       | bp_os_loc  | bp_os         | Y               | Y               |
 
     And metasfresh contains M_Warehouse:
-      | Identifier  |
+      | Identifier   |
       | warehouse_os |
 
 
@@ -102,9 +102,9 @@ Feature: Split sales order — create a continuation order for unshipped quantit
       | product_os2 | false     |
       | product_os3 | false     |
     And metasfresh contains M_ProductPrices
-      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | plv_os                 | product_os2  | 12.00    | PCE               | Normal                        |
-      | plv_os                 | product_os3  | 15.00    | PCE               | Normal                        |
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_os2     | plv_os                 | product_os2  | 12.00    | PCE               | Normal                        |
+      | pp_os3     | plv_os                 | product_os3  | 15.00    | PCE               | Normal                        |
 
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
@@ -161,8 +161,8 @@ Feature: Split sales order — create a continuation order for unshipped quantit
       | Identifier   | IsStocked |
       | product_os30 | false     |
     And metasfresh contains M_ProductPrices
-      | M_PriceList_Version_ID | M_Product_ID  | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | plv_os                 | product_os30  | 8.00     | PCE               | Normal                        |
+      | Identifier | M_PriceList_Version_ID | M_Product_ID  | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_os30    | plv_os                 | product_os30  | 8.00     | PCE               | Normal                        |
 
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
@@ -253,8 +253,8 @@ Feature: Split sales order — create a continuation order for unshipped quantit
       | Identifier   | IsStocked |
       | product_os50 | false     |
     And metasfresh contains M_ProductPrices
-      | M_PriceList_Version_ID | M_Product_ID  | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | plv_os                 | product_os50  | 9.00     | PCE               | Normal                        |
+      | Identifier | M_PriceList_Version_ID | M_Product_ID  | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_os50    | plv_os                 | product_os50  | 9.00     | PCE               | Normal                        |
 
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderSplit.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderSplit.feature
@@ -68,6 +68,11 @@ Feature: Split sales order — create a continuation order for unshipped quantit
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override |
       | sched_os10_1          | D            | true                | false       | 8                     |
 
+    # Wait for the async shipment workpackage to complete and create the M_InOut
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID  |
+      | sched_os10_1          | inout_os10  |
+
     When the C_Order_Split process is invoked on "so_os10"
 
     # NEW continuation order must exist with POReference = old SO's DocumentNo
@@ -122,13 +127,19 @@ Feature: Split sales order — create a continuation order for unshipped quantit
       | sched_os20_B | sol_os20_B     | N             |
       | sched_os20_C | sol_os20_C     | N             |
 
-    # Ship all 5 of line A and 4 of line B in one generate-shipments run
+    # Ship all 5 of line A and 4 of line B in two generate-shipments runs
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
       | sched_os20_A          | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID    |
+      | sched_os20_A          | inout_os20_A  |
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override |
       | sched_os20_B          | D            | true                | false       | 4                     |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID    |
+      | sched_os20_B          | inout_os20_B  |
 
     When the C_Order_Split process is invoked on "so_os20"
 
@@ -182,9 +193,15 @@ Feature: Split sales order — create a continuation order for unshipped quantit
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
       | sched_os30_A          | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID    |
+      | sched_os30_A          | inout_os30_A  |
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override |
       | sched_os30_B          | D            | true                | false       | 6                     |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID    |
+      | sched_os30_B          | inout_os30_B  |
 
     When the C_Order_Split process is invoked on "so_os30"
 
@@ -229,6 +246,9 @@ Feature: Split sales order — create a continuation order for unshipped quantit
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override |
       | sched_os40_1          | D            | true                | false       | 4                     |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID  |
+      | sched_os40_1          | inout_os40  |
 
     And metasfresh contains M_QtyReservations:
       | Identifier      | C_OrderLine_ID | M_Product_ID | M_Warehouse_ID | Qty    | QtyTU |
@@ -274,6 +294,9 @@ Feature: Split sales order — create a continuation order for unshipped quantit
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
       | sched_os50_A          | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID    |
+      | sched_os50_A          | inout_os50_A  |
 
     When the C_Order_Split process is invoked on "so_os50"
 
@@ -335,6 +358,9 @@ Feature: Split sales order — create a continuation order for unshipped quantit
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
       | sched_os70_1          | D            | true                | false       |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID  |
+      | sched_os70_1          | inout_os70  |
 
     When the C_Order_Split process is invoked on "so_os70" expecting validation failure
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderSplit.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderSplit.feature
@@ -1,0 +1,344 @@
+@from:cucumber
+@allure.label.epic:E0155_Material_Disposition
+@allure.label.feature:F19012_Material_Cockpit_v2_for_Reservation_in_Sales_Order
+@ghActions:run_on_executor5
+Feature: Split sales order — create a continuation order for unshipped quantity
+
+  When a completed sales order that has at least one shipment is split via the C_Order_Split process,
+  the system creates a continuation (NEW) SO with one line per old-SO line that still has unshipped
+  quantity, and closes all shipment schedules and active reservations of the original (OLD) SO.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2026-05-17T13:30:13+02:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_os      |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Currency.ISO_Code | SOTrx |
+      | pl_os      | ps_os              | EUR                 | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_os     | pl_os          |
+
+    And metasfresh contains M_Products:
+      | Identifier | IsStocked |
+      | product_os | false     |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | plv_os                 | product_os   | 10.00    | PCE               | Normal                        |
+
+    And metasfresh contains C_BPartners:
+      | Identifier | IsCustomer | M_PricingSystem_ID |
+      | bp_os      | true       | ps_os              |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | bp_os_loc  | bp_os         | Y               | Y               |
+
+    And metasfresh contains M_Warehouse:
+      | Identifier  |
+      | warehouse_os |
+
+
+  @from:cucumber
+  @Id:S_OS_10
+  Scenario: Happy path — single line partial delivery, process creates continuation order with residue qty
+  # OLD SO has 1 line QtyOrdered=10, QtyDelivered=8.
+  # After split: OLD line untouched; NEW SO created with POReference=oldSO.DocumentNo,
+  # DocStatus=DR, C_Project_ID cleared, 1 line with QtyEntered=2 QtyDelivered=0.
+
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | so_os10    | true    | bp_os         | 2026-05-17  | warehouse_os   | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier   | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_os10_1   | so_os10    | product_os   | 10         |
+    And the order identified by so_os10 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier    | C_OrderLine_ID | IsToRecompute |
+      | sched_os10_1  | sol_os10_1     | N             |
+
+    # Deliver 8 of 10 (partial shipment)
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override |
+      | sched_os10_1          | D            | true                | false       | 8                     |
+
+    When the C_Order_Split process is invoked on "so_os10"
+
+    # NEW continuation order must exist with POReference = old SO's DocumentNo
+    Then the continuation order for "so_os10" is found and stored as "new_so_os10"
+
+    # NEW SO: DocStatus=DR, C_Project_ID null
+    And validate the created orders
+      | C_Order_ID  | DocStatus | C_Project_ID |
+      | new_so_os10 | DR        | null         |
+
+    # NEW SO: exactly 1 line with QtyEntered=2 (residue)
+    And the continuation order "new_so_os10" has exactly 1 line with QtyEntered=2 for product "product_os"
+
+    # OLD line is untouched (QtyOrdered=10 unchanged)
+    And validate C_OrderLine:
+      | C_OrderLine_ID | QtyOrdered |
+      | sol_os10_1     | 10         |
+
+
+  @from:cucumber
+  @Id:S_OS_20
+  Scenario: Multi-line mix — fully shipped line stays on OLD SO, partial and never-shipped lines go to NEW SO
+  # OLD SO has 3 lines:
+  #   line A: QtyOrdered=5, QtyDelivered=5 (fully shipped — stays on OLD SO only)
+  #   line B: QtyOrdered=10, QtyDelivered=4 (partial — goes to NEW SO with residue qty=6)
+  #   line C: QtyOrdered=7, QtyDelivered=0 (never shipped — goes to NEW SO with qty=7)
+  # 1 shipment exists (for lines A and B).
+  # After split: NEW SO has exactly 2 lines (B residue=6 and C=7); A stays on OLD SO only.
+
+    Given metasfresh contains M_Products:
+      | Identifier  | IsStocked |
+      | product_os2 | false     |
+      | product_os3 | false     |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | plv_os                 | product_os2  | 12.00    | PCE               | Normal                        |
+      | plv_os                 | product_os3  | 15.00    | PCE               | Normal                        |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | so_os20    | true    | bp_os         | 2026-05-17  | warehouse_os   | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_os20_A  | so_os20    | product_os   | 5          |
+      | sol_os20_B  | so_os20    | product_os2  | 10         |
+      | sol_os20_C  | so_os20    | product_os3  | 7          |
+    And the order identified by so_os20 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier   | C_OrderLine_ID | IsToRecompute |
+      | sched_os20_A | sol_os20_A     | N             |
+      | sched_os20_B | sol_os20_B     | N             |
+      | sched_os20_C | sol_os20_C     | N             |
+
+    # Ship all 5 of line A and 4 of line B in one generate-shipments run
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | sched_os20_A          | D            | true                | false       |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override |
+      | sched_os20_B          | D            | true                | false       | 4                     |
+
+    When the C_Order_Split process is invoked on "so_os20"
+
+    # NEW SO created
+    Then the continuation order for "so_os20" is found and stored as "new_so_os20"
+
+    # NEW SO must have exactly 2 lines (B residue=6 and C=7); A (fully shipped) must NOT appear
+    And the continuation order "new_so_os20" has exactly 2 lines
+    And the continuation order "new_so_os20" has exactly 1 line with QtyEntered=6 for product "product_os2"
+    And the continuation order "new_so_os20" has exactly 1 line with QtyEntered=7 for product "product_os3"
+    And the continuation order "new_so_os20" has no line for product "product_os"
+
+
+  @from:cucumber
+  @Id:S_OS_30
+  Scenario: Fully-delivered line stays on OLD SO — not copied to continuation order
+  # OLD SO has 2 lines:
+  #   line A: QtyOrdered=5, QtyDelivered=5 (fully delivered — stays on OLD SO; QtyOrdered <= QtyDelivered)
+  #   line B: QtyOrdered=10, QtyDelivered=6 (partial — goes to NEW SO with residue qty=4)
+  # After split: NEW SO has exactly 1 line for B; A is NOT in the NEW SO.
+  #
+  # Note on design: the original scenario S_OS_30 specified an over-delivered line (QtyOrdered=5,
+  # QtyDelivered=7). Over-delivery cannot be set up via the standard generate-shipments step defs
+  # (the system enforces QtyDelivered <= QtyOrdered). This scenario tests the equivalent code path:
+  # any line where QtyOrdered <= QtyDelivered is excluded from the NEW SO. A fully-delivered line
+  # (5/5) exercises exactly the same `QtyOrdered > QtyDelivered` branch as an over-delivered line.
+  # The true over-delivery edge case should be covered by the OrderSplitCommandTest unit tests.
+
+    Given metasfresh contains M_Products:
+      | Identifier   | IsStocked |
+      | product_os30 | false     |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID  | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | plv_os                 | product_os30  | 8.00     | PCE               | Normal                        |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | so_os30    | true    | bp_os         | 2026-05-17  | warehouse_os   | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_os30_A  | so_os30    | product_os   | 5          |
+      | sol_os30_B  | so_os30    | product_os30 | 10         |
+    And the order identified by so_os30 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier   | C_OrderLine_ID | IsToRecompute |
+      | sched_os30_A | sol_os30_A     | N             |
+      | sched_os30_B | sol_os30_B     | N             |
+
+    # Ship all 5 of line A (fully delivers it) and 6 of line B (partial)
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | sched_os30_A          | D            | true                | false       |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override |
+      | sched_os30_B          | D            | true                | false       | 6                     |
+
+    When the C_Order_Split process is invoked on "so_os30"
+
+    # NEW SO has exactly 1 line for B (residue=4); A (fully delivered, stays on OLD)
+    Then the continuation order for "so_os30" is found and stored as "new_so_os30"
+    And the continuation order "new_so_os30" has exactly 1 line with QtyEntered=4 for product "product_os30"
+    And the continuation order "new_so_os30" has no line for product "product_os"
+
+
+  @from:cucumber
+  @Id:S_OS_40
+  Scenario: Active reservations on OLD SO lines are closed after split
+  # OLD SO has 1 line QtyOrdered=10, QtyDelivered=4.
+  # An active M_QtyReservation for that line (Qty=6, Processed=N) exists.
+  # After split: the reservation has Processed=Y (closed by the process).
+
+    Given metasfresh contains M_HU_PI:
+      | M_HU_PI_ID   |
+      | huPI_os40    |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType |
+      | huPIV_os40         | huPI_os40  | TU          |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID  | M_HU_PI_Version_ID | ItemType |
+      | huPIItem_os40    | huPIV_os40         | MI       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID | Qty    |
+      | huPIP_os40              | huPIItem_os40   | product_os   | 10 PCE |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | so_os40    | true    | bp_os         | 2026-05-17  | warehouse_os   | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_os40_1  | so_os40    | product_os   | 10         |
+    And the order identified by so_os40 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier   | C_OrderLine_ID | IsToRecompute |
+      | sched_os40_1 | sol_os40_1     | N             |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override |
+      | sched_os40_1          | D            | true                | false       | 4                     |
+
+    And metasfresh contains M_QtyReservations:
+      | Identifier      | C_OrderLine_ID | M_Product_ID | M_Warehouse_ID | Qty    | QtyTU |
+      | reservation_os40 | sol_os40_1    | product_os   | warehouse_os   | 6 PCE  | 1     |
+
+    When the C_Order_Split process is invoked on "so_os40"
+
+    # Reservation must be closed (Processed=Y) after the split
+    Then validate M_QtyReservations:
+      | Identifier       | Processed |
+      | reservation_os40 | true      |
+
+
+  @from:cucumber
+  @Id:S_OS_50
+  Scenario: All shipment schedules on OLD SO are closed after split
+  # OLD SO has 2 lines. Both have M_ShipmentSchedule rows.
+  # 1 shipment exists for line A only; line B has no shipment.
+  # After split: every M_ShipmentSchedule for the old SO has IsClosed=Y.
+
+    Given metasfresh contains M_Products:
+      | Identifier   | IsStocked |
+      | product_os50 | false     |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID  | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | plv_os                 | product_os50  | 9.00     | PCE               | Normal                        |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | so_os50    | true    | bp_os         | 2026-05-17  | warehouse_os   | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_os50_A  | so_os50    | product_os   | 5          |
+      | sol_os50_B  | so_os50    | product_os50 | 8          |
+    And the order identified by so_os50 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier   | C_OrderLine_ID | IsToRecompute |
+      | sched_os50_A | sol_os50_A     | N             |
+      | sched_os50_B | sol_os50_B     | N             |
+
+    # Ship line A only
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | sched_os50_A          | D            | true                | false       |
+
+    When the C_Order_Split process is invoked on "so_os50"
+
+    # All shipment schedules for the old SO must now be closed
+    Then after not more than 30s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | IsClosed |
+      | sched_os50_A                     | true     |
+      | sched_os50_B                     | true     |
+
+
+  @from:cucumber
+  @Id:S_OS_60
+  Scenario: Validation — process rejects order with no completed shipment
+  # OLD SO has 1 line QtyOrdered=10, QtyDelivered=0 and NO M_InOut exists.
+  # Process must fail with an error containing "C_Order_Split_NoShipments".
+  # No NEW SO is created; OLD line retains QtyOrdered=10.
+
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | so_os60    | true    | bp_os         | 2026-05-17  | warehouse_os   | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_os60_1  | so_os60    | product_os   | 10         |
+    And the order identified by so_os60 is completed
+
+    When the C_Order_Split process is invoked on "so_os60" expecting validation failure
+
+    Then the validation error message includes "C_Order_Split_NoShipments"
+
+    # No continuation order created
+    And no continuation order exists for "so_os60"
+
+    # OLD line unchanged
+    And validate C_OrderLine:
+      | C_OrderLine_ID | QtyOrdered |
+      | sol_os60_1     | 10         |
+
+
+  @from:cucumber
+  @Id:S_OS_70
+  Scenario: Validation — process rejects order where all qty is already delivered
+  # OLD SO has 1 line QtyOrdered=10 QtyDelivered=10; a completed shipment for the full qty exists.
+  # Process must fail with an error containing "C_Order_Split_NothingToSplit".
+  # No NEW SO is created.
+
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | so_os70    | true    | bp_os         | 2026-05-17  | warehouse_os   | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID | M_Product_ID | QtyEntered |
+      | sol_os70_1  | so_os70    | product_os   | 10         |
+    And the order identified by so_os70 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier   | C_OrderLine_ID | IsToRecompute |
+      | sched_os70_1 | sol_os70_1     | N             |
+
+    # Ship the full qty
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | sched_os70_1          | D            | true                | false       |
+
+    When the C_Order_Split process is invoked on "so_os70" expecting validation failure
+
+    Then the validation error message includes "C_Order_Split_NothingToSplit"
+
+    # No continuation order created
+    And no continuation order exists for "so_os70"

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderSplit.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderSplit.feature
@@ -66,7 +66,7 @@ Feature: Split sales order — create a continuation order for unshipped quantit
     # Deliver 8 of 10 (partial shipment)
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
-      | sched_os10_1          | D            | false               | false       | 8                                               |
+      | sched_os10_1          | D            | true                | false       | 8                                               |
 
     # Wait for the async shipment workpackage to complete and create the M_InOut
     And after not more than 60s, M_InOut is found:
@@ -136,7 +136,7 @@ Feature: Split sales order — create a continuation order for unshipped quantit
       | sched_os20_A          | inout_os20_A  |
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
-      | sched_os20_B          | D            | false               | false       | 4                                               |
+      | sched_os20_B          | D            | true                | false       | 4                                               |
     And after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID    |
       | sched_os20_B          | inout_os20_B  |
@@ -198,7 +198,7 @@ Feature: Split sales order — create a continuation order for unshipped quantit
       | sched_os30_A          | inout_os30_A  |
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
-      | sched_os30_B          | D            | false               | false       | 6                                               |
+      | sched_os30_B          | D            | true                | false       | 6                                               |
     And after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID    |
       | sched_os30_B          | inout_os30_B  |
@@ -245,7 +245,7 @@ Feature: Split sales order — create a continuation order for unshipped quantit
 
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
-      | sched_os40_1          | D            | false               | false       | 4                                               |
+      | sched_os40_1          | D            | true                | false       | 4                                               |
     And after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID  |
       | sched_os40_1          | inout_os40  |

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
@@ -1,10 +1,12 @@
 package de.metas.inoutcandidate.qty_reservation;
 
+import com.google.common.collect.ImmutableSet;
 import de.metas.handlingunits.QtyTU;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
 import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleSegments;
 import de.metas.order.IOrderLineBL;
 import de.metas.order.OrderAndLineId;
+import de.metas.order.OrderLineId;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -17,6 +19,8 @@ import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.I_C_OrderLine;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
+
+import java.util.Collection;
 
 @Service
 @RequiredArgsConstructor
@@ -108,6 +112,25 @@ public class QtyReservationService
 	public QtyTU getReservedQtyTU(@NonNull final OrderAndLineId orderLineId)
 	{
 		return repository.getReservedQtyTU(orderLineId);
+	}
+
+	/**
+	 * Closes every active (Processed=N, IsActive=Y) M_QtyReservation row for the given order lines by
+	 * setting QtyDelivered = Qty — the persistence layer then flips Processed=Y derived from
+	 * isFullyDelivered(). Rows are not deleted; they're preserved for audit.
+	 * <p>
+	 * Used by OrderSplitCommand after the continuation order has been created, to free the
+	 * "promised but no longer ship-able" qty from the original SO's reservations.
+	 */
+	public void closeAllActiveForOrderLines(@NonNull final Collection<OrderLineId> orderLineIds)
+	{
+		if (orderLineIds.isEmpty())
+		{
+			return;
+		}
+		repository.updateByOrderLineIds(
+				ImmutableSet.copyOf(orderLineIds),
+				r -> r.withQtyDelivered(r.getQty()));
 	}
 
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/C_Order_Split.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/C_Order_Split.java
@@ -9,9 +9,8 @@ import org.compiere.model.I_C_Order;
 /**
  * AD_Process Java implementation for {@code C_Order_Split}.
  * <p>
- * Wired by the AD_Process row (migration {@code 5804910_sys_me03_29261_AD_Process_C_Order_Split.sql})
- * via the {@code Classname} column. Invoked from the sales-order window action menu (binding via
- * {@code AD_Table_Process} — migration {@code 5804940_*.sql}).
+ * Wired by the AD_Process row with {@code Value='C_Order_Split'} via the {@code Classname} column.
+ * Invoked from the sales-order window action menu (bound via {@code AD_Table_Process}).
  * <p>
  * Reads the current {@code C_Order} record, delegates to {@link OrderSplitCommand#split(OrderSplitRequest)},
  * and reports the new continuation-order ID + copied line count in the process result summary.

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/C_Order_Split.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/C_Order_Split.java
@@ -1,0 +1,36 @@
+package de.metas.order.split;
+
+import de.metas.order.OrderId;
+import de.metas.process.JavaProcess;
+import lombok.NonNull;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_C_Order;
+
+/**
+ * AD_Process Java implementation for {@code C_Order_Split}.
+ * <p>
+ * Wired by the AD_Process row (migration {@code 5804910_sys_me03_29261_AD_Process_C_Order_Split.sql})
+ * via the {@code Classname} column. Invoked from the sales-order window action menu (binding via
+ * {@code AD_Table_Process} — migration {@code 5804940_*.sql}).
+ * <p>
+ * Reads the current {@code C_Order} record, delegates to {@link OrderSplitCommand#split(OrderSplitRequest)},
+ * and reports the new continuation-order ID + copied line count in the process result summary.
+ */
+public class C_Order_Split extends JavaProcess
+{
+	private final OrderSplitCommand splitCommand =
+			SpringContextHolder.instance.getBean(OrderSplitCommand.class);
+
+	@Override
+	@NonNull
+	protected String doIt()
+	{
+		final I_C_Order order = getRecord(I_C_Order.class);
+		final OrderSplitResult result = splitCommand.split(OrderSplitRequest.builder()
+				.orderId(OrderId.ofRepoId(order.getC_Order_ID()))
+				.build());
+
+		return "Split complete — new C_Order_ID = " + result.getNewOrderId().getRepoId()
+				+ ", copied " + result.getCopiedLineCount() + " line(s).";
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
@@ -39,8 +39,62 @@ public class OrderSplitCommand
 
 		final I_C_Order newOrder = createContinuationOrderHeader(oldOrder);
 
-		// Line cloning lands in Task 8b
-		throw new UnsupportedOperationException("Line cloning not yet wired (Task 8b)");
+		final int copiedLineCount = createContinuationOrderLines(oldLines, newOrder);
+
+		// closeOldShipmentSchedules + closeOldReservations land in Task 9
+		throw new UnsupportedOperationException("Old SO finalization not yet wired (Task 9)");
+	}
+
+	private int createContinuationOrderLines(
+			@NonNull final List<I_C_OrderLine> oldLines,
+			@NonNull final I_C_Order newOrder)
+	{
+		int copiedLineCount = 0;
+		int nextLineNo = 10;
+
+		for (final I_C_OrderLine oldLine : oldLines)
+		{
+			final BigDecimal residue = oldLine.getQtyOrdered().subtract(oldLine.getQtyDelivered());
+			if (residue.signum() <= 0)
+			{
+				continue;  // QtyOrdered <= QtyDelivered → stays on OLD SO (D0/D0')
+			}
+
+			final I_C_OrderLine newLine = InterfaceWrapperHelper.copy()
+					.setFrom(oldLine)
+					.setSkipCalculatedColumns(true)
+					.copyToNew(I_C_OrderLine.class);
+
+			newLine.setC_Order_ID(newOrder.getC_Order_ID());
+			newLine.setLine(nextLineNo);
+			nextLineNo += 10;
+
+			newLine.setQtyDelivered(BigDecimal.ZERO);
+			newLine.setQtyInvoiced(BigDecimal.ZERO);
+			newLine.setDateDelivered(null);
+			newLine.setDateInvoiced(null);
+			newLine.setProcessed(false);
+
+			// D1 — defence: clear project on the line
+			newLine.setC_Project_ID(0);
+
+			// D6 — let price-lookup interceptor populate pricing on save
+			newLine.setIsManualPrice(false);
+
+			// D12 — German audit suffix on Description (preserve existing text)
+			final String oldDesc = newLine.getDescription();
+			final String descSuffix = " (aus Position " + oldLine.getLine() + ")";
+			newLine.setDescription(oldDesc == null ? descSuffix.trim() : oldDesc + descSuffix);
+
+			// Set QtyEntered LAST so the BL price-lookup interceptor sees a fresh,
+			// non-manual line with the correct qty.
+			newLine.setQtyEntered(residue);
+
+			InterfaceWrapperHelper.save(newLine);
+			copiedLineCount++;
+		}
+
+		return copiedLineCount;
 	}
 
 	private I_C_Order createContinuationOrderHeader(@NonNull final I_C_Order oldOrder)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
@@ -96,6 +96,11 @@ public class OrderSplitCommand
 			newLine.setLine(nextLineNo);
 			nextLineNo += 10;
 
+			// DateOrdered is denormalized from C_Order and has a NOT-NULL constraint on C_OrderLine.
+			// setSkipCalculatedColumns(true) skips it during the copy → we must set it explicitly
+			// from the new header (which itself was copied from the old SO, so the date is preserved).
+			newLine.setDateOrdered(newOrder.getDateOrdered());
+
 			newLine.setQtyDelivered(BigDecimal.ZERO);
 			newLine.setQtyInvoiced(BigDecimal.ZERO);
 			newLine.setDateDelivered(null);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
@@ -5,15 +5,20 @@ import de.metas.document.engine.IDocument;
 import de.metas.i18n.AdMessageKey;
 import de.metas.inout.IInOutDAO;
 import de.metas.inout.InOutQuery;
+import de.metas.inoutcandidate.api.IShipmentScheduleBL;
+import de.metas.inoutcandidate.qty_reservation.QtyReservationService;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.order.IOrderBL;
 import de.metas.order.IOrderDAO;
+import de.metas.order.OrderLineId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_OrderLine;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -26,9 +31,12 @@ public class OrderSplitCommand
 	public static final AdMessageKey MSG_NO_SHIPMENTS = AdMessageKey.of("C_Order_Split_NoShipments");
 	public static final AdMessageKey MSG_NOTHING_TO_SPLIT = AdMessageKey.of("C_Order_Split_NothingToSplit");
 
+	private final QtyReservationService qtyReservationService;
+
 	private final IOrderBL orderBL = Services.get(IOrderBL.class);
 	private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
 	private final IInOutDAO inOutDAO = Services.get(IInOutDAO.class);
+	private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
 
 	public OrderSplitResult split(@NonNull final OrderSplitRequest request)
 	{
@@ -41,8 +49,31 @@ public class OrderSplitCommand
 
 		final int copiedLineCount = createContinuationOrderLines(oldLines, newOrder);
 
-		// closeOldShipmentSchedules + closeOldReservations land in Task 9
-		throw new UnsupportedOperationException("Old SO finalization not yet wired (Task 9)");
+		closeOldShipmentSchedules(oldLines);
+		closeOldReservations(oldLines);
+
+		return OrderSplitResult.builder()
+				.oldOrderId(de.metas.order.OrderId.ofRepoId(oldOrder.getC_Order_ID()))
+				.newOrderId(de.metas.order.OrderId.ofRepoId(newOrder.getC_Order_ID()))
+				.copiedLineCount(copiedLineCount)
+				.build();
+	}
+
+	private void closeOldShipmentSchedules(@NonNull final List<I_C_OrderLine> oldLines)
+	{
+		final com.google.common.collect.ImmutableList<TableRecordReference> orderLineRefs = oldLines.stream()
+				.map(ol -> TableRecordReference.of(
+						I_C_OrderLine.Table_Name, ol.getC_OrderLine_ID()))
+				.collect(com.google.common.collect.ImmutableList.toImmutableList());
+		shipmentScheduleBL.closeShipmentSchedulesFor(orderLineRefs);
+	}
+
+	private void closeOldReservations(@NonNull final List<I_C_OrderLine> oldLines)
+	{
+		final List<OrderLineId> orderLineIds = oldLines.stream()
+				.map(ol -> OrderLineId.ofRepoId(ol.getC_OrderLine_ID()))
+				.collect(java.util.stream.Collectors.toList());
+		qtyReservationService.closeAllActiveForOrderLines(orderLineIds);
 	}
 
 	private int createContinuationOrderLines(

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
@@ -1,0 +1,61 @@
+package de.metas.order.split;
+
+import de.metas.i18n.AdMessageKey;
+import de.metas.inout.IInOutDAO;
+import de.metas.inout.InOutQuery;
+import de.metas.interfaces.I_C_OrderLine;
+import de.metas.order.IOrderBL;
+import de.metas.order.IOrderDAO;
+import de.metas.util.Services;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.I_C_Order;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrderSplitCommand
+{
+	public static final AdMessageKey MSG_NO_SHIPMENTS = AdMessageKey.of("C_Order_Split_NoShipments");
+	public static final AdMessageKey MSG_NOTHING_TO_SPLIT = AdMessageKey.of("C_Order_Split_NothingToSplit");
+
+	private final IOrderBL orderBL = Services.get(IOrderBL.class);
+	private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
+	private final IInOutDAO inOutDAO = Services.get(IInOutDAO.class);
+
+	public OrderSplitResult split(@NonNull final OrderSplitRequest request)
+	{
+		final I_C_Order oldOrder = orderBL.getById(request.getOrderId());
+		final List<I_C_OrderLine> oldLines = orderDAO.retrieveOrderLines(request.getOrderId());
+
+		validate(request.getOrderId(), oldLines);
+
+		// Continuation order creation lands in Tasks 8a/8b/9.
+		throw new UnsupportedOperationException("createContinuationOrder not yet wired (Tasks 8a/8b/9)");
+	}
+
+	private void validate(
+			@NonNull final de.metas.order.OrderId oldOrderId,
+			@NonNull final List<I_C_OrderLine> oldLines)
+	{
+		// Guard 1: ≥1 completed shipment (DocStatus IN ('CO', 'CL'))
+		final boolean hasCompletedShipment = inOutDAO.retrieveByQuery(
+						InOutQuery.builder().orderId(oldOrderId).build())
+				.anyMatch(io -> "CO".equals(io.getDocStatus()) || "CL".equals(io.getDocStatus()));
+		if (!hasCompletedShipment)
+		{
+			throw new AdempiereException(MSG_NO_SHIPMENTS);
+		}
+
+		// Guard 2: ≥1 line with QtyOrdered > QtyDelivered
+		final boolean hasUnshippedResidue = oldLines.stream()
+				.anyMatch(ol -> ol.getQtyOrdered().compareTo(ol.getQtyDelivered()) > 0);
+		if (!hasUnshippedResidue)
+		{
+			throw new AdempiereException(MSG_NOTHING_TO_SPLIT);
+		}
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
@@ -3,8 +3,6 @@ package de.metas.order.split;
 import de.metas.document.engine.DocStatus;
 import de.metas.document.engine.IDocument;
 import de.metas.i18n.AdMessageKey;
-import de.metas.inout.IInOutDAO;
-import de.metas.inout.InOutQuery;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.qty_reservation.QtyReservationService;
 import de.metas.interfaces.I_C_OrderLine;
@@ -34,7 +32,6 @@ public class OrderSplitCommand
 
 	private final IOrderBL orderBL = Services.get(IOrderBL.class);
 	private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
-	private final IInOutDAO inOutDAO = Services.get(IInOutDAO.class);
 	private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
 
 	public OrderSplitResult split(@NonNull final OrderSplitRequest request)
@@ -168,11 +165,13 @@ public class OrderSplitCommand
 			@NonNull final de.metas.order.OrderId oldOrderId,
 			@NonNull final List<I_C_OrderLine> oldLines)
 	{
-		// Guard 1: ≥1 completed shipment (DocStatus IN ('CO', 'CL'))
-		final boolean hasCompletedShipment = inOutDAO.retrieveByQuery(
-						InOutQuery.builder().orderId(oldOrderId).build())
-				.anyMatch(io -> "CO".equals(io.getDocStatus()) || "CL".equals(io.getDocStatus()));
-		if (!hasCompletedShipment)
+		// Guard 1: ≥1 line has been shipped (QtyDelivered > 0).
+		// Using QtyDelivered as the canonical "has shipments" indicator avoids querying
+		// M_InOut directly (M_InOut.C_Order_ID is not always populated when shipments
+		// are generated from shipment schedules — the relation lives in M_InOutLine.C_OrderLine_ID).
+		final boolean hasAnyShipment = oldLines.stream()
+				.anyMatch(ol -> ol.getQtyDelivered().signum() > 0);
+		if (!hasAnyShipment)
 		{
 			throw new AdempiereException(MSG_NO_SHIPMENTS);
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
@@ -57,11 +57,34 @@ public class OrderSplitCommand
 
 	private void closeOldShipmentSchedules(@NonNull final List<I_C_OrderLine> oldLines)
 	{
-		final com.google.common.collect.ImmutableList<TableRecordReference> orderLineRefs = oldLines.stream()
-				.map(ol -> TableRecordReference.of(
-						org.compiere.model.I_C_OrderLine.Table_Name, ol.getC_OrderLine_ID()))
-				.collect(com.google.common.collect.ImmutableList.toImmutableList());
-		shipmentScheduleBL.closeShipmentSchedulesFor(orderLineRefs);
+		// Load all M_ShipmentSchedules for the OLD order lines and close (IsClosed=Y) the ones
+		// that are not yet closed AND not yet processed. Already-processed schedules (those of
+		// fully-delivered lines) need no action — they're effectively closed by completion.
+		// We deliberately avoid IShipmentScheduleBL.closeShipmentSchedulesFor here because that
+		// API throws on processed schedules, which is too strict for our multi-line case where
+		// some schedules complete naturally via shipment.
+		final java.util.Set<Integer> oldOrderLineIds = oldLines.stream()
+				.map(org.compiere.model.I_C_OrderLine::getC_OrderLine_ID)
+				.collect(java.util.stream.Collectors.toSet());
+		if (oldOrderLineIds.isEmpty())
+		{
+			return;
+		}
+		final java.util.List<de.metas.inoutcandidate.model.I_M_ShipmentSchedule> schedules =
+				Services.get(org.adempiere.ad.dao.IQueryBL.class)
+						.createQueryBuilder(de.metas.inoutcandidate.model.I_M_ShipmentSchedule.class)
+						.addOnlyActiveRecordsFilter()
+						.addInArrayFilter(de.metas.inoutcandidate.model.I_M_ShipmentSchedule.COLUMNNAME_C_OrderLine_ID, oldOrderLineIds)
+						.create()
+						.list();
+		for (final de.metas.inoutcandidate.model.I_M_ShipmentSchedule schedule : schedules)
+		{
+			if (schedule.isClosed() || schedule.isProcessed())
+			{
+				continue;
+			}
+			shipmentScheduleBL.closeShipmentSchedule(schedule);
+		}
 	}
 
 	private void closeOldReservations(@NonNull final List<I_C_OrderLine> oldLines)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
@@ -1,5 +1,7 @@
 package de.metas.order.split;
 
+import de.metas.document.engine.DocStatus;
+import de.metas.document.engine.IDocument;
 import de.metas.i18n.AdMessageKey;
 import de.metas.inout.IInOutDAO;
 import de.metas.inout.InOutQuery;
@@ -10,9 +12,11 @@ import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_Order;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Service
@@ -33,8 +37,47 @@ public class OrderSplitCommand
 
 		validate(request.getOrderId(), oldLines);
 
-		// Continuation order creation lands in Tasks 8a/8b/9.
-		throw new UnsupportedOperationException("createContinuationOrder not yet wired (Tasks 8a/8b/9)");
+		final I_C_Order newOrder = createContinuationOrderHeader(oldOrder);
+
+		// Line cloning lands in Task 8b
+		throw new UnsupportedOperationException("Line cloning not yet wired (Task 8b)");
+	}
+
+	private I_C_Order createContinuationOrderHeader(@NonNull final I_C_Order oldOrder)
+	{
+		final I_C_Order newOrder = InterfaceWrapperHelper.copy()
+				.setFrom(oldOrder)
+				.setSkipCalculatedColumns(true)
+				.copyToNew(I_C_Order.class);
+
+		// Reset doc state
+		newOrder.setDocStatus(DocStatus.Drafted.getCode());
+		newOrder.setDocAction(IDocument.ACTION_Complete);
+		newOrder.setDocumentNo(null);
+		newOrder.setProcessed(false);
+		newOrder.setIsApproved(false);
+		newOrder.setIsDelivered(false);
+		newOrder.setIsInvoiced(false);
+		newOrder.setIsPrinted(false);
+		newOrder.setPosted(false);
+		newOrder.setGrandTotal(BigDecimal.ZERO);
+		newOrder.setTotalLines(BigDecimal.ZERO);
+		newOrder.setDatePrinted(null);
+		newOrder.setRef_Order_ID(0);
+		newOrder.setLink_Order_ID(0);
+
+		// D1 — clear project
+		newOrder.setC_Project_ID(0);
+		// D5 — backref to old SO
+		newOrder.setPOReference(oldOrder.getDocumentNo());
+
+		// D11 — German audit suffix on Description (preserve existing text)
+		final String oldDesc = newOrder.getDescription();
+		final String suffix = " (Fortsetzung von " + oldOrder.getDocumentNo() + ")";
+		newOrder.setDescription(oldDesc == null ? suffix.trim() : oldDesc + suffix);
+
+		InterfaceWrapperHelper.save(newOrder);
+		return newOrder;
 	}
 
 	private void validate(

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
@@ -79,10 +79,13 @@ public class OrderSplitCommand
 						.list();
 		for (final de.metas.inoutcandidate.model.I_M_ShipmentSchedule schedule : schedules)
 		{
-			if (schedule.isClosed() || schedule.isProcessed())
+			if (schedule.isClosed())
 			{
-				continue;
+				continue;  // already closed → idempotent skip
 			}
+			// Close all non-closed schedules — including Processed ones (fully-shipped) — so
+			// the OLD SO is uniformly frozen for further shipping. The singular
+			// closeShipmentSchedule API does NOT check Processed, so it works for both states.
 			shipmentScheduleBL.closeShipmentSchedule(schedule);
 		}
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
@@ -4,22 +4,25 @@ import de.metas.document.engine.DocStatus;
 import de.metas.document.engine.IDocument;
 import de.metas.i18n.AdMessageKey;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.inoutcandidate.qty_reservation.QtyReservationService;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.order.IOrderBL;
 import de.metas.order.IOrderDAO;
+import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
-import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.I_C_Order;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,69 +36,70 @@ public class OrderSplitCommand
 	private final IOrderBL orderBL = Services.get(IOrderBL.class);
 	private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
 	private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
+	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 	public OrderSplitResult split(@NonNull final OrderSplitRequest request)
 	{
 		final I_C_Order oldOrder = orderBL.getById(request.getOrderId());
 		final List<I_C_OrderLine> oldLines = orderDAO.retrieveOrderLines(request.getOrderId());
 
-		validate(request.getOrderId(), oldLines);
+		validate(oldLines);
 
 		final I_C_Order newOrder = createContinuationOrderHeader(oldOrder);
 
 		final int copiedLineCount = createContinuationOrderLines(oldLines, newOrder);
 
-		closeOldShipmentSchedules(oldLines);
-		closeOldReservations(oldLines);
+		final List<OrderLineId> oldOrderLineIds = toOrderLineIds(oldLines);
+		closeOldShipmentSchedules(oldOrderLineIds);
+		closeOldReservations(oldOrderLineIds);
 
 		return OrderSplitResult.builder()
-				.oldOrderId(de.metas.order.OrderId.ofRepoId(oldOrder.getC_Order_ID()))
-				.newOrderId(de.metas.order.OrderId.ofRepoId(newOrder.getC_Order_ID()))
+				.oldOrderId(OrderId.ofRepoId(oldOrder.getC_Order_ID()))
+				.newOrderId(OrderId.ofRepoId(newOrder.getC_Order_ID()))
 				.copiedLineCount(copiedLineCount)
 				.build();
 	}
 
-	private void closeOldShipmentSchedules(@NonNull final List<I_C_OrderLine> oldLines)
+	private static List<OrderLineId> toOrderLineIds(@NonNull final List<I_C_OrderLine> oldLines)
 	{
-		// Load all M_ShipmentSchedules for the OLD order lines and close (IsClosed=Y) the ones
-		// that are not yet closed AND not yet processed. Already-processed schedules (those of
-		// fully-delivered lines) need no action — they're effectively closed by completion.
-		// We deliberately avoid IShipmentScheduleBL.closeShipmentSchedulesFor here because that
-		// API throws on processed schedules, which is too strict for our multi-line case where
-		// some schedules complete naturally via shipment.
-		final java.util.Set<Integer> oldOrderLineIds = oldLines.stream()
-				.map(org.compiere.model.I_C_OrderLine::getC_OrderLine_ID)
-				.collect(java.util.stream.Collectors.toSet());
+		return oldLines.stream()
+				.map(ol -> OrderLineId.ofRepoId(ol.getC_OrderLine_ID()))
+				.collect(Collectors.toList());
+	}
+
+	private void closeOldShipmentSchedules(@NonNull final List<OrderLineId> oldOrderLineIds)
+	{
+		// Load all M_ShipmentSchedules for the OLD order lines and close (IsClosed=Y) every
+		// non-closed schedule — including already-Processed ones (those of fully-delivered
+		// lines). This uniformly freezes the OLD SO for further shipping. We deliberately
+		// avoid IShipmentScheduleBL.closeShipmentSchedulesFor because that API throws on
+		// Processed schedules, which is too strict for our multi-line case where some
+		// schedules complete naturally via shipment.
 		if (oldOrderLineIds.isEmpty())
 		{
 			return;
 		}
-		final java.util.List<de.metas.inoutcandidate.model.I_M_ShipmentSchedule> schedules =
-				Services.get(org.adempiere.ad.dao.IQueryBL.class)
-						.createQueryBuilder(de.metas.inoutcandidate.model.I_M_ShipmentSchedule.class)
-						.addOnlyActiveRecordsFilter()
-						.addInArrayFilter(de.metas.inoutcandidate.model.I_M_ShipmentSchedule.COLUMNNAME_C_OrderLine_ID, oldOrderLineIds)
-						.create()
-						.list();
-		for (final de.metas.inoutcandidate.model.I_M_ShipmentSchedule schedule : schedules)
+		final List<I_M_ShipmentSchedule> schedules = queryBL
+				.createQueryBuilder(I_M_ShipmentSchedule.class)
+				.addOnlyActiveRecordsFilter()
+				.addInArrayFilter(I_M_ShipmentSchedule.COLUMNNAME_C_OrderLine_ID, oldOrderLineIds)
+				.create()
+				.list();
+		for (final I_M_ShipmentSchedule schedule : schedules)
 		{
 			if (schedule.isClosed())
 			{
 				continue;  // already closed → idempotent skip
 			}
-			// Close all non-closed schedules — including Processed ones (fully-shipped) — so
-			// the OLD SO is uniformly frozen for further shipping. The singular
-			// closeShipmentSchedule API does NOT check Processed, so it works for both states.
+			// The singular closeShipmentSchedule API does NOT check Processed, so it works
+			// for both fully-shipped and partial-shipment cases.
 			shipmentScheduleBL.closeShipmentSchedule(schedule);
 		}
 	}
 
-	private void closeOldReservations(@NonNull final List<I_C_OrderLine> oldLines)
+	private void closeOldReservations(@NonNull final List<OrderLineId> oldOrderLineIds)
 	{
-		final List<OrderLineId> orderLineIds = oldLines.stream()
-				.map(ol -> OrderLineId.ofRepoId(ol.getC_OrderLine_ID()))
-				.collect(java.util.stream.Collectors.toList());
-		qtyReservationService.closeAllActiveForOrderLines(orderLineIds);
+		qtyReservationService.closeAllActiveForOrderLines(oldOrderLineIds);
 	}
 
 	private int createContinuationOrderLines(
@@ -192,9 +196,7 @@ public class OrderSplitCommand
 		return newOrder;
 	}
 
-	private void validate(
-			@NonNull final de.metas.order.OrderId oldOrderId,
-			@NonNull final List<I_C_OrderLine> oldLines)
+	private void validate(@NonNull final List<I_C_OrderLine> oldLines)
 	{
 		// Guard 1: ≥1 line has been shipped (QtyDelivered > 0).
 		// Using QtyDelivered as the canonical "has shipments" indicator avoids querying

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitCommand.java
@@ -18,7 +18,6 @@ import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.I_C_Order;
-import org.compiere.model.I_C_OrderLine;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -63,7 +62,7 @@ public class OrderSplitCommand
 	{
 		final com.google.common.collect.ImmutableList<TableRecordReference> orderLineRefs = oldLines.stream()
 				.map(ol -> TableRecordReference.of(
-						I_C_OrderLine.Table_Name, ol.getC_OrderLine_ID()))
+						org.compiere.model.I_C_OrderLine.Table_Name, ol.getC_OrderLine_ID()))
 				.collect(com.google.common.collect.ImmutableList.toImmutableList());
 		shipmentScheduleBL.closeShipmentSchedulesFor(orderLineRefs);
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitRequest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitRequest.java
@@ -1,0 +1,13 @@
+package de.metas.order.split;
+
+import de.metas.order.OrderId;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+@Value
+@Builder
+public class OrderSplitRequest
+{
+	@NonNull OrderId orderId;
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/split/OrderSplitResult.java
@@ -1,0 +1,15 @@
+package de.metas.order.split;
+
+import de.metas.order.OrderId;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+@Value
+@Builder
+public class OrderSplitResult
+{
+	@NonNull OrderId oldOrderId;
+	@NonNull OrderId newOrderId;
+	int copiedLineCount;
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/QtyReservationServiceCloseAllActiveTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/QtyReservationServiceCloseAllActiveTest.java
@@ -1,0 +1,86 @@
+package de.metas.inoutcandidate.qty_reservation;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
+import de.metas.order.OrderLineId;
+import de.metas.util.Services;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_OrderLine;
+import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_M_Product;
+import org.compiere.model.I_M_QtyReservation;
+import org.compiere.model.I_M_Warehouse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.save;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QtyReservationServiceCloseAllActiveTest
+{
+	private QtyReservationService service;
+
+	@BeforeEach
+	void setup()
+	{
+		AdempiereTestHelper.get().init();
+
+		// Register a mocked IShipmentScheduleInvalidateBL because QtyReservationService requires it
+		final IShipmentScheduleInvalidateBL mockInvalidateBL = Mockito.mock(IShipmentScheduleInvalidateBL.class);
+
+		final QtyReservationRepository repository = new QtyReservationRepository();
+		service = new QtyReservationService(mockInvalidateBL, repository);
+	}
+
+	@Test
+	void closesActiveReservationsSetsProcessedToY()
+	{
+		// Arrange — a UOM, product, warehouse, order line, and an active M_QtyReservation
+		final I_C_UOM uom = newInstance(I_C_UOM.class);
+		save(uom);
+
+		final I_M_Product product = newInstance(I_M_Product.class);
+		product.setC_UOM_ID(uom.getC_UOM_ID());
+		save(product);
+
+		final I_M_Warehouse warehouse = newInstance(I_M_Warehouse.class);
+		save(warehouse);
+
+		final I_C_OrderLine line = newInstance(I_C_OrderLine.class);
+		line.setM_Product_ID(product.getM_Product_ID());
+		line.setC_UOM_ID(uom.getC_UOM_ID());
+		line.setQtyOrdered(new BigDecimal("10"));
+		save(line);
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(line.getC_OrderLine_ID());
+
+		final I_M_QtyReservation reservation = newInstance(I_M_QtyReservation.class);
+		reservation.setC_OrderLine_ID(line.getC_OrderLine_ID());
+		reservation.setM_Product_ID(product.getM_Product_ID());
+		reservation.setM_Warehouse_ID(warehouse.getM_Warehouse_ID());
+		reservation.setC_UOM_ID(uom.getC_UOM_ID());
+		reservation.setQty(new BigDecimal("6"));
+		reservation.setQtyDelivered(BigDecimal.ZERO);
+		reservation.setQtyTU(new BigDecimal("1"));
+		reservation.setProcessed(false);
+		reservation.setAttributesKey("");                // empty key = AttributesKey.NONE
+		reservation.setSupplyType("OH");                 // canonical SupplyType code
+		save(reservation);
+
+		// Act
+		service.closeAllActiveForOrderLines(ImmutableSet.of(orderLineId));
+
+		// Assert — reload the row and verify Processed=Y (and QtyDelivered now == Qty)
+		final I_M_QtyReservation reloaded = Services.get(org.adempiere.ad.dao.IQueryBL.class)
+				.createQueryBuilder(I_M_QtyReservation.class)
+				.addEqualsFilter(I_M_QtyReservation.COLUMNNAME_C_OrderLine_ID, line.getC_OrderLine_ID())
+				.create()
+				.firstOnlyNotNull();
+
+		assertThat(reloaded.isProcessed()).as("Processed should be Y after close").isTrue();
+		assertThat(reloaded.getQtyDelivered()).as("QtyDelivered should equal Qty").isEqualByComparingTo(new BigDecimal("6"));
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/split/OrderSplitCommandTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/split/OrderSplitCommandTest.java
@@ -1,5 +1,9 @@
 package de.metas.order.split;
 
+import de.metas.inoutcandidate.api.IShipmentScheduleBL;
+import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
+import de.metas.inoutcandidate.qty_reservation.QtyReservationRepository;
+import de.metas.inoutcandidate.qty_reservation.QtyReservationService;
 import de.metas.order.IOrderDAO;
 import de.metas.order.OrderId;
 import de.metas.util.Services;
@@ -13,6 +17,7 @@ import org.compiere.model.I_M_InOut;
 import org.compiere.model.I_M_InOutLine;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -30,7 +35,20 @@ class OrderSplitCommandTest
 	void setup()
 	{
 		AdempiereTestHelper.get().init();
-		command = new OrderSplitCommand();
+
+		// Register mock IShipmentScheduleBL so the call does not NPE
+		final IShipmentScheduleBL mockBL = Mockito.mock(IShipmentScheduleBL.class);
+		Services.registerService(IShipmentScheduleBL.class, mockBL);
+
+		// Create QtyReservationService with mock dependencies
+		final IShipmentScheduleInvalidateBL mockInvalidateBL =
+				Mockito.mock(IShipmentScheduleInvalidateBL.class);
+		final QtyReservationRepository repository = new QtyReservationRepository();
+		final QtyReservationService qtyReservationService = new QtyReservationService(
+				mockInvalidateBL,
+				repository);
+
+		command = new OrderSplitCommand(qtyReservationService);
 	}
 
 	@Test
@@ -123,17 +141,10 @@ class OrderSplitCommandTest
 		shipmentLine.setMovementQty(new BigDecimal("8"));
 		save(shipmentLine);
 
-		// Act — expect Task-8b stub to throw; we assert on the already-saved NEW header
-		try
-		{
-			command.split(OrderSplitRequest.builder()
-					.orderId(OrderId.ofRepoId(order.getC_Order_ID()))
-					.build());
-		}
-		catch (final UnsupportedOperationException expected)
-		{
-			// Task 8b will replace this throw with line cloning
-		}
+		// Act
+		command.split(OrderSplitRequest.builder()
+				.orderId(OrderId.ofRepoId(order.getC_Order_ID()))
+				.build());
 
 		// Assert — exactly one NEW C_Order exists with POReference = old DocumentNo
 		final List<I_C_Order> newOrders = Services.get(IQueryBL.class)
@@ -162,14 +173,12 @@ class OrderSplitCommandTest
 		newOrderLine(order, "10", "4");                 // residue 6 → moves to NEW
 		newOrderLineOverDelivered(order, "5", "7");     // over-delivered → stays on OLD
 
-		try
-		{
-			command.split(OrderSplitRequest.builder()
-					.orderId(OrderId.ofRepoId(order.getC_Order_ID()))
-					.build());
-		}
-		catch (final UnsupportedOperationException expected) { /* Task 9 stub */ }
+		// Act
+		command.split(OrderSplitRequest.builder()
+				.orderId(OrderId.ofRepoId(order.getC_Order_ID()))
+				.build());
 
+		// Assert
 		final I_C_Order newOrder = findNewOrderByPOReference("SO-RES-001");
 		final java.util.List<de.metas.interfaces.I_C_OrderLine> newLines = Services.get(IOrderDAO.class)
 				.retrieveOrderLines(OrderId.ofRepoId(newOrder.getC_Order_ID()));
@@ -188,14 +197,12 @@ class OrderSplitCommandTest
 		line.setPriceEntered(new BigDecimal("12.50"));
 		save(line);
 
-		try
-		{
-			command.split(OrderSplitRequest.builder()
-					.orderId(OrderId.ofRepoId(order.getC_Order_ID()))
-					.build());
-		}
-		catch (final UnsupportedOperationException expected) { /* Task 9 stub */ }
+		// Act
+		command.split(OrderSplitRequest.builder()
+				.orderId(OrderId.ofRepoId(order.getC_Order_ID()))
+				.build());
 
+		// Assert
 		final I_C_Order newOrder = findNewOrderByPOReference("SO-PR-001");
 		final java.util.List<de.metas.interfaces.I_C_OrderLine> newLines = Services.get(IOrderDAO.class)
 				.retrieveOrderLines(OrderId.ofRepoId(newOrder.getC_Order_ID()));
@@ -208,6 +215,56 @@ class OrderSplitCommandTest
 		// either way it should be non-null and non-negative.
 		assertThat(newLine.getPriceActual()).isNotNull();
 		assertThat(newLine.getPriceActual().signum()).isGreaterThanOrEqualTo(0);
+	}
+
+	@Test
+	void closesOldShipmentSchedulesAndReservations()
+	{
+		final I_C_Order order = createOrderWithShipment("SO-CLOSE-001");
+		final I_C_OrderLine line = newOrderLine(order, "10", "4");           // residue 6
+
+		// Add an active M_QtyReservation row for the line.
+		// Setup mirrors the QtyReservationServiceCloseAllActiveTest fixture from Task 7.
+		final org.compiere.model.I_C_UOM uom = newInstance(org.compiere.model.I_C_UOM.class);
+		save(uom);
+		final org.compiere.model.I_M_Product product = newInstance(org.compiere.model.I_M_Product.class);
+		product.setC_UOM_ID(uom.getC_UOM_ID());
+		save(product);
+		final org.compiere.model.I_M_Warehouse warehouse = newInstance(org.compiere.model.I_M_Warehouse.class);
+		save(warehouse);
+		// Wire the line to the product/uom so QtyReservation's loader can build the domain.
+		line.setM_Product_ID(product.getM_Product_ID());
+		line.setC_UOM_ID(uom.getC_UOM_ID());
+		save(line);
+
+		final org.compiere.model.I_M_QtyReservation reservation = newInstance(org.compiere.model.I_M_QtyReservation.class);
+		reservation.setC_OrderLine_ID(line.getC_OrderLine_ID());
+		reservation.setM_Product_ID(product.getM_Product_ID());
+		reservation.setM_Warehouse_ID(warehouse.getM_Warehouse_ID());
+		reservation.setC_UOM_ID(uom.getC_UOM_ID());
+		reservation.setQty(new BigDecimal("6"));
+		reservation.setQtyDelivered(BigDecimal.ZERO);
+		reservation.setQtyTU(new BigDecimal("1"));
+		reservation.setProcessed(false);
+		reservation.setAttributesKey("");
+		reservation.setSupplyType("OH");
+		save(reservation);
+
+		// Act
+		final OrderSplitResult result = command.split(OrderSplitRequest.builder()
+				.orderId(OrderId.ofRepoId(order.getC_Order_ID()))
+				.build());
+
+		// Assert — reservation closed
+		org.adempiere.model.InterfaceWrapperHelper.refresh(reservation);
+		assertThat(reservation.isProcessed()).as("Reservation should be Processed=Y").isTrue();
+		assertThat(reservation.getQtyDelivered()).as("QtyDelivered should equal Qty (6)")
+				.isEqualByComparingTo(new BigDecimal("6"));
+
+		// Result populated
+		assertThat(result.getCopiedLineCount()).isEqualTo(1);
+		assertThat(result.getOldOrderId().getRepoId()).isEqualTo(order.getC_Order_ID());
+		assertThat(result.getNewOrderId().getRepoId()).isNotEqualTo(order.getC_Order_ID());
 	}
 
 	// -------------------------------------------------------------------------

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/split/OrderSplitCommandTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/split/OrderSplitCommandTest.java
@@ -1,0 +1,86 @@
+package de.metas.order.split;
+
+import de.metas.order.OrderId;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_OrderLine;
+import org.compiere.model.I_M_InOut;
+import org.compiere.model.I_M_InOutLine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.save;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OrderSplitCommandTest
+{
+	private OrderSplitCommand command;
+
+	@BeforeEach
+	void setup()
+	{
+		AdempiereTestHelper.get().init();
+		command = new OrderSplitCommand();
+	}
+
+	@Test
+	void rejectsWhenNoCompletedShipment()
+	{
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setDocStatus("CO");
+		order.setIsSOTrx(true);
+		save(order);
+
+		final I_C_OrderLine line = newInstance(I_C_OrderLine.class);
+		line.setC_Order_ID(order.getC_Order_ID());
+		line.setQtyOrdered(new BigDecimal("10"));
+		line.setQtyDelivered(BigDecimal.ZERO);
+		save(line);
+
+		// No M_InOut → guard 1 must fire
+		assertThatThrownBy(() -> command.split(OrderSplitRequest.builder()
+				.orderId(OrderId.ofRepoId(order.getC_Order_ID()))
+				.build()))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("C_Order_Split_NoShipments");
+	}
+
+	@Test
+	void rejectsWhenNothingToSplit()
+	{
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setDocStatus("CO");
+		order.setIsSOTrx(true);
+		save(order);
+
+		final I_C_OrderLine line = newInstance(I_C_OrderLine.class);
+		line.setC_Order_ID(order.getC_Order_ID());
+		line.setQtyOrdered(new BigDecimal("10"));
+		line.setQtyDelivered(new BigDecimal("10"));  // fully delivered → no residue
+		save(line);
+
+		// Add a completed shipment for the line → guard 1 passes
+		final I_M_InOut shipment = newInstance(I_M_InOut.class);
+		shipment.setC_Order_ID(order.getC_Order_ID());
+		shipment.setDocStatus("CO");
+		shipment.setIsSOTrx(true);
+		save(shipment);
+
+		final I_M_InOutLine shipmentLine = newInstance(I_M_InOutLine.class);
+		shipmentLine.setM_InOut_ID(shipment.getM_InOut_ID());
+		shipmentLine.setC_OrderLine_ID(line.getC_OrderLine_ID());
+		shipmentLine.setMovementQty(new BigDecimal("10"));
+		save(shipmentLine);
+
+		// Guard 1 passes (shipment exists), guard 2 fires (no residue)
+		assertThatThrownBy(() -> command.split(OrderSplitRequest.builder()
+				.orderId(OrderId.ofRepoId(order.getC_Order_ID()))
+				.build()))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("C_Order_Split_NothingToSplit");
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/split/OrderSplitCommandTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/split/OrderSplitCommandTest.java
@@ -1,5 +1,6 @@
 package de.metas.order.split;
 
+import de.metas.order.IOrderDAO;
 import de.metas.order.OrderId;
 import de.metas.util.Services;
 import org.adempiere.ad.dao.IQueryBL;
@@ -150,5 +151,116 @@ class OrderSplitCommandTest
 		assertThat(newOrder.getDescription())
 				.contains("Original description")
 				.contains("Fortsetzung von SO-ORIG-001");
+	}
+
+	@Test
+	void selectsOnlyLinesWithUnshippedResidue()
+	{
+		final I_C_Order order = createOrderWithShipment("SO-RES-001");
+		// 3 lines: fully delivered (10/10 → stays), partial (10/4 → moves residue 6), over-delivered (5/7 → stays)
+		newOrderLine(order, "10", "10");                // fully delivered → stays on OLD
+		newOrderLine(order, "10", "4");                 // residue 6 → moves to NEW
+		newOrderLineOverDelivered(order, "5", "7");     // over-delivered → stays on OLD
+
+		try
+		{
+			command.split(OrderSplitRequest.builder()
+					.orderId(OrderId.ofRepoId(order.getC_Order_ID()))
+					.build());
+		}
+		catch (final UnsupportedOperationException expected) { /* Task 9 stub */ }
+
+		final I_C_Order newOrder = findNewOrderByPOReference("SO-RES-001");
+		final java.util.List<de.metas.interfaces.I_C_OrderLine> newLines = Services.get(IOrderDAO.class)
+				.retrieveOrderLines(OrderId.ofRepoId(newOrder.getC_Order_ID()));
+
+		assertThat(newLines).hasSize(1);
+		assertThat(newLines.get(0).getQtyEntered()).isEqualByComparingTo(new BigDecimal("6"));
+	}
+
+	@Test
+	void clonesLineQtyAndAllowsPriceLookupToRun()
+	{
+		final I_C_Order order = createOrderWithShipment("SO-PR-001");
+		final I_C_OrderLine line = newOrderLine(order, "10", "8");           // residue 2
+
+		line.setPriceActual(new BigDecimal("12.50"));
+		line.setPriceEntered(new BigDecimal("12.50"));
+		save(line);
+
+		try
+		{
+			command.split(OrderSplitRequest.builder()
+					.orderId(OrderId.ofRepoId(order.getC_Order_ID()))
+					.build());
+		}
+		catch (final UnsupportedOperationException expected) { /* Task 9 stub */ }
+
+		final I_C_Order newOrder = findNewOrderByPOReference("SO-PR-001");
+		final java.util.List<de.metas.interfaces.I_C_OrderLine> newLines = Services.get(IOrderDAO.class)
+				.retrieveOrderLines(OrderId.ofRepoId(newOrder.getC_Order_ID()));
+
+		assertThat(newLines).hasSize(1);
+		final de.metas.interfaces.I_C_OrderLine newLine = newLines.get(0);
+		assertThat(newLine.getQtyEntered()).isEqualByComparingTo(new BigDecimal("2"));
+		assertThat(newLine.isManualPrice()).isFalse();
+		// Pricing may have been re-derived by the interceptor OR may equal the cloned value;
+		// either way it should be non-null and non-negative.
+		assertThat(newLine.getPriceActual()).isNotNull();
+		assertThat(newLine.getPriceActual().signum()).isGreaterThanOrEqualTo(0);
+	}
+
+	// -------------------------------------------------------------------------
+	// Test helpers
+	// -------------------------------------------------------------------------
+
+	private I_C_Order createOrderWithShipment(final String documentNo)
+	{
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setDocStatus("CO");
+		order.setDocumentNo(documentNo);
+		order.setIsSOTrx(true);
+		save(order);
+
+		final I_M_InOut shipment = newInstance(I_M_InOut.class);
+		shipment.setC_Order_ID(order.getC_Order_ID());
+		shipment.setDocStatus("CO");
+		shipment.setIsSOTrx(true);
+		save(shipment);
+
+		return order;
+	}
+
+	private I_C_OrderLine newOrderLine(
+			final I_C_Order order,
+			final String qtyOrdered,
+			final String qtyDelivered)
+	{
+		final I_C_OrderLine line = newInstance(I_C_OrderLine.class);
+		line.setC_Order_ID(order.getC_Order_ID());
+		line.setQtyOrdered(new BigDecimal(qtyOrdered));
+		line.setQtyDelivered(new BigDecimal(qtyDelivered));
+		line.setLine(10);
+		save(line);
+		return line;
+	}
+
+	private I_C_OrderLine newOrderLineOverDelivered(
+			final I_C_Order order,
+			final String qtyOrdered,
+			final String qtyDelivered)
+	{
+		// Same as newOrderLine but explicit naming for over-delivered case (QtyDelivered > QtyOrdered).
+		// In-memory tests don't enforce QtyDelivered <= QtyOrdered, so we can simulate over-delivery here.
+		return newOrderLine(order, qtyOrdered, qtyDelivered);
+	}
+
+	private I_C_Order findNewOrderByPOReference(final String poReference)
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_C_Order.class)
+				.addEqualsFilter(I_C_Order.COLUMNNAME_POReference, poReference)
+				.create()
+				.firstOnlyNotNull();
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/split/OrderSplitCommandTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/split/OrderSplitCommandTest.java
@@ -1,19 +1,24 @@
 package de.metas.order.split;
 
 import de.metas.order.OrderId;
+import de.metas.util.Services;
+import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.test.AdempiereTestHelper;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_OrderLine;
+import org.compiere.model.I_C_Project;
 import org.compiere.model.I_M_InOut;
 import org.compiere.model.I_M_InOutLine;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.save;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class OrderSplitCommandTest
@@ -82,5 +87,68 @@ class OrderSplitCommandTest
 				.build()))
 				.isInstanceOf(AdempiereException.class)
 				.hasMessageContaining("C_Order_Split_NothingToSplit");
+	}
+
+	@Test
+	void clonesHeaderClearsProjectSetsPOReference()
+	{
+		final I_C_Project project = newInstance(I_C_Project.class);
+		project.setName("PROJECT_X");
+		save(project);
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setDocStatus("CO");
+		order.setDocumentNo("SO-ORIG-001");
+		order.setIsSOTrx(true);
+		order.setC_Project_ID(project.getC_Project_ID());
+		order.setDescription("Original description");
+		save(order);
+
+		final I_C_OrderLine line = newInstance(I_C_OrderLine.class);
+		line.setC_Order_ID(order.getC_Order_ID());
+		line.setQtyOrdered(new BigDecimal("10"));
+		line.setQtyDelivered(new BigDecimal("8"));  // residue = 2 → validation passes
+		save(line);
+
+		final I_M_InOut shipment = newInstance(I_M_InOut.class);
+		shipment.setC_Order_ID(order.getC_Order_ID());
+		shipment.setDocStatus("CO");
+		shipment.setIsSOTrx(true);
+		save(shipment);
+
+		final I_M_InOutLine shipmentLine = newInstance(I_M_InOutLine.class);
+		shipmentLine.setM_InOut_ID(shipment.getM_InOut_ID());
+		shipmentLine.setC_OrderLine_ID(line.getC_OrderLine_ID());
+		shipmentLine.setMovementQty(new BigDecimal("8"));
+		save(shipmentLine);
+
+		// Act — expect Task-8b stub to throw; we assert on the already-saved NEW header
+		try
+		{
+			command.split(OrderSplitRequest.builder()
+					.orderId(OrderId.ofRepoId(order.getC_Order_ID()))
+					.build());
+		}
+		catch (final UnsupportedOperationException expected)
+		{
+			// Task 8b will replace this throw with line cloning
+		}
+
+		// Assert — exactly one NEW C_Order exists with POReference = old DocumentNo
+		final List<I_C_Order> newOrders = Services.get(IQueryBL.class)
+				.createQueryBuilder(I_C_Order.class)
+				.addEqualsFilter(I_C_Order.COLUMNNAME_POReference, "SO-ORIG-001")
+				.addNotEqualsFilter(I_C_Order.COLUMNNAME_C_Order_ID, order.getC_Order_ID())
+				.create()
+				.list(I_C_Order.class);
+		assertThat(newOrders).hasSize(1);
+
+		final I_C_Order newOrder = newOrders.get(0);
+		assertThat(newOrder.getDocStatus()).isEqualTo("DR");
+		assertThat(newOrder.getC_Project_ID()).isZero();
+		assertThat(newOrder.getPOReference()).isEqualTo("SO-ORIG-001");
+		assertThat(newOrder.getDescription())
+				.contains("Original description")
+				.contains("Fortsetzung von SO-ORIG-001");
 	}
 }

--- a/workspace_migrate.properties
+++ b/workspace_migrate.properties
@@ -1,0 +1,6 @@
+db.host=localhost
+db.port=4432
+db.name=metasfresh
+db.user=metasfresh
+db.password=metasfresh
+db.type=postgresql

--- a/workspace_migrate.properties
+++ b/workspace_migrate.properties
@@ -1,6 +1,0 @@
-db.host=localhost
-db.port=4432
-db.name=metasfresh
-db.user=metasfresh
-db.password=metasfresh
-db.type=postgresql


### PR DESCRIPTION
## Summary

Implements a new `AD_Process` `C_Order_Split` invoked on a partly-shipped sales order. It splits the order into two:

- the **OLD SO** is left untouched at the document/line level (`QtyOrdered` preserved), but all its `M_ShipmentSchedule` rows are closed (`IsClosed=Y`) and all active `M_QtyReservation` rows are closed (`Processed=Y`);
- a **NEW (continuation) SO** is created in `DocStatus=DR` with one line per old-SO line that still has unshipped quantity (`QtyEntered = old.QtyOrdered − old.QtyDelivered`); pricing flows from the current pricelist (`IsManualPrice=N`); `C_Project_ID` is cleared so the user can re-reserve against a different project; `POReference` is set to the OLD SO's DocumentNo as a backref.

Invoice candidates on the OLD SO are deliberately left untouched.

Target branch: `swift_eagle_release`. Hotfix: No (auto-port handles forward propagation).

## Changes

### AD metadata (6 migrations under `backend/de.metas.business/.../20-de.metas.business/`)

- 2 AD_Messages (`C_Order_Split_NoShipments`, `C_Order_Split_NothingToSplit`) with German base text + `en_US` / `de_DE` / `de_CH` translations + ErrorCodes (`ORDER_SPLIT_NO_SHIPMENTS`, `ORDER_SPLIT_NOTHING_TO_SPLIT`)
- AD_Process registration (DE base + en_US trl)
- AD_Process_Access seed
- AD_Table_Process binding to C_Order + sales-order window (`AD_Window_ID=143`)

### Backend code (`backend/de.metas.swat/de.metas.swat.base/.../order/split/`)

- `OrderSplitRequest` / `OrderSplitResult` — Lombok value objects
- `OrderSplitCommand` — Spring `@Service` orchestrator: `validate()` → `createContinuationOrderHeader()` → `createContinuationOrderLines()` → `closeOldShipmentSchedules()` → `closeOldReservations()`
- `C_Order_Split` — `JavaProcess` wrapper (zero parameters)
- `QtyReservationService.closeAllActiveForOrderLines(Collection<OrderLineId>)` — new helper that delegates to the repository's `updateByOrderLineIds` with `r -> r.withQtyDelivered(r.getQty())` to flip `Processed=Y` via the `isFullyDelivered()` derivation

### Tests

- 6 unit tests in `OrderSplitCommandTest` (validation guards, header clone, line selection by residue, pricing-lookup, OLD SO finalization)
- 1 unit test in `QtyReservationServiceCloseAllActiveTest` for the new helper
- 7 cucumber scenarios in `orderSplit.feature` (`S_OS_10` happy path, `S_OS_20` multi-line, `S_OS_30` fully-delivered exclusion, `S_OS_40` reservation closure, `S_OS_50` shipment-schedule closure, `S_OS_60` no-shipment validation, `S_OS_70` nothing-to-split validation)

## Decision points worth flagging

- **`S_OS_30` cucumber substitution** — cucumber scenario uses a fully-delivered line (5/5) instead of over-delivered (5/7) because cucumber step defs cannot produce `QtyDelivered > QtyOrdered`. The true over-delivery case is exercised in the unit test `selectsOnlyLinesWithUnshippedResidue`.
- **`AD_Process_Access` role names** — seed targets `System / GardenAdmin / metasfresh Admin` (dev). Production access is auto-granted by the model interceptor on `AD_Process` insert and propagated.

## Test plan

- [x] CI green on this PR (compile + cucumber + unit tests against `swift_eagle_release`)
- [x] Cucumber `orderSplit.feature` GREEN — all 7 scenarios
- [x] Unit tests GREEN — 6 `OrderSplitCommandTest` + 1 `QtyReservationServiceCloseAllActiveTest`
- [x] Migration scripts apply cleanly
- [ ] Manual: invoke the process from the sales-order window action menu against a partly-shipped SO and verify a continuation order appears