### PR TITLE
Fix SEPA pain.001 PmtInf/NbOfTxs mismatch causing AM18 at UBS

### DIFF
--- a/backend/de.metas.payment.sepa/base/src/main/java/de/metas/payment/sepa/sepamarshaller/impl/SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02.java
+++ b/backend/de.metas.payment.sepa/base/src/main/java/de/metas/payment/sepa/sepamarshaller/impl/SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02.java
@@ -336,11 +336,6 @@ public class SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02 implements 
 			final CreditTransferTransactionInformation10CH cdtTrfTxInf = createCreditTransferTransactionInformation(pmtInf, sepaLine);
 			pmtInf.getCdtTrfTxInf().add(cdtTrfTxInf);
 
-			if (sepaLine.isGroupLine() && sepaLine.getNumberOfReferences() > 0)
-			{
-				pmtInf.setNbOfTxs(String.valueOf(sepaLine.getNumberOfReferences()));
-			}
-
 			final BigDecimal transactionAmount = cdtTrfTxInf.getAmt().getInstdAmt().getValue();
 			pmtInf.setCtrlSum(pmtInf.getCtrlSum().add(transactionAmount));
 
@@ -349,6 +344,12 @@ public class SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02 implements 
 
 		for (final PaymentInstructionInformation3CH pmtInf : currency2pmtInf.values())
 		{
+			// NbOfTxs must equal the actual number of CdtTrfTxInf elements in this PmtInf block.
+			// (A previous approach set this from sepaLine.getNumberOfReferences() for group lines,
+			// which produced a value that didn't match the real transaction count and caused
+			// ISO error AM18 at UBS and other banks that enforce this field strictly.)
+			pmtInf.setNbOfTxs(String.valueOf(pmtInf.getCdtTrfTxInf().size()));
+
 			// Update GroupHeader's control amount
 			final BigDecimal groupHeaderCtrlAmt = creditTransferInitiation.getGrpHdr().getCtrlSum();
 			final BigDecimal groupHeaderCtrlAmtNew = groupHeaderCtrlAmt.add(pmtInf.getCtrlSum());

--- a/backend/de.metas.payment.sepa/base/src/test/java/de/metas/payment/sepa/sepamarshaller/impl/SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02_Test.java
+++ b/backend/de.metas.payment.sepa/base/src/test/java/de/metas/payment/sepa/sepamarshaller/impl/SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02_Test.java
@@ -270,7 +270,7 @@ public class SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02_Test
 		final List<PaymentInstructionInformation3CH> pmtInf = xmlDocument.getCstmrCdtTrfInitn().getPmtInf();
 		final PaymentInstructionInformation3CH pmtInf1 = pmtInf.get(0);
 		assertThat(pmtInf1).isNotNull();
-		assertThat(pmtInf1.getNbOfTxs()).isNull();
+		assertThat(pmtInf1.getNbOfTxs()).isEqualTo("1");
 		assertThat(pmtInf1.getCtrlSum()).isEqualTo("10");
 
 		final List<CreditTransferTransactionInformation10CH> information3CH = pmtInf1.getCdtTrfTxInf();
@@ -285,7 +285,7 @@ public class SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02_Test
 		final PaymentInstructionInformation3CH groupedPmtInf1 = pmtInf.get(1);
 		assertThat(groupedPmtInf1).isNotNull();
 		// number of grouped invoices
-		assertThat(groupedPmtInf1.getNbOfTxs()).isEqualTo("2");
+		assertThat(groupedPmtInf1.getNbOfTxs()).isEqualTo("1");
 		// total of all aggregated amounts
 		assertThat(groupedPmtInf1.getCtrlSum()).isEqualTo("11");
 


### PR DESCRIPTION
PmtInf/NbOfTxs was being set from sepaLine.getNumberOfReferences() for group lines. This produced a count that reflected the number of underlying invoice references rather than the actual number of CdtTrfTxInf XML elements, causing a discrepancy with GrpHdr/NbOfTxs.

UBS (and other strict banks) enforce ISO error AM18: the announced transaction count in PmtInf/NbOfTxs must match the actual number of CdtTrfTxInf elements found. The SIX validator does not check this cross-field constraint.

Fix: remove the group-line special case; instead set PmtInf/NbOfTxs from pmtInf.getCdtTrfTxInf().size() in the post-processing loop so it always reflects the true XML structure.