### PR TITLE
Tax Declaration — UAT follow-up: open created Correction + correction-group layout

### DIFF
--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CreateCorrection.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CreateCorrection.java
@@ -21,7 +21,7 @@ public class C_TaxDeclaration_CreateCorrection extends JavaProcess implements IP
 		}
 
 		final I_C_TaxDeclaration taxDeclaration = context.getSelectedModel(I_C_TaxDeclaration.class);
-		if (!taxDeclaration.isProcessed())
+		if (taxDeclaration == null || !taxDeclaration.isProcessed())
 		{
 			return ProcessPreconditionsResolution.rejectWithInternalReason("Tax declaration is not yet locked");
 		}
@@ -37,7 +37,8 @@ public class C_TaxDeclaration_CreateCorrection extends JavaProcess implements IP
 	@Override
 	protected String doIt()
 	{
-		taxDeclarationService.createCorrection(TaxDeclarationId.ofRepoId(getRecord_ID()));
+		final TaxDeclarationId correctionId = taxDeclarationService.createCorrection(TaxDeclarationId.ofRepoId(getRecord_ID()));
+		getResult().setRecordToOpen(I_C_TaxDeclaration.Table_Name, correctionId);
 		return MSG_OK;
 	}
 }

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
@@ -35,7 +35,9 @@ public class TaxDeclarationService
 				new Object[] { id });
 	}
 
-	/** Spawns a Correction for {@code originalId}, inheriting its acctSchema/period/dateAcct. */
+	/**
+	 * Spawns a Correction for {@code originalId}, inheriting its acctSchema/period/dateAcct.
+	 */
 	public TaxDeclarationId createCorrection(@NonNull final TaxDeclarationId originalId)
 	{
 		final I_C_TaxDeclaration original = taxDeclarationRepository.getById(originalId);
@@ -48,7 +50,7 @@ public class TaxDeclarationService
 			throw new AdempiereException(MSG_TaxDeclaration_OriginalMustBeOriginal);
 		}
 
-		return taxDeclarationRepository.createTaxDeclaration(TaxDeclarationCreateRequest.builder()
+		final TaxDeclarationId correctionId = taxDeclarationRepository.createTaxDeclaration(TaxDeclarationCreateRequest.builder()
 				.adOrgId(OrgId.ofRepoId(original.getAD_Org_ID()))
 				.acctSchemaId(AcctSchemaId.ofRepoId(original.getC_AcctSchema_ID()))
 				.periodRepoId(original.getC_Period_ID())
@@ -56,5 +58,9 @@ public class TaxDeclarationService
 				.isCorrection(true)
 				.originalId(originalId)
 				.build());
+
+		build(correctionId);
+
+		return correctionId;
 	}
 }

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805170_sys_me03_29631_C_TaxDeclaration_window_correction_group.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805170_sys_me03_29631_C_TaxDeclaration_window_correction_group.sql
@@ -1,0 +1,74 @@
+-- Tax Declaration — window 542146 layout follow-up
+--   * Make IsCorrection readonly in the window (set by the Create Correction process; user must not toggle)
+--   * Group the 4 Correction-lifecycle fields into a dedicated AD_UI_ElementGroup on column 2,
+--     below the existing "flags" group
+--   * Reorder column 2 vertical stack:  flags -> correction -> dates -> org
+--   * "dates" element-group moves from column 1 to column 2
+--
+-- Ref: https://github.com/metasfresh/me03/issues/29631
+
+-- 1) Make IsCorrection readonly in the window
+UPDATE AD_Field
+   SET IsReadOnly = 'Y',
+       Updated = TO_TIMESTAMP('2026-05-28 00:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+ WHERE AD_Field_ID = 780479 /*IsCorrection — From ID Server*/;
+
+-- 2) Create new AD_UI_ElementGroup "correction" on column 549512 (col-2 of section 547771)
+INSERT INTO AD_UI_ElementGroup (
+    AD_UI_ElementGroup_ID, AD_Client_ID, AD_Org_ID, IsActive,
+    Created, CreatedBy, Updated, UpdatedBy,
+    AD_UI_Column_ID, Name, SeqNo, UIStyle)
+VALUES (
+    555411 /*From ID Server*/, 0, 0, 'Y',
+    TO_TIMESTAMP('2026-05-28 00:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+    TO_TIMESTAMP('2026-05-28 00:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+    549512, 'correction', 20, NULL);
+
+-- 3) Reorder column-2 element-groups so the stack becomes:
+--      flags      (555375) seq=10  — unchanged
+--      correction (555411) seq=20  — new (inserted above)
+--      dates      (555374) seq=30  — moved from column 549485 (col-1) to 549512 (col-2)
+--      org        (555376) seq=40  — re-numbered from 20 to 40 to make room
+UPDATE AD_UI_ElementGroup
+   SET AD_UI_Column_ID = 549512,
+       SeqNo = 30,
+       Updated = TO_TIMESTAMP('2026-05-28 00:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+ WHERE AD_UI_ElementGroup_ID = 555374 /*dates*/;
+
+UPDATE AD_UI_ElementGroup
+   SET SeqNo = 40,
+       Updated = TO_TIMESTAMP('2026-05-28 00:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+ WHERE AD_UI_ElementGroup_ID = 555376 /*org*/;
+
+-- 4) Move the 4 Correction-lifecycle AD_UI_Element rows into the new group,
+--    renumber SeqNo within the group starting at 10
+UPDATE AD_UI_Element
+   SET AD_UI_ElementGroup_ID = 555411 /*From ID Server*/,
+       SeqNo = 10,
+       Updated = TO_TIMESTAMP('2026-05-28 00:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+ WHERE AD_UI_Element_ID = 651834 /*IsCorrection — From ID Server*/;
+
+UPDATE AD_UI_Element
+   SET AD_UI_ElementGroup_ID = 555411 /*From ID Server*/,
+       SeqNo = 20,
+       Updated = TO_TIMESTAMP('2026-05-28 00:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+ WHERE AD_UI_Element_ID = 651835 /*C_TaxDeclaration_Original_ID — From ID Server*/;
+
+UPDATE AD_UI_Element
+   SET AD_UI_ElementGroup_ID = 555411 /*From ID Server*/,
+       SeqNo = 30,
+       Updated = TO_TIMESTAMP('2026-05-28 00:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+ WHERE AD_UI_Element_ID = 651836 /*IsCorrectionNeeded — From ID Server*/;
+
+UPDATE AD_UI_Element
+   SET AD_UI_ElementGroup_ID = 555411 /*From ID Server*/,
+       SeqNo = 40,
+       Updated = TO_TIMESTAMP('2026-05-28 00:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+ WHERE AD_UI_Element_ID = 651837 /*CorrectionNeededReason — From ID Server*/;

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessExecutionResult.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/process/ProcessExecutionResult.java
@@ -389,6 +389,17 @@ public class ProcessExecutionResult
 		}
 	}
 
+	public void setRecordToOpen(@NonNull final String tableName, @NonNull final RepoIdAware recordId)
+	{
+		setRecordToOpen(RecordsToOpen.builder()
+				.record(TableRecordReference.of(tableName, recordId))
+				.adWindowId(null)
+				.target(OpenTarget.SingleDocument)
+				.targetTab(RecordsToOpen.TargetTab.NEW_TAB)
+				.automaticallySetReferencingDocumentPaths(true)
+				.build());
+	}
+
 	public void setRecordsToOpen(@NonNull final String tableName, final Collection<Integer> recordIds, final String adWindowId)
 	{
 		if (recordIds == null || recordIds.isEmpty())


### PR DESCRIPTION
Follow-up to https://github.com/metasfresh/metasfresh/pull/24253 after UAT review on https://danthermuat.metasfresh.com/window/542146/1000003 (issue https://github.com/metasfresh/me03/issues/29631).

## Behaviour fixes

- `C_TaxDeclaration_CreateCorrection` process now **opens the newly created Correction document** (`getResult().setRecordToOpen(...)`); previously the UI stayed on the Original.
- `TaxDeclarationService.createCorrection(...)` now **invokes `build(correctionId)`** right after inserting the header, so the new Correction has its lines populated on first open.
- New convenience overload `ProcessExecutionResult.setRecordToOpen(tableName, recordId)` to remove builder boilerplate at the (single) call site.

## Window 542146 / tab `Steuererklärung` layout

- `IsCorrection` is computed by the Create Correction process and must not be toggled by the user — now `AD_Field.IsReadOnly='Y'`.
- The 4 Correction-lifecycle fields (`IsCorrection`, `C_TaxDeclaration_Original_ID`, `IsCorrectionNeeded`, `CorrectionNeededReason`) move out of the col-1 \`default\` element group into their own new `correction` `AD_UI_ElementGroup` on column 2.
- Column-2 vertical stack becomes: \`flags (existing) → correction (new) → dates (moved from col-1) → org (existing)\`.
- The `dates` element-group is reassigned from `AD_UI_Column` 549485 (col-1) to 549512 (col-2).

## Migration

- `backend/de.metas.acct.base/.../43-de.metas.acct/5805170_sys_me03_29631_C_TaxDeclaration_window_correction_group.sql`
- Applied locally against \`deep_tundra_uat\`; column-2 stack + new group contents asserted directly in DB; translations intact (de_DE / de_CH base + en_US override).

## Local validation

- Compile: \`de.metas.adempiere.adempiere/base\` + \`de.metas.acct.base\` — GREEN.
- JUnit: \`TaxDeclarationDocumentHandlerTest\` — 4/4 GREEN. Covers `reactivateIt` + `completeIt` paths on a Correction.
- Cucumber \`tax_declaration\` locally: BLOCKED on stale `.m2-local` jars in unrelated modules (verified the failing files are not in this PR's diff). Relying on CI for the full cucumber gate.

Ref: https://github.com/metasfresh/me03/issues/29631