### PR TITLE
Tax Declaration — fix unit-test regression: move build() out of createCorrection

### DIFF
--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CreateCorrection.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CreateCorrection.java
@@ -38,6 +38,7 @@ public class C_TaxDeclaration_CreateCorrection extends JavaProcess implements IP
 	protected String doIt()
 	{
 		final TaxDeclarationId correctionId = taxDeclarationService.createCorrection(TaxDeclarationId.ofRepoId(getRecord_ID()));
+		taxDeclarationService.build(correctionId);
 		getResult().setRecordToOpen(I_C_TaxDeclaration.Table_Name, correctionId);
 		return MSG_OK;
 	}

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
@@ -50,7 +50,7 @@ public class TaxDeclarationService
 			throw new AdempiereException(MSG_TaxDeclaration_OriginalMustBeOriginal);
 		}
 
-		final TaxDeclarationId correctionId = taxDeclarationRepository.createTaxDeclaration(TaxDeclarationCreateRequest.builder()
+		return taxDeclarationRepository.createTaxDeclaration(TaxDeclarationCreateRequest.builder()
 				.adOrgId(OrgId.ofRepoId(original.getAD_Org_ID()))
 				.acctSchemaId(AcctSchemaId.ofRepoId(original.getC_AcctSchema_ID()))
 				.periodRepoId(original.getC_Period_ID())
@@ -58,9 +58,5 @@ public class TaxDeclarationService
 				.isCorrection(true)
 				.originalId(originalId)
 				.build());
-
-		build(correctionId);
-
-		return correctionId;
 	}
 }


### PR DESCRIPTION
Hotfix for the regression introduced by https://github.com/metasfresh/metasfresh/pull/24316 (merge commit https://github.com/metasfresh/metasfresh/commit/7954a2de2b6c94d5b3f31ec1bff9f0a4f62afee4).

## Symptom

\`test (java)\` job RED on \`new_dawn_uat\` since the merge — https://github.com/metasfresh/metasfresh/actions/runs/26566689678/job/78267886510.

Failing test: \`de.metas.acct.tax.TaxDeclarationServiceTest#createCorrection_returnsCorrectionWithInheritedFields\` — \`org.adempiere.exceptions.DBNoConnectionException: NoDBConnection\`.

Stack:
\`\`\`
at de.metas.acct.tax.TaxDeclarationService.build(TaxDeclarationService.java:32)
at de.metas.acct.tax.TaxDeclarationService.createCorrection(TaxDeclarationService.java:62)
at de.metas.acct.tax.TaxDeclarationServiceTest.createCorrection_returnsCorrectionWithInheritedFields:100
\`\`\`

## Root cause

PR #24316 added \`build(correctionId)\` inside \`TaxDeclarationService.createCorrection(...)\` so the new Correction document has lines populated on first open. \`build(...)\` calls a real Postgres function (\`de_metas_acct.tax_declaration_build(...)\`), so unit tests running in POJO mode (no DB) hit \`NoDBConnection\` even though their target was just the header-inheritance assertion.

## Fix

\`createCorrection\` is now a pure header-creation operation again — unit-testable in POJO mode. The JavaProcess \`C_TaxDeclaration_CreateCorrection.doIt()\` now orchestrates:

\`\`\`java
final TaxDeclarationId correctionId = taxDeclarationService.createCorrection(...);
taxDeclarationService.build(correctionId);
getResult().setRecordToOpen(I_C_TaxDeclaration.Table_Name, correctionId);
\`\`\`

Same end-user behaviour as PR #24316: the Create Correction process still creates the header, builds the lines, and navigates to the new document.

## Local validation

- Compile: \`de.metas.acct.base\` GREEN (1:22 min).
- \`TaxDeclarationServiceTest\` 3/3 GREEN (1:06 min).
- \`TaxDeclarationDocumentHandlerTest\` 4/4 GREEN (1:05 min).

Ref: https://github.com/metasfresh/me03/issues/29631