### PR TITLE
Remove legacy repo.metasfresh.com references from dev-support maven settings

### DIFF
--- a/misc/dev-support/maven/settings.xml
+++ b/misc/dev-support/maven/settings.xml
@@ -28,37 +28,10 @@
                 -->
             </properties>
 
-            <repositories>
-                <!--
-                    <repository>
-                        <id>metasfresh-repo</id>
-                        <releases>
-                            <enabled>true</enabled>
-                            <updatePolicy>always</updatePolicy>
-                            <checksumPolicy>warn</checksumPolicy>
-                        </releases>
-                        <url>https://repo.metasfresh.com/content/groups/mvn-master/</url>
-                    </repository>
-                 -->
-                <repository>
-                    <id>metasfresh-3rdparty</id>
-                    <releases>
-                        <enabled>true</enabled>
-                        <updatePolicy>daily</updatePolicy>
-                        <checksumPolicy>warn</checksumPolicy>
-                    </releases>
-                    <url>https://repo.metasfresh.com/repository/mvn-3rdparty-all/</url>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <!-- our main repo is also our plugin repo; also see https://maven.apache.org/pom.html#Plugin_Repositories -->
-                <!-- see https://github.com/metasfresh/metasfresh-parent/issues/3 -->
-                <pluginRepository>
-                    <id>metasfresh-repo</id>
-                    <name>metasfresh maven repository (master branch)</name>
-                    <url>https://repo.metasfresh.com/repository/mvn-master/</url>
-                </pluginRepository>
-            </pluginRepositories>
+            <!--
+                repo.metasfresh.com was the legacy Jenkins-era artifact server; it is no longer in use.
+                Build dependencies resolve against Maven Central (the default) only.
+            -->
         </profile>
 
     </profiles>


### PR DESCRIPTION
## Summary

`repo.metasfresh.com` is decommissioned. This removes the dead `<server>` and `<mirror>` entries from `misc/dev-support/maven/settings.xml`, leaving Maven Central as the only active repo.

Split out from https://github.com/metasfresh/metasfresh/pull/24264 (DD_Order picking reconcile) — unrelated to that feature; piggybacked there originally to keep the maven-repo bootstrap effort moving.

## Test plan

- [ ] CI green
- [ ] No reference to `repo.metasfresh.com` remains in the file