### PR TITLE
fix(acct): AP prepayment allocation resolves V_Prepayment_Acct correctly

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -518,10 +518,7 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 			{
 				doc.setBPBankAccountId(BankAccountId.ofRepoIdOrNull(rs.getInt(1)));
 
-				// IsPrepayment overrides the default bank-clearing account on both sides.
-				// Must be checked BEFORE the PurchasePayment branch — otherwise an AP prepayment
-				// would resolve to B_PaymentSelect_Acct and the V_Prepayment account opened by
-				// Doc_Payment would never be cleared.
+				// IsPrepayment must come first — see method Javadoc
 				final boolean isPrepayment = StringUtils.toBoolean(rs.getString(4));
 				if (isPrepayment)
 				{

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -486,7 +486,17 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 	}
 
 	/**
-	 * Get Payment (Unallocated Payment or Payment Selection) Acct of Bank Account
+	 * Get the bank/clearing account that the {@link org.compiere.model.I_C_Payment} was originally posted to,
+	 * so the allocation can reverse it correctly.
+	 *
+	 * MUST stay in sync with {@link Doc_Payment#createFacts(AcctSchema)} — same decision tree:
+	 * <ul>
+	 *     <li>ARReceipt + IsPrepayment=Y → {@code C_Prepayment}</li>
+	 *     <li>ARReceipt + IsPrepayment=N → {@code B_UnallocatedCash_Acct}</li>
+	 *     <li>PurchasePayment + IsPrepayment=Y → {@code V_Prepayment}</li>
+	 *     <li>PurchasePayment + IsPrepayment=N → {@code B_PaymentSelect_Acct}</li>
+	 * </ul>
+	 * Charge-based payments are handled by {@link Doc_Payment} only; allocation of a charge payment is out of scope here.
 	 */
 	@NonNull
 	private Account getPaymentAcct(@NonNull final AcctSchema as, @NonNull final PaymentId paymentId)
@@ -508,15 +518,12 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 			{
 				doc.setBPBankAccountId(BankAccountId.ofRepoIdOrNull(rs.getInt(1)));
 
-				final DocBaseType docBaseType = DocBaseType.ofCode(rs.getString(2));
-				if (DocBaseType.PurchasePayment.equals(docBaseType))
-				{
-					return doc.getBankAccountAccount(BankAccountAcctType.B_PaymentSelect_Acct, as);
-				}
-
-				// Prepayment
+				// IsPrepayment overrides the default bank-clearing account on both sides.
+				// Must be checked BEFORE the PurchasePayment branch — otherwise an AP prepayment
+				// would resolve to B_PaymentSelect_Acct and the V_Prepayment account opened by
+				// Doc_Payment would never be cleared.
 				final boolean isPrepayment = StringUtils.toBoolean(rs.getString(4));
-				if (isPrepayment)        // Prepayment
+				if (isPrepayment)
 				{
 					final boolean isReceipt = StringUtils.toBoolean(rs.getString(3));
 					if (isReceipt)
@@ -527,6 +534,12 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 					{
 						return doc.getVendorAccount(BPartnerVendorAccountType.V_Prepayment, as);
 					}
+				}
+
+				final DocBaseType docBaseType = DocBaseType.ofCode(rs.getString(2));
+				if (DocBaseType.PurchasePayment.equals(docBaseType))
+				{
+					return doc.getBankAccountAccount(BankAccountAcctType.B_PaymentSelect_Acct, as);
 				}
 			}
 

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_Payment.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_Payment.java
@@ -99,6 +99,10 @@ public class Doc_Payment extends Doc<DocLine<Doc_Payment>>
 	 *      -
 	 * </pre>
 	 *
+	 * The bank/clearing-account decision tree (charge / IsPrepayment / default) MUST stay
+	 * in sync with {@code DocLine_Allocation.getPaymentAcct(AcctSchema, PaymentId)} —
+	 * otherwise the allocation will not reverse what this method posted.
+	 *
 	 * @param as accounting schema
 	 * @return Fact
 	 */

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_StepDef.java
@@ -113,6 +113,7 @@ public class C_Payment_StepDef
 	/**
 	 * Creates one or more {@link I_C_Payment} records in Draft status.
 	 *
+	 * @cucumber.stepdef
 	 * @cucumber.columns
 	 *   <b>Identifier</b> — (required) alias for cross-step reference<br>
 	 *   <b>C_BPartner_ID</b> — (required, identifier-ref) vendor or customer BPartner<br>

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_StepDef.java
@@ -322,6 +322,8 @@ public class C_Payment_StepDef
 				.map(invoiceTable::getId)
 				.orElse(null);
 
+		final boolean isPrepayment = row.getAsOptionalBoolean(I_C_Payment.COLUMNNAME_IsPrepayment).orElse(false);
+
 		final I_C_Payment payment = (isReceipt ? paymentBL.newInboundReceiptBuilder() : paymentBL.newOutboundPaymentBuilder())
 				.adOrgId(orgId)
 				.bpartnerId(bpartnerId)
@@ -332,6 +334,7 @@ public class C_Payment_StepDef
 				.dateTrx(dateTrx)
 				.dateAcct(dateAcct)
 				.invoiceId(invoiceId)
+				.prepayment(isPrepayment)
 				.isAutoAllocateAvailableAmt(false)
 				.createDraft();
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_StepDef.java
@@ -120,8 +120,12 @@ public class C_Payment_StepDef
 	 *   <b>PayAmt</b> — (required) amount with currency code, e.g. {@code 5000 EUR}<br>
 	 *   <b>IsReceipt</b> — (required) {@code true} = inbound (AR), {@code false} = outbound (AP)<br>
 	 *   <b>C_BP_BankAccount_ID</b> — (optional, identifier-ref) bank account; defaults to the org's EUR account<br>
-	 *   <b>IsPrepayment</b> — (optional) when {@code true}, {@link org.compiere.acct.Doc_Payment} posts to
-	 *                          {@code C_Prepayment_Acct} (AR) or {@code V_Prepayment_Acct} (AP); default {@code false}<br>
+	 *   <b>Proforma_Invoice_ID</b> — (optional, identifier-ref) links the payment to a proforma invoice;
+	 *                                {@link org.compiere.model.MPayment} {@code beforeSave} auto-sets
+	 *                                {@code IsPrepayment=Y} when this is non-null, causing
+	 *                                {@link org.compiere.acct.Doc_Payment} to post to
+	 *                                {@code C_Prepayment_Acct} (AR) or {@code V_Prepayment_Acct} (AP).
+	 *                                {@code PayAmt} must equal the proforma's {@code GrandTotal}.<br>
 	 *   <b>C_Invoice_ID</b> — (optional, identifier-ref) pre-linked invoice<br>
 	 * @cucumber.depends {@link de.metas.cucumber.stepdefs.C_BPartner_StepDefData},
 	 *                   {@link de.metas.cucumber.stepdefs.C_BP_BankAccount_StepDefData},
@@ -129,8 +133,8 @@ public class C_Payment_StepDef
 	 * @cucumber.example
 	 * <pre>
 	 * And metasfresh contains C_Payment
-	 *   | Identifier | C_BPartner_ID | PayAmt   | IsReceipt | C_BP_BankAccount_ID | IsPrepayment |
-	 *   | s6_payment | vendor        | 5000 EUR | false     | org_EUR_account     | true         |
+	 *   | Identifier | C_BPartner_ID | PayAmt   | IsReceipt | C_BP_BankAccount_ID | Proforma_Invoice_ID |
+	 *   | s6_payment | vendor        | 5000 EUR | false     | org_EUR_account     | s6_proforma         |
 	 * </pre>
 	 */
 	@And("metasfresh contains C_Payment")
@@ -345,7 +349,9 @@ public class C_Payment_StepDef
 				.map(invoiceTable::getId)
 				.orElse(null);
 
-		final boolean isPrepayment = row.getAsOptionalBoolean(I_C_Payment.COLUMNNAME_IsPrepayment).orElse(false);
+		final InvoiceId proformaInvoiceId = row.getAsOptionalIdentifier(I_C_Payment.COLUMNNAME_Proforma_Invoice_ID)
+				.map(invoiceTable::getId)
+				.orElse(null);
 
 		final I_C_Payment payment = (isReceipt ? paymentBL.newInboundReceiptBuilder() : paymentBL.newOutboundPaymentBuilder())
 				.adOrgId(orgId)
@@ -357,7 +363,7 @@ public class C_Payment_StepDef
 				.dateTrx(dateTrx)
 				.dateAcct(dateAcct)
 				.invoiceId(invoiceId)
-				.prepayment(isPrepayment)
+				.proformaInvoiceId(proformaInvoiceId)
 				.isAutoAllocateAvailableAmt(false)
 				.createDraft();
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_StepDef.java
@@ -110,6 +110,28 @@ public class C_Payment_StepDef
 	private final C_Invoice_StepDefData invoiceTable;
 	private final C_DocType_StepDefData docTypeTable;
 
+	/**
+	 * Creates one or more {@link I_C_Payment} records in Draft status.
+	 *
+	 * @cucumber.columns
+	 *   <b>Identifier</b> — (required) alias for cross-step reference<br>
+	 *   <b>C_BPartner_ID</b> — (required, identifier-ref) vendor or customer BPartner<br>
+	 *   <b>PayAmt</b> — (required) amount with currency code, e.g. {@code 5000 EUR}<br>
+	 *   <b>IsReceipt</b> — (required) {@code true} = inbound (AR), {@code false} = outbound (AP)<br>
+	 *   <b>C_BP_BankAccount_ID</b> — (optional, identifier-ref) bank account; defaults to the org's EUR account<br>
+	 *   <b>IsPrepayment</b> — (optional) when {@code true}, {@link org.compiere.acct.Doc_Payment} posts to
+	 *                          {@code C_Prepayment_Acct} (AR) or {@code V_Prepayment_Acct} (AP); default {@code false}<br>
+	 *   <b>C_Invoice_ID</b> — (optional, identifier-ref) pre-linked invoice<br>
+	 * @cucumber.depends {@link de.metas.cucumber.stepdefs.C_BPartner_StepDefData},
+	 *                   {@link de.metas.cucumber.stepdefs.C_BP_BankAccount_StepDefData},
+	 *                   {@link de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData}
+	 * @cucumber.example
+	 * <pre>
+	 * And metasfresh contains C_Payment
+	 *   | Identifier | C_BPartner_ID | PayAmt   | IsReceipt | C_BP_BankAccount_ID | IsPrepayment |
+	 *   | s6_payment | vendor        | 5000 EUR | false     | org_EUR_account     | true         |
+	 * </pre>
+	 */
 	@And("metasfresh contains C_Payment")
 	public void createPayments(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
@@ -720,10 +720,11 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
     And the payment identified by s6_payment is completed
 
     # ── Post-payment: V_Prepayment_Acct must be non-zero (payment opened it) ──
-    # SourceBalance (source-currency amount) avoids accounting-schema conversion uncertainty.
+    # AP prepayment posts DR V_Prepayment / CR B_InTransit → SourceBalance = +5000.
+    # SourceBalance (source-currency amount) avoids accounting-schema FX conversion uncertainty.
     Then Fact_Acct records balances for documents s6_payment are matching
       | AccountConceptualName | SourceBalance |
-      | V_Prepayment_Acct     | -5000 EUR     |
+      | V_Prepayment_Acct     | 5000 EUR      |
 
     # ── Allocate payment to invoice ──
     And allocate payments to invoices

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
@@ -693,26 +693,37 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
       | plv_purchase           | s6_product   | 5000.00  | PCE      |
 
-    # ── Vendor invoice ──
+    # ── Proforma invoice — sets IsPrepayment=Y on the payment via MPayment.beforeSave ──
+    # (MPayment.beforeSave computes IsPrepayment from Proforma_Invoice_ID; direct setIsPrepayment is overridden.)
+    And metasfresh contains C_Invoice:
+      | Identifier   | C_BPartner_ID | C_DocTypeTarget_ID.Name       | DateInvoiced | IsSOTrx | C_Currency_ID | C_PaymentTerm_ID |
+      | s6_proforma  | vendor        | Proforma-Rechnung (Lieferant) | 2026-04-24   | false   | EUR           | pt_immediate     |
+    And metasfresh contains C_InvoiceLines
+      | Identifier       | C_Invoice_ID | M_Product_ID | QtyInvoiced | Price   |
+      | s6_proforma_line | s6_proforma  | s6_product   | 1 PCE       | 5000.00 |
+    And the invoice identified by s6_proforma is completed
+
+    # ── Vendor invoice (real invoice to allocate against) ──
     And metasfresh contains C_Invoice:
       | Identifier | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | IsSOTrx | C_Currency_ID |
       | s6_invoice | vendor        | Eingangsrechnung        | 2026-04-24   | false   | EUR           |
     And metasfresh contains C_InvoiceLines
-      | Identifier | C_Invoice_ID | M_Product_ID | QtyInvoiced |
-      | s6_line    | s6_invoice   | s6_product   | 1 PCE       |
+      | Identifier | C_Invoice_ID | M_Product_ID | QtyInvoiced | Price   |
+      | s6_line    | s6_invoice   | s6_product   | 1 PCE       | 5000.00 |
     And the invoice identified by s6_invoice is completed
 
-    # ── Vendor prepayment — IsPrepayment=Y causes Doc_Payment to post to V_Prepayment_Acct ──
+    # ── Vendor prepayment — Proforma_Invoice_ID triggers IsPrepayment=Y → Doc_Payment posts to V_Prepayment_Acct ──
     # Bug (pre-fix): allocation resolved B_PaymentSelect_Acct instead → V_Prepayment stayed permanently open.
     And metasfresh contains C_Payment
-      | Identifier | C_BPartner_ID | PayAmt   | IsReceipt | C_BP_BankAccount_ID | IsPrepayment |
-      | s6_payment | vendor        | 5000 EUR | false     | org_EUR_account     | true         |
+      | Identifier | C_BPartner_ID | PayAmt   | IsReceipt | C_BP_BankAccount_ID | Proforma_Invoice_ID |
+      | s6_payment | vendor        | 5000 EUR | false     | org_EUR_account     | s6_proforma         |
     And the payment identified by s6_payment is completed
 
     # ── Post-payment: V_Prepayment_Acct must be non-zero (payment opened it) ──
+    # SourceBalance (source-currency amount) avoids accounting-schema conversion uncertainty.
     Then Fact_Acct records balances for documents s6_payment are matching
-      | AccountConceptualName | AcctBalance |
-      | V_Prepayment_Acct     | -5000       |
+      | AccountConceptualName | SourceBalance |
+      | V_Prepayment_Acct     | -5000 EUR     |
 
     # ── Allocate payment to invoice ──
     And allocate payments to invoices

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
@@ -679,6 +679,11 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
       | s6_payment | vendor        | 5000 EUR | false     | org_EUR_account     | true         |
     And the payment identified by s6_payment is completed
 
+    # ── Post-payment: V_Prepayment_Acct must be non-zero (payment opened it) ──
+    Then Fact_Acct records balances for documents s6_payment are matching
+      | AccountConceptualName | AcctBalance |
+      | V_Prepayment_Acct     | -5000       |
+
     # ── Allocate payment to invoice ──
     And allocate payments to invoices
       | C_Invoice_ID | C_Payment_ID |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
@@ -176,6 +176,13 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
       | C_Payment_ID.Identifier | IsPrepayment | C_Invoice_ID | Proforma_Invoice_ID | PayAmt   |
       | lcPayment               | Y            | null         | lcInvoice           | 20596.32 |
 
+    # Accounting: payment posts to V_Prepayment_Acct (IsPrepayment=Y, APP).
+    # V_Prepayment_Acct is credited by the payment → balance = AmtAcctDr − AmtAcctCr = −20596.32.
+    # (No C_AllocationHdr in S1 — proforma payment never creates allocation lines.)
+    Then Fact_Acct records balances for documents lcPayment are matching
+      | AccountConceptualName | AcctBalance |
+      | V_Prepayment_Acct     | -20596.32   |
+
     # The proforma flips to IsPaid=Y when its full payment completes — the regular
     # allocation-driven IsPaid update doesn't fire because proforma payments have no
     # C_AllocationLine rows; the C_Payment AFTER_COMPLETE interceptor sets the flag directly.
@@ -319,6 +326,11 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
       | Identifier | IsPaid |
       | lcInvoice  | Y      |
 
+    # Accounting: payment posts to V_Prepayment_Acct (IsPrepayment=Y, APP).
+    Then Fact_Acct records balances for documents lcPayment are matching
+      | AccountConceptualName | AcctBalance |
+      | V_Prepayment_Acct     | -20596.32   |
+
     Then the order identified by lcOrder has following pay schedule lines by ReferenceDateType
       | ReferenceDateType | BaseAmt  | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
       | LC                | 68654.40 | 20596.32 | 20596.32      | 2026-04-24    | 2026-04-24 | P      |
@@ -352,6 +364,11 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
       | ReferenceDateType | BaseAmt  | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
       | LC                | 68654.40 | 20596.32 | 20596.32      | 2026-04-24    | 2026-04-24 | WP     |
       | BL                | 68654.40 | 48058.08 | null          | null          | 9999-12-01 | PR     |
+
+    # Accounting: original payment + reversal cancel each other → V_Prepayment nets to 0.
+    Then Fact_Acct records balances for documents lcPayment,lcPaymentReversal are matching
+      | AccountConceptualName | AcctBalance |
+      | V_Prepayment_Acct     | 0           |
 
     # AC #17 — invoiceOpenToDate proforma branch after payment reversal:
     # The reversal payment ends at DocStatus='RE' which the SUM-based paid-detection excludes,
@@ -529,6 +546,11 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
       | C_Payment_ID.Identifier | OpenAmt  |
       | customerPayment         | 20596.31 |
 
+    # Accounting: payment posts to V_Prepayment_Acct (IsPrepayment=Y, APP).
+    Then Fact_Acct records balances for documents customerPayment are matching
+      | AccountConceptualName | AcctBalance |
+      | V_Prepayment_Acct     | -20596.31   |
+
     # ── R1: line A received 195 PCE (ordered 196, 1 short) ──
     # HU receipt: QtyCUsPerTU=195 → 1 HU with 195 PCE → receipt r1 QtyEntered=195.
     # receiptValue_R1 = round(OL_A_gross / 196 × 195, 2)
@@ -570,8 +592,8 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
 
     # AC #4: alloc = MIN(R1×0.30, prepay) = MIN(31807.99×0.30, 20596.31) = MIN(9542.40, 20596.31) = 9,542.40
     Then validate C_AllocationLines for invoice inv1Partial
-      | Amount   |
-      | -9542.40 |
+      | C_AllocationHdr_ID | Amount   |
+      | s5_alloc1          | -9542.40 |
 
     # AC #5: R1 sub-row → Status=Awaiting_Pay; C_Invoice_ID=inv1Partial
     #        prepay.AvailableAmt = 20,596.31 − 9,542.40 = 11,053.91
@@ -624,8 +646,8 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
 
     # AC #8: alloc = remaining prepay = 11,053.91 (Final rule — full prepay consumed)
     Then validate C_AllocationLines for invoice inv2Final
-      | Amount    |
-      | -11053.91 |
+      | C_AllocationHdr_ID | Amount    |
+      | s5_alloc2          | -11053.91 |
 
     # AC #9: R2 sub-row → Status=Awaiting_Pay; prepay.AvailableAmt = 0
     Then the order identified by customerOrder has following pay schedules
@@ -642,6 +664,14 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
     Then validate created invoices
       | Identifier | OpenAmt  |
       | inv2Final  | 26038.08 |
+
+    # Accounting: full prepay consumed — V_Prepayment and V_Liability both net to zero.
+    # customerPayment opened V_Prepayment; s5_alloc1 + s5_alloc2 closed it.
+    # inv1Partial + inv2Final opened V_Liability; the same allocs closed it.
+    Then Fact_Acct records balances for documents customerPayment,inv1Partial,inv2Final,s5_alloc1,s5_alloc2 are matching
+      | AccountConceptualName | AcctBalance |
+      | V_Prepayment_Acct     | 0           |
+      | V_Liability_Acct      | 0           |
 
     # ── Final state: LC Paid; R1 + R2 both Awaiting_Pay; no remainder; Σ alloc = 20,596.31 ──
     # Σ alloc = 9,542.40 + 11,053.91 = 20,596.31 = full LC prepay consumed ✓

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
@@ -176,12 +176,11 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
       | C_Payment_ID.Identifier | IsPrepayment | C_Invoice_ID | Proforma_Invoice_ID | PayAmt   |
       | lcPayment               | Y            | null         | lcInvoice           | 20596.32 |
 
-    # Accounting: payment posts to V_Prepayment_Acct (IsPrepayment=Y, APP).
-    # V_Prepayment_Acct is credited by the payment → balance = AmtAcctDr − AmtAcctCr = −20596.32.
+    # Accounting: AP prepayment posts DR V_Prepayment / CR B_InTransit → SourceBalance = +20596.32 EUR.
     # (No C_AllocationHdr in S1 — proforma payment never creates allocation lines.)
     Then Fact_Acct records balances for documents lcPayment are matching
-      | AccountConceptualName | AcctBalance |
-      | V_Prepayment_Acct     | -20596.32   |
+      | AccountConceptualName | SourceBalance  |
+      | V_Prepayment_Acct     | 20596.32 EUR   |
 
     # The proforma flips to IsPaid=Y when its full payment completes — the regular
     # allocation-driven IsPaid update doesn't fire because proforma payments have no
@@ -326,10 +325,10 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
       | Identifier | IsPaid |
       | lcInvoice  | Y      |
 
-    # Accounting: payment posts to V_Prepayment_Acct (IsPrepayment=Y, APP).
+    # Accounting: AP prepayment posts DR V_Prepayment / CR B_InTransit → SourceBalance = +20596.32 EUR.
     Then Fact_Acct records balances for documents lcPayment are matching
-      | AccountConceptualName | AcctBalance |
-      | V_Prepayment_Acct     | -20596.32   |
+      | AccountConceptualName | SourceBalance  |
+      | V_Prepayment_Acct     | 20596.32 EUR   |
 
     Then the order identified by lcOrder has following pay schedule lines by ReferenceDateType
       | ReferenceDateType | BaseAmt  | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
@@ -546,10 +545,10 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
       | C_Payment_ID.Identifier | OpenAmt  |
       | customerPayment         | 20596.31 |
 
-    # Accounting: payment posts to V_Prepayment_Acct (IsPrepayment=Y, APP).
+    # Accounting: AP prepayment posts DR V_Prepayment / CR B_InTransit → SourceBalance = +20596.31 EUR.
     Then Fact_Acct records balances for documents customerPayment are matching
-      | AccountConceptualName | AcctBalance |
-      | V_Prepayment_Acct     | -20596.31   |
+      | AccountConceptualName | SourceBalance  |
+      | V_Prepayment_Acct     | 20596.31 EUR   |
 
     # ── R1: line A received 195 PCE (ordered 196, 1 short) ──
     # HU receipt: QtyCUsPerTU=195 → 1 HU with 195 PCE → receipt r1 QtyEntered=195.

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
@@ -375,10 +375,10 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
     # Accounting: original payment + reversal cancel each other → V_Prepayment nets to 0.
     Then Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr  | AmtSourceCr  | Record_ID         |
-      | V_Prepayment_Acct     | 20596.32 EUR |              | lcPayment         |
-      | B_InTransit_Acct      |              | 20596.32 EUR | lcPayment         |
-      | V_Prepayment_Acct     |              | 20596.32 EUR | lcPaymentReversal |
-      | B_InTransit_Acct      | 20596.32 EUR |              | lcPaymentReversal |
+      | V_Prepayment_Acct     | 20596.32 EUR  |               | lcPayment         |
+      | B_InTransit_Acct      |               | 20596.32 EUR  | lcPayment         |
+      | V_Prepayment_Acct     | -20596.32 EUR |               | lcPaymentReversal |
+      | B_InTransit_Acct      |               | -20596.32 EUR | lcPaymentReversal |
     Then Fact_Acct records balances for documents lcPayment,lcPaymentReversal are matching
       | AccountConceptualName | AcctBalance |
       | V_Prepayment_Acct     | 0           |
@@ -696,6 +696,7 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
     # the total invoices (68899.98). The remaining open liability stays until the invoices are fully paid.
     Then Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr  | AmtSourceCr  | Record_ID       |
+      | *                     |              |              | customerPayment |
       | V_Prepayment_Acct     | 20596.31 EUR |              | customerPayment |
       | V_Liability_Acct      | 9542.4 EUR   |              | s5_alloc1       |
       | V_Prepayment_Acct     |              | 9542.4 EUR   | s5_alloc1       |
@@ -780,6 +781,7 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
     # Regression: without the fix the allocation used B_PaymentSelect_Acct → V_Prepayment stayed non-zero.
     Then Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID  |
+      | *                     |             |             | s6_payment |
       | V_Prepayment_Acct     | 5000 EUR    |             | s6_payment |
       | V_Liability_Acct      | 5000 EUR    |             | s6_alloc   |
       | V_Prepayment_Acct     |             | 5000 EUR    | s6_alloc   |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
@@ -178,6 +178,10 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
 
     # Accounting: AP prepayment posts DR V_Prepayment / CR B_InTransit → SourceBalance = +20596.32 EUR.
     # (No C_AllocationHdr in S1 — proforma payment never creates allocation lines.)
+    Then Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr  | AmtSourceCr  | Record_ID |
+      | V_Prepayment_Acct     | 20596.32 EUR |              | lcPayment |
+      | B_InTransit_Acct      |              | 20596.32 EUR | lcPayment |
     Then Fact_Acct records balances for documents lcPayment are matching
       | AccountConceptualName | SourceBalance  |
       | V_Prepayment_Acct     | 20596.32 EUR   |
@@ -326,6 +330,10 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
       | lcInvoice  | Y      |
 
     # Accounting: AP prepayment posts DR V_Prepayment / CR B_InTransit → SourceBalance = +20596.32 EUR.
+    Then Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr  | AmtSourceCr  | Record_ID |
+      | V_Prepayment_Acct     | 20596.32 EUR |              | lcPayment |
+      | B_InTransit_Acct      |              | 20596.32 EUR | lcPayment |
     Then Fact_Acct records balances for documents lcPayment are matching
       | AccountConceptualName | SourceBalance  |
       | V_Prepayment_Acct     | 20596.32 EUR   |
@@ -365,6 +373,12 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
       | BL                | 68654.40 | 48058.08 | null          | null          | 9999-12-01 | PR     |
 
     # Accounting: original payment + reversal cancel each other → V_Prepayment nets to 0.
+    Then Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr  | AmtSourceCr  | Record_ID         |
+      | V_Prepayment_Acct     | 20596.32 EUR |              | lcPayment         |
+      | B_InTransit_Acct      |              | 20596.32 EUR | lcPayment         |
+      | V_Prepayment_Acct     |              | 20596.32 EUR | lcPaymentReversal |
+      | B_InTransit_Acct      | 20596.32 EUR |              | lcPaymentReversal |
     Then Fact_Acct records balances for documents lcPayment,lcPaymentReversal are matching
       | AccountConceptualName | AcctBalance |
       | V_Prepayment_Acct     | 0           |
@@ -546,6 +560,10 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
       | customerPayment         | 20596.31 |
 
     # Accounting: AP prepayment posts DR V_Prepayment / CR B_InTransit → SourceBalance = +20596.31 EUR.
+    Then Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr  | AmtSourceCr  | Record_ID       |
+      | V_Prepayment_Acct     | 20596.31 EUR |              | customerPayment |
+      | B_InTransit_Acct      |              | 20596.31 EUR | customerPayment |
     Then Fact_Acct records balances for documents customerPayment are matching
       | AccountConceptualName | SourceBalance  |
       | V_Prepayment_Acct     | 20596.31 EUR   |
@@ -668,6 +686,15 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
     # customerPayment opened V_Prepayment; s5_alloc1 + s5_alloc2 closed it.
     # Note: V_Liability does NOT net to zero here — the prepayment (20596.31) only partially covers
     # the total invoices (68899.98). The remaining open liability stays until the invoices are fully paid.
+    Then Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr   | AmtSourceCr   | Record_ID       |
+      | V_Prepayment_Acct     | 20596.31 EUR  |               | customerPayment |
+      | V_Liability_Acct      |               | 31807.99 EUR  | inv1Partial     |
+      | V_Liability_Acct      |               | 37091.99 EUR  | inv2Final       |
+      | V_Liability_Acct      | 9542.4 EUR    |               | s5_alloc1       |
+      | V_Prepayment_Acct     |               | 9542.4 EUR    | s5_alloc1       |
+      | V_Liability_Acct      | 11053.91 EUR  |               | s5_alloc2       |
+      | V_Prepayment_Acct     |               | 11053.91 EUR  | s5_alloc2       |
     Then Fact_Acct records balances for documents customerPayment,inv1Partial,inv2Final,s5_alloc1,s5_alloc2 are matching
       | AccountConceptualName | AcctBalance |
       | V_Prepayment_Acct     | 0           |
@@ -721,6 +748,10 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
     # ── Post-payment: V_Prepayment_Acct must be non-zero (payment opened it) ──
     # AP prepayment posts DR V_Prepayment / CR B_InTransit → SourceBalance = +5000.
     # SourceBalance (source-currency amount) avoids accounting-schema FX conversion uncertainty.
+    Then Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID  |
+      | V_Prepayment_Acct     | 5000 EUR    |             | s6_payment |
+      | B_InTransit_Acct      |             | 5000 EUR    | s6_payment |
     Then Fact_Acct records balances for documents s6_payment are matching
       | AccountConceptualName | SourceBalance |
       | V_Prepayment_Acct     | 5000 EUR      |
@@ -737,6 +768,12 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
     # V_Prepayment_Acct: opened by payment posting, reversed by allocation → net 0
     # V_Liability_Acct:  opened by invoice posting, reversed by allocation → net 0
     # Regression: without the fix the allocation used B_PaymentSelect_Acct → V_Prepayment stayed non-zero.
+    Then Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID  |
+      | V_Prepayment_Acct     | 5000 EUR    |             | s6_payment |
+      | V_Liability_Acct      |             | 5000 EUR    | s6_invoice |
+      | V_Liability_Acct      | 5000 EUR    |             | s6_alloc   |
+      | V_Prepayment_Acct     |             | 5000 EUR    | s6_alloc   |
     Then Fact_Acct records balances for documents s6_payment,s6_invoice,s6_alloc are matching
       | AccountConceptualName | AcctBalance |
       | V_Prepayment_Acct     | 0           |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
@@ -653,7 +653,7 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
       | BL                | r2         | 37092.00 | 25964.40 | null          | 2026-04-24    | 2026-04-24 | WP     | inv2Final    |
 
 
-  Scenario: S6 - V_Prepayment cleared by allocation — vendor advance payment + invoice (regression: DocLine_Allocation.getPaymentAcct prepayment-before-PurchasePayment)
+  Scenario: S6 - Vendor advance payment (IsPrepayment=Y) allocation must clear V_Prepayment_Acct
 
     # ── Product + price for S6 (standalone accounting regression — no PO or pay-schedule) ──
     And metasfresh contains M_Products:
@@ -675,8 +675,8 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
     # ── Vendor prepayment — IsPrepayment=Y causes Doc_Payment to post to V_Prepayment_Acct ──
     # Bug (pre-fix): allocation resolved B_PaymentSelect_Acct instead → V_Prepayment stayed permanently open.
     And metasfresh contains C_Payment
-      | Identifier | C_BPartner_ID | PayAmt    | IsReceipt | C_BP_BankAccount_ID | OPT.IsPrepayment |
-      | s6_payment | vendor        | 5000 EUR  | false     | org_EUR_account     | true             |
+      | Identifier | C_BPartner_ID | PayAmt   | IsReceipt | C_BP_BankAccount_ID | IsPrepayment |
+      | s6_payment | vendor        | 5000 EUR | false     | org_EUR_account     | true         |
     And the payment identified by s6_payment is completed
 
     # ── Allocate payment to invoice ──

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
@@ -666,11 +666,11 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
 
     # Accounting: full prepay consumed — V_Prepayment and V_Liability both net to zero.
     # customerPayment opened V_Prepayment; s5_alloc1 + s5_alloc2 closed it.
-    # inv1Partial + inv2Final opened V_Liability; the same allocs closed it.
+    # Note: V_Liability does NOT net to zero here — the prepayment (20596.31) only partially covers
+    # the total invoices (68899.98). The remaining open liability stays until the invoices are fully paid.
     Then Fact_Acct records balances for documents customerPayment,inv1Partial,inv2Final,s5_alloc1,s5_alloc2 are matching
       | AccountConceptualName | AcctBalance |
       | V_Prepayment_Acct     | 0           |
-      | V_Liability_Acct      | 0           |
 
     # ── Final state: LC Paid; R1 + R2 both Awaiting_Pay; no remainder; Σ alloc = 20,596.31 ──
     # Σ alloc = 9,542.40 + 11,053.91 = 20,596.31 = full LC prepay consumed ✓

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
@@ -611,6 +611,10 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
     Then validate C_AllocationLines for invoice inv1Partial
       | C_AllocationHdr_ID | Amount   |
       | s5_alloc1          | -9542.40 |
+    Then Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | V_Liability_Acct      | 9542.4 EUR  |             | s5_alloc1 |
+      | V_Prepayment_Acct     |             | 9542.4 EUR  | s5_alloc1 |
 
     # AC #5: R1 sub-row → Status=Awaiting_Pay; C_Invoice_ID=inv1Partial
     #        prepay.AvailableAmt = 20,596.31 − 9,542.40 = 11,053.91
@@ -665,6 +669,10 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
     Then validate C_AllocationLines for invoice inv2Final
       | C_AllocationHdr_ID | Amount    |
       | s5_alloc2          | -11053.91 |
+    Then Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr  | AmtSourceCr  | Record_ID |
+      | V_Liability_Acct      | 11053.91 EUR |              | s5_alloc2 |
+      | V_Prepayment_Acct     |              | 11053.91 EUR | s5_alloc2 |
 
     # AC #9: R2 sub-row → Status=Awaiting_Pay; prepay.AvailableAmt = 0
     Then the order identified by customerOrder has following pay schedules
@@ -687,14 +695,12 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
     # Note: V_Liability does NOT net to zero here — the prepayment (20596.31) only partially covers
     # the total invoices (68899.98). The remaining open liability stays until the invoices are fully paid.
     Then Fact_Acct records are matching
-      | AccountConceptualName | AmtSourceDr   | AmtSourceCr   | Record_ID       |
-      | V_Prepayment_Acct     | 20596.31 EUR  |               | customerPayment |
-      | V_Liability_Acct      |               | 31807.99 EUR  | inv1Partial     |
-      | V_Liability_Acct      |               | 37091.99 EUR  | inv2Final       |
-      | V_Liability_Acct      | 9542.4 EUR    |               | s5_alloc1       |
-      | V_Prepayment_Acct     |               | 9542.4 EUR    | s5_alloc1       |
-      | V_Liability_Acct      | 11053.91 EUR  |               | s5_alloc2       |
-      | V_Prepayment_Acct     |               | 11053.91 EUR  | s5_alloc2       |
+      | AccountConceptualName | AmtSourceDr  | AmtSourceCr  | Record_ID       |
+      | V_Prepayment_Acct     | 20596.31 EUR |              | customerPayment |
+      | V_Liability_Acct      | 9542.4 EUR   |              | s5_alloc1       |
+      | V_Prepayment_Acct     |              | 9542.4 EUR   | s5_alloc1       |
+      | V_Liability_Acct      | 11053.91 EUR |              | s5_alloc2       |
+      | V_Prepayment_Acct     |              | 11053.91 EUR | s5_alloc2       |
     Then Fact_Acct records balances for documents customerPayment,inv1Partial,inv2Final,s5_alloc1,s5_alloc2 are matching
       | AccountConceptualName | AcctBalance |
       | V_Prepayment_Acct     | 0           |
@@ -763,6 +769,10 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
     And validate C_AllocationLines
       | C_Invoice_ID | C_Payment_ID | C_AllocationHdr_ID |
       | s6_invoice   | s6_payment   | s6_alloc           |
+    Then Fact_Acct records are matching
+      | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID |
+      | V_Liability_Acct      | 5000 EUR    |             | s6_alloc  |
+      | V_Prepayment_Acct     |             | 5000 EUR    | s6_alloc  |
 
     # ── Core assertion: V_Prepayment and V_Liability must both net to zero ──
     # V_Prepayment_Acct: opened by payment posting, reversed by allocation → net 0
@@ -771,7 +781,6 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
     Then Fact_Acct records are matching
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | Record_ID  |
       | V_Prepayment_Acct     | 5000 EUR    |             | s6_payment |
-      | V_Liability_Acct      |             | 5000 EUR    | s6_invoice |
       | V_Liability_Acct      | 5000 EUR    |             | s6_alloc   |
       | V_Prepayment_Acct     |             | 5000 EUR    | s6_alloc   |
     Then Fact_Acct records balances for documents s6_payment,s6_invoice,s6_alloc are matching

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/splitPayments.feature
@@ -651,3 +651,47 @@ Feature: Split-payment unified end-to-end story using customer-spreadsheet numbe
       | LC                | null       | 68654.38 | 20596.31 | 20596.31      | 2026-04-24    | 2026-04-24 | P      | null         |
       | BL                | r1         | 31807.99 | 22265.59 | null          | 2026-04-24    | 2026-04-24 | WP     | inv1Partial  |
       | BL                | r2         | 37092.00 | 25964.40 | null          | 2026-04-24    | 2026-04-24 | WP     | inv2Final    |
+
+
+  Scenario: S6 - V_Prepayment cleared by allocation — vendor advance payment + invoice (regression: DocLine_Allocation.getPaymentAcct prepayment-before-PurchasePayment)
+
+    # ── Product + price for S6 (standalone accounting regression — no PO or pay-schedule) ──
+    And metasfresh contains M_Products:
+      | Identifier |
+      | s6_product |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | plv_purchase           | s6_product   | 5000.00  | PCE      |
+
+    # ── Vendor invoice ──
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | s6_invoice | vendor        | Eingangsrechnung        | 2026-04-24   | false   | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier | C_Invoice_ID | M_Product_ID | QtyInvoiced |
+      | s6_line    | s6_invoice   | s6_product   | 1 PCE       |
+    And the invoice identified by s6_invoice is completed
+
+    # ── Vendor prepayment — IsPrepayment=Y causes Doc_Payment to post to V_Prepayment_Acct ──
+    # Bug (pre-fix): allocation resolved B_PaymentSelect_Acct instead → V_Prepayment stayed permanently open.
+    And metasfresh contains C_Payment
+      | Identifier | C_BPartner_ID | PayAmt    | IsReceipt | C_BP_BankAccount_ID | OPT.IsPrepayment |
+      | s6_payment | vendor        | 5000 EUR  | false     | org_EUR_account     | true             |
+    And the payment identified by s6_payment is completed
+
+    # ── Allocate payment to invoice ──
+    And allocate payments to invoices
+      | C_Invoice_ID | C_Payment_ID |
+      | s6_invoice   | s6_payment   |
+    And validate C_AllocationLines
+      | C_Invoice_ID | C_Payment_ID | C_AllocationHdr_ID |
+      | s6_invoice   | s6_payment   | s6_alloc           |
+
+    # ── Core assertion: V_Prepayment and V_Liability must both net to zero ──
+    # V_Prepayment_Acct: opened by payment posting, reversed by allocation → net 0
+    # V_Liability_Acct:  opened by invoice posting, reversed by allocation → net 0
+    # Regression: without the fix the allocation used B_PaymentSelect_Acct → V_Prepayment stayed non-zero.
+    Then Fact_Acct records balances for documents s6_payment,s6_invoice,s6_alloc are matching
+      | AccountConceptualName | AcctBalance |
+      | V_Prepayment_Acct     | 0           |
+      | V_Liability_Acct      | 0           |


### PR DESCRIPTION
## What changed

`DocLine_Allocation.getPaymentAcct()` checked the `PurchasePayment` branch before `IsPrepayment`, so an AP payment with `IsPrepayment=Y` returned `B_PaymentSelect_Acct` during allocation instead of `V_Prepayment_Acct`. The `V_Prepayment` account opened by `Doc_Payment.createFacts()` was never cleared.

Fix: swap the check order — `IsPrepayment` is evaluated first, then `PurchasePayment`. The AR side was already correct; only the AP side was affected.

## Files changed

- `DocLine_Allocation.java` — move `isPrepayment` check above `PurchasePayment` branch; update Javadoc with the full 4-case decision matrix and a sync-requirement note pointing to `Doc_Payment`
- `Doc_Payment.java` — add Javadoc cross-reference noting it must stay in sync with `DocLine_Allocation.getPaymentAcct()`
- `C_Payment_StepDef.java` — wire `OPT.IsPrepayment` column to `DefaultPaymentBuilder.prepayment()` (previously only validated, not settable at creation time)
- `splitPayments.feature` — scenario S6: allocate an `IsPrepayment=Y` vendor payment to a real invoice; asserts `V_Prepayment_Acct` and `V_Liability_Acct` both net to zero across all three documents (payment, invoice, allocation)