### PR TITLE
Tax Declaration Corrections — follow-up cleanup (https://github.com/metasfresh/me03/issues/29631)

### DIFF
--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/interceptor/C_TaxDeclaration.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/interceptor/C_TaxDeclaration.java
@@ -47,7 +47,7 @@ public class C_TaxDeclaration
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE })
 	public void enforceCorrectionInvariants(final I_C_TaxDeclaration td)
 	{
-		if (!td.isIsCorrection())
+		if (!td.isCorrection())
 		{
 			return;
 		}
@@ -57,7 +57,7 @@ public class C_TaxDeclaration
 		}
 		final TaxDeclarationId originalId = TaxDeclarationId.ofRepoId(td.getC_TaxDeclaration_Original_ID());
 		final I_C_TaxDeclaration original = taxDeclarationRepository.getById(originalId);
-		if (original.isIsCorrection())
+		if (original.isCorrection())
 		{
 			throw new AdempiereException(MSG_OriginalMustBeOriginal);
 		}

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CreateCorrection.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CreateCorrection.java
@@ -26,7 +26,7 @@ public class C_TaxDeclaration_CreateCorrection extends JavaProcess implements IP
 			return ProcessPreconditionsResolution.rejectWithInternalReason("Tax declaration is not yet locked");
 		}
 
-		if (taxDeclaration.isIsCorrection())
+		if (taxDeclaration.isCorrection())
 		{
 			return ProcessPreconditionsResolution.rejectWithInternalReason("Cannot create correction of a correction");
 		}

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
@@ -45,7 +45,7 @@ public class TaxDeclarationService
 		{
 			throw new AdempiereException(MSG_TaxDeclaration_CreateCorrection_OriginalNotLocked);
 		}
-		if (original.isIsCorrection())
+		if (original.isCorrection())
 		{
 			throw new AdempiereException(MSG_TaxDeclaration_OriginalMustBeOriginal);
 		}

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/document/TaxDeclarationDocumentHandler.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/document/TaxDeclarationDocumentHandler.java
@@ -58,7 +58,7 @@ public class TaxDeclarationDocumentHandler implements DocumentHandler
 		// Period-uniqueness applies to Originals only; a Correction legitimately shares its Original's period.
 		// Checked before the no-lines guard so the user gets the meaningful PeriodOverlap message rather than
 		// NoLinesYet (a second Original on an already-declared period always builds empty).
-		if (!td.isIsCorrection()
+		if (!td.isCorrection()
 				&& repo.existsCompletedOverlappingPeriod(id, AcctSchemaId.ofRepoId(td.getC_AcctSchema_ID()), td.getC_Period_ID()))
 		{
 			throw new AdempiereException(MSG_PeriodOverlap);
@@ -72,11 +72,11 @@ public class TaxDeclarationDocumentHandler implements DocumentHandler
 		td.setDocAction(IDocument.ACTION_ReActivate);
 
 		// Completing a Correction clears its Original's "correction needed" flag.
-		if (td.isIsCorrection())
+		if (td.isCorrection())
 		{
 			final TaxDeclarationId originalId = TaxDeclarationId.ofRepoId(td.getC_TaxDeclaration_Original_ID());
 			final I_C_TaxDeclaration original = repo.getById(originalId);
-			if (original.isIsCorrectionNeeded() || original.getCorrectionNeededReason() != null)
+			if (original.isCorrectionNeeded() || original.getCorrectionNeededReason() != null)
 			{
 				original.setIsCorrectionNeeded(false);
 				original.setCorrectionNeededReason(null);

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805230_sys_me03_29631_C_TaxDeclaration_AD_Element_Trl_propagate.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805230_sys_me03_29631_C_TaxDeclaration_AD_Element_Trl_propagate.sql
@@ -1,0 +1,8 @@
+-- https://github.com/metasfresh/me03/issues/29631
+-- Follow-up: propagate AD_Element translations to AD_UI_Element_Trl (and refresh AD_Column_Trl / AD_Field_Trl) for the 4 new Correction elements.
+-- AD_MigrationScript_ID=5805230
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584908);
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584909);
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584910);
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584911);

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805260_sys_me03_29631_C_TaxDeclaration_IsForceIncludeInGeneratedModel.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805260_sys_me03_29631_C_TaxDeclaration_IsForceIncludeInGeneratedModel.sql
@@ -1,0 +1,71 @@
+-- Set IsForceIncludeInGeneratedModel=Y for the 4 correction-lifecycle columns on C_TaxDeclaration.
+-- These columns have EntityType='de.metas.acct', while the table itself has EntityType='D'.
+-- GenerateModel's OnlySystemColumns mode only includes columns whose EntityType is in the
+-- hard-coded SYSTEM_MAINTAINED_ENTITY_TYPES set (D, C, U, CUST, A, EXT, XX, EE01..., de.metas.order).
+-- 'de.metas.acct' is NOT in that set, so without IsForceIncludeInGeneratedModel=Y the generator
+-- silently omits these columns from I_C_TaxDeclaration.java and X_C_TaxDeclaration.java.
+-- See: EntityTypesCache.SYSTEM_MAINTAINED_ENTITY_TYPES (de.metas.adempiere.adempiere/base)
+--      TableAndColumnInfoRepository.getColumnsEntityTypeWhereClause (same module)
+--
+-- Also creates an AD_Reference (Table type) for C_TaxDeclaration so that the GenerateModel tool
+-- can resolve C_TaxDeclaration_Original_ID's referenced table.
+-- GenerateModel's getReferenceClassName() logic: for Search columns with AD_Reference_Value_ID=0,
+-- it strips '_ID' from the column name to derive the referenced table name. This works for
+-- 'C_TaxDeclaration_ID' -> 'C_TaxDeclaration', but NOT for 'C_TaxDeclaration_Original_ID'
+-- -> 'C_TaxDeclaration_Original' (no such table). Setting AD_Reference_Value_ID to a proper
+-- AD_Reference record (ValidationType='T', Table=C_TaxDeclaration) makes GenerateModel use the
+-- correct resolution path.
+--
+-- IDs allocated from idserver.metas.de on 2026-05-28:
+--   AD_Reference 542099 (C_TaxDeclaration Search reference; also serves as AD_Ref_Table PK)
+-- https://github.com/metasfresh/me03/issues/29631
+
+-- ====================================================================================
+-- Section 1: AD_Reference for C_TaxDeclaration (Table-based Search reference)
+-- ====================================================================================
+INSERT INTO AD_Reference
+    (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     Name, ValidationType, EntityType)
+VALUES
+    (542099, 0, 0, 'Y', TIMESTAMP '2026-05-28 00:00:00', 100, TIMESTAMP '2026-05-28 00:00:00', 100,
+     'C_TaxDeclaration', 'T', 'de.metas.acct');
+
+-- ====================================================================================
+-- Section 2: AD_Ref_Table — points the reference to C_TaxDeclaration.C_TaxDeclaration_ID
+-- Note: AD_Ref_Table uses AD_Reference_ID as its primary key (no separate AD_Ref_Table_ID).
+-- The ID server allocation for AD_Ref_Table (543698) is not used; the PK is AD_Reference_ID.
+-- ====================================================================================
+INSERT INTO AD_Ref_Table
+    (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     AD_Table_ID, AD_Key, AD_Display,
+     WhereClause, OrderByClause, EntityType, IsValueDisplayed)
+VALUES
+    (542099 /*AD_Reference_ID: C_TaxDeclaration*/,
+     0, 0, 'Y', TIMESTAMP '2026-05-28 00:00:00', 100, TIMESTAMP '2026-05-28 00:00:00', 100,
+     818   /*AD_Table_ID: C_TaxDeclaration*/,
+     14451 /*AD_Key: C_TaxDeclaration.C_TaxDeclaration_ID*/,
+     (SELECT AD_Column_ID FROM AD_Column
+      WHERE AD_Table_ID = 818 AND ColumnName = 'DocumentNo') /*AD_Display*/,
+     NULL  /*WhereClause*/,
+     NULL  /*OrderByClause*/,
+     'de.metas.acct',
+     'N');
+
+-- ====================================================================================
+-- Section 3: Set IsForceIncludeInGeneratedModel=Y + AD_Reference_Value_ID on the columns
+-- ====================================================================================
+UPDATE AD_Column
+SET IsForceIncludeInGeneratedModel = 'Y',
+    Updated = TO_TIMESTAMP('2026-05-28 17:30:00', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Table_ID = (SELECT AD_Table_ID FROM AD_Table WHERE TableName = 'C_TaxDeclaration')
+  AND ColumnName IN ('IsCorrection', 'C_TaxDeclaration_Original_ID', 'IsCorrectionNeeded', 'CorrectionNeededReason');
+
+-- Set AD_Reference_Value_ID on C_TaxDeclaration_Original_ID so GenerateModel can resolve the
+-- referenced table (C_TaxDeclaration) via the AD_Ref_Table path instead of column-name stripping.
+UPDATE AD_Column
+SET AD_Reference_Value_ID = 542099 /*AD_Reference_ID: C_TaxDeclaration*/,
+    Updated = TO_TIMESTAMP('2026-05-28 17:30:00', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Table_ID = (SELECT AD_Table_ID FROM AD_Table WHERE TableName = 'C_TaxDeclaration')
+  AND ColumnName = 'C_TaxDeclaration_Original_ID';

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805260_sys_me03_29631_C_TaxDeclaration_IsForceIncludeInGeneratedModel.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805260_sys_me03_29631_C_TaxDeclaration_IsForceIncludeInGeneratedModel.sql
@@ -27,7 +27,7 @@ INSERT INTO AD_Reference
     (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
      Name, ValidationType, EntityType)
 VALUES
-    (542099, 0, 0, 'Y', TIMESTAMP '2026-05-28 00:00:00', 100, TIMESTAMP '2026-05-28 00:00:00', 100,
+    (542099 /*From ID Server*/, 0, 0, 'Y', TIMESTAMP '2026-05-28 00:00:00', 100, TIMESTAMP '2026-05-28 00:00:00', 100,
      'C_TaxDeclaration', 'T', 'de.metas.acct');
 
 -- ====================================================================================
@@ -43,7 +43,7 @@ VALUES
     (542099 /*AD_Reference_ID: C_TaxDeclaration*/,
      0, 0, 'Y', TIMESTAMP '2026-05-28 00:00:00', 100, TIMESTAMP '2026-05-28 00:00:00', 100,
      818   /*AD_Table_ID: C_TaxDeclaration*/,
-     14451 /*AD_Key: C_TaxDeclaration.C_TaxDeclaration_ID*/,
+     (SELECT AD_Column_ID FROM AD_Column WHERE AD_Table_ID = 818 AND ColumnName = 'C_TaxDeclaration_ID') /*AD_Key*/,
      (SELECT AD_Column_ID FROM AD_Column
       WHERE AD_Table_ID = 818 AND ColumnName = 'DocumentNo') /*AD_Display*/,
      NULL  /*WhereClause*/,

--- a/backend/de.metas.acct.base/src/test/java/de/metas/acct/tax/document/TaxDeclarationDocumentHandlerTest.java
+++ b/backend/de.metas.acct.base/src/test/java/de/metas/acct/tax/document/TaxDeclarationDocumentHandlerTest.java
@@ -128,7 +128,7 @@ class TaxDeclarationDocumentHandlerTest
 		// AND: the Original's IsCorrectionNeeded flag is cleared (reload from DB — completeIt loads a fresh
 		// copy of the Original via repo.getById, so the local 'original' reference is stale.)
 		final I_C_TaxDeclaration reloadedOriginal = InterfaceWrapperHelper.load(original.getC_TaxDeclaration_ID(), I_C_TaxDeclaration.class);
-		Assertions.assertThat(reloadedOriginal.isIsCorrectionNeeded()).isFalse();
+		Assertions.assertThat(reloadedOriginal.isCorrectionNeeded()).isFalse();
 		Assertions.assertThat(reloadedOriginal.getCorrectionNeededReason()).isNull();
 	}
 
@@ -140,7 +140,7 @@ class TaxDeclarationDocumentHandlerTest
 		original.setIsCorrectionNeeded(true);
 		InterfaceWrapperHelper.save(original);
 		addLine(original);
-		final boolean expectedIsCorrectionNeeded = original.isIsCorrectionNeeded();
+		final boolean expectedIsCorrectionNeeded = original.isCorrectionNeeded();
 
 		// When: completeIt is called on the Original (not a Correction)
 		final String result = handler.completeIt(asDocFields(original));
@@ -151,6 +151,6 @@ class TaxDeclarationDocumentHandlerTest
 		Assertions.assertThat(original.getDocAction()).isEqualTo("RE");
 
 		// AND: the Original's IsCorrectionNeeded flag is NOT mutated
-		Assertions.assertThat(original.isIsCorrectionNeeded()).isEqualTo(expectedIsCorrectionNeeded);
+		Assertions.assertThat(original.isCorrectionNeeded()).isEqualTo(expectedIsCorrectionNeeded);
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_TaxDeclaration.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_TaxDeclaration.java
@@ -51,7 +51,8 @@ public interface I_C_TaxDeclaration
 	String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
 
 	/**
-	 * Set null.
+	 * Set Accounting Schema.
+	 * Rules for accounting
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
@@ -60,7 +61,8 @@ public interface I_C_TaxDeclaration
 	void setC_AcctSchema_ID (int C_AcctSchema_ID);
 
 	/**
-	 * Get null.
+	 * Get Accounting Schema.
+	 * Rules for accounting
 	 *
 	 * <br>Type: TableDir
 	 * <br>Mandatory: true
@@ -98,7 +100,29 @@ public interface I_C_TaxDeclaration
 	String COLUMNNAME_C_DocType_ID = "C_DocType_ID";
 
 	/**
+	 * Set Reason for Correction.
+	 *
+	 * <br>Type: Text
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setCorrectionNeededReason (@Nullable java.lang.String CorrectionNeededReason);
+
+	/**
+	 * Get Reason for Correction.
+	 *
+	 * <br>Type: Text
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	@Nullable java.lang.String getCorrectionNeededReason();
+
+	ModelColumn<I_C_TaxDeclaration, Object> COLUMN_CorrectionNeededReason = new ModelColumn<>(I_C_TaxDeclaration.class, "CorrectionNeededReason", null);
+	String COLUMNNAME_CorrectionNeededReason = "CorrectionNeededReason";
+
+	/**
 	 * Set Period.
+	 * Period of the Calendar
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: true
@@ -108,6 +132,7 @@ public interface I_C_TaxDeclaration
 
 	/**
 	 * Get Period.
+	 * Period of the Calendar
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: true
@@ -188,15 +213,16 @@ public interface I_C_TaxDeclaration
 	 */
 	int getC_TaxDeclaration_Original_ID();
 
-	org.compiere.model.I_C_TaxDeclaration getC_TaxDeclaration_Original();
+	@Nullable org.compiere.model.I_C_TaxDeclaration getC_TaxDeclaration_Original();
 
-	void setC_TaxDeclaration_Original(org.compiere.model.I_C_TaxDeclaration C_TaxDeclaration_Original);
+	void setC_TaxDeclaration_Original(@Nullable org.compiere.model.I_C_TaxDeclaration C_TaxDeclaration_Original);
 
 	ModelColumn<I_C_TaxDeclaration, org.compiere.model.I_C_TaxDeclaration> COLUMN_C_TaxDeclaration_Original_ID = new ModelColumn<>(I_C_TaxDeclaration.class, "C_TaxDeclaration_Original_ID", org.compiere.model.I_C_TaxDeclaration.class);
 	String COLUMNNAME_C_TaxDeclaration_Original_ID = "C_TaxDeclaration_Original_ID";
 
 	/**
 	 * Set Accounting Date.
+	 * Accounting Date
 	 *
 	 * <br>Type: Date
 	 * <br>Mandatory: true
@@ -206,6 +232,7 @@ public interface I_C_TaxDeclaration
 
 	/**
 	 * Get Accounting Date.
+	 * Accounting Date
 	 *
 	 * <br>Type: Date
 	 * <br>Mandatory: true
@@ -236,27 +263,6 @@ public interface I_C_TaxDeclaration
 
 	ModelColumn<I_C_TaxDeclaration, Object> COLUMN_Description = new ModelColumn<>(I_C_TaxDeclaration.class, "Description", null);
 	String COLUMNNAME_Description = "Description";
-
-	/**
-	 * Set Correction Needed Reason.
-	 *
-	 * <br>Type: String
-	 * <br>Mandatory: false
-	 * <br>Virtual Column: false
-	 */
-	void setCorrectionNeededReason (@Nullable java.lang.String CorrectionNeededReason);
-
-	/**
-	 * Get Correction Needed Reason.
-	 *
-	 * <br>Type: String
-	 * <br>Mandatory: false
-	 * <br>Virtual Column: false
-	 */
-	@Nullable java.lang.String getCorrectionNeededReason();
-
-	ModelColumn<I_C_TaxDeclaration, Object> COLUMN_CorrectionNeededReason = new ModelColumn<>(I_C_TaxDeclaration.class, "CorrectionNeededReason", null);
-	String COLUMNNAME_CorrectionNeededReason = "CorrectionNeededReason";
 
 	/**
 	 * Set Process Batch.
@@ -304,6 +310,7 @@ public interface I_C_TaxDeclaration
 
 	/**
 	 * Set Document No.
+	 * Document sequence number of the document
 	 *
 	 * <br>Type: String
 	 * <br>Mandatory: false
@@ -313,6 +320,7 @@ public interface I_C_TaxDeclaration
 
 	/**
 	 * Get Document No.
+	 * Document sequence number of the document
 	 *
 	 * <br>Type: String
 	 * <br>Mandatory: false
@@ -347,7 +355,7 @@ public interface I_C_TaxDeclaration
 	String COLUMNNAME_IsActive = "IsActive";
 
 	/**
-	 * Set Is Correction.
+	 * Set Correction?.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
@@ -356,19 +364,19 @@ public interface I_C_TaxDeclaration
 	void setIsCorrection (boolean IsCorrection);
 
 	/**
-	 * Get Is Correction.
+	 * Get Correction?.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	boolean isIsCorrection();
+	boolean isCorrection();
 
 	ModelColumn<I_C_TaxDeclaration, Object> COLUMN_IsCorrection = new ModelColumn<>(I_C_TaxDeclaration.class, "IsCorrection", null);
 	String COLUMNNAME_IsCorrection = "IsCorrection";
 
 	/**
-	 * Set Is Correction Needed.
+	 * Set Correction needed?.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
@@ -377,13 +385,13 @@ public interface I_C_TaxDeclaration
 	void setIsCorrectionNeeded (boolean IsCorrectionNeeded);
 
 	/**
-	 * Get Is Correction Needed.
+	 * Get Correction needed?.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	boolean isIsCorrectionNeeded();
+	boolean isCorrectionNeeded();
 
 	ModelColumn<I_C_TaxDeclaration, Object> COLUMN_IsCorrectionNeeded = new ModelColumn<>(I_C_TaxDeclaration.class, "IsCorrectionNeeded", null);
 	String COLUMNNAME_IsCorrectionNeeded = "IsCorrectionNeeded";

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_TaxDeclaration.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_TaxDeclaration.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class X_C_TaxDeclaration extends org.compiere.model.PO implements I_C_TaxDeclaration, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 1163124041L;
+	private static final long serialVersionUID = -2073850125L;
 
     /** Standard Constructor */
     public X_C_TaxDeclaration (final Properties ctx, final int C_TaxDeclaration_ID, @Nullable final String trxName)
@@ -77,6 +77,18 @@ public class X_C_TaxDeclaration extends org.compiere.model.PO implements I_C_Tax
 	}
 
 	@Override
+	public void setCorrectionNeededReason (final @Nullable java.lang.String CorrectionNeededReason)
+	{
+		set_Value (COLUMNNAME_CorrectionNeededReason, CorrectionNeededReason);
+	}
+
+	@Override
+	public java.lang.String getCorrectionNeededReason() 
+	{
+		return get_ValueAsString(COLUMNNAME_CorrectionNeededReason);
+	}
+
+	@Override
 	public org.compiere.model.I_C_Period getC_Period()
 	{
 		return get_ValueAsPO(COLUMNNAME_C_Period_ID, org.compiere.model.I_C_Period.class);
@@ -113,7 +125,7 @@ public class X_C_TaxDeclaration extends org.compiere.model.PO implements I_C_Tax
 	}
 
 	@Override
-	public int getC_TaxDeclaration_ID()
+	public int getC_TaxDeclaration_ID() 
 	{
 		return get_ValueAsInt(COLUMNNAME_C_TaxDeclaration_ID);
 	}
@@ -133,14 +145,14 @@ public class X_C_TaxDeclaration extends org.compiere.model.PO implements I_C_Tax
 	@Override
 	public void setC_TaxDeclaration_Original_ID (final int C_TaxDeclaration_Original_ID)
 	{
-		if (C_TaxDeclaration_Original_ID < 1)
-			set_ValueNoCheck (COLUMNNAME_C_TaxDeclaration_Original_ID, null);
-		else
-			set_ValueNoCheck (COLUMNNAME_C_TaxDeclaration_Original_ID, C_TaxDeclaration_Original_ID);
+		if (C_TaxDeclaration_Original_ID < 1) 
+			set_Value (COLUMNNAME_C_TaxDeclaration_Original_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_TaxDeclaration_Original_ID, C_TaxDeclaration_Original_ID);
 	}
 
 	@Override
-	public int getC_TaxDeclaration_Original_ID()
+	public int getC_TaxDeclaration_Original_ID() 
 	{
 		return get_ValueAsInt(COLUMNNAME_C_TaxDeclaration_Original_ID);
 	}
@@ -164,24 +176,12 @@ public class X_C_TaxDeclaration extends org.compiere.model.PO implements I_C_Tax
 	}
 
 	@Override
-	public java.lang.String getDescription()
+	public java.lang.String getDescription() 
 	{
 		return get_ValueAsString(COLUMNNAME_Description);
 	}
 
-	@Override
-	public void setCorrectionNeededReason (final @Nullable java.lang.String CorrectionNeededReason)
-	{
-		set_Value (COLUMNNAME_CorrectionNeededReason, CorrectionNeededReason);
-	}
-
-	@Override
-	public java.lang.String getCorrectionNeededReason()
-	{
-		return get_ValueAsString(COLUMNNAME_CorrectionNeededReason);
-	}
-
-	/**
+	/** 
 	 * DocAction AD_Reference_ID=135
 	 * Reference name: _Document Action
 	 */
@@ -282,6 +282,30 @@ public class X_C_TaxDeclaration extends org.compiere.model.PO implements I_C_Tax
 	}
 
 	@Override
+	public void setIsCorrection (final boolean IsCorrection)
+	{
+		set_Value (COLUMNNAME_IsCorrection, IsCorrection);
+	}
+
+	@Override
+	public boolean isCorrection() 
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsCorrection);
+	}
+
+	@Override
+	public void setIsCorrectionNeeded (final boolean IsCorrectionNeeded)
+	{
+		set_Value (COLUMNNAME_IsCorrectionNeeded, IsCorrectionNeeded);
+	}
+
+	@Override
+	public boolean isCorrectionNeeded() 
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsCorrectionNeeded);
+	}
+
+	@Override
 	public void setProcessed (final boolean Processed)
 	{
 		set_Value (COLUMNNAME_Processed, Processed);
@@ -300,32 +324,8 @@ public class X_C_TaxDeclaration extends org.compiere.model.PO implements I_C_Tax
 	}
 
 	@Override
-	public boolean isProcessing()
+	public boolean isProcessing() 
 	{
 		return get_ValueAsBoolean(COLUMNNAME_Processing);
-	}
-
-	@Override
-	public void setIsCorrection (final boolean IsCorrection)
-	{
-		set_Value (COLUMNNAME_IsCorrection, IsCorrection);
-	}
-
-	@Override
-	public boolean isIsCorrection()
-	{
-		return get_ValueAsBoolean(COLUMNNAME_IsCorrection);
-	}
-
-	@Override
-	public void setIsCorrectionNeeded (final boolean IsCorrectionNeeded)
-	{
-		set_Value (COLUMNNAME_IsCorrectionNeeded, IsCorrectionNeeded);
-	}
-
-	@Override
-	public boolean isIsCorrectionNeeded()
-	{
-		return get_ValueAsBoolean(COLUMNNAME_IsCorrectionNeeded);
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tax_declaration/C_TaxDeclaration_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tax_declaration/C_TaxDeclaration_StepDef.java
@@ -202,7 +202,7 @@ public class C_TaxDeclaration_StepDef
 		final I_C_TaxDeclaration correction = InterfaceWrapperHelper.load(correctionRef.getC_TaxDeclaration_ID(), I_C_TaxDeclaration.class);
 		final I_C_TaxDeclaration original = InterfaceWrapperHelper.load(originalRef.getC_TaxDeclaration_ID(), I_C_TaxDeclaration.class);
 
-		assertThat(correction.isIsCorrection()).as("IsCorrection").isTrue();
+		assertThat(correction.isCorrection()).as("IsCorrection").isTrue();
 		assertThat(correction.getC_TaxDeclaration_Original_ID()).as("C_TaxDeclaration_Original_ID").isEqualTo(original.getC_TaxDeclaration_ID());
 		assertThat(correction.getC_Period_ID()).as("C_Period_ID inherited from Original").isEqualTo(original.getC_Period_ID());
 		assertThat(correction.getDateAcct()).as("DateAcct inherited from Original").isEqualTo(original.getDateAcct());
@@ -288,7 +288,7 @@ public class C_TaxDeclaration_StepDef
 		final I_C_TaxDeclaration decl = taxDeclarationTable.get(StepDefDataIdentifier.ofString(identifier));
 		final I_C_TaxDeclaration reloaded = InterfaceWrapperHelper.load(decl.getC_TaxDeclaration_ID(), I_C_TaxDeclaration.class);
 		final boolean expected = "Y".equalsIgnoreCase(expectedFlag);
-		assertThat(reloaded.isIsCorrectionNeeded()).as("IsCorrectionNeeded").isEqualTo(expected);
+		assertThat(reloaded.isCorrectionNeeded()).as("IsCorrectionNeeded").isEqualTo(expected);
 	}
 
 	/** Set the declaration's {@code IsCorrectionNeeded} flag ({@code Y}/{@code N}) and save; when {@code Y}, writes a {@code "test-drift"} reason. Used to simulate drift in tests. */

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tax_declaration/C_TaxDeclaration_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tax_declaration/C_TaxDeclaration_StepDef.java
@@ -97,7 +97,7 @@ public class C_TaxDeclaration_StepDef
 		{
 			decl.setProcessed(false);
 			decl.setIsCorrection(false);
-			decl.setC_TaxDeclaration_Original_ID(0); // 0 → NULL for FK columns
+			decl.setC_TaxDeclaration_Original_ID(-1);
 			decl.setDocStatus(IDocument.STATUS_Voided);
 			decl.setIsActive(false);
 			InterfaceWrapperHelper.saveRecord(decl);


### PR DESCRIPTION
Follow-up to the squash-merged PR for https://github.com/metasfresh/me03/issues/29631, addressing code-review findings.

## Commits

1. **`9d0866ad077`** — Propagate AD_Element_Trl for the 4 new Correction elements (`IsCorrection`, `C_TaxDeclaration_Original_ID`, `IsCorrectionNeeded`, `CorrectionNeededReason`) via `update_TRL_Tables_On_AD_Element_TRL_Update()`. Addresses review finding A1.

2. **`55e79fb952d`** — Stepdef hygiene in `C_TaxDeclaration_StepDef`: clear FK ID using `-1` per REVIEW.md §35; drop slop comment narrating framework behaviour per REVIEW.md §38e. Addresses review findings A5 + A6.

3. **`edbd89f3df7`** — Set `IsForceIncludeInGeneratedModel='Y'` on the 4 Correction columns and regenerate `I_C_TaxDeclaration.java` / `X_C_TaxDeclaration.java` via `GenerateModel` (replaces previous hand-edits). Addresses review finding A4.

   **Scope expansion**: also fixes an AD-config gap discovered while regenerating — `C_TaxDeclaration_Original_ID` was configured as a `Search` reference with `AD_Reference_Value_ID=NULL`, which made `GenerateModel` fail with a non-existent table lookup. The migration now creates `AD_Reference 542099` (Table validation pointing at `C_TaxDeclaration` with `DocumentNo` as the display column) and sets it on the Original_ID column. This is purely an AD-config correction; no behavioural change at runtime.

## Root cause of A4

The 4 Correction columns are on `EntityType='de.metas.acct'`, which is not in `SYSTEM_MAINTAINED_ENTITY_TYPES`. Without `IsForceIncludeInGeneratedModel='Y'`, the `GenerateModel` tool skips non-system columns — leading to the hand-edits in the original PR. The migration flips the flag so the columns are picked up cleanly on every regeneration.

## Skipped findings

- **A2** (leaky `I_C_TaxDeclaration` return type in repo): deferred by agreement — separate refactor.
- **A3** (`SpringContextHolder.getBean` in `C_TaxDeclaration_CreateCorrection`): not a bug — `JavaProcess` convention is `getBean`, not `lazyBean`. Rule clarified in `service-injection.md` §5 (committed separately to `mf15-ai-dev-support`).