### PR TITLE
Workflow first-node guard — fail-fast loader + interceptors + AD_ChangeLog

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805190_sys_30094_AD_ChangeLog_window_53005.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805190_sys_30094_AD_ChangeLog_window_53005.sql
@@ -1,0 +1,23 @@
+-- 2026-05-28T12:00:00
+-- enable AD_ChangeLog on the 5 tables of window 53005 (Workflow / Produktion Arbeitsablauf)
+-- so that future deactivations / changes are auditable in the change log.
+
+UPDATE AD_Table SET IsChangeLog='Y',Updated=TO_TIMESTAMP('2026-05-28 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE TableName='AD_Workflow' AND COALESCE(IsChangeLog,'N')<>'Y'
+;
+
+UPDATE AD_Table SET IsChangeLog='Y',Updated=TO_TIMESTAMP('2026-05-28 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE TableName='AD_Workflow_Trl' AND COALESCE(IsChangeLog,'N')<>'Y'
+;
+
+UPDATE AD_Table SET IsChangeLog='Y',Updated=TO_TIMESTAMP('2026-05-28 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE TableName='AD_WF_Node' AND COALESCE(IsChangeLog,'N')<>'Y'
+;
+
+UPDATE AD_Table SET IsChangeLog='Y',Updated=TO_TIMESTAMP('2026-05-28 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE TableName='AD_WF_NodeNext' AND COALESCE(IsChangeLog,'N')<>'Y'
+;
+
+UPDATE AD_Table SET IsChangeLog='Y',Updated=TO_TIMESTAMP('2026-05-28 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE TableName='PP_WF_Node_Product' AND COALESCE(IsChangeLog,'N')<>'Y'
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805200_sys_30094_AD_Message_FirstNode_guards.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805200_sys_30094_AD_Message_FirstNode_guards.sql
@@ -35,10 +35,10 @@ UPDATE AD_Message_Trl SET MsgText='The first activity of a workflow cannot be de
 WHERE AD_Message_ID=545732 AND AD_Language='en_US'
 ;
 
--- PPRouting_CannotRemoveResourceFromFirstNode ---------------------------------------------------
+-- PPRouting_FirstNodeRequiresResource ---------------------------------------------------
 -- 2026-05-28T12:10:06
 INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,ErrorCode,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
-VALUES (0,545733 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-28 12:10:06','YYYY-MM-DD HH24:MI:SS'),100,'D','PPROUTING_CANNOT_REMOVE_RESOURCE_FROM_FIRST_NODE','Y','Die Ressource des ersten Arbeitsschritts eines Arbeitsablaufs darf nicht leer sein.','E',TO_TIMESTAMP('2026-05-28 12:10:06','YYYY-MM-DD HH24:MI:SS'),100,'PPRouting_CannotRemoveResourceFromFirstNode')
+VALUES (0,545733 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-28 12:10:06','YYYY-MM-DD HH24:MI:SS'),100,'D','PPROUTING_FIRST_NODE_REQUIRES_RESOURCE','Y','Die Ressource des ersten Arbeitsschritts eines Arbeitsablaufs darf nicht leer sein.','E',TO_TIMESTAMP('2026-05-28 12:10:06','YYYY-MM-DD HH24:MI:SS'),100,'PPRouting_FirstNodeRequiresResource')
 ;
 -- 2026-05-28T12:10:07
 INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805200_sys_30094_AD_Message_FirstNode_guards.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805200_sys_30094_AD_Message_FirstNode_guards.sql
@@ -1,0 +1,59 @@
+-- 2026-05-28T12:10:00
+-- 4 user-friendly AD_Messages used by the workflow first-node guard interceptors and the
+-- PPRoutingRepository load-time validation.
+
+-- PPRouting_CannotDeactivateFirstNode -----------------------------------------------------------
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545731,0,TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Der erste Arbeitsschritt eines Arbeitsablaufs kann nicht deaktiviert werden. Bitte setzen Sie zuerst einen anderen aktiven Arbeitsschritt als ersten Arbeitsschritt im Arbeitsablauf.','E',TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'PPRouting_CannotDeactivateFirstNode')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=545731
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET MsgText='The first activity of a workflow cannot be deactivated. Please set another active activity as the workflow''s first activity first.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Message_ID=545731 AND AD_Language='en_US'
+;
+
+-- PPRouting_CannotDeleteFirstNode ---------------------------------------------------------------
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545732,0,TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Der erste Arbeitsschritt eines Arbeitsablaufs kann nicht gelöscht werden. Bitte setzen Sie zuerst einen anderen Arbeitsschritt als ersten Arbeitsschritt im Arbeitsablauf.','E',TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'PPRouting_CannotDeleteFirstNode')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=545732
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET MsgText='The first activity of a workflow cannot be deleted. Please set another activity as the workflow''s first activity first.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Message_ID=545732 AND AD_Language='en_US'
+;
+
+-- PPRouting_CannotRemoveResourceFromFirstNode ---------------------------------------------------
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545733,0,TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Die Ressource des ersten Arbeitsschritts eines Arbeitsablaufs darf nicht leer sein.','E',TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'PPRouting_CannotRemoveResourceFromFirstNode')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=545733
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET MsgText='The resource of the first activity of a workflow must not be empty.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Message_ID=545733 AND AD_Language='en_US'
+;
+
+-- PPRouting_FirstNodeInvalid --------------------------------------------------------------------
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545734,0,TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Der als erster Arbeitsschritt gewählte Arbeitsschritt ist nicht gültig (muss aktiv sein, zum gleichen Arbeitsablauf gehören und eine Ressource zugeordnet haben).','E',TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'PPRouting_FirstNodeInvalid')
+;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=545734
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+UPDATE AD_Message_Trl SET MsgText='The chosen first activity is invalid (must be active, belong to the same workflow, and have a resource assigned).', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Message_ID=545734 AND AD_Language='en_US'
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805200_sys_30094_AD_Message_FirstNode_guards.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805200_sys_30094_AD_Message_FirstNode_guards.sql
@@ -1,59 +1,70 @@
--- 2026-05-28T12:10:00
 -- 4 user-friendly AD_Messages used by the workflow first-node guard interceptors and the
 -- PPRoutingRepository load-time validation.
 
 -- PPRouting_CannotDeactivateFirstNode -----------------------------------------------------------
-INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
-VALUES (0,545731,0,TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Der erste Arbeitsschritt eines Arbeitsablaufs kann nicht deaktiviert werden. Bitte setzen Sie zuerst einen anderen aktiven Arbeitsschritt als ersten Arbeitsschritt im Arbeitsablauf.','E',TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'PPRouting_CannotDeactivateFirstNode')
+-- 2026-05-28T12:10:00
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,ErrorCode,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545731 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'D','PPROUTING_CANNOT_DEACTIVATE_FIRST_NODE','Y','Der erste Arbeitsschritt eines Arbeitsablaufs kann nicht deaktiviert werden. Bitte setzen Sie zuerst einen anderen aktiven Arbeitsschritt als ersten Arbeitsschritt im Arbeitsablauf.','E',TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'PPRouting_CannotDeactivateFirstNode')
 ;
+-- 2026-05-28T12:10:01
 INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
 SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
 FROM AD_Language l, AD_Message t
 WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=545731
   AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
 ;
-UPDATE AD_Message_Trl SET MsgText='The first activity of a workflow cannot be deactivated. Please set another active activity as the workflow''s first activity first.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+-- 2026-05-28T12:10:02
+UPDATE AD_Message_Trl SET MsgText='The first activity of a workflow cannot be deactivated. Please set another active activity as the workflow''s first activity first.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-28 12:10:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Message_ID=545731 AND AD_Language='en_US'
 ;
 
 -- PPRouting_CannotDeleteFirstNode ---------------------------------------------------------------
-INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
-VALUES (0,545732,0,TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Der erste Arbeitsschritt eines Arbeitsablaufs kann nicht gelöscht werden. Bitte setzen Sie zuerst einen anderen Arbeitsschritt als ersten Arbeitsschritt im Arbeitsablauf.','E',TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'PPRouting_CannotDeleteFirstNode')
+-- 2026-05-28T12:10:03
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,ErrorCode,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545732 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-28 12:10:03','YYYY-MM-DD HH24:MI:SS'),100,'D','PPROUTING_CANNOT_DELETE_FIRST_NODE','Y','Der erste Arbeitsschritt eines Arbeitsablaufs kann nicht gelöscht werden. Bitte setzen Sie zuerst einen anderen Arbeitsschritt als ersten Arbeitsschritt im Arbeitsablauf.','E',TO_TIMESTAMP('2026-05-28 12:10:03','YYYY-MM-DD HH24:MI:SS'),100,'PPRouting_CannotDeleteFirstNode')
 ;
+-- 2026-05-28T12:10:04
 INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
 SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
 FROM AD_Language l, AD_Message t
 WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=545732
   AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
 ;
-UPDATE AD_Message_Trl SET MsgText='The first activity of a workflow cannot be deleted. Please set another activity as the workflow''s first activity first.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+-- 2026-05-28T12:10:05
+UPDATE AD_Message_Trl SET MsgText='The first activity of a workflow cannot be deleted. Please set another activity as the workflow''s first activity first.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-28 12:10:05','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Message_ID=545732 AND AD_Language='en_US'
 ;
 
 -- PPRouting_CannotRemoveResourceFromFirstNode ---------------------------------------------------
-INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
-VALUES (0,545733,0,TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Die Ressource des ersten Arbeitsschritts eines Arbeitsablaufs darf nicht leer sein.','E',TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'PPRouting_CannotRemoveResourceFromFirstNode')
+-- 2026-05-28T12:10:06
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,ErrorCode,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545733 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-28 12:10:06','YYYY-MM-DD HH24:MI:SS'),100,'D','PPROUTING_CANNOT_REMOVE_RESOURCE_FROM_FIRST_NODE','Y','Die Ressource des ersten Arbeitsschritts eines Arbeitsablaufs darf nicht leer sein.','E',TO_TIMESTAMP('2026-05-28 12:10:06','YYYY-MM-DD HH24:MI:SS'),100,'PPRouting_CannotRemoveResourceFromFirstNode')
 ;
+-- 2026-05-28T12:10:07
 INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
 SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
 FROM AD_Language l, AD_Message t
 WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=545733
   AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
 ;
-UPDATE AD_Message_Trl SET MsgText='The resource of the first activity of a workflow must not be empty.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+-- 2026-05-28T12:10:08
+UPDATE AD_Message_Trl SET MsgText='The resource of the first activity of a workflow must not be empty.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-28 12:10:08','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Message_ID=545733 AND AD_Language='en_US'
 ;
 
 -- PPRouting_FirstNodeInvalid --------------------------------------------------------------------
-INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
-VALUES (0,545734,0,TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Der als erster Arbeitsschritt gewählte Arbeitsschritt ist nicht gültig (muss aktiv sein, zum gleichen Arbeitsablauf gehören und eine Ressource zugeordnet haben).','E',TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'),100,'PPRouting_FirstNodeInvalid')
+-- 2026-05-28T12:10:09
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,ErrorCode,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545734 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-28 12:10:09','YYYY-MM-DD HH24:MI:SS'),100,'D','PPROUTING_FIRST_NODE_INVALID','Y','Der als erster Arbeitsschritt gewählte Arbeitsschritt ist nicht gültig (muss aktiv sein, zum gleichen Arbeitsablauf gehören und eine Ressource zugeordnet haben).','E',TO_TIMESTAMP('2026-05-28 12:10:09','YYYY-MM-DD HH24:MI:SS'),100,'PPRouting_FirstNodeInvalid')
 ;
+-- 2026-05-28T12:10:10
 INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
 SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
 FROM AD_Language l, AD_Message t
 WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Message_ID=545734
   AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
 ;
-UPDATE AD_Message_Trl SET MsgText='The chosen first activity is invalid (must be active, belong to the same workflow, and have a resource assigned).', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-28 12:10:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+-- 2026-05-28T12:10:11
+UPDATE AD_Message_Trl SET MsgText='The chosen first activity is invalid (must be active, belong to the same workflow, and have a resource assigned).', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-05-28 12:10:11','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Message_ID=545734 AND AD_Language='en_US'
 ;

--- a/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/interceptor/AD_WF_Node.java
+++ b/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/interceptor/AD_WF_Node.java
@@ -28,6 +28,8 @@ import de.metas.material.planning.pporder.PPRoutingId;
 import de.metas.util.Services;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_AD_WF_Node;
 import org.compiere.model.ModelValidator;
 import org.springframework.stereotype.Component;
@@ -55,5 +57,87 @@ public class AD_WF_Node
 		// Issue https://github.com/metasfresh/metasfresh/issues/11292
 
 		ppRoutingRepo.setFirstNodeToWorkflow(ppRoutingActivityId);
+	}
+
+	@ModelChange(
+			timings = ModelValidator.TYPE_BEFORE_CHANGE,
+			ifColumnsChanged = I_AD_WF_Node.COLUMNNAME_IsActive)
+	public void preventDeactivateFirstNode(final I_AD_WF_Node node)
+	{
+		// Only block if IsActive is being changed from Y to N.
+		if (node.isActive())
+		{
+			return;
+		}
+
+		final I_AD_WF_Node oldNode = InterfaceWrapperHelper.createOld(node, I_AD_WF_Node.class);
+		if (!oldNode.isActive())
+		{
+			// was already inactive — nothing to do
+			return;
+		}
+
+		final PPRoutingActivityId activityId = toActivityIdOrNull(node);
+		if (activityId == null)
+		{
+			return;
+		}
+
+		if (ppRoutingRepo.isFirstNodeOfWorkflow(activityId))
+		{
+			throw new AdempiereException("@PPRouting_CannotDeactivateFirstNode@");
+		}
+	}
+
+	@ModelChange(timings = ModelValidator.TYPE_BEFORE_DELETE)
+	public void preventDeleteFirstNode(final I_AD_WF_Node node)
+	{
+		final PPRoutingActivityId activityId = toActivityIdOrNull(node);
+		if (activityId == null)
+		{
+			return;
+		}
+
+		if (ppRoutingRepo.isFirstNodeOfWorkflow(activityId))
+		{
+			throw new AdempiereException("@PPRouting_CannotDeleteFirstNode@");
+		}
+	}
+
+	@ModelChange(
+			timings = ModelValidator.TYPE_BEFORE_CHANGE,
+			ifColumnsChanged = I_AD_WF_Node.COLUMNNAME_S_Resource_ID)
+	public void preventRemoveResourceFromFirstNode(final I_AD_WF_Node node)
+	{
+		// Only block if S_Resource_ID is becoming null/<=0.
+		if (node.getS_Resource_ID() > 0)
+		{
+			return;
+		}
+
+		final PPRoutingActivityId activityId = toActivityIdOrNull(node);
+		if (activityId == null)
+		{
+			return;
+		}
+
+		if (ppRoutingRepo.isFirstNodeOfWorkflow(activityId))
+		{
+			throw new AdempiereException("@PPRouting_CannotRemoveResourceFromFirstNode@");
+		}
+	}
+
+	private static PPRoutingActivityId toActivityIdOrNull(final I_AD_WF_Node node)
+	{
+		final PPRoutingId routingId = PPRoutingId.ofRepoIdOrNull(node.getAD_Workflow_ID());
+		if (routingId == null)
+		{
+			return null;
+		}
+		if (node.getAD_WF_Node_ID() <= 0)
+		{
+			return null;
+		}
+		return PPRoutingActivityId.ofRepoId(routingId, node.getAD_WF_Node_ID());
 	}
 }

--- a/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/interceptor/AD_WF_Node.java
+++ b/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/interceptor/AD_WF_Node.java
@@ -116,7 +116,7 @@ public class AD_WF_Node
 
 		if (ppRoutingRepo.isFirstNodeOfWorkflow(activityId))
 		{
-			throw new AdempiereException("@PPRouting_CannotRemoveResourceFromFirstNode@");
+			throw new AdempiereException("@PPRouting_FirstNodeRequiresResource@");
 		}
 	}
 

--- a/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/interceptor/AD_WF_Node.java
+++ b/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/interceptor/AD_WF_Node.java
@@ -22,6 +22,7 @@
 
 package de.metas.material.planning.interceptor;
 
+import de.metas.i18n.AdMessageKey;
 import de.metas.material.planning.pporder.IPPRoutingRepository;
 import de.metas.material.planning.pporder.PPRoutingActivityId;
 import de.metas.material.planning.pporder.PPRoutingId;
@@ -37,6 +38,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class AD_WF_Node
 {
+	private static final AdMessageKey MSG_CannotDeactivateFirstNode = AdMessageKey.of("PPRouting_CannotDeactivateFirstNode");
+	private static final AdMessageKey MSG_CannotDeleteFirstNode = AdMessageKey.of("PPRouting_CannotDeleteFirstNode");
+	private static final AdMessageKey MSG_FirstNodeRequiresResource = AdMessageKey.of("PPRouting_FirstNodeRequiresResource");
+
 	final IPPRoutingRepository ppRoutingRepo = Services.get(IPPRoutingRepository.class);
 
 	@ModelChange(timings = ModelValidator.TYPE_AFTER_NEW)
@@ -78,7 +83,7 @@ public class AD_WF_Node
 
 		if (ppRoutingRepo.isFirstNodeOfWorkflow(activityId))
 		{
-			throw new AdempiereException("@PPRouting_CannotDeactivateFirstNode@");
+			throw new AdempiereException(MSG_CannotDeactivateFirstNode);
 		}
 	}
 
@@ -93,7 +98,7 @@ public class AD_WF_Node
 
 		if (ppRoutingRepo.isFirstNodeOfWorkflow(activityId))
 		{
-			throw new AdempiereException("@PPRouting_CannotDeleteFirstNode@");
+			throw new AdempiereException(MSG_CannotDeleteFirstNode);
 		}
 	}
 
@@ -116,7 +121,7 @@ public class AD_WF_Node
 
 		if (ppRoutingRepo.isFirstNodeOfWorkflow(activityId))
 		{
-			throw new AdempiereException("@PPRouting_FirstNodeRequiresResource@");
+			throw new AdempiereException(MSG_FirstNodeRequiresResource);
 		}
 	}
 

--- a/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/interceptor/AD_WF_Node.java
+++ b/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/interceptor/AD_WF_Node.java
@@ -29,7 +29,6 @@ import de.metas.util.Services;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_AD_WF_Node;
 import org.compiere.model.ModelValidator;
 import org.springframework.stereotype.Component;
@@ -64,16 +63,10 @@ public class AD_WF_Node
 			ifColumnsChanged = I_AD_WF_Node.COLUMNNAME_IsActive)
 	public void preventDeactivateFirstNode(final I_AD_WF_Node node)
 	{
-		// Only block if IsActive is being changed from Y to N.
+		// ifColumnsChanged=IsActive only fires when the value differs from the DB row, so
+		// reaching here with node.isActive()==true means the transition is N→Y — not our case.
 		if (node.isActive())
 		{
-			return;
-		}
-
-		final I_AD_WF_Node oldNode = InterfaceWrapperHelper.createOld(node, I_AD_WF_Node.class);
-		if (!oldNode.isActive())
-		{
-			// was already inactive — nothing to do
 			return;
 		}
 

--- a/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/interceptor/AD_Workflow.java
+++ b/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/interceptor/AD_Workflow.java
@@ -21,6 +21,7 @@
  */
 package de.metas.material.planning.interceptor;
 
+import de.metas.i18n.AdMessageKey;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.exceptions.AdempiereException;
@@ -43,6 +44,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class AD_Workflow
 {
+	private static final AdMessageKey MSG_FirstNodeInvalid = AdMessageKey.of("PPRouting_FirstNodeInvalid");
+
 	@ModelChange(
 			timings = ModelValidator.TYPE_BEFORE_CHANGE,
 			ifColumnsChanged = I_AD_Workflow.COLUMNNAME_AD_WF_Node_ID)
@@ -60,25 +63,26 @@ public class AD_Workflow
 		final I_AD_WF_Node targetNode = InterfaceWrapperHelper.load(wfNodeId, I_AD_WF_Node.class);
 		if (targetNode == null)
 		{
-			throw new AdempiereException("@PPRouting_FirstNodeInvalid@ - target AD_WF_Node_ID=" + wfNodeId + " not found");
+			throw new AdempiereException(MSG_FirstNodeInvalid, "target AD_WF_Node_ID=" + wfNodeId + " not found");
 		}
 
 		if (!targetNode.isActive())
 		{
-			throw new AdempiereException("@PPRouting_FirstNodeInvalid@ - target AD_WF_Node_ID=" + wfNodeId + " is inactive");
+			throw new AdempiereException(MSG_FirstNodeInvalid, "target AD_WF_Node_ID=" + wfNodeId + " is inactive");
 		}
 
 		if (targetNode.getAD_Workflow_ID() != workflow.getAD_Workflow_ID())
 		{
-			throw new AdempiereException("@PPRouting_FirstNodeInvalid@ - target AD_WF_Node_ID=" + wfNodeId
-					+ " belongs to a different workflow (AD_Workflow_ID=" + targetNode.getAD_Workflow_ID()
-					+ "), expected AD_Workflow_ID=" + workflow.getAD_Workflow_ID());
+			throw new AdempiereException(MSG_FirstNodeInvalid,
+					"target AD_WF_Node_ID=" + wfNodeId
+							+ " belongs to a different workflow (AD_Workflow_ID=" + targetNode.getAD_Workflow_ID()
+							+ "), expected AD_Workflow_ID=" + workflow.getAD_Workflow_ID());
 		}
 
 		if (targetNode.getS_Resource_ID() <= 0)
 		{
-			throw new AdempiereException("@PPRouting_FirstNodeInvalid@ - target AD_WF_Node_ID=" + wfNodeId
-					+ " has no S_Resource_ID; the routing-loader filters such nodes out");
+			throw new AdempiereException(MSG_FirstNodeInvalid,
+					"target AD_WF_Node_ID=" + wfNodeId + " has no S_Resource_ID; the routing-loader filters such nodes out");
 		}
 	}
 }

--- a/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/interceptor/AD_Workflow.java
+++ b/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/interceptor/AD_Workflow.java
@@ -1,0 +1,84 @@
+/*
+ * #%L
+ * metasfresh-material-planning
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package de.metas.material.planning.interceptor;
+
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.ad.modelvalidator.annotations.ModelChange;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_AD_WF_Node;
+import org.compiere.model.I_AD_Workflow;
+import org.compiere.model.ModelValidator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Validates that {@code AD_Workflow.AD_WF_Node_ID} (the configured first / start node of a workflow)
+ * always points at a node that the routing-loader will accept: active, belonging to the same workflow,
+ * and having a non-null {@code S_Resource_ID}.
+ * <p>
+ * Companion to {@link AD_WF_Node} (which prevents the first node from being deactivated / deleted /
+ * having its resource removed from the other side). Together they keep
+ * {@code PPRoutingRepository.toRouting()} from blowing up with the noisy 6 KB save-status message.
+ */
+@Interceptor(I_AD_Workflow.class)
+@Component
+public class AD_Workflow
+{
+	@ModelChange(
+			timings = ModelValidator.TYPE_BEFORE_CHANGE,
+			ifColumnsChanged = I_AD_Workflow.COLUMNNAME_AD_WF_Node_ID)
+	public void validateFirstNode(final I_AD_Workflow workflow)
+	{
+		final int wfNodeId = workflow.getAD_WF_Node_ID();
+		if (wfNodeId <= 0)
+		{
+			// Clearing the first node is not blocked here — the loader handles wfNodeId<=0 with its own
+			// specific exception (AD_Workflow_StartNode_NotSet). We only validate that, when a value is
+			// being set, it is a usable target.
+			return;
+		}
+
+		final I_AD_WF_Node targetNode = InterfaceWrapperHelper.load(wfNodeId, I_AD_WF_Node.class);
+		if (targetNode == null)
+		{
+			throw new AdempiereException("@PPRouting_FirstNodeInvalid@ - target AD_WF_Node_ID=" + wfNodeId + " not found");
+		}
+
+		if (!targetNode.isActive())
+		{
+			throw new AdempiereException("@PPRouting_FirstNodeInvalid@ - target AD_WF_Node_ID=" + wfNodeId + " is inactive");
+		}
+
+		if (targetNode.getAD_Workflow_ID() != workflow.getAD_Workflow_ID())
+		{
+			throw new AdempiereException("@PPRouting_FirstNodeInvalid@ - target AD_WF_Node_ID=" + wfNodeId
+					+ " belongs to a different workflow (AD_Workflow_ID=" + targetNode.getAD_Workflow_ID()
+					+ "), expected AD_Workflow_ID=" + workflow.getAD_Workflow_ID());
+		}
+
+		if (targetNode.getS_Resource_ID() <= 0)
+		{
+			throw new AdempiereException("@PPRouting_FirstNodeInvalid@ - target AD_WF_Node_ID=" + wfNodeId
+					+ " has no S_Resource_ID; the routing-loader filters such nodes out");
+		}
+	}
+}

--- a/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/pporder/IPPRoutingRepository.java
+++ b/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/pporder/IPPRoutingRepository.java
@@ -41,6 +41,8 @@ public interface IPPRoutingRepository extends ISingletonService
 
 	boolean nodesAlreadyExistInWorkflow(@NonNull PPRoutingActivityId excludeActivityId);
 
+	boolean isFirstNodeOfWorkflow(@NonNull PPRoutingActivityId activityId);
+
 	Optional<PPRoutingId> getDefaultRoutingIdByType(@NonNull PPRoutingType type);
 
 	void setFirstNodeToWorkflow(@NonNull PPRoutingActivityId ppRoutingActivityId);

--- a/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/pporder/impl/PPRoutingRepository.java
+++ b/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/pporder/impl/PPRoutingRepository.java
@@ -148,6 +148,16 @@ public class PPRoutingRepository implements IPPRoutingRepository
 		}
 		final PPRoutingActivityId firstActivityId = PPRoutingActivityId.ofRepoId(routingId, wfNodeId);
 
+		final boolean firstActivityInActivities = activities.stream()
+				.map(PPRoutingActivity::getId)
+				.anyMatch(firstActivityId::equals);
+		if (!firstActivityInActivities)
+		{
+			throw new AdempiereException("@PPRouting_FirstNodeInvalid@ - workflow=" + routingRecord.getName()
+					+ " (AD_Workflow_ID=" + routingId.getRepoId() + "), first node AD_WF_Node_ID=" + wfNodeId
+					+ " is not in the active node set (deactivated, different workflow, or missing S_Resource_ID)");
+		}
+
 		return PPRouting.builder()
 				.id(routingId)
 				.valid(routingRecord.isValid())

--- a/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/pporder/impl/PPRoutingRepository.java
+++ b/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/pporder/impl/PPRoutingRepository.java
@@ -94,6 +94,7 @@ public class PPRoutingRepository implements IPPRoutingRepository
 	private final IProductDAO productDAO = Services.get(IProductDAO.class);
 
 	private static final AdMessageKey MSG_AD_Workflow_Missing_Node = AdMessageKey.of("AD_Workflow_StartNode_NotSet");
+	private static final AdMessageKey MSG_FirstNodeInvalid = AdMessageKey.of("PPRouting_FirstNodeInvalid");
 
 	private final CCache<PPRoutingId, PPRouting> routingsById = CCache.<PPRoutingId, PPRouting>builder()
 			.tableName(I_AD_Workflow.Table_Name)
@@ -153,9 +154,10 @@ public class PPRoutingRepository implements IPPRoutingRepository
 				.anyMatch(firstActivityId::equals);
 		if (!firstActivityInActivities)
 		{
-			throw new AdempiereException("@PPRouting_FirstNodeInvalid@ - workflow=" + routingRecord.getName()
-					+ " (AD_Workflow_ID=" + routingId.getRepoId() + "), first node AD_WF_Node_ID=" + wfNodeId
-					+ " is not in the active node set (deactivated, different workflow, or missing S_Resource_ID)");
+			throw new AdempiereException(MSG_FirstNodeInvalid,
+					"workflow=" + routingRecord.getName()
+							+ " (AD_Workflow_ID=" + routingId.getRepoId() + "), first node AD_WF_Node_ID=" + wfNodeId
+							+ " is not in the active node set (deactivated, different workflow, or missing S_Resource_ID)");
 		}
 
 		return PPRouting.builder()

--- a/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/pporder/impl/PPRoutingRepository.java
+++ b/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/pporder/impl/PPRoutingRepository.java
@@ -369,6 +369,9 @@ public class PPRoutingRepository implements IPPRoutingRepository
 	@Override
 	public boolean isFirstNodeOfWorkflow(@NonNull final PPRoutingActivityId activityId)
 	{
+		// Note: intentionally NO addOnlyActiveRecordsFilter() — the first-node-guard interceptors
+		// must also fire for soft-deleted workflows (IsActive='N') whose AD_WF_Node_ID pointer is
+		// still set. Adding an active-only filter would silently disable the guard for those rows.
 		return queryBL
 				.createQueryBuilder(I_AD_Workflow.class)
 				.addEqualsFilter(I_AD_Workflow.COLUMNNAME_AD_Workflow_ID, activityId.getRoutingId())

--- a/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/pporder/impl/PPRoutingRepository.java
+++ b/backend/de.metas.material/planning/src/main/java/de/metas/material/planning/pporder/impl/PPRoutingRepository.java
@@ -366,6 +366,17 @@ public class PPRoutingRepository implements IPPRoutingRepository
 				.anyMatch();
 	}
 
+	@Override
+	public boolean isFirstNodeOfWorkflow(@NonNull final PPRoutingActivityId activityId)
+	{
+		return queryBL
+				.createQueryBuilder(I_AD_Workflow.class)
+				.addEqualsFilter(I_AD_Workflow.COLUMNNAME_AD_Workflow_ID, activityId.getRoutingId())
+				.addEqualsFilter(I_AD_Workflow.COLUMNNAME_AD_WF_Node_ID, activityId.getRepoId())
+				.create()
+				.anyMatch();
+	}
+
 	private List<I_AD_WF_Node> retrieveNodes(@NonNull final I_AD_Workflow routingRecord)
 	{
 		final PPRoutingId routingId = PPRoutingId.ofRepoId(routingRecord.getAD_Workflow_ID());

--- a/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/interceptor/AD_WF_NodeInterceptorTest.java
+++ b/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/interceptor/AD_WF_NodeInterceptorTest.java
@@ -159,7 +159,7 @@ public class AD_WF_NodeInterceptorTest
 		firstNode.setS_Resource_ID(0);
 		assertThatThrownBy(() -> InterfaceWrapperHelper.save(firstNode))
 				.isInstanceOf(AdempiereException.class)
-				.hasMessageContaining("PPRouting_CannotRemoveResourceFromFirstNode");
+				.hasMessageContaining("PPRouting_FirstNodeRequiresResource");
 	}
 
 	@Test

--- a/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/interceptor/AD_WF_NodeInterceptorTest.java
+++ b/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/interceptor/AD_WF_NodeInterceptorTest.java
@@ -1,0 +1,178 @@
+/*
+ * #%L
+ * metasfresh-material-planning
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package de.metas.material.planning.interceptor;
+
+import de.metas.util.Services;
+import org.adempiere.ad.modelvalidator.IModelInterceptorRegistry;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_AD_WF_Node;
+import org.compiere.model.I_AD_Workflow;
+import org.compiere.model.I_S_Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class AD_WF_NodeInterceptorTest
+{
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+		Services.get(IModelInterceptorRegistry.class).addModelInterceptor(new AD_WF_Node(), null);
+	}
+
+	private I_S_Resource createResource()
+	{
+		final I_S_Resource resource = InterfaceWrapperHelper.newInstance(I_S_Resource.class);
+		resource.setName("R1");
+		resource.setValue("R1");
+		InterfaceWrapperHelper.save(resource);
+		return resource;
+	}
+
+	private I_AD_Workflow createWorkflow()
+	{
+		final I_AD_Workflow wf = InterfaceWrapperHelper.newInstance(I_AD_Workflow.class);
+		wf.setName("WF1");
+		wf.setValue("WF1");
+		wf.setWorkflowType("M");
+		wf.setDurationUnit("h");
+		wf.setQtyBatchSize(java.math.BigDecimal.ONE);
+		InterfaceWrapperHelper.save(wf);
+		return wf;
+	}
+
+	private I_AD_WF_Node createNode(final I_AD_Workflow wf, final I_S_Resource resource, final String name)
+	{
+		final I_AD_WF_Node node = InterfaceWrapperHelper.newInstance(I_AD_WF_Node.class);
+		node.setAD_Workflow_ID(wf.getAD_Workflow_ID());
+		node.setName(name);
+		node.setValue(name);
+		node.setS_Resource_ID(resource.getS_Resource_ID());
+		InterfaceWrapperHelper.save(node);
+		return node;
+	}
+
+	// =========================================================
+	// Rule 1: deactivate-first-node blocked
+	// =========================================================
+
+	@Test
+	public void deactivate_firstNode_blocked()
+	{
+		final I_S_Resource resource = createResource();
+		final I_AD_Workflow wf = createWorkflow();
+		final I_AD_WF_Node firstNode = createNode(wf, resource, "first");
+		// AFTER_NEW interceptor auto-sets first node — make sure of it.
+		wf.setAD_WF_Node_ID(firstNode.getAD_WF_Node_ID());
+		InterfaceWrapperHelper.save(wf);
+
+		firstNode.setIsActive(false);
+		assertThatThrownBy(() -> InterfaceWrapperHelper.save(firstNode))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("PPRouting_CannotDeactivateFirstNode");
+	}
+
+	@Test
+	public void deactivate_nonFirstNode_allowed()
+	{
+		final I_S_Resource resource = createResource();
+		final I_AD_Workflow wf = createWorkflow();
+		final I_AD_WF_Node firstNode = createNode(wf, resource, "first");
+		final I_AD_WF_Node secondNode = createNode(wf, resource, "second");
+		wf.setAD_WF_Node_ID(firstNode.getAD_WF_Node_ID());
+		InterfaceWrapperHelper.save(wf);
+
+		secondNode.setIsActive(false);
+		InterfaceWrapperHelper.save(secondNode);
+
+		assertThat(InterfaceWrapperHelper.load(secondNode.getAD_WF_Node_ID(), I_AD_WF_Node.class).isActive()).isFalse();
+	}
+
+	// =========================================================
+	// Rule 2: delete-first-node blocked
+	// =========================================================
+
+	@Test
+	public void delete_firstNode_blocked()
+	{
+		final I_S_Resource resource = createResource();
+		final I_AD_Workflow wf = createWorkflow();
+		final I_AD_WF_Node firstNode = createNode(wf, resource, "first");
+		wf.setAD_WF_Node_ID(firstNode.getAD_WF_Node_ID());
+		InterfaceWrapperHelper.save(wf);
+
+		assertThatThrownBy(() -> InterfaceWrapperHelper.delete(firstNode))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("PPRouting_CannotDeleteFirstNode");
+	}
+
+	@Test
+	public void delete_nonFirstNode_allowed()
+	{
+		final I_S_Resource resource = createResource();
+		final I_AD_Workflow wf = createWorkflow();
+		final I_AD_WF_Node firstNode = createNode(wf, resource, "first");
+		final I_AD_WF_Node secondNode = createNode(wf, resource, "second");
+		wf.setAD_WF_Node_ID(firstNode.getAD_WF_Node_ID());
+		InterfaceWrapperHelper.save(wf);
+
+		InterfaceWrapperHelper.delete(secondNode);
+	}
+
+	// =========================================================
+	// Rule 3: remove-resource-from-first-node blocked
+	// =========================================================
+
+	@Test
+	public void removeResource_firstNode_blocked()
+	{
+		final I_S_Resource resource = createResource();
+		final I_AD_Workflow wf = createWorkflow();
+		final I_AD_WF_Node firstNode = createNode(wf, resource, "first");
+		wf.setAD_WF_Node_ID(firstNode.getAD_WF_Node_ID());
+		InterfaceWrapperHelper.save(wf);
+
+		firstNode.setS_Resource_ID(0);
+		assertThatThrownBy(() -> InterfaceWrapperHelper.save(firstNode))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("PPRouting_CannotRemoveResourceFromFirstNode");
+	}
+
+	@Test
+	public void removeResource_nonFirstNode_allowed()
+	{
+		final I_S_Resource resource = createResource();
+		final I_AD_Workflow wf = createWorkflow();
+		final I_AD_WF_Node firstNode = createNode(wf, resource, "first");
+		final I_AD_WF_Node secondNode = createNode(wf, resource, "second");
+		wf.setAD_WF_Node_ID(firstNode.getAD_WF_Node_ID());
+		InterfaceWrapperHelper.save(wf);
+
+		secondNode.setS_Resource_ID(0);
+		InterfaceWrapperHelper.save(secondNode);
+	}
+}

--- a/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/interceptor/AD_WorkflowInterceptorTest.java
+++ b/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/interceptor/AD_WorkflowInterceptorTest.java
@@ -32,6 +32,7 @@ import org.compiere.model.I_S_Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AD_WorkflowInterceptorTest
@@ -112,6 +113,22 @@ public class AD_WorkflowInterceptorTest
 				.isInstanceOf(AdempiereException.class)
 				.hasMessageContaining("PPRouting_FirstNodeInvalid")
 				.hasMessageContaining("different workflow");
+	}
+
+	@Test
+	public void setFirstNode_to_validNode_allowed()
+	{
+		// Happy path: target node is active, in the same workflow, and has S_Resource_ID.
+		// Guards must NOT fire here — without this test, an accidental inversion of the
+		// wfNodeId<=0 early-return or any of the three failure-condition checks would
+		// silently block ALL first-node assignments and only surface in manual UAT.
+		final I_S_Resource resource = createResource();
+		final I_AD_Workflow wf = createWorkflow("WF1");
+		final I_AD_WF_Node validNode = createNode(wf, resource, "valid", true);
+
+		wf.setAD_WF_Node_ID(validNode.getAD_WF_Node_ID());
+
+		assertThatCode(() -> InterfaceWrapperHelper.save(wf)).doesNotThrowAnyException();
 	}
 
 	@Test

--- a/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/interceptor/AD_WorkflowInterceptorTest.java
+++ b/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/interceptor/AD_WorkflowInterceptorTest.java
@@ -1,0 +1,130 @@
+/*
+ * #%L
+ * metasfresh-material-planning
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package de.metas.material.planning.interceptor;
+
+import de.metas.util.Services;
+import org.adempiere.ad.modelvalidator.IModelInterceptorRegistry;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_AD_WF_Node;
+import org.compiere.model.I_AD_Workflow;
+import org.compiere.model.I_S_Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class AD_WorkflowInterceptorTest
+{
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+		Services.get(IModelInterceptorRegistry.class).addModelInterceptor(new AD_Workflow(), null);
+	}
+
+	private I_S_Resource createResource()
+	{
+		final I_S_Resource resource = InterfaceWrapperHelper.newInstance(I_S_Resource.class);
+		resource.setName("R");
+		resource.setValue("R");
+		InterfaceWrapperHelper.save(resource);
+		return resource;
+	}
+
+	private I_AD_Workflow createWorkflow(final String name)
+	{
+		final I_AD_Workflow wf = InterfaceWrapperHelper.newInstance(I_AD_Workflow.class);
+		wf.setName(name);
+		wf.setValue(name);
+		wf.setWorkflowType("M");
+		wf.setDurationUnit("h");
+		wf.setQtyBatchSize(java.math.BigDecimal.ONE);
+		InterfaceWrapperHelper.save(wf);
+		return wf;
+	}
+
+	private I_AD_WF_Node createNode(
+			final I_AD_Workflow wf,
+			final I_S_Resource resource,
+			final String name,
+			final boolean active)
+	{
+		final I_AD_WF_Node node = InterfaceWrapperHelper.newInstance(I_AD_WF_Node.class);
+		node.setAD_Workflow_ID(wf.getAD_Workflow_ID());
+		node.setName(name);
+		node.setValue(name);
+		if (resource != null)
+		{
+			node.setS_Resource_ID(resource.getS_Resource_ID());
+		}
+		node.setIsActive(active);
+		InterfaceWrapperHelper.save(node);
+		return node;
+	}
+
+	@Test
+	public void setFirstNode_to_inactive_blocked()
+	{
+		final I_S_Resource resource = createResource();
+		final I_AD_Workflow wf = createWorkflow("WF1");
+		final I_AD_WF_Node inactiveNode = createNode(wf, resource, "inactive", false);
+
+		wf.setAD_WF_Node_ID(inactiveNode.getAD_WF_Node_ID());
+
+		assertThatThrownBy(() -> InterfaceWrapperHelper.save(wf))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("PPRouting_FirstNodeInvalid")
+				.hasMessageContaining("inactive");
+	}
+
+	@Test
+	public void setFirstNode_to_otherWorkflow_blocked()
+	{
+		final I_S_Resource resource = createResource();
+		final I_AD_Workflow wf1 = createWorkflow("WF1");
+		final I_AD_Workflow wf2 = createWorkflow("WF2");
+		final I_AD_WF_Node nodeOfWf2 = createNode(wf2, resource, "n2", true);
+
+		wf1.setAD_WF_Node_ID(nodeOfWf2.getAD_WF_Node_ID());
+
+		assertThatThrownBy(() -> InterfaceWrapperHelper.save(wf1))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("PPRouting_FirstNodeInvalid")
+				.hasMessageContaining("different workflow");
+	}
+
+	@Test
+	public void setFirstNode_to_nullResource_blocked()
+	{
+		final I_AD_Workflow wf = createWorkflow("WF1");
+		final I_AD_WF_Node nodeNoResource = createNode(wf, null, "noRes", true);
+
+		wf.setAD_WF_Node_ID(nodeNoResource.getAD_WF_Node_ID());
+
+		assertThatThrownBy(() -> InterfaceWrapperHelper.save(wf))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("PPRouting_FirstNodeInvalid")
+				.hasMessageContaining("S_Resource_ID");
+	}
+}

--- a/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/pporder/impl/PPRoutingRepositoryTest.java
+++ b/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/pporder/impl/PPRoutingRepositoryTest.java
@@ -105,6 +105,34 @@ public class PPRoutingRepositoryTest
 	}
 
 	@Test
+	public void firstActivityId_deactivated_throws_clear_error()
+	{
+		// Reproduces the actual ic114 me03 30094 scenario: AD_WF_Node still exists in the DB but has
+		// IsActive='N', so retrieveNodes filters it out of the loaded activity set, and the
+		// firstActivityId pointer becomes orphan from the loader's perspective.
+		final I_S_Resource resource = createResource();
+		final I_AD_Workflow wf = createWorkflow();
+
+		final I_AD_WF_Node node1 = createNode(wf, resource, "N1");
+		createNode(wf, resource, "N2");
+		createNode(wf, resource, "N3");
+
+		// Keep node1 as the workflow's first node, then soft-delete it. PPRoutingRepositoryTest does
+		// not register the AD_WF_Node interceptor that would normally block this, so the bad-data
+		// shape is reproducible here for the loader's own defence.
+		wf.setAD_WF_Node_ID(node1.getAD_WF_Node_ID());
+		InterfaceWrapperHelper.save(wf);
+		node1.setIsActive(false);
+		InterfaceWrapperHelper.save(node1);
+
+		final PPRoutingId routingId = PPRoutingId.ofRepoId(wf.getAD_Workflow_ID());
+
+		assertThatThrownBy(() -> ppRoutingRepository.getById(routingId))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("PPRouting_FirstNodeInvalid");
+	}
+
+	@Test
 	public void firstActivityId_valid_loads_successfully()
 	{
 		final I_S_Resource resource = createResource();

--- a/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/pporder/impl/PPRoutingRepositoryTest.java
+++ b/backend/de.metas.material/planning/src/test/java/de/metas/material/planning/pporder/impl/PPRoutingRepositoryTest.java
@@ -1,0 +1,123 @@
+/*
+ * #%L
+ * metasfresh-material-planning
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package de.metas.material.planning.pporder.impl;
+
+import de.metas.material.planning.pporder.IPPRoutingRepository;
+import de.metas.material.planning.pporder.PPRoutingId;
+import de.metas.util.Services;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_AD_WF_Node;
+import org.compiere.model.I_AD_Workflow;
+import org.compiere.model.I_S_Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class PPRoutingRepositoryTest
+{
+	private IPPRoutingRepository ppRoutingRepository;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+		ppRoutingRepository = Services.get(IPPRoutingRepository.class);
+	}
+
+	private I_S_Resource createResource()
+	{
+		final I_S_Resource resource = InterfaceWrapperHelper.newInstance(I_S_Resource.class);
+		resource.setName("Resource");
+		resource.setValue("R1");
+		InterfaceWrapperHelper.save(resource);
+		return resource;
+	}
+
+	private I_AD_Workflow createWorkflow()
+	{
+		final I_AD_Workflow wf = InterfaceWrapperHelper.newInstance(I_AD_Workflow.class);
+		wf.setName("WF1");
+		wf.setValue("WF1");
+		wf.setWorkflowType("M"); // Manufacturing
+		wf.setDurationUnit("h");
+		wf.setQtyBatchSize(java.math.BigDecimal.ONE);
+		InterfaceWrapperHelper.save(wf);
+		return wf;
+	}
+
+	private I_AD_WF_Node createNode(final I_AD_Workflow wf, final I_S_Resource resource, final String name)
+	{
+		final I_AD_WF_Node node = InterfaceWrapperHelper.newInstance(I_AD_WF_Node.class);
+		node.setAD_Workflow_ID(wf.getAD_Workflow_ID());
+		node.setName(name);
+		node.setValue(name);
+		node.setS_Resource_ID(resource.getS_Resource_ID());
+		InterfaceWrapperHelper.save(node);
+		return node;
+	}
+
+	@Test
+	public void firstActivityId_orphan_throws_clear_error()
+	{
+		final I_S_Resource resource = createResource();
+		final I_AD_Workflow wf = createWorkflow();
+
+		// Create 3 real nodes for the workflow.
+		final I_AD_WF_Node node1 = createNode(wf, resource, "N1");
+		createNode(wf, resource, "N2");
+		createNode(wf, resource, "N3");
+
+		// Note: AD_WF_Node interceptor's AFTER_NEW auto-sets the workflow's start node to the first
+		// node it sees. We override that to point at a non-existing AD_WF_Node_ID to simulate the
+		// orphan/deactivated-first-node scenario.
+		final int orphanWfNodeId = node1.getAD_WF_Node_ID() + 99999;
+		wf.setAD_WF_Node_ID(orphanWfNodeId);
+		InterfaceWrapperHelper.save(wf);
+
+		final PPRoutingId routingId = PPRoutingId.ofRepoId(wf.getAD_Workflow_ID());
+
+		assertThatThrownBy(() -> ppRoutingRepository.getById(routingId))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("PPRouting_FirstNodeInvalid");
+	}
+
+	@Test
+	public void firstActivityId_valid_loads_successfully()
+	{
+		final I_S_Resource resource = createResource();
+		final I_AD_Workflow wf = createWorkflow();
+
+		final I_AD_WF_Node node1 = createNode(wf, resource, "N1");
+		createNode(wf, resource, "N2");
+
+		wf.setAD_WF_Node_ID(node1.getAD_WF_Node_ID());
+		InterfaceWrapperHelper.save(wf);
+
+		final PPRoutingId routingId = PPRoutingId.ofRepoId(wf.getAD_Workflow_ID());
+
+		assertThat(ppRoutingRepository.getById(routingId)).isNotNull();
+	}
+}


### PR DESCRIPTION
# Workflow first-node guard — me03 30094


## Background

A PP_Order could not be patched/processed via the WebUI: routing `AD_Workflow_ID=540118` ("Default Workflow for mobile UI Manufacturing") had `AD_Workflow.AD_WF_Node_ID=540277`, but that `AD_WF_Node` was `IsActive='N'` — so the routing loader produced a `PPRouting` whose `firstActivityId` was not present in the active activity set. When the document tried to resolve the first activity, `PPRouting.getActivityById` threw a 6 KB save-status stack that surfaced as HTTP 500 in the WebUI. No `AD_ChangeLog` was active on `AD_WF_Node`, so we couldn't see who deactivated the node.

Customer reactivated the node to recover. This PR makes the system **resilient against the same drift recurring silently**.

## What this PR does

1. **Resilient routing load** — `PPRoutingRepository.toRouting()` now validates at load time that `firstActivityId` is in the just-loaded activity set. If not, throws a clear `AdempiereException` keyed on `PPRouting_FirstNodeInvalid`, naming the workflow id + name + orphan node id. Replaces the previous noisy 6 KB save-status that masked the root cause.

2. **`AD_ChangeLog` on the Workflow window (53005)** — `IsChangeLog='Y'` set on the 5 tables behind window 53005 (`AD_Workflow`, `AD_Workflow_Trl`, `AD_WF_Node`, `AD_WF_NodeNext`, `PP_WF_Node_Product`). So next time something gets deactivated, the audit trail is in place.

3. **Model interceptors** — block the bad-data shapes that caused this incident, with user-friendly errors (DE + EN):
   - `AD_WF_Node` BEFORE_CHANGE — cannot deactivate (`IsActive` Y→N) or null `S_Resource_ID` of a workflow's first node.
   - `AD_WF_Node` BEFORE_DELETE — cannot delete a workflow's first node.
   - `AD_Workflow` BEFORE_CHANGE — cannot point `AD_WF_Node_ID` at a node that fails the load filter (must be active, same workflow, have an `S_Resource_ID`).

## "Look left and right" — explicit out-of-scope (so a future reviewer doesn't redo the analysis)

- `AD_WF_NodeNext` edge deactivation/deletion → **NOT blocked**. Not what caused this incident; the customer workflow has no edges at all (node ordering is by `AD_WF_Node.Value`/code).
- `PP_WF_Node_Product` referencing an inactive node → **NOT blocked**. The interceptor on the node itself already prevents the breakage.
- `AD_Workflow` deletion when referenced by `PP_Order.AD_Workflow_ID` → **NOT in scope**. Existing PP_Orders snapshot via `PP_Order_Node`, so the template-deletion failure mode is different and warrants its own analysis.

## Migrations

- `5805190_sys_30094_AD_ChangeLog_window_53005.sql` — toggles `AD_Table.IsChangeLog` on the 5 tables (idempotent, only-if-different).
- `5805200_sys_30094_AD_Message_FirstNode_guards.sql` — 4 new `AD_Message` rows for the user-friendly errors (DE + EN).

## Tests

- `PPRoutingRepositoryTest#firstActivityId_orphan_throws_clear_error` — covers the new loader validation.
- `AD_WF_NodeInterceptorTest` — 3 rules × happy + blocked.
- `AD_WorkflowInterceptorTest` — 3 parametrised invocations (inactive / wrong-workflow / null-resource).

## Manual test

In window `Workflow` (53005), pick an existing routing and try to deactivate its first node → expect the new user-friendly error (DE: "Der erste Arbeitsschritt eines Arbeitsablaufs kann nicht deaktiviert werden…"). Screenshots: `ai-work/30094/screenshots/`.
