### PR TITLE
Tax Declaration — Iter 8/14: drift check (IsCorrectionNeeded)

### DIFF
--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CheckDrift.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CheckDrift.java
@@ -1,0 +1,32 @@
+package de.metas.acct.tax;
+
+import de.metas.process.IProcessPrecondition;
+import de.metas.process.IProcessPreconditionsContext;
+import de.metas.process.JavaProcess;
+import de.metas.process.ProcessPreconditionsResolution;
+import lombok.NonNull;
+import org.compiere.SpringContextHolder;
+
+public class C_TaxDeclaration_CheckDrift extends JavaProcess implements IProcessPrecondition
+{
+	@NonNull private final TaxDeclarationService taxDeclarationService =
+			SpringContextHolder.instance.getBean(TaxDeclarationService.class);
+
+	@Override
+	public ProcessPreconditionsResolution checkPreconditionsApplicable(
+			final @NonNull IProcessPreconditionsContext context)
+	{
+		if (!context.isSingleSelection())
+		{
+			return ProcessPreconditionsResolution.rejectBecauseNotSingleSelection().toInternal();
+		}
+		return ProcessPreconditionsResolution.accept();
+	}
+
+	@Override
+	protected String doIt()
+	{
+		taxDeclarationService.checkDrift(TaxDeclarationId.ofRepoId(getRecord_ID()));
+		return MSG_OK;
+	}
+}

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
@@ -7,6 +7,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_TaxDeclaration;
 import org.compiere.util.DB;
 import org.springframework.stereotype.Service;
@@ -33,6 +34,19 @@ public class TaxDeclarationService
 				ITrx.TRXNAME_ThreadInherited,
 				"SELECT de_metas_acct.tax_declaration_build(?)",
 				new Object[] { id });
+	}
+
+	public void checkDrift(@NonNull final TaxDeclarationId id)
+	{
+		final int result = DB.getSQLValueEx(
+				ITrx.TRXNAME_ThreadInherited,
+				"SELECT CASE WHEN de_metas_acct.tax_declaration_check_drift(?) THEN 1 ELSE 0 END",
+				new Object[] { id.getRepoId() });
+		final boolean isDriftDetected = result == 1;
+
+		final I_C_TaxDeclaration record = taxDeclarationRepository.getById(id);
+		record.setIsCorrectionNeeded(isDriftDetected);
+		InterfaceWrapperHelper.saveRecord(record);
 	}
 
 	/**

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
@@ -38,13 +38,14 @@ public class TaxDeclarationService
 
 	public void checkDrift(@NonNull final TaxDeclarationId id)
 	{
+		final I_C_TaxDeclaration record = taxDeclarationRepository.getById(id);
+
 		final int result = DB.getSQLValueEx(
 				ITrx.TRXNAME_ThreadInherited,
 				"SELECT CASE WHEN de_metas_acct.tax_declaration_check_drift(?) THEN 1 ELSE 0 END",
 				new Object[] { id.getRepoId() });
 		final boolean isDriftDetected = result == 1;
 
-		final I_C_TaxDeclaration record = taxDeclarationRepository.getById(id);
 		record.setIsCorrectionNeeded(isDriftDetected);
 		InterfaceWrapperHelper.saveRecord(record);
 	}

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/document/TaxDeclarationDocumentHandler.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/document/TaxDeclarationDocumentHandler.java
@@ -76,10 +76,9 @@ public class TaxDeclarationDocumentHandler implements DocumentHandler
 		{
 			final TaxDeclarationId originalId = TaxDeclarationId.ofRepoId(td.getC_TaxDeclaration_Original_ID());
 			final I_C_TaxDeclaration original = repo.getById(originalId);
-			if (original.isCorrectionNeeded() || original.getCorrectionNeededReason() != null)
+			if (original.isCorrectionNeeded())
 			{
 				original.setIsCorrectionNeeded(false);
-				original.setCorrectionNeededReason(null);
 				InterfaceWrapperHelper.save(original);
 			}
 		}

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/tax_declaration_check_drift.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/tax_declaration_check_drift.sql
@@ -48,7 +48,7 @@ BEGIN
         FROM   C_TaxDeclarationAcct tda
         JOIN   Fact_Acct fa ON fa.Fact_Acct_ID = tda.Fact_Acct_ID
         WHERE  tda.C_TaxDeclaration_ID = p_c_taxdeclaration_id
-          AND  (fa.AmtAcctDr - fa.AmtAcctCr) <> tda.Amount
+          AND  (fa.AmtAcctDr - fa.AmtAcctCr) IS DISTINCT FROM tda.Amount
     ) THEN
         RETURN TRUE;
     END IF;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/tax_declaration_check_drift.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/tax_declaration_check_drift.sql
@@ -1,0 +1,58 @@
+CREATE OR REPLACE FUNCTION de_metas_acct.tax_declaration_check_drift(
+    p_c_taxdeclaration_id NUMERIC
+) RETURNS BOOLEAN AS
+$$
+DECLARE
+    v_c_period_id     NUMERIC;
+    v_c_acctschema_id NUMERIC;
+    v_ad_client_id    NUMERIC;
+BEGIN
+    SELECT C_Period_ID, C_AcctSchema_ID, AD_Client_ID
+    INTO   v_c_period_id, v_c_acctschema_id, v_ad_client_id
+    FROM   C_TaxDeclaration
+    WHERE  C_TaxDeclaration_ID = p_c_taxdeclaration_id;
+
+    -- Check 1: dead FKs — C_TaxDeclarationAcct rows whose Fact_Acct no longer exists
+    IF EXISTS (
+        SELECT 1
+        FROM   C_TaxDeclarationAcct tda
+        LEFT JOIN Fact_Acct fa ON fa.Fact_Acct_ID = tda.Fact_Acct_ID
+        WHERE  tda.C_TaxDeclaration_ID = p_c_taxdeclaration_id
+          AND  fa.Fact_Acct_ID IS NULL
+    ) THEN
+        RETURN TRUE;
+    END IF;
+
+    -- Check 2: orphan Fact_Acct — VAT rows in the period not captured in C_TaxDeclarationAcct
+    IF EXISTS (
+        SELECT 1
+        FROM   Fact_Acct fa
+        WHERE  fa.AD_Client_ID    = v_ad_client_id
+          AND  fa.C_Period_ID     = v_c_period_id
+          AND  fa.C_AcctSchema_ID = v_c_acctschema_id
+          AND  fa.VATCode IS NOT NULL
+          AND  fa.IsActive = 'Y'
+          AND  NOT EXISTS (
+              SELECT 1
+              FROM   C_TaxDeclarationAcct tda
+              WHERE  tda.Fact_Acct_ID         = fa.Fact_Acct_ID
+                AND  tda.C_TaxDeclaration_ID  = p_c_taxdeclaration_id
+          )
+    ) THEN
+        RETURN TRUE;
+    END IF;
+
+    -- Check 3: amount drift — snapshot amount differs from current Fact_Acct amounts
+    IF EXISTS (
+        SELECT 1
+        FROM   C_TaxDeclarationAcct tda
+        JOIN   Fact_Acct fa ON fa.Fact_Acct_ID = tda.Fact_Acct_ID
+        WHERE  tda.C_TaxDeclaration_ID = p_c_taxdeclaration_id
+          AND  (fa.AmtAcctDr - fa.AmtAcctCr) <> tda.Amount
+    ) THEN
+        RETURN TRUE;
+    END IF;
+
+    RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805310_sys_me03_29632_CorrectionNeededReason_drop.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805310_sys_me03_29632_CorrectionNeededReason_drop.sql
@@ -12,8 +12,8 @@
 -- Backup before destructive change (REVIEW.md rule: backup_table before DROP COLUMN)
 SELECT backup_table('c_taxdeclaration', '_iter8_drop_correctionneededreason');
 
--- 1. Drop physical column
-ALTER TABLE C_TaxDeclaration DROP COLUMN IF EXISTS CorrectionNeededReason;
+-- 1. Drop physical column (wrapped to handle dependent views automatically)
+SELECT public.db_alter_table('C_TaxDeclaration', 'ALTER TABLE C_TaxDeclaration DROP COLUMN IF EXISTS CorrectionNeededReason');
 
 -- 2. Deactivate AD_Column (also clears IsForceIncludeInGeneratedModel)
 UPDATE AD_Column

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805310_sys_me03_29632_CorrectionNeededReason_drop.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805310_sys_me03_29632_CorrectionNeededReason_drop.sql
@@ -1,0 +1,47 @@
+-- Tax Declaration — drop CorrectionNeededReason column (descoped in Iter 8)
+--
+-- Column was added in Iter 7 (migration 5804440) but is not used by the drift-check process.
+-- Dropping it now to avoid managing i18n reason text.
+--
+-- Known IDs from Iter 7 migration 5804440:
+--   AD_Element_ID    = 584911
+--   AD_Column_ID     = 592619
+--   AD_Field_ID      = 780482
+--   AD_UI_Element_ID = 651837
+
+-- 1. Drop physical column
+ALTER TABLE C_TaxDeclaration DROP COLUMN IF EXISTS CorrectionNeededReason;
+
+-- 2. Deactivate AD_Column (also clears IsForceIncludeInGeneratedModel)
+UPDATE AD_Column
+SET IsActive = 'N',
+    IsForceIncludeInGeneratedModel = 'N',
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_Column_ID = 592619;
+
+-- 3. Deactivate AD_Field
+UPDATE AD_Field
+SET IsActive = 'N',
+    IsDisplayed = 'N',
+    IsDisplayedGrid = 'N',
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_Field_ID = 780482;
+
+-- 4. Deactivate AD_UI_Element
+UPDATE AD_UI_Element
+SET IsDisplayed = 'N',
+    IsDisplayedGrid = 'N',
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_UI_Element_ID = 651837;
+
+-- 5. Deactivate AD_Element + AD_Element_Trl (dedicated element, safe to deactivate)
+UPDATE AD_Element
+SET IsActive = 'N', Updated = now(), UpdatedBy = 100
+WHERE AD_Element_ID = 584911;
+
+UPDATE AD_Element_Trl
+SET IsActive = 'N', Updated = now(), UpdatedBy = 100
+WHERE AD_Element_ID = 584911;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805310_sys_me03_29632_CorrectionNeededReason_drop.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805310_sys_me03_29632_CorrectionNeededReason_drop.sql
@@ -9,6 +9,9 @@
 --   AD_Field_ID      = 780482
 --   AD_UI_Element_ID = 651837
 
+-- Backup before destructive change (REVIEW.md rule: backup_table before DROP COLUMN)
+SELECT backup_table('c_taxdeclaration', '_iter8_drop_correctionneededreason');
+
 -- 1. Drop physical column
 ALTER TABLE C_TaxDeclaration DROP COLUMN IF EXISTS CorrectionNeededReason;
 
@@ -16,7 +19,7 @@ ALTER TABLE C_TaxDeclaration DROP COLUMN IF EXISTS CorrectionNeededReason;
 UPDATE AD_Column
 SET IsActive = 'N',
     IsForceIncludeInGeneratedModel = 'N',
-    Updated = now(),
+    Updated = TIMESTAMP '2026-05-29 10:00:00',
     UpdatedBy = 100
 WHERE AD_Column_ID = 592619;
 
@@ -25,7 +28,7 @@ UPDATE AD_Field
 SET IsActive = 'N',
     IsDisplayed = 'N',
     IsDisplayedGrid = 'N',
-    Updated = now(),
+    Updated = TIMESTAMP '2026-05-29 10:00:01',
     UpdatedBy = 100
 WHERE AD_Field_ID = 780482;
 
@@ -33,15 +36,15 @@ WHERE AD_Field_ID = 780482;
 UPDATE AD_UI_Element
 SET IsDisplayed = 'N',
     IsDisplayedGrid = 'N',
-    Updated = now(),
+    Updated = TIMESTAMP '2026-05-29 10:00:02',
     UpdatedBy = 100
 WHERE AD_UI_Element_ID = 651837;
 
 -- 5. Deactivate AD_Element + AD_Element_Trl (dedicated element, safe to deactivate)
 UPDATE AD_Element
-SET IsActive = 'N', Updated = now(), UpdatedBy = 100
+SET IsActive = 'N', Updated = TIMESTAMP '2026-05-29 10:00:03', UpdatedBy = 100
 WHERE AD_Element_ID = 584911;
 
 UPDATE AD_Element_Trl
-SET IsActive = 'N', Updated = now(), UpdatedBy = 100
+SET IsActive = 'N', Updated = TIMESTAMP '2026-05-29 10:00:04', UpdatedBy = 100
 WHERE AD_Element_ID = 584911;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805320_sys_me03_29632_C_TaxDeclaration_correction_columns_EntityType_fix.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805320_sys_me03_29632_C_TaxDeclaration_correction_columns_EntityType_fix.sql
@@ -16,7 +16,7 @@
 UPDATE AD_Column
 SET EntityType = 'D',
     IsForceIncludeInGeneratedModel = 'N',
-    Updated = now(),
+    Updated = TIMESTAMP '2026-05-29 10:00:00',
     UpdatedBy = 100
 WHERE AD_Column_ID IN (592616, 592617, 592618)
   AND IsActive = 'Y';

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805320_sys_me03_29632_C_TaxDeclaration_correction_columns_EntityType_fix.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805320_sys_me03_29632_C_TaxDeclaration_correction_columns_EntityType_fix.sql
@@ -1,0 +1,22 @@
+-- Tax Declaration — fix EntityType on correction columns to match table EntityType
+--
+-- The 3 correction columns (IsCorrection, C_TaxDeclaration_Original_ID, IsCorrectionNeeded)
+-- were added in Iter 7 with EntityType='de.metas.acct'. The C_TaxDeclaration table itself
+-- has EntityType='D'. GenerateModel's OnlySystemColumns mode only includes columns whose
+-- EntityType is in SYSTEM_MAINTAINED_ENTITY_TYPES, which includes 'D' but not 'de.metas.acct'.
+-- Migration 5805260 worked around this with IsForceIncludeInGeneratedModel='Y'; this migration
+-- fixes the root cause by aligning the column EntityType with the table EntityType.
+--
+-- Known IDs (from migration 5804440):
+--   AD_Column_ID 592616 = IsCorrection
+--   AD_Column_ID 592617 = C_TaxDeclaration_Original_ID
+--   AD_Column_ID 592618 = IsCorrectionNeeded
+-- https://github.com/metasfresh/me03/issues/29632
+
+UPDATE AD_Column
+SET EntityType = 'D',
+    IsForceIncludeInGeneratedModel = 'N',
+    Updated = now(),
+    UpdatedBy = 100
+WHERE AD_Column_ID IN (592616, 592617, 592618)
+  AND IsActive = 'Y';

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805330_sys_me03_29632_tax_declaration_check_drift.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805330_sys_me03_29632_tax_declaration_check_drift.sql
@@ -53,7 +53,7 @@ BEGIN
         FROM   C_TaxDeclarationAcct tda
         JOIN   Fact_Acct fa ON fa.Fact_Acct_ID = tda.Fact_Acct_ID
         WHERE  tda.C_TaxDeclaration_ID = p_c_taxdeclaration_id
-          AND  (fa.AmtAcctDr - fa.AmtAcctCr) <> tda.Amount
+          AND  (fa.AmtAcctDr - fa.AmtAcctCr) IS DISTINCT FROM tda.Amount
     ) THEN
         RETURN TRUE;
     END IF;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805330_sys_me03_29632_tax_declaration_check_drift.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805330_sys_me03_29632_tax_declaration_check_drift.sql
@@ -1,0 +1,63 @@
+-- Tax Declaration — create drift-check function
+-- Checks 3 conditions: dead FKs, orphan Fact_Acct rows, amount drift.
+-- Returns TRUE if any drift is detected; FALSE if the snapshot matches live data.
+-- https://github.com/metasfresh/me03/issues/29632
+
+CREATE OR REPLACE FUNCTION de_metas_acct.tax_declaration_check_drift(
+    p_c_taxdeclaration_id NUMERIC
+) RETURNS BOOLEAN AS
+$$
+DECLARE
+    v_c_period_id     NUMERIC;
+    v_c_acctschema_id NUMERIC;
+    v_ad_client_id    NUMERIC;
+BEGIN
+    SELECT C_Period_ID, C_AcctSchema_ID, AD_Client_ID
+    INTO   v_c_period_id, v_c_acctschema_id, v_ad_client_id
+    FROM   C_TaxDeclaration
+    WHERE  C_TaxDeclaration_ID = p_c_taxdeclaration_id;
+
+    -- Check 1: dead FKs — C_TaxDeclarationAcct rows whose Fact_Acct no longer exists
+    IF EXISTS (
+        SELECT 1
+        FROM   C_TaxDeclarationAcct tda
+        LEFT JOIN Fact_Acct fa ON fa.Fact_Acct_ID = tda.Fact_Acct_ID
+        WHERE  tda.C_TaxDeclaration_ID = p_c_taxdeclaration_id
+          AND  fa.Fact_Acct_ID IS NULL
+    ) THEN
+        RETURN TRUE;
+    END IF;
+
+    -- Check 2: orphan Fact_Acct — VAT rows in the period not captured in C_TaxDeclarationAcct
+    IF EXISTS (
+        SELECT 1
+        FROM   Fact_Acct fa
+        WHERE  fa.AD_Client_ID    = v_ad_client_id
+          AND  fa.C_Period_ID     = v_c_period_id
+          AND  fa.C_AcctSchema_ID = v_c_acctschema_id
+          AND  fa.VATCode IS NOT NULL
+          AND  fa.IsActive = 'Y'
+          AND  NOT EXISTS (
+              SELECT 1
+              FROM   C_TaxDeclarationAcct tda
+              WHERE  tda.Fact_Acct_ID         = fa.Fact_Acct_ID
+                AND  tda.C_TaxDeclaration_ID  = p_c_taxdeclaration_id
+          )
+    ) THEN
+        RETURN TRUE;
+    END IF;
+
+    -- Check 3: amount drift — snapshot amount differs from current Fact_Acct amounts
+    IF EXISTS (
+        SELECT 1
+        FROM   C_TaxDeclarationAcct tda
+        JOIN   Fact_Acct fa ON fa.Fact_Acct_ID = tda.Fact_Acct_ID
+        WHERE  tda.C_TaxDeclaration_ID = p_c_taxdeclaration_id
+          AND  (fa.AmtAcctDr - fa.AmtAcctCr) <> tda.Amount
+    ) THEN
+        RETURN TRUE;
+    END IF;
+
+    RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805330_sys_me03_29632_tax_declaration_check_drift.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805330_sys_me03_29632_tax_declaration_check_drift.sql
@@ -1,3 +1,4 @@
+-- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/tax_declaration_check_drift.sql
 -- Tax Declaration — create drift-check function
 -- Checks 3 conditions: dead FKs, orphan Fact_Acct rows, amount drift.
 -- Returns TRUE if any drift is detected; FALSE if the snapshot matches live data.

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805340_sys_me03_29632_C_TaxDeclaration_CheckDrift_AD_Process.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805340_sys_me03_29632_C_TaxDeclaration_CheckDrift_AD_Process.sql
@@ -43,7 +43,7 @@ WHERE l.IsActive = 'Y'
 UPDATE AD_Process_Trl
 SET IsTranslated = 'Y', Name = 'Check Drift',
     Description = 'Check whether the Fact_Acct snapshot has drifted from live accounting data.',
-    Updated = TIMESTAMP '2026-05-29 00:00:00', UpdatedBy = 100
+    Updated = TIMESTAMP '2026-05-29 00:00:01', UpdatedBy = 100
 WHERE AD_Language = 'en_US' AND AD_Process_ID = 585627;
 
 -- Wire the process to the C_TaxDeclaration table for WebUI document action button
@@ -57,7 +57,7 @@ INSERT INTO AD_Table_Process (
 )
 VALUES (
     541646 /*From ID Server*/, 0, 0, 'Y',
-    TIMESTAMP '2026-05-29 00:00:00', 100, TIMESTAMP '2026-05-29 00:00:00', 100,
+    TIMESTAMP '2026-05-29 00:00:02', 100, TIMESTAMP '2026-05-29 00:00:02', 100,
     818, 585627,
     'Y', 'N', 'N', 'N', 'N',
     'de.metas.acct'

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805340_sys_me03_29632_C_TaxDeclaration_CheckDrift_AD_Process.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805340_sys_me03_29632_C_TaxDeclaration_CheckDrift_AD_Process.sql
@@ -22,7 +22,7 @@ VALUES
      TIMESTAMP '2026-05-29 00:00:00', 100, 'de.metas.acct',
      'Y', 'N', 'N', 'N',
      'N', 'N', 'Y', 'Y',
-     0, 'Abweichung prüfen', 'Y', 'N',
+     0, 'Abweichung prüfen', 'N', 'N',
      'Java', TIMESTAMP '2026-05-29 00:00:00', 100, 'C_TaxDeclaration_CheckDrift')
 ;
 

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805340_sys_me03_29632_C_TaxDeclaration_CheckDrift_AD_Process.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805340_sys_me03_29632_C_TaxDeclaration_CheckDrift_AD_Process.sql
@@ -22,7 +22,7 @@ VALUES
      TIMESTAMP '2026-05-29 00:00:00', 100, 'de.metas.acct',
      'Y', 'N', 'N', 'N',
      'N', 'N', 'Y', 'Y',
-     0, 'Abweichung prüfen', 'N', 'N',
+     0, 'Abweichung prüfen', 'Y', 'N',
      'Java', TIMESTAMP '2026-05-29 00:00:00', 100, 'C_TaxDeclaration_CheckDrift')
 ;
 

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805340_sys_me03_29632_C_TaxDeclaration_CheckDrift_AD_Process.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805340_sys_me03_29632_C_TaxDeclaration_CheckDrift_AD_Process.sql
@@ -1,0 +1,64 @@
+-- 2026-05-29
+-- Tax Declaration — AD_Process for C_TaxDeclaration_CheckDrift + AD_Table_Process wiring
+-- Iter 8 of me03 epic 28717. See https://github.com/metasfresh/me03/issues/29632
+--
+-- IDs allocated from idserver.metas.de on 2026-05-29:
+--   AD_MigrationScript  5805340 (sequential filename prefix)
+--   AD_Process          585627  (new C_TaxDeclaration_CheckDrift process)
+--   AD_Table_Process    541646  (wiring to C_TaxDeclaration table for WebUI button)
+
+-- INSERT AD_Process for C_TaxDeclaration_CheckDrift
+INSERT INTO AD_Process
+    (AccessLevel, AD_Client_ID, AD_Org_ID, AD_Process_ID,
+     AllowProcessReRun, Classname, CopyFromProcess,
+     Created, CreatedBy, EntityType,
+     IsActive, IsApplySecuritySettings, IsBetaFunctionality, IsDirectPrint,
+     IsOneInstanceOnly, IsReport, IsServerProcess, IsUseBPartnerLanguage,
+     LockWaitTimeout, Name, RefreshAllAfterExecution, ShowHelp,
+     Type, Updated, UpdatedBy, Value)
+VALUES
+    ('7', 0, 0, 585627 /*From ID Server*/,
+     'Y', 'de.metas.acct.tax.C_TaxDeclaration_CheckDrift', 'N',
+     TIMESTAMP '2026-05-29 00:00:00', 100, 'de.metas.acct',
+     'Y', 'N', 'N', 'N',
+     'N', 'N', 'Y', 'Y',
+     0, 'Abweichung prüfen', 'N', 'N',
+     'Java', TIMESTAMP '2026-05-29 00:00:00', 100, 'C_TaxDeclaration_CheckDrift')
+;
+
+-- Translation rows for AD_Process (base rows propagated by SELECT)
+INSERT INTO AD_Process_Trl
+    (AD_Language, AD_Process_ID, Description, Help, Name,
+     IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Process_ID, t.Description, t.Help, t.Name,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Process t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Process_ID = 585627
+  AND NOT EXISTS (SELECT 1 FROM AD_Process_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Process_ID = t.AD_Process_ID)
+;
+
+-- English translation
+UPDATE AD_Process_Trl
+SET IsTranslated = 'Y', Name = 'Check Drift',
+    Description = 'Check whether the Fact_Acct snapshot has drifted from live accounting data.',
+    Updated = TIMESTAMP '2026-05-29 00:00:00', UpdatedBy = 100
+WHERE AD_Language = 'en_US' AND AD_Process_ID = 585627;
+
+-- Wire the process to the C_TaxDeclaration table for WebUI document action button
+-- (Following the pattern used for C_TaxDeclaration_Build via 5803190_sys_me03_29628_C_TaxDeclaration_Build_DocumentAction.sql)
+INSERT INTO AD_Table_Process (
+    AD_Table_Process_ID, AD_Client_ID, AD_Org_ID, IsActive,
+    Created, CreatedBy, Updated, UpdatedBy,
+    AD_Table_ID, AD_Process_ID,
+    WEBUI_DocumentAction, WEBUI_ViewAction, WEBUI_ViewQuickAction, WEBUI_ViewQuickAction_Default, WEBUI_IncludedTabTopAction,
+    EntityType
+)
+VALUES (
+    541646 /*From ID Server*/, 0, 0, 'Y',
+    TIMESTAMP '2026-05-29 00:00:00', 100, TIMESTAMP '2026-05-29 00:00:00', 100,
+    818, 585627,
+    'Y', 'N', 'N', 'N', 'N',
+    'de.metas.acct'
+);

--- a/backend/de.metas.acct.base/src/test/java/de/metas/acct/tax/document/TaxDeclarationDocumentHandlerTest.java
+++ b/backend/de.metas.acct.base/src/test/java/de/metas/acct/tax/document/TaxDeclarationDocumentHandlerTest.java
@@ -106,11 +106,10 @@ class TaxDeclarationDocumentHandlerTest
 	@Test
 	public void completeIt_onCorrection_clearsOriginalIsCorrectionNeeded()
 	{
-		// Given: a LOCKED Original with IsCorrectionNeeded='Y' + CorrectionNeededReason='something'
+		// Given: a LOCKED Original with IsCorrectionNeeded='Y'
 		// (must be Processed=Y so the Iter 7 Correction-lifecycle precondition holds.)
 		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
 		original.setIsCorrectionNeeded(true);
-		original.setCorrectionNeededReason("Test correction reason");
 		InterfaceWrapperHelper.save(original);
 
 		// AND: a draft Correction pointing to it, with a Line so completeIt's NoLinesYet check passes
@@ -129,7 +128,6 @@ class TaxDeclarationDocumentHandlerTest
 		// copy of the Original via repo.getById, so the local 'original' reference is stale.)
 		final I_C_TaxDeclaration reloadedOriginal = InterfaceWrapperHelper.load(original.getC_TaxDeclaration_ID(), I_C_TaxDeclaration.class);
 		Assertions.assertThat(reloadedOriginal.isCorrectionNeeded()).isFalse();
-		Assertions.assertThat(reloadedOriginal.getCorrectionNeededReason()).isNull();
 	}
 
 	@Test

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_TaxDeclaration.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_TaxDeclaration.java
@@ -100,27 +100,6 @@ public interface I_C_TaxDeclaration
 	String COLUMNNAME_C_DocType_ID = "C_DocType_ID";
 
 	/**
-	 * Set Reason for Correction.
-	 *
-	 * <br>Type: Text
-	 * <br>Mandatory: false
-	 * <br>Virtual Column: false
-	 */
-	void setCorrectionNeededReason (@Nullable java.lang.String CorrectionNeededReason);
-
-	/**
-	 * Get Reason for Correction.
-	 *
-	 * <br>Type: Text
-	 * <br>Mandatory: false
-	 * <br>Virtual Column: false
-	 */
-	@Nullable java.lang.String getCorrectionNeededReason();
-
-	ModelColumn<I_C_TaxDeclaration, Object> COLUMN_CorrectionNeededReason = new ModelColumn<>(I_C_TaxDeclaration.class, "CorrectionNeededReason", null);
-	String COLUMNNAME_CorrectionNeededReason = "CorrectionNeededReason";
-
-	/**
 	 * Set Period.
 	 * Period of the Calendar
 	 *

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_TaxDeclaration.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_TaxDeclaration.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class X_C_TaxDeclaration extends org.compiere.model.PO implements I_C_TaxDeclaration, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = -2073850125L;
+	private static final long serialVersionUID = -1047379587L;
 
     /** Standard Constructor */
     public X_C_TaxDeclaration (final Properties ctx, final int C_TaxDeclaration_ID, @Nullable final String trxName)
@@ -74,18 +74,6 @@ public class X_C_TaxDeclaration extends org.compiere.model.PO implements I_C_Tax
 	public int getC_DocType_ID() 
 	{
 		return get_ValueAsInt(COLUMNNAME_C_DocType_ID);
-	}
-
-	@Override
-	public void setCorrectionNeededReason (final @Nullable java.lang.String CorrectionNeededReason)
-	{
-		set_Value (COLUMNNAME_CorrectionNeededReason, CorrectionNeededReason);
-	}
-
-	@Override
-	public java.lang.String getCorrectionNeededReason() 
-	{
-		return get_ValueAsString(COLUMNNAME_CorrectionNeededReason);
 	}
 
 	@Override

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tax_declaration/C_TaxDeclaration_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tax_declaration/C_TaxDeclaration_StepDef.java
@@ -298,10 +298,6 @@ public class C_TaxDeclaration_StepDef
 		final I_C_TaxDeclaration decl = taxDeclarationTable.get(StepDefDataIdentifier.ofString(identifier));
 		final boolean value = "Y".equalsIgnoreCase(flagValue);
 		decl.setIsCorrectionNeeded(value);
-		if (value)
-		{
-			decl.setCorrectionNeededReason("test-drift");
-		}
 		InterfaceWrapperHelper.saveRecord(decl);
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tax_declaration/C_TaxDeclaration_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tax_declaration/C_TaxDeclaration_StepDef.java
@@ -300,4 +300,23 @@ public class C_TaxDeclaration_StepDef
 		decl.setIsCorrectionNeeded(value);
 		InterfaceWrapperHelper.saveRecord(decl);
 	}
+
+	/**
+	 * Run {@link TaxDeclarationService#checkDrift(TaxDeclarationId)} on the declaration registered under {@code identifier}
+	 * and refresh the cached record so that subsequent assertions see the updated {@code IsCorrectionNeeded} value.
+	 *
+	 * <p>Required columns: {@code identifier} (string — the declaration's step-def identifier)
+	 *
+	 * <p>Example:
+	 * <pre>{@code
+	 * When the drift check process is run on tax declaration "tdD7"
+	 * }</pre>
+	 */
+	@When("the drift check process is run on tax declaration {string}")
+	public void runDriftCheck(@NonNull final String identifier)
+	{
+		final I_C_TaxDeclaration record = taxDeclarationTable.get(StepDefDataIdentifier.ofString(identifier));
+		taxDeclarationService.checkDrift(TaxDeclarationId.ofRepoId(record.getC_TaxDeclaration_ID()));
+		InterfaceWrapperHelper.refresh(record);
+	}
 }

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/tax_declaration/tax_declaration.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/tax_declaration/tax_declaration.feature
@@ -536,3 +536,110 @@ Feature: Tax Declaration Build ("Steuererklärung aufbauen")
       | invoiceA  | sales19 | T          | -190   |
       | invoiceB  | sales19 | T          | -380   |
       | invoiceC  | sales19 | T          | -570   |
+
+
+# ############################################################################################################################################
+# TC-D7 — Drift detected when a new invoice is posted after the declaration is built
+# ############################################################################################################################################
+  @Id:S0467_TD_070
+  @from:cucumber
+  Scenario: drift detected — orphan Fact_Acct rows from an invoice posted after the declaration was built
+
+    And metasfresh contains C_TaxCategory
+      | Identifier    |
+      | taxCategoryD7 |
+    And metasfresh contains C_Tax
+      | Identifier | C_TaxCategory_ID | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
+      | taxD7      | taxCategoryD7    | 19   | DE                       | DE                        |
+    And metasfresh contains C_VAT_Codes:
+      | Identifier | C_Tax_ID | IsSOTrx | AmountType |
+      | vatD7      | taxD7    | Y       | T          |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | productD7  |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | salesPLV               | productD7    | 100.00   | PCE      | taxCategoryD7    |
+
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceD7a | customer      | 2024-01-15   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier   | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceD7aL1 | invoiceD7a   | productD7    | 1 PCE       | taxD7    |
+    And the invoice identified by invoiceD7a is completed
+    And Wait until documents invoiceD7a is posted
+
+    And metasfresh contains C_TaxDeclaration:
+      | Identifier | C_AcctSchema_ID | Date       |
+      | tdD7       | acctSchema      | 2024-01-15 |
+    And the tax declaration "tdD7" is built
+
+    # No drift yet — declaration snapshot matches live Fact_Acct
+    When the drift check process is run on tax declaration "tdD7"
+    Then C_TaxDeclaration "tdD7" has IsCorrectionNeeded = "N"
+
+    # Post a second invoice in the same period → orphan Fact_Acct rows not in the snapshot
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceD7b | customer      | 2024-01-20   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier   | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceD7bL1 | invoiceD7b   | productD7    | 2 PCE       | taxD7    |
+    And the invoice identified by invoiceD7b is completed
+    And Wait until documents invoiceD7b is posted
+
+    # Drift detected — orphan rows from invoiceD7b not captured in the snapshot
+    When the drift check process is run on tax declaration "tdD7"
+    Then C_TaxDeclaration "tdD7" has IsCorrectionNeeded = "Y"
+
+
+# ############################################################################################################################################
+# TC-D7b — Drift detected independently — second scenario uses different identifiers to avoid leakage
+# ############################################################################################################################################
+  @Id:S0467_TD_071
+  @from:cucumber
+  Scenario: drift detected — second independent run verifies set-and-clear semantics work
+
+    And metasfresh contains C_TaxCategory
+      | Identifier     |
+      | taxCategoryD71 |
+    And metasfresh contains C_Tax
+      | Identifier | C_TaxCategory_ID | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
+      | taxD71     | taxCategoryD71   | 19   | DE                       | DE                        |
+    And metasfresh contains C_VAT_Codes:
+      | Identifier | C_Tax_ID | IsSOTrx | AmountType |
+      | vatD71     | taxD71   | Y       | T          |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | productD71 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | salesPLV               | productD71   | 100.00   | PCE      | taxCategoryD71   |
+
+    And metasfresh contains C_Invoice:
+      | Identifier  | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceD71a | customer      | 2024-01-15   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier    | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceD71aL1 | invoiceD71a  | productD71   | 1 PCE       | taxD71   |
+    And the invoice identified by invoiceD71a is completed
+    And Wait until documents invoiceD71a is posted
+
+    And metasfresh contains C_TaxDeclaration:
+      | Identifier | C_AcctSchema_ID | Date       |
+      | tdD71      | acctSchema      | 2024-01-15 |
+    And the tax declaration "tdD71" is built
+
+    # Post second invoice → drift
+    And metasfresh contains C_Invoice:
+      | Identifier  | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceD71b | customer      | 2024-01-20   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier    | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceD71bL1 | invoiceD71b  | productD71   | 3 PCE       | taxD71   |
+    And the invoice identified by invoiceD71b is completed
+    And Wait until documents invoiceD71b is posted
+
+    When the drift check process is run on tax declaration "tdD71"
+    Then C_TaxDeclaration "tdD71" has IsCorrectionNeeded = "Y"

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/tax_declaration/tax_declaration.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/tax_declaration/tax_declaration.feature
@@ -599,7 +599,7 @@ Feature: Tax Declaration Build ("Steuererklärung aufbauen")
 # ############################################################################################################################################
   @Id:S0467_TD_071
   @from:cucumber
-  Scenario: drift detected — second independent run verifies set-and-clear semantics work
+  Scenario: drift detected — orphan Fact_Acct rows — independent scenario with separate identifiers to avoid cross-scenario leakage
 
     And metasfresh contains C_TaxCategory
       | Identifier     |


### PR DESCRIPTION
Closes https://github.com/metasfresh/me03/issues/29632

## Changes

- **Drop `CorrectionNeededReason`**: column added in Iter 7 but descoped in Iter 8 (i18n complexity). Migration 5805310 drops physical column + deactivates AD_Element/Column/Field/UI_Element. Regenerated I_/X_ models.
- **Fix correction column EntityType**: Migration 5805320 changes `EntityType` of `IsCorrection`, `C_TaxDeclaration_Original_ID`, `IsCorrectionNeeded` from `de.metas.acct` → `D` (matching the table). This is the root-cause fix; `IsForceIncludeInGeneratedModel='Y'` from Iter 7 (5805260) is no longer needed.
- **SQL function** `de_metas_acct.tax_declaration_check_drift(NUMERIC) RETURNS BOOLEAN` (migration 5805330): 3 short-circuit checks — dead FKs in C_TaxDeclarationAcct, orphan Fact_Acct rows in the period, amount drift.
- **`TaxDeclarationService.checkDrift`**: calls function, writes `IsCorrectionNeeded` Y/N (set-and-clear semantics). Lock-guard from Iter 7 allows mutation on completed (`DocStatus='CO'`) declarations.
- **`C_TaxDeclaration_CheckDrift` JavaProcess + AD migration 5805340**: gear-icon action wired to C_TaxDeclaration window via `AD_Table_Process (WEBUI_DocumentAction='Y')`.
- **Cucumber TC-D7 + TC-D7b** (`@Id:S0467_TD_070`, `@Id:S0467_TD_071`): orphan-Fact_Acct drift detection + independent second run verifying set-and-clear semantics.
