### PR TITLE
Add Goods Purchased report (Jasper + SQL)

### DIFF
--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report.jrxml
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report.jrxml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.0.final using JasperReports Library version 6.5.1  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="report" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" resourceBundle="de/metas/reports/goodspurchased/report" uuid="a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d">
+	<property name="ireport.scriptlethandling" value="0"/>
+	<property name="ireport.encoding" value="UTF-8"/>
+	<property name="ireport.zoom" value="0.9090909090909095"/>
+	<property name="ireport.x" value="0"/>
+	<property name="ireport.y" value="0"/>
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="jasperreports\dev.xml"/>
+	<import value="net.sf.jasperreports.engine.*"/>
+	<import value="java.util.*"/>
+	<import value="net.sf.jasperreports.engine.data.*"/>
+	<parameter name="C_BPartner_ID" class="java.math.BigDecimal"/>
+	<parameter name="DateFrom" class="java.util.Date"/>
+	<parameter name="DateTo" class="java.util.Date"/>
+	<parameter name="M_Product_ID" class="java.math.BigDecimal"/>
+	<queryString>
+		<![CDATA[SELECT '';]]>
+	</queryString>
+	<field name="?column?" class="java.lang.String"/>
+	<background>
+		<band splitType="Stretch"/>
+	</background>
+	<title>
+		<band splitType="Stretch"/>
+	</title>
+	<pageHeader>
+		<band height="65" splitType="Stretch">
+			<line>
+				<reportElement key="line" positionType="FixRelativeToBottom" x="0" y="62" width="782" height="1" forecolor="#000000" uuid="b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e"/>
+				<graphicElement>
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</graphicElement>
+			</line>
+			<subreport isUsingCache="true">
+				<reportElement key="subreport-2" x="0" y="0" width="770" height="60" uuid="c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f"/>
+				<subreportParameter name="DateFrom">
+					<subreportParameterExpression><![CDATA[$P{DateFrom}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="DateTo">
+					<subreportParameterExpression><![CDATA[$P{DateTo}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="C_BPartner_ID">
+					<subreportParameterExpression><![CDATA[$P{C_BPartner_ID}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="M_Product_ID">
+					<subreportParameterExpression><![CDATA[$P{M_Product_ID}]]></subreportParameterExpression>
+				</subreportParameter>
+				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
+				<subreportExpression><![CDATA["de/metas/reports/goodspurchased/report_title.jasper"]]></subreportExpression>
+			</subreport>
+		</band>
+	</pageHeader>
+	<columnHeader>
+		<band splitType="Stretch"/>
+	</columnHeader>
+	<detail>
+		<band height="41" splitType="Stretch">
+			<subreport isUsingCache="true">
+				<reportElement key="subreport-4" x="0" y="0" width="782" height="40" uuid="d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a"/>
+				<subreportParameter name="DateFrom">
+					<subreportParameterExpression><![CDATA[$P{DateFrom}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="DateTo">
+					<subreportParameterExpression><![CDATA[$P{DateTo}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="C_BPartner_ID">
+					<subreportParameterExpression><![CDATA[$P{C_BPartner_ID}]]></subreportParameterExpression>
+				</subreportParameter>
+				<subreportParameter name="M_Product_ID">
+					<subreportParameterExpression><![CDATA[$P{M_Product_ID}]]></subreportParameterExpression>
+				</subreportParameter>
+				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
+				<subreportExpression><![CDATA["de/metas/reports/goodspurchased/report_details.jasper"]]></subreportExpression>
+			</subreport>
+		</band>
+	</detail>
+	<columnFooter>
+		<band splitType="Stretch"/>
+	</columnFooter>
+	<pageFooter>
+		<band height="21" splitType="Stretch">
+			<textField pattern="" isBlankWhenNull="false">
+				<reportElement key="textField" x="590" y="8" width="170" height="13" uuid="e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b"/>
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Right">
+					<font fontName="Arial" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{page} + "  " + $V{PAGE_NUMBER} + "  " + $R{of}]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
+				<reportElement key="textField" x="746" y="8" width="36" height="13" forecolor="#000000" backcolor="#FFFFFF" uuid="f6a7b8c9-d0e1-4f2a-3b4c-5d6e7f8a9b0c"/>
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Right" verticalAlignment="Top" rotation="None">
+					<font fontName="Arial" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfEncoding="CP1252" isPdfEmbedded="false"/>
+					<paragraph lineSpacing="Single"/>
+				</textElement>
+				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+			<line>
+				<reportElement key="line" x="0" y="1" width="782" height="1" forecolor="#000000" uuid="a7b8c9d0-e1f2-4a3b-4c5d-6e7f8a9b0c1d"/>
+				<graphicElement>
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</graphicElement>
+			</line>
+			<textField pattern="" isBlankWhenNull="false">
+				<reportElement key="textField" x="0" y="8" width="81" height="13" uuid="b8c9d0e1-f2a3-4b4c-5d6e-7f8a9b0c1d2e"/>
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement>
+					<font fontName="Arial" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
+			</textField>
+		</band>
+	</pageFooter>
+	<summary>
+		<band splitType="Stretch"/>
+	</summary>
+</jasperReport>

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report.properties
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report.properties
@@ -1,0 +1,19 @@
+page=Seite
+of=von
+all=Alle
+
+parm1=Geschäftspartner:
+parm2=Artikel:
+timeframe=Zeitraum:
+headline=Einkauf nach Produkt und Lieferant
+
+sum=Summe
+totalsum=Gesamtsumme:
+subtotal=Zwischensumme:
+product=ArtNr
+ProductName=Bezeichnung
+PackingInstruction=Packvorschrift
+Vendor=Lieferant
+QtyTU=Menge
+Weight=Gewicht
+PurchaseValue=Einkaufswert

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report_de_CH.properties
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report_de_CH.properties
@@ -1,0 +1,19 @@
+page=Seite
+of=von
+all=Alle
+
+parm1=Geschäftspartner:
+parm2=Artikel:
+timeframe=Zeitraum:
+headline=Einkauf nach Produkt und Lieferant
+
+sum=Summe
+totalsum=Gesamtsumme:
+subtotal=Zwischensumme:
+product=ArtNr
+ProductName=Bezeichnung
+PackingInstruction=Packvorschrift
+Vendor=Lieferant
+QtyTU=Menge
+Weight=Gewicht
+PurchaseValue=Einkaufswert

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report_de_DE.properties
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report_de_DE.properties
@@ -1,0 +1,19 @@
+page=Seite
+of=von
+all=Alle
+
+parm1=Geschäftspartner:
+parm2=Artikel:
+timeframe=Zeitraum:
+headline=Einkauf nach Produkt und Lieferant
+
+sum=Summe
+totalsum=Gesamtsumme:
+subtotal=Zwischensumme:
+product=ArtNr
+ProductName=Bezeichnung
+PackingInstruction=Packvorschrift
+Vendor=Lieferant
+QtyTU=Menge
+Weight=Gewicht
+PurchaseValue=Einkaufswert

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report_details.jrxml
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report_details.jrxml
@@ -1,0 +1,459 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.0.final using JasperReports Library version 6.5.1  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="report_details" pageWidth="782" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" resourceBundle="de/metas/reports/goodspurchased/report" uuid="09a0b1c2-d3e4-4f5a-6b7c-8d9e0f1a2b3c">
+	<property name="ireport.scriptlethandling" value="0"/>
+	<property name="ireport.encoding" value="UTF-8"/>
+	<property name="ireport.zoom" value="2.0"/>
+	<property name="ireport.x" value="0"/>
+	<property name="ireport.y" value="0"/>
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="jasperreports\dev.xml"/>
+	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
+	<import value="net.sf.jasperreports.engine.*"/>
+	<import value="java.util.*"/>
+	<import value="net.sf.jasperreports.engine.data.*"/>
+	<parameter name="C_BPartner_ID" class="java.math.BigDecimal" isForPrompting="false"/>
+	<parameter name="DateFrom" class="java.util.Date" isForPrompting="false"/>
+	<parameter name="DateTo" class="java.util.Date" isForPrompting="false"/>
+	<parameter name="M_Product_ID" class="java.math.BigDecimal" isForPrompting="false"/>
+	<queryString>
+		<![CDATA[SELECT *
+FROM report.goods_purchase_report(
+        p_date_from =>  $P{DateFrom}::date,
+        p_date_to =>  $P{DateTo}::date,
+        p_bpartner_id => $P{C_BPartner_ID},
+        p_product_id =>  $P{M_Product_ID}
+     );
+;]]>
+	</queryString>
+	<field name="partner_param" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="partner_param"/>
+		<property name="com.jaspersoft.studio.field.label" value="partner_param"/>
+	</field>
+	<field name="product_param" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="product_param"/>
+		<property name="com.jaspersoft.studio.field.label" value="product_param"/>
+	</field>
+	<field name="productno" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="productno"/>
+		<property name="com.jaspersoft.studio.field.label" value="productno"/>
+	</field>
+	<field name="productname" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="productname"/>
+		<property name="com.jaspersoft.studio.field.label" value="productname"/>
+	</field>
+	<field name="packinginstruction" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="packinginstruction"/>
+		<property name="com.jaspersoft.studio.field.label" value="packinginstruction"/>
+	</field>
+	<field name="vendor_value" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="vendor_value"/>
+		<property name="com.jaspersoft.studio.field.label" value="vendor_value"/>
+	</field>
+	<field name="vendor" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="vendor"/>
+		<property name="com.jaspersoft.studio.field.label" value="vendor"/>
+	</field>
+	<field name="qtytu" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="qtytu"/>
+		<property name="com.jaspersoft.studio.field.label" value="qtytu"/>
+	</field>
+	<field name="weight" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="weight"/>
+		<property name="com.jaspersoft.studio.field.label" value="weight"/>
+	</field>
+	<field name="purchasevalue" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="purchasevalue"/>
+		<property name="com.jaspersoft.studio.field.label" value="purchasevalue"/>
+	</field>
+	<field name="producttotal_qtytu" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="producttotal_qtytu"/>
+		<property name="com.jaspersoft.studio.field.label" value="producttotal_qtytu"/>
+	</field>
+	<field name="producttotal_weight" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="producttotal_weight"/>
+		<property name="com.jaspersoft.studio.field.label" value="producttotal_weight"/>
+	</field>
+	<field name="producttotal_purchasevalue" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="producttotal_purchasevalue"/>
+		<property name="com.jaspersoft.studio.field.label" value="producttotal_purchasevalue"/>
+	</field>
+	<field name="grandtotal_qtytu" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="grandtotal_qtytu"/>
+		<property name="com.jaspersoft.studio.field.label" value="grandtotal_qtytu"/>
+	</field>
+	<field name="grandtotal_weight" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="grandtotal_weight"/>
+		<property name="com.jaspersoft.studio.field.label" value="grandtotal_weight"/>
+	</field>
+	<field name="grandtotal_purchasevalue" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="grandtotal_purchasevalue"/>
+		<property name="com.jaspersoft.studio.field.label" value="grandtotal_purchasevalue"/>
+	</field>
+	<field name="currency" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="currency"/>
+		<property name="com.jaspersoft.studio.field.label" value="currency"/>
+	</field>
+	<group name="currency">
+		<groupExpression><![CDATA[$F{currency}]]></groupExpression>
+		<groupFooter>
+			<band height="28">
+				<!-- GrandTotal row -->
+				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+					<reportElement key="textField-gt-label" x="0" y="11" width="267" height="12" forecolor="#000000" uuid="1a2b3c4d-e5f6-4a7b-8c9d-0e1f2a3b4c5d">
+						<property name="com.jaspersoft.studio.unit.leftIndent" value="px"/>
+					</reportElement>
+					<box>
+						<pen lineWidth="0.75" lineColor="#000000"/>
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+					<textElement textAlignment="Left">
+						<font fontName="Arial" size="8" isBold="true"/>
+						<paragraph leftIndent="2"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$R{totalsum}+ "  "+ $F{currency}]]></textFieldExpression>
+				</textField>
+				<textField isStretchWithOverflow="true" pattern="#,##0.00" isBlankWhenNull="true">
+					<reportElement key="textField-gt-qty" x="267" y="11" width="73" height="12" isRemoveLineWhenBlank="true" uuid="2b3c4d5e-f6a7-4b8c-9d0e-1f2a3b4c5d6e">
+						<property name="com.jaspersoft.studio.unit.leftIndent" value="px"/>
+					</reportElement>
+					<box>
+						<pen lineWidth="0.75" lineColor="#000000"/>
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+					<textElement>
+						<font fontName="Arial" size="8" isBold="true"/>
+						<paragraph leftIndent="2"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{grandtotal_qtytu}]]></textFieldExpression>
+				</textField>
+				<textField isStretchWithOverflow="true" pattern="#,##0.00" isBlankWhenNull="true">
+					<reportElement key="textField-gt-weight" x="340" y="11" width="115" height="12" uuid="3c4d5e6f-a7b8-4c9d-0e1f-2a3b4c5d6e7f">
+						<property name="com.jaspersoft.studio.unit.rightIndent" value="px"/>
+					</reportElement>
+					<box>
+						<pen lineWidth="0.75" lineColor="#000000"/>
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+					<textElement textAlignment="Right">
+						<font fontName="Arial" size="8" isBold="true"/>
+						<paragraph rightIndent="2"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{grandtotal_weight}]]></textFieldExpression>
+				</textField>
+				<textField isStretchWithOverflow="true" pattern="#,##0.00" isBlankWhenNull="true">
+					<reportElement key="textField-gt-pvalue" x="455" y="11" width="327" height="12" uuid="4d5e6f7a-b8c9-4d0e-1f2a-3b4c5d6e7f8a">
+						<property name="com.jaspersoft.studio.unit.rightIndent" value="px"/>
+					</reportElement>
+					<box>
+						<pen lineWidth="0.75" lineColor="#000000"/>
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+					<textElement textAlignment="Right">
+						<font fontName="Arial" size="8" isBold="true"/>
+						<paragraph rightIndent="2"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{grandtotal_purchasevalue}]]></textFieldExpression>
+				</textField>
+			</band>
+		</groupFooter>
+	</group>
+	<group name="Product">
+		<groupExpression><![CDATA[$F{productno}]]></groupExpression>
+		<groupHeader>
+			<band height="34">
+				<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				<rectangle>
+					<reportElement key="rectangle-1" x="0" y="21" width="782" height="13" backcolor="#808080" uuid="5e6f7a8b-c9d0-4e1f-2a3b-4c5d6e7f8a9b"/>
+					<graphicElement>
+						<pen lineWidth="0.0" lineStyle="Solid"/>
+					</graphicElement>
+				</rectangle>
+				<!-- column header: Lieferant (vendor_value placeholder, left-aligned) -->
+				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+					<reportElement key="textField-hdr-vendor-val" x="0" y="21" width="80" height="12" forecolor="#FFFFFF" uuid="6f7a8b9c-d0e1-4f2a-3b4c-5d6e7f8a9b0c">
+						<property name="com.jaspersoft.studio.unit.leftIndent" value="px"/>
+					</reportElement>
+					<box>
+						<pen lineWidth="0.75" lineColor="#000000"/>
+						<topPen lineWidth="0.75" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.75" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.75" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+					<textElement textAlignment="Left">
+						<font fontName="Arial" size="8"/>
+						<paragraph leftIndent="2"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$R{Vendor}]]></textFieldExpression>
+				</textField>
+				<!-- vendor name column (empty header, just border) -->
+				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+					<reportElement key="textField-hdr-vendor-name" x="80" y="21" width="187" height="12" forecolor="#FFFFFF" uuid="7a8b9c0d-e1f2-4a3b-4c5d-6e7f8a9b0c1d"/>
+					<box>
+						<pen lineWidth="0.75" lineColor="#000000"/>
+						<topPen lineWidth="0.75" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.75" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.75" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+					<textElement textAlignment="Left">
+						<font fontName="Arial" size="8"/>
+					</textElement>
+				</textField>
+				<!-- QtyTU column header -->
+				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+					<reportElement key="textField-hdr-qty" x="267" y="21" width="73" height="12" forecolor="#FFFFFF" uuid="8b9c0d1e-f2a3-4b4c-5d6e-7f8a9b0c1d2e">
+						<property name="com.jaspersoft.studio.unit.leftIndent" value="px"/>
+					</reportElement>
+					<box>
+						<pen lineWidth="0.75" lineColor="#000000"/>
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+					<textElement textAlignment="Left">
+						<font fontName="Arial" size="8"/>
+						<paragraph leftIndent="2"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$R{QtyTU}]]></textFieldExpression>
+				</textField>
+				<!-- Weight column header -->
+				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+					<reportElement key="textField-hdr-weight" x="340" y="21" width="115" height="12" forecolor="#FFFFFF" uuid="9c0d1e2f-a3b4-4c5d-6e7f-8a9b0c1d2e3f">
+						<property name="com.jaspersoft.studio.unit.rightIndent" value="px"/>
+					</reportElement>
+					<box>
+						<pen lineWidth="0.75" lineColor="#000000"/>
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+					<textElement textAlignment="Right">
+						<font fontName="Arial" size="8"/>
+						<paragraph rightIndent="2"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$R{Weight}]]></textFieldExpression>
+				</textField>
+				<!-- PurchaseValue column header -->
+				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+					<reportElement key="textField-hdr-pvalue" x="455" y="21" width="327" height="12" forecolor="#FFFFFF" uuid="0d1e2f3a-b4c5-4d6e-7f8a-9b0c1d2e3f4a">
+						<property name="com.jaspersoft.studio.unit.rightIndent" value="px"/>
+					</reportElement>
+					<box>
+						<pen lineWidth="0.75" lineColor="#000000"/>
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+					<textElement textAlignment="Right">
+						<font fontName="Arial" size="8"/>
+						<paragraph rightIndent="2"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$R{PurchaseValue}]]></textFieldExpression>
+				</textField>
+				<!-- Product number + name title above the column headers -->
+				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+					<reportElement key="textField-product-title" x="0" y="7" width="426" height="12" forecolor="#000000" uuid="1e2f3a4b-c5d6-4e7f-8a9b-0c1d2e3f4a5b"/>
+					<box>
+						<pen lineColor="#000000"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+					<textElement textAlignment="Left">
+						<font fontName="Arial" size="8" isBold="true"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{productno}+ "  " + $F{productname}]]></textFieldExpression>
+				</textField>
+			</band>
+		</groupHeader>
+		<groupFooter>
+			<band height="12">
+				<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				<!-- ProductTotal row -->
+				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+					<reportElement key="textField-pt-label" x="0" y="0" width="267" height="12" forecolor="#000000" uuid="2f3a4b5c-d6e7-4f8a-9b0c-1d2e3f4a5b6c">
+						<property name="com.jaspersoft.studio.unit.leftIndent" value="px"/>
+					</reportElement>
+					<box>
+						<pen lineWidth="0.75" lineColor="#000000"/>
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+					<textElement textAlignment="Left">
+						<font fontName="Arial" size="8" isBold="true"/>
+						<paragraph leftIndent="2"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$R{sum} +"  " + $F{currency}+" "+ $F{productno}+ "  " + $F{productname}]]></textFieldExpression>
+				</textField>
+				<textField isStretchWithOverflow="true" pattern="#,##0.00" isBlankWhenNull="true">
+					<reportElement key="textField-pt-qty" x="267" y="0" width="73" height="12" isRemoveLineWhenBlank="true" uuid="3a4b5c6d-e7f8-4a9b-0c1d-2e3f4a5b6c7d">
+						<property name="com.jaspersoft.studio.unit.leftIndent" value="px"/>
+					</reportElement>
+					<box>
+						<pen lineWidth="0.75" lineColor="#000000"/>
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+					<textElement>
+						<font fontName="Arial" size="8" isBold="true"/>
+						<paragraph leftIndent="2"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{producttotal_qtytu}]]></textFieldExpression>
+				</textField>
+				<textField isStretchWithOverflow="true" pattern="#,##0.00" isBlankWhenNull="true">
+					<reportElement key="textField-pt-weight" x="340" y="0" width="115" height="12" uuid="4b5c6d7e-f8a9-4b0c-1d2e-3f4a5b6c7d8e">
+						<property name="com.jaspersoft.studio.unit.rightIndent" value="px"/>
+					</reportElement>
+					<box>
+						<pen lineWidth="0.75" lineColor="#000000"/>
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+					<textElement textAlignment="Right">
+						<font fontName="Arial" size="8" isBold="true"/>
+						<paragraph rightIndent="2"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{producttotal_weight}]]></textFieldExpression>
+				</textField>
+				<textField isStretchWithOverflow="true" pattern="#,##0.00" isBlankWhenNull="true">
+					<reportElement key="textField-pt-pvalue" x="455" y="0" width="327" height="12" uuid="5c6d7e8f-a9b0-4c1d-2e3f-4a5b6c7d8e9f">
+						<property name="com.jaspersoft.studio.unit.rightIndent" value="px"/>
+					</reportElement>
+					<box>
+						<pen lineWidth="0.75" lineColor="#000000"/>
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+					<textElement textAlignment="Right">
+						<font fontName="Arial" size="8" isBold="true"/>
+						<paragraph rightIndent="2"/>
+					</textElement>
+					<textFieldExpression><![CDATA[$F{producttotal_purchasevalue}]]></textFieldExpression>
+				</textField>
+			</band>
+		</groupFooter>
+	</group>
+	<detail>
+		<band height="12" splitType="Stretch">
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<!-- vendor_value column -->
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement key="textField-vendor-val" x="0" y="0" width="80" height="12" uuid="6d7e8f9a-b0c1-4d2e-3f4a-5b6c7d8e9f0a">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.leftIndent" value="px"/>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.75" lineColor="#000000"/>
+					<topPen lineWidth="0.75" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.75" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.75" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement>
+					<font fontName="Arial" size="8" isBold="false"/>
+					<paragraph leftIndent="2"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{vendor_value}]]></textFieldExpression>
+			</textField>
+			<!-- vendor name column -->
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement key="textField-vendor-name" x="80" y="0" width="187" height="12" uuid="7e8f9a0b-c1d2-4e3f-4a5b-6c7d8e9f0a1b">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.75" lineColor="#000000"/>
+					<topPen lineWidth="0.75" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.75" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.75" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement>
+					<font fontName="Arial" size="8" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{vendor}]]></textFieldExpression>
+			</textField>
+			<!-- QtyTU column -->
+			<textField isStretchWithOverflow="true" pattern="#,##0.00" isBlankWhenNull="true">
+				<reportElement key="textField-qty" x="267" y="0" width="73" height="12" isRemoveLineWhenBlank="true" uuid="8f9a0b1c-d2e3-4f4a-5b6c-7d8e9f0a1b2c">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.leftIndent" value="px"/>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.75" lineColor="#000000"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement>
+					<font fontName="Arial" size="8" isBold="false"/>
+					<paragraph leftIndent="2"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{qtytu}]]></textFieldExpression>
+			</textField>
+			<!-- Weight column -->
+			<textField isStretchWithOverflow="true" pattern="#,##0.00" isBlankWhenNull="true">
+				<reportElement key="textField-weight" x="340" y="0" width="115" height="12" uuid="9a0b1c2d-e3f4-4a5b-6c7d-8e9f0a1b2c3d">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.rightIndent" value="px"/>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.75" lineColor="#000000"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Right">
+					<font fontName="Arial" size="8" isBold="false"/>
+					<paragraph rightIndent="2"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{weight}]]></textFieldExpression>
+			</textField>
+			<!-- PurchaseValue column -->
+			<textField isStretchWithOverflow="true" pattern="#,##0.00" isBlankWhenNull="true">
+				<reportElement key="textField-pvalue" x="455" y="0" width="327" height="12" uuid="0b1c2d3e-f4a5-4b6c-7d8e-9f0a1b2c3d4e">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="com.jaspersoft.studio.unit.rightIndent" value="px"/>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.75" lineColor="#000000"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Right">
+					<font fontName="Arial" size="8" isBold="false"/>
+					<paragraph rightIndent="2"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{purchasevalue}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report_en_GB.properties
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report_en_GB.properties
@@ -1,0 +1,19 @@
+page=Page
+of=of
+all=All
+
+parm1=Business Partner:
+parm2=Product:
+timeframe=Time Period:
+headline=Purchase by Product and Vendor Report
+
+sum=Sum
+totalsum=Total Sum:
+subtotal=Subtotal:
+product=Product no.
+ProductName=Product
+PackingInstruction=Packing Instruction
+Vendor=Vendor
+QtyTU=Qty TU
+Weight=Weight
+PurchaseValue=Purchase Value

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report_en_US.properties
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report_en_US.properties
@@ -1,0 +1,19 @@
+page=Page
+of=of
+all=All
+
+parm1=Business Partner:
+parm2=Product:
+timeframe=Time Period:
+headline=Purchase by Product and Vendor Report
+
+sum=Sum
+totalsum=Total Sum:
+subtotal=Subtotal:
+product=Product no.
+ProductName=Product
+PackingInstruction=Packing Instruction
+Vendor=Vendor
+QtyTU=Qty TU
+Weight=Weight
+PurchaseValue=Purchase Value

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report_title.jrxml
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/reports/goodspurchased/report_title.jrxml
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.0.final using JasperReports Library version 6.5.1  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="report_title" pageWidth="842" pageHeight="501" orientation="Landscape" columnWidth="842" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" resourceBundle="de/metas/reports/goodspurchased/report" uuid="c9d0e1f2-a3b4-4c5d-6e7f-8a9b0c1d2e3f">
+	<property name="ireport.scriptlethandling" value="0"/>
+	<property name="ireport.encoding" value="UTF-8"/>
+	<property name="ireport.zoom" value="2.5937424601000028"/>
+	<property name="ireport.x" value="314"/>
+	<property name="ireport.y" value="0"/>
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="jasperreports\dev.xml"/>
+	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
+	<property name="com.jaspersoft.studio.unit." value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.topMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.bottomMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.leftMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
+	<import value="net.sf.jasperreports.engine.*"/>
+	<import value="java.util.*"/>
+	<import value="net.sf.jasperreports.engine.data.*"/>
+	<parameter name="C_BPartner_ID" class="java.math.BigDecimal" isForPrompting="false"/>
+	<parameter name="DateFrom" class="java.util.Date" isForPrompting="false"/>
+	<parameter name="DateTo" class="java.util.Date" isForPrompting="false"/>
+	<parameter name="M_Product_ID" class="java.math.BigDecimal" isForPrompting="false"/>
+	<queryString>
+		<![CDATA[SELECT *
+FROM report.goods_purchase_report(
+        p_date_from =>  $P{DateFrom}::date,
+        p_date_to =>  $P{DateTo}::date,
+        p_bpartner_id => $P{C_BPartner_ID},
+        p_product_id =>  $P{M_Product_ID}
+     )
+     limit 1
+;]]>
+	</queryString>
+	<field name="partner_param" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="partner_param"/>
+		<property name="com.jaspersoft.studio.field.label" value="partner_param"/>
+	</field>
+	<field name="product_param" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="product_param"/>
+		<property name="com.jaspersoft.studio.field.label" value="product_param"/>
+	</field>
+	<field name="productno" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="productno"/>
+		<property name="com.jaspersoft.studio.field.label" value="productno"/>
+	</field>
+	<field name="productname" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="productname"/>
+		<property name="com.jaspersoft.studio.field.label" value="productname"/>
+	</field>
+	<field name="packinginstruction" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="packinginstruction"/>
+		<property name="com.jaspersoft.studio.field.label" value="packinginstruction"/>
+	</field>
+	<field name="vendor_value" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="vendor_value"/>
+		<property name="com.jaspersoft.studio.field.label" value="vendor_value"/>
+	</field>
+	<field name="vendor" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="vendor"/>
+		<property name="com.jaspersoft.studio.field.label" value="vendor"/>
+	</field>
+	<field name="qtytu" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="qtytu"/>
+		<property name="com.jaspersoft.studio.field.label" value="qtytu"/>
+	</field>
+	<field name="weight" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="weight"/>
+		<property name="com.jaspersoft.studio.field.label" value="weight"/>
+	</field>
+	<field name="purchasevalue" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="purchasevalue"/>
+		<property name="com.jaspersoft.studio.field.label" value="purchasevalue"/>
+	</field>
+	<field name="producttotal_qtytu" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="producttotal_qtytu"/>
+		<property name="com.jaspersoft.studio.field.label" value="producttotal_qtytu"/>
+	</field>
+	<field name="producttotal_weight" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="producttotal_weight"/>
+		<property name="com.jaspersoft.studio.field.label" value="producttotal_weight"/>
+	</field>
+	<field name="producttotal_purchasevalue" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="producttotal_purchasevalue"/>
+		<property name="com.jaspersoft.studio.field.label" value="producttotal_purchasevalue"/>
+	</field>
+	<field name="grandtotal_qtytu" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="grandtotal_qtytu"/>
+		<property name="com.jaspersoft.studio.field.label" value="grandtotal_qtytu"/>
+	</field>
+	<field name="grandtotal_weight" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="grandtotal_weight"/>
+		<property name="com.jaspersoft.studio.field.label" value="grandtotal_weight"/>
+	</field>
+	<field name="grandtotal_purchasevalue" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="grandtotal_purchasevalue"/>
+		<property name="com.jaspersoft.studio.field.label" value="grandtotal_purchasevalue"/>
+	</field>
+	<field name="currency" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="currency"/>
+		<property name="com.jaspersoft.studio.field.label" value="currency"/>
+	</field>
+	<background>
+		<band splitType="Stretch"/>
+	</background>
+	<title>
+		<band height="89" splitType="Stretch">
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement key="textField-1" x="0" y="4" width="841" height="19" uuid="d0e1f2a3-b4c5-4d6e-7f8a-9b0c1d2e3f4a"/>
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Center">
+					<font fontName="Arial" size="14" isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{headline}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement key="textField-2" x="44" y="35" width="98" height="12" uuid="e1f2a3b4-c5d6-4e7f-8a9b-0c1d2e3f4a5b"/>
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement>
+					<font size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{parm1}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement key="textField-3" x="142" y="35" width="167" height="12" uuid="f2a3b4c5-d6e7-4f8a-9b0c-1d2e3f4a5b6c"/>
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement>
+					<font size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{partner_param}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true" pattern="###0" isBlankWhenNull="true">
+				<reportElement key="textField-6" x="142" y="47" width="167" height="12" uuid="a3b4c5d6-e7f8-4a9b-0c1d-2e3f4a5b6c7d"/>
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement>
+					<font size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{product_param}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement key="textField-7" x="44" y="47" width="98" height="12" uuid="b4c5d6e7-f8a9-4b0c-1d2e-3f4a5b6c7d8e"/>
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement>
+					<font size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{parm2}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true" pattern="dd.MM.yyyy" isBlankWhenNull="true">
+				<reportElement key="textField-dateFrom" x="142" y="59" width="50" height="12" uuid="c5d6e7f8-a9b0-4c1d-2e3f-4a5b6c7d8e9f"/>
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement>
+					<font size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{DateFrom}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement key="textField-timeframe" x="44" y="59" width="98" height="12" uuid="d6e7f8a9-b0c1-4d2e-3f4a-5b6c7d8e9f0a"/>
+				<textElement markup="none">
+					<font size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$R{timeframe}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement key="textField-dash" x="194" y="59" width="16" height="12" uuid="e7f8a9b0-c1d2-4e3f-4a5b-6c7d8e9f0a1b"/>
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement>
+					<font size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA["-"]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true" pattern="dd.MM.yyyy" isBlankWhenNull="true">
+				<reportElement key="textField-dateTo" x="210" y="59" width="50" height="12" uuid="f8a9b0c1-d2e3-4f4a-5b6c-7d8e9f0a1b2c"/>
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement>
+					<font size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{DateTo}]]></textFieldExpression>
+			</textField>
+		</band>
+	</title>
+	<pageHeader>
+		<band splitType="Stretch"/>
+	</pageHeader>
+	<columnHeader>
+		<band splitType="Stretch"/>
+	</columnHeader>
+	<detail>
+		<band splitType="Stretch"/>
+	</detail>
+	<columnFooter>
+		<band splitType="Stretch"/>
+	</columnFooter>
+	<pageFooter>
+		<band splitType="Stretch"/>
+	</pageFooter>
+	<summary>
+		<band splitType="Stretch"/>
+	</summary>
+</jasperReport>

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/goods_purchase_report.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/goods_purchase_report.sql
@@ -1,0 +1,104 @@
+DROP FUNCTION IF EXISTS report.goods_purchase_report(
+    p_date_from   DATE,
+    p_date_to     DATE,
+    p_bpartner_id NUMERIC,
+    p_product_id  NUMERIC
+)
+;
+
+CREATE OR REPLACE FUNCTION report.goods_purchase_report(
+    p_date_from   DATE,
+    p_date_to     DATE,
+    p_bpartner_id NUMERIC DEFAULT NULL,
+    p_product_id  NUMERIC DEFAULT NULL
+)
+    RETURNS TABLE
+            (
+                partner_param              TEXT,
+                product_param              TEXT,
+                ProductNo                  VARCHAR, -- ArtNr
+                ProductName                VARCHAR, -- Bezeichnung
+                PackingInstruction         VARCHAR, -- Packvorschrift
+                vendor_value               VARCHAR, -- Lieferant Value
+                Vendor                     VARCHAR, -- Lieferant
+                QtyTU                      NUMERIC, -- Menge
+                Weight                     NUMERIC, -- Gewicht
+                PurchaseValue              NUMERIC, -- Einkaufswert
+                ProductTotal_QtyTU         NUMERIC, -- Summe Artikel – Menge
+                ProductTotal_Weight        NUMERIC, -- Summe Artikel – Gewicht
+                ProductTotal_PurchaseValue NUMERIC, -- Summe Artikel – Einkaufswert
+                GrandTotal_QtyTU           NUMERIC, -- Gesamtsumme – Menge       (per currency)
+                GrandTotal_Weight          NUMERIC, -- Gesamtsumme – Gewicht     (per currency)
+                GrandTotal_PurchaseValue   NUMERIC, -- Gesamtsumme – Einkaufswert (per currency)
+                currency                   CHAR(3)
+            )
+AS
+$$
+BEGIN
+    RETURN QUERY
+        WITH base_data AS (SELECT (SELECT value || ' ' || name FROM C_BPartner WHERE C_BPartner_ID = p_bpartner_id) AS partner_param,
+                                  (SELECT value || ' ' || name FROM m_product WHERE m_product_id = p_product_id)    AS product_param,
+
+                                  p.Value                                                                            AS ProductNo,
+                                  p.Name                                                                             AS ProductName,
+                                  COALESCE(
+                                          (SELECT pip.Name
+                                           FROM M_HU_PI_Item_Product pip
+                                                    JOIN M_HU_PI_Item pii ON pip.M_HU_PI_Item_ID = pii.M_HU_PI_Item_ID
+                                           WHERE pip.M_Product_ID = p.M_Product_ID
+                                             AND pip.IsActive = 'Y'
+                                           LIMIT 1),
+                                          ''
+                                  )                                                                                  AS PackingInstruction,
+                                  bp.value                                                                           AS vendor_value,
+                                  bp.Name                                                                            AS Vendor,
+                                  SUM(il.QtyEnteredTU)                                                              AS QtyTU,
+                                  SUM(il.QtyEntered * p.Weight)                                                     AS Weight,
+                                  SUM(il.linenetamt)                                                                 AS PurchaseValue,
+                                  cu.iso_code                                                                        AS currency
+                           FROM C_InvoiceLine il
+                                    JOIN C_Invoice i ON il.C_Invoice_ID = i.C_Invoice_ID
+                                    JOIN M_Product p ON il.M_Product_ID = p.M_Product_ID
+                                    JOIN C_BPartner bp ON i.C_BPartner_ID = bp.C_BPartner_ID
+                                    JOIN c_currency cu ON i.C_Currency_ID = cu.C_Currency_ID
+                           WHERE i.DateInvoiced BETWEEN p_date_from AND p_date_to
+                             AND i.IsSOTrx = 'N'
+                             AND i.DocStatus IN ('CO', 'CL')
+                             AND il.IsDescription = 'N'
+                             AND (p_bpartner_id IS NULL OR bp.C_BPartner_ID = p_bpartner_id)
+                             AND (p_product_id IS NULL OR p.M_Product_ID = p_product_id)
+                           GROUP BY p.Value,
+                                    p.Name,
+                                    p.M_Product_ID,
+                                    bp.C_BPartner_ID,
+                                    bp.value,
+                                    bp.Name,
+                                    cu.iso_code)
+        SELECT base_data.partner_param,
+               base_data.product_param,
+               base_data.ProductNo,
+               base_data.ProductName,
+               base_data.PackingInstruction,
+               base_data.vendor_value,
+               base_data.Vendor,
+               base_data.QtyTU,
+               base_data.Weight,
+               base_data.PurchaseValue,
+               -- ProductTotal: per product + currency
+               SUM(base_data.QtyTU) OVER (PARTITION BY base_data.ProductNo, base_data.currency)           AS ProductTotal_QtyTU,
+               SUM(base_data.Weight) OVER (PARTITION BY base_data.ProductNo, base_data.currency)          AS ProductTotal_Weight,
+               SUM(base_data.PurchaseValue) OVER (PARTITION BY base_data.ProductNo, base_data.currency)   AS ProductTotal_PurchaseValue,
+               -- GrandTotal: per currency only — never mix currencies!
+               SUM(base_data.QtyTU) OVER (PARTITION BY base_data.currency)                                AS GrandTotal_QtyTU,
+               SUM(base_data.Weight) OVER (PARTITION BY base_data.currency)                               AS GrandTotal_Weight,
+               SUM(base_data.PurchaseValue) OVER (PARTITION BY base_data.currency)                        AS GrandTotal_PurchaseValue,
+               base_data.currency
+        FROM base_data
+        ORDER BY base_data.currency,
+                 base_data.ProductNo,
+                 base_data.vendor_value,
+                 base_data.Vendor;
+END;
+$$
+    LANGUAGE plpgsql
+;

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5805410_sys_goods_purchase_report.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5805410_sys_goods_purchase_report.sql
@@ -1,0 +1,105 @@
+-- Source DDL: backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/goods_purchase_report.sql
+DROP FUNCTION IF EXISTS report.goods_purchase_report(
+    p_date_from   DATE,
+    p_date_to     DATE,
+    p_bpartner_id NUMERIC,
+    p_product_id  NUMERIC
+)
+;
+
+CREATE OR REPLACE FUNCTION report.goods_purchase_report(
+    p_date_from   DATE,
+    p_date_to     DATE,
+    p_bpartner_id NUMERIC DEFAULT NULL,
+    p_product_id  NUMERIC DEFAULT NULL
+)
+    RETURNS TABLE
+            (
+                partner_param              TEXT,
+                product_param              TEXT,
+                ProductNo                  VARCHAR, -- ArtNr
+                ProductName                VARCHAR, -- Bezeichnung
+                PackingInstruction         VARCHAR, -- Packvorschrift
+                vendor_value               VARCHAR, -- Lieferant Value
+                Vendor                     VARCHAR, -- Lieferant
+                QtyTU                      NUMERIC, -- Menge
+                Weight                     NUMERIC, -- Gewicht
+                PurchaseValue              NUMERIC, -- Einkaufswert
+                ProductTotal_QtyTU         NUMERIC, -- Summe Artikel – Menge
+                ProductTotal_Weight        NUMERIC, -- Summe Artikel – Gewicht
+                ProductTotal_PurchaseValue NUMERIC, -- Summe Artikel – Einkaufswert
+                GrandTotal_QtyTU           NUMERIC, -- Gesamtsumme – Menge       (per currency)
+                GrandTotal_Weight          NUMERIC, -- Gesamtsumme – Gewicht     (per currency)
+                GrandTotal_PurchaseValue   NUMERIC, -- Gesamtsumme – Einkaufswert (per currency)
+                currency                   CHAR(3)
+            )
+AS
+$$
+BEGIN
+    RETURN QUERY
+        WITH base_data AS (SELECT (SELECT value || ' ' || name FROM C_BPartner WHERE C_BPartner_ID = p_bpartner_id) AS partner_param,
+                                  (SELECT value || ' ' || name FROM m_product WHERE m_product_id = p_product_id)    AS product_param,
+
+                                  p.Value                                                                            AS ProductNo,
+                                  p.Name                                                                             AS ProductName,
+                                  COALESCE(
+                                          (SELECT pip.Name
+                                           FROM M_HU_PI_Item_Product pip
+                                                    JOIN M_HU_PI_Item pii ON pip.M_HU_PI_Item_ID = pii.M_HU_PI_Item_ID
+                                           WHERE pip.M_Product_ID = p.M_Product_ID
+                                             AND pip.IsActive = 'Y'
+                                           LIMIT 1),
+                                          ''
+                                  )                                                                                  AS PackingInstruction,
+                                  bp.value                                                                           AS vendor_value,
+                                  bp.Name                                                                            AS Vendor,
+                                  SUM(il.QtyEnteredTU)                                                              AS QtyTU,
+                                  SUM(il.QtyEntered * p.Weight)                                                     AS Weight,
+                                  SUM(il.linenetamt)                                                                 AS PurchaseValue,
+                                  cu.iso_code                                                                        AS currency
+                           FROM C_InvoiceLine il
+                                    JOIN C_Invoice i ON il.C_Invoice_ID = i.C_Invoice_ID
+                                    JOIN M_Product p ON il.M_Product_ID = p.M_Product_ID
+                                    JOIN C_BPartner bp ON i.C_BPartner_ID = bp.C_BPartner_ID
+                                    JOIN c_currency cu ON i.C_Currency_ID = cu.C_Currency_ID
+                           WHERE i.DateInvoiced BETWEEN p_date_from AND p_date_to
+                             AND i.IsSOTrx = 'N'
+                             AND i.DocStatus IN ('CO', 'CL')
+                             AND il.IsDescription = 'N'
+                             AND (p_bpartner_id IS NULL OR bp.C_BPartner_ID = p_bpartner_id)
+                             AND (p_product_id IS NULL OR p.M_Product_ID = p_product_id)
+                           GROUP BY p.Value,
+                                    p.Name,
+                                    p.M_Product_ID,
+                                    bp.C_BPartner_ID,
+                                    bp.value,
+                                    bp.Name,
+                                    cu.iso_code)
+        SELECT base_data.partner_param,
+               base_data.product_param,
+               base_data.ProductNo,
+               base_data.ProductName,
+               base_data.PackingInstruction,
+               base_data.vendor_value,
+               base_data.Vendor,
+               base_data.QtyTU,
+               base_data.Weight,
+               base_data.PurchaseValue,
+               -- ProductTotal: per product + currency
+               SUM(base_data.QtyTU) OVER (PARTITION BY base_data.ProductNo, base_data.currency)           AS ProductTotal_QtyTU,
+               SUM(base_data.Weight) OVER (PARTITION BY base_data.ProductNo, base_data.currency)          AS ProductTotal_Weight,
+               SUM(base_data.PurchaseValue) OVER (PARTITION BY base_data.ProductNo, base_data.currency)   AS ProductTotal_PurchaseValue,
+               -- GrandTotal: per currency only — never mix currencies!
+               SUM(base_data.QtyTU) OVER (PARTITION BY base_data.currency)                                AS GrandTotal_QtyTU,
+               SUM(base_data.Weight) OVER (PARTITION BY base_data.currency)                               AS GrandTotal_Weight,
+               SUM(base_data.PurchaseValue) OVER (PARTITION BY base_data.currency)                        AS GrandTotal_PurchaseValue,
+               base_data.currency
+        FROM base_data
+        ORDER BY base_data.currency,
+                 base_data.ProductNo,
+                 base_data.vendor_value,
+                 base_data.Vendor;
+END;
+$$
+    LANGUAGE plpgsql
+;

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5805420_AddReportGoodsPurchased.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/75-de.metas.fresh.reports/5805420_AddReportGoodsPurchased.sql
@@ -1,0 +1,148 @@
+-- Value: goods_purchase_report
+-- Classname: de.metas.report.jasper.client.process.JasperReportStarter
+-- JasperReport: @PREFIX@de/metas/reports/goodspurchased/report.jasper
+-- 2026-05-29T00:00:00.000Z
+INSERT INTO AD_Process (AccessLevel,AD_Client_ID,AD_Org_ID,AD_Process_ID,AllowProcessReRun,Classname,Created,CreatedBy,CSVFieldQuote,Description,EntityType,IsActive,IsApplySecuritySettings,IsBetaFunctionality,IsDirectPrint,IsFormatExcelFile,IsIncludeCSVHeaderRow,IsLogWarning,IsNotifyUserAfterExecution,IsOneInstanceOnly,IsReport,IsTranslateExcelHeaders,IsUpdateExportDate,IsUseBPartnerLanguage,JasperReport,JasperReport_Tabular,Name,PostgrestResponseFormat,RefreshAllAfterExecution,ShowHelp,Type,Updated,UpdatedBy,Value) VALUES ('3',0,0,585628 /*From ID Server*/,'Y','de.metas.report.jasper.client.process.JasperReportStarter',TO_TIMESTAMP('2026-05-29 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'"','Purchase by Product and Vendor Report (Jasper)','D','Y','N','N','N','Y','Y','N','N','N','Y','Y','N','Y','@PREFIX@de/metas/reports/goodspurchased/report.jasper','','Purchase by Product and Vendor Report (Jasper)','json','N','Y','JasperReportsSQL',TO_TIMESTAMP('2026-05-29 00:00:00.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'goods_purchase_report')
+;
+
+-- 2026-05-29T00:00:01.000Z
+INSERT INTO AD_Process_Trl (AD_Language,AD_Process_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Process_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Process t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_ID=585628 AND NOT EXISTS (SELECT 1 FROM AD_Process_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_ID=t.AD_Process_ID)
+;
+
+-- Process: goods_purchase_report(de.metas.report.jasper.client.process.JasperReportStarter)
+-- 2026-05-29T00:00:02.000Z
+UPDATE AD_Process_Trl SET Description='Einkauf nach Produkt und Lieferant (Jasper)', IsTranslated='Y', Name='Einkauf nach Produkt und Lieferant (Jasper)',Updated=TO_TIMESTAMP('2026-05-29 00:00:02.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Language in ('de_CH', 'de_DE') AND AD_Process_ID=585628
+;
+
+-- 2026-05-29T00:00:02.100Z
+UPDATE AD_Process base SET Description=trl.Description, Name=trl.Name, Updated=trl.Updated, UpdatedBy=trl.UpdatedBy FROM AD_Process_Trl trl  WHERE trl.AD_Process_ID=base.AD_Process_ID AND trl.AD_Language in ('de_CH', 'de_DE') AND trl.AD_Language=getBaseLanguage()
+;
+
+-- Process: goods_purchase_report(de.metas.report.jasper.client.process.JasperReportStarter)
+-- 2026-05-29T00:00:03.000Z
+UPDATE AD_Process_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-29 00:00:03.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Process_ID=585628
+;
+
+-- Process: goods_purchase_report(de.metas.report.jasper.client.process.JasperReportStarter)
+-- 2026-05-29T00:00:03.100Z
+UPDATE AD_Process_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-29 00:00:03.100000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Language='en_GB' AND AD_Process_ID=585628
+;
+
+-- Process: goods_purchase_report(de.metas.report.jasper.client.process.JasperReportStarter)
+-- ParameterName: DateFrom
+-- 2026-05-29T00:00:04.000Z
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,ShowInactiveValues,Updated,UpdatedBy) VALUES (0,1581,0,585628,543233 /*From ID Server*/,15,'DateFrom',TO_TIMESTAMP('2026-05-29 00:00:04.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Startdatum eines Abschnittes','U',0,'Datum von bezeichnet das Startdatum eines Abschnittes','Y','N','Y','N','Y','N','Datum von',10,'N',TO_TIMESTAMP('2026-05-29 00:00:04.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-05-29T00:00:04.100Z
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Process_Para t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_Para_ID=543233 AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+-- Process: goods_purchase_report(de.metas.report.jasper.client.process.JasperReportStarter)
+-- ParameterName: DateFrom
+-- 2026-05-29T00:00:04.200Z
+UPDATE AD_Process_Para SET EntityType='D',Updated=TO_TIMESTAMP('2026-05-29 00:00:04.200000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Process_Para_ID=543233
+;
+
+-- Process: goods_purchase_report(de.metas.report.jasper.client.process.JasperReportStarter)
+-- ParameterName: DateTo
+-- 2026-05-29T00:00:05.000Z
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,ShowInactiveValues,Updated,UpdatedBy) VALUES (0,1582,0,585628,543234 /*From ID Server*/,15,'DateTo',TO_TIMESTAMP('2026-05-29 00:00:05.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Enddatum eines Abschnittes','D',0,'Datum bis bezeichnet das Enddatum eines Abschnittes (inklusiv)','Y','N','Y','N','Y','N','Datum bis',20,'N',TO_TIMESTAMP('2026-05-29 00:00:05.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-05-29T00:00:05.100Z
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Process_Para t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_Para_ID=543234 AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+-- Process: goods_purchase_report(de.metas.report.jasper.client.process.JasperReportStarter)
+-- ParameterName: DateTo
+-- 2026-05-29T00:00:05.200Z
+UPDATE AD_Process_Para SET EntityType='D',Updated=TO_TIMESTAMP('2026-05-29 00:00:05.200000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Process_Para_ID=543234
+;
+
+-- Process: goods_purchase_report(de.metas.report.jasper.client.process.JasperReportStarter)
+-- ParameterName: C_BPartner_ID
+-- 2026-05-29T00:00:06.000Z
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,AD_Reference_Value_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,ShowInactiveValues,Updated,UpdatedBy) VALUES (0,187,0,585628,543235 /*From ID Server*/,30,173,'C_BPartner_ID',TO_TIMESTAMP('2026-05-29 00:00:06.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Bezeichnet einen Geschäftspartner','U',0,'Ein Geschäftspartner ist jemand, mit dem Sie interagieren. Dies kann Lieferanten, Kunden, Mitarbeiter oder Handelsvertreter umfassen.','Y','N','Y','N','N','N','Geschäftspartner',30,'N',TO_TIMESTAMP('2026-05-29 00:00:06.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-05-29T00:00:06.100Z
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Process_Para t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_Para_ID=543235 AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+-- Process: goods_purchase_report(de.metas.report.jasper.client.process.JasperReportStarter)
+-- ParameterName: M_Product_ID
+-- 2026-05-29T00:00:07.000Z
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,AD_Reference_Value_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,ShowInactiveValues,Updated,UpdatedBy) VALUES (0,454,0,585628,543236 /*From ID Server*/,30,540272,'M_Product_ID',TO_TIMESTAMP('2026-05-29 00:00:07.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Produkt, Leistung, Artikel','U',0,'Bezeichnet eine Einheit, die in dieser Organisation gekauft oder verkauft wird.','Y','N','Y','N','N','N','Produkt',40,'N',TO_TIMESTAMP('2026-05-29 00:00:07.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-05-29T00:00:07.100Z
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Process_Para t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_Para_ID=543236 AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+-- 2026-05-29T00:00:08.000Z
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,584925 /*From ID Server*/,0,TO_TIMESTAMP('2026-05-29 00:00:08.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','Purchase by Product and Vendor Report (Jasper)','Purchase by Product and Vendor Report (Jasper)',TO_TIMESTAMP('2026-05-29 00:00:08.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-05-29T00:00:08.100Z
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=584925 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- Element: goods_purchase_report
+-- 2026-05-29T00:00:08.200Z
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Einkauf nach Produkt und Lieferant (Jasper)', PrintName='Einkauf nach Produkt und Lieferant (Jasper)',Updated=TO_TIMESTAMP('2026-05-29 00:00:08.200000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=584925 AND AD_Language in ( 'de_CH', 'de_DE')
+;
+
+-- 2026-05-29T00:00:08.300Z
+UPDATE AD_Element base SET Name=trl.Name, PrintName=trl.PrintName, Updated=trl.Updated, UpdatedBy=trl.UpdatedBy FROM AD_Element_Trl trl  WHERE trl.AD_Element_ID=base.AD_Element_ID AND trl.AD_Language in ( 'de_CH', 'de_DE') AND trl.AD_Language=getBaseLanguage()
+;
+
+-- 2026-05-29T00:00:08.400Z
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(584925,'de_CH')
+;
+
+-- 2026-05-29T00:00:08.500Z
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(584925,'de_DE')
+;
+
+-- Element: goods_purchase_report
+-- 2026-05-29T00:00:08.600Z
+UPDATE AD_Element_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-29 00:00:08.600000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=584925 AND AD_Language='en_GB'
+;
+
+-- 2026-05-29T00:00:08.700Z
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(584925,'en_GB')
+;
+
+-- Element: goods_purchase_report
+-- 2026-05-29T00:00:08.800Z
+UPDATE AD_Element_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-05-29 00:00:08.800000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=584925 AND AD_Language='en_US'
+;
+
+-- 2026-05-29T00:00:08.900Z
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(584925,'en_US')
+;
+
+-- Name: Purchase by Product and Vendor Report (Jasper)
+-- Action Type: R
+-- Report: goods_purchase_report(de.metas.report.jasper.client.process.JasperReportStarter)
+-- 2026-05-29T00:00:09.000Z
+INSERT INTO AD_Menu (Action,AD_Client_ID,AD_Element_ID,AD_Menu_ID,AD_Org_ID,AD_Process_ID,Created,CreatedBy,EntityType,InternalName,IsActive,IsCreateNew,IsReadOnly,IsSOTrx,IsSummary,Name,Updated,UpdatedBy) VALUES ('R',0,584925,542332 /*From ID Server*/,0,585628,TO_TIMESTAMP('2026-05-29 00:00:09.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'de.metas.fresh','goods_purchase_report','Y','N','N','N','N','Purchase by Product and Vendor Report (Jasper)',TO_TIMESTAMP('2026-05-29 00:00:09.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-05-29T00:00:09.100Z
+INSERT INTO AD_Menu_Trl (AD_Language,AD_Menu_ID, Description,Name,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Menu_ID, t.Description,t.Name,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Menu t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Menu_ID=542332 AND NOT EXISTS (SELECT 1 FROM AD_Menu_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Menu_ID=t.AD_Menu_ID)
+;
+
+-- 2026-05-29T00:00:09.200Z
+INSERT INTO AD_TreeNodeMM (AD_Client_ID,AD_Org_ID, IsActive,Created,CreatedBy,Updated,UpdatedBy, AD_Tree_ID, Node_ID, Parent_ID, SeqNo) SELECT t.AD_Client_ID,0, 'Y', now(), 100, now(), 100,t.AD_Tree_ID, 542332, 0, 999 FROM AD_Tree t WHERE t.AD_Client_ID=0 AND t.IsActive='Y' AND t.IsAllNodes='Y' AND t.AD_Table_ID=116 AND NOT EXISTS (SELECT * FROM AD_TreeNodeMM e WHERE e.AD_Tree_ID=t.AD_Tree_ID AND Node_ID=542332)
+;
+
+-- 2026-05-29T00:00:09.300Z
+/* DDL */  select update_menu_translation_from_ad_element(584925)
+;
+
+-- Place new report under Purchase > Reports (Node_ID=1000049)
+-- 2026-05-29T00:00:09.400Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000049, SeqNo=0, Updated=now(), UpdatedBy=100 WHERE  Node_ID=542332 AND AD_Tree_ID=10
+;


### PR DESCRIPTION
Introduce a new "Goods Purchased" report: adds JasperReports templates (report.jrxml, report_details.jrxml, report_title.jrxml) and localized resource bundles (de_DE, de_CH, en_GB, en_US, default). Adds a SQL function definition goods_purchase_report and system install scripts to register the report. The report accepts parameters (C_BPartner_ID, DateFrom, DateTo, M_Product_ID), groups by product and currency, and renders product/vendor lines with product totals and grand totals (qty, weight, purchase value).