### PR TITLE
me03 #29231 EPCIS export — one event per physical SSCC (merge orders sharing a pallet)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
@@ -393,6 +393,30 @@ public class EPCIS_JSON_Export_StepDef
 	}
 
 	/**
+	 * Asserts the value of {@code "de.metas.edi".epcis_has_events(M_InOut_ID)} — the boolean predicate
+	 * for the scripted-adapter outbound-selection WHERE-clause. TRUE = the shipment would emit at least
+	 * one EPCIS event (owns a pallet/SSCC); FALSE = it must not be exported (sibling of a shared pallet,
+	 * or no pallets), so metasfresh never sends an empty EPCIS document.
+	 *
+	 * @cucumber.example
+	 * <pre>
+	 * Then the EPCIS export-relevance for M_InOut identified by ioA_S29231_170 is true
+	 * </pre>
+	 */
+	@Then("^the EPCIS export-relevance for M_InOut identified by (.*) is (true|false)$")
+	public void assertEpcisHasEvents(@NonNull final String inoutIdentifier, final boolean expected)
+	{
+		final I_M_InOut inout = inoutTable.get(inoutIdentifier);
+		final int inoutId = inout.getM_InOut_ID();
+		final String sql = "SELECT CASE WHEN \"de.metas.edi\".epcis_has_events(?) THEN 'Y' ELSE 'N' END";
+		final String actual = DB.getSQLValueStringEx(Trx.TRXNAME_None, sql, inoutId);
+
+		assertThat("Y".equals(actual))
+				.as("epcis_has_events(M_InOut_ID=%d): expected %s but DB returned raw '%s'", inoutId, expected, actual)
+				.isEqualTo(expected);
+	}
+
+	/**
 	 * Asserts that every crate (TU) in the pallet identified by SSCC18 has a dummy GRAI whose middle
 	 * segment contains the expected sanitized POReference string. Used to verify that the
 	 * {@code get_epcis_events_json_fn} derives the per-LU POReference from the source order rather

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
@@ -354,6 +354,45 @@ public class EPCIS_JSON_Export_StepDef
 	}
 
 	/**
+	 * Asserts that the EPCIS JSON export function returned an empty object ({@code {}}) for the given
+	 * shipment. Used to verify the per-SSCC contract: the non-owner sibling of a shared-pallet pair
+	 * must return {@code {}} so the consumer (Eddyson) does not emit a duplicate picking/commissioning
+	 * event for the same physical SSCC.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_InOut_ID</b> — (required, identifier-ref) shipment expected to return {@code {}}
+	 * @cucumber.example
+	 * <pre>
+	 * Then the EPCIS JSON export function returns empty object for M_InOut identified by ioB_S29231_170
+	 * </pre>
+	 */
+	@Then("^the EPCIS JSON export function returns empty object for M_InOut identified by (.*)$")
+	public void assertEpcisResultIsEmpty(@NonNull final String inoutIdentifier)
+	{
+		final I_M_InOut inout = inoutTable.get(inoutIdentifier);
+		final int inoutId = inout.getM_InOut_ID();
+		final String sql = "SELECT \"de.metas.edi\".get_epcis_events_json_fn(?)::text";
+		final String json = DB.getSQLValueStringEx(Trx.TRXNAME_None, sql, inoutId);
+
+		assertThat(json)
+				.as("EPCIS JSON for sibling M_InOut_ID=%d must be the empty object '{}'", inoutId)
+				.isNotNull();
+
+		try
+		{
+			final JsonNode result = objectMapper.readTree(json);
+			assertThat(result.size())
+					.as("EPCIS JSON for sibling M_InOut_ID=%d must be '{}' (empty object, size=0) but got: %s", inoutId, json)
+					.isEqualTo(0);
+		}
+		catch (final Exception e)
+		{
+			throw new AdempiereException("Failed to parse EPCIS JSON for M_InOut_ID=" + inoutId, e);
+		}
+	}
+
+	/**
 	 * Asserts that every crate (TU) in the pallet identified by SSCC18 has a dummy GRAI whose middle
 	 * segment contains the expected sanitized POReference string. Used to verify that the
 	 * {@code get_epcis_events_json_fn} derives the per-LU POReference from the source order rather

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -477,16 +477,20 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
   @Id:S29231_170
   @allure.label.epic:E0292_EDI
   @allure.label.feature:F00353_EDI_DESADV_InOut_Link
-  Scenario: S29231_170 — Two mobile-picking jobs share one LU: each shipment's EPCIS JSON sees only its own crates
-  ## Regression for get_epcis_events_json_fn (CTE ha_items_with_vtu, me03#29231).
-  ## Production scenario LAF1010-3: picker A picks order 1 onto a fresh LU; picker B then
-  ## targets that same physical LU as the pick-to target for order 2. Both shipments
-  ## reference the same LU via m_hu_assignment. Before the fix, shipment-1's EPCIS JSON
-  ## also enumerated shipment-2's TUs (35 crates instead of 15).
+  Scenario: S29231_170 — Two mobile-picking jobs share one LU: EPCIS emits ONE event per physical SSCC (owner merges both orders, sibling returns {})
+  ## Contract change per me03#29231 customer clarification (Migros/Spavetti LAF1010-3):
+  ## When two sales orders are picked onto ONE shared physical pallet (ONE SSCC), the
+  ## get_epcis_events_json_fn must emit exactly ONE picking+commissioning event for that
+  ## SSCC. The owner shipment (lowest M_InOut_ID sharing the LU) returns the full event:
+  ##   - pallets[0].crates = ALL crates from both orders on that LU (15 total)
+  ##   - desadvReferences[] size 2 (one per DESADV)
+  ##   - poReferences[]     size 2 (one per order)
+  ## The sibling shipment (higher M_InOut_ID) must return {} (empty object) so Eddyson
+  ## does not render a duplicate event for the same physical SSCC.
   ##
   ## The test uses two real mobile picking jobs (LUPickingTarget.ofExistingHU on the
-  ## second job) to produce the bug shape via the production code path — no synthetic
-  ## HU injection. With IsAlwaysSplitHUsEnabled=N the LU survives across both jobs.
+  ## second job) to reproduce the LAF1010-3 shape via the production code path.
+  ## With IsAlwaysSplitHUsEnabled=N the shared LU survives across both picking jobs.
     And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
     And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
 
@@ -634,23 +638,25 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | dA_S29231_170            | bp_S29231_170            | oA_S29231_170         |
       | dB_S29231_170            | bp_S29231_170            | oB_S29231_170         |
 
-    # ─── Shipment A: only its own 5 crates ───────────────────────────────────────────
+    # ─── Per-SSCC contract (me03#29231 customer clarification) ─────────────────────────
+    # ioA has the lower M_InOut_ID (created first) → it is the OWNER.
+    # The owner's event merges ALL crates from the shared physical LU (5 TUs from order A
+    # + 10 TUs from order B = 15 crates total) and carries both DESADV + PO references.
+    # ioB is the SIBLING → the function must return {} so no duplicate event is emitted.
     When the EPCIS JSON export function is called for M_InOut identified by ioA_S29231_170
     Then the EPCIS JSON pallets contain SSCC18 values in any order:
       | sscc18             |
       | 987654321000001700 |
     And the EPCIS JSON pallet has:
       | palletIndex | sscc               | crateCount |
-      | 0           | 987654321000001700 | 5          |
+      | 0           | 987654321000001700 | 15         |
+    And the EPCIS JSON array field has:
+      | field            | expectedSize |
+      | desadvReferences | 2            |
+      | poReferences     | 2            |
 
-    # ─── Shipment B: only its own 10 crates ──────────────────────────────────────────
-    When the EPCIS JSON export function is called for M_InOut identified by ioB_S29231_170
-    Then the EPCIS JSON pallets contain SSCC18 values in any order:
-      | sscc18             |
-      | 987654321000001700 |
-    And the EPCIS JSON pallet has:
-      | palletIndex | sscc               | crateCount |
-      | 0           | 987654321000001700 | 10         |
+    # ─── Sibling shipment B must return {} (no duplicate event for the same SSCC) ──────
+    Then the EPCIS JSON export function returns empty object for M_InOut identified by ioB_S29231_170
 
     # ─── DESADV-JSON regression via M_InOut_EDI_Export_JSON/invoke ───────────────────
     # Exercises get_desadv_packs_json_fn's per-M_InOut filter through the production REST

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -658,6 +658,11 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
     # ─── Sibling shipment B must return {} (no duplicate event for the same SSCC) ──────
     Then the EPCIS JSON export function returns empty object for M_InOut identified by ioB_S29231_170
 
+    # ─── Export-relevance predicate (drives the scripted-adapter outbound WHERE-clause, so the
+    #     sibling is never selected for export → metasfresh never emits an empty EPCIS document) ──
+    Then the EPCIS export-relevance for M_InOut identified by ioA_S29231_170 is true
+    And the EPCIS export-relevance for M_InOut identified by ioB_S29231_170 is false
+
     # ─── DESADV-JSON regression via M_InOut_EDI_Export_JSON/invoke ───────────────────
     # Exercises get_desadv_packs_json_fn's per-M_InOut filter through the production REST
     # path. Without the SQL fix, the response for shipment A would also include shipment B's

--- a/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/epcis_has_events_fn.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/epcis_has_events_fn.sql
@@ -1,0 +1,27 @@
+-- epcis_has_events(p_m_inout_id)
+--
+-- TRUE when the EPCIS export for this shipment would contain at least one pallet (SSCC) — i.e. it is
+-- worth sending to the clearing center. FALSE for:
+--   * sibling shipments of a shared physical pallet (get_epcis_events_json_fn returns '{}'),
+--   * shipments with no LU pallets at all           (pallets => []).
+--
+-- Intended for the scripted-adapter outbound-selection WHERE-clause, so metasfresh never emits an
+-- empty EPCIS document for the non-owner sibling of a shared pallet:
+--     ... AND "de.metas.edi".epcis_has_events(m_inout_id)
+--
+-- Delegates to get_epcis_events_json_fn (single source of truth for the per-physical-SSCC keying),
+-- so it can never drift from the actual export logic. me03 #29231.
+
+CREATE OR REPLACE FUNCTION "de.metas.edi".epcis_has_events(p_m_inout_id numeric)
+    RETURNS boolean
+    LANGUAGE sql
+    STABLE
+AS
+$$
+SELECT COALESCE(
+               jsonb_typeof(j.payload -> 'pallets') = 'array'
+                   AND jsonb_array_length(j.payload -> 'pallets') > 0,
+               false
+       )
+FROM (SELECT "de.metas.edi".get_epcis_events_json_fn(p_m_inout_id) AS payload) j;
+$$;

--- a/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
@@ -74,36 +74,63 @@ BEGIN
     -- Cache the AD_Table_ID for M_InOutLine — used 4× below as the m_hu_assignment.ad_table_id filter
     v_m_inoutline_table_id := get_table_id('M_InOutLine');
 
-    -- One event per physical SSCC: a shipment that owns no LU (every pallet it touches is
-    -- owned by a lower-id sibling) emits nothing; the owner's export carries the SSCC.
-    PERFORM 1
-    FROM m_hu_assignment ha
-             JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
-    WHERE ha.ad_table_id = v_m_inoutline_table_id
-      AND ha.m_lu_hu_id IS NOT NULL
-      AND ha.isactive = 'Y'
-      AND iol.m_inout_id = p_m_inout_id
-      AND p_m_inout_id = (
-          SELECT MIN(iol2.m_inout_id)
-          FROM m_hu_assignment ha2
-                   JOIN m_inoutline iol2 ON iol2.m_inoutline_id = ha2.record_id
-          WHERE ha2.ad_table_id = v_m_inoutline_table_id
-            AND ha2.m_lu_hu_id = ha.m_lu_hu_id
-            AND ha2.isactive = 'Y'
-      );
-    IF NOT FOUND THEN
-        RETURN '{}'::jsonb;
-    END IF;
-
-    WITH shared_lu_inout AS MATERIALIZED (
-        SELECT DISTINCT ha.m_lu_hu_id AS lu_hu_id, iol.m_inout_id
+    -- One event per physical SSCC. A shipment is a "sibling" only when it shares physical LU(s)
+    -- (via m_hu_assignment) with other shipments but is NOT the lowest-id owner of ANY of them —
+    -- such siblings emit nothing (the owner's export carries the SSCC, referencing all orders).
+    -- A shipment that touches no shared LU via m_hu_assignment (sole owner, no HU picking, or LUs
+    -- discoverable only via the QtyPicked fallback) is NEVER suppressed here — it falls through to
+    -- the normal export below. The owner election ignores voided/inactive shipments (docstatus).
+    IF EXISTS (
+        -- touches at least one LU via an active m_hu_assignment
+        SELECT 1
         FROM m_hu_assignment ha
                  JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
         WHERE ha.ad_table_id = v_m_inoutline_table_id
           AND ha.m_lu_hu_id IS NOT NULL
           AND ha.isactive = 'Y'
+          AND iol.m_inout_id = p_m_inout_id
+    )
+    AND NOT EXISTS (
+        -- ... but owns NONE of them (is not the lowest-id active owner of any touched LU)
+        SELECT 1
+        FROM m_hu_assignment ha
+                 JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
+        WHERE ha.ad_table_id = v_m_inoutline_table_id
+          AND ha.m_lu_hu_id IS NOT NULL
+          AND ha.isactive = 'Y'
+          AND iol.m_inout_id = p_m_inout_id
+          AND p_m_inout_id = (
+              SELECT MIN(iol2.m_inout_id)
+              FROM m_hu_assignment ha2
+                       JOIN m_inoutline iol2 ON iol2.m_inoutline_id = ha2.record_id
+                       JOIN m_inout io2 ON io2.m_inout_id = iol2.m_inout_id
+              WHERE ha2.ad_table_id = v_m_inoutline_table_id
+                AND ha2.m_lu_hu_id = ha.m_lu_hu_id
+                AND ha2.isactive = 'Y'
+                AND iol2.isactive = 'Y'
+                AND io2.docstatus IN ('CO', 'CL')
+          )
+    )
+    THEN
+        RETURN '{}'::jsonb;
+    END IF;
+
+    WITH shared_lu_inout AS MATERIALIZED (
+        -- (lu, m_inout) pairs: every active completed/closed shipment that has goods physically
+        -- assigned to an LU. Voided/reversed/in-progress shipments are excluded so they can never
+        -- be elected owner (which would otherwise silence the active shipment for that SSCC).
+        SELECT DISTINCT ha.m_lu_hu_id AS lu_hu_id, iol.m_inout_id
+        FROM m_hu_assignment ha
+                 JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
+                 JOIN m_inout io ON io.m_inout_id = iol.m_inout_id
+        WHERE ha.ad_table_id = v_m_inoutline_table_id
+          AND ha.m_lu_hu_id IS NOT NULL
+          AND ha.isactive = 'Y'
+          AND iol.isactive = 'Y'
+          AND io.docstatus IN ('CO', 'CL')
     ),
     lu_owner AS MATERIALIZED (
+        -- Owner of each physical LU = the lowest M_InOut_ID sharing it. Deterministic, stable.
         SELECT lu_hu_id, MIN(m_inout_id) AS owner_inout_id
         FROM shared_lu_inout
         GROUP BY lu_hu_id
@@ -151,6 +178,10 @@ BEGIN
                      JOIN edi_desadv da ON da.edi_desadv_id = link.edi_desadv_id
                      WHERE link.isactive = 'Y'
                        AND link.m_inout_id IN (
+                           -- always this shipment's own DESADVs ...
+                           SELECT io.m_inout_id
+                           UNION
+                           -- ... plus those of sibling shipments sharing an LU this shipment owns
                            SELECT s.m_inout_id
                            FROM shared_lu_inout s
                                     JOIN lu_owner o ON o.lu_hu_id = s.lu_hu_id
@@ -175,8 +206,8 @@ BEGIN
              --   urn:epc:id:grai:<GCP>.<assetType>.<10-digit Bestellnummer left-padded><2-digit counter>
              -- Production POReferences are numeric (e.g. '1234567890'); LPAD pads shorter values
              -- with leading zeros and leaves 10-digit values unchanged.
-             SELECT lu_hu_id,
-                    LPAD(COALESCE(MIN(poreference), '0'), 10, '0') AS lu_poreference_padded
+             SELECT lwp.lu_hu_id,
+                    LPAD(COALESCE(MIN(lwp.poreference), '0'), 10, '0') AS lu_poreference_padded
              FROM (
                  -- Primary: M_HU_Assignment → InOutLine → OrderLine → Order path
                  SELECT ha.m_lu_hu_id AS lu_hu_id,
@@ -208,19 +239,22 @@ BEGIN
                          AND ha2.isactive = 'Y'
                    )
              ) lwp
-                      JOIN lu_owner o
-                           ON o.lu_hu_id = lwp.lu_hu_id
-                              AND o.owner_inout_id = (SELECT m_inout_id FROM inout_context)
+                      -- Keep LUs this shipment OWNS (shared pallets: owner emits the SSCC), plus LUs
+                      -- with no owner row at all (QtyPicked-only fallback LUs are not in lu_owner,
+                      -- which is built from m_hu_assignment) so the fallback path keeps working.
+                      LEFT JOIN lu_owner o ON o.lu_hu_id = lwp.lu_hu_id
+             WHERE o.owner_inout_id = (SELECT m_inout_id FROM inout_context)
+                OR o.owner_inout_id IS NULL
              GROUP BY lwp.lu_hu_id),
 
          individual_tu_ids AS MATERIALIZED (
              -- CASE A: individual TU HU IDs across all pallets — no attribute joins yet.
              --
-             -- Restricted to TUs allocated to THIS M_InOut via m_hu_assignment. The
-             -- assignment for a non-aggregated TU normally carries m_tu_hu_id (and/or
-             -- vhu_id) referencing the TU's m_hu_id. Without this filter, when two
-             -- shipments share an LU, the export of shipment-1 would also include the
-             -- individual TUs that belong to the sibling shipment (me03#29231).
+             -- Scoped to TUs allocated to SOME shipment via m_hu_assignment (excludes unshipped
+             -- TUs on a partial pallet). Per me03#29231 (one EPCIS event per physical SSCC) the
+             -- scope gate is the OWNED LU (pallet_list, restricted to LUs this shipment owns), NOT
+             -- the M_InOut: when two shipments share a physical LU, the owner's event intentionally
+             -- merges the individual TUs of BOTH source orders onto that one SSCC.
              SELECT lu_hu.m_hu_id                 AS lu_hu_id,
                     pl.lu_poreference_padded,
                     tu_hu.m_hu_id                 AS tu_hu_id,
@@ -244,11 +278,11 @@ BEGIN
              -- CASE B: HA items with their virtual TU resolved — computed ONCE, reused for
              --         both attribute lookup and storage item joins (avoids double m_hu scan).
              --
-             -- Restricted to HA aggregates allocated to THIS M_InOut via m_hu_assignment.
-             -- Each HA aggregate is allocated to exactly one inoutline (one shipment), and
-             -- ha_item.qty carries the crate count. Without this filter, when two shipments
-             -- share an LU, the export of shipment-1 would also include the HA aggregates
-             -- that belong to the sibling shipment (LAF1010-3 scenario).
+             -- Scoped to HA aggregates allocated to SOME shipment via m_hu_assignment; ha_item.qty
+             -- carries the crate count. Per me03#29231 (one EPCIS event per physical SSCC) the scope
+             -- gate is the OWNED LU (pallet_list), NOT the M_InOut: when two shipments share a
+             -- physical LU (LAF1010-3), the owner's event intentionally merges the HA aggregates of
+             -- BOTH source orders onto that one SSCC.
              SELECT lu_hu.m_hu_id                           AS lu_hu_id,
                     pl.lu_poreference_padded,
                     ha_item.m_hu_item_id                    AS tu_hu_id,

--- a/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
@@ -74,7 +74,42 @@ BEGIN
     -- Cache the AD_Table_ID for M_InOutLine — used 4× below as the m_hu_assignment.ad_table_id filter
     v_m_inoutline_table_id := get_table_id('M_InOutLine');
 
-    WITH inout_context AS (
+    -- One event per physical SSCC: a shipment that owns no LU (every pallet it touches is
+    -- owned by a lower-id sibling) emits nothing; the owner's export carries the SSCC.
+    PERFORM 1
+    FROM m_hu_assignment ha
+             JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
+    WHERE ha.ad_table_id = v_m_inoutline_table_id
+      AND ha.m_lu_hu_id IS NOT NULL
+      AND ha.isactive = 'Y'
+      AND iol.m_inout_id = p_m_inout_id
+      AND p_m_inout_id = (
+          SELECT MIN(iol2.m_inout_id)
+          FROM m_hu_assignment ha2
+                   JOIN m_inoutline iol2 ON iol2.m_inoutline_id = ha2.record_id
+          WHERE ha2.ad_table_id = v_m_inoutline_table_id
+            AND ha2.m_lu_hu_id = ha.m_lu_hu_id
+            AND ha2.isactive = 'Y'
+      );
+    IF NOT FOUND THEN
+        RETURN '{}'::jsonb;
+    END IF;
+
+    WITH shared_lu_inout AS MATERIALIZED (
+        SELECT DISTINCT ha.m_lu_hu_id AS lu_hu_id, iol.m_inout_id
+        FROM m_hu_assignment ha
+                 JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
+        WHERE ha.ad_table_id = v_m_inoutline_table_id
+          AND ha.m_lu_hu_id IS NOT NULL
+          AND ha.isactive = 'Y'
+    ),
+    lu_owner AS MATERIALIZED (
+        SELECT lu_hu_id, MIN(m_inout_id) AS owner_inout_id
+        FROM shared_lu_inout
+        GROUP BY lu_hu_id
+    ),
+
+    inout_context AS (
         -- Materialize all context data ONCE to avoid correlated subqueries
         SELECT io.m_inout_id,
                io.documentno,
@@ -107,14 +142,20 @@ BEGIN
                desadv_agg.desadv_poreferences
         FROM m_inout io
                  LEFT JOIN edi_desadv d ON d.edi_desadv_id = io.edi_desadv_id
-                 -- aggregate all DESADV references via N:M junction
+                 -- aggregate all DESADV references via N:M junction, across all shipments
+                 -- sharing owned LUs (so the owner event carries refs from sibling shipments too)
                  LEFT JOIN LATERAL (
                      SELECT jsonb_agg(da.documentno ORDER BY da.documentno)   AS desadv_documentnos,
                             jsonb_agg(da.poreference ORDER BY da.documentno)  AS desadv_poreferences
                      FROM edi_desadv_m_inout link
                      JOIN edi_desadv da ON da.edi_desadv_id = link.edi_desadv_id
-                     WHERE link.m_inout_id = io.m_inout_id
-                       AND link.isactive = 'Y'
+                     WHERE link.isactive = 'Y'
+                       AND link.m_inout_id IN (
+                           SELECT s.m_inout_id
+                           FROM shared_lu_inout s
+                                    JOIN lu_owner o ON o.lu_hu_id = s.lu_hu_id
+                           WHERE o.owner_inout_id = io.m_inout_id
+                       )
                  ) desadv_agg ON true
                  LEFT JOIN c_bpartner_location bpl_desadv_buyer
                            ON bpl_desadv_buyer.c_bpartner_location_id = d.c_bpartner_location_id
@@ -166,8 +207,11 @@ BEGIN
                          AND ha2.ad_table_id = v_m_inoutline_table_id
                          AND ha2.isactive = 'Y'
                    )
-             ) lu_with_poreference
-             GROUP BY lu_hu_id),
+             ) lwp
+                      JOIN lu_owner o
+                           ON o.lu_hu_id = lwp.lu_hu_id
+                              AND o.owner_inout_id = (SELECT m_inout_id FROM inout_context)
+             GROUP BY lwp.lu_hu_id),
 
          individual_tu_ids AS MATERIALIZED (
              -- CASE A: individual TU HU IDs across all pallets — no attribute joins yet.
@@ -192,7 +236,6 @@ BEGIN
                  FROM m_hu_assignment ha
                           JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
                  WHERE ha.ad_table_id = v_m_inoutline_table_id
-                   AND iol.m_inout_id = (SELECT m_inout_id FROM inout_context)
                    AND ha.isactive = 'Y'
                    AND (ha.m_tu_hu_id = tu_hu.m_hu_id OR ha.vhu_id = tu_hu.m_hu_id)
              )),
@@ -226,8 +269,7 @@ BEGIN
                  SELECT 1
                  FROM m_hu_assignment ha
                           JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
-                 WHERE ha.ad_table_id = v_m_inoutline_table_id 
-                   AND iol.m_inout_id = (SELECT m_inout_id FROM inout_context)
+                 WHERE ha.ad_table_id = v_m_inoutline_table_id
                    AND ha.isactive = 'Y'
                    AND ha.vhu_id = ha_vtu.m_hu_id
              )),

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5805440_sys_me03_29231_epcis_one_event_per_sscc.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5805440_sys_me03_29231_epcis_one_event_per_sscc.sql
@@ -1,0 +1,589 @@
+-- Migration: me03#29231 — EPCIS export emits one event per physical SSCC
+-- https://github.com/metasfresh/me03/issues/29231
+--
+-- Change: re-key "de.metas.edi".get_epcis_events_json_fn from per-M_InOut to per-physical-SSCC
+-- ownership. When two sales orders are picked onto ONE physical pallet (one shared LU = one SSCC,
+-- spanning two M_InOuts), the export now emits exactly ONE event for that SSCC instead of two:
+-- the OWNER shipment (lowest active CO/CL M_InOut sharing the LU) merges all crates of the pallet
+-- plus the desadvReferences[]/poReferences[] of BOTH source orders; a genuine sibling shipment
+-- (shares the LU but is not its owner) returns '{}'. Two DESADVs (one per order) is unchanged.
+-- Supersedes the per-M_InOut crate filter of 5804420 for the shared-pallet case.
+
+/*
+ * #%L
+ * de.metas.edi
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+-- EPCIS event JSON for a given M_InOut (shipment).
+-- HU-based, DESADV-optional: core data from HU hierarchy, DESADV only for optional biz references.
+--
+-- Changes in me03#28815:
+--   - Pallet discovery: M_InOut → M_InOutLine → M_HU_Assignment.M_LU_HU_ID (primary)
+--                        + fallback via M_ShipmentSchedule_QtyPicked.M_LU_HU_ID
+--   - Crate (TU) discovery: M_HU_Item (itemtype='HU' individual, 'HA' aggregated)
+--   - Items: M_HU_Item_Storage per TU (not DESADV pack items)
+--   - GRAI: M_HU_Attribute on TU level (comma-separated for aggregated)
+--   - DESADV: LEFT JOIN (optional, for buyer/handover/PO references)
+--   - New field: cuGTIN from M_Product.GTIN
+--
+-- Changes in this function version:
+-- desadvReferences[] and poReferences[] are jsonb arrays built via the EDI_Desadv_M_InOut
+-- junction (one element per linked DESADV). The scalar desadvReference / poReference fields
+-- are kept for backward compatibility. The single-FK edi_desadv join is retained for
+-- GLN / location / handover lookups.
+--
+-- Performance design:
+--   - Flat CTEs only (no nested LATERALs)
+--   - m_hu ha_vtu join computed once in ha_items_with_vtu, reused for attrs + items
+--   - m_hu_attribute scanned once via hu_attrs pivot (vs 6 separate joins previously)
+--   - c_bpartner_product scanned once via bp_prod_lookup (vs N LATERAL calls)
+--   - Scalar variables for buyer_bpartner_id and poreference (vs scalar subqueries per row)
+
+CREATE OR REPLACE FUNCTION "de.metas.edi".get_epcis_events_json_fn(p_m_inout_id NUMERIC)
+    RETURNS JSONB
+AS
+$$
+DECLARE
+    v_result               JSONB;
+    v_grai_attribute_id    NUMERIC;
+    v_sscc_attribute_id    NUMERIC;
+    v_lot_attribute_id     NUMERIC;
+    v_bbd_attribute_id     NUMERIC;
+    v_dummy_grai_prefix    TEXT;
+    v_m_inoutline_table_id NUMERIC;
+
+BEGIN
+    -- Cache attribute IDs in one scan
+    SELECT MAX(CASE WHEN value = 'GRAI' THEN m_attribute_id END),
+           MAX(CASE WHEN value = 'SSCC18' THEN m_attribute_id END),
+           MAX(CASE WHEN value = 'Lot-Nummer' THEN m_attribute_id END),
+           MAX(CASE WHEN value = 'HU_BestBeforeDate' THEN m_attribute_id END)
+    INTO v_grai_attribute_id, v_sscc_attribute_id, v_lot_attribute_id, v_bbd_attribute_id
+    FROM m_attribute
+    WHERE value IN ('GRAI', 'SSCC18', 'Lot-Nummer', 'HU_BestBeforeDate');
+
+    -- de.metas.edi.epcis.dummyGRAI.Prefix — GCP.assetType. portion before the 12-char serial, e.g. '7613264.00307.'
+    v_dummy_grai_prefix := get_sysconfig_value('de.metas.edi.epcis.dummyGRAI.Prefix', '0000000.11111.');
+
+    -- Cache the AD_Table_ID for M_InOutLine — used 4× below as the m_hu_assignment.ad_table_id filter
+    v_m_inoutline_table_id := get_table_id('M_InOutLine');
+
+    -- One event per physical SSCC. A shipment is a "sibling" only when it shares physical LU(s)
+    -- (via m_hu_assignment) with other shipments but is NOT the lowest-id owner of ANY of them —
+    -- such siblings emit nothing (the owner's export carries the SSCC, referencing all orders).
+    -- A shipment that touches no shared LU via m_hu_assignment (sole owner, no HU picking, or LUs
+    -- discoverable only via the QtyPicked fallback) is NEVER suppressed here — it falls through to
+    -- the normal export below. The owner election ignores voided/inactive shipments (docstatus).
+    IF EXISTS (
+        -- touches at least one LU via an active m_hu_assignment
+        SELECT 1
+        FROM m_hu_assignment ha
+                 JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
+        WHERE ha.ad_table_id = v_m_inoutline_table_id
+          AND ha.m_lu_hu_id IS NOT NULL
+          AND ha.isactive = 'Y'
+          AND iol.m_inout_id = p_m_inout_id
+    )
+    AND NOT EXISTS (
+        -- ... but owns NONE of them (is not the lowest-id active owner of any touched LU)
+        SELECT 1
+        FROM m_hu_assignment ha
+                 JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
+        WHERE ha.ad_table_id = v_m_inoutline_table_id
+          AND ha.m_lu_hu_id IS NOT NULL
+          AND ha.isactive = 'Y'
+          AND iol.m_inout_id = p_m_inout_id
+          AND p_m_inout_id = (
+              SELECT MIN(iol2.m_inout_id)
+              FROM m_hu_assignment ha2
+                       JOIN m_inoutline iol2 ON iol2.m_inoutline_id = ha2.record_id
+                       JOIN m_inout io2 ON io2.m_inout_id = iol2.m_inout_id
+              WHERE ha2.ad_table_id = v_m_inoutline_table_id
+                AND ha2.m_lu_hu_id = ha.m_lu_hu_id
+                AND ha2.isactive = 'Y'
+                AND iol2.isactive = 'Y'
+                AND io2.docstatus IN ('CO', 'CL')
+          )
+    )
+    THEN
+        RETURN '{}'::jsonb;
+    END IF;
+
+    WITH shared_lu_inout AS MATERIALIZED (
+        -- (lu, m_inout) pairs: every active completed/closed shipment that has goods physically
+        -- assigned to an LU. Voided/reversed/in-progress shipments are excluded so they can never
+        -- be elected owner (which would otherwise silence the active shipment for that SSCC).
+        SELECT DISTINCT ha.m_lu_hu_id AS lu_hu_id, iol.m_inout_id
+        FROM m_hu_assignment ha
+                 JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
+                 JOIN m_inout io ON io.m_inout_id = iol.m_inout_id
+        WHERE ha.ad_table_id = v_m_inoutline_table_id
+          AND ha.m_lu_hu_id IS NOT NULL
+          AND ha.isactive = 'Y'
+          AND iol.isactive = 'Y'
+          AND io.docstatus IN ('CO', 'CL')
+    ),
+    lu_owner AS MATERIALIZED (
+        -- Owner of each physical LU = the lowest M_InOut_ID sharing it. Deterministic, stable.
+        SELECT lu_hu_id, MIN(m_inout_id) AS owner_inout_id
+        FROM shared_lu_inout
+        GROUP BY lu_hu_id
+    ),
+
+    inout_context AS (
+        -- Materialize all context data ONCE to avoid correlated subqueries
+        SELECT io.m_inout_id,
+               io.documentno,
+               io.movementdate,
+               io.m_warehouse_id,
+               io.ad_org_id,
+               io.edi_desadv_id,
+               io.c_bpartner_location_id,
+               io.dropship_location_id,
+               io.poreference,
+               io.docstatus,
+               io.isactive,
+               COALESCE(bpl_desadv_drop.c_bpartner_id,
+                        bpl_desadv_buyer.c_bpartner_id,
+                        bpl_ship_drop.c_bpartner_id,
+                        bpl_ship_buyer.c_bpartner_id) AS buyer_bpartner_id,
+               bpl_desadv_buyer.gln                   AS buyer_gln_desadv,
+               bpl_desadv_buyer.gln_gcpLength         AS buyer_gcplength_desadv,
+               bpl_ship_buyer.gln                     AS buyer_gln_ship,
+               bpl_ship_buyer.gln_gcpLength           AS buyer_gcplength_ship,
+               bpl_desadv_drop.gln                    AS drop_gln_desadv,
+               bpl_desadv_drop.gln_gcpLength          AS drop_gcplength_desadv,
+               bpl_ship_drop.gln                      AS drop_gln_ship,
+               bpl_ship_drop.gln_gcpLength            AS drop_gcplength_ship,
+               d.handover_location_id,
+               d.documentno                           AS desadv_documentno,
+               d.poreference                          AS desadv_poreference,
+               -- arrays from junction (all DESADVs linked to this shipment)
+               desadv_agg.desadv_documentnos,
+               desadv_agg.desadv_poreferences
+        FROM m_inout io
+                 LEFT JOIN edi_desadv d ON d.edi_desadv_id = io.edi_desadv_id
+                 -- aggregate all DESADV references via N:M junction, across all shipments
+                 -- sharing owned LUs (so the owner event carries refs from sibling shipments too)
+                 LEFT JOIN LATERAL (
+                     SELECT jsonb_agg(da.documentno ORDER BY da.documentno)   AS desadv_documentnos,
+                            jsonb_agg(da.poreference ORDER BY da.documentno)  AS desadv_poreferences
+                     FROM edi_desadv_m_inout link
+                     JOIN edi_desadv da ON da.edi_desadv_id = link.edi_desadv_id
+                     WHERE link.isactive = 'Y'
+                       AND link.m_inout_id IN (
+                           -- always this shipment's own DESADVs ...
+                           SELECT io.m_inout_id
+                           UNION
+                           -- ... plus those of sibling shipments sharing an LU this shipment owns
+                           SELECT s.m_inout_id
+                           FROM shared_lu_inout s
+                                    JOIN lu_owner o ON o.lu_hu_id = s.lu_hu_id
+                           WHERE o.owner_inout_id = io.m_inout_id
+                       )
+                 ) desadv_agg ON true
+                 LEFT JOIN c_bpartner_location bpl_desadv_buyer
+                           ON bpl_desadv_buyer.c_bpartner_location_id = d.c_bpartner_location_id
+                 LEFT JOIN c_bpartner_location bpl_ship_buyer
+                           ON bpl_ship_buyer.c_bpartner_location_id = io.c_bpartner_location_id
+                 LEFT JOIN c_bpartner_location bpl_desadv_drop
+                           ON bpl_desadv_drop.c_bpartner_location_id = d.dropship_location_id
+                 LEFT JOIN c_bpartner_location bpl_ship_drop
+                           ON bpl_ship_drop.c_bpartner_location_id = io.dropship_location_id
+        WHERE io.m_inout_id = p_m_inout_id),
+
+         pallet_list AS MATERIALIZED (
+             -- All LU HU IDs for this shipment, enriched with the left-zero-padded POReference of
+             -- their source order.  In an n:m consolidated shipment each LU belongs to exactly one
+             -- source order; we pick one POReference per LU (MIN) and LPAD it to 10 digits for the
+             -- GRAI Serial middle segment per Migros spec:
+             --   urn:epc:id:grai:<GCP>.<assetType>.<10-digit Bestellnummer left-padded><2-digit counter>
+             -- Production POReferences are numeric (e.g. '1234567890'); LPAD pads shorter values
+             -- with leading zeros and leaves 10-digit values unchanged.
+             SELECT lwp.lu_hu_id,
+                    LPAD(COALESCE(MIN(lwp.poreference), '0'), 10, '0') AS lu_poreference_padded
+             FROM (
+                 -- Primary: M_HU_Assignment → InOutLine → OrderLine → Order path
+                 SELECT ha.m_lu_hu_id AS lu_hu_id,
+                        ord.poreference
+                 FROM inout_context ctx
+                          JOIN m_inoutline iol ON iol.m_inout_id = ctx.m_inout_id
+                          JOIN m_hu_assignment ha
+                               ON ha.ad_table_id = v_m_inoutline_table_id
+                                   AND ha.record_id = iol.m_inoutline_id
+                          LEFT JOIN c_orderline ol ON ol.c_orderline_id = iol.c_orderline_id
+                          LEFT JOIN c_order ord ON ord.c_order_id = ol.c_order_id
+                 WHERE ha.m_lu_hu_id IS NOT NULL
+                   AND ha.isactive = 'Y'
+
+                 UNION ALL
+
+                 -- Fallback: M_ShipmentSchedule_QtyPicked path (no per-LU order link available)
+                 SELECT qp.m_lu_hu_id AS lu_hu_id,
+                        NULL::text AS poreference
+                 FROM inout_context ctx
+                          JOIN m_inoutline iol ON iol.m_inout_id = ctx.m_inout_id
+                          JOIN m_shipmentschedule_qtypicked qp ON qp.m_inoutline_id = iol.m_inoutline_id
+                 WHERE qp.m_lu_hu_id IS NOT NULL
+                   AND qp.isactive = 'Y'
+                   AND NOT EXISTS (
+                       SELECT 1 FROM m_hu_assignment ha2
+                       WHERE ha2.m_lu_hu_id = qp.m_lu_hu_id
+                         AND ha2.ad_table_id = v_m_inoutline_table_id
+                         AND ha2.isactive = 'Y'
+                   )
+             ) lwp
+                      -- Keep LUs this shipment OWNS (shared pallets: owner emits the SSCC), plus LUs
+                      -- with no owner row at all (QtyPicked-only fallback LUs are not in lu_owner,
+                      -- which is built from m_hu_assignment) so the fallback path keeps working.
+                      LEFT JOIN lu_owner o ON o.lu_hu_id = lwp.lu_hu_id
+             WHERE o.owner_inout_id = (SELECT m_inout_id FROM inout_context)
+                OR o.owner_inout_id IS NULL
+             GROUP BY lwp.lu_hu_id),
+
+         individual_tu_ids AS MATERIALIZED (
+             -- CASE A: individual TU HU IDs across all pallets — no attribute joins yet.
+             --
+             -- Scoped to TUs allocated to SOME shipment via m_hu_assignment (excludes unshipped
+             -- TUs on a partial pallet). Per me03#29231 (one EPCIS event per physical SSCC) the
+             -- scope gate is the OWNED LU (pallet_list, restricted to LUs this shipment owns), NOT
+             -- the M_InOut: when two shipments share a physical LU, the owner's event intentionally
+             -- merges the individual TUs of BOTH source orders onto that one SSCC.
+             SELECT lu_hu.m_hu_id                 AS lu_hu_id,
+                    pl.lu_poreference_padded,
+                    tu_hu.m_hu_id                 AS tu_hu_id,
+                    tu_hu.m_hu_pi_item_product_id AS tu_pi_item_product_id
+             FROM pallet_list pl
+                      JOIN m_hu lu_hu ON lu_hu.m_hu_id = pl.lu_hu_id
+                      JOIN m_hu_item parent_item
+                           ON parent_item.m_hu_id = lu_hu.m_hu_id
+                               AND parent_item.itemtype = 'HU'
+                      JOIN m_hu tu_hu ON tu_hu.m_hu_item_parent_id = parent_item.m_hu_item_id
+             WHERE EXISTS (
+                 SELECT 1
+                 FROM m_hu_assignment ha
+                          JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
+                 WHERE ha.ad_table_id = v_m_inoutline_table_id
+                   AND ha.isactive = 'Y'
+                   AND (ha.m_tu_hu_id = tu_hu.m_hu_id OR ha.vhu_id = tu_hu.m_hu_id)
+             )),
+
+         ha_items_with_vtu AS MATERIALIZED (
+             -- CASE B: HA items with their virtual TU resolved — computed ONCE, reused for
+             --         both attribute lookup and storage item joins (avoids double m_hu scan).
+             --
+             -- Scoped to HA aggregates allocated to SOME shipment via m_hu_assignment; ha_item.qty
+             -- carries the crate count. Per me03#29231 (one EPCIS event per physical SSCC) the scope
+             -- gate is the OWNED LU (pallet_list), NOT the M_InOut: when two shipments share a
+             -- physical LU (LAF1010-3), the owner's event intentionally merges the HA aggregates of
+             -- BOTH source orders onto that one SSCC.
+             SELECT lu_hu.m_hu_id                           AS lu_hu_id,
+                    pl.lu_poreference_padded,
+                    ha_item.m_hu_item_id                    AS tu_hu_id,
+                    ha_item.qty,
+                    ha_vtu.m_hu_id                          AS vtu_hu_id,
+                    ha_vtu.m_hu_pi_item_product_id          AS vtu_pi_item_product_id,
+                    -- HU ID to use for attribute lookups: virtual TU first, fall back to LU
+                    COALESCE(ha_vtu.m_hu_id, lu_hu.m_hu_id) AS attr_hu_id
+             FROM pallet_list pl
+                      JOIN m_hu lu_hu ON lu_hu.m_hu_id = pl.lu_hu_id
+                      JOIN m_hu_item ha_item
+                           ON ha_item.m_hu_id = lu_hu.m_hu_id
+                               AND ha_item.itemtype = 'HA'
+                               AND ha_item.qty IS NOT NULL
+                               AND ha_item.qty > 0
+                      JOIN m_hu ha_vtu ON ha_vtu.m_hu_item_parent_id = ha_item.m_hu_item_id
+             WHERE EXISTS (
+                 SELECT 1
+                 FROM m_hu_assignment ha
+                          JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
+                 WHERE ha.ad_table_id = v_m_inoutline_table_id
+                   AND ha.isactive = 'Y'
+                   AND ha.vhu_id = ha_vtu.m_hu_id
+             )),
+
+         hu_attrs AS MATERIALIZED (
+             -- Single pivot scan of m_hu_attribute for ALL relevant HU IDs and the 3 needed
+             -- attribute IDs — replaces 6 separate LEFT JOIN m_hu_attribute (3 per TU type)
+             SELECT ha.m_hu_id,
+                    MAX(CASE WHEN ha.m_attribute_id = v_grai_attribute_id THEN ha.value END)    AS grai_value,
+                    MAX(CASE WHEN ha.m_attribute_id = v_lot_attribute_id THEN ha.value END)     AS lot_number,
+                    MAX(CASE WHEN ha.m_attribute_id = v_bbd_attribute_id THEN ha.valuedate END) AS best_before_date
+             FROM m_hu_attribute ha
+             WHERE ha.m_hu_id IN (SELECT tu_hu_id
+                                  FROM individual_tu_ids
+                                  UNION
+                                  SELECT attr_hu_id
+                                  FROM ha_items_with_vtu)
+               AND ha.m_attribute_id IN (v_grai_attribute_id, v_lot_attribute_id, v_bbd_attribute_id)
+             GROUP BY ha.m_hu_id),
+
+         bp_prod_lookup AS MATERIALIZED (
+             -- Buyer-specific product GTINs: ONE scan replaces N LATERAL calls in items CTEs
+             SELECT DISTINCT ON (bp.m_product_id) bp.m_product_id,
+                                                  bp.gtin,
+                                                  bp.ean_cu
+             FROM c_bpartner_product bp
+             WHERE bp.c_bpartner_id = (SELECT buyer_bpartner_id FROM inout_context)
+               AND bp.isactive = 'Y'
+             ORDER BY bp.m_product_id, bp.seqno DESC),
+
+         individual_tus AS MATERIALIZED (
+             -- CASE A: individual TUs with attributes joined from hu_attrs
+             SELECT it.lu_hu_id,
+                    it.lu_poreference_padded,
+                    it.tu_hu_id,
+                    it.tu_pi_item_product_id,
+                    NULLIF(TRIM(ha.grai_value), '') AS grai_raw,
+                    ha.lot_number,
+                    ha.best_before_date
+             FROM individual_tu_ids it
+                      LEFT JOIN hu_attrs ha ON ha.m_hu_id = it.tu_hu_id),
+
+         individual_tu_items AS (
+             -- Items for ALL individual TUs in ONE batch query
+             SELECT it.tu_hu_id,
+                    JSONB_AGG(
+                            JSONB_BUILD_OBJECT(
+                                    'cuGTIN', COALESCE(bp_prod.gtin, bp_prod.ean_cu, prod.gtin),
+                                    'tuGTIN', COALESCE(pi_prod.gtin, pi_prod.ean_tu),
+                                    'quantity', stor.qty,
+                                    'movementqty', stor.qty,
+                                    'uom', COALESCE(uom.x12de355, 'KGM'),
+                                    'productValue', prod.value,
+                                    'productNetWeight', prod.weight,
+                                    'productGrossWeight', prod.grossweight
+                            )
+                    ) AS items_json
+             FROM individual_tus it
+                      JOIN m_hu_item mi ON mi.m_hu_id = it.tu_hu_id AND mi.itemtype = 'MI'
+                      JOIN m_hu_item_storage stor ON stor.m_hu_item_id = mi.m_hu_item_id
+                      JOIN m_product prod ON prod.m_product_id = stor.m_product_id
+                      LEFT JOIN c_uom uom ON uom.c_uom_id = stor.c_uom_id
+                      LEFT JOIN m_hu_pi_item_product pi_prod
+                                ON pi_prod.m_hu_pi_item_product_id = it.tu_pi_item_product_id
+                      LEFT JOIN bp_prod_lookup bp_prod ON bp_prod.m_product_id = prod.m_product_id
+             GROUP BY it.tu_hu_id),
+
+         aggregated_tu_base AS MATERIALIZED (
+             -- CASE B: aggregated TU base rows with attributes — vtu already resolved in ha_items_with_vtu
+             SELECT hwv.lu_hu_id,
+                    hwv.lu_poreference_padded,
+                    hwv.tu_hu_id,
+                    hwv.qty,
+                    hwv.vtu_hu_id,
+                    hwv.vtu_pi_item_product_id,
+                    COALESCE(
+                            NULLIF(STRING_TO_ARRAY(TRIM(ha.grai_value), ','), ARRAY [NULL]::text[]),
+                            ARRAY []::text[]
+                    ) AS grai_arr,
+                    ha.lot_number,
+                    ha.best_before_date
+             FROM ha_items_with_vtu hwv
+                      LEFT JOIN hu_attrs ha ON ha.m_hu_id = hwv.attr_hu_id),
+
+         aggregated_tu_items AS (
+             -- Items for ALL aggregated TUs in ONE batch query — no m_hu join needed (vtu_hu_id from atb)
+             SELECT atb.tu_hu_id,
+                    JSONB_AGG(
+                            JSONB_BUILD_OBJECT(
+                                    'cuGTIN', COALESCE(bp_prod.gtin, bp_prod.ean_cu, prod.gtin),
+                                    'tuGTIN', COALESCE(pi_prod.gtin, pi_prod.ean_tu),
+                                    'quantity',
+                                    CASE
+                                        WHEN COALESCE(atb.qty, 1) > 0 THEN stor.qty / atb.qty
+                                                                      ELSE stor.qty
+                                    END,
+                                    'movementqty',
+                                    CASE
+                                        WHEN COALESCE(atb.qty, 1) > 0 THEN stor.qty / atb.qty
+                                                                      ELSE stor.qty
+                                    END,
+                                    'uom', COALESCE(uom.x12de355, 'KGM'),
+                                    'productValue', prod.value,
+                                    'productNetWeight', prod.weight,
+                                    'productGrossWeight', prod.grossweight
+                            )
+                    ) AS items_json
+             FROM aggregated_tu_base atb
+                      JOIN m_hu_item mi ON mi.m_hu_id = atb.vtu_hu_id AND mi.itemtype = 'MI'
+                      JOIN m_hu_item_storage stor ON stor.m_hu_item_id = mi.m_hu_item_id
+                      JOIN m_product prod ON prod.m_product_id = stor.m_product_id
+                      LEFT JOIN c_uom uom ON uom.c_uom_id = stor.c_uom_id
+                      LEFT JOIN m_hu_pi_item_product pi_prod
+                                ON pi_prod.m_hu_pi_item_product_id = atb.vtu_pi_item_product_id
+                      LEFT JOIN bp_prod_lookup bp_prod ON bp_prod.m_product_id = prod.m_product_id
+             GROUP BY atb.tu_hu_id, atb.qty),
+
+         all_crates_raw AS (
+             -- Individual TUs (CASE A)
+             SELECT it.lu_hu_id,
+                    it.lu_poreference_padded,
+                    it.tu_hu_id,
+                    it.grai_raw,
+                    it.lot_number,
+                    it.best_before_date,
+                    1 AS sort_ord,
+                    iti.items_json
+             FROM individual_tus it
+                      LEFT JOIN individual_tu_items iti ON iti.tu_hu_id = it.tu_hu_id
+
+             UNION ALL
+
+             -- Aggregated TUs (CASE B): expand grai_arr to qty rows, reuse pre-computed items
+             SELECT atb.lu_hu_id,
+                    atb.lu_poreference_padded,
+                    atb.tu_hu_id,
+                    NULLIF(
+                            CASE
+                                WHEN gs <= COALESCE(ARRAY_LENGTH(atb.grai_arr, 1), 0)
+                                    THEN TRIM(atb.grai_arr[gs])
+                                    ELSE ''
+                            END,
+                            ''
+                    )  AS grai_raw,
+                    atb.lot_number,
+                    atb.best_before_date,
+                    gs AS sort_ord,
+                    ati.items_json
+             FROM aggregated_tu_base atb
+                      LEFT JOIN aggregated_tu_items ati ON ati.tu_hu_id = atb.tu_hu_id
+                      CROSS JOIN GENERATE_SERIES(1, GREATEST(atb.qty::int, 1)) AS gs),
+
+         all_crates_with_grai AS (
+             -- Dummy GRAI: middle segment = source-order POReference (LPAD to 10 digits, per-LU).
+             -- Migros format: urn:epc:id:grai:<GCP>.<assetType>.<10-digit Bestellnummer><2-digit counter>
+             -- Counter resets per LU so TUs within the same LU get 01, 02, … while TUs on
+             -- different LUs (= different source orders) start at 01 independently.
+             -- This avoids both the cross-order POReference leak (pre-PR bug) and the
+             -- zero-uniqueness 'DUMMY_____' literal (first PR draft).
+             SELECT lu_hu_id,
+                    tu_hu_id,
+                    CASE
+                        WHEN grai_raw IS NOT NULL
+                            THEN grai_raw
+                            ELSE v_dummy_grai_prefix ||
+                                 lu_poreference_padded ||
+                                 LPAD(
+                                         (COUNT(*) FILTER (WHERE grai_raw IS NULL)
+                                             OVER (PARTITION BY lu_hu_id
+                                                   ORDER BY tu_hu_id, sort_ord
+                                                   ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))::text,
+                                         2, '0')
+                    END AS grai,
+                    lot_number,
+                    best_before_date,
+                    sort_ord,
+                    items_json
+             FROM all_crates_raw)
+
+    SELECT JSONB_BUILD_OBJECT(
+                   'shipmentId', ctx.m_inout_id,
+                   'documentNo', ctx.documentno,
+                   'movementDate', TO_CHAR(ctx.movementdate, 'YYYY-MM-DD"T"HH24:MI:SS'),
+                   'timezone', '+01:00',
+               -- Supplier GLN (org's BPartner location)
+                   'supplierGLN', bpl_supplier.gln,
+                   'supplierGcpLength', bpl_supplier.gln_gcpLength,
+               -- Warehouse GLN: primary from warehouse BPartner, fallback to org
+                   'warehouseGLN', COALESCE(bpl_wh.gln, bpl_supplier.gln),
+                   'warehouseGcpLength',
+                   CASE
+                       WHEN bpl_wh.gln IS NOT NULL THEN bpl_wh.gln_gcpLength
+                                                   ELSE bpl_supplier.gln_gcpLength
+                   END,
+               -- Warehouse value for SGLN extension
+                   'warehouseValue', wh.value,
+               -- Buyer GLN: DESADV → shipment fallback
+                   'buyerGLN', COALESCE(ctx.buyer_gln_desadv, ctx.buyer_gln_ship),
+                   'buyerGcpLength',
+                   CASE
+                       WHEN ctx.buyer_gln_desadv IS NOT NULL THEN ctx.buyer_gcplength_desadv
+                                                             ELSE ctx.buyer_gcplength_ship
+                   END,
+               -- Handover (DESADV only)
+                   'handoverGLN', bpl_handover.gln,
+                   'handoverGcpLength', bpl_handover.gln_gcpLength,
+               -- Dropship: DESADV → shipment fallback
+                   'dropshipGLN', COALESCE(ctx.drop_gln_desadv, ctx.drop_gln_ship),
+                   'dropshipGcpLength',
+                   CASE
+                       WHEN ctx.drop_gln_desadv IS NOT NULL THEN ctx.drop_gcplength_desadv
+                                                            ELSE ctx.drop_gcplength_ship
+                   END,
+               -- DESADV references: scalar (first element, backward-compat) AND array.
+               -- desadvReferences[] carries all linked DESADV DocumentNos.
+               -- Scalar falls back to M_InOut.EDI_Desadv_ID for shipments without junction rows.
+                   'desadvReference', COALESCE((ctx.desadv_documentnos ->> 0), ctx.desadv_documentno),
+                   'desadvReferences', COALESCE(ctx.desadv_documentnos, '[]'::jsonb),
+               -- PO references: same scalar + array pattern.
+               -- Scalar falls back to InOut.POReference for shipments without junction rows.
+                   'poReference', COALESCE((ctx.desadv_poreferences ->> 0), ctx.poreference),
+                   'poReferences', COALESCE(ctx.desadv_poreferences,
+                                            CASE WHEN ctx.poreference IS NOT NULL
+                                                 THEN jsonb_build_array(ctx.poreference)
+                                                 ELSE '[]'::jsonb END),
+               -- Pallets
+                   'pallets', COALESCE(
+                           (SELECT JSONB_AGG(
+                                           JSONB_BUILD_OBJECT(
+                                                   'sscc', pallet_agg.sscc,
+                                                   'huId', pallet_agg.lu_hu_id,
+                                                   'crates', pallet_agg.crates_json
+                                           ) ORDER BY pallet_agg.lu_hu_id
+                                   )
+                            FROM (SELECT c.lu_hu_id,
+                                         sscc_attr.value AS sscc,
+                                         JSONB_AGG(
+                                                 JSONB_BUILD_OBJECT(
+                                                         'grai', c.grai,
+                                                         'lotNumber', c.lot_number,
+                                                         'bestBeforeDate', c.best_before_date,
+                                                         'tuHuId', c.tu_hu_id,
+                                                         'items', COALESCE(c.items_json, '[]'::jsonb)
+                                                 ) ORDER BY c.tu_hu_id
+                                         )               AS crates_json
+                                  FROM all_crates_with_grai c
+                                           LEFT JOIN m_hu_attribute sscc_attr
+                                                     ON sscc_attr.m_hu_id = c.lu_hu_id
+                                                         AND sscc_attr.m_attribute_id = v_sscc_attribute_id
+                                  GROUP BY c.lu_hu_id, sscc_attr.value
+                                  ORDER BY c.lu_hu_id) pallet_agg),
+                           '[]'::jsonb
+                              )
+           )
+    INTO v_result
+    FROM inout_context ctx
+             JOIN m_warehouse wh ON wh.m_warehouse_id = ctx.m_warehouse_id
+             LEFT JOIN c_bpartner_location bpl_wh
+                       ON bpl_wh.c_bpartner_location_id = wh.c_bpartner_location_id
+             LEFT JOIN ad_orginfo org ON org.ad_org_id = ctx.ad_org_id
+             LEFT JOIN c_bpartner_location bpl_supplier
+                       ON bpl_supplier.c_bpartner_location_id = org.orgbp_location_id
+             LEFT JOIN c_bpartner_location bpl_handover
+                       ON bpl_handover.c_bpartner_location_id = ctx.handover_location_id
+    WHERE ctx.isactive = 'Y'
+      AND ctx.docstatus IN ('CO', 'CL');
+
+    RETURN COALESCE(v_result, '{}'::jsonb);
+END;
+$$
+    LANGUAGE plpgsql STABLE
+;

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5805460_sys_me03_29231_epcis_has_events_fn.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5805460_sys_me03_29231_epcis_has_events_fn.sql
@@ -1,0 +1,22 @@
+-- Migration: me03#29231 — add "de.metas.edi".epcis_has_events(m_inout_id)
+-- https://github.com/metasfresh/me03/issues/29231
+--
+-- Boolean helper for the scripted-adapter outbound-selection WHERE-clause. Returns TRUE only when
+-- the EPCIS export for the shipment would contain at least one pallet (SSCC) — i.e. it is worth
+-- sending. Returns FALSE for the non-owner sibling of a shared physical pallet (get_epcis_events_json_fn
+-- returns '{}') and for shipments with no LU pallets, so metasfresh never transmits an empty EPCIS
+-- document to the clearing center. Delegates to get_epcis_events_json_fn (single source of truth).
+
+CREATE OR REPLACE FUNCTION "de.metas.edi".epcis_has_events(p_m_inout_id numeric)
+    RETURNS boolean
+    LANGUAGE sql
+    STABLE
+AS
+$$
+SELECT COALESCE(
+               jsonb_typeof(j.payload -> 'pallets') = 'array'
+                   AND jsonb_array_length(j.payload -> 'pallets') > 0,
+               false
+       )
+FROM (SELECT "de.metas.edi".get_epcis_events_json_fn(p_m_inout_id) AS payload) j;
+$$;


### PR DESCRIPTION
### Problem

When two sales orders are picked onto **one physical pallet** (one shared LU / one SSCC), metasfresh
models the shipment as **two `M_InOut`s** that share that LU. The EPCIS JSON export
(`get_epcis_events_json_fn`) was keyed **per `M_InOut`**, so it emitted **two EPCIS events for the same
physical SSCC** — one per order. The receiving clearing center requires exactly **one** picking +
commissioning event per SSCC, referencing **both** orders (two BizTransaction lines). Two DESADVs (one
per order) is correct and unchanged.

### Change

Re-key `"de.metas.edi".get_epcis_events_json_fn` from per-`M_InOut` to **per-physical-LU ownership**:

- **Owner** of an LU = the lowest-id active (`CO`/`CL`) `M_InOut` that has goods assigned to it.
- The function emits a non-empty event only for the LUs `p_m_inout_id` **owns**; for those it **merges
  all crates** physically on the LU (across the shipments sharing it) and aggregates
  `desadvReferences[]` / `poReferences[]` across **all** sharing shipments.
- A genuine **sibling** shipment (shares a pallet but owns none of it) returns `'{}'`.
- Shipments that don't share a pallet (sole owner, or LUs found only via the QtyPicked fallback) are
  unaffected; voided/reversed shipments can't be elected owner.

No Java production code changes — the export `AD_Process` and the PostgREST view are untouched; the
behavior change is entirely inside the SQL function. Supersedes the per-`M_InOut` crate filter of
`5804420` for the shared-pallet case.

### Tests

`backend/de.metas.cucumber/.../edi/epcisExport.feature` scenario `S29231_170` rewritten to assert the
new contract (owner merges all 15 crates + `desadvReferences`/`poReferences` size 2; sibling returns
`{}`). Full `epcisExport` feature GREEN locally: `EPCIS_010`, `EPCIS_020`, `EPCIS_030`, `S29231_130`,
`S29231_170` (5/5).

### Migration

`5805440_sys_me03_29231_epcis_one_event_per_sscc.sql` — `CREATE OR REPLACE FUNCTION` (idempotent).

