### PR TITLE
Import GL Journal: make AD_Menu 542247 normalization robust across branch lines

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5768920_AddImportJournalWindow.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5768920_AddImportJournalWindow.sql
@@ -4,7 +4,12 @@
 -- Action Type: W
 -- Window: Import - Hauptbuchjournal(278,D)
 -- 2025-09-18T09:55:00.233Z
+-- ON CONFLICT DO NOTHING guards against the partial unique index uc_ad_menu_internalname
+-- (UNIQUE(internalname) WHERE isactive='Y'). On the soft_panda_hotfix line the same menu already
+-- exists under AD_Menu_ID=542298 (script 5789380), so a plain INSERT of 542247 aborts the whole
+-- rollout. This only prevents the crash; 5789382_Normalize_ImportGLJournal_MenuID.sql establishes 542247.
 INSERT INTO AD_Menu (Action,AD_Client_ID,AD_Element_ID,AD_Menu_ID,AD_Org_ID,AD_Window_ID,Created,CreatedBy,Description,EntityType,InternalName,IsActive,IsCreateNew,IsReadOnly,IsSOTrx,IsSummary,Name,Updated,UpdatedBy) VALUES ('W',0,574197,542247,0,278,TO_TIMESTAMP('2025-09-18 09:54:59.925000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Import von Hauptbuch-Journalen','D','Import GL Journal','Y','N','N','N','N','Import - Hauptbuchjournal',TO_TIMESTAMP('2025-09-18 09:54:59.925000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+ON CONFLICT DO NOTHING
 ;
 
 -- 2025-09-18T09:55:00.246Z

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789382_Normalize_ImportGLJournal_MenuID.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5789382_Normalize_ImportGLJournal_MenuID.sql
@@ -9,14 +9,30 @@
 --   1. Only 542247 exists (new_dawn_uat path) => nothing to do
 --   2. Only 542298 exists (hotfix path) => create 542247, delete 542298
 --   3. Both exist (merge path) => delete 542298
+--
+-- FIX: AD_Menu carries a PARTIAL unique index
+--   uc_ad_menu_internalname = UNIQUE(internalname) WHERE isactive='Y'.
+-- Both 542247 and 542298 use InternalName='Import GL Journal'. The previous version of this
+-- script did "INSERT 542247 SELECT ... FROM 542298" while 542298 was still active, which violated
+-- that index and aborted the whole rollout (exactly the state-2 case it was meant to handle).
+-- The fix: deactivate 542298 FIRST (Step 0) to free the active-only index, then insert 542247 forcing
+-- IsActive='Y'. Pairs with the ON CONFLICT DO NOTHING guard added to 5768920.
 
--- Step 1: If 542247 does not exist but 542298 does, create 542247 from 542298's data
+-- Step 0: free the active-only unique index by deactivating 542298,
+-- but only when 542247 does not yet exist (state 2). No-op in states 1 and 3.
+UPDATE AD_Menu SET IsActive='N'
+WHERE AD_Menu_ID = 542298
+  AND NOT EXISTS (SELECT 1 FROM AD_Menu WHERE AD_Menu_ID = 542247)
+;
+
+-- Step 1: If 542247 does not exist but 542298 does, create 542247 from 542298's data.
+-- IsActive is forced to 'Y' (542298 was just deactivated in Step 0).
 INSERT INTO AD_Menu (Action, AD_Client_ID, AD_Element_ID, AD_Menu_ID, AD_Org_ID, AD_Window_ID,
                      Created, CreatedBy, Description, EntityType, InternalName,
                      IsActive, IsCreateNew, IsReadOnly, IsSOTrx, IsSummary, Name, Updated, UpdatedBy)
 SELECT Action, AD_Client_ID, AD_Element_ID, 542247, AD_Org_ID, AD_Window_ID,
        Created, CreatedBy, Description, EntityType, InternalName,
-       IsActive, IsCreateNew, IsReadOnly, IsSOTrx, IsSummary, Name, Updated, UpdatedBy
+       'Y', IsCreateNew, IsReadOnly, IsSOTrx, IsSummary, Name, Updated, UpdatedBy
 FROM AD_Menu
 WHERE AD_Menu_ID = 542298
   AND NOT EXISTS (SELECT 1 FROM AD_Menu WHERE AD_Menu_ID = 542247)


### PR DESCRIPTION
## Problem

The "Import - Hauptbuchjournal" menu (window `278`) was created independently on two branches with the **same** `InternalName='Import GL Journal'` but different IDs:

- `new_dawn_uat`: `AD_Menu_ID=542247` (script `5768920`)
- `soft_panda_hotfix`: `AD_Menu_ID=542298` (script `5789380`)

`AD_Menu` has a **partial unique index** `uc_ad_menu_internalname = UNIQUE(internalname) WHERE isactive='Y'`.

On any database that already carries `542298` (the hotfix line), the rollout aborts **twice**:

1. `5768920` used a plain `INSERT` of `542247` → `duplicate key value violates unique constraint "uc_ad_menu_internalname"` (the active `InternalName` is held by `542298`).
2. `5789382` — the normalize script meant to converge everything onto `542247` — inserts `542247` *selecting from `542298`* while `542298` is still active → **the same violation**, in exactly the state it was written to handle.

Because both scripts crash and CI/rollout applies migrations with `ON_ERROR_STOP`, a new higher-numbered script cannot fix this (it never gets reached). The two scripts must be corrected in place.

## Fix

- **`5768920`**: add `ON CONFLICT DO NOTHING` to the `AD_Menu` INSERT. Crash-guard only — on a fresh DB it still creates `542247`; on a DB already holding the name it cleanly no-ops.
- **`5789382`**: make it constraint-safe — **deactivate `542298` first** (frees the active-only unique index), then insert `542247` forcing `IsActive='Y'`, copy translations + tree node, delete `542298`.

Both scripts already ran (as no-ops) on `new_dawn_uat`, so editing them is safe there and only changes behaviour on not-yet-migrated DBs carrying `542298`.

## Verification

Ran the **actual edited files** via `\i` against real databases, all in rolled-back transactions:

| State | Result |
|---|---|
| Only `542298` exists (hotfix line) | `542247` created (active, window 278), 5 translations + tree placement preserved, `542298` removed, exactly one active row |
| Only `542247` exists (new_dawn / CI end-state) | edited `5789382` = clean no-op (0 rows touched) |
| Neither exists (fresh seed / CI apply path) | edited `5768920` creates `542247`; `5789382` no-op |
