### PR TITLE
flaky-metric: bump Action Node.js 20 -> 24

### DIFF
--- a/.github/workflows/flaky-metric.yaml
+++ b/.github/workflows/flaky-metric.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install deps
         working-directory: .github/flaky-metric


### PR DESCRIPTION
## Summary

GitHub's runner emits a deprecation warning that Node.js 20 is deprecated for actions when the flaky-metric workflow runs. Bump the `actions/setup-node` `node-version` for the workflow's `run` steps from `20` to `24`.

## Scope

`.github/workflows/flaky-metric.yaml` only — a one-line version bump. No tool/code change.

## Validation

The extractor and its test suite already run on Node 24 (this is the local dev runtime); `node --test` → 24/24 green. `npm ci` uses the committed lockfile, which resolves the same on Node 24.