### PR TITLE
ci: bump download-artifact actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/generate-allure-report/action.yml
+++ b/.github/actions/generate-allure-report/action.yml
@@ -43,7 +43,7 @@ runs:
     # Download previous history from last successful run on same branch
     - name: Download previous Allure history
       if: inputs.history-artifact-name != ''
-      uses: dawidd6/action-download-artifact@v9
+      uses: dawidd6/action-download-artifact@v21
       with:
         name: ${{ inputs.history-artifact-name }}
         path: ${{ inputs.results-dir }}/history

--- a/.github/actions/generate-junit-html/action.yml
+++ b/.github/actions/generate-junit-html/action.yml
@@ -33,7 +33,7 @@ runs:
     # Download previous history from last run on same branch
     - name: Download previous Allure history
       if: inputs.history-artifact-name != ''
-      uses: dawidd6/action-download-artifact@v9
+      uses: dawidd6/action-download-artifact@v21
       with:
         name: ${{ inputs.history-artifact-name }}
         path: junit-history-temp

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -696,7 +696,7 @@ jobs:
           echo -e "$INIT_BUILD_PROPS" > docker-builds/metadata/build-info.properties
           echo -e "$INIT_GIT_PROPS" > docker-builds/metadata/git.properties
       - name: download-migration-cli-jar
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: migration-cli-jar
           path: .
@@ -1638,7 +1638,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download all Cucumber Allure results
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: cucumber-allure-results-*
           path: all-cucumber-results/
@@ -2004,7 +2004,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download all shard Allure results
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: allure-results-frontend-*
           path: allure-results-merged


### PR DESCRIPTION
## Summary

Two `download-artifact` actions were still on the Node.js 20 runtime after the org-wide Node-24 migration. GitHub deprecates Node 20 on 2026-06-02 (forced default) and removes it 2026-09-16.

- `actions/download-artifact@v6` → `@v8` — 3 occurrences in `cicd.yaml`
- `dawidd6/action-download-artifact@v9` → `@v21` — 2 occurrences in composite-action files

The asymmetry that caused the miss: `actions/upload-artifact@v6` and `actions/checkout@v6` already run on `node24`, but for the `download-artifact` repo specifically, v6 is the last `node20` major (the cutover is at v7).

## Verification

Each target major's `action.yml` declares `runs.using: node24`:

- `actions/download-artifact@v8` (latest major) — `node24`
- `dawidd6/action-download-artifact@v21` (latest major) — `node24`

For `dawidd6/action-download-artifact@v21`, confirmed all 6 inputs used here (`name`, `path`, `workflow_conclusion`, `branch`, `if_no_artifact_found`, `search_artifacts`) are still declared, so no input changes needed.