### PR TITLE
mobileUI: fix virtual keyboard popup regression on mobile scan

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/sysconfig/SysconfigCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/sysconfig/SysconfigCommand.java
@@ -1,11 +1,16 @@
 package de.metas.frontend_testing.masterdata.sysconfig;
 
 import com.google.common.collect.ImmutableMap;
+import de.metas.organization.ClientAndOrgId;
 import de.metas.organization.OrgId;
 import de.metas.util.Services;
 import lombok.Builder;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.service.ClientId;
 import org.adempiere.service.ISysConfigBL;
+import org.compiere.model.I_AD_SysConfig;
+import org.compiere.model.X_AD_SysConfig;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -28,8 +33,6 @@ public class SysconfigCommand
 		}
 
 		final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
-		final int adClientId = ClientId.METASFRESH.getRepoId();
-		final int adOrgId = OrgId.MAIN.getRepoId();
 
 		final ImmutableMap.Builder<String, String> previousValues = ImmutableMap.builder();
 
@@ -38,15 +41,76 @@ public class SysconfigCommand
 			final String name = entry.getKey();
 			final String newValue = entry.getValue();
 
-			final String previousValue = sysConfigBL.getValue(name, null, adClientId, adOrgId);
+			final ClientAndOrgId target = computeTarget(name);
+
+			// Capture the value that exists at exactly this level (not the cascaded/effective value),
+			// so a later restore via setSysconfigs round-trips back to the same level.
+			// Note: AD_SysConfig has no delete API, so a sysconfig that did not exist at this level
+			// beforehand cannot be fully removed on restore - acceptable for test masterdata.
+			final String previousValue = retrieveValueAtLevel(name, target);
 			if (previousValue != null)
 			{
 				previousValues.put(name, previousValue);
 			}
 
-			sysConfigBL.setValue(name, newValue, ClientId.METASFRESH, OrgId.MAIN);
+			sysConfigBL.setValue(name, newValue, target.getClientId(), target.getOrgId());
 		}
 
 		return previousValues.build();
+	}
+
+	/**
+	 * Determines the (client, org) at which the given sysconfig must be written, based on its
+	 * {@code ConfigurationLevel} as declared on the system record. System/Client-level parameters
+	 * cannot be saved at org level (the {@code AD_SysConfig} interceptor throws "Can't Save Org
+	 * Level ..."), so we target the matching level:
+	 * <ul>
+	 *     <li>System ({@code S}) → client=SYSTEM, org=ANY</li>
+	 *     <li>Client ({@code C}) → client=METASFRESH, org=ANY</li>
+	 *     <li>Organization ({@code O}) or unknown → client=METASFRESH, org=MAIN</li>
+	 * </ul>
+	 */
+	private static ClientAndOrgId computeTarget(@NonNull final String name)
+	{
+		final I_AD_SysConfig systemRecord = retrieveRecordAtLevel(name, ClientAndOrgId.SYSTEM);
+		final String configurationLevel = systemRecord != null ? systemRecord.getConfigurationLevel() : null;
+
+		if (X_AD_SysConfig.CONFIGURATIONLEVEL_System.equals(configurationLevel))
+		{
+			return ClientAndOrgId.SYSTEM;
+		}
+		else if (X_AD_SysConfig.CONFIGURATIONLEVEL_Client.equals(configurationLevel))
+		{
+			return ClientAndOrgId.ofClientAndOrg(ClientId.METASFRESH, OrgId.ANY);
+		}
+		else
+		{
+			return ClientAndOrgId.MAIN;
+		}
+	}
+
+	@Nullable
+	private static String retrieveValueAtLevel(@NonNull final String name, @NonNull final ClientAndOrgId clientAndOrgId)
+	{
+		final I_AD_SysConfig record = retrieveRecordAtLevel(name, clientAndOrgId);
+		return record != null ? record.getValue() : null;
+	}
+
+	/**
+	 * Reads the exact {@code AD_SysConfig} record for the given name at the given client/org.
+	 * Intentionally does NOT filter on {@code IsActive}, to mirror the {@code AD_SysConfig}
+	 * interceptor's own {@code retrieveConfigLevel} lookup (which also ignores IsActive) - so that
+	 * {@link #computeTarget} predicts exactly whether the interceptor would reject the write.
+	 */
+	@Nullable
+	private static I_AD_SysConfig retrieveRecordAtLevel(@NonNull final String name, @NonNull final ClientAndOrgId clientAndOrgId)
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_AD_SysConfig.class)
+				.addEqualsFilter(I_AD_SysConfig.COLUMNNAME_Name, name)
+				.addEqualsFilter(I_AD_SysConfig.COLUMNNAME_AD_Client_ID, clientAndOrgId.getClientId().getRepoId())
+				.addEqualsFilter(I_AD_SysConfig.COLUMNNAME_AD_Org_ID, clientAndOrgId.getOrgId().getRepoId())
+				.create()
+				.first(I_AD_SysConfig.class);
 	}
 }

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -7,7 +7,7 @@
 | Module | Covered | Total | % |
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
-| Barcode Scanner Modes | 8 | 11 | 73% |
+| Barcode Scanner Modes | 8 | 9 | 89% |
 | Picking | 44 | 47 | 94% |
 | Distribution | 30 | 33 | 91% |
 | Manufacturing | 23 | 29 | 79% |

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -7,6 +7,7 @@
 | Module | Covered | Total | % |
 |---|---|---|---|
 | Login / Home | 8 | 10 | 80% |
+| Barcode Scanner Modes | 3 | 4 | 75% |
 | Picking | 44 | 47 | 94% |
 | Distribution | 30 | 33 | 91% |
 | Manufacturing | 23 | 29 | 79% |
@@ -39,8 +40,25 @@
 | Scan HU ID (M_HU_ID) from home screen → navigates to HU Manager, qty shown | `home_screen.spec.js` |
 | Scan ExternalBarcode from home screen → navigates to HU Manager, qty shown | `home_screen.spec.js` |
 | Scan workplace QR code from home screen → opens Workplace Manager, name and assigned status shown | `home_screen.spec.js` |
+| DataWedge IME — scan HU QR code via InputConnection injection → navigates to HU Manager, qty shown | `home_screen.spec.js` |
 
-**4/4 — 100%**
+**5/5 — 100%**
+
+---
+
+## Barcode Scanner Modes
+
+### Input path coverage
+
+| Scenario | Test |
+|---|---|
+| Mode A — DataWedge IME: set input value + fire input/change + Enter keyup → barcode forwarded | `home_screen.spec.js` |
+| Mode C1 — Keystroke scanner: keydown events on window, rate-based buffering → barcode forwarded | covered across 35+ spec files |
+| Mode C2 — Ctrl+V paste: clipboard mocked, keydown Ctrl+V on window → barcode forwarded | `barcode_scanner_modes.spec.js` |
+| Mode C3 — Manual typing: fill visible editable input + Enter → barcode forwarded | `barcode_scanner_modes.spec.js` |
+| ❌ Mode B — Camera (ZXing/BrowserMultiFormatReader): getUserMedia() decode → barcode forwarded | — (not testable in CI, requires real camera) |
+
+**3/4 — 75%** (Mode B excluded — untestable in Playwright CI)
 
 ---
 

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -7,7 +7,7 @@
 | Module | Covered | Total | % |
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
-| Barcode Scanner Modes | 8 | 9 | 89% |
+| Barcode Scanner Modes | 8 | 11 | 73% |
 | Picking | 44 | 47 | 94% |
 | Distribution | 30 | 33 | 91% |
 | Manufacturing | 23 | 29 | 79% |
@@ -71,7 +71,7 @@
 | ❌ `scanDuplicatesIntervalMillis` — duplicate barcode within interval suppressed, outside interval forwarded | — |
 | ❌ `triggerOnChangeIfLengthGreaterThan` — onChange fires only once input length exceeds threshold | — |
 
-**4/5 — 80%** (Mode B excluded — untestable in Playwright CI; `scanDuplicatesIntervalMillis` and `triggerOnChangeIfLengthGreaterThan` not yet covered)
+**4/7 — 57%** (Mode B excluded — untestable in Playwright CI; `scanDuplicatesIntervalMillis` and `triggerOnChangeIfLengthGreaterThan` not yet covered)
 
 ---
 

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -6,8 +6,8 @@
 
 | Module | Covered | Total | % |
 |---|---|---|---|
-| Login / Home | 8 | 10 | 80% |
-| Barcode Scanner Modes | 3 | 4 | 75% |
+| Login / Home | 8 | 11 | 73% |
+| Barcode Scanner Modes | 8 | 11 | 73% |
 | Picking | 44 | 47 | 94% |
 | Distribution | 30 | 33 | 91% |
 | Manufacturing | 23 | 29 | 79% |
@@ -40,25 +40,38 @@
 | Scan HU ID (M_HU_ID) from home screen → navigates to HU Manager, qty shown | `home_screen.spec.js` |
 | Scan ExternalBarcode from home screen → navigates to HU Manager, qty shown | `home_screen.spec.js` |
 | Scan workplace QR code from home screen → opens Workplace Manager, name and assigned status shown | `home_screen.spec.js` |
-| DataWedge IME — scan HU QR code via InputConnection injection → navigates to HU Manager, qty shown | `home_screen.spec.js` |
+| ❌ Generated HU QR code scan from home screen → navigates correctly | — |
 
-**5/5 — 100%**
+**4/5 — 80%**
 
 ---
 
 ## Barcode Scanner Modes
 
+### Attribute regression guards
+
+| Scenario | Test |
+|---|---|
+| `#input-text` has `type="text"` (never `type="hidden"`) — DataWedge IME requires a real text input | `barcode_scanner_modes.spec.js` |
+| `#input-text` has `inputmode="none"` by default — virtual keyboard suppressed on device | `barcode_scanner_modes.spec.js` |
+| `#input-text` does NOT have `readonly` attribute — DataWedge IME (InputConnection) must not be blocked | `barcode_scanner_modes.spec.js` |
+| `#input-text` has CSS class `input-text-offscreen` when `showInputText=N`, and `type="text"` (not `type="hidden"`) | `barcode_scanner_modes.spec.js` |
+
+**4/4 — 100%**
+
 ### Input path coverage
 
 | Scenario | Test |
 |---|---|
-| Mode A — DataWedge IME: set input value + fire input/change + Enter keyup → barcode forwarded | `home_screen.spec.js` |
-| Mode C1 — Keystroke scanner: keydown events on window, rate-based buffering → barcode forwarded | covered across 35+ spec files |
+| Mode A — DataWedge IME: set input value + fire input/change + Enter keyup → barcode forwarded | `barcode_scanner_modes.spec.js` |
+| Mode C1 — Keystroke scanner: keydown events on window, rate-based buffering → barcode forwarded | `barcode_scanner_modes.spec.js` |
 | Mode C2 — Ctrl+V paste: clipboard mocked, keydown Ctrl+V on window → barcode forwarded | `barcode_scanner_modes.spec.js` |
 | Mode C3 — Manual typing: fill visible editable input + Enter → barcode forwarded | `barcode_scanner_modes.spec.js` |
 | ❌ Mode B — Camera (ZXing/BrowserMultiFormatReader): getUserMedia() decode → barcode forwarded | — (not testable in CI, requires real camera) |
+| ❌ `scanDuplicatesIntervalMillis` — duplicate barcode within interval suppressed, outside interval forwarded | — |
+| ❌ `triggerOnChangeIfLengthGreaterThan` — onChange fires only once input length exceeds threshold | — |
 
-**3/4 — 75%** (Mode B excluded — untestable in Playwright CI)
+**4/5 — 80%** (Mode B excluded — untestable in Playwright CI; `scanDuplicatesIntervalMillis` and `triggerOnChangeIfLengthGreaterThan` not yet covered)
 
 ---
 

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -7,7 +7,7 @@
 | Module | Covered | Total | % |
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
-| Barcode Scanner Modes | 8 | 11 | 73% |
+| Barcode Scanner Modes | 5 | 8 | 63% |
 | Picking | 44 | 47 | 94% |
 | Distribution | 30 | 33 | 91% |
 | Manufacturing | 23 | 29 | 79% |
@@ -48,18 +48,15 @@
 
 ## Barcode Scanner Modes
 
-### Attribute regression guards
+### HTML state of #input-text
 
 | Scenario | Test |
 |---|---|
-| `#input-text` has `type="text"` (never `type="hidden"`) — DataWedge IME requires a real text input | `barcode_scanner_modes.spec.js` |
-| `#input-text` has `inputmode="none"` by default — virtual keyboard suppressed on device | `barcode_scanner_modes.spec.js` |
-| `#input-text` does NOT have `readonly` attribute — DataWedge IME (InputConnection) must not be blocked | `barcode_scanner_modes.spec.js` |
-| `#input-text` has CSS class `input-text-offscreen` when `showInputText=N`, and `type="text"` (not `type="hidden"`) | `barcode_scanner_modes.spec.js` |
+| `type=text`, `inputmode=none`, `readonly` absent, CSS-hidden — all four DataWedge-required HTML properties in one check | `barcode_scanner_modes.spec.js` |
 
-**4/4 — 100%**
+**1/1 — 100%**
 
-### Input path coverage
+### Scan paths
 
 | Scenario | Test |
 |---|---|

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -1,0 +1,115 @@
+import { test } from '../../playwright.config';
+import { Backend } from '../utils/screens/Backend';
+import { LoginScreen } from '../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../utils/screens/ApplicationsListScreen';
+import { HUManagerScreen } from '../utils/screens/huManager/HUManagerScreen';
+import { BarcodeScannerComponent } from '../utils/components/BarcodeScannerComponent';
+import { allure } from 'allure-playwright';
+
+const createMasterdata = async ({ extraSysconfigs } = {}) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            sysconfigs: {
+                ...extraSysconfigs,
+            },
+            login: { user: { language: 'en_US' } },
+            products: { P1: {} },
+            warehouses: { wh1: {} },
+            packingInstructions: {
+                PI: { lu: 'LU', qtyTUsPerLU: 20, tu: 'TU', product: 'P1', qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                HU1: { product: 'P1', warehouse: 'wh1', qty: 80 },
+            },
+        },
+    });
+};
+
+// ---------------------------------------------------------------------------
+// Mode C2 — Ctrl+V paste
+// The useKeyboardBarcodeReader hook intercepts Ctrl+V, reads the clipboard via
+// navigator.clipboard.readText(), and calls onReadDone immediately.
+// ---------------------------------------------------------------------------
+// noinspection JSUnusedLocalSymbols
+test('Paste — scan via Ctrl+V clipboard', async ({ page, context }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0295: Frontend MobileUI');
+    allure.tag('F12000: Frontend MobileUI');
+    allure.tag('F12000');
+    allure.story('Barcode scanning modes — Ctrl+V paste');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+    const huBarcode = masterdata.handlingUnits.HU1.qrCode;
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    // Grant clipboard-read permission so navigator.clipboard.readText() resolves.
+    await context.grantPermissions(['clipboard-read']);
+
+    // Mock navigator.clipboard.readText to return the HU QR code without needing
+    // the OS clipboard. The hook calls readText() asynchronously after the keydown.
+    await page.evaluate((barcode) => {
+        Object.defineProperty(navigator, 'clipboard', {
+            value: {
+                readText: () => Promise.resolve(barcode),
+            },
+            configurable: true,
+        });
+    }, huBarcode);
+
+    // Wait for the scanner input to be in the DOM before firing the paste event.
+    await BarcodeScannerComponent.waitToAttach({});
+
+    // Dispatch Ctrl+V on the window — the hook's keydown listener picks it up.
+    await page.evaluate(() => {
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'v', ctrlKey: true, bubbles: true }));
+    });
+
+    // The hook resolves the clipboard Promise asynchronously, then calls
+    // validateScannedBarcodeAndForward which navigates to the HU Manager.
+    await HUManagerScreen.waitForScreen();
+    await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
+});
+
+// ---------------------------------------------------------------------------
+// Mode C3 — Manual typing into visible editable input
+// When barcodeScanner.showInputText=Y and isInputTextReadonly=N the input is
+// both visible and editable. Pressing Enter in the input fires onKeyUp which
+// calls validateScannedBarcodeAndForward directly.
+// ---------------------------------------------------------------------------
+// noinspection JSUnusedLocalSymbols
+test('Manual typing — visible editable input submits on Enter', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0295: Frontend MobileUI');
+    allure.tag('F12000: Frontend MobileUI');
+    allure.tag('F12000');
+    allure.story('Barcode scanning modes — manual typing into visible input');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({
+        extraSysconfigs: {
+            // Make the input visible so Playwright can locate and fill it.
+            'mobileui.frontend.barcodeScanner.showInputText': 'Y',
+            // Ensure the input is editable (not inputMode="none") so fill() works.
+            'mobileui.frontend.barcodeScanner.isInputTextReadonly': 'N',
+        },
+    });
+    const huBarcode = masterdata.handlingUnits.HU1.qrCode;
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    // The input is visible and editable in this configuration.
+    // fill() sets the value without triggering the onChange debounce.
+    // Pressing Enter fires onKeyUp → handleInputTextKeyPress →
+    // validateScannedBarcodeAndForward in BarcodeScannerComponent.
+    const inputLocator = page.locator('#input-text');
+    await inputLocator.fill(huBarcode);
+    await page.keyboard.press('Enter');
+
+    await HUManagerScreen.waitForScreen();
+    await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
+});

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -63,16 +63,27 @@ test('#input-text HTML: type=text, inputMode=none, readOnly absent, CSS-hidden',
 // scanning the HU's QR code must navigate to the HU Manager and show the HU quantity.
 test.describe('Scan paths', () => {
 
-    // Sysconfigs changed by a test (showInputText/isInputTextReadonly are global). Captured per
-    // test and restored in afterEach so the editable-input config never leaks into later specs —
-    // even when the test fails before reaching its end.
-    let previousSysconfigs = null;
+    // The manual-typing test flips two GLOBAL barcode-scanner sysconfigs to make the input
+    // visible + editable. They MUST be reset after each test: a leaked isInputTextReadonly='N'
+    // makes every later spec's scanner editable, and BarcodeScannerComponent.type() then
+    // double-inserts characters (see e2e/mobile-webui/CLAUDE.md "Barcode Scanner Testing"),
+    // breaking unrelated picking scans.
+    //
+    // Reset is deterministic — NOT via masterdata's previousSysconfigs — because the masterdata
+    // API can set a sysconfig but cannot delete a row it created (isInputTextReadonly has no
+    // pre-existing row, so a previous-value restore is a no-op and the 'N' row would persist).
+    // The mobile-webui suite always runs on a mobile device, so the scanner defaults are
+    // showInputText='Y' and isInputTextReadonly='Y' (readonly). afterEach runs even on failure.
+    let scannerSysconfigsChanged = false;
 
     test.afterEach(async () => {
-        if (previousSysconfigs && Object.keys(previousSysconfigs).length > 0) {
-            await Backend.setSysconfigs(previousSysconfigs);
+        if (scannerSysconfigsChanged) {
+            await Backend.setSysconfigs({
+                'mobileui.frontend.barcodeScanner.showInputText': 'Y',
+                'mobileui.frontend.barcodeScanner.isInputTextReadonly': 'Y',
+            });
+            scannerSysconfigsChanged = false;
         }
-        previousSysconfigs = null;
     });
 
     // noinspection JSUnusedLocalSymbols
@@ -147,8 +158,8 @@ test.describe('Scan paths', () => {
                 'mobileui.frontend.barcodeScanner.isInputTextReadonly': 'N',
             },
         });
-        // Captured for afterEach restore (see top of describe block).
-        previousSysconfigs = masterdata.previousSysconfigs;
+        // Signals afterEach to reset the scanner sysconfigs (see top of describe block).
+        scannerSysconfigsChanged = true;
 
         await LoginScreen.login(masterdata.login.user);
         await ApplicationsListScreen.expectVisible();

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -6,12 +6,8 @@ import { HUManagerScreen } from '../utils/screens/huManager/HUManagerScreen';
 import { BarcodeScannerComponent } from '../utils/components/BarcodeScannerComponent';
 import { allure } from 'allure-playwright';
 
-// ---------------------------------------------------------------------------
-// Masterdata helpers
-// ---------------------------------------------------------------------------
-
-// Minimal — login only, no HU/orders. Used by attribute-guard tests T1–T4.
-// Falls back to full HU masterdata if Backend requires products/warehouses.
+// Minimal masterdata: login only, no HU/orders. Used by the attribute-guard tests,
+// which only need the barcode input to render — so they run in seconds.
 const createLoginMasterdata = async ({ extraSysconfigs } = {}) => {
     return await Backend.createMasterdata({
         language: 'en_US',
@@ -22,7 +18,7 @@ const createLoginMasterdata = async ({ extraSysconfigs } = {}) => {
     });
 };
 
-// Full — login + HU. Used by functional tests T5–T8.
+// Full masterdata: login + a handling unit, so scanning its QR code navigates to the HU Manager.
 const createMasterdataWithHU = async ({ extraSysconfigs } = {}) => {
     return await Backend.createMasterdata({
         language: 'en_US',
@@ -41,191 +37,172 @@ const createMasterdataWithHU = async ({ extraSysconfigs } = {}) => {
     });
 };
 
-// ---------------------------------------------------------------------------
-// Group 1 — Attribute regression guards (T1–T4)
-// These tests detect if the #input-text DOM attributes are accidentally
-// reverted to a state that breaks DataWedge IME or causes keyboard popups.
-// Login-only masterdata — run in seconds.
-// ---------------------------------------------------------------------------
+// These tests detect if the #input-text DOM attributes are accidentally reverted
+// to a state that breaks DataWedge IME text injection or causes a virtual keyboard popup.
+test.describe('Attribute regression guards', () => {
 
-// noinspection JSUnusedLocalSymbols
-test('Input attribute: type=text present — never type=hidden', async ({ page }) => {
-    await allure.epic('E0295: Frontend MobileUI');
-    await allure.feature('F12000: Frontend MobileUI');
-    await allure.story('Barcode scanning modes');
-    await allure.severity('critical');
+    // noinspection JSUnusedLocalSymbols
+    test('input type is text, not hidden', async ({ page }) => {
+        await allure.epic('E0295: Frontend MobileUI');
+        await allure.feature('F12000: Frontend MobileUI');
+        await allure.story('Barcode scanning modes');
+        await allure.severity('critical');
 
-    const masterdata = await createLoginMasterdata();
-    await LoginScreen.login(masterdata.login.user);
-    await ApplicationsListScreen.expectVisible();
+        const masterdata = await createLoginMasterdata();
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
 
-    await BarcodeScannerComponent.expectAttributes({ type: 'text' });
-});
-
-// noinspection JSUnusedLocalSymbols
-test('Input attribute: inputMode=none present — virtual keyboard suppressed by default', async ({ page }) => {
-    await allure.epic('E0295: Frontend MobileUI');
-    await allure.feature('F12000: Frontend MobileUI');
-    await allure.story('Barcode scanning modes');
-    await allure.severity('critical');
-
-    const masterdata = await createLoginMasterdata();
-    await LoginScreen.login(masterdata.login.user);
-    await ApplicationsListScreen.expectVisible();
-
-    // HTML attribute is lowercase 'inputmode' (case-insensitive in HTML, but Playwright matches the attribute name).
-    await BarcodeScannerComponent.expectAttributes({ inputmode: 'none' });
-});
-
-// noinspection JSUnusedLocalSymbols
-test('Input attribute: readOnly absent — DataWedge IME connection must not be broken', async ({ page }) => {
-    await allure.epic('E0295: Frontend MobileUI');
-    await allure.feature('F12000: Frontend MobileUI');
-    await allure.story('Barcode scanning modes');
-    await allure.severity('critical');
-
-    const masterdata = await createLoginMasterdata();
-    await LoginScreen.login(masterdata.login.user);
-    await ApplicationsListScreen.expectVisible();
-
-    // readonly attribute must be absent — DataWedge IME injects via InputConnection,
-    // which is blocked when the input is readonly.
-    await BarcodeScannerComponent.expectAttributes({ readonly: null });
-});
-
-// noinspection JSUnusedLocalSymbols
-test('Input CSS: offscreen class present and type=text (not type=hidden) when showInputText=N', async ({ page }) => {
-    await allure.epic('E0295: Frontend MobileUI');
-    await allure.feature('F12000: Frontend MobileUI');
-    await allure.story('Barcode scanning modes');
-    await allure.severity('critical');
-
-    // showInputText defaults to N — this is the normal operating mode.
-    const masterdata = await createLoginMasterdata();
-    await LoginScreen.login(masterdata.login.user);
-    await ApplicationsListScreen.expectVisible();
-
-    // Belt-and-suspenders: input is hidden via CSS class, NOT via type=hidden.
-    // type=hidden would break DataWedge IME (InputConnection requires an actual text input).
-    await BarcodeScannerComponent.expectCssClass({ present: 'input-text-offscreen' });
-    await BarcodeScannerComponent.expectAttributes({ type: 'text' });
-});
-
-// ---------------------------------------------------------------------------
-// Group 2 — Functional scan paths (T5–T8)
-// All require HU masterdata.
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// Mode A — DataWedge IME (moved from home_screen.spec.js)
-// Simulates Zebra DataWedge IME text injection (InputConnection) into #input-text.
-// ---------------------------------------------------------------------------
-// noinspection JSUnusedLocalSymbols
-test('Mode A — DataWedge IME: scan via InputConnection injection (typeViaIME)', async ({ page }) => {
-    await allure.epic('E0295: Frontend MobileUI');
-    await allure.feature('F12000: Frontend MobileUI');
-    await allure.story('Barcode scanning modes');
-    await allure.severity('critical');
-
-    const masterdata = await createMasterdataWithHU();
-    await LoginScreen.login(masterdata.login.user);
-    await ApplicationsListScreen.expectVisible();
-    await ApplicationsListScreen.scanBarcodeViaIME(masterdata.handlingUnits.HU1.qrCode);
-    await HUManagerScreen.waitForScreen();
-    await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
-});
-
-// ---------------------------------------------------------------------------
-// Mode C1 — Keystroke (keyboard wedge / USB HID scanner)
-// Dispatches keydown events on document (same as ApplicationsListScreen.scanBarcode).
-// ---------------------------------------------------------------------------
-// noinspection JSUnusedLocalSymbols
-test('Mode C1 — Keystroke: scan via keyboard events on offscreen input', async ({ page }) => {
-    await allure.epic('E0295: Frontend MobileUI');
-    await allure.feature('F12000: Frontend MobileUI');
-    await allure.story('Barcode scanning modes');
-    await allure.severity('critical');
-
-    const masterdata = await createMasterdataWithHU();
-    await LoginScreen.login(masterdata.login.user);
-    await ApplicationsListScreen.expectVisible();
-
-    // ApplicationsListScreen.scanBarcode() delegates to BarcodeScannerComponent.type(),
-    // which dispatches keydown events on document — exactly how a USB/BT keyboard wedge works.
-    await ApplicationsListScreen.scanBarcode(masterdata.handlingUnits.HU1.qrCode);
-    await HUManagerScreen.waitForScreen();
-    await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
-});
-
-// ---------------------------------------------------------------------------
-// Mode C2 — Ctrl+V paste
-// The useKeyboardBarcodeReader hook intercepts Ctrl+V, reads the clipboard via
-// navigator.clipboard.readText(), and calls onReadDone immediately.
-// ---------------------------------------------------------------------------
-// noinspection JSUnusedLocalSymbols
-test('Mode C2 — Paste: scan via Ctrl+V clipboard', async ({ page, context }) => {
-    await allure.epic('E0295: Frontend MobileUI');
-    await allure.feature('F12000: Frontend MobileUI');
-    await allure.story('Barcode scanning modes');
-    await allure.severity('critical');
-
-    const masterdata = await createMasterdataWithHU();
-    const huBarcode = masterdata.handlingUnits.HU1.qrCode;
-
-    await LoginScreen.login(masterdata.login.user);
-    await ApplicationsListScreen.expectVisible();
-
-    // Grant clipboard-read permission so navigator.clipboard.readText() resolves.
-    await context.grantPermissions(['clipboard-read']);
-
-    // pasteViaClipboard mocks navigator.clipboard.readText and dispatches Ctrl+V on window.
-    // The hook resolves the clipboard Promise asynchronously, then calls
-    // validateScannedBarcodeAndForward which navigates to the HU Manager.
-    await BarcodeScannerComponent.pasteViaClipboard(huBarcode);
-    await HUManagerScreen.waitForScreen();
-    await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
-});
-
-// ---------------------------------------------------------------------------
-// Mode C3 — Manual typing into visible editable input
-// When barcodeScanner.showInputText=Y and isInputTextReadonly=N the input is
-// both visible and editable. Pressing Enter in the input fires onKeyUp which
-// calls validateScannedBarcodeAndForward directly.
-// ---------------------------------------------------------------------------
-// noinspection JSUnusedLocalSymbols
-test('Mode C3 — Manual: visible editable input, isInputTextReadonly=N, fill+Enter', async ({ page }) => {
-    await allure.epic('E0295: Frontend MobileUI');
-    await allure.feature('F12000: Frontend MobileUI');
-    await allure.story('Barcode scanning modes');
-    await allure.severity('critical');
-
-    const masterdata = await createMasterdataWithHU({
-        extraSysconfigs: {
-            // Make the input visible so Playwright can locate and fill it.
-            'mobileui.frontend.barcodeScanner.showInputText': 'Y',
-            // Ensure the input is editable (not inputMode="none") so fill() works.
-            'mobileui.frontend.barcodeScanner.isInputTextReadonly': 'N',
-        },
+        await BarcodeScannerComponent.expectAttributes({ type: 'text' });
     });
 
-    await LoginScreen.login(masterdata.login.user);
-    await ApplicationsListScreen.expectVisible();
+    // noinspection JSUnusedLocalSymbols
+    test('inputMode=none suppresses virtual keyboard by default', async ({ page }) => {
+        await allure.epic('E0295: Frontend MobileUI');
+        await allure.feature('F12000: Frontend MobileUI');
+        await allure.story('Barcode scanning modes');
+        await allure.severity('critical');
 
-    // Navigate to HU Manager so the barcode scanner renders from SysConfig (no hardcoded prop).
-    // The ApplicationsListScreen hardcodes isShowInputText={false}, which would override the
-    // SysConfig and make the attribute assertion below meaningless.
-    await ApplicationsListScreen.startApplication('huManager');
-    await HUManagerScreen.waitForScreen();
+        const masterdata = await createLoginMasterdata();
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
 
-    // Regression guard: when isInputTextReadonly=N, inputmode attribute must be absent
-    // (virtual keyboard suppression is disabled to allow manual typing).
-    await BarcodeScannerComponent.expectAttributes({ inputmode: null });
+        // HTML attribute is lowercase 'inputmode' (case-insensitive in HTML, but Playwright matches the attribute name).
+        await BarcodeScannerComponent.expectAttributes({ inputmode: 'none' });
+    });
 
-    // fill + Enter exercises the manual-typing path: onKeyUp → handleInputTextKeyPress →
-    // validateScannedBarcodeAndForward. BarcodeScannerComponent.typeManually() encapsulates
-    // the locator so the spec stays free of direct page.locator() calls.
-    await BarcodeScannerComponent.typeManually(masterdata.handlingUnits.HU1.qrCode);
+    // noinspection JSUnusedLocalSymbols
+    test('readOnly attribute is absent — DataWedge IME connection preserved', async ({ page }) => {
+        await allure.epic('E0295: Frontend MobileUI');
+        await allure.feature('F12000: Frontend MobileUI');
+        await allure.story('Barcode scanning modes');
+        await allure.severity('critical');
 
-    await HUManagerScreen.waitForHUInfoPanel();
-    await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
+        const masterdata = await createLoginMasterdata();
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+
+        // readonly attribute must be absent — DataWedge IME injects via InputConnection,
+        // which is blocked when the input is readonly.
+        await BarcodeScannerComponent.expectAttributes({ readonly: null });
+    });
+
+    // noinspection JSUnusedLocalSymbols
+    test('input is CSS-hidden, not removed from DOM, when showInputText=N', async ({ page }) => {
+        await allure.epic('E0295: Frontend MobileUI');
+        await allure.feature('F12000: Frontend MobileUI');
+        await allure.story('Barcode scanning modes');
+        await allure.severity('critical');
+
+        // showInputText defaults to N — this is the normal operating mode.
+        const masterdata = await createLoginMasterdata();
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+
+        // Belt-and-suspenders: input is hidden via CSS class, NOT via type=hidden.
+        // type=hidden would break DataWedge IME (InputConnection requires an actual text input).
+        await BarcodeScannerComponent.expectCssClass({ present: 'input-text-offscreen' });
+        await BarcodeScannerComponent.expectAttributes({ type: 'text' });
+    });
+
+});
+
+// Each test drives one real-world way a barcode reaches the app, end to end:
+// scanning the HU's QR code must navigate to the HU Manager and show the HU quantity.
+test.describe('Scan paths', () => {
+
+    // noinspection JSUnusedLocalSymbols
+    test('DataWedge IME — InputConnection injection forwards barcode', async ({ page }) => {
+        await allure.epic('E0295: Frontend MobileUI');
+        await allure.feature('F12000: Frontend MobileUI');
+        await allure.story('Barcode scanning modes');
+        await allure.severity('critical');
+
+        const masterdata = await createMasterdataWithHU();
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.scanBarcodeViaIME(masterdata.handlingUnits.HU1.qrCode);
+        await HUManagerScreen.waitForScreen();
+        await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
+    });
+
+    // noinspection JSUnusedLocalSymbols
+    test('hardware scanner keystrokes forward barcode via window-level hook', async ({ page }) => {
+        await allure.epic('E0295: Frontend MobileUI');
+        await allure.feature('F12000: Frontend MobileUI');
+        await allure.story('Barcode scanning modes');
+        await allure.severity('critical');
+
+        const masterdata = await createMasterdataWithHU();
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+
+        // ApplicationsListScreen.scanBarcode() delegates to BarcodeScannerComponent.type(),
+        // which dispatches keydown events on document — exactly how a USB/BT keyboard wedge works.
+        await ApplicationsListScreen.scanBarcode(masterdata.handlingUnits.HU1.qrCode);
+        await HUManagerScreen.waitForScreen();
+        await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
+    });
+
+    // noinspection JSUnusedLocalSymbols
+    test('Ctrl+V clipboard paste forwards barcode', async ({ page, context }) => {
+        await allure.epic('E0295: Frontend MobileUI');
+        await allure.feature('F12000: Frontend MobileUI');
+        await allure.story('Barcode scanning modes');
+        await allure.severity('critical');
+
+        const masterdata = await createMasterdataWithHU();
+        const huBarcode = masterdata.handlingUnits.HU1.qrCode;
+
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+
+        // Grant clipboard-read permission so navigator.clipboard.readText() resolves.
+        await context.grantPermissions(['clipboard-read']);
+
+        // pasteViaClipboard mocks navigator.clipboard.readText and dispatches Ctrl+V on window.
+        // The hook resolves the clipboard Promise asynchronously, then calls
+        // validateScannedBarcodeAndForward which navigates to the HU Manager.
+        await BarcodeScannerComponent.pasteViaClipboard(huBarcode);
+        await HUManagerScreen.waitForScreen();
+        await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
+    });
+
+    // noinspection JSUnusedLocalSymbols
+    test('manual typing with visible editable input forwards barcode on Enter', async ({ page }) => {
+        await allure.epic('E0295: Frontend MobileUI');
+        await allure.feature('F12000: Frontend MobileUI');
+        await allure.story('Barcode scanning modes');
+        await allure.severity('critical');
+
+        const masterdata = await createMasterdataWithHU({
+            extraSysconfigs: {
+                // Make the input visible so Playwright can locate and fill it.
+                'mobileui.frontend.barcodeScanner.showInputText': 'Y',
+                // Ensure the input is editable (not inputMode="none") so fill() works.
+                'mobileui.frontend.barcodeScanner.isInputTextReadonly': 'N',
+            },
+        });
+
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+
+        // Navigate to HU Manager so the barcode scanner renders from SysConfig (no hardcoded prop).
+        // The ApplicationsListScreen hardcodes isShowInputText={false}, which would override the
+        // SysConfig and make the attribute assertion below meaningless.
+        await ApplicationsListScreen.startApplication('huManager');
+        await HUManagerScreen.waitForScreen();
+
+        // Regression guard: when isInputTextReadonly=N, inputmode attribute must be absent
+        // (virtual keyboard suppression is disabled to allow manual typing).
+        await BarcodeScannerComponent.expectAttributes({ inputmode: null });
+
+        // fill + Enter exercises the manual-typing path: onKeyUp → handleInputTextKeyPress →
+        // validateScannedBarcodeAndForward. BarcodeScannerComponent.typeManually() encapsulates
+        // the locator so the spec stays free of direct page.locator() calls.
+        await BarcodeScannerComponent.typeManually(masterdata.handlingUnits.HU1.qrCode);
+
+        await HUManagerScreen.waitForHUInfoPanel();
+        await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
+    });
+
 });

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -63,6 +63,18 @@ test('#input-text HTML: type=text, inputMode=none, readOnly absent, CSS-hidden',
 // scanning the HU's QR code must navigate to the HU Manager and show the HU quantity.
 test.describe('Scan paths', () => {
 
+    // Sysconfigs changed by a test (showInputText/isInputTextReadonly are global). Captured per
+    // test and restored in afterEach so the editable-input config never leaks into later specs —
+    // even when the test fails before reaching its end.
+    let previousSysconfigs = null;
+
+    test.afterEach(async () => {
+        if (previousSysconfigs && Object.keys(previousSysconfigs).length > 0) {
+            await Backend.setSysconfigs(previousSysconfigs);
+        }
+        previousSysconfigs = null;
+    });
+
     // noinspection JSUnusedLocalSymbols
     test('DataWedge IME — InputConnection injection forwards barcode', async ({ page }) => {
         await allure.epic('E0295: Frontend MobileUI');
@@ -135,6 +147,8 @@ test.describe('Scan paths', () => {
                 'mobileui.frontend.barcodeScanner.isInputTextReadonly': 'N',
             },
         });
+        // Captured for afterEach restore (see top of describe block).
+        previousSysconfigs = masterdata.previousSysconfigs;
 
         await LoginScreen.login(masterdata.login.user);
         await ApplicationsListScreen.expectVisible();

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -224,24 +224,25 @@ test('Mode C3 — Manual: visible editable input, isInputTextReadonly=N, fill+En
             'mobileui.frontend.barcodeScanner.isInputTextReadonly': 'N',
         },
     });
-    const huBarcode = masterdata.handlingUnits.HU1.qrCode;
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
 
-    // Navigate to HU Manager first so the barcode scanner is in the right context.
-    // The ApplicationsListScreen scanner itself will forward the barcode,
-    // but we also do the inline attribute assert here before scanning.
+    // Navigate to HU Manager so the barcode scanner renders from SysConfig (no hardcoded prop).
+    // The ApplicationsListScreen hardcodes isShowInputText={false}, which would override the
+    // SysConfig and make the attribute assertion below meaningless.
+    await ApplicationsListScreen.startApplication('huManager');
+    await HUManagerScreen.waitForScreen();
 
-    // Inline attribute assert: when isInputTextReadonly=N, inputmode attribute is absent
+    // Regression guard: when isInputTextReadonly=N, inputmode attribute must be absent
     // (virtual keyboard suppression is disabled to allow manual typing).
     await BarcodeScannerComponent.expectAttributes({ inputmode: null });
 
     // fill + Enter exercises the manual-typing path: onKeyUp → handleInputTextKeyPress →
     // validateScannedBarcodeAndForward. BarcodeScannerComponent.typeManually() encapsulates
     // the locator so the spec stays free of direct page.locator() calls.
-    await BarcodeScannerComponent.typeManually(huBarcode);
+    await BarcodeScannerComponent.typeManually(masterdata.handlingUnits.HU1.qrCode);
 
-    await HUManagerScreen.waitForScreen();
+    await HUManagerScreen.waitForHUInfoPanel();
     await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
 });

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -34,11 +34,10 @@ const createMasterdata = async ({ extraSysconfigs } = {}) => {
 // noinspection JSUnusedLocalSymbols
 test('Paste — scan via Ctrl+V clipboard', async ({ page, context }) => {
     // === ALLURE METADATA ===
-    allure.epic('E0295: Frontend MobileUI');
-    allure.tag('F12000: Frontend MobileUI');
-    allure.tag('F12000');
-    allure.story('Barcode scanning modes — Ctrl+V paste');
-    allure.severity('normal');
+    await allure.epic('E0295: Frontend MobileUI');
+    await allure.feature('F12000: Frontend MobileUI');
+    await allure.story('Barcode scanning modes — Ctrl+V paste');
+    await allure.severity('normal');
 
     const masterdata = await createMasterdata();
     const huBarcode = masterdata.handlingUnits.HU1.qrCode;
@@ -83,11 +82,10 @@ test('Paste — scan via Ctrl+V clipboard', async ({ page, context }) => {
 // noinspection JSUnusedLocalSymbols
 test('Manual typing — visible editable input submits on Enter', async ({ page }) => {
     // === ALLURE METADATA ===
-    allure.epic('E0295: Frontend MobileUI');
-    allure.tag('F12000: Frontend MobileUI');
-    allure.tag('F12000');
-    allure.story('Barcode scanning modes — manual typing into visible input');
-    allure.severity('normal');
+    await allure.epic('E0295: Frontend MobileUI');
+    await allure.feature('F12000: Frontend MobileUI');
+    await allure.story('Barcode scanning modes — manual typing into visible input');
+    await allure.severity('normal');
 
     const masterdata = await createMasterdata({
         extraSysconfigs: {
@@ -102,13 +100,10 @@ test('Manual typing — visible editable input submits on Enter', async ({ page 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
 
-    // The input is visible and editable in this configuration.
-    // fill() sets the value without triggering the onChange debounce.
-    // Pressing Enter fires onKeyUp → handleInputTextKeyPress →
-    // validateScannedBarcodeAndForward in BarcodeScannerComponent.
-    const inputLocator = page.locator('#input-text');
-    await inputLocator.fill(huBarcode);
-    await page.keyboard.press('Enter');
+    // fill + Enter exercises the manual-typing path: onKeyUp → handleInputTextKeyPress →
+    // validateScannedBarcodeAndForward. BarcodeScannerComponent.typeManually() encapsulates
+    // the locator so the spec stays free of direct page.locator() calls.
+    await BarcodeScannerComponent.typeManually(huBarcode);
 
     await HUManagerScreen.waitForScreen();
     await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -37,73 +37,26 @@ const createMasterdataWithHU = async ({ extraSysconfigs } = {}) => {
     });
 };
 
-// These tests detect if the #input-text DOM attributes are accidentally reverted
-// to a state that breaks DataWedge IME text injection or causes a virtual keyboard popup.
-test.describe('Attribute regression guards', () => {
+// Regression guard: all four HTML properties of #input-text must hold simultaneously for
+// DataWedge IME to work and for the virtual keyboard to stay suppressed.
+// Any single regression (e.g. readOnly added back, type changed to hidden) breaks DataWedge.
+// noinspection JSUnusedLocalSymbols
+test('#input-text HTML: type=text, inputMode=none, readOnly absent, CSS-hidden', async ({ page }) => {
+    await allure.epic('E0295: Frontend MobileUI');
+    await allure.feature('F12000: Frontend MobileUI');
+    await allure.story('Barcode scanning modes');
+    await allure.severity('critical');
 
-    // noinspection JSUnusedLocalSymbols
-    test('input type is text, not hidden', async ({ page }) => {
-        await allure.epic('E0295: Frontend MobileUI');
-        await allure.feature('F12000: Frontend MobileUI');
-        await allure.story('Barcode scanning modes');
-        await allure.severity('critical');
+    const masterdata = await createLoginMasterdata();
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
 
-        const masterdata = await createLoginMasterdata();
-        await LoginScreen.login(masterdata.login.user);
-        await ApplicationsListScreen.expectVisible();
-
-        await BarcodeScannerComponent.expectAttributes({ type: 'text' });
-    });
-
-    // noinspection JSUnusedLocalSymbols
-    test('inputMode=none suppresses virtual keyboard by default', async ({ page }) => {
-        await allure.epic('E0295: Frontend MobileUI');
-        await allure.feature('F12000: Frontend MobileUI');
-        await allure.story('Barcode scanning modes');
-        await allure.severity('critical');
-
-        const masterdata = await createLoginMasterdata();
-        await LoginScreen.login(masterdata.login.user);
-        await ApplicationsListScreen.expectVisible();
-
-        // HTML attribute is lowercase 'inputmode' (case-insensitive in HTML, but Playwright matches the attribute name).
-        await BarcodeScannerComponent.expectAttributes({ inputmode: 'none' });
-    });
-
-    // noinspection JSUnusedLocalSymbols
-    test('readOnly attribute is absent — DataWedge IME connection preserved', async ({ page }) => {
-        await allure.epic('E0295: Frontend MobileUI');
-        await allure.feature('F12000: Frontend MobileUI');
-        await allure.story('Barcode scanning modes');
-        await allure.severity('critical');
-
-        const masterdata = await createLoginMasterdata();
-        await LoginScreen.login(masterdata.login.user);
-        await ApplicationsListScreen.expectVisible();
-
-        // readonly attribute must be absent — DataWedge IME injects via InputConnection,
-        // which is blocked when the input is readonly.
-        await BarcodeScannerComponent.expectAttributes({ readonly: null });
-    });
-
-    // noinspection JSUnusedLocalSymbols
-    test('input is CSS-hidden, not removed from DOM, when showInputText=N', async ({ page }) => {
-        await allure.epic('E0295: Frontend MobileUI');
-        await allure.feature('F12000: Frontend MobileUI');
-        await allure.story('Barcode scanning modes');
-        await allure.severity('critical');
-
-        // showInputText defaults to N — this is the normal operating mode.
-        const masterdata = await createLoginMasterdata();
-        await LoginScreen.login(masterdata.login.user);
-        await ApplicationsListScreen.expectVisible();
-
-        // Belt-and-suspenders: input is hidden via CSS class, NOT via type=hidden.
-        // type=hidden would break DataWedge IME (InputConnection requires an actual text input).
-        await BarcodeScannerComponent.expectCssClass({ present: 'input-text-offscreen' });
-        await BarcodeScannerComponent.expectAttributes({ type: 'text' });
-    });
-
+    // type=text: required for Android InputConnection (type=hidden cannot receive focus)
+    // inputmode=none: suppresses virtual keyboard while keeping InputConnection alive
+    // readonly absent: readOnly kills InputConnection — DataWedge injection silently fails
+    // input-text-offscreen: CSS-hidden, NOT removed from DOM (type=hidden would break IME)
+    await BarcodeScannerComponent.expectAttributes({ type: 'text', inputmode: 'none', readonly: null });
+    await BarcodeScannerComponent.expectCssClass({ present: 'input-text-offscreen' });
 });
 
 // Each test drives one real-world way a barcode reaches the app, end to end:

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -178,27 +178,10 @@ test('Mode C2 — Paste: scan via Ctrl+V clipboard', async ({ page, context }) =
     // Grant clipboard-read permission so navigator.clipboard.readText() resolves.
     await context.grantPermissions(['clipboard-read']);
 
-    // Mock navigator.clipboard.readText to return the HU QR code without needing
-    // the OS clipboard. The hook calls readText() asynchronously after the keydown.
-    await page.evaluate((barcode) => {
-        Object.defineProperty(navigator, 'clipboard', {
-            value: {
-                readText: () => Promise.resolve(barcode),
-            },
-            configurable: true,
-        });
-    }, huBarcode);
-
-    // Wait for the scanner input to be in the DOM before firing the paste event.
-    await BarcodeScannerComponent.waitToAttach({});
-
-    // Dispatch Ctrl+V on the window — the hook's keydown listener picks it up.
-    await page.evaluate(() => {
-        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'v', ctrlKey: true, bubbles: true }));
-    });
-
+    // pasteViaClipboard mocks navigator.clipboard.readText and dispatches Ctrl+V on window.
     // The hook resolves the clipboard Promise asynchronously, then calls
     // validateScannedBarcodeAndForward which navigates to the HU Manager.
+    await BarcodeScannerComponent.pasteViaClipboard(huBarcode);
     await HUManagerScreen.waitForScreen();
     await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
 });

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -6,13 +6,28 @@ import { HUManagerScreen } from '../utils/screens/huManager/HUManagerScreen';
 import { BarcodeScannerComponent } from '../utils/components/BarcodeScannerComponent';
 import { allure } from 'allure-playwright';
 
-const createMasterdata = async ({ extraSysconfigs } = {}) => {
+// ---------------------------------------------------------------------------
+// Masterdata helpers
+// ---------------------------------------------------------------------------
+
+// Minimal — login only, no HU/orders. Used by attribute-guard tests T1–T4.
+// Falls back to full HU masterdata if Backend requires products/warehouses.
+const createLoginMasterdata = async ({ extraSysconfigs } = {}) => {
     return await Backend.createMasterdata({
         language: 'en_US',
         request: {
-            sysconfigs: {
-                ...extraSysconfigs,
-            },
+            sysconfigs: { ...extraSysconfigs },
+            login: { user: { language: 'en_US' } },
+        },
+    });
+};
+
+// Full — login + HU. Used by functional tests T5–T8.
+const createMasterdataWithHU = async ({ extraSysconfigs } = {}) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            sysconfigs: { ...extraSysconfigs },
             login: { user: { language: 'en_US' } },
             products: { P1: {} },
             warehouses: { wh1: {} },
@@ -27,19 +42,134 @@ const createMasterdata = async ({ extraSysconfigs } = {}) => {
 };
 
 // ---------------------------------------------------------------------------
+// Group 1 — Attribute regression guards (T1–T4)
+// These tests detect if the #input-text DOM attributes are accidentally
+// reverted to a state that breaks DataWedge IME or causes keyboard popups.
+// Login-only masterdata — run in seconds.
+// ---------------------------------------------------------------------------
+
+// noinspection JSUnusedLocalSymbols
+test('Input attribute: type=text present — never type=hidden', async ({ page }) => {
+    await allure.epic('E0295: Frontend MobileUI');
+    await allure.feature('F12000: Frontend MobileUI');
+    await allure.story('Barcode scanning modes');
+    await allure.severity('critical');
+
+    const masterdata = await createLoginMasterdata();
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await BarcodeScannerComponent.expectAttributes({ type: 'text' });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Input attribute: inputMode=none present — virtual keyboard suppressed by default', async ({ page }) => {
+    await allure.epic('E0295: Frontend MobileUI');
+    await allure.feature('F12000: Frontend MobileUI');
+    await allure.story('Barcode scanning modes');
+    await allure.severity('critical');
+
+    const masterdata = await createLoginMasterdata();
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    // HTML attribute is lowercase 'inputmode' (case-insensitive in HTML, but Playwright matches the attribute name).
+    await BarcodeScannerComponent.expectAttributes({ inputmode: 'none' });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Input attribute: readOnly absent — DataWedge IME connection must not be broken', async ({ page }) => {
+    await allure.epic('E0295: Frontend MobileUI');
+    await allure.feature('F12000: Frontend MobileUI');
+    await allure.story('Barcode scanning modes');
+    await allure.severity('critical');
+
+    const masterdata = await createLoginMasterdata();
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    // readonly attribute must be absent — DataWedge IME injects via InputConnection,
+    // which is blocked when the input is readonly.
+    await BarcodeScannerComponent.expectAttributes({ readonly: null });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Input CSS: offscreen class present and type=text (not type=hidden) when showInputText=N', async ({ page }) => {
+    await allure.epic('E0295: Frontend MobileUI');
+    await allure.feature('F12000: Frontend MobileUI');
+    await allure.story('Barcode scanning modes');
+    await allure.severity('critical');
+
+    // showInputText defaults to N — this is the normal operating mode.
+    const masterdata = await createLoginMasterdata();
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    // Belt-and-suspenders: input is hidden via CSS class, NOT via type=hidden.
+    // type=hidden would break DataWedge IME (InputConnection requires an actual text input).
+    await BarcodeScannerComponent.expectCssClass({ present: 'input-text-offscreen' });
+    await BarcodeScannerComponent.expectAttributes({ type: 'text' });
+});
+
+// ---------------------------------------------------------------------------
+// Group 2 — Functional scan paths (T5–T8)
+// All require HU masterdata.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Mode A — DataWedge IME (moved from home_screen.spec.js)
+// Simulates Zebra DataWedge IME text injection (InputConnection) into #input-text.
+// ---------------------------------------------------------------------------
+// noinspection JSUnusedLocalSymbols
+test('Mode A — DataWedge IME: scan via InputConnection injection (typeViaIME)', async ({ page }) => {
+    await allure.epic('E0295: Frontend MobileUI');
+    await allure.feature('F12000: Frontend MobileUI');
+    await allure.story('Barcode scanning modes');
+    await allure.severity('critical');
+
+    const masterdata = await createMasterdataWithHU();
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.scanBarcodeViaIME(masterdata.handlingUnits.HU1.qrCode);
+    await HUManagerScreen.waitForScreen();
+    await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
+});
+
+// ---------------------------------------------------------------------------
+// Mode C1 — Keystroke (keyboard wedge / USB HID scanner)
+// Dispatches keydown events on document (same as ApplicationsListScreen.scanBarcode).
+// ---------------------------------------------------------------------------
+// noinspection JSUnusedLocalSymbols
+test('Mode C1 — Keystroke: scan via keyboard events on offscreen input', async ({ page }) => {
+    await allure.epic('E0295: Frontend MobileUI');
+    await allure.feature('F12000: Frontend MobileUI');
+    await allure.story('Barcode scanning modes');
+    await allure.severity('critical');
+
+    const masterdata = await createMasterdataWithHU();
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    // ApplicationsListScreen.scanBarcode() delegates to BarcodeScannerComponent.type(),
+    // which dispatches keydown events on document — exactly how a USB/BT keyboard wedge works.
+    await ApplicationsListScreen.scanBarcode(masterdata.handlingUnits.HU1.qrCode);
+    await HUManagerScreen.waitForScreen();
+    await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
+});
+
+// ---------------------------------------------------------------------------
 // Mode C2 — Ctrl+V paste
 // The useKeyboardBarcodeReader hook intercepts Ctrl+V, reads the clipboard via
 // navigator.clipboard.readText(), and calls onReadDone immediately.
 // ---------------------------------------------------------------------------
 // noinspection JSUnusedLocalSymbols
-test('Paste — scan via Ctrl+V clipboard', async ({ page, context }) => {
-    // === ALLURE METADATA ===
+test('Mode C2 — Paste: scan via Ctrl+V clipboard', async ({ page, context }) => {
     await allure.epic('E0295: Frontend MobileUI');
     await allure.feature('F12000: Frontend MobileUI');
-    await allure.story('Barcode scanning modes — Ctrl+V paste');
-    await allure.severity('normal');
+    await allure.story('Barcode scanning modes');
+    await allure.severity('critical');
 
-    const masterdata = await createMasterdata();
+    const masterdata = await createMasterdataWithHU();
     const huBarcode = masterdata.handlingUnits.HU1.qrCode;
 
     await LoginScreen.login(masterdata.login.user);
@@ -80,14 +210,13 @@ test('Paste — scan via Ctrl+V clipboard', async ({ page, context }) => {
 // calls validateScannedBarcodeAndForward directly.
 // ---------------------------------------------------------------------------
 // noinspection JSUnusedLocalSymbols
-test('Manual typing — visible editable input submits on Enter', async ({ page }) => {
-    // === ALLURE METADATA ===
+test('Mode C3 — Manual: visible editable input, isInputTextReadonly=N, fill+Enter', async ({ page }) => {
     await allure.epic('E0295: Frontend MobileUI');
     await allure.feature('F12000: Frontend MobileUI');
-    await allure.story('Barcode scanning modes — manual typing into visible input');
-    await allure.severity('normal');
+    await allure.story('Barcode scanning modes');
+    await allure.severity('critical');
 
-    const masterdata = await createMasterdata({
+    const masterdata = await createMasterdataWithHU({
         extraSysconfigs: {
             // Make the input visible so Playwright can locate and fill it.
             'mobileui.frontend.barcodeScanner.showInputText': 'Y',
@@ -99,6 +228,14 @@ test('Manual typing — visible editable input submits on Enter', async ({ page 
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
+
+    // Navigate to HU Manager first so the barcode scanner is in the right context.
+    // The ApplicationsListScreen scanner itself will forward the barcode,
+    // but we also do the inline attribute assert here before scanning.
+
+    // Inline attribute assert: when isInputTextReadonly=N, inputmode attribute is absent
+    // (virtual keyboard suppression is disabled to allow manual typing).
+    await BarcodeScannerComponent.expectAttributes({ inputmode: null });
 
     // fill + Enter exercises the manual-typing path: onKeyUp → handleInputTextKeyPress →
     // validateScannedBarcodeAndForward. BarcodeScannerComponent.typeManually() encapsulates

--- a/e2e/mobile-webui/tests/spec/home_screen.spec.js
+++ b/e2e/mobile-webui/tests/spec/home_screen.spec.js
@@ -63,25 +63,6 @@ test.describe('Scan HU codes', () => {
         await runTest({ masterdata, huBarcode: masterdata.handlingUnits.HU1.huId });
     });
 
-    // Tests the BarcodeScannerComponent in IME mode (Zebra DataWedge text injection)
-    // on the home screen. This is a generic scanner test — not tied to any specific workflow.
-    // The home screen scanner is a visible BarcodeScannerComponent (not hidden like in picking).
-    // noinspection JSUnusedLocalSymbols
-    test('Scan HU QR Code via IME', async ({ page }) => {
-        allure.epic('E0295: Frontend MobileUI');
-        allure.tag('F12000: Frontend MobileUI');
-        allure.tag('F12000');
-        allure.story('Scan HU codes from home screen via IME (Zebra DataWedge)');
-        allure.severity('critical');
-
-        const masterdata = await createMasterdata();
-        await LoginScreen.login(masterdata.login.user);
-        await ApplicationsListScreen.expectVisible();
-        await ApplicationsListScreen.scanBarcodeViaIME(masterdata.handlingUnits.HU1.qrCode);
-        await HUManagerScreen.waitForScreen();
-        await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
-    });
-
     // noinspection JSUnusedLocalSymbols
     test('Scan ExternalBarcode', async ({ page }) => {
         // === ALLURE METADATA ===

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -124,4 +124,13 @@ export const BarcodeScannerComponent = {
     waitForInputFieldToGetEmpty: async () => await test.step(`${NAME} - Wait for input field to get empty`, async () => {
         await expect(page.locator('#input-text')).toHaveValue('');
     }),
+
+    // Fills the visible editable input and presses Enter — exercises the manual-typing path
+    // (onChange debounce / onKeyUp Enter) in BarcodeScannerComponent. Only valid when
+    // barcodeScanner.showInputText=Y and barcodeScanner.isInputTextReadonly=N.
+    typeManually: async (barcode) => await test.step(`${NAME} - Type manually and press Enter`, async () => {
+        await BarcodeScannerComponent.waitToAttach({});
+        await page.locator('#input-text').fill(barcode);
+        await page.keyboard.press('Enter');
+    }),
 }

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -147,6 +147,22 @@ export const BarcodeScannerComponent = {
         }
     }),
 
+    // Simulates Ctrl+V paste: mocks navigator.clipboard.readText to return the barcode,
+    // then dispatches a keydown Ctrl+V on window — the useKeyboardBarcodeReader hook
+    // intercepts it and calls onReadDone(clipboardText).
+    pasteViaClipboard: async (barcode) => await test.step(`${NAME} - Paste via Ctrl+V`, async () => {
+        await BarcodeScannerComponent.waitToAttach({});
+        await page.evaluate((value) => {
+            Object.defineProperty(navigator, 'clipboard', {
+                value: { readText: () => Promise.resolve(value) },
+                configurable: true,
+            });
+        }, barcode);
+        await page.evaluate(() => {
+            window.dispatchEvent(new KeyboardEvent('keydown', { key: 'v', ctrlKey: true, bubbles: true }));
+        });
+    }),
+
     expectCssClass: async ({ present, absent }) => await test.step(`${NAME} - Expect CSS class (present=${present}, absent=${absent})`, async () => {
         await BarcodeScannerComponent.waitToAttach({});
         if (present) await expect(page.locator('#input-text')).toHaveClass(new RegExp(`(^|\\s)${present}(\\s|$)`));

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -133,4 +133,23 @@ export const BarcodeScannerComponent = {
         await page.locator('#input-text').fill(barcode);
         await page.keyboard.press('Enter');
     }),
+
+    // Asserts DOM attributes on #input-text. Pass null as value to assert the attribute is ABSENT.
+    // Example: expectAttributes({ type: 'text', inputmode: 'none', readonly: null })
+    expectAttributes: async (expectedAttrs) => await test.step(`${NAME} - Expect attributes: ${JSON.stringify(expectedAttrs)}`, async () => {
+        await BarcodeScannerComponent.waitToAttach({});
+        for (const [attr, expectedValue] of Object.entries(expectedAttrs)) {
+            if (expectedValue === null) {
+                await expect(page.locator('#input-text')).not.toHaveAttribute(attr);
+            } else {
+                await expect(page.locator('#input-text')).toHaveAttribute(attr, expectedValue);
+            }
+        }
+    }),
+
+    expectCssClass: async ({ present, absent }) => await test.step(`${NAME} - Expect CSS class (present=${present}, absent=${absent})`, async () => {
+        await BarcodeScannerComponent.waitToAttach({});
+        if (present) await expect(page.locator('#input-text')).toHaveClass(new RegExp(present));
+        if (absent) await expect(page.locator('#input-text')).not.toHaveClass(new RegExp(absent));
+    }),
 }

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -149,7 +149,7 @@ export const BarcodeScannerComponent = {
 
     expectCssClass: async ({ present, absent }) => await test.step(`${NAME} - Expect CSS class (present=${present}, absent=${absent})`, async () => {
         await BarcodeScannerComponent.waitToAttach({});
-        if (present) await expect(page.locator('#input-text')).toHaveClass(new RegExp(present));
-        if (absent) await expect(page.locator('#input-text')).not.toHaveClass(new RegExp(absent));
+        if (present) await expect(page.locator('#input-text')).toHaveClass(new RegExp(`(^|\\s)${present}(\\s|$)`));
+        if (absent) await expect(page.locator('#input-text')).not.toHaveClass(new RegExp(`(^|\\s)${absent}(\\s|$)`));
     }),
 }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
@@ -121,9 +121,19 @@ const BarcodeScannerComponent = ({
       if (isShowVideo) {
         videoRef?.current?.scrollIntoView({ behaviour: 'smooth', block: 'center', inline: 'end' });
       }
-      inputTextRef?.current?.focus();
+      if (!isInputTextReadonly) {
+        inputTextRef?.current?.focus();
+      }
     } /* no deps, call it on each render */
   );
+
+  // DataWedge IME needs a focused editable input to establish InputConnection.
+  // Focus once on mount; the window-level hook handles all subsequent scan events.
+  useEffect(() => {
+    if (isInputTextReadonly) {
+      inputTextRef?.current?.focus();
+    }
+  }, []); // eslint-disable-line
 
   useKeyboardBarcodeReader({
     onReadDone: (barcode) => {
@@ -253,9 +263,14 @@ const BarcodeScannerComponent = ({
   };
 
   const handleInputTextBlur = () => {
-    setTimeout(() => {
-      inputTextRef?.current?.focus();
-    }, 2000);
+    // Only re-focus editable inputs. Re-focusing a readonly input inside a 2s
+    // timer triggered by a user tap lands in a user-gesture context where
+    // inputMode="none" is ignored on some Android browsers.
+    if (!isInputTextReadonly) {
+      setTimeout(() => {
+        inputTextRef?.current?.focus();
+      }, 2000);
+    }
   };
 
   return (

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
@@ -263,14 +263,9 @@ const BarcodeScannerComponent = ({
   };
 
   const handleInputTextBlur = () => {
-    // Only re-focus editable inputs. Re-focusing a readonly input inside a 2s
-    // timer triggered by a user tap lands in a user-gesture context where
-    // inputMode="none" is ignored on some Android browsers.
-    if (!isInputTextReadonly) {
-      setTimeout(() => {
-        inputTextRef?.current?.focus();
-      }, 2000);
-    }
+    setTimeout(() => {
+      inputTextRef?.current?.focus();
+    }, 2000);
   };
 
   return (


### PR DESCRIPTION
## What

Restores virtual keyboard suppression on mobile barcode scan screens.

## Root cause

Commit https://github.com/metasfresh/metasfresh/commit/fb6b08205c98e235fabf3f7925d9a56d1d735c7d
(DataWedge IME fix) replaced `readOnly` with `inputMode="none"` on the
barcode input — correct for DataWedge support — but also removed the
`if (!isInputTextReadonly)` guard from the `useEffect` that calls
`focus()` on every render.

React re-renders triggered by user interactions fire effects inside
Chrome's event-flush cycle, which can land in a user-gesture context.
In that context Chrome ignores `inputMode="none"` and opens the virtual
keyboard. With `readOnly` this path was safe because readonly inputs
never open the keyboard regardless of gesture context.

## Fix

`BarcodeScannerComponent.jsx`:

1. **Restore the per-render focus guard** — `useEffect` (no deps) now
   calls `focus()` only when `!isInputTextReadonly` (manual-input mode).

2. **Add a mount-time focus for DataWedge IME** — a separate `useEffect`
   with `[]` deps focuses the input once on mount when `isInputTextReadonly=true`.
   This establishes the `InputConnection` that DataWedge IME needs without
   triggering the keyboard on every re-render.

3. **Blur re-focus kept for all inputs** — the 2-second `setTimeout`
   re-focus in `handleInputTextBlur` is unchanged. A `setTimeout`
   callback does not inherit Chrome's user-gesture token, so
   `inputMode="none"` suppresses the keyboard there. DataWedge IME
   recovery (re-establishing `InputConnection` after accidental focus
   loss) depends on this re-focus.

## What stays the same

- `inputMode="none"` is kept (DataWedge IME needs editable input)
- `readOnly` is NOT reintroduced
- DataWedge IME connection established on mount, recovered after blur