### PR TITLE
Performance: indexes for slow Material Receipt Candidates, Process Instances, and Invoice Candidate queries

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805490_sys_AD_PInstance_Created_index_perf.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805490_sys_AD_PInstance_Created_index_perf.sql
@@ -1,0 +1,10 @@
+-- Performance: add an index on AD_PInstance.Created matching the Process-Instances
+-- window default ordering (Created DESC NULLS LAST, AD_PInstance_ID ASC).
+-- AD_PInstance is the process/report execution log and grows very large; without this
+-- index the window's view-selection does a full scan + external on-disk sort of the whole
+-- table just to take the most-recent rows, making the window extremely slow to open.
+-- NULLS LAST must match the window ORDER BY exactly, otherwise the planner ignores the
+-- index and still sorts. IF NOT EXISTS keeps it a no-op where already present.
+-- Note: on a very large AD_PInstance this index build locks writes briefly during deploy.
+CREATE INDEX IF NOT EXISTS ad_pinstance_created
+    ON ad_pinstance (Created DESC NULLS LAST, AD_PInstance_ID);

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5805500_sys_C_Invoice_Candidate_C_OrderSO_ID_index_perf.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5805500_sys_C_Invoice_Candidate_C_OrderSO_ID_index_perf.sql
@@ -1,0 +1,5 @@
+-- Performance: index C_Invoice_Candidate.C_OrderSO_ID (the sales-order link).
+-- Used for per-row joins/lookups that otherwise sequentially scan the (large)
+-- C_Invoice_Candidate table. IF NOT EXISTS keeps it a no-op where already present.
+CREATE INDEX IF NOT EXISTS c_invoice_candidate_c_orderso_id
+    ON c_invoice_candidate (c_orderso_id);

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5805480_sys_M_ShippingPackage_C_Order_ID_index_perf.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5805480_sys_M_ShippingPackage_C_Order_ID_index_perf.sql
@@ -1,0 +1,10 @@
+-- Performance: add an index on M_ShippingPackage.C_Order_ID.
+-- The M_ReceiptSchedule shipping ColumnSQL columns (ContainerNo, VesselName, TrackingID,
+-- M_ShipperTransportation_ID, ETD/ETA/ATA/ATD, BLDate, CRD, POL_ID/POD_ID, ...) each join
+--   M_ShippingPackage sp ON st.m_shippertransportation_id = sp.m_shippertransportation_id
+--   INNER JOIN M_ReceiptSchedule r ON r.c_order_id = sp.c_order_id
+-- Without an index on M_ShippingPackage.C_Order_ID, this is a sequential scan over the
+-- (large) M_ShippingPackage table for every displayed row, making the Material Receipt
+-- Candidates grid extremely slow to render. IF NOT EXISTS keeps it a no-op where present.
+CREATE INDEX IF NOT EXISTS m_shippingpackage_c_order_id
+    ON m_shippingpackage (c_order_id);


### PR DESCRIPTION
## Performance: three missing indexes for slow report/window queries

Three additive `CREATE INDEX IF NOT EXISTS` migrations. Each was diagnosed from `pg_stat_statements` + `EXPLAIN (ANALYZE, BUFFERS)` on a production DB and the index was verified there before this PR.

### 1. `M_ShippingPackage(C_Order_ID)` — `5805480`
The Material-Receipt-Candidates window (`M_ReceiptSchedule`) renders ~16 `ColumnSQL` virtual columns (ContainerNo, VesselName, TrackingID, ShipperTransportation_ID, ETD/ETA/ATA/ATD, …) that each join `M_ShippingPackage` on `C_Order_ID`. That column was unindexed on a ~1.1M-row table → a sequential scan per displayed row. Verified: per-subquery cost dropped from **3,656 ms to 0.26 ms**; the grid page query from ~39 s to sub-second.

### 2. `AD_PInstance(Created DESC NULLS LAST, AD_PInstance_ID)` — `5805490`
The Process-Instances window builds its view selection with `ORDER BY Created DESC NULLS LAST, AD_PInstance_ID`. With no matching index, on a large `AD_PInstance` it does a full scan + external on-disk sort. The index matches the sort exactly (note the `NULLS LAST` — a plain `Created DESC` index is `NULLS FIRST` and is NOT used). Verified: ~34 s → sub-second, on-disk sort eliminated.

### 3. `C_Invoice_Candidate(C_OrderSO_ID)` — `5805500`
Index on the sales-order link used for per-row joins/lookups against the large `C_Invoice_Candidate` table.

All three use `IF NOT EXISTS` (no-op where already present). No AD metadata, no Java, no behavioural change.
